### PR TITLE
bump default CUDA to 13.2 across CI workflows and docs (#3881)

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -10,7 +10,7 @@ on:
       torch-spec:
         description: 'Torch installation specification'
         type: string
-        default: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
+        default: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu132'
       gpu-arch-type:
         description: 'GPU architecture type'
         type: string
@@ -18,7 +18,7 @@ on:
       gpu-arch-version:
         description: 'GPU architecture version'
         type: string
-        default: '12.8'
+        default: '13.2'
       runner:
         description: 'Runner to use for the build'
         type: string
@@ -35,6 +35,10 @@ on:
         description: 'Target platform architecture (e.g., x86_64, aarch64)'
         type: string
         default: 'x86_64'
+      arch-label:
+        description: 'Label used in the artifact name to identify the build arch (e.g. cuda13.2, rocm7.1). Defaults to gpu-arch-type + gpu-arch-version when empty. Set explicitly when those inputs do not describe the toolkit baked into docker-image (e.g. CUDA wheel built on a CPU runner with gpu-arch-type=cpu).'
+        type: string
+        default: ''
       timeout:
         description: 'Job timeout in minutes'
         type: number
@@ -55,7 +59,7 @@ jobs:
       gpu-arch-type: ${{ inputs.gpu-arch-type }}
       gpu-arch-version: ${{ inputs.gpu-arch-version }}
       submodules: recursive
-      upload-artifact: monarch-py${{ matrix.python-version }}-${{ inputs.gpu-arch-type }}${{ inputs.gpu-arch-version }}-${{ inputs.platform }}
+      upload-artifact: monarch-py${{ matrix.python-version }}-${{ inputs.arch-label != '' && inputs.arch-label || format('{0}{1}', inputs.gpu-arch-type, inputs.gpu-arch-version) }}-${{ inputs.platform }}
       script: |
         source scripts/common-setup.sh
         setup_build_environment ${{ matrix.python-version }}

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -54,7 +54,7 @@ jobs:
           file: ./Dockerfile.nightly
           push: false # Just building the image, not publishing
           build-args: |
-            PYTORCH_TAG=2.13.0.dev20260513-cuda12.6-cudnn9-runtime
+            PYTORCH_TAG=2.13.0.dev20260513-cuda13.2-cudnn9-runtime
           build-contexts: |
             monarch-wheels=${{ runner.temp }}/monarch_wheels
           outputs: type=docker,dest=${{ runner.temp }}/monarch_image.tar

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -27,9 +27,16 @@ jobs:
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       timeout: 120
-      runner: linux.g5.4xlarge.nvidia.gpu
-      gpu-arch-type: cuda
-      gpu-arch-version: "12.8"
+      # Building docs needs the CUDA toolkit but not host-GPU access; matching
+      # pytorch core's pattern of CPU-only ephemeral runners for build-style
+      # jobs avoids the nvidia-container-cli host-driver-vs-CUDA version
+      # check (no g4dn-fleet AMI yet carries an NVIDIA driver that satisfies
+      # cuda>=13.2). Docs build at cu132 to match the wheels we ship; PR GPU
+      # CI runs at cu130 — see set-matrix.yaml.
+      runner: linux.c7i.2xlarge
+      docker-image: "pytorch/manylinux2_28-builder:cuda13.2"
+      gpu-arch-type: cpu
+      gpu-arch-version: ""
       submodules: recursive
       upload-artifact: docs
       script: |
@@ -53,7 +60,7 @@ jobs:
         setup_build_environment 3.13
 
         # Install PyTorch with CUDA support (matching build-cuda.yml)
-        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128
+        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu132
 
         # Setup Tensor Engine
         setup_tensor_engine

--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -21,10 +21,25 @@ jobs:
     with:
       # TODO add 3.14 once we figure out py03 issue
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
-      runner: linux.g5.4xlarge.nvidia.gpu
-      torch-spec: 'torch==2.12.0 --extra-index-url https://download.pytorch.org/whl/cu128'
-      gpu-arch-type: cuda
-      gpu-arch-version: '12.8'
+      # Stable releases ship cu132 even though PR CI tests at cu130 (see
+      # set-matrix.yaml): pytorch core does the same split — publish cu132
+      # binaries, GPU-test only at cu130 — because no g4dn-fleet AMI yet
+      # carries an NVIDIA driver that satisfies nvidia-container-cli's
+      # cuda>=13.2 check.
+      #
+      # Building a wheel needs the CUDA toolkit (nvcc, headers, libs) but not
+      # host-GPU access. The cuda13.2 builder image supplies the toolkit; we
+      # set gpu-arch-type=cpu so test-infra's linux_job_v2.yml skips the
+      # `setup-nvidia` step that mounts `--gpus all` and triggers
+      # nvidia-container-cli's host-driver-vs-CUDA version check. Passing an
+      # already-tagged docker-image makes test-infra use it verbatim instead
+      # of auto-suffixing it from gpu-arch-type/version.
+      runner: linux.c7i.2xlarge
+      docker-image: 'pytorch/manylinux2_28-builder:cuda13.2'
+      torch-spec: 'torch==2.12.0 --extra-index-url https://download.pytorch.org/whl/cu132'
+      gpu-arch-type: cpu
+      gpu-arch-version: ''
+      arch-label: cuda13.2
       version: ${{ github.event.inputs.version }}
       platform: x86_64
 
@@ -33,10 +48,10 @@ jobs:
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       runner: linux.arm64.2xlarge
-      docker-image: 'pytorch/manylinuxaarch64-builder:cuda12.8'
-      torch-spec: 'torch==2.12.0 --extra-index-url https://download.pytorch.org/whl/cu128'
+      docker-image: 'pytorch/manylinuxaarch64-builder:cuda13.2'
+      torch-spec: 'torch==2.12.0 --extra-index-url https://download.pytorch.org/whl/cu132'
       gpu-arch-type: cuda
-      gpu-arch-version: '12.8'
+      gpu-arch-version: '13.2'
       version: ${{ github.event.inputs.version }}
       platform: aarch64
 
@@ -104,7 +119,7 @@ jobs:
         run: |
           VERSION="${{ github.event.inputs.version }}"
           PRERELEASE="${{ github.event.inputs.is_prerelease }}"
-          TAGS="ghcr.io/${{ github.repository }}:${VERSION}-cuda12.6"
+          TAGS="ghcr.io/${{ github.repository }}:${VERSION}-cuda13.2"
           if [[ "$PRERELEASE" == "false" ]]; then
             TAGS="$TAGS,ghcr.io/${{ github.repository }}:latest"
           fi
@@ -118,7 +133,7 @@ jobs:
           push: true # Push the image to the registry
           tags: ${{ steps.determine-tags.outputs.tags }}
           build-args: |
-            PYTORCH_TAG=2.12.0-cuda12.6-cudnn9-runtime
+            PYTORCH_TAG=2.12.0-cuda13.2-cudnn9-runtime
             MONARCH_VERSION=${{ github.event.inputs.version }}
 
   create-docs-branch:

--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -12,7 +12,12 @@ on:
         description: 'Override default CUDA runner label'
         required: false
         type: string
-        default: linux.g5.4xlarge.nvidia.gpu
+        # Matches what pytorch core uses for CUDA GPU smoke tests
+        # (caffe2/.github/workflows/generated-linux-binary-manywheel-nightly.yml).
+        # PR CI builds and tests at CUDA 13.0 because pytorch's own PR/trunk
+        # GPU jobs do the same (test-h100.yml runs on cuda13.0); release
+        # wheels ship cu132 from build-dist.yml on a CPU runner.
+        default: linux.g4dn.4xlarge.nvidia.gpu
     outputs:
       test-matrix:
         description: Test matrix (py3.10 only)
@@ -38,14 +43,20 @@ jobs:
         run: |
           set -euox pipefail
 
+          # PR CI is pinned to CUDA 13.0 (cu130) to match pytorch core: their
+          # PR/trunk GPU jobs (e.g. test-h100.yml) run cuda13.0, and the
+          # g4dn fleet's host driver currently fails nvidia-container-cli's
+          # check against cuda13.2 containers. Release/nightly wheels still
+          # ship cu132 via wheels.yml / publish_release.yml on a CPU runner.
+
           # Define test matrices (py3.10 only)
-          CUDA='{"name": "cuda", "runner": "${{ inputs.runner-cuda }}", "gpu-arch-type": "cuda", "gpu-arch-version": "12.8", "docker-image": "pytorch/manylinux2_28-builder:cuda12.8", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128"}'
+          CUDA='{"name": "cuda", "runner": "${{ inputs.runner-cuda }}", "gpu-arch-type": "cuda", "gpu-arch-version": "13.0", "docker-image": "pytorch/manylinux2_28-builder:cuda13.0", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu130"}'
           ROCM_71='{"name": "rocm7.1", "runner": "${{ inputs.runner-rocm }}", "gpu-arch-type": "rocm", "gpu-arch-version": "7.1", "docker-image": "pytorch/manylinux2_28-builder:rocm7.1", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/rocm7.1/"}'
           ROCM_72='{"name": "rocm7.2", "runner": "${{ inputs.runner-rocm }}", "gpu-arch-type": "rocm", "gpu-arch-version": "7.2", "docker-image": "pytorch/manylinux2_28-builder:rocm7.2", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/rocm7.2/"}'
 
           # Define build matrices (includes python-version)
-          CUDA_PY310='{"name": "cuda", "python-version": "3.10", "docker-image": "pytorch/manylinux2_28-builder:cuda12.8", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128"}'
-          CUDA_PY312='{"name": "cuda", "python-version": "3.12", "docker-image": "pytorch/manylinux2_28-builder:cuda12.8", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128"}'
+          CUDA_PY310='{"name": "cuda", "python-version": "3.10", "docker-image": "pytorch/manylinux2_28-builder:cuda13.0", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu130"}'
+          CUDA_PY312='{"name": "cuda", "python-version": "3.12", "docker-image": "pytorch/manylinux2_28-builder:cuda13.0", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu130"}'
           ROCM_71_PY310='{"name": "rocm7.1", "python-version": "3.10", "docker-image": "pytorch/manylinux2_28-builder:rocm7.1", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/rocm7.1/"}'
           ROCM_72_PY310='{"name": "rocm7.2", "python-version": "3.10", "docker-image": "pytorch/manylinux2_28-builder:rocm7.2", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/rocm7.2/"}'
 

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -19,7 +19,7 @@ jobs:
             docker-image: pytorch/almalinux-builder
           - name: arm64
             runner: linux.arm64.2xlarge
-            docker-image: pytorch/manylinuxaarch64-builder:cuda12.8
+            docker-image: pytorch/manylinuxaarch64-builder:cuda13.2
     uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
     with:
       timeout: 120
@@ -45,7 +45,7 @@ jobs:
         install_system_dependencies
 
         # Install PyTorch (needed for ABI compatibility, no GPU required)
-        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128
+        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu132
 
         # Run CPU-safe Rust tests (no GPU hardware available)
         echo "Running CPU Rust tests..."

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -29,10 +29,25 @@ jobs:
     uses: ./.github/workflows/build-dist.yml
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
-      runner: linux.g5.4xlarge.nvidia.gpu
-      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
-      gpu-arch-type: cuda
-      gpu-arch-version: '12.8'
+      # Nightly wheels ship cu132 even though PR CI tests at cu130 (see
+      # set-matrix.yaml): pytorch core does the same split — publish cu132
+      # binaries, GPU-test only at cu130 — because no g4dn-fleet AMI yet
+      # carries an NVIDIA driver that satisfies nvidia-container-cli's
+      # cuda>=13.2 check.
+      #
+      # Building a wheel needs the CUDA toolkit (nvcc, headers, libs) but not
+      # host-GPU access. The cuda13.2 builder image supplies the toolkit; we
+      # set gpu-arch-type=cpu so test-infra's linux_job_v2.yml skips the
+      # `setup-nvidia` step that mounts `--gpus all` and triggers
+      # nvidia-container-cli's host-driver-vs-CUDA version check. Passing an
+      # already-tagged docker-image makes test-infra use it verbatim instead
+      # of auto-suffixing it from gpu-arch-type/version.
+      runner: linux.c7i.2xlarge
+      docker-image: 'pytorch/manylinux2_28-builder:cuda13.2'
+      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu132'
+      gpu-arch-type: cpu
+      gpu-arch-version: ''
+      arch-label: cuda13.2
       platform: x86_64
 
   build-arm64:
@@ -40,10 +55,10 @@ jobs:
     with:
       python-versions: '["3.10", "3.11", "3.12", "3.13"]'
       runner: linux.arm64.2xlarge
-      docker-image: 'pytorch/manylinuxaarch64-builder:cuda12.8'
-      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu128'
+      docker-image: 'pytorch/manylinuxaarch64-builder:cuda13.2'
+      torch-spec: '--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu132'
       gpu-arch-type: cuda
-      gpu-arch-version: '12.8'
+      gpu-arch-version: '13.2'
       platform: aarch64
 
   build-macos:
@@ -101,7 +116,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           # Docker container only has python 3.12, so we need to use the x86_64 3.12 wheel.
-          name: monarch-py3.12-cuda12.8-x86_64
+          name: monarch-py3.12-cuda13.2-x86_64
           path: ${{ runner.temp }}/monarch_wheels
           merge-multiple: true
 
@@ -116,7 +131,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Get tag for publishing
-        run: echo "DOCKER_TAG=0.6.0.dev$(date +'%Y%m%d')-cuda12.6" >> $GITHUB_ENV
+        run: echo "DOCKER_TAG=0.6.0.dev$(date +'%Y%m%d')-cuda13.2" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -130,6 +145,6 @@ jobs:
             ghcr.io/${{ github.repository }}-nightly:latest
           # TODO: find docker tag that gets updated automatically.
           build-args: |
-            PYTORCH_TAG=2.13.0.dev20260513-cuda12.6-cudnn9-runtime
+            PYTORCH_TAG=2.13.0.dev20260513-cuda13.2-cudnn9-runtime
           build-contexts: |
             monarch-wheels=${{ runner.temp }}/monarch_wheels

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Override on build from CI.
-ARG PYTORCH_TAG=2.12.0-cuda12.6-cudnn9-runtime
+ARG PYTORCH_TAG=2.12.0-cuda13.2-cudnn9-runtime
 
 # Build from latest pytorch stable image; should be relatively in sync with torchmonarch and pytorch.
 FROM ghcr.io/pytorch/pytorch:${PYTORCH_TAG}

--- a/Dockerfile.nightly
+++ b/Dockerfile.nightly
@@ -1,5 +1,5 @@
 # Override on build from CI, default only to prevent warnings.
-ARG PYTORCH_TAG=2.13.0.dev20260513-cuda12.6-cudnn9-runtime
+ARG PYTORCH_TAG=2.13.0.dev20260513-cuda13.2-cudnn9-runtime
 
 # Build from latest pytorch nightly base image; should be relatively in sync with torchmonarch and pytorch-nightly.
 FROM ghcr.io/pytorch/pytorch-nightly:${PYTORCH_TAG}

--- a/MONARCH_INFO.md
+++ b/MONARCH_INFO.md
@@ -109,9 +109,9 @@ uv sync
 - `MONARCH_GPU_PLATFORM` - Select GPU platform: `cuda`, `rocm`, or `none` (CPU-only tensor engine). Leave unset to auto-detect; required when both CUDA and ROCm are installed
 
 **PyTorch Index Configuration:**
-The project uses PyTorch from specific indices (see `pyproject.toml`). Default is `pytorch-cu128`. To change:
+The project uses PyTorch from specific indices (see `pyproject.toml`). Default is `pytorch-cu132`. To change:
 ```bash
-uv sync --extra-index-url https://download.pytorch.org/whl/cu126
+uv sync --extra-index-url https://download.pytorch.org/whl/cu130
 ```
 
 ### Meta Internal Build (Buck2)
@@ -304,7 +304,7 @@ Default pytest timeout is 5 minutes (configured in `pyproject.toml`).
 
 1. **Rust Python Linking Errors**: If you see "could not find native static library `python3.12`", activate your Python environment first
 2. **C++11 ABI Mismatches**: The build auto-detects PyTorch's ABI, but mismatches cause runtime errors
-3. **CUDA Version Mismatches**: Ensure your CUDA installation matches the PyTorch index (e.g., cu128 = CUDA 12.8)
+3. **CUDA Version Mismatches**: Ensure your CUDA installation matches the PyTorch index (e.g., cu132 = CUDA 13.2)
 4. **Missing tensor_engine**: If you get import errors for RDMA/distributed tensors, rebuild with `USE_TENSOR_ENGINE=1`
 
 ## Development Workflow

--- a/README.md
+++ b/README.md
@@ -96,13 +96,13 @@ brew install uv
 ```
 
 **Configuring PyTorch Index**: By default, Monarch builds with PyTorch from the
-`pytorch-cu128` index (CUDA 12.8). To use a different CUDA version:
+`pytorch-cu132` index (CUDA 13.2). To use a different CUDA version:
 
 - Edit `[tool.uv.sources]` in `pyproject.toml` to point to a different index
-  (e.g., `pytorch-cu126`, `pytorch-cu130`, or `pytorch-cpu`)
+  (e.g., `pytorch-cu130`, or `pytorch-cpu`)
 - Or use `--extra-index-url` when running uv:
   ```sh
-  uv sync --extra-index-url https://download.pytorch.org/whl/cu126
+  uv sync --extra-index-url https://download.pytorch.org/whl/cu130
   ```
 
 #### Understanding Tensor Engine
@@ -160,7 +160,7 @@ rustup default nightly
 sudo dnf install -y cmake ninja-build protobuf-compiler libunwind
 
 # Install the correct cuda and cuda-toolkit versions for your machine
-sudo dnf install cuda-toolkit-12-8 cuda-12-8
+sudo dnf install cuda-toolkit-13-2 cuda-13-2
 
 # Install clang-devel, nccl-devel, and libstdc++-static
 sudo dnf install clang-devel libnccl-devel libstdc++-static
@@ -202,7 +202,7 @@ export CC=clang
 export CXX=clang++
 
 # Install the correct cuda and cuda-toolkit versions for your machine
-sudo apt install -y cuda-toolkit-12-8 cuda-12-8
+sudo apt install -y cuda-toolkit-13-2 cuda-13-2
 
 # Install RDMA libraries (needed for tensor_engine builds)
 sudo apt install -y rdma-core libibverbs1 libmlx5-1 libibverbs-dev

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 #   1. setup.py needs to detect torch installation paths and C++11 ABI
 #   2. C++ extensions (monarch.common._C, gradient_generator) link against libtorch
 #   3. Build-time torch detection determines whether to enable tensor_engine feature
-# The torch index is controlled by [tool.uv.sources] below (e.g., pytorch-cu128)
+# The torch index is controlled by [tool.uv.sources] below (e.g., pytorch-cu132)
 requires = ["setuptools>=77", "setuptools-rust", "wheel", "numpy", "torch"]
 build-backend = "setuptools.build_meta"
 
@@ -71,15 +71,20 @@ url = "https://download.pytorch.org/whl/cu130"
 explicit = true
 
 [[tool.uv.index]]
+name = "pytorch-cu132"
+url = "https://download.pytorch.org/whl/cu132"
+explicit = true
+
+[[tool.uv.index]]
 name = "pytorch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [tool.uv.sources]
 # Override with: uv sync --extra-index-url https://download.pytorch.org/whl/nightly/{platform} e.g.
-# uv sync --extra-index-url https://download.pytorch.org/whl/nightly/cu128
+# uv sync --extra-index-url https://download.pytorch.org/whl/nightly/cu132
 torch = [
-    { index = "pytorch-cu128", marker = "sys_platform != 'darwin'"  },
+    { index = "pytorch-cu132", marker = "sys_platform != 'darwin'"  },
     # MacOS cannot have cuda symbols, so default to CPU.
     { index = "pytorch-cpu", marker = "sys_platform == 'darwin'" },
 ]

--- a/python/monarch/common/tensor.py
+++ b/python/monarch/common/tensor.py
@@ -839,7 +839,7 @@ def check_torch_version() -> None:
     The check is performed by comparing the major, minor, and patch versions of the runtime PyTorch version
     with the build-time PyTorch version. If they do not match, a RuntimeError is raised.
     """
-    # torch version as a string may contain optional suffixes like "+cu128", and
+    # torch version as a string may contain optional suffixes like "+cu132", and
     # we can only compare the major/minor/patch version. Parse into a tuple of
     # integers.
     runtime_torch_version = torch.__version__.split(".")

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -148,8 +148,8 @@ setup_tensor_engine() {
 # Usage: setup_pytorch_with_headers <gpu-arch-type> <gpu-arch-version> <torch-spec>
 setup_pytorch_with_headers() {
     local gpu_arch_type=${1:-"cuda"}
-    local gpu_arch_version=${2:-"12.8"}
-    local torch_spec=${3:-"--pre torch --index-url https://download.pytorch.org/whl/nightly/cu128"}
+    local gpu_arch_version=${2:-"13.2"}
+    local torch_spec=${3:-"--pre torch --index-url https://download.pytorch.org/whl/nightly/cu132"}
 
     echo "Setting up PyTorch with C++ headers (${gpu_arch_type} ${gpu_arch_version})..."
 
@@ -159,12 +159,13 @@ setup_pytorch_with_headers() {
     if [[ "${gpu_arch_type}" == "rocm" ]]; then
         # ROCm uses version with dots: "7.1" -> "rocm7.1"
         libtorch_variant="rocm${gpu_arch_version}"
-        libtorch_filename="libtorch-shared-with-deps-latest.zip"
     else
-        # CUDA uses version without dots: "12.8" -> "cu128"
+        # CUDA uses version without dots: "13.2" -> "cu132"
         libtorch_variant="cu$(echo "${gpu_arch_version}" | tr -d '.')"
-        libtorch_filename="libtorch-cxx11-abi-shared-with-deps-latest.zip"
     fi
+    # PyTorch nightlies unified on cxx11 ABI and dropped the -cxx11-abi- infix;
+    # cu130+ only publishes libtorch-shared-with-deps-latest.zip.
+    libtorch_filename="libtorch-shared-with-deps-latest.zip"
     local libtorch_url="https://download.pytorch.org/libtorch/nightly/${libtorch_variant}/${libtorch_filename}"
 
     echo "Downloading libtorch from: ${libtorch_url}"

--- a/scripts/install_nightly.py
+++ b/scripts/install_nightly.py
@@ -73,7 +73,7 @@ def main() -> None:
         f"torch=={torch_version}",
         "--pre",
         "--extra-index-url",
-        "https://download.pytorch.org/whl/nightly/cu128",
+        "https://download.pytorch.org/whl/nightly/cu132",
     ]
 
     print(f"Executing command:\n\t{' '.join(pip_command)}\n\n")

--- a/torch-requirements.txt
+++ b/torch-requirements.txt
@@ -1,2 +1,2 @@
---index-url https://download.pytorch.org/whl/nightly/cu128
+--index-url https://download.pytorch.org/whl/nightly/cu132
 torch --pre


### PR DESCRIPTION
Summary:

Bumps Monarch's OSS GitHub Actions workflows and supporting config from CUDA 12.8 to 13.2. PR CI, nightly wheels, the doc build, and the stable release publisher now resolve PyTorch from the `cu132` index, use the `pytorch/manylinux*-builder:cuda13.2` builder images, and target `cuda13.2-cudnn9-runtime` for published Docker images. The `pytorch-cu126` and `pytorch-cu128` indices stay in `pyproject.toml` so contributors can opt into older toolchains; they are just no longer the default.

PR GPU CI pins to `cu130` because no g4dn-fleet AMI yet has an NVIDIA driver satisfying `nvidia-container-cli`'s `cuda>=13.2` check; release/nightly wheels still ship `cu132`. Same split as pytorch core (`test-h100.yml` is cuda13.0).

Walkthrough:

- `.github/workflows/` (`set-matrix.yaml`, `build-dist.yml`, `wheels.yml`, `build-docker.yml`, `publish_release.yml`, `doc_build.yml`, `test-cpu-rust.yml`): all CUDA inputs — torch index, builder docker image, `gpu-arch-version`, `PYTORCH_TAG`, GHCR tag suffix, artifact names — move from `cu128` / `cuda12.8` to `cu132` / `cuda13.2`. `wheels.yml` was previously pinned to a stale `cuda12.6` runtime; that is now `cuda13.2` to match the rest of the pipeline.
- Top-level: `Dockerfile{,.nightly}` `ARG PYTORCH_TAG` defaults, `torch-requirements.txt`, `scripts/common-setup.sh` defaults, `scripts/install_nightly.py`, and the `+cu128` example comment in `python/monarch/common/tensor.py` all updated.
- Docs: `README.md` and `MONARCH_INFO.md` document `pytorch-cu132` as the default; Fedora/Ubuntu setup snippets install `cuda-toolkit-13-2` / `cuda-13-2`.

Out of scope: `examples/skypilot/*` keeps `pytorch/pytorch:2.9.1-cuda12.8-cudnn9-runtime` (2.9.1 predates `cuda13.2`); `examples/kubernetes/oci_kubernetes_job/*` keeps the externally-published `dochakov-oci/monarch-oci:...-cuda12.8-rdma-01` image; generated artifacts (`*.egg-info/`, `build/lib.*/`, `uv.lock`) regenerate on next build.

Reviewed By: pzhan9

Differential Revision: D105197611


