### PR TITLE
test Gateway::attach panics on duplicate live proc (#3900)

### DIFF
--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -389,3 +389,124 @@ impl crate::mailbox::MailboxSender for Gateway {
         Gateway::flush(self).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use hyperactor_config::Flattrs;
+    use tokio::time;
+
+    use super::*;
+    use crate::Label;
+    use crate::mailbox::MailboxSender;
+    use crate::mailbox::PortLocation;
+    use crate::mailbox::monitored_return_handle;
+    use crate::port::Port;
+    use crate::proc::Proc;
+    use crate::testing::ids::test_actor_id;
+
+    /// `Gateway::post_unchecked` demuxes inbound envelopes by
+    /// destination `ProcId` to the matching attached proc's muxer,
+    /// and falls through to the configured forwarder for unknown
+    /// destinations. Attached procs only receive envelopes addressed
+    /// to them — a stranger-addressed envelope does not leak to local
+    /// receivers.
+    #[tokio::test]
+    async fn test_gateway_post_demuxes_by_proc_id() {
+        #[derive(Clone)]
+        struct CountingSender(Arc<AtomicUsize>);
+
+        #[async_trait]
+        impl MailboxSender for CountingSender {
+            fn post_unchecked(
+                &self,
+                _envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let forwarded = Arc::new(AtomicUsize::new(0));
+        let gateway = Gateway::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(CountingSender(forwarded.clone())),
+        );
+
+        let alpha = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let beta = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("beta")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        let (alpha_client, _) = alpha.instance("client").unwrap();
+        let (alpha_port, mut alpha_rx) = alpha_client.bind_handler_port::<u64>();
+        let PortLocation::Bound(alpha_dest) = alpha_port.location() else {
+            panic!("alpha handler port must be bound");
+        };
+
+        let (beta_client, _) = beta.instance("client").unwrap();
+        let (beta_port, mut beta_rx) = beta_client.bind_handler_port::<u64>();
+        let PortLocation::Bound(beta_dest) = beta_port.location() else {
+            panic!("beta handler port must be bound");
+        };
+
+        let sender = test_actor_id("sender", "client");
+
+        gateway.post(
+            MessageEnvelope::serialize(sender.clone(), alpha_dest.clone(), &111u64, Flattrs::new())
+                .unwrap(),
+            monitored_return_handle(),
+        );
+        let received = time::timeout(Duration::from_secs(5), alpha_rx.recv())
+            .await
+            .expect("alpha_rx timed out")
+            .expect("alpha_rx closed");
+        assert_eq!(received, 111);
+        assert_eq!(forwarded.load(Ordering::SeqCst), 0);
+
+        gateway.post(
+            MessageEnvelope::serialize(sender.clone(), beta_dest.clone(), &222u64, Flattrs::new())
+                .unwrap(),
+            monitored_return_handle(),
+        );
+        let received = time::timeout(Duration::from_secs(5), beta_rx.recv())
+            .await
+            .expect("beta_rx timed out")
+            .expect("beta_rx closed");
+        assert_eq!(received, 222);
+        assert_eq!(forwarded.load(Ordering::SeqCst), 0);
+
+        let stranger_proc = ProcAddr::unique(ChannelAddr::Local(9999), "stranger");
+        let stranger_dest = stranger_proc
+            .actor_addr("ghost")
+            .port_addr(Port::from(0u64));
+        gateway.post(
+            MessageEnvelope::serialize(sender, stranger_dest, &333u64, Flattrs::new()).unwrap(),
+            monitored_return_handle(),
+        );
+        assert_eq!(forwarded.load(Ordering::SeqCst), 1);
+        assert!(
+            time::timeout(Duration::from_millis(50), alpha_rx.recv())
+                .await
+                .is_err(),
+            "alpha_rx received a message after stranger post",
+        );
+        assert!(
+            time::timeout(Duration::from_millis(50), beta_rx.recv())
+                .await
+                .is_err(),
+            "beta_rx received a message after stranger post",
+        );
+    }
+}

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -409,6 +409,8 @@ mod tests {
     use crate::port::Port;
     use crate::proc::Proc;
     use crate::testing::ids::test_actor_id;
+    use crate::testing::pingpong::PingPongActor;
+    use crate::testing::pingpong::PingPongMessage;
 
     /// `Gateway::post_unchecked` demuxes inbound envelopes by
     /// destination `ProcId` to the matching attached proc's muxer,
@@ -507,6 +509,68 @@ mod tests {
                 .await
                 .is_err(),
             "beta_rx received a message after stranger post",
+        );
+    }
+
+    /// Ping-pong between two `PingPongActor`s on two procs that share
+    /// one served gateway. Each cross-proc hop goes out via the
+    /// gateway's forwarder (`DialMailboxRouter`) and comes back in
+    /// via the gateway's demux.
+    #[tokio::test]
+    async fn test_ping_pong_across_shared_gateway() {
+        let gateway = Gateway::new();
+
+        let alpha = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let beta = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("beta")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        // Serve the gateway on its reserved local address
+        // (first-serve rule). Outbound from one proc to the other
+        // goes Proc::post_unchecked → forwarder (DialMailboxRouter) →
+        // dial the served address → gateway's channel server →
+        // Gateway::post_unchecked demux → destination proc's muxer.
+        let _serve = Gateway::serve(&gateway, ChannelAddr::any(ChannelTransport::Local)).unwrap();
+
+        let (client, _) = alpha.instance("client").unwrap();
+        let (undeliverable_msg_tx, mut undeliverable_rx) =
+            client.open_port::<Undeliverable<MessageEnvelope>>();
+
+        let ping_actor = PingPongActor::new(Some(undeliverable_msg_tx.bind()), None, None);
+        let pong_actor = PingPongActor::new(Some(undeliverable_msg_tx.bind()), None, None);
+        let ping_handle = alpha.spawn::<PingPongActor>("ping", ping_actor).unwrap();
+        let pong_handle = beta.spawn::<PingPongActor>("pong", pong_actor).unwrap();
+
+        let (local_port, local_receiver) = client.open_once_port();
+
+        ping_handle
+            .send(
+                &client,
+                PingPongMessage(10, pong_handle.bind(), local_port.bind()),
+            )
+            .unwrap();
+
+        let received = time::timeout(Duration::from_secs(5), local_receiver.recv())
+            .await
+            .expect("local_receiver timed out")
+            .expect("ping pong did not complete");
+        assert!(received);
+
+        // Every hop should have made it through dial+demux+delivery.
+        // An undeliverable here would indicate a dial failure, a
+        // misroute by the gateway's demux, or a missing attached
+        // proc.
+        assert!(
+            time::timeout(Duration::from_millis(50), undeliverable_rx.recv())
+                .await
+                .is_err(),
+            "unexpected undeliverable during cross-proc ping-pong",
         );
     }
 }

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -648,4 +648,31 @@ mod tests {
             assert!(procs.get(&proc_id).is_none());
         }
     }
