### PR TITLE
Bump pytorch from 2.11.0 to 2.12.0 for stable monarch release; track 2.13.0 nightly base image

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -22,7 +22,7 @@ jobs:
       # TODO add 3.14 once we figure out py03 issue
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       runner: linux.g5.4xlarge.nvidia.gpu
-      torch-spec: 'torch==2.11.0 --extra-index-url https://download.pytorch.org/whl/cu128'
+      torch-spec: 'torch==2.12.0 --extra-index-url https://download.pytorch.org/whl/cu128'
       gpu-arch-type: cuda
       gpu-arch-version: '12.8'
       version: ${{ github.event.inputs.version }}
@@ -34,7 +34,7 @@ jobs:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       runner: linux.arm64.2xlarge
       docker-image: 'pytorch/manylinuxaarch64-builder:cuda12.8'
-      torch-spec: 'torch==2.11.0 --extra-index-url https://download.pytorch.org/whl/cu128'
+      torch-spec: 'torch==2.12.0 --extra-index-url https://download.pytorch.org/whl/cu128'
       gpu-arch-type: cuda
       gpu-arch-version: '12.8'
       version: ${{ github.event.inputs.version }}
@@ -45,7 +45,7 @@ jobs:
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       runner: macos-latest
-      torch-spec: 'torch==2.11.0 --extra-index-url https://download.pytorch.org/whl/cpu'
+      torch-spec: 'torch==2.12.0 --extra-index-url https://download.pytorch.org/whl/cpu'
       version: ${{ github.event.inputs.version }}
 
   publish:
@@ -118,7 +118,7 @@ jobs:
           push: true # Push the image to the registry
           tags: ${{ steps.determine-tags.outputs.tags }}
           build-args: |
-            PYTORCH_TAG=2.11.0-cuda12.8-cudnn9-runtime
+            PYTORCH_TAG=2.12.0-cuda12.8-cudnn9-runtime
             MONARCH_VERSION=${{ github.event.inputs.version }}
 
   create-docs-branch:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -130,6 +130,6 @@ jobs:
             ghcr.io/${{ github.repository }}-nightly:latest
           # TODO: find docker tag that gets updated automatically.
           build-args: |
-            PYTORCH_TAG=2.12.0.dev20260324-cuda12.8-cudnn9-runtime
+            PYTORCH_TAG=2.13.0.dev20260513-runtime
           build-contexts: |
             monarch-wheels=${{ runner.temp }}/monarch_wheels

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Override on build from CI.
-ARG PYTORCH_TAG=2.11.0-cuda12.8-cudnn9-runtime
+ARG PYTORCH_TAG=2.12.0-cuda12.8-cudnn9-runtime
 
 # Build from latest pytorch stable image; should be relatively in sync with torchmonarch and pytorch.
 FROM ghcr.io/pytorch/pytorch:${PYTORCH_TAG}

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -1,5 +1,5 @@
 # Override on build from CI, default only to prevent warnings.
-ARG PYTORCH_TAG=2.12.0.dev20260324-cuda12.8-cudnn9-runtime
+ARG PYTORCH_TAG=2.13.0.dev20260513-runtime
 
 # Build from latest pytorch nightly base image; should be relatively in sync with torchmonarch and pytorch-nightly.
 FROM ghcr.io/pytorch/pytorch-nightly:${PYTORCH_TAG}


### PR DESCRIPTION
Summary:
Bumps the stable PyTorch version used to build and publish `torchmonarch` wheels and the stable docker image from `2.11.0` to `2.12.0`, and bumps the nightly docker base image to a `2.13.0.dev` tag. The `--pre torch` nightly torch-specs in the build/test workflows are intentionally left unpinned so they continue tracking whatever the pytorch nightly index serves.

Changes:
- `.github/workflows/publish_release.yml`: bump all three `torch==2.11.0` torch-specs (x86_64, aarch64, macos) to `torch==2.12.0`; bump stable docker `PYTORCH_TAG` to `2.12.0-cuda12.8-cudnn9-runtime`.
- `.github/workflows/wheels.yml`: bump nightly docker `PYTORCH_TAG` to `2.13.0.dev20260513-runtime`.
- `Dockerfile`: bump default `ARG PYTORCH_TAG` to `2.12.0-cuda12.8-cudnn9-runtime` so local builds match CI.
- `Dockerfile.nightly`: bump default `ARG PYTORCH_TAG` to `2.13.0.dev20260513-runtime` so local builds match CI.

Differential Revision: D105063791


