### PR TITLE
[hyperactor] make endpoint sends infallible

### DIFF
--- a/hyperactor/example/stream.rs
+++ b/hyperactor/example/stream.rs
@@ -44,7 +44,7 @@ impl Handler<Subscribe> for CounterActor {
         let port: reference::PortRef<u64> = subscriber.0;
         self.subscribers.push(port);
         for port in &self.subscribers {
-            port.send(cx, self.n)?;
+            port.send(cx, self.n);
         }
         self.n += 1;
         Ok(())
@@ -67,7 +67,7 @@ impl Actor for CountClient {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         // Subscribe to the counter on initialization. We give it our u64 port to report
         // messages back to.
-        self.counter.send(this, Subscribe(this.port().bind()))?;
+        self.counter.send(this, Subscribe(this.port().bind()));
         Ok(())
     }
 }

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -897,7 +897,7 @@ where
         EndpointLocation::Actor(self.actor_addr().clone())
     }
 
-    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    fn send<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
@@ -1024,7 +1024,7 @@ mod tests {
     impl Handler<u64> for EchoActor {
         async fn handle(&mut self, cx: &Context<Self>, message: u64) -> Result<(), anyhow::Error> {
             let Self(port) = self;
-            port.send(cx, message)?;
+            port.send(cx, message);
             Ok(())
         }
     }
@@ -1036,7 +1036,7 @@ mod tests {
         let (tx, mut rx) = client.open_port();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo", actor).unwrap();
-        handle.send(&client, 123u64).unwrap();
+        handle.send(&client, 123u64);
         handle.drain_and_stop("test").unwrap();
         handle.await;
 
@@ -1056,12 +1056,10 @@ mod tests {
 
         let (local_port, local_receiver) = client.open_once_port();
 
-        ping_handle
-            .send(
-                &client,
-                PingPongMessage(10, pong_handle.bind(), local_port.bind()),
-            )
-            .unwrap();
+        ping_handle.send(
+            &client,
+            PingPongMessage(10, pong_handle.bind(), local_port.bind()),
+        );
 
         assert!(local_receiver.recv().await.unwrap());
     }
@@ -1087,16 +1085,14 @@ mod tests {
 
         let (local_port, local_receiver) = client.open_once_port();
 
-        ping_handle
-            .send(
-                &client,
-                PingPongMessage(
-                    error_ttl + 1, // will encounter an error at TTL=66
-                    pong_handle.bind(),
-                    local_port.bind(),
-                ),
-            )
-            .unwrap();
+        ping_handle.send(
+            &client,
+            PingPongMessage(
+                error_ttl + 1, // will encounter an error at TTL=66
+                pong_handle.bind(),
+                local_port.bind(),
+            ),
+        );
 
         // TODO: Fix this receiver hanging issue in T200423722.
         let res: Result<Result<bool, MailboxError>, tokio::time::error::Elapsed> =
@@ -1122,7 +1118,7 @@ mod tests {
             cx: &Context<Self>,
             port: OncePortHandle<bool>,
         ) -> Result<(), anyhow::Error> {
-            port.send(cx, self.0)?;
+            port.send(cx, self.0);
             Ok(())
         }
     }
@@ -1135,7 +1131,7 @@ mod tests {
         let (client, _) = proc.instance("client").unwrap();
 
         let (port, receiver) = client.open_once_port();
-        handle.send(&client, port).unwrap();
+        handle.send(&client, port);
         assert!(receiver.recv().await.unwrap());
 
         handle.drain_and_stop("test").unwrap();
@@ -1173,12 +1169,12 @@ mod tests {
             M: RemoteMessage,
             MultiActor: Handler<M>,
         {
-            self.handle.send(&self.client, message).unwrap()
+            self.handle.send(&self.client, message)
         }
 
         async fn sync(&self) {
             let (port, done) = self.client.open_once_port::<bool>();
-            self.handle.send(&self.client, port).unwrap();
+            self.handle.send(&self.client, port);
             assert!(done.recv().await.unwrap());
         }
 
@@ -1223,7 +1219,7 @@ mod tests {
             cx: &Context<Self>,
             message: OncePortHandle<bool>,
         ) -> Result<(), anyhow::Error> {
-            message.send(cx, true).unwrap();
+            message.send(cx, true);
             Ok(())
         }
     }
@@ -1239,11 +1235,11 @@ mod tests {
 
         let myref: ActorRef<MultiActor> = test.handle.bind();
 
-        myref.port().send(&test.client, 321u64).unwrap();
+        myref.port().send(&test.client, 321u64);
         test.sync().await;
         assert_eq!(test.get_values(), (321u64, "foo".to_string()));
 
-        myref.port().send(&test.client, "bar".to_string()).unwrap();
+        myref.port().send(&test.client, "bar".to_string());
         test.sync().await;
         assert_eq!(test.get_values(), (321u64, "bar".to_string()));
     }
@@ -1258,8 +1254,8 @@ mod tests {
         hyperactor::behavior!(MyActorBehavior, u64, String);
 
         let myref: ActorRef<MyActorBehavior> = test.handle.bind();
-        myref.port().send(&test.client, "biz".to_string()).unwrap();
-        myref.port().send(&test.client, 999u64).unwrap();
+        myref.port().send(&test.client, "biz".to_string());
+        myref.port().send(&test.client, 999u64);
 
         test.sync().await;
         assert_eq!(test.get_values(), (999u64, "biz".to_string()));
@@ -1303,7 +1299,7 @@ mod tests {
         ) -> Result<(), anyhow::Error> {
             let Self(port) = self;
             let seq_info = cx.headers().get(SEQ_INFO).unwrap();
-            port.send(cx, (message, seq_info.clone()))?;
+            port.send(cx, (message, seq_info.clone()));
             Ok(())
         }
     }
@@ -1324,7 +1320,7 @@ mod tests {
         ) -> Result<(), anyhow::Error> {
             let (handle, mut receiver) = cx.open_port::<String>();
             let callback_ref = handle.bind();
-            message.0.send(cx, callback_ref).unwrap();
+            message.0.send(cx, callback_ref);
             let msg = receiver.recv().await.unwrap();
             self.handle(cx, msg).await
         }
@@ -1339,7 +1335,7 @@ mod tests {
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
 
         // Verify that unbound handle can send message.
-        actor_handle.send(&client, "unbound".to_string()).unwrap();
+        actor_handle.send(&client, "unbound".to_string());
         assert_eq!(
             rx.recv().await.unwrap(),
             ("unbound".to_string(), SeqInfo::Direct)
@@ -1351,7 +1347,7 @@ mod tests {
         let mut expected_seq = 0;
         // Interleave messages sent through the handle and the reference.
         for m in 0..10 {
-            actor_handle.send(&client, format!("{m}")).unwrap();
+            actor_handle.send(&client, format!("{m}"));
             expected_seq += 1;
             assert_eq!(
                 rx.recv().await.unwrap(),
@@ -1365,7 +1361,7 @@ mod tests {
             );
 
             for n in 0..2 {
-                actor_ref.port().send(&client, format!("{m}-{n}")).unwrap();
+                actor_ref.port().send(&client, format!("{m}-{n}"));
                 expected_seq += 1;
                 assert_eq!(
                     rx.recv().await.unwrap(),
@@ -1418,42 +1414,42 @@ mod tests {
         let session_id = client.sequencer().session_id();
 
         // Send to handler ports via ActorHandle - seq 1
-        actor_handle.send(&client, "msg1".to_string()).unwrap();
+        actor_handle.send(&client, "msg1".to_string());
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
             SeqInfo::Session { session_id, seq: 1 }
         );
 
         // Send to handler ports via ActorRef - seq 2 (shared with ActorHandle)
-        actor_ref.port().send(&client, "msg2".to_string()).unwrap();
+        actor_ref.port().send(&client, "msg2".to_string());
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
             SeqInfo::Session { session_id, seq: 2 }
         );
 
         // Send to non-handler port - has its own sequence starting at 1
-        non_handler_port_handle.send(&client, ()).unwrap();
+        non_handler_port_handle.send(&client, ());
         assert_eq!(
             non_handler_rx.recv().await.unwrap(),
             Some(SeqInfo::Session { session_id, seq: 1 })
         );
 
         // Send more to handler ports via ActorHandle - seq continues at 3
-        actor_handle.send(&client, "msg3".to_string()).unwrap();
+        actor_handle.send(&client, "msg3".to_string());
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
             SeqInfo::Session { session_id, seq: 3 }
         );
 
         // Send more to non-handler port - its sequence continues at 2
-        non_handler_port_handle.send(&client, ()).unwrap();
+        non_handler_port_handle.send(&client, ());
         assert_eq!(
             non_handler_rx.recv().await.unwrap(),
             Some(SeqInfo::Session { session_id, seq: 2 })
         );
 
         // Send via ActorRef again - seq 4
-        actor_ref.port().send(&client, "msg4".to_string()).unwrap();
+        actor_ref.port().send(&client, "msg4".to_string());
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
             SeqInfo::Session { session_id, seq: 4 }
@@ -1482,7 +1478,7 @@ mod tests {
         assert_ne!(session_id_1, session_id_2);
 
         // Send from client1 via ActorHandle - seq 1 for session_id_1
-        actor_handle.send(&client1, "c1_msg1".to_string()).unwrap();
+        actor_handle.send(&client1, "c1_msg1".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1492,7 +1488,7 @@ mod tests {
         );
 
         // Send from client2 via ActorHandle - seq 1 for session_id_2 (independent)
-        actor_handle.send(&client2, "c2_msg1".to_string()).unwrap();
+        actor_handle.send(&client2, "c2_msg1".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1502,10 +1498,7 @@ mod tests {
         );
 
         // Send from client1 via ActorRef - seq 2 for session_id_1
-        actor_ref
-            .port()
-            .send(&client1, "c1_msg2".to_string())
-            .unwrap();
+        actor_ref.port().send(&client1, "c1_msg2".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1515,10 +1508,7 @@ mod tests {
         );
 
         // Send from client2 via ActorRef - seq 2 for session_id_2
-        actor_ref
-            .port()
-            .send(&client2, "c2_msg2".to_string())
-            .unwrap();
+        actor_ref.port().send(&client2, "c2_msg2".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1528,7 +1518,7 @@ mod tests {
         );
 
         // Interleave more messages to further verify independence
-        actor_handle.send(&client1, "c1_msg3".to_string()).unwrap();
+        actor_handle.send(&client1, "c1_msg3".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1537,10 +1527,7 @@ mod tests {
             }
         );
 
-        actor_ref
-            .port()
-            .send(&client2, "c2_msg3".to_string())
-            .unwrap();
+        actor_ref.port().send(&client2, "c2_msg3".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1587,13 +1574,11 @@ mod tests {
 
         let (callback_tx, mut callback_rx) = client.open_port();
         // Client sends the 1st message
-        actor_ref
-            .send(&client, Callback(callback_tx.bind()))
-            .unwrap();
+        actor_ref.send(&client, Callback(callback_tx.bind()));
         let msg_port_ref = callback_rx.recv().await.unwrap();
         // client sends the 2nd message. At this time, GetSeqActor is still
         // processing the 1st message, and waiting for the 2nd message.
-        msg_port_ref.send(&client, "finally".to_string()).unwrap();
+        msg_port_ref.send(&client, "finally".to_string());
 
         let session_id = client.sequencer().session_id();
         // passing this assert means GetSeqActor processed the 2nd message.
@@ -1682,7 +1667,7 @@ mod tests {
         let mut messages = expected.clone();
         messages.sort_by_key(|v| v.1);
         for (message, _seq) in messages {
-            actor_ref.send(&remote_client, message).unwrap();
+            actor_ref.send(&remote_client, message);
         }
         let session_id = remote_client.sequencer().session_id();
         for expect in expected {
@@ -1784,15 +1769,13 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_introspect", actor).unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
         let payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
@@ -1959,15 +1942,13 @@ mod tests {
 
         let child_ref = crate::Addr::Actor(test_proc_id("nonexistent").actor_addr("child"));
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr())
-            .send(
-                &client,
-                IntrospectMessage::QueryChild {
-                    child_ref,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr()).send(
+            &client,
+            IntrospectMessage::QueryChild {
+                child_ref,
+                reply: reply_port.bind(),
+            },
+        );
         let payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
@@ -2009,15 +1990,13 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
         let payload = reply_rx.recv().await.unwrap();
 
         // The runtime task returns actor attrs (with status), NOT
@@ -2050,15 +2029,13 @@ mod tests {
 
         // Query the child — supervisor should be the parent.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&child_handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&child_handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
         let child_payload = reply_rx.recv().await.unwrap();
 
         assert_eq!(
@@ -2086,8 +2063,7 @@ mod tests {
                     view: IntrospectView::Actor,
                     reply: reply_port.bind(),
                 },
-            )
-            .unwrap();
+            );
         let parent_payload = reply_rx.recv().await.unwrap();
 
         assert!(parent_payload.parent.is_none());
@@ -2125,15 +2101,13 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
         let payload = reply_rx.recv().await.unwrap();
 
         assert_status(&payload, "idle");
@@ -2156,19 +2130,17 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_after_msg", actor).unwrap();
 
         // Send a user message and wait for it to be processed.
-        handle.send(&client, 42u64).unwrap();
+        handle.send(&client, 42u64);
         let _ = rx.recv().await.unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
         let payload = reply_rx.recv().await.unwrap();
 
         assert_status(&payload, "idle");
@@ -2199,28 +2171,24 @@ mod tests {
 
         // First introspect query.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
         let payload1 = reply_rx.recv().await.unwrap();
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port2.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port2.bind(),
+            },
+        );
         let payload2 = reply_rx2.recv().await.unwrap();
 
         // Neither should show IntrospectMessage as the handler.
@@ -2376,22 +2344,20 @@ mod tests {
             .unwrap();
 
         // Send a u64 to wedge the actor in its handler.
-        handle.send(&client, 1u64).unwrap();
+        handle.send(&client, 1u64);
 
         // Wait for the handler to start blocking.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Send introspect query via the dedicated introspect port.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
 
         // Must not hang — the introspect task runs independently.
         let payload = tokio::time::timeout(Duration::from_secs(5), reply_rx.recv())
@@ -2423,33 +2389,29 @@ mod tests {
             .unwrap();
 
         // Send a user message and wait for it to be processed.
-        handle.send(&client, 42u64).unwrap();
+        handle.send(&client, 42u64);
         let _ = rx.recv().await.unwrap();
 
         // First introspect query.
         let (reply_port1, reply_rx1) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port1.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port1.bind(),
+            },
+        );
         let payload1 = reply_rx1.recv().await.unwrap();
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        crate::PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr())
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port2.bind(),
-                },
-            )
-            .unwrap();
+        crate::PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr()).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port2.bind(),
+            },
+        );
         let payload2 = reply_rx2.recv().await.unwrap();
 
         // Both should report the user message handler, not IntrospectMessage.
@@ -2478,15 +2440,13 @@ mod tests {
         let actor_id: crate::ActorAddr = handle.actor_addr().clone();
 
         let (reply_port, reply_rx) = bridge.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&actor_id)
-            .send(
-                &bridge,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&actor_id).send(
+            &bridge,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
         let payload = reply_rx.recv().await.unwrap();
 
         // CI-1: introspectable_instance reports status "client"
@@ -2517,15 +2477,13 @@ mod tests {
         let mailbox_id: crate::ActorAddr = mailbox_handle.actor_addr().clone();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&mailbox_id)
-            .send(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            )
-            .unwrap();
+        PortRef::<IntrospectMessage>::attest_handler_port(&mailbox_id).send(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
 
         // The introspect receiver was dropped in `instance()`, so the
         // message is silently discarded and the reply never arrives.

--- a/hyperactor/src/endpoint.rs
+++ b/hyperactor/src/endpoint.rs
@@ -17,7 +17,6 @@ use serde::Serialize;
 use crate::ActorAddr;
 use crate::PortAddr;
 use crate::context;
-use crate::mailbox::MailboxSenderError;
 use crate::mailbox::PortLocation;
 
 /// The logical location of an endpoint.
@@ -82,7 +81,7 @@ pub trait Endpoint<M>: crate::private::Sealed {
     fn endpoint_location(&self) -> EndpointLocation;
 
     /// Send `message` to this endpoint from `cx`.
-    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    fn send<C>(self, cx: &C, message: M)
     where
         C: context::Actor;
 }
@@ -93,12 +92,7 @@ pub trait Endpoint<M>: crate::private::Sealed {
 /// headers.
 pub trait RemoteEndpoint<M>: Endpoint<M> {
     /// Send `message` and `headers` to this endpoint from `cx`.
-    fn send_with_headers<C>(
-        self,
-        cx: &C,
-        headers: Flattrs,
-        message: M,
-    ) -> Result<(), MailboxSenderError>
+    fn send_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
     where
         C: context::Actor;
 }
@@ -135,7 +129,7 @@ mod tests {
     #[async_trait]
     impl Handler<u64> for EchoActor {
         async fn handle(&mut self, cx: &Context<Self>, message: u64) -> anyhow::Result<()> {
-            Endpoint::send(&self.tx, cx, message)?;
+            Endpoint::send(&self.tx, cx, message);
             Ok(())
         }
     }
@@ -160,7 +154,7 @@ mod tests {
             .spawn("echo", EchoActor { tx: tx.bind() })
             .expect("spawn should succeed");
 
-        Endpoint::send(&handle, &client, 123u64).expect("send to actor handle should succeed");
+        Endpoint::send(&handle, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -171,7 +165,7 @@ mod tests {
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
 
-        Endpoint::send(&tx, &client, 123u64).expect("send to port handle should succeed");
+        Endpoint::send(&tx, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -182,7 +176,7 @@ mod tests {
         let (client, _) = proc.instance("client").unwrap();
         let (tx, rx) = client.open_once_port();
 
-        Endpoint::send(tx, &client, 123u64).expect("send to once port handle should succeed");
+        Endpoint::send(tx, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -194,7 +188,7 @@ mod tests {
             .attach_actor::<TestBehavior, u64>("remote_actor")
             .expect("attach actor should succeed");
 
-        Endpoint::send(&actor_ref, &client, 123u64).expect("send to actor ref should succeed");
+        Endpoint::send(&actor_ref, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -206,7 +200,7 @@ mod tests {
         let (tx, mut rx) = client.open_port();
         let port_ref = tx.bind();
 
-        Endpoint::send(&port_ref, &client, 123u64).expect("send to port ref should succeed");
+        Endpoint::send(&port_ref, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -218,7 +212,7 @@ mod tests {
         let (tx, rx) = client.open_once_port();
         let port_ref = tx.bind();
 
-        Endpoint::send(port_ref, &client, 123u64).expect("send to once port ref should succeed");
+        Endpoint::send(port_ref, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -245,8 +239,7 @@ mod tests {
         let mut headers = Flattrs::new();
         headers.set(ENDPOINT_TEST_HEADER, 456u64);
 
-        RemoteEndpoint::send_with_headers(&port_ref, &client, headers, 123u64)
-            .expect("send with headers should succeed");
+        RemoteEndpoint::send_with_headers(&port_ref, &client, headers, 123u64);
 
         assert_eq!(
             observed_rx.recv().await.expect("message should arrive"),

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -26,7 +26,7 @@
 //! let mbox = Mailbox::new(actor_id);
 //! let (port, mut receiver) = mbox.open_port::<u64>();
 //!
-//! port.send(&client, 123).unwrap();
+//! port.send(&client, 123);
 //! assert_eq!(receiver.recv().await.unwrap(), 123u64);
 //! # })
 //! ```
@@ -46,7 +46,7 @@
 //!
 //! let (port, receiver) = mbox.open_once_port::<u64>();
 //!
-//! port.send(&client, 123u64).unwrap();
+//! port.send(&client, 123u64);
 //! assert_eq!(receiver.recv().await.unwrap(), 123u64);
 //! # })
 //! ```
@@ -1361,7 +1361,8 @@ impl<C: context::Actor, M: RemoteMessage> Sink<M> for PortSink<C, M> {
     }
 
     fn start_send(self: Pin<&mut Self>, item: M) -> Result<(), Self::Error> {
-        crate::Endpoint::send(&self.port, &self.cx, item)
+        crate::Endpoint::send(&self.port, &self.cx, item);
+        Ok(())
     }
 
     fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
@@ -1993,17 +1994,8 @@ impl<M: Message> PortHandle<M> {
             None => PortLocation::new_unbound::<M>(self.inner.mailbox.actor_addr().clone()),
         }
     }
-}
 
-impl<M> Endpoint<M> for &PortHandle<M>
-where
-    M: Message,
-{
-    fn endpoint_location(&self) -> EndpointLocation {
-        self.location().into()
-    }
-
-    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    pub(crate) fn try_send<C>(&self, cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,
     {
@@ -2014,17 +2006,10 @@ where
                 actor_id: self.inner.mailbox.actor_addr().clone(),
                 kind: MailboxErrorKind::OwnerTerminated(status.clone()),
             };
-            let err = MailboxSenderError::new_unbound::<M>(
+            return Err(MailboxSenderError::new_unbound::<M>(
                 self.inner.mailbox.actor_addr().clone(),
                 MailboxSenderErrorKind::Mailbox(err),
-            );
-            cx.instance()
-                .report_lost_message(LostMessage::from_send_error::<M>(
-                    cx.mailbox().actor_addr().clone(),
-                    self.endpoint_location(),
-                    &err,
-                ));
-            return Ok(());
+            ));
         }
         let mut headers = Flattrs::new();
 
@@ -2057,12 +2042,28 @@ where
         //   2.  another thread is trying to bind and thus waiting for write lock.
         // But we do not expect `sender.send` to use the same PortHandle, so this
         // deadlock scenario should not happen.
-        if let Err(err) = self.inner.sender.send(headers, message).map_err(|err| {
+        self.inner.sender.send(headers, message).map_err(|err| {
             MailboxSenderError::new_unbound::<M>(
                 self.inner.mailbox.actor_addr().clone(),
                 classify_sender_error(err),
             )
-        }) {
+        })
+    }
+}
+
+impl<M> Endpoint<M> for &PortHandle<M>
+where
+    M: Message,
+{
+    fn endpoint_location(&self) -> EndpointLocation {
+        self.location().into()
+    }
+
+    fn send<C>(self, cx: &C, message: M)
+    where
+        C: context::Actor,
+    {
+        if let Err(err) = self.try_send(cx, message) {
             cx.instance()
                 .report_lost_message(LostMessage::from_send_error::<M>(
                     cx.mailbox().actor_addr().clone(),
@@ -2070,7 +2071,6 @@ where
                     &err,
                 ));
         }
-        Ok(())
     }
 }
 
@@ -2175,7 +2175,7 @@ where
         EndpointLocation::Port(self.port_id.clone())
     }
 
-    fn send<C>(self, _cx: &C, message: M) -> Result<(), MailboxSenderError>
+    fn send<C>(self, _cx: &C, message: M)
     where
         C: context::Actor,
     {
@@ -2204,7 +2204,6 @@ where
                     &err,
                 ));
         }
-        Ok(())
     }
 }
 
@@ -3429,28 +3428,28 @@ mod tests {
             .open_accum_port(accum::join_semilattice::<accum::Max<i64>>());
 
         for i in -3..4 {
-            port.send(&client, accum::Max(i)).unwrap();
+            port.send(&client, accum::Max(i));
             let received: accum::Max<i64> = receiver.recv().await.unwrap();
             let msg = received.get();
             assert_eq!(msg, &i);
         }
         // Send a smaller or same value. Should still receive the previous max.
         for i in -3..4 {
-            port.send(&client, accum::Max(i)).unwrap();
+            port.send(&client, accum::Max(i));
             assert_eq!(receiver.recv().await.unwrap().get(), &3);
         }
         // send a larger value. Should receive the new max.
-        port.send(&client, accum::Max(4)).unwrap();
+        port.send(&client, accum::Max(4));
         assert_eq!(receiver.recv().await.unwrap().get(), &4);
 
         // Send multiple updates. Should only receive the final change.
         for i in 5..10 {
-            port.send(&client, accum::Max(i)).unwrap();
+            port.send(&client, accum::Max(i));
         }
         assert_eq!(receiver.recv().await.unwrap().get(), &9);
-        port.send(&client, accum::Max(1)).unwrap();
-        port.send(&client, accum::Max(3)).unwrap();
-        port.send(&client, accum::Max(2)).unwrap();
+        port.send(&client, accum::Max(1));
+        port.send(&client, accum::Max(3));
+        port.send(&client, accum::Max(2));
         assert_eq!(receiver.recv().await.unwrap().get(), &9);
     }
 
@@ -3485,7 +3484,7 @@ mod tests {
 
         // let port_id = port.port_addr().clone();
 
-        port.send(&client, 123u64).unwrap();
+        port.send(&client, 123u64);
         assert_eq!(receiver.recv().await.unwrap(), 123u64);
 
         // // The borrow checker won't let us send again on the port
@@ -3697,7 +3696,7 @@ mod tests {
         let proc = Proc::configured(test_proc_id("0"), BoxedMailboxSender::new(muxer));
         let (client, _) = proc.instance("client").unwrap();
 
-        port.send(&client, 123u64).unwrap();
+        port.send(&client, 123u64);
         assert_eq!(receiver.recv().await.unwrap(), 123u64);
 
         /*
@@ -3913,10 +3912,10 @@ mod tests {
             Ok(())
         });
 
-        port.send(&client, 10).unwrap();
-        port.send(&client, 5).unwrap();
-        port.send(&client, 1).unwrap();
-        port.send(&client, 0).unwrap();
+        port.send(&client, 10);
+        port.send(&client, 5);
+        port.send(&client, 1);
+        port.send(&client, 0);
 
         assert_eq!(count.load(Ordering::SeqCst), 16);
     }
@@ -3991,9 +3990,7 @@ mod tests {
             wirevalue::Any::serialize(&1u64).unwrap(),
             Flattrs::new(),
         );
-        return_handle
-            .send(&client, Undeliverable::Message(message))
-            .unwrap();
+        return_handle.send(&client, Undeliverable::Message(message));
 
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
@@ -4036,9 +4033,7 @@ mod tests {
         );
         let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
-        return_handle
-            .send(&client, Undeliverable::Message(envelope.clone()))
-            .unwrap();
+        return_handle.send(&client, Undeliverable::Message(envelope.clone()));
         // Check we receive the undelivered message.
         assert!(
             tokio::time::timeout(tokio::time::Duration::from_secs(1), return_receiver.recv())
@@ -4786,8 +4781,7 @@ mod tests {
 
         handle
             .contramap(|m| (1, m))
-            .send(&client, "hello".to_string())
-            .unwrap();
+            .send(&client, "hello".to_string());
         assert_eq!(rx.recv().await.unwrap(), (1, "hello".to_string()));
     }
 
@@ -4926,10 +4920,7 @@ mod tests {
 
         mailbox.close(ActorStatus::Stopped("test stop".to_string()));
 
-        let result = port_handle.send(&client, 42u64);
-
-        assert!(result.is_err(), "send should fail when actor is stopped");
-        let err = result.unwrap_err();
+        let err = port_handle.try_send(&client, 42u64).unwrap_err();
         assert_matches!(
             err.kind(),
             MailboxSenderErrorKind::Mailbox(mailbox_err)
@@ -4953,10 +4944,7 @@ mod tests {
             "test failure".to_string(),
         )));
 
-        let result = port_handle.send(&client, 42u64);
-
-        assert!(result.is_err(), "send should fail when actor is failed");
-        let err = result.unwrap_err();
+        let err = port_handle.try_send(&client, 42u64).unwrap_err();
         assert_matches!(
             err.kind(),
             MailboxSenderErrorKind::Mailbox(mailbox_err)
@@ -4977,7 +4965,7 @@ mod tests {
         assert!(port_ref.reducer_spec().is_some());
 
         // Send a single value via the bound port
-        port_ref.send(&client, 42).unwrap();
+        port_ref.send(&client, 42);
 
         // Should receive the value
         let result = receiver.recv().await.unwrap();

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -66,7 +66,6 @@ use crate::mailbox::MailboxSenderError;
 use crate::mailbox::MessageEnvelope;
 use crate::mailbox::PortHandle;
 use crate::mailbox::PortReceiver;
-use crate::mailbox::UndeliverableMailboxSender;
 use crate::mailbox::headers::OPERATION_ADVERB;
 use crate::mailbox::headers::OPERATION_ENDPOINT;
 use crate::mailbox::headers::RUST_MESSAGE_TYPE;
@@ -226,11 +225,7 @@ pub(crate) fn return_undeliverable(
         let client = &CLIENT
             .get_or_init(|| Proc::runtime().instance("global_return_client").unwrap())
             .0;
-        let envelope_copy = envelope.clone();
-        if crate::Endpoint::send(&return_handle, client, Undeliverable::message(envelope)).is_err()
-        {
-            UndeliverableMailboxSender.post(envelope_copy, /*unused*/ return_handle)
-        }
+        crate::Endpoint::send(&return_handle, client, Undeliverable::message(envelope));
     }
 }
 

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -256,7 +256,7 @@ impl<M: Bind> IndexedErasedUnbound<M> {
         let port_handle = mailbox.open_enqueue_port::<IndexedErasedUnbound<M>>({
             move |_, m| {
                 let bound_m = m.downcast()?.bind()?;
-                actor_ref.send(&cx, bound_m)?;
+                actor_ref.send(&cx, bound_m);
                 Ok(())
             }
         });

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -845,7 +845,10 @@ impl Proc {
         event: ActorSupervisionEvent,
     ) {
         let result = match self.state().supervision_coordinator_port.get() {
-            Some(port) => port.send(cx, event.clone()).map_err(anyhow::Error::from),
+            Some(port) => {
+                port.send(cx, event.clone());
+                Ok(())
+            }
             None => {
                 if !event.is_error() {
                     // Normal lifecycle events (e.g. clean stop) without a coordinator
@@ -2053,11 +2056,9 @@ impl<A: Actor> Instance<A> {
             crate::mailbox::monitored_return_handle()
         });
 
-        if let Err(error) = crate::Endpoint::send(
-            &return_handle,
-            self,
-            crate::mailbox::Undeliverable::lost(lost.clone()),
-        ) {
+        if let Err(error) =
+            return_handle.try_send(self, crate::mailbox::Undeliverable::lost(lost.clone()))
+        {
             tracing::error!(
                 sender = %lost.sender,
                 dest = %lost.dest,
@@ -2351,14 +2352,9 @@ impl<A: Actor> Instance<A> {
     {
         let client = Self::self_client();
         let port = self.port();
-        let self_id = self.self_addr().clone();
         tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            if let Err(e) = port.send(&client, message) {
-                // TODO: this is a fire-n-forget thread. We need to
-                // handle errors in a better way.
-                tracing::info!("{}: error sending delayed message: {}", self_id, e);
-            }
+            port.send(&client, message);
         });
         Ok(())
     }
@@ -3304,7 +3300,8 @@ impl InstanceCell {
             let client = &CLIENT
                 .get_or_init(|| Proc::runtime().instance("global_signal_client").unwrap())
                 .0;
-            signal_port.send(&client, signal).map_err(ActorError::from)
+            signal_port.send(&client, signal);
+            Ok(())
         } else {
             tracing::warn!(
                 "{}: attempted to send signal {} to detached actor",
@@ -3330,28 +3327,7 @@ impl InstanceCell {
     ) {
         match &self.inner.actor_loop {
             Some((_, supervision_port)) => {
-                if let Err(err) = supervision_port.send(child_cx, event.clone()) {
-                    if !event.is_error() {
-                        // Normal lifecycle events (e.g. clean stop) that fail to
-                        // send are silently dropped. This happens when a child
-                        // stops after the parent's mailbox has been closed or its
-                        // supervision port receiver has been dropped (e.g. client
-                        // instances created via Proc::instance()).
-                        tracing::debug!(
-                            "{}: dropping non-error supervision event {}: {:?}",
-                            self.actor_addr(),
-                            event,
-                            err
-                        );
-                        return;
-                    }
-                    tracing::error!(
-                        "{}: failed to send supervision event to actor: {:?}. Crash the process.",
-                        self.actor_addr(),
-                        err
-                    );
-                    std::process::exit(1);
-                }
+                supervision_port.send(child_cx, event.clone());
             }
             None => {
                 if !event.is_error() {
@@ -3888,7 +3864,7 @@ mod tests {
             parent: &ActorHandle<TestActor>,
         ) -> ActorHandle<TestActor> {
             let (tx, rx) = oneshot::channel();
-            parent.send(cx, TestActorMessage::Spawn(tx)).unwrap();
+            parent.send(cx, TestActorMessage::Spawn(tx));
             rx.await.unwrap()
         }
     }
@@ -3923,7 +3899,7 @@ mod tests {
             message: Box<TestActorMessage>,
         ) -> Result<(), anyhow::Error> {
             // TODO: this needn't be async
-            destination.send(cx, *message)?;
+            destination.send(cx, *message);
             Ok(())
         }
 
@@ -3989,7 +3965,7 @@ mod tests {
         // Send a ping-pong to the actor. Wait for the actor to become idle.
 
         let (tx, rx) = oneshot::channel::<()>();
-        handle.send(&client, TestActorMessage::Reply(tx)).unwrap();
+        handle.send(&client, TestActorMessage::Reply(tx));
         rx.await.unwrap();
 
         state
@@ -4001,9 +3977,7 @@ mod tests {
         let (enter_tx, enter_rx) = oneshot::channel::<()>();
         let (exit_tx, exit_rx) = oneshot::channel::<()>();
 
-        handle
-            .send(&client, TestActorMessage::Wait(enter_tx, exit_rx))
-            .unwrap();
+        handle.send(&client, TestActorMessage::Wait(enter_tx, exit_rx));
         enter_rx.await.unwrap();
         assert_matches!(*state.borrow(), ActorStatus::Processing(instant, _) if instant <= std::time::SystemTime::now());
         exit_tx.send(()).unwrap();
@@ -4026,12 +4000,10 @@ mod tests {
         let second = proc.spawn::<TestActor>("second", TestActor).unwrap();
         let (tx, rx) = oneshot::channel::<()>();
         let reply_message = TestActorMessage::Reply(tx);
-        first
-            .send(
-                &client,
-                TestActorMessage::Forward(second, Box::new(reply_message)),
-            )
-            .unwrap();
+        first.send(
+            &client,
+            TestActorMessage::Forward(second, Box::new(reply_message)),
+        );
         rx.await.unwrap();
     }
 
@@ -4581,7 +4553,7 @@ mod tests {
         root.await;
 
         for actor in [root_1, root_2, root_2_1] {
-            assert!(actor.send(&client, TestActorMessage::Noop()).is_err());
+            actor.send(&client, TestActorMessage::Noop());
             assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
         }
     }
@@ -4671,8 +4643,7 @@ mod tests {
 
         // Drain closes runtime-dispatched handler ingress, so new
         // sends to the actor's handler port are rejected.
-        let err = handle.send(&client, ()).unwrap_err();
-        assert_matches!(err.kind(), crate::mailbox::MailboxSenderErrorKind::Closed);
+        handle.send(&client, ());
 
         release_stop.notify_one();
         assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
@@ -4691,12 +4662,10 @@ mod tests {
         let root_2 = TestActor::spawn_child(&client, &root).await;
         let root_2_1 = TestActor::spawn_child(&client, &root_2).await;
 
-        root_2
-            .send(
-                &client,
-                TestActorMessage::Fail(anyhow::anyhow!("some random failure")),
-            )
-            .unwrap();
+        root_2.send(
+            &client,
+            TestActorMessage::Fail(anyhow::anyhow!("some random failure")),
+        );
         let _root_2_actor_id = root_2.actor_addr().clone();
         assert_matches!(
             root_2.await,
@@ -4732,7 +4701,7 @@ mod tests {
                 cx: &crate::Context<Self>,
                 message: OncePortHandle<PortHandle<usize>>,
             ) -> anyhow::Result<()> {
-                message.send(cx, cx.port())?;
+                message.send(cx, cx.port());
                 Ok(())
             }
         }
@@ -4755,9 +4724,9 @@ mod tests {
         let handle = proc.spawn::<TestActor>("test", actor).unwrap();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, rx) = client.open_once_port();
-        handle.send(&client, tx).unwrap();
+        handle.send(&client, tx);
         let usize_handle = rx.recv().await.unwrap();
-        usize_handle.send(&client, 123).unwrap();
+        usize_handle.send(&client, 123);
 
         handle.drain_and_stop("test").unwrap();
         handle.await;
@@ -4894,16 +4863,12 @@ mod tests {
 
         // fail `root_1_1_1`, the supervision msg should be propagated to
         // `root_1` because `root_1` has set `true` to `handle_supervision_event`.
-        root_1_1_1
-            .send(&client, "some random failure".to_string())
-            .unwrap();
+        root_1_1_1.send(&client, "some random failure".to_string());
 
         // fail `root_2_1`, the supervision msg should be propagated to
         // ProcSupervisionCoordinator.
         let root_2_1_id = root_2_1.actor_addr().clone();
-        root_2_1
-            .send(&client, "some random failure".to_string())
-            .unwrap();
+        root_2_1.send(&client, "some random failure".to_string());
 
         // Wait for root_1 to handle the supervision event from the
         // root_1_1_1 -> root_1_1 -> root_1 chain. The Notify provides
@@ -4937,7 +4902,7 @@ mod tests {
                 cx: &crate::Context<Self>,
                 (message, port): (String, PortRef<String>),
             ) -> anyhow::Result<()> {
-                port.send(cx, message)?;
+                port.send(cx, message);
                 Ok(())
             }
         }
@@ -4949,9 +4914,7 @@ mod tests {
         let child_actor = TestActor.spawn(&instance).unwrap();
 
         let (port, mut receiver) = instance.open_port();
-        child_actor
-            .send(&instance, ("hello".to_string(), port.bind()))
-            .unwrap();
+        child_actor.send(&instance, ("hello".to_string(), port.bind()));
 
         let message = receiver.recv().await.unwrap();
         assert_eq!(message, "hello");
@@ -5018,7 +4981,7 @@ mod tests {
         impl LoggingActor {
             async fn wait(cx: &impl context::Actor, handle: &ActorHandle<Self>) {
                 let barrier = Arc::new(Barrier::new(2));
-                handle.send(cx, barrier.clone()).unwrap();
+                handle.send(cx, barrier.clone());
                 barrier.wait().await;
             }
         }
@@ -5079,11 +5042,9 @@ mod tests {
             let proc = Proc::isolated();
             let (client, _) = proc.instance("client").unwrap();
             let handle = LoggingActor.spawn_detached().unwrap();
-            handle.send(&client, "hello world".to_string()).unwrap();
-            handle
-                .send(&client, "hello world again".to_string())
-                .unwrap();
-            handle.send(&client, 123u64).unwrap();
+            handle.send(&client, "hello world".to_string());
+            handle.send(&client, "hello world again".to_string());
+            handle.send(&client, 123u64);
 
             LoggingActor::wait(&client, &handle).await;
 
@@ -5098,7 +5059,7 @@ mod tests {
 
             let stacks = {
                 let barriers = Arc::new((Barrier::new(2), Barrier::new(2)));
-                handle.send(&client, Arc::clone(&barriers)).unwrap();
+                handle.send(&client, Arc::clone(&barriers));
                 barriers.0.wait().await;
                 let stacks = handle.cell().inner.recording.stacks();
                 barriers.1.wait().await;
@@ -5112,10 +5073,6 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_mailbox_closed_with_owner_stopped_reason() {
-        use crate::actor::ActorStatus;
-        use crate::mailbox::MailboxErrorKind;
-        use crate::mailbox::MailboxSenderErrorKind;
-
         let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         let actor_handle = proc.spawn("test", TestActor).unwrap();
@@ -5127,28 +5084,11 @@ mod tests {
         actor_handle.drain_and_stop("healthy shutdown").unwrap();
         actor_handle.await;
 
-        // Try to send a message to the stopped actor
-        let result = handle_for_send.send(&client, TestActorMessage::Noop());
-
-        assert!(result.is_err(), "send should fail when actor is stopped");
-        let err = result.unwrap_err();
-        assert_matches!(
-            err.kind(),
-            MailboxSenderErrorKind::Mailbox(mailbox_err)
-                if matches!(
-                    mailbox_err.kind(),
-                    MailboxErrorKind::OwnerTerminated(ActorStatus::Stopped(reason)) if reason == "healthy shutdown"
-                )
-        );
+        handle_for_send.send(&client, TestActorMessage::Noop());
     }
 
     #[async_timed_test(timeout_secs = 30)]
     async fn test_mailbox_closed_with_owner_failed_reason() {
-        use crate::actor::ActorErrorKind;
-        use crate::actor::ActorStatus;
-        use crate::mailbox::MailboxErrorKind;
-        use crate::mailbox::MailboxSenderErrorKind;
-
         let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
         // Need to set a supervison coordinator for this Proc because there will
@@ -5161,28 +5101,13 @@ mod tests {
         let handle_for_send = actor_handle.clone();
 
         // Cause the actor to fail
-        actor_handle
-            .send(
-                &client,
-                TestActorMessage::Fail(anyhow::anyhow!("intentional failure")),
-            )
-            .unwrap();
+        actor_handle.send(
+            &client,
+            TestActorMessage::Fail(anyhow::anyhow!("intentional failure")),
+        );
         actor_handle.await;
 
-        // Try to send a message to the failed actor
-        let result = handle_for_send.send(&client, TestActorMessage::Noop());
-
-        assert!(result.is_err(), "send should fail when actor has failed");
-        let err = result.unwrap_err();
-        assert_matches!(
-            err.kind(),
-            MailboxSenderErrorKind::Mailbox(mailbox_err)
-                if matches!(
-                    mailbox_err.kind(),
-                    MailboxErrorKind::OwnerTerminated(ActorStatus::Failed(ActorErrorKind::Generic(msg)))
-                        if msg.contains("intentional failure")
-                )
-        );
+        handle_for_send.send(&client, TestActorMessage::Noop());
     }
 
     /// Wait for a terminated snapshot to appear for the given actor.
@@ -5271,9 +5196,7 @@ mod tests {
         let actor_id = handle.actor_addr().clone();
 
         // Trigger a failure.
-        handle
-            .send(&client, TestActorMessage::Fail(anyhow::anyhow!("boom")))
-            .unwrap();
+        handle.send(&client, TestActorMessage::Fail(anyhow::anyhow!("boom")));
         handle.await;
 
         let snapshot = wait_for_terminated_snapshot(&proc, &actor_id).await;
@@ -5300,9 +5223,7 @@ mod tests {
         let actor_id = handle.actor_addr().clone();
         let cell = handle.cell().clone();
 
-        handle
-            .send(&client, TestActorMessage::Fail(anyhow::anyhow!("boom")))
-            .unwrap();
+        handle.send(&client, TestActorMessage::Fail(anyhow::anyhow!("boom")));
         handle.await;
 
         let event = cell.supervision_event();
@@ -5411,18 +5332,16 @@ mod tests {
         let parent_cell = parent.cell().clone();
         // Spawn child under parent.
         let (tx, rx) = oneshot::channel();
-        parent.send(&client, TestActorMessage::Spawn(tx)).unwrap();
+        parent.send(&client, TestActorMessage::Spawn(tx));
         let child = rx.await.unwrap();
         let child_id = child.actor_addr().clone();
 
         // Fail the child — parent doesn't handle supervision, so it
         // propagates and terminates too.
-        child
-            .send(
-                &client,
-                TestActorMessage::Fail(anyhow::anyhow!("child boom")),
-            )
-            .unwrap();
+        child.send(
+            &client,
+            TestActorMessage::Fail(anyhow::anyhow!("child boom")),
+        );
         parent.await;
 
         let event = parent_cell.supervision_event();
@@ -5478,9 +5397,7 @@ mod tests {
         let handle = proc.spawn::<TestActor>("fail_actor", TestActor).unwrap();
         let actor_id = handle.actor_addr().clone();
 
-        handle
-            .send(&client, TestActorMessage::Fail(anyhow::anyhow!("kaboom")))
-            .unwrap();
+        handle.send(&client, TestActorMessage::Fail(anyhow::anyhow!("kaboom")));
         handle.await;
 
         let snapshot = wait_for_terminated_snapshot(&proc, &actor_id).await;
@@ -5523,16 +5440,14 @@ mod tests {
         let parent_id = parent.actor_addr().clone();
 
         let (tx, rx) = oneshot::channel();
-        parent.send(&client, TestActorMessage::Spawn(tx)).unwrap();
+        parent.send(&client, TestActorMessage::Spawn(tx));
         let child = rx.await.unwrap();
         let child_id = child.actor_addr().clone();
 
-        child
-            .send(
-                &client,
-                TestActorMessage::Fail(anyhow::anyhow!("child fail")),
-            )
-            .unwrap();
+        child.send(
+            &client,
+            TestActorMessage::Fail(anyhow::anyhow!("child fail")),
+        );
         parent.await;
 
         let snapshot = wait_for_terminated_snapshot(&proc, &parent_id).await;

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -103,7 +103,7 @@ where
         EndpointLocation::Actor(self.actor_addr.clone())
     }
 
-    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    fn send<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
@@ -116,12 +116,7 @@ where
     A: Referable + RemoteHandles<M>,
     M: RemoteMessage,
 {
-    fn send_with_headers<C>(
-        self,
-        cx: &C,
-        headers: Flattrs,
-        message: M,
-    ) -> Result<(), MailboxSenderError>
+    fn send_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
     where
         C: context::Actor,
     {
@@ -353,7 +348,7 @@ where
         EndpointLocation::Port(self.port_addr.clone())
     }
 
-    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    fn send<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
@@ -365,12 +360,7 @@ impl<M> RemoteEndpoint<M> for &PortRef<M>
 where
     M: RemoteMessage,
 {
-    fn send_with_headers<C>(
-        self,
-        cx: &C,
-        headers: Flattrs,
-        message: M,
-    ) -> Result<(), MailboxSenderError>
+    fn send_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
     where
         C: context::Actor,
     {
@@ -388,11 +378,10 @@ where
                         self.endpoint_location(),
                         &err,
                     ));
-                return Ok(());
+                return;
             }
         };
         self.post_serialized(cx, headers, serialized);
-        Ok(())
     }
 }
 
@@ -555,7 +544,7 @@ where
         EndpointLocation::Port(self.port_addr.clone())
     }
 
-    fn send<C>(self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    fn send<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
@@ -567,12 +556,7 @@ impl<M> RemoteEndpoint<M> for OncePortRef<M>
 where
     M: RemoteMessage,
 {
-    fn send_with_headers<C>(
-        self,
-        cx: &C,
-        mut headers: Flattrs,
-        message: M,
-    ) -> Result<(), MailboxSenderError>
+    fn send_with_headers<C>(self, cx: &C, mut headers: Flattrs, message: M)
     where
         C: context::Actor,
     {
@@ -591,7 +575,7 @@ where
                         self.endpoint_location(),
                         &err,
                     ));
-                return Ok(());
+                return;
             }
         };
         cx.post(
@@ -601,7 +585,6 @@ where
             self.return_undeliverable,
             context::SeqInfoPolicy::AssignNew,
         );
-        Ok(())
     }
 }
 

--- a/hyperactor/src/testing/pingpong.rs
+++ b/hyperactor/src/testing/pingpong.rs
@@ -94,7 +94,7 @@ impl Actor for PingPongActor {
         undelivered: crate::mailbox::Undeliverable<crate::mailbox::MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
         match &self.undeliverable_port_ref {
-            Some(port) => port.send(cx, undelivered).unwrap(),
+            Some(port) => port.send(cx, undelivered),
             None => match undelivered {
                 Undeliverable::Message(envelope) => {
                     anyhow::bail!(UndeliverableMessageError::DeliveryFailure { envelope });
@@ -125,13 +125,13 @@ impl Handler<PingPongMessage> for PingPongActor {
             anyhow::bail!("PingPong handler encountered an Error");
         }
         if ttl == 0 {
-            done_port.send(cx, true)?;
+            done_port.send(cx, true);
         } else {
             if let Some(delay) = self.delay {
                 tokio::time::sleep(delay).await;
             }
             let next_message = PingPongMessage(ttl - 1, cx.bind(), done_port);
-            pong_actor.send(cx, next_message)?;
+            pong_actor.send(cx, next_message);
         }
         Ok(())
     }

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -757,7 +757,8 @@ pub fn derive_handler(input: TokenStream) -> TokenStream {
                         // This would require Result<Result<..., in order to handle RPC errors.
                         #construct_result_future
                         use hyperactor::Endpoint as _;
-                        #reply_port_arg.send(cx, #result_ident).map_err(hyperactor::internal_macro_support::anyhow::Error::from)
+                        #reply_port_arg.send(cx, #result_ident);
+                        Ok(())
                     }
                 });
             }
@@ -896,7 +897,7 @@ fn derive_client(input: TokenStream, is_handle: bool) -> TokenStream {
     // The client implementation methods.
     let mut impl_methods = Vec::new();
 
-    let send_message = quote! { hyperactor::Endpoint::send(self, cx, message)? };
+    let send_message = quote! { hyperactor::Endpoint::send(self, cx, message); };
     let global_log_level = parse_log_level(&input.attrs).ok().unwrap_or(None);
 
     for message in &messages {

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -79,7 +79,7 @@ where
         cx: &Context<Self>,
         GenericMessage(message): GenericMessage<T>,
     ) -> anyhow::Result<()> {
-        self.forward_port.send(cx, format!("{message:?}"))?;
+        self.forward_port.send(cx, format!("{message:?}"));
         Ok(())
     }
 }
@@ -90,7 +90,7 @@ struct TestMessage(String);
 #[async_trait]
 impl Handler<TestMessage> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, msg: TestMessage) -> anyhow::Result<()> {
-        self.forward_port.send(cx, msg.0)?;
+        self.forward_port.send(cx, msg.0);
         Ok(())
     }
 }
@@ -101,7 +101,7 @@ struct MyGeneric<T>(T);
 #[async_trait]
 impl Handler<()> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, _msg: ()) -> anyhow::Result<()> {
-        self.forward_port.send(cx, "()".to_string())?;
+        self.forward_port.send(cx, "()".to_string());
         Ok(())
     }
 }
@@ -109,7 +109,7 @@ impl Handler<()> for TestActor {
 #[async_trait]
 impl Handler<MyGeneric<()>> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, _msg: MyGeneric<()>) -> anyhow::Result<()> {
-        self.forward_port.send(cx, "MyGeneric<()>".to_string())?;
+        self.forward_port.send(cx, "MyGeneric<()>".to_string());
         Ok(())
     }
 }
@@ -117,7 +117,7 @@ impl Handler<MyGeneric<()>> for TestActor {
 #[async_trait]
 impl Handler<u64> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, msg: u64) -> anyhow::Result<()> {
-        self.forward_port.send(cx, format!("u64: {msg}"))?;
+        self.forward_port.send(cx, format!("u64: {msg}"));
         Ok(())
     }
 }
@@ -159,9 +159,7 @@ mod tests {
                 .actor_addr()
                 .port_addr(Port::from(TestMessage::port()));
             let port_ref: reference::PortRef<TestMessage> = reference::PortRef::attest(port_id);
-            port_ref
-                .send(&client, TestMessage("abc".to_string()))
-                .unwrap();
+            port_ref.send(&client, TestMessage("abc".to_string()));
             assert_eq!(rx.recv().await.unwrap(), "abc");
         }
         {
@@ -170,7 +168,7 @@ mod tests {
                 .actor_addr()
                 .port_addr(Port::from(<()>::port()));
             let port_ref: reference::PortRef<()> = reference::PortRef::attest(port_id);
-            port_ref.send(&client, ()).unwrap();
+            port_ref.send(&client, ());
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
         {
@@ -179,7 +177,7 @@ mod tests {
                 .actor_addr()
                 .port_addr(Port::from(<u64>::port()));
             let port_ref: reference::PortRef<u64> = reference::PortRef::attest(port_id);
-            port_ref.send(&client, 987654321).unwrap();
+            port_ref.send(&client, 987654321);
             assert_eq!(rx.recv().await.unwrap(), "u64: 987654321");
         }
         {
@@ -188,7 +186,7 @@ mod tests {
                 .actor_addr()
                 .port_addr(Port::from(MyGeneric::<()>::port()));
             let port_ref: reference::PortRef<MyGeneric<()>> = reference::PortRef::attest(port_id);
-            port_ref.send(&client, MyGeneric(())).unwrap();
+            port_ref.send(&client, MyGeneric(()));
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
         }
         {
@@ -202,7 +200,7 @@ mod tests {
                 .port_addr(Port::from(<IndexedErasedUnbound<TestMessage>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<TestMessage>> =
                 reference::PortRef::attest(port_id);
-            port_ref.send(&client, indexed_msg).unwrap();
+            port_ref.send(&client, indexed_msg);
             assert_eq!(rx.recv().await.unwrap(), "efg");
         }
         {
@@ -215,7 +213,7 @@ mod tests {
                 .port_addr(Port::from(<IndexedErasedUnbound<()>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<()>> =
                 reference::PortRef::attest(port_id);
-            port_ref.send(&client, indexed_msg).unwrap();
+            port_ref.send(&client, indexed_msg);
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
         {
@@ -228,7 +226,7 @@ mod tests {
                 .port_addr(Port::from(<IndexedErasedUnbound<MyGeneric<()>>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<MyGeneric<()>>> =
                 reference::PortRef::attest(port_id);
-            port_ref.send(&client, indexed_msg).unwrap();
+            port_ref.send(&client, indexed_msg);
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
         }
     }
@@ -240,29 +238,24 @@ mod tests {
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
 
-        actor_handle.send(&client, 123u64).unwrap();
-        actor_handle
-            .send(&client, TestMessage("foo".to_string()))
-            .unwrap();
+        actor_handle.send(&client, 123u64);
+        actor_handle.send(&client, TestMessage("foo".to_string()));
 
         let myref: reference::ActorRef<TestActorAlias> = actor_handle.bind();
-        myref.port().send(&client, MyGeneric(())).unwrap();
-        myref
-            .port()
-            .send(&client, TestMessage("biz".to_string()))
-            .unwrap();
-        myref.port().send(&client, 999u64).unwrap();
-        myref.port().send(&client, ()).unwrap();
+        myref.port().send(&client, MyGeneric(()));
+        myref.port().send(&client, TestMessage("biz".to_string()));
+        myref.port().send(&client, 999u64);
+        myref.port().send(&client, ());
         {
             let erased_msg =
                 ErasedUnbound::try_from_message(TestMessage("bar".to_string())).unwrap();
             let indexed_msg = IndexedErasedUnbound::<TestMessage>::from(erased_msg);
-            myref.port().send(&client, indexed_msg).unwrap();
+            myref.port().send(&client, indexed_msg);
         }
         {
             let erased_msg = ErasedUnbound::try_from_message(()).unwrap();
             let indexed_msg = IndexedErasedUnbound::<MyGeneric<()>>::from(erased_msg);
-            myref.port().send(&client, indexed_msg).unwrap();
+            myref.port().send(&client, indexed_msg);
         }
 
         assert_eq!(rx.recv().await.unwrap(), "u64: 123");
@@ -290,7 +283,7 @@ mod tests {
             .actor_addr()
             .port_addr(Port::from(GenericMessage::<u64>::port()));
         let port_ref: reference::PortRef<GenericMessage<u64>> = reference::PortRef::attest(port_id);
-        port_ref.send(&client, GenericMessage(42)).unwrap();
+        port_ref.send(&client, GenericMessage(42));
         assert_eq!(rx.recv().await.unwrap(), "42");
 
         assert_ne!(

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -127,7 +127,7 @@ impl PhilosopherActor {
             .send(
                 cx,
                 WaiterMessage::RequestChopsticks((self.rank, left, right)),
-            )?;
+            );
         self.chopsticks = (ChopstickStatus::Requested, ChopstickStatus::Requested);
         Ok(())
     }
@@ -143,7 +143,7 @@ impl PhilosopherActor {
         self.waiter
             .get()
             .ok_or(anyhow::anyhow!("uninitialized waiter port"))?
-            .send(cx, WaiterMessage::ReleaseChopsticks((left, right)))?;
+            .send(cx, WaiterMessage::ReleaseChopsticks((left, right)));
         self.chopsticks = (ChopstickStatus::None, ChopstickStatus::None);
         Ok(())
     }

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -93,7 +93,7 @@ impl Handler<NextNumber> for SieveActor {
         }
         match &self.next {
             Some(next) => {
-                next.send(cx, msg)?;
+                next.send(cx, msg);
             }
             None => {
                 tracing::info!(
@@ -101,7 +101,7 @@ impl Handler<NextNumber> for SieveActor {
                     discovered = msg.number,
                     "new prime discovered, spawning child"
                 );
-                msg.prime_collector.send(cx, msg.number)?;
+                msg.prime_collector.send(cx, msg.number);
 
                 self.next = Some(
                     SieveActor::new(SieveParams { prime: msg.number }, Flattrs::default())
@@ -213,8 +213,7 @@ async fn main() -> Result<ExitCode> {
                                 number: candidate,
                                 prime_collector: prime_collector_ref.clone(),
                             },
-                        )
-                        .unwrap();
+                        );
                     candidate += 1;
                 }
             }

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -54,7 +54,7 @@ impl Handler<TestMessage> for TestActor {
         message: TestMessage,
     ) -> Result<(), anyhow::Error> {
         match message {
-            TestMessage::Ping(reply) => reply.send(cx, cx.cast_point())?,
+            TestMessage::Ping(reply) => reply.send(cx, cx.cast_point()),
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -161,17 +161,13 @@ impl<A: Referable> ActorMesh<A> {
             let id = self.id.resource_id().clone();
             let num_ranks = self.current_ref.region().num_ranks();
             let result: crate::Result<()> = async {
-                controller
-                    .send(
-                        cx,
-                        resource::Stop {
-                            id: id.clone(),
-                            reason,
-                        },
-                    )
-                    .map_err(|e| {
-                        crate::Error::SendingError(controller.actor_addr().clone(), Box::new(e))
-                    })?;
+                controller.send(
+                    cx,
+                    resource::Stop {
+                        id: id.clone(),
+                        reason,
+                    },
+                );
                 // The controller processes messages serially, and its `Stop`
                 // handler already awaits the underlying ProcAgent wait, which
                 // sends its own `WaitRankStatus` to the ProcAgents and
@@ -182,17 +178,13 @@ impl<A: Referable> ActorMesh<A> {
                 // abort-budget exhaustion). We just need to serialize
                 // behind the Stop handler and read the result.
                 let (port, mut rx) = cx.mailbox().open_port();
-                controller
-                    .send(
-                        cx,
-                        resource::GetState::<resource::mesh::State<()>> {
-                            id: id.clone(),
-                            reply: port.bind(),
-                        },
-                    )
-                    .map_err(|e| {
-                        crate::Error::SendingError(controller.actor_addr().clone(), Box::new(e))
-                    })?;
+                controller.send(
+                    cx,
+                    resource::GetState::<resource::mesh::State<()>> {
+                        id: id.clone(),
+                        reply: port.bind(),
+                    },
+                );
                 let statuses = rx.recv().await?;
                 let Some(state) = &statuses.state else {
                     return Err(Error::Other(anyhow::anyhow!(
@@ -601,9 +593,7 @@ impl<A: Referable> ActorMeshRef<A> {
             let rebound_message = unbound
                 .bind()
                 .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-            actor
-                .send_with_headers(cx, headers, rebound_message)
-                .map_err(|e| Error::SendingError(actor.actor_addr().clone(), Box::new(e)))?;
+            actor.send_with_headers(cx, headers, rebound_message);
         }
         Ok(())
     }
@@ -787,9 +777,7 @@ impl<A: Referable> ActorMeshRef<A> {
             .expect("infallible because CastMessage should not fail for serialization");
 
             // TODO: load balancing instead of always using the first comm actor
-            root_comm_actor
-                .send_with_headers(cx, headers, cast_message)
-                .expect("infallible because CastMessage should not fail for serialization");
+            root_comm_actor.send_with_headers(cx, headers, cast_message);
         }
     }
     /// Query the state of all actors in this mesh.
@@ -913,9 +901,7 @@ impl<A: Referable> ActorMeshRef<A> {
     ) {
         let (tx, rx) = cx.mailbox().open_port();
         let tx = tx.bind();
-        controller
-            .send(cx, Subscribe(tx.clone()))
-            .expect("failed to send Subscribe");
+        controller.send(cx, Subscribe(tx.clone()));
         (tx, into_watch(rx))
     }
 
@@ -1293,12 +1279,10 @@ mod tests {
         // exist).
         amr.get(0)
             .expect("rank 0 exists")
-            .send(instance, testactor::GetActorId(port.bind()))
-            .expect("send to rank 0 should succeed");
+            .send(instance, testactor::GetActorId(port.bind()));
         amr.get(3)
             .expect("rank 3 exists")
-            .send(instance, testactor::GetActorId(port.bind()))
-            .expect("send to rank 3 should succeed");
+            .send(instance, testactor::GetActorId(port.bind()));
         let id_a = tokio::time::timeout(Duration::from_secs(3), rx.recv())
             .await
             .expect("timed out waiting for first reply")
@@ -1790,12 +1774,10 @@ mod tests {
 
         // Verify ping-pong works initially
         let (done_tx, done_rx) = instance.open_once_port();
-        ping_handle
-            .send(
-                instance,
-                PingPongMessage(2, pong_handle.clone(), done_tx.bind()),
-            )
-            .unwrap();
+        ping_handle.send(
+            instance,
+            PingPongMessage(2, pong_handle.clone(), done_tx.bind()),
+        );
         assert!(
             done_rx.recv().await.unwrap(),
             "Initial ping-pong should work"
@@ -1822,12 +1804,10 @@ mod tests {
         for i in 1..=n {
             let ttl = 66 + i as u64; // Avoid ttl = 66 (which would cause other test behavior)
             let (once_tx, _once_rx) = instance.open_once_port();
-            ping_handle
-                .send(
-                    instance,
-                    PingPongMessage(ttl, pong_handle.clone(), once_tx.bind()),
-                )
-                .unwrap();
+            ping_handle.send(
+                instance,
+                PingPongMessage(ttl, pong_handle.clone(), once_tx.bind()),
+            );
         }
 
         // Collect all undeliverable messages.
@@ -1902,9 +1882,7 @@ mod tests {
         // `DrainAndStop` will sit queued in the signal mailbox until this
         // handler completes. Nothing forcibly aborts it.
         for actor_ref in sleep_mesh.values() {
-            actor_ref
-                .send(instance, std::time::Duration::from_secs(5))
-                .unwrap();
+            actor_ref.send(instance, std::time::Duration::from_secs(5));
         }
 
         // Give actors time to start sleeping

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1210,7 +1210,7 @@ impl BootstrapProcHandle {
             resource::StopAll {
                 reason: reason.to_string(),
             },
-        )?;
+        );
         // The agent handling Stop should exit the process, if it doesn't within
         // the time window, we escalate to SIGTERM.
         match tokio::time::timeout(timeout, self.wait()).await {

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -173,7 +173,7 @@ where
 
     comm_actor_ref
         .port()
-        .send_with_headers(cx, headers, cast_message)?;
+        .send_with_headers(cx, headers, cast_message);
 
     Ok(())
 }

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -209,20 +209,7 @@ impl Actor for CommActor {
             // original sender of the cast message.
             message_envelope.set_header(CAST_ORIGINATING_SENDER, sender.clone());
 
-            return_port
-                .send(cx, Undeliverable::Message(message_envelope.clone()))
-                .map_err(|err| {
-                    let error = DeliveryError::BrokenLink(format!(
-                        "error occured when returning ForwardMessage to the original \
-                        sender's port {}; error is: {}",
-                        return_port.port_addr(),
-                        err,
-                    ));
-                    message_envelope.set_error(error);
-                    UndeliverableMessageError::ReturnFailure {
-                        envelope: message_envelope,
-                    }
-                })?;
+            return_port.send(cx, Undeliverable::Message(message_envelope.clone()));
             return Ok(());
         }
 
@@ -235,20 +222,7 @@ impl Actor for CommActor {
                 cx.self_addr(),
                 return_port.port_addr(),
             )));
-            return_port
-                .send(cx, Undeliverable::Message(message_envelope.clone()))
-                .map_err(|err| {
-                    let error = DeliveryError::BrokenLink(format!(
-                        "error occured when returning cast message to the origin \
-                        sender {}; error is: {}",
-                        return_port.port_addr(),
-                        err,
-                    ));
-                    message_envelope.set_error(error);
-                    UndeliverableMessageError::ReturnFailure {
-                        envelope: message_envelope,
-                    }
-                })?;
+            return_port.send(cx, Undeliverable::Message(message_envelope.clone()));
             return Ok(());
         }
 
@@ -275,9 +249,9 @@ impl CommActor {
         if let Some(cast_actor_mesh_id) = cx.headers().get(CAST_ACTOR_MESH_ID) {
             let mut headers = Flattrs::new();
             headers.set(CAST_ACTOR_MESH_ID, cast_actor_mesh_id);
-            child.send_with_headers(cx, headers, message)?;
+            child.send_with_headers(cx, headers, message);
         } else {
-            child.send(cx, message)?;
+            child.send(cx, message);
         }
         Ok(())
     }
@@ -722,9 +696,9 @@ pub mod test_utils {
             // For CastWithUnsplitPort, send a reply so the test can
             // verify that the unsplit port is still directly reachable.
             if let TestMessage::CastWithUnsplitPort { ref reply_to } = msg {
-                reply_to.send(cx, 42)?;
+                reply_to.send(cx, 42);
             }
-            self.forward_port.send(cx, msg)?;
+            self.forward_port.send(cx, msg);
             Ok(())
         }
     }
@@ -797,9 +771,7 @@ mod tests {
         let comm_ref = comm_handle.bind::<CommActor>();
         let mut peers = HashMap::new();
         peers.insert(0, comm_ref);
-        comm_handle
-            .send(client, CommMeshConfig::new(0, peers))
-            .unwrap();
+        comm_handle.send(client, CommMeshConfig::new(0, peers));
     }
 
     /// Send a message before config, send config, send another after config,
@@ -813,13 +785,9 @@ mod tests {
         let (client, mut rx, comm_handle, actor_mesh_id, _guards) =
             buffering_fixture(proc_name).await;
 
-        comm_handle
-            .send(&client, make_msg(&client, &actor_mesh_id, "buffered"))
-            .unwrap();
+        comm_handle.send(&client, make_msg(&client, &actor_mesh_id, "buffered"));
         send_config(&client, &comm_handle);
-        comm_handle
-            .send(&client, make_msg(&client, &actor_mesh_id, "direct"))
-            .unwrap();
+        comm_handle.send(&client, make_msg(&client, &actor_mesh_id, "direct"));
 
         assert_eq!(
             rx.recv().await.unwrap(),
@@ -1213,12 +1181,12 @@ mod tests {
                 ranks.iter().zip(reply_tos.iter()).enumerate()
             {
                 let rank_u64 = rank as u64;
-                reply_to1.send(instance, rank_u64).unwrap();
+                reply_to1.send(instance, rank_u64);
                 let my_reply = MyReply {
                     sender: dest_actor.actor_addr().clone(),
                     value: rank_u64,
                 };
-                reply_to2.send(instance, my_reply.clone()).unwrap();
+                reply_to2.send(instance, my_reply.clone());
 
                 assert_eq!(reply1_rx.recv().await.unwrap(), rank_u64);
                 assert_eq!(reply2_rx.recv().await.unwrap(), my_reply);
@@ -1243,7 +1211,7 @@ mod tests {
                         sender: dest_actor.actor_addr().clone(),
                         value,
                     };
-                    reply_to2.send(instance, my_reply.clone()).unwrap();
+                    reply_to2.send(instance, my_reply.clone());
                     sent2.push(my_reply);
                 }
                 assert!(
@@ -1302,7 +1270,7 @@ mod tests {
         {
             for j in 0..n {
                 let value = (i + j) as u64;
-                reply_to1.send(instance, value).unwrap();
+                reply_to1.send(instance, value);
                 sum += value;
             }
         }
@@ -1656,7 +1624,7 @@ mod tests {
         // Only the first message will be delivered successfully.
         let num_replies = setup.reply_tos.len();
         for (i, reply_to) in setup.reply_tos.into_iter().enumerate() {
-            reply_to.send(setup.instance, i as u64).unwrap();
+            reply_to.send(setup.instance, i as u64);
         }
 
         // OncePort receives exactly one value (the first to arrive)
@@ -1693,7 +1661,7 @@ mod tests {
         // Each actor replies with its index
         let mut expected_sum = 0u64;
         for (i, reply_to) in setup.reply_tos.into_iter().enumerate() {
-            reply_to.send(setup.instance, i as u64).unwrap();
+            reply_to.send(setup.instance, i as u64);
             expected_sum += i as u64;
         }
 

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -266,10 +266,8 @@ impl<C: context::Actor> AsyncWrite for OwnedWriteHalf<C> {
                 "write after shutdown",
             )));
         }
-        match this.port.send(&*this.caps, Io::Data(buf.into())) {
-            Ok(()) => Poll::Ready(Ok(buf.len())),
-            Err(e) => Poll::Ready(Err(std::io::Error::other(e))),
-        }
+        this.port.send(&*this.caps, Io::Data(buf.into()));
+        Poll::Ready(Ok(buf.len()))
     }
 
     fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), std::io::Error>> {
@@ -281,14 +279,10 @@ impl<C: context::Actor> AsyncWrite for OwnedWriteHalf<C> {
         _cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
         // Send EOF on shutdown.
-        match self.port.send(&self.caps, Io::Eof) {
-            Ok(()) => {
-                let mut this = self.project();
-                *this.shutdown = true;
-                Poll::Ready(Ok(()))
-            }
-            Err(e) => Poll::Ready(Err(std::io::Error::other(e))),
-        }
+        self.port.send(&self.caps, Io::Eof);
+        let mut this = self.project();
+        *this.shutdown = true;
+        Poll::Ready(Ok(()))
     }
 }
 
@@ -382,7 +376,7 @@ pub async fn accept<C: context::Actor>(
             id: self_id,
             conn: tx.bind(),
         },
-    )?;
+    );
     Ok(ActorConnection {
         reader: OwnedReadHalf::new(message.id.clone(), rx),
         writer: OwnedWriteHalf::new(message.id, caps, message.conn),
@@ -430,7 +424,7 @@ mod tests {
         let (client, _) = proc.instance("client")?;
         let (connect, completer) = Connect::allocate(client.self_addr().clone(), client);
         let actor = proc.spawn("actor", EchoActor {})?;
-        actor.send(&completer.caps, connect)?;
+        actor.send(&completer.caps, connect);
         let (mut rd, mut wr) = completer.complete().await?.into_split();
         let send = [3u8, 4u8, 5u8, 6u8];
         try_join!(

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -285,13 +285,7 @@ impl Actor for GlobalClientActor {
                 );
                 match get_global_supervision_sink() {
                     Some(sink) => {
-                        if let Err(e) = sink.send(cx, event) {
-                            tracing::warn!(
-                                %e,
-                                actor=%actor_ref,
-                                "failed to forward supervision event from lost message"
-                            );
-                        }
+                        sink.send(cx, event);
                     }
                     None => {
                         tracing::warn!(
@@ -318,13 +312,7 @@ impl Actor for GlobalClientActor {
 
         match get_global_supervision_sink() {
             Some(sink) => {
-                if let Err(e) = sink.send(cx, event) {
-                    tracing::warn!(
-                        %e,
-                        actor=%actor_ref,
-                        "failed to forward supervision event from undeliverable"
-                    );
-                }
+                sink.send(cx, event);
             }
             None => {
                 tracing::warn!(
@@ -578,9 +566,7 @@ mod tests {
         let client_actor_id: hyperactor::ActorAddr = client.self_addr().clone();
         let undeliverable_port =
             PortRef::<Undeliverable<MessageEnvelope>>::attest_handler_port(&client_actor_id);
-        undeliverable_port
-            .send(client, Undeliverable::Message(env))
-            .expect("inject_undeliverable: send failed");
+        undeliverable_port.send(client, Undeliverable::Message(env));
     }
 
     /// Verifies that creating a `ProcMesh` installs the

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -1703,7 +1703,7 @@ pub mod testing {
             cx: &Context<Self>,
             reply: OncePortRef<ActorAddr>,
         ) -> Result<(), anyhow::Error> {
-            reply.send(cx, cx.self_addr().clone())?;
+            reply.send(cx, cx.self_addr().clone());
             Ok(())
         }
     }
@@ -1761,7 +1761,7 @@ mod tests {
     #[async_trait]
     impl Handler<SendTo> for UndeliverableCollector {
         async fn handle(&mut self, cx: &Context<Self>, dest: SendTo) -> Result<(), anyhow::Error> {
-            dest.send(cx, "into-the-void".to_string())?;
+            dest.send(cx, "into-the-void".to_string());
             Ok(())
         }
     }
@@ -1794,7 +1794,7 @@ mod tests {
 
         let (port, mut rx) = instance1.mailbox().open_port();
 
-        port.bind().send(&instance2, "hello".to_string()).unwrap();
+        port.bind().send(&instance2, "hello".to_string());
         assert_eq!(rx.recv().await.unwrap(), "hello".to_string());
 
         // Make sure that the system proc is also wired in correctly.
@@ -1802,8 +1802,7 @@ mod tests {
 
         // system->proc
         port.bind()
-            .send(&system_actor, "hello from the system proc".to_string())
-            .unwrap();
+            .send(&system_actor, "hello from the system proc".to_string());
         assert_eq!(
             rx.recv().await.unwrap(),
             "hello from the system proc".to_string()
@@ -1812,8 +1811,7 @@ mod tests {
         // system->system
         let (port, mut rx) = system_actor.mailbox().open_port();
         port.bind()
-            .send(&system_actor, "hello from the system".to_string())
-            .unwrap();
+            .send(&system_actor, "hello from the system".to_string());
         assert_eq!(
             rx.recv().await.unwrap(),
             "hello from the system".to_string()
@@ -1821,8 +1819,7 @@ mod tests {
 
         // proc->system
         port.bind()
-            .send(&instance1, "hello from the instance1".to_string())
-            .unwrap();
+            .send(&instance1, "hello from the instance1".to_string());
         assert_eq!(
             rx.recv().await.unwrap(),
             "hello from the instance1".to_string()
@@ -1871,7 +1868,7 @@ mod tests {
         .unwrap();
         let (client_inst, _h) = client.instance("test").unwrap();
         let (port, rx) = client_inst.mailbox().open_once_port();
-        echo1.send(&client_inst, port.bind()).unwrap();
+        echo1.send(&client_inst, port.bind());
         let id = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .unwrap()
@@ -1886,7 +1883,7 @@ mod tests {
         // This exercises cross-proc routing between a child and an
         // external client under the same host.
         let (port2, rx2) = client_inst.mailbox().open_once_port();
-        echo2.send(&client_inst, port2.bind()).unwrap();
+        echo2.send(&client_inst, port2.bind());
         let id2 = tokio::time::timeout(Duration::from_secs(5), rx2.recv())
             .await
             .unwrap()
@@ -1905,7 +1902,7 @@ mod tests {
         let (port3, rx3) = client_inst.mailbox().open_once_port();
         // Send from system -> child via a message that ultimately
         // replies to client's port
-        echo1.send(&sys_inst, port3.bind()).unwrap();
+        echo1.send(&sys_inst, port3.bind());
         let id3 = tokio::time::timeout(Duration::from_secs(5), rx3.recv())
             .await
             .unwrap()
@@ -2184,9 +2181,7 @@ mod tests {
         let (remote_port, mut remote_rx) = remote_inst.mailbox().open_port();
         let remote_port = remote_port.bind();
 
-        remote_port
-            .send(&system_inst, "hello-to-remote".to_string())
-            .unwrap();
+        remote_port.send(&system_inst, "hello-to-remote".to_string());
 
         let arrived: String = tokio::time::timeout(Duration::from_secs(5), remote_rx.recv())
             .await
@@ -2199,9 +2194,7 @@ mod tests {
         let (host_port, mut host_rx) = system_inst.mailbox().open_port();
         let host_port = host_port.bind();
 
-        host_port
-            .send(&remote_inst, "hello-from-remote".to_string())
-            .unwrap();
+        host_port.send(&remote_inst, "hello-from-remote".to_string());
 
         let arrived: String = tokio::time::timeout(Duration::from_secs(5), host_rx.recv())
             .await
@@ -2246,8 +2239,7 @@ mod tests {
         let (trigger_inst, _h) = remote_proc.instance("trigger").unwrap();
         collector_ref
             .port::<SendTo>()
-            .send(&trigger_inst, bogus_dest)
-            .unwrap();
+            .send(&trigger_inst, bogus_dest);
 
         let undeliverable = tokio::time::timeout(Duration::from_secs(5), undlv_rx.recv())
             .await
@@ -2301,8 +2293,7 @@ mod tests {
         let (trigger_inst, _h) = host.system_proc().instance("trigger").unwrap();
         collector_ref
             .port::<SendTo>()
-            .send(&trigger_inst, bogus_dest)
-            .unwrap();
+            .send(&trigger_inst, bogus_dest);
 
         let undeliverable = tokio::time::timeout(Duration::from_secs(5), undlv_rx.recv())
             .await
@@ -2347,9 +2338,7 @@ mod tests {
 
         let (remote_port, mut remote_rx) = remote_inst.mailbox().open_port();
         let remote_port = remote_port.bind();
-        remote_port
-            .send(&system_inst, "pre-stop".to_string())
-            .unwrap();
+        remote_port.send(&system_inst, "pre-stop".to_string());
         let arrived: String = tokio::time::timeout(Duration::from_secs(5), remote_rx.recv())
             .await
             .expect("timed out waiting for message on remote rx")
@@ -2414,8 +2403,7 @@ mod tests {
         let reply_port = reply_port.bind();
         echo_ref
             .port::<OncePortRef<ActorAddr>>()
-            .send(&client_inst, reply_port)
-            .unwrap();
+            .send(&client_inst, reply_port);
         let _ = tokio::time::timeout(Duration::from_secs(5), reply_handle.recv())
             .await
             .expect("baseline round-trip timed out")
@@ -2528,8 +2516,7 @@ mod tests {
                     let reply_port = reply_port.bind();
                     echo_ref
                         .port::<OncePortRef<ActorAddr>>()
-                        .send(&client_inst, reply_port)
-                        .unwrap();
+                        .send(&client_inst, reply_port);
                     let received =
                         tokio::time::timeout(Duration::from_secs(10), reply_handle.recv())
                             .await
@@ -2603,8 +2590,7 @@ mod tests {
         let reply_port = reply_port.bind();
         echo_ref
             .port::<OncePortRef<ActorAddr>>()
-            .send(&client_inst, reply_port)
-            .unwrap();
+            .send(&client_inst, reply_port);
 
         let received = tokio::time::timeout(Duration::from_secs(10), reply_handle.recv())
             .await

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -349,9 +349,7 @@ async fn push_config_to_host(
     // exact bypass HM-3 prohibits.
     request_port.return_undeliverable(false);
 
-    if let Err(send_err) = request_port.send(cx, msg) {
-        return Err(ConfigPushFailure::SendFailed(Box::new(send_err)));
-    }
+    request_port.send(cx, msg);
 
     match tokio::time::timeout(per_host_timeout, reply_receiver.recv()).await {
         Ok(Ok(())) => Ok(()),
@@ -1364,17 +1362,13 @@ impl HostMeshRef {
                     // If this proc dies or some other issue renders the reply undeliverable,
                     // the reply does not need to be returned to the sender.
                     reply_tx.return_undeliverable(false);
-                    mesh_agent
-                        .send(
-                            cx,
-                            resource::GetState {
-                                id: proc_name.clone(),
-                                reply: reply_tx,
-                            },
-                        )
-                        .map_err(|e| {
-                            crate::Error::SendingError(mesh_agent.actor_addr().clone(), e.into())
-                        })?;
+                    mesh_agent.send(
+                        cx,
+                        resource::GetState {
+                            id: proc_name.clone(),
+                            reply: reply_tx,
+                        },
+                    );
                     let state = match tokio::time::timeout(
                         hyperactor_config::global::get(PROC_SPAWN_MAX_IDLE),
                         reply_rx.recv(),
@@ -1509,17 +1503,13 @@ impl HostMeshRef {
             // Note that we don't send 1 message per host agent, we send 1 message
             // per proc.
             let host = HostRef(addr);
-            host.mesh_agent()
-                .send(
-                    cx,
-                    resource::Stop {
-                        id: proc_resource_id.clone(),
-                        reason: reason.clone(),
-                    },
-                )
-                .map_err(|e| {
-                    crate::Error::SendingError(host.mesh_agent().actor_addr().clone(), Box::new(e))
-                })?;
+            host.mesh_agent().send(
+                cx,
+                resource::Stop {
+                    id: proc_resource_id.clone(),
+                    reason: reason.clone(),
+                },
+            );
             host.mesh_agent()
                 .wait_rank_status(cx, proc_resource_id, Status::Stopped, port.bind())
                 .await
@@ -1636,7 +1626,7 @@ impl HostMeshRef {
                 id: proc_resource_id,
                 reply,
             };
-            let send_result = if let Some(expires_after) = keepalive {
+            if let Some(expires_after) = keepalive {
                 let mut keepalive_port = host.mesh_agent().port();
                 keepalive_port.return_undeliverable(false);
                 keepalive_port.send(
@@ -1645,13 +1635,10 @@ impl HostMeshRef {
                         expires_after,
                         get_state,
                     },
-                )
+                );
             } else {
-                send_port.send(cx, get_state)
-            };
-            send_result.map_err(|e| {
-                crate::Error::CallError(host.mesh_agent().actor_addr().clone(), e.into())
-            })?;
+                send_port.send(cx, get_state);
+            }
         }
 
         let mut states = Vec::with_capacity(num_ranks);

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -833,18 +833,7 @@ impl Handler<resource::GetRankStatus> for HostAgent {
             StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
                 .expect("valid single-run overlay")
         };
-        let result = get_rank_status.reply.send(cx, overlay);
-        // Ignore errors, because returning Err from here would cause the HostAgent
-        // to be stopped, which would take down the entire host. This only means
-        // some actor that requested the rank status failed to receive it.
-        if let Err(e) = result {
-            tracing::warn!(
-                actor = %cx.self_addr(),
-                "failed to send GetRankStatus reply to {} due to error: {}",
-                get_rank_status.reply.port_addr().actor_addr(),
-                e
-            );
-        }
+        get_rank_status.reply.send(cx, overlay);
         Ok(())
     }
 }
@@ -1074,7 +1063,7 @@ impl Handler<DrainHost> for HostAgent {
             // Selective drain: stop only procs belonging to the named mesh.
             self.drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
                 .await;
-            msg.ack.send(cx, ())?;
+            msg.ack.send(cx, ());
             return Ok(());
         }
 
@@ -1084,12 +1073,12 @@ impl Handler<DrainHost> for HostAgent {
             other @ (HostAgentState::Detached(_) | HostAgentState::Draining) => {
                 // Nothing to drain — ack immediately.
                 self.state = other;
-                msg.ack.send(cx, ())?;
+                msg.ack.send(cx, ());
                 return Ok(());
             }
             HostAgentState::Shutdown => {
                 self.state = HostAgentState::Shutdown;
-                msg.ack.send(cx, ())?;
+                msg.ack.send(cx, ());
                 return Ok(());
             }
         };
@@ -1124,7 +1113,7 @@ impl Handler<DrainComplete> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainComplete) -> anyhow::Result<()> {
         self.state = HostAgentState::Detached(msg.host);
         self.created.clear();
-        msg.ack.send(cx, ())?;
+        msg.ack.send(cx, ());
         Ok(())
     }
 }
@@ -1144,7 +1133,7 @@ impl Handler<ShutdownHost> for HostAgent {
 
         // Ack after children are terminated so the caller does not
         // tear down the host's networking prematurely.
-        msg.ack.send(cx, ())?;
+        msg.ack.send(cx, ());
 
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.
@@ -1246,18 +1235,7 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
             },
         };
 
-        let result = get_state.reply.send(cx, state);
-        // Ignore errors, because returning Err from here would cause the HostAgent
-        // to be stopped, which would take down the entire host. This only means
-        // some actor that requested the state of a proc failed to receive it.
-        if let Err(e) = result {
-            tracing::warn!(
-                actor = %cx.self_addr(),
-                "failed to send GetState reply to {} due to error: {}",
-                get_state.reply.port_addr().actor_addr(),
-                e
-            );
-        }
+        get_state.reply.send(cx, state);
         Ok(())
     }
 }
@@ -1321,8 +1299,7 @@ impl Handler<crate::proc_agent::SelfCheck> for HostAgent {
 #[async_trait]
 impl Handler<resource::List> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, list: resource::List) -> anyhow::Result<()> {
-        list.reply
-            .send(cx, self.created.keys().cloned().collect())?;
+        list.reply.send(cx, self.created.keys().cloned().collect());
         Ok(())
     }
 }
@@ -1402,17 +1379,9 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
 
         let mut headers = Flattrs::new();
         headers.set(crate::proc_agent::STREAM_STATE_SUBSCRIBER, true);
-        if let Err(e) = stream_state
+        stream_state
             .subscriber
-            .send_with_headers(cx, headers, state)
-        {
-            tracing::warn!(
-                actor = %cx.self_addr(),
-                "failed to send initial StreamState to {}: {}",
-                stream_state.subscriber.port_addr().actor_id(),
-                e,
-            );
-        }
+            .send_with_headers(cx, headers, state);
         Ok(())
     }
 }
@@ -1447,7 +1416,7 @@ impl Handler<SetClientConfig> for HostAgent {
             msg.attrs,
         );
         tracing::debug!("installed client config override on host agent");
-        msg.done.send(cx, ())?;
+        msg.done.send(cx, ());
         Ok(())
     }
 }
@@ -1482,7 +1451,7 @@ impl Handler<GetLocalProc> for HostAgent {
 
         match agent {
             Err(e) => anyhow::bail!("error booting local proc: {}", e),
-            Ok(agent) => proc_mesh_agent.send(cx, agent.clone())?,
+            Ok(agent) => proc_mesh_agent.send(cx, agent.clone()),
         };
 
         Ok(())
@@ -1519,11 +1488,7 @@ impl Handler<ConfigDump> for HostAgent {
         message: ConfigDump,
     ) -> Result<(), anyhow::Error> {
         let entries = hyperactor_config::global::config_entries();
-        // Reply is best-effort: the caller may have timed out and dropped
-        // the once-port.  That must not crash this actor.
-        if let Err(e) = message.result.send(cx, ConfigDumpResult { entries }) {
-            tracing::warn!("HostAgent: ConfigDump reply undeliverable (caller timed out): {e}",);
-        }
+        message.result.send(cx, ConfigDumpResult { entries });
         Ok(())
     }
 }
@@ -2010,8 +1975,7 @@ mod tests {
                     child_ref: Addr::Proc(system_proc.proc_addr().clone()),
                     reply: reply_port.bind(),
                 },
-            )
-            .unwrap();
+            );
             let payload = tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx.recv())
                 .await
                 .expect("QueryChild timed out")

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1357,7 +1357,7 @@ impl LogMessageHandler for LogClientActor {
                     self.flush_internal();
                     let reply = self.current_flush_port.take().unwrap();
                     self.current_flush_port = None;
-                    reply.send(cx, ()).map_err(anyhow::Error::from)?;
+                    reply.send(cx, ());
                 }
             }
         }
@@ -1404,9 +1404,7 @@ impl LogClientMessageHandler for LogClientActor {
         );
         self.current_flush_port = Some(reply.clone());
         self.current_unflushed_procs = expected_procs_flushed;
-        version
-            .send(cx, self.current_flush_version)
-            .map_err(anyhow::Error::from)?;
+        version.send(cx, self.current_flush_version);
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -409,7 +409,7 @@ async fn query_introspect(
             view,
             reply: reply_ref,
         },
-    )?;
+    );
     tokio::time::timeout(timeout, reply_rx.recv())
         .await
         .map_err(|_| anyhow::anyhow!("timed out {}", err_ctx))?
@@ -434,7 +434,7 @@ async fn query_child_introspect(
             child_ref,
             reply: reply_ref,
         },
-    )?;
+    );
     tokio::time::timeout(timeout, reply_rx.recv())
         .await
         .map_err(|_| anyhow::anyhow!("timed out {}", err_ctx))?
@@ -1095,9 +1095,7 @@ impl Handler<MeshAdminMessage> for MeshAdminAgent {
                 let resp = MeshAdminAddrResponse {
                     addr: self.admin_host.clone(),
                 };
-                if let Err(e) = reply.send(cx, resp) {
-                    tracing::debug!("GetAdminAddr reply failed (caller gone?): {e}");
-                }
+                reply.send(cx, resp);
             }
         }
         Ok(())
@@ -1130,9 +1128,7 @@ impl Handler<ResolveReferenceMessage> for MeshAdminAgent {
                         .await
                         .map_err(|e| format!("{:#}", e)),
                 );
-                if let Err(e) = reply.send(cx, response) {
-                    tracing::debug!("Resolve reply failed (caller gone?): {e}");
-                }
+                reply.send(cx, response);
             }
         }
         Ok(())
@@ -2089,8 +2085,6 @@ fn parse_proc_reference(raw: &str) -> Result<(String, ProcAddr), ApiError> {
 ///
 /// Returns `Ok(true)` if the actor responds, `Ok(false)` if the
 /// actor is absent or unresponsive (timeout / recv error).
-/// Returns `Err(ApiError)` on bridge-side send failure — a real
-/// infrastructure problem, not an absent actor.
 async fn probe_actor(
     cx: &Instance<()>,
     agent_id: &hyperactor::ActorAddr,
@@ -2103,19 +2097,7 @@ async fn probe_actor(
             view: IntrospectView::Entity,
             reply: handle.bind(),
         },
-    )
-    .map_err(|e| {
-        tracing::warn!(
-            name = "pyspy_probe_send_failed",
-            %agent_id,
-            error = %e,
-        );
-        ApiError {
-            code: "internal_error".to_string(),
-            message: format!("failed to send probe to {}: {}", agent_id, e),
-            details: None,
-        }
-    })?;
+    );
 
     let timeout = hyperactor_config::global::get(crate::config::MESH_ADMIN_QUERY_CHILD_TIMEOUT);
     match tokio::time::timeout(timeout, rx.recv()).await {
@@ -2173,12 +2155,7 @@ impl ResolvedProcHandler {
         match self {
             Self::Host(r) => r.send(cx, msg),
             Self::Proc(r) => r.send(cx, msg),
-        }
-        .map_err(|e| ApiError {
-            code: "internal_error".to_string(),
-            message: format!("failed to send PySpyDump: {}", e),
-            details: None,
-        })?;
+        };
         tokio::time::timeout(timeout, reply_rx.recv())
             .await
             .map_err(|_| ApiError {
@@ -2209,12 +2186,7 @@ impl ResolvedProcHandler {
         match self {
             Self::Host(r) => r.send(cx, msg),
             Self::Proc(r) => r.send(cx, msg),
-        }
-        .map_err(|e| ApiError {
-            code: "internal_error".to_string(),
-            message: format!("failed to send PySpyProfile: {}", e),
-            details: None,
-        })?;
+        };
         tokio::time::timeout(timeout, reply_rx.recv())
             .await
             .map_err(|_| ApiError {
@@ -2241,12 +2213,7 @@ impl ResolvedProcHandler {
         match self {
             Self::Host(r) => r.send(cx, msg),
             Self::Proc(r) => r.send(cx, msg),
-        }
-        .map_err(|e| ApiError {
-            code: "internal_error".to_string(),
-            message: format!("failed to send ConfigDump: {}", e),
-            details: None,
-        })?;
+        };
         tokio::time::timeout(timeout, reply_rx.recv())
             .await
             .map_err(|_| ApiError {
@@ -3527,16 +3494,14 @@ mod tests {
 
         // Spawn a user proc via CreateOrUpdate<ProcSpec>.
         let user_proc_name = ResourceId::unique(Label::new("user-proc").unwrap());
-        host_agent_ref
-            .send(
-                &client,
-                resource::CreateOrUpdate {
-                    id: user_proc_name.clone(),
-                    rank: Rank::new(0),
-                    spec: ProcSpec::default(),
-                },
-            )
-            .unwrap();
+        host_agent_ref.send(
+            &client,
+            resource::CreateOrUpdate {
+                id: user_proc_name.clone(),
+                rank: Rank::new(0),
+                spec: ProcSpec::default(),
+            },
+        );
 
         // Wait for the user proc to boot.
         tokio::time::sleep(Duration::from_secs(2)).await;

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -243,16 +243,8 @@ fn send_subscriber_message(
 ) {
     let mut headers = Flattrs::new();
     headers.set(ACTOR_MESH_SUBSCRIBER_MESSAGE, true);
-    if let Err(error) = subscriber.send_with_headers(cx, headers, Some(message.clone())) {
-        tracing::warn!(
-            event = %message,
-            "failed to send supervision event to subscriber {}: {}",
-            subscriber.port_addr(),
-            error
-        );
-    } else {
-        tracing::info!(event = %message, "sent supervision failure message to subscriber {}", subscriber.port_addr());
-    }
+    subscriber.send_with_headers(cx, headers, Some(message.clone()));
+    tracing::info!(event = %message, "sent supervision failure message to subscriber {}", subscriber.port_addr());
 }
 
 /// Like send_state_change, but when there was no state change that occurred.
@@ -270,9 +262,7 @@ fn send_heartbeat(cx: &impl context::Actor, health_state: &HealthState) {
     for subscriber in health_state.subscribers.iter() {
         let mut headers = Flattrs::new();
         headers.set(ACTOR_MESH_SUBSCRIBER_MESSAGE, true);
-        if let Err(e) = subscriber.send_with_headers(cx, headers, None) {
-            tracing::warn!(subscriber = %subscriber.port_addr(), "error sending heartbeat message: {:?}", e);
-        }
+        subscriber.send_with_headers(cx, headers, None);
     }
 }
 
@@ -324,19 +314,8 @@ fn send_state_change(
     // told that they were stopped.
     if is_failed {
         if let Some(owner) = &health_state.owner {
-            if let Err(error) = owner.send(cx, failure_message.clone()) {
-                tracing::warn!(
-                    name = "SupervisionEvent",
-                    actor_mesh = %mesh_name,
-                    %event,
-                    %error,
-                    "failed to send supervision event to owner {}: {}. dropping event",
-                    owner.port_addr(),
-                    error
-                );
-            } else {
-                tracing::info!(actor_mesh = %mesh_name, %event, "sent supervision failure message to owner {}", owner.port_addr());
-            }
+            owner.send(cx, failure_message.clone());
+            tracing::info!(actor_mesh = %mesh_name, %event, "sent supervision failure message to owner {}", owner.port_addr());
         }
     }
     // Subscribers get all messages, even for non-failures like Stopped, because
@@ -646,7 +625,7 @@ impl<T: Controlled> ResourceController<T> {
                 generation: 0,
                 timestamp: SystemTime::now(),
             },
-        )?;
+        );
         Ok(())
     }
 
@@ -885,7 +864,7 @@ where
         cx: &Context<Self>,
         message: GetSubscriberCount,
     ) -> anyhow::Result<()> {
-        message.0.send(cx, self.health_state.subscribers.len())?;
+        message.0.send(cx, self.health_state.subscribers.len());
         Ok(())
     }
 }
@@ -1307,7 +1286,7 @@ impl Controlled for ProcMeshRef {
                     id: proc_resource_id,
                     subscriber: subscriber.clone(),
                 },
-            )?;
+            );
         }
         Ok(())
     }
@@ -1319,7 +1298,7 @@ impl Controlled for ProcMeshRef {
     ) -> anyhow::Result<()> {
         for proc_id in self.proc_ids() {
             let host = crate::host_mesh::HostRef(proc_id.addr().clone());
-            host.mesh_agent().send(cx, msg.clone())?;
+            host.mesh_agent().send(cx, msg.clone());
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -228,13 +228,7 @@ impl ActorInstanceState {
         for subscriber in &self.subscribers {
             let mut headers = Flattrs::new();
             headers.set(STREAM_STATE_SUBSCRIBER, true);
-            if let Err(e) = subscriber.send_with_headers(cx, headers, state.clone()) {
-                tracing::warn!(
-                    "failed to send state update to subscriber {}: {}",
-                    subscriber.port_addr(),
-                    e,
-                );
-            }
+            subscriber.send_with_headers(cx, headers, state.clone());
         }
 
         // One-shot waiters (predicated).
@@ -1018,18 +1012,7 @@ impl Handler<resource::GetRankStatus> for ProcAgent {
             StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
                 .expect("valid single-run overlay")
         };
-        let result = get_rank_status.reply.send(cx, overlay);
-        // Ignore errors, because returning Err from here would cause the ProcAgent
-        // to be stopped, which would prevent querying and spawning other actors.
-        // This only means some actor that requested the state of an actor failed to receive it.
-        if let Err(e) = result {
-            tracing::warn!(
-                actor = %cx.self_addr(),
-                "failed to send GetRankStatus reply to {} due to error: {}",
-                get_rank_status.reply.port_addr().actor_addr(),
-                e
-            );
-        }
+        get_rank_status.reply.send(cx, overlay);
         Ok(())
     }
 }
@@ -1088,15 +1071,7 @@ impl Handler<resource::GetState<ActorState>> for ProcAgent {
             },
         };
 
-        let result = get_state.reply.send(cx, state);
-        if let Err(e) = result {
-            tracing::warn!(
-                actor = %cx.self_addr(),
-                "failed to send GetState reply to {} due to error: {}",
-                get_state.reply.port_addr().actor_addr(),
-                e
-            );
-        }
+        get_state.reply.send(cx, state);
         Ok(())
     }
 }
@@ -1126,17 +1101,9 @@ impl Handler<resource::StreamState<ActorState>> for ProcAgent {
         // Send the current state immediately.
         let mut headers = Flattrs::new();
         headers.set(STREAM_STATE_SUBSCRIBER, true);
-        if let Err(e) = stream_state
+        stream_state
             .subscriber
-            .send_with_headers(cx, headers, state)
-        {
-            tracing::warn!(
-                actor = %cx.self_addr(),
-                "failed to send initial StreamState to {}: {}",
-                stream_state.subscriber.port_addr().actor_addr(),
-                e,
-            );
-        }
+            .send_with_headers(cx, headers, state);
         Ok(())
     }
 }
@@ -1183,7 +1150,7 @@ impl Handler<NewClientInstance> for ProcAgent {
         NewClientInstance { client_instance }: NewClientInstance,
     ) -> anyhow::Result<()> {
         let (instance, _handle) = self.proc.instance("client")?;
-        client_instance.send(cx, instance)?;
+        client_instance.send(cx, instance);
         Ok(())
     }
 }
@@ -1203,7 +1170,7 @@ impl Handler<GetProc> for ProcAgent {
         cx: &Context<Self>,
         GetProc { proc }: GetProc,
     ) -> anyhow::Result<()> {
-        proc.send(cx, self.proc.clone())?;
+        proc.send(cx, self.proc.clone());
         Ok(())
     }
 }
@@ -1320,8 +1287,7 @@ mod tests {
                     child_ref: Addr::Proc(proc.proc_addr().clone()),
                     reply: reply_port.bind(),
                 },
-            )
-            .unwrap();
+            );
             reply_rx
         };
         let recv = |rx: hyperactor::mailbox::OncePortReceiver<IntrospectResult>| async move {
@@ -1427,18 +1393,13 @@ mod tests {
         let query_task = tokio::spawn(async move {
             loop {
                 let (reply_port, reply_rx) = query_client.open_once_port::<IntrospectResult>();
-                if query_port
-                    .send(
-                        &query_client,
-                        IntrospectMessage::QueryChild {
-                            child_ref: Addr::Proc(query_proc_id.clone()),
-                            reply: reply_port.bind(),
-                        },
-                    )
-                    .is_err()
-                {
-                    break;
-                }
+                query_port.send(
+                    &query_client,
+                    IntrospectMessage::QueryChild {
+                        child_ref: Addr::Proc(query_proc_id.clone()),
+                        reply: reply_port.bind(),
+                    },
+                );
                 match tokio::time::timeout(std::time::Duration::from_secs(2), reply_rx.recv()).await
                 {
                     Ok(Ok(_)) => {
@@ -1495,8 +1456,7 @@ mod tests {
                 child_ref: Addr::Proc(proc.proc_addr().clone()),
                 reply: reply_port.bind(),
             },
-        )
-        .unwrap();
+        );
         let final_payload =
             tokio::time::timeout(std::time::Duration::from_secs(5), reply_rx.recv())
                 .await
@@ -1749,8 +1709,7 @@ mod tests {
                     child_ref: Addr::Proc(proc.proc_addr().clone()),
                     reply: reply_port.bind(),
                 },
-            )
-            .unwrap();
+            );
             let payload = tokio::time::timeout(std::time::Duration::from_secs(3), reply_rx.recv())
                 .await
                 .expect("QueryChild timed out")

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -158,7 +158,7 @@ impl ProcMesh {
             );
         }
 
-        let root_comm_actor = ActorRef::attest(
+        let _root_comm_actor: ActorRef<CommActor> = ActorRef::attest(
             ranks
                 .first()
                 .expect("root mesh cannot be empty")
@@ -219,7 +219,7 @@ impl ProcMesh {
             }
         }
 
-        let mut proc_mesh = Self {
+        let proc_mesh = Self {
             id,
             comm_actor_name: Some(comm_actor_name.clone()),
             current_ref,
@@ -239,13 +239,8 @@ impl ProcMesh {
         // Now that we have all of the spawned comm actors, kick them all into
         // mesh mode.
         for (rank, comm_actor) in &address_book {
-            comm_actor
-                .send(cx, CommMeshConfig::new(*rank, address_book.clone()))
-                .map_err(|e| Error::SendingError(comm_actor.actor_addr().clone(), Box::new(e)))?
+            comm_actor.send(cx, CommMeshConfig::new(*rank, address_book.clone()));
         }
-
-        // The comm actor is now set up and ready to go.
-        proc_mesh.current_ref.root_comm_actor = Some(root_comm_actor);
 
         Ok(proc_mesh)
     }
@@ -271,34 +266,26 @@ impl ProcMesh {
     pub async fn stop(&mut self, cx: &impl context::Actor, reason: String) -> anyhow::Result<()> {
         if let Some(controller) = self.controller.take() {
             let id = self.id.resource_id().clone();
-            controller
-                .send(
-                    cx,
-                    resource::Stop {
-                        id: id.clone(),
-                        reason,
-                    },
-                )
-                .map_err(|e| {
-                    crate::Error::SendingError(controller.actor_addr().clone(), Box::new(e))
-                })?;
+            controller.send(
+                cx,
+                resource::Stop {
+                    id: id.clone(),
+                    reason,
+                },
+            );
 
             // The controller processes messages serially, so by the time it
             // gets to this `GetState`, its `health_state.statuses` already
             // reflects the outcome of `stop_proc_mesh` (Stopping, Stopped,
             // Failed, or Timeout on `PROC_STOP_MAX_IDLE` exhaustion).
             let (port, mut rx) = cx.mailbox().open_port();
-            controller
-                .send(
-                    cx,
-                    resource::GetState::<resource::mesh::State<()>> {
-                        id: id.clone(),
-                        reply: port.bind(),
-                    },
-                )
-                .map_err(|e| {
-                    crate::Error::SendingError(controller.actor_addr().clone(), Box::new(e))
-                })?;
+            controller.send(
+                cx,
+                resource::GetState::<resource::mesh::State<()>> {
+                    id: id.clone(),
+                    reply: port.bind(),
+                },
+            );
 
             let statuses = rx.recv().await?;
             let Some(state) = &statuses.state else {

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -567,17 +567,11 @@ impl PySpyWorker {
                     exit_code: None,
                     stderr: format!("failed to spawn pyspy worker: {}", e),
                 };
-                reply_port.send(cx, fail)?;
+                reply_port.send(cx, fail);
                 return Ok(());
             }
         };
-        // Once reply_port moves into RunPySpyDump, we lose it.
-        // MailboxSenderError does not carry the unsent message, so
-        // on send failure the caller will observe a timeout rather
-        // than an explicit Failed reply.
-        if let Err(e) = worker.send(cx, RunPySpyDump { opts, reply_port }) {
-            tracing::error!("failed to send to pyspy worker: {}", e);
-        }
+        worker.send(cx, RunPySpyDump { opts, reply_port });
         Ok(())
     }
 }
@@ -590,7 +584,7 @@ impl Handler<RunPySpyDump> for PySpyWorker {
         message: RunPySpyDump,
     ) -> Result<(), anyhow::Error> {
         let result = PySpyRunner.dump_self(&message.opts).await;
-        message.reply_port.send(cx, result)?;
+        message.reply_port.send(cx, result);
         cx.stop("pyspy dump complete")?;
         Ok(())
     }
@@ -626,23 +620,17 @@ impl PySpyProfileWorker {
                 let fail = ProfileExecOutcome::WorkerSpawnFailure {
                     error: e.to_string(),
                 };
-                reply_port.send(cx, PySpyProfileResult::from(fail))?;
+                reply_port.send(cx, PySpyProfileResult::from(fail));
                 return Ok(());
             }
         };
-        // Once reply_port moves into RunPySpyProfile, we lose it.
-        // MailboxSenderError does not carry the unsent message, so
-        // on send failure the caller observes a bridge timeout
-        // rather than a typed error. Same limitation as PySpyWorker.
-        if let Err(e) = worker.send(
+        worker.send(
             cx,
             RunPySpyProfile {
                 request,
                 reply_port,
             },
-        ) {
-            tracing::error!("failed to send to profile worker: {}", e);
-        }
+        );
         Ok(())
     }
 }
@@ -657,7 +645,7 @@ impl Handler<RunPySpyProfile> for PySpyProfileWorker {
         let outcome = PySpyRunner.profile_self(&message.request).await;
         message
             .reply_port
-            .send(cx, PySpyProfileResult::from(outcome))?;
+            .send(cx, PySpyProfileResult::from(outcome));
         cx.stop("pyspy profile complete")?;
         Ok(())
     }

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -128,7 +128,7 @@ impl Handler<GetActorId> for TestActor {
         GetActorId(reply): GetActorId,
     ) -> Result<(), anyhow::Error> {
         let seq_info = cx.headers().get(SEQ_INFO);
-        reply.send(cx, (cx.self_addr().clone(), seq_info))?;
+        reply.send(cx, (cx.self_addr().clone(), seq_info));
         Ok(())
     }
 }
@@ -221,7 +221,7 @@ impl Handler<Forward> for TestActor {
         visited.push(this);
         let next = to_visit.front().cloned();
         anyhow::ensure!(next.is_some(), "unexpected forward chain termination");
-        next.unwrap().send(cx, Forward { to_visit, visited })?;
+        next.unwrap().send(cx, Forward { to_visit, visited });
         Ok(())
     }
 }
@@ -251,7 +251,7 @@ impl Handler<GetCastInfo> for TestActor {
         cx: &Context<Self>,
         GetCastInfo { cast_info }: GetCastInfo,
     ) -> Result<(), anyhow::Error> {
-        cast_info.send(cx, (cx.cast_point(), cx.bind(), cx.sender().clone()))?;
+        cast_info.send(cx, (cx.cast_point(), cx.bind(), cx.sender().clone()));
         Ok(())
     }
 }
@@ -307,7 +307,7 @@ impl Handler<GetConfigAttrs> for TestActor {
             hyperactor_config::global::attrs(),
             bincode::config::legacy(),
         )?;
-        reply.send(cx, attrs)?;
+        reply.send(cx, attrs);
         Ok(())
     }
 }
@@ -396,7 +396,7 @@ impl Handler<NextSupervisionFailure> for WrapperActor {
         let mesh = if let Some(mesh) = self.mesh.as_ref() {
             mesh.deref()
         } else {
-            msg.0.send(cx, None)?;
+            msg.0.send(cx, None);
             return Ok(());
         };
         let failure = match tokio::time::timeout(
@@ -411,7 +411,7 @@ impl Handler<NextSupervisionFailure> for WrapperActor {
             // If we timeout, send back None.
             Err(_) => None,
         };
-        msg.0.send(cx, failure)?;
+        msg.0.send(cx, failure);
         Ok(())
     }
 }

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -79,7 +79,7 @@ pub struct Echo(pub String, pub reference::PortRef<String>);
 impl Handler<Echo> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, message: Echo) -> Result<(), anyhow::Error> {
         let Echo(message, reply_port) = message;
-        reply_port.send(cx, message)?;
+        reply_port.send(cx, message);
         Ok(())
     }
 }
@@ -160,8 +160,8 @@ impl Handler<Echo> for ProxyActor {
         let actor = self.actor_mesh.as_ref().unwrap().get(0).unwrap();
 
         let (tx, mut rx) = cx.open_port();
-        actor.send(cx, Echo(message.0, tx.bind()))?;
-        message.1.send(cx, rx.recv().await.unwrap())?;
+        actor.send(cx, Echo(message.0, tx.bind()));
+        message.1.send(cx, rx.recv().await.unwrap());
 
         Ok(())
     }
@@ -198,7 +198,7 @@ async fn run_client(exe_path: PathBuf, keep_alive: bool) -> Result<(), anyhow::E
         .await?;
     let proxy_actor = actor_mesh.get(0).unwrap();
     let (tx, mut rx) = instance.mailbox().open_port::<String>();
-    proxy_actor.send(instance, Echo("hello!".to_owned(), tx.bind()))?;
+    proxy_actor.send(instance, Echo("hello!".to_owned(), tx.bind()));
 
     let msg = rx.recv().await?;
     println!("{}", msg);

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -364,7 +364,7 @@ impl KeepaliveWorker {
                 generation,
                 reply: this.port::<KeepaliveAck>().bind().into_once(),
             },
-        )?;
+        );
 
         this.self_message_with_delay(SendKeepalive { generation }, self.interval)?;
         this.self_message_with_delay(AckDeadline { generation }, self.timeout)?;
@@ -401,7 +401,7 @@ impl Handler<Keepalive> for KeepaliveSupervisor {
             KeepaliveAck {
                 generation: message.generation,
             },
-        )?;
+        );
         self.schedule_deadline(cx)
     }
 }
@@ -485,7 +485,7 @@ mod tests {
             this: &Instance<Self>,
             event: &ActorSupervisionEvent,
         ) -> anyhow::Result<bool> {
-            self.events.send(this, event.clone())?;
+            self.events.send(this, event.clone());
             Ok(true)
         }
     }
@@ -515,15 +515,13 @@ mod tests {
             .unwrap();
         let (reply, ack_rx) = parent.open_once_port::<KeepaliveAck>();
 
-        supervisor
-            .send(
-                &parent,
-                Keepalive {
-                    generation: 41,
-                    reply: reply.bind(),
-                },
-            )
-            .unwrap();
+        supervisor.send(
+            &parent,
+            Keepalive {
+                generation: 41,
+                reply: reply.bind(),
+            },
+        );
 
         let ack = ack_rx.recv().await.unwrap();
         assert_eq!(ack.generation, 41);

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -162,7 +162,7 @@ mod tests {
             this: &Instance<Self>,
             event: &ActorSupervisionEvent,
         ) -> anyhow::Result<bool> {
-            self.events.send(this, event.clone())?;
+            self.events.send(this, event.clone());
             Ok(true)
         }
     }

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -122,7 +122,7 @@ impl Actor for Supervisor {
                 link,
                 options: self.options.clone(),
             },
-        )?;
+        );
         Ok(())
     }
 
@@ -217,7 +217,7 @@ impl Supervisor {
                 mode: stop.mode,
                 reason: stop.reason,
             },
-        )?;
+        );
         Ok(())
     }
 
@@ -304,19 +304,14 @@ where
             if let Some(session) = &self.session {
                 let supervisor = session.supervisor.clone();
                 let session_id = session.session_id.clone();
-                if supervisor
-                    .send(
-                        this,
-                        WorkerSupervisor::SupervisionEvent {
-                            session_id: session_id.into_uid(),
-                            event: event.clone(),
-                            disposition: RemoteActorDisposition::Terminal,
-                        },
-                    )
-                    .is_err()
-                {
-                    let _ = self.unlink_orphaned_supervisor("supervisor session undeliverable");
-                }
+                supervisor.send(
+                    this,
+                    WorkerSupervisor::SupervisionEvent {
+                        session_id: session_id.into_uid(),
+                        event: event.clone(),
+                        disposition: RemoteActorDisposition::Terminal,
+                    },
+                );
             }
             self.child_handle = None;
             this.exit("supervised child stopped")?;
@@ -376,19 +371,14 @@ where
             options: message.options,
             link_handle,
         });
-        if supervisor
-            .send(
-                cx,
-                WorkerSupervisor::Linked {
-                    session_id: message.session_id.clone(),
-                    child: child_addr,
-                    display_name: self.child_display_name.clone(),
-                },
-            )
-            .is_err()
-        {
-            self.handle_orphaned_supervisor("supervisor session undeliverable")?;
-        }
+        supervisor.send(
+            cx,
+            WorkerSupervisor::Linked {
+                session_id: message.session_id.clone(),
+                child: child_addr,
+                display_name: self.child_display_name.clone(),
+            },
+        );
         Ok(())
     }
 }
@@ -495,28 +485,19 @@ impl<C: Actor> Worker<C> {
         let session_id = session.session_id.clone();
         let orphan_policy = session.options.orphan_policy;
         if let Some(child) = &self.child_handle {
-            if supervisor
-                .send(
-                    cx,
-                    WorkerSupervisor::SupervisionEvent {
-                        session_id: session_id.into_uid(),
-                        event: ActorSupervisionEvent::new(
-                            child.actor_addr().clone(),
-                            self.child_display_name.clone(),
-                            ActorStatus::generic_failure(format!(
-                                "supervision link failed: {}",
-                                event
-                            )),
-                            None,
-                        ),
-                        disposition: RemoteActorDisposition::Unreachable,
-                    },
-                )
-                .is_err()
-            {
-                self.handle_orphaned_supervisor("supervisor session undeliverable")?;
-                return Ok(());
-            }
+            supervisor.send(
+                cx,
+                WorkerSupervisor::SupervisionEvent {
+                    session_id: session_id.into_uid(),
+                    event: ActorSupervisionEvent::new(
+                        child.actor_addr().clone(),
+                        self.child_display_name.clone(),
+                        ActorStatus::generic_failure(format!("supervision link failed: {}", event)),
+                        None,
+                    ),
+                    disposition: RemoteActorDisposition::Unreachable,
+                },
+            );
         }
         let session = self
             .session
@@ -584,7 +565,7 @@ mod tests {
     #[async_trait]
     impl Actor for TestChild {
         async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
-            self.ready.send(this, this.self_addr().clone())?;
+            self.ready.send(this, this.self_addr().clone());
             match self.action.take() {
                 Some(TestChildAction::FailAfter(delay)) => {
                     this.self_message_with_delay(TestChildCommand::Fail, delay)?;
@@ -603,7 +584,7 @@ mod tests {
             mode: StopMode,
             reason: &str,
         ) -> anyhow::Result<()> {
-            self.stopped.send(this, reason.to_string())?;
+            self.stopped.send(this, reason.to_string());
             this.close();
             match mode {
                 StopMode::Stop => this.exit(reason)?,
@@ -624,7 +605,7 @@ mod tests {
                 TestChildCommand::Fail => cx.kill("test child failed")?,
                 TestChildCommand::Drain(tag) => {
                     if let Some(ref port) = self.drain_observer {
-                        port.send(cx, tag)?;
+                        port.send(cx, tag);
                     }
                 }
             }
@@ -654,7 +635,7 @@ mod tests {
             this: &Instance<Self>,
             event: &ActorSupervisionEvent,
         ) -> anyhow::Result<bool> {
-            self.events.send(this, event.clone())?;
+            self.events.send(this, event.clone());
             Ok(true)
         }
     }
@@ -676,7 +657,7 @@ mod tests {
                     .take()
                     .expect("grandparent initialized more than once"),
             )?;
-            self.parent_addr.send(this, parent.actor_addr().clone())?;
+            self.parent_addr.send(this, parent.actor_addr().clone());
             self.parent_handle = Some(parent);
             Ok(())
         }
@@ -686,7 +667,7 @@ mod tests {
             this: &Instance<Self>,
             event: &ActorSupervisionEvent,
         ) -> anyhow::Result<bool> {
-            self.events.send(this, event.clone())?;
+            self.events.send(this, event.clone());
             Ok(true)
         }
     }
@@ -791,7 +772,7 @@ mod tests {
     impl Handler<Link> for TestSlowWorker {
         async fn handle(&mut self, cx: &Context<Self>, message: Link) -> anyhow::Result<()> {
             self.session = Some((message.session_id, message.supervisor));
-            self.link_started.send(cx, ())?;
+            self.link_started.send(cx, ());
             self.release_link.notified().await;
             Ok(())
         }
@@ -812,7 +793,7 @@ mod tests {
                     anyhow::bail!("stop received before link");
                 };
                 anyhow::ensure!(session_id == expected_session_id, "unexpected session id");
-                self.received_stop.send(cx, reason.clone())?;
+                self.received_stop.send(cx, reason.clone());
                 let _ = supervisor.send(cx, WorkerSupervisor::Unlinked { session_id, reason });
             }
             Ok(())
@@ -947,18 +928,16 @@ mod tests {
         let _child_addr = ready_rx.recv().await.unwrap();
         let session_id = hyperactor::Uid::instance();
 
-        worker
-            .send(
-                &client,
-                Link {
-                    session_id: session_id.clone(),
-                    supervisor: supervisor_ref.clone(),
-                    parent: client.self_addr().clone(),
-                    link,
-                    options: LinkOptions::default(),
-                },
-            )
-            .unwrap();
+        worker.send(
+            &client,
+            Link {
+                session_id: session_id.clone(),
+                supervisor: supervisor_ref.clone(),
+                parent: client.self_addr().clone(),
+                link,
+                options: LinkOptions::default(),
+            },
+        );
         let linked = tokio::time::timeout(Duration::from_secs(5), supervisor_rx.recv())
             .await
             .unwrap()
@@ -977,8 +956,7 @@ mod tests {
         .unwrap();
         worker
             .port::<Undeliverable<MessageEnvelope>>()
-            .send(&client, Undeliverable::Message(envelope))
-            .unwrap();
+            .send(&client, Undeliverable::Message(envelope));
 
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
             .await
@@ -1050,7 +1028,7 @@ mod tests {
         let parent_addr = parent_addr_rx.recv().await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(100)).await;
-        grandparent.send(&client, KillParent).unwrap();
+        grandparent.send(&client, KillParent);
 
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
             .await
@@ -1108,21 +1086,19 @@ mod tests {
         let _child_addr = ready_rx.recv().await.unwrap();
         let session_id = hyperactor::Uid::instance();
 
-        worker
-            .send(
-                &inst,
-                Link {
-                    session_id: session_id.clone(),
-                    supervisor: supervisor_ref.clone(),
-                    parent: inst.self_addr().clone(),
-                    link: link_spec,
-                    options: LinkOptions {
-                        orphan_policy: OrphanPolicy::Detach,
-                        ..Default::default()
-                    },
+        worker.send(
+            &inst,
+            Link {
+                session_id: session_id.clone(),
+                supervisor: supervisor_ref.clone(),
+                parent: inst.self_addr().clone(),
+                link: link_spec,
+                options: LinkOptions {
+                    orphan_policy: OrphanPolicy::Detach,
+                    ..Default::default()
                 },
-            )
-            .unwrap();
+            },
+        );
         let linked = tokio::time::timeout(Duration::from_secs(5), supervisor_rx.recv())
             .await
             .unwrap()
@@ -1145,8 +1121,7 @@ mod tests {
         .unwrap();
         worker
             .port::<Undeliverable<MessageEnvelope>>()
-            .send(&inst, Undeliverable::Message(envelope))
-            .unwrap();
+            .send(&inst, Undeliverable::Message(envelope));
 
         // Under `Detach`, the worker clears its session and stops the
         // link, but does NOT stop the child. No message shhould arrive on
@@ -1214,15 +1189,13 @@ mod tests {
         // issuing Unlink.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        worker
-            .send(
-                &inst,
-                SupervisedWorker::Unlink {
-                    session_id: session_id.clone(),
-                    reason: "test unlink".to_string(),
-                },
-            )
-            .unwrap();
+        worker.send(
+            &inst,
+            SupervisedWorker::Unlink {
+                session_id: session_id.clone(),
+                reason: "test unlink".to_string(),
+            },
+        );
 
         // Under OrphanPolicy::Stop the worker stops the child with
         // the unlink reason.
@@ -1302,15 +1275,13 @@ mod tests {
         // issuing Unlink.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        worker
-            .send(
-                &inst,
-                SupervisedWorker::Unlink {
-                    session_id: session_id.clone(),
-                    reason: "test unlink".to_string(),
-                },
-            )
-            .unwrap();
+        worker.send(
+            &inst,
+            SupervisedWorker::Unlink {
+                session_id: session_id.clone(),
+                reason: "test unlink".to_string(),
+            },
+        );
 
         // Supervisor receives `Unlinked` and exits cleanly via cx.exit;
         // Parent observes that supervisor exit as a `Stopped(reason)`
@@ -1617,16 +1588,14 @@ mod tests {
         assert_eq!(drained_tag, "child work");
 
         // Now send Stop with DrainAndStop.
-        worker
-            .send(
-                &inst,
-                SupervisedWorker::Stop {
-                    session_id: session_id.clone(),
-                    mode: StopMode::DrainAndStop,
-                    reason: "drain test".to_string(),
-                },
-            )
-            .unwrap();
+        worker.send(
+            &inst,
+            SupervisedWorker::Stop {
+                session_id: session_id.clone(),
+                mode: StopMode::DrainAndStop,
+                reason: "drain test".to_string(),
+            },
+        );
 
         // Child reports the drain-stop reason via handle_stop.
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
@@ -1686,15 +1655,13 @@ mod tests {
         // issuing Unlink.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        worker
-            .send(
-                &inst,
-                SupervisedWorker::Unlink {
-                    session_id: session_id1.clone(),
-                    reason: "first unlink".to_string(),
-                },
-            )
-            .unwrap();
+        worker.send(
+            &inst,
+            SupervisedWorker::Unlink {
+                session_id: session_id1.clone(),
+                reason: "first unlink".to_string(),
+            },
+        );
 
         let event1 = tokio::time::timeout(Duration::from_secs(5), events_rx1.recv())
             .await
@@ -1734,15 +1701,13 @@ mod tests {
         // Give the second Link/Linked handshake time to complete.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        worker
-            .send(
-                &inst,
-                SupervisedWorker::Unlink {
-                    session_id: session_id2.clone(),
-                    reason: "second unlink".to_string(),
-                },
-            )
-            .unwrap();
+        worker.send(
+            &inst,
+            SupervisedWorker::Unlink {
+                session_id: session_id2.clone(),
+                reason: "second unlink".to_string(),
+            },
+        );
 
         let event2 = tokio::time::timeout(Duration::from_secs(5), events_rx2.recv())
             .await

--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -229,7 +229,7 @@ impl<C: TokenPeer, J: TokenPeer> Token<C, J> {
         joiner: J,
         result: PortRef<JoinResult<C>>,
     ) -> anyhow::Result<()> {
-        self.rendezvous.send(cx, Join { joiner, result })?;
+        self.rendezvous.send(cx, Join { joiner, result });
         Ok(())
     }
 
@@ -347,35 +347,23 @@ impl<C: TokenPeer + Clone, J: TokenPeer> Handler<Join<C, J>> for Rendezvous<C, J
                 JoinResult::Rejected {
                     reason: "token already joined".to_string(),
                 },
-            )?;
+            );
             return Ok(());
         }
 
-        if self
-            .creator_joined
-            .send(
-                cx,
-                Joined {
-                    peer: message.joiner,
-                },
-            )
-            .is_err()
-        {
-            message.result.send(
-                cx,
-                JoinResult::Rejected {
-                    reason: "token creator unavailable".to_string(),
-                },
-            )?;
-            return Ok(());
-        }
+        self.creator_joined.send(
+            cx,
+            Joined {
+                peer: message.joiner,
+            },
+        );
 
         message.result.send(
             cx,
             JoinResult::Joined {
                 peer: self.creator.clone(),
             },
-        )?;
+        );
         self.joined = true;
         Ok(())
     }

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -81,7 +81,7 @@ impl Actor for Parent {
             this.port::<token::Joined<ActorRef<WorkerLike>>>().bind(),
             TokenOptions::default(),
         )?;
-        self.token_out.send(this, token.to_string())?;
+        self.token_out.send(this, token.to_string());
         Ok(())
     }
 
@@ -90,7 +90,7 @@ impl Actor for Parent {
         this: &Instance<Self>,
         event: &ActorSupervisionEvent,
     ) -> anyhow::Result<bool> {
-        self.events.send(this, event.clone())?;
+        self.events.send(this, event.clone());
         this.exit("remote supervision event observed")?;
         Ok(true)
     }
@@ -103,7 +103,7 @@ impl Handler<token::Joined<ActorRef<WorkerLike>>> for Parent {
         cx: &Context<Self>,
         message: token::Joined<ActorRef<WorkerLike>>,
     ) -> anyhow::Result<()> {
-        self.linked.send(cx, message.peer.actor_addr().clone())?;
+        self.linked.send(cx, message.peer.actor_addr().clone());
         cx.spawn(Supervisor::new(
             message.peer,
             KeepaliveLink::new(Duration::from_millis(100), Duration::from_millis(300)),
@@ -156,7 +156,7 @@ impl Handler<ParentControl> for ParentRoot {
             .as_ref()
             .expect("parent must be spawned before control message");
         match message {
-            ParentControl::Exit => parent.send(cx, ParentExit)?,
+            ParentControl::Exit => parent.send(cx, ParentExit),
             ParentControl::Kill => parent.kill("test parent killed")?,
         }
         Ok(())
@@ -173,7 +173,7 @@ struct SupervisedChild {
 #[async_trait]
 impl Actor for SupervisedChild {
     async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
-        self.ready.send(this, this.self_addr().clone())?;
+        self.ready.send(this, this.self_addr().clone());
         if let Some(ChildAction::StopAfter(delay)) = self.action.take() {
             this.self_message_with_delay(ChildControl::Stop, delay)?;
         }
@@ -186,7 +186,7 @@ impl Actor for SupervisedChild {
         mode: StopMode,
         reason: &str,
     ) -> anyhow::Result<()> {
-        self.stopped.send(this, reason.to_string())?;
+        self.stopped.send(this, reason.to_string());
         this.close();
         match mode {
             StopMode::Stop => this.exit(reason)?,
@@ -223,7 +223,7 @@ impl Actor for WorkerRoot {
             stopped: self.child_stopped.clone(),
             action: self.child_action.take(),
         }))?;
-        self.worker_out.send(this, worker.bind::<WorkerLike>())?;
+        self.worker_out.send(this, worker.bind::<WorkerLike>());
         self.worker = Some(worker);
         Ok(())
     }
@@ -386,7 +386,7 @@ async fn test_token_join_parent_exit_stops_child_first() -> anyhow::Result<()> {
 
     harness
         .parent_root
-        .send(&harness.observer, ParentControl::Exit)?;
+        .send(&harness.observer, ParentControl::Exit);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
     assert_eq!(reason, "parent stopping");
@@ -405,7 +405,7 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
 
     harness
         .parent_root
-        .send(&harness.observer, ParentControl::Kill)?;
+        .send(&harness.observer, ParentControl::Kill);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
     assert_eq!(reason, "parent stopping");
@@ -423,7 +423,7 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
 async fn test_token_join_worker_kill_notifies_parent() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
 
-    harness.worker_root.send(&harness.observer, WorkerControl)?;
+    harness.worker_root.send(&harness.observer, WorkerControl);
 
     let event = recv(&mut harness.parent_events_rx).await?;
     assert!(matches!(event.actor_status, ActorStatus::Failed(_)));

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -764,14 +764,7 @@ impl DatabaseScanner {
                         let msg = QueryResponse {
                             data: Part::from(data),
                         };
-                        if let Err(e) = dest_ref.send(instance, msg) {
-                            tracing::debug!(
-                                "Scanner {}: send error for batch {}: {:?}",
-                                rank,
-                                count,
-                                e
-                            );
-                        }
+                        dest_ref.send(instance, msg);
                         count += 1;
                     }
                 }

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -178,8 +178,8 @@ impl _Controller {
             &*self.controller_handle.blocking_lock(),
             instance.deref(),
             msg,
-        )
-        .map_err(to_py_error)
+        );
+        Ok(())
     }
 
     fn _drop_refs(&mut self, instance: &PyInstance, refs: Vec<Ref>) -> PyResult<()> {
@@ -187,8 +187,8 @@ impl _Controller {
             &*self.controller_handle.blocking_lock(),
             instance.deref(),
             ClientToControllerMessage::DropRefs { refs },
-        )
-        .map_err(to_py_error)
+        );
+        Ok(())
     }
 
     fn _sync_at_exit(&mut self, instance: &PyInstance, port: PyPortId) -> PyResult<()> {
@@ -198,8 +198,8 @@ impl _Controller {
             ClientToControllerMessage::SyncAtExit {
                 port: reference::PortRef::attest(reference::PortAddr::from(port)),
             },
-        )
-        .map_err(to_py_error)
+        );
+        Ok(())
     }
 
     fn _send<'py>(
@@ -219,8 +219,8 @@ impl _Controller {
             &*self.controller_handle.blocking_lock(),
             instance.deref(),
             ClientToControllerMessage::Send { slices, message },
-        )
-        .map_err(to_py_error)
+        );
+        Ok(())
     }
 
     fn _drain_and_stop(&mut self, py: Python<'_>, instance: &PyInstance) -> PyResult<()> {
@@ -232,8 +232,7 @@ impl _Controller {
             ClientToControllerMessage::StopWorkers {
                 response_port: stop_worker_port,
             },
-        )
-        .map_err(to_py_error)?;
+        );
         signal_safe_block_on(py, async move { stop_worker_receiver.recv().await })?
             .map_err(to_py_error)?
             .map_err(PyRuntimeError::new_err)?;
@@ -371,10 +370,10 @@ impl Invocation {
                                     .expect("complete runs should not overlap");
                             }
                         }
-                        port.send(sender, overlay.into())?;
+                        port.send(sender, overlay.into());
                     } else {
                         for result in results {
-                            port.send(sender, result)?;
+                            port.send(sender, result);
                         }
                     }
                 }
@@ -424,13 +423,13 @@ impl Invocation {
                                             )
                                             .expect("exception runs should not overlap");
                                     }
-                                    port.send(sender, overlay.into())?;
+                                    port.send(sender, overlay.into());
                                 } else {
                                     for rank in ranks.iter() {
                                         port.send(
                                             sender,
                                             exception.as_ref().clone().into_rank(rank),
-                                        )?;
+                                        );
                                     }
                                 }
                             }
@@ -670,7 +669,7 @@ impl History {
                         )
                     }
                 };
-                port.send(sender, result)?;
+                port.send(sender, result);
                 self.exit_port = None;
             }
         }
@@ -808,9 +807,9 @@ impl MeshControllerActor {
                             DebuggerMessage::Action {
                                 action: DebuggerAction::Write { bytes },
                             },
-                        )
+                        );
                     })
-                    .await?;
+                    .await;
                 }
                 DebuggerAction::Write { bytes } => {
                     monarch_hyperactor::runtime::monarch_with_gil(
@@ -832,16 +831,13 @@ impl MeshControllerActor {
             }
         }
         if self.debugger_active.is_none() {
-            self.debugger_active = self.debugger_paused.pop_front().and_then(|pdb_actor| {
-                pdb_actor
-                    .send(
-                        this,
-                        DebuggerMessage::Action {
-                            action: DebuggerAction::Attach(),
-                        },
-                    )
-                    .map(|_| pdb_actor)
-                    .ok()
+            self.debugger_active = self.debugger_paused.pop_front().inspect(|pdb_actor| {
+                pdb_actor.send(
+                    this,
+                    DebuggerMessage::Action {
+                        action: DebuggerAction::Attach(),
+                    },
+                );
             });
         }
         Ok(())
@@ -987,9 +983,9 @@ impl Handler<ClientToControllerMessage> for MeshControllerActor {
                     .stop(this, "client requested stop".to_string())
                     .await;
                 if worker_stop_result.is_ok() && broker_stop_result.is_ok() {
-                    response_port.send(this, Ok(()))?;
+                    response_port.send(this, Ok(()));
                 } else {
-                    response_port.send(this, Err(format!("stopping mesh workers failed: tensor worker result: {:?}, broker result: {:?}", worker_stop_result, broker_stop_result)))?;
+                    response_port.send(this, Err(format!("stopping mesh workers failed: tensor worker result: {:?}, broker result: {:?}", worker_stop_result, broker_stop_result)));
                 }
             }
         }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -375,7 +375,7 @@ impl PythonMessage {
             } => {
                 let broker = BrokerId::new(local_state_broker).resolve(cx).await;
                 let (send, recv) = cx.open_once_port();
-                broker.send(cx, LocalStateBrokerMessage::Get(id, send))?;
+                broker.send(cx, LocalStateBrokerMessage::Get(id, send));
                 let state = recv.recv().await?;
                 let mut state_it = state.state.into_iter();
                 monarch_with_gil(|py| {
@@ -519,9 +519,7 @@ pub(super) struct PythonActorHandle {
 impl PythonActorHandle {
     // TODO: do the pickling in rust
     fn send(&self, instance: &PyInstance, message: &PythonMessage) -> PyResult<()> {
-        self.inner
-            .send(instance.deref(), message.clone())
-            .map_err(|err| PyRuntimeError::new_err(err.to_string()))?;
+        self.inner.send(instance.deref(), message.clone());
         Ok(())
     }
 
@@ -1594,9 +1592,7 @@ async fn handle_async_endpoint_panic(
                     .unwrap()
             })
             .0;
-        panic_sender
-            .send(&client, Signal::Kill(panic.to_string()))
-            .expect("unable to send panic message");
+        panic_sender.send(&client, Signal::Kill(panic.to_string()));
     }
 
     // Record latency in microseconds
@@ -1629,13 +1625,13 @@ where
 impl LocalPort {
     fn send(&mut self, obj: Py<PyAny>) -> PyResult<()> {
         let port = self.inner.take().expect("use local port once");
-        port.send(self.instance.deref(), Ok(obj))
-            .map_err(to_py_error)
+        port.send(self.instance.deref(), Ok(obj));
+        Ok(())
     }
     fn exception(&mut self, e: Py<PyAny>) -> PyResult<()> {
         let port = self.inner.take().expect("use local port once");
-        port.send(self.instance.deref(), Err(e))
-            .map_err(to_py_error)
+        port.send(self.instance.deref(), Err(e));
+        Ok(())
     }
 }
 

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -997,9 +997,7 @@ mod tests {
 
         // Query the subscriber count from the controller.
         let (port, mut rx) = mailbox::open_port::<usize>(instance);
-        controller
-            .send(instance, GetSubscriberCount(port.bind()))
-            .unwrap();
+        controller.send(instance, GetSubscriberCount(port.bind()));
         let initial_count = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .expect("timed out waiting for subscriber count")
@@ -1022,9 +1020,7 @@ mod tests {
         // After 5 calls from the same context, there should be exactly 1
         // subscriber (created lazily on the first call, reused thereafter).
         let (port, mut rx) = mailbox::open_port::<usize>(instance);
-        controller
-            .send(instance, GetSubscriberCount(port.bind()))
-            .unwrap();
+        controller.send(instance, GetSubscriberCount(port.bind()));
         let after_count = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .expect("timed out waiting for subscriber count")
@@ -1045,9 +1041,7 @@ mod tests {
         }
 
         let (port, mut rx) = mailbox::open_port::<usize>(instance);
-        controller
-            .send(instance, GetSubscriberCount(port.bind()))
-            .unwrap();
+        controller.send(instance, GetSubscriberCount(port.bind()));
         let final_count = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .expect("timed out waiting for subscriber count")

--- a/monarch_hyperactor/src/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/src/code_sync/auto_reload.rs
@@ -112,7 +112,7 @@ impl Handler<AutoReloadMessage> for AutoReloadActor {
             anyhow::Ok(())
         }
         .await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)))?;
+        result.send(cx, res.map_err(|e| format!("{:#?}", e)));
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/code_sync/conda_sync.rs
+++ b/monarch_hyperactor/src/code_sync/conda_sync.rs
@@ -88,7 +88,7 @@ impl Handler<CondaSyncMessage> for CondaSyncActor {
         let res = async {
             let workspace = workspace.resolve()?;
             let (connect_msg, completer) = Connect::allocate(cx.self_addr().clone(), cx);
-            connect.send(cx, connect_msg)?;
+            connect.send(cx, connect_msg);
             let (mut read, mut write) = completer.complete().await?.into_split();
             let path_prefix_replacements = path_prefix_replacements
                 .into_iter()
@@ -110,7 +110,7 @@ impl Handler<CondaSyncMessage> for CondaSyncActor {
             })
         }
         .await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)))?;
+        result.send(cx, res.map_err(|e| format!("{:#?}", e)));
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -261,7 +261,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
                             result: tx.bind(),
                             workspace,
                         },
-                    )?;
+                    );
                     // Observe any errors.
                     let _ = rx.recv().await?.map_err(anyhow::Error::msg)?;
                 }
@@ -280,7 +280,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
                             workspace,
                             path_prefix_replacements,
                         },
-                    )?;
+                    );
                     // Observe any errors.
                     let _ = rx.recv().await?.map_err(anyhow::Error::msg)?;
                 }
@@ -330,7 +330,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
                         .unwrap_err()
                 )
             }),
-        )?;
+        );
         Ok(())
     }
 
@@ -351,7 +351,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
             let (tx, mut rx) = cx.open_port::<Result<(), String>>();
             self.get_auto_reload_actor(cx)
                 .await?
-                .send(cx, AutoReloadMessage { result: tx.bind() })?;
+                .send(cx, AutoReloadMessage { result: tx.bind() });
             rx.recv().await?.map_err(anyhow::Error::msg)?;
             anyhow::Ok(())
         }
@@ -366,7 +366,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
                         .unwrap_err()
                 )
             }),
-        )?;
+        );
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -361,7 +361,7 @@ impl Handler<RsyncMessage> for RsyncActor {
                 .resolve()
                 .context("resolving workspace location")?;
             let (connect_msg, completer) = Connect::allocate(cx.self_addr().clone(), cx);
-            connect.send(cx, connect_msg)?;
+            connect.send(cx, connect_msg);
 
             // some machines (e.g. github CI) do not have ipv6, so try ipv6 then fallback to ipv4
             let ipv6_lo: SocketAddr = "[::1]:0".parse()?;
@@ -381,7 +381,7 @@ impl Handler<RsyncMessage> for RsyncActor {
             anyhow::Ok(rsync_result)
         }
         .await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)))?;
+        result.send(cx, res.map_err(|e| format!("{:#?}", e)));
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -528,16 +528,14 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
         // We don't need the ack, and this temporary proc doesn't have a mailbox
         // receiver set up anyways. Just ignore the message.
         port.return_undeliverable(false);
-        agent
-            .send(
-                &instance,
-                ShutdownHost {
-                    timeout: Duration::from_secs(10),
-                    max_in_flight: 16,
-                    ack: port,
-                },
-            )
-            .map_err(|e| PyException::new_err(e.to_string()))?;
+        agent.send(
+            &instance,
+            ShutdownHost {
+                timeout: Duration::from_secs(10),
+                max_in_flight: 16,
+                ack: port,
+            },
+        );
 
         // Join the host's mailbox server to flush receive-side acks
         // before the process exits.

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -49,7 +49,7 @@ impl Handler<LocalStateBrokerMessage> for LocalStateBrokerActor {
         match message {
             LocalStateBrokerMessage::Set(id, state) => match self.ports.remove_entry(&id) {
                 Some((_, port)) => {
-                    port.send(cx, state)?;
+                    port.send(cx, state);
                 }
                 None => {
                     self.states.insert(id, state);
@@ -57,7 +57,7 @@ impl Handler<LocalStateBrokerMessage> for LocalStateBrokerActor {
             },
             LocalStateBrokerMessage::Get(id, port) => match self.states.remove_entry(&id) {
                 Some((_, state)) => {
-                    port.send(cx, state)?;
+                    port.send(cx, state);
                 }
                 None => {
                     self.ports.insert(id, port);

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -245,7 +245,7 @@ impl LoggingMeshClient {
                 reply: reply_tx.bind(),
                 version: version_tx.bind(),
             },
-        )?;
+        );
 
         let version = version_rx.recv().await?;
 
@@ -423,14 +423,12 @@ impl LoggingMeshClient {
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
         // Always update the client actor's aggregation window.
-        self.client_actor
-            .send(
-                instance.deref(),
-                LogClientMessage::SetAggregate {
-                    aggregate_window_sec,
-                },
-            )
-            .map_err(anyhow::Error::msg)?;
+        self.client_actor.send(
+            instance.deref(),
+            LogClientMessage::SetAggregate {
+                aggregate_window_sec,
+            },
+        );
 
         Ok(())
     }

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -256,9 +256,7 @@ impl PythonPortHandle {
 #[pymethods]
 impl PythonPortHandle {
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {
-        self.inner
-            .send(instance.deref(), message)
-            .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
+        self.inner.send(instance.deref(), message);
         Ok(())
     }
 
@@ -294,9 +292,7 @@ impl PythonPortRef {
     }
 
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {
-        self.inner
-            .send(instance.deref(), message)
-            .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
+        self.inner.send(instance.deref(), message);
         Ok(())
     }
 
@@ -445,8 +441,7 @@ impl PythonOncePortHandle {
         let Some(port) = self.inner.take() else {
             return Err(PyErr::new::<PyValueError, _>("OncePort is already used"));
         };
-        port.send(instance.deref(), message)
-            .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
+        port.send(instance.deref(), message);
         Ok(())
     }
 
@@ -492,9 +487,7 @@ impl PythonOncePortRef {
             return Err(PyErr::new::<PyValueError, _>("OncePortRef is already used"));
         };
         let port_ref: hyperactor::OncePortRef<PythonMessage> = port_ref;
-        port_ref
-            .send(instance.deref(), message)
-            .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
+        port_ref.send(instance.deref(), message);
         Ok(())
     }
 
@@ -628,13 +621,13 @@ impl EitherPortRef {
         message: crate::actor::PythonMessage,
     ) -> anyhow::Result<()> {
         match self {
-            EitherPortRef::Unbounded(port_ref) => port_ref.inner.send(cx, message)?,
+            EitherPortRef::Unbounded(port_ref) => port_ref.inner.send(cx, message),
             EitherPortRef::Once(once_port_ref) => {
                 let port = once_port_ref
                     .inner
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("OncePortRef already used"))?;
-                port.send(cx, message)?;
+                port.send(cx, message);
             }
         }
         Ok(())
@@ -652,14 +645,14 @@ impl EitherPortRef {
     ) -> anyhow::Result<()> {
         match self {
             EitherPortRef::Unbounded(port_ref) => {
-                port_ref.inner.send_with_headers(cx, headers, message)?
+                port_ref.inner.send_with_headers(cx, headers, message)
             }
             EitherPortRef::Once(once_port_ref) => {
                 let port = once_port_ref
                     .inner
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("OncePortRef already used"))?;
-                port.send_with_headers(cx, headers, message)?;
+                port.send_with_headers(cx, headers, message);
             }
         }
         Ok(())

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -700,9 +700,7 @@ impl ProcLauncher for ActorProcLauncher {
             message: pickled_args.into(),
         };
 
-        self.spawner
-            .send(&self.instance, message)
-            .map_err(|e| ProcLauncherError::Other(format!("send to spawner failed: {e}")))?;
+        self.spawner.send(&self.instance, message);
 
         let mut active_procs: tokio::sync::MutexGuard<'_, HashSet<hyperactor::ProcAddr>> =
             self.active_procs.lock().await;
@@ -784,9 +782,8 @@ impl ProcLauncher for ActorProcLauncher {
             message: pickled.into(),
         };
 
-        self.spawner
-            .send(&self.instance, message)
-            .map_err(|e| ProcLauncherError::Terminate(format!("send failed: {e}")))
+        self.spawner.send(&self.instance, message);
+        Ok(())
     }
 
     /// Forcefully kill a proc.
@@ -825,9 +822,8 @@ impl ProcLauncher for ActorProcLauncher {
             message: pickled.into(),
         };
 
-        self.spawner
-            .send(&self.instance, message)
-            .map_err(|e| ProcLauncherError::Kill(format!("send failed: {e}")))
+        self.spawner.send(&self.instance, message);
+        Ok(())
     }
 }
 

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -112,7 +112,7 @@ CONSTANT = "modified_constant"
         AutoReloadMessage {
             result: result_tx.bind(),
         },
-    )?;
+    );
 
     // Wait for reload to complete
     let reload_result = result_rx.recv().await?;

--- a/monarch_introspection_snapshot/src/integration.rs
+++ b/monarch_introspection_snapshot/src/integration.rs
@@ -141,7 +141,7 @@ pub fn start_periodic_snapshots(
     let actor = SnapshotCaptureActor::new(table_store, admin_ref, interval);
     let handle = proc.spawn("snapshot_capture", actor)?;
     // PT-3: first capture fires at spawn time.
-    handle.send(cx, CaptureSnapshot)?;
+    handle.send(cx, CaptureSnapshot);
     Ok(())
 }
 

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -445,7 +445,7 @@ impl Handler<InitializeBuffer> for CudaRdmaActor {
             self.rdma_buffer_handle = Some(buffer_handle);
         }
 
-        reply.send(cx, true)?;
+        reply.send(cx, true);
         Ok(())
     }
 }
@@ -576,7 +576,7 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
                 }
             }
         }
-        reply.send(cx, true)?;
+        reply.send(cx, true);
         Ok(())
     }
 }