+
+    /// `Gateway::attach` panics when a second proc with the same
+    /// `ProcId` is built against the same gateway while the first is
+    /// still alive. The check is in `Gateway::attach`, invoked from
+    /// `Proc::builder().build()` via `Proc::from_parts_unchecked`.
+    #[test]
+    #[should_panic(expected = "gateway already has a live proc")]
+    fn test_gateway_attach_panics_on_duplicate_live_proc() {
+        let gateway = Gateway::isolated();
+        let proc_id = ProcId::instance(Label::strip("alpha"));
+
+        // Hold the first proc in a binding so it stays alive across
+        // the second build; if the first were dropped, the gateway's
+        // stale-entry path would silently replace it instead of
+        // panicking.
+        let _first = Proc::builder()
+            .proc_id(proc_id.clone())
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        let _second = Proc::builder()
+            .proc_id(proc_id)
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+    }
 }

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -573,4 +573,79 @@ mod tests {
             "unexpected undeliverable during cross-proc ping-pong",
         );
     }
+
+    /// `Gateway::post_unchecked` removes stale `WeakProc` entries
+    /// lazily on the post path. Dropping a proc leaves a dead
+    /// `WeakProc` in the gateway's `procs` map; the next post to that
+    /// proc's id falls through to the forwarder and removes the stale
+    /// entry.
+    #[tokio::test]
+    async fn test_gateway_post_removes_stale_weak_procs() {
+        #[derive(Clone)]
+        struct CountingSender(Arc<AtomicUsize>);
+
+        #[async_trait]
+        impl MailboxSender for CountingSender {
+            fn post_unchecked(
+                &self,
+                _envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let forwarded = Arc::new(AtomicUsize::new(0));
+        let gateway = Gateway::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(CountingSender(forwarded.clone())),
+        );
+
+        let proc = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let proc_id = proc.proc_id().clone();
+        let dest = proc
+            .proc_addr()
+            .actor_addr("worker")
+            .port_addr(Port::from(0u64));
+
+        // Sanity: proc is attached.
+        assert_eq!(gateway.inner.procs.read().unwrap().len(), 1);
+
+        drop(proc);
+
+        // The entry is still present, but it is now a *stale* WeakProc:
+        // upgrade must fail.
+        {
+            let procs = gateway.inner.procs.read().unwrap();
+            assert_eq!(procs.len(), 1);
+            assert!(
+                procs.get(&proc_id).and_then(WeakProc::upgrade).is_none(),
+                "expected dropped proc to remain only as a stale WeakProc entry",
+            );
+        }
+
+        gateway.post(
+            MessageEnvelope::serialize(
+                test_actor_id("sender", "client"),
+                dest,
+                &42u64,
+                Flattrs::new(),
+            )
+            .unwrap(),
+            monitored_return_handle(),
+        );
+
+        // Envelope fell through to the forwarder; stale entry
+        // removed.
+        assert_eq!(forwarded.load(Ordering::SeqCst), 1);
+        {
+            let procs = gateway.inner.procs.read().unwrap();
+            assert_eq!(procs.len(), 0);
+            assert!(procs.get(&proc_id).is_none());
+        }
+    }
 }


### PR DESCRIPTION
Summary:

add test_gateway_attach_panics_on_duplicate_live_proc to gateway.rs's mod tests block. constructs a Gateway::isolated(), builds a proc with a chosen ProcId, and then builds a second proc with the same ProcId against the same gateway. the second Proc::builder().build() panics from inside Gateway::attach, matched by #[should_panic(expected = "gateway already has a live proc")].

the first proc is held in a _first binding so it stays alive across the second build. if it were dropped, the gateway's stale-entry replace path would silently swap in the second proc (that's G13's territory) instead of panicking. keeping the first alive is what scopes this test to the duplicate-live invariant at Gateway::attach.
  
plain #[test] rather than #[tokio::test] — no async, no channels, no await. matches the nearby test_builder_procs_can_share_gateway_with_distinct_ids and test_isolated_procs_use_distinct_gateways.

fourth and final test in the "Now" bucket; this one pins the panic guard against two live procs sharing a ProcId. each test covers a distinct architectural invariant of the gateway primitive.

Differential Revision: D105331610


