### PR TITLE
Add global cargo nextest timeout (#3855)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,7 @@
+[profile.default]
+# All tests timeout after 5 minutes.
+slow-timeout = { period = "30s", terminate-after = 10 }
+
 [profile.ci]
 # Do not cancel the test run on the first failure.
 fail-fast = false


### PR DESCRIPTION
Summary:

Add a global timeout for all tests run using cargo nextest. The only goal of this is to ensure
that the CI job doesn't waste resources running a test that'll never complete. As such, this
default must be high enough to have confidence that the test wasn't going to work.

I chose 5 minutes to balance the confidence that the test is broken against maximum time
we allow the test suite to run in CI. As we add more tests we may need to lower this.

If this works well, we can start removing all the individual test timeouts that are much lower,
which occasionally fail under load. Or we can keep them if we need tighter test bounds.
There is no implied goal of reducing this global timeout, we probably never want to change it.

Differential Revision: D105027998


