### PR TITLE
Update KubernetesJob to use PodTemplateSpec (#3872)

### DIFF
--- a/docs/source/examples/ddp/kubernetes_ddp.py
+++ b/docs/source/examples/ddp/kubernetes_ddp.py
@@ -78,23 +78,24 @@ Alternatively, you can pre-provision workers with YAML manifests::
       replicas: 2  # Number of worker pods (hosts)
       port: 26600
       podTemplate:
-        containers:
-        - name: worker
-          image: ghcr.io/meta-pytorch/monarch:latest
-          resources:
-            limits:
-              nvidia.com/gpu: 4
-            requests:
-              nvidia.com/gpu: 4
-          command:
-            - python
-            - -u
-            - -c
-            - |
-              from monarch.actor import run_worker_loop_forever
-              import socket
-              address = f"tcp://{socket.getfqdn()}:26600"
-              run_worker_loop_forever(address=address, ca="trust_all_connections")
+        spec:
+          containers:
+          - name: worker
+            image: ghcr.io/meta-pytorch/monarch:latest
+            resources:
+              limits:
+                nvidia.com/gpu: 4
+              requests:
+                nvidia.com/gpu: 4
+            command:
+              - python
+              - -u
+              - -c
+              - |
+                from monarch.actor import run_worker_loop_forever
+                import socket
+                address = f"tcp://{socket.getfqdn()}:26600"
+                run_worker_loop_forever(address=address, ca="trust_all_connections")
 
 Deploy with::
 
@@ -180,6 +181,7 @@ from kubernetes.client import (
     V1EmptyDirVolumeSource,
     V1EnvVar,
     V1PodSpec,
+    V1PodTemplateSpec,
     V1ResourceRequirements,
     V1Volume,
     V1VolumeMount,
@@ -227,8 +229,8 @@ _TRAIN_SCRIPT_CONTENT = textwrap.dedent("""\
 """)
 
 
-def build_gpu_pod_spec(gpus_per_host: int) -> V1PodSpec:
-    """Build a V1PodSpec with GPU resources and shared memory for NCCL.
+def build_gpu_pod_template(gpus_per_host: int) -> V1PodTemplateSpec:
+    """Build a V1PodTemplateSpec with GPU resources and shared memory for NCCL.
 
     The bootstrap command writes train.py to the worker filesystem
     before starting the Monarch worker loop, so the SPMDActor can
@@ -241,28 +243,32 @@ def build_gpu_pod_spec(gpus_per_host: int) -> V1PodSpec:
         + _WORKER_BOOTSTRAP_SCRIPT
     )
     gpu_resources = {"nvidia.com/gpu": str(gpus_per_host)}
-    return V1PodSpec(
-        containers=[
-            V1Container(
-                name="worker",
-                image="ghcr.io/meta-pytorch/monarch:latest",
-                command=["python", "-u", "-c", bootstrap],
-                env=[V1EnvVar(name="MONARCH_PORT", value="26600")],
-                resources=V1ResourceRequirements(
-                    limits=gpu_resources,
-                    requests=gpu_resources,
-                ),
-                volume_mounts=[
-                    V1VolumeMount(name="dshm", mount_path="/dev/shm"),
-                ],
-            )
-        ],
-        volumes=[
-            V1Volume(
-                name="dshm",
-                empty_dir=V1EmptyDirVolumeSource(medium="Memory", size_limit="16Gi"),
-            )
-        ],
+    return V1PodTemplateSpec(
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="worker",
+                    image="ghcr.io/meta-pytorch/monarch:latest",
+                    command=["python", "-u", "-c", bootstrap],
+                    env=[V1EnvVar(name="MONARCH_PORT", value="26600")],
+                    resources=V1ResourceRequirements(
+                        limits=gpu_resources,
+                        requests=gpu_resources,
+                    ),
+                    volume_mounts=[
+                        V1VolumeMount(name="dshm", mount_path="/dev/shm"),
+                    ],
+                )
+            ],
+            volumes=[
+                V1Volume(
+                    name="dshm",
+                    empty_dir=V1EmptyDirVolumeSource(
+                        medium="Memory", size_limit="16Gi"
+                    ),
+                )
+            ],
+        ),
     )
 
 
