### PR TITLE
Enable slicing (#3871)

### DIFF
--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -9,6 +9,7 @@
 //! The CastActor: a system actor that bootstraps and manages casting domains.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -129,14 +130,20 @@ impl CastDomainId {
         );
 
         let root_rank = region.slice().offset();
-        let entry_point = &members[&root_rank];
-        let member_mesh = ValueMesh::build_indexed(region.clone(), members.clone())?;
+        let entry_point = members
+            .get(&root_rank)
+            .expect("members coverage was checked above")
+            .clone();
+        let member_mesh = Arc::new(ValueMesh::build_indexed(region.clone(), members)?);
+
         let domain_ref = CastDomainRef::from_entry_point(
             self.clone(),
-            cast_actor_ref_for_member(entry_point),
-            member_mesh,
+            cast_actor_ref_for_member(&entry_point),
+            Arc::clone(&member_mesh),
         );
-        let root_tile = MaterializedTile::from_map(Tile::from_view(&region), members);
+        let root_tile =
+            MaterializedTile::from_value_mesh_with_tile(Tile::from_view(&region), member_mesh);
+
         domain_ref.entry_point.post(
             cx,
             CreateCastDomain {
@@ -167,7 +174,7 @@ pub struct CastDomainRef {
     /// Entry-point [`CastActor`] ref for initiating casts.
     entry_point: ActorRef<CastActor>,
     /// Destination actor addresses keyed by this domain's rank space.
-    members: ValueMesh<ActorAddr>,
+    members: Arc<ValueMesh<ActorAddr>>,
 }
 
 impl CastDomainRef {
@@ -175,7 +182,7 @@ impl CastDomainRef {
     fn from_entry_point(
         id: CastDomainId,
         entry_point: ActorRef<CastActor>,
-        members: ValueMesh<ActorAddr>,
+        members: Arc<ValueMesh<ActorAddr>>,
     ) -> Self {
         Self {
             id,
@@ -263,7 +270,7 @@ impl CastDomainRef {
         dest_port: u64,
     ) -> Result<(Uuid, ValueMesh<u64>)> {
         let sequencer = cx.instance().sequencer();
-        let seqs = self.members.clone().map_into(|member| {
+        let seqs = self.members.as_ref().map_into(|member| {
             let port = member.port_addr(Port::from(dest_port));
             let SeqInfo::Session { session_id: _, seq } = sequencer.assign_seq(&port) else {
                 unreachable!("assign_seq always returns SeqInfo::Session");
@@ -1291,7 +1298,10 @@ mod tests {
                 .iter()
                 .map(|rank| (rank, member(rank)))
                 .collect::<HashMap<_, _>>();
-            let root_tile = MaterializedTile::from_map(Tile::from_view(&region), members.clone());
+            let root_tile = MaterializedTile::from_value_mesh_with_tile(
+                Tile::from_view(&region),
+                Arc::new(ValueMesh::build_indexed(region.clone(), members.clone()).unwrap()),
+            );
 
             let mut seen_roots = BTreeSet::new();
             validate_domain_tree(&members, &root_tile, &mut seen_roots)?;
@@ -1309,7 +1319,10 @@ mod tests {
                 .iter()
                 .map(|rank| (rank, member(rank)))
                 .collect::<HashMap<_, _>>();
-            let root = MaterializedTile::from_map(Tile::from_view(&region), members.clone());
+            let root = MaterializedTile::from_value_mesh_with_tile(
+                Tile::from_view(&region),
+                Arc::new(ValueMesh::build_indexed(region.clone(), members.clone()).unwrap()),
+            );
             let mut seen_roots = BTreeSet::new();
 
             validate_domain_tree(&members, &root, &mut seen_roots)?;
@@ -1526,7 +1539,10 @@ mod tests {
         let receiver_id = ActorAddr::root(cast_proc.proc_addr().clone(), Label::strip("receiver"));
         let cast_domain_id = CastDomainId::new();
         let region = Region::from(Shape::unity());
-        let root_tile = MaterializedTile::new(Tile::from_view(&region), vec![receiver_id]);
+        let root_tile = MaterializedTile::from_value_mesh_with_tile(
+            Tile::from_view(&region),
+            Arc::new(ValueMesh::new(region.clone(), vec![receiver_id]).unwrap()),
+        );
 
         Handler::<CreateCastDomain>::handle(
             &mut cast_actor,

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -46,6 +46,7 @@ use ndslice::Shape;
 use ndslice::view::BuildFromRegionIndexed;
 use ndslice::view::MapIntoExt;
 use ndslice::view::Ranked;
+use ndslice::view::View;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -204,6 +205,54 @@ impl CastDomainRef {
     /// The [`CastActor`] entry point for this domain.
     pub fn entry_point(&self) -> &ActorRef<CastActor> {
         &self.entry_point
+    }
+
+    /// Destination actor addresses keyed by this domain's rank space.
+    pub fn members(&self) -> &ValueMesh<ActorAddr> {
+        &self.members
+    }
+
+    /// Materialize a new slice domain described relative to this domain.
+    ///
+    /// The returned ref is the handle for the slice. It gets a fresh domain id
+    /// whose entrypoint is the slice's actual root CastActor. The parent ref's
+    /// dense members are used only to derive the slice definition and sender
+    /// side sequence map; the cast path enters directly at the slice root.
+    pub fn materialize_slice(
+        &self,
+        cx: &impl context::Actor,
+        region: Region,
+        tiling_policy: TilingPolicy,
+    ) -> anyhow::Result<CastDomainRef> {
+        let slice_id = CastDomainId::new();
+        let slice_member_mesh = Arc::new(self.members.subset(region.clone())?);
+        let slice_tile = MaterializedTile::from_value_mesh_with_tile(
+            Tile::from_view(&region),
+            Arc::clone(&slice_member_mesh),
+        );
+
+        let slice_entrypoint = cast_actor_ref_for_member(
+            slice_tile
+                .root_item()
+                .ok_or_else(|| anyhow::anyhow!("slice root tile must have at least one member"))?,
+        );
+
+        let slice_ref = CastDomainRef::from_entry_point(
+            slice_id.clone(),
+            slice_entrypoint.clone(),
+            slice_member_mesh,
+        );
+
+        slice_entrypoint.post(
+            cx,
+            CreateCastDomain {
+                cast_domain_id: slice_id.clone(),
+                region,
+                tiling_policy,
+                tile: slice_tile,
+            },
+        );
+        Ok(slice_ref)
     }
 
     /// Cast a message to all members of this domain with caller-supplied headers.
@@ -715,12 +764,9 @@ impl Handler<CastMessage> for CastActor {
         {
             let seq = *message
                 .seqs
-                .get(domain.point_in_domain.rank())
+                .get_by_base_rank(domain.base_rank_in_domain)
                 .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "missing seq for domain rank {}",
-                        domain.point_in_domain.rank()
-                    )
+                    anyhow::anyhow!("missing seq for base rank {}", domain.base_rank_in_domain)
                 })?;
             let mut headers = message.headers.clone();
             headers.set(CAST_POINT, domain.point_in_domain.clone());
@@ -837,6 +883,7 @@ mod tests {
     use hyperactor::proc::Proc;
     use ndslice::Shape;
     use ndslice::Slice;
+    use ndslice::ViewExt;
     use ndslice::shape;
     use proptest::prelude::*;
     use timed_test::async_timed_test;
@@ -963,6 +1010,45 @@ mod tests {
             .get(domain_id)
             .cloned()
             .unwrap_or_default()
+    }
+
+    fn members(count: usize) -> Vec<ActorAddr> {
+        (0..count)
+            .map(|i| {
+                ActorAddr::root(
+                    format!("proc{i}@inproc://{i}").parse::<ProcAddr>().unwrap(),
+                    Label::strip("member"),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn test_subset_members_preserves_selected_member_order() {
+        // parent local ranks / members:
+        //
+        // row=0: 0  1      members[0] members[1]
+        // row=1: 2  3      members[2] members[3]
+        // row=2: 4  5      members[4] members[5]
+        // row=3: 6  7      members[6] members[7]
+        let parent_view = Region::from(shape!(row = 4, col = 2));
+
+        // selected region = row 1..3
+        let child_view = parent_view
+            .range("row", ndslice::Range(1, Some(3), 1))
+            .unwrap();
+        let members = members(8);
+        let parent_members = ValueMesh::new(parent_view.clone(), members.clone()).unwrap();
+
+        let child_members = parent_members.subset(child_view.clone()).unwrap();
+        let child_members = (0..Ranked::region(&child_members).num_ranks())
+            .map(|rank| Ranked::get(&child_members, rank).unwrap().clone())
+            .collect::<Vec<_>>();
+
+        // child local ranks -> parent/base ranks:
+        // row=0: 0->2  1->3
+        // row=1: 2->4  3->5
+        assert_eq!(child_members, &members[2..6]);
     }
 
     // -- Integration test infrastructure --
@@ -1413,6 +1499,40 @@ mod tests {
         }
     }
 
+    fn expected_reply_counts(proc_names: &[&str]) -> BTreeMap<String, u64> {
+        proc_names
+            .iter()
+            .map(|proc_name| (proc_name.to_string(), 1))
+            .collect()
+    }
+
+    async fn cast_and_collect_reply_counts(
+        test_mesh: &CastTestMesh,
+        cast_domain: &CastDomainRef,
+        payload: &str,
+    ) -> BTreeMap<String, u64> {
+        let (reply_handle, reply_rx) = context::Mailbox::mailbox(&test_mesh.client)
+            .open_reduce_port(TestReplyCountsAccumulator);
+        let reply_ref = reply_handle.bind();
+
+        cast_domain
+            .cast(
+                &test_mesh.client,
+                Flattrs::new(),
+                TestRequestWithReply {
+                    payload: payload.to_string(),
+                    reply_to: reply_ref,
+                },
+            )
+            .unwrap();
+
+        match tokio::time::timeout(Duration::from_secs(5), reply_rx.recv()).await {
+            Ok(Ok(reply_counts)) => reply_counts.counts_by_proc,
+            Ok(Err(e)) => panic!("reply recv error: {e}"),
+            Err(_) => panic!("timed out waiting for reduced replies"),
+        }
+    }
+
     #[async_timed_test(timeout_secs = 30)]
     async fn test_cast_message_delivery_8_procs() {
         let config = hyperactor_config::global::lock();
@@ -1624,6 +1744,146 @@ mod tests {
             destroyed,
             (0..8).map(|rank| format!("proc_{rank}")).collect()
         );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_slice_cast_reaches_exactly_selected_members() {
+        let n = 8;
+        let mut test_mesh = CastTestMesh::new(n);
+        test_mesh.spawn_split_port_receivers();
+        let root_cast_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+
+        for (case_name, range, expected_procs) in [
+            (
+                "a_0_to_1",
+                ndslice::Range(0, Some(1), 1),
+                ["proc_0", "proc_1", "proc_2", "proc_3"],
+            ),
+            (
+                "a_1_to_2",
+                ndslice::Range(1, Some(2), 1),
+                ["proc_4", "proc_5", "proc_6", "proc_7"],
+            ),
+        ] {
+            let payload = format!("slice-{case_name}");
+            let slice_region = Region::from(shape!(a = 2, b = 2, c = 2))
+                .range("a", range)
+                .unwrap();
+            let slice_cast_domain = root_cast_domain
+                .materialize_slice(
+                    &test_mesh.client,
+                    slice_region,
+                    TilingPolicy::BlockPartitioning,
+                )
+                .unwrap();
+
+            assert_eq!(
+                cast_and_collect_reply_counts(&test_mesh, &slice_cast_domain, &payload,).await,
+                expected_reply_counts(&expected_procs)
+            );
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_sender_sequenced_casts_are_observed_in_projection_order() {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(
+            hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER,
+            true,
+        );
+
+        let n = 4;
+        let mut test_mesh = CastTestMesh::new(n);
+        test_mesh.spawn_delivery_receivers();
+        let root = test_mesh.root_domain(shape!(rank = 4));
+
+        let rank_0_to_2 = root
+            .materialize_slice(
+                &test_mesh.client,
+                Region::from(shape!(rank = 4))
+                    .range("rank", ndslice::Range(0, Some(2), 1))
+                    .unwrap(),
+                TilingPolicy::BlockPartitioning,
+            )
+            .unwrap();
+
+        let rank_1_to_3 = root
+            .materialize_slice(
+                &test_mesh.client,
+                Region::from(shape!(rank = 4))
+                    .range("rank", ndslice::Range(1, Some(3), 1))
+                    .unwrap(),
+                TilingPolicy::BlockPartitioning,
+            )
+            .unwrap();
+
+        let rank_2_to_4 = root
+            .materialize_slice(
+                &test_mesh.client,
+                Region::from(shape!(rank = 4))
+                    .range("rank", ndslice::Range(2, Some(4), 1))
+                    .unwrap(),
+                TilingPolicy::BlockPartitioning,
+            )
+            .unwrap();
+
+        let casts = [
+            (
+                &root,
+                "root-0",
+                vec!["proc_0", "proc_1", "proc_2", "proc_3"],
+            ),
+            (&rank_0_to_2, "rank_0_to_2-1", vec!["proc_0", "proc_1"]),
+            (&rank_1_to_3, "rank_1_to_3-2", vec!["proc_1", "proc_2"]),
+            (&rank_2_to_4, "rank_2_to_4-3", vec!["proc_2", "proc_3"]),
+            (
+                &root,
+                "root-4",
+                vec!["proc_0", "proc_1", "proc_2", "proc_3"],
+            ),
+        ];
+
+        let mut expected_histories: BTreeMap<String, Vec<String>> = test_mesh
+            .proc_names()
+            .into_iter()
+            .map(|proc_name| (proc_name, Vec::new()))
+            .collect();
+
+        for (domain, payload, expected_receivers) in &casts {
+            domain
+                .cast(
+                    &test_mesh.client,
+                    Flattrs::new(),
+                    TestDelivery {
+                        payload: payload.to_string(),
+                    },
+                )
+                .unwrap();
+
+            for proc_name in expected_receivers {
+                expected_histories
+                    .get_mut(*proc_name)
+                    .unwrap()
+                    .push(payload.to_string());
+            }
+        }
+
+        let observed_histories: BTreeMap<String, Vec<String>> =
+            cast_and_collect_histories(&test_mesh, &root)
+                .await
+                .into_iter()
+                .map(|(proc_name, history)| {
+                    (
+                        proc_name,
+                        history
+                            .into_iter()
+                            .map(|delivery| delivery.payload)
+                            .collect(),
+                    )
+                })
+                .collect();
+
+        assert_eq!(observed_histories, expected_histories);
     }
 
     // -- Port splitting test infrastructure --

--- a/hyperactor_cast/src/tile.rs
+++ b/hyperactor_cast/src/tile.rs
@@ -64,16 +64,17 @@
 
 #![allow(dead_code)]
 
-use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 
+use hyperactor::value_mesh::ValueMesh;
 use ndslice::Region;
 use ndslice::Slice;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
 use serde::Serializer;
+use serde::de::Error as DeError;
 use serde::ser::SerializeStruct;
 
 /// Decomposable affine tile.
@@ -155,19 +156,19 @@ impl Tile {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct MaterializedTile<T> {
     tile: Tile,
-    items_by_rank: Arc<HashMap<usize, T>>,
+    items: Arc<ValueMesh<T>>,
 }
 
-impl<T: Serialize> Serialize for MaterializedTile<T> {
+impl<T: Serialize + 'static> Serialize for MaterializedTile<T> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        // In memory, child materialized tiles created by `subtile()` may share
-        // a root-level `items_by_rank` map so that further subtiles are O(1).
-        // On the wire, send only the active tile's items in `tile.space()`
-        // iteration order. The serialized tile carries the ranks, so the
-        // receiver can rebuild the compact rank map without index shifts.
+        // In memory, child materialized tiles created by `subtile()` share a
+        // root-level ValueMesh so that further subtiles are O(1). On the wire,
+        // send only the active tile's items in `tile.ranks()` order. The
+        // serialized tile carries the ranks, so the receiver can rebuild a
+        // compact ValueMesh without index shifts.
         let mut state = serializer.serialize_struct("MaterializedTile", 2)?;
         state.serialize_field("tile", &self.tile)?;
         state.serialize_field("items", &self.items().collect::<Vec<_>>())?;
@@ -175,7 +176,7 @@ impl<T: Serialize> Serialize for MaterializedTile<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de>> Deserialize<'de> for MaterializedTile<T> {
+impl<'de, T: Deserialize<'de> + 'static> Deserialize<'de> for MaterializedTile<T> {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'de>,
@@ -186,39 +187,40 @@ impl<'de, T: Deserialize<'de>> Deserialize<'de> for MaterializedTile<T> {
             items: Vec<T>,
         }
 
-        // The wire form stores only active-tile items. `new()` zips those
-        // values with the serialized tile's ranks, rebuilding a rank-addressed
-        // map scoped to this tile rather than the sender's full shared map.
+        // Wire carries only this tile's items, positional in `tile.ranks()` order
+        // (see `Serialize`); rebuild a `ValueMesh` scoped to the tile, not the
+        // sender's (shared, possibly larger) backing.
         let wire = MaterializedTileWire::deserialize(deserializer)?;
-        Ok(Self::new(wire.tile, wire.items))
+
+        let items = Arc::new(
+            ValueMesh::new(
+                Region::new(
+                    (0..wire.tile.space().sizes().len())
+                        .map(|dim| format!("dim{dim}"))
+                        .collect(),
+                    wire.tile.space().clone(),
+                ),
+                wire.items,
+            )
+            .map_err(|err| D::Error::custom(format!("invalid materialized tile items: {err}")))?,
+        );
+        Ok(Self::from_value_mesh_with_tile(wire.tile, items))
     }
 }
 
-impl<T> MaterializedTile<T> {
-    /// Pair `tile` with one item per rank in `tile.ranks()` order.
+impl<T: 'static> MaterializedTile<T> {
+    /// Construct a materialized tile from a complete item mesh and explicit
+    /// tile geometry.
     ///
-    /// The item at position `i` in `items` is associated with the `i`th rank
-    /// yielded by `tile.ranks()`.
-    pub(crate) fn new(tile: Tile, items: Vec<T>) -> Self {
-        assert_eq!(tile.rank_count(), items.len());
-        let items_by_rank = tile.ranks().zip(items).collect();
-        Self {
-            tile,
-            items_by_rank: Arc::new(items_by_rank),
-        }
-    }
-
-    /// Construct a materialized tile from items already keyed by rank.
-    ///
-    /// `items_by_rank` must contain exactly one item for every rank covered by
-    /// `tile`.
-    pub(crate) fn from_map(tile: Tile, items_by_rank: HashMap<usize, T>) -> Self {
-        assert_eq!(tile.rank_count(), items_by_rank.len());
-        assert!(tile.ranks().all(|rank| items_by_rank.contains_key(&rank)));
-        Self {
-            tile,
-            items_by_rank: Arc::new(items_by_rank),
-        }
+    /// `items` may cover a larger region than `tile`, but it must contain every
+    /// base rank covered by `tile`.
+    pub(crate) fn from_value_mesh_with_tile(tile: Tile, items: Arc<ValueMesh<T>>) -> Self {
+        debug_assert!(
+            tile.ranks()
+                .all(|rank| items.get_by_base_rank(rank).is_some()),
+            "tile ranks must be covered by the items mesh",
+        );
+        Self { tile, items }
     }
 
     /// Geometry carried by this materialized tile.
@@ -236,7 +238,7 @@ impl<T> MaterializedTile<T> {
         if !self.tile.space().contains(rank) {
             return None;
         }
-        self.items_by_rank.get(&rank)
+        self.items.get_by_base_rank(rank)
     }
 
     /// Item at this tile's natural representative rank.
@@ -277,11 +279,11 @@ impl<T> MaterializedTile<T> {
     pub(crate) fn subtile(&self, tile: Tile) -> Self {
         debug_assert!(
             tile.ranks()
-                .all(|rank| self.items_by_rank.contains_key(&rank))
+                .all(|rank| self.items.get_by_base_rank(rank).is_some())
         );
         Self {
             tile,
-            items_by_rank: Arc::clone(&self.items_by_rank),
+            items: Arc::clone(&self.items),
         }
     }
 }
@@ -1013,10 +1015,10 @@ mod tests {
         // ```
         let view = Region::from(shape!(row = 2, col = 4));
         let root = Tile::from_view(&view);
-        let materialized = MaterializedTile::new(
-            root.clone(),
-            root.ranks().map(|rank| format!("A{rank}")).collect(),
-        );
+        let mesh =
+            ValueMesh::new(view, root.ranks().map(|rank| format!("A{rank}")).collect()).unwrap();
+        let materialized =
+            MaterializedTile::from_value_mesh_with_tile(root.clone(), Arc::new(mesh));
         let child =
             materialized.subtile(Tile::from_space(root.space().select(0, 1, 2, 1).unwrap()));
 


### PR DESCRIPTION
Summary:

Enable slice domains derived from existing cast domains. `CastDomainRef::materialize_slice` now returns a fresh `CastDomainRef` whose entrypoint is the slice's    actual root `CastActor`, rather than routing casts through the parent/root domain entrypoint.

A slice domain is installed as its own compacted cast tree over only the selected ranks. The parent domain's dense members are used to derive the slice-local member order, then `CreateCastDomain` is sent directly to the slice root so future casts enter through that local root.

  ```
  root/base ranks:
  0 1 2
  3 4 5
  6 7 8

  root domain:
  0
  |-- 3
  |   |-- 6
  |   |   |-- 7
  |   |   `-- 8
  |   |-- 4
  |   `-- 5
  |-- 1
  `-- 2
```

case 1: slice includes global rank 0
  slice = {0, 1, 2}

  slice domain:
  0  [slice root, delivers]
  |-- 1  [delivers]
  `-- 2  [delivers]

case 2: slice does not include global rank 0
  slice = {6, 7, 8}

  slice domain:
  6  [slice root, delivers]
  |-- 7  [delivers]
  `-- 8  [delivers]

CastDomainRef now carries the domain Region and dense member list needed to materialize slices locally. sliced_members remaps parent-local members into the slice's dense local rank order so delivery and sender-side sequence vectors stay aligned with the slice view.

Add coverage for slice delivery over root-containing and non-root slices, plus an ordering test that casts through overlapping slices and the root, collects actor-local delivery histories with a reducer, and verifies each actor observes the expected projection of the sender's cast order.

Reviewed By: shayne-fletcher

Differential Revision: D102423104


