### PR TITLE
[hyperactor] remove mailbox forwarders

### DIFF
--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -839,7 +839,7 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
 
 /// Introspect task: runs on a dedicated tokio task per actor,
 /// handling [`IntrospectMessage`] by reading [`InstanceCell`]
-/// directly and replying via the actor's [`Mailbox`].
+/// directly and replying through the owning [`Proc`](crate::Proc).
 ///
 /// The actor's message loop never sees these messages.
 ///
@@ -848,7 +848,6 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
 /// Exercises S1, S2, S4, S5, S6, S11 (see module doc).
 pub(crate) async fn serve_introspect(
     cell: InstanceCell,
-    mailbox: crate::mailbox::Mailbox,
     mut receiver: crate::mailbox::PortReceiver<IntrospectMessage>,
 ) {
     use crate::actor::ActorStatus;
@@ -917,7 +916,7 @@ pub(crate) async fn serve_introspect(
                     },
                     IntrospectView::Actor => live_actor_payload(&cell),
                 };
-                mailbox.serialize_and_send_once(
+                cell.proc().serialize_and_send_once(
                     reply,
                     payload,
                     crate::mailbox::monitored_return_handle(),
@@ -947,7 +946,7 @@ pub(crate) async fn serve_introspect(
                         as_of: SystemTime::now(),
                     }
                 });
