### PR TITLE
test Token::FromStr error paths (#3857)

### DIFF
--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -715,4 +715,33 @@ mod tests {
         rendezvous.stop("test").unwrap();
         rendezvous.await;
     }
+
+    #[test]
+    fn test_token_from_str_rejects_corrupt_base64() {
+        let result: Result<Token<CreatorRef, JoinerRef>, _> = "%%%".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_token_from_str_rejects_invalid_json() {
+        let encoded = BASE64_STANDARD.encode(b"not json at all");
+        let result: Result<Token<CreatorRef, JoinerRef>, _> = encoded.parse();
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_token_from_str_rejects_mismatched_type_uris() {
+        let proc = Proc::isolated();
+        let rendezvous = proc.spawn("rendezvous", RendezvousStub).unwrap();
+        let token = Token::<CreatorRef, JoinerRef>::new(
+            rendezvous.bind::<RendezvousLike<CreatorRef, JoinerRef>>(),
+        );
+
+        let encoded = token.encode().unwrap();
+        let result: Result<Token<CreatorRef, OtherJoinerRef>, _> = encoded.parse();
+        assert!(result.is_err());
+
+        rendezvous.stop("test").unwrap();
+        rendezvous.await;
+    }
 }

--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -490,6 +490,25 @@ mod tests {
     )]
     struct OtherJoinerRef;
 
+    #[derive(
+        Clone,
+        Debug,
+        Serialize,
+        Deserialize,
+        Named,
+        PartialEq,
+        Eq,
+        PartialOrd,
+        Ord,
+        Bind,
+        Unbind
+    )]
+    enum MultiJoinerRef {
+        One,
+        Two,
+        Three,
+    }
+
     #[tokio::test]
     async fn test_create_delivers_join_to_both_sides() {
         let proc = Proc::isolated();
@@ -547,6 +566,69 @@ mod tests {
             JoinResult::Rejected {
                 reason: "token already joined".to_string()
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_multi_token_accepts_every_join() {
+        let proc = Proc::isolated();
+        let (creator, _creator_hndl) = proc.instance("creator").unwrap();
+        let (creator_joined, mut creator_joined_rx) = creator.open_port::<Joined<MultiJoinerRef>>();
+        let token = create(
+            &creator,
+            CreatorRef,
+            creator_joined.bind(),
+            Options {
+                policy: Policy::Multi,
+            },
+        )
+        .unwrap();
+
+        let (joiner1, _joiner1_handle) = proc.instance("joiner1").unwrap();
+        let (joiner2, _joiner2_handle) = proc.instance("joiner2").unwrap();
+        let (joiner3, _joiner3_handle) = proc.instance("joiner3").unwrap();
+
+        let (r1, mut r1_rx) = joiner1.open_port::<JoinResult<CreatorRef>>();
+        let (r2, mut r2_rx) = joiner2.open_port::<JoinResult<CreatorRef>>();
+        let (r3, mut r3_rx) = joiner3.open_port::<JoinResult<CreatorRef>>();
+
+        token
+            .join(&joiner1, MultiJoinerRef::One, r1.bind())
+            .unwrap();
+        token
+            .join(&joiner2, MultiJoinerRef::Two, r2.bind())
+            .unwrap();
+        token
+            .join(&joiner3, MultiJoinerRef::Three, r3.bind())
+            .unwrap();
+
+        let mut joined = vec![
+            creator_joined_rx.recv().await.unwrap().peer,
+            creator_joined_rx.recv().await.unwrap().peer,
+            creator_joined_rx.recv().await.unwrap().peer,
+        ];
+        joined.sort();
+
+        assert_eq!(
+            joined,
+            vec![
+                MultiJoinerRef::One,
+                MultiJoinerRef::Two,
+                MultiJoinerRef::Three,
+            ]
+        );
+
+        assert_eq!(
+            r1_rx.recv().await.unwrap(),
+            JoinResult::Joined { peer: CreatorRef }
+        );
+        assert_eq!(
+            r2_rx.recv().await.unwrap(),
+            JoinResult::Joined { peer: CreatorRef }
+        );
+        assert_eq!(
+            r3_rx.recv().await.unwrap(),
+            JoinResult::Joined { peer: CreatorRef }
         );
     }
 


### PR DESCRIPTION
Summary:

adds three unit tests in `fbcode/monarch/hyperactor_remote/src/token.rs::tests` covering the three failure paths of `Token::FromStr::from_str` (`token.rs:288-304`): base64 decode failure, JSON parse failure, and type-URI mismatch. before this diff the only failure-mode coverage was the type-URI-mismatch case tested via `Deserialize` in `test_token_rejects_incompatible_type_parameters` (`token.rs:702-717`); the `FromStr` entry point itself had no direct failure-mode test.

each test targets one branch of the parse pipeline. `test_token_from_str_rejects_corrupt_base64` parses `"%%%"` (characters outside the base64 alphabet) — `BASE64_STANDARD.decode()` returns `Err`. `test_token_from_str_rejects_invalid_json` parses `BASE64_STANDARD.encode(b"not json at all")` — base64 decode succeeds but `serde_json::from_slice` fails because the bytes aren't a `TokenPayload`. `test_token_from_str_rejects_mismatched_type_uris` constructs a real `Token<CreatorRef, JoinerRef>` via `Proc::local()` + `RendezvousStub` (mirroring `test_token_rejects_incompatible_type_parameters`), encodes it, then parses as `Token<CreatorRef, OtherJoinerRef>` — base64 + JSON both succeed but `payload.validate()` fails.

the type-URI test is worth keeping even though `Deserialize` already exercises the validate step: a future regression that dropped `payload.validate()?` from `FromStr` alone (while leaving the `Deserialize` path intact) would not be caught by the existing test. assertions: each parse's `Result` is `Err`. error-message contents are not matched — the underlying errors (`base64::DecodeError`, `serde_json::Error`, the validate error) are foreign-crate types whose Display output is not stable API; asserting `is_err()` is the right granularity for "this parse path rejects this input".

Reviewed By: mariusae, thedavekwon

Differential Revision: D105038701


