### PR TITLE
[hyperactor] report send failures through undeliverables

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -35,6 +35,7 @@ use crate as hyperactor; // for macros
 use crate::ActorAddr;
 use crate::ActorRef;
 use crate::Data;
+use crate::EndpointLocation;
 use crate::Message;
 use crate::RemoteMessage;
 use crate::context;
@@ -206,11 +207,18 @@ pub trait Actor: Sized + Send + 'static {
 /// [`Actor::handle_undeliverable_message`] can fallback to this default.
 pub fn handle_undeliverable_message<A: Actor>(
     cx: &Instance<A>,
-    Undeliverable(envelope): Undeliverable<MessageEnvelope>,
+    undeliverable: Undeliverable<MessageEnvelope>,
 ) -> Result<(), anyhow::Error> {
-    assert_eq!(envelope.sender(), cx.self_addr());
-
-    anyhow::bail!(UndeliverableMessageError::DeliveryFailure { envelope });
+    match undeliverable {
+        Undeliverable::Message(envelope) => {
+            assert_eq!(envelope.sender(), cx.self_addr());
+            anyhow::bail!(UndeliverableMessageError::DeliveryFailure { envelope });
+        }
+        Undeliverable::Lost(lost) => {
+            assert_eq!(&lost.sender, cx.self_addr());
+            anyhow::bail!(UndeliverableMessageError::Lost { lost });
+        }
+    }
 }
 
 /// An actor that does nothing. It is used to represent "client only" actors,
@@ -269,9 +277,18 @@ impl<A: Actor> Handler<Undeliverable<MessageEnvelope>> for A {
         cx: &Context<Self>,
         message: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
-        let sender = message.0.sender().clone();
-        let dest = message.0.dest().clone();
-        let error = message.0.error_msg().unwrap_or(String::new());
+        let (sender, dest, error) = match &message {
+            Undeliverable::Message(envelope) => (
+                envelope.sender().to_string(),
+                envelope.dest().to_string(),
+                envelope.error_msg().unwrap_or(String::new()),
+            ),
+            Undeliverable::Lost(lost) => (
+                lost.sender.to_string(),
+                lost.dest.to_string(),
+                lost.error.clone(),
+            ),
+        };
         match self.handle_undeliverable_message(cx, message).await {
             Ok(_) => {
                 tracing::debug!(
@@ -876,6 +893,10 @@ where
     A: Actor + Handler<M>,
     M: Message,
 {
+    fn endpoint_location(&self) -> EndpointLocation {
+        EndpointLocation::Actor(self.actor_addr().clone())
+    }
+
     fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,

--- a/hyperactor/src/endpoint.rs
+++ b/hyperactor/src/endpoint.rs
@@ -8,10 +8,69 @@
 
 //! Generic send endpoints.
 
-use hyperactor_config::Flattrs;
+use std::fmt;
 
+use hyperactor_config::Flattrs;
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::ActorAddr;
+use crate::PortAddr;
 use crate::context;
 use crate::mailbox::MailboxSenderError;
+use crate::mailbox::PortLocation;
+
+/// The logical location of an endpoint.
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, typeuri::Named)]
+pub enum EndpointLocation {
+    /// An actor endpoint.
+    Actor(ActorAddr),
+    /// A port endpoint.
+    Port(PortAddr),
+    /// A local port handle that has not been bound to a routable port.
+    Local {
+        /// The actor that owns the local endpoint.
+        actor: ActorAddr,
+        /// The local endpoint's message type.
+        message_type: String,
+    },
+}
+
+impl EndpointLocation {
+    /// The actor address associated with this endpoint location.
+    pub fn actor_addr(&self) -> ActorAddr {
+        match self {
+            Self::Actor(actor) => actor.clone(),
+            Self::Port(port) => port.actor_addr(),
+            Self::Local { actor, .. } => actor.clone(),
+        }
+    }
+}
+
+impl From<PortLocation> for EndpointLocation {
+    fn from(location: PortLocation) -> Self {
+        match location {
+            PortLocation::Bound(port) => Self::Port(port),
+            PortLocation::Unbound(actor, message_type) => Self::Local {
+                actor,
+                message_type: message_type.to_string(),
+            },
+        }
+    }
+}
+
+impl fmt::Display for EndpointLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Actor(actor) => write!(f, "{}", actor),
+            Self::Port(port) => write!(f, "{}", port),
+            Self::Local {
+                actor,
+                message_type,
+            } => write!(f, "{}<{}>", actor, message_type),
+        }
+    }
+}
 
 /// A typed endpoint that can receive `M`.
 ///
