### PR TITLE
[hyperactor] remove mailbox forwarders

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -113,7 +113,6 @@ use std::ops::Bound::Excluded;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Condvar;
-use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::RwLock;
 use std::sync::Weak;
@@ -916,9 +915,6 @@ impl MailboxSender for UndeliverableMailboxSender {
     }
 }
 
-static BOXED_PANICKING_MAILBOX_SENDER: LazyLock<BoxedMailboxSender> =
-    LazyLock::new(|| BoxedMailboxSender::new(PanickingMailboxSender));
-
 /// Convenience boxing implementation for MailboxSender. Most APIs
 /// are parameterized on MailboxSender implementations, and it's thus
 /// difficult to work with dyn values.  BoxedMailboxSender bridges this
@@ -1383,19 +1379,16 @@ pub struct Mailbox {
 
 impl Mailbox {
     /// Create a runtime-owned mailbox associated with the provided actor ID.
-    pub(crate) fn new(actor_id: impl Into<ActorAddr>, forwarder: BoxedMailboxSender) -> Self {
+    pub(crate) fn new(actor_id: impl Into<ActorAddr>) -> Self {
         Self {
-            inner: Arc::new(State::new(actor_id.into(), forwarder)),
+            inner: Arc::new(State::new(actor_id.into())),
         }
     }
 
     /// Create a new detached mailbox associated with the provided actor ID.
     pub fn new_detached(actor_id: impl Into<ActorAddr>) -> Self {
         Self {
-            inner: Arc::new(State::new(
-                actor_id.into(),
-                BOXED_PANICKING_MAILBOX_SENDER.clone(),
-            )),
+            inner: Arc::new(State::new(actor_id.into())),
         }
     }
 
@@ -1772,7 +1765,12 @@ impl MailboxSender for Mailbox {
         );
 
         if envelope.dest().actor_id() != self.inner.actor_id.id() {
-            return self.inner.forwarder.post(envelope, return_handle);
+            let err = DeliveryError::Mailbox(format!(
+                "mailbox owner {} cannot deliver to {}",
+                self.inner.actor_id,
+                envelope.dest().actor_addr()
+            ));
+            return envelope.undeliverable(err, return_handle);
         }
 
         let port_index = envelope.dest().index();
@@ -2753,9 +2751,6 @@ struct State {
     /// The next port ID to allocate.
     next_port: AtomicU64,
 
-    /// The forwarder for this mailbox.
-    forwarder: BoxedMailboxSender,
-
     /// If a value is present, the mailbox has been closed with the provided
     /// status, and any subsequent `Mailbox::post_unchecked` calls will fail.
     closed: RwLock<Option<ActorStatus>>,
@@ -2766,14 +2761,13 @@ struct State {
 
 impl State {
     /// Create a new state with the provided owning ActorAddr.
-    fn new(actor_id: ActorAddr, forwarder: BoxedMailboxSender) -> Self {
+    fn new(actor_id: ActorAddr) -> Self {
         Self {
             actor_id,
             ports: DashMap::new(),
             // The first 1024 ports are allocated to actor handlers.
             // Other port IDs are ephemeral.
             next_port: AtomicU64::new(USER_PORT_OFFSET),
-            forwarder,
             closed: RwLock::new(None),
             handler_ingress: Arc::new(HandlerIngressGate::new()),
         }
@@ -3357,6 +3351,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mailbox_rejects_messages_for_other_actors() {
+        let mbox = Mailbox::new_detached(test_actor_id("0", "owner"));
+        let dest = test_actor_id("0", "other").port_addr(Port::from(1234));
+        let envelope =
+            MessageEnvelope::serialize(mbox.actor_addr().clone(), dest, &42u64, Flattrs::new())
+                .expect("serialize");
+        let (return_handle, mut return_rx) = undeliverable::new_undeliverable_port();
+
+        mbox.post(envelope, return_handle);
+
+        let Undeliverable(undelivered) =
+            tokio::time::timeout(Duration::from_secs(1), return_rx.recv())
+                .await
+                .expect("timed out waiting for undeliverable")
+                .expect("return port closed");
+        assert!(
+            undelivered
+                .error_msg()
+                .expect("expected error")
+                .contains("cannot deliver to")
+        );
+    }
+
+    #[tokio::test]
     async fn test_mailbox_accum() {
         let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
@@ -3908,7 +3926,7 @@ mod tests {
         use crate::testing::proc_supervison::ProcSupervisionCoordinator;
 
         let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
-            BOXED_PANICKING_MAILBOX_SENDER.clone(),
+            BoxedMailboxSender::new(PanickingMailboxSender),
         ));
         let proc_id = test_proc_id("quux_0");
         let mut proc = Proc::configured(proc_id.clone(), proc_forwarder);
@@ -3999,10 +4017,7 @@ mod tests {
             // Create dummy state and port_id to create PortReceiver. They are
             // not used in the test.
             let dummy_actor_ref: ActorAddr = test_actor_id("world_0", "actor");
-            let dummy_state = State::new(
-                dummy_actor_ref.clone(),
-                BOXED_PANICKING_MAILBOX_SENDER.clone(),
-            );
+            let dummy_state = State::new(dummy_actor_ref.clone());
             let dummy_port_id = dummy_actor_ref.port_addr(Port::from(0));
             let (sender, receiver) = mpsc::unbounded_channel::<M>();
             let receiver = PortReceiver {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -946,7 +946,7 @@ impl Proc {
 
     /// Bind a mailbox to the proc.
     fn bind_mailbox(&self, actor_id: ActorAddr) -> Mailbox {
-        let mbox = Mailbox::new(actor_id, BoxedMailboxSender::new(self.downgrade()));
+        let mbox = Mailbox::new(actor_id);
 
         // TODO: T210748165 tie the muxer entry to the lifecycle of the mailbox held
         // by the caller. This will likely require a weak reference.
@@ -1888,7 +1888,7 @@ impl<A: Actor> Instance<A> {
         parent: Option<InstanceCell>,
     ) -> (Self, InstanceReceivers<A>) {
         // Set up messaging
-        let mailbox = Mailbox::new(actor_id.clone(), BoxedMailboxSender::new(proc.downgrade()));
+        let mailbox = Mailbox::new(actor_id.clone());
         let (work_tx, work_rx) = ordered_channel(
             actor_id.to_string(),
             hyperactor_config::global::get(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3879
* #3888
* __->__ #3878
* #3877
* #3876
* #3875
* #3873
* #3887

Remove forwarding policy from Mailbox state. Runtime mailboxes are now pure actor-local port tables, and proc-owned mailbox construction no longer injects WeakProc as a mailbox fallback. Directly posting an envelope for another actor to a mailbox now returns an undeliverable mailbox error instead of forwarding.

Differential Revision: [D105177457](https://our.internmc.facebook.com/intern/diff/D105177457/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105177457/)!