### PR TITLE
test that a Policy::Multi token accepts every join (#3856)

### DIFF
--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -490,6 +490,25 @@ mod tests {
     )]
     struct OtherJoinerRef;
 
+    #[derive(
+        Clone,
+        Debug,
+        Serialize,
+        Deserialize,
+        Named,
+        PartialEq,
+        Eq,
+        PartialOrd,
+        Ord,
+        Bind,
+        Unbind
+    )]
+    enum MultiJoinerRef {
+        One,
+        Two,
+        Three,
+    }
+
     #[tokio::test]
     async fn test_create_delivers_join_to_both_sides() {
         let proc = Proc::isolated();
@@ -547,6 +566,69 @@ mod tests {
             JoinResult::Rejected {
                 reason: "token already joined".to_string()
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multi_token_accepts_every_join() {
+        let proc = Proc::isolated();
+        let (creator, _creator_hndl) = proc.instance("creator").unwrap();
+        let (creator_joined, mut creator_joined_rx) = creator.open_port::<Joined<MultiJoinerRef>>();
+        let token = create(
+            &creator,
+            CreatorRef,
+            creator_joined.bind(),
+            Options {
+                policy: Policy::Multi,
+            },
+        )
+        .unwrap();
+
+        let (joiner1, _joiner1_handle) = proc.instance("joiner1").unwrap();
+        let (joiner2, _joiner2_handle) = proc.instance("joiner2").unwrap();
+        let (joiner3, _joiner3_handle) = proc.instance("joiner3").unwrap();
+
+        let (r1, mut r1_rx) = joiner1.open_port::<JoinResult<CreatorRef>>();
+        let (r2, mut r2_rx) = joiner2.open_port::<JoinResult<CreatorRef>>();
+        let (r3, mut r3_rx) = joiner3.open_port::<JoinResult<CreatorRef>>();
+
+        token
+            .join(&joiner1, MultiJoinerRef::One, r1.bind())
+            .unwrap();
+        token
+            .join(&joiner2, MultiJoinerRef::Two, r2.bind())
+            .unwrap();
+        token
+            .join(&joiner3, MultiJoinerRef::Three, r3.bind())
+            .unwrap();
+
+        let mut joined = vec![
+            creator_joined_rx.recv().await.unwrap().peer,
+            creator_joined_rx.recv().await.unwrap().peer,
+            creator_joined_rx.recv().await.unwrap().peer,
+        ];
+        joined.sort();
+
+        assert_eq!(
+            joined,
+            vec![
+                MultiJoinerRef::One,
+                MultiJoinerRef::Two,
+                MultiJoinerRef::Three,
+            ]
+        );
+
+        assert_eq!(
+            r1_rx.recv().await.unwrap(),
+            JoinResult::Joined { peer: CreatorRef }
+        );
+        assert_eq!(
+            r2_rx.recv().await.unwrap(),
+            JoinResult::Joined { peer: CreatorRef }
+        );
+        assert_eq!(
+            r3_rx.recv().await.unwrap(),
+            JoinResult::Joined { peer: CreatorRef }
         );
     }
 


### PR DESCRIPTION
Summary:

adds a unit test in `fbcode/monarch/hyperactor_remote/src/token.rs::tests` covering `Policy::Multi` — the default policy of the token/join rendezvous primitive (`token.rs:90`). `test_once_token_rejects_later_joins` (`token.rs:517-551`) covers `Once`, but `Multi` had no test until this diff.

the test mirrors the `Once` test's shape but uses three independent joiners with distinct peer values so the creator-side notifications are individually identifiable. a new `MultiJoinerRef` enum (`One`, `Two`, `Three`) sits next to the existing `CreatorRef`/`JoinerRef`/`OtherJoinerRef` test types — it derives `Ord`  so the test can sort the three collected `Joined` notifications before comparing as a multiset (the rendezvous actor processes joins sequentially but the test does not pin delivery order at the creator's port).

three joiners (`joiner1`/`joiner2`/`joiner3`) each call `token.join(...)` once with their own peer value and result port. assertions: the creator's `creator_joined_rx` receives three notifications whose sorted peer values equal `[One, Two, Three]`, and each joiner's result port receives `JoinResult::Joined { peer: CreatorRef }`. the token is constructed with explicit `Options { policy: Policy::Multi }` rather than `Options::default()` to mirror the explicit-policy style of the `Once` test and to read directly as a policy test rather than a default-policy test.

Reviewed By: mariusae

Differential Revision: D105031425