@@ -298,7 +304,7 @@ async def main(
     # ~~~~~~~~~~~~~~~~~~~~~
     # Create a ``KubernetesJob`` in the ``monarch-tests`` namespace.
     # With ``--provision``, the job creates MonarchMesh CRDs via the K8s API
-    # using ``pod_spec`` for full control over the pod template (needed for
+    # using ``pod_template`` for full control over the pod template (needed for
     # the shared memory volume that NCCL requires). Without ``--provision``,
     # it attaches to pre-provisioned pods.
 
@@ -308,7 +314,7 @@ async def main(
         k8s_job.add_mesh(
             mesh_name,
             num_replicas=num_hosts,
-            pod_spec=build_gpu_pod_spec(gpus_per_host),
+            pod_template=build_gpu_pod_template(gpus_per_host),
             labels=labels,
         )
     else:

--- a/docs/source/examples/ddp/manifests/ddp_mesh.yaml
+++ b/docs/source/examples/ddp/manifests/ddp_mesh.yaml
@@ -66,50 +66,51 @@ spec:
   port: 26600
 
   podTemplate:
-    containers:
-    - name: worker
-      image: ghcr.io/meta-pytorch/monarch:latest
+    spec:
+      containers:
+      - name: worker
+        image: ghcr.io/meta-pytorch/monarch:latest
 
-      resources:
-        limits:
-          nvidia.com/gpu: 4
-        requests:
-          nvidia.com/gpu: 4
+        resources:
+          limits:
+            nvidia.com/gpu: 4
+          requests:
+            nvidia.com/gpu: 4
 
-      env:
-        - name: MONARCH_PORT
-          value: "26600"
+        env:
+          - name: MONARCH_PORT
+            value: "26600"
 
-      command:
-        - python
-        - -u
-        - -c
-        - |
-          import os
-          import socket
-          import logging
-          from monarch.actor import run_worker_loop_forever
-          logging.basicConfig(level=logging.INFO)
-          logger = logging.getLogger("monarch-worker")
-          port = os.environ.get("MONARCH_PORT", "26600")
-          # Use FQDN for cross-pod DNS resolution
-          hostname = socket.getfqdn()
-          address = f"tcp://{hostname}:{port}"
-          logger.info(f"--- Starting Monarch Worker ---")
-          logger.info(f"Identity: {hostname}")
-          logger.info(f"Listening on: {address}")
-          run_worker_loop_forever(address=address, ca="trust_all_connections")
+        command:
+          - python
+          - -u
+          - -c
+          - |
+            import os
+            import socket
+            import logging
+            from monarch.actor import run_worker_loop_forever
+            logging.basicConfig(level=logging.INFO)
+            logger = logging.getLogger("monarch-worker")
+            port = os.environ.get("MONARCH_PORT", "26600")
+            # Use FQDN for cross-pod DNS resolution
+            hostname = socket.getfqdn()
+            address = f"tcp://{hostname}:{port}"
+            logger.info(f"--- Starting Monarch Worker ---")
+            logger.info(f"Identity: {hostname}")
+            logger.info(f"Listening on: {address}")
+            run_worker_loop_forever(address=address, ca="trust_all_connections")
 
-      # Shared memory for NCCL (default 64MB is insufficient)
-      volumeMounts:
+        # Shared memory for NCCL (default 64MB is insufficient)
+        volumeMounts:
+          - name: dshm
+            mountPath: /dev/shm
+
+      volumes:
         - name: dshm
-          mountPath: /dev/shm
-
-    volumes:
-      - name: dshm
-        emptyDir:
-          medium: Memory
-          sizeLimit: "16Gi"
+          emptyDir:
+            medium: Memory
+            sizeLimit: "16Gi"
 ---
 # Controller pod for running the DDP training script
 apiVersion: v1

--- a/docs/source/examples/grpo/kubernetes_grpo.py
+++ b/docs/source/examples/grpo/kubernetes_grpo.py
@@ -55,7 +55,7 @@ This example calls ``monarch.configure(rdma_allow_tcp_fallback=True)`` so
 cross-pod ``RDMABuffer`` reads fall back to TCP on clusters without an RDMA
 CNI / device plugin. This is demonstrative, not performance-tuned. On a
 cluster with ibverbs plumbing, drop the ``configure()`` call and add the
-appropriate device resource requests to ``build_pod_spec``.
+appropriate device resource requests to ``build_pod_template``.
 
 Pod startup time
 ----------------
@@ -146,6 +146,7 @@ from kubernetes.client import (
     V1EmptyDirVolumeSource,
     V1EnvVar,
     V1PodSpec,
+    V1PodTemplateSpec,
     V1Probe,
     V1ResourceRequirements,
     V1TCPSocketAction,
@@ -869,8 +870,8 @@ PIP_INSTALL = textwrap.dedent("""\
 """)
 
 
-def build_pod_spec(gpus: int) -> V1PodSpec:
-    """Shared pod spec for learner and generator meshes.
+def build_pod_template(gpus: int) -> V1PodTemplateSpec:
+    """Shared pod template for learner and generator meshes.
 
     Prepends a pip-install prefix to the Monarch worker bootstrap so that
     ``transformers``, ``tokenizers``, and ``accelerate`` are present before
@@ -913,38 +914,42 @@ def build_pod_spec(gpus: int) -> V1PodSpec:
                 value="expandable_segments:True",
             ),
         )
-    return V1PodSpec(
-        containers=[
-            V1Container(
-                name="worker",
-                image=MONARCH_IMAGE,
-                command=["python", "-u", "-c", bootstrap],
-                env=env,
-                resources=resources,
-                # Mark pod Ready only once the Monarch worker loop is actually
-                # listening on :26600. Without this, K8s reports Ready as soon
-                # as the container starts -- which is during pip install, long
-                # before run_worker_loop_forever binds the port. The controller
-                # then connects too early and the 30s message delivery timeout
-                # fires before the worker is reachable.
-                readiness_probe=V1Probe(
-                    tcp_socket=V1TCPSocketAction(port=26600),
-                    initial_delay_seconds=30,
-                    period_seconds=5,
-                    timeout_seconds=5,
-                    failure_threshold=60,
-                ),
-                volume_mounts=[
-                    V1VolumeMount(name="dshm", mount_path="/dev/shm"),
-                ],
-            )
-        ],
-        volumes=[
-            V1Volume(
-                name="dshm",
-                empty_dir=V1EmptyDirVolumeSource(medium="Memory", size_limit="16Gi"),
-            )
-        ],
+    return V1PodTemplateSpec(
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="worker",
+                    image=MONARCH_IMAGE,
+                    command=["python", "-u", "-c", bootstrap],
+                    env=env,
+                    resources=resources,
+                    # Mark pod Ready only once the Monarch worker loop is actually
+                    # listening on :26600. Without this, K8s reports Ready as soon
+                    # as the container starts -- which is during pip install, long
+                    # before run_worker_loop_forever binds the port. The controller
+                    # then connects too early and the 30s message delivery timeout
+                    # fires before the worker is reachable.
+                    readiness_probe=V1Probe(
+                        tcp_socket=V1TCPSocketAction(port=26600),
+                        initial_delay_seconds=30,
+                        period_seconds=5,
+                        timeout_seconds=5,
+                        failure_threshold=60,
+                    ),
+                    volume_mounts=[
+                        V1VolumeMount(name="dshm", mount_path="/dev/shm"),
+                    ],
+                )
+            ],
+            volumes=[
+                V1Volume(
+                    name="dshm",
+                    empty_dir=V1EmptyDirVolumeSource(
+                        medium="Memory", size_limit="16Gi"
+                    ),
+                )
+            ],
+        ),
     )
 
 
