### PR TITLE
[hyperactor] remove InstanceSlot from Proc instances

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -451,7 +451,7 @@ struct ProcState {
     reserved_child_uids: DashSet<crate::id::Uid>,
 
     /// All actor instances in this proc.
-    instances: DashMap<ActorId, InstanceSlot>,
+    instances: DashMap<ActorId, WeakInstanceCell>,
 
     /// Proc-level queue-pressure accounting (PD-6 through PD-9).
     /// Runtime-driven — updated from `account_enqueue` /
@@ -478,13 +478,6 @@ struct ProcState {
     /// gracefully stop the server and join it (flushing receive-side
     /// acks) during shutdown.
     mailbox_server_handle: std::sync::Mutex<Option<crate::mailbox::MailboxServerHandle>>,
-}
-
-// Stores the instance along with its addr.
-// This is temporary until we have gateways.
-struct InstanceSlot {
-    actor_addr: ActorAddr,
-    cell: WeakInstanceCell,
 }
 
 struct TerminatedSnapshot {
@@ -1094,8 +1087,8 @@ impl Proc {
         F: FnMut(&InstanceCell, usize),
     {
         for entry in self.state().instances.iter() {
-            if entry.value().actor_addr.is_root() {
-                if let Some(cell) = entry.value().cell.upgrade() {
+            if entry.key().uid().is_singleton() {
+                if let Some(cell) = entry.value().upgrade() {
                     cell.traverse(f);
                 }
             }
@@ -1119,10 +1112,15 @@ impl Proc {
 
     /// Look up an instance by ActorAddr.
     pub fn get_instance(&self, actor_id: &ActorAddr) -> Option<InstanceCell> {
+        self.get_instance_by_id(actor_id.id())
+    }
+
+    /// Look up an instance by ActorId.
+    pub fn get_instance_by_id(&self, actor_id: &ActorId) -> Option<InstanceCell> {
         self.state()
             .instances
-            .get(actor_id.id())
-            .and_then(|slot| slot.cell.upgrade())
+            .get(actor_id)
+            .and_then(|cell| cell.upgrade())
     }
 
     /// Returns the ActorAddrs of all root actors in this proc.
@@ -1137,9 +1135,14 @@ impl Proc {
         self.state()
             .instances
             .iter()
-            .filter_map(|slot| {
-                let actor_addr = &slot.value().actor_addr;
-                actor_addr.is_root().then(|| actor_addr.clone())
+            .filter_map(|entry| {
+                entry
+                    .key()
+                    .uid()
+                    .is_singleton()
+                    .then(|| entry.value().upgrade())
+                    .flatten()
+                    .map(|cell| cell.actor_addr().clone())
             })
             .collect()
     }
@@ -1156,33 +1159,28 @@ impl Proc {
         self.state()
             .instances
             .iter()
-            .filter(|entry| {
-                entry
-                    .value()
-                    .cell
-                    .upgrade()
-                    .is_some_and(|cell| !cell.status().borrow().is_terminal())
+            .filter_map(|entry| {
+                let cell = entry.value().upgrade()?;
+                (!cell.status().borrow().is_terminal()).then(|| cell.actor_addr().clone())
             })
-            .map(|entry| entry.value().actor_addr.clone())
             .collect()
     }
 
-    /// Snapshot all instance keys from the DashMap without inspecting
+    /// Snapshot all instance ids from the DashMap without inspecting
     /// values. Each shard read lock is held only long enough to clone
-    /// the key — no `Weak::upgrade()`, no `watch::borrow()`, no
+    /// the id — no `Weak::upgrade()`, no `watch::borrow()`, no
     /// `is_terminal()` check. This minimises shard lock hold time to
     /// avoid convoy starvation with concurrent `insert`/`remove`
     /// operations during rapid actor churn.
     ///
-    /// The returned list may include actors that are terminal or
-    /// whose `WeakInstanceCell` no longer upgrades. Callers should
-    /// tolerate stale entries (e.g. by handling "not found" on
-    /// subsequent per-actor lookups).
-    pub fn all_instance_keys(&self) -> Vec<ActorAddr> {
+    /// The returned list may include actors that are terminal or whose
+    /// `WeakInstanceCell` no longer upgrades. Callers should tolerate stale
+    /// ids (e.g. by handling "not found" on subsequent per-actor lookups).
+    pub fn all_instance_keys(&self) -> Vec<ActorId> {
         self.state()
             .instances
             .iter()
-            .map(|entry| entry.value().actor_addr.clone())
+            .map(|entry| entry.key().clone())
             .collect()
     }
 
@@ -1275,7 +1273,7 @@ impl Proc {
             .instances
             .get(root)
             .into_iter()
-            .flat_map(|entry| entry.cell.upgrade())
+            .flat_map(|entry| entry.value().upgrade())
             .map(|cell| {
                 let actor_addr = cell.actor_addr().clone();
                 let r1 = actor_addr.clone();
@@ -1322,7 +1320,7 @@ impl Proc {
                 tracing::error!(subject = %self.proc_addr().subject(), "no actor {} found", actor_id);
                 return None;
             }
-            Some(entry) => entry.value().cell.upgrade(),
+            Some(entry) => entry.value().upgrade(),
         }; // entry (shard read lock) dropped here
         match cell {
             None => None, // the actor's cell has been dropped
@@ -1394,8 +1392,9 @@ impl Proc {
             .state()
             .instances
             .iter()
-            .filter(|entry| entry.value().actor_addr.is_root())
-            .map(|entry| entry.value().actor_addr.clone())
+            .filter(|entry| entry.key().uid().is_singleton())
+            .filter_map(|entry| entry.value().upgrade())
+            .map(|cell| cell.actor_addr().clone())
             .collect::<Vec<_>>()
         {
             if coordinator_id.as_ref() == Some(&actor_id) {
@@ -1536,7 +1535,6 @@ impl Proc {
             .inner
             .instances
             .get(actor_ref.actor_addr().id())?
-            .cell
             .upgrade()?;
         // An actor whose status is terminal has stopped processing
         // messages even if its InstanceCell Arc is still alive (e.g.
@@ -3213,13 +3211,9 @@ impl InstanceCell {
             }),
         };
         cell.maybe_link_parent();
-        proc.inner.instances.insert(
-            actor_id.id().clone(),
-            InstanceSlot {
-                actor_addr: actor_id,
-                cell: cell.downgrade(),
-            },
-        );
+        proc.inner
+            .instances
+            .insert(actor_id.id().clone(), cell.downgrade());
         cell
     }
 
@@ -5782,7 +5776,7 @@ mod tests {
             let mut total: u64 = 0;
             let mut max: u64 = 0;
             for actor_id in proc.all_instance_keys() {
-                if let Some(cell) = proc.get_instance(&actor_id) {
+                if let Some(cell) = proc.get_instance_by_id(&actor_id) {
                     let depth = cell.queue_depth();
                     total = total.saturating_add(depth);
                     max = max.max(depth);

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -542,20 +542,24 @@ impl Actor for HostAgent {
                     // all_actor_ids() causes convoy starvation with
                     // concurrent insert/remove operations, stalling
                     // the spawn/exit path. all_instance_keys() just
-                    // clones keys — microseconds per shard. The
-                    // is_system check uses individual point lookups
-                    // outside the iteration. Stale keys (terminal
-                    // actors) may appear but are harmless — the TUI
-                    // handles "not found" gracefully.
+                    // clones keys — microseconds per shard. Actor
+                    // addresses and the is_system check use individual
+                    // point lookups outside the iteration. Stale keys
+                    // are harmless: if the point lookup fails, the actor
+                    // has already gone away.
                     let all_keys = proc.all_instance_keys();
                     let mut actors: Vec<hyperactor::introspect::IntrospectRef> =
                         Vec::with_capacity(all_keys.len());
                     let mut system_actors: Vec<crate::introspect::NodeRef> = Vec::new();
                     for id in all_keys {
-                        if proc.get_instance(&id).is_some_and(|cell| cell.is_system()) {
-                            system_actors.push(crate::introspect::NodeRef::Actor(id.clone()));
+                        if let Some(cell) = proc.get_instance_by_id(&id) {
+                            let actor_addr = cell.actor_addr().clone();
+                            if cell.is_system() {
+                                system_actors
+                                    .push(crate::introspect::NodeRef::Actor(actor_addr.clone()));
+                            }
+                            actors.push(hyperactor::introspect::IntrospectRef::Actor(actor_addr));
                         }
-                        actors.push(hyperactor::introspect::IntrospectRef::Actor(id));
                     }
                     let mut attrs = hyperactor_config::Attrs::new();
                     attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
@@ -574,7 +578,7 @@ impl Actor for HostAgent {
                     // Per-actor max from the live actor scan.
                     let mut queue_max: u64 = 0;
                     for aid in proc.all_instance_keys() {
-                        if let Some(cell) = proc.get_instance(&aid) {
+                        if let Some(cell) = proc.get_instance_by_id(&aid) {
                             queue_max = queue_max.max(cell.queue_depth());
                         }
                     }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -128,11 +128,12 @@ fn collect_live_children(
     let mut children = Vec::with_capacity(all_keys.len());
     let mut system_children = Vec::new();
     for id in all_keys {
-        if let Some(cell) = proc.get_instance(&id) {
+        if let Some(cell) = proc.get_instance_by_id(&id) {
+            let actor_addr = cell.actor_addr().clone();
             if cell.is_system() {
-                system_children.push(crate::introspect::NodeRef::Actor(id.clone()));
+                system_children.push(crate::introspect::NodeRef::Actor(actor_addr.clone()));
             }
-            children.push(hyperactor::introspect::IntrospectRef::Actor(id));
+            children.push(hyperactor::introspect::IntrospectRef::Actor(actor_addr));
         }
     }
     (children, system_children)
@@ -477,7 +478,7 @@ impl ProcAgent {
         // Per-actor max still needs the per-actor scan (PD-4: live actors only).
         let mut queue_max: u64 = 0;
         for actor_id in self.proc.all_instance_keys() {
-            if let Some(cell) = self.proc.get_instance(&actor_id) {
+            if let Some(cell) = self.proc.get_instance_by_id(&actor_id) {
                 queue_max = queue_max.max(cell.queue_depth());
             }
         }
@@ -602,7 +603,7 @@ impl Actor for ProcAgent {
                     );
                     let mut queue_max: u64 = 0;
                     for aid in proc.all_instance_keys() {
-                        if let Some(cell) = proc.get_instance(&aid) {
+                        if let Some(cell) = proc.get_instance_by_id(&aid) {
                             queue_max = queue_max.max(cell.queue_depth());
                         }
                     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3879
* #3888
* #3878
* #3877
* #3876
* #3875
* __->__ #3873
* #3887

Store weak instance cells directly in the proc instance map instead of wrapping them in InstanceSlot with a cached ActorAddr. The instance cell already owns the authoritative actor address, and the cheap scan path now returns ActorIds directly so introspection can clone keys without upgrading cells during DashMap iteration. Update the mesh introspection callers to perform point lookups when they need live actor addresses or system flags. Also update newly landed Proc::local test call sites to Proc::isolated.

Differential Revision: [D105100126](https://our.internmc.facebook.com/intern/diff/D105100126/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105100126/)!