### PR TITLE
arc-refcount registered MRs via IbvMemoryRegion

### DIFF
--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -14,7 +14,6 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 dashmap = { version = "6.1.0", features = ["rayon", "serde"] }
 erased-serde = "0.4.10"
-futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -69,6 +69,7 @@ use hyperactor::OncePortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelAddr;
+use hyperactor::context::Mailbox;
 use hyperactor::id::Label;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
@@ -83,7 +84,7 @@ use monarch_rdma::IbvConfig;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
-use monarch_rdma::backend::ibverbs::manager_actor::IbvManagerMessageClient;
+use monarch_rdma::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
 use monarch_rdma::cu_check;
 use monarch_rdma::local_memory::RdmaLocalMemory;
 use monarch_rdma::local_memory::UnsafeLocalMemory;
@@ -512,14 +513,25 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
             .resolve_ibv()
             .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for remote buffer"))?;
 
-        let qp = local_ibv_manager
+        let local_ibv_manager_handle = local_ibv_manager
+            .downcast_handle(cx)
+            .ok_or_else(|| anyhow::anyhow!("local IbvManagerActor is not in this process"))?;
+        let (reply_handle, reply_rx) = cx
+            .mailbox()
+            .open_once_port::<Result<monarch_rdma::backend::ibverbs::queue_pair::IbvQueuePair, String>>();
+        local_ibv_manager_handle
             .request_queue_pair(
                 cx,
                 remote_ibv_manager.clone(),
                 local_ibv.device_name.clone(),
                 remote_ibv.device_name.clone(),
+                reply_handle,
             )
-            .await?
+            .await?;
+        let qp = reply_rx
+            .recv()
+            .await
+            .map_err(|e| anyhow::anyhow!("request_queue_pair reply channel closed: {e}"))?
             .map_err(|e| anyhow::anyhow!(e))?;
 
         unsafe {

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -25,7 +25,11 @@ use super::primitives::IbvDevice;
 /// * `context`: A pointer to the RDMA device context.
 /// * `pd`: A pointer to the protection domain, which provides isolation between
 ///   different connections.
-#[derive(Clone)]
+///
+/// `IbvDomain` is not `Clone`: the `Drop` impl runs
+/// `ibv_dealloc_pd` and copying the pointer would lead to a
+/// double-free. Share the domain across owners via
+/// `Arc<IbvDomain>` instead.
 pub struct IbvDomain {
     pub context: *mut rdmaxcel_sys::ibv_context,
     pub pd: *mut rdmaxcel_sys::ibv_pd,
@@ -52,6 +56,9 @@ unsafe impl Sync for IbvDomain {}
 
 impl Drop for IbvDomain {
     fn drop(&mut self) {
+        if self.pd.is_null() {
+            return;
+        }
         unsafe {
             rdmaxcel_sys::ibv_dealloc_pd(self.pd);
         }

--- a/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
@@ -16,7 +16,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::PollTarget;
-    use super::super::manager_actor::IbvManagerMessageClient;
+    use super::super::manager_actor::request_queue_pair;
     use super::super::primitives::IbvQpType;
     use super::super::primitives::get_all_devices;
     use super::super::test_utils::IbvTestEnv;
@@ -33,30 +33,19 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         // Poll for completion
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 2).await?;
-
-        env.ibv_actor_1
-            .release_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                qp_1,
-            )
-            .await?;
 
         env.verify_buffers(BSIZE, 0).await?;
         Ok(())
@@ -72,29 +61,18 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 2).await?;
-
-        env.ibv_actor_1
-            .release_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                qp_1,
-            )
-            .await?;
 
         env.verify_buffers(BSIZE, 0).await?;
         Ok(())
@@ -112,16 +90,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.get(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         // Poll for completion
@@ -143,16 +120,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 2).await?;
 