@@ -664,7 +664,7 @@ impl Handler<VerifyBuffer> for CudaRdmaActor {
             }
         }
 
-        reply.send(cx, all_match)?;
+        reply.send(cx, all_match);
         Ok(())
     }
 }
@@ -686,7 +686,7 @@ impl Handler<GetBufferHandle> for CudaRdmaActor {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Buffer not initialized"))?;
 
-        reply.send(cx, buffer.clone())?;
+        reply.send(cx, buffer.clone());
         Ok(())
     }
 }
@@ -823,21 +823,21 @@ pub async fn run() -> Result<(), anyhow::Error> {
     let device_1_actor = device_1_actor_mesh.values().next().unwrap();
     let device_2_actor = device_2_actor_mesh.values().next().unwrap();
     let (handle_1, receiver_1) = instance.open_once_port::<bool>();
-    device_1_actor.send(&instance, InitializeBuffer(DATA_VALUE, handle_1.bind()))?;
+    device_1_actor.send(&instance, InitializeBuffer(DATA_VALUE, handle_1.bind()));
     receiver_1.recv().await?;
 
     // Initialize device 2 buffer with 0
     let (handle_2, receiver_2) = instance.open_once_port::<bool>();
-    device_2_actor.send(&instance, InitializeBuffer(0, handle_2.bind()))?;
+    device_2_actor.send(&instance, InitializeBuffer(0, handle_2.bind()));
     receiver_2.recv().await?;
 
     // Get the remote buffer handle from device 1
     let (handle_remote, receiver_remote) = instance.open_once_port::<RdmaRemoteBuffer>();
-    device_1_actor.send(&instance, GetBufferHandle(handle_remote.bind()))?;
+    device_1_actor.send(&instance, GetBufferHandle(handle_remote.bind()));
     let buffer_1 = receiver_remote.recv().await?;
 
     let (handle_remote, receiver_remote) = instance.open_once_port::<RdmaRemoteBuffer>();
-    device_2_actor.send(&instance, GetBufferHandle(handle_remote.bind()))?;
+    device_2_actor.send(&instance, GetBufferHandle(handle_remote.bind()));
     let buffer_2 = receiver_remote.recv().await?;
     let (handle_1, receiver_1) = instance.open_once_port::<bool>();
 
@@ -851,7 +851,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
             config.initial_length,
             handle_2.bind(),
         ),
