### PR TITLE
[hyperactor] add generic send endpoint traits

### DIFF
--- a/hyperactor/src/endpoint.rs
+++ b/hyperactor/src/endpoint.rs
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Generic send endpoints.
+
+use hyperactor_config::Flattrs;
+
+use crate::Actor;
+use crate::ActorHandle;
+use crate::ActorRef;
+use crate::Handler;
+use crate::Message;
+use crate::OncePortHandle;
+use crate::OncePortRef;
+use crate::PortHandle;
+use crate::PortRef;
+use crate::RemoteHandles;
+use crate::RemoteMessage;
+use crate::actor::Referable;
+use crate::context;
+use crate::mailbox::MailboxSenderError;
+
+/// A typed endpoint that can receive `M`.
+///
+/// This trait abstracts over local actor handles, local port handles, remote
+/// actor refs, remote port refs, and one-shot ports. It is sealed so that
+/// Hyperactor owns the send semantics for each endpoint kind.
+pub trait Endpoint<M>: crate::private::Sealed {
+    /// Send `message` to this endpoint from `cx`.
+    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor;
+}
+
+/// A typed endpoint that can receive `M` with message headers.
+///
+/// `RemoteEndpoint` is implemented only for endpoints whose send path preserves
+/// headers.
+pub trait RemoteEndpoint<M>: Endpoint<M> {
+    /// Send `message` and `headers` to this endpoint from `cx`.
+    fn send_with_headers<C>(
+        self,
+        cx: &C,
+        headers: Flattrs,
+        message: M,
+    ) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor;
+}
+
+impl<A, M> Endpoint<M> for &ActorHandle<A>
+where
+    A: Actor + Handler<M>,
+    M: Message,
+{
+    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        ActorHandle::send(self, cx, message)
+    }
+}
+
+impl<M> Endpoint<M> for &PortHandle<M>
+where
+    M: Message,
+{
+    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        PortHandle::send(self, cx, message)
+    }
+}
+
+impl<M> Endpoint<M> for OncePortHandle<M>
+where
+    M: Message,
+{
+    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        OncePortHandle::send(self, cx, message)
+    }
+}
+
+impl<A, M> Endpoint<M> for &ActorRef<A>
+where
+    A: Referable + RemoteHandles<M>,
+    M: RemoteMessage,
+{
+    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        ActorRef::send(self, cx, message)
+    }
+}
+
+impl<A, M> RemoteEndpoint<M> for &ActorRef<A>
+where
+    A: Referable + RemoteHandles<M>,
+    M: RemoteMessage,
+{
+    fn send_with_headers<C>(
+        self,
+        cx: &C,
+        headers: Flattrs,
+        message: M,
+    ) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        ActorRef::send_with_headers(self, cx, headers, message)
+    }
+}
+
+impl<M> Endpoint<M> for &PortRef<M>
+where
+    M: RemoteMessage,
+{
+    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        PortRef::send(self, cx, message)
+    }
+}
+
+impl<M> RemoteEndpoint<M> for &PortRef<M>
+where
+    M: RemoteMessage,
+{
+    fn send_with_headers<C>(
+        self,
+        cx: &C,
+        headers: Flattrs,
+        message: M,
+    ) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        PortRef::send_with_headers(self, cx, headers, message)
+    }
+}
+
+impl<M> Endpoint<M> for OncePortRef<M>
+where
+    M: RemoteMessage,
+{
+    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        OncePortRef::send(self, cx, message)
+    }
+}
+
+impl<M> RemoteEndpoint<M> for OncePortRef<M>
+where
+    M: RemoteMessage,
+{
+    fn send_with_headers<C>(
+        self,
+        cx: &C,
+        headers: Flattrs,
+        message: M,
+    ) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+    {
+        OncePortRef::send_with_headers(self, cx, headers, message)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use async_trait::async_trait;
+    use hyperactor_config::Flattrs;
+    use hyperactor_config::declare_attrs;
+    use tokio::sync::mpsc;
+    use typeuri::Named;
+
+    use super::*;
+    use crate::actor::Referable;
+    use crate::actor::RemoteHandles;
+    use crate::proc::Context;
+    use crate::proc::Proc;
+
+    declare_attrs! {
+        attr ENDPOINT_TEST_HEADER: u64;
+    }
+
+    #[derive(Debug)]
+    struct EchoActor {
+        tx: PortRef<u64>,
+    }
+
+    #[async_trait]
+    impl Actor for EchoActor {}
+
+    #[async_trait]
+    impl Handler<u64> for EchoActor {
+        async fn handle(&mut self, cx: &Context<Self>, message: u64) -> anyhow::Result<()> {
+            Endpoint::send(&self.tx, cx, message)?;
+            Ok(())
+        }
+    }
+
+    struct TestBehavior;
+
+    impl Named for TestBehavior {
+        fn typename() -> &'static str {
+            "hyperactor::endpoint::tests::TestBehavior"
+        }
+    }
+
+    impl Referable for TestBehavior {}
+    impl RemoteHandles<u64> for TestBehavior {}
+
+    #[tokio::test]
+    async fn test_endpoint_actor_handle() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (tx, mut rx) = client.open_port();
+        let handle = proc
+            .spawn("echo", EchoActor { tx: tx.bind() })
+            .expect("spawn should succeed");
+
+        Endpoint::send(&handle, &client, 123u64).expect("send to actor handle should succeed");
+
+        assert_eq!(rx.recv().await.expect("message should arrive"), 123);
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_port_handle() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (tx, mut rx) = client.open_port();
+
+        Endpoint::send(&tx, &client, 123u64).expect("send to port handle should succeed");
+
+        assert_eq!(rx.recv().await.expect("message should arrive"), 123);
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_once_port_handle() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (tx, rx) = client.open_once_port();
+
+        Endpoint::send(tx, &client, 123u64).expect("send to once port handle should succeed");
+
+        assert_eq!(rx.recv().await.expect("message should arrive"), 123);
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_actor_ref() {
+        let proc = Proc::isolated();
+        let (client, actor_ref, mut rx) = proc
+            .attach_actor::<TestBehavior, u64>("remote_actor")
+            .expect("attach actor should succeed");
+
+        Endpoint::send(&actor_ref, &client, 123u64).expect("send to actor ref should succeed");
+
+        assert_eq!(rx.recv().await.expect("message should arrive"), 123);
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_port_ref() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (tx, mut rx) = client.open_port();
+        let port_ref = tx.bind();
+
+        Endpoint::send(&port_ref, &client, 123u64).expect("send to port ref should succeed");
+
+        assert_eq!(rx.recv().await.expect("message should arrive"), 123);
+    }
+
+    #[tokio::test]
+    async fn test_endpoint_once_port_ref() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (tx, rx) = client.open_once_port();
+        let port_ref = tx.bind();
+
+        Endpoint::send(port_ref, &client, 123u64).expect("send to once port ref should succeed");
+
+        assert_eq!(rx.recv().await.expect("message should arrive"), 123);
+    }
+
+    #[tokio::test]
+    async fn test_remote_endpoint_headers() {
+        let proc = Proc::isolated();
+        let (client, _) = proc.instance("client").unwrap();
+        let (observed_tx, mut observed_rx) = mpsc::unbounded_channel();
+        let port = client.mailbox_for_py().open_handler_enqueue_port(
+            move |headers: Flattrs, message: u64| {
+                observed_tx
+                    .send((
+                        headers
+                            .get(ENDPOINT_TEST_HEADER)
+                            .expect("header should be present"),
+                        message,
+                    ))
+                    .expect("test receiver should be alive");
+                Ok(())
+            },
+        );
+        let port_ref = port.bind();
+        let mut headers = Flattrs::new();
+        headers.set(ENDPOINT_TEST_HEADER, 456u64);
+
+        RemoteEndpoint::send_with_headers(&port_ref, &client, headers, 123u64)
+            .expect("send with headers should succeed");
+
+        assert_eq!(
+            observed_rx.recv().await.expect("message should arrive"),
+            (456, 123)
+        );
+    }
+}

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -66,6 +66,7 @@ pub mod addr;
 pub mod channel;
 pub mod config;
 pub mod context;
