### PR TITLE
[hyperactor] consolidate mailbox constructors

### DIFF
--- a/docs/source/books/hyperactor-book/src/mailboxes/mailbox.md
+++ b/docs/source/books/hyperactor-book/src/mailboxes/mailbox.md
@@ -2,7 +2,7 @@
 
 A `Mailbox` represents an actor's in-process inbox. It owns and manages all of the actor's ports, provides APIs to open and bind them, and routes messages based on their destination `PortId`.
 
-A mailbox routes local messages directly to its ports. If a message is addressed to a different actor, the mailbox uses its configured forwarder to relay the message. If the message cannot be delivered-for instance, if the destination port is unbound-the mailbox wraps it as undeliverable and returns it via the supplied handle.
+A mailbox routes messages for its actor directly to its ports. If a message is addressed to a different actor, the mailbox treats it as undeliverable; cross-actor and cross-proc routing happens through `Proc` and `Gateway`.
 
 This section covers:
 
@@ -10,30 +10,21 @@ This section covers:
 - Port binding and registration
 - Internal mailbox state and delivery logic
 
-The `State` holds all delivery infrastructure: active ports, the actor's ID, a port allocator, and a forwarding mechanism. Multiple clones of a `Mailbox` share access to the same state:
+The `State` holds the actor's ID, active ports, and a port allocator. Multiple clones of a `Mailbox` share access to the same state:
 ```rust
 pub struct Mailbox {
     state: Arc<State>,
 }
 ```