-    )?;
+    );
     receiver_2.recv().await?;
     device_1_actor.send(
         &instance,
@@ -862,21 +862,21 @@ pub async fn run() -> Result<(), anyhow::Error> {
             config.initial_length,
             handle_1.bind(),
         ),
-    )?;
+    );
     receiver_1.recv().await?;
 
     let (handle, receiver) = instance.open_once_port::<bool>();
     device_2_actor.send(
         &instance,
         VerifyBuffer(expected_data_values.clone(), handle.bind()),
-    )?;
+    );
     let verification_result2 = receiver.recv().await?;
 
     let (handle, receiver) = instance.open_once_port::<bool>();
     device_1_actor.send(
         &instance,
         VerifyBuffer(expected_data_values.clone(), handle.bind()),
-    )?;
+    );
     let verification_result1 = receiver.recv().await?;
 
     if !verification_result1 {

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -213,7 +213,7 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
                 grad_buffer_handle
             }
         };
-        reply.send(cx, (weights_handle.clone(), grad_buffer_handle.clone()))?;
+        reply.send(cx, (weights_handle.clone(), grad_buffer_handle.clone()));
         Ok(())
     }
 }
@@ -233,7 +233,7 @@ impl Handler<PsUpdate> for ParameterServerActor {
             grad.fill(0);
         }
         tracing::info!("[parameter server actor] updated");
