### PR TITLE
[hyperactor] serve procs through Gateway

### DIFF
--- a/docs/source/books/hyperactor-book/src/actors/actor.md
+++ b/docs/source/books/hyperactor-book/src/actors/actor.md
@@ -24,7 +24,7 @@ pub trait Actor: Sized + Send + 'static {
     }
 
     fn spawn_detached(self) -> Result<ActorHandle<Self>, anyhow::Error> {
-        Proc::local().spawn("anon", self)
+        Proc::isolated().spawn("anon", self)
     }
 
     fn spawn_server_task<F>(future: F) -> JoinHandle<F::Output>
@@ -108,7 +108,7 @@ This method takes ownership of `self` (the actor instance) and spawns it as a ch
 
 ```rust
 fn spawn_detached(self) -> Result<ActorHandle<Self>, anyhow::Error> {
-    Proc::local().spawn("anon", self)
+    Proc::isolated().spawn("anon", self)
 }
 ```
 This method takes ownership of `self` and creates a root actor on a fresh, isolated proc.

--- a/docs/source/books/hyperactor-book/src/macros/behavior.md
+++ b/docs/source/books/hyperactor-book/src/macros/behavior.md
@@ -48,7 +48,7 @@ The behavior can include any type of message:
 After spawning the real actor, re-type its id as the behavior:
 
 ```rust
-let mut proc = Proc::local();
+let mut proc = Proc::isolated();
 let shopping_list_actor: ActorHandle<ShoppingListActor> =
     proc.spawn("shopping", ()).await?;
 let (client, _) = proc.instance("client").unwrap();

--- a/docs/source/books/hyperactor-book/src/macros/handler.md
+++ b/docs/source/books/hyperactor-book/src/macros/handler.md
@@ -144,7 +144,7 @@ The `cx` parameter provides the actor context required to send messages and open
 
 #### Example Usage
 ```rust
-let mut proc = Proc::local();
+let mut proc = Proc::isolated();
 let actor = proc.spawn::<ShoppingListActor>("shopping", ()).await?;
 let client = proc.attach("client").unwrap();
 

