### PR TITLE
factor `Actor::handle_stop` default into free function

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -106,13 +106,7 @@ pub trait Actor: Sized + Send + 'static {
         mode: StopMode,
         reason: &str,
     ) -> Result<(), anyhow::Error> {
-        // After `close`, no more messages may be enqueued.
-        // exit_after_drain will drain any pending messages before exiting.
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason).map_err(anyhow::Error::from),
-            StopMode::DrainAndStop => this.exit_after_drain(reason).map_err(anyhow::Error::from),
-        }
+        handle_stop(this, mode, reason)
     }
 
     /// Cleanup things used by this actor before shutting down. Notably this function
@@ -210,6 +204,23 @@ pub fn handle_undeliverable_message<A: Actor>(
     assert_eq!(envelope.sender(), cx.self_addr());
 
     anyhow::bail!(UndeliverableMessageError::DeliveryFailure { envelope });
+}
+
+/// Default implementation of [`Actor::handle_stop`]. Defined as a free
+/// function so that `Actor` implementations that override
+/// [`Actor::handle_stop`] can fall back to this default.
+pub fn handle_stop<A: Actor>(
+    this: &Instance<A>,
+    mode: StopMode,
+    reason: &str,
+) -> Result<(), anyhow::Error> {
+    // After `close`, no more messages may be enqueued.
+    // exit_after_drain will drain any pending messages before exiting.
+    this.close();
+    match mode {
+        StopMode::Stop => this.exit(reason).map_err(anyhow::Error::from),
+        StopMode::DrainAndStop => this.exit_after_drain(reason).map_err(anyhow::Error::from),
+    }
 }
 
 /// An actor that does nothing. It is used to represent "client only" actors,


### PR DESCRIPTION
Summary: Expose the default body of `Actor::handle_stop` as a free `handle_stop` function, mirroring the existing pattern for `handle_undeliverable_message`. This lets `Actor` implementations override `handle_stop` to inject custom setup (e.g. flipping a `stopping` flag so a self-driving handler state machine stops scheduling new work) and then delegate back to the default close + exit-after-drain sequence without re-implementing it.

Differential Revision: D105248931