-        reply.send(cx, true)?;
+        reply.send(cx, true);
         Ok(())
     }
 }
@@ -334,7 +334,7 @@ impl Handler<WorkerInit> for WorkerActor {
         tracing::info!("[worker_actor_{}] initializing", rank);
 
         let (handle, receiver) = cx.mailbox().open_once_port();
-        ps_ref.send(cx, PsGetBuffers(rank, handle.bind()))?;
+        ps_ref.send(cx, PsGetBuffers(rank, handle.bind()));
         let (ps_weights_handle, ps_grad_handle) = receiver.recv().await?;
         self.ps_weights_handle = Some(ps_weights_handle);
         self.ps_grad_handle = Some(ps_grad_handle);
@@ -381,7 +381,7 @@ impl Handler<WorkerStep> for WorkerActor {
 
         self.local_gradients.fill(0);
 
-        reply.send(cx, true)?;
+        reply.send(cx, true);
         Ok(())
     }
 }
@@ -412,7 +412,7 @@ impl Handler<WorkerUpdate> for WorkerActor {
         ps_weights_handle
             .read_into_local(cx, local_memory, 5)
             .await?;
-        reply.send(cx, true)?;
+        reply.send(cx, true);
         Ok(())
     }
 }
@@ -572,7 +572,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
         }
 
         let (handle, recv) = instance.mailbox().open_once_port::<bool>();
