### PR TITLE
[monarch] Gate monarch_rdma's CUDA/ibverbs code behind a `cuda` feature

### DIFF
--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -424,7 +424,27 @@ pub fn setup_cpp_static_libs() -> CppStaticLibsConfig {
 /// Detection order:
 /// 1. `MONARCH_GPU_PLATFORM` environment variable ("cuda", "rocm", or "none")
 /// 2. Auto-detect: one of CUDA or ROCm must be present; panic if both or neither are found
+///
+/// Panics if `MONARCH_GPU_PLATFORM=none` is set. Use
+/// [`detect_gpu_platform_allow_none`] from crates that support a stub
+/// mode.
 pub fn detect_gpu_platform() -> (bool, String) {
+    match detect_gpu_platform_allow_none() {
+        Some((is_rocm, home)) => (is_rocm, home),
+        None => panic!(
+            "MONARCH_GPU_PLATFORM=none but a GPU build target was requested; \
+             rebuild without the tensor_engine_gpu feature"
+        ),
+    }
+}
+
+/// Like [`detect_gpu_platform`] but returns `None` when the caller has
+/// opted into a no-GPU "stub" build via `MONARCH_GPU_PLATFORM=none`.
+///
+/// When no explicit platform is set and neither CUDA nor ROCm is
+/// detected, this still panics — silent stub builds mask configuration
+/// bugs. Callers that want a stub build must opt in explicitly.
+pub fn detect_gpu_platform_allow_none() -> Option<(bool, String)> {
     if let Ok(platform) = env::var("MONARCH_GPU_PLATFORM") {
         match platform.to_lowercase().as_str() {
             "" => {}
@@ -432,18 +452,20 @@ pub fn detect_gpu_platform() -> (bool, String) {
                 let rocm_home = rocm::validate_rocm_installation()
                     .expect("MONARCH_GPU_PLATFORM=rocm but ROCm installation not found");
                 println!("cargo:warning=Using ROCm from {} (explicit)", rocm_home);
-                return (true, rocm_home);
+                return Some((true, rocm_home));
             }
             "cuda" => {
                 let cuda_home = validate_cuda_installation()
                     .expect("MONARCH_GPU_PLATFORM=cuda but CUDA installation not found");
                 println!("cargo:warning=Using CUDA from {} (explicit)", cuda_home);
-                return (false, cuda_home);
+                return Some((false, cuda_home));
             }
-            "none" => panic!(
-                "MONARCH_GPU_PLATFORM=none but a GPU build target was requested; \
-                 rebuild without the tensor_engine_gpu feature"
-            ),
+            "none" => {
+                println!(
+                    "cargo:warning=MONARCH_GPU_PLATFORM=none; building without GPU support"
+                );
+                return None;
+            }
             _ => panic!(
                 "Invalid MONARCH_GPU_PLATFORM value: {}. Must be 'cuda', 'rocm', or 'none'",
                 platform
@@ -459,18 +481,20 @@ pub fn detect_gpu_platform() -> (bool, String) {
         (true, false) => {
             let rocm_home = rocm_result.unwrap();
             println!("cargo:warning=Using ROCm from {}", rocm_home);
-            (true, rocm_home)
+            Some((true, rocm_home))
         }
         (false, true) => {
             let cuda_home = cuda_result.unwrap();
             println!("cargo:warning=Using CUDA from {}", cuda_home);
-            (false, cuda_home)
+            Some((false, cuda_home))
         }
         (true, true) => {
             panic!("Both ROCm and CUDA detected. Set MONARCH_GPU_PLATFORM=cuda, =rocm, or =none.");
         }
         (false, false) => {
-            panic!("Neither CUDA nor ROCm installation found");
+            panic!(
+                "Neither CUDA nor ROCm installation found. To build without a GPU backend, set MONARCH_GPU_PLATFORM=none."
+            );
         }
     }
 }

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -51,5 +51,5 @@ monarch_cpp_static_libs = { path = "../monarch_cpp_static_libs", optional = true
 default = ["tensor_engine"]
 distributed_sql_telemetry = ["dep:monarch_distributed_telemetry", "dep:monarch_introspection_snapshot"]
 extension-module = ["pyo3/extension-module"]
-tensor_engine = ["dep:monarch_messages", "dep:monarch_tensor_worker", "dep:torch-sys-cuda"]
-tensor_engine_gpu = ["dep:monarch_cpp_static_libs", "dep:monarch_rdma_extension", "dep:nccl-sys", "dep:rdmaxcel-sys", "monarch_messages/cuda", "monarch_tensor_worker/cuda", "tensor_engine", "torch-sys-cuda/cuda"]
+tensor_engine = ["dep:monarch_messages", "dep:monarch_rdma_extension", "dep:monarch_tensor_worker", "dep:torch-sys-cuda"]
+tensor_engine_gpu = ["dep:monarch_cpp_static_libs", "dep:nccl-sys", "dep:rdmaxcel-sys", "monarch_messages/cuda", "monarch_rdma_extension/cuda", "monarch_tensor_worker/cuda", "tensor_engine", "torch-sys-cuda/cuda"]

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -19,7 +19,7 @@ hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 rand = "0.10.1"
-rdmaxcel-sys = { path = "../rdmaxcel-sys" }
+rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
 regex = "1.12.3"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
@@ -34,6 +34,6 @@ ndslice = { version = "0.0.0", path = "../ndslice" }
 timed_test = { version = "0.0.0", path = "../timed_test" }
 
 [features]
-cuda = []
+cuda = ["dep:rdmaxcel-sys"]
 default = []
-test-utils = []
+test-utils = ["cuda"]

--- a/monarch_rdma/extension/Cargo.toml
+++ b/monarch_rdma/extension/Cargo.toml
@@ -24,3 +24,7 @@ typeuri = { version = "0.0.0", path = "../../typeuri" }
 
 [build-dependencies]
 build_utils = { path = "../../build_utils" }
+
+[features]
+cuda = ["monarch_rdma/cuda"]
+default = []

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -24,6 +24,7 @@ use monarch_rdma::local_memory::Keepalive;
 use monarch_rdma::local_memory::KeepaliveLocalMemory;
 use monarch_rdma::local_memory::RdmaLocalMemory;
 use monarch_rdma::rdma_supported;
+#[cfg(feature = "cuda")]
 use monarch_rdma::register_segment_scanner;
 use monarch_types::py_module_add_function;
 use pyo3::IntoPyObjectExt;
@@ -43,6 +44,7 @@ use typeuri::Named;
 ///
 /// # Safety
 /// This function is called from C code as a callback.
+#[cfg(feature = "cuda")]
 unsafe extern "C" fn pytorch_segment_scanner(
     segments_out: *mut monarch_rdma::rdmaxcel_sys::rdmaxcel_scanned_segment_t,
     max_segments: usize,
@@ -358,10 +360,18 @@ impl PyRdmaManager {
 
         let proc_mesh = proc_mesh.downcast::<PyProcMesh>()?.borrow().mesh_ref()?;
         PyPythonTask::new(async move {
+            // CPU-only builds collapse RdmaManagerActor's Params to `()`
+            // because IbvConfig isn't compiled in.
+            #[cfg(feature = "cuda")]
             let actor_mesh: ActorMesh<RdmaManagerActor> = proc_mesh
                 // Pass None to use default config - RdmaManagerActor will use default IbverbsConfig
                 // TODO - make IbverbsConfig configurable
                 .spawn_service(client.deref(), "rdma_manager", &None)
+                .await
+                .map_err(|err| PyException::new_err(err.to_string()))?;
+            #[cfg(not(feature = "cuda"))]
+            let actor_mesh: ActorMesh<RdmaManagerActor> = proc_mesh
+                .spawn_service(client.deref(), "rdma_manager", &())
                 .await
                 .map_err(|err| PyException::new_err(err.to_string()))?;
 
@@ -390,6 +400,9 @@ fn rdma_supported_py() -> bool {
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     // Register the PyTorch segment scanner callback.
     // This calls torch.cuda.memory._snapshot() to get CUDA memory segments.
+    // CPU-only builds have no CUDA segments to scan, so the registration is
+    // skipped along with the scanner.
+    #[cfg(feature = "cuda")]
     register_segment_scanner(Some(pytorch_segment_scanner));
 
     module.add_class::<PyLocalMemoryHandle>()?;

--- a/monarch_rdma/src/backend.rs
+++ b/monarch_rdma/src/backend.rs
@@ -10,6 +10,7 @@
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod cuda_test_utils;
+#[cfg(feature = "cuda")]
 pub mod ibverbs;
 pub mod tcp;
 
@@ -31,6 +32,7 @@ use crate::RdmaTransportLevel;
 /// using that backend on a particular buffer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RdmaRemoteBackendContext {
+    #[cfg(feature = "cuda")]
     Ibverbs(
         ActorRef<ibverbs::manager_actor::IbvManagerActor>,
         ibverbs::IbvBuffer,

--- a/monarch_rdma/src/lib.rs
+++ b/monarch_rdma/src/lib.rs
@@ -15,18 +15,32 @@ use local_memory::RdmaLocalMemory;
 use serde::Deserialize;
 use serde::Serialize;
 
+#[cfg(feature = "cuda")]
 #[macro_use]
 mod macros;
 
 pub mod backend;
 pub mod config;
 pub mod device_selection;
+#[cfg(feature = "cuda")]
 pub mod efa;
 pub mod local_memory;
 mod rdma_components;
 mod rdma_manager_actor;
 
+#[cfg(feature = "cuda")]
 pub use backend::ibverbs::primitives::*;
+
+/// Whether ibverbs is available.
+///
+/// In CPU-only builds (no `cuda` feature) the ibverbs backend is not
+/// compiled in, so this is trivially `false`. In `cuda` builds, the
+/// `pub use backend::ibverbs::primitives::*` re-export above shadows
+/// this stub with the real runtime probe.
+#[cfg(not(feature = "cuda"))]
+pub fn ibverbs_supported() -> bool {
+    false
+}
 
 /// Whether any RDMA backend is available on this system.
 ///
@@ -36,12 +50,15 @@ pub fn rdma_supported() -> bool {
     ibverbs_supported() || hyperactor_config::global::get(config::RDMA_ALLOW_TCP_FALLBACK)
 }
 pub use rdma_components::RdmaRemoteBuffer;
+#[cfg(feature = "cuda")]
 pub use rdma_components::SegmentScannerFn;
 // Re-export segment scanner types for extension crate
+#[cfg(feature = "cuda")]
 pub use rdma_components::register_segment_scanner;
 pub use rdma_components::*;
 pub use rdma_manager_actor::*;
 // Re-export rdmaxcel_sys for extension crate to access types
+#[cfg(feature = "cuda")]
 pub use rdmaxcel_sys;
 pub use test_utils::is_cuda_available;
 
@@ -76,6 +93,7 @@ pub enum RdmaTransportLevel {
 
 /// Print comprehensive RDMA device information for debugging.
 /// Controlled by MONARCH_DEBUG_RDMA environment variable.
+#[cfg(feature = "cuda")]
 pub fn print_device_info_if_debug_enabled(context: *mut rdmaxcel_sys::ibv_context) {
     if std::env::var("MONARCH_DEBUG_RDMA").is_ok() {
         unsafe {
@@ -85,6 +103,7 @@ pub fn print_device_info_if_debug_enabled(context: *mut rdmaxcel_sys::ibv_contex
 }
 
 /// Print comprehensive RDMA device information for debugging (always prints).
+#[cfg(feature = "cuda")]
 pub fn print_device_info(context: *mut rdmaxcel_sys::ibv_context) {
     unsafe {
         rdmaxcel_sys::rdmaxcel_print_device_info(context);

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -26,6 +26,7 @@ use serde::Serialize;
 ///
 /// Probes the CUDA driver via `cuPointerGetAttribute`; returns `false`
 /// when CUDA is unavailable or the pointer is not device memory.
+#[cfg(feature = "cuda")]
 pub fn is_device_ptr(addr: usize) -> bool {
     // SAFETY: FFI call that queries pointer metadata without accessing
     // the pointed-to memory.
@@ -42,12 +43,14 @@ pub fn is_device_ptr(addr: usize) -> bool {
 
 /// RAII guard that restores the previous CUDA context on drop and, if a
 /// primary context was retained, releases it.
+#[cfg(feature = "cuda")]
 pub(crate) struct CudaCtxGuard {
     prev: rdmaxcel_sys::CUcontext,
     /// Set when the fallback path called `cuDevicePrimaryCtxRetain`.
     retained_device: Option<rdmaxcel_sys::CUdevice>,
 }
 
+#[cfg(feature = "cuda")]
 impl Drop for CudaCtxGuard {
     fn drop(&mut self) {
         unsafe {
@@ -72,6 +75,7 @@ impl Drop for CudaCtxGuard {
 /// # Safety
 ///
 /// `addr` must be a valid CUDA device pointer.
+#[cfg(feature = "cuda")]
 pub(crate) unsafe fn set_ctx_for_ptr(addr: usize) -> Result<CudaCtxGuard, anyhow::Error> {
     let mut prev: rdmaxcel_sys::CUcontext = std::ptr::null_mut();
     unsafe {
@@ -188,6 +192,7 @@ unsafe fn write_cpu(addr: usize, offset: usize, src: &[u8]) {
 ///
 /// The caller must ensure that `addr` is a valid CUDA device pointer to an
 /// allocation of at least `offset + dst.len()` bytes.
+#[cfg(feature = "cuda")]
 unsafe fn read_gpu(addr: usize, offset: usize, dst: &mut [u8]) -> Result<(), anyhow::Error> {
     let _guard = unsafe { set_ctx_for_ptr(addr)? };
     let rc = unsafe {
@@ -210,6 +215,7 @@ unsafe fn read_gpu(addr: usize, offset: usize, dst: &mut [u8]) -> Result<(), any
 ///
 /// The caller must ensure that `addr` is a valid CUDA device pointer to an
 /// allocation of at least `offset + src.len()` bytes.
+#[cfg(feature = "cuda")]
 unsafe fn write_gpu(addr: usize, offset: usize, src: &[u8]) -> Result<(), anyhow::Error> {
     let _guard = unsafe { set_ctx_for_ptr(addr)? };
     let rc = unsafe {
@@ -277,16 +283,20 @@ impl Debug for KeepaliveLocalMemory {
 }
 
 impl KeepaliveLocalMemory {
-    /// Create a new handle. Probes the CUDA driver to determine whether
-    /// `addr` is a device pointer and sets the bandwidth fields
-    /// accordingly.
+    /// Create a new handle. On CUDA builds, probes the CUDA driver to
+    /// determine whether `addr` is a device pointer and sets the bandwidth
+    /// fields accordingly. On CPU-only builds, always treats `addr` as
+    /// host memory.
     pub fn new(addr: usize, size: usize, keepalive: Arc<dyn Keepalive>) -> Self {
         // TODO(slurye): Using placeholder values for now. Fill in with real values.
+        #[cfg(feature = "cuda")]
         let (host_bw, device_bw) = if is_device_ptr(addr) {
             (None, Some(1))
         } else {
             (Some(1), None)
         };
+        #[cfg(not(feature = "cuda"))]
+        let (host_bw, device_bw): (Option<u64>, Option<u64>) = (Some(1), None);
         Self {
             addr,
             size,
@@ -317,7 +327,12 @@ impl RdmaLocalMemory for KeepaliveLocalMemory {
                 read_cpu(self.addr, offset, dst);
                 Ok(())
             } else {
-                read_gpu(self.addr, offset, dst)
+                #[cfg(feature = "cuda")]
+                {
+                    read_gpu(self.addr, offset, dst)
+                }
+                #[cfg(not(feature = "cuda"))]
+                unreachable!("device memory dispatch requires the cuda feature")
             }
         }
     }
@@ -332,7 +347,12 @@ impl RdmaLocalMemory for KeepaliveLocalMemory {
                 write_cpu(self.addr, offset, src);
                 Ok(())
             } else {
-                write_gpu(self.addr, offset, src)
+                #[cfg(feature = "cuda")]
+                {
+                    write_gpu(self.addr, offset, src)
+                }
+                #[cfg(not(feature = "cuda"))]
+                unreachable!("device memory dispatch requires the cuda feature")
             }
         }
     }
@@ -370,12 +390,12 @@ impl RdmaLocalMemory for UnsafeLocalMemory {
         // SAFETY: The caller is responsible for ensuring the allocation is
         // live; check_bounds verified the access is in range.
         unsafe {
+            #[cfg(feature = "cuda")]
             if is_device_ptr(self.addr) {
-                read_gpu(self.addr, offset, dst)
-            } else {
-                read_cpu(self.addr, offset, dst);
-                Ok(())
+                return read_gpu(self.addr, offset, dst);
             }
+            read_cpu(self.addr, offset, dst);
+            Ok(())
         }
     }
 
@@ -384,12 +404,12 @@ impl RdmaLocalMemory for UnsafeLocalMemory {
         // SAFETY: The caller is responsible for ensuring the allocation is
         // live; check_bounds verified the access is in range.
         unsafe {
+            #[cfg(feature = "cuda")]
             if is_device_ptr(self.addr) {
-                write_gpu(self.addr, offset, src)
-            } else {
-                write_cpu(self.addr, offset, src);
-                Ok(())
+                return write_gpu(self.addr, offset, src);
             }
+            write_cpu(self.addr, offset, src);
+            Ok(())
         }
     }
 }

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -58,8 +58,11 @@ use crate::RdmaOpType;
 use crate::ReleaseBufferClient;
 use crate::backend::RdmaBackend;
 use crate::backend::RdmaRemoteBackendContext;
+#[cfg(feature = "cuda")]
 use crate::backend::ibverbs::IbvBuffer;
+#[cfg(feature = "cuda")]
 use crate::backend::ibverbs::manager_actor::IbvBackend;
+#[cfg(feature = "cuda")]
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
 use crate::backend::tcp::manager_actor::TcpBackend;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
@@ -85,6 +88,7 @@ wirevalue::register_type!(RdmaRemoteBuffer);
 /// on `submit`), so we use an enum that delegates to the concrete handle.
 #[derive(Debug)]
 pub enum RdmaLocalBackend {
+    #[cfg(feature = "cuda")]
     Ibv(IbvBackend),
     Tcp(TcpBackend),
 }
@@ -97,6 +101,7 @@ impl RdmaLocalBackend {
         timeout: Duration,
     ) -> Result<(), anyhow::Error> {
         match self {
+            #[cfg(feature = "cuda")]
             RdmaLocalBackend::Ibv(h) => h.submit(cx, ops, timeout).await,
             RdmaLocalBackend::Tcp(h) => h.submit(cx, ops, timeout).await,
         }
@@ -114,6 +119,7 @@ impl RdmaRemoteBuffer {
         &self,
         client: &(impl context::Actor + Send + Sync),
     ) -> Result<RdmaLocalBackend, anyhow::Error> {
+        #[cfg(feature = "cuda")]
         if self.has_ibverbs_backend() {
             if let Ok(ibv_handle) = IbvManagerActor::local_handle(client).await {
                 return Ok(RdmaLocalBackend::Ibv(IbvBackend(ibv_handle)));
@@ -205,16 +211,23 @@ impl RdmaRemoteBuffer {
     }
 
     /// Whether this buffer has an ibverbs backend context.
+    #[cfg(feature = "cuda")]
     fn has_ibverbs_backend(&self) -> bool {
         self.backends
             .iter()
             .any(|b| matches!(b, RdmaRemoteBackendContext::Ibverbs(..)))
     }
 
+    #[cfg(not(feature = "cuda"))]
+    fn has_ibverbs_backend(&self) -> bool {
+        false
+    }
+
     /// Extract the ibverbs backend context for this buffer.
     ///
     /// Returns `None` if the buffer has no ibverbs backend context
     /// (i.e., the remote side was created without ibverbs).
+    #[cfg(feature = "cuda")]
     pub fn resolve_ibv(&self) -> Option<(ActorRef<IbvManagerActor>, IbvBuffer)> {
         self.backends.iter().find_map(|b| match b {
             RdmaRemoteBackendContext::Ibverbs(mgr, buf) => Some((mgr.clone(), buf.clone())),
@@ -228,6 +241,7 @@ impl RdmaRemoteBuffer {
             .iter()
             .find_map(|b| match b {
                 RdmaRemoteBackendContext::Tcp(tcp_ref) => Some((tcp_ref.clone(), self.id)),
+                #[cfg(feature = "cuda")]
                 _ => None,
             })
             .ok_or_else(|| anyhow::anyhow!("tcp backend not found for buffer: {:?}", self))
@@ -280,6 +294,7 @@ pub async fn validate_execution_context() -> Result<(), anyhow::Error> {
 ///
 /// Each protection domain maintains independent segment registrations, so
 /// callers must pass the PD whose lkeys they intend to use.
+#[cfg(feature = "cuda")]
 pub fn get_registered_cuda_segments(
     pd: *mut rdmaxcel_sys::ibv_pd,
 ) -> Vec<rdmaxcel_sys::rdma_segment_info_t> {
@@ -310,6 +325,7 @@ pub fn get_registered_cuda_segments(
 }
 
 /// Segment scanner callback type alias for convenience.
+#[cfg(feature = "cuda")]
 pub type SegmentScannerFn = rdmaxcel_sys::RdmaxcelSegmentScannerFn;
 
 /// Register a segment scanner callback.
@@ -327,6 +343,7 @@ pub type SegmentScannerFn = rdmaxcel_sys::RdmaxcelSegmentScannerFn;
 ///
 /// The provided callback function must be safe to call from C code and must
 /// properly handle the segment buffer.
+#[cfg(feature = "cuda")]
 pub fn register_segment_scanner(scanner: SegmentScannerFn) {
     // SAFETY: We are registering a callback function pointer with rdmaxcel.
     unsafe { rdmaxcel_sys::rdmaxcel_register_segment_scanner(scanner) }

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -46,15 +46,20 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::backend::RdmaRemoteBackendContext;
+#[cfg(feature = "cuda")]
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
+#[cfg(feature = "cuda")]
 use crate::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
+#[cfg(feature = "cuda")]
 use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
+#[cfg(feature = "cuda")]
 use crate::backend::ibverbs::primitives::IbvConfig;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::RdmaLocalMemory;
 use crate::rdma_components::RdmaRemoteBuffer;
 
 /// Helper function to get detailed error messages from RDMAXCEL error codes
+#[cfg(feature = "cuda")]
 pub fn get_rdmaxcel_error_message(error_code: i32) -> String {
     unsafe {
         let c_str = rdmaxcel_sys::rdmaxcel_error_string(error_code);
@@ -98,11 +103,13 @@ wirevalue::register_type!(ReleaseBuffer);
 
 /// Serializable query for resolving the [`IbvManagerActor`] ref
 /// from a remote [`RdmaManagerActor`]. Only used in testing.
+#[cfg(feature = "cuda")]
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
 pub struct GetIbvActorRef {
     #[reply]
     pub reply: OncePortRef<Option<ActorRef<IbvManagerActor>>>,
 }
+#[cfg(feature = "cuda")]
 wirevalue::register_type!(GetIbvActorRef);
 
 /// Serializable query for resolving the [`TcpManagerActor`] ref
@@ -144,17 +151,30 @@ impl<A: Actor> RdmaBackendActor<A> {
 }
 
 #[derive(Debug)]
-#[hyperactor::export(
-    handlers = [
-        GetIbvActorRef,
-        GetTcpActorRef,
-        ReleaseBuffer,
-    ],
+#[cfg_attr(
+    feature = "cuda",
+    hyperactor::export(
+        handlers = [
+            GetIbvActorRef,
+            GetTcpActorRef,
+            ReleaseBuffer,
+        ],
+    )
+)]
+#[cfg_attr(
+    not(feature = "cuda"),
+    hyperactor::export(
+        handlers = [
+            GetTcpActorRef,
+            ReleaseBuffer,
+        ],
+    )
 )]
 #[hyperactor::spawnable]
 pub struct RdmaManagerActor {
     next_remote_buf_id: usize,
     buffers: HashMap<usize, Arc<dyn RdmaLocalMemory>>,
+    #[cfg(feature = "cuda")]
     ibverbs: Option<RdmaBackendActor<IbvManagerActor>>,
     tcp: RdmaBackendActor<TcpManagerActor>,
 }
@@ -176,6 +196,7 @@ impl RdmaManagerActor {
     }
 }
 
+#[cfg(feature = "cuda")]
 #[async_trait]
 impl RemoteSpawn for RdmaManagerActor {
     type Params = Option<IbvConfig>;
@@ -219,9 +240,33 @@ impl RemoteSpawn for RdmaManagerActor {
     }
 }
 
+/// CPU-only build: ibverbs is never compiled in, so the manager always
+/// falls through to TCP. Returns an error only when TCP fallback is also
+/// disabled — matching the runtime behavior of the `cuda` build when no
+/// hardware is found.
+#[cfg(not(feature = "cuda"))]
+#[async_trait]
+impl RemoteSpawn for RdmaManagerActor {
+    type Params = ();
+
+    async fn new(_params: Self::Params, _environment: Flattrs) -> Result<Self, anyhow::Error> {
+        anyhow::ensure!(
+            hyperactor_config::global::get(crate::config::RDMA_ALLOW_TCP_FALLBACK),
+            "ibverbs is not compiled into this build and TCP fallback is disabled"
+        );
+        let tcp = RdmaBackendActor::Created(TcpManagerActor::new());
+        Ok(Self {
+            next_remote_buf_id: 0,
+            buffers: HashMap::new(),
+            tcp,
+        })
+    }
+}
+
 #[async_trait]
 impl Actor for RdmaManagerActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        #[cfg(feature = "cuda")]
         if let Some(ibv) = &mut self.ibverbs {
             ibv.spawn(this)?;
         }
@@ -244,6 +289,7 @@ impl Actor for RdmaManagerActor {
     }
 }
 
+#[cfg(feature = "cuda")]
 #[async_trait]
 #[hyperactor::handle(GetIbvActorRef)]
 impl GetIbvActorRefHandler for RdmaManagerActor {
@@ -271,9 +317,12 @@ impl GetTcpActorRefHandler for RdmaManagerActor {
 impl ReleaseBufferHandler for RdmaManagerActor {
     async fn release_buffer(&mut self, cx: &Context<Self>, id: usize) -> Result<(), anyhow::Error> {
         self.buffers.remove(&id);
+        #[cfg(feature = "cuda")]
         if let Some(ibv) = &self.ibverbs {
             ibv.handle().release_buffer(cx, id).await?;
         }
+        #[cfg(not(feature = "cuda"))]
+        let _ = cx;
         Ok(())
     }
 }
@@ -292,6 +341,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
 
         let mut backends = Vec::new();
 
+        #[cfg(feature = "cuda")]
         if let Some(ibv) = &self.ibverbs {
             let ibv_buffer = ibv
                 .handle()

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -6,18 +6,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#[cfg(feature = "cuda")]
 use std::sync::Once;
+#[cfg(feature = "cuda")]
 use std::sync::atomic::AtomicBool;
+#[cfg(feature = "cuda")]
 use std::sync::atomic::Ordering;
 
 /// Cached result of CUDA availability check
+#[cfg(feature = "cuda")]
 static CUDA_AVAILABLE: AtomicBool = AtomicBool::new(false);
+#[cfg(feature = "cuda")]
 static INIT: Once = Once::new();
 
 /// Safely checks if CUDA is available on the system.
 ///
 /// This function attempts to initialize CUDA and determine if it's available.
 /// The result is cached after the first call, so subsequent calls are very fast.
+///
+/// In CPU-only builds (no `cuda` feature), this trivially returns `false`.
 ///
 /// # Returns
 ///
@@ -34,6 +41,7 @@ static INIT: Once = Once::new();
 ///     println!("CUDA is not available, falling back to CPU-only mode");
 /// }
 /// ```
+#[cfg(feature = "cuda")]
 pub fn is_cuda_available() -> bool {
     INIT.call_once(|| {
         let available = check_cuda_available();
@@ -42,7 +50,13 @@ pub fn is_cuda_available() -> bool {
     CUDA_AVAILABLE.load(Ordering::SeqCst)
 }
 
+#[cfg(not(feature = "cuda"))]
+pub fn is_cuda_available() -> bool {
+    false
+}
+
 /// Internal function that performs the actual CUDA availability check
+#[cfg(feature = "cuda")]
 fn check_cuda_available() -> bool {
     unsafe {
         // Try to initialize CUDA

--- a/rdmaxcel-sys/build.rs
+++ b/rdmaxcel-sys/build.rs
@@ -24,7 +24,9 @@ fn main() {
     let cpp_static_libs_config = build_utils::CppStaticLibsConfig::from_env();
     let rdma_include = &cpp_static_libs_config.rdma_include_dir;
 
-    // Detect platform: ROCm or CUDA
+    // This crate is gated behind the `cuda` feature in monarch_rdma; cargo
+    // only runs build.rs once a downstream consumer enables that feature, so
+    // a GPU toolchain must be available here.
     let (is_rocm, compute_home) = build_utils::detect_gpu_platform();
 
     // Get the directory of the current crate

--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -126,6 +126,27 @@ CUresult stub_entry(Args... /*unused*/) {
   return CUDA_ERROR_NOT_INITIALIZED;
 }
 
+} // namespace
+
+DriverAPI* DriverAPI::stub() {
+  static DriverAPI s = []() {
+    DriverAPI api{};
+#define ASSIGN_STUB(name, sym) api.name##_ = &stub_entry;
+    RDMAXCEL_CUDA_DRIVER_API(ASSIGN_STUB)
+#undef ASSIGN_STUB
+    return api;
+  }();
+  return &s;
+}
+
+} // namespace rdmaxcel
+
+// GPU-backed `DriverAPI::get()` and its `create_driver_api` helper.
+// Relies on the `RDMAXCEL_CUDA_DRIVER_API` X-macro and `STRINGIFY` defined
+// above.
+namespace rdmaxcel {
+namespace {
+
 DriverAPI create_driver_api() {
 #ifdef USE_ROCM
   // Try to open libamdhip64.so - RTLD_NOLOAD means only succeed if already

--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,7 @@ if build_tensor_engine:
         elif build_rocm:
             print(f"  - ROCm: {rocm_home}")
     else:
-        print("✓ Building WITH tensor_engine (CPU-only, no GPU/NCCL/RDMA)")
+        print("✓ Building WITH tensor_engine (CPU-only, no GPU/NCCL; RDMA via TCP fallback)")
         print(f"  - PyTorch: {torch_config['lib_path']}")
     print(f"  - C++11 ABI: {'enabled' if torch_config['cxx11_abi'] else 'disabled'}")
 else:
@@ -217,6 +217,12 @@ if build_cuda:
     env_vars["CUDA_HOME"] = cuda_home
 elif build_rocm:
     env_vars["ROCM_PATH"] = rocm_home
+else:
+    # CPU-only tensor_engine build (or actors-only): tell rdmaxcel-sys
+    # to compile its stub implementation instead of linking against a
+    # non-existent CUDA/ROCm toolchain. This keeps the RDMA TCP
+    # fallback available when there is no GPU.
+    env_vars["MONARCH_GPU_PLATFORM"] = "none"
 
 os.environ.update(env_vars)
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

Building `monarch_rdma_extension` previously required `rdmaxcel-sys`, which in turn requires a CUDA or ROCm toolchain. That coupling kept `monarch_rdma_extension` out of the default `tensor_engine` feature, so `get_rdma_backend()` returned `"none"` on hosts without GPU headers and the TCP fallback was unreachable.

Make `cuda` an explicit feature on `monarch_rdma` (default-on) and `monarch_rdma_extension`, and make `rdmaxcel-sys` an optional dep that the feature pulls in. Every CUDA/ibverbs/EFA item in `monarch_rdma` is now `#[cfg(feature = "cuda")]`: the ibverbs and EFA backends, segment scanner, the `Ibv` arms of `RdmaLocalBackend` / `RdmaRemoteBackendContext` / `RdmaManagerActor`, `is_device_ptr`, `CudaCtxGuard`, `read_gpu`/`write_gpu`, the device-memory branch of `KeepaliveLocalMemory`, `is_cuda_available`, `print_device_info*`, and the `IbvManagerActor` references. CPU-only builds get small stubs for `ibverbs_supported() -> false`, `is_cuda_available() -> false`, and `has_ibverbs_backend() -> false`, plus a separate `RemoteSpawn` impl for `RdmaManagerActor` whose `Params = ()` and which errors out only when `RDMA_ALLOW_TCP_FALLBACK` is also disabled. In the CPU-only branch of `KeepaliveLocalMemory::new`, the `is_device_ptr` probe is skipped and the handle is always constructed as host-accessible -- the FFI fix from D102407431 already makes the probe safe to call, but skipping it entirely keeps `monarch_rdma` free of any CUDA symbol references in CPU-only builds.

In the extension crate, the segment-scanner registration is gated behind `cuda`. `RdmaManagerActor::spawn_service` calls also branch by feature so the CPU-only build passes `&()` instead of `&None`.

Move `monarch_rdma_extension` from `tensor_engine_gpu` into `tensor_engine` so CPU-only wheels actually ship the extension, and add `monarch_rdma_extension/cuda` to `tensor_engine_gpu` so GPU builds keep the same behavior. `setup.py` now exports `MONARCH_GPU_PLATFORM=none` whenever `build_tensor_engine=true` and no GPU is detected. `build_utils::detect_gpu_platform_allow_none()` is the new stub-aware entry point that returns `Option`; the existing `detect_gpu_platform()` still panics on `none` for callers like `nccl-sys` that genuinely require a GPU toolchain. (No call site swaps to the `_allow_none` variant in this diff -- it's introduced for downstream commits in the stack.)

At runtime in a CPU-only build this means `ibverbs_supported()` returns false, `rdma_supported()` returns true via the `RDMA_ALLOW_TCP_FALLBACK` default, and `get_rdma_backend()` returns `"tcp"`. The TCP backend works end-to-end because it touches none of the gated symbols.

Internal:
On the Buck side, define a public `with_gpu` constraint in `//monarch/monarch_extension/BUCK` using the unified `constraint()` rule from `@prelude//:rules.bzl` (the modern replacement for the deprecated `constraint_setting`/`constraint_value` pair). It lives next to the existing `with_torch` constraint and exposes `has_gpu` (default) and `no_gpu` as value subtargets. `monarch_rdma/BUCK` selects on `:with_gpu[no_gpu]` to drop the `:rdmaxcel-sys` dep and the `cuda`/`test-utils` features; `monarch_rdma/extension/BUCK` does the same to drop its own `cuda` feature. `rdmaxcel-sys/BUCK` itself stays GPU-only -- under `[no_gpu]` consumers simply don't depend on it, rather than swapping in a stub variant. Engage with `buck2 build ... --modifier 'fbcode//monarch/monarch_extension:with_gpu[no_gpu]'`.

Differential Revision: [D102407433](https://our.internmc.facebook.com/intern/diff/D102407433/)