@@ -1014,12 +1019,12 @@ async def main(
     k8s_job.add_mesh(
         "learner",
         num_replicas=1,
-        pod_spec=build_pod_spec(gpus=2),
+        pod_template=build_pod_template(gpus=2),
     )
     k8s_job.add_mesh(
         "generator",
         num_replicas=num_generator_hosts,
-        pod_spec=build_pod_spec(gpus=gpus_per_generator),
+        pod_template=build_pod_template(gpus=gpus_per_generator),
     )
 
     learner_mesh = None

--- a/docs/source/examples/otel_collector.py
+++ b/docs/source/examples/otel_collector.py
@@ -222,7 +222,7 @@ import os
 import socket
 import time
 
-from kubernetes.client import V1Container, V1EnvVar, V1PodSpec
+from kubernetes.client import V1Container, V1EnvVar, V1PodSpec, V1PodTemplateSpec
 from monarch._src.job.kubernetes import _WORKER_BOOTSTRAP_SCRIPT
 from monarch.actor import Actor, endpoint
 from monarch.job.kubernetes import KubernetesJob
@@ -260,35 +260,37 @@ class WorkActor(Actor):
 
 
 # %%
-# Build the worker pod spec with OTEL environment variables.
+# Build the worker pod template with OTEL environment variables.
 
 
-def build_worker_pod_spec(port: int) -> V1PodSpec:
-    """Build a V1PodSpec with OTEL_EXPORTER_OTLP_ENDPOINT configured."""
-    return V1PodSpec(
-        containers=[
-            V1Container(
-                name="worker",
-                image="ghcr.io/meta-pytorch/monarch:latest",
-                image_pull_policy="Always",
-                command=["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
-                env=[
-                    V1EnvVar(name="MONARCH_PORT", value=str(port)),
-                    V1EnvVar(
-                        name="OTEL_EXPORTER_OTLP_ENDPOINT",
-                        value=_OTEL_ENDPOINT,
-                    ),
-                    V1EnvVar(
-                        name="OTEL_SERVICE_NAME",
-                        value="monarch-worker",
-                    ),
-                    V1EnvVar(
-                        name="MONARCH_FILE_LOG",
-                        value="trace",
-                    ),
-                ],
-            )
-        ]
+def build_worker_pod_template(port: int) -> V1PodTemplateSpec:
+    """Build a V1PodTemplateSpec with OTEL_EXPORTER_OTLP_ENDPOINT configured."""
+    return V1PodTemplateSpec(
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="worker",
+                    image="ghcr.io/meta-pytorch/monarch:latest",
+                    image_pull_policy="Always",
+                    command=["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
+                    env=[
+                        V1EnvVar(name="MONARCH_PORT", value=str(port)),
+                        V1EnvVar(
+                            name="OTEL_EXPORTER_OTLP_ENDPOINT",
+                            value=_OTEL_ENDPOINT,
+                        ),
+                        V1EnvVar(
+                            name="OTEL_SERVICE_NAME",
+                            value="monarch-worker",
+                        ),
+                        V1EnvVar(
+                            name="MONARCH_FILE_LOG",
+                            value="trace",
+                        ),
+                    ],
+                )
+            ]
+        ),
     )
 
 
@@ -324,7 +326,7 @@ def main():
     job.add_mesh(
         "workers",
         num_replicas=args.num_replicas,
-        pod_spec=build_worker_pod_spec(port),
+        pod_template=build_worker_pod_template(port),
         port=port,
     )
 

--- a/examples/kubernetes/gpu_collective_demo/manifests/gpu_mesh.yaml
+++ b/examples/kubernetes/gpu_collective_demo/manifests/gpu_mesh.yaml
@@ -8,38 +8,38 @@ spec:
   replicas: 2
   port: 26600
   podTemplate:
-    containers:
-    - name: worker
-      # We use a public image and inline the python commands below.
-      image: ghcr.io/meta-pytorch/monarch:latest
+    spec:
+      containers:
+      - name: worker
+        # We use a public image and inline the python commands below.
+        image: ghcr.io/meta-pytorch/monarch:latest
 
-      # Ensure we always try to pull (helpful during development)
-      imagePullPolicy: Always
+        # Ensure we always try to pull (helpful during development)
+        imagePullPolicy: Always
 
-      # Request all 4 GPUs on the node for exclusive access
-      resources:
-        limits:
-          nvidia.com/gpu: 4
-        requests:
-          nvidia.com/gpu: 4
+        # Request all 4 GPUs on the node for exclusive access
+        resources:
+          limits:
+            nvidia.com/gpu: 4
+          requests:
+            nvidia.com/gpu: 4
 
-      # TODO: Remove after we have a worker.py in the image.
-      command:
-        - python
-        - -u
-        - -c
-        - |
-          import os
-          import socket
-          import logging
-          from monarch.actor import run_worker_loop_forever
-          logging.basicConfig(level=logging.INFO)
-          logger = logging.getLogger("monarch-worker")
-          port = os.environ.get("MONARCH_PORT", "26600")
-          # Use FQDN instead of short hostname for cross-pod resolution
-          hostname = socket.getfqdn()
-          address = f"tcp://{hostname}:{port}"
-          logger.info(f"--- Starting Monarch Worker ---")
-          logger.info(f"Identity: {hostname}")
-          logger.info(f"Listening on: {address}")
-          run_worker_loop_forever(address=address, ca="trust_all_connections")
+        command:
+          - python
+          - -u
+          - -c
+          - |
+            import os
+            import socket
+            import logging
+            from monarch.actor import run_worker_loop_forever
+            logging.basicConfig(level=logging.INFO)
+            logger = logging.getLogger("monarch-worker")
+            port = os.environ.get("MONARCH_PORT", "26600")
+            # Use FQDN instead of short hostname for cross-pod resolution
+            hostname = socket.getfqdn()
+            address = f"tcp://{hostname}:{port}"
+            logger.info(f"--- Starting Monarch Worker ---")
+            logger.info(f"Identity: {hostname}")
+            logger.info(f"Listening on: {address}")
+            run_worker_loop_forever(address=address, ca="trust_all_connections")

--- a/examples/kubernetes/hello_kubernetes_job/README.md
+++ b/examples/kubernetes/hello_kubernetes_job/README.md
@@ -37,7 +37,7 @@ kubectl cp hello_kubernetes_job.py monarch-tests/hello-controller:/tmp/hello_kub
 
 # Run with --provision to create MonarchMesh CRDs from Python
 kubectl exec -it hello-controller -n monarch-tests -- python /tmp/hello_kubernetes_job.py --provision
- 
+
 # (Optional) Run with Kueue for gang scheduling (mesh level)
 kubectl exec -it hello-controller -n monarch-tests -- python /tmp/hello_kubernetes_job.py --provision --kueue user-queue
 ```
@@ -107,7 +107,7 @@ kubectl exec -it hello-controller -n monarch-tests -- /bin/bash
 
 # Inside the controller, run the example
 python /tmp/hello_kubernetes_job.py
- 
+
 # (Optional) Run with Kueue for gang scheduling
 python /tmp/hello_kubernetes_job.py --kueue user-queue
 ```

--- a/examples/kubernetes/hello_kubernetes_job/manifests/hello_mesh.yaml
+++ b/examples/kubernetes/hello_kubernetes_job/manifests/hello_mesh.yaml
@@ -60,28 +60,29 @@ spec:
   port: 26600
 
   podTemplate:
-    containers:
-    - name: worker
-      image: ghcr.io/meta-pytorch/monarch:latest
-      command:
-        - python
-        - -u
-        - -c
-        - |
-          import os
-          import socket
-          import logging
-          from monarch.actor import run_worker_loop_forever
-          logging.basicConfig(level=logging.INFO)
-          logger = logging.getLogger("monarch-worker")
-          port = os.environ.get("MONARCH_PORT", "26600")
-          # Use FQDN for cross-pod DNS resolution
-          hostname = socket.getfqdn()
-          address = f"tcp://{hostname}:{port}"
-          logger.info(f"--- Starting Monarch Worker ---")
-          logger.info(f"Identity: {hostname}")
-          logger.info(f"Listening on: {address}")
-          run_worker_loop_forever(address=address, ca="trust_all_connections")
+    spec:
+      containers:
+      - name: worker
+        image: ghcr.io/meta-pytorch/monarch:latest
+        command:
+          - python
+          - -u
+          - -c
+          - |
+            import os
+            import socket
+            import logging
+            from monarch.actor import run_worker_loop_forever
+            logging.basicConfig(level=logging.INFO)
+            logger = logging.getLogger("monarch-worker")
+            port = os.environ.get("MONARCH_PORT", "26600")
+            # Use FQDN for cross-pod DNS resolution
+            hostname = socket.getfqdn()
+            address = f"tcp://{hostname}:{port}"
+            logger.info(f"--- Starting Monarch Worker ---")
+            logger.info(f"Identity: {hostname}")
+            logger.info(f"Listening on: {address}")
+            run_worker_loop_forever(address=address, ca="trust_all_connections")
 ---
 apiVersion: monarch.pytorch.org/v1alpha1
 kind: MonarchMesh
@@ -99,28 +100,29 @@ spec:
   port: 26600
 
   podTemplate:
-    containers:
-    - name: worker
-      image: ghcr.io/meta-pytorch/monarch:latest
-      command:
-        - python
-        - -u
-        - -c
-        - |
-          import os
-          import socket
-          import logging
-          from monarch.actor import run_worker_loop_forever
-          logging.basicConfig(level=logging.INFO)
-          logger = logging.getLogger("monarch-worker")
-          port = os.environ.get("MONARCH_PORT", "26600")
-          # Use FQDN for cross-pod DNS resolution
-          hostname = socket.getfqdn()
-          address = f"tcp://{hostname}:{port}"
-          logger.info(f"--- Starting Monarch Worker ---")
-          logger.info(f"Identity: {hostname}")
-          logger.info(f"Listening on: {address}")
-          run_worker_loop_forever(address=address, ca="trust_all_connections")
+    spec:
+      containers:
+      - name: worker
+        image: ghcr.io/meta-pytorch/monarch:latest
+        command:
+          - python
+          - -u
+          - -c
+          - |
+            import os
+            import socket
+            import logging
+            from monarch.actor import run_worker_loop_forever
+            logging.basicConfig(level=logging.INFO)
+            logger = logging.getLogger("monarch-worker")
+            port = os.environ.get("MONARCH_PORT", "26600")
+            # Use FQDN for cross-pod DNS resolution
+            hostname = socket.getfqdn()
+            address = f"tcp://{hostname}:{port}"
+            logger.info(f"--- Starting Monarch Worker ---")
+            logger.info(f"Identity: {hostname}")
+            logger.info(f"Listening on: {address}")
+            run_worker_loop_forever(address=address, ca="trust_all_connections")
 ---
 # Controller pod for running the hello_kubernetes_job script
 apiVersion: v1

--- a/examples/kubernetes/oci_kubernetes_job/deployment_files/controller.py
+++ b/examples/kubernetes/oci_kubernetes_job/deployment_files/controller.py
@@ -20,6 +20,7 @@ from kubernetes.client import (
     V1EnvVar,
     V1HostPathVolumeSource,
     V1PodSpec,
+    V1PodTemplateSpec,
     V1ResourceRequirements,
     V1SecurityContext,
     V1Volume,
@@ -51,10 +52,10 @@ with open(TRAIN_SCRIPT, "r") as _f:
     _TRAIN_SCRIPT_CONTENT = _f.read()
 
 
-def build_gpu_pod_spec(
+def build_gpu_pod_template(
     image: str, gpus_per_host: int, gpu_vendor: str, rdma: bool
-) -> V1PodSpec:
-    """Build a V1PodSpec for a MonarchMesh worker pod.
+) -> V1PodTemplateSpec:
+    """Build a V1PodTemplateSpec for a MonarchMesh worker pod.
 
     Without ``rdma``: GPU resources and shared memory for NCCL.
 
@@ -124,22 +125,24 @@ def build_gpu_pod_spec(
     else:
         gpu_resources = {f"{gpu_vendor}.com/gpu": str(gpus_per_host)}
 
-    return V1PodSpec(
-        containers=[
-            V1Container(
-                name="worker",
-                image=image,
-                command=["python", "-u", "-c", bootstrap],
-                env=env,
-                security_context=security_context,
-                resources=V1ResourceRequirements(
-                    limits=gpu_resources,
-                    requests=gpu_resources,
-                ),
-                volume_mounts=volume_mounts,
-            )
-        ],
-        volumes=volumes,
+    return V1PodTemplateSpec(
+        spec=V1PodSpec(
+            containers=[
+                V1Container(
+                    name="worker",
+                    image=image,
+                    command=["python", "-u", "-c", bootstrap],
+                    env=env,
+                    security_context=security_context,
+                    resources=V1ResourceRequirements(
+                        limits=gpu_resources,
+                        requests=gpu_resources,
+                    ),
+                    volume_mounts=volume_mounts,
+                )
+            ],
+            volumes=volumes,
+        ),
     )
 
 
@@ -180,7 +183,7 @@ async def main(
     # ~~~~~~~~~~~~~~~~~~~~~
     # Create a ``KubernetesJob`` in the ``monarch-tests`` namespace.
     # With ``--provision``, the job creates MonarchMesh CRDs via the K8s API
-    # using ``pod_spec`` for full control over the pod template (needed for
+    # using ``pod_template`` for full control over the pod template (needed for
     # the shared memory volume that NCCL requires). Without ``--provision``,
     # it attaches to pre-provisioned pods.
 
@@ -189,7 +192,7 @@ async def main(
         k8s_job.add_mesh(
             mesh_name,
             num_replicas=num_hosts,
-            pod_spec=build_gpu_pod_spec(image, gpus_per_host, gpu_vendor, rdma),
+            pod_template=build_gpu_pod_template(image, gpus_per_host, gpu_vendor, rdma),
         )
     else:
         k8s_job.add_mesh(mesh_name, num_replicas=num_hosts)

--- a/examples/rdma_pingpong/rdma_pingpong.py
+++ b/examples/rdma_pingpong/rdma_pingpong.py
@@ -145,6 +145,7 @@ def main(
             V1PodAffinityTerm,
             V1PodAntiAffinity,
             V1PodSpec,
+            V1PodTemplateSpec,
             V1ResourceRequirements,
         )
         from monarch._src.job.kubernetes import _WORKER_BOOTSTRAP_SCRIPT
@@ -160,40 +161,42 @@ def main(
         # required pod_affinity term keyed on your provider's fabric label
         # so the two replicas land on the same fabric. Without it, the example will fail.
         worker_resources = {"nvidia.com/gpu": "1", "rdma/ib": "1"}
-        pod_spec = V1PodSpec(
-            affinity=V1Affinity(
-                pod_anti_affinity=V1PodAntiAffinity(
-                    required_during_scheduling_ignored_during_execution=[
-                        V1PodAffinityTerm(
-                            topology_key="kubernetes.io/hostname",
-                            label_selector=V1LabelSelector(
-                                match_expressions=[
-                                    V1LabelSelectorRequirement(
-                                        key="monarch.pytorch.org/mesh-name",
-                                        operator="In",
-                                        values=["workers"],
-                                    ),
-                                ],
+        pod_template = V1PodTemplateSpec(
+            spec=V1PodSpec(
+                affinity=V1Affinity(
+                    pod_anti_affinity=V1PodAntiAffinity(
+                        required_during_scheduling_ignored_during_execution=[
+                            V1PodAffinityTerm(
+                                topology_key="kubernetes.io/hostname",
+                                label_selector=V1LabelSelector(
+                                    match_expressions=[
+                                        V1LabelSelectorRequirement(
+                                            key="monarch.pytorch.org/mesh-name",
+                                            operator="In",
+                                            values=["workers"],
+                                        ),
+                                    ],
+                                ),
                             ),
-                        ),
-                    ],
-                ),
-            ),
-            containers=[
-                V1Container(
-                    name="worker",
-                    image=k8s_image,
-                    command=["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
-                    env=[V1EnvVar(name="MONARCH_PORT", value="26600")],
-                    resources=V1ResourceRequirements(
-                        requests=worker_resources,
-                        limits=worker_resources,
+                        ],
                     ),
                 ),
-            ],
+                containers=[
+                    V1Container(
+                        name="worker",
+                        image=k8s_image,
+                        command=["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
+                        env=[V1EnvVar(name="MONARCH_PORT", value="26600")],
+                        resources=V1ResourceRequirements(
+                            requests=worker_resources,
+                            limits=worker_resources,
+                        ),
+                    ),
+                ],
+            ),
         )
         job = KubernetesJob(namespace=k8s_namespace)
-        job.add_mesh("workers", num_replicas=2, pod_spec=pod_spec)
+        job.add_mesh("workers", num_replicas=2, pod_template=pod_template)
     else:
         from monarch.job import SlurmJob
 

--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -85,15 +85,14 @@ class KubernetesJob(JobTrait):
 
     *Pre-provisioned* -- connect to pre-provisioned pods discovered via label
     selectors. Compatible with the MonarchMesh operator, third-party
-    schedulers, or manually created pods. Used when ``image_spec`` or ``pod_spec``
-    is not specified in ``add_mesh``.
+    schedulers, or manually created pods. Used when ``image_spec`` or
+    ``pod_template`` is not specified in ``add_mesh``.
 
     *Provisioning* -- create MonarchMesh CRDs via the K8s API so the
     pre-installed operator provisions StatefulSets and Services
-    automatically. Pass ``image_spec`` or ``pod_spec`` (a ``V1PodSpec``) to
-    ``add_mesh`` to enable provisioning for that
-    mesh. If the MonarchMesh CRD
-    already exists, it is patched instead
+    automatically. Pass ``image_spec`` or ``pod_template`` (a
+    ``V1PodTemplateSpec``) to ``add_mesh`` to enable provisioning for that
+    mesh. If the MonarchMesh CRD already exists, it is patched instead
     of created.
     """
 
@@ -124,14 +123,14 @@ class KubernetesJob(JobTrait):
         pod_rank_label: str = "apps.kubernetes.io/pod-index",
         image_spec: ImageSpec | None = None,
         port: int = _DEFAULT_MONARCH_PORT,
-        pod_spec: client.V1PodSpec | None = None,
+        pod_template: client.V1PodTemplateSpec | None = None,
         labels: dict[str, str] | None = None,
     ) -> None:
         """
         Add a mesh specification.
 
         In *attach-only* mode (default), meshes are discovered by label
-        selector. In *provisioning* mode (``image_spec`` or ``pod_spec``
+        selector. In *provisioning* mode (``image_spec`` or ``pod_template``
         supplied), a MonarchMesh CRD is created so the operator can
         provision the pods.
 
@@ -145,12 +144,12 @@ class KubernetesJob(JobTrait):
             label_selector: Custom label selector for pod discovery. Cannot be set when provisioning.
             pod_rank_label: Label key containing the pod rank. Cannot be customized when provisioning.
             image_spec: ``ImageSpec`` with container image and optional resources for simple provisioning.
-                   Mutually exclusive with ``pod_spec``.
+                   Mutually exclusive with ``pod_template``.
             port: Monarch worker port (default: 26600).
-            pod_spec: ``V1PodSpec`` for advanced provisioning (e.g. custom volumes, sidecars).
-                      Mutually exclusive with ``image_spec``.
+            pod_template: ``V1PodTemplateSpec`` for advanced provisioning (e.g. custom volumes, sidecars,
+                          pod-level labels/annotations). Mutually exclusive with ``image_spec``.
             labels: Optional labels to apply to the MonarchMesh CRD metadata.
-                    Only used when provisioning (``image_spec`` or ``pod_spec`` supplied).
+                    Only used when provisioning (``image_spec`` or ``pod_template`` supplied).
 
         Raises:
             ValueError: On invalid name or conflicting parameters.
@@ -174,10 +173,10 @@ class KubernetesJob(JobTrait):
                 f"Mesh name '{name}' is invalid. Name must end with an alphanumeric character."
             )
 
-        provisioned = image_spec is not None or pod_spec is not None
+        provisioned = image_spec is not None or pod_template is not None
 
-        if image_spec is not None and pod_spec is not None:
-            raise ValueError("'image_spec' and 'pod_spec' are mutually exclusive.")
+        if image_spec is not None and pod_template is not None:
+            raise ValueError("'image_spec' and 'pod_template' are mutually exclusive.")
         if provisioned and label_selector is not None:
             raise ValueError("'label_selector' cannot be customized when provisioning.")
         if provisioned and pod_rank_label != "apps.kubernetes.io/pod-index":
@@ -198,9 +197,11 @@ class KubernetesJob(JobTrait):
             mesh_entry["labels"] = labels
 
         if image_spec is not None:
-            mesh_entry["pod_spec"] = self._build_worker_pod_spec(image_spec, port)
-        elif pod_spec is not None:
-            mesh_entry["pod_spec"] = pod_spec
+            mesh_entry["pod_template"] = self._build_worker_pod_template(
+                image_spec, port
+            )
+        elif pod_template is not None:
+            mesh_entry["pod_template"] = pod_template
 
         self._meshes[name] = mesh_entry
 
@@ -238,8 +239,8 @@ class KubernetesJob(JobTrait):
         api_client = client.ApiClient()
 
         for mesh_name, mesh_config in provisioned.items():
-            pod_spec_dict = api_client.sanitize_for_serialization(
-                mesh_config["pod_spec"]
+            pod_template_dict = api_client.sanitize_for_serialization(
+                mesh_config["pod_template"]
             )
             metadata: Dict[str, Any] = {
                 "name": mesh_name,
@@ -255,7 +256,7 @@ class KubernetesJob(JobTrait):
                 "spec": {
                     "replicas": mesh_config["num_replicas"],
                     "port": mesh_config["port"],
-                    "podTemplate": pod_spec_dict,
+                    "podTemplate": pod_template_dict,
                 },
             }
 
@@ -284,14 +285,14 @@ class KubernetesJob(JobTrait):
                     raise
 
     @staticmethod
-    def _build_worker_pod_spec(
+    def _build_worker_pod_template(
         image_spec: ImageSpec,
         port: int,
-    ) -> client.V1PodSpec:
+    ) -> client.V1PodTemplateSpec:
         """
-        Build a V1PodSpec for the MonarchMesh CRD.
+        Build a V1PodTemplateSpec for the MonarchMesh CRD.
 
-        Generates a single-container pod spec with a worker bootstrap
+        Generates a single-container pod template with a worker bootstrap
         script that starts ``run_worker_loop_forever``.
 
         Args:
@@ -299,7 +300,7 @@ class KubernetesJob(JobTrait):
             port: Monarch worker port.
 
         Returns:
-            V1PodSpec suitable for the ``podTemplate`` CRD field.
+            V1PodTemplateSpec suitable for the ``podTemplate`` CRD field.
         """
         resources = None
         if image_spec.resources is not None:
@@ -315,7 +316,9 @@ class KubernetesJob(JobTrait):
             env=[client.V1EnvVar(name="MONARCH_PORT", value=str(port))],
             resources=resources,
         )
-        return client.V1PodSpec(containers=[container])
+        return client.V1PodTemplateSpec(
+            spec=client.V1PodSpec(containers=[container]),
+        )
 
     def _is_pod_worker_ready(self, pod: client.V1Pod) -> bool:
         """

--- a/python/tests/_src/job/test_kubernetes.py
+++ b/python/tests/_src/job/test_kubernetes.py
@@ -18,6 +18,7 @@ from kubernetes.client import (
     V1PodCondition,
     V1PodSpec,
     V1PodStatus,
+    V1PodTemplateSpec,
 )
 from kubernetes.client.rest import ApiException
 from monarch._src.job.kubernetes import (
@@ -153,33 +154,33 @@ class TestAddMesh(unittest.TestCase):
         job = self._make_job()
         job.add_mesh("workers", num_replicas=2, image_spec=ImageSpec("myimage:latest"))
         self.assertTrue(job._meshes["workers"]["provisioned"])
-        self.assertIn("pod_spec", job._meshes["workers"])
+        self.assertIn("pod_template", job._meshes["workers"])
 
-    def test_pod_spec_marks_provisioned(self) -> None:
+    def test_pod_template_marks_provisioned(self) -> None:
         job = self._make_job()
-        spec = V1PodSpec(
-            containers=[V1Container(name="w", image="img")],
+        template = V1PodTemplateSpec(
+            spec=V1PodSpec(containers=[V1Container(name="w", image="img")]),
         )
-        job.add_mesh("workers", num_replicas=1, pod_spec=spec)
+        job.add_mesh("workers", num_replicas=1, pod_template=template)
         self.assertTrue(job._meshes["workers"]["provisioned"])
-        self.assertEqual(job._meshes["workers"]["pod_spec"], spec)
+        self.assertEqual(job._meshes["workers"]["pod_template"], template)
 
     def test_attach_only_not_provisioned(self) -> None:
         job = self._make_job()
         job.add_mesh("workers", num_replicas=1)
         self.assertFalse(job._meshes["workers"]["provisioned"])
-        self.assertNotIn("pod_spec", job._meshes["workers"])
+        self.assertNotIn("pod_template", job._meshes["workers"])
 
-    def test_image_and_pod_spec_mutually_exclusive(self) -> None:
+    def test_image_and_pod_template_mutually_exclusive(self) -> None:
         job = self._make_job()
         with self.assertRaises(
-            ValueError, msg="image and pod_sepc are mutually exclusive"
+            ValueError, msg="image and pod_template are mutually exclusive"
         ):
             job.add_mesh(
                 "workers",
                 num_replicas=1,
                 image_spec=ImageSpec("img"),
-                pod_spec=V1PodSpec(containers=[]),
+                pod_template=V1PodTemplateSpec(spec=V1PodSpec(containers=[])),
             )
 
     def test_label_selector_forbidden_with_provisioning(self) -> None:
@@ -275,18 +276,20 @@ class TestCreate(unittest.TestCase):
         mock_api = MagicMock()
         mock_custom_api_cls.return_value = mock_api
 
-        # ApiClient.sanitize_for_serialization converts V1PodSpec to dict
+        # ApiClient.sanitize_for_serialization converts V1PodTemplateSpec to dict
         mock_api_client = MagicMock()
         mock_api_client_cls.return_value = mock_api_client
         mock_api_client.sanitize_for_serialization.return_value = {
-            "containers": [
-                {
-                    "name": "worker",
-                    "image": "myimage:latest",
-                    "command": ["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
-                    "env": [{"name": "MONARCH_PORT", "value": "9999"}],
-                }
-            ]
+            "spec": {
+                "containers": [
+                    {
+                        "name": "worker",
+                        "image": "myimage:latest",
+                        "command": ["python", "-u", "-c", _WORKER_BOOTSTRAP_SCRIPT],
+                        "env": [{"name": "MONARCH_PORT", "value": "9999"}],
+                    }
+                ]
+            }
         }
 
         job._create(None)
@@ -301,7 +304,8 @@ class TestCreate(unittest.TestCase):
         self.assertEqual(body["metadata"]["name"], "workers")
         self.assertEqual(body["spec"]["replicas"], 3)
         self.assertEqual(
-            body["spec"]["podTemplate"]["containers"][0]["image"], "myimage:latest"
+            body["spec"]["podTemplate"]["spec"]["containers"][0]["image"],
+            "myimage:latest",
         )
         self.assertEqual(body["spec"]["port"], 9999)
 
@@ -396,6 +400,36 @@ class TestCreate(unittest.TestCase):
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertEqual(body["metadata"]["name"], "provisioned")
 
+    @patch("monarch._src.job.kubernetes.client.CustomObjectsApi")
+    @patch("monarch._src.job.kubernetes.config.load_incluster_config")
+    def test_create_preserves_pod_template_metadata(
+        self,
+        mock_load_config: MagicMock,
+        mock_custom_api_cls: MagicMock,
+    ) -> None:
+        """Pod-level labels/annotations on ``pod_template`` reach the CRD body."""
+        job = self._make_job()
+        pod_template = V1PodTemplateSpec(
+            metadata=V1ObjectMeta(
+                labels={"pod-label": "pod-value"},
+                annotations={"pod-annotation": "ann-value"},
+            ),
+            spec=V1PodSpec(containers=[V1Container(name="worker", image="img")]),
+        )
+        job.add_mesh("workers", num_replicas=1, pod_template=pod_template)
+
+        mock_api = MagicMock()
+        mock_custom_api_cls.return_value = mock_api
+
+        job._create(None)
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        template_metadata = body["spec"]["podTemplate"]["metadata"]
+        self.assertEqual(template_metadata["labels"], {"pod-label": "pod-value"})
+        self.assertEqual(
+            template_metadata["annotations"], {"pod-annotation": "ann-value"}
+        )
+
     def test_create_noop_when_all_attach_only(self) -> None:
         """No K8s API calls when no meshes are provisioned."""
         job = self._make_job()
@@ -417,15 +451,15 @@ class TestCreate(unittest.TestCase):
             job._create(None)
 
 
-class TestBuildWorkerPodSpec(unittest.TestCase):
-    """Tests for KubernetesJob._build_worker_pod_spec."""
+class TestBuildWorkerPodTemplate(unittest.TestCase):
+    """Tests for KubernetesJob._build_worker_pod_template."""
 
-    def test_basic_pod_spec(self) -> None:
-        spec = KubernetesJob._build_worker_pod_spec(
+    def test_basic_pod_template(self) -> None:
+        template = KubernetesJob._build_worker_pod_template(
             ImageSpec("myimage:latest"), port=26600
         )
-        self.assertEqual(len(spec.containers), 1)
-        container = spec.containers[0]
+        self.assertEqual(len(template.spec.containers), 1)
+        container = template.spec.containers[0]
         self.assertEqual(container.name, "worker")
         self.assertEqual(container.image, "myimage:latest")
         self.assertEqual(
@@ -437,18 +471,18 @@ class TestBuildWorkerPodSpec(unittest.TestCase):
         self.assertIsNone(container.resources)
 
     def test_custom_port_in_env(self) -> None:
-        spec = KubernetesJob._build_worker_pod_spec(ImageSpec("img"), port=9999)
-        self.assertEqual(spec.containers[0].env[0].value, "9999")
+        template = KubernetesJob._build_worker_pod_template(ImageSpec("img"), port=9999)
+        self.assertEqual(template.spec.containers[0].env[0].value, "9999")
 
     def test_resources_set(self) -> None:
-        spec = KubernetesJob._build_worker_pod_spec(
+        template = KubernetesJob._build_worker_pod_template(
             ImageSpec(
                 "img",
                 resources={"cpu": "4", "memory": "8Gi", "nvidia.com/gpu": 2},
             ),
             port=26600,
         )
-        container = spec.containers[0]
+        container = template.spec.containers[0]
         expected = {"cpu": "4", "memory": "8Gi", "nvidia.com/gpu": "2"}
         self.assertEqual(container.resources.requests, expected)
         self.assertEqual(container.resources.limits, expected)


### PR DESCRIPTION
Summary:

Use PodTemplateSpec with the update of v0.2.0 of monarch-operator.

also, change `KuberntesJob::add_mesh` to use PodTemplateSpec directly

Reviewed By: dulinriley

Differential Revision: D105086117


