### PR TITLE
test cross-proc actor messaging via served shared gateway (#3898)

### DIFF
--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -409,6 +409,8 @@ mod tests {
     use crate::port::Port;
     use crate::proc::Proc;
     use crate::testing::ids::test_actor_id;
+    use crate::testing::pingpong::PingPongActor;
+    use crate::testing::pingpong::PingPongMessage;
 
     /// `Gateway::post_unchecked` demuxes inbound envelopes by
     /// destination `ProcId` to the matching attached proc's muxer,
@@ -507,6 +509,57 @@ mod tests {
                 .await
                 .is_err(),
             "beta_rx received a message after stranger post",
+        );
+    }
+
+    /// Ping-pong between two `PingPongActor`s on two procs that share
+    /// one gateway. Each cross-proc hop goes `Proc::post_unchecked` →
+    /// `Gateway::post_unchecked` demux → destination proc's muxer
+    /// directly, without touching the gateway's forwarder.
+    #[tokio::test]
+    async fn test_ping_pong_across_shared_gateway() {
+        let gateway = Gateway::isolated();
+
+        let alpha = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let beta = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("beta")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        let (client, _) = alpha.instance("client").unwrap();
+        let (undeliverable_msg_tx, mut undeliverable_rx) =
+            client.open_port::<Undeliverable<MessageEnvelope>>();
+
+        let ping_actor = PingPongActor::new(Some(undeliverable_msg_tx.bind()), None, None);
+        let pong_actor = PingPongActor::new(Some(undeliverable_msg_tx.bind()), None, None);
+        let ping_handle = alpha.spawn::<PingPongActor>("ping", ping_actor).unwrap();
+        let pong_handle = beta.spawn::<PingPongActor>("pong", pong_actor).unwrap();
+
+        let (local_port, local_receiver) = client.open_once_port();
+
+        ping_handle
+            .send(
+                &client,
+                PingPongMessage(10, pong_handle.bind(), local_port.bind()),
+            )
+            .unwrap();
+
+        let received = time::timeout(Duration::from_secs(5), local_receiver.recv())
+            .await
+            .expect("local_receiver timed out")
+            .expect("ping pong did not complete");
+        assert!(received);
+
+        assert!(
+            time::timeout(Duration::from_millis(50), undeliverable_rx.recv())
+                .await
+                .is_err(),
+            "unexpected undeliverable during cross-proc ping-pong",
         );
     }
 }

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -389,3 +389,124 @@ impl crate::mailbox::MailboxSender for Gateway {
         Gateway::flush(self).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use hyperactor_config::Flattrs;
+    use tokio::time;
+
+    use super::*;
+    use crate::Label;
+    use crate::mailbox::MailboxSender;
+    use crate::mailbox::PortLocation;
+    use crate::mailbox::monitored_return_handle;
+    use crate::port::Port;
+    use crate::proc::Proc;
+    use crate::testing::ids::test_actor_id;
+
+    /// `Gateway::post_unchecked` demuxes inbound envelopes by
+    /// destination `ProcId` to the matching attached proc's muxer,
+    /// and falls through to the configured forwarder for unknown
+    /// destinations. Attached procs only receive envelopes addressed
+    /// to them — a stranger-addressed envelope does not leak to local
+    /// receivers.
+    #[tokio::test]
+    async fn test_gateway_post_demuxes_by_proc_id() {
+        #[derive(Clone)]
+        struct CountingSender(Arc<AtomicUsize>);
+
+        #[async_trait]
+        impl MailboxSender for CountingSender {
+            fn post_unchecked(
+                &self,
+                _envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let forwarded = Arc::new(AtomicUsize::new(0));
+        let gateway = Gateway::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(CountingSender(forwarded.clone())),
+        );
+
+        let alpha = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let beta = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("beta")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        let (alpha_client, _) = alpha.instance("client").unwrap();
+        let (alpha_port, mut alpha_rx) = alpha_client.bind_handler_port::<u64>();
+        let PortLocation::Bound(alpha_dest) = alpha_port.location() else {
+            panic!("alpha handler port must be bound");
+        };
+
+        let (beta_client, _) = beta.instance("client").unwrap();
+        let (beta_port, mut beta_rx) = beta_client.bind_handler_port::<u64>();
+        let PortLocation::Bound(beta_dest) = beta_port.location() else {
+            panic!("beta handler port must be bound");
+        };
+
+        let sender = test_actor_id("sender", "client");
+
+        gateway.post(
+            MessageEnvelope::serialize(sender.clone(), alpha_dest.clone(), &111u64, Flattrs::new())
+                .unwrap(),
+            monitored_return_handle(),
+        );
+        let received = time::timeout(Duration::from_secs(5), alpha_rx.recv())
+            .await
+            .expect("alpha_rx timed out")
+            .expect("alpha_rx closed");
+        assert_eq!(received, 111);
+        assert_eq!(forwarded.load(Ordering::SeqCst), 0);
+
+        gateway.post(
+            MessageEnvelope::serialize(sender.clone(), beta_dest.clone(), &222u64, Flattrs::new())
+                .unwrap(),
+            monitored_return_handle(),
+        );
+        let received = time::timeout(Duration::from_secs(5), beta_rx.recv())
+            .await
+            .expect("beta_rx timed out")
+            .expect("beta_rx closed");
+        assert_eq!(received, 222);
+        assert_eq!(forwarded.load(Ordering::SeqCst), 0);
+
+        let stranger_proc = ProcAddr::unique(ChannelAddr::Local(9999), "stranger");
+        let stranger_dest = stranger_proc
+            .actor_addr("ghost")
+            .port_addr(Port::from(0u64));
+        gateway.post(
+            MessageEnvelope::serialize(sender, stranger_dest, &333u64, Flattrs::new()).unwrap(),
+            monitored_return_handle(),
+        );
+        assert_eq!(forwarded.load(Ordering::SeqCst), 1);
+        assert!(
+            time::timeout(Duration::from_millis(50), alpha_rx.recv())
+                .await
+                .is_err(),
+            "alpha_rx received a message after stranger post",
+        );
+        assert!(
+            time::timeout(Duration::from_millis(50), beta_rx.recv())
+                .await
+                .is_err(),
+            "beta_rx received a message after stranger post",
+        );
+    }
+}

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1627,7 +1627,7 @@ impl MailboxSender for Proc {
         if self.is_local_delivery_target(&dest_proc) {
             self.state().proc_muxer.post(envelope, return_handle)
         } else {
-            self.forwarder().post(envelope, return_handle)
+            self.state().gateway.post(envelope, return_handle)
         }
     }
 


### PR DESCRIPTION
Summary:

Proc::post_unchecked for non-local destinations now delegates to Gateway::post_unchecked (which demuxes to attached peer procs or falls through to its forwarder) instead of going straight to the gateway's forwarder field. two procs sharing one gateway can now exchange messages in-process via the gateway's demux — no channel, no dial, no serve required.

add test_ping_pong_across_shared_gateway to gateway.rs's mod tests block. two PingPongActors on two procs that share one Gateway::configured(...,  PanickingMailboxSender) play ping-pong. each cross-proc hop goes ActorRef::send → Context::post → Proc::post_unchecked → Gateway::post_unchecked demux → destination proc's muxer. the panicking forwarder pins it: any hop that falls through to the forwarder panics the test.
  
PingPongActor (from hyperactor/src/testing/pingpong.rs) is reused because TestActorMessage (the pattern in proc.rs's test_proc_actors_messaging) carries oneshot::Sender / anyhow::Error and is not cross-proc serializable. negative assertion on the undeliverable port confirms no hop landed at a dead address.

Reviewed By: mariusae

Differential Revision: D105328599


