### PR TITLE
wire IbvProcessorActor into IbvManagerActor and tighten QP lifecycle (#3886)

### DIFF
--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -14,9 +14,11 @@ backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 dashmap = { version = "6.1.0", features = ["rayon", "serde"] }
 erased-serde = "0.4.10"
+futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
+lru = { version = "0.16.4", default-features = false }
 rand = "0.10.1"
 rdmaxcel-sys = { path = "../rdmaxcel-sys" }
 regex = "1.12.3"

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -69,7 +69,6 @@ use hyperactor::OncePortRef;
 use hyperactor::RemoteSpawn;
 use hyperactor::Unbind;
 use hyperactor::channel::ChannelAddr;
-use hyperactor::context::Mailbox;
 use hyperactor::id::Label;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
@@ -84,7 +83,7 @@ use monarch_rdma::IbvConfig;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
-use monarch_rdma::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
+use monarch_rdma::backend::ibverbs::manager_actor::request_queue_pair;
 use monarch_rdma::cu_check;
 use monarch_rdma::local_memory::RdmaLocalMemory;
 use monarch_rdma::local_memory::UnsafeLocalMemory;
@@ -516,23 +515,15 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
         let local_ibv_manager_handle = local_ibv_manager
             .downcast_handle(cx)
             .ok_or_else(|| anyhow::anyhow!("local IbvManagerActor is not in this process"))?;
-        let (reply_handle, reply_rx) = cx
-            .mailbox()
-            .open_once_port::<Result<monarch_rdma::backend::ibverbs::queue_pair::IbvQueuePair, String>>();
-        local_ibv_manager_handle
-            .request_queue_pair(
-                cx,
-                remote_ibv_manager.clone(),
-                local_ibv.device_name.clone(),
-                remote_ibv.device_name.clone(),
-                reply_handle,
-            )
-            .await?;
-        let qp = reply_rx
-            .recv()
-            .await
-            .map_err(|e| anyhow::anyhow!("request_queue_pair reply channel closed: {e}"))?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        let qp = request_queue_pair(
+            &local_ibv_manager_handle,
+            cx,
+            remote_ibv_manager.clone(),
+            local_ibv.device_name.clone(),
+            remote_ibv.device_name.clone(),
+        )
+        .await?
+        .map_err(|e| anyhow::anyhow!(e))?;
 
         unsafe {
             let ibv_qp = qp.qp as *mut rdmaxcel_sys::ibv_qp;

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -11,6 +11,7 @@
 use std::sync::Arc;
 
 use hyperactor::ActorRef;
+use hyperactor::actor::Referable;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -19,6 +20,7 @@ pub mod device_selection;
 pub(crate) mod domain;
 pub mod manager_actor;
 pub mod primitives;
+mod processor_actor;
 pub mod queue_pair;
 
 use manager_actor::IbvManagerActor;
@@ -51,10 +53,26 @@ pub struct IbvBuffer {
 }
 
 /// A single RDMA op for the [`IbvBackend`](manager_actor::IbvBackend).
-#[derive(Debug, Clone, Named)]
-pub struct IbvOp {
+///
+/// Generic over the manager actor type so unit tests can swap in a
+/// mock; production code uses the default `IbvOp<IbvManagerActor>`.
+#[derive(Debug, Named)]
+pub struct IbvOp<M: Referable = IbvManagerActor> {
     pub op_type: RdmaOpType,
     pub local_memory: Arc<dyn RdmaLocalMemory>,
     pub remote_buffer: IbvBuffer,
-    pub remote_manager: ActorRef<IbvManagerActor>,
+    pub remote_manager: ActorRef<M>,
+}
+
+// Hand-rolled `Clone` to avoid the `M: Clone` bound the derive macro
+// would add (`ActorRef<M>` is `Clone` for all `M: Referable`).
+impl<M: Referable> Clone for IbvOp<M> {
+    fn clone(&self) -> Self {
+        Self {
+            op_type: self.op_type,
+            local_memory: Arc::clone(&self.local_memory),
+            remote_buffer: self.remote_buffer.clone(),
+            remote_manager: self.remote_manager.clone(),
+        }
+    }
 }

--- a/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/ibv_manager_actor_tests.rs
@@ -827,8 +827,10 @@ mod tests {
     // ============================================================
 
     /// Two concurrent local `request_queue_pair` calls for the same
-    /// `(self_device, peer, other_device)` key must both succeed and
-    /// return the same QP; that QP must be usable for data-plane ops.
+    /// `(self_device, peer, other_device)` key. Only one can claim
+    /// the (single-owner) `IbvQueuePair`; the other surfaces an
+    /// "already been claimed" error. The winning side's QP must be
+    /// usable for data-plane ops.
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_concurrent_request_queue_pair_converges() -> Result<(), anyhow::Error> {
         const BSIZE: usize = 32;
@@ -855,12 +857,27 @@ mod tests {
                 other_device.clone(),
             ),
         );
-        let qp1 = r1?.map_err(|e| anyhow::anyhow!(e))?;
-        let mut qp2 = r2?.map_err(|e| anyhow::anyhow!(e))?;
-        assert_eq!(qp1.qp, qp2.qp);
+        let r1 = r1?;
+        let r2 = r2?;
+        let (mut qp, loser) = match (r1, r2) {
+            (Ok(qp), Err(e)) => (qp, e),
+            (Err(e), Ok(qp)) => (qp, e),
+            (Ok(_), Ok(_)) => {
+                panic!("expected exactly one concurrent request to claim the QP; both succeeded")
+            }
+            (Err(a), Err(b)) => panic!(
+                "expected exactly one concurrent request to claim the QP; both failed: {a} / {b}"
+            ),
+        };
+        assert!(
+            loser.contains("already pending")
+                || loser.contains("already claimed")
+                || loser.contains("already been claimed"),
+            "loser should surface the 'already pending' / 'already claimed' tombstone, got: {loser}"
+        );
 
-        let wr_id = qp2.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
-        wait_for_completion(&mut qp2, PollTarget::Send, &wr_id, 2).await?;
+        let wr_id = qp.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
+        wait_for_completion(&mut qp, PollTarget::Send, &wr_id, 2).await?;
         env.verify_buffers(BSIZE, 0).await?;
         Ok(())
     }
@@ -897,7 +914,11 @@ mod tests {
             ),
         );
         let mut qp1 = r_local?.map_err(|e| anyhow::anyhow!(e))?;
-        let _ = r_remote?.map_err(|e| anyhow::anyhow!(e))?;
+        // Bind the remote QP so it stays alive for the duration of
+        // the put/completion below. `IbvQueuePair` is single-owner
+        // and `let _ = ...` would drop it immediately, destroying
+        // the peer side of the connection before qp1's WR completes.
+        let _qp2 = r_remote?.map_err(|e| anyhow::anyhow!(e))?;
         let wr_id = qp1.put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
         wait_for_completion(&mut qp1, PollTarget::Send, &wr_id, 2).await?;
         env.verify_buffers(BSIZE, 0).await?;

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -41,9 +41,6 @@ use std::time::Instant;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use backoff::ExponentialBackoff;
-use backoff::ExponentialBackoffBuilder;
-use backoff::backoff::Backoff;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
@@ -70,6 +67,7 @@ use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
 use super::primitives::mlx5dv_supported;
 use super::primitives::resolve_qp_type;
+use super::processor_actor::PollSleepPolicy;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::PeerInfo;
 use super::queue_pair::PollCompletionError;
@@ -198,69 +196,6 @@ pub(super) struct QpInitializerDone {
 pub(super) struct QpInitializerFailed {
     pub(super) qp_key: QpKey,
     pub(super) error: String,
-}
-
-/// Adaptive wait between completion polls.
-///
-/// While the elapsed time since [`Self::yield_now`] was first called
-/// is below `yield_window`, the policy yields cooperatively
-/// (`tokio::task::yield_now`) — keeping latency tight when the WR
-/// completes shortly after being posted. `tokio::time::sleep` has a
-/// minimum resolution of ~1ms (the timer wheel tick), so even a
-/// `sleep(Duration::from_micros(100))` would block that long; `yield_now` is
-/// sub-millisecond and lets the next poll fire as soon as the runtime
-/// schedules us. Past `yield_window` the policy switches to an
-/// exponential backoff (1ms initial, doubling, capped at 10ms) so
-/// long-running operations don't keep the runtime spinning.
-///
-/// `yield_window` is read from
-/// [`crate::config::RDMA_CQ_BUSY_POLL_WINDOW`]. When it's `None`
-/// (the default) the policy disables the cutoff and only ever
-/// yields, never sleeps.
-struct PollSleepPolicy {
-    yield_window: Option<Duration>,
-    started_at: Option<Instant>,
-    backoff: Option<ExponentialBackoff>,
-}
-
-impl PollSleepPolicy {
-    fn new() -> Self {
-        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
-        Self {
-            yield_window,
-            started_at: None,
-            backoff: None,
-        }
-    }
-
-    /// Suspend the current task before the next poll. If no yield
-    /// window is configured (the default), always yields. Otherwise,
-    /// yields while within the window and then walks an exponential
-    /// backoff up to 10ms past it.
-    async fn yield_now(&mut self) {
-        let Some(window) = self.yield_window else {
-            tokio::task::yield_now().await;
-            return;
-        };
-        let started = *self.started_at.get_or_insert_with(Instant::now);
-        if started.elapsed() < window {
-            tokio::task::yield_now().await;
-            return;
-        }
-        let backoff = self.backoff.get_or_insert_with(|| {
-            ExponentialBackoffBuilder::new()
-                .with_initial_interval(Duration::from_millis(1))
-                .with_max_interval(Duration::from_millis(10))
-                .with_multiplier(2.0)
-                .with_randomization_factor(0.0)
-                .with_max_elapsed_time(None)
-                .build()
-        });
-        match backoff.next_backoff() {
-            Some(delay) => tokio::time::sleep(delay).await,
-            None => tokio::task::yield_now().await,
-        }
-    }
 }
 
 /// Look up `(addr, size)` in a slice of registered CUDA segments

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -29,15 +29,16 @@
 //! handler and offloads the handshake to a per-QP child actor,
 //! [`QueuePairInitializer`]. The store of QPs ([`Self::qps`]) is
 //! keyed by [`QpKey`] and holds a [`QpState`]: `Pending { info,
-//! initializer, waiters }` while the handshake runs, `Ready(qp)`
-//! once this side is RTS and has observed the peer's RTS, or
-//! `Failed(error)` as a tombstone after a fatal error.
+//! initializer, waiter }` while the handshake runs, `Ready(qp)`
+//! once this side is RTS and has observed the peer's RTS,
+//! `Consumed` after the processor (or a test) has claimed the QP
+//! (`IbvQueuePair` is single-owner, so it can only be handed out
+//! once), or `Failed(error)` as a tombstone after a fatal error.
 
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
-use std::time::Instant;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -57,7 +58,6 @@ use serde::Serialize;
 use typeuri::Named;
 
 use super::IbvBuffer;
-use super::IbvOp;
 use super::domain::IbvDomain;
 use super::primitives::IbvConfig;
 use super::primitives::IbvDevice;
@@ -67,17 +67,15 @@ use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
 use super::primitives::mlx5dv_supported;
 use super::primitives::resolve_qp_type;
-use super::processor_actor::PollSleepPolicy;
+use super::processor_actor::IbvProcessorActor;
+use super::processor_actor::RegisterMr;
+use super::processor_actor::RequestQueuePair;
+use super::processor_actor::SubmitOps;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::PeerInfo;
-use super::queue_pair::PollCompletionError;
-use super::queue_pair::PollTarget;
-use super::queue_pair::QpGuard;
 use super::queue_pair::QpKey;
 use super::queue_pair::QueuePairInitializer;
-use super::queue_pair::destroy_qp;
 use crate::RdmaOp;
-use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
 use crate::local_memory::RdmaLocalMemory;
@@ -101,15 +99,15 @@ wirevalue::register_type!(EnsureQueuePair<IbvManagerActor>);
 
 /// Per-QpKey state in [`IbvManagerActor::qps`].
 ///
-/// `Pending` covers the entire handshake (an initializer is running);
-/// `Ready` is the terminal usable state; `Failed` is a tombstone that
-/// records the error so subsequent `RequestQueuePair` / `EnsureQueuePair`
-/// calls for the same key surface the same error rather than retrying
-/// or hanging.
+/// `Pending` covers the entire handshake (an initializer is
+/// running); `Ready` holds the freshly-handshaken QP until the
+/// processor claims it; `Consumed` is the post-claim tombstone;
+/// `Failed` is a fatal-error tombstone that surfaces the original
+/// error to later `RequestQueuePair` / `EnsureQueuePair` callers.
 ///
-/// TODO: add recovery — allow retries via an explicit message or after
-/// a backoff. For now the entry stays `Failed` for the life of the
-/// manager.
+/// TODO: add recovery — allow retries via an explicit message or
+/// after a backoff. For now `Failed` (and `Consumed`) entries stay
+/// for the life of the manager.
 #[derive(Debug)]
 enum QpState {
     Pending {
@@ -117,13 +115,20 @@ enum QpState {
         /// repeated `EnsureQueuePair` calls don't have to re-extract it.
         info: IbvQpInfo,
         /// Child actor driving the handshake. Stopped on
-        /// `QpInitializerDone`/`QpInitializerFailed`.
+        /// [`QpInitializerDone`]/[`QpInitializerFailed`].
         initializer: ActorHandle<QueuePairInitializer<IbvManagerActor>>,
-        /// Local `RequestQueuePair` callers waiting for the QP. Drained
-        /// to `Ok(qp.clone())` on `Ready`, or `Err(_)` on failure.
-        waiters: Vec<OncePortHandle<Result<IbvQueuePair, String>>>,
+        /// Single parked [`RequestQueuePair`] caller. The QP is
+        /// single-owner so only one request can ever be satisfied;
+        /// a second concurrent request arriving while this slot is
+        /// occupied is rejected immediately with a clear error.
+        waiter: Option<OncePortHandle<Result<IbvQueuePair, String>>>,
     },
     Ready(IbvQueuePair),
+    /// The processor has taken ownership of this QP. The manager
+    /// keeps the tombstone so a duplicate `RequestQueuePair` or a
+    /// late `EnsureQueuePair` for the same key surfaces a clear
+    /// error rather than silently recreating the QP.
+    Consumed,
     Failed(String),
 }
 
@@ -143,13 +148,6 @@ wirevalue::register_type!(IbvManagerMessage);
 /// Local-only messages for [`IbvManagerActor`].
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
-    /// Register a memory region, returning the MR view and device name.
-    RegisterMr {
-        addr: usize,
-        size: usize,
-        #[reply]
-        reply: OncePortHandle<Result<(IbvMemoryRegionView, String), String>>,
-    },
     /// Register a remote-facing buffer's MR and return its
     /// [`IbvBuffer`]. Called by
     /// [`crate::rdma_manager_actor::RdmaManagerActor::request_buffer`]
@@ -163,30 +161,15 @@ pub enum IbvManagerLocalMessage {
         #[reply]
         reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
-    /// User-facing entry point: get a connected `IbvQueuePair` for
-    /// `(self_device, other actor's id, other_device)`. Lazily creates
-    /// the QP + initializer if absent; if a handshake is in flight,
-    /// the reply port is queued and answered when the QP becomes
-    /// `Ready` (or fails).
-    ///
-    /// No `#[reply]` because the handler may park `reply` on the
-    /// `Pending` entry and answer it later from [`QpInitializerDone`]/
-    /// [`QpInitializerFailed`].
-    RequestQueuePair {
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        reply: OncePortHandle<Result<IbvQueuePair, String>>,
-    },
 }
 
 /// Local-only handshake-success report. The initializer sends this
 /// to its owning manager once both sides have reached RTS, handing
-/// over the freshly-connected [`QpGuard`].
+/// over the freshly-connected [`IbvQueuePair`].
 #[derive(Debug)]
 pub(super) struct QpInitializerDone {
     pub(super) qp_key: QpKey,
-    pub(super) qp: QpGuard,
+    pub(super) qp: IbvQueuePair,
 }
 
 /// Local-only handshake-failure report. The initializer sends this
@@ -259,15 +242,27 @@ pub(super) struct SegmentInfo {
 pub struct IbvManagerActor {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
+    /// Child data-path actor. Spawned in [`Actor::init`]. The
+    /// manager forwards [`SubmitOps`] from [`IbvBackend`] to it,
+    /// and the processor sends `RegisterMr` / `RequestQueuePair`
+    /// back to the manager as it resolves MRs and peer QPs on the
+    /// data path.
+    processor: OnceLock<ActorHandle<IbvProcessorActor<IbvManagerActor, IbvQueuePair>>>,
+
     /// Per-QP state, keyed from this manager's perspective. See [`QpKey`].
     qps: HashMap<QpKey, QpState>,
 
-    /// Map of RDMA device names to their domains and loopback QPs.
-    /// Created lazily when memory is registered for a specific
-    /// device. `Arc<IbvDomain>` so every `IbvMemoryRegionView`
-    /// registered against the domain can hold a clone and keep the
-    /// PD alive until the last MR is dereg'd.
-    device_domains: HashMap<String, (Arc<IbvDomain>, Option<IbvQueuePair>)>,
+    /// Per-device protection domains. Created lazily when memory is
+    /// registered or a peer QP is requested for the device. The
+    /// `Arc<IbvDomain>` is cloned into every `IbvMemoryRegionView`
+    /// and `IbvQueuePair` the manager hands out, so the PD outlives
+    /// the resources that reference it.
+    device_domains: HashMap<String, Arc<IbvDomain>>,
+
+    /// Per-device loopback QPs used by the mlx5dv segment scanner.
+    /// EFA / non-mlx5dv devices have no entry. Owned by the manager
+    /// for the lifetime of the device.
+    loopback_qps: HashMap<String, IbvQueuePair>,
 
     config: IbvConfig,
 
@@ -302,56 +297,17 @@ impl Actor for IbvManagerActor {
         self.owner
             .set(owner)
             .expect("owner should only be set once during init");
+        let mr_lru_capacity = hyperactor_config::global::get(crate::config::RDMA_MR_LRU_CACHE_SIZE);
+        let processor = IbvProcessorActor::<IbvManagerActor, IbvQueuePair>::new(
+            Instance::handle(this),
+            self.config.clone(),
+            mr_lru_capacity,
+        );
+        let processor_handle = this.spawn(processor)?;
+        self.processor
+            .set(processor_handle)
+            .expect("processor should only be set once during init");
         Ok(())
-    }
-}
-
-impl Drop for IbvManagerActor {
-    fn drop(&mut self) {
-        // 1. Clean up QPs. `Pending` entries hold the qp via the
-        // initializer; signal the initializer to stop and let the
-        // runtime tear it down. `Failed` is a tombstone with no
-        // resources. Pending waiters won't be answered and their
-        // callers will observe the dropped reply ports as `Err(_)`.
-        for (_key, state) in self.qps.drain() {
-            match state {
-                QpState::Ready(_) => {
-                    // TODO(slurye): Proper cleanup of QPs. Currently there's no safe way to do this
-                    // because `IbvQueuePair` can have arbitrary clones and there's no way to guarantee
-                    // that none of them are still in use.
-                }
-                QpState::Pending { initializer, .. } => {
-                    let _ = initializer.drain_and_stop("IbvManagerActor dropped");
-                }
-                QpState::Failed(_) => {}
-            }
-        }
-
-        // 2. Drop buffer registrations. Each entry's
-        // `IbvMemoryRegionView` carries the only manager-side
-        // reference to that MR's `Arc<IbvMemoryRegion>` and its
-        // `Arc<IbvDomain>`. They run their FFI cleanup from their
-        // `Drop`s once no surviving view holds a clone.
-        self.buffer_registrations.clear();
-
-        // 3. Drop the segments-owner Arc. `deregister_segments`
-        // runs from `IbvMemoryRegion::Segments::Drop` when the last
-        // segment-backed view also goes away.
-        self.segments_mr.take();
-
-        // 4. Drop device domains (PDs + loopback QPs). Loopback QPs
-        // are tied to this map only; destroy them explicitly. PD
-        // teardown waits on the last `Arc<IbvDomain>` clone (held
-        // by any outstanding view) to drop.
-        for (_device_name, (domain, qp)) in self.device_domains.drain() {
-            if let Some(qp) = qp {
-                // SAFETY: `device_domains` is the only holder of
-                // these loopback QPs; we just drained it and the
-                // manager is being dropped, so no clones survive.
-                unsafe { destroy_qp(&qp) };
-            }
-            drop(domain);
-        }
     }
 }
 
@@ -403,8 +359,10 @@ impl IbvManagerActor {
 
         let actor = Self {
             owner: OnceLock::new(),
+            processor: OnceLock::new(),
             qps: HashMap::new(),
             device_domains: HashMap::new(),
+            loopback_qps: HashMap::new(),
             config,
             mlx5dv_enabled,
             segments_mr: None,
@@ -415,14 +373,17 @@ impl IbvManagerActor {
         Ok(actor)
     }
 
-    /// Get or create a domain and loopback QP for the specified RDMA device
+    /// Get or create a domain and loopback QP for the specified RDMA
+    /// device. Returns the shared `Arc<IbvDomain>`; the loopback QP
+    /// (when applicable) lives in [`Self::loopback_qps`] and is only
+    /// inspected by `build_per_device_pd_qp_arrays`.
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
         rdma_device: &IbvDevice,
-    ) -> Result<(Arc<IbvDomain>, Option<IbvQueuePair>), anyhow::Error> {
-        if let Some((domain, qp)) = self.device_domains.get(device_name) {
-            return Ok((Arc::clone(domain), qp.clone()));
+    ) -> Result<Arc<IbvDomain>, anyhow::Error> {
+        if let Some(domain) = self.device_domains.get(device_name) {
+            return Ok(Arc::clone(domain));
         }
 
         // Create new domain for this device
@@ -435,16 +396,15 @@ impl IbvManagerActor {
 
         // Create loopback QP for this domain if mlx5dv is supported (needed for segment registration)
         // For EFA, we don't need a loopback QP for segment scanning
-        let qp = if mlx5dv_supported() && !crate::efa::is_efa_device() {
-            let mut qp = QpGuard::new(
-                IbvQueuePair::new(domain.context, domain.pd, self.config.clone()).map_err(|e| {
+        if mlx5dv_supported() && !crate::efa::is_efa_device() {
+            let mut qp =
+                IbvQueuePair::new(Arc::clone(&domain), self.config.clone()).map_err(|e| {
                     anyhow::anyhow!(
                         "could not create loopback QP for device {}: {}",
                         device_name,
                         e
                     )
-                })?,
-            );
+                })?;
 
             // Get connection info and connect to itself
             let endpoint = qp.get_qp_info().map_err(|e| {
@@ -459,15 +419,12 @@ impl IbvManagerActor {
                 )
             })?;
 
-            Some(qp)
-        } else {
-            None
-        };
+            self.loopback_qps.insert(device_name.to_string(), qp);
+        }
 
-        let qp = qp.map(|qp| qp.into_inner());
         self.device_domains
-            .insert(device_name.to_string(), (Arc::clone(&domain), qp.clone()));
-        Ok((domain, qp))
+            .insert(device_name.to_string(), Arc::clone(&domain));
+        Ok(domain)
     }
 
     /// Build parallel PD/QP arrays indexed by CUDA device ordinal
@@ -483,10 +440,11 @@ impl IbvManagerActor {
         let mut qps = Vec::with_capacity(cuda_map.len());
         for maybe_device in cuda_map {
             if let Some(device) = maybe_device {
-                if let Some((domain, qp)) = self.device_domains.get(device.name()) {
+                if let Some(domain) = self.device_domains.get(device.name()) {
                     pds.push(domain.pd);
                     qps.push(
-                        qp.as_ref()
+                        self.loopback_qps
+                            .get(device.name())
                             .map(|q| q.qp as *mut rdmaxcel_sys::rdmaxcel_qp_t)
                             .unwrap_or(std::ptr::null_mut()),
                     );
@@ -558,8 +516,11 @@ impl IbvManagerActor {
                 addr
             );
 
-            // Get or create domain and loopback QP for this device
-            let (domain, _qp) = self.get_or_create_device_domain(&device_name, &rdma_device)?;
+            // Get or create the protection domain for this device.
+            // The loopback QP (when applicable) lives in
+            // `self.loopback_qps` and is consulted lazily by
+            // `build_per_device_pd_qp_arrays` below.
+            let domain = self.get_or_create_device_domain(&device_name, &rdma_device)?;
 
             let access = if crate::efa::is_efa_device() {
                 crate::efa::mr_access_flags()
@@ -702,7 +663,7 @@ impl IbvManagerActor {
     /// `IbvQueuePair`, capture its `IbvQpInfo`, and spawn a
     /// `QueuePairInitializer` to drive the handshake. Returns the
     /// `QpState` entry — either the freshly-inserted `Pending` one,
-    /// or the existing `Pending`/`Ready`/`Failed`.
+    /// or the existing `Pending`/`Ready`/`Consumed`/`Failed`.
     fn ensure_queue_pair_impl(
         &mut self,
         cx: &Context<'_, Self>,
@@ -715,15 +676,14 @@ impl IbvManagerActor {
                 .into_iter()
                 .find(|d| d.name() == self_device)
                 .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
-            let (domain, _) = self.get_or_create_device_domain(self_device, &rdma_device)?;
-            // Wrap the freshly-created QP in a `QpGuard` immediately
-            // so that any early-return path below (e.g. `get_qp_info`
-            // failing) destroys the underlying `rdmaxcel_qp_t` via
-            // the guard's `Drop` rather than leaking it.
-            let mut qp = QpGuard::new(
-                IbvQueuePair::new(domain.context, domain.pd, self.config.clone())
-                    .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {}", e))?,
-            );
+            let domain = self.get_or_create_device_domain(self_device, &rdma_device)?;
+            // The freshly-created QP is moved straight into the
+            // initializer; any early-return path below (e.g.
+            // `get_qp_info` failing) drops it, and
+            // `IbvQueuePair::Drop` destroys the underlying
+            // `rdmaxcel_qp_t`.
+            let mut qp = IbvQueuePair::new(domain, self.config.clone())
+                .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {}", e))?;
             let info = qp
                 .get_qp_info()
                 .map_err(|e| anyhow::anyhow!("could not extract QP info: {}", e))?;
@@ -735,7 +695,7 @@ impl IbvManagerActor {
                 QpState::Pending {
                     info,
                     initializer,
-                    waiters: Vec::new(),
+                    waiter: None,
                 },
             );
         }
@@ -794,16 +754,17 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
                 let notify_rts = initializer.bind::<QueuePairInitializer<Self>>().port();
                 reply.send(cx, PeerInfo(Ok((info.clone(), notify_rts))))?;
             }
-            QpState::Ready(_) => {
-                // `Ready` means a prior handshake completed and the
-                // initializer was stopped — we can't hand back an
-                // initializer ref. Reaching here represents a logic
-                // error (peer is asking us to redo a handshake we've
-                // already finished); surface it as `Err`.
+            QpState::Ready(_) | QpState::Consumed => {
+                // The handshake for this key already completed (and
+                // the initializer was stopped, so we can't hand back
+                // a fresh `NotifyRts` port). Reaching here represents
+                // a peer asking us to redo work that's already done;
+                // surface it as `Err` rather than silently
+                // recreating the QP.
                 reply.send(
                     cx,
                     PeerInfo(Err(format!(
-                        "EnsureQueuePair on already-Ready entry {qp_key:?}"
+                        "EnsureQueuePair on already-completed entry {qp_key:?}"
                     ))),
                 )?;
             }
@@ -818,15 +779,6 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
 #[async_trait]
 #[hyperactor::handle(IbvManagerLocalMessage)]
 impl IbvManagerLocalMessageHandler for IbvManagerActor {
-    async fn register_mr(
-        &mut self,
-        _cx: &Context<Self>,
-        addr: usize,
-        size: usize,
-    ) -> Result<Result<(IbvMemoryRegionView, String), String>, anyhow::Error> {
-        Ok(self.register_mr_impl(addr, size).map_err(|e| e.to_string()))
-    }
-
     async fn register_remote_buffer(
         &mut self,
         _cx: &Context<Self>,
@@ -852,34 +804,6 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
             .insert(remote_buf_id, (buf.clone(), mrv));
         Ok(Ok(buf))
     }
-
-    async fn request_queue_pair(
-        &mut self,
-        cx: &Context<Self>,
-        other: ActorRef<IbvManagerActor>,
-        self_device: String,
-        other_device: String,
-        reply: OncePortHandle<Result<IbvQueuePair, String>>,
-    ) -> Result<(), anyhow::Error> {
-        let qp_key = QpKey {
-            self_device,
-            other_id: other.actor_addr().id().clone(),
-            other_device,
-        };
-        let state = match self.ensure_queue_pair_impl(cx, other, &qp_key) {
-            Ok(state) => state,
-            Err(e) => {
-                reply.send(cx, Err(e.to_string()))?;
-                return Ok(());
-            }
-        };
-        match state {
-            QpState::Pending { waiters, .. } => waiters.push(reply),
-            QpState::Ready(qp) => reply.send(cx, Ok(qp.clone()))?,
-            QpState::Failed(error) => reply.send(cx, Err(error.clone()))?,
-        }
-        Ok(())
-    }
 }
 
 #[async_trait]
@@ -890,37 +814,38 @@ impl Handler<QpInitializerDone> for IbvManagerActor {
         msg: QpInitializerDone,
     ) -> Result<(), anyhow::Error> {
         let QpInitializerDone { qp_key, qp } = msg;
-        let qp = qp.into_inner();
-        // Take the entry out, transition to Ready, drain waiters,
-        // then stop the initializer.
-        let initializer = match self.qps.remove(&qp_key) {
+        // Transition `Pending → Ready`, handing the QP to the parked
+        // waiter (if any) and tombstoning as `Consumed`. Otherwise
+        // leave the QP in `Ready` so the next `RequestQueuePair`
+        // claims it.
+        let (initializer, waiter) = match self.qps.remove(&qp_key) {
             Some(QpState::Pending {
-                waiters,
+                waiter,
                 initializer,
                 ..
-            }) => {
-                for w in waiters {
-                    let waiter_dbg = format!("{w:?}");
-                    if let Err(e) = w.send(cx, Ok(qp.clone())) {
-                        tracing::error!(
-                            "QpInitializerDone: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
-                        );
-                    }
-                }
-                initializer
-            }
+            }) => (initializer, waiter),
             other => {
                 unreachable!("QpInitializerDone received but state is {other:?}: {qp_key:?}")
             }
         };
-        self.qps.insert(qp_key.clone(), QpState::Ready(qp));
+        if let Some(w) = waiter {
+            let waiter_dbg = format!("{w:?}");
+            if let Err(e) = w.send(cx, Ok(qp)) {
+                tracing::error!(
+                    "QpInitializerDone: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
+                );
+            }
+            self.qps.insert(qp_key.clone(), QpState::Consumed);
+        } else {
+            self.qps.insert(qp_key.clone(), QpState::Ready(qp));
+        }
         initializer.drain_and_stop("QpInitializerDone")?;
         let status = initializer.await;
         if status.is_failed() {
-            // The QP itself is already `Ready` and waiters have been
-            // drained, so a non-clean initializer shutdown is not
-            // user-visible — log and move on rather than crashing
-            // the manager.
+            // The QP has been handed off (or is parked in `Ready`)
+            // and the primary waiter has been answered, so a
+            // non-clean initializer shutdown is not user-visible —
+            // log and move on rather than crashing the manager.
             tracing::error!(
                 "QueuePairInitializer for {qp_key:?} terminated with failure after Done: {status:?}"
             );
@@ -939,11 +864,11 @@ impl Handler<QpInitializerFailed> for IbvManagerActor {
         let QpInitializerFailed { qp_key, error } = msg;
         let initializer = match self.qps.remove(&qp_key) {
             Some(QpState::Pending {
-                waiters,
+                waiter,
                 initializer,
                 ..
             }) => {
-                for w in waiters {
+                if let Some(w) = waiter {
                     let waiter_dbg = format!("{w:?}");
                     if let Err(e) = w.send(cx, Err(error.clone())) {
                         tracing::error!(
@@ -972,33 +897,135 @@ impl Handler<QpInitializerFailed> for IbvManagerActor {
     }
 }
 
-/// Free helper around [`IbvManagerLocalMessage::RequestQueuePair`] — opens
-/// a `OncePortHandle` for the reply, sends the message, and awaits the
-/// answer. Exists because `RequestQueuePair` doesn't use `#[reply]`
-/// (the handler may park the port until the QP becomes `Ready`), so
-/// the auto-derived client method only does fire-and-forget.
-pub(super) async fn request_queue_pair(
+#[async_trait]
+impl Handler<SubmitOps<IbvManagerActor>> for IbvManagerActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: SubmitOps<IbvManagerActor>,
+    ) -> Result<(), anyhow::Error> {
+        // Forward straight to the processor. `SubmitOps` carries the
+        // caller's reply port, so the processor's response goes
+        // back to the original caller without bouncing through the
+        // manager again.
+        self.processor
+            .get()
+            .expect("processor spawned during Actor::init")
+            .send(cx, msg)?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<RegisterMr> for IbvManagerActor {
+    async fn handle(&mut self, cx: &Context<Self>, msg: RegisterMr) -> Result<(), anyhow::Error> {
+        let RegisterMr { addr, size, reply } = msg;
+        let result = self
+            .register_mr_impl(addr, size)
+            .map(|(mrv, _device_name)| mrv)
+            .map_err(|e| e.to_string());
+        reply.send(cx, result)?;
+        Ok(())
+    }
+}
+
+/// Send a [`RequestQueuePair`] to the manager and await the QP it
+/// hands back.
+///
+/// Note: a successful return *transfers ownership* of the
+/// underlying QP to the caller — the manager tombstones the entry
+/// as [`QpState::Consumed`] and any later request for the same key
+/// fails.
+pub async fn request_queue_pair(
     actor: &ActorHandle<IbvManagerActor>,
     cx: &(impl hyperactor::context::Actor + Send + Sync),
     other: ActorRef<IbvManagerActor>,
     self_device: String,
     other_device: String,
 ) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
+    let qp_key = QpKey {
+        self_device,
+        other_id: other.actor_addr().id().clone(),
+        other_device,
+    };
     let (reply, rx) = cx
         .mailbox()
         .open_once_port::<Result<IbvQueuePair, String>>();
-    actor
-        .request_queue_pair(cx, other, self_device, other_device, reply)
-        .await?;
+    actor.send(
+        cx,
+        RequestQueuePair {
+            qp_key,
+            remote_manager: other,
+            reply,
+        },
+    )?;
     rx.recv()
         .await
         .map_err(|e| anyhow::anyhow!("request_queue_pair port closed: {e}"))
 }
 
-/// Wrapper around [`ActorHandle<IbvManagerActor>`] that moves the RDMA
-/// data-plane (post send/recv, poll CQ) off the actor loop while keeping
-/// state-mutating operations (MR registration/deregistration, QP management)
-/// serialized through actor messages.
+#[async_trait]
+impl Handler<RequestQueuePair<IbvManagerActor, IbvQueuePair>> for IbvManagerActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: RequestQueuePair<IbvManagerActor, IbvQueuePair>,
+    ) -> Result<(), anyhow::Error> {
+        let RequestQueuePair {
+            qp_key,
+            remote_manager,
+            reply,
+        } = msg;
+        let state = match self.ensure_queue_pair_impl(cx, remote_manager, &qp_key) {
+            Ok(state) => state,
+            Err(e) => {
+                reply.send(cx, Err(e.to_string()))?;
+                return Ok(());
+            }
+        };
+        match state {
+            QpState::Pending { waiter, .. } => {
+                if waiter.is_some() {
+                    // The (single-owner) QP can satisfy exactly one
+                    // request. Reject any concurrent caller right
+                    // away rather than letting them queue behind a
+                    // request whose handle they will never receive.
+                    reply.send(
+                        cx,
+                        Err(format!(
+                            "RequestQueuePair for {qp_key:?}: another request is already pending"
+                        )),
+                    )?;
+                } else {
+                    *waiter = Some(reply);
+                }
+            }
+            QpState::Ready(_) => {
+                // Take the QP out, hand it to the caller, and
+                // tombstone the entry as `Consumed`.
+                let qp = match self.qps.insert(qp_key.clone(), QpState::Consumed) {
+                    Some(QpState::Ready(qp)) => qp,
+                    _ => unreachable!("just matched Ready"),
+                };
+                reply.send(cx, Ok(qp))?;
+            }
+            QpState::Consumed => {
+                reply.send(
+                    cx,
+                    Err(format!(
+                        "RequestQueuePair for {qp_key:?} but QP has already been claimed"
+                    )),
+                )?;
+            }
+            QpState::Failed(error) => reply.send(cx, Err(error.clone()))?,
+        }
+        Ok(())
+    }
+}
+
+/// Wrapper around [`ActorHandle<IbvManagerActor>`] for the ibverbs
+/// data plane. `submit` sends a [`SubmitOps`] to the manager, which
+/// forwards it to its private [`IbvProcessorActor`] child.
 #[derive(Debug, Clone)]
 pub struct IbvBackend(pub ActorHandle<IbvManagerActor>);
 
@@ -1009,146 +1036,14 @@ impl std::ops::Deref for IbvBackend {
     }
 }
 
-impl IbvBackend {
-    /// Waits for the completion of RDMA operations.
-    ///
-    /// Polls the completion queue until all specified work requests complete
-    /// or until the timeout is reached. Pure CQ polling — no actor state needed.
-    async fn wait_for_completion(
-        local_buf: &IbvBuffer,
-        qp: &mut IbvQueuePair,
-        poll_target: PollTarget,
-        expected_wr_ids: &[u64],
-        timeout: Duration,
-    ) -> Result<(), anyhow::Error> {
-        let start_time = std::time::Instant::now();
-
-        let mut remaining: std::collections::HashSet<u64> =
-            expected_wr_ids.iter().copied().collect();
-        let mut poll_policy = PollSleepPolicy::new();
-
-        while start_time.elapsed() < timeout {
-            if remaining.is_empty() {
-                return Ok(());
-            }
-
-            let wr_ids_to_poll: Vec<u64> = remaining.iter().copied().collect();
-            match qp.poll_completion(poll_target, &wr_ids_to_poll) {
-                Ok(completions) => {
-                    for (wr_id, _wc) in completions {
-                        remaining.remove(&wr_id);
-                    }
-                    if remaining.is_empty() {
-                        return Ok(());
-                    }
-                    poll_policy.yield_now().await;
-                }
-                Err(e) => {
-                    // When the returned error is WR_FLUSH_ERR, which is generally a
-                    // secondary error, drain the remaining completions to find the
-                    // original root cause error. WR_FLUSH_ERR means the QP entered
-                    // error state due to a DIFFERENT WR's failure, so the actual root
-                    // cause may be cached or still in the CQ.
-                    let mut root_cause: Option<PollCompletionError> = None;
-                    if e.is_wr_flush_err() {
-                        for &wr_id in &wr_ids_to_poll {
-                            if let Err(inner_err) = qp.poll_completion(poll_target, &[wr_id]) {
-                                if !inner_err.is_wr_flush_err() {
-                                    root_cause = Some(inner_err);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    let error_detail = if let Some(cause) = root_cause {
-                        format!(
-                            "RDMA polling completion failed: {} (root cause: {})",
-                            e, cause
-                        )
-                    } else {
-                        format!("RDMA polling completion failed: {}", e)
-                    };
-                    return Err(anyhow::anyhow!(
-                        "{} [lkey={}, rkey={}, addr=0x{:x}, size={}]",
-                        error_detail,
-                        local_buf.lkey,
-                        local_buf.rkey,
-                        local_buf.addr,
-                        local_buf.size
-                    ));
-                }
-            }
-        }
-        tracing::error!(
-            "timed out while waiting on request completion for wr_ids={:?}",
-            remaining
-        );
-        Err(anyhow::anyhow!(
-            "[ibv_buffer({:?})] rdma operation did not complete in time (expected wr_ids={:?})",
-            local_buf,
-            expected_wr_ids
-        ))
-    }
-
-    /// Core submit logic: registers a local MR via actor message,
-    /// resolves the remote `IbvBuffer` lazily, and executes the op.
-    /// `local_mrv` is kept in scope for the duration of the op so
-    /// its `Arc<IbvMemoryRegion>` (and the PD it lives on) survive
-    /// until completion; on drop, the FFI MR is deregistered.
-    async fn execute_op(
-        &self,
-        cx: &(impl hyperactor::context::Actor + Send + Sync),
-        op: IbvOp,
-        timeout: Duration,
-    ) -> Result<(), anyhow::Error> {
-        let (local_mrv, local_device_name) = self
-            .register_mr(cx, op.local_memory.addr(), op.local_memory.size())
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
-
-        let local_buffer = IbvBuffer {
-            mr_id: local_mrv.id,
-            lkey: local_mrv.lkey,
-            rkey: local_mrv.rkey,
-            addr: local_mrv.rdma_addr,
-            size: local_mrv.size,
-            device_name: local_device_name,
-        };
-
-        let result = async {
-            let mut qp = request_queue_pair(
-                &self.0,
-                cx,
-                op.remote_manager.clone(),
-                local_buffer.device_name.clone(),
-                op.remote_buffer.device_name.clone(),
-            )
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
-
-            let wr_id = match op.op_type {
-                RdmaOpType::WriteFromLocal => qp.put(local_buffer.clone(), op.remote_buffer)?,
-                RdmaOpType::ReadIntoLocal => qp.get(local_buffer.clone(), op.remote_buffer)?,
-            };
-
-            Self::wait_for_completion(&local_buffer, &mut qp, PollTarget::Send, &wr_id, timeout)
-                .await
-        }
-        .await;
-
-        drop(local_mrv);
-        result
-    }
-}
-
 #[async_trait]
 impl RdmaBackend for IbvBackend {
     type TransportInfo = ();
 
-    /// Submit a batch of RDMA operations.
-    ///
-    /// Resolves ibv ops, then executes each directly — registering/deregistering
-    /// MRs via actor messages, while performing QP put/get and CQ polling locally.
+    /// Submit a batch of RDMA operations via the manager's data-path
+    /// child actor. On any per-op failure the returned `Err`
+    /// enumerates every failed op (with its original batch index)
+    /// and its underlying error message.
     async fn submit(
         &mut self,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
@@ -1160,7 +1055,7 @@ impl RdmaBackend for IbvBackend {
             let (remote_manager, remote_buffer) = op.remote.resolve_ibv().ok_or_else(|| {
                 anyhow::anyhow!("ibverbs backend not found for buffer: {:?}", op.remote)
             })?;
-            ibv_ops.push(IbvOp {
+            ibv_ops.push(super::IbvOp {
                 op_type: op.op_type,
                 local_memory: op.local.clone(),
                 remote_buffer,
@@ -1168,15 +1063,35 @@ impl RdmaBackend for IbvBackend {
             });
         }
 
-        let deadline = Instant::now() + timeout;
-        for op in ibv_ops {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return Err(anyhow::anyhow!("submit timed out"));
-            }
-            self.execute_op(cx, op, remaining).await?;
+        let (reply, rx) = cx.mailbox().open_once_port::<Vec<Result<(), String>>>();
+        self.0.send(
+            cx,
+            SubmitOps {
+                ops: ibv_ops,
+                timeout,
+                reply,
+            },
+        )?;
+        let results = rx
+            .recv()
+            .await
+            .map_err(|e| anyhow::anyhow!("SubmitOps reply port closed: {e}"))?;
+        let total = results.len();
+        let failures: Vec<String> = results
+            .into_iter()
+            .enumerate()
+            .filter_map(|(i, res)| res.err().map(|e| format!("op {i}: {e}")))
+            .collect();
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow::anyhow!(
+                "{} of {} submitted ibverbs ops failed:\n  {}",
+                failures.len(),
+                total,
+                failures.join("\n  ")
+            ))
         }
-        Ok(())
     }
 
     fn transport_level(&self) -> RdmaTransportLevel {

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1024,6 +1024,25 @@ impl From<rdmaxcel_sys::ibv_wc> for IbvWc {
 }
 
 impl IbvWc {
+    /// Test-only constructor
+    #[cfg(test)]
+    pub(super) fn for_test(wr_id: u64, valid: bool) -> Self {
+        Self {
+            wr_id,
+            len: 0,
+            valid,
+            error: None,
+            opcode: rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_WRITE,
+            bytes: None,
+            qp_num: 0,
+            src_qp: 0,
+            pkey_index: 0,
+            slid: 0,
+            sl: 0,
+            dlid_path_bits: 0,
+        }
+    }
+
     /// Returns the Work Request ID associated with this work completion.
     ///
     /// The Work Request ID is used to identify the specific operation that completed.

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -1,0 +1,666 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! `IbvProcessorActor` — data-path child of `IbvManagerActor`.
+//!
+//! Owns the peer queue pairs handed off from the manager via
+//! [`RequestQueuePair`], caches local MR registrations via
+//! [`RegisterMr`], and runs batches of [`IbvOp`]s submitted through
+//! [`SubmitOps`]. Generic over a [`Manager`] actor type and a
+//! [`QueuePair`] type so unit tests can swap in mocks.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::ActorHandle;
+use hyperactor::ActorRef;
+use hyperactor::Context;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::OncePortHandle;
+use hyperactor::actor::Referable;
+use hyperactor::context::Mailbox;
+use lru::LruCache;
+use tokio::sync::Mutex;
+use tokio::sync::OwnedMutexGuard;
+
+use super::IbvOp;
+use super::primitives::IbvConfig;
+use super::primitives::IbvMemoryRegionView;
+use super::queue_pair::QpKey;
+
+/// A queue-pair value the processor owns end-to-end. The trait is a
+/// marker today; data-path methods (post send / poll completion)
+/// land alongside the real per-batch WR accounting in a follow-up.
+pub(super) trait QueuePair: std::fmt::Debug + Send + Sync + 'static {}
+
+/// Local-only message: ask the manager to register an MR for
+/// `[addr, addr + size)` and return the resulting view.
+#[cfg_attr(not(test), expect(dead_code, reason = "wired up in D105213930"))]
+#[derive(Debug)]
+pub(super) struct RegisterMr {
+    pub addr: usize,
+    pub size: usize,
+    pub reply: OncePortHandle<Result<IbvMemoryRegionView, String>>,
+}
+
+/// Local-only message: ask the manager to set up (and transfer
+/// ownership of) a peer queue pair. The manager hands the QP value
+/// across the reply port and forgets it on its own side — the
+/// processor becomes the sole owner.
+#[cfg_attr(not(test), expect(dead_code, reason = "wired up in D105213930"))]
+#[derive(Debug)]
+pub(super) struct RequestQueuePair<M: Referable, Qp: QueuePair> {
+    pub qp_key: QpKey,
+    #[expect(dead_code, reason = "read by IbvManagerActor handler in D105213930")]
+    pub remote_manager: ActorRef<M>,
+    pub reply: OncePortHandle<Result<Qp, String>>,
+}
+
+/// Bundle of trait bounds for an actor type that can serve the
+/// processor's slow-path requests. `Referable` is required so the
+/// processor can carry `ActorRef<Self>` inside [`RequestQueuePair`].
+pub(super) trait Manager<Qp: QueuePair>:
+    Actor + Referable + Handler<RegisterMr> + Handler<RequestQueuePair<Self, Qp>>
+{
+}
+
+impl<T, Qp: QueuePair> Manager<Qp> for T where
+    T: Actor + Referable + Handler<RegisterMr> + Handler<RequestQueuePair<Self, Qp>>
+{
+}
+
+/// Local-only message handled by [`IbvProcessorActor`]: run a batch
+/// of ops to completion and reply with per-op results.
+#[derive(Debug)]
+pub(super) struct SubmitOps<M: Referable> {
+    pub ops: Vec<IbvOp<M>>,
+    pub timeout: Duration,
+    pub reply: OncePortHandle<Vec<Result<(), String>>>,
+}
+
+/// Single-purpose child actor that runs the ibverbs data path.
+/// Generic over a [`Manager`] (slow path) and [`QueuePair`] (data
+/// path) so it can be unit-tested with mocks.
+#[derive(Debug)]
+pub(super) struct IbvProcessorActor<M: Actor, Qp> {
+    manager: ActorHandle<M>,
+    config: IbvConfig,
+    mr_lru: LruCache<(usize, usize), IbvMemoryRegionView>,
+    /// Peer QPs the processor took ownership of via
+    /// [`RequestQueuePair`]. Each entry is its own `Arc<Mutex<Qp>>`
+    /// so the data path can hand out an
+    /// [`OwnedMutexGuard`](tokio::sync::OwnedMutexGuard) per QP and
+    /// lock distinct QPs concurrently from the parallel per-QP
+    /// futures in `process_batch`.
+    peer_qps: HashMap<QpKey, Arc<Mutex<Qp>>>,
+}
+
+#[cfg_attr(not(test), expect(dead_code, reason = "wired up in D105213930"))]
+impl<M, Qp> IbvProcessorActor<M, Qp>
+where
+    M: Manager<Qp>,
+    Qp: QueuePair,
+{
+    /// `mr_lru_capacity` should be non-zero. A zero value is
+    /// clamped to one with a `tracing::warn`; we treat the
+    /// degenerate single-entry LRU as the floor rather than
+    /// crashing the manager.
+    pub(super) fn new(manager: ActorHandle<M>, config: IbvConfig, mr_lru_capacity: usize) -> Self {
+        let mr_lru_capacity = NonZeroUsize::new(mr_lru_capacity).unwrap_or_else(|| {
+            tracing::warn!(
+                "RDMA_MR_LRU_CACHE_SIZE was 0; clamping to 1 (LRU disabled in practice)"
+            );
+            NonZeroUsize::MIN
+        });
+        Self {
+            manager,
+            config,
+            mr_lru: LruCache::new(mr_lru_capacity),
+            peer_qps: HashMap::new(),
+        }
+    }
+
+    /// Resolve `(addr, size)` via the LRU cache, asking the manager
+    /// on miss.
+    async fn resolve_mr(
+        &mut self,
+        cx: &Context<'_, Self>,
+        addr: usize,
+        size: usize,
+    ) -> Result<IbvMemoryRegionView, String> {
+        if let Some(mrv) = self.mr_lru.get(&(addr, size)).cloned() {
+            return Ok(mrv);
+        }
+        let (reply, rx) = cx
+            .mailbox()
+            .open_once_port::<Result<IbvMemoryRegionView, String>>();
+        self.manager
+            .send(cx, RegisterMr { addr, size, reply })
+            .map_err(|e| {
+                format!(
+                    "Requesting MR registration from {:?} failed [virtual_addr=0x{:x}, size={}]: {}",
+                    self.manager, addr, size, e
+                )
+            })?;
+        let mrv = rx
+            .recv()
+            .await
+            .map_err(|e| {
+                format!(
+                    "MR registration port closed [virtual_addr=0x{:x}, size={}]: {}",
+                    addr, size, e
+                )
+            })?
+            .map_err(|e| {
+                format!(
+                    "MR registration failed [virtual_addr=0x{:x}, size={}]: {}",
+                    addr, size, e
+                )
+            })?;
+        self.mr_lru.put((addr, size), mrv.clone());
+        Ok(mrv)
+    }
+
+    /// Return an [`OwnedMutexGuard`] over the QP for `qp_key`,
+    /// requesting a fresh QP from the manager and inserting it into
+    /// `peer_qps` on miss. The QP stays in the map for the lifetime
+    /// of the actor; the caller drives the QP through the guard and
+    /// the lock releases when the guard drops. Locking is via
+    /// `try_lock_owned` because the actor serializes its handlers
+    /// and only one `submit_ops` is in flight at a time, so the
+    /// guard is always uncontended at acquisition.
+    async fn get_or_request_qp(
+        &mut self,
+        cx: &Context<'_, Self>,
+        qp_key: &QpKey,
+        remote_manager: ActorRef<M>,
+    ) -> Result<OwnedMutexGuard<Qp>, String> {
+        if !self.peer_qps.contains_key(qp_key) {
+            let (reply, rx) = cx.mailbox().open_once_port::<Result<Qp, String>>();
+            self.manager
+                .send(
+                    cx,
+                    RequestQueuePair {
+                        qp_key: qp_key.clone(),
+                        remote_manager,
+                        reply,
+                    },
+                )
+                .map_err(|e| {
+                    format!(
+                        "Requesting QP from {:?} failed for {} -> {} on {}: {}",
+                        self.manager, qp_key.self_device, qp_key.other_id, qp_key.other_device, e
+                    )
+                })?;
+            let qp = rx
+                .recv()
+                .await
+                .map_err(|e| {
+                    format!(
+                        "QP setup port closed for {} -> {} on {}: {}",
+                        qp_key.self_device, qp_key.other_id, qp_key.other_device, e
+                    )
+                })?
+                .map_err(|e| {
+                    format!(
+                        "QP setup failed for {} -> {} on {}: {}",
+                        qp_key.self_device, qp_key.other_id, qp_key.other_device, e
+                    )
+                })?;
+            self.peer_qps
+                .insert(qp_key.clone(), Arc::new(Mutex::new(qp)));
+        }
+        Ok(Arc::clone(self.peer_qps.get(qp_key).expect("just ensured"))
+            .try_lock_owned()
+            .expect("no other holders"))
+    }
+
+    async fn process_batch(
+        &mut self,
+        cx: &Context<'_, Self>,
+        ops: Vec<IbvOp<M>>,
+        timeout: Duration,
+    ) -> Vec<Result<(), String>> {
+        let n = ops.len();
+        let mut results: Vec<Result<(), String>> = (0..n)
+            .map(|i| Err(format!("op {} not processed (internal bug)", i)))
+            .collect();
+
+        // Resolve MRs and group ops by QP key.
+        let mut by_qp: HashMap<QpKey, Vec<(usize, IbvOp<M>, IbvMemoryRegionView)>> = HashMap::new();
+        for (i, op) in ops.into_iter().enumerate() {
+            match self
+                .resolve_mr(cx, op.local_memory.addr(), op.local_memory.size())
+                .await
+            {
+                Ok(mrv) => {
+                    let qp_key = QpKey {
+                        self_device: mrv.device_name.clone(),
+                        other_id: op.remote_manager.actor_addr().id().clone(),
+                        other_device: op.remote_buffer.device_name.clone(),
+                    };
+                    by_qp.entry(qp_key).or_default().push((i, op, mrv));
+                }
+                Err(e) => {
+                    results[i] = Err(e);
+                }
+            }
+        }
+
+        // Acquire an `OwnedMutexGuard` per QP and build a per-QP
+        // future. The guards don't borrow `self`, so the resulting
+        // futures can run concurrently in `join_all`.
+        let max_send_wr = self.config.max_send_wr;
+        let max_rd_atomic = self.config.max_rd_atomic as u32;
+        let mut group_futures = Vec::with_capacity(by_qp.len());
+        for (qp_key, group) in by_qp {
+            let remote_manager = group[0].1.remote_manager.clone();
+            let guard = match self.get_or_request_qp(cx, &qp_key, remote_manager).await {
+                Ok(g) => g,
+                Err(msg) => {
+                    for (orig_idx, _, _) in group {
+                        results[orig_idx] = Err(msg.clone());
+                    }
+                    continue;
+                }
+            };
+            group_futures.push(async move {
+                let mut qp = guard;
+                process_qp_group(&mut *qp, group, timeout, max_send_wr, max_rd_atomic).await
+            });
+        }
+
+        for group_results in futures::future::join_all(group_futures).await {
+            for (orig_idx, res) in group_results {
+                results[orig_idx] = res;
+            }
+        }
+
+        results
+    }
+}
+
+/// Stub. The real per-QP processing — `PostedOps`-driven posting,
+/// CQ polling, and WR accounting — lands in a follow-up. Marks
+/// every op in `group` as successful so the actor can be exercised
+/// end-to-end without a working data path.
+async fn process_qp_group<M, Qp>(
+    _qp: &mut Qp,
+    group: Vec<(usize, IbvOp<M>, IbvMemoryRegionView)>,
+    _timeout: Duration,
+    _max_send_wr: u32,
+    _max_rd_atomic: u32,
+) -> Vec<(usize, Result<(), String>)>
+where
+    M: Referable,
+    Qp: QueuePair,
+{
+    group
+        .into_iter()
+        .map(|(orig_idx, _, _)| (orig_idx, Ok(())))
+        .collect()
+}
+
+#[async_trait]
+impl<M, Qp> Actor for IbvProcessorActor<M, Qp>
+where
+    M: Manager<Qp>,
+    Qp: QueuePair,
+{
+    async fn init(&mut self, _this: &Instance<Self>) -> anyhow::Result<()> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<M, Qp> Handler<SubmitOps<M>> for IbvProcessorActor<M, Qp>
+where
+    M: Manager<Qp>,
+    Qp: QueuePair,
+{
+    async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps<M>) -> anyhow::Result<()> {
+        let SubmitOps {
+            ops,
+            timeout,
+            reply,
+        } = msg;
+        let results = self.process_batch(cx, ops, timeout).await;
+        reply
+            .send(cx, results)
+            .map_err(|e| anyhow::anyhow!("SubmitOps reply send failed: {e}"))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+
+    use hyperactor::ActorRef;
+    use hyperactor::Proc;
+    use hyperactor::ProcAddr;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::id::Label;
+    use hyperactor::id::ProcId;
+    use hyperactor::id::Uid;
+    use typeuri::Named;
+
+    use super::super::IbvBuffer;
+    use super::super::domain::IbvDomain;
+    use super::super::primitives::IbvMemoryRegion;
+    use super::*;
+    use crate::RdmaOpType;
+    use crate::local_memory::RdmaLocalMemory;
+
+    fn null_domain() -> Arc<IbvDomain> {
+        Arc::new(IbvDomain {
+            context: std::ptr::null_mut(),
+            pd: std::ptr::null_mut(),
+        })
+    }
+
+    #[derive(Debug, Default)]
+    struct MockManagerInner {
+        register_mr_calls: Vec<(usize, usize)>,
+        request_qp_calls: Vec<QpKey>,
+        next_mr_id: usize,
+    }
+
+    #[derive(Debug, Named)]
+    struct MockManagerActor {
+        inner: Arc<StdMutex<MockManagerInner>>,
+    }
+
+    impl Referable for MockManagerActor {}
+
+    #[async_trait]
+    impl Actor for MockManagerActor {}
+
+    #[async_trait]
+    impl Handler<RegisterMr> for MockManagerActor {
+        async fn handle(&mut self, cx: &Context<Self>, msg: RegisterMr) -> anyhow::Result<()> {
+            let id = {
+                let mut inner = self.inner.lock().unwrap();
+                inner.register_mr_calls.push((msg.addr, msg.size));
+                let id = inner.next_mr_id;
+                inner.next_mr_id += 1;
+                id
+            };
+            let mrv = IbvMemoryRegionView::new(
+                id,
+                msg.addr,
+                msg.addr,
+                msg.size,
+                0x1234,
+                0x5678,
+                "dev0".to_string(),
+                Arc::new(IbvMemoryRegion::Direct {
+                    mr: std::ptr::null_mut(),
+                    _domain: null_domain(),
+                }),
+            );
+            msg.reply.send(cx, Ok(mrv))?;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct MockQp;
+    impl QueuePair for MockQp {}
+
+    #[async_trait]
+    impl Handler<RequestQueuePair<MockManagerActor, MockQp>> for MockManagerActor {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: RequestQueuePair<MockManagerActor, MockQp>,
+        ) -> anyhow::Result<()> {
+            self.inner
+                .lock()
+                .unwrap()
+                .request_qp_calls
+                .push(msg.qp_key.clone());
+            msg.reply.send(cx, Ok(MockQp))?;
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct FakeLocalMemory {
+        addr: usize,
+        size: usize,
+    }
+
+    impl RdmaLocalMemory for FakeLocalMemory {
+        fn addr(&self) -> usize {
+            self.addr
+        }
+        fn size(&self) -> usize {
+            self.size
+        }
+        fn read_at(&self, _offset: usize, _dst: &mut [u8]) -> anyhow::Result<()> {
+            unimplemented!("test stub")
+        }
+        fn write_at(&self, _offset: usize, _src: &[u8]) -> anyhow::Result<()> {
+            unimplemented!("test stub")
+        }
+    }
+
+    fn fake_remote_ref(label: &str, uid: u64) -> ActorRef<MockManagerActor> {
+        let proc_id = ProcId::new(Uid::Instance(uid, None), Some(Label::new(label).unwrap()));
+        let proc_addr = ProcAddr::new(proc_id, ChannelAddr::Local(1).into());
+        ActorRef::attest(proc_addr.actor_addr("remote-mgr"))
+    }
+
+    fn fake_op_with_remote(
+        addr: usize,
+        size: usize,
+        remote_device: &str,
+        remote_manager: ActorRef<MockManagerActor>,
+    ) -> IbvOp<MockManagerActor> {
+        IbvOp {
+            op_type: RdmaOpType::WriteFromLocal,
+            local_memory: Arc::new(FakeLocalMemory { addr, size }),
+            remote_buffer: IbvBuffer {
+                mr_id: 1,
+                lkey: 0,
+                rkey: 0,
+                addr: 0x4000_0000,
+                size,
+                device_name: remote_device.to_string(),
+            },
+            remote_manager,
+        }
+    }
+
+    fn fake_op(addr: usize, size: usize, remote_device: &str) -> IbvOp<MockManagerActor> {
+        fake_op_with_remote(
+            addr,
+            size,
+            remote_device,
+            fake_remote_ref("remote-a", 0xabc123),
+        )
+    }
+
+    struct Harness {
+        client: hyperactor::Instance<()>,
+        processor: ActorHandle<IbvProcessorActor<MockManagerActor, MockQp>>,
+        mgr_inner: Arc<StdMutex<MockManagerInner>>,
+    }
+
+    async fn setup_with_lru(lru_capacity: usize) -> Harness {
+        let proc = Proc::new();
+        let (client, _) = proc.instance("client").unwrap();
+        let mgr_inner = Arc::new(StdMutex::new(MockManagerInner::default()));
+        let mgr = MockManagerActor {
+            inner: Arc::clone(&mgr_inner),
+        };
+        let mgr_handle = proc.spawn::<MockManagerActor>("mgr", mgr).unwrap();
+        let processor = IbvProcessorActor::<MockManagerActor, MockQp>::new(
+            mgr_handle,
+            super::super::primitives::IbvConfig::default(),
+            lru_capacity,
+        );
+        let processor_handle = proc
+            .spawn::<IbvProcessorActor<MockManagerActor, MockQp>>("processor", processor)
+            .unwrap();
+        Harness {
+            client,
+            processor: processor_handle,
+            mgr_inner,
+        }
+    }
+
+    async fn setup() -> Harness {
+        setup_with_lru(1024).await
+    }
+
+    async fn submit(
+        harness: &Harness,
+        ops: Vec<IbvOp<MockManagerActor>>,
+    ) -> Vec<Result<(), String>> {
+        let (reply, rx) = harness.client.mailbox().open_once_port();
+        harness
+            .processor
+            .send(
+                &harness.client,
+                SubmitOps {
+                    ops,
+                    timeout: Duration::from_secs(5),
+                    reply,
+                },
+            )
+            .unwrap();
+        rx.recv().await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn submit_ops_returns_ok_for_each_op_via_stub() {
+        let h = setup().await;
+        let results = submit(&h, vec![fake_op(0x1000, 4096, "dev0")]).await;
+        assert_eq!(results.len(), 1);
+        assert!(
+            results[0].is_ok(),
+            "stub should return Ok: {:?}",
+            results[0]
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_ops_caches_mr_lru_across_submits() {
+        let h = setup().await;
+        // Submit the same op twice. The second submit hits the LRU
+        // and skips the manager round-trip.
+        let _ = submit(&h, vec![fake_op(0x1000, 4096, "dev_remote_a")]).await;
+        let _ = submit(&h, vec![fake_op(0x1000, 4096, "dev_remote_a")]).await;
+        assert_eq!(
+            h.mgr_inner.lock().unwrap().register_mr_calls,
+            vec![(0x1000, 4096)],
+            "second submit should hit the LRU cache",
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_ops_reuses_qp_across_calls() {
+        let h = setup().await;
+        // First submit: request a QP, store it in `peer_qps`.
+        let _ = submit(&h, vec![fake_op(0x1000, 4096, "dev_remote_a")]).await;
+        // Second submit with the same QP key: should reuse the
+        // stored QP, not call the manager again.
+        let _ = submit(&h, vec![fake_op(0x1000, 4096, "dev_remote_a")]).await;
+        assert_eq!(
+            h.mgr_inner.lock().unwrap().request_qp_calls.len(),
+            1,
+            "second submit should reuse the cached peer QP",
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_ops_dispatches_one_request_per_distinct_qp_key() {
+        let h = setup().await;
+        // Cover all three `QpKey` axes in a single batch:
+        // - two ops to the same key (dedup);
+        // - one op with a distinct `other_device`;
+        // - one op with a distinct `other_id` (remote manager).
+        // The mock manager always returns "dev0" as the local
+        // device, so `self_device` is constant.
+        let remote_a = fake_remote_ref("remote-a", 0xa1);
+        let remote_b = fake_remote_ref("remote-b", 0xb2);
+        let other_a = remote_a.actor_addr().id().clone();
+        let other_b = remote_b.actor_addr().id().clone();
+        let ops = vec![
+            fake_op_with_remote(0x1000, 4096, "dev_x", remote_a.clone()),
+            fake_op_with_remote(0x2000, 4096, "dev_x", remote_a.clone()),
+            fake_op_with_remote(0x3000, 4096, "dev_y", remote_a.clone()),
+            fake_op_with_remote(0x4000, 4096, "dev_x", remote_b.clone()),
+        ];
+        let results = submit(&h, ops).await;
+        assert!(results.iter().all(|r| r.is_ok()));
+        let inner = h.mgr_inner.lock().unwrap();
+        let got: HashSet<QpKey> = inner.request_qp_calls.iter().cloned().collect();
+        let expected: HashSet<QpKey> = [
+            QpKey {
+                self_device: "dev0".into(),
+                other_id: other_a.clone(),
+                other_device: "dev_x".into(),
+            },
+            QpKey {
+                self_device: "dev0".into(),
+                other_id: other_a,
+                other_device: "dev_y".into(),
+            },
+            QpKey {
+                self_device: "dev0".into(),
+                other_id: other_b,
+                other_device: "dev_x".into(),
+            },
+        ]
+        .into_iter()
+        .collect();
+        assert_eq!(inner.request_qp_calls.len(), 3, "no duplicate requests");
+        assert_eq!(got, expected);
+    }
+
+    #[tokio::test]
+    async fn submit_ops_mr_lru_eviction_re_requests() {
+        // LRU of size 2: registering a third distinct `(addr, size)`
+        // evicts the least-recently-used entry. A subsequent op for
+        // the evicted MR has to round-trip the manager again.
+        let h = setup_with_lru(2).await;
+        let _ = submit(
+            &h,
+            vec![
+                fake_op(0x1000, 4096, "dev0"),
+                fake_op(0x2000, 4096, "dev0"),
+                // Third entry evicts (0x1000, 4096) since the
+                // earlier ops are touched in order.
+                fake_op(0x3000, 4096, "dev0"),
+            ],
+        )
+        .await;
+        // (0x1000, 4096) is no longer in the cache. Requesting it
+        // again triggers a fresh register_mr call.
+        let _ = submit(&h, vec![fake_op(0x1000, 4096, "dev0")]).await;
+        assert_eq!(
+            h.mgr_inner.lock().unwrap().register_mr_calls,
+            vec![
+                (0x1000, 4096),
+                (0x2000, 4096),
+                (0x3000, 4096),
+                (0x1000, 4096),
+            ],
+        );
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -43,6 +43,7 @@ use super::IbvOp;
 use super::primitives::IbvConfig;
 use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvWc;
+use super::queue_pair::IbvQueuePair;
 use super::queue_pair::MAX_RDMA_MSG_SIZE;
 use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
@@ -60,6 +61,24 @@ pub(super) trait QueuePair: std::fmt::Debug + Send + Sync + 'static {
         target: PollTarget,
         expected_wr_ids: &HashSet<u64>,
     ) -> Result<Vec<(u64, IbvWc)>, PollCompletionError>;
+}
+
+impl QueuePair for IbvQueuePair {
+    fn put(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> anyhow::Result<Vec<u64>> {
+        IbvQueuePair::put(self, lhandle, rhandle)
+    }
+
+    fn get(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> anyhow::Result<Vec<u64>> {
+        IbvQueuePair::get(self, lhandle, rhandle)
+    }
+
+    fn poll_completion(
+        &mut self,
+        target: PollTarget,
+        expected_wr_ids: &HashSet<u64>,
+    ) -> Result<Vec<(u64, IbvWc)>, PollCompletionError> {
+        IbvQueuePair::poll_completion(self, target, expected_wr_ids)
+    }
 }
 
 /// Adaptive wait between completion polls.
@@ -360,7 +379,6 @@ impl<'a, Qp: QueuePair> PostedOps<'a, Qp> {
 
 /// Local-only message: ask the manager to register an MR for
 /// `[addr, addr + size)` and return the resulting view.
-#[cfg_attr(not(test), expect(dead_code, reason = "wired up in D105213930"))]
 #[derive(Debug)]
 pub(super) struct RegisterMr {
     pub addr: usize,
@@ -372,11 +390,9 @@ pub(super) struct RegisterMr {
 /// ownership of) a peer queue pair. The manager hands the QP value
 /// across the reply port and forgets it on its own side — the
 /// processor becomes the sole owner.
-#[cfg_attr(not(test), expect(dead_code, reason = "wired up in D105213930"))]
 #[derive(Debug)]
 pub(super) struct RequestQueuePair<M: Referable, Qp: QueuePair> {
     pub qp_key: QpKey,
-    #[expect(dead_code, reason = "read by IbvManagerActor handler in D105213930")]
     pub remote_manager: ActorRef<M>,
     pub reply: OncePortHandle<Result<Qp, String>>,
 }
@@ -420,7 +436,6 @@ pub(super) struct IbvProcessorActor<M: Actor, Qp> {
     peer_qps: HashMap<QpKey, Arc<Mutex<Qp>>>,
 }
 
-#[cfg_attr(not(test), expect(dead_code, reason = "wired up in D105213930"))]
 impl<M, Qp> IbvProcessorActor<M, Qp>
 where
     M: Manager<Qp>,

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -15,11 +15,16 @@
 //! [`QueuePair`] type so unit tests can swap in mocks.
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
+use std::time::Instant;
 
 use async_trait::async_trait;
+use backoff::ExponentialBackoff;
+use backoff::ExponentialBackoffBuilder;
+use backoff::backoff::Backoff;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
@@ -33,15 +38,325 @@ use lru::LruCache;
 use tokio::sync::Mutex;
 use tokio::sync::OwnedMutexGuard;
 
+use super::IbvBuffer;
 use super::IbvOp;
 use super::primitives::IbvConfig;
 use super::primitives::IbvMemoryRegionView;
+use super::primitives::IbvWc;
+use super::queue_pair::MAX_RDMA_MSG_SIZE;
+use super::queue_pair::PollCompletionError;
+use super::queue_pair::PollTarget;
 use super::queue_pair::QpKey;
+use crate::RdmaOpType;
 
-/// A queue-pair value the processor owns end-to-end. The trait is a
-/// marker today; data-path methods (post send / poll completion)
-/// land alongside the real per-batch WR accounting in a follow-up.
-pub(super) trait QueuePair: std::fmt::Debug + Send + Sync + 'static {}
+/// Data-path operations the processor performs against a queue pair.
+/// Implemented on the real `IbvQueuePair` and on `MockQueuePair` in
+/// tests.
+pub(super) trait QueuePair: std::fmt::Debug + Send + Sync + 'static {
+    fn put(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> anyhow::Result<Vec<u64>>;
+    fn get(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> anyhow::Result<Vec<u64>>;
+    fn poll_completion(
+        &mut self,
+        target: PollTarget,
+        expected_wr_ids: &HashSet<u64>,
+    ) -> Result<Vec<(u64, IbvWc)>, PollCompletionError>;
+}
+
+/// Adaptive wait between completion polls.
+///
+/// While the elapsed time since [`Self::yield_now`] was first called
+/// is below `yield_window`, the policy yields cooperatively
+/// (`tokio::task::yield_now`) — keeping latency tight when the WR
+/// completes shortly after being posted. `tokio::time::sleep` has a
+/// minimum resolution of ~1ms (the timer wheel tick), so even a
+/// `sleep(Duration::from_micros(100))` would block that long;
+/// `yield_now` is sub-millisecond and lets the next poll fire as
+/// soon as the runtime schedules us. Past `yield_window` the policy
+/// switches to an exponential backoff (1ms initial, doubling, capped
+/// at 10ms) so long-running operations don't keep the runtime
+/// spinning.
+///
+/// `yield_window` is read from
+/// [`crate::config::RDMA_CQ_BUSY_POLL_WINDOW`]. When it's `None`
+/// (the default) the policy disables the cutoff and only ever
+/// yields, never sleeps.
+pub(super) struct PollSleepPolicy {
+    yield_window: Option<Duration>,
+    started_at: Option<Instant>,
+    backoff: Option<ExponentialBackoff>,
+}
+
+impl PollSleepPolicy {
+    pub(super) fn new() -> Self {
+        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
+        Self {
+            yield_window,
+            started_at: None,
+            backoff: None,
+        }
+    }
+
+    /// Suspend the current task before the next poll. If no yield
+    /// window is configured (the default), always yields. Otherwise,
+    /// yields while within the window and then walks an exponential
+    /// backoff up to 10ms past it.
+    pub(super) async fn yield_now(&mut self) {
+        let Some(window) = self.yield_window else {
+            tokio::task::yield_now().await;
+            return;
+        };
+        let started = *self.started_at.get_or_insert_with(Instant::now);
+        if started.elapsed() < window {
+            tokio::task::yield_now().await;
+            return;
+        }
+        let backoff = self.backoff.get_or_insert_with(|| {
+            ExponentialBackoffBuilder::new()
+                .with_initial_interval(Duration::from_millis(1))
+                .with_max_interval(Duration::from_millis(10))
+                .with_multiplier(2.0)
+                .with_randomization_factor(0.0)
+                .with_max_elapsed_time(None)
+                .build()
+        });
+        match backoff.next_backoff() {
+            Some(delay) => tokio::time::sleep(delay).await,
+            None => tokio::task::yield_now().await,
+        }
+    }
+}
+
+/// Per-op state tracked while WRs are in flight on a queue pair.
+/// Holds the [`IbvMemoryRegionView`] so the FFI MR survives until
+/// the last WR completes and so error messages can name the MR.
+struct PostedOpEntry {
+    pending: HashSet<u64>,
+    is_read: bool,
+    mrv: IbvMemoryRegionView,
+}
+
+/// Tracks ops posted to a queue pair and their pending WR ids,
+/// honoring `max_send_wr` and `max_rd_atomic`. Generic over
+/// [`QueuePair`] so it can be unit-tested with a mock QP.
+struct PostedOps<'a, Qp: QueuePair> {
+    qp: &'a mut Qp,
+    max_send_wr: u32,
+    max_rd_atomic: u32,
+    /// Running count of in-flight read WRs.
+    in_flight_reads: u32,
+    /// Running count of in-flight write WRs.
+    in_flight_writes: u32,
+    /// WR id → op index.
+    wr_to_op: HashMap<u64, usize>,
+    /// Op index → per-op state.
+    op_state: HashMap<usize, PostedOpEntry>,
+}
+
+impl<'a, Qp: QueuePair> PostedOps<'a, Qp> {
+    fn new(qp: &'a mut Qp, max_send_wr: u32, max_rd_atomic: u32) -> Self {
+        Self {
+            qp,
+            max_send_wr,
+            max_rd_atomic,
+            in_flight_reads: 0,
+            in_flight_writes: 0,
+            wr_to_op: HashMap::new(),
+            op_state: HashMap::new(),
+        }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.op_state.is_empty()
+    }
+
+    /// Try to post `op` to the QP, using `mrv` as the local MR.
+    /// Computes the WR count (one per `MAX_RDMA_MSG_SIZE` chunk of
+    /// the local buffer — the QP will issue exactly this many WRs).
+    /// Returns:
+    /// - `Ok(Ok(()))` and posts the op when it fits.
+    /// - `Ok(Err((read_excess, slot_excess)))` *without posting*
+    ///   when the op would push past `max_rd_atomic` (`read_excess`,
+    ///   read completions only) or `max_send_wr` (`slot_excess`,
+    ///   completions of any type). The caller should
+    ///   [`drain`](Self::drain) at least that much headroom and retry.
+    ///   A read completion satisfies both constraints, so the two
+    ///   excesses overlap rather than add.
+    /// - `Err(_)` if the op alone exceeds what the QP can ever
+    ///   handle, or some other failure occurs.
+    fn post<M: Referable>(
+        &mut self,
+        orig_idx: usize,
+        op: &IbvOp<M>,
+        mrv: &IbvMemoryRegionView,
+    ) -> anyhow::Result<Result<(), (u32, u32)>> {
+        let local_size = op.local_memory.size();
+        let wrs = (local_size.div_ceil(MAX_RDMA_MSG_SIZE).max(1)) as u32;
+        let is_read = matches!(op.op_type, RdmaOpType::ReadIntoLocal);
+        if wrs > self.max_send_wr {
+            return Err(anyhow::anyhow!(
+                "op is too large for this QP to handle (would split into {} WRs) [{}]",
+                wrs,
+                mrv,
+            ));
+        } else if is_read && wrs > self.max_rd_atomic {
+            return Err(anyhow::anyhow!(
+                "op is too large for this QP to handle (would split into {} RDMA_READs) [{}]",
+                wrs,
+                mrv,
+            ));
+        }
+        let projected_total = self.wr_to_op.len() as u32 + wrs;
+        let projected_reads = self.in_flight_reads + if is_read { wrs } else { 0 };
+        let read_excess = projected_reads.saturating_sub(self.max_rd_atomic);
+        let slot_excess = projected_total.saturating_sub(self.max_send_wr);
+        if read_excess > 0 || slot_excess > 0 {
+            return Ok(Err((read_excess, slot_excess)));
+        }
+        let local_buf = IbvBuffer {
+            mr_id: mrv.id,
+            lkey: mrv.lkey,
+            rkey: mrv.rkey,
+            addr: mrv.rdma_addr,
+            size: mrv.size,
+            device_name: mrv.device_name.clone(),
+        };
+        let wr_ids = match op.op_type {
+            RdmaOpType::WriteFromLocal => self.qp.put(local_buf, op.remote_buffer.clone())?,
+            RdmaOpType::ReadIntoLocal => self.qp.get(local_buf, op.remote_buffer.clone())?,
+        };
+        let mut pending = HashSet::with_capacity(wr_ids.len());
+        for id in &wr_ids {
+            self.wr_to_op.insert(*id, orig_idx);
+            pending.insert(*id);
+        }
+        if is_read {
+            self.in_flight_reads += wr_ids.len() as u32;
+        } else {
+            self.in_flight_writes += wr_ids.len() as u32;
+        }
+        self.op_state.insert(
+            orig_idx,
+            PostedOpEntry {
+                pending,
+                is_read,
+                mrv: mrv.clone(),
+            },
+        );
+        Ok(Ok(()))
+    }
+
+    /// Poll the QP until at least `reads_needed` read completions
+    /// have arrived AND the in-flight WR count has dropped by at
+    /// least `slots_needed` (counting completions of either type),
+    /// or until `deadline` is reached. A read completion counts
+    /// toward both targets simultaneously, so the caller can pass
+    /// the two excesses returned by [`Self::post`] without
+    /// double-counting. Successful ops yield `(orig_idx, Ok(()))`;
+    /// on `Err` from `poll_completion` or on timeout the
+    /// still-outstanding ops yield `(orig_idx, Err(...))` and `self`
+    /// is left empty so callers can post a fresh batch.
+    async fn drain(
+        &mut self,
+        deadline: Instant,
+        reads_needed: u32,
+        slots_needed: u32,
+    ) -> Vec<(usize, Result<(), String>)> {
+        let mut results: Vec<(usize, Result<(), String>)> = Vec::new();
+        let read_target = self.in_flight_reads.saturating_sub(reads_needed);
+        let slot_target =
+            (self.in_flight_reads + self.in_flight_writes).saturating_sub(slots_needed);
+        let mut poll_policy = PollSleepPolicy::new();
+        // Maintained incrementally as completions are processed so
+        // we don't reallocate a fresh set on every poll cycle.
+        let mut to_poll: HashSet<u64> = self.wr_to_op.keys().copied().collect();
+        while self.in_flight_reads > read_target
+            || self.in_flight_reads + self.in_flight_writes > slot_target
+        {
+            if Instant::now() >= deadline {
+                tracing::error!(
+                    "timed out while waiting on request completion for wr_ids={:?}",
+                    self.wr_to_op.keys().copied().collect::<Vec<_>>()
+                );
+                for (orig_idx, entry) in self.op_state.drain() {
+                    results.push((
+                        orig_idx,
+                        Err(format!(
+                            "rdma operation did not complete in time [{}, expected wr_ids={:?}]",
+                            entry.mrv,
+                            entry.pending.into_iter().collect::<Vec<_>>(),
+                        )),
+                    ));
+                }
+                self.wr_to_op.clear();
+                self.in_flight_reads = 0;
+                self.in_flight_writes = 0;
+                return results;
+            }
+            match self.qp.poll_completion(PollTarget::Send, &to_poll) {
+                Ok(completions) => {
+                    if completions.is_empty() {
+                        poll_policy.yield_now().await;
+                        continue;
+                    }
+                    for (wr_id, _wc) in completions {
+                        // TODO: validate `_wc.status == IBV_WC_SUCCESS`
+                        // and surface non-success completions as
+                        // per-op errors instead of treating every
+                        // returned completion as success.
+                        to_poll.remove(&wr_id);
+                        let orig_idx = self
+                            .wr_to_op
+                            .remove(&wr_id)
+                            .expect("completed wr_id missing from wr_to_op");
+                        let entry = self
+                            .op_state
+                            .get_mut(&orig_idx)
+                            .expect("orig_idx missing from op_state");
+                        entry.pending.remove(&wr_id);
+                        if entry.is_read {
+                            self.in_flight_reads -= 1;
+                        } else {
+                            self.in_flight_writes -= 1;
+                        }
+                        if entry.pending.is_empty() {
+                            self.op_state.remove(&orig_idx);
+                            results.push((orig_idx, Ok(())));
+                        }
+                    }
+                }
+                Err(e) => {
+                    let error_detail = format!("RDMA polling completion failed: {}", e);
+                    for (orig_idx, entry) in self.op_state.drain() {
+                        results.push((
+                            orig_idx,
+                            Err(format!(
+                                "{} [{}, expected wr_ids={:?}]",
+                                error_detail,
+                                entry.mrv,
+                                entry.pending.into_iter().collect::<Vec<_>>(),
+                            )),
+                        ));
+                    }
+                    self.wr_to_op.clear();
+                    self.in_flight_reads = 0;
+                    self.in_flight_writes = 0;
+                    return results;
+                }
+            }
+        }
+        results
+    }
+
+    /// Drain every in-flight WR by `deadline`.
+    async fn drain_all(&mut self, deadline: Instant) -> Vec<(usize, Result<(), String>)> {
+        self.drain(
+            deadline,
+            self.in_flight_reads,
+            self.in_flight_reads + self.in_flight_writes,
+        )
+        .await
+    }
+}
 
 /// Local-only message: ask the manager to register an MR for
 /// `[addr, addr + size)` and return the resulting view.
@@ -290,25 +605,55 @@ where
     }
 }
 
-/// Stub. The real per-QP processing — `PostedOps`-driven posting,
-/// CQ polling, and WR accounting — lands in a follow-up. Marks
-/// every op in `group` as successful so the actor can be exercised
-/// end-to-end without a working data path.
+/// Run all of `group`'s ops through [`PostedOps`] on `qp`. Pulled
+/// out of the actor body so it can be unit-tested directly against
+/// a mock QP without spawning the processor.
 async fn process_qp_group<M, Qp>(
-    _qp: &mut Qp,
+    qp: &mut Qp,
     group: Vec<(usize, IbvOp<M>, IbvMemoryRegionView)>,
-    _timeout: Duration,
-    _max_send_wr: u32,
-    _max_rd_atomic: u32,
+    timeout: Duration,
+    max_send_wr: u32,
+    max_rd_atomic: u32,
 ) -> Vec<(usize, Result<(), String>)>
 where
     M: Referable,
     Qp: QueuePair,
 {
-    group
-        .into_iter()
-        .map(|(orig_idx, _, _)| (orig_idx, Ok(())))
-        .collect()
+    let mut posted = PostedOps::new(qp, max_send_wr, max_rd_atomic);
+
+    let mut results = Vec::with_capacity(group.len());
+    let deadline = Instant::now() + timeout;
+
+    for (orig_idx, op, mrv) in group {
+        loop {
+            match posted.post(orig_idx, &op, &mrv) {
+                Ok(Ok(())) => break,
+                Ok(Err((reads_to_drain, slots_to_drain))) => {
+                    results.extend(posted.drain(deadline, reads_to_drain, slots_to_drain).await);
+                }
+                Err(e) => {
+                    let verb = match op.op_type {
+                        RdmaOpType::WriteFromLocal => "WriteFromLocal",
+                        RdmaOpType::ReadIntoLocal => "ReadIntoLocal",
+                    };
+                    results.push((
+                        orig_idx,
+                        Err(format!(
+                            "post {} failed [local: {}, remote: {:?}]: {}",
+                            verb, mrv, op.remote_buffer, e,
+                        )),
+                    ));
+                    break;
+                }
+            }
+        }
+    }
+
+    if !posted.is_empty() {
+        results.extend(posted.drain_all(deadline).await);
+    }
+
+    results
 }
 
 #[async_trait]
@@ -345,6 +690,7 @@ where
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
+    use std::collections::VecDeque;
     use std::sync::Arc;
     use std::sync::Mutex as StdMutex;
 
@@ -371,11 +717,152 @@ mod tests {
         })
     }
 
+    // ----------------------------- MockQp -----------------------------
+
+    #[derive(Debug)]
+    struct MockQpInner {
+        next_wr_id: u64,
+        posted_puts: Vec<(IbvBuffer, IbvBuffer, Vec<u64>)>,
+        posted_gets: Vec<(IbvBuffer, IbvBuffer, Vec<u64>)>,
+        /// Completions waiting to be returned from `poll_completion`,
+        /// in order. Each call to `poll_completion` returns all
+        /// pending completions whose wr_id is in `expected_wr_ids`.
+        pending_completions: VecDeque<(u64, IbvWc)>,
+        /// If `Some`, the next `poll_completion` call returns this
+        /// error and clears it.
+        poll_error: Option<PollCompletionError>,
+        /// When `true`, `put`/`get` push completions for every
+        /// generated `wr_id` so the QP self-completes.
+        auto_complete: bool,
+    }
+
+    impl MockQpInner {
+        fn new(auto_complete: bool) -> Self {
+            Self {
+                next_wr_id: 0,
+                posted_puts: Vec::new(),
+                posted_gets: Vec::new(),
+                pending_completions: VecDeque::new(),
+                poll_error: None,
+                auto_complete,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct MockQp {
+        inner: Arc<StdMutex<MockQpInner>>,
+    }
+
+    impl MockQp {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(StdMutex::new(MockQpInner::new(false))),
+            }
+        }
+
+        fn new_auto_complete() -> Self {
+            Self {
+                inner: Arc::new(StdMutex::new(MockQpInner::new(true))),
+            }
+        }
+
+        fn queue_completion(&self, wr_id: u64) {
+            self.inner
+                .lock()
+                .unwrap()
+                .pending_completions
+                .push_back((wr_id, IbvWc::for_test(wr_id, true)));
+        }
+
+        fn queue_poll_error(&self, err: PollCompletionError) {
+            self.inner.lock().unwrap().poll_error = Some(err);
+        }
+
+        fn posted_put_count(&self) -> usize {
+            self.inner.lock().unwrap().posted_puts.len()
+        }
+
+        fn posted_get_count(&self) -> usize {
+            self.inner.lock().unwrap().posted_gets.len()
+        }
+    }
+
+    impl QueuePair for MockQp {
+        fn put(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> anyhow::Result<Vec<u64>> {
+            let mut inner = self.inner.lock().unwrap();
+            let wrs = lhandle.size.div_ceil(MAX_RDMA_MSG_SIZE).max(1);
+            let mut wr_ids = Vec::with_capacity(wrs);
+            for _ in 0..wrs {
+                wr_ids.push(inner.next_wr_id);
+                inner.next_wr_id += 1;
+            }
+            if inner.auto_complete {
+                for id in &wr_ids {
+                    inner
+                        .pending_completions
+                        .push_back((*id, IbvWc::for_test(*id, true)));
+                }
+            }
+            inner.posted_puts.push((lhandle, rhandle, wr_ids.clone()));
+            Ok(wr_ids)
+        }
+
+        fn get(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> anyhow::Result<Vec<u64>> {
+            let mut inner = self.inner.lock().unwrap();
+            let wrs = lhandle.size.div_ceil(MAX_RDMA_MSG_SIZE).max(1);
+            let mut wr_ids = Vec::with_capacity(wrs);
+            for _ in 0..wrs {
+                wr_ids.push(inner.next_wr_id);
+                inner.next_wr_id += 1;
+            }
+            if inner.auto_complete {
+                for id in &wr_ids {
+                    inner
+                        .pending_completions
+                        .push_back((*id, IbvWc::for_test(*id, true)));
+                }
+            }
+            inner.posted_gets.push((lhandle, rhandle, wr_ids.clone()));
+            Ok(wr_ids)
+        }
+
+        fn poll_completion(
+            &mut self,
+            _target: PollTarget,
+            expected_wr_ids: &HashSet<u64>,
+        ) -> Result<Vec<(u64, IbvWc)>, PollCompletionError> {
+            let mut inner = self.inner.lock().unwrap();
+            if let Some(err) = inner.poll_error.take() {
+                return Err(err);
+            }
+            let mut matched = Vec::new();
+            let mut remaining = VecDeque::new();
+            while let Some((wr_id, wc)) = inner.pending_completions.pop_front() {
+                if expected_wr_ids.contains(&wr_id) {
+                    matched.push((wr_id, wc));
+                } else {
+                    remaining.push_back((wr_id, wc));
+                }
+            }
+            inner.pending_completions = remaining;
+            Ok(matched)
+        }
+    }
+
+    // -------------------------- MockManagerActor -----------------------
+
     #[derive(Debug, Default)]
     struct MockManagerInner {
         register_mr_calls: Vec<(usize, usize)>,
         request_qp_calls: Vec<QpKey>,
         next_mr_id: usize,
+        /// QPs returned from `RequestQueuePair`. Tests may
+        /// pre-populate this map to install a pre-configured
+        /// `MockQp` for a given `QpKey` (e.g. one with a queued
+        /// `poll_error`); otherwise the handler lazily inserts a
+        /// fresh auto-completing `MockQp`.
+        qps: HashMap<QpKey, MockQp>,
     }
 
     #[derive(Debug, Named)]
@@ -416,10 +903,6 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
-    struct MockQp;
-    impl QueuePair for MockQp {}
-
     #[async_trait]
     impl Handler<RequestQueuePair<MockManagerActor, MockQp>> for MockManagerActor {
         async fn handle(
@@ -427,15 +910,21 @@ mod tests {
             cx: &Context<Self>,
             msg: RequestQueuePair<MockManagerActor, MockQp>,
         ) -> anyhow::Result<()> {
-            self.inner
-                .lock()
-                .unwrap()
-                .request_qp_calls
-                .push(msg.qp_key.clone());
-            msg.reply.send(cx, Ok(MockQp))?;
+            let qp = {
+                let mut inner = self.inner.lock().unwrap();
+                inner.request_qp_calls.push(msg.qp_key.clone());
+                inner
+                    .qps
+                    .entry(msg.qp_key.clone())
+                    .or_insert_with(MockQp::new_auto_complete)
+                    .clone()
+            };
+            msg.reply.send(cx, Ok(qp))?;
             Ok(())
         }
     }
+
+    // ------------------------ IbvOp / mrv helpers ----------------------
 
     #[derive(Debug)]
     struct FakeLocalMemory {
@@ -464,35 +953,394 @@ mod tests {
         ActorRef::attest(proc_addr.actor_addr("remote-mgr"))
     }
 
-    fn fake_op_with_remote(
+    fn fake_buffer(device: &str, addr: usize, size: usize) -> IbvBuffer {
+        IbvBuffer {
+            mr_id: 1,
+            lkey: 0x1234,
+            rkey: 0x5678,
+            addr,
+            size,
+            device_name: device.to_string(),
+        }
+    }
+
+    fn mrv_at(addr: usize, size: usize) -> IbvMemoryRegionView {
+        IbvMemoryRegionView::new(
+            1,
+            addr,
+            addr,
+            size,
+            0x1234,
+            0x5678,
+            "dev0".to_string(),
+            Arc::new(IbvMemoryRegion::Direct {
+                mr: std::ptr::null_mut(),
+                _domain: null_domain(),
+            }),
+        )
+    }
+
+    fn make_op(
+        op_type: RdmaOpType,
         addr: usize,
         size: usize,
         remote_device: &str,
         remote_manager: ActorRef<MockManagerActor>,
     ) -> IbvOp<MockManagerActor> {
         IbvOp {
-            op_type: RdmaOpType::WriteFromLocal,
+            op_type,
             local_memory: Arc::new(FakeLocalMemory { addr, size }),
-            remote_buffer: IbvBuffer {
-                mr_id: 1,
-                lkey: 0,
-                rkey: 0,
-                addr: 0x4000_0000,
-                size,
-                device_name: remote_device.to_string(),
-            },
+            remote_buffer: fake_buffer(remote_device, 0x4000_0000, size),
             remote_manager,
         }
     }
 
     fn fake_op(addr: usize, size: usize, remote_device: &str) -> IbvOp<MockManagerActor> {
-        fake_op_with_remote(
+        make_op(
+            RdmaOpType::WriteFromLocal,
             addr,
             size,
             remote_device,
             fake_remote_ref("remote-a", 0xabc123),
         )
     }
+
+    fn fake_op_with_remote(
+        addr: usize,
+        size: usize,
+        remote_device: &str,
+        remote_manager: ActorRef<MockManagerActor>,
+    ) -> IbvOp<MockManagerActor> {
+        make_op(
+            RdmaOpType::WriteFromLocal,
+            addr,
+            size,
+            remote_device,
+            remote_manager,
+        )
+    }
+
+    // --------------------------- PostedOps tests -----------------------
+
+    fn post_write(
+        posted: &mut PostedOps<'_, MockQp>,
+        idx: usize,
+        size: usize,
+    ) -> anyhow::Result<Result<(), (u32, u32)>> {
+        let op = make_op(
+            RdmaOpType::WriteFromLocal,
+            0x1000_0000,
+            size,
+            "dev0",
+            fake_remote_ref("remote-a", 0xabc123),
+        );
+        let mrv = mrv_at(0x1000_0000, size);
+        posted.post(idx, &op, &mrv)
+    }
+
+    fn post_read(
+        posted: &mut PostedOps<'_, MockQp>,
+        idx: usize,
+        size: usize,
+    ) -> anyhow::Result<Result<(), (u32, u32)>> {
+        let op = make_op(
+            RdmaOpType::ReadIntoLocal,
+            0x1000_0000,
+            size,
+            "dev0",
+            fake_remote_ref("remote-a", 0xabc123),
+        );
+        let mrv = mrv_at(0x1000_0000, size);
+        posted.post(idx, &op, &mrv)
+    }
+
+    #[tokio::test]
+    async fn posted_ops_empty_drain_is_noop() {
+        let mut qp = MockQp::new();
+        let mut posted = PostedOps::new(&mut qp, 4, 2);
+        assert!(posted.is_empty());
+        let res = posted
+            .drain(Instant::now() + Duration::from_secs(1), 0, 0)
+            .await;
+        assert!(res.is_empty());
+    }
+
+    #[tokio::test]
+    async fn posted_ops_post_within_limits_succeeds() {
+        let mut qp = MockQp::new();
+        let mut posted = PostedOps::new(&mut qp, 4, 2);
+        let r = post_write(&mut posted, 0, 4096).expect("post should succeed");
+        assert_eq!(r, Ok(()), "op within limits should report no excess");
+        assert!(!posted.is_empty());
+        assert_eq!(qp.posted_put_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn posted_ops_post_signals_read_excess() {
+        let mut qp = MockQp::new();
+        let mut posted = PostedOps::new(&mut qp, 4, 2);
+        // Two reads fill `max_rd_atomic`.
+        assert_eq!(post_read(&mut posted, 0, 4096).unwrap(), Ok(()));
+        assert_eq!(post_read(&mut posted, 1, 4096).unwrap(), Ok(()));
+        // Third read should report 1 read in excess and not post.
+        assert_eq!(post_read(&mut posted, 2, 4096).unwrap(), Err((1, 0)));
+        assert_eq!(qp.posted_get_count(), 2);
+    }
+
+    #[tokio::test]
+    async fn posted_ops_post_signals_write_excess() {
+        let mut qp = MockQp::new();
+        let mut posted = PostedOps::new(&mut qp, 4, 2);
+        for i in 0..4usize {
+            assert_eq!(post_write(&mut posted, i, 4096).unwrap(), Ok(()));
+        }
+        // Fifth write should report 1 write in excess.
+        assert_eq!(post_write(&mut posted, 4, 4096).unwrap(), Err((0, 1)));
+        assert_eq!(qp.posted_put_count(), 4);
+    }
+
+    #[tokio::test]
+    async fn posted_ops_post_signals_both_excesses() {
+        let mut qp = MockQp::new();
+        let mut posted = PostedOps::new(&mut qp, 8, 2);
+        // 7 writes + 1 single-WR read fill the QP at 8/8 send_wr and
+        // 1/2 max_rd_atomic.
+        for i in 0..7usize {
+            assert_eq!(post_write(&mut posted, i, 4096).unwrap(), Ok(()));
+        }
+        assert_eq!(post_read(&mut posted, 7, 4096).unwrap(), Ok(()));
+        // A 2-WR read on top would push reads to 3/2 (1 over
+        // max_rd_atomic) and total to 10/8 (2 over max_send_wr).
+        // The drain must free 1 read slot and 2 total slots;
+        // draining the 1 read counts toward both targets.
+        assert_eq!(
+            post_read(&mut posted, 8, 2 * MAX_RDMA_MSG_SIZE).unwrap(),
+            Err((1, 2)),
+        );
+        assert_eq!(qp.posted_put_count(), 7);
+        assert_eq!(qp.posted_get_count(), 1);
+    }
+
+    /// A write that needs only a `max_send_wr` slot when the QP is
+    /// full of reads must drain a read to make progress: `drain`
+    /// with `slots_needed=1` has to count a read completion against
+    /// the total-slots target, not look for a write-specific
+    /// completion.
+    #[tokio::test]
+    async fn posted_ops_drain_frees_slot_for_write_when_reads_fill_qp() {
+        let mut qp = MockQp::new();
+        let qp_ctl = qp.clone();
+        let mut posted = PostedOps::new(&mut qp, 4, 4);
+        for i in 0..4usize {
+            assert_eq!(post_read(&mut posted, i, 4096).unwrap(), Ok(()));
+        }
+        assert_eq!(post_write(&mut posted, 4, 4096).unwrap(), Err((0, 1)));
+        qp_ctl.queue_completion(0);
+        let drained = posted
+            .drain(Instant::now() + Duration::from_secs(5), 0, 1)
+            .await;
+        assert_eq!(drained, vec![(0, Ok(()))]);
+        assert_eq!(post_write(&mut posted, 4, 4096).unwrap(), Ok(()));
+    }
+
+    #[tokio::test]
+    async fn posted_ops_empty_op_uses_one_wr() {
+        let mut qp = MockQp::new();
+        let qp_ctl = qp.clone();
+        let mut posted = PostedOps::new(&mut qp, 4, 2);
+        // A 0-byte op should still produce exactly one WR.
+        assert_eq!(post_write(&mut posted, 0, 0).unwrap(), Ok(()));
+        assert_eq!(
+            qp_ctl.inner.lock().unwrap().posted_puts[0].2,
+            vec![0u64],
+            "0-byte op should produce exactly wr_id 0",
+        );
+        qp_ctl.queue_completion(0);
+        let results = posted
+            .drain_all(Instant::now() + Duration::from_secs(5))
+            .await;
+        assert_eq!(results, vec![(0, Ok(()))]);
+        assert!(posted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn posted_ops_chunked_op_succeeds_when_all_wrs_complete() {
+        let mut qp = MockQp::new();
+        let qp_ctl = qp.clone();
+        let mut posted = PostedOps::new(&mut qp, 4, 4);
+        // Single op chunked into 3 WRs (wr_ids 0, 1, 2).
+        assert_eq!(
+            post_write(&mut posted, 0, 3 * MAX_RDMA_MSG_SIZE).unwrap(),
+            Ok(()),
+        );
+        for id in [0u64, 1, 2] {
+            qp_ctl.queue_completion(id);
+        }
+        let results = posted
+            .drain_all(Instant::now() + Duration::from_secs(5))
+            .await;
+        assert_eq!(results, vec![(0, Ok(()))]);
+        assert!(posted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn posted_ops_chunked_op_blocks_until_last_wr() {
+        let mut qp = MockQp::new();
+        let qp_ctl = qp.clone();
+        let mut posted = PostedOps::new(&mut qp, 4, 4);
+        // 3-WR op (wr_ids 0, 1, 2); only 2 of 3 complete.
+        assert_eq!(
+            post_write(&mut posted, 0, 3 * MAX_RDMA_MSG_SIZE).unwrap(),
+            Ok(()),
+        );
+        qp_ctl.queue_completion(0);
+        qp_ctl.queue_completion(1);
+        let results = posted
+            .drain_all(Instant::now() + Duration::from_millis(50))
+            .await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].0, 0);
+        let err = results[0].1.as_ref().unwrap_err();
+        assert!(
+            err.contains("did not complete in time"),
+            "chunked op should time out when 1 WR is still outstanding: {}",
+            err
+        );
+        assert!(posted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn posted_ops_drain_completes_in_flight_ops() {
+        let mut qp = MockQp::new();
+        let qp_ctl = qp.clone();
+        let mut posted = PostedOps::new(&mut qp, 8, 4);
+        // 4 ops: 2 reads (wr_ids 0, 1) then 2 writes (wr_ids 2, 3).
+        assert_eq!(post_read(&mut posted, 0, 4096).unwrap(), Ok(()));
+        assert_eq!(post_read(&mut posted, 1, 4096).unwrap(), Ok(()));
+        assert_eq!(post_write(&mut posted, 2, 4096).unwrap(), Ok(()));
+        assert_eq!(post_write(&mut posted, 3, 4096).unwrap(), Ok(()));
+        for id in [0u64, 1, 2, 3] {
+            qp_ctl.queue_completion(id);
+        }
+        let results = posted
+            .drain(Instant::now() + Duration::from_secs(5), 2, 2)
+            .await;
+        let mut by_idx: Vec<(usize, Result<(), String>)> = results;
+        by_idx.sort_by_key(|(i, _)| *i);
+        assert_eq!(
+            by_idx,
+            vec![(0, Ok(())), (1, Ok(())), (2, Ok(())), (3, Ok(()))],
+        );
+        assert!(posted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn posted_ops_drain_partial_leaves_remaining() {
+        let mut qp = MockQp::new();
+        let qp_ctl = qp.clone();
+        let mut posted = PostedOps::new(&mut qp, 8, 4);
+        // 4 reads (wr_ids 0, 1, 2, 3).
+        for i in 0..4usize {
+            assert_eq!(post_read(&mut posted, i, 4096).unwrap(), Ok(()));
+        }
+        // Queue completions for wr_ids 0 and 1 only; drain just 2.
+        qp_ctl.queue_completion(0);
+        qp_ctl.queue_completion(1);
+        let first = posted
+            .drain(Instant::now() + Duration::from_secs(5), 2, 0)
+            .await;
+        let mut by_idx: Vec<(usize, Result<(), String>)> = first;
+        by_idx.sort_by_key(|(i, _)| *i);
+        assert_eq!(by_idx, vec![(0, Ok(())), (1, Ok(()))]);
+        assert!(!posted.is_empty(), "ops 2 and 3 are still in flight");
+        // Queue the remaining completions; a follow-up drain picks
+        // them up and clears `posted`.
+        qp_ctl.queue_completion(2);
+        qp_ctl.queue_completion(3);
+        let mut second = posted
+            .drain_all(Instant::now() + Duration::from_secs(5))
+            .await;
+        second.sort_by_key(|(i, _)| *i);
+        assert_eq!(second, vec![(2, Ok(())), (3, Ok(()))]);
+        assert!(posted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn posted_ops_drain_all_finishes_in_flight() {
+        let mut qp = MockQp::new();
+        let qp_ctl = qp.clone();
+        let mut posted = PostedOps::new(&mut qp, 8, 4);
+        // 3 ops: 2 writes (wr_ids 0, 1) and 1 read (wr_id 2).
+        assert_eq!(post_write(&mut posted, 0, 4096).unwrap(), Ok(()));
+        assert_eq!(post_write(&mut posted, 1, 4096).unwrap(), Ok(()));
+        assert_eq!(post_read(&mut posted, 2, 4096).unwrap(), Ok(()));
+        for id in [0u64, 1, 2] {
+            qp_ctl.queue_completion(id);
+        }
+        let results = posted
+            .drain_all(Instant::now() + Duration::from_secs(5))
+            .await;
+        let mut by_idx: Vec<(usize, Result<(), String>)> = results;
+        by_idx.sort_by_key(|(i, _)| *i);
+        assert_eq!(by_idx, vec![(0, Ok(())), (1, Ok(())), (2, Ok(()))]);
+        assert!(posted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn posted_ops_drain_surfaces_poll_error() {
+        let mut qp = MockQp::new();
+        let qp_ctl = qp.clone();
+        let mut posted = PostedOps::new(&mut qp, 8, 4);
+        // 3 ops: every one should surface the error.
+        assert_eq!(post_write(&mut posted, 0, 4096).unwrap(), Ok(()));
+        assert_eq!(post_write(&mut posted, 1, 4096).unwrap(), Ok(()));
+        assert_eq!(post_read(&mut posted, 2, 4096).unwrap(), Ok(()));
+        qp_ctl.queue_poll_error(PollCompletionError::for_test("boom"));
+        let mut results = posted
+            .drain_all(Instant::now() + Duration::from_secs(5))
+            .await;
+        results.sort_by_key(|(i, _)| *i);
+        assert_eq!(results.len(), 3);
+        for (idx, (orig_idx, res)) in results.iter().enumerate() {
+            assert_eq!(*orig_idx, idx);
+            let err = res.as_ref().expect_err(&format!("op {} expected Err", idx));
+            assert!(
+                err.contains("boom"),
+                "op {} missing poll error: {}",
+                idx,
+                err
+            );
+        }
+        assert!(posted.is_empty());
+    }
+
+    #[tokio::test]
+    async fn posted_ops_drain_times_out() {
+        let mut qp = MockQp::new();
+        let mut posted = PostedOps::new(&mut qp, 8, 4);
+        // 3 ops; no completions queued.
+        assert_eq!(post_write(&mut posted, 0, 4096).unwrap(), Ok(()));
+        assert_eq!(post_read(&mut posted, 1, 4096).unwrap(), Ok(()));
+        assert_eq!(post_write(&mut posted, 2, 4096).unwrap(), Ok(()));
+        let mut results = posted
+            .drain_all(Instant::now() + Duration::from_millis(50))
+            .await;
+        results.sort_by_key(|(i, _)| *i);
+        assert_eq!(results.len(), 3);
+        for (idx, (orig_idx, res)) in results.iter().enumerate() {
+            assert_eq!(*orig_idx, idx);
+            let err = res.as_ref().expect_err(&format!("op {} expected Err", idx));
+            assert!(
+                err.contains("did not complete in time"),
+                "op {} missing timeout message: {}",
+                idx,
+                err
+            );
+        }
+        assert!(posted.is_empty());
+    }
+
+    // ---------------------- IbvProcessorActor tests --------------------
 
     struct Harness {
         client: hyperactor::Instance<()>,
@@ -547,15 +1395,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn submit_ops_returns_ok_for_each_op_via_stub() {
+    async fn submit_ops_returns_ok_for_each_op() {
         let h = setup().await;
         let results = submit(&h, vec![fake_op(0x1000, 4096, "dev0")]).await;
         assert_eq!(results.len(), 1);
-        assert!(
-            results[0].is_ok(),
-            "stub should return Ok: {:?}",
-            results[0]
-        );
+        assert!(results[0].is_ok(), "op should complete: {:?}", results[0]);
     }
 
     #[tokio::test]
@@ -575,10 +1419,7 @@ mod tests {
     #[tokio::test]
     async fn submit_ops_reuses_qp_across_calls() {
         let h = setup().await;
-        // First submit: request a QP, store it in `peer_qps`.
         let _ = submit(&h, vec![fake_op(0x1000, 4096, "dev_remote_a")]).await;
-        // Second submit with the same QP key: should reuse the
-        // stored QP, not call the manager again.
         let _ = submit(&h, vec![fake_op(0x1000, 4096, "dev_remote_a")]).await;
         assert_eq!(
             h.mgr_inner.lock().unwrap().request_qp_calls.len(),
@@ -661,6 +1502,108 @@ mod tests {
                 (0x3000, 4096),
                 (0x1000, 4096),
             ],
+        );
+    }
+
+    // ------------------- IbvProcessorActor + PostedOps -----------------
+
+    /// End-to-end: the processor groups ops by QP key, locks each
+    /// peer QP, and runs the group through `PostedOps`. Verify that
+    /// each peer QP sees exactly the local/remote buffers from its
+    /// own group (and not any other group's).
+    #[tokio::test]
+    async fn submit_ops_funnels_buffers_to_correct_qps() {
+        let h = setup().await;
+        let remote_a = fake_remote_ref("remote-a", 0xa1);
+        let remote_b = fake_remote_ref("remote-b", 0xb2);
+        let ops = vec![
+            // QP_A_x: two ops.
+            fake_op_with_remote(0x1000, 4096, "dev_x", remote_a.clone()),
+            fake_op_with_remote(0x2000, 4096, "dev_x", remote_a.clone()),
+            // QP_A_y: one op.
+            fake_op_with_remote(0x3000, 4096, "dev_y", remote_a.clone()),
+            // QP_B_x: one op.
+            fake_op_with_remote(0x4000, 4096, "dev_x", remote_b.clone()),
+        ];
+        let results = submit(&h, ops).await;
+        assert!(results.iter().all(|r| r.is_ok()));
+
+        let inner = h.mgr_inner.lock().unwrap();
+        let qp_key = |other_id, other_device: &str| QpKey {
+            self_device: "dev0".into(),
+            other_id,
+            other_device: other_device.into(),
+        };
+        let id_a = remote_a.actor_addr().id().clone();
+        let id_b = remote_b.actor_addr().id().clone();
+
+        // Within a single QP, ops are processed serially in the
+        // order they appear in the batch — `posted_puts` is a Vec
+        // recording that order.
+        let posted_addrs = |key: &QpKey| -> Vec<(usize, usize)> {
+            inner.qps[key]
+                .inner
+                .lock()
+                .unwrap()
+                .posted_puts
+                .iter()
+                .map(|(local, remote, _)| (local.addr, remote.addr))
+                .collect()
+        };
+
+        assert_eq!(
+            posted_addrs(&qp_key(id_a.clone(), "dev_x")),
+            vec![(0x1000, 0x4000_0000), (0x2000, 0x4000_0000)],
+        );
+        assert_eq!(
+            posted_addrs(&qp_key(id_a, "dev_y")),
+            vec![(0x3000, 0x4000_0000)],
+        );
+        assert_eq!(
+            posted_addrs(&qp_key(id_b, "dev_x")),
+            vec![(0x4000, 0x4000_0000)],
+        );
+    }
+
+    /// End-to-end: a pre-seeded `MockQp` with a queued poll error
+    /// fails its group's op, while a sibling group on a healthy QP
+    /// still succeeds.
+    #[tokio::test]
+    async fn submit_ops_propagates_per_qp_poll_errors() {
+        let h = setup().await;
+        let remote = fake_remote_ref("remote-a", 0xa1);
+        let other_id = remote.actor_addr().id().clone();
+        let bad_key = QpKey {
+            self_device: "dev0".into(),
+            other_id,
+            other_device: "dev_bad".into(),
+        };
+        // Seed a non-auto-completing QP that errors on the first
+        // poll; the processor will receive it from
+        // `RequestQueuePair` instead of creating a fresh one.
+        let bad_qp = MockQp::new();
+        bad_qp.queue_poll_error(PollCompletionError::for_test("simulated-poll-error"));
+        h.mgr_inner.lock().unwrap().qps.insert(bad_key, bad_qp);
+
+        let results = submit(
+            &h,
+            vec![
+                fake_op_with_remote(0x1000, 4096, "dev_good", remote.clone()),
+                fake_op_with_remote(0x2000, 4096, "dev_bad", remote.clone()),
+            ],
+        )
+        .await;
+        assert_eq!(results.len(), 2);
+        assert!(
+            results[0].is_ok(),
+            "op 0 (healthy QP) should succeed: {:?}",
+            results[0]
+        );
+        let err = results[1].as_ref().expect_err("op 1 (bad QP) should fail");
+        assert!(
+            err.contains("simulated-poll-error"),
+            "op 1 should surface the seeded poll error: {}",
+            err,
         );
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -15,8 +15,10 @@
 /// Maximum size for a single RDMA operation in bytes (1 GiB).
 pub(super) const MAX_RDMA_MSG_SIZE: usize = 1024 * 1024 * 1024;
 
+use std::collections::HashSet;
 use std::io::Error;
 use std::result::Result;
+use std::sync::Arc;
 use std::time::Duration;
 
 use async_trait::async_trait;
@@ -38,6 +40,7 @@ use serde::Serialize;
 use typeuri::Named;
 
 use super::IbvBuffer;
+use super::domain::IbvDomain;
 use super::manager_actor::EnsureQueuePair;
 use super::manager_actor::QpInitializerDone;
 use super::manager_actor::QpInitializerFailed;
@@ -118,12 +121,20 @@ pub enum PollTarget {
 /// 5. Perform RDMA operations with `put()` or `get()`
 /// 6. Poll for completions with `poll_completion()`
 ///
-/// # Notes
-/// - The `qp` field stores a pointer to `rdmaxcel_qp_t` (not `ibv_qp`)
-/// - `rdmaxcel_qp_t` contains atomic counters and completion caches internally
-/// - This makes IbvQueuePair trivially Clone and Serialize
-/// - Multiple clones share the same underlying rdmaxcel_qp_t via the pointer
-#[derive(Debug, Serialize, Deserialize, Named, Clone)]
+/// # Ownership
+///
+/// `IbvQueuePair` owns the underlying `rdmaxcel_qp_t` and is
+/// deliberately not `Clone`: each instance is the unique owner of
+/// its FFI resource and runs `rdmaxcel_qp_destroy` from its `Drop`
+/// impl. Moving the value (e.g. handing it across an actor reply
+/// port) transfers ownership; the originating side must not retain
+/// any reference to the freed pointer.
+///
+/// The QP holds an [`Arc<IbvDomain>`] so its context and protection
+/// domain are guaranteed to outlive the FFI resource, even after the
+/// owning [`super::manager_actor::IbvManagerActor`] has dropped its
+/// own clone of the domain.
+#[derive(Debug)]
 pub struct IbvQueuePair {
     pub send_cq: usize,    // *mut rdmaxcel_sys::ibv_cq,
     pub recv_cq: usize,    // *mut rdmaxcel_sys::ibv_cq,
@@ -131,11 +142,26 @@ pub struct IbvQueuePair {
     pub dv_qp: usize,      // *mut rdmaxcel_sys::mlx5dv_qp,
     pub dv_send_cq: usize, // *mut rdmaxcel_sys::mlx5dv_cq,
     pub dv_recv_cq: usize, // *mut rdmaxcel_sys::mlx5dv_cq,
-    context: usize,        // *mut rdmaxcel_sys::ibv_context,
+    domain: Arc<IbvDomain>,
     config: IbvConfig,
     is_efa: bool,
 }
-wirevalue::register_type!(IbvQueuePair);
+
+impl Drop for IbvQueuePair {
+    fn drop(&mut self) {
+        // SAFETY: `IbvQueuePair` is not `Clone`, so this is the
+        // unique owner of `self.qp`. `qp == 0` covers the
+        // zero-initialized test fixture from `fake_qp()`; the real
+        // constructor always produces a non-null pointer.
+        if self.qp == 0 {
+            return;
+        }
+        unsafe {
+            let rdmaxcel_qp = self.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
+            rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
+        }
+    }
+}
 
 impl IbvQueuePair {
     fn is_efa(&self) -> bool {
@@ -173,25 +199,25 @@ impl IbvQueuePair {
     /// Creates a new IbvQueuePair.
     ///
     /// Initializes a new Queue Pair (QP) and associated Completion Queues (CQ)
-    /// using the provided context and protection domain. The QP is created in
-    /// the RESET state and must be transitioned via `connect()` before use.
+    /// using the provided domain. The QP is created in the RESET state and
+    /// must be transitioned via `connect()` before use.
+    ///
+    /// The [`Arc<IbvDomain>`] is retained inside the QP so the device
+    /// context and protection domain are guaranteed to outlive the FFI
+    /// resource.
     ///
     /// # Errors
     ///
     /// Returns errors if CQ or QP creation fails.
-    pub fn new(
-        context: *mut rdmaxcel_sys::ibv_context,
-        pd: *mut rdmaxcel_sys::ibv_pd,
-        config: IbvConfig,
-    ) -> Result<Self, anyhow::Error> {
+    pub fn new(domain: Arc<IbvDomain>, config: IbvConfig) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an IbvQueuePair from config {}", config);
         unsafe {
             // Resolve Auto to a concrete QP type based on device capabilities
             let resolved_qp_type = resolve_qp_type(config.qp_type);
             let is_efa = resolved_qp_type == rdmaxcel_sys::RDMA_QP_TYPE_EFA;
             let qp = rdmaxcel_sys::rdmaxcel_qp_create(
-                context,
-                pd,
+                domain.context,
+                domain.pd,
                 config.cq_entries,
                 config.max_send_wr.try_into().unwrap(),
                 config.max_recv_wr.try_into().unwrap(),
@@ -220,7 +246,7 @@ impl IbvQueuePair {
                     dv_qp: 0,
                     dv_send_cq: 0,
                     dv_recv_cq: 0,
-                    context: context as usize,
+                    domain,
                     config,
                     is_efa: true,
                 });
@@ -258,7 +284,7 @@ impl IbvQueuePair {
                 dv_qp: dv_qp as usize,
                 dv_send_cq: dv_send_cq as usize,
                 dv_recv_cq: dv_recv_cq as usize,
-                context: context as usize,
+                domain,
                 config,
                 is_efa: false,
             })
@@ -268,7 +294,7 @@ impl IbvQueuePair {
     /// Returns the connection info needed by a remote peer to connect to this QP.
     pub fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
         unsafe {
-            let context = self.context as *mut rdmaxcel_sys::ibv_context;
+            let context = self.domain.context;
             let qp = self.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
             let mut port_attr = rdmaxcel_sys::ibv_port_attr::default();
             let errno = rdmaxcel_sys::ibv_query_port(
@@ -763,7 +789,7 @@ impl IbvQueuePair {
 
         unsafe {
             let qp = self.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
-            let context = self.context as *mut rdmaxcel_sys::ibv_context;
+            let context = self.domain.context;
             let ops = &mut (*context).ops;
             let errno;
             if op_type == IbvOperation::Recv {
@@ -957,7 +983,7 @@ impl IbvQueuePair {
     /// # Arguments
     ///
     /// * `target` - Which completion queue to poll (Send, Receive)
-    /// * `expected_wr_ids` - Slice of work request IDs to wait for
+    /// * `expected_wr_ids` - Set of work request IDs to wait for
     ///
     /// # Returns
     ///
@@ -966,7 +992,7 @@ impl IbvQueuePair {
     pub fn poll_completion(
         &mut self,
         target: PollTarget,
-        expected_wr_ids: &[u64],
+        expected_wr_ids: &HashSet<u64>,
     ) -> Result<Vec<(u64, IbvWc)>, PollCompletionError> {
         if expected_wr_ids.is_empty() {
             return Ok(Vec::new());
@@ -1094,10 +1120,11 @@ impl IbvQueuePair {
 // `PeerInfo`, connected, and sent our `NotifyRts`) and
 // `peer_rts_received` (we observed the peer's `NotifyRts`). When
 // both are true the handshake hands the qp to the manager via
-// [`QpInitializerDone`]. The `terminal` flag short-circuits any
-// further handler work after success or failure. The qp is held in
-// a `QpGuard` so any failure path (or aborted message delivery)
-// destroys it.
+// [`QpInitializerDone`], transferring ownership. The `terminal`
+// flag short-circuits any further handler work after success or
+// failure. The qp is held in an `Option<IbvQueuePair>`: any
+// failure path (or aborted message delivery) drops it, and
+// `IbvQueuePair::Drop` destroys the underlying FFI resource.
 
 /// Identifies a per-peer queue pair held by one
 /// [`super::manager_actor::IbvManagerActor`]. The same conceptual
@@ -1129,55 +1156,6 @@ wirevalue::register_type!(NotifyRts);
 /// the initializer to abort the handshake.
 #[derive(Debug)]
 struct InitializationFailed;
-
-/// RAII wrapper that destroys the wrapped queue pair on drop.
-/// Use `into_inner` to extract the qp without destroying.
-#[derive(Debug)]
-pub(super) struct QpGuard {
-    qp: Option<IbvQueuePair>,
-}
-
-impl QpGuard {
-    pub(super) fn new(qp: IbvQueuePair) -> Self {
-        Self { qp: Some(qp) }
-    }
-
-    /// Consume the guard and return the qp; suppresses Drop's destroy.
-    pub(super) fn into_inner(mut self) -> IbvQueuePair {
-        self.qp.take().expect("QpGuard already drained")
-    }
-
-    /// Delegates to [`IbvQueuePair::connect`].
-    pub(super) fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
-        self.qp
-            .as_mut()
-            .expect("QpGuard already drained")
-            .connect(info)
-    }
-
-    /// Delegates to [`IbvQueuePair::get_qp_info`].
-    pub(super) fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
-        self.qp
-            .as_mut()
-            .expect("QpGuard already drained")
-            .get_qp_info()
-    }
-}
-
-impl Drop for QpGuard {
-    fn drop(&mut self) {
-        if let Some(qp) = self.qp.take() {
-            // SAFETY: `QpGuard` owns the `IbvQueuePair` and exposes
-            // no API that hands out a reference to it, so safe code
-            // cannot have cloned the underlying `rdmaxcel_qp_t`
-            // pointer out from under us. The only way to extract a
-            // live clone is `into_inner`, which consumes `self` and
-            // skips this `Drop`; reaching here means `into_inner`
-            // was never called.
-            unsafe { destroy_qp(&qp) };
-        }
-    }
-}
 
 /// Bundle of trait bounds for an actor type that can play the role
 /// of [`QueuePairInitializer`]'s owner/peer manager.
@@ -1213,8 +1191,8 @@ pub(super) struct QueuePairInitializer<A: QpOwner> {
     qp_key: QpKey,
     /// Held until the handshake succeeds (handed to the manager
     /// via [`QpInitializerDone`]) or fails (dropped here, which
-    /// destroys the qp via `QpGuard::drop`).
-    qp: Option<QpGuard>,
+    /// destroys the qp via `IbvQueuePair::Drop`).
+    qp: Option<IbvQueuePair>,
     /// Per-side handshake budget pulled from
     /// `RDMA_QP_INIT_TIMEOUT` at construction.
     timeout: Duration,
@@ -1240,7 +1218,7 @@ where
         owner: ActorHandle<A>,
         other: ActorRef<A>,
         qp_key: QpKey,
-        qp: QpGuard,
+        qp: IbvQueuePair,
     ) -> Self {
         let timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
         Self {
@@ -1295,7 +1273,7 @@ where
     }
 
     /// Transition to the terminal success state and hand the qp
-    /// guard to the owning manager via [`QpInitializerDone`].
+    /// to the owning manager via [`QpInitializerDone`].
     fn done(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         if let Some(h) = self.timeout_handle.take() {
             h.abort();
@@ -1325,7 +1303,7 @@ where
             .as_mut()
             .expect("qp present pre-terminal")
             .connect(&peer_endpoint)
-            .map_err(|e| format!("QpGuard::connect failed: {e}"))?;
+            .map_err(|e| format!("IbvQueuePair::connect failed: {e}"))?;
         peer_notify_rts
             .send(cx, NotifyRts)
             .map_err(|e| format!("failed to send NotifyRts to peer: {e}"))?;
@@ -1393,30 +1371,6 @@ where
     fn drop(&mut self) {
         if let Some(h) = self.timeout_handle.take() {
             h.abort();
-        }
-    }
-}
-
-/// Destroy the underlying `rdmaxcel_qp_t`.
-///
-/// # Safety
-///
-/// `IbvQueuePair` derives [`Clone`] but the wrapped `rdmaxcel_qp_t`
-/// pointer is shared by all clones; this call frees that pointer. The
-/// caller must guarantee no remaining clones of `qp` are in use (no
-/// other code is reading from or posting to `qp.qp`, and no future
-/// code will), since accessing a freed `rdmaxcel_qp_t` is undefined
-/// behavior.
-pub(super) unsafe fn destroy_qp(qp: &IbvQueuePair) {
-    // SAFETY: The caller has guaranteed no other live clone of `qp`
-    // observes `qp.qp` (see this function's `# Safety` section). This
-    // is truly unsafe -- the current implementation does not properly
-    // track outstanding clones. An imminent change will fix this, but
-    // for now it isn't a regression.
-    unsafe {
-        if qp.qp != 0 {
-            let rdmaxcel_qp = qp.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
-            rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
         }
     }
 }
@@ -1506,7 +1460,6 @@ mod tests {
     use hyperactor_config::Flattrs;
 
     use super::*;
-    use crate::backend::ibverbs::domain::IbvDomain;
     use crate::backend::ibverbs::manager_actor::EnsureQueuePair;
     use crate::backend::ibverbs::primitives::IbvConfig;
     use crate::backend::ibverbs::primitives::get_all_devices;
@@ -1525,8 +1478,8 @@ mod tests {
         let domain = IbvDomain::new(config.device.clone());
         assert!(domain.is_ok());
 
-        let domain = domain.unwrap();
-        let queue_pair = IbvQueuePair::new(domain.context, domain.pd, config.clone());
+        let domain = Arc::new(domain.unwrap());
+        let queue_pair = IbvQueuePair::new(domain, config.clone());
         assert!(queue_pair.is_ok());
     }
 
@@ -1546,21 +1499,11 @@ mod tests {
             ..Default::default()
         };
 
-        let server_domain = IbvDomain::new(server_config.device.clone()).unwrap();
-        let client_domain = IbvDomain::new(client_config.device.clone()).unwrap();
+        let server_domain = Arc::new(IbvDomain::new(server_config.device.clone()).unwrap());
+        let client_domain = Arc::new(IbvDomain::new(client_config.device.clone()).unwrap());
 
-        let mut server_qp = IbvQueuePair::new(
-            server_domain.context,
-            server_domain.pd,
-            server_config.clone(),
-        )
-        .unwrap();
-        let mut client_qp = IbvQueuePair::new(
-            client_domain.context,
-            client_domain.pd,
-            client_config.clone(),
-        )
-        .unwrap();
+        let mut server_qp = IbvQueuePair::new(server_domain, server_config.clone()).unwrap();
+        let mut client_qp = IbvQueuePair::new(client_domain, client_config.clone()).unwrap();
 
         let server_connection_info = server_qp.get_qp_info().unwrap();
         let client_connection_info = client_qp.get_qp_info().unwrap();
@@ -1597,9 +1540,11 @@ mod tests {
         DropReply,
     }
 
-    /// Zero-initialized [`IbvQueuePair`]. `qp == 0` so `QpGuard::Drop`
-    /// is a no-op; tests using this must not exercise [`IbvQueuePair::connect`]
-    /// (it would deref a null pointer).
+    /// Zero-initialized [`IbvQueuePair`]. `qp == 0` so
+    /// `IbvQueuePair::Drop` is a no-op; tests using this must not
+    /// exercise [`IbvQueuePair::connect`] (it would deref a null
+    /// pointer). The domain is null too; `IbvDomain::Drop` is a no-op
+    /// on a null `pd`.
     fn fake_qp() -> IbvQueuePair {
         IbvQueuePair {
             send_cq: 0,
@@ -1608,7 +1553,10 @@ mod tests {
             dv_qp: 0,
             dv_send_cq: 0,
             dv_recv_cq: 0,
-            context: 0,
+            domain: Arc::new(IbvDomain {
+                context: std::ptr::null_mut(),
+                pd: std::ptr::null_mut(),
+            }),
             config: IbvConfig::default(),
             is_efa: false,
         }
@@ -1616,13 +1564,13 @@ mod tests {
 
     /// A real (loopback) `IbvQueuePair` and its `IbvQpInfo`. Returns
     /// `None` when no RDMA device is present.
-    fn loopback_qp() -> Option<(QpGuard, IbvQpInfo)> {
+    fn loopback_qp() -> Option<(IbvQueuePair, IbvQpInfo)> {
         if get_all_devices().is_empty() {
             return None;
         }
         let config = IbvConfig::default();
-        let domain = IbvDomain::new(config.device.clone()).ok()?;
-        let mut qp = QpGuard::new(IbvQueuePair::new(domain.context, domain.pd, config).ok()?);
+        let domain = Arc::new(IbvDomain::new(config.device.clone()).ok()?);
+        let mut qp = IbvQueuePair::new(domain, config).ok()?;
         let info = qp.get_qp_info().ok()?;
         Some((qp, info))
     }
@@ -1679,7 +1627,9 @@ mod tests {
     #[async_trait]
     impl Handler<QpInitializerDone> for MockManager {
         async fn handle(&mut self, _cx: &Context<Self>, msg: QpInitializerDone) -> Result<()> {
-            let _ = msg.qp.into_inner();
+            // The mock takes ownership; dropping the `IbvQueuePair`
+            // here destroys it.
+            drop(msg.qp);
             self.state.lock().unwrap().done.push(msg.qp_key);
             Ok(())
         }
@@ -1705,7 +1655,7 @@ mod tests {
     }
 
     impl Harness {
-        fn build(qp: QpGuard, response: MockResponse) -> Result<Self> {
+        fn build(qp: IbvQueuePair, response: MockResponse) -> Result<Self> {
             let proc = Proc::new();
             let state = Arc::new(Mutex::new(MockState::default()));
             let mock = MockManager {
@@ -1766,11 +1716,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_peer_info_error_transitions_to_failed() {
-        let harness = Harness::build(
-            QpGuard::new(fake_qp()),
-            MockResponse::Error("peer rejected".into()),
-        )
-        .unwrap();
+        let harness =
+            Harness::build(fake_qp(), MockResponse::Error("peer rejected".into())).unwrap();
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert_eq!(error, "peer rejected");
@@ -1788,7 +1735,7 @@ mod tests {
             Duration::from_millis(200),
         );
 
-        let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
+        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert!(
@@ -1872,7 +1819,7 @@ mod tests {
     /// envelope's error message.
     #[tokio::test]
     async fn test_undeliverable_in_awaiting_transitions_to_failed() {
-        let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
+        let harness = Harness::build(fake_qp(), MockResponse::DropReply).unwrap();
         let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
         harness.init_handle.send(&peer, undeliverable).unwrap();
@@ -1908,11 +1855,7 @@ mod tests {
     /// `QpInitializerFailed` callback.
     #[tokio::test]
     async fn test_undeliverable_after_terminated_does_not_re_fail() {
-        let harness = Harness::build(
-            QpGuard::new(fake_qp()),
-            MockResponse::Error("first fail".into()),
-        )
-        .unwrap();
+        let harness = Harness::build(fake_qp(), MockResponse::Error("first fail".into())).unwrap();
         let _ = harness.await_failed().await;
 
         let undeliverable = fake_undeliverable(&harness.proc, "late bounce");

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -13,7 +13,7 @@
 //! methods for establishing connections and performing RDMA operations.
 
 /// Maximum size for a single RDMA operation in bytes (1 GiB).
-const MAX_RDMA_MSG_SIZE: usize = 1024 * 1024 * 1024;
+pub(super) const MAX_RDMA_MSG_SIZE: usize = 1024 * 1024 * 1024;
 
 use std::io::Error;
 use std::result::Result;
@@ -73,6 +73,16 @@ impl PollCompletionError {
     /// error state due to a different work request's failure.
     pub fn is_wr_flush_err(&self) -> bool {
         self.status == Some(rdmaxcel_sys::ibv_wc_status::IBV_WC_WR_FLUSH_ERR)
+    }
+
+    /// Test-only constructor
+    #[cfg(test)]
+    pub(super) fn for_test(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            status: None,
+            vendor_err: None,
+        }
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -286,8 +286,7 @@ pub async fn wait_for_completion(
             return Ok(true);
         }
 
-        let wr_ids_to_poll: Vec<u64> = remaining.iter().copied().collect();
-        match qp.poll_completion(poll_target, &wr_ids_to_poll) {
+        match qp.poll_completion(poll_target, &remaining) {
             Ok(completions) => {
                 for (wr_id, _wc) in completions {
                     remaining.remove(&wr_id);

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -68,6 +68,18 @@ declare_attrs! {
     ))
     pub attr RDMA_CQ_BUSY_POLL_WINDOW: Option<Duration> = None;
 
+    /// Capacity of the per-processor LRU cache that memoizes
+    /// `IbvMemoryRegionView`s by `(virtual_addr, size)`. Hits skip
+    /// the manager round-trip; misses ask the manager to register
+    /// the region and insert the result. A value of `0` is clamped
+    /// to `1` (the LRU is effectively disabled at that size, but
+    /// the processor still functions).
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_MR_LRU_CACHE_SIZE".to_string()),
+        Some("rdma_mr_lru_cache_size".to_string()),
+    ))
+    pub attr RDMA_MR_LRU_CACHE_SIZE: usize = 1024;
+
     /// Per-side budget for the `QueuePairInitializer` handshake. The
     /// timer arms once when we send `EnsureQueuePair` and is rearmed
     /// after we hit RTS while still waiting for the peer's


### PR DESCRIPTION
Summary:

Wire the manager to its new `IbvProcessorActor` child and move the ibverbs data path off the manager loop. `IbvQueuePair` becomes single-owner with RAII destruction, so the prior pattern of handing out clones and explicitly destroying them is gone.

- `IbvQueuePair` is no longer `Clone`. It owns its `rdmaxcel_qp_t`; `Drop` calls `rdmaxcel_qp_destroy`. Moving the value transfers ownership; `QpGuard` is deleted (`QueuePairInitializer` holds `Option<IbvQueuePair>` directly).
- `IbvManagerActor::init` spawns the processor and stores it in a `OnceLock`. The manager handles `RegisterMr` and `RequestQueuePair<IbvManagerActor, IbvQueuePair>` directly; the old `IbvManagerLocalMessage::{RegisterMr, RequestQueuePair}` variants are removed.
- New `QpState::Consumed` tombstone: once the QP is claimed out of `Ready`, the entry transitions to `Consumed` so duplicate `RequestQueuePair` calls and late `EnsureQueuePair` peer messages surface "already claimed" rather than silently recreating the QP. A `Pending` entry parks at most one waiter; a second concurrent caller gets an explicit error.
- `device_domains` is split into `HashMap<String, Arc<IbvDomain>>` for PDs and `HashMap<String, IbvQueuePair>` for the segment-scanner loopback QPs.
- `IbvBackend::submit` forwards a `SubmitOps` whose reply port rides through to the processor, so the processor answers the caller in one hop.
- `impl QueuePair for IbvQueuePair` is added in `processor_actor.rs`.

Test wiring updates: `test_concurrent_request_queue_pair_converges` now asserts the single-owner contract (one racing request wins, loser sees "already claimed"); `test_bidirectional_concurrent_request_queue_pair` binds the peer-side QP so its `Drop` doesn't tear down the peer connection before the local side's WR completes.

Reviewed By: zdevito

Differential Revision: D105213930