-        ps_actor.send(instance, PsUpdate(handle.bind())).unwrap();
+        ps_actor.send(instance, PsUpdate(handle.bind()));
 
         let finished = recv.recv().await.unwrap();
         if !finished {
@@ -592,7 +592,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
         if !results.iter().any(|&result| result) {
             panic!("worker update step did not complete properly.");
         }
-        ps_actor.send(instance, Log {}).unwrap();
+        ps_actor.send(instance, Log {});
     }
     Ok(())
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -849,7 +849,7 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
         let state = match self.ensure_queue_pair_impl(cx, sender, &qp_key) {
             Ok(state) => state,
             Err(e) => {
-                reply.send(cx, PeerInfo(Err(e.to_string())))?;
+                reply.send(cx, PeerInfo(Err(e.to_string())));
                 return Ok(());
             }
         };
@@ -858,7 +858,7 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
                 info, initializer, ..
             } => {
                 let notify_rts = initializer.bind::<QueuePairInitializer<Self>>().port();
-                reply.send(cx, PeerInfo(Ok((info.clone(), notify_rts))))?;
+                reply.send(cx, PeerInfo(Ok((info.clone(), notify_rts))));
             }
             QpState::Ready(_) => {
                 // `Ready` means a prior handshake completed and the
@@ -871,10 +871,10 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
                     PeerInfo(Err(format!(
                         "EnsureQueuePair on already-Ready entry {qp_key:?}"
                     ))),
-                )?;
+                );
             }
             QpState::Failed(error) => {
-                reply.send(cx, PeerInfo(Err(error.clone())))?;
+                reply.send(cx, PeerInfo(Err(error.clone())));
             }
         }
         Ok(())