@@ -19,6 +78,9 @@ use crate::mailbox::MailboxSenderError;
 /// actor refs, remote port refs, and one-shot ports. It is sealed so that
 /// Hyperactor owns the send semantics for each endpoint kind.
 pub trait Endpoint<M>: crate::private::Sealed {
+    /// The logical location of this endpoint.
+    fn endpoint_location(&self) -> EndpointLocation;
+
     /// Send `message` to this endpoint from `cx`.
     fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
     where

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -123,6 +123,7 @@ pub use addr::Location;
 pub use addr::PortAddr;
 pub use addr::ProcAddr;
 pub use endpoint::Endpoint;
+pub use endpoint::EndpointLocation;
 pub use endpoint::RemoteEndpoint;
 pub use gateway::Gateway;
 #[doc(inline)]

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -142,6 +142,7 @@ use typeuri::Named;
 use crate::ActorAddr;
 use crate::Addr;
 use crate::Endpoint;
+use crate::EndpointLocation;
 // for macros
 use crate::OncePortRef;
 use crate::PortAddr;
@@ -170,6 +171,7 @@ use crate::port::Port;
 
 mod undeliverable;
 /// For [`Undeliverable`], a message type for delivery failures.
+pub use undeliverable::LostMessage;
 pub use undeliverable::Undeliverable;
 pub use undeliverable::UndeliverableMessageError;
 pub use undeliverable::custom_monitored_return_handle;
@@ -1074,8 +1076,8 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                 .build()
                 .expect("mailbox server proc builder is valid");
             let (client, _) = proc.instance("undeliverable_supervisor").unwrap();
-            while let Ok(Undeliverable(mut envelope)) = undeliverable_rx.recv().await {
-                if let Ok(Undeliverable(e)) =
+            while let Ok(Undeliverable::Message(mut envelope)) = undeliverable_rx.recv().await {
+                if let Ok(Undeliverable::Message(e)) =
                     envelope.deserialized::<Undeliverable<MessageEnvelope>>()
                 {
                     // A non-returnable undeliverable.
@@ -1091,7 +1093,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                 return_port.post_serialized(
                     &client,
                     Flattrs::new(),
-                    wirevalue::Any::serialize(&Undeliverable(envelope)).unwrap(),
+                    wirevalue::Any::serialize(&Undeliverable::Message(envelope)).unwrap(),
                 );
             }
         });
@@ -1997,6 +1999,10 @@ impl<M> Endpoint<M> for &PortHandle<M>
 where
     M: Message,
 {
+    fn endpoint_location(&self) -> EndpointLocation {
+        self.location().into()
+    }
+
     fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,
@@ -2008,10 +2014,17 @@ where
                 actor_id: self.inner.mailbox.actor_addr().clone(),
                 kind: MailboxErrorKind::OwnerTerminated(status.clone()),
             };
-            return Err(MailboxSenderError::new_unbound::<M>(
+            let err = MailboxSenderError::new_unbound::<M>(
                 self.inner.mailbox.actor_addr().clone(),
                 MailboxSenderErrorKind::Mailbox(err),
-            ));
+            );
+            cx.instance()
+                .report_lost_message(LostMessage::from_send_error::<M>(
+                    cx.mailbox().actor_addr().clone(),
+                    self.endpoint_location(),
+                    &err,
+                ));
+            return Ok(());
         }
         let mut headers = Flattrs::new();
 
@@ -2044,12 +2057,20 @@ where
         //   2.  another thread is trying to bind and thus waiting for write lock.
         // But we do not expect `sender.send` to use the same PortHandle, so this
         // deadlock scenario should not happen.
-        self.inner.sender.send(headers, message).map_err(|err| {
+        if let Err(err) = self.inner.sender.send(headers, message).map_err(|err| {
             MailboxSenderError::new_unbound::<M>(
                 self.inner.mailbox.actor_addr().clone(),
                 classify_sender_error(err),
             )
-        })
+        }) {
+            cx.instance()
+                .report_lost_message(LostMessage::from_send_error::<M>(
+                    cx.mailbox().actor_addr().clone(),
+                    self.endpoint_location(),
+                    &err,
+                ));
+        }
+        Ok(())
     }
 }
 
@@ -2150,6 +2171,10 @@ impl<M> Endpoint<M> for OncePortHandle<M>
 where
     M: Message,
 {
+    fn endpoint_location(&self) -> EndpointLocation {
+        EndpointLocation::Port(self.port_id.clone())
+    }
+
     fn send<C>(self, _cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,
@@ -2164,13 +2189,21 @@ where
         );
 
         let actor_id = self.mailbox.actor_addr().clone();
-        self.sender.send(message).map_err(|_| {
+        let endpoint_location = self.endpoint_location();
+        if let Err(err) = self.sender.send(message).map_err(|_| {
             // Here, the value is returned when the port is
             // closed.  We should consider having a similar
             // API for send_once, though arguably it makes less
             // sense in this context.
             MailboxSenderError::new_unbound::<M>(actor_id, MailboxSenderErrorKind::Closed)
-        })?;
+        }) {
+            _cx.instance()
+                .report_lost_message(LostMessage::from_send_error::<M>(
+                    _cx.mailbox().actor_addr().clone(),
+                    endpoint_location,
+                    &err,
+                ));
+        }
         Ok(())
     }
 }
