### PR TITLE
[hyperactor] add runtime-owned delayed posting

### DIFF
--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -256,7 +256,7 @@ impl<M: Bind> IndexedErasedUnbound<M> {
         let port_handle = mailbox.open_enqueue_port::<IndexedErasedUnbound<M>>({
             move |_, m| {
                 let bound_m = m.downcast()?.bind()?;
-                actor_ref.post(&cx, bound_m);
+                (&actor_ref).post(&cx, bound_m);
                 Ok(())
             }
         });

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -88,6 +88,7 @@
 
 use std::any::Any;
 use std::any::TypeId;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
@@ -97,12 +98,13 @@ use std::panic::AssertUnwindSafe;
 use std::panic::Location as PanicLocation;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::sync::Condvar;
+use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::sync::Weak;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
-#[cfg(test)]
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
@@ -125,6 +127,7 @@ use hyperactor_telemetry::notify_message_status;
 use hyperactor_telemetry::recorder::Recording;
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -1825,6 +1828,9 @@ struct InstanceState<A: Actor> {
 
     ports: Arc<HandlerPorts<A>>,
 
+    /// Runtime-owned delayed-post scheduler.
+    delayed_posts: DelayedPosts<A>,
+
     /// A watch for communicating the actor's state.
     status_tx: watch::Sender<ActorStatus>,
 
@@ -1836,6 +1842,303 @@ struct InstanceState<A: Actor> {
 
     /// Per-instance local storage.
     instance_locals: ActorLocalStorage,
+}
+
+type DelayedPost<A> = Box<dyn FnOnce(&Instance<A>) + Send>;
+
+trait PostAfterEndpoint<A: Actor, M: Message>: Send {
+    fn endpoint_location(&self) -> crate::EndpointLocation;
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A>;
+}
+
+impl<A, M> PostAfterEndpoint<A, M> for &Instance<A>
+where
+    A: Actor + Handler<M>,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::EndpointLocation::Actor(self.self_addr().clone())
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        let dest = self.clone_for_py();
+        Box::new(move |this| crate::Endpoint::post(&dest, this, message))
+    }
+}
+
+impl<A, M> PostAfterEndpoint<A, M> for &Context<'_, A>
+where
+    A: Actor + Handler<M>,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::EndpointLocation::Actor(self.self_addr().clone())
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        let dest = self.clone_for_py();
+        Box::new(move |this| crate::Endpoint::post(&dest, this, message))
+    }
+}
+
+impl<A, M> PostAfterEndpoint<A, M> for Instance<A>
+where
+    A: Actor + Handler<M>,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::EndpointLocation::Actor(self.self_addr().clone())
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        Box::new(move |this| crate::Endpoint::post(&self, this, message))
+    }
+}
+
+impl<A, B, M> PostAfterEndpoint<A, M> for ActorHandle<B>
+where
+    A: Actor,
+    B: Actor + Handler<M>,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::Endpoint::endpoint_location(&self)
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        Box::new(move |this| crate::Endpoint::post(&self, this, message))
+    }
+}
+
+impl<A, M> PostAfterEndpoint<A, M> for PortHandle<M>
+where
+    A: Actor,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::Endpoint::endpoint_location(&self)
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        Box::new(move |this| crate::Endpoint::post(&self, this, message))
+    }
+}
+
+impl<A, M> PostAfterEndpoint<A, M> for OncePortHandle<M>
+where
+    A: Actor,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::Endpoint::endpoint_location(self)
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        Box::new(move |this| crate::Endpoint::post(self, this, message))
+    }
+}
+
+impl<A, B, M> PostAfterEndpoint<A, M> for ActorRef<B>
+where
+    A: Actor,
+    B: Referable + RemoteHandles<M>,
+    M: RemoteMessage,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::Endpoint::endpoint_location(&self)
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        Box::new(move |this| crate::Endpoint::post(&self, this, message))
+    }
+}
+
+impl<A, M> PostAfterEndpoint<A, M> for crate::PortRef<M>
+where
+    A: Actor,
+    M: RemoteMessage,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::Endpoint::endpoint_location(&self)
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        Box::new(move |this| crate::Endpoint::post(&self, this, message))
+    }
+}
+
+impl<A, M> PostAfterEndpoint<A, M> for crate::OncePortRef<M>
+where
+    A: Actor,
+    M: RemoteMessage,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::Endpoint::endpoint_location(self)
+    }
+
+    fn into_delayed_post(self, message: M) -> DelayedPost<A> {
+        Box::new(move |this| crate::Endpoint::post(self, this, message))
+    }
+}
+
+struct DelayedPosts<A: Actor> {
+    ingress: Arc<DelayedPostIngressGate>,
+    state: Mutex<DelayedPostState<A>>,
+    notify: Notify,
+}
+
+struct DelayedPostState<A: Actor> {
+    queue: BTreeMap<(tokio::time::Instant, u64), DelayedPost<A>>,
+    next_order: u64,
+}
+
+impl<A: Actor> DelayedPosts<A> {
+    fn new() -> Self {
+        Self {
+            ingress: Arc::new(DelayedPostIngressGate::new()),
+            state: Mutex::new(DelayedPostState {
+                queue: BTreeMap::new(),
+                next_order: 0,
+            }),
+            notify: Notify::new(),
+        }
+    }
+
+    fn push(&self, deadline: tokio::time::Instant, post: DelayedPost<A>) {
+        let mut state = self.state.lock().unwrap();
+        let order = state.next_order;
+        state.next_order = state.next_order.wrapping_add(1);
+        state.queue.insert((deadline, order), post);
+        drop(state);
+        self.notify.notify_one();
+    }
+
+    fn next_deadline(&self) -> Option<tokio::time::Instant> {
+        self.state
+            .lock()
+            .unwrap()
+            .queue
+            .keys()
+            .next()
+            .map(|(deadline, _)| *deadline)
+    }
+
+    fn pop_due(&self, now: tokio::time::Instant) -> Vec<DelayedPost<A>> {
+        let mut posts = Vec::new();
+        let mut state = self.state.lock().unwrap();
+        while let Some((&(deadline, _), _)) = state.queue.first_key_value() {
+            if deadline > now {
+                break;
+            }
+            let (_, post) = state.queue.pop_first().expect("delayed post should exist");
+            posts.push(post);
+        }
+        posts
+    }
+
+    fn drain(&self) {
+        self.ingress.drain();
+    }
+
+    fn is_draining(&self) -> bool {
+        self.ingress.is_draining()
+    }
+}
+
+const DELAYED_POST_INGRESS_DRAINING: usize = 1usize << (usize::BITS as usize - 1);
+const DELAYED_POST_INGRESS_ACTIVE_MASK: usize = !DELAYED_POST_INGRESS_DRAINING;
+
+struct DelayedPostIngressGate {
+    state: AtomicUsize,
+    wait_lock: Mutex<()>,
+    drained: Condvar,
+}
+
+struct DelayedPostIngressGuard {
+    gate: Arc<DelayedPostIngressGate>,
+}
+
+impl DelayedPostIngressGate {
+    fn new() -> Self {
+        Self {
+            state: AtomicUsize::new(0),
+            wait_lock: Mutex::new(()),
+            drained: Condvar::new(),
+        }
+    }
+
+    fn try_enter(self: &Arc<Self>) -> Result<DelayedPostIngressGuard, ()> {
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            if state & DELAYED_POST_INGRESS_DRAINING != 0 {
+                return Err(());
+            }
+
+            let active = state & DELAYED_POST_INGRESS_ACTIVE_MASK;
+            assert!(
+                active < DELAYED_POST_INGRESS_ACTIVE_MASK,
+                "too many active delayed post sends"
+            );
+
+            match self.state.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Ok(DelayedPostIngressGuard {
+                        gate: Arc::clone(self),
+                    });
+                }
+                Err(next_state) => state = next_state,
+            }
+        }
+    }
+
+    fn drain(&self) {
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            if state & DELAYED_POST_INGRESS_DRAINING != 0 {
+                break;
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state | DELAYED_POST_INGRESS_DRAINING,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => break,
+                Err(next_state) => state = next_state,
+            }
+        }
+
+        let mut wait_guard = self.wait_lock.lock().unwrap();
+        while self.state.load(Ordering::Acquire) & DELAYED_POST_INGRESS_ACTIVE_MASK != 0 {
+            wait_guard = self.drained.wait(wait_guard).unwrap();
+        }
+    }
+
+    fn is_draining(&self) -> bool {
+        self.state.load(Ordering::Acquire) & DELAYED_POST_INGRESS_DRAINING != 0
+    }
+}
+
+impl Drop for DelayedPostIngressGuard {
+    fn drop(&mut self) {
+        let previous = self.gate.state.fetch_sub(1, Ordering::AcqRel);
+        assert!(
+            previous & DELAYED_POST_INGRESS_ACTIVE_MASK != 0,
+            "delayed post ingress active count underflow"
+        );
+        if previous & DELAYED_POST_INGRESS_DRAINING != 0
+            && previous & DELAYED_POST_INGRESS_ACTIVE_MASK == 1
+        {
+            let _wait_guard = self.gate.wait_lock.lock().unwrap();
+            self.gate.drained.notify_all();
+        }
+    }
 }
 
 impl<A: Actor> InstanceState<A> {
@@ -1949,6 +2252,7 @@ impl<A: Actor> Instance<A> {
             cell,
             mailbox,
             ports,
+            delayed_posts: DelayedPosts::new(),
             status_tx,
             sequencer: Sequencer::new(instance_id),
             id: instance_id,
@@ -2220,6 +2524,7 @@ impl<A: Actor> Instance<A> {
 
     /// Close handler ingress for this actor.
     pub fn close(&self) {
+        self.inner.delayed_posts.drain();
         self.inner.mailbox.drain();
     }
 
@@ -2344,19 +2649,50 @@ impl<A: Actor> Instance<A> {
             .0
     }
 
-    /// Send a message to the actor itself with a delay usually to trigger some event.
-    pub fn self_message_with_delay<M>(&self, message: M, delay: Duration) -> Result<(), ActorError>
+    /// Post `message` to `dest` after `delay`.
+    ///
+    /// Delayed posts are owned by the actor runtime. They are best-effort:
+    /// messages are posted no earlier than `delay`, and any delayed posts that
+    /// have not fired when the actor shuts down are discarded.
+    #[allow(private_bounds)]
+    pub fn post_after<D, M>(&self, dest: D, message: M, delay: Duration)
     where
         M: Message,
-        A: Handler<M>,
+        D: PostAfterEndpoint<A, M>,
     {
-        let client = Self::self_client();
-        let port = self.port();
-        tokio::spawn(async move {
-            tokio::time::sleep(delay).await;
-            port.post(&client, message);
-        });
-        Ok(())
+        let dest_location = dest.endpoint_location();
+        if matches!(*self.inner.status_tx.borrow(), ActorStatus::Client) {
+            self.report_lost_message(crate::mailbox::LostMessage {
+                sender: self.mailbox().actor_addr().clone(),
+                dest: dest_location,
+                message_type: Some(std::any::type_name::<M>().to_string()),
+                error: "delayed posts require an actor runtime".to_string(),
+            });
+            return;
+        }
+        let Ok(_guard) = self.inner.delayed_posts.ingress.try_enter() else {
+            self.report_lost_message(crate::mailbox::LostMessage {
+                sender: self.mailbox().actor_addr().clone(),
+                dest: dest_location,
+                message_type: Some(std::any::type_name::<M>().to_string()),
+                error: "actor runtime is stopping".to_string(),
+            });
+            return;
+        };
+        if self.is_stopping() || self.is_terminal() {
+            self.report_lost_message(crate::mailbox::LostMessage {
+                sender: self.mailbox().actor_addr().clone(),
+                dest: dest_location,
+                message_type: Some(std::any::type_name::<M>().to_string()),
+                error: "actor runtime is stopping".to_string(),
+            });
+            return;
+        }
+
+        self.inner.delayed_posts.push(
+            tokio::time::Instant::now() + delay,
+            dest.into_delayed_post(message),
+        );
     }
 
     /// Start an A-typed actor onto this instance with the provided params. When spawn returns,
@@ -2624,6 +2960,7 @@ impl<A: Actor> Instance<A> {
             if !self.is_stopping() {
                 self.change_status(ActorStatus::Idle);
             }
+            let next_delayed_deadline = self.inner.delayed_posts.next_deadline();
             let metric_pairs = hyperactor_telemetry::kv_pairs!("actor_id" => actor_id_str.clone());
             tokio::select! {
                 biased;
@@ -2670,6 +3007,21 @@ impl<A: Actor> Instance<A> {
                             actor_id: Box::new(self.self_addr().clone()),
                             kind: Box::new(kind),
                         });
+                    }
+                }
+                _ = self.inner.delayed_posts.notify.notified(), if !self.is_stopping() && !self.inner.delayed_posts.is_draining() => {
+                }
+                _ = async {
+                    match next_delayed_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                }, if !self.is_stopping() && !self.inner.delayed_posts.is_draining() && next_delayed_deadline.is_some() => {
+                    let now = tokio::time::Instant::now();
+                    if let Ok(_guard) = self.inner.delayed_posts.ingress.try_enter() {
+                        for post in self.inner.delayed_posts.pop_due(now) {
+                            post(self);
+                        }
                     }
                 }
                 Ok(supervision_event) = supervision_event_receiver.recv() => {
@@ -3002,6 +3354,58 @@ impl<A: Actor> context::Actor for &Context<'_, A> {
     type A = A;
     fn instance(&self) -> &Instance<A> {
         self
+    }
+}
+
+impl<A, M> crate::Endpoint<M> for &Instance<A>
+where
+    A: Actor + Handler<M>,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::EndpointLocation::Actor(self.self_addr().clone())
+    }
+
+    fn post<C>(self, cx: &C, message: M)
+    where
+        C: context::Actor,
+    {
+        let port = self.port();
+        crate::Endpoint::post(&port, cx, message)
+    }
+}
+
+impl<A, M> crate::Endpoint<M> for &Context<'_, A>
+where
+    A: Actor + Handler<M>,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::EndpointLocation::Actor(self.self_addr().clone())
+    }
+
+    fn post<C>(self, cx: &C, message: M)
+    where
+        C: context::Actor,
+    {
+        crate::Endpoint::post(self.instance, cx, message)
+    }
+}
+
+impl<A, M> crate::Endpoint<M> for Instance<A>
+where
+    A: Actor + Handler<M>,
+    M: Message,
+{
+    fn endpoint_location(&self) -> crate::EndpointLocation {
+        crate::EndpointLocation::Actor(self.self_addr().clone())
+    }
+
+    fn post<C>(self, cx: &C, message: M)
+    where
+        C: context::Actor,
+    {
+        crate::Endpoint::post(&self, cx, message)
     }
 }
 