@@ -172,26 +148,24 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
-        let mut qp_2 = env
-            .ibv_actor_2
-            .request_queue_pair(
-                &env.client_2,
-                env.ibv_actor_1.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_2 = request_queue_pair(
+            &env.ibv_handle_2,
+            &env.client_2,
+            env.ibv_actor_1.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.recv(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         let wr_id = qp_2.put_with_recv(env.ibv_buffer_2.clone(), env.ibv_buffer_1.clone())?;
         wait_for_completion(&mut qp_2, PollTarget::Send, &wr_id, 5).await?;
@@ -214,16 +188,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.enqueue_put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         qp_1.ring_doorbell()?;
         // Poll for completion
@@ -247,16 +220,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
-        let mut qp_2 = env
-            .ibv_actor_2
-            .request_queue_pair(
-                &env.client_2,
-                env.ibv_actor_1.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_2 = request_queue_pair(
+            &env.ibv_handle_2,
+            &env.client_2,
+            env.ibv_actor_1.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_2.enqueue_get(env.ibv_buffer_2.clone(), env.ibv_buffer_1.clone())?;
         qp_2.ring_doorbell()?;
         // Poll for completion
@@ -339,16 +311,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.enqueue_put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         ring_db_gpu(&qp_1).await?;
         // Poll for completion
@@ -381,16 +352,15 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         qp_1.enqueue_get(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         ring_db_gpu(&qp_1).await?;
         // Poll for completion
@@ -422,26 +392,24 @@ mod tests {
             return Ok(());
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
-        let mut qp_2 = env
-            .ibv_actor_2
-            .request_queue_pair(
-                &env.client_2,
-                env.ibv_actor_1.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_2 = request_queue_pair(
+            &env.ibv_handle_2,
+            &env.client_2,
+            env.ibv_actor_1.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         recv_wqe_gpu(
             &mut qp_1,
             &env.ibv_buffer_1,
@@ -481,16 +449,15 @@ mod tests {
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cpu:1").await?;
         // Pre-initialize comms, and wait for hardware to transition to send state
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 5).await?;
@@ -517,16 +484,15 @@ mod tests {
         }
         let env = IbvTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
         // Pre-initialize comms, and wait for hardware to transition to send state
-        let mut qp_1 = env
-            .ibv_actor_1
-            .request_queue_pair(
-                &env.client_1,
-                env.ibv_actor_2.clone(),
-                env.ibv_buffer_1.device_name.clone(),
-                env.ibv_buffer_2.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp_1 = request_queue_pair(
+            &env.ibv_handle_1,
+            &env.client_1,
+            env.ibv_actor_2.clone(),
+            env.ibv_buffer_1.device_name.clone(),
+            env.ibv_buffer_2.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp_1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
 
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 5).await?;
@@ -853,6 +819,88 @@ mod tests {
         env.cleanup().await?;
 
         println!("2GB RDMA write test completed successfully");
+        Ok(())
+    }
+
+    // ============================================================
+    // Wiring tests for IbvManagerActor's QP state machine.
+    // ============================================================
+
+    /// Two concurrent local `request_queue_pair` calls for the same
+    /// `(self_device, peer, other_device)` key must both succeed and
+    /// return the same QP; that QP must be usable for data-plane ops.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_concurrent_request_queue_pair_converges() -> Result<(), anyhow::Error> {
+        const BSIZE: usize = 32;
+        if get_all_devices().is_empty() {
+            panic!("Skipping test: RDMA devices not available");
+        }
+        let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
+        let self_device = env.ibv_buffer_1.device_name.clone();
+        let other_device = env.ibv_buffer_2.device_name.clone();
+
+        let (r1, r2) = tokio::join!(
+            request_queue_pair(
+                &env.ibv_handle_1,
+                &env.client_1,
+                env.ibv_actor_2.clone(),
+                self_device.clone(),
+                other_device.clone(),
+            ),
+            request_queue_pair(
+                &env.ibv_handle_1,
+                &env.client_1,
+                env.ibv_actor_2.clone(),
+                self_device.clone(),
+                other_device.clone(),
+            ),
+        );
+        let qp1 = r1?.map_err(|e| anyhow::anyhow!(e))?;
+        let mut qp2 = r2?.map_err(|e| anyhow::anyhow!(e))?;
+        assert_eq!(qp1.qp, qp2.qp);
+
+        let wr_id = qp2.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
+        wait_for_completion(&mut qp2, PollTarget::Send, &wr_id, 2).await?;
+        env.verify_buffers(BSIZE, 0).await?;
+        Ok(())
+    }
+
+    /// Two managers call `request_queue_pair` for each other at the
+    /// same time. Each side spawns a [`QueuePairInitializer`] and the
+    /// two initializers must rendezvous on the wire (peer endpoint +
+    /// `NotifyRts`) without either side deadlocking the other. The
+    /// resulting QP must be usable for a data-plane op.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_bidirectional_concurrent_request_queue_pair() -> Result<(), anyhow::Error> {
+        const BSIZE: usize = 32;
+        if get_all_devices().is_empty() {
+            panic!("Skipping test: RDMA devices not available");
+        }
+        let env = IbvTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
+        let dev_1 = env.ibv_buffer_1.device_name.clone();
+        let dev_2 = env.ibv_buffer_2.device_name.clone();
+
+        let (r_local, r_remote) = tokio::join!(
+            request_queue_pair(
+                &env.ibv_handle_1,
+                &env.client_1,
+                env.ibv_actor_2.clone(),
+                dev_1.clone(),
+                dev_2.clone(),
+            ),
+            request_queue_pair(
+                &env.ibv_handle_2,
+                &env.client_2,
+                env.ibv_actor_1.clone(),
+                dev_2.clone(),
+                dev_1.clone(),
+            ),
+        );
+        let mut qp1 = r_local?.map_err(|e| anyhow::anyhow!(e))?;
+        let _ = r_remote?.map_err(|e| anyhow::anyhow!(e))?;
+        let wr_id = qp1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
+        wait_for_completion(&mut qp1, PollTarget::Send, &wr_id, 2).await?;
+        env.verify_buffers(BSIZE, 0).await?;
         Ok(())
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -39,7 +39,9 @@ use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
+use hyperactor::PortRef;
 use hyperactor::RefClient;
+use hyperactor::actor::Referable;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -55,8 +57,11 @@ use super::primitives::ibverbs_supported;
 use super::primitives::mlx5dv_supported;
 use super::primitives::resolve_qp_type;
 use super::queue_pair::IbvQueuePair;
+use super::queue_pair::PeerInfo;
 use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
+use super::queue_pair::QpGuard;
+use super::queue_pair::QpKey;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
@@ -117,6 +122,21 @@ pub enum IbvManagerMessage {
 }
 wirevalue::register_type!(IbvManagerMessage);
 
+/// Cross-proc message: peer asks for our endpoint, lazily creating
+/// the entry on our side if absent. Generic over the manager actor
+/// type so tests can swap in a mock. The handler impl on
+/// `IbvManagerActor` lands in a follow-up commit; this commit only
+/// defines the type so `QueuePairInitializer` can compile.
+#[derive(Debug, Serialize, Deserialize, Named)]
+#[serde(bound(serialize = "", deserialize = ""))]
+pub(super) struct EnsureQueuePair<A: Referable> {
+    pub(super) sender: ActorRef<A>,
+    pub(super) sender_device: String,
+    pub(super) receiver_device: String,
+    pub(super) reply: PortRef<PeerInfo>,
+}
+wirevalue::register_type!(EnsureQueuePair<IbvManagerActor>);
+
 /// Local-only messages for MR registration/deregistration.
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
@@ -146,6 +166,27 @@ pub enum IbvManagerLocalMessage {
         #[reply]
         reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
+}
+
+/// Local-only handshake-success report. The initializer sends this
+/// to its owning manager once both sides have reached RTS, handing
+/// over the freshly-connected [`QpGuard`]. Wired up in a follow-up
+/// commit; the [`Handler`] impl is `unreachable!` until then.
+#[derive(Debug)]
+pub(super) struct QpInitializerDone {
+    pub(super) qp_key: QpKey,
+    pub(super) qp: QpGuard,
+}
+
+/// Local-only handshake-failure report. The initializer sends this
+/// to its owning manager when the handshake aborted; the underlying
+/// QP has already been dropped on the initializer side. Wired up in
+/// a follow-up commit; the [`Handler`] impl is `unreachable!` until
+/// then.
+#[derive(Debug)]
+pub(super) struct QpInitializerFailed {
+    pub(super) qp_key: QpKey,
+    pub(super) error: String,
 }
 
 /// Adaptive wait between completion polls.
@@ -1098,6 +1139,32 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         };
         self.buffer_registrations.insert(remote_buf_id, buf.clone());
         Ok(Ok(buf))
+    }
+}
+
+#[async_trait]
+impl Handler<QpInitializerDone> for IbvManagerActor {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        _msg: QpInitializerDone,
+    ) -> Result<(), anyhow::Error> {
+        unreachable!(
+            "IbvManagerActor does not yet spawn QueuePairInitializer; wired up in a follow-up commit"
+        )
+    }
+}
+
+#[async_trait]
+impl Handler<QpInitializerFailed> for IbvManagerActor {
+    async fn handle(
+        &mut self,
+        _cx: &Context<Self>,
+        _msg: QpInitializerFailed,
+    ) -> Result<(), anyhow::Error> {
+        unreachable!(
+            "IbvManagerActor does not yet spawn QueuePairInitializer; wired up in a follow-up commit"
+        )
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -64,6 +64,7 @@ use super::IbvOp;
 use super::domain::IbvDomain;
 use super::primitives::IbvConfig;
 use super::primitives::IbvDevice;
+use super::primitives::IbvMemoryRegion;
 use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
@@ -85,7 +86,6 @@ use crate::local_memory::RdmaLocalMemory;
 use crate::rdma_components::get_registered_cuda_segments;
 use crate::rdma_manager_actor::GetIbvActorRefClient;
 use crate::rdma_manager_actor::RdmaManagerActor;
-use crate::rdma_manager_actor::get_rdmaxcel_error_message;
 use crate::validate_execution_context;
 
 /// Cross-proc message: peer asks for our endpoint, lazily creating
@@ -151,12 +151,6 @@ pub enum IbvManagerLocalMessage {
         size: usize,
         #[reply]
         reply: OncePortHandle<Result<(IbvMemoryRegionView, String), String>>,
-    },
-    /// Deregister a memory region by its MR view id.
-    DeregisterMr {
-        id: usize,
-        #[reply]
-        reply: OncePortHandle<Result<(), String>>,
     },
     /// Register a remote-facing buffer's MR and return its
     /// [`IbvBuffer`]. Called by
@@ -285,17 +279,14 @@ pub(super) fn lookup_segment_for_address(
     segments: &[rdmaxcel_sys::rdma_segment_info_t],
     addr: usize,
     size: usize,
-    id: usize,
-) -> Option<IbvMemoryRegionView> {
+) -> Option<SegmentInfo> {
     for segment in segments {
         let start_addr = segment.phys_address;
         let end_addr = start_addr + segment.mr_size;
         if start_addr <= addr && addr + size <= end_addr {
             let offset = addr - start_addr;
             let rdma_addr = segment.mr_addr + offset;
-            return Some(IbvMemoryRegionView {
-                id,
-                virtual_addr: addr,
+            return Some(SegmentInfo {
                 rdma_addr,
                 size,
                 lkey: segment.lkey,
@@ -304,6 +295,19 @@ pub(super) fn lookup_segment_for_address(
         }
     }
     None
+}
+
+/// Result of a successful [`lookup_segment_for_address`] hit. Just
+/// the device-derived facts about the matched mkey; the caller
+/// composes these with whatever provenance it needs (mrv id,
+/// device name, refcounted owners) when materializing an
+/// [`IbvMemoryRegionView`].
+#[derive(Debug)]
+pub(super) struct SegmentInfo {
+    pub(super) rdma_addr: usize,
+    pub(super) size: usize,
+    pub(super) lkey: u32,
+    pub(super) rkey: u32,
 }
 
 /// Manages all ibverbs-specific RDMA resources and operations.
@@ -324,23 +328,32 @@ pub struct IbvManagerActor {
     qps: HashMap<QpKey, QpState>,
 
     /// Map of RDMA device names to their domains and loopback QPs.
-    /// Created lazily when memory is registered for a specific device.
-    device_domains: HashMap<String, (IbvDomain, Option<IbvQueuePair>)>,
+    /// Created lazily when memory is registered for a specific
+    /// device. `Arc<IbvDomain>` so every `IbvMemoryRegionView`
+    /// registered against the domain can hold a clone and keep the
+    /// PD alive until the last MR is dereg'd.
+    device_domains: HashMap<String, (Arc<IbvDomain>, Option<IbvQueuePair>)>,
 
     config: IbvConfig,
 
     mlx5dv_enabled: bool,
 
-    /// Map of MR view id to ibv_mr*. CUDA segments register as `0`
-    /// since they're managed independently. Used only for
-    /// registration/deregistration bookkeeping.
-    mr_map: HashMap<usize, usize>,
+    /// Singleton Arc owning the CUDA segment scanner state. `Some`
+    /// once `register_segments` succeeds; cloned into every
+    /// segment-backed view. `deregister_segments` runs from the
+    /// `IbvMemoryRegion::Segments` Drop when the last reference goes
+    /// away.
+    segments_mr: Option<Arc<IbvMemoryRegion>>,
 
     /// Id for next mrv created.
     mrv_id: usize,
 
-    /// Map from buffer_id to registration details.
-    buffer_registrations: HashMap<usize, IbvBuffer>,
+    /// Map from buffer_id to the buffer's `(IbvBuffer, view)`. The
+    /// view keeps the MR (and its PD) alive for the lifetime of the
+    /// registration; `ReleaseBuffer` drops the entry, and the FFI
+    /// resources are released by the `Arc`s' `Drop`s once no other
+    /// holder of those views remains.
+    buffer_registrations: HashMap<usize, (IbvBuffer, IbvMemoryRegionView)>,
 }
 
 #[async_trait]
@@ -379,7 +392,22 @@ impl Drop for IbvManagerActor {
             }
         }
 
-        // 2. Clean up device domains (which contain PDs and loopback QPs)
+        // 2. Drop buffer registrations. Each entry's
+        // `IbvMemoryRegionView` carries the only manager-side
+        // reference to that MR's `Arc<IbvMemoryRegion>` and its
+        // `Arc<IbvDomain>`. They run their FFI cleanup from their
+        // `Drop`s once no surviving view holds a clone.
+        self.buffer_registrations.clear();
+
+        // 3. Drop the segments-owner Arc. `deregister_segments`
+        // runs from `IbvMemoryRegion::Segments::Drop` when the last
+        // segment-backed view also goes away.
+        self.segments_mr.take();
+
+        // 4. Drop device domains (PDs + loopback QPs). Loopback QPs
+        // are tied to this map only; destroy them explicitly. PD
+        // teardown waits on the last `Arc<IbvDomain>` clone (held
+        // by any outstanding view) to drop.
         for (_device_name, (domain, qp)) in self.device_domains.drain() {
             if let Some(qp) = qp {
                 // SAFETY: `device_domains` is the only holder of
@@ -388,39 +416,6 @@ impl Drop for IbvManagerActor {
                 unsafe { destroy_qp(&qp) };
             }
             drop(domain);
-        }
-
-        // 3. Clean up memory regions
-        let _mr_count = self.mr_map.len();
-        for (id, mr_ptr) in self.mr_map.drain() {
-            if mr_ptr != 0 {
-                unsafe {
-                    let result = rdmaxcel_sys::ibv_dereg_mr(mr_ptr as *mut rdmaxcel_sys::ibv_mr);
-                    if result != 0 {
-                        tracing::error!(
-                            "Failed to deregister MR with id {}: error code {}",
-                            id,
-                            result
-                        );
-                    }
-                }
-            }
-        }
-
-        // 4. Deregister all CUDA segments (if using mlx5dv)
-        // The segment scanner in Python handles compatibility checks
-        if self.mlx5dv_enabled {
-            unsafe {
-                let result = rdmaxcel_sys::deregister_segments();
-                if result != 0 {
-                    let error_msg = get_rdmaxcel_error_message(result);
-                    tracing::error!(
-                        "Failed to deregister CUDA segments: {} (error code: {})",
-                        error_msg,
-                        result
-                    );
-                }
-            }
         }
     }
 }
@@ -477,7 +472,7 @@ impl IbvManagerActor {
             device_domains: HashMap::new(),
             config,
             mlx5dv_enabled,
-            mr_map: HashMap::new(),
+            segments_mr: None,
             mrv_id: 0,
             buffer_registrations: HashMap::new(),
         };
@@ -490,15 +485,15 @@ impl IbvManagerActor {
         &mut self,
         device_name: &str,
         rdma_device: &IbvDevice,
-    ) -> Result<(IbvDomain, Option<IbvQueuePair>), anyhow::Error> {
+    ) -> Result<(Arc<IbvDomain>, Option<IbvQueuePair>), anyhow::Error> {
         if let Some((domain, qp)) = self.device_domains.get(device_name) {
-            return Ok((domain.clone(), qp.clone()));
+            return Ok((Arc::clone(domain), qp.clone()));
         }
 
         // Create new domain for this device
-        let domain = IbvDomain::new(rdma_device.clone()).map_err(|e| {
+        let domain = Arc::new(IbvDomain::new(rdma_device.clone()).map_err(|e| {
             anyhow::anyhow!("could not create domain for device {}: {}", device_name, e)
-        })?;
+        })?);
 
         // Print device info if MONARCH_DEBUG_RDMA=1 is set (before initial QP creation)
         crate::print_device_info_if_debug_enabled(domain.context);
@@ -536,7 +531,7 @@ impl IbvManagerActor {
 
         let qp = qp.map(|qp| qp.into_inner());
         self.device_domains
-            .insert(device_name.to_string(), (domain.clone(), qp.clone()));
+            .insert(device_name.to_string(), (Arc::clone(&domain), qp.clone()));
         Ok((domain, qp))
     }
 
@@ -573,16 +568,12 @@ impl IbvManagerActor {
     }
 
     fn find_cuda_segment_for_address(
-        &mut self,
+        &self,
         addr: usize,
         size: usize,
         pd: *mut rdmaxcel_sys::ibv_pd,
-    ) -> Option<IbvMemoryRegionView> {
-        let registered_segments = get_registered_cuda_segments(pd);
-        let id = self.mrv_id;
-        let mrv = lookup_segment_for_address(&registered_segments, addr, size, id)?;
-        self.mrv_id += 1;
-        Some(mrv)
+    ) -> Option<SegmentInfo> {
+        lookup_segment_for_address(&get_registered_cuda_segments(pd), addr, size)
     }
 
     fn register_mr_impl(
@@ -644,18 +635,17 @@ impl IbvManagerActor {
                     | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_ATOMIC
             };
 
-            let mut mr: *mut rdmaxcel_sys::ibv_mr = std::ptr::null_mut();
             let mrv;
 
             if is_cuda {
                 // First, try to use segment scanning if mlx5dv is enabled
-                let mut segment_mrv = None;
+                let mut segment_info = None;
                 if self.mlx5dv_enabled {
                     // Try to find in already registered segments
-                    segment_mrv = self.find_cuda_segment_for_address(addr, size, domain.pd);
+                    segment_info = self.find_cuda_segment_for_address(addr, size, domain.pd);
 
                     // If not found, trigger a re-sync with the allocator and retry
-                    if segment_mrv.is_none() {
+                    if segment_info.is_none() {
                         let (mut pds, mut qps) = self.build_per_device_pd_qp_arrays();
                         let err = rdmaxcel_sys::register_segments(
                             pds.as_mut_ptr(),
@@ -666,14 +656,40 @@ impl IbvManagerActor {
                         // Only retry if register_segments succeeded
                         // If it fails (e.g., scanner returns 0 segments), we'll fall back to dmabuf
                         if err == 0 {
-                            segment_mrv = self.find_cuda_segment_for_address(addr, size, domain.pd);
+                            // The scanner just registered (or
+                            // re-synced) global segment state. Lazily
+                            // install the singleton `segments_mr` now,
+                            // independent of whether *this* address
+                            // matches a segment. Without this, a
+                            // subsequent retry that doesn't find a
+                            // segment would leak the newly-registered
+                            // global state on manager teardown.
+                            self.segments_mr
+                                .get_or_insert_with(|| Arc::new(IbvMemoryRegion::Segments));
+                            segment_info =
+                                self.find_cuda_segment_for_address(addr, size, domain.pd);
                         }
                     }
                 }
 
                 // Use segment if found, otherwise fall back to direct dmabuf registration
-                if let Some(mrv_from_segment) = segment_mrv {
-                    mrv = mrv_from_segment;
+                if let Some(info) = segment_info {
+                    let segments_mr = Arc::clone(
+                        self.segments_mr
+                            .get_or_insert_with(|| Arc::new(IbvMemoryRegion::Segments)),
+                    );
+                    let id = self.mrv_id;
+                    self.mrv_id += 1;
+                    mrv = IbvMemoryRegionView::new(
+                        id,
+                        addr,
+                        info.rdma_addr,
+                        info.size,
+                        info.lkey,
+                        info.rkey,
+                        device_name.clone(),
+                        segments_mr,
+                    );
                 } else {
                     // Dmabuf path: used when mlx5dv is disabled OR scanner returns no segments
                     let mut fd: i32 = -1;
@@ -693,24 +709,30 @@ impl IbvManagerActor {
                             fd
                         ));
                     }
-                    mr =
+                    let mr =
                         rdmaxcel_sys::ibv_reg_dmabuf_mr(domain.pd, 0, size, 0, fd, access.0 as i32);
                     if mr.is_null() {
                         return Err(anyhow::anyhow!("Failed to register dmabuf MR"));
                     }
-                    mrv = IbvMemoryRegionView {
-                        id: self.mrv_id,
-                        virtual_addr: addr,
-                        rdma_addr: (*mr).addr as usize,
-                        size,
-                        lkey: (*mr).lkey,
-                        rkey: (*mr).rkey,
-                    };
+                    let id = self.mrv_id;
                     self.mrv_id += 1;
+                    mrv = IbvMemoryRegionView::new(
+                        id,
+                        addr,
+                        (*mr).addr as usize,
+                        size,
+                        (*mr).lkey,
+                        (*mr).rkey,
+                        device_name.clone(),
+                        Arc::new(IbvMemoryRegion::Direct {
+                            mr,
+                            _domain: Arc::clone(&domain),
+                        }),
+                    );
                 }
             } else {
                 // CPU memory path
-                mr = rdmaxcel_sys::ibv_reg_mr(
+                let mr = rdmaxcel_sys::ibv_reg_mr(
                     domain.pd,
                     addr as *mut std::ffi::c_void,
                     size,
@@ -721,30 +743,24 @@ impl IbvManagerActor {
                     return Err(anyhow::anyhow!("failed to register standard MR"));
                 }
 
-                mrv = IbvMemoryRegionView {
-                    id: self.mrv_id,
-                    virtual_addr: addr,
-                    rdma_addr: (*mr).addr as usize,
-                    size,
-                    lkey: (*mr).lkey,
-                    rkey: (*mr).rkey,
-                };
+                let id = self.mrv_id;
                 self.mrv_id += 1;
+                mrv = IbvMemoryRegionView::new(
+                    id,
+                    addr,
+                    (*mr).addr as usize,
+                    size,
+                    (*mr).lkey,
+                    (*mr).rkey,
+                    device_name.clone(),
+                    Arc::new(IbvMemoryRegion::Direct {
+                        mr,
+                        _domain: Arc::clone(&domain),
+                    }),
+                );
             }
-            self.mr_map.insert(mrv.id, mr as usize);
             Ok((mrv, device_name))
         }
-    }
-
-    fn deregister_mr_impl(&mut self, id: usize) -> Result<(), anyhow::Error> {
-        if let Some(mr_ptr) = self.mr_map.remove(&id) {
-            if mr_ptr != 0 {
-                unsafe {
-                    rdmaxcel_sys::ibv_dereg_mr(mr_ptr as *mut rdmaxcel_sys::ibv_mr);
-                }
-            }
-        }
-        Ok(())
     }
 
     /// Lazy QP creation: if `qp_key` is absent, create the local
@@ -803,10 +819,10 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         _cx: &Context<Self>,
         remote_buf_id: usize,
     ) -> Result<(), anyhow::Error> {
-        if let Some(buf) = self.buffer_registrations.remove(&remote_buf_id) {
-            self.deregister_mr_impl(buf.mr_id)
-                .map_err(|e| anyhow::anyhow!("could not deregister buffer: {}", e))?;
-        }
+        // Dropping the entry releases the manager's `Arc` clones on
+        // the view's MR and PD; FFI cleanup happens via their `Drop`s
+        // once the last referencing view is gone.
+        self.buffer_registrations.remove(&remote_buf_id);
         Ok(())
     }
 }
@@ -876,21 +892,13 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         Ok(self.register_mr_impl(addr, size).map_err(|e| e.to_string()))
     }
 
-    async fn deregister_mr(
-        &mut self,
-        _cx: &Context<Self>,
-        id: usize,
-    ) -> Result<Result<(), String>, anyhow::Error> {
-        Ok(self.deregister_mr_impl(id).map_err(|e| e.to_string()))
-    }
-
     async fn register_remote_buffer(
         &mut self,
         _cx: &Context<Self>,
         remote_buf_id: usize,
         local: Arc<dyn RdmaLocalMemory>,
     ) -> Result<Result<IbvBuffer, String>, anyhow::Error> {
-        if let Some(buf) = self.buffer_registrations.get(&remote_buf_id) {
+        if let Some((buf, _)) = self.buffer_registrations.get(&remote_buf_id) {
             return Ok(Ok(buf.clone()));
         }
         let (mrv, device_name) = match self.register_mr_impl(local.addr(), local.size()) {
@@ -905,7 +913,8 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
             size: mrv.size,
             device_name,
         };
-        self.buffer_registrations.insert(remote_buf_id, buf.clone());
+        self.buffer_registrations
+            .insert(remote_buf_id, (buf.clone(), mrv));
         Ok(Ok(buf))
     }
 
@@ -1146,15 +1155,17 @@ impl IbvBackend {
         ))
     }
 
-    /// Core submit logic: registers local MR via actor message, resolves remote
-    /// IbvBuffer lazily, executes the op locally, and deregisters local MR.
+    /// Core submit logic: registers a local MR via actor message,
+    /// resolves the remote `IbvBuffer` lazily, and executes the op.
+    /// `local_mrv` is kept in scope for the duration of the op so
+    /// its `Arc<IbvMemoryRegion>` (and the PD it lives on) survive
+    /// until completion; on drop, the FFI MR is deregistered.
     async fn execute_op(
         &self,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
         op: IbvOp,
         timeout: Duration,
     ) -> Result<(), anyhow::Error> {
-        // Register the local memory via actor message
         let (local_mrv, local_device_name) = self
             .register_mr(cx, op.local_memory.addr(), op.local_memory.size())
             .await?
@@ -1169,7 +1180,7 @@ impl IbvBackend {
             device_name: local_device_name,
         };
 
-        let op_result = async {
+        let result = async {
             let mut qp = request_queue_pair(
                 &self.0,
                 cx,
@@ -1190,22 +1201,8 @@ impl IbvBackend {
         }
         .await;
 
-        // Always deregister the locally registered MR via actor message
-        let dereg_result = self
-            .deregister_mr(cx, local_buffer.mr_id)
-            .await?
-            .map_err(|e| anyhow::anyhow!(e));
-
-        match (op_result, dereg_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(e), Ok(())) => Err(e),
-            (Ok(()), Err(e)) => Err(e),
-            (Err(op_err), Err(dereg_err)) => Err(anyhow::anyhow!(
-                "deregister MR error: {}; op error: {}",
-                dereg_err,
-                op_err
-            )),
-        }
+        drop(local_mrv);
+        result
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -15,9 +15,25 @@
 //! - Queue pair creation and connection establishment
 //! - RDMA domain and protection domain management
 //! - Device selection and PCI-to-RDMA device mapping
+//!
+//! ## Queue-pair lifecycle
+//!
+//! Bringing up a queue pair to a peer is a two-sided handshake (each
+//! side has its own QP and must learn the other side's endpoint
+//! before transitioning `INIT → RTR → RTS`). Doing all of that in
+//! response to a single message would block our actor loop while
+//! awaiting peer RPCs, and the peer's symmetric request would block
+//! waiting for us — a deadlock.
+//!
+//! Instead, [`IbvManagerActor`] does only sync bookkeeping in the
+//! handler and offloads the handshake to a per-QP child actor,
+//! [`QueuePairInitializer`]. The store of QPs ([`Self::qps`]) is
+//! keyed by [`QpKey`] and holds a [`QpState`]: `Pending { info,
+//! initializer, waiters }` while the handshake runs, `Ready(qp)`
+//! once this side is RTS and has observed the peer's RTS, or
+//! `Failed(error)` as a tombstone after a fatal error.
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -28,17 +44,14 @@ use async_trait::async_trait;
 use backoff::ExponentialBackoff;
 use backoff::ExponentialBackoffBuilder;
 use backoff::backoff::Backoff;
-use futures::lock::Mutex;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
-use hyperactor::OncePortRef;
 use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::actor::Referable;
@@ -62,6 +75,8 @@ use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
 use super::queue_pair::QpGuard;
 use super::queue_pair::QpKey;
+use super::queue_pair::QueuePairInitializer;
+use super::queue_pair::destroy_qp;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
@@ -73,60 +88,9 @@ use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::rdma_manager_actor::get_rdmaxcel_error_message;
 use crate::validate_execution_context;
 
-/// Messages handled by [`IbvManagerActor`].
-#[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
-pub enum IbvManagerMessage {
-    /// Release a buffer registration by `remote_buf_id`. Fire-and-forget
-    /// (no reply port) to avoid blocking the caller during teardown.
-    ReleaseBuffer { remote_buf_id: usize },
-    RequestQueuePair {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        #[reply]
-        reply: OncePortRef<Result<IbvQueuePair, String>>,
-    },
-    Connect {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        endpoint: IbvQpInfo,
-    },
-    InitializeQP {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        #[reply]
-        reply: OncePortRef<bool>,
-    },
-    ConnectionInfo {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        #[reply]
-        reply: OncePortRef<IbvQpInfo>,
-    },
-    ReleaseQueuePair {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        qp: IbvQueuePair,
-    },
-    GetQpState {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        #[reply]
-        reply: OncePortRef<u32>,
-    },
-}
-wirevalue::register_type!(IbvManagerMessage);
-
 /// Cross-proc message: peer asks for our endpoint, lazily creating
 /// the entry on our side if absent. Generic over the manager actor
-/// type so tests can swap in a mock. The handler impl on
-/// `IbvManagerActor` lands in a follow-up commit; this commit only
-/// defines the type so `QueuePairInitializer` can compile.
+/// type so tests can swap in a mock.
 #[derive(Debug, Serialize, Deserialize, Named)]
 #[serde(bound(serialize = "", deserialize = ""))]
 pub(super) struct EnsureQueuePair<A: Referable> {
@@ -137,7 +101,48 @@ pub(super) struct EnsureQueuePair<A: Referable> {
 }
 wirevalue::register_type!(EnsureQueuePair<IbvManagerActor>);
 
-/// Local-only messages for MR registration/deregistration.
+/// Per-QpKey state in [`IbvManagerActor::qps`].
+///
+/// `Pending` covers the entire handshake (an initializer is running);
+/// `Ready` is the terminal usable state; `Failed` is a tombstone that
+/// records the error so subsequent `RequestQueuePair` / `EnsureQueuePair`
+/// calls for the same key surface the same error rather than retrying
+/// or hanging.
+///
+/// TODO: add recovery — allow retries via an explicit message or after
+/// a backoff. For now the entry stays `Failed` for the life of the
+/// manager.
+#[derive(Debug)]
+enum QpState {
+    Pending {
+        /// Local endpoint, captured when the QP was first created so
+        /// repeated `EnsureQueuePair` calls don't have to re-extract it.
+        info: IbvQpInfo,
+        /// Child actor driving the handshake. Stopped on
+        /// `QpInitializerDone`/`QpInitializerFailed`.
+        initializer: ActorHandle<QueuePairInitializer<IbvManagerActor>>,
+        /// Local `RequestQueuePair` callers waiting for the QP. Drained
+        /// to `Ok(qp.clone())` on `Ready`, or `Err(_)` on failure.
+        waiters: Vec<OncePortHandle<Result<IbvQueuePair, String>>>,
+    },
+    Ready(IbvQueuePair),
+    Failed(String),
+}
+
+/// Cross-proc messages handled by [`IbvManagerActor`].
+///
+/// `EnsureQueuePair` is defined as a separate top-level message
+/// because it's generic over the manager actor type to allow
+/// mocking in tests.
+#[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
+pub enum IbvManagerMessage {
+    /// Release a buffer registration by `remote_buf_id`. Fire-and-forget
+    /// (no reply port) to avoid blocking the caller during teardown.
+    ReleaseBuffer { remote_buf_id: usize },
+}
+wirevalue::register_type!(IbvManagerMessage);
+
+/// Local-only messages for [`IbvManagerActor`].
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
     /// Register a memory region, returning the MR view and device name.
@@ -166,12 +171,26 @@ pub enum IbvManagerLocalMessage {
         #[reply]
         reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
+    /// User-facing entry point: get a connected `IbvQueuePair` for
+    /// `(self_device, other actor's id, other_device)`. Lazily creates
+    /// the QP + initializer if absent; if a handshake is in flight,
+    /// the reply port is queued and answered when the QP becomes
+    /// `Ready` (or fails).
+    ///
+    /// No `#[reply]` because the handler may park `reply` on the
+    /// `Pending` entry and answer it later from [`QpInitializerDone`]/
+    /// [`QpInitializerFailed`].
+    RequestQueuePair {
+        other: ActorRef<IbvManagerActor>,
+        self_device: String,
+        other_device: String,
+        reply: OncePortHandle<Result<IbvQueuePair, String>>,
+    },
 }
 
 /// Local-only handshake-success report. The initializer sends this
 /// to its owning manager once both sides have reached RTS, handing
-/// over the freshly-connected [`QpGuard`]. Wired up in a follow-up
-/// commit; the [`Handler`] impl is `unreachable!` until then.
+/// over the freshly-connected [`QpGuard`].
 #[derive(Debug)]
 pub(super) struct QpInitializerDone {
     pub(super) qp_key: QpKey,
@@ -180,9 +199,7 @@ pub(super) struct QpInitializerDone {
 
 /// Local-only handshake-failure report. The initializer sends this
 /// to its owning manager when the handshake aborted; the underlying
-/// QP has already been dropped on the initializer side. Wired up in
-/// a follow-up commit; the [`Handler`] impl is `unreachable!` until
-/// then.
+/// QP has already been dropped on the initializer side.
 #[derive(Debug)]
 pub(super) struct QpInitializerFailed {
     pub(super) qp_key: QpKey,
@@ -297,34 +314,32 @@ pub(super) fn lookup_segment_for_address(
 #[hyperactor::export(
     handlers = [
         IbvManagerMessage,
+        EnsureQueuePair<IbvManagerActor>,
     ],
 )]
 pub struct IbvManagerActor {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
-    // Nested map: local_device -> (ActorId, remote_device) -> IbvQueuePair
-    device_qps: HashMap<String, HashMap<(ActorId, String), IbvQueuePair>>,
+    /// Per-QP state, keyed from this manager's perspective. See [`QpKey`].
+    qps: HashMap<QpKey, QpState>,
 
-    // Track QPs currently being created to prevent duplicate creation
-    // Wrapped in Arc<Mutex> to allow safe concurrent access
-    pending_qp_creation: Arc<Mutex<HashSet<(String, ActorId, String)>>>,
-
-    // Map of RDMA device names to their domains and loopback QPs
-    // Created lazily when memory is registered for a specific device
+    /// Map of RDMA device names to their domains and loopback QPs.
+    /// Created lazily when memory is registered for a specific device.
     device_domains: HashMap<String, (IbvDomain, Option<IbvQueuePair>)>,
 
     config: IbvConfig,
 
     mlx5dv_enabled: bool,
 
-    // Map of unique IbvMemoryRegionView to ibv_mr*.  In case of cuda w/ pytorch its -1
-    // since its managed independently.  Only used for registration/deregistration purposes
+    /// Map of MR view id to ibv_mr*. CUDA segments register as `0`
+    /// since they're managed independently. Used only for
+    /// registration/deregistration bookkeeping.
     mr_map: HashMap<usize, usize>,
 
-    // Id for next mrv created
+    /// Id for next mrv created.
     mrv_id: usize,
 
-    // Map from buffer_id to registration details.
+    /// Map from buffer_id to registration details.
     buffer_registrations: HashMap<usize, IbvBuffer>,
 }
 
@@ -345,30 +360,32 @@ impl Actor for IbvManagerActor {
 
 impl Drop for IbvManagerActor {
     fn drop(&mut self) {
-        // Helper function to destroy QP resources
-        // We can't use Drop on IbvQueuePair because it derives Clone
-        // Note: rdmaxcel_qp_destroy handles destroying both the QP and its CQs internally,
-        // so we must NOT call ibv_destroy_cq separately (would cause double-free/SIGSEGV)
-        fn destroy_queue_pair(qp: &IbvQueuePair, _context: &str) {
-            unsafe {
-                if qp.qp != 0 {
-                    let rdmaxcel_qp = qp.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
-                    rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
+        // 1. Clean up QPs. `Pending` entries hold the qp via the
+        // initializer; signal the initializer to stop and let the
+        // runtime tear it down. `Failed` is a tombstone with no
+        // resources. Pending waiters won't be answered and their
+        // callers will observe the dropped reply ports as `Err(_)`.
+        for (_key, state) in self.qps.drain() {
+            match state {
+                QpState::Ready(_) => {
+                    // TODO(slurye): Proper cleanup of QPs. Currently there's no safe way to do this
+                    // because `IbvQueuePair` can have arbitrary clones and there's no way to guarantee
+                    // that none of them are still in use.
                 }
-            }
-        }
-
-        // 1. Clean up all queue pairs (both regular and loopback)
-        for (_device_name, device_map) in self.device_qps.drain() {
-            for ((actor_id, _remote_device), qp) in device_map {
-                destroy_queue_pair(&qp, &format!("actor {:?}", actor_id));
+                QpState::Pending { initializer, .. } => {
+                    let _ = initializer.drain_and_stop("IbvManagerActor dropped");
+                }
+                QpState::Failed(_) => {}
             }
         }
 
         // 2. Clean up device domains (which contain PDs and loopback QPs)
-        for (device_name, (domain, qp)) in self.device_domains.drain() {
+        for (_device_name, (domain, qp)) in self.device_domains.drain() {
             if let Some(qp) = qp {
-                destroy_queue_pair(&qp, &format!("loopback QP on device {}", device_name));
+                // SAFETY: `device_domains` is the only holder of
+                // these loopback QPs; we just drained it and the
+                // manager is being dropped, so no clones survive.
+                unsafe { destroy_qp(&qp) };
             }
             drop(domain);
         }
@@ -456,8 +473,7 @@ impl IbvManagerActor {
 
         let actor = Self {
             owner: OnceLock::new(),
-            device_qps: HashMap::new(),
-            pending_qp_creation: Arc::new(Mutex::new(HashSet::new())),
+            qps: HashMap::new(),
             device_domains: HashMap::new(),
             config,
             mlx5dv_enabled,
@@ -490,14 +506,15 @@ impl IbvManagerActor {
         // Create loopback QP for this domain if mlx5dv is supported (needed for segment registration)
         // For EFA, we don't need a loopback QP for segment scanning
         let qp = if mlx5dv_supported() && !crate::efa::is_efa_device() {
-            let mut qp = IbvQueuePair::new(domain.context, domain.pd, self.config.clone())
-                .map_err(|e| {
+            let mut qp = QpGuard::new(
+                IbvQueuePair::new(domain.context, domain.pd, self.config.clone()).map_err(|e| {
                     anyhow::anyhow!(
                         "could not create loopback QP for device {}: {}",
                         device_name,
                         e
                     )
-                })?;
+                })?,
+            );
 
             // Get connection info and connect to itself
             let endpoint = qp.get_qp_info().map_err(|e| {
@@ -517,6 +534,7 @@ impl IbvManagerActor {
             None
         };
 
+        let qp = qp.map(|qp| qp.into_inner());
         self.device_domains
             .insert(device_name.to_string(), (domain.clone(), qp.clone()));
         Ok((domain, qp))
@@ -729,183 +747,51 @@ impl IbvManagerActor {
         Ok(())
     }
 
-    async fn request_queue_pair_impl(
+    /// Lazy QP creation: if `qp_key` is absent, create the local
+    /// `IbvQueuePair`, capture its `IbvQpInfo`, and spawn a
+    /// `QueuePairInitializer` to drive the handshake. Returns the
+    /// `QpState` entry — either the freshly-inserted `Pending` one,
+    /// or the existing `Pending`/`Ready`/`Failed`.
+    fn ensure_queue_pair_impl(
         &mut self,
         cx: &Context<'_, Self>,
         other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<IbvQueuePair, anyhow::Error> {
-        let self_ref: ActorRef<IbvManagerActor> = cx.bind();
-        let other_id = other.actor_addr().id().clone();
-
-        // Use the nested map structure: local_device -> (actor_id, remote_device) -> IbvQueuePair
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        // Check if queue pair exists in map
-        let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get(&self_device);
-        if let Some(device_map) = device_map {
-            if let Some(qp) = device_map.get(&inner_key) {
-                return Ok(qp.clone());
-            }
+        qp_key: &QpKey,
+    ) -> Result<&mut QpState, anyhow::Error> {
+        if !self.qps.contains_key(qp_key) {
+            let self_device = &qp_key.self_device;
+            let rdma_device = super::primitives::get_all_devices()
+                .into_iter()
+                .find(|d| d.name() == self_device)
+                .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
+            let (domain, _) = self.get_or_create_device_domain(self_device, &rdma_device)?;
+            // Wrap the freshly-created QP in a `QpGuard` immediately
+            // so that any early-return path below (e.g. `get_qp_info`
+            // failing) destroys the underlying `rdmaxcel_qp_t` via
+            // the guard's `Drop` rather than leaking it.
+            let mut qp = QpGuard::new(
+                IbvQueuePair::new(domain.context, domain.pd, self.config.clone())
+                    .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {}", e))?,
+            );
+            let info = qp
+                .get_qp_info()
+                .map_err(|e| anyhow::anyhow!("could not extract QP info: {}", e))?;
+            let initializer =
+                QueuePairInitializer::new(Instance::handle(cx), other, qp_key.clone(), qp)
+                    .spawn(cx)?;
+            self.qps.insert(
+                qp_key.clone(),
+                QpState::Pending {
+                    info,
+                    initializer,
+                    waiters: Vec::new(),
+                },
+            );
         }
-
-        // Try to acquire lock and mark as pending (hold lock only once!)
-        let pending_key = (self_device.clone(), other_id.clone(), other_device.clone());
-        let mut pending: futures::lock::MutexGuard<'_, HashSet<(String, ActorId, String)>> =
-            self.pending_qp_creation.lock().await;
-
-        if pending.contains(&pending_key) {
-            // Another task is creating this QP, release lock and wait
-            drop(pending);
-
-            // Loop checking device_qps until QP is created (no more locks needed)
-            // Timeout after 1 second
-            let start = Instant::now();
-            let timeout = Duration::from_secs(1);
-
-            loop {
-                tokio::time::sleep(Duration::from_micros(200)).await;
-
-                // Check if QP was created while we waited
-                let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
-                    self.device_qps.get(&self_device);
-                if let Some(device_map) = device_map {
-                    if let Some(qp) = device_map.get(&inner_key) {
-                        return Ok(qp.clone());
-                    }
-                }
-
-                // Check for timeout
-                if start.elapsed() >= timeout {
-                    return Err(anyhow::anyhow!(
-                        "Timeout waiting for QP creation (device {} -> actor {} device {}). \
-                         Another task is creating it but hasn't completed in 1 second",
-                        self_device,
-                        other_id,
-                        other_device
-                    ));
-                }
-            }
-        } else {
-            // Not pending, add to set and proceed with creation
-            pending.insert(pending_key.clone());
-            drop(pending);
-            // Fall through to create QP
-        }
-
-        // Queue pair doesn't exist - need to create connection
-        let result = async {
-            let is_loopback =
-                other_id == *self_ref.actor_addr().id() && self_device == other_device;
-
-            if is_loopback {
-                // Loopback connection setup
-                self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                let endpoint = self
-                    .connection_info(cx, other.clone(), other_device.clone(), self_device.clone())
-                    .await?;
-                self.connect(
-                    cx,
-                    other.clone(),
-                    self_device.clone(),
-                    other_device.clone(),
-                    endpoint,
-                )
-                .await?;
-            } else {
-                // Remote connection setup
-                self.initialize_qp(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                other
-                    .initialize_qp(
-                        cx,
-                        self_ref.clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-                let other_endpoint: IbvQpInfo = other
-                    .connection_info(
-                        cx,
-                        self_ref.clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-                self.connect(
-                    cx,
-                    other.clone(),
-                    self_device.clone(),
-                    other_device.clone(),
-                    other_endpoint,
-                )
-                .await?;
-                let local_endpoint = self
-                    .connection_info(cx, other.clone(), self_device.clone(), other_device.clone())
-                    .await?;
-                other
-                    .connect(
-                        cx,
-                        self_ref.clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                        local_endpoint,
-                    )
-                    .await?;
-
-                // BARRIER: Ensure remote side has completed its connection and is ready
-                let remote_state = other
-                    .get_qp_state(
-                        cx,
-                        self_ref.clone(),
-                        other_device.clone(),
-                        self_device.clone(),
-                    )
-                    .await?;
-
-                if remote_state != rdmaxcel_sys::ibv_qp_state::IBV_QPS_RTS {
-                    return Err(anyhow::anyhow!(
-                        "Remote QP not in RTS state after connection setup. \
-                         Local is ready but remote is in state {}. \
-                         This indicates a synchronization issue in connection setup.",
-                        remote_state
-                    ));
-                }
-            }
-
-            // Now that connection is established, get and clone the queue pair
-            let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
-                self.device_qps.get(&self_device);
-            if let Some(device_map) = device_map {
-                if let Some(qp) = device_map.get(&inner_key) {
-                    Ok(qp.clone())
-                } else {
-                    Err(anyhow::anyhow!(
-                        "Failed to create connection for actor {} on device {}",
-                        other_id,
-                        other_device
-                    ))
-                }
-            } else {
-                Err(anyhow::anyhow!(
-                    "Failed to create connection for actor {} on device {} - no device map",
-                    other_id,
-                    other_device
-                ))
-            }
-        }
-        .await;
-
-        // Always remove from pending set when done (success or failure)
-        let mut pending: futures::lock::MutexGuard<'_, HashSet<(String, ActorId, String)>> =
-            self.pending_qp_creation.lock().await;
-        pending.remove(&pending_key);
-        drop(pending);
-
-        result
+        Ok(self
+            .qps
+            .get_mut(qp_key)
+            .expect("entry just inserted or pre-existing"))
     }
 }
 
@@ -923,176 +809,58 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         }
         Ok(())
     }
+}
 
-    async fn request_queue_pair(
+#[async_trait]
+impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
+    async fn handle(
         &mut self,
         cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
-        Ok(self
-            .request_queue_pair_impl(cx, other, self_device, other_device)
-            .await
-            .map_err(|e| e.to_string()))
-    }
-
-    async fn connect(
-        &mut self,
-        _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        endpoint: IbvQpInfo,
+        msg: EnsureQueuePair<IbvManagerActor>,
     ) -> Result<(), anyhow::Error> {
-        tracing::debug!("connecting with {:?}", other);
-        let other_id = other.actor_addr().id().clone();
-
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get_mut(&self_device);
-        if let Some(device_map) = device_map {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => {
-                    qp.connect(&endpoint).map_err(|e| {
-                        anyhow::anyhow!("could not connect to RDMA endpoint: {}", e)
-                    })?;
-                    Ok(())
-                }
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {}",
-                    other_id
-                )),
+        let EnsureQueuePair {
+            sender,
+            sender_device,
+            receiver_device,
+            reply,
+        } = msg;
+        let qp_key = QpKey {
+            self_device: receiver_device,
+            other_id: sender.actor_addr().id().clone(),
+            other_device: sender_device,
+        };
+        let state = match self.ensure_queue_pair_impl(cx, sender, &qp_key) {
+            Ok(state) => state,
+            Err(e) => {
+                reply.send(cx, PeerInfo(Err(e.to_string())))?;
+                return Ok(());
             }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for device {}",
-                self_device
-            ))
-        }
-    }
-
-    async fn initialize_qp(
-        &mut self,
-        _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<bool, anyhow::Error> {
-        let other_id = other.actor_addr().id().clone();
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        // Check if QP already exists in nested structure
-        let device_map: Option<&HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get(&self_device);
-        if let Some(device_map) = device_map {
-            if device_map.contains_key(&inner_key) {
-                return Ok(true);
+        };
+        match state {
+            QpState::Pending {
+                info, initializer, ..
+            } => {
+                let notify_rts = initializer.bind::<QueuePairInitializer<Self>>().port();
+                reply.send(cx, PeerInfo(Ok((info.clone(), notify_rts))))?;
+            }
+            QpState::Ready(_) => {
+                // `Ready` means a prior handshake completed and the
+                // initializer was stopped — we can't hand back an
+                // initializer ref. Reaching here represents a logic
+                // error (peer is asking us to redo a handshake we've
+                // already finished); surface it as `Err`.
+                reply.send(
+                    cx,
+                    PeerInfo(Err(format!(
+                        "EnsureQueuePair on already-Ready entry {qp_key:?}"
+                    ))),
+                )?;
+            }
+            QpState::Failed(error) => {
+                reply.send(cx, PeerInfo(Err(error.clone())))?;
             }
         }
-
-        // The domain is guaranteed to exist here: register_mr is always called before
-        // initialize_qp, either in execute_op or in register_remote_buffer at
-        // buffer-creation time, and register_mr always calls get_or_create_device_domain.
-        let (domain, _) = self.device_domains.get(&self_device).ok_or_else(|| {
-            anyhow::anyhow!(
-                "device domain for '{}' not found; register_mr must be called before initialize_qp",
-                self_device
-            )
-        })?;
-        let (domain_context, domain_pd) = (domain.context, domain.pd);
-
-        let qp = IbvQueuePair::new(domain_context, domain_pd, self.config.clone())
-            .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {}", e))?;
-
-        // Insert the QP into the nested map structure
-        self.device_qps
-            .entry(self_device.clone())
-            .or_insert_with(HashMap::new)
-            .insert(inner_key, qp);
-
-        tracing::debug!(
-            "successfully created a connection with {:?} for local device {} -> remote device {}",
-            other,
-            self_device,
-            other_device
-        );
-
-        Ok(true)
-    }
-
-    async fn connection_info(
-        &mut self,
-        _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<IbvQpInfo, anyhow::Error> {
-        tracing::debug!("getting connection info with {:?}", other);
-        let other_id = other.actor_addr().id().clone();
-
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get_mut(&self_device);
-        if let Some(device_map) = device_map {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => {
-                    let connection_info = qp.get_qp_info()?;
-                    Ok(connection_info)
-                }
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {}",
-                    other_id
-                )),
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for self device {}",
-                self_device
-            ))
-        }
-    }
-
-    async fn release_queue_pair(
-        &mut self,
-        _cx: &Context<Self>,
-        _other: ActorRef<IbvManagerActor>,
-        _self_device: String,
-        _other_device: String,
-        _qp: IbvQueuePair,
-    ) -> Result<(), anyhow::Error> {
         Ok(())
-    }
-
-    async fn get_qp_state(
-        &mut self,
-        _cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-    ) -> Result<u32, anyhow::Error> {
-        let other_id = other.actor_addr().id().clone();
-        let inner_key = (other_id.clone(), other_device.clone());
-
-        let device_map: Option<&mut HashMap<(ActorId, String), IbvQueuePair>> =
-            self.device_qps.get_mut(&self_device);
-        if let Some(device_map) = device_map {
-            match device_map.get_mut(&inner_key) {
-                Some(qp) => qp.state(),
-                None => Err(anyhow::anyhow!(
-                    "No connection found for actor {} on device {}",
-                    other_id,
-                    other_device
-                )),
-            }
-        } else {
-            Err(anyhow::anyhow!(
-                "No device map found for self device {}",
-                self_device
-            ))
-        }
     }
 }
 
@@ -1140,18 +908,80 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         self.buffer_registrations.insert(remote_buf_id, buf.clone());
         Ok(Ok(buf))
     }
+
+    async fn request_queue_pair(
+        &mut self,
+        cx: &Context<Self>,
+        other: ActorRef<IbvManagerActor>,
+        self_device: String,
+        other_device: String,
+        reply: OncePortHandle<Result<IbvQueuePair, String>>,
+    ) -> Result<(), anyhow::Error> {
+        let qp_key = QpKey {
+            self_device,
+            other_id: other.actor_addr().id().clone(),
+            other_device,
+        };
+        let state = match self.ensure_queue_pair_impl(cx, other, &qp_key) {
+            Ok(state) => state,
+            Err(e) => {
+                reply.send(cx, Err(e.to_string()))?;
+                return Ok(());
+            }
+        };
+        match state {
+            QpState::Pending { waiters, .. } => waiters.push(reply),
+            QpState::Ready(qp) => reply.send(cx, Ok(qp.clone()))?,
+            QpState::Failed(error) => reply.send(cx, Err(error.clone()))?,
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
 impl Handler<QpInitializerDone> for IbvManagerActor {
     async fn handle(
         &mut self,
-        _cx: &Context<Self>,
-        _msg: QpInitializerDone,
+        cx: &Context<Self>,
+        msg: QpInitializerDone,
     ) -> Result<(), anyhow::Error> {
-        unreachable!(
-            "IbvManagerActor does not yet spawn QueuePairInitializer; wired up in a follow-up commit"
-        )
+        let QpInitializerDone { qp_key, qp } = msg;
+        let qp = qp.into_inner();
+        // Take the entry out, transition to Ready, drain waiters,
+        // then stop the initializer.
+        let initializer = match self.qps.remove(&qp_key) {
+            Some(QpState::Pending {
+                waiters,
+                initializer,
+                ..
+            }) => {
+                for w in waiters {
+                    let waiter_dbg = format!("{w:?}");
+                    if let Err(e) = w.send(cx, Ok(qp.clone())) {
+                        tracing::error!(
+                            "QpInitializerDone: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
+                        );
+                    }
+                }
+                initializer
+            }
+            other => {
+                unreachable!("QpInitializerDone received but state is {other:?}: {qp_key:?}")
+            }
+        };
+        self.qps.insert(qp_key.clone(), QpState::Ready(qp));
+        initializer.drain_and_stop("QpInitializerDone")?;
+        let status = initializer.await;
+        if status.is_failed() {
+            // The QP itself is already `Ready` and waiters have been
+            // drained, so a non-clean initializer shutdown is not
+            // user-visible — log and move on rather than crashing
+            // the manager.
+            tracing::error!(
+                "QueuePairInitializer for {qp_key:?} terminated with failure after Done: {status:?}"
+            );
+        }
+        Ok(())
     }
 }
 
@@ -1159,13 +989,66 @@ impl Handler<QpInitializerDone> for IbvManagerActor {
 impl Handler<QpInitializerFailed> for IbvManagerActor {
     async fn handle(
         &mut self,
-        _cx: &Context<Self>,
-        _msg: QpInitializerFailed,
+        cx: &Context<Self>,
+        msg: QpInitializerFailed,
     ) -> Result<(), anyhow::Error> {
-        unreachable!(
-            "IbvManagerActor does not yet spawn QueuePairInitializer; wired up in a follow-up commit"
-        )
+        let QpInitializerFailed { qp_key, error } = msg;
+        let initializer = match self.qps.remove(&qp_key) {
+            Some(QpState::Pending {
+                waiters,
+                initializer,
+                ..
+            }) => {
+                for w in waiters {
+                    let waiter_dbg = format!("{w:?}");
+                    if let Err(e) = w.send(cx, Err(error.clone())) {
+                        tracing::error!(
+                            "QpInitializerFailed: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
+                        );
+                    }
+                }
+                initializer
+            }
+            other => {
+                unreachable!("QpInitializerFailed received but state is {other:?}: {qp_key:?}")
+            }
+        };
+        // Tombstone the entry: subsequent `RequestQueuePair` calls
+        // for the same key surface the same error rather than
+        // retrying or hanging. TODO: add recovery.
+        self.qps.insert(qp_key.clone(), QpState::Failed(error));
+        initializer.drain_and_stop("QpInitializerFailed")?;
+        let status = initializer.await;
+        if status.is_failed() {
+            tracing::error!(
+                "QueuePairInitializer for {qp_key:?} terminated with failure after Failed: {status:?}"
+            );
+        }
+        Ok(())
     }
+}
+
+/// Free helper around [`IbvManagerLocalMessage::RequestQueuePair`] — opens
+/// a `OncePortHandle` for the reply, sends the message, and awaits the
+/// answer. Exists because `RequestQueuePair` doesn't use `#[reply]`
+/// (the handler may park the port until the QP becomes `Ready`), so
+/// the auto-derived client method only does fire-and-forget.
+pub(super) async fn request_queue_pair(
+    actor: &ActorHandle<IbvManagerActor>,
+    cx: &(impl hyperactor::context::Actor + Send + Sync),
+    other: ActorRef<IbvManagerActor>,
+    self_device: String,
+    other_device: String,
+) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
+    let (reply, rx) = cx
+        .mailbox()
+        .open_once_port::<Result<IbvQueuePair, String>>();
+    actor
+        .request_queue_pair(cx, other, self_device, other_device, reply)
+        .await?;
+    rx.recv()
+        .await
+        .map_err(|e| anyhow::anyhow!("request_queue_pair port closed: {e}"))
 }
 
 /// Wrapper around [`ActorHandle<IbvManagerActor>`] that moves the RDMA
@@ -1287,15 +1170,15 @@ impl IbvBackend {
         };
 
         let op_result = async {
-            let mut qp = self
-                .request_queue_pair(
-                    cx,
-                    op.remote_manager.clone(),
-                    local_buffer.device_name.clone(),
-                    op.remote_buffer.device_name.clone(),
-                )
-                .await?
-                .map_err(|e| anyhow::anyhow!(e))?;
+            let mut qp = request_queue_pair(
+                &self.0,
+                cx,
+                op.remote_manager.clone(),
+                local_buffer.device_name.clone(),
+                op.remote_buffer.device_name.clone(),
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
 
             let wr_id = match op.op_type {
                 RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -507,9 +507,8 @@ fn test_lookup_segment_respects_mr_size_when_scanner_reports_larger_phys_size() 
     // Inside the bound region: hit; rdma_addr is offset from the
     // registered `mr_addr`, not the physical address.
     let in_bound_addr = PHYS_ADDR + 4 * 1024 * 1024;
-    let in_bound = lookup_segment_for_address(&segments, in_bound_addr, 1024, 0)
+    let in_bound = lookup_segment_for_address(&segments, in_bound_addr, 1024)
         .expect("in-bound address should hit the segment cache");
-    assert_eq!(in_bound.virtual_addr, in_bound_addr);
     assert_eq!(in_bound.rdma_addr, MR_ADDR + 4 * 1024 * 1024);
     assert_eq!(in_bound.lkey, LKEY);
     assert_eq!(in_bound.rkey, RKEY);
@@ -518,7 +517,7 @@ fn test_lookup_segment_respects_mr_size_when_scanner_reports_larger_phys_size() 
     // caller falls through to dmabuf.
     let in_gap_addr = PHYS_ADDR + MR_SIZE + 1024;
     assert!(
-        lookup_segment_for_address(&segments, in_gap_addr, 1024, 0).is_none(),
+        lookup_segment_for_address(&segments, in_gap_addr, 1024).is_none(),
         "address in the [mr_size, phys_size) gap must not be reported \
          as covered by the indirect mkey",
     );
@@ -526,14 +525,14 @@ fn test_lookup_segment_respects_mr_size_when_scanner_reports_larger_phys_size() 
     // Request straddling the mr_size boundary must miss.
     let straddling_addr = PHYS_ADDR + MR_SIZE - 512;
     assert!(
-        lookup_segment_for_address(&segments, straddling_addr, 4096, 0).is_none(),
+        lookup_segment_for_address(&segments, straddling_addr, 4096).is_none(),
         "request straddling the mr_size boundary must miss",
     );
 
     // Past `phys_size`: out of range.
     let past_end_addr = PHYS_ADDR + PHYS_SIZE + 1;
     assert!(
-        lookup_segment_for_address(&segments, past_end_addr, 1, 0).is_none(),
+        lookup_segment_for_address(&segments, past_end_addr, 1).is_none(),
         "address past phys_size must miss",
     );
 }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -28,11 +28,14 @@
 //! - `IbvWc`: Wrapper around ibverbs work completion structure, used to track the status of RDMA operations.
 use std::ffi::CStr;
 use std::fmt;
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
+
+use super::domain::IbvDomain;
 
 #[derive(
     Default,
@@ -743,6 +746,84 @@ fn ibverbs_supported_impl() -> bool {
     }
 }
 
+/// Refcounted owner of an ibverbs memory region. The intended
+/// sharing pattern is `Arc<IbvMemoryRegion>` cloned into every
+/// [`IbvMemoryRegionView`] backed by the region; the FFI resource
+/// is released by [`Drop`] when the last clone goes away.
+///
+/// `Direct` carries an `Arc<IbvDomain>` so the PD the MR was
+/// registered against outlives the `ibv_dereg_mr` call. The struct
+/// field order is significant: the `mr` pointer is dereg'd in
+/// `Drop` before the `_domain` field is released, so the PD is
+/// still alive when libibverbs walks back to it. The eventual
+/// `ibv_dealloc_pd` only fires when every other `Arc<IbvDomain>`
+/// (e.g. the manager's `device_domains` entry) is also gone.
+#[derive(Debug)]
+pub(super) enum IbvMemoryRegion {
+    /// A standalone `ibv_mr*` registered via `ibv_reg_mr` /
+    /// `ibv_reg_dmabuf_mr`.
+    Direct {
+        mr: *mut rdmaxcel_sys::ibv_mr,
+        /// PD the MR was registered against, kept alive past
+        /// `ibv_dereg_mr` via this clone. Never read directly.
+        _domain: Arc<IbvDomain>,
+    },
+    /// Singleton owner shared by every segment-backed view from the
+    /// mlx5dv segment scanner. `Drop` calls
+    /// `rdmaxcel_sys::deregister_segments`.
+    Segments,
+}
+
+// SAFETY: `IbvMemoryRegion::Direct`'s `*mut ibv_mr` is treated as
+// thread-safe by libibverbs for deregistration; `Segments` holds no
+// data. The intended sharing pattern is `Arc<IbvMemoryRegion>`.
+unsafe impl Send for IbvMemoryRegion {}
+unsafe impl Sync for IbvMemoryRegion {}
+
+impl Drop for IbvMemoryRegion {
+    fn drop(&mut self) {
+        match self {
+            IbvMemoryRegion::Direct { mr, .. } => {
+                if mr.is_null() {
+                    return;
+                }
+                // SAFETY: `*mr` was returned by `ibv_reg_mr` /
+                // `ibv_reg_dmabuf_mr` at construction (see
+                // `register_mr_impl`) and is non-null per the
+                // null-check above. The intended sharing pattern
+                // is `Arc<IbvMemoryRegion>`, so `Drop` runs exactly
+                // once when the last clone goes away, meaning
+                // `ibv_dereg_mr` is called exactly once on this
+                // pointer. The PD the MR was registered against is
+                // kept alive by the sibling `_domain` `Arc<IbvDomain>`
+                // until after this dereg returns.
+                let result = unsafe { rdmaxcel_sys::ibv_dereg_mr(*mr) };
+                if result != 0 {
+                    tracing::error!(
+                        "failed to deregister MR at {:p}: error code {}",
+                        *mr,
+                        result
+                    );
+                }
+            }
+            IbvMemoryRegion::Segments => {
+                // SAFETY: `IbvMemoryRegion::Segments` is the
+                // singleton owner of the mlx5dv scanner's globally
+                // registered segments. `register_mr_impl` lazily
+                // wraps it in `Arc::new(...)` at most once per
+                // manager (stored in `IbvManagerActor::segments_mr`)
+                // and clones it into every segment-backed view, so
+                // `deregister_segments` runs exactly once when the
+                // last reference is dropped.
+                let result = unsafe { rdmaxcel_sys::deregister_segments() };
+                if result != 0 {
+                    tracing::error!("failed to deregister CUDA segments: error code {}", result);
+                }
+            }
+        }
+    }
+}
+
 /// Represents a view of a memory region that can be registered with an RDMA device.
 ///
 /// This is a 'view' of a registered Memory Region, allowing multiple views into a single
@@ -757,17 +838,7 @@ fn ibverbs_supported_impl() -> bool {
 /// # Safety
 /// The caller must ensure the memory remains valid and is not freed, moved, or
 /// overwritten while RDMA operations are in progress.
-
-#[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    std::hash::Hash,
-    Serialize,
-    Deserialize,
-    Clone,
-    Copy
-)]
+#[derive(Debug, Clone)]
 pub struct IbvMemoryRegionView {
     // id should be unique with a given rdmam manager
     pub id: usize,
@@ -780,34 +851,25 @@ pub struct IbvMemoryRegionView {
     pub size: usize,
     pub lkey: u32,
     pub rkey: u32,
+    /// Name of the RDMA device the view's protection domain is on.
+    pub device_name: String,
+    /// Keeps the underlying FFI MR (and, transitively, the PD it
+    /// was registered against) alive for the lifetime of any clone
+    /// of this view; the last drop triggers deregistration. Never
+    /// read directly.
+    pub(super) _mr: Arc<IbvMemoryRegion>,
 }
 
-// SAFETY: IbvMemoryRegionView can be safely sent between threads because it only
-// contains address and size information without any thread-local state. However,
-// this DOES NOT provide any protection against data races in the underlying memory.
-// If one thread initiates an RDMA operation while another thread modifies the same
-// memory region, undefined behavior will occur. The caller is responsible for proper
-// synchronization of access to the underlying memory.
-unsafe impl Send for IbvMemoryRegionView {}
-
-// SAFETY: IbvMemoryRegionView is safe for concurrent access by multiple threads
-// as it only provides a view into memory without modifying its own state. However,
-// it provides NO PROTECTION against concurrent access to the underlying memory region.
-// The caller must ensure proper synchronization when:
-// 1. Initiating RDMA operations while local code reads/writes the same memory
-// 2. Performing multiple overlapping RDMA operations on the same memory region
-// 3. Freeing or reallocating memory that has in-flight RDMA operations
-unsafe impl Sync for IbvMemoryRegionView {}
-
 impl IbvMemoryRegionView {
-    /// Creates a new `IbvMemoryRegionView` with the given address and size.
-    pub fn new(
+    pub(super) fn new(
         id: usize,
         virtual_addr: usize,
         rdma_addr: usize,
         size: usize,
         lkey: u32,
         rkey: u32,
+        device_name: String,
+        mr: Arc<IbvMemoryRegion>,
     ) -> Self {
         Self {
             id,
@@ -816,7 +878,23 @@ impl IbvMemoryRegionView {
             size,
             lkey,
             rkey,
+            device_name,
+            _mr: mr,
         }
+    }
+}
+
+/// Compact identifier for log messages and per-op errors. Carries
+/// the MR-identifying fields all in one place so callers that
+/// embed an `IbvMemoryRegionView` in their error format get a
+/// consistent shape.
+impl fmt::Display for IbvMemoryRegionView {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "lkey={}, rkey={}, virtual_addr=0x{:x}, rdma_addr=0x{:x}, size={}",
+            self.lkey, self.rkey, self.virtual_addr, self.rdma_addr, self.size,
+        )
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -19,11 +19,28 @@ use std::io::Error;
 use std::result::Result;
 use std::time::Duration;
 
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::ActorHandle;
+use hyperactor::ActorId;
+use hyperactor::ActorRef;
+use hyperactor::Context;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::PortRef;
+use hyperactor::actor::Binds;
+use hyperactor::actor::Referable;
+use hyperactor::actor::RemoteHandles;
+use hyperactor::mailbox::MessageEnvelope;
+use hyperactor::mailbox::Undeliverable;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
 use super::IbvBuffer;
+use super::manager_actor::EnsureQueuePair;
+use super::manager_actor::QpInitializerDone;
+use super::manager_actor::QpInitializerFailed;
 use super::primitives::Gid;
 use super::primitives::IbvConfig;
 use super::primitives::IbvOperation;
@@ -1051,10 +1068,441 @@ impl IbvQueuePair {
     }
 }
 
+// =====================================================================
+// QueuePairInitializer
+// =====================================================================
+//
+// Drives one local `IbvQueuePair` through `INIT → RTR → RTS` off the
+// owning `IbvManagerActor`'s mailbox. Each peer spawns its own
+// initializer; the two converge by exchanging `NotifyRts` directly
+// after one round-trip through the peer's manager (`EnsureQueuePair`
+// → `PeerInfo`). A side declares itself "Ready" as soon as it
+// observes the peer's `NotifyRts`; it does not wait for the peer to
+// observe its own.
+//
+// Progress is tracked by two flags — `our_rts_sent` (we received
+// `PeerInfo`, connected, and sent our `NotifyRts`) and
+// `peer_rts_received` (we observed the peer's `NotifyRts`). When
+// both are true the handshake hands the qp to the manager via
+// [`QpInitializerDone`]. The `terminal` flag short-circuits any
+// further handler work after success or failure. The qp is held in
+// a `QpGuard` so any failure path (or aborted message delivery)
+// destroys it.
+
+/// Identifies a per-peer queue pair held by one
+/// [`super::manager_actor::IbvManagerActor`]. The same conceptual
+/// QP is referenced by two distinct keys, one from each side: each
+/// manager stores the local view (its own device, the peer's actor
+/// id, the peer's device).
+#[derive(Clone, Hash, Eq, PartialEq, Debug, Serialize, Deserialize, Named)]
+pub(super) struct QpKey {
+    pub(super) self_device: String,
+    pub(super) other_id: ActorId,
+    pub(super) other_device: String,
+}
+
+/// Cross-proc reply payload for [`EnsureQueuePair`]: peer's endpoint
+/// plus a `PortRef` to the peer initializer's `NotifyRts` port, or
+/// an error string from the peer side.
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub(super) struct PeerInfo(pub(super) Result<(IbvQpInfo, PortRef<NotifyRts>), String>);
+wirevalue::register_type!(PeerInfo);
+
+/// Cross-proc fire-and-forget. Sent from one initializer to the peer
+/// initializer once we hit RTS. A queue pair can begin sending to
+/// its peer as soon as it receives this message.
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub(super) struct NotifyRts;
+wirevalue::register_type!(NotifyRts);
+
+/// Local-only self-message fired by the timeout task. Triggers
+/// the initializer to abort the handshake.
+#[derive(Debug)]
+#[cfg_attr(not(test), allow(dead_code))]
+struct InitializationFailed;
+
+/// RAII wrapper that destroys the wrapped queue pair on drop.
+/// Use `into_inner` to extract the qp without destroying.
+#[derive(Debug)]
+pub(super) struct QpGuard {
+    qp: Option<IbvQueuePair>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl QpGuard {
+    fn new(qp: IbvQueuePair) -> Self {
+        Self { qp: Some(qp) }
+    }
+
+    /// Consume the guard and return the qp; suppresses Drop's destroy.
+    pub(super) fn into_inner(mut self) -> IbvQueuePair {
+        self.qp.take().expect("QpGuard already drained")
+    }
+
+    /// Delegates to [`IbvQueuePair::connect`].
+    pub(super) fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
+        self.qp
+            .as_mut()
+            .expect("QpGuard already drained")
+            .connect(info)
+    }
+
+    /// Delegates to [`IbvQueuePair::get_qp_info`].
+    pub(super) fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
+        self.qp
+            .as_mut()
+            .expect("QpGuard already drained")
+            .get_qp_info()
+    }
+}
+
+impl Drop for QpGuard {
+    fn drop(&mut self) {
+        if let Some(qp) = self.qp.take() {
+            // SAFETY: `QpGuard` owns the `IbvQueuePair` and exposes
+            // no API that hands out a reference to it, so safe code
+            // cannot have cloned the underlying `rdmaxcel_qp_t`
+            // pointer out from under us. The only way to extract a
+            // live clone is `into_inner`, which consumes `self` and
+            // skips this `Drop`; reaching here means `into_inner`
+            // was never called.
+            unsafe { destroy_qp(&qp) };
+        }
+    }
+}
+
+/// Bundle of trait bounds for an actor type that can play the role
+/// of [`QueuePairInitializer`]'s owner/peer manager.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) trait QpOwner:
+    Actor
+    + Referable
+    + Binds<Self>
+    + RemoteHandles<EnsureQueuePair<Self>>
+    + Handler<QpInitializerDone>
+    + Handler<QpInitializerFailed>
+{
+}
+
+impl<T> QpOwner for T where
+    T: Actor
+        + Referable
+        + Binds<T>
+        + RemoteHandles<EnsureQueuePair<T>>
+        + Handler<QpInitializerDone>
+        + Handler<QpInitializerFailed>
+{
+}
+
+/// Per-peer queue-pair handshake actor. See module docs.
+///
+/// Generic over the manager actor type `A` so tests can swap in a
+/// mock.
+#[derive(Debug)]
+#[hyperactor::export(handlers = [PeerInfo, NotifyRts])]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(super) struct QueuePairInitializer<A: QpOwner> {
+    owner: ActorHandle<A>,
+    other: ActorRef<A>,
+    qp_key: QpKey,
+    /// Held until the handshake succeeds (handed to the manager
+    /// via [`QpInitializerDone`]) or fails (dropped here, which
+    /// destroys the qp via `QpGuard::drop`).
+    qp: Option<QpGuard>,
+    /// Per-side handshake budget pulled from
+    /// `RDMA_QP_INIT_TIMEOUT` at construction.
+    timeout: Duration,
+    /// Set in `Handler<PeerInfo>` after we connect the qp and send
+    /// our `NotifyRts` to the peer.
+    our_rts_sent: bool,
+    /// Set in `Handler<NotifyRts>` when the peer's `NotifyRts`
+    /// arrives.
+    peer_rts_received: bool,
+    /// Set by `done`/`fail` once a terminal report has been
+    /// dispatched to the owner. All further handler work
+    /// short-circuits.
+    terminal: bool,
+    /// Currently-armed timeout. `arm_timeout` aborts any prior one.
+    timeout_handle: Option<tokio::task::JoinHandle<()>>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
+impl<A> QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    pub(super) fn new(
+        owner: ActorHandle<A>,
+        other: ActorRef<A>,
+        qp_key: QpKey,
+        qp: IbvQueuePair,
+    ) -> Self {
+        let timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
+        Self {
+            owner,
+            other,
+            qp_key,
+            qp: Some(QpGuard::new(qp)),
+            timeout,
+            our_rts_sent: false,
+            peer_rts_received: false,
+            terminal: false,
+            timeout_handle: None,
+        }
+    }
+
+    /// Arm a fresh `InitializationFailed` timer, aborting any prior one.
+    fn arm_timeout(&mut self, this: &Instance<Self>) {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+        let self_handle: ActorHandle<Self> = this.handle();
+        let timeout = self.timeout;
+        let task = tokio::spawn(async move {
+            tokio::time::sleep(timeout).await;
+            if let Err(e) = self_handle.send(Instance::<Self>::self_client(), InitializationFailed)
+            {
+                tracing::error!(
+                    "QueuePairInitializer: failed to deliver timeout self-message: {e}"
+                );
+            }
+        });
+        self.timeout_handle = Some(task);
+    }
+
+    /// Transition to the terminal failed state, drop the qp guard
+    /// (destroying any qp held), and report failure to the owning
+    /// manager.
+    fn fail(&mut self, this: &Instance<Self>, error: String) -> Result<(), anyhow::Error> {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+        self.qp = None;
+        self.terminal = true;
+        self.owner.send(
+            this,
+            QpInitializerFailed {
+                qp_key: self.qp_key.clone(),
+                error,
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Transition to the terminal success state and hand the qp
+    /// guard to the owning manager via [`QpInitializerDone`].
+    fn done(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+        let qp = self.qp.take().expect("qp present in done()");
+        self.terminal = true;
+        self.owner.send(
+            this,
+            QpInitializerDone {
+                qp_key: self.qp_key.clone(),
+                qp,
+            },
+        )?;
+        Ok(())
+    }
+
+    /// Connect our qp to the peer endpoint, then notify the peer
+    /// that we've reached RTS. Returns the failure string for
+    /// [`Self::fail`] on error.
+    fn connect_and_notify(
+        &mut self,
+        cx: &Context<Self>,
+        info: Result<(IbvQpInfo, PortRef<NotifyRts>), String>,
+    ) -> Result<(), String> {
+        let (peer_endpoint, peer_notify_rts) = info?;
+        self.qp
+            .as_mut()
+            .expect("qp present pre-terminal")
+            .connect(&peer_endpoint)
+            .map_err(|e| format!("QpGuard::connect failed: {e}"))?;
+        peer_notify_rts
+            .send(cx, NotifyRts)
+            .map_err(|e| format!("failed to send NotifyRts to peer: {e}"))?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A> Actor for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        // Send the QueuePairInitializer's PeerInfo actor port so that the reply
+        // is routed back to this actor's handler automatically.
+        let reply = this.bind::<Self>().port();
+        let sender = self.owner.bind();
+        let sender_device = self.qp_key.self_device.clone();
+        let receiver_device = self.qp_key.other_device.clone();
+        self.other.send(
+            this,
+            EnsureQueuePair {
+                sender,
+                sender_device,
+                receiver_device,
+                reply,
+            },
+        )?;
+
+        self.arm_timeout(this);
+        Ok(())
+    }
+
+    async fn cleanup(
+        &mut self,
+        _this: &Instance<Self>,
+        _err: Option<&hyperactor::actor::ActorError>,
+    ) -> Result<(), anyhow::Error> {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+        Ok(())
+    }
+
+    async fn handle_undeliverable_message(
+        &mut self,
+        this: &Instance<Self>,
+        Undeliverable(envelope): Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        if self.terminal {
+            tracing::warn!(
+                "undeliverable message after handshake terminated: {}",
+                envelope.error_msg().unwrap_or_default()
+            );
+            return Ok(());
+        }
+        self.fail(this, envelope.error_msg().unwrap_or_default())
+    }
+}
+
+impl<A> Drop for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    fn drop(&mut self) {
+        if let Some(h) = self.timeout_handle.take() {
+            h.abort();
+        }
+    }
+}
+
+/// Destroy the underlying `rdmaxcel_qp_t`.
+///
+/// # Safety
+///
+/// `IbvQueuePair` derives [`Clone`] but the wrapped `rdmaxcel_qp_t`
+/// pointer is shared by all clones; this call frees that pointer. The
+/// caller must guarantee no remaining clones of `qp` are in use (no
+/// other code is reading from or posting to `qp.qp`, and no future
+/// code will), since accessing a freed `rdmaxcel_qp_t` is undefined
+/// behavior.
+pub(super) unsafe fn destroy_qp(qp: &IbvQueuePair) {
+    // SAFETY: The caller has guaranteed no other live clone of `qp`
+    // observes `qp.qp` (see this function's `# Safety` section). This
+    // is truly unsafe -- the current implementation does not properly
+    // track outstanding clones. An imminent change will fix this, but
+    // for now it isn't a regression.
+    unsafe {
+        if qp.qp != 0 {
+            let rdmaxcel_qp = qp.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
+            rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
+        }
+    }
+}
+
+#[async_trait]
+impl<A> Handler<PeerInfo> for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    async fn handle(&mut self, cx: &Context<Self>, msg: PeerInfo) -> Result<(), anyhow::Error> {
+        if self.terminal {
+            tracing::warn!("PeerInfo received after queue pair already terminal");
+            return Ok(());
+        }
+        debug_assert!(!self.our_rts_sent, "duplicate PeerInfo");
+        if let Err(e) = self.connect_and_notify(cx, msg.0) {
+            return self.fail(cx, e);
+        }
+        self.our_rts_sent = true;
+        if self.peer_rts_received {
+            return self.done(cx);
+        }
+        // Rearm the timeout for the remaining wait on the peer's
+        // `NotifyRts` so a hang past this point still surfaces as a
+        // failure.
+        self.arm_timeout(cx);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A> Handler<NotifyRts> for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    async fn handle(&mut self, cx: &Context<Self>, _msg: NotifyRts) -> Result<(), anyhow::Error> {
+        if self.terminal {
+            tracing::warn!("NotifyRts received after queue pair already terminal");
+            return Ok(());
+        }
+        debug_assert!(!self.peer_rts_received, "duplicate NotifyRts");
+        self.peer_rts_received = true;
+        if self.our_rts_sent {
+            return self.done(cx);
+        }
+        // Rearm the timeout for the remaining wait on our own
+        // `PeerInfo` reply.
+        self.arm_timeout(cx);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<A> Handler<InitializationFailed> for QueuePairInitializer<A>
+where
+    A: QpOwner,
+{
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        _msg: InitializationFailed,
+    ) -> Result<(), anyhow::Error> {
+        if self.terminal {
+            return Ok(());
+        }
+        self.fail(cx, "QP initialization timed out".into())
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+    use std::time::Duration;
+    use std::time::Instant;
+
+    use anyhow::Result;
+    use async_trait::async_trait;
+    use hyperactor::Context;
+    use hyperactor::Handler;
+    use hyperactor::PortRef;
+    use hyperactor::mailbox::DeliveryError;
+    use hyperactor::mailbox::MessageEnvelope;
+    use hyperactor::mailbox::Undeliverable;
+    use hyperactor::port::Port;
+    use hyperactor::proc::Proc;
+    use hyperactor_config::Flattrs;
+
     use super::*;
     use crate::backend::ibverbs::domain::IbvDomain;
+    use crate::backend::ibverbs::manager_actor::EnsureQueuePair;
     use crate::backend::ibverbs::primitives::IbvConfig;
     use crate::backend::ibverbs::primitives::get_all_devices;
 
@@ -1114,5 +1562,351 @@ mod tests {
 
         assert!(server_qp.connect(&client_connection_info).is_ok());
         assert!(client_qp.connect(&server_connection_info).is_ok());
+    }
+
+    /// Outcomes recorded by [`MockManager`] for assertions.
+    #[derive(Default, Debug)]
+    struct MockState {
+        done: Vec<QpKey>,
+        failed: Vec<(QpKey, String)>,
+        /// Number of `NotifyRts` messages the mock received from the
+        /// initializer (i.e., how many times the initializer reached
+        /// the "we've hit RTS" point and sent us a notification).
+        notify_rts: usize,
+    }
+
+    /// Scripted reply for the next `EnsureQueuePair` the mock sees.
+    /// After a single reply the mock disarms back to `DropReply`.
+    #[derive(Debug)]
+    enum MockResponse {
+        /// Reply with `PeerInfo(Ok((info, mock_notify_rts_port)))`. The
+        /// caller must drive the initializer's `NotifyRts` port from
+        /// the test to reach `Succeeded`.
+        Success(IbvQpInfo),
+        /// Like `Success`, but the `PortRef<NotifyRts>` handed back is
+        /// attested to an unreachable address in the mock's own proc
+        /// so the initializer's `NotifyRts` send bounces back as
+        /// undeliverable.
+        SuccessWithBogusNotifyRts(IbvQpInfo),
+        Error(String),
+        DropReply,
+    }
+
+    /// Zero-initialized [`IbvQueuePair`]. `qp == 0` so `QpGuard::Drop`
+    /// is a no-op; tests using this must not exercise [`IbvQueuePair::connect`]
+    /// (it would deref a null pointer).
+    fn fake_qp() -> IbvQueuePair {
+        IbvQueuePair {
+            send_cq: 0,
+            recv_cq: 0,
+            qp: 0,
+            dv_qp: 0,
+            dv_send_cq: 0,
+            dv_recv_cq: 0,
+            context: 0,
+            config: IbvConfig::default(),
+            is_efa: false,
+        }
+    }
+
+    /// A real (loopback) `IbvQueuePair` and its `IbvQpInfo`. Returns
+    /// `None` when no RDMA device is present.
+    fn loopback_qp() -> Option<(IbvQueuePair, IbvQpInfo)> {
+        if get_all_devices().is_empty() {
+            return None;
+        }
+        let config = IbvConfig::default();
+        let domain = IbvDomain::new(config.device.clone()).ok()?;
+        let mut qp = IbvQueuePair::new(domain.context, domain.pd, config).ok()?;
+        let info = qp.get_qp_info().ok()?;
+        Some((qp, info))
+    }
+
+    #[derive(Debug)]
+    #[hyperactor::export(handlers = [EnsureQueuePair<MockManager>, NotifyRts])]
+    struct MockManager {
+        state: Arc<Mutex<MockState>>,
+        response: MockResponse,
+    }
+
+    #[async_trait]
+    impl Actor for MockManager {}
+
+    #[async_trait]
+    impl Handler<EnsureQueuePair<MockManager>> for MockManager {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: EnsureQueuePair<MockManager>,
+        ) -> Result<()> {
+            let response = std::mem::replace(&mut self.response, MockResponse::DropReply);
+            match response {
+                MockResponse::Success(info) => {
+                    let notify_rts = cx.bind::<MockManager>().port::<NotifyRts>();
+                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))))?;
+                }
+                MockResponse::SuccessWithBogusNotifyRts(info) => {
+                    let bogus = hyperactor::context::Mailbox::mailbox(cx)
+                        .actor_addr()
+                        .proc_addr()
+                        .actor_addr("bogus")
+                        .port_addr(Port::from(0u64));
+                    let notify_rts = PortRef::<NotifyRts>::attest(bogus);
+                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))))?;
+                }
+                MockResponse::Error(e) => {
+                    msg.reply.send(cx, PeerInfo(Err(e)))?;
+                }
+                MockResponse::DropReply => {}
+            }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<NotifyRts> for MockManager {
+        async fn handle(&mut self, _cx: &Context<Self>, _msg: NotifyRts) -> Result<()> {
+            self.state.lock().unwrap().notify_rts += 1;
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<QpInitializerDone> for MockManager {
+        async fn handle(&mut self, _cx: &Context<Self>, msg: QpInitializerDone) -> Result<()> {
+            let _ = msg.qp.into_inner();
+            self.state.lock().unwrap().done.push(msg.qp_key);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<QpInitializerFailed> for MockManager {
+        async fn handle(&mut self, _cx: &Context<Self>, msg: QpInitializerFailed) -> Result<()> {
+            self.state
+                .lock()
+                .unwrap()
+                .failed
+                .push((msg.qp_key, msg.error));
+            Ok(())
+        }
+    }
+
+    struct Harness {
+        proc: Proc,
+        init_handle: ActorHandle<QueuePairInitializer<MockManager>>,
+        state: Arc<Mutex<MockState>>,
+        qp_key: QpKey,
+    }
+
+    impl Harness {
+        fn build(qp: IbvQueuePair, response: MockResponse) -> Result<Self> {
+            let proc = Proc::new();
+            let state = Arc::new(Mutex::new(MockState::default()));
+            let mock = MockManager {
+                state: state.clone(),
+                response,
+            };
+            let mock_handle = proc.spawn("mock", mock)?;
+            let mock_ref = mock_handle.bind::<MockManager>();
+            let qp_key = QpKey {
+                self_device: "mock0".into(),
+                other_id: mock_ref.actor_addr().id().clone(),
+                other_device: "mock0".into(),
+            };
+            let initializer = QueuePairInitializer::new(mock_handle, mock_ref, qp_key.clone(), qp);
+            let init_handle = proc.spawn("initializer", initializer)?;
+            // Bind well-known ports so PeerInfo/NotifyRts can route.
+            let _ = init_handle.bind::<QueuePairInitializer<MockManager>>();
+            Ok(Harness {
+                proc,
+                init_handle,
+                state,
+                qp_key,
+            })
+        }
+
+        async fn await_done(&self) -> QpKey {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                if let Some(key) = self.state.lock().unwrap().done.first().cloned() {
+                    return key;
+                }
+                if Instant::now() >= deadline {
+                    panic!(
+                        "QpInitializerDone not delivered within 5s; state={:?}",
+                        self.state.lock().unwrap()
+                    );
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+
+        async fn await_failed(&self) -> (QpKey, String) {
+            let deadline = Instant::now() + Duration::from_secs(5);
+            loop {
+                if let Some(entry) = self.state.lock().unwrap().failed.first().cloned() {
+                    return entry;
+                }
+                if Instant::now() >= deadline {
+                    panic!(
+                        "QpInitializerFailed was not delivered within 5s; state={:?}",
+                        self.state.lock().unwrap()
+                    );
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_peer_info_error_transitions_to_failed() {
+        let harness =
+            Harness::build(fake_qp(), MockResponse::Error("peer rejected".into())).unwrap();
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert_eq!(error, "peer rejected");
+        // No spurious done callbacks.
+        assert!(harness.state.lock().unwrap().done.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_initial_timeout_transitions_to_failed() {
+        // Drop the configured per-handshake budget to 200ms so the
+        // test doesn't sit on the default 30s.
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(
+            crate::config::RDMA_QP_INIT_TIMEOUT,
+            Duration::from_millis(200),
+        );
+
+        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert!(
+            error.contains("timed out"),
+            "expected timeout error, got {error}"
+        );
+    }
+
+    /// Real loopback handshake. The mock replies `Success`, the
+    /// initializer connects the qp to itself and sends `NotifyRts` to
+    /// the mock; the test then delivers `NotifyRts` directly to the
+    /// initializer's well-known port to drive it to success.
+    #[tokio::test]
+    async fn test_loopback_handshake_succeeds() -> Result<()> {
+        let Some((qp, info)) = loopback_qp() else {
+            panic!("Skipping test: RDMA devices not available");
+        };
+        let harness = Harness::build(qp, MockResponse::Success(info))?;
+
+        let (peer, _) = harness.proc.instance("peer")?;
+        harness.init_handle.send(&peer, NotifyRts)?;
+
+        let key = harness.await_done().await;
+        assert_eq!(key, harness.qp_key);
+        let state = harness.state.lock().unwrap();
+        assert!(state.failed.is_empty());
+        assert_eq!(
+            state.notify_rts, 1,
+            "initializer must send exactly one NotifyRts to the peer after qp.connect"
+        );
+        Ok(())
+    }
+
+    /// Real loopback `qp.connect` succeeds and the initializer
+    /// flips `our_rts_sent`, but the test never delivers `NotifyRts`
+    /// back to the initializer's port. The rearmed timer fires and
+    /// the handshake is reported as failed.
+    #[tokio::test]
+    async fn test_notify_rts_timeout_after_peer_info() -> Result<()> {
+        let Some((qp, info)) = loopback_qp() else {
+            panic!("Skipping test: RDMA devices not available");
+        };
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(
+            crate::config::RDMA_QP_INIT_TIMEOUT,
+            Duration::from_millis(200),
+        );
+
+        let harness = Harness::build(qp, MockResponse::Success(info))?;
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert!(
+            error.contains("timed out"),
+            "expected timeout error, got {error}"
+        );
+        // Receiving exactly one NotifyRts confirms the initializer
+        // ran `qp.connect` + sent NotifyRts to the peer and was
+        // waiting on the peer's `NotifyRts` when the rearmed timer
+        // fired.
+        assert_eq!(harness.state.lock().unwrap().notify_rts, 1);
+        Ok(())
+    }
+
+    fn fake_undeliverable(proc: &Proc, error: &str) -> Undeliverable<MessageEnvelope> {
+        let mut envelope = MessageEnvelope::serialize(
+            proc.proc_addr().actor_addr("test-sender"),
+            proc.proc_addr()
+                .actor_addr("test-dest")
+                .port_addr(Port::from(0u64)),
+            &0u64,
+            Flattrs::default(),
+        )
+        .unwrap();
+        envelope.set_error(DeliveryError::Mailbox(error.into()));
+        Undeliverable(envelope)
+    }
+
+    /// In an awaiting state, an undeliverable message returned to the
+    /// initializer trips `handle_undeliverable_message` into `fail()`,
+    /// which reports `QpInitializerFailed` to the owner with the
+    /// envelope's error message.
+    #[tokio::test]
+    async fn test_undeliverable_in_awaiting_transitions_to_failed() {
+        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
+        let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
+        let (peer, _) = harness.proc.instance("peer").unwrap();
+        harness.init_handle.send(&peer, undeliverable).unwrap();
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert!(
+            error.contains("simulated bounce"),
+            "expected delivery error, got {error}"
+        );
+    }
+
+    /// `PeerInfo` carries a `PortRef<NotifyRts>` attested to a bogus
+    /// address; the initializer's send bounces back as undeliverable
+    /// after `our_rts_sent` is set, and `handle_undeliverable_message`
+    /// trips `fail()`.
+    #[tokio::test]
+    async fn test_notify_rts_undeliverable_transitions_to_failed() -> Result<()> {
+        let Some((qp, info)) = loopback_qp() else {
+            panic!("Skipping test: RDMA devices not available");
+        };
+        let harness = Harness::build(qp, MockResponse::SuccessWithBogusNotifyRts(info))?;
+        let (key, error) = harness.await_failed().await;
+        assert_eq!(key, harness.qp_key);
+        assert!(
+            error.contains("address not routable"),
+            "expected delivery error, got {error:?}"
+        );
+        Ok(())
+    }
+
+    /// Once the initializer is terminal, a late undeliverable is
+    /// just warn-logged and must not produce a second
+    /// `QpInitializerFailed` callback.
+    #[tokio::test]
+    async fn test_undeliverable_after_terminated_does_not_re_fail() {
+        let harness = Harness::build(fake_qp(), MockResponse::Error("first fail".into())).unwrap();
+        let _ = harness.await_failed().await;
+
+        let undeliverable = fake_undeliverable(&harness.proc, "late bounce");
+        let (peer, _) = harness.proc.instance("peer").unwrap();
+        harness.init_handle.send(&peer, undeliverable).unwrap();
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(harness.state.lock().unwrap().failed.len(), 1);
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1118,7 +1118,6 @@ wirevalue::register_type!(NotifyRts);
 /// Local-only self-message fired by the timeout task. Triggers
 /// the initializer to abort the handshake.
 #[derive(Debug)]
-#[cfg_attr(not(test), allow(dead_code))]
 struct InitializationFailed;
 
 /// RAII wrapper that destroys the wrapped queue pair on drop.
@@ -1128,9 +1127,8 @@ pub(super) struct QpGuard {
     qp: Option<IbvQueuePair>,
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 impl QpGuard {
-    fn new(qp: IbvQueuePair) -> Self {
+    pub(super) fn new(qp: IbvQueuePair) -> Self {
         Self { qp: Some(qp) }
     }
 
@@ -1173,7 +1171,6 @@ impl Drop for QpGuard {
 
 /// Bundle of trait bounds for an actor type that can play the role
 /// of [`QueuePairInitializer`]'s owner/peer manager.
-#[cfg_attr(not(test), allow(dead_code))]
 pub(super) trait QpOwner:
     Actor
     + Referable
@@ -1200,7 +1197,6 @@ impl<T> QpOwner for T where
 /// mock.
 #[derive(Debug)]
 #[hyperactor::export(handlers = [PeerInfo, NotifyRts])]
-#[cfg_attr(not(test), allow(dead_code))]
 pub(super) struct QueuePairInitializer<A: QpOwner> {
     owner: ActorHandle<A>,
     other: ActorRef<A>,
@@ -1226,7 +1222,6 @@ pub(super) struct QueuePairInitializer<A: QpOwner> {
     timeout_handle: Option<tokio::task::JoinHandle<()>>,
 }
 
-#[cfg_attr(not(test), allow(dead_code))]
 impl<A> QueuePairInitializer<A>
 where
     A: QpOwner,
@@ -1235,14 +1230,14 @@ where
         owner: ActorHandle<A>,
         other: ActorRef<A>,
         qp_key: QpKey,
-        qp: IbvQueuePair,
+        qp: QpGuard,
     ) -> Self {
         let timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
         Self {
             owner,
             other,
             qp_key,
-            qp: Some(QpGuard::new(qp)),
+            qp: Some(qp),
             timeout,
             our_rts_sent: false,
             peer_rts_received: false,
@@ -1611,13 +1606,13 @@ mod tests {
 
     /// A real (loopback) `IbvQueuePair` and its `IbvQpInfo`. Returns
     /// `None` when no RDMA device is present.
-    fn loopback_qp() -> Option<(IbvQueuePair, IbvQpInfo)> {
+    fn loopback_qp() -> Option<(QpGuard, IbvQpInfo)> {
         if get_all_devices().is_empty() {
             return None;
         }
         let config = IbvConfig::default();
         let domain = IbvDomain::new(config.device.clone()).ok()?;
-        let mut qp = IbvQueuePair::new(domain.context, domain.pd, config).ok()?;
+        let mut qp = QpGuard::new(IbvQueuePair::new(domain.context, domain.pd, config).ok()?);
         let info = qp.get_qp_info().ok()?;
         Some((qp, info))
     }
@@ -1700,7 +1695,7 @@ mod tests {
     }
 
     impl Harness {
-        fn build(qp: IbvQueuePair, response: MockResponse) -> Result<Self> {
+        fn build(qp: QpGuard, response: MockResponse) -> Result<Self> {
             let proc = Proc::new();
             let state = Arc::new(Mutex::new(MockState::default()));
             let mock = MockManager {
@@ -1761,8 +1756,11 @@ mod tests {
 
     #[tokio::test]
     async fn test_peer_info_error_transitions_to_failed() {
-        let harness =
-            Harness::build(fake_qp(), MockResponse::Error("peer rejected".into())).unwrap();
+        let harness = Harness::build(
+            QpGuard::new(fake_qp()),
+            MockResponse::Error("peer rejected".into()),
+        )
+        .unwrap();
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert_eq!(error, "peer rejected");
@@ -1780,7 +1778,7 @@ mod tests {
             Duration::from_millis(200),
         );
 
-        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
+        let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert!(
@@ -1864,7 +1862,7 @@ mod tests {
     /// envelope's error message.
     #[tokio::test]
     async fn test_undeliverable_in_awaiting_transitions_to_failed() {
-        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
+        let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
         harness.init_handle.send(&peer, undeliverable).unwrap();
@@ -1900,7 +1898,11 @@ mod tests {
     /// `QpInitializerFailed` callback.
     #[tokio::test]
     async fn test_undeliverable_after_terminated_does_not_re_fail() {
-        let harness = Harness::build(fake_qp(), MockResponse::Error("first fail".into())).unwrap();
+        let harness = Harness::build(
+            QpGuard::new(fake_qp()),
+            MockResponse::Error("first fail".into()),
+        )
+        .unwrap();
         let _ = harness.await_failed().await;
 
         let undeliverable = fake_undeliverable(&harness.proc, "late bounce");

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use hyperactor::Actor;
+use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
@@ -465,6 +466,11 @@ pub struct IbvTestEnv {
     pub actor_2: ActorRef<RdmaManagerActor>,
     pub ibv_actor_1: ActorRef<IbvManagerActor>,
     pub ibv_actor_2: ActorRef<IbvManagerActor>,
+    /// In-proc handles for the same actors as `ibv_actor_*`.
+    /// Tests that need to call local-only messages such as
+    /// `RequestQueuePair` go through these.
+    pub ibv_handle_1: ActorHandle<IbvManagerActor>,
+    pub ibv_handle_2: ActorHandle<IbvManagerActor>,
     pub rdma_handle_1: RdmaRemoteBuffer,
     pub rdma_handle_2: RdmaRemoteBuffer,
     pub local_memory_1: Arc<dyn RdmaLocalMemory>,
@@ -645,6 +651,14 @@ impl IbvTestEnv {
         let (ibv_actor_2, ibv_buffer_2) = rdma_handle_2
             .resolve_ibv()
             .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 2"))?;
+        let ibv_handle_1: ActorHandle<IbvManagerActor> =
+            ibv_actor_1
+                .downcast_handle(&instance_1)
+                .ok_or_else(|| anyhow::anyhow!("ibv_actor_1 is not in proc_1"))?;
+        let ibv_handle_2: ActorHandle<IbvManagerActor> =
+            ibv_actor_2
+                .downcast_handle(&instance_2)
+                .ok_or_else(|| anyhow::anyhow!("ibv_actor_2 is not in proc_2"))?;
 
         // Fill buffer1 with test data
         if parsed_accel1.0 == "cuda" {
@@ -674,6 +688,8 @@ impl IbvTestEnv {
             actor_2,
             ibv_actor_1,
             ibv_actor_2,
+            ibv_handle_1,
+            ibv_handle_2,
             rdma_handle_1,
             rdma_handle_2,
             local_memory_1,

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -67,4 +67,16 @@ declare_attrs! {
         Some("rdma_cq_busy_poll_window".to_string()),
     ))
     pub attr RDMA_CQ_BUSY_POLL_WINDOW: Option<Duration> = None;
+
+    /// Per-side budget for the `QueuePairInitializer` handshake. The
+    /// timer arms once when we send `EnsureQueuePair` and is rearmed
+    /// after we hit RTS while still waiting for the peer's
+    /// `NotifyRts`. If it fires the entry is tombstoned with a
+    /// `qp_initializer_failed` so further `RequestQueuePair` calls
+    /// for the same key surface the same error rather than hanging.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_QP_INIT_TIMEOUT".to_string()),
+        Some("rdma_qp_init_timeout".to_string()),
+    ))
+    pub attr RDMA_QP_INIT_TIMEOUT: Duration = Duration::from_secs(30);
 }


### PR DESCRIPTION
Summary:
Switch the FFI lifecycle for registered memory regions and protection domains to RAII via `Arc<IbvMemoryRegion>` and `Arc<IbvDomain>`. Eliminates the manual `ibv_dereg_mr` / `deregister_segments` paths the manager used to drive on `Drop` and on `DeregisterMr`.

- New `IbvMemoryRegion` enum (`Direct { mr, domain }` | `Segments`) deregisters the FFI resource from its own `Drop`. `IbvMemoryRegionView` carries an `Arc<IbvMemoryRegion>` so every clone keeps the MR (and its PD) alive until the last view drops.
- `IbvDomain` loses `Clone` (the bitwise copy was a latent double-free) and is shared as `Arc<IbvDomain>`, cloned into every Direct MR so the PD outlives all views registered against it.
- `IbvManagerActor` loses `mr_map`, `deregister_mr_impl`, the `IbvManagerLocalMessage::DeregisterMr` variant, and the explicit deregister round-trip in `IbvBackend::execute_op`. A new `segments_mr: Option<Arc<IbvMemoryRegion>>` lazily owns the singleton scanner state.
- `lookup_segment_for_address` returns a plain `SegmentInfo` value (`{virtual_addr, rdma_addr, size, lkey, rkey}`); MR materialization and `Arc` plumbing now live solely in `register_mr_impl`.

Reviewed By: zdevito

Differential Revision: D105213929


