### PR TITLE
Fix nightly pytorch docker images

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -54,7 +54,7 @@ jobs:
           file: ./Dockerfile.nightly
           push: false # Just building the image, not publishing
           build-args: |
-            PYTORCH_TAG=2.12.0.dev20260324-cuda12.8-cudnn9-runtime
+            PYTORCH_TAG=2.13.0.dev20260513-cuda12.6-cudnn9-runtime
           build-contexts: |
             monarch-wheels=${{ runner.temp }}/monarch_wheels
           outputs: type=docker,dest=${{ runner.temp }}/monarch_image.tar

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -130,6 +130,6 @@ jobs:
             ghcr.io/${{ github.repository }}-nightly:latest
           # TODO: find docker tag that gets updated automatically.
           build-args: |
-            PYTORCH_TAG=2.13.0.dev20260513-runtime
+            PYTORCH_TAG=2.13.0.dev20260513-cuda12.6-cudnn9-runtime
           build-contexts: |
             monarch-wheels=${{ runner.temp }}/monarch_wheels

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -1,5 +1,5 @@
 # Override on build from CI, default only to prevent warnings.
-ARG PYTORCH_TAG=2.13.0.dev20260513-runtime
+ARG PYTORCH_TAG=2.13.0.dev20260513-cuda12.6-cudnn9-runtime
 
 # Build from latest pytorch nightly base image; should be relatively in sync with torchmonarch and pytorch-nightly.
 FROM ghcr.io/pytorch/pytorch-nightly:${PYTORCH_TAG}


### PR DESCRIPTION
Summary:
The docker images selected previously for the nightly builds against pytorch 2.13 don't
exist. Also, cuda12.8 was removed from the released docker image lists on ghcr.

Downgrade to cuda12.6. This doesn't change the PyPI availability, just docker. This
means our published docker images may build against cuda 12.8 but be used at runtime
with cuda 12.6. I don't think this is a problem because we do a static build against cuda
at build time, so as long as the runtime symbols are forwards-compatible from 12.6 we
should be ok.

For the next release we should upgrade to cuda 13 since pytorch seems to have more
support for those versions.

Reviewed By: thedavekwon

Differential Revision: D105193062


