### PR TITLE
[hyperactor] remove current-actor proc shutdown exception

### DIFF
--- a/hyperactor/example/derive.rs
+++ b/hyperactor/example/derive.rs
@@ -201,7 +201,7 @@ async fn main() -> Result<(), anyhow::Error> {
     );
 
     let _ = proc
-        .destroy_and_wait::<()>(Duration::from_secs(1), None, "example cleanup")
+        .destroy_and_wait(Duration::from_secs(1), "example cleanup")
         .await?;
     Ok(())
 }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -3959,7 +3959,7 @@ mod tests {
         assert!(msg_str.contains("sender:") && msg_str.contains("quux_0"));
         assert!(msg_str.contains("dest:") && msg_str.contains("corge_0"));
 
-        proc.destroy_and_wait::<()>(tokio::time::Duration::from_secs(1), None, "test cleanup")
+        proc.destroy_and_wait(tokio::time::Duration::from_secs(1), "test cleanup")
             .await
             .unwrap();
     }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1262,11 +1262,7 @@ impl Proc {
     /// Call `abort` on the `JoinHandle` associated with the given
     /// root actor. If successful return `Some(root.clone())` else
     /// `None`.
-    pub fn abort_root_actor(
-        &self,
-        root: &ActorId,
-        this_handle: Option<&JoinHandle<()>>,
-    ) -> Option<impl Future<Output = ActorAddr>> {
+    pub fn abort_root_actor(&self, root: &ActorId) -> Option<impl Future<Output = ActorAddr>> {
         self.state()
             .instances
             .get(root)
@@ -1276,23 +1272,14 @@ impl Proc {
                 let actor_addr = cell.actor_addr().clone();
                 let r1 = actor_addr.clone();
                 let r2 = actor_addr;
-                // If abort_root_actor was called from inside an actor task, we don't want to abort that actor's task yet.
-                let skip_abort = this_handle.is_some_and(|this_h| {
-                    cell.inner
-                        .actor_task_handle
-                        .get()
-                        .is_some_and(|other_h| std::ptr::eq(this_h, other_h))
-                });
                 // `Instance::start()` is infallible and should
                 // complete quickly, so calling `wait()` on `actor_task_handle`
                 // should be safe (i.e., not hang forever).
                 async move {
                     tokio::task::spawn_blocking(move || {
-                        if !skip_abort {
-                            let h = cell.inner.actor_task_handle.wait();
-                            tracing::debug!("{}: aborting {:?}", r1, h);
-                            h.abort();
-                        }
+                        let h = cell.inner.actor_task_handle.wait();
+                        tracing::debug!("{}: aborting {:?}", r1, h);
+                        h.abort();
                     })
                     .await
                     .unwrap();
@@ -1341,45 +1328,13 @@ impl Proc {
     /// Stop the proc. Returns a pair of:
     /// - the actors observed to stop;
     /// - the actors not observed to stop when timeout.
-    ///
-    /// If `cx` is specified, it means this method was called from inside an actor
-    /// in which case we shouldn't wait for it to stop and need to delay aborting
-    /// its task.
-    pub async fn destroy_and_wait<A: Actor>(
-        &mut self,
-        timeout: Duration,
-        cx: Option<&Context<'_, A>>,
-        reason: &str,
-    ) -> Result<(Vec<ActorAddr>, Vec<ActorAddr>), anyhow::Error> {
-        self.destroy_and_wait_except_current::<A>(timeout, cx, false, reason)
-            .await
-    }
-
-    /// Stop the proc. Returns a pair of:
-    /// - the actors observed to stop;
-    /// - the actors not observed to stop when timeout.
-    ///
-    /// If `cx` is specified, it means this method was called from inside an actor
-    /// in which case we shouldn't wait for it to stop and need to delay aborting
-    /// its task.
-    /// If except_current is true, don't stop the actor represented by "cx" at
-    /// all.
     #[hyperactor::instrument(fields(subject = self.proc_addr().subject().to_string()))]
-    pub async fn destroy_and_wait_except_current<A: Actor>(
+    pub async fn destroy_and_wait(
         &mut self,
         timeout: Duration,
-        cx: Option<&Context<'_, A>>,
-        except_current: bool,
         reason: &str,
     ) -> Result<(Vec<ActorAddr>, Vec<ActorAddr>), anyhow::Error> {
         tracing::debug!("proc stopping");
-
-        let (this_handle, this_actor_id) = cx.map_or((None, None), |cx| {
-            (
-                Some(cx.actor_task_handle().expect("cannot call destroy_and_wait from inside an actor unless actor has finished starting")),
-                Some(cx.self_addr())
-            )
-        });
 
         let coordinator_id = self.supervision_coordinator_actor_addr().cloned();
 
@@ -1406,7 +1361,6 @@ impl Proc {
 
         let waits: Vec<_> = statuses
             .iter_mut()
-            .filter(|(actor_id, _)| Some(*actor_id) != this_actor_id)
             .map(|(actor_id, root)| {
                 let actor_id = actor_id.clone();
                 async move {
@@ -1431,7 +1385,7 @@ impl Proc {
             .iter()
             .filter(|(actor_id, _)| !stopped_actors.contains(actor_id))
             .map(|(actor_id, _)| {
-                let f = self.abort_root_actor(actor_id.id(), this_handle);
+                let f = self.abort_root_actor(actor_id.id());
                 async move {
                     let _ = if let Some(f) = f { Some(f.await) } else { None };
                     // If `is_none(&_)` then the associated actor's
@@ -1449,9 +1403,7 @@ impl Proc {
         // events have already been enqueued by this point, and the
         // coordinator's DrainAndStop path drains queued supervision
         // events before exiting.
-        if let Some(ref coord_id) = coordinator_id
-            && this_actor_id != Some(coord_id)
-        {
+        if let Some(ref coord_id) = coordinator_id {
             if let Some(mut status) = self.stop_actor(coord_id.id(), reason.to_string()) {
                 let stopped = tokio::time::timeout(
                     timeout,
@@ -1462,7 +1414,7 @@ impl Proc {
                 if stopped {
                     stopped_actors.push(coord_id.clone());
                 } else {
-                    if let Some(f) = self.abort_root_actor(coord_id.id(), this_handle) {
+                    if let Some(f) = self.abort_root_actor(coord_id.id()) {
                         f.await;
                     }
                     aborted_actors.push(coord_id.clone());
@@ -1487,14 +1439,6 @@ impl Proc {
             }
             Ok(Ok(())) => {}
         }
-
-        if let Some(this_handle) = this_handle
-            && let Some(this_actor_id) = this_actor_id
-            && !except_current
-        {
-            tracing::debug!("{}: aborting (delayed) {:?}", this_actor_id, this_handle);
-            this_handle.abort()
-        };
 
         tracing::info!(
             "destroy_and_wait: {} actors stopped, {} actors aborted",
@@ -5340,7 +5284,7 @@ mod tests {
         // simultaneously, supervision event delivery would fail and crash
         // the process. The fact that this completes without crashing proves
         // the coordinator outlived the other actors.
-        proc.destroy_and_wait::<()>(Duration::from_secs(5), None, "test")
+        proc.destroy_and_wait(Duration::from_secs(5), "test")
             .await
             .unwrap();
 

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -657,7 +657,7 @@ fn parse_messages(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 ///     );
 ///
 ///     let _ = proc
-///         .destroy_and_wait::<()>(Duration::from_secs(1), None)
+///         .destroy_and_wait(Duration::from_secs(1), "example cleanup")
 ///         .await?;
 ///     Ok(())
 /// }

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -1065,10 +1065,10 @@ pub enum LocalProcStatus {
 /// The proc runs inside this same OS process; there is **no** child
 /// process to signal. Lifecycle is purely proc-level:
 /// - `terminate(timeout)`: delegates to
-///   `Proc::destroy_and_wait(timeout, None)`, which drains and, at the
+///   `Proc::destroy_and_wait(timeout)`, which drains and, at the
 ///   deadline, aborts remaining actors.
 /// - `kill()`: uses a zero deadline to emulate a forced stop via
-///   `destroy_and_wait(Duration::ZERO, None)`.
+///   `destroy_and_wait(Duration::ZERO)`.
 /// - `wait()`: trivial (no external lifecycle to observe).
 ///
 ///   No OS signals are sent or required.
@@ -1118,10 +1118,7 @@ impl<S> LocalProcManager<S> {
         let stopping = Arc::clone(&self.stopping);
         let reason = reason.to_string();
         tokio::spawn(async move {
-            if let Err(e) = proc_handle
-                .destroy_and_wait::<()>(timeout, None, &reason)
-                .await
-            {
+            if let Err(e) = proc_handle.destroy_and_wait(timeout, &reason).await {
                 tracing::warn!(error = %e, "request_stop(local): destroy_and_wait failed");
             }
             if let Some(tx) = stopping.lock().await.get(&proc_ref) {
@@ -1177,7 +1174,7 @@ where
 
         let results = stream::iter(procs.into_iter().map(|mut p| async move {
             // For local manager, graceful proc-level stop.
-            match p.destroy_and_wait::<()>(timeout, None, reason).await {
+            match p.destroy_and_wait(timeout, reason).await {
                 Ok(_) => true,
                 Err(e) => {
                     tracing::warn!(error=%e, "terminate_all(local): destroy_and_wait failed");
@@ -1217,7 +1214,7 @@ where
             guard.remove(proc)
         };
         if let Some(mut p) = procs {
-            p.destroy_and_wait::<()>(timeout, None, reason).await
+            p.destroy_and_wait(timeout, reason).await
         } else {
             Err(anyhow::anyhow!("proc {} doesn't exist", proc))
         }
@@ -1312,7 +1309,7 @@ impl<A: Actor + Referable> ProcHandle for LocalHandle<A> {
         // Graceful stop of the *proc* (actors) with a deadline. This
         // will drain and then abort remaining actors at expiry.
         let _ = proc
-            .destroy_and_wait::<()>(timeout, None, reason)
+            .destroy_and_wait(timeout, reason)
             .await
             .map_err(TerminateError::Io)?;
 
@@ -1331,7 +1328,7 @@ impl<A: Actor + Referable> ProcHandle for LocalHandle<A> {
         };
 
         let _ = proc
-            .destroy_and_wait::<()>(Duration::from_millis(0), None, "kill")
+            .destroy_and_wait(Duration::from_millis(0), "kill")
             .await
             .map_err(TerminateError::Io)?;
 

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -76,7 +76,7 @@ impl PyProc {
         let mut inner = self.inner.clone();
         let (_stopped, aborted) = signal_safe_block_on(py, async move {
             inner
-                .destroy_and_wait::<()>(Duration::from_secs(timeout_in_secs), None, "destroy")
+                .destroy_and_wait(Duration::from_secs(timeout_in_secs), "destroy")
                 .await
                 .map_err(|e| PyRuntimeError::new_err(e.to_string()))
         })??;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3911

Remove the unused destroy_and_wait_except_current path and simplify Proc::destroy_and_wait to take only the timeout and shutdown reason. All production call sites already used cx = None, so the proc-level shutdown behavior remains the same: drain roots, wait up to the deadline, abort stragglers, stop the coordinator last, and flush the gateway. Update Rust, Python binding, examples, and macro docs to the new signature.
@exported-using-ghexport

Differential Revision: [D105322533](https://our.internmc.facebook.com/intern/diff/D105322533/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105322533/)!