+pub mod endpoint;
 /// Gateway management for proc connectivity.
 pub mod gateway;
 pub mod id;
@@ -121,6 +122,8 @@ pub use addr::AddrParseError;
 pub use addr::Location;
 pub use addr::PortAddr;
 pub use addr::ProcAddr;
+pub use endpoint::Endpoint;
+pub use endpoint::RemoteEndpoint;
 pub use gateway::Gateway;
 #[doc(inline)]
 pub use hyperactor_macros::Bind;
@@ -216,4 +219,10 @@ mod private {
     impl<A: crate::Actor> Sealed for &crate::proc::Context<'_, A> {}
     impl Sealed for crate::mailbox::Mailbox {}
     impl Sealed for &crate::mailbox::Mailbox {}
+    impl<A: crate::Actor> Sealed for &crate::actor::ActorHandle<A> {}
+    impl<M: crate::Message> Sealed for &crate::mailbox::PortHandle<M> {}
+    impl<M: crate::Message> Sealed for crate::mailbox::OncePortHandle<M> {}
+    impl<A: crate::actor::Referable> Sealed for &crate::ref_::ActorRef<A> {}
+    impl<M: crate::RemoteMessage> Sealed for &crate::ref_::PortRef<M> {}
+    impl<M: crate::RemoteMessage> Sealed for crate::ref_::OncePortRef<M> {}
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3920
* #3919
* #3918
* #3917
* #3916
* __->__ #3915

Add sealed `Endpoint<M>` and `RemoteEndpoint<M>` traits in a new `hyperactor::endpoint` module. Implement the traits for actor handles, port handles, actor refs, port refs, and one-shot endpoints while preserving the existing `MailboxSenderError` return behavior for this first migration stage. Re-export the new traits from the crate root and add focused tests for each endpoint shape and remote header preservation.

This sets the stage for removing the scattered `send` APIs throughout (handle, ref) x (actor, port), and replacing them with a single, consistent send API.

Because it is now backed by a trait, we can generalize over endpoints, without worrying about whether they are handlers, refs, actors, or ports.

Differential Revision: [D105068908](https://our.internmc.facebook.com/intern/diff/D105068908/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105068908/)!