### PR TITLE
test Gateway::attach silently replaces dead WeakProc entry (#3913)

### DIFF
--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -675,4 +675,76 @@ mod tests {
             .build()
             .unwrap();
     }
+
+    /// `Gateway::flush()` propagates the flush to each attached
+    /// proc's muxer (which in turn flushes its bound senders) and
+    /// then to the gateway's forwarder. Verified by binding a
+    /// `FlushCountingSender` into each proc's muxer and asserting all
+    /// three counters (alpha's, beta's, the forwarder's) increment
+    /// exactly once.
+    #[tokio::test]
+    async fn test_gateway_flush_propagates_to_attached_procs() {
+        #[derive(Clone)]
+        struct FlushCountingSender(Arc<AtomicUsize>);
+
+        #[async_trait]
+        impl MailboxSender for FlushCountingSender {
+            fn post_unchecked(
+                &self,
+                _envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                // Not exercised by this test.
+            }
+
+            async fn flush(&self) -> Result<(), anyhow::Error> {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let alpha_flushed = Arc::new(AtomicUsize::new(0));
+        let beta_flushed = Arc::new(AtomicUsize::new(0));
+        let forwarder_flushed = Arc::new(AtomicUsize::new(0));
+
+        let gateway = Gateway::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(FlushCountingSender(forwarder_flushed.clone())),
+        );
+
+        let alpha = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let beta = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("beta")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        // Bind a flush-counting probe into each proc's muxer. Use a
+        // fabricated actor id under the proc — no actor is spawned
+        // there; the muxer just routes flushes to whatever's bound.
+        let alpha_probe = alpha.proc_addr().actor_addr("alpha_probe").id().clone();
+        let beta_probe = beta.proc_addr().actor_addr("beta_probe").id().clone();
+        assert!(
+            alpha
+                .muxer()
+                .bind(alpha_probe, FlushCountingSender(alpha_flushed.clone()))
+        );
+        assert!(
+            beta.muxer()
+                .bind(beta_probe, FlushCountingSender(beta_flushed.clone()))
+        );
+
+        // Sanity: two procs attached, both live.
+        assert_eq!(gateway.inner.procs.read().unwrap().len(), 2);
+
+        gateway.flush().await.unwrap();
+
+        assert_eq!(alpha_flushed.load(Ordering::SeqCst), 1);
+        assert_eq!(beta_flushed.load(Ordering::SeqCst), 1);
+        assert_eq!(forwarder_flushed.load(Ordering::SeqCst), 1);
+    }
 }

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -747,4 +747,56 @@ mod tests {
         assert_eq!(beta_flushed.load(Ordering::SeqCst), 1);
         assert_eq!(forwarder_flushed.load(Ordering::SeqCst), 1);
     }
+
+    /// After the gateway is dropped, `WeakGateway::post_unchecked`
+    /// (the sender used by gateway-served mailbox tasks) bounces
+    /// envelopes as `BrokenLink` rather than panicking or hanging.
+    /// Tested directly against `WeakGateway` — no channel server, no
+    /// task lifecycle — because the bounce is in-process and
+    /// observable at the caller's return port without going through
+    /// any serialize/dispatch path.
+    #[tokio::test]
+    async fn test_weak_gateway_bounces_broken_link_after_drop() {
+        let gateway = Gateway::isolated();
+        let weak = WeakGateway::new(&gateway);
+        drop(gateway);
+
+        // Scratch proc just to host the return port.
+        let scratch = Proc::isolated();
+        let (scratch_client, _) = scratch.instance("return").unwrap();
+        let (return_handle, mut return_rx) =
+            scratch_client.open_port::<Undeliverable<MessageEnvelope>>();
+
+        // Fabricate a destination — its contents don't matter; the
+        // bounce happens at WeakGateway::upgrade before any demux
+        // would run.
+        let dest_proc = ProcAddr::unique(ChannelAddr::Local(1234), "stranger");
+        let dest = dest_proc.actor_addr("ghost").port_addr(Port::from(0u64));
+        let envelope = MessageEnvelope::serialize(
+            test_actor_id("sender", "client"),
+            dest.clone(),
+            &42u64,
+            Flattrs::new(),
+        )
+        .unwrap();
+
+        // Post directly through the WeakGateway. Upgrade fails →
+        // envelope.undeliverable(BrokenLink, return_handle) sends
+        // synchronously to our return port.
+        weak.post(envelope, return_handle);
+
+        let Undeliverable(envelope) = time::timeout(Duration::from_secs(5), return_rx.recv())
+            .await
+            .expect("return_rx timed out")
+            .expect("return_rx closed");
+        assert_eq!(envelope.dest(), &dest);
+        assert!(
+            envelope
+                .errors()
+                .iter()
+                .any(|e| matches!(e, DeliveryError::BrokenLink(_))),
+            "expected BrokenLink bounce, got {:?}",
+            envelope.errors(),
+        );
+    }
 }

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -389,3 +389,124 @@ impl crate::mailbox::MailboxSender for Gateway {
         Gateway::flush(self).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use hyperactor_config::Flattrs;
+    use tokio::time;
+
+    use super::*;
+    use crate::Label;
+    use crate::mailbox::MailboxSender;
+    use crate::mailbox::PortLocation;
+    use crate::mailbox::monitored_return_handle;
+    use crate::port::Port;
+    use crate::proc::Proc;
+    use crate::testing::ids::test_actor_id;
+
+    /// `Gateway::post_unchecked` demuxes inbound envelopes by
+    /// destination `ProcId` to the matching attached proc's muxer,
+    /// and falls through to the configured forwarder for unknown
+    /// destinations. Attached procs only receive envelopes addressed
+    /// to them — a stranger-addressed envelope does not leak to local
+    /// receivers.
+    #[tokio::test]
+    async fn test_gateway_post_demuxes_by_proc_id() {
+        #[derive(Clone)]
+        struct CountingSender(Arc<AtomicUsize>);
+
+        #[async_trait]
+        impl MailboxSender for CountingSender {
+            fn post_unchecked(
+                &self,
+                _envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let forwarded = Arc::new(AtomicUsize::new(0));
+        let gateway = Gateway::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(CountingSender(forwarded.clone())),
+        );
+
+        let alpha = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let beta = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("beta")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        let (alpha_client, _) = alpha.instance("client").unwrap();
+        let (alpha_port, mut alpha_rx) = alpha_client.bind_handler_port::<u64>();
+        let PortLocation::Bound(alpha_dest) = alpha_port.location() else {
+            panic!("alpha handler port must be bound");
+        };
+
+        let (beta_client, _) = beta.instance("client").unwrap();
+        let (beta_port, mut beta_rx) = beta_client.bind_handler_port::<u64>();
+        let PortLocation::Bound(beta_dest) = beta_port.location() else {
+            panic!("beta handler port must be bound");
+        };
+
+        let sender = test_actor_id("sender", "client");
+
+        gateway.post(
+            MessageEnvelope::serialize(sender.clone(), alpha_dest.clone(), &111u64, Flattrs::new())
+                .unwrap(),
+            monitored_return_handle(),
+        );
+        let received = time::timeout(Duration::from_secs(5), alpha_rx.recv())
+            .await
+            .expect("alpha_rx timed out")
+            .expect("alpha_rx closed");
+        assert_eq!(received, 111);
+        assert_eq!(forwarded.load(Ordering::SeqCst), 0);
+
+        gateway.post(
+            MessageEnvelope::serialize(sender.clone(), beta_dest.clone(), &222u64, Flattrs::new())
+                .unwrap(),
+            monitored_return_handle(),
+        );
+        let received = time::timeout(Duration::from_secs(5), beta_rx.recv())
+            .await
+            .expect("beta_rx timed out")
+            .expect("beta_rx closed");
+        assert_eq!(received, 222);
+        assert_eq!(forwarded.load(Ordering::SeqCst), 0);
+
+        let stranger_proc = ProcAddr::unique(ChannelAddr::Local(9999), "stranger");
+        let stranger_dest = stranger_proc
+            .actor_addr("ghost")
+            .port_addr(Port::from(0u64));
+        gateway.post(
+            MessageEnvelope::serialize(sender, stranger_dest, &333u64, Flattrs::new()).unwrap(),
+            monitored_return_handle(),
+        );
+        assert_eq!(forwarded.load(Ordering::SeqCst), 1);
+        assert!(
+            time::timeout(Duration::from_millis(50), alpha_rx.recv())
+                .await
+                .is_err(),
+            "alpha_rx received a message after stranger post",
+        );
+        assert!(
+            time::timeout(Duration::from_millis(50), beta_rx.recv())
+                .await
+                .is_err(),
+            "beta_rx received a message after stranger post",
+        );
+    }
+}

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -463,7 +463,7 @@ mod tests {
             panic!("beta handler port must be bound");
         };
 
-        let sender = test_actor_id("sender", "client");
+        let sender = test_actor_id("test", "sender");
 
         gateway.post(
             MessageEnvelope::serialize(sender.clone(), alpha_dest.clone(), &111u64, Flattrs::new())
@@ -630,7 +630,7 @@ mod tests {
 
         gateway.post(
             MessageEnvelope::serialize(
-                test_actor_id("sender", "client"),
+                test_actor_id("test", "sender"),
                 dest,
                 &42u64,
                 Flattrs::new(),
@@ -773,7 +773,7 @@ mod tests {
         let dest_proc = ProcAddr::unique(ChannelAddr::Local(1234), "stranger");
         let dest = dest_proc.actor_addr("ghost").port_addr(Port::from(0u64));
         let envelope = MessageEnvelope::serialize(
-            test_actor_id("sender", "client"),
+            test_actor_id("test", "sender"),
             dest.clone(),
             &42u64,
             Flattrs::new(),
@@ -798,5 +798,63 @@ mod tests {
             "expected BrokenLink bounce, got {:?}",
             envelope.errors(),
         );
+    }
+
+    /// `Gateway::attach` silently replaces a stale `WeakProc` entry
+    /// (one whose strong reference has dropped). No panic; the new
+    /// proc takes over routing for that `ProcId`.
+    #[tokio::test]
+    async fn test_gateway_attach_silently_replaces_dead_entry() {
+        let gateway = Gateway::isolated();
+        let proc_id = ProcId::instance(Label::strip("alpha"));
+
+        let first = Proc::builder()
+            .proc_id(proc_id.clone())
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        drop(first);
+
+        // The entry is still present but stale (upgrade fails).
+        {
+            let procs = gateway.inner.procs.read().unwrap();
+            assert_eq!(procs.len(), 1);
+            assert!(
+                procs.get(&proc_id).and_then(WeakProc::upgrade).is_none(),
+                "expected first proc to remain only as a stale WeakProc entry",
+            );
+        }
+
+        // Attach a second proc with the same id. The dead WeakProc
+        // entry is silently replaced; no panic; map still has exactly
+        // one entry.
+        let second = Proc::builder()
+            .proc_id(proc_id.clone())
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        assert_eq!(gateway.inner.procs.read().unwrap().len(), 1);
+
+        // Verify the new proc is reachable via the gateway.
+        let (client, _) = second.instance("client").unwrap();
+        let (port, mut rx) = client.bind_handler_port::<u64>();
+        let dest = port.bind().port_addr().clone();
+
+        gateway.post(
+            MessageEnvelope::serialize(
+                test_actor_id("test", "sender"),
+                dest,
+                &42u64,
+                Flattrs::new(),
+            )
+            .unwrap(),
+            monitored_return_handle(),
+        );
+
+        let received = time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("rx timed out")
+            .expect("rx closed");
+        assert_eq!(received, 42);
     }
 }

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -409,6 +409,8 @@ mod tests {
     use crate::port::Port;
     use crate::proc::Proc;
     use crate::testing::ids::test_actor_id;
+    use crate::testing::pingpong::PingPongActor;
+    use crate::testing::pingpong::PingPongMessage;
 
     /// `Gateway::post_unchecked` demuxes inbound envelopes by
     /// destination `ProcId` to the matching attached proc's muxer,
@@ -507,6 +509,68 @@ mod tests {
                 .await
                 .is_err(),
             "beta_rx received a message after stranger post",
+        );
+    }
+
+    /// Ping-pong between two `PingPongActor`s on two procs that share
+    /// one served gateway. Each cross-proc hop goes out via the
+    /// gateway's forwarder (`DialMailboxRouter`) and comes back in
+    /// via the gateway's demux.
+    #[tokio::test]
+    async fn test_ping_pong_across_shared_gateway() {
+        let gateway = Gateway::new();
+
+        let alpha = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let beta = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("beta")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        // Serve the gateway on its reserved local address
+        // (first-serve rule). Outbound from one proc to the other
+        // goes Proc::post_unchecked → forwarder (DialMailboxRouter) →
+        // dial the served address → gateway's channel server →
+        // Gateway::post_unchecked demux → destination proc's muxer.
+        let _serve = Gateway::serve(&gateway, ChannelAddr::any(ChannelTransport::Local)).unwrap();
+
+        let (client, _) = alpha.instance("client").unwrap();
+        let (undeliverable_msg_tx, mut undeliverable_rx) =
+            client.open_port::<Undeliverable<MessageEnvelope>>();
+
+        let ping_actor = PingPongActor::new(Some(undeliverable_msg_tx.bind()), None, None);
+        let pong_actor = PingPongActor::new(Some(undeliverable_msg_tx.bind()), None, None);
+        let ping_handle = alpha.spawn::<PingPongActor>("ping", ping_actor).unwrap();
+        let pong_handle = beta.spawn::<PingPongActor>("pong", pong_actor).unwrap();
+
+        let (local_port, local_receiver) = client.open_once_port();
+
+        ping_handle
+            .send(
+                &client,
+                PingPongMessage(10, pong_handle.bind(), local_port.bind()),
+            )
+            .unwrap();
+
+        let received = time::timeout(Duration::from_secs(5), local_receiver.recv())
+            .await
+            .expect("local_receiver timed out")
+            .expect("ping pong did not complete");
+        assert!(received);
+
+        // Every hop should have made it through dial+demux+delivery.
+        // An undeliverable here would indicate a dial failure, a
+        // misroute by the gateway's demux, or a missing attached
+        // proc.
+        assert!(
+            time::timeout(Duration::from_millis(50), undeliverable_rx.recv())
+                .await
+                .is_err(),
+            "unexpected undeliverable during cross-proc ping-pong",
         );
     }
 }

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -648,4 +648,31 @@ mod tests {
             assert!(procs.get(&proc_id).is_none());
         }
     }
+
+    /// `Gateway::attach` panics when a second proc with the same
+    /// `ProcId` is built against the same gateway while the first is
+    /// still alive. The check is in `Gateway::attach`, invoked from
+    /// `Proc::builder().build()` via `Proc::from_parts_unchecked`.
+    #[test]
+    #[should_panic(expected = "gateway already has a live proc")]
+    fn test_gateway_attach_panics_on_duplicate_live_proc() {
+        let gateway = Gateway::isolated();
+        let proc_id = ProcId::instance(Label::strip("alpha"));
+
+        // Hold the first proc in a binding so it stays alive across
+        // the second build; if the first were dropped, the gateway's
+        // stale-entry path would silently replace it instead of
+        // panicking.
+        let _first = Proc::builder()
+            .proc_id(proc_id.clone())
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+
+        let _second = Proc::builder()
+            .proc_id(proc_id)
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+    }
 }

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -573,4 +573,79 @@ mod tests {
             "unexpected undeliverable during cross-proc ping-pong",
         );
     }
+
+    /// `Gateway::post_unchecked` removes stale `WeakProc` entries
+    /// lazily on the post path. Dropping a proc leaves a dead
+    /// `WeakProc` in the gateway's `procs` map; the next post to that
+    /// proc's id falls through to the forwarder and removes the stale
+    /// entry.
+    #[tokio::test]
+    async fn test_gateway_post_removes_stale_weak_procs() {
+        #[derive(Clone)]
+        struct CountingSender(Arc<AtomicUsize>);
+
+        #[async_trait]
+        impl MailboxSender for CountingSender {
+            fn post_unchecked(
+                &self,
+                _envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let forwarded = Arc::new(AtomicUsize::new(0));
+        let gateway = Gateway::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(CountingSender(forwarded.clone())),
+        );
+
+        let proc = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("alpha")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let proc_id = proc.proc_id().clone();
+        let dest = proc
+            .proc_addr()
+            .actor_addr("worker")
+            .port_addr(Port::from(0u64));
+
+        // Sanity: proc is attached.
+        assert_eq!(gateway.inner.procs.read().unwrap().len(), 1);
+
+        drop(proc);
+
+        // The entry is still present, but it is now a *stale* WeakProc:
+        // upgrade must fail.
+        {
+            let procs = gateway.inner.procs.read().unwrap();
+            assert_eq!(procs.len(), 1);
+            assert!(
+                procs.get(&proc_id).and_then(WeakProc::upgrade).is_none(),
+                "expected dropped proc to remain only as a stale WeakProc entry",
+            );
+        }
+
+        gateway.post(
+            MessageEnvelope::serialize(
+                test_actor_id("sender", "client"),
+                dest,
+                &42u64,
+                Flattrs::new(),
+            )
+            .unwrap(),
+            monitored_return_handle(),
+        );
+
+        // Envelope fell through to the forwarder; stale entry
+        // removed.
+        assert_eq!(forwarded.load(Ordering::SeqCst), 1);
+        {
+            let procs = gateway.inner.procs.read().unwrap();
+            assert_eq!(procs.len(), 0);
+            assert!(procs.get(&proc_id).is_none());
+        }
+    }
 }


### PR DESCRIPTION
Summary:

add test_gateway_attach_silently_replaces_dead_entry to gateway.rs. builds a proc with some ProcId, drops it, verifies the stale WeakProc entry remains in the gateway's procs map, then builds a second proc with the same ProcId. asserts the dead entry is silently replaced (no panic, map still has one entry) and the new proc is reachable via gateway.post(...).

Differential Revision: D105358655