-The `new` function creates a mailbox with the provided actor ID and forwarder for external destinations:
+The `new` function creates a mailbox with the provided actor ID:
 ```rust
 impl Mailbox {
-    pub fn new(actor_id: ActorId, forwarder: BoxedMailboxSender) -> Self {
+    pub fn new(actor_id: ActorId) -> Self {
         Self {
-            state: Arc::new(State::new(actor_id, forwarder)),
+            state: Arc::new(State::new(actor_id)),
         }
     }
 }
-```
-`new_detached` mailboxes are not connected to an external message forwarder and can only deliver to its own ports:
-```rust
-impl Mailbox {
-    pub fn new_detached(actor_id: ActorId) -> Self {
-        Self {
-            state: Arc::new(State::new(actor_id, BOXED_PANICKING_MAILBOX_SENDER.clone())),
-        }
-    }
 ```
 
 A mailbox can open ports, each identified by a unique `PortId` within the owning actor. The most common form is `open_port`, which creates a fresh, unbounded channel for message delivery:

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -249,7 +249,7 @@ fn bench_mailbox_message_sizes(c: &mut Criterion) {
             let mut b = b.to_async(Runtime::new().unwrap());
             b.iter_custom(|iters| async move {
                 let actor_id = test_actor_id("world_0", "actor");
-                let mbox = Mailbox::new_detached(actor_id);
+                let mbox = Mailbox::new(actor_id);
                 let (port, mut receiver) = mbox.open_port::<Message>();
                 let port = port.bind();
 
@@ -279,7 +279,7 @@ fn bench_mailbox_message_rates(c: &mut Criterion) {
             let mut b = b.to_async(Runtime::new().unwrap());
             b.iter_custom(|iters| async move {
                 let actor_id = test_actor_id("world_0", "actor");
-                let mbox = Mailbox::new_detached(actor_id);
+                let mbox = Mailbox::new(actor_id);
                 let (port, mut receiver) = mbox.open_port::<Message>();
                 let port = port.bind();
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -23,7 +23,7 @@
 //! # let proc = Proc::isolated();
 //! # let (client, _) = proc.instance("client").unwrap();
 //! # let actor_id = proc.proc_addr().actor_addr("actor");
-//! let mbox = Mailbox::new_detached(actor_id);
+//! let mbox = Mailbox::new(actor_id);
 //! let (port, mut receiver) = mbox.open_port::<u64>();
 //!
 //! port.send(&client, 123).unwrap();
@@ -42,7 +42,7 @@
 //! # let proc = Proc::isolated();
 //! # let (client, _) = proc.instance("client").unwrap();
 //! # let actor_id = proc.proc_addr().actor_addr("actor");
-//! let mbox = Mailbox::new_detached(actor_id);
+//! let mbox = Mailbox::new(actor_id);
 //!
 //! let (port, receiver) = mbox.open_once_port::<u64>();
 //!
@@ -1378,15 +1378,8 @@ pub struct Mailbox {
 }
 
 impl Mailbox {
-    /// Create a runtime-owned mailbox associated with the provided actor ID.
-    pub(crate) fn new(actor_id: impl Into<ActorAddr>) -> Self {
-        Self {
-            inner: Arc::new(State::new(actor_id.into())),
-        }
-    }
-
-    /// Create a new detached mailbox associated with the provided actor ID.
-    pub fn new_detached(actor_id: impl Into<ActorAddr>) -> Self {
+    /// Create a mailbox associated with the provided actor ID.
+    pub fn new(actor_id: impl Into<ActorAddr>) -> Self {
         Self {
             inner: Arc::new(State::new(actor_id.into())),
         }
@@ -3331,7 +3324,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_basic() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         let (port, mut receiver) = mbox.open_port::<u64>();
         let port = port.bind();
 
@@ -3352,7 +3345,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_rejects_messages_for_other_actors() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "owner"));
+        let mbox = Mailbox::new(test_actor_id("0", "owner"));
         let dest = test_actor_id("0", "other").port_addr(Port::from(1234));
         let envelope =
             MessageEnvelope::serialize(mbox.actor_addr().clone(), dest, &42u64, Flattrs::new())
@@ -3410,7 +3403,7 @@ mod tests {
 
     #[test]
     fn test_port_and_reducer() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         // accum port could have reducer typehash
         {
             let accumulator = accum::join_semilattice::<accum::Max<u64>>();
@@ -3457,7 +3450,7 @@ mod tests {
     #[tokio::test]
     #[ignore] // changed error behavior
     async fn test_mailbox_receiver_drop() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         let (port, mut receiver) = mbox.open_port::<u64>();
         // Make sure we go through "remote" path.
         let port = port.bind();
@@ -3475,7 +3468,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_type_mismatch_does_not_evict_unbounded_port() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         let (port, mut receiver) = mbox.open_port::<u64>();
         let port = port.bind();
         let port_index = port.port_addr().index();
@@ -3517,7 +3510,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_closed_unbounded_port_is_removed_after_send_failure() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         let port_index = mbox.allocate_port();
         let port_id = mbox.actor_addr().port_addr(Port::from(port_index));
         let port = crate::PortRef::attest(port_id.clone());
@@ -3569,7 +3562,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_once_type_mismatch_preserves_sender_until_delivery() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         let (port, receiver) = mbox.open_once_port::<u64>();
         let port = port.bind();
         let port_index = port.port_addr().index();
@@ -3615,7 +3608,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_drain() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
 
         let (port, mut receiver) = mbox.open_port();
         let port = port.bind();
@@ -3636,8 +3629,8 @@ mod tests {
     async fn test_mailbox_muxer() {
         let muxer = MailboxMuxer::new();
 
-        let mbox0 = Mailbox::new_detached(test_actor_id("0", "actor1"));
-        let mbox1 = Mailbox::new_detached(test_actor_id("0", "actor2"));
+        let mbox0 = Mailbox::new(test_actor_id("0", "actor1"));
+        let mbox1 = Mailbox::new(test_actor_id("0", "actor2"));
 
         muxer.bind(mbox0.actor_addr().id().clone(), mbox0.clone());
         muxer.bind(mbox1.actor_addr().id().clone(), mbox1.clone());
@@ -3663,7 +3656,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_local_client_server() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "actor0"));
+        let mbox = Mailbox::new(test_actor_id("0", "actor0"));
         let (tx, rx) = channel::local::new();
         let serve_handle = mbox.clone().serve(rx);
         let client = MailboxClient::new(tx);
@@ -3681,10 +3674,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_mailbox_router() {
-        let mbox0 = Mailbox::new_detached(test_actor_id("world0_0", "actor0"));
-        let mbox1 = Mailbox::new_detached(test_actor_id("world1_0", "actor0"));
-        let mbox2 = Mailbox::new_detached(test_actor_id("world1_1", "actor0"));
-        let mbox3 = Mailbox::new_detached(test_actor_id("world1_1", "actor1"));
+        let mbox0 = Mailbox::new(test_actor_id("world0_0", "actor0"));
+        let mbox1 = Mailbox::new(test_actor_id("world1_0", "actor0"));
+        let mbox2 = Mailbox::new(test_actor_id("world1_1", "actor0"));
+        let mbox3 = Mailbox::new(test_actor_id("world1_1", "actor1"));
 
         let comms: Vec<(OncePortRef<u64>, OncePortReceiver<u64>)> =
             [&mbox0, &mbox1, &mbox2, &mbox3]
@@ -3711,7 +3704,7 @@ mod tests {
 
         // Test undeliverable messages, and that it is delivered with the appropriate fallback.
 
-        let mbox4 = Mailbox::new_detached(test_actor_id("fallback_0", "actor"));
+        let mbox4 = Mailbox::new(test_actor_id("fallback_0", "actor"));
 
         let (return_handle, mut return_receiver) =
             crate::mailbox::undeliverable::new_undeliverable_port();
@@ -3803,10 +3796,10 @@ mod tests {
     #[tokio::test]
     #[ignore] // TODO: there's a leak here, fix it
     async fn test_dial_mailbox_router_default() {
-        let mbox0 = Mailbox::new_detached(test_actor_id("world0_0", "actor0"));
-        let mbox1 = Mailbox::new_detached(test_actor_id("world1_0", "actor0"));
-        let mbox2 = Mailbox::new_detached(test_actor_id("world1_1", "actor0"));
-        let mbox3 = Mailbox::new_detached(test_actor_id("world1_1", "actor1"));
+        let mbox0 = Mailbox::new(test_actor_id("world0_0", "actor0"));
+        let mbox1 = Mailbox::new(test_actor_id("world1_0", "actor0"));
+        let mbox2 = Mailbox::new(test_actor_id("world1_1", "actor0"));
+        let mbox3 = Mailbox::new(test_actor_id("world1_1", "actor1"));
 
         // We don't need to dial here, since we gain direct access to the
         // underlying routers.
@@ -4679,7 +4672,7 @@ mod tests {
     #[tokio::test]
     async fn message_ttl_success_local_delivery() {
         let actor_id = test_actor_id("world_0", "ttl_actor");
-        let mailbox = Mailbox::new_detached(actor_id.clone());
+        let mailbox = Mailbox::new(actor_id.clone());
         let (_undeliverable_tx, mut undeliverable_rx) =
             mailbox.bind_handler_port::<Undeliverable<MessageEnvelope>>();
 
@@ -4735,7 +4728,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "already bound")]
     fn test_bind_port_handle_to_handler_port_twice() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         let (handle, _rx) = mbox.open_port::<String>();
         handle.bind_handler_port();
         handle.bind_handler_port();
@@ -4743,7 +4736,7 @@ mod tests {
 
     #[test]
     fn test_bind_port_handle_to_handler_port() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         let default_port = mbox.actor_addr().port_addr(Port::from(String::port()));
         let (handle, _rx) = mbox.open_port::<String>();
         // Handle's port index is allocated by mailbox, not the handler port.
@@ -4760,7 +4753,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "already bound")]
     fn test_bind_port_handle_to_handler_port_when_already_bound() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "test"));
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
         let (handle, _rx) = mbox.open_port::<String>();
         // Bound handle to the port allocated by mailbox.
         handle.bind();
@@ -4773,13 +4766,13 @@ mod tests {
     async fn test_mailbox_post_fails_when_actor_stopped() {
         let actor_id = test_actor_id("0", "stopped_actor");
 
-        let mailbox = Mailbox::new_detached(actor_id.clone());
+        let mailbox = Mailbox::new(actor_id.clone());
 
         mailbox.close(ActorStatus::Stopped("test stop".to_string()));
 
         let (user_port, _user_rx) = mailbox.open_port::<u64>();
 
-        // Use a separate detached mailbox for the return handle since
+        // Use a separate return mailbox since
         // the main mailbox is stopped and won't accept messages.
         let (return_handle, mut return_rx) = undeliverable::new_undeliverable_port();
 
@@ -4812,7 +4805,7 @@ mod tests {
 
         let actor_id = test_actor_id("0", "failed_actor");
 
-        let mailbox = Mailbox::new_detached(actor_id.clone());
+        let mailbox = Mailbox::new(actor_id.clone());
 
         let (user_port, _user_rx) = mailbox.open_port::<u64>();
 
@@ -4820,7 +4813,7 @@ mod tests {
             "test failure".to_string(),
         )));
 
-        // Use a separate detached mailbox for the return handle since
+        // Use a separate return mailbox since
         // the main mailbox is failed and won't accept messages.
         let (return_handle, mut return_rx) = undeliverable::new_undeliverable_port();
 
@@ -4851,7 +4844,7 @@ mod tests {
     async fn test_port_handle_send_fails_when_actor_stopped() {
         let actor_id = test_actor_id("0", "stopped_actor");
 
-        let mailbox = Mailbox::new_detached(actor_id.clone());
+        let mailbox = Mailbox::new(actor_id.clone());
 
         let (port_handle, _rx) = mailbox.open_port::<u64>();
         let proc = Proc::isolated();
@@ -4876,7 +4869,7 @@ mod tests {
 
         let actor_id = test_actor_id("0", "failed_actor");
 
-        let mailbox = Mailbox::new_detached(actor_id.clone());
+        let mailbox = Mailbox::new(actor_id.clone());
 
         let (port_handle, _rx) = mailbox.open_port::<u64>();
         let proc = Proc::isolated();
@@ -4943,7 +4936,7 @@ mod tests {
     /// mailbox.
     #[tokio::test]
     async fn test_flush_over_unix_channel() {
-        let mbox = Mailbox::new_detached(test_actor_id("0", "actor0"));
+        let mbox = Mailbox::new(test_actor_id("0", "actor0"));
 
         // Serve the mailbox on a unix domain socket channel.
         let (addr, rx) = channel::serve(ChannelAddr::any(ChannelTransport::Unix)).unwrap();
@@ -4982,7 +4975,7 @@ mod tests {
 
     #[test]
     fn test_drain_waits_for_active_handler_enqueue() {
-        let mailbox = Mailbox::new_detached(test_actor_id("drain", "actor"));
+        let mailbox = Mailbox::new(test_actor_id("drain", "actor"));
         let (entered_tx, entered_rx) = std::sync::mpsc::channel();
         let release = Arc::new((std::sync::Mutex::new(false), std::sync::Condvar::new()));
         let delivered = Arc::new(AtomicUsize::new(0));

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -85,7 +85,7 @@ pub(crate) fn new_undeliverable_port() -> (
     PortReceiver<Undeliverable<MessageEnvelope>>,
 ) {
     let proc = Proc::isolated();
-    crate::mailbox::Mailbox::new_detached(proc.proc_addr().actor_addr("undeliverable"))
+    crate::mailbox::Mailbox::new(proc.proc_addr().actor_addr("undeliverable"))
         .open_port::<Undeliverable<MessageEnvelope>>()
 }
 

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -151,9 +151,8 @@ mod tests {
             MailboxClient::dial(backend_addr).unwrap(),
         );
 
-        let (return_handle, mut return_rx) =
-            Mailbox::new_detached(test_actor_id("world_0", "proc"))
-                .open_port::<Undeliverable<MessageEnvelope>>();
+        let (return_handle, mut return_rx) = Mailbox::new(test_actor_id("world_0", "proc"))
+            .open_port::<Undeliverable<MessageEnvelope>>();
 
         // Existing address on the host:
         let envelope = MessageEnvelope::new(

--- a/monarch_tensor_worker/src/borrow.rs
+++ b/monarch_tensor_worker/src/borrow.rs
@@ -74,9 +74,9 @@ impl Borrow {
         to_stream: Arc<ActorHandle<StreamActor>>,
     ) -> Result<Borrow> {
         let (first_use_sender, first_use_receiver) =
-            Mailbox::new_detached(to_stream.actor_addr().clone()).open_port();
+            Mailbox::new(to_stream.actor_addr().clone()).open_port();
         let (last_use_sender, last_use_receiver) =
-            Mailbox::new_detached(from_stream.actor_addr().clone()).open_port();
+            Mailbox::new(from_stream.actor_addr().clone()).open_port();
 
         from_stream
             .borrow_create(cx, borrow_id, tensor_ref, first_use_sender)


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* __->__ #3879
* #3878
* #3877
* #3876
* #3875
* #3873
* #3823
* #3822
* #3821
* #3820
* #3819
* #3818

Make Mailbox::new the public constructor now that mailboxes no longer own forwarding policy. Remove Mailbox::new_detached and update the remaining mailbox users, benchmarks, tests, and Hyperactor book docs to describe mailboxes as actor-local port tables.

Differential Revision: [D105177458](https://our.internmc.facebook.com/intern/diff/D105177458/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105177458/)!