### PR TITLE
Fix PyShared.__await__ borrow race by taking &self

### DIFF
--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -826,7 +826,7 @@ impl PyShared {
     /// Note: `await shared` is only supported inside the
     /// `PythonTask.from_coroutine(...)` world (because it ultimately
     /// awaits a `PythonTask`).
-    fn __await__(&mut self, py: Python<'_>) -> PyResult<PythonTaskAwaitIterator> {
+    fn __await__(&self, py: Python<'_>) -> PyResult<PythonTaskAwaitIterator> {
         let task = self.task()?;
         Ok(PythonTaskAwaitIterator::new(task.into_py_any(py)?))
     }


### PR DESCRIPTION
Summary:
`PyShared.__await__` was declared `&mut self`, so pyo3 took a `PyRefMut` for every call. pyo3's borrow checker uses an atomic counter that is independent of the GIL, so a `PyRefMut` request fails with `RuntimeError: Already borrowed` whenever *any* other borrow on the same instance is alive — including a `PyRef` held by another thread that has released the GIL. The body of `__await__` does not mutate `self`; demoting the receiver to `&self` lets it take a (compatible) `PyRef` instead, eliminating the conflict.

In production this surfaced as flaky `RuntimeError: Already borrowed` in `test_host_mesh::test_with_python_executable`, raised from `host_mesh.py:191`'s `await self._hy_host_mesh`. The race fires when something else in the actor-mesh send pipeline is holding a `PyRef<PyShared>` across a GIL release (e.g. while `signal_safe_block_on` is running) at the same moment a tokio worker on another thread drives `await shared` on the same instance.

Repro of the mechanism: any path that keeps a `PyRef<PyShared>` alive across a GIL release is sufficient. A 1-line synthetic demonstration is to add `let _g = py_shared.borrow();` just before the fallback `PyShared::block_on(py_shared.borrow(), py)?` in `reduce_shared`. With that added: every concurrent awaiter on the same Shared deterministically fails on the old `&mut self __await__` and succeeds on the new `&self __await__`.

Natural repro: stress-run `test_host_mesh::test_with_python_executable`. The old binary failed 2/200 stress runs at 16 workers (an earlier session measured ~3.8% at 32 workers × 500). With this fix applied, 32 workers × 2000 stress runs passed with zero borrow-race failures.

Differential Revision: D105059760


