### PR TITLE
delete deprecated `defaults.config()`

### DIFF
--- a/python/monarch/_src/tools/commands.py
+++ b/python/monarch/_src/tools/commands.py
@@ -56,9 +56,9 @@ def create(
 
     .. doc-test::
 
-        from monarch.tools.config import defaults
+        from monarch.tools.config import Config, defaults
 
-        config = defaults.config(scheduler="slurm")
+        config = Config(scheduler="slurm")
         config.appdef = defaults.component_fn(scheduler=config.scheduler)()
 
         config.scheduler_args.update(
@@ -269,9 +269,9 @@ async def get_or_create(
 
     .. code-block:: python
 
-        from monarch.tools.config import defaults
+        from monarch.tools.config import Config, defaults
 
-        config = defaults.config(scheduler)
+        config = Config(scheduler=scheduler)
         config.appdef = defaults.component_fn(config.scheduler)()
 
         server_handle = get_or_create(name="my_job_name", config)

--- a/python/monarch/tools/config/defaults.py
+++ b/python/monarch/tools/config/defaults.py
@@ -8,11 +8,8 @@
 
 """Defines defaults for ``monarch.tools``"""
 
-import warnings
 from typing import Callable
 
-from monarch.tools.config import Config
-from monarch.tools.config.workspace import Workspace
 from torchx import specs
 from torchx.schedulers import (
     docker_scheduler,
@@ -41,19 +38,6 @@ def scheduler_factories() -> dict[str, SchedulerFactory]:
         "slurm": slurm_scheduler.create_scheduler,
         "k8s": kubernetes_scheduler.create_scheduler,
     }
-
-
-def config(scheduler: str, workspace: str | None = None) -> Config:
-    """The default :py:class:`~monarch.tools.config.Config` to use when submitting to the provided ``scheduler``."""
-    warnings.warn(
-        "`defaults.config()` is deprecated, prefer instantiating `Config()` directly",
-        FutureWarning,
-        stacklevel=2,
-    )
-    return Config(
-        scheduler=scheduler,
-        workspace=Workspace(dirs={workspace: ""}) if workspace else Workspace.null(),
-    )
 
 
 def dryrun_info_formatter(dryrun_info: specs.AppDryRunInfo) -> Callable[..., str]:

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -59,7 +59,8 @@ from monarch.actor import (
     ProcMesh,
 )
 from monarch.config import configure, configured, parametrize_config
-from monarch.tools.config import defaults
+from monarch.tools.config import Config
+from monarch.tools.config.workspace import Workspace
 from scoped_state import scoped_state
 from typing_extensions import assert_type
 
@@ -1125,7 +1126,10 @@ async def test_sync_workspace() -> None:
         pm = host.spawn_procs(per_host={"gpus": 1})
         code_sync_mesh = host
 
-        config = defaults.config("slurm", workspace_src)
+        config = Config(
+            scheduler="slurm",
+            workspace=Workspace(dirs={workspace_src: ""}),
+        )
         await code_sync_mesh.sync_workspace(
             workspace=config.workspace, auto_reload=True
         )

--- a/python/tests/tools/config/test_defaults.py
+++ b/python/tests/tools/config/test_defaults.py
@@ -9,39 +9,10 @@ import unittest
 
 from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
     defaults,
-    NOT_SET,
 )
-from torchx.specs import AppDef
 
 
 class TestDefaults(unittest.TestCase):
-    def test_default_config(self) -> None:
-        for scheduler in defaults.scheduler_factories():
-            with self.subTest(scheduler=scheduler):
-                config = defaults.config(scheduler)
-
-                # make sure that we've set the scheduler name when returning the config
-                self.assertEqual(scheduler, config.scheduler)
-
-                # make sure a new Config is returned each time
-                # by modifying the returned config
-                #   -> re-getting the default configs for the same scheduler
-                #   -> validating the changes are not persisted in the new config
-                self.assertNotIn("foo", config.scheduler_args)
-                config.scheduler_args["foo"] = "bar"
-                self.assertNotIn("foo", defaults.config(scheduler).scheduler_args)
-
-    def test_default_config_appdef(self) -> None:
-        for scheduler, _ in {
-            "mast": {"image": "_DUMMY_FBPKG_:0"},
-            "whatever": {"image": "_DUMMY_FBPKG_:0"},
-            "mast_conda": {},
-        }.items():
-            config = defaults.config(
-                scheduler,
-            )
-            self.assertEqual(AppDef(name=NOT_SET), config.appdef)
-
     def test_default_scheduler_factories(self) -> None:
         # just make sure the common schedulers are present
         self.assertIn("local_cwd", defaults.scheduler_factories())


### PR DESCRIPTION
Summary: `defaults.config()` has been emitting a `FutureWarning` for some time and had no production callers in fbsource. Delete it.

Differential Revision: D105213956