@@ -3846,6 +4250,59 @@ mod tests {
     struct TestActor;
 
     impl Actor for TestActor {}
+
+    #[derive(Debug)]
+    struct DelayedSelfActor {
+        ready: Option<OncePortRef<()>>,
+        fired: Option<OncePortRef<()>>,
+        delay: Duration,
+    }
+
+    #[derive(Debug)]
+    struct DelayedSelfTick;
+
+    #[async_trait]
+    impl Actor for DelayedSelfActor {
+        async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+            if let Some(ready) = self.ready.take() {
+                ready.post(this, ());
+            }
+            this.post_after(this, DelayedSelfTick, self.delay);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<DelayedSelfTick> for DelayedSelfActor {
+        async fn handle(
+            &mut self,
+            cx: &crate::Context<Self>,
+            _message: DelayedSelfTick,
+        ) -> anyhow::Result<()> {
+            if let Some(fired) = self.fired.take() {
+                fired.post(cx, ());
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Debug)]
+    struct DelayedPortActor {
+        reply: Option<PortRef<u64>>,
+        delay: Duration,
+    }
+
+    #[async_trait]
+    impl Actor for DelayedPortActor {
+        async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+            this.post_after(
+                self.reply.take().expect("reply port should be present"),
+                123u64,
+                self.delay,
+            );
+            Ok(())
+        }
+    }
 
     #[derive(Handler, HandleClient, Debug)]
     enum TestActorMessage {
@@ -4732,6 +5189,81 @@ mod tests {
         handle.await;
 
         assert_eq!(state.load(Ordering::SeqCst), 123);
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_post_after_self_message() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (ready, ready_rx) = client.open_once_port();
+        let (fired, fired_rx) = client.open_once_port();
+        let delay = Duration::from_millis(50);
+        let start = tokio::time::Instant::now();
+        let handle = proc
+            .spawn(
+                "test",
+                DelayedSelfActor {
+                    ready: Some(ready.bind()),
+                    fired: Some(fired.bind()),
+                    delay,
+                },
+            )
+            .unwrap();
+
+        ready_rx.recv().await.unwrap();
+        fired_rx.recv().await.unwrap();
+
+        assert!(start.elapsed() >= delay);
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_post_after_port_ref() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (reply, mut reply_rx) = client.open_port();
+        let delay = Duration::from_millis(50);
+        let start = tokio::time::Instant::now();
+        let handle = proc
+            .spawn(
+                "test",
+                DelayedPortActor {
+                    reply: Some(reply.bind()),
+                    delay,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(reply_rx.recv().await.unwrap(), 123);
+        assert!(start.elapsed() >= delay);
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_post_after_discards_pending_messages_on_shutdown() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (ready, ready_rx) = client.open_once_port();
+        let (fired, fired_rx) = client.open_once_port();
+        let handle = proc
+            .spawn(
+                "test",
+                DelayedSelfActor {
+                    ready: Some(ready.bind()),
+                    fired: Some(fired.bind()),
+                    delay: Duration::from_secs(60),
+                },
+            )
+            .unwrap();
+
+        ready_rx.recv().await.unwrap();
+        handle.drain_and_stop("test").unwrap();
+        assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
+
+        let result = tokio::time::timeout(Duration::from_millis(100), fired_rx.recv()).await;
+        assert!(!matches!(result, Ok(Ok(()))));
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -641,7 +641,7 @@ impl Actor for HostAgent {
         // extending the keepalive and tears them down.
         if let Some(delay) = hyperactor_config::global::get(crate::proc_agent::MESH_ORPHAN_TIMEOUT)
         {
-            this.self_message_with_delay(crate::proc_agent::SelfCheck::default(), delay)?;
+            this.post_after(this, crate::proc_agent::SelfCheck::default(), delay);
         }
 
         Ok(())
@@ -1291,7 +1291,7 @@ impl Handler<crate::proc_agent::SelfCheck> for HostAgent {
             }
         }
 
-        cx.self_message_with_delay(crate::proc_agent::SelfCheck::default(), duration)?;
+        cx.post_after(cx, crate::proc_agent::SelfCheck::default(), duration);
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -996,7 +996,7 @@ pub struct LogForwardActor {
 impl Actor for LogForwardActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         this.set_system();
-        this.self_message_with_delay(LogForwardMessage::Forward {}, Duration::from_secs(0))?;
+        this.post_after(this, LogForwardMessage::Forward {}, Duration::from_secs(0));
 
         // Make sure we start the flush loop periodically so the log channel will not deadlock.
         self.flush_tx
@@ -1109,7 +1109,7 @@ impl LogForwardMessageHandler for LogForwardActor {
         }
 
         // This is not ideal as we are using raw tx/rx.
-        ctx.self_message_with_delay(LogForwardMessage::Forward {}, Duration::from_secs(0))?;
+        ctx.post_after(ctx, LogForwardMessage::Forward {}, Duration::from_secs(0));
 
         Ok(())
     }
@@ -1298,20 +1298,14 @@ impl LogMessageHandler for LogClientActor {
                     match self.next_flush_deadline {
                         None => {
                             self.next_flush_deadline = Some(new_deadline);
-                            cx.self_message_with_delay(
-                                LogMessage::Flush { sync_version: None },
-                                delay,
-                            )?;
+                            cx.post_after(cx, LogMessage::Flush { sync_version: None }, delay);
                         }
                         Some(deadline) => {
                             // Some early log lines have alrady triggered the flush.
                             if new_deadline < deadline {
                                 // This can happen if the user has adjusted the aggregation window.
                                 self.next_flush_deadline = Some(new_deadline);
-                                cx.self_message_with_delay(
-                                    LogMessage::Flush { sync_version: None },
-                                    delay,
-                                )?;
+                                cx.post_after(cx, LogMessage::Flush { sync_version: None }, delay);
                             }
                         }
                     }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -567,16 +567,11 @@ impl<T: Controlled> ResourceController<T> {
     ///
     /// `send_fn` bridges the type gap: the caller passes a closure that
     /// captures the typed `Instance`/`Context` and calls
-    /// `self_message_with_delay`.
-    fn schedule_next_check(
-        &self,
-        send_fn: impl FnOnce(CheckState, Duration) -> Result<(), ActorError>,
-    ) -> Result<(), ActorError> {
+    /// `post_after`.
+    fn schedule_next_check(&self, send_fn: impl FnOnce(CheckState, Duration)) {
         if self.monitor.is_some() {
             let delay = hyperactor_config::global::get(SUPERVISION_POLL_FREQUENCY);
-            send_fn(CheckState(SystemTime::now() + delay), delay)
-        } else {
-            Ok(())
+            send_fn(CheckState(SystemTime::now() + delay), delay);
         }
     }
 
@@ -657,7 +652,7 @@ impl<T: Controlled> ResourceController<T> {
 
         match result {
             PollResult::Reschedule => {
-                self.schedule_next_check(|msg, delay| cx.self_message_with_delay(msg, delay))?;
+                self.schedule_next_check(|msg, delay| cx.post_after(cx, msg, delay));
             }
             PollResult::Processed { did_notify } => {
                 // Suppress heartbeats once any rank is terminating: the mesh is on
@@ -667,7 +662,7 @@ impl<T: Controlled> ResourceController<T> {
                     send_heartbeat(cx, &self.health_state);
                 }
                 if !self.health_state.all_terminating() {
-                    self.schedule_next_check(|msg, delay| cx.self_message_with_delay(msg, delay))?;
+                    self.schedule_next_check(|msg, delay| cx.post_after(cx, msg, delay));
                 } else {
                     self.monitor.take();
                 }
@@ -726,7 +721,7 @@ where
 
         // Start the monitor task.
         self.monitor = Some(());
-        self.schedule_next_check(|msg, delay| this.self_message_with_delay(msg, delay))?;
+        self.schedule_next_check(|msg, delay| this.post_after(this, msg, delay));
 
         let owner = if let Some(owner) = &self.health_state.owner {
             owner.to_string()

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -649,17 +649,18 @@ impl Actor for ProcAgent {
         });
 
         if let Some(delay) = &self.mesh_orphan_timeout {
-            this.self_message_with_delay(SelfCheck::default(), *delay)?;
+            this.post_after(this, SelfCheck::default(), *delay);
         }
         if cfg!(target_os = "linux") {
             let interval = hyperactor_config::global::get(PROCESS_MEMORY_METRIC_INTERVAL);
             if !interval.is_zero() {
-                this.self_message_with_delay(
+                this.post_after(
+                    this,
                     RepublishIntrospect {
                         emit_memory_metrics: true,
                     },
                     interval,
-                )?;
+                );
             }
         }
         Ok(())
@@ -727,7 +728,8 @@ impl Handler<ActorSupervisionEvent> for ProcAgent {
             // Multiple rapid events coalesce into one republish.
             if !self.introspect_dirty {
                 self.introspect_dirty = true;
-                let _ = cx.self_message_with_delay(
+                cx.post_after(
+                    cx,
                     RepublishIntrospect {
                         emit_memory_metrics: false,
                     },
@@ -787,12 +789,13 @@ impl Handler<RepublishIntrospect> for ProcAgent {
             }
             let interval = hyperactor_config::global::get(PROCESS_MEMORY_METRIC_INTERVAL);
             if !interval.is_zero() {
-                cx.self_message_with_delay(
+                cx.post_after(
+                    cx,
                     RepublishIntrospect {
                         emit_memory_metrics: true,
                     },
                     interval,
-                )?;
+                );
             }
         }
         Ok(())
@@ -1220,7 +1223,7 @@ impl Handler<SelfCheck> for ProcAgent {
         }
 
         // Reschedule.
-        cx.self_message_with_delay(SelfCheck::default(), duration)?;
+        cx.post_after(cx, SelfCheck::default(), duration);
         Ok(())
     }
 }

--- a/hyperactor_remote/example/token_supervision.rs
+++ b/hyperactor_remote/example/token_supervision.rs
@@ -127,7 +127,7 @@ impl Handler<token::Joined<ActorRef<WorkerLike>>> for Parent {
             write_text(path, "linked").await?;
         }
         if let Some(delay) = self.exit_after_link {
-            cx.self_message_with_delay(ParentCommand::Exit, delay)?;
+            cx.post_after(cx, ParentCommand::Exit, delay);
         }
         Ok(())
     }

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -358,7 +358,7 @@ impl KeepaliveWorker {
     fn send_keepalive(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
         self.generation += 1;
         let generation = self.generation;
-        self.supervisor.post(
+        (&self.supervisor).post(
             this,
             Keepalive {
                 generation,
@@ -366,8 +366,8 @@ impl KeepaliveWorker {
             },
         );
 
-        this.self_message_with_delay(SendKeepalive { generation }, self.interval)?;
-        this.self_message_with_delay(AckDeadline { generation }, self.timeout)?;
+        this.post_after(this, SendKeepalive { generation }, self.interval);
+        this.post_after(this, AckDeadline { generation }, self.timeout);
         Ok(())
     }
 }
@@ -431,12 +431,13 @@ impl KeepaliveSupervisor {
     }
 
     fn schedule_deadline(&self, this: &Instance<Self>) -> anyhow::Result<()> {
-        this.self_message_with_delay(
+        this.post_after(
+            this,
             Deadline {
                 generation: self.generation,
             },
             self.timeout,
-        )?;
+        );
         Ok(())
     }
 }

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -113,7 +113,7 @@ impl Actor for Supervisor {
             .expect("supervisor initialized more than once")
             .spawn_supervisor(this)?;
         self.link_handle = Some(link_handle);
-        self.worker.post(
+        (&self.worker).post(
             this,
             Link {
                 session_id: self.session_id.clone(),
@@ -210,7 +210,7 @@ impl Supervisor {
         let Some(stop) = self.pending_stop.take() else {
             return Ok(());
         };
-        self.worker.post(
+        (&self.worker).post(
             cx,
             SupervisedWorker::Stop {
                 session_id: self.session_id.clone(),
@@ -568,10 +568,10 @@ mod tests {
             self.ready.post(this, this.self_addr().clone());
             match self.action.take() {
                 Some(TestChildAction::FailAfter(delay)) => {
-                    this.self_message_with_delay(TestChildCommand::Fail, delay)?;
+                    this.post_after(this, TestChildCommand::Fail, delay);
                 }
                 Some(TestChildAction::DrainAfter(delay, tag)) => {
-                    this.self_message_with_delay(TestChildCommand::Drain(tag), delay)?;
+                    this.post_after(this, TestChildCommand::Drain(tag), delay);
                 }
                 None => {}
             }

--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -229,7 +229,7 @@ impl<C: TokenPeer, J: TokenPeer> Token<C, J> {
         joiner: J,
         result: PortRef<JoinResult<C>>,
     ) -> anyhow::Result<()> {
-        self.rendezvous.post(cx, Join { joiner, result });
+        (&self.rendezvous).post(cx, Join { joiner, result });
         Ok(())
     }
 
@@ -351,7 +351,7 @@ impl<C: TokenPeer + Clone, J: TokenPeer> Handler<Join<C, J>> for Rendezvous<C, J
             return Ok(());
         }
 
-        self.creator_joined.post(
+        (&self.creator_joined).post(
             cx,
             Joined {
                 peer: message.joiner,

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -175,7 +175,7 @@ impl Actor for SupervisedChild {
     async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
         self.ready.post(this, this.self_addr().clone());
         if let Some(ChildAction::StopAfter(delay)) = self.action.take() {
-            this.self_message_with_delay(ChildControl::Stop, delay)?;
+            this.post_after(this, ChildControl::Stop, delay);
         }
         Ok(())
     }

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -313,7 +313,7 @@ wirevalue::register_type!(CaptureSnapshot);
 /// delegates per-tick execution to [`run_periodic_tick`].
 ///
 /// The spawn site sends the first `CaptureSnapshot` (PT-3). The
-/// handler reschedules after each tick via `self_message_with_delay`.
+/// handler reschedules after each tick via `post_after`.
 /// Stopped by framework lifecycle (`DrainAndStop` on proc teardown).
 #[hyperactor::export(handlers = [CaptureSnapshot])]
 pub struct SnapshotCaptureActor {
@@ -353,11 +353,8 @@ impl Handler<CaptureSnapshot> for SnapshotCaptureActor {
         };
         run_periodic_tick(&self.service, resolve).await;
 
-        // Reschedule. If the actor is stopping, this spawns a
-        // detached task whose eventual port.send() fails harmlessly.
-        if let Err(e) = cx.self_message_with_delay(CaptureSnapshot, self.interval) {
-            tracing::error!("snapshot capture actor failed to reschedule: {:#}", e);
-        }
+        // Reschedule through the actor runtime instead of detached work.
+        cx.post_after(cx, CaptureSnapshot, self.interval);
         Ok(())
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -48,6 +48,7 @@ use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::Context;
+use hyperactor::Endpoint as _;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
@@ -848,7 +849,7 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
         let state = match self.ensure_queue_pair_impl(cx, sender, &qp_key) {
             Ok(state) => state,
             Err(e) => {
-                reply.send(cx, PeerInfo(Err(e.to_string())))?;
+                reply.post(cx, PeerInfo(Err(e.to_string())));
                 return Ok(());
             }
         };
@@ -857,7 +858,7 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
                 info, initializer, ..
             } => {
                 let notify_rts = initializer.bind::<QueuePairInitializer<Self>>().port();
-                reply.send(cx, PeerInfo(Ok((info.clone(), notify_rts))))?;
+                reply.post(cx, PeerInfo(Ok((info.clone(), notify_rts))));
             }
             QpState::Ready(_) => {
                 // `Ready` means a prior handshake completed and the
@@ -865,15 +866,15 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
                 // initializer ref. Reaching here represents a logic
                 // error (peer is asking us to redo a handshake we've
                 // already finished); surface it as `Err`.
-                reply.send(
+                reply.post(
                     cx,
                     PeerInfo(Err(format!(
                         "EnsureQueuePair on already-Ready entry {qp_key:?}"
                     ))),
-                )?;
+                );
             }
             QpState::Failed(error) => {
-                reply.send(cx, PeerInfo(Err(error.clone())))?;
+                reply.post(cx, PeerInfo(Err(error.clone())));
             }
         }
         Ok(())
@@ -934,14 +935,14 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         let state = match self.ensure_queue_pair_impl(cx, other, &qp_key) {
             Ok(state) => state,
             Err(e) => {
-                reply.send(cx, Err(e.to_string()))?;
+                reply.post(cx, Err(e.to_string()));
                 return Ok(());
             }
         };
         match state {
             QpState::Pending { waiters, .. } => waiters.push(reply),
-            QpState::Ready(qp) => reply.send(cx, Ok(qp.clone()))?,
-            QpState::Failed(error) => reply.send(cx, Err(error.clone()))?,
+            QpState::Ready(qp) => reply.post(cx, Ok(qp.clone())),
+            QpState::Failed(error) => reply.post(cx, Err(error.clone())),
         }
         Ok(())
     }
@@ -965,12 +966,7 @@ impl Handler<QpInitializerDone> for IbvManagerActor {
                 ..
             }) => {
                 for w in waiters {
-                    let waiter_dbg = format!("{w:?}");
-                    if let Err(e) = w.send(cx, Ok(qp.clone())) {
-                        tracing::error!(
-                            "QpInitializerDone: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
-                        );
-                    }
+                    w.post(cx, Ok(qp.clone()));
                 }
                 initializer
             }
@@ -1009,12 +1005,7 @@ impl Handler<QpInitializerFailed> for IbvManagerActor {
                 ..
             }) => {
                 for w in waiters {
-                    let waiter_dbg = format!("{w:?}");
-                    if let Err(e) = w.send(cx, Err(error.clone())) {
-                        tracing::error!(
-                            "QpInitializerFailed: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
-                        );
-                    }
+                    w.post(cx, Err(error.clone()));
                 }
                 initializer
             }

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -24,6 +24,7 @@ use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::Context;
+use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
@@ -144,14 +145,7 @@ where
         let (reply, rx) = cx
             .mailbox()
             .open_once_port::<Result<IbvMemoryRegionView, String>>();
-        self.manager
-            .send(cx, RegisterMr { addr, size, reply })
-            .map_err(|e| {
-                format!(
-                    "Requesting MR registration from {:?} failed [virtual_addr=0x{:x}, size={}]: {}",
-                    self.manager, addr, size, e
-                )
-            })?;
+        self.manager.post(cx, RegisterMr { addr, size, reply });
         let mrv = rx
             .recv()
             .await
@@ -187,21 +181,14 @@ where
     ) -> Result<OwnedMutexGuard<Qp>, String> {
         if !self.peer_qps.contains_key(qp_key) {
             let (reply, rx) = cx.mailbox().open_once_port::<Result<Qp, String>>();
-            self.manager
-                .send(
-                    cx,
-                    RequestQueuePair {
-                        qp_key: qp_key.clone(),
-                        remote_manager,
-                        reply,
-                    },
-                )
-                .map_err(|e| {
-                    format!(
-                        "Requesting QP from {:?} failed for {} -> {} on {}: {}",
-                        self.manager, qp_key.self_device, qp_key.other_id, qp_key.other_device, e
-                    )
-                })?;
+            self.manager.post(
+                cx,
+                RequestQueuePair {
+                    qp_key: qp_key.clone(),
+                    remote_manager,
+                    reply,
+                },
+            );
             let qp = rx
                 .recv()
                 .await
@@ -335,9 +322,7 @@ where
             reply,
         } = msg;
         let results = self.process_batch(cx, ops, timeout).await;
-        reply
-            .send(cx, results)
-            .map_err(|e| anyhow::anyhow!("SubmitOps reply send failed: {e}"))?;
+        reply.post(cx, results);
         Ok(())
     }
 }
@@ -411,7 +396,7 @@ mod tests {
                     _domain: null_domain(),
                 }),
             );
-            msg.reply.send(cx, Ok(mrv))?;
+            msg.reply.post(cx, Ok(mrv));
             Ok(())
         }
     }
@@ -432,7 +417,7 @@ mod tests {
                 .unwrap()
                 .request_qp_calls
                 .push(msg.qp_key.clone());
-            msg.reply.send(cx, Ok(MockQp))?;
+            msg.reply.post(cx, Ok(MockQp));
             Ok(())
         }
     }
@@ -532,17 +517,14 @@ mod tests {
         ops: Vec<IbvOp<MockManagerActor>>,
     ) -> Vec<Result<(), String>> {
         let (reply, rx) = harness.client.mailbox().open_once_port();
-        harness
-            .processor
-            .send(
-                &harness.client,
-                SubmitOps {
-                    ops,
-                    timeout: Duration::from_secs(5),
-                    reply,
-                },
-            )
-            .unwrap();
+        harness.processor.post(
+            &harness.client,
+            SubmitOps {
+                ops,
+                timeout: Duration::from_secs(5),
+                reply,
+            },
+        );
         rx.recv().await.unwrap()
     }
 

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -25,6 +25,7 @@ use hyperactor::ActorHandle;
 use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Context;
+use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::PortRef;
@@ -1255,12 +1256,7 @@ where
         let timeout = self.timeout;
         let task = tokio::spawn(async move {
             tokio::time::sleep(timeout).await;
-            if let Err(e) = self_handle.send(Instance::<Self>::self_client(), InitializationFailed)
-            {
-                tracing::error!(
-                    "QueuePairInitializer: failed to deliver timeout self-message: {e}"
-                );
-            }
+            self_handle.post(Instance::<Self>::self_client(), InitializationFailed);
         });
         self.timeout_handle = Some(task);
     }
@@ -1274,13 +1270,13 @@ where
         }
         self.qp = None;
         self.terminal = true;
-        self.owner.send(
+        self.owner.post(
             this,
             QpInitializerFailed {
                 qp_key: self.qp_key.clone(),
                 error,
             },
-        )?;
+        );
         Ok(())
     }
 
@@ -1292,13 +1288,13 @@ where
         }
         let qp = self.qp.take().expect("qp present in done()");
         self.terminal = true;
-        self.owner.send(
+        self.owner.post(
             this,
             QpInitializerDone {
                 qp_key: self.qp_key.clone(),
                 qp,
             },
-        )?;
+        );
         Ok(())
     }
 
@@ -1316,9 +1312,7 @@ where
             .expect("qp present pre-terminal")
             .connect(&peer_endpoint)
             .map_err(|e| format!("QpGuard::connect failed: {e}"))?;
-        peer_notify_rts
-            .send(cx, NotifyRts)
-            .map_err(|e| format!("failed to send NotifyRts to peer: {e}"))?;
+        peer_notify_rts.post(cx, NotifyRts);
         Ok(())
     }
 }
@@ -1335,7 +1329,7 @@ where
         let sender = self.owner.bind();
         let sender_device = self.qp_key.self_device.clone();
         let receiver_device = self.qp_key.other_device.clone();
-        self.other.send(
+        self.other.post(
             this,
             EnsureQueuePair {
                 sender,
@@ -1343,7 +1337,7 @@ where
                 receiver_device,
                 reply,
             },
-        )?;
+        );
 
         self.arm_timeout(this);
         Ok(())
@@ -1363,16 +1357,20 @@ where
     async fn handle_undeliverable_message(
         &mut self,
         this: &Instance<Self>,
-        Undeliverable(envelope): Undeliverable<MessageEnvelope>,
+        undeliverable: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
+        let error = match undeliverable {
+            Undeliverable::Message(envelope) => envelope.error_msg().unwrap_or_default(),
+            Undeliverable::Lost(lost) => lost.error,
+        };
         if self.terminal {
             tracing::warn!(
                 "undeliverable message after handshake terminated: {}",
-                envelope.error_msg().unwrap_or_default()
+                error
             );
             return Ok(());
         }
-        self.fail(this, envelope.error_msg().unwrap_or_default())
+        self.fail(this, error)
     }
 }
 
@@ -1638,7 +1636,7 @@ mod tests {
             match response {
                 MockResponse::Success(info) => {
                     let notify_rts = cx.bind::<MockManager>().port::<NotifyRts>();
-                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))))?;
+                    msg.reply.post(cx, PeerInfo(Ok((info, notify_rts))));
                 }
                 MockResponse::SuccessWithBogusNotifyRts(info) => {
                     let bogus = hyperactor::context::Mailbox::mailbox(cx)
@@ -1647,10 +1645,10 @@ mod tests {
                         .actor_addr("bogus")
                         .port_addr(Port::from(0u64));
                     let notify_rts = PortRef::<NotifyRts>::attest(bogus);
-                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))))?;
+                    msg.reply.post(cx, PeerInfo(Ok((info, notify_rts))));
                 }
                 MockResponse::Error(e) => {
-                    msg.reply.send(cx, PeerInfo(Err(e)))?;
+                    msg.reply.post(cx, PeerInfo(Err(e)));
                 }
                 MockResponse::DropReply => {}
             }