-                mailbox.serialize_and_send_once(
+                cell.proc().serialize_and_send_once(
                     reply,
                     payload,
                     crate::mailbox::monitored_return_handle(),

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -113,7 +113,6 @@ use std::ops::Bound::Excluded;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Condvar;
-use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::RwLock;
 use std::sync::Weak;
@@ -916,9 +915,6 @@ impl MailboxSender for UndeliverableMailboxSender {
     }
 }
 
-static BOXED_PANICKING_MAILBOX_SENDER: LazyLock<BoxedMailboxSender> =
-    LazyLock::new(|| BoxedMailboxSender::new(PanickingMailboxSender));
-
 /// Convenience boxing implementation for MailboxSender. Most APIs
 /// are parameterized on MailboxSender implementations, and it's thus
 /// difficult to work with dyn values.  BoxedMailboxSender bridges this
@@ -1383,19 +1379,16 @@ pub struct Mailbox {
 
 impl Mailbox {
     /// Create a runtime-owned mailbox associated with the provided actor ID.
-    pub(crate) fn new(actor_id: impl Into<ActorAddr>, forwarder: BoxedMailboxSender) -> Self {
+    pub(crate) fn new(actor_id: impl Into<ActorAddr>) -> Self {
         Self {
-            inner: Arc::new(State::new(actor_id.into(), forwarder)),
+            inner: Arc::new(State::new(actor_id.into())),
         }
     }
 
     /// Create a new detached mailbox associated with the provided actor ID.
     pub fn new_detached(actor_id: impl Into<ActorAddr>) -> Self {
         Self {
-            inner: Arc::new(State::new(
-                actor_id.into(),
-                BOXED_PANICKING_MAILBOX_SENDER.clone(),
-            )),
+            inner: Arc::new(State::new(actor_id.into())),
         }
     }
 
@@ -1772,7 +1765,12 @@ impl MailboxSender for Mailbox {
         );
 
         if envelope.dest().actor_id() != self.inner.actor_id.id() {
-            return self.inner.forwarder.post(envelope, return_handle);
+            let err = DeliveryError::Mailbox(format!(
+                "mailbox owner {} cannot deliver to {}",
+                self.inner.actor_id,
+                envelope.dest().actor_addr()
+            ));
+            return envelope.undeliverable(err, return_handle);
         }
 
         let port_index = envelope.dest().index();
@@ -2753,9 +2751,6 @@ struct State {
     /// The next port ID to allocate.
     next_port: AtomicU64,
 
-    /// The forwarder for this mailbox.
-    forwarder: BoxedMailboxSender,
-
     /// If a value is present, the mailbox has been closed with the provided
     /// status, and any subsequent `Mailbox::post_unchecked` calls will fail.
     closed: RwLock<Option<ActorStatus>>,
@@ -2766,14 +2761,13 @@ struct State {
 
 impl State {
     /// Create a new state with the provided owning ActorAddr.
-    fn new(actor_id: ActorAddr, forwarder: BoxedMailboxSender) -> Self {
+    fn new(actor_id: ActorAddr) -> Self {
         Self {
             actor_id,
             ports: DashMap::new(),
             // The first 1024 ports are allocated to actor handlers.
             // Other port IDs are ephemeral.
             next_port: AtomicU64::new(USER_PORT_OFFSET),
-            forwarder,
             closed: RwLock::new(None),
             handler_ingress: Arc::new(HandlerIngressGate::new()),
         }
@@ -3357,6 +3351,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_mailbox_rejects_messages_for_other_actors() {
+        let mbox = Mailbox::new_detached(test_actor_id("0", "owner"));
+        let dest = test_actor_id("0", "other").port_addr(Port::from(1234));
+        let envelope =
+            MessageEnvelope::serialize(mbox.actor_addr().clone(), dest, &42u64, Flattrs::new())
+                .expect("serialize");
+        let (return_handle, mut return_rx) = undeliverable::new_undeliverable_port();
+
+        mbox.post(envelope, return_handle);
+
+        let Undeliverable(undelivered) =
+            tokio::time::timeout(Duration::from_secs(1), return_rx.recv())
+                .await
+                .expect("timed out waiting for undeliverable")
+                .expect("return port closed");
+        assert!(
+            undelivered
+                .error_msg()
+                .expect("expected error")
+                .contains("cannot deliver to")
+        );
+    }
+
+    #[tokio::test]
     async fn test_mailbox_accum() {
         let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
@@ -3908,7 +3926,7 @@ mod tests {
         use crate::testing::proc_supervison::ProcSupervisionCoordinator;
 
         let proc_forwarder = BoxedMailboxSender::new(DialMailboxRouter::new_with_default(
-            BOXED_PANICKING_MAILBOX_SENDER.clone(),
+            BoxedMailboxSender::new(PanickingMailboxSender),
         ));
         let proc_id = test_proc_id("quux_0");
         let mut proc = Proc::configured(proc_id.clone(), proc_forwarder);
@@ -3999,10 +4017,7 @@ mod tests {
             // Create dummy state and port_id to create PortReceiver. They are
             // not used in the test.
             let dummy_actor_ref: ActorAddr = test_actor_id("world_0", "actor");
-            let dummy_state = State::new(
-                dummy_actor_ref.clone(),
-                BOXED_PANICKING_MAILBOX_SENDER.clone(),
-            );
+            let dummy_state = State::new(dummy_actor_ref.clone());
             let dummy_port_id = dummy_actor_ref.port_addr(Port::from(0));
             let (sender, receiver) = mpsc::unbounded_channel::<M>();
             let receiver = PortReceiver {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -946,7 +946,7 @@ impl Proc {
 
     /// Bind a mailbox to the proc.
     fn bind_mailbox(&self, actor_id: ActorAddr) -> Mailbox {
-        let mbox = Mailbox::new(actor_id, BoxedMailboxSender::new(self.downgrade()));
+        let mbox = Mailbox::new(actor_id);
 
         // TODO: T210748165 tie the muxer entry to the lifecycle of the mailbox held
         // by the caller. This will likely require a weak reference.
@@ -1036,7 +1036,6 @@ impl Proc {
         instance.change_status(ActorStatus::Client);
         tokio::spawn(crate::introspect::serve_introspect(
             instance.inner.cell.clone(),
-            instance.inner.mailbox.clone(),
             receivers.introspect,
         ));
         Ok((instance, handle))
@@ -1060,7 +1059,6 @@ impl Proc {
 
         tokio::spawn(crate::introspect::serve_introspect(
             instance.inner.cell.clone(),
-            instance.inner.mailbox.clone(),
             receivers.introspect,
         ));
 
@@ -1888,7 +1886,7 @@ impl<A: Actor> Instance<A> {
         parent: Option<InstanceCell>,
     ) -> (Self, InstanceReceivers<A>) {
         // Set up messaging
-        let mailbox = Mailbox::new(actor_id.clone(), BoxedMailboxSender::new(proc.downgrade()));
+        let mailbox = Mailbox::new(actor_id.clone());
         let (work_tx, work_rx) = ordered_channel(
             actor_id.to_string(),
             hyperactor_config::global::get(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER),
@@ -2335,11 +2333,10 @@ impl<A: Actor> Instance<A> {
         let actor_handle = ActorHandle::new(self.inner.cell.clone(), self.inner.ports.clone());
 
         // Spawn the introspect task — a separate tokio task that
-        // reads InstanceCell directly and replies via the actor's
-        // Mailbox. The actor loop never sees IntrospectMessage.
+        // reads InstanceCell directly and replies through the owning Proc. The
+        // actor loop never sees IntrospectMessage.
         tokio::spawn(crate::introspect::serve_introspect(
             self.inner.cell.clone(),
-            self.inner.mailbox.clone(),
             receivers.introspect,
         ));
 
@@ -3224,6 +3221,11 @@ impl InstanceCell {
     /// The actor's address.
     pub fn actor_addr(&self) -> &ActorAddr {
         &self.inner.actor_id
+    }
+
+    /// The proc in which this actor is running.
+    pub(crate) fn proc(&self) -> &Proc {
+        &self.inner.proc
     }
 
     /// The actor's uid.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3879
* #3878
* #3888
* __->__ #3887
* #3877
* #3876
* #3875
* #3873

Remove forwarding policy from Mailbox state. Runtime mailboxes are now pure actor-local port tables, and proc-owned mailbox construction no longer injects WeakProc as a mailbox fallback. Directly posting an envelope for another actor to a mailbox now returns an undeliverable mailbox error instead of forwarding.

Differential Revision: [D105177457](https://our.internmc.facebook.com/intern/diff/D105177457/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105177457/)!