### PR TITLE
[monarch] Make rdmaxcel driver API loading total instead of throwing

### DIFF
--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -10,7 +10,6 @@
 #include <cuda_runtime.h>
 #include <dlfcn.h>
 #include <iostream>
-#include <stdexcept>
 
 // Two-level stringify macro to ensure macro arguments are expanded before
 // stringification
@@ -118,6 +117,15 @@ struct DriverAPI {
 
 namespace {
 
+// Fallback entry used when the driver library or a symbol cannot be loaded.
+// Returns CUDA_ERROR_NOT_INITIALIZED to the Rust caller. The variadic
+// template lets one definition match the heterogeneous driver signatures
+// in RDMAXCEL_CUDA_DRIVER_API.
+template <typename... Args>
+CUresult stub_entry(Args... /*unused*/) {
+  return CUDA_ERROR_NOT_INITIALIZED;
+}
+
 DriverAPI create_driver_api() {
 #ifdef USE_ROCM
   // Try to open libamdhip64.so - RTLD_NOLOAD means only succeed if already
@@ -131,8 +139,8 @@ DriverAPI create_driver_api() {
   }
 
   if (!handle) {
-    throw std::runtime_error(
-        std::string("[RdmaXcel] Can't open libamdhip64.so: ") + dlerror());
+    std::cerr << "[RdmaXcel] Can't open libamdhip64.so: " << dlerror()
+              << std::endl;
   }
 #else
   // Try to open libcuda.so.1 - RTLD_NOLOAD means only succeed if already loaded
@@ -145,19 +153,24 @@ DriverAPI create_driver_api() {
   }
 
   if (!handle) {
-    throw std::runtime_error(
-        std::string("[RdmaXcel] Can't open libcuda.so.1: ") + dlerror());
+    std::cerr << "[RdmaXcel] Can't open libcuda.so.1: " << dlerror()
+              << std::endl;
   }
 #endif
 
   DriverAPI r{};
 
-#define LOOKUP_CUDA_ENTRY(name, sym)                                           \
-  r.name##_ = reinterpret_cast<decltype(&sym)>(dlsym(handle, STRINGIFY(sym))); \
-  if (!r.name##_) {                                                            \
-    throw std::runtime_error(                                                  \
-        std::string("[RdmaXcel] Can't find ") + STRINGIFY(sym) + ": " +        \
-        dlerror());                                                            \
+#define LOOKUP_CUDA_ENTRY(name, sym)                                     \
+  if (!handle) {                                                         \
+    r.name##_ = &stub_entry;                                             \
+  } else {                                                               \
+    r.name##_ =                                                          \
+        reinterpret_cast<decltype(&sym)>(dlsym(handle, STRINGIFY(sym))); \
+    if (!r.name##_) {                                                    \
+      std::cerr << "[RdmaXcel] Can't find " << STRINGIFY(sym) << ": "    \
+                << dlerror() << std::endl;                               \
+      r.name##_ = &stub_entry;                                           \
+    }                                                                    \
   }
 
   RDMAXCEL_CUDA_DRIVER_API(LOOKUP_CUDA_ENTRY)
@@ -169,7 +182,7 @@ DriverAPI create_driver_api() {
 } // namespace
 
 DriverAPI* DriverAPI::get() {
-  // Ensure we have a valid CUDA context for this thread
+  // Ensure we have a valid CUDA context for this thread.
   cudaFree(0);
   static DriverAPI singleton = create_driver_api();
   return &singleton;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Each `extern "C"` wrapper in `rdmaxcel-sys/src/driver_api.cpp` forwards through `rdmaxcel::DriverAPI::get()`, which lazily constructs a singleton via `create_driver_api()`. The constructor used to throw `std::runtime_error` when `libcuda.so.1` (or `libamdhip64.so` on ROCm) was unavailable, or when a required symbol could not be resolved via `dlsym`. Letting a C++ exception cross an `extern "C"` boundary is undefined behavior, and in practice triggered `std::terminate()` with the cryptic message `terminate() called, exception stack follows... Exception type: std::runtime_error`. This crashed the process on any host without a working CUDA install the first time Rust issued a driver API call.

Make `create_driver_api()` total: when `dlopen` fails, or a symbol cannot be resolved, log the error to stderr and assign the corresponding entry to a generic `stub_entry` template that returns `CUDA_ERROR_NOT_INITIALIZED`. The X-macro that drives the real table now also drives the fallback, so the two stay in lockstep without a separate stub table. With no path through the loader that throws, `DriverAPI::get()` no longer needs a `try`/`catch` and the dispatch wrappers no longer need exception guards. Callers on the Rust side see a clean `CUresult` error code they already handle.

Differential Revision: [D102407431](https://our.internmc.facebook.com/intern/diff/D102407431/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D102407431/)!