@@ -1799,7 +1797,7 @@ mod tests {
         let harness = Harness::build(qp, MockResponse::Success(info))?;
 
         let (peer, _) = harness.proc.instance("peer")?;
-        harness.init_handle.send(&peer, NotifyRts)?;
+        harness.init_handle.post(&peer, NotifyRts);
 
         let key = harness.await_done().await;
         assert_eq!(key, harness.qp_key);
@@ -1853,7 +1851,7 @@ mod tests {
         )
         .unwrap();
         envelope.set_error(DeliveryError::Mailbox(error.into()));
-        Undeliverable(envelope)
+        Undeliverable::Message(envelope)
     }
 
     /// In an awaiting state, an undeliverable message returned to the
@@ -1865,7 +1863,7 @@ mod tests {
         let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
-        harness.init_handle.send(&peer, undeliverable).unwrap();
+        harness.init_handle.post(&peer, undeliverable);
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert!(
@@ -1907,7 +1905,7 @@ mod tests {
 
         let undeliverable = fake_undeliverable(&harness.proc, "late bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
-        harness.init_handle.send(&peer, undeliverable).unwrap();
+        harness.init_handle.post(&peer, undeliverable);
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(harness.state.lock().unwrap().failed.len(), 1);
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3897
* __->__ #3903
* #3894
* #3893
* #3892
* #3891
* #3890

Add `Instance::post_after` as an infallible delayed-post API built on endpoint destinations, including actor/context endpoint support for self-delayed posts. Delayed posts are owned by the actor runtime, scheduled through a runtime queue with ingress draining semantics matching ordinary handler ingress, and scheduling rejections are reported through the lost-message undeliverable path. Migrate existing delayed self-message call sites to `post_after` and remove `self_message_with_delay`.

Differential Revision: [D105327249](https://our.internmc.facebook.com/intern/diff/D105327249/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105327249/)!