### PR TITLE
[hyperactor] hide mailbox forwarder constructor

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1382,9 +1382,8 @@ pub struct Mailbox {
 }
 
 impl Mailbox {
-    /// Create a new mailbox associated with the provided actor ID, using the provided
-    /// forwarder for external destinations.
-    pub fn new(actor_id: impl Into<ActorAddr>, forwarder: BoxedMailboxSender) -> Self {
+    /// Create a runtime-owned mailbox associated with the provided actor ID.
+    pub(crate) fn new(actor_id: impl Into<ActorAddr>, forwarder: BoxedMailboxSender) -> Self {
         Self {
             inner: Arc::new(State::new(actor_id.into(), forwarder)),
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3879
* #3888
* #3878
* #3877
* __->__ #3876
* #3875
* #3873
* #3887

Make the forwarder-taking Mailbox constructor crate-internal so external callers cannot create mailboxes with independent forwarding policy. Production mailbox construction remains owned by Proc while we keep the temporary WeakProc fallback internally.

Differential Revision: [D105177459](https://our.internmc.facebook.com/intern/diff/D105177459/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105177459/)!