@@ -3371,11 +3404,14 @@ mod tests {
 
         mbox.post(envelope, return_handle);
 
-        let Undeliverable(undelivered) =
+        let Undeliverable::Message(undelivered) =
             tokio::time::timeout(Duration::from_secs(1), return_rx.recv())
                 .await
                 .expect("timed out waiting for undeliverable")
-                .expect("return port closed");
+                .expect("return port closed")
+        else {
+            panic!("expected returned message");
+        };
         assert!(
             undelivered
                 .error_msg()
@@ -3498,11 +3534,12 @@ mod tests {
             return_handle.clone(),
         );
 
-        let Undeliverable(envelope) =
-            tokio::time::timeout(Duration::from_secs(1), return_receiver.recv())
-                .await
-                .expect("undeliverable mismatch should arrive")
-                .unwrap();
+        let envelope = tokio::time::timeout(Duration::from_secs(1), return_receiver.recv())
+            .await
+            .expect("undeliverable mismatch should arrive")
+            .unwrap()
+            .into_message()
+            .expect("expected returned envelope");
         assert!(
             envelope
                 .error_msg()
@@ -3548,11 +3585,12 @@ mod tests {
         mbox.serialize_and_send(&port, 123u64, return_handle.clone())
             .unwrap();
 
-        let Undeliverable(envelope) =
-            tokio::time::timeout(Duration::from_secs(1), return_receiver.recv())
-                .await
-                .expect("closed port should produce undeliverable")
-                .unwrap();
+        let envelope = tokio::time::timeout(Duration::from_secs(1), return_receiver.recv())
+            .await
+            .expect("closed port should produce undeliverable")
+            .unwrap()
+            .into_message()
+            .expect("expected returned envelope");
         let first_error = envelope.error_msg().expect("expected delivery error");
         assert!(
             first_error.contains("port not bound in mailbox"),
@@ -3565,11 +3603,12 @@ mod tests {
 
         mbox.serialize_and_send(&port, 456u64, return_handle)
             .unwrap();
-        let Undeliverable(envelope) =
-            tokio::time::timeout(Duration::from_secs(1), return_receiver.recv())
-                .await
-                .expect("removed port should produce unbound undeliverable")
-                .unwrap();
+        let envelope = tokio::time::timeout(Duration::from_secs(1), return_receiver.recv())
+            .await
+            .expect("removed port should produce unbound undeliverable")
+            .unwrap()
+            .into_message()
+            .expect("expected returned envelope");
         let second_error = envelope.error_msg().expect("expected delivery error");
         assert_eq!(
             first_error, second_error,
@@ -3592,11 +3631,12 @@ mod tests {
             return_handle.clone(),
         );
 
-        let Undeliverable(envelope) =
-            tokio::time::timeout(Duration::from_secs(1), return_receiver.recv())
-                .await
-                .expect("once-port mismatch should arrive")
-                .unwrap();
+        let envelope = tokio::time::timeout(Duration::from_secs(1), return_receiver.recv())
+            .await
+            .expect("once-port mismatch should arrive")
+            .unwrap()
+            .into_message()
+            .expect("expected returned envelope");
         assert!(
             envelope
                 .error_msg()
@@ -3951,7 +3991,9 @@ mod tests {
             wirevalue::Any::serialize(&1u64).unwrap(),
             Flattrs::new(),
         );
-        return_handle.send(&client, Undeliverable(message)).unwrap();
+        return_handle
+            .send(&client, Undeliverable::Message(message))
+            .unwrap();
 
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
@@ -3995,7 +4037,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         return_handle
-            .send(&client, Undeliverable(envelope.clone()))
+            .send(&client, Undeliverable::Message(envelope.clone()))
             .unwrap();
         // Check we receive the undelivered message.
         assert!(
@@ -4006,7 +4048,7 @@ mod tests {
         // Setup a monitor for the receiver and show that if there are
         // no outstanding return handles it terminates.
         let monitor_handle = tokio::spawn(async move {
-            while let Ok(Undeliverable(mut envelope)) = return_receiver.recv().await {
+            while let Ok(Undeliverable::Message(mut envelope)) = return_receiver.recv().await {
                 envelope.set_error(DeliveryError::BrokenLink(
                     "returned in unit test".to_string(),
                 ));
@@ -4510,7 +4552,13 @@ mod tests {
 
         // Verify the undeliverable message has the correct destination
         let split_port_ref: PortAddr = split_port_id;
-        assert_eq!(undeliverable.0.dest(), &split_port_ref);
+        assert_eq!(
+            undeliverable
+                .into_message()
+                .expect("expected returned envelope")
+                .dest(),
+            &split_port_ref
+        );
 
         // Verify no additional messages arrived at the original receiver
         let msg = receiver.try_recv().unwrap();
@@ -4675,11 +4723,12 @@ mod tests {
         AsyncLoopForwarder.post(envelope, ret_port.clone());
 
         // We expect the undeliverable to come back once TTL expires.
-        let Undeliverable(undelivered) =
-            tokio::time::timeout(Duration::from_secs(5), ret_rx.recv())
-                .await
-                .expect("timed out waiting for undeliverable")
-                .expect("channel closed");
+        let undelivered = tokio::time::timeout(Duration::from_secs(5), ret_rx.recv())
+            .await
+            .expect("timed out waiting for undeliverable")
+            .expect("channel closed")
+            .into_message()
+            .expect("expected returned envelope");
 
         // Sanity: round-trip payload still deserializes.
         let got: u64 = undelivered.deserialized().expect("deserialize");
@@ -4808,7 +4857,11 @@ mod tests {
             .expect("timed out waiting for undeliverable")
             .expect("return port closed");
 
-        let err = undeliverable.0.error_msg().expect("expected error");
+        let err = undeliverable
+            .into_message()
+            .expect("expected returned envelope")
+            .error_msg()
+            .expect("expected error");
         assert!(
             err.contains(&format!("owner {} is stopped", actor_id)),
             "error should indicate actor stopped: {}",
@@ -4849,7 +4902,11 @@ mod tests {
             .expect("timed out waiting for undeliverable")
             .expect("return port closed");
 
-        let err = undeliverable.0.error_msg().expect("expected error");
+        let err = undeliverable
+            .into_message()
+            .expect("expected returned envelope")
+            .error_msg()
+            .expect("expected error");
         assert!(
             err.contains(&format!("owner {} failed", actor_id)),
             "error should indicate actor failed: {}",

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -48,17 +48,21 @@
 
 use std::sync::OnceLock;
 
+use enum_as_inner::EnumAsInner;
 use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 
+use crate::ActorAddr;
 use crate::ActorHandle;
+use crate::EndpointLocation;
 use crate::Instance;
 // for macros
 use crate::Message;
 use crate::Proc;
 use crate::mailbox::DeliveryError;
 use crate::mailbox::MailboxSender;
+use crate::mailbox::MailboxSenderError;
 use crate::mailbox::MessageEnvelope;
 use crate::mailbox::PortHandle;
 use crate::mailbox::PortReceiver;
@@ -67,15 +71,63 @@ use crate::mailbox::headers::OPERATION_ADVERB;
 use crate::mailbox::headers::OPERATION_ENDPOINT;
 use crate::mailbox::headers::RUST_MESSAGE_TYPE;
 
-/// An undeliverable `M`-typed message (in practice `M` is
-/// [MessageEnvelope]).
+/// Metadata for a message that could not be delivered and could not be
+/// returned.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, typeuri::Named)]
-pub struct Undeliverable<M: Message>(pub M);
+pub struct LostMessage {
+    /// The actor that attempted the send.
+    pub sender: ActorAddr,
+    /// The destination that rejected the message.
+    pub dest: EndpointLocation,
+    /// The message type, if known.
+    pub message_type: Option<String>,
+    /// The delivery failure.
+    pub error: String,
+}
+
+impl LostMessage {
+    /// Construct lost-message metadata from a local send error.
+    pub(crate) fn from_send_error<M: Message>(
+        sender: ActorAddr,
+        dest: EndpointLocation,
+        error: &MailboxSenderError,
+    ) -> Self {
+        Self {
+            sender,
+            dest,
+            message_type: Some(std::any::type_name::<M>().to_string()),
+            error: error.to_string(),
+        }
+    }
+}
+
+/// An undeliverable `M`-typed message.
+#[derive(
+    Debug,
+    EnumAsInner,
+    Serialize,
+    Deserialize,
+    Clone,
+    PartialEq,
+    typeuri::Named
+)]
+pub enum Undeliverable<M: Message> {
+    /// The message was returned intact.
+    Message(M),
+    /// The message was lost before it could be returned.
+    Lost(LostMessage),
+}
 
 impl<M: Message> Undeliverable<M> {
-    /// Return the inner M-typed message.
-    pub fn into_inner(self) -> M {
-        self.0
+    /// Construct an undeliverable message that preserves the original payload.
+    pub fn message(message: M) -> Self {
+        Self::Message(message)
+    }
+
+    /// Construct an undeliverable message that carries only lost-message
+    /// metadata.
+    pub fn lost(message: LostMessage) -> Self {
+        Self::Lost(message)
     }
 }
 
@@ -105,11 +157,25 @@ pub fn monitored_return_handle() -> PortHandle<Undeliverable<MessageEnvelope>> {
         // dropped and the task will never return.
         let (h, _) = new_undeliverable_port();
         crate::init::get_runtime().spawn(async move {
-            while let Ok(Undeliverable(mut envelope)) = rx.recv().await {
-                envelope.set_error(DeliveryError::BrokenLink(
-                    "message returned to undeliverable port".to_string(),
-                ));
-                super::UndeliverableMailboxSender.post(envelope, /*unused */ h.clone());
+            while let Ok(undeliverable) = rx.recv().await {
+                match undeliverable {
+                    Undeliverable::Message(mut envelope) => {
+                        envelope.set_error(DeliveryError::BrokenLink(
+                            "message returned to undeliverable port".to_string(),
+                        ));
+                        super::UndeliverableMailboxSender
+                            .post(envelope, /*unused */ h.clone());
+                    }
+                    Undeliverable::Lost(lost) => {
+                        tracing::error!(
+                            sender = %lost.sender,
+                            dest = %lost.dest,
+                            message_type = lost.message_type.as_deref().unwrap_or("unknown"),
+                            error = %lost.error,
+                            "lost message returned to undeliverable port"
+                        );
+                    }
+                }
             }
         });
         return_handle
@@ -126,11 +192,24 @@ pub fn custom_monitored_return_handle(caller: &str) -> PortHandle<Undeliverable<
     let caller = caller.to_owned();
     let (return_handle, mut rx) = new_undeliverable_port();
     tokio::task::spawn(async move {
-        while let Ok(Undeliverable(mut envelope)) = rx.recv().await {
-            envelope.set_error(DeliveryError::BrokenLink(
-                "message returned to undeliverable port".to_string(),
-            ));
-            tracing::error!("{caller} took back an undeliverable message: {}", envelope);
+        while let Ok(undeliverable) = rx.recv().await {
+            match undeliverable {
+                Undeliverable::Message(mut envelope) => {
+                    envelope.set_error(DeliveryError::BrokenLink(
+                        "message returned to undeliverable port".to_string(),
+                    ));
+                    tracing::error!("{caller} took back an undeliverable message: {}", envelope);
+                }
+                Undeliverable::Lost(lost) => {
+                    tracing::error!(
+                        sender = %lost.sender,
+                        dest = %lost.dest,
+                        message_type = lost.message_type.as_deref().unwrap_or("unknown"),
+                        error = %lost.error,
+                        "{caller} took back a lost message"
+                    );
+                }
+            }
         }
     });
     return_handle
@@ -148,7 +227,8 @@ pub(crate) fn return_undeliverable(
             .get_or_init(|| Proc::runtime().instance("global_return_client").unwrap())
             .0;
         let envelope_copy = envelope.clone();
-        if crate::Endpoint::send(&return_handle, client, Undeliverable(envelope)).is_err() {
+        if crate::Endpoint::send(&return_handle, client, Undeliverable::message(envelope)).is_err()
+        {
             UndeliverableMailboxSender.post(envelope_copy, /*unused*/ return_handle)
         }
     }
@@ -169,6 +249,12 @@ pub enum UndeliverableMessageError {
         /// The undelivered message.
         envelope: MessageEnvelope,
     },
+
+    /// A message was lost before it could be returned.
+    Lost {
+        /// The lost-message metadata.
+        lost: LostMessage,
+    },
 }
 
 /// Compute the top-line prefix for a bounced envelope (UE-3, UE-4).
@@ -183,6 +269,9 @@ fn undeliverable_prefix(error: &UndeliverableMessageError) -> String {
     let envelope = match error {
         UndeliverableMessageError::DeliveryFailure { envelope }
         | UndeliverableMessageError::ReturnFailure { envelope } => envelope,
+        UndeliverableMessageError::Lost { lost } => {
+            return format!("lost message to {}", lost.dest);
+        }
     };
     if let Some(endpoint) = envelope.headers().get(OPERATION_ENDPOINT) {
         let adverb = envelope
@@ -201,6 +290,7 @@ fn undeliverable_prefix(error: &UndeliverableMessageError) -> String {
                 envelope.sender()
             )
         }
+        UndeliverableMessageError::Lost { lost } => format!("lost message to {}", lost.dest),
     }
 }
 
@@ -225,6 +315,22 @@ impl std::fmt::Display for UndeliverableMessageError {
                 "original sender",
                 "original dest",
             ),
+            UndeliverableMessageError::Lost { lost } => {
+                writeln!(f, "{}:", undeliverable_prefix(self))?;
+                writeln!(
+                    f,
+                    "\tdescription: message was lost before it could be returned"
+                )?;
+                writeln!(f, "\tsender: {}", lost.sender)?;
+                writeln!(f, "\tdest: {}", lost.dest)?;
+                writeln!(
+                    f,
+                    "\tmessage type: {}",
+                    lost.message_type.as_deref().unwrap_or("unknown")
+                )?;
+                writeln!(f, "\terror: {}", lost.error)?;
+                return Ok(());
+            }
         };
 
         writeln!(f, "{}:", undeliverable_prefix(self))?;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2032,6 +2032,43 @@ impl<A: Actor> Instance<A> {
         self.inner.self_addr()
     }
 
+    /// Report a message that could not be delivered and could not be returned.
+    pub(crate) fn report_lost_message(&self, lost: crate::mailbox::LostMessage) {
+        static REPORT_LOST_WARNED_MAILBOXES: OnceLock<DashSet<ActorAddr>> = OnceLock::new();
+
+        let mailbox = &self.inner.mailbox;
+        let return_handle = mailbox.bound_return_handle().unwrap_or_else(|| {
+            let actor_id = mailbox.actor_addr();
+            if REPORT_LOST_WARNED_MAILBOXES
+                .get_or_init(DashSet::new)
+                .insert(actor_id.clone())
+            {
+                let bt = std::backtrace::Backtrace::force_capture();
+                tracing::warn!(
+                    actor_id = ?actor_id,
+                    backtrace = ?bt,
+                    "actor attempted to report a lost message without binding Undeliverable<MessageEnvelope>"
+                );
+            }
+            crate::mailbox::monitored_return_handle()
+        });
+
+        if let Err(error) = crate::Endpoint::send(
+            &return_handle,
+            self,
+            crate::mailbox::Undeliverable::lost(lost.clone()),
+        ) {
+            tracing::error!(
+                sender = %lost.sender,
+                dest = %lost.dest,
+                message_type = lost.message_type.as_deref().unwrap_or("unknown"),
+                error = %lost.error,
+                return_error = %error,
+                "lost message could not be reported"
+            );
+        }
+    }
+
     /// Snapshot of this actor's introspection payload.
     ///
     /// Returns an [`IntrospectResult`] built from live [`InstanceCell`]
@@ -4365,7 +4402,9 @@ mod tests {
             return_handle,
         );
 
-        let Undeliverable(envelope) = undeliverable_rx.recv().await.unwrap();
+        let Undeliverable::Message(envelope) = undeliverable_rx.recv().await.unwrap() else {
+            panic!("expected returned message");
+        };
         assert_eq!(envelope.dest(), &remote_dest);
     }
 

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -26,6 +26,7 @@ use crate::Actor;
 use crate::ActorAddr;
 use crate::ActorHandle;
 use crate::Endpoint;
+use crate::EndpointLocation;
 use crate::PortAddr;
 use crate::RemoteEndpoint;
 use crate::RemoteHandles;
@@ -35,6 +36,7 @@ use crate::accum::StreamingReducerOpts;
 use crate::actor::Referable;
 use crate::context;
 use crate::context::MailboxExt;
+use crate::mailbox::LostMessage;
 use crate::mailbox::MailboxSenderError;
 use crate::mailbox::MailboxSenderErrorKind;
 use crate::mailbox::PortSink;
@@ -97,6 +99,10 @@ where
     A: Referable + RemoteHandles<M>,
     M: RemoteMessage,
 {
+    fn endpoint_location(&self) -> EndpointLocation {
+        EndpointLocation::Actor(self.actor_addr.clone())
+    }
+
     fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,
@@ -343,6 +349,10 @@ impl<M> Endpoint<M> for &PortRef<M>
 where
     M: RemoteMessage,
 {
+    fn endpoint_location(&self) -> EndpointLocation {
+        EndpointLocation::Port(self.port_addr.clone())
+    }
+
     fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,
@@ -364,12 +374,23 @@ where
     where
         C: context::Actor,
     {
-        let serialized = wirevalue::Any::serialize(&message).map_err(|err| {
+        let serialized = match wirevalue::Any::serialize(&message).map_err(|err| {
             MailboxSenderError::new_bound(
                 self.port_addr.clone(),
                 MailboxSenderErrorKind::Serialize(err.into()),
             )
-        })?;
+        }) {
+            Ok(serialized) => serialized,
+            Err(err) => {
+                cx.instance()
+                    .report_lost_message(LostMessage::from_send_error::<M>(
+                        cx.mailbox().actor_addr().clone(),
+                        self.endpoint_location(),
+                        &err,
+                    ));
+                return Ok(());
+            }
+        };
         self.post_serialized(cx, headers, serialized);
         Ok(())
     }
@@ -530,6 +551,10 @@ impl<M> Endpoint<M> for OncePortRef<M>
 where
     M: RemoteMessage,
 {
+    fn endpoint_location(&self) -> EndpointLocation {
+        EndpointLocation::Port(self.port_addr.clone())
+    }
+
     fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,
@@ -552,12 +577,23 @@ where
         C: context::Actor,
     {
         crate::mailbox::headers::set_send_timestamp(&mut headers);
-        let serialized = wirevalue::Any::serialize(&message).map_err(|err| {
+        let serialized = match wirevalue::Any::serialize(&message).map_err(|err| {
             MailboxSenderError::new_bound(
                 self.port_addr.clone(),
                 MailboxSenderErrorKind::Serialize(err.into()),
             )
-        })?;
+        }) {
+            Ok(serialized) => serialized,
+            Err(err) => {
+                cx.instance()
+                    .report_lost_message(LostMessage::from_send_error::<M>(
+                        cx.mailbox().actor_addr().clone(),
+                        self.endpoint_location(),
+                        &err,
+                    ));
+                return Ok(());
+            }
+        };
         cx.post(
             self.port_addr.clone(),
             headers,

--- a/hyperactor/src/testing/pingpong.rs
+++ b/hyperactor/src/testing/pingpong.rs
@@ -95,10 +95,14 @@ impl Actor for PingPongActor {
     ) -> Result<(), anyhow::Error> {
         match &self.undeliverable_port_ref {
             Some(port) => port.send(cx, undelivered).unwrap(),
-            None => {
-                let Undeliverable(envelope) = undelivered;
-                anyhow::bail!(UndeliverableMessageError::DeliveryFailure { envelope });
-            }
+            None => match undelivered {
+                Undeliverable::Message(envelope) => {
+                    anyhow::bail!(UndeliverableMessageError::DeliveryFailure { envelope });
+                }
+                Undeliverable::Lost(lost) => {
+                    anyhow::bail!(UndeliverableMessageError::Lost { lost });
+                }
+            },
         }
 
         Ok(())

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1839,10 +1839,11 @@ mod tests {
             match tokio::time::timeout(std::time::Duration::from_secs(1), undeliverable_rx.recv())
                 .await
             {
-                Ok(Ok(Undeliverable(envelope))) => {
+                Ok(Ok(Undeliverable::Message(envelope))) => {
                     let _: PingPongMessage = envelope.deserialized().unwrap();
                     count += 1;
                 }
+                Ok(Ok(Undeliverable::Lost(_))) => break,
                 Ok(Err(_)) => break, // Channel closed
                 Err(_) => break,     // Timeout
             }

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -176,7 +176,13 @@ mod tests {
         );
         proc_dialer.post(envelope.clone(), return_handle.clone());
         assert_matches!(
-            &return_rx.recv().await.unwrap().into_inner().errors()[..],
+            &return_rx
+                .recv()
+                .await
+                .unwrap()
+                .into_message()
+                .expect("expected returned envelope")
+                .errors()[..],
             &[DeliveryError::BrokenLink(_)]
         );
 

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -74,13 +74,16 @@ declare_attrs! {
 pub fn update_undeliverable_envelope_for_casting(
     mut envelope: Undeliverable<MessageEnvelope>,
 ) -> Undeliverable<MessageEnvelope> {
-    let old_actor = envelope.0.sender().clone();
-    if let Some(actor_id) = envelope.0.headers().get(CAST_ORIGINATING_SENDER) {
+    let Some(message) = envelope.as_message_mut() else {
+        return envelope;
+    };
+    let old_actor = message.sender().clone();
+    if let Some(actor_id) = message.headers().get(CAST_ORIGINATING_SENDER) {
         tracing::debug!(
             actor_id = %old_actor,
             "remapped comm-actor id to id from CAST_ORIGINATING_SENDER {}", actor_id
         );
-        envelope.0.update_sender(actor_id);
+        message.update_sender(actor_id);
     }
     // Else do nothing, it wasn't from a comm actor.
     envelope

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -186,7 +186,12 @@ impl Actor for CommActor {
         cx: &Instance<Self>,
         undelivered: hyperactor::mailbox::Undeliverable<hyperactor::mailbox::MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
-        let Undeliverable(mut message_envelope) = undelivered;
+        let mut message_envelope = match undelivered {
+            Undeliverable::Message(message_envelope) => message_envelope,
+            Undeliverable::Lost(lost) => {
+                anyhow::bail!(UndeliverableMessageError::Lost { lost });
+            }
+        };
 
         // 1. Case delivery failure at a "forwarding" step.
         if let Ok(ForwardMessage { message, .. }) =
@@ -205,7 +210,7 @@ impl Actor for CommActor {
             message_envelope.set_header(CAST_ORIGINATING_SENDER, sender.clone());
 
             return_port
-                .send(cx, Undeliverable(message_envelope.clone()))
+                .send(cx, Undeliverable::Message(message_envelope.clone()))
                 .map_err(|err| {
                     let error = DeliveryError::BrokenLink(format!(
                         "error occured when returning ForwardMessage to the original \
@@ -231,7 +236,7 @@ impl Actor for CommActor {
                 return_port.port_addr(),
             )));
             return_port
-                .send(cx, Undeliverable(message_envelope.clone()))
+                .send(cx, Undeliverable::Message(message_envelope.clone()))
                 .map_err(|err| {
                     let error = DeliveryError::BrokenLink(format!(
                         "error occured when returning cast message to the origin \

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -268,8 +268,42 @@ impl Actor for GlobalClientActor {
     async fn handle_undeliverable_message(
         &mut self,
         cx: &Instance<Self>,
-        Undeliverable(mut env): Undeliverable<MessageEnvelope>,
+        undeliverable: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
+        let mut env = match undeliverable {
+            Undeliverable::Message(env) => env,
+            Undeliverable::Lost(lost) => {
+                let actor_ref = lost.sender.clone();
+                let event = ActorSupervisionEvent::new(
+                    actor_ref.clone(),
+                    None,
+                    ActorStatus::generic_failure(format!(
+                        "message not delivered to {}: {}",
+                        lost.dest, lost.error
+                    )),
+                    None,
+                );
+                match get_global_supervision_sink() {
+                    Some(sink) => {
+                        if let Err(e) = sink.send(cx, event) {
+                            tracing::warn!(
+                                %e,
+                                actor=%actor_ref,
+                                "failed to forward supervision event from lost message"
+                            );
+                        }
+                    }
+                    None => {
+                        tracing::warn!(
+                            actor=%actor_ref,
+                            error=%lost.error,
+                            "no supervision sink; lost message logged but not forwarded"
+                        );
+                    }
+                }
+                return Ok(());
+            }
+        };
         env.set_error(DeliveryError::BrokenLink(
             "message returned to global root client".to_string(),
         ));
@@ -545,7 +579,7 @@ mod tests {
         let undeliverable_port =
             PortRef::<Undeliverable<MessageEnvelope>>::attest_handler_port(&client_actor_id);
         undeliverable_port
-            .send(client, Undeliverable(env))
+            .send(client, Undeliverable::Message(env))
             .expect("inject_undeliverable: send failed");
     }
 

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -2254,7 +2254,14 @@ mod tests {
             .expect("timed out waiting for undeliverable")
             .expect("channel closed");
 
-        assert_eq!(undeliverable.0.dest().actor_id(), bogus_actor.id());
+        assert_eq!(
+            undeliverable
+                .into_message()
+                .expect("expected returned envelope")
+                .dest()
+                .actor_id(),
+            bogus_actor.id()
+        );
     }
 
     #[tokio::test]
@@ -2302,7 +2309,14 @@ mod tests {
             .expect("timed out waiting for undeliverable")
             .expect("channel closed");
 
-        assert_eq!(undeliverable.0.dest().actor_id(), bogus_actor.id());
+        assert_eq!(
+            undeliverable
+                .into_message()
+                .expect("expected returned envelope")
+                .dest()
+                .actor_id(),
+            bogus_actor.id()
+        );
     }
 
     #[tokio::test]

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -1054,14 +1054,23 @@ impl Actor for MeshAdminAgent {
     async fn handle_undeliverable_message(
         &mut self,
         _cx: &Instance<Self>,
-        hyperactor::mailbox::Undeliverable(envelope): hyperactor::mailbox::Undeliverable<
-            hyperactor::mailbox::MessageEnvelope,
-        >,
+        undeliverable: hyperactor::mailbox::Undeliverable<hyperactor::mailbox::MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
-        tracing::debug!(
-            "admin agent: undeliverable message to {} (port not bound?), ignoring",
-            envelope.dest(),
-        );
+        match undeliverable {
+            hyperactor::mailbox::Undeliverable::Message(envelope) => {
+                tracing::debug!(
+                    "admin agent: undeliverable message to {} (port not bound?), ignoring",
+                    envelope.dest(),
+                );
+            }
+            hyperactor::mailbox::Undeliverable::Lost(lost) => {
+                tracing::debug!(
+                    "admin agent: lost message to {} ({}), ignoring",
+                    lost.dest,
+                    lost.error,
+                );
+            }
+        }
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -787,12 +787,15 @@ where
         mut envelope: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
         envelope = update_undeliverable_envelope_for_casting(envelope);
-        if let Some(true) = envelope.0.headers().get(ACTOR_MESH_SUBSCRIBER_MESSAGE) {
+        let Some(returned) = envelope.as_message() else {
+            return handle_undeliverable_message(cx, envelope);
+        };
+        if let Some(true) = returned.headers().get(ACTOR_MESH_SUBSCRIBER_MESSAGE) {
             // Remove from the subscriber list (if it existed) so we don't
             // send to this subscriber again.
             // NOTE: The only part of the port that is used for equality checks is
             // the port id, so create a new one just for the comparison.
-            let dest_port_id = envelope.0.dest().clone();
+            let dest_port_id = returned.dest().clone();
             let port = hyperactor::PortRef::<Option<MeshFailure>>::attest(dest_port_id);
             let did_exist = self.health_state.subscribers.remove(&port);
             if did_exist {
@@ -804,14 +807,14 @@ where
                 );
             }
             Ok(())
-        } else if envelope.0.headers().get(CAST_ACTOR_MESH_ID).is_some() {
+        } else if returned.headers().get(CAST_ACTOR_MESH_ID).is_some() {
             // A cast message we sent (e.g. StreamState or KeepaliveGetState)
             // was returned by the CommActor because it could not be forwarded.
             // This is expected when the network session is broken. Log and
             // continue — the supervision polling loop will detect the failure.
             tracing::warn!(
                 actor_id = %cx.self_addr(),
-                dest = %envelope.0.dest(),
+                dest = %returned.dest(),
                 "ResourceController: ignoring undeliverable cast message",
             );
             Ok(())

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -676,8 +676,11 @@ impl Actor for ProcAgent {
         cx: &Instance<Self>,
         envelope: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
-        if let Some(true) = envelope.0.headers().get(STREAM_STATE_SUBSCRIBER) {
-            let dest_port_id: PortAddr = envelope.0.dest().clone();
+        let Some(returned) = envelope.as_message() else {
+            return handle_undeliverable_message(cx, envelope);
+        };
+        if let Some(true) = returned.headers().get(STREAM_STATE_SUBSCRIBER) {
+            let dest_port_id: PortAddr = returned.dest().clone();
             let port = PortRef::<resource::State<ActorState>>::attest(dest_port_id);
             // Remove this subscriber from whichever actor instance holds it.
             for instance in self.actor_states.values_mut() {

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -977,7 +977,7 @@ mod tests {
         .unwrap();
         worker
             .port::<Undeliverable<MessageEnvelope>>()
-            .send(&client, Undeliverable(envelope))
+            .send(&client, Undeliverable::Message(envelope))
             .unwrap();
 
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
@@ -1145,7 +1145,7 @@ mod tests {
         .unwrap();
         worker
             .port::<Undeliverable<MessageEnvelope>>()
-            .send(&inst, Undeliverable(envelope))
+            .send(&inst, Undeliverable::Message(envelope))
             .unwrap();
 
         // Under `Detach`, the worker clears its session and stops the

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -30,6 +30,7 @@ use hyperactor::actor::Signal;
 use hyperactor::context::Actor as ContextActor;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
+use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::IndexedErasedUnbound;
@@ -1027,23 +1028,32 @@ impl Actor for PythonActor {
         ins: &Instance<Self>,
         mut envelope: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
-        if envelope.0.sender() != ins.self_addr() {
+        if envelope
+            .as_message()
+            .is_some_and(|envelope| envelope.sender() != ins.self_addr())
+        {
             // This can happen if the sender is comm. Update the envelope.
             envelope = update_undeliverable_envelope_for_casting(envelope);
         }
+        let envelope = match envelope {
+            Undeliverable::Message(envelope) => envelope,
+            Undeliverable::Lost(lost) => {
+                return Err(UndeliverableMessageError::Lost { lost }.into());
+            }
+        };
         assert_eq!(
-            envelope.0.sender(),
+            envelope.sender(),
             ins.self_addr(),
             "undeliverable message was returned to the wrong actor. \
             Return address = {}, src actor = {}, dest handler port = {}, message type = {}, envelope headers = {}",
-            envelope.0.sender(),
+            envelope.sender(),
             ins.self_addr(),
-            envelope.0.dest(),
-            envelope.0.data().typename().unwrap_or("unknown"),
-            envelope.0.headers()
+            envelope.dest(),
+            envelope.data().typename().unwrap_or("unknown"),
+            envelope.headers()
         );
 
-        let cx = Context::new(ins, envelope.0.headers().clone());
+        let cx = Context::new(ins, envelope.headers().clone());
 
         let (envelope, handled) = monarch_with_gil(|py| {
             let py_cx = match &self.instance {
@@ -1063,7 +1073,7 @@ impl Actor for PythonActor {
             }
             .into_bound_py_any(py)?;
             let py_envelope = PythonUndeliverableMessageEnvelope {
-                inner: Some(envelope),
+                inner: Some(Undeliverable::Message(envelope)),
             }
             .into_bound_py_any(py)?;
             let handled = self

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -391,31 +391,42 @@ impl PythonUndeliverableMessageEnvelope {
 #[pymethods]
 impl PythonUndeliverableMessageEnvelope {
     fn __repr__(&self) -> PyResult<String> {
+        let inner = self.inner()?;
+        let Some(envelope) = inner.as_message() else {
+            return Ok("UndeliverableMessageEnvelope(lost)".to_string());
+        };
         Ok(format!(
             "UndeliverableMessageEnvelope(sender={}, dest={}, error={})",
-            self.inner()?.0.sender(),
-            self.inner()?.0.dest(),
+            envelope.sender(),
+            envelope.dest(),
             self.error_msg()?
         ))
     }
 
     fn sender(&self) -> PyResult<PyActorAddr> {
+        let envelope = self.inner()?.as_message().ok_or_else(|| {
+            PyErr::new::<PyRuntimeError, _>("lost undeliverable messages do not have an envelope")
+        })?;
         Ok(PyActorAddr {
-            inner: self.inner()?.0.sender().clone(),
+            inner: envelope.sender().clone(),
         })
     }
 
     fn dest(&self) -> PyResult<PyPortId> {
-        let port_id: hyperactor::PortAddr = self.inner()?.0.dest().clone();
+        let envelope = self.inner()?.as_message().ok_or_else(|| {
+            PyErr::new::<PyRuntimeError, _>("lost undeliverable messages do not have an envelope")
+        })?;
+        let port_id: hyperactor::PortAddr = envelope.dest().clone();
         Ok(port_id.into())
     }
 
     fn error_msg(&self) -> PyResult<String> {
-        Ok(self
-            .inner()?
-            .0
-            .error_msg()
-            .unwrap_or_else(|| "None".to_string()))
+        match self.inner()? {
+            Undeliverable::Message(envelope) => {
+                Ok(envelope.error_msg().unwrap_or_else(|| "None".to_string()))
+            }
+            Undeliverable::Lost(lost) => Ok(lost.error.clone()),
+        }
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1364,16 +1364,20 @@ where
     async fn handle_undeliverable_message(
         &mut self,
         this: &Instance<Self>,
-        Undeliverable(envelope): Undeliverable<MessageEnvelope>,
+        undeliverable: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
+        let error = match undeliverable {
+            Undeliverable::Message(envelope) => envelope.error_msg().unwrap_or_default(),
+            Undeliverable::Lost(lost) => lost.error,
+        };
         if self.terminal {
             tracing::warn!(
                 "undeliverable message after handshake terminated: {}",
-                envelope.error_msg().unwrap_or_default()
+                error
             );
             return Ok(());
         }
-        self.fail(this, envelope.error_msg().unwrap_or_default())
+        self.fail(this, error)
     }
 }
 
@@ -1854,7 +1858,7 @@ mod tests {
         )
         .unwrap();
         envelope.set_error(DeliveryError::Mailbox(error.into()));
-        Undeliverable(envelope)
+        Undeliverable::Message(envelope)
     }
 
     /// In an awaiting state, an undeliverable message returned to the


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3920
* #3919
* #3918
* __->__ #3917
* #3916
* #3915

Walkthrough:

Data type changes: `EndpointLocation` is the structured destination metadata for endpoint-shaped values. `Undeliverable<M>` is now an enum with `Message(M)` for returned payloads and `Lost(LostMessage)` for failures where only metadata can be reported. `LostMessage` records the sender, endpoint location, optional message type, and error. `Undeliverable<M>` derives `EnumAsInner`, so callers use the generated `as_message`, `as_message_mut`, `into_message`, and `into_lost` accessors.

API changes: `Endpoint<M>` now exposes `endpoint_location()` so send paths can report typed destination metadata without reverse-engineering it from an error string. This also adds crate-private `Instance::report_lost_message`, which sends lost-message metadata through the existing actor undeliverable handler path; callers reach it through `cx.instance()`. This is the plumbing needed for infallible send: endpoint implementations can report failures through the context's instance instead of requiring callers to interpret delivery errors directly. This diff keeps the current `Result` send signatures as an incremental step, while routing local endpoint failures and remote serialization failures into the undeliverable path.

Semantic implications: handlers of `Undeliverable<MessageEnvelope>` must now handle both returned envelopes and lost-message metadata. Remote/routed delivery failures still return envelopes when available; local non-envelope failures may produce `Lost` without recovering the original message, matching the current lack of payload recovery while centralizing failure reporting for the later infallible-send API flip.

Differential Revision: [D105267804](https://our.internmc.facebook.com/intern/diff/D105267804/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105267804/)!