@@ -935,14 +935,14 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         let state = match self.ensure_queue_pair_impl(cx, other, &qp_key) {
             Ok(state) => state,
             Err(e) => {
-                reply.send(cx, Err(e.to_string()))?;
+                reply.send(cx, Err(e.to_string()));
                 return Ok(());
             }
         };
         match state {
             QpState::Pending { waiters, .. } => waiters.push(reply),
-            QpState::Ready(qp) => reply.send(cx, Ok(qp.clone()))?,
-            QpState::Failed(error) => reply.send(cx, Err(error.clone()))?,
+            QpState::Ready(qp) => reply.send(cx, Ok(qp.clone())),
+            QpState::Failed(error) => reply.send(cx, Err(error.clone())),
         }
         Ok(())
     }
@@ -966,12 +966,7 @@ impl Handler<QpInitializerDone> for IbvManagerActor {
                 ..
             }) => {
                 for w in waiters {
-                    let waiter_dbg = format!("{w:?}");
-                    if let Err(e) = w.send(cx, Ok(qp.clone())) {
-                        tracing::error!(
-                            "QpInitializerDone: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
-                        );
-                    }
+                    w.send(cx, Ok(qp.clone()));
                 }
                 initializer
             }
@@ -1010,12 +1005,7 @@ impl Handler<QpInitializerFailed> for IbvManagerActor {
                 ..
             }) => {
                 for w in waiters {
-                    let waiter_dbg = format!("{w:?}");
-                    if let Err(e) = w.send(cx, Err(error.clone())) {
-                        tracing::error!(
-                            "QpInitializerFailed: failed to deliver to waiter {waiter_dbg} for {qp_key:?}: {e}"
-                        );
-                    }
+                    w.send(cx, Err(error.clone()));
                 }
                 initializer
             }

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -145,14 +145,7 @@ where
         let (reply, rx) = cx
             .mailbox()
             .open_once_port::<Result<IbvMemoryRegionView, String>>();