--- a/hyperactor/example/derive.rs
+++ b/hyperactor/example/derive.rs
@@ -130,7 +130,7 @@ hyperactor::behavior!(ShoppingApi, ShoppingList, ClearList, GetItemCount,);
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {
-    let mut proc = Proc::local();
+    let mut proc = Proc::isolated();
 
     // Spawn our actor, and get a handle for rank 0.
     let shopping_list_actor: hyperactor::ActorHandle<ShoppingListActor> =

--- a/hyperactor/example/stream.rs
+++ b/hyperactor/example/stream.rs
@@ -81,7 +81,7 @@ impl Handler<u64> for CountClient {
 
 #[tokio::main]
 async fn main() {
-    let proc = Proc::local();
+    let proc = Proc::isolated();
 
     let counter_actor: ActorHandle<CounterActor> =
         proc.spawn("counter", CounterActor::default()).unwrap();

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -115,7 +115,7 @@ pub trait Actor: Sized + Send + 'static {
     /// Actors spawned through `spawn_detached` are not attached to a supervision
     /// hierarchy, and not managed by a [`Proc`].
     fn spawn_detached(self) -> Result<ActorHandle<Self>, anyhow::Error> {
-        Proc::local().spawn("anon", self)
+        Proc::isolated().spawn("anon", self)
     }
 
     /// This method is used by the runtime to spawn the actor server. It can be
@@ -826,7 +826,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_server_basic() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
         let actor = EchoActor(tx.bind());
@@ -840,7 +840,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ping_pong() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (undeliverable_msg_tx, _) = client.open_port();
 
@@ -863,7 +863,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_ping_pong_on_handler_error() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (undeliverable_msg_tx, _) = client.open_port();
 
@@ -924,7 +924,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_init() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let actor = InitActor(false);
         let handle = proc.spawn::<InitActor>("init", actor).unwrap();
         let (client, _) = proc.instance("client").unwrap();
@@ -949,7 +949,7 @@ mod tests {
 
     impl MultiValuesTest {
         async fn new() -> Self {
-            let proc = Proc::local();
+            let proc = Proc::isolated();
             let values: MultiValues = Arc::new(Mutex::new((0, "".to_string())));
             let actor = MultiActor(values.clone());
             let handle = proc.spawn::<MultiActor>("myactor", actor).unwrap();
@@ -1069,7 +1069,7 @@ mod tests {
 
         // Just test that we can round-trip the handle through a downcast.
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let handle = proc.spawn("nothing", NothingActor).unwrap();
         let cell = handle.cell();
 
@@ -1127,7 +1127,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_actor_handle_basic() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
 
@@ -1179,7 +1179,7 @@ mod tests {
     // Test that actor ports share a sequence while non-actor ports get their own.
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_mixed_actor_and_non_actor_ports() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         // Port for receiving seq info from actor handler
@@ -1258,7 +1258,7 @@ mod tests {
     // Test that messages from different clients get independent sequence schemes.
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_multiple_clients() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client1, _) = proc.instance("client1").unwrap();
         let (client2, _) = proc.instance("client2").unwrap();
 
@@ -1370,7 +1370,7 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
 
@@ -1458,7 +1458,7 @@ mod tests {
     }
 
     async fn assert_out_of_order_delivery(expected: Vec<(String, u64)>, relay_orders: Vec<usize>) {
-        let local_proc: Proc = Proc::local();
+        let local_proc: Proc = Proc::isolated();
         let (client, _) = local_proc.instance("local").unwrap();
         let (tx, mut rx) = client.open_port();
 
@@ -1569,7 +1569,7 @@ mod tests {
     /// wiring behaves as expected.
     #[tokio::test]
     async fn test_introspect_query_default_payload() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -1714,7 +1714,7 @@ mod tests {
     /// terminated snapshot tests).
     #[tokio::test]
     async fn test_ia1_ia4_running_actor_attrs() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -1743,7 +1743,7 @@ mod tests {
     // .. }`).
     #[tokio::test]
     async fn test_introspect_query_child_not_found() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -1788,7 +1788,7 @@ mod tests {
         #[async_trait]
         impl Actor for CustomIntrospectActor {}
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let handle = proc
             .spawn("custom_introspect", CustomIntrospectActor)
@@ -1825,7 +1825,7 @@ mod tests {
     /// that the parent's payload lists the child in `children`.
     #[tokio::test]
     async fn test_introspect_query_supervision_child() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         // Spawn parent.
@@ -1903,7 +1903,7 @@ mod tests {
     /// initialization completes.
     #[tokio::test]
     async fn test_introspect_fresh_actor_status() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -1941,7 +1941,7 @@ mod tests {
     /// after-user-traffic case).
     #[tokio::test]
     async fn test_introspect_after_user_message() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -1977,7 +1977,7 @@ mod tests {
     /// actor — `None`, not `IntrospectMessage`.
     #[tokio::test]
     async fn test_introspect_consecutive_queries() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -2040,7 +2040,7 @@ mod tests {
             attr TEST_KEY_B: u64;
         }
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -2077,7 +2077,7 @@ mod tests {
     /// invoke it via `query_child()`, and confirm the response.
     #[tokio::test]
     async fn test_query_child_handler_round_trip() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -2156,7 +2156,7 @@ mod tests {
             }
         }
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let handle = proc.spawn("wedged", WedgedActor).unwrap();
 
@@ -2201,7 +2201,7 @@ mod tests {
     /// report the user message handler.
     #[tokio::test]
     async fn test_introspect_no_perturbation() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
@@ -2265,7 +2265,7 @@ mod tests {
     /// and is fully navigable in admin tooling.
     #[tokio::test]
     async fn test_introspectable_instance_responds_to_query() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (bridge, handle) = proc.introspectable_instance("bridge").unwrap();
         let actor_id: crate::ActorAddr = handle.actor_addr().clone();
 
@@ -2303,7 +2303,7 @@ mod tests {
     /// `introspectable_instance` instead.
     #[tokio::test]
     async fn test_instance_does_not_respond_to_query() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _client_handle) = proc.instance("client").unwrap();
         let (_mailbox, mailbox_handle) = proc.instance("mailbox").unwrap();
         let mailbox_id: crate::ActorAddr = mailbox_handle.actor_addr().clone();
@@ -2334,7 +2334,7 @@ mod tests {
     /// causing `serve_introspect` to store a terminated snapshot.
     #[tokio::test]
     async fn test_introspectable_instance_snapshot_on_drop() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (instance, handle) = proc.introspectable_instance("bridge").unwrap();
         let actor_id = handle.actor_addr().clone();
 

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -220,7 +220,7 @@ mod tests {
 
         let _ = remote
             .gspawn(
-                &Proc::local(),
+                &Proc::isolated(),
                 "hyperactor::actor::remote::tests::MyActor",
                 Uid::instance_labeled(Label::new("actor").unwrap()),
                 bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
@@ -231,7 +231,7 @@ mod tests {
 
         let err = remote
             .gspawn(
-                &Proc::local(),
+                &Proc::isolated(),
                 "hyperactor::actor::remote::tests::MyActor",
                 Uid::instance_labeled(Label::new("actor").unwrap()),
                 bincode::serde::encode_to_vec(false, bincode::config::legacy()).unwrap(),

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -1213,10 +1213,10 @@ fn serve_inner<M: RemoteMessage>(
             let (port, rx) = local::serve::<M>();
             Ok((ChannelAddr::Local(port), ChannelRxKind::Local(rx)))
         }
-        ChannelAddr::Local(a) => Err(ChannelError::InvalidAddress(format!(
-            "invalid local addr: {}",
-            a
-        ))),
+        ChannelAddr::Local(a) => Ok((
+            ChannelAddr::Local(a),
+            ChannelRxKind::Local(local::bind::<M>(a)?),
+        )),
         ChannelAddr::Alias { dial_to, bind_to } => {
             let (bound_addr, rx) = serve_inner::<M>(*bind_to, listener)?;
             let alias_addr = ChannelAddr::Alias {
@@ -1238,6 +1238,11 @@ pub fn serve_local<M: RemoteMessage>() -> (ChannelAddr, ChannelRx<M>) {
             inner: ChannelRxKind::Local(rx),
         },
     )
+}
+
+/// Reserve a local channel address that can be served later.
+pub fn reserve_local_addr() -> ChannelAddr {
+    ChannelAddr::Local(local::reserve())
 }
 
 #[cfg(test)]
@@ -1408,6 +1413,23 @@ mod tests {
             ChannelAddr::from_zmq_url("tls://[::1]:443").unwrap(),
             ChannelAddr::Tls(TlsAddr::new("::1", 443))
         );
+    }
+
+    #[tokio::test]
+    async fn test_reserved_local_addr_can_be_served() {
+        let addr = reserve_local_addr();
+        assert!(dial::<u64>(addr.clone()).is_err());
+
+        let (bound_addr, mut rx) = serve::<u64>(addr.clone()).unwrap();
+        assert_eq!(bound_addr, addr);
+
+        let tx = dial::<u64>(addr.clone()).unwrap();
+        tx.post(123);
+        assert_eq!(rx.recv().await.unwrap(), 123);
+        drop(rx);
+
+        let (rebound_addr, _rx) = serve::<u64>(addr.clone()).unwrap();
+        assert_eq!(rebound_addr, addr);
     }
 
     #[test]

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -33,6 +33,12 @@ struct Ports {
 }
 
 impl Ports {
+    fn reserve(&mut self) -> u64 {
+        let port = self.next_port;
+        self.next_port += 1;
+        port
+    }
+
     fn alloc(
         &mut self,
     ) -> (
@@ -40,14 +46,28 @@ impl Ports {
         mpsc::UnboundedReceiver<Message>,
         watch::Sender<TxStatus>,
     ) {
-        let port = self.next_port;
-        self.next_port += 1;
+        let port = self.reserve();
+        let (rx, status_tx) = self.bind(port).expect("fresh local port must bind");
+        (port, rx, status_tx)
+    }
+
+    fn bind(
+        &mut self,
+        port: u64,
+    ) -> Result<(mpsc::UnboundedReceiver<Message>, watch::Sender<TxStatus>), ChannelError> {
+        if self.ports.contains_key(&port) {
+            return Err(ChannelError::InvalidAddress(format!(
+                "local addr already bound: {}",
+                port
+            )));
+        }
+        self.next_port = self.next_port.max(port.saturating_add(1));
         let (tx, rx) = mpsc::unbounded_channel::<Message>();
         let (status_tx, status_rx) = watch::channel(TxStatus::Active);
         if self.ports.insert(port, (tx.clone(), status_rx)).is_some() {
             panic!("port reused")
         }
-        (port, rx, status_tx)
+        Ok((rx, status_tx))
     }
 
     fn free(&mut self, port: u64) {
@@ -180,6 +200,22 @@ pub fn serve<M: RemoteMessage>() -> (u64, LocalRx<M>) {
             _phantom: PhantomData,
         },
     )
+}
+
+/// Reserve a local address that can be served later.
+pub fn reserve() -> u64 {
+    PORTS.lock().unwrap().reserve()
+}
+
+/// Bind a specific local port. The server is shut down when the returned Rx is dropped.
+pub fn bind<M: RemoteMessage>(port: u64) -> Result<LocalRx<M>, ChannelError> {
+    let (data_rx, status_tx) = PORTS.lock().unwrap().bind(port)?;
+    Ok(LocalRx {
+        data_rx,
+        status_tx,
+        port,
+        _phantom: PhantomData,
+    })
 }
 
 #[cfg(test)]

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -6,48 +6,88 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Shared reachability state for Hyperactor procs.
+//! Connectivity layer for Hyperactor procs.
 
+use std::collections::HashMap;
 use std::fmt;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::RwLock;
+use std::sync::Weak;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
+
+use async_trait::async_trait;
 
 use crate::Location;
 use crate::ProcAddr;
 use crate::ProcId;
+use crate::channel;
 use crate::channel::ChannelAddr;
+use crate::channel::ChannelError;
 use crate::channel::ChannelTransport;
 use crate::mailbox::BoxedMailboxSender;
+use crate::mailbox::DeliveryError;
+use crate::mailbox::DialMailboxRouter;
+use crate::mailbox::IntoBoxedMailboxSender as _;
 use crate::mailbox::MailboxSender as _;
-use crate::mailbox::PanickingMailboxSender;
+use crate::mailbox::MailboxServer as _;
+use crate::mailbox::MailboxServerHandle;
+use crate::mailbox::MessageEnvelope;
+use crate::mailbox::PortHandle;
+use crate::mailbox::Undeliverable;
+use crate::mailbox::UnroutableMailboxSender;
+use crate::proc::Proc;
+use crate::proc::WeakProc;
 
-/// Shared ingress, egress, and advertised reachability state for one or more procs.
+/// Connectivity boundary for one or more procs.
 #[derive(Clone)]
 pub struct Gateway {
     inner: Arc<GatewayState>,
 }
 
 struct GatewayState {
+    /// The location to use when no server is active.
+    fallback_location: Location,
+
     /// The location used when constructing routeable addresses for
     /// newly bound refs.
     default_location: RwLock<Location>,
 
     /// Sender used to forward messages outside of the proc.
     forwarder: BoxedMailboxSender,
+
+    /// Procs attached to this gateway, keyed by runtime identity.
+    procs: RwLock<HashMap<ProcId, WeakProc>>,
+
+    /// Locations currently served by this gateway. The last location
+    /// is the default advertised location.
+    active_servers: RwLock<Vec<Location>>,
 }
 
 impl Gateway {
-    /// Create a fresh local-only gateway.
+    /// Create a fresh unserved gateway with dial-based forwarding.
     pub fn new() -> Self {
         Self::configured(
-            ChannelAddr::any(ChannelTransport::Local).into(),
-            BoxedMailboxSender::new(PanickingMailboxSender),
+            channel::reserve_local_addr().into(),
+            DialMailboxRouter::new().into_boxed(),
+        )
+    }
+
+    /// Create a fresh unserved local-only gateway.
+    pub fn isolated() -> Self {
+        Self::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(UnroutableMailboxSender),
         )
     }
 
     /// Return the process-wide default gateway.
-    pub fn default() -> &'static Self {
+    pub fn process_default() -> &'static Self {
         static DEFAULT_GATEWAY: OnceLock<Gateway> = OnceLock::new();
         DEFAULT_GATEWAY.get_or_init(Self::new)
     }
@@ -55,8 +95,11 @@ impl Gateway {
     pub(crate) fn configured(default_location: Location, forwarder: BoxedMailboxSender) -> Self {
         Self {
             inner: Arc::new(GatewayState {
+                fallback_location: default_location.clone(),
                 default_location: RwLock::new(default_location),
                 forwarder,
+                procs: RwLock::new(HashMap::new()),
+                active_servers: RwLock::new(Vec::new()),
             }),
         }
     }
@@ -80,7 +123,107 @@ impl Gateway {
         &self.inner.forwarder
     }
 
+    pub(crate) fn attach(&self, proc: &Proc) {
+        let proc_id = proc.proc_id().clone();
+        if let Some(existing) = self
+            .inner
+            .procs
+            .write()
+            .unwrap()
+            .insert(proc_id.clone(), proc.downgrade())
+            && existing.upgrade().is_some()
+        {
+            panic!("gateway already has a live proc with id {}", proc_id)
+        }
+    }
+
+    pub(crate) fn serve_rx(
+        &self,
+        rx: impl channel::Rx<MessageEnvelope> + Send + 'static,
+    ) -> MailboxServerHandle {
+        WeakGateway::new(self).serve(rx)
+    }
+
+    /// Serve this gateway on the provided channel address.
+    ///
+    /// When serving [`ChannelAddr::any`] for the local transport, the gateway
+    /// uses the local address that was reserved when the gateway was created.
+    /// Serving also updates the gateway's default location to the served
+    /// address.
+    pub fn serve(&self, addr: ChannelAddr) -> Result<GatewayServeHandle, ChannelError> {
+        let (location, handle) = self.serve_inner(addr)?;
+        Ok(GatewayServeHandle {
+            gateway: self.clone(),
+            location,
+            handle,
+            stopped: Arc::new(AtomicBool::new(false)),
+        })
+    }
+
+    fn serve_inner(
+        &self,
+        addr: ChannelAddr,
+    ) -> Result<(Location, MailboxServerHandle), ChannelError> {
+        let addr = self.resolve_serve_addr(addr);
+        let (addr, rx) = channel::serve(addr)?;
+        let location = Location::from(addr);
+        self.add_server(location.clone());
+        Ok((location, self.serve_rx(rx)))
+    }
+
+    fn resolve_serve_addr(&self, addr: ChannelAddr) -> ChannelAddr {
+        if addr == ChannelAddr::any(ChannelTransport::Local)
+            && self.inner.active_servers.read().unwrap().is_empty()
+            && matches!(self.inner.fallback_location.addr(), ChannelAddr::Local(_))
+        {
+            return self.inner.fallback_location.addr().clone();
+        }
+        addr
+    }
+
+    fn add_server(&self, location: Location) {
+        let mut active_servers = self.inner.active_servers.write().unwrap();
+        active_servers.push(location.clone());
+        *self.inner.default_location.write().unwrap() = location;
+    }
+
+    fn remove_server(&self, location: &Location) {
+        let mut active_servers = self.inner.active_servers.write().unwrap();
+        if let Some(index) = active_servers.iter().rposition(|active| active == location) {
+            active_servers.remove(index);
+        }
+        let default_location = active_servers
+            .last()
+            .cloned()
+            .unwrap_or_else(|| self.inner.fallback_location.clone());
+        *self.inner.default_location.write().unwrap() = default_location;
+    }
+
+    /// Flush pending gateway traffic.
+    ///
+    /// This first flushes the muxers for all live procs attached to the
+    /// gateway, then flushes the gateway's forwarder. Flushing the proc muxers
+    /// drains local delivery and any return paths rooted in attached procs;
+    /// flushing the forwarder drains outbound traffic that the gateway has
+    /// routed away from those procs.
+    ///
+    /// The live proc set is snapshotted before awaiting, so we do not hold the
+    /// proc map while flushing. Procs that have already been dropped are
+    /// ignored. Concurrent posts may race with this operation; `flush` only
+    /// guarantees that each flushed sender observes its usual sender-level
+    /// flush semantics at the time it is flushed.
     pub(crate) async fn flush(&self) -> Result<(), anyhow::Error> {
+        let procs = self
+            .inner
+            .procs
+            .read()
+            .unwrap()
+            .values()
+            .filter_map(WeakProc::upgrade)
+            .collect::<Vec<_>>();
+        for proc in procs {
+            proc.muxer().flush().await?;
+        }
         self.inner.forwarder.flush().await
     }
 }
@@ -90,5 +233,130 @@ impl fmt::Debug for Gateway {
         f.debug_struct("Gateway")
             .field("default_location", &self.default_location())
             .finish()
+    }
+}
+
+/// A running gateway server.
+#[derive(Debug)]
+pub struct GatewayServeHandle {
+    gateway: Gateway,
+    location: Location,
+    handle: MailboxServerHandle,
+    stopped: Arc<AtomicBool>,
+}
+
+impl GatewayServeHandle {
+    /// Signal the gateway server to stop.
+    pub fn stop(&self, reason: &str) {
+        if !self.stopped.swap(true, Ordering::AcqRel) {
+            self.handle.stop(reason);
+            self.gateway.remove_server(&self.location);
+        }
+    }
+}
+
+impl Future for GatewayServeHandle {
+    type Output = <MailboxServerHandle as Future>::Output;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        // SAFETY: `handle` is structurally pinned with `GatewayServeHandle`:
+        // this type is `!Unpin` because `MailboxServerHandle` is `!Unpin`, it
+        // has no `Drop` impl that moves `handle`, and no method moves `handle`
+        // out of a pinned `GatewayServeHandle`.
+        let handle = unsafe {
+            self.as_mut()
+                .map_unchecked_mut(|container| &mut container.handle)
+        };
+        let result = handle.poll(cx);
+        if result.is_ready() {
+            // SAFETY: We only mutate unpinned bookkeeping fields after polling
+            // the pinned `handle`; this does not move `handle` or any other
+            // pinned field out of `self`.
+            let this = unsafe { self.get_unchecked_mut() };
+            if !this.stopped.swap(true, Ordering::AcqRel) {
+                this.gateway.remove_server(&this.location);
+            }
+        }
+        result
+    }
+}
+
+#[derive(Clone, Debug)]
+struct WeakGateway(Weak<GatewayState>);
+
+impl WeakGateway {
+    fn new(gateway: &Gateway) -> Self {
+        Self(Arc::downgrade(&gateway.inner))
+    }
+
+    fn upgrade(&self) -> Option<Gateway> {
+        self.0.upgrade().map(|inner| Gateway { inner })
+    }
+}
+
+#[async_trait]
+impl crate::mailbox::MailboxSender for WeakGateway {
+    fn post_unchecked(
+        &self,
+        envelope: MessageEnvelope,
+        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+    ) {
+        match self.upgrade() {
+            Some(gateway) => gateway.post(envelope, return_handle),
+            None => envelope.undeliverable(
+                DeliveryError::BrokenLink("failed to upgrade WeakGateway".to_string()),
+                return_handle,
+            ),
+        }
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        match self.upgrade() {
+            Some(gateway) => Gateway::flush(&gateway).await,
+            None => Ok(()),
+        }
+    }
+}
+
+#[async_trait]
+impl crate::mailbox::MailboxSender for Gateway {
+    fn post_unchecked(
+        &self,
+        envelope: MessageEnvelope,
+        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+    ) {
+        let dest_proc = envelope.dest().actor_addr().proc_addr();
+        let weak_proc = self
+            .inner
+            .procs
+            .read()
+            .unwrap()
+            .get(dest_proc.id())
+            .cloned();
+        let proc = weak_proc.as_ref().and_then(WeakProc::upgrade);
+
+        if weak_proc.is_some() && proc.is_none() {
+            let mut procs = self.inner.procs.write().unwrap();
+            if procs
+                .get(dest_proc.id())
+                .and_then(WeakProc::upgrade)
+                .is_none()
+            {
+                procs.remove(dest_proc.id());
+            }
+        }
+
+        if let Some(proc) = proc {
+            if proc.is_local_delivery_target(&dest_proc) {
+                proc.muxer().post(envelope, return_handle);
+                return;
+            }
+        }
+
+        self.inner.forwarder.post(envelope, return_handle)
+    }
+
+    async fn flush(&self) -> Result<(), anyhow::Error> {
+        Gateway::flush(self).await
     }
 }

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -66,7 +66,7 @@ pub mod addr;
 pub mod channel;
 pub mod config;
 pub mod context;
-/// Gateway management for proc reachability.
+/// Gateway management for proc connectivity.
 pub mod gateway;
 pub mod id;
 mod init;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -20,7 +20,7 @@
 //! # use hyperactor::Proc;
 //! # use hyperactor::{ActorAddr, ProcAddr};
 //! # tokio_test::block_on(async {
-//! # let proc = Proc::local();
+//! # let proc = Proc::isolated();
 //! # let (client, _) = proc.instance("client").unwrap();
 //! # let actor_id = proc.proc_addr().actor_addr("actor");
 //! let mbox = Mailbox::new_detached(actor_id);
@@ -39,7 +39,7 @@
 //! # use hyperactor::Proc;
 //! # use hyperactor::{ActorAddr, ProcAddr};
 //! # tokio_test::block_on(async {
-//! # let proc = Proc::local();
+//! # let proc = Proc::isolated();
 //! # let (client, _) = proc.instance("client").unwrap();
 //! # let actor_id = proc.proc_addr().actor_addr("actor");
 //! let mbox = Mailbox::new_detached(actor_id);
@@ -3193,7 +3193,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_accum() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (port, mut receiver) = client
             .mailbox()
@@ -3249,7 +3249,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // error behavior changed, but we will bring it back
     async fn test_mailbox_once() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         let (port, receiver) = client.open_once_port::<u64>();
@@ -3670,7 +3670,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_enqueue_port() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         let count = Arc::new(AtomicUsize::new(0));
@@ -3799,7 +3799,7 @@ mod tests {
             wirevalue::Any::serialize(&1u64).unwrap(),
             Flattrs::new(),
         );
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         return_handle
             .send(&client, Undeliverable(envelope.clone()))
@@ -3995,7 +3995,7 @@ mod tests {
         reducer_spec: Option<ReducerSpec>,
         reducer_mode: ReducerMode,
     ) -> Setup {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (actor0, actor0_handle) = proc.instance("actor0").unwrap();
         let (actor1, actor1_handle) = proc.instance("actor1").unwrap();
 
@@ -4126,7 +4126,7 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _config_guard =
             config.override_key(crate::config::SPLIT_MAX_BUFFER_AGE, Duration::from_mins(10));
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (actor, _actor_handle) = proc.instance("actor").unwrap();
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
@@ -4249,7 +4249,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_split_port_once_mode_basic() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (actor, _actor_handle) = proc.instance("actor").unwrap();
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
@@ -4277,7 +4277,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_split_port_once_mode_teardown() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (actor, _actor_handle) = proc.instance("actor").unwrap();
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
@@ -4553,7 +4553,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_port_contramap() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (handle, mut rx) = client.open_port();
 
@@ -4695,7 +4695,7 @@ mod tests {
         );
 
         let (port_handle, _rx) = mailbox.open_port::<u64>();
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         mailbox.close(ActorStatus::Stopped("test stop".to_string()));
@@ -4723,7 +4723,7 @@ mod tests {
         );
 
         let (port_handle, _rx) = mailbox.open_port::<u64>();
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         mailbox.close(ActorStatus::Failed(ActorErrorKind::Generic(
@@ -4743,7 +4743,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_open_reduce_port() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         // Open an accumulator port with sum reducer
@@ -4763,7 +4763,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_open_reduce_port_reducer_spec_preserved() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         // Test that different accumulators produce different reducer_specs

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -84,7 +84,7 @@ pub(crate) fn new_undeliverable_port() -> (
     PortHandle<Undeliverable<MessageEnvelope>>,
     PortReceiver<Undeliverable<MessageEnvelope>>,
 ) {
-    let proc = Proc::local();
+    let proc = Proc::isolated();
     crate::mailbox::Mailbox::new_detached(proc.proc_addr().actor_addr("undeliverable"))
         .open_port::<Undeliverable<MessageEnvelope>>()
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -102,6 +102,7 @@ use std::sync::RwLock;
 use std::sync::Weak;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
+#[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -176,7 +177,6 @@ use crate::mailbox::Mailbox;
 use crate::mailbox::MailboxClient;
 use crate::mailbox::MailboxMuxer;
 use crate::mailbox::MailboxSender;
-use crate::mailbox::MailboxServer as _;
 use crate::mailbox::MessageEnvelope;
 use crate::mailbox::OncePortHandle;
 use crate::mailbox::OncePortReceiver;
@@ -407,9 +407,6 @@ impl channel::Rx<MessageEnvelope> for AttachRx {
     }
 }
 
-/// This is used to mint new local ranks for [`Proc::local`].
-static NEXT_LOCAL_RANK: AtomicUsize = AtomicUsize::new(0);
-
 /// A proc instance is the runtime managing a single proc in Hyperactor.
 /// It is responsible for spawning actors in the proc, multiplexing messages
 /// to/within actors in the proc, and providing fallback routing to external
@@ -582,9 +579,9 @@ impl Builder {
         let gateway = match (self.gateway, self.forwarder) {
             (Some(gateway), None) => gateway,
             (None, Some(forwarder)) => {
-                Gateway::configured(ChannelAddr::any(ChannelTransport::Local).into(), forwarder)
+                Gateway::configured(channel::reserve_local_addr().into(), forwarder)
             }
-            (None, None) => Gateway::default().clone(),
+            (None, None) => Gateway::process_default().clone(),
             (Some(_), Some(_)) => anyhow::bail!("cannot set both gateway and forwarder"),
         };
         Ok(Proc::from_parts_unchecked(proc_id, gateway))
@@ -600,10 +597,10 @@ impl Proc {
             status = "Created"
         );
 
-        Self {
+        let proc = Self {
             inner: Arc::new(ProcState {
-                proc_id,
-                gateway,
+                proc_id: proc_id.clone(),
+                gateway: gateway.clone(),
                 proc_muxer: MailboxMuxer::new(),
                 reserved_roots: DashSet::new(),
                 instances: DashMap::new(),
@@ -613,7 +610,9 @@ impl Proc {
                 supervision_coordinator_actor_id: OnceLock::new(),
                 mailbox_server_handle: std::sync::Mutex::new(None),
             }),
-        }
+        };
+        gateway.attach(&proc);
+        proc
     }
 
     fn from_parts(proc_id: ProcId, gateway: Gateway) -> Self {
@@ -672,7 +671,7 @@ impl Proc {
     /// Create a proc with a random id on a fresh local-only gateway.
     pub fn isolated() -> Self {
         Self::builder()
-            .gateway(Gateway::new())
+            .gateway(Gateway::isolated())
             .build()
             .expect("isolated proc builder is valid")
     }
@@ -706,7 +705,7 @@ impl Proc {
             ))
             .build()
             .expect("direct proc builder is valid");
-        let handle = proc.clone().serve(rx);
+        let handle = proc.gateway().serve_rx(rx);
         *proc.inner.mailbox_server_handle.lock().unwrap() = Some(handle);
         Ok(proc)
     }
@@ -763,7 +762,7 @@ impl Proc {
         // Wrap the inner mailbox server handle so that stopping/
         // joining the outer handle also joins the dial-side
         // `DuplexClient`.
-        let inner_handle = proc.clone().serve(AttachRx(duplex_rx));
+        let inner_handle = proc.gateway().serve_rx(AttachRx(duplex_rx));
         let (stopped_tx, mut stopped_rx) = tokio::sync::watch::channel(false);
         let wrapped_join = tokio::spawn(async move {
             let _ = stopped_rx.wait_for(|stopped| *stopped).await;
@@ -842,17 +841,6 @@ impl Proc {
         }
     }
 
-    /// Create a new local-only proc. This proc is not allowed to forward messages
-    /// outside of the proc itself.
-    pub fn local() -> Self {
-        let rank = NEXT_LOCAL_RANK.fetch_add(1, Ordering::Relaxed);
-        Self::builder()
-            .proc_id(ProcId::instance(Label::strip(&format!("local_{}", rank))))
-            .gateway(Gateway::new())
-            .build()
-            .expect("local proc builder is valid")
-    }
-
     /// The proc's runtime identity.
     pub fn proc_id(&self) -> &ProcId {
         &self.state().proc_id
@@ -873,7 +861,7 @@ impl Proc {
         self.state().proc_addr()
     }
 
-    /// The proc's shared reachability boundary.
+    /// The proc's connectivity boundary.
     pub fn gateway(&self) -> Gateway {
         self.state().gateway.clone()
     }
@@ -1562,7 +1550,7 @@ impl Proc {
     /// transport-level acks before the channel is torn down.
     ///
     /// No-op if no mailbox server handle is stored (e.g. for
-    /// `Proc::configured` or `Proc::local` procs that don't serve).
+    /// `Proc::configured` or `Proc::isolated` procs that don't serve).
     pub async fn join_mailbox_server(&self) {
         let handle = self.inner.mailbox_server_handle.lock().unwrap().take();
         if let Some(handle) = handle {
@@ -1571,7 +1559,7 @@ impl Proc {
         }
     }
 
-    fn is_local_delivery_target(&self, dest_proc: &ProcAddr) -> bool {
+    pub(crate) fn is_local_delivery_target(&self, dest_proc: &ProcAddr) -> bool {
         let local_proc_id = self.proc_id();
         if requires_location_for_local_delivery_identity(dest_proc.id()) {
             // TODO: check all bound addresses for this proc, not only
@@ -1632,12 +1620,7 @@ impl MailboxSender for Proc {
     }
 
     async fn flush(&self) -> Result<(), anyhow::Error> {
-        let gateway = self.gateway();
-        let (r1, r2) =
-            futures::future::join(self.state().proc_muxer.flush(), gateway.flush()).await;
-        r1?;
-        r2?;
-        Ok(())
+        self.gateway().flush().await
     }
 }
 
@@ -3792,7 +3775,7 @@ mod tests {
     #[tracing_test::traced_test]
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_actor() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let handle = proc.spawn("test", TestActor).unwrap();
 
@@ -3842,7 +3825,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_proc_actors_messaging() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let first = proc.spawn::<TestActor>("first", TestActor).unwrap();
         let second = proc.spawn::<TestActor>("second", TestActor).unwrap();
@@ -4028,7 +4011,7 @@ mod tests {
         use crate::mailbox::monitored_return_handle;
         use crate::testing::ids::test_actor_id;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (instance, _) = proc.instance("worker").unwrap();
         let (port, mut receiver) = instance.bind_actor_port::<u64>();
 
@@ -4054,7 +4037,7 @@ mod tests {
 
     #[test]
     fn test_default_location_changes_new_bindings_not_lookup() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let gateway = proc.gateway();
         let (_instance, handle) = proc.instance("worker").unwrap();
 
@@ -4115,6 +4098,77 @@ mod tests {
         assert_eq!(second.default_location(), second_location);
     }
 
+    #[tokio::test]
+    async fn test_gateway_serve_updates_location_and_stops() {
+        let proc = Proc::isolated();
+        let gateway = proc.gateway();
+        let initial_location = proc.default_location();
+
+        let server = Gateway::serve(&gateway, ChannelAddr::any(ChannelTransport::Local)).unwrap();
+
+        assert_eq!(proc.default_location(), initial_location);
+        assert_eq!(proc.default_location(), gateway.default_location());
+        assert_eq!(proc.proc_addr(), gateway.proc_addr(proc.proc_id()));
+
+        let next_server =
+            Gateway::serve(&gateway, ChannelAddr::any(ChannelTransport::Local)).unwrap();
+
+        assert_ne!(proc.default_location(), initial_location);
+        assert_eq!(proc.default_location(), gateway.default_location());
+        assert_eq!(proc.proc_addr(), gateway.proc_addr(proc.proc_id()));
+
+        next_server.stop("test complete");
+        next_server.await.unwrap().unwrap();
+
+        assert_eq!(proc.default_location(), initial_location);
+        assert_eq!(proc.default_location(), gateway.default_location());
+
+        server.stop("test complete");
+        server.await.unwrap().unwrap();
+
+        assert_eq!(proc.default_location(), initial_location);
+        assert_eq!(proc.default_location(), gateway.default_location());
+    }
+
+    #[tokio::test]
+    async fn test_direct_proc_server_stops_via_join_mailbox_server() {
+        let proc = Proc::direct(
+            ChannelAddr::any(ChannelTransport::Local),
+            "direct".to_string(),
+        )
+        .unwrap();
+
+        assert_eq!(proc.proc_addr(), proc.gateway().proc_addr(proc.proc_id()));
+
+        proc.join_mailbox_server().await;
+    }
+
+    #[tokio::test]
+    async fn test_local_only_gateway_returns_undeliverable_messages() {
+        use crate::testing::ids::test_actor_id;
+
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (return_handle, mut undeliverable_rx) =
+            client.open_port::<Undeliverable<MessageEnvelope>>();
+        let remote_proc = ProcAddr::unique(ChannelAddr::Local(1234), "remote");
+        let remote_dest = remote_proc.actor_addr("worker").port_addr(Port::from(0));
+
+        proc.post(
+            MessageEnvelope::serialize(
+                test_actor_id("sender", "client"),
+                remote_dest.clone(),
+                &123u64,
+                Flattrs::new(),
+            )
+            .unwrap(),
+            return_handle,
+        );
+
+        let Undeliverable(envelope) = undeliverable_rx.recv().await.unwrap();
+        assert_eq!(envelope.dest(), &remote_dest);
+    }
+
     #[derive(Debug, Default)]
     #[export]
     struct LookupTestActor;
@@ -4140,7 +4194,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_actor_lookup() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _handle) = proc.instance("client").unwrap();
 
         let target_actor = proc.spawn::<TestActor>("target", TestActor).unwrap();
@@ -4207,7 +4261,7 @@ mod tests {
     #[tracing_test::traced_test]
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_child() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         let first = proc.spawn::<TestActor>("first", TestActor).unwrap();
@@ -4276,7 +4330,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_child_lifecycle() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
@@ -4295,7 +4349,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_parent_failure() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         // Need to set a supervison coordinator for this Proc because there will
         // be actor failure(s) in this test which trigger supervision.
@@ -4364,7 +4418,7 @@ mod tests {
             }
         }
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let state = Arc::new(AtomicUsize::new(0));
         let actor = TestActor(state.clone());
         let handle = proc.spawn::<TestActor>("test", actor).unwrap();
@@ -4385,7 +4439,7 @@ mod tests {
         // Need this custom hook to store panic backtrace in task_local.
         panic_handler::set_panic_hook();
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         // Need to set a supervison coordinator for this Proc because there will
         // be actor failure(s) in this test which trigger supervision.
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -4465,7 +4519,7 @@ mod tests {
             should_handle,
         };
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (mut reported_event, _coordinator) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -4557,7 +4611,7 @@ mod tests {
             }
         }
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
 
         let (instance, handle) = proc.instance("my_test_actor").unwrap();
 
@@ -4591,7 +4645,7 @@ mod tests {
         }
 
         let process = async {
-            let proc = Proc::local();
+            let proc = Proc::isolated();
             // Intentionally not setting a proc supervison coordinator. This
             // should cause the process to terminate.
             // ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -4691,7 +4745,7 @@ mod tests {
         }
 
         trace_and_block(async {
-            let proc = Proc::local();
+            let proc = Proc::isolated();
             let (client, _) = proc.instance("client").unwrap();
             let handle = LoggingActor.spawn_detached().unwrap();
             handle.send(&client, "hello world".to_string()).unwrap();
@@ -4731,7 +4785,7 @@ mod tests {
         use crate::mailbox::MailboxErrorKind;
         use crate::mailbox::MailboxSenderErrorKind;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let actor_handle = proc.spawn("test", TestActor).unwrap();
 
@@ -4764,7 +4818,7 @@ mod tests {
         use crate::mailbox::MailboxErrorKind;
         use crate::mailbox::MailboxSenderErrorKind;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         // Need to set a supervison coordinator for this Proc because there will
         // be actor failure(s) in this test which trigger supervision.
@@ -4833,7 +4887,7 @@ mod tests {
     //   - the actor id moves from the live set to the terminated set.
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_stored_on_stop() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (_client, _client_handle) = proc.instance("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("actor", TestActor).unwrap();
@@ -4877,7 +4931,7 @@ mod tests {
     // and asserts the snapshot reports a `failed:*` actor_status.
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_stored_on_failure() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _client_handle) = proc.instance("client").unwrap();
         // Supervision coordinator required for actor failure handling.
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -4907,7 +4961,7 @@ mod tests {
     // Exercises FI-1/FI-2 (see introspect.rs module-scope comment).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_stored_on_failure() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _client_handle) = proc.instance("client").unwrap();
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -4932,7 +4986,7 @@ mod tests {
     // Exercises FI-2 (see introspect.rs module-scope comment).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_on_clean_stop() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (_client, _client_handle) = proc.instance("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("stop_actor", TestActor).unwrap();
@@ -4954,7 +5008,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_coordinator_receives_clean_stop() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (_client, _client_handle) = proc.instance("client").unwrap();
         let (mut reported_event, _coordinator_handle) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -4977,7 +5031,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_coordinator_shuts_down_last_during_destroy() {
-        let mut proc = Proc::local();
+        let mut proc = Proc::isolated();
         let (_client, _client_handle) = proc.instance("client").unwrap();
         let (mut reported_event, _coordinator_handle) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -5018,7 +5072,7 @@ mod tests {
     // Exercises FI-4 (see introspect.rs module-scope comment).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_on_propagated_failure() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _client_handle) = proc.instance("client").unwrap();
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5060,7 +5114,7 @@ mod tests {
     // resolve_actor_ref closes that race window.
     #[async_timed_test(timeout_secs = 30)]
     async fn test_resolve_actor_ref_none_for_terminal_actor() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (_client, _client_handle) = proc.instance("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("target", TestActor).unwrap();
@@ -5086,7 +5140,7 @@ mod tests {
     // Exercises FI-3 (see introspect module doc).
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_has_failure_info() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _client_handle) = proc.instance("client").unwrap();
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5130,7 +5184,7 @@ mod tests {
     // Exercises FI-4 (see introspect module doc).
     #[async_timed_test(timeout_secs = 60)]
     async fn test_propagated_failure_info() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _client_handle) = proc.instance("client").unwrap();
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5166,7 +5220,7 @@ mod tests {
     /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_creates_descriptive_name() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let handle = proc
             .spawn_named_child(root.cell().clone(), "my_controller", TestActor)
@@ -5181,7 +5235,7 @@ mod tests {
     /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_increments_index() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let first = proc
             .spawn_named_child(root.cell().clone(), "my_controller", TestActor)
@@ -5196,7 +5250,7 @@ mod tests {
     /// spawn_named_child passes Some(parent) to spawn_inner.
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_preserves_supervision() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let child = proc
             .spawn_named_child(root.cell().clone(), "supervised_child", TestActor)
@@ -5209,7 +5263,7 @@ mod tests {
     /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_unchanged() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let child = proc.spawn_child(root.cell().clone(), TestActor).unwrap();
         assert!(!child.actor_addr().is_root());
@@ -5218,7 +5272,7 @@ mod tests {
     /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_different_names_different_pids() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let a = proc
             .spawn_named_child(root.cell().clone(), "controller_a", TestActor)
@@ -5234,7 +5288,7 @@ mod tests {
     /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_no_child_overwrite() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let _a = proc
             .spawn_named_child(root.cell().clone(), "ctrl", TestActor)
@@ -5249,7 +5303,7 @@ mod tests {
     /// Exercises AI-1 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_with_name_does_not_pollute_roots() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let _child = proc
             .spawn_named_child(root.cell().clone(), "foo", TestActor)
@@ -5263,7 +5317,7 @@ mod tests {
     /// Exercises AI-3 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ai3_controller_actor_ids_unique_across_parents_same_proc() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let parent_a = proc.spawn::<TestActor>("parent_a", TestActor).unwrap();
         let parent_b = proc.spawn::<TestActor>("parent_b", TestActor).unwrap();
 
@@ -5285,7 +5339,7 @@ mod tests {
     /// Exercises AI-3 (see module doc).
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ai3_no_controller_overwrite_in_parent_or_proc_maps() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let parent_a = proc.spawn::<TestActor>("parent_a", TestActor).unwrap();
         let parent_b = proc.spawn::<TestActor>("parent_b", TestActor).unwrap();
 
@@ -5313,7 +5367,7 @@ mod tests {
     // Exercises FI-6 (see introspect module doc).
     #[async_timed_test(timeout_secs = 60)]
     async fn test_stopped_snapshot_has_no_failure_info() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (_client, _client_handle) = proc.instance("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("stop_actor", TestActor).unwrap();
@@ -5349,7 +5403,7 @@ mod tests {
     // with the existing OTel ACTOR_MESSAGE_QUEUE_SIZE accounting.
     #[async_timed_test(timeout_secs = 10)]
     async fn test_queue_depth_increment_decrement() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let handle = proc.spawn("qd_test", TestActor).unwrap();
         let actor_ref: crate::ActorRef<TestActor> = handle.bind();
@@ -5404,7 +5458,7 @@ mod tests {
     // snapshot of currently queued work, not backlog history.
     #[async_timed_test(timeout_secs = 10)]
     async fn test_proc_queue_depth_aggregation_under_pressure() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
 
         // Spawn two actors.
@@ -5484,7 +5538,7 @@ mod tests {
     // and watermark is 0.
     #[async_timed_test(timeout_secs = 5)]
     async fn test_retained_queue_stats_cold_start() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         assert_eq!(proc.queue_depth_total(), 0);
         assert_eq!(proc.queue_depth_high_water_mark(), 0);
         assert_eq!(proc.last_nonzero_queue_depth_age_ms(), None);
@@ -5494,7 +5548,7 @@ mod tests {
     // retains the peak and last-nonzero is Some.
     #[async_timed_test(timeout_secs = 10)]
     async fn test_retained_queue_stats_burst_then_drain() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let h = proc.spawn("ret_test", TestActor).unwrap();
 

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -616,7 +616,7 @@ fn parse_messages(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), anyhow::Error> {
-///     let mut proc = Proc::local();
+///     let mut proc = Proc::isolated();
 ///
 ///     // Spawn our actor, and get a handle for rank 0.
 ///     let shopping_list_actor: hyperactor::ActorHandle<ShoppingListActor> =

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -182,7 +182,7 @@ mod tests {
     // Verify it compiles
     #[async_timed_test(timeout_secs = 30)]
     async fn test_client_macros() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let actor_handle = proc.spawn("foo", TestVariantFormsActor {}).unwrap();
 

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -144,7 +144,7 @@ mod tests {
     // will not be bound, and the send will fail.
     #[async_timed_test(timeout_secs = 30)]
     async fn test_binds() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
@@ -233,7 +233,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ref_alias() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
@@ -275,7 +275,7 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_generic_export() {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1309,19 +1309,20 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 300)]
     #[cfg(fbcode_build)]
     async fn test_actor_states_with_panic() {
         hyperactor_telemetry::initialize_logging_for_test();
 
+        let instance = testing::instance();
         let config = hyperactor_config::global::lock();
         let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(120));
+        let _actor_spawn = config.override_key(ACTOR_SPAWN_MAX_IDLE, Duration::from_secs(120));
         let _host_spawn = config.override_key(
             hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
             Duration::from_secs(120),
         );
 
-        let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
         let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
@@ -1413,7 +1414,7 @@ mod tests {
 
     #[cfg(fbcode_build)]
     #[assert_no_process_leak]
-    #[async_timed_test(timeout_secs = 60)]
+    #[async_timed_test(timeout_secs = 300)]
     async fn test_actor_states_with_process_exit() {
         hyperactor_telemetry::initialize_logging_for_test();
 
@@ -1421,17 +1422,17 @@ mod tests {
         let _poll = config.override_key(SUPERVISION_POLL_FREQUENCY, Duration::from_secs(1));
         let _guard = config.override_key(GET_ACTOR_STATE_MAX_IDLE, Duration::from_secs(1));
         let _proc_guard = config.override_key(GET_PROC_STATE_MAX_IDLE, Duration::from_secs(1));
-        let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
+        let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(120));
         let _host_spawn = config.override_key(
             hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
-            Duration::from_secs(60),
+            Duration::from_secs(120),
         );
 
         let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
         let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
-        let num_replicas = 2;
+        let num_replicas = 1;
         let mut hm = testing::host_mesh(num_replicas).await;
         let proc_mesh = hm
             .spawn(instance, "test", Extent::unity(), None, None)
@@ -1518,44 +1519,47 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
-    #[async_timed_test(timeout_secs = 120)]
+    #[async_timed_test(timeout_secs = 300)]
     #[cfg(fbcode_build)]
     async fn test_actor_states_on_sliced_mesh() {
         hyperactor_telemetry::initialize_logging_for_test();
-
-        let config = hyperactor_config::global::lock();
-        let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(120));
-        let _host_spawn = config.override_key(
-            hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
-            Duration::from_secs(120),
-        );
 
         let instance = testing::instance();
         // Listen for supervision events sent to the parent instance.
         let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
         let supervisor = supervision_port.bind();
-        let num_replicas = 2;
-        let mut hm = testing::host_mesh(num_replicas).await;
-        let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None, None)
-            .await
-            .unwrap();
-        let child_name = ActorMeshId::unique(Label::new("child").unwrap());
+        let (mut hm, _actor_mesh, sliced, sliced_replicas, child_name) = {
+            let config = hyperactor_config::global::lock();
+            let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(120));
+            let _actor_spawn = config.override_key(ACTOR_SPAWN_MAX_IDLE, Duration::from_secs(120));
+            let _host_spawn = config.override_key(
+                hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
+                Duration::from_secs(120),
+            );
+            let num_replicas = 2;
+            let hm = testing::host_mesh(num_replicas).await;
+            let proc_mesh = hm
+                .spawn(instance, "test", Extent::unity(), None, None)
+                .await
+                .unwrap();
+            let child_name = ActorMeshId::unique(Label::new("child").unwrap());
 
-        // Need to use a wrapper as there's no way to customize the handler for MeshFailure
-        // on the client instance. The client would just panic with the message.
-        let actor_mesh: ActorMesh<testactor::WrapperActor> = proc_mesh
-            .spawn(
-                instance,
-                "wrapper",
-                &(proc_mesh.deref().clone(), supervisor, child_name.clone()),
-            )
-            .await
-            .unwrap();
-        let sliced = actor_mesh
-            .range("hosts", 1..2)
-            .expect("slice should be valid");
-        let sliced_replicas = sliced.len();
+            // Need to use a wrapper as there's no way to customize the handler for MeshFailure
+            // on the client instance. The client would just panic with the message.
+            let actor_mesh: ActorMesh<testactor::WrapperActor> = proc_mesh
+                .spawn(
+                    instance,
+                    "wrapper",
+                    &(proc_mesh.deref().clone(), supervisor, child_name.clone()),
+                )
+                .await
+                .unwrap();
+            let sliced = actor_mesh
+                .range("hosts", 1..2)
+                .expect("slice should be valid");
+            let sliced_replicas = sliced.len();
+            (hm, actor_mesh, sliced, sliced_replicas, child_name)
+        };
 
         // TODO: check that independent slice refs don't get the supervision event.
         sliced
@@ -1675,11 +1679,8 @@ mod tests {
             )
             .unwrap();
 
-        let mut received_ranks: HashSet<usize> = HashSet::new();
-        for _ in 0..1 {
-            let (point, _actor_ref, _sender) = cast_info_rx.recv().await.unwrap();
-            received_ranks.insert(point.rank());
-        }
+        let (point, _actor_ref, _sender) = cast_info_rx.recv().await.unwrap();
+        let received_ranks = HashSet::from([point.rank()]);
         assert_eq!(received_ranks, HashSet::from([0]));
 
         // Also cast with sel!(*) — all ranks should be reached via V1.
@@ -1739,19 +1740,23 @@ mod tests {
         hyperactor_telemetry::initialize_logging_for_test();
 
         let instance = testing::instance();
-        let config = hyperactor_config::global::lock();
-        let _proc_spawn_guard = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
-        let _host_spawn_guard = config.override_key(
-            hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
-            Duration::from_secs(60),
-        );
 
         // Create a proc mesh with 2 hosts.
-        let mut hm = testing::host_mesh(2).await;
-        let proc_mesh = hm
-            .spawn(instance, "test", Extent::unity(), None, None)
-            .await
-            .unwrap();
+        let (mut hm, proc_mesh) = {
+            let config = hyperactor_config::global::lock();
+            let _proc_spawn_guard =
+                config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
+            let _host_spawn_guard = config.override_key(
+                hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
+                Duration::from_secs(60),
+            );
+            let hm = testing::host_mesh(2).await;
+            let proc_mesh = hm
+                .spawn(instance, "test", Extent::unity(), None, None)
+                .await
+                .unwrap();
+            (hm, proc_mesh)
+        };
 
         // Set up undeliverable message port for collecting undeliverables
         let (undeliverable_port, mut undeliverable_rx) =
@@ -1803,6 +1808,7 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         // Set message delivery timeout for faster test
+        let config = hyperactor_config::global::lock();
         let _guard = config.override_key(
             hyperactor::config::MESSAGE_DELIVERY_TIMEOUT,
             std::time::Duration::from_secs(5),
@@ -1866,7 +1872,6 @@ mod tests {
         // handler waits for ProcAgents to report `Stopped`. Shorten it
         // from 30s to 1s so the test finishes quickly.
         let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(ACTOR_SPAWN_MAX_IDLE, std::time::Duration::from_secs(1));
         let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
         let _host_spawn = config.override_key(
             hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
@@ -1886,6 +1891,7 @@ mod tests {
         // than timeout
         let mut sleep_mesh: ActorMesh<testactor::SleepActor> =
             proc_mesh.spawn(instance, "sleepers", &()).await.unwrap();
+        let _guard = config.override_key(ACTOR_SPAWN_MAX_IDLE, std::time::Duration::from_secs(1));
 
         // Send each actor a message to sleep for 5 seconds. `Instance::run`
         // only polls the signal receiver at message boundaries, so

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -3124,7 +3124,7 @@ mod tests {
 
         // Create a local instance just to call the local bootstrap actor.
         // We should find a way to avoid this for local handles.
-        let temp_proc = Proc::local();
+        let temp_proc = Proc::isolated();
         let (temp_instance, _) = temp_proc.instance("temp").unwrap();
 
         let handle = host(

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -425,7 +425,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_simple_connection() -> Result<()> {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _) = proc.instance("client")?;
         let (connect, completer) = Connect::allocate(client.self_addr().clone(), client);
         let actor = proc.spawn("actor", EchoActor {})?;
@@ -450,7 +450,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_connection_close_on_drop() -> Result<()> {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _client_handle) = proc.instance("client")?;
 
         let (connect, completer) =
@@ -477,7 +477,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_no_eof_on_drop_after_shutdown() -> Result<()> {
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _client_handle) = proc.instance("client")?;
 
         let (connect, completer) =

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -372,12 +372,12 @@ async fn bootstrap_host() -> GlobalState {
 
     // 5. Get local_proc via HostAgent (lazily boots ProcAgent).
     //
-    // We use a throwaway Proc::local() for the bootstrap request-reply
+    // We use a throwaway Proc::isolated() for the bootstrap request-reply
     // calls, matching Python's bootstrap_host() (host_mesh.rs:330-333).
     // This creates a temporary in-process-only proc context during init
     // — intentionally acceptable for cross-language symmetry and easier
     // reasoning about the bootstrap sequence.
-    let temp_proc = Proc::local();
+    let temp_proc = Proc::isolated();
     let (bootstrap_cx, _guard) = temp_proc
         .instance("bootstrap")
         .expect("failed to create bootstrap instance");

--- a/monarch_extension/src/debugger.rs
+++ b/monarch_extension/src/debugger.rs
@@ -206,7 +206,7 @@ mod tests {
     fn test_pdb_actor() {
         Python::initialize();
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (_, controller_ref, controller_rx) = proc
             .attach_actor::<ControllerActor, ControllerMessage>("controller")
             .unwrap();

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -370,7 +370,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
         hyperactor_mesh::global_context::register_client_host(host_mesh.clone());
 
         // We require a temporary instance to make a call to the host/proc agent.
-        let temp_proc = Proc::local();
+        let temp_proc = Proc::isolated();
         let (temp_instance, _) = temp_proc
             .instance("temp")
             .map_err(|e| PyException::new_err(e.to_string()))?;
@@ -509,7 +509,7 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
 
     PyPythonTask::new(async move {
         // Create a temporary instance to send the shutdown message
-        let temp_proc = hyperactor::Proc::local();
+        let temp_proc = hyperactor::Proc::isolated();
         let (instance, _) = temp_proc
             .instance("shutdown_requester")
             .map_err(|e| PyException::new_err(e.to_string()))?;

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -45,7 +45,7 @@ impl PyProc {
     #[pyo3(signature = ())]
     fn new() -> PyResult<Self> {
         Ok(Self {
-            inner: Proc::local(),
+            inner: Proc::isolated(),
         })
     }
 

--- a/monarch_tensor_worker/src/borrow.rs
+++ b/monarch_tensor_worker/src/borrow.rs
@@ -196,7 +196,7 @@ mod tests {
     async fn basic_borrow_test_impl(device: Device) -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc
@@ -351,7 +351,7 @@ mod tests {
     async fn borrow_errored_value() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc

--- a/monarch_tensor_worker/src/comm.rs
+++ b/monarch_tensor_worker/src/comm.rs
@@ -436,7 +436,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn all_reduce() {
         test_setup().unwrap();
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _handle) = proc.instance("client").unwrap();
 
         let unique_id = UniqueId::new_nccl().unwrap();
@@ -503,7 +503,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn group_send_recv() {
         test_setup().unwrap();
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _handle) = proc.instance("client").unwrap();
 
         let unique_id = UniqueId::new_nccl().unwrap();
@@ -578,7 +578,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn reduce() -> Result<()> {
         test_setup()?;
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, _handle) = proc.instance("client")?;
 
         let unique_id = UniqueId::new_nccl()?;
@@ -650,7 +650,7 @@ mod tests {
     async fn worker_reduce() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let world_size = 4;
@@ -838,7 +838,7 @@ mod tests {
     async fn send_tensor() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let handle1 = proc
@@ -1023,7 +1023,7 @@ mod tests {
     async fn send_tensor_local() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let handle = proc

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -1131,7 +1131,7 @@ mod tests {
     async fn basic_worker() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc
@@ -1240,7 +1240,7 @@ mod tests {
     async fn error_sends_response() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc
@@ -1303,7 +1303,7 @@ mod tests {
     async fn mutated_refs_are_updated_with_error() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc
@@ -1377,7 +1377,7 @@ mod tests {
     async fn accessing_errored_dependency() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc
@@ -1456,7 +1456,7 @@ mod tests {
     async fn py_remote_function_calls() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc
@@ -1758,7 +1758,7 @@ mod tests {
     async fn delete_refs() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, _) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc
@@ -1836,7 +1836,7 @@ mod tests {
     async fn request_status() -> Result<()> {
         test_setup()?;
 
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
         let worker_handle = proc
@@ -1925,7 +1925,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn backend_network_init() {
         test_setup().unwrap();
-        let proc = Proc::local();
+        let proc = Proc::isolated();
         let (client, controller_ref, _) = proc.attach_actor("controller").unwrap();
 
         let worker_handle1 = proc

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -1981,7 +1981,7 @@ mod tests {
         async fn new_with_world_size(world_size: usize) -> Result<Self> {
             test_util::test_setup()?;
 
-            let proc = Proc::local();
+            let proc = Proc::isolated();
             let (_, controller_actor, controller_rx) =
                 proc.attach_actor::<ControllerActor, ControllerMessage>("controller")?;
             let (client, _handle) = proc.instance("client")?;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3845
* #3822
* #3821
* #3820
* #3819
* #3818

Procs previously relied on external forwarders for message routing. This centralizes routing in the Gateway so that procs attached to the same gateway can deliver messages locally before falling back to remote forwarding. Gateway::serve now binds a channel, tracks active servers in priority order, and updates the default advertised location from the last active server. GatewayServeHandle removes its location when dropped or stopped. Local gateways use a reserved channel address so proc addresses remain stable before and after serving. Proc::isolated replaces Proc::local as the canonical unserved constructor. Flushing now delegates to the gateway, which flushes local muxers first and then the forwarder, consolidating the operational path.

Differential Revision: [D104674503](https://our.internmc.facebook.com/intern/diff/D104674503/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D104674503/)!