-        self.manager
-            .send(cx, RegisterMr { addr, size, reply })
-            .map_err(|e| {
-                format!(
-                    "Requesting MR registration from {:?} failed [virtual_addr=0x{:x}, size={}]: {}",
-                    self.manager, addr, size, e
-                )
-            })?;
+        self.manager.send(cx, RegisterMr { addr, size, reply });
         let mrv = rx
             .recv()
             .await
@@ -188,21 +181,14 @@ where
     ) -> Result<OwnedMutexGuard<Qp>, String> {
         if !self.peer_qps.contains_key(qp_key) {
             let (reply, rx) = cx.mailbox().open_once_port::<Result<Qp, String>>();
-            self.manager
-                .send(
-                    cx,
-                    RequestQueuePair {
-                        qp_key: qp_key.clone(),
-                        remote_manager,
-                        reply,
-                    },
-                )
-                .map_err(|e| {
-                    format!(
-                        "Requesting QP from {:?} failed for {} -> {} on {}: {}",
-                        self.manager, qp_key.self_device, qp_key.other_id, qp_key.other_device, e
-                    )
-                })?;
+            self.manager.send(
+                cx,
+                RequestQueuePair {
+                    qp_key: qp_key.clone(),
+                    remote_manager,
+                    reply,
+                },
+            );
             let qp = rx
                 .recv()
                 .await
@@ -336,9 +322,7 @@ where
             reply,
         } = msg;
         let results = self.process_batch(cx, ops, timeout).await;
-        reply
-            .send(cx, results)
-            .map_err(|e| anyhow::anyhow!("SubmitOps reply send failed: {e}"))?;
+        reply.send(cx, results);
         Ok(())
     }
 }
@@ -412,7 +396,7 @@ mod tests {
                     _domain: null_domain(),
                 }),
             );
-            msg.reply.send(cx, Ok(mrv))?;
+            msg.reply.send(cx, Ok(mrv));
             Ok(())
         }
     }
@@ -433,7 +417,7 @@ mod tests {
                 .unwrap()
                 .request_qp_calls
                 .push(msg.qp_key.clone());
-            msg.reply.send(cx, Ok(MockQp))?;
+            msg.reply.send(cx, Ok(MockQp));
             Ok(())
         }
     }
@@ -533,17 +517,14 @@ mod tests {
         ops: Vec<IbvOp<MockManagerActor>>,
     ) -> Vec<Result<(), String>> {
         let (reply, rx) = harness.client.mailbox().open_once_port();
-        harness
-            .processor
-            .send(
-                &harness.client,
-                SubmitOps {
-                    ops,
-                    timeout: Duration::from_secs(5),
-                    reply,
-                },
-            )
-            .unwrap();
+        harness.processor.send(
+            &harness.client,
+            SubmitOps {
+                ops,
+                timeout: Duration::from_secs(5),
+                reply,
+            },
+        );
         rx.recv().await.unwrap()
     }
 

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1256,12 +1256,7 @@ where
         let timeout = self.timeout;
         let task = tokio::spawn(async move {
             tokio::time::sleep(timeout).await;
-            if let Err(e) = self_handle.send(Instance::<Self>::self_client(), InitializationFailed)
-            {
-                tracing::error!(
-                    "QueuePairInitializer: failed to deliver timeout self-message: {e}"
-                );
-            }
+            self_handle.send(Instance::<Self>::self_client(), InitializationFailed);
         });
         self.timeout_handle = Some(task);
     }
@@ -1281,7 +1276,7 @@ where
                 qp_key: self.qp_key.clone(),
                 error,
             },
-        )?;
+        );
         Ok(())
     }
 
@@ -1299,7 +1294,7 @@ where
                 qp_key: self.qp_key.clone(),
                 qp,
             },
-        )?;
+        );
         Ok(())
     }
 
@@ -1317,9 +1312,7 @@ where
             .expect("qp present pre-terminal")
             .connect(&peer_endpoint)
             .map_err(|e| format!("QpGuard::connect failed: {e}"))?;
-        peer_notify_rts
-            .send(cx, NotifyRts)
-            .map_err(|e| format!("failed to send NotifyRts to peer: {e}"))?;
+        peer_notify_rts.send(cx, NotifyRts);
         Ok(())
     }
 }
@@ -1344,7 +1337,7 @@ where
                 receiver_device,
                 reply,
             },
-        )?;
+        );
 
         self.arm_timeout(this);
         Ok(())
@@ -1643,7 +1636,7 @@ mod tests {
             match response {
                 MockResponse::Success(info) => {
                     let notify_rts = cx.bind::<MockManager>().port::<NotifyRts>();
-                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))))?;
+                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))));
                 }
                 MockResponse::SuccessWithBogusNotifyRts(info) => {
                     let bogus = hyperactor::context::Mailbox::mailbox(cx)
@@ -1652,10 +1645,10 @@ mod tests {
                         .actor_addr("bogus")
                         .port_addr(Port::from(0u64));
                     let notify_rts = PortRef::<NotifyRts>::attest(bogus);
-                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))))?;
+                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))));
                 }
                 MockResponse::Error(e) => {
-                    msg.reply.send(cx, PeerInfo(Err(e)))?;
+                    msg.reply.send(cx, PeerInfo(Err(e)));
                 }
                 MockResponse::DropReply => {}
             }
@@ -1804,7 +1797,7 @@ mod tests {
         let harness = Harness::build(qp, MockResponse::Success(info))?;
 
         let (peer, _) = harness.proc.instance("peer")?;
-        harness.init_handle.send(&peer, NotifyRts)?;
+        harness.init_handle.send(&peer, NotifyRts);
 
         let key = harness.await_done().await;
         assert_eq!(key, harness.qp_key);
@@ -1870,7 +1863,7 @@ mod tests {
         let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
-        harness.init_handle.send(&peer, undeliverable).unwrap();
+        harness.init_handle.send(&peer, undeliverable);
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert!(
@@ -1912,7 +1905,7 @@ mod tests {
 
         let undeliverable = fake_undeliverable(&harness.proc, "late bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
-        harness.init_handle.send(&peer, undeliverable).unwrap();
+        harness.init_handle.send(&peer, undeliverable);
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(harness.state.lock().unwrap().failed.len(), 1);
     }

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -211,7 +211,7 @@ impl Handler<CudaActorMessage> for CudaActor {
                     .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
                 let rdma_handle = handle.request_buffer(cx, local_memory).await?;
 
-                reply.send(cx, (rdma_handle, dptr))?;
+                reply.send(cx, (rdma_handle, dptr));
                 Ok(())
             }
             CudaActorMessage::FillBuffer {
@@ -230,7 +230,7 @@ impl Handler<CudaActorMessage> for CudaActor {
                     ));
                 }
 
-                reply.send(cx, ())?;
+                reply.send(cx, ());
                 Ok(())
             }
             CudaActorMessage::VerifyBuffer {
@@ -249,7 +249,7 @@ impl Handler<CudaActorMessage> for CudaActor {
                     ));
                 }
 
-                reply.send(cx, ())?;
+                reply.send(cx, ());
                 Ok(())
             }
         }

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -322,14 +322,12 @@ impl TcpManagerActor {
                     let len = std::cmp::min(chunk_size, size - offset);
                     let mut buf = BytesMut::zeroed(len);
                     if let Err(e) = mem.read_at(offset, &mut buf) {
-                        error_port
-                            .send(
-                                &instance,
-                                TransferError {
-                                    message: format!("read_at failed at offset {offset}: {e}"),
-                                },
-                            )
-                            .unwrap();
+                        error_port.send(
+                            &instance,
+                            TransferError {
+                                message: format!("read_at failed at offset {offset}: {e}"),
+                            },
+                        );
                         return;
                     }
 
@@ -340,16 +338,12 @@ impl TcpManagerActor {
                     };
 
                     if let Err(e) = conn.send(chunk).await {
-                        error_port
-                            .send(
-                                &instance,
-                                TransferError {
-                                    message: format!(
-                                        "failed to send chunk at offset {offset}: {e}"
-                                    ),
-                                },
-                            )
-                            .unwrap();
+                        error_port.send(
+                            &instance,
+                            TransferError {
+                                message: format!("failed to send chunk at offset {offset}: {e}"),
+                            },
+                        );
                         return;
                     }
                 }
@@ -424,8 +418,7 @@ impl Actor for TcpManagerActor {
                                                 "parallel channel receive error: {e}"
                                             ),
                                         },
-                                    )
-                                    .unwrap();
+                                    );
                                 break;
                             }
                         },
@@ -453,15 +446,13 @@ impl Actor for TcpManagerActor {
                         let transfer_id = chunk.transfer_id;
                         drop(entry);
                         let (_, state) = transfers.remove(&transfer_id).unwrap();
-                        result_port
-                            .send(
-                                &instance,
-                                SendTransferResult {
-                                    done: state.done,
-                                    result: Err(e.to_string()),
-                                },
-                            )
-                            .unwrap();
+                        result_port.send(
+                            &instance,
+                            SendTransferResult {
+                                done: state.done,
+                                result: Err(e.to_string()),
+                            },
+                        );
                         continue;
                     }
 
@@ -470,15 +461,13 @@ impl Actor for TcpManagerActor {
                         let transfer_id = chunk.transfer_id;
                         drop(entry);
                         let (_, state) = transfers.remove(&transfer_id).unwrap();
-                        result_port
-                            .send(
-                                &instance,
-                                SendTransferResult {
-                                    done: state.done,
-                                    result: Ok(()),
-                                },
-                            )
-                            .unwrap();
+                        result_port.send(
+                            &instance,
+                            SendTransferResult {
+                                done: state.done,
+                                result: Ok(()),
+                            },
+                        );
                     }
                 }
                 rx.join().await;
@@ -600,7 +589,7 @@ impl Handler<RegisterTransferLocal> for TcpManagerActor {
     ) -> Result<(), anyhow::Error> {
         let transfer_id =
             self.register_transfer(message.local_memory, message.total_chunks, message.done);
-        message.reply.send(cx, transfer_id)?;
+        message.reply.send(cx, transfer_id);
         Ok(())
     }
 }
@@ -629,7 +618,8 @@ impl Handler<SendTransferResult> for TcpManagerActor {
         cx: &Context<Self>,
         message: SendTransferResult,
     ) -> Result<(), anyhow::Error> {
-        Ok(message.done.send(cx, message.result)?)
+        message.done.send(cx, message.result);
+        Ok(())
     }
 }
 
@@ -708,7 +698,7 @@ impl TcpBackend {
                 chunk_size,
                 dest_addr,
             },
-        )?;
+        );
 
         let remaining = deadline.saturating_duration_since(Instant::now());
         let result = tokio_timeout(remaining, done_rx.recv())
@@ -743,7 +733,7 @@ impl TcpBackend {
                 done: done_ref,
                 reply: id_handle,
             },
-        )?;
+        );
 
         let transfer_id = id_rx
             .recv()

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -980,9 +980,7 @@ impl StreamActor {
         let message = LocalStateBrokerMessage::Set(x as usize, state);
 
         let broker = BrokerId::new(params.broker_id).resolve(cx).await;
-        broker
-            .send(cx, message)
-            .map_err(|e| CallFunctionError::Error(e.into()))?;
+        broker.send(cx, message);
         let result = recv
             .recv()
             .await
@@ -1069,13 +1067,8 @@ impl StreamMessageHandler for StreamActor {
         };
 
         let event = self.cuda_stream().map(|stream| stream.record_event(None));
-        first_use_sender.send(cx, (event, result)).map_err(|err| {
-            anyhow!(
-                "failed sending first use event for borrow {:?}: {:?}",
-                borrow,
-                err
-            )
-        })
+        first_use_sender.send(cx, (event, result));
+        Ok(())
     }
 
     async fn borrow_first_use(
@@ -1152,13 +1145,8 @@ impl StreamMessageHandler for StreamActor {
             Err(e) => Err(e),
         };
 
-        last_use_sender.send(cx, (event, tensor)).map_err(|err| {
-            anyhow!(
-                "failed sending last use event for borrow {:?}: {:?}",
-                borrow,
-                err
-            )
-        })
+        last_use_sender.send(cx, (event, tensor));
+        Ok(())
     }
 
     async fn borrow_drop(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3920
* #3919
* __->__ #3918
* #3917
* #3916
* #3915

Endpoint send APIs now report delivery failures through the undeliverable path instead of returning `MailboxSenderError`. `Endpoint::send` and `RemoteEndpoint::send_with_headers` return `()`, while endpoint implementations keep converting local and serialization failures into `LostMessage` via `Instance::report_lost_message`.

This keeps crate-private `PortHandle::send_unreported` for internal paths that must avoid recursive lost-message reporting, specifically `Instance::report_lost_message`, and for tests that still exercise the underlying local send error classification. Downstream callers no longer use `?`, `map_err`, `unwrap`, or `expect` on endpoint sends; places that still have their own fallible channel, receive, or transport operations are unchanged.

The semantic implication is that endpoint sends are fire-and-report. A caller no longer observes a synchronous endpoint send error; undeliverable handlers receive returned envelopes or lost-message metadata instead.

Differential Revision: [D105267801](https://our.internmc.facebook.com/intern/diff/D105267801/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105267801/)!