### PR TITLE
[hyperactor] rename endpoint send APIs to post

### DIFF
--- a/hyperactor/example/stream.rs
+++ b/hyperactor/example/stream.rs
@@ -44,7 +44,7 @@ impl Handler<Subscribe> for CounterActor {
         let port: reference::PortRef<u64> = subscriber.0;
         self.subscribers.push(port);
         for port in &self.subscribers {
-            port.send(cx, self.n);
+            port.post(cx, self.n);
         }
         self.n += 1;
         Ok(())
@@ -67,7 +67,7 @@ impl Actor for CountClient {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         // Subscribe to the counter on initialization. We give it our u64 port to report
         // messages back to.
-        self.counter.send(this, Subscribe(this.port().bind()));
+        self.counter.post(this, Subscribe(this.port().bind()));
         Ok(())
     }
 }

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -897,11 +897,11 @@ where
         EndpointLocation::Actor(self.actor_addr().clone())
     }
 
-    fn send<C>(self, cx: &C, message: M)
+    fn post<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
-        Endpoint::send(&self.ports.get(), cx, message)
+        Endpoint::post(&self.ports.get(), cx, message)
     }
 }
 
@@ -1024,7 +1024,7 @@ mod tests {
     impl Handler<u64> for EchoActor {
         async fn handle(&mut self, cx: &Context<Self>, message: u64) -> Result<(), anyhow::Error> {
             let Self(port) = self;
-            port.send(cx, message);
+            port.post(cx, message);
             Ok(())
         }
     }
@@ -1036,7 +1036,7 @@ mod tests {
         let (tx, mut rx) = client.open_port();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo", actor).unwrap();
-        handle.send(&client, 123u64);
+        handle.post(&client, 123u64);
         handle.drain_and_stop("test").unwrap();
         handle.await;
 
@@ -1056,7 +1056,7 @@ mod tests {
 
         let (local_port, local_receiver) = client.open_once_port();
 
-        ping_handle.send(
+        ping_handle.post(
             &client,
             PingPongMessage(10, pong_handle.bind(), local_port.bind()),
         );
@@ -1085,7 +1085,7 @@ mod tests {
 
         let (local_port, local_receiver) = client.open_once_port();
 
-        ping_handle.send(
+        ping_handle.post(
             &client,
             PingPongMessage(
                 error_ttl + 1, // will encounter an error at TTL=66
@@ -1118,7 +1118,7 @@ mod tests {
             cx: &Context<Self>,
             port: OncePortHandle<bool>,
         ) -> Result<(), anyhow::Error> {
-            port.send(cx, self.0);
+            port.post(cx, self.0);
             Ok(())
         }
     }
@@ -1131,7 +1131,7 @@ mod tests {
         let (client, _) = proc.instance("client").unwrap();
 
         let (port, receiver) = client.open_once_port();
-        handle.send(&client, port);
+        handle.post(&client, port);
         assert!(receiver.recv().await.unwrap());
 
         handle.drain_and_stop("test").unwrap();
@@ -1169,12 +1169,12 @@ mod tests {
             M: RemoteMessage,
             MultiActor: Handler<M>,
         {
-            self.handle.send(&self.client, message)
+            self.handle.post(&self.client, message)
         }
 
         async fn sync(&self) {
             let (port, done) = self.client.open_once_port::<bool>();
-            self.handle.send(&self.client, port);
+            self.handle.post(&self.client, port);
             assert!(done.recv().await.unwrap());
         }
 
@@ -1219,7 +1219,7 @@ mod tests {
             cx: &Context<Self>,
             message: OncePortHandle<bool>,
         ) -> Result<(), anyhow::Error> {
-            message.send(cx, true);
+            message.post(cx, true);
             Ok(())
         }
     }
@@ -1235,11 +1235,11 @@ mod tests {
 
         let myref: ActorRef<MultiActor> = test.handle.bind();
 
-        myref.port().send(&test.client, 321u64);
+        myref.port().post(&test.client, 321u64);
         test.sync().await;
         assert_eq!(test.get_values(), (321u64, "foo".to_string()));
 
-        myref.port().send(&test.client, "bar".to_string());
+        myref.port().post(&test.client, "bar".to_string());
         test.sync().await;
         assert_eq!(test.get_values(), (321u64, "bar".to_string()));
     }
@@ -1254,8 +1254,8 @@ mod tests {
         hyperactor::behavior!(MyActorBehavior, u64, String);
 
         let myref: ActorRef<MyActorBehavior> = test.handle.bind();
-        myref.port().send(&test.client, "biz".to_string());
-        myref.port().send(&test.client, 999u64);
+        myref.port().post(&test.client, "biz".to_string());
+        myref.port().post(&test.client, 999u64);
 
         test.sync().await;
         assert_eq!(test.get_values(), (999u64, "biz".to_string()));
@@ -1299,7 +1299,7 @@ mod tests {
         ) -> Result<(), anyhow::Error> {
             let Self(port) = self;
             let seq_info = cx.headers().get(SEQ_INFO).unwrap();
-            port.send(cx, (message, seq_info.clone()));
+            port.post(cx, (message, seq_info.clone()));
             Ok(())
         }
     }
@@ -1320,7 +1320,7 @@ mod tests {
         ) -> Result<(), anyhow::Error> {
             let (handle, mut receiver) = cx.open_port::<String>();
             let callback_ref = handle.bind();
-            message.0.send(cx, callback_ref);
+            message.0.post(cx, callback_ref);
             let msg = receiver.recv().await.unwrap();
             self.handle(cx, msg).await
         }
@@ -1335,7 +1335,7 @@ mod tests {
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
 
         // Verify that unbound handle can send message.
-        actor_handle.send(&client, "unbound".to_string());
+        actor_handle.post(&client, "unbound".to_string());
         assert_eq!(
             rx.recv().await.unwrap(),
             ("unbound".to_string(), SeqInfo::Direct)
@@ -1347,7 +1347,7 @@ mod tests {
         let mut expected_seq = 0;
         // Interleave messages sent through the handle and the reference.
         for m in 0..10 {
-            actor_handle.send(&client, format!("{m}"));
+            actor_handle.post(&client, format!("{m}"));
             expected_seq += 1;
             assert_eq!(
                 rx.recv().await.unwrap(),
@@ -1361,7 +1361,7 @@ mod tests {
             );
 
             for n in 0..2 {
-                actor_ref.port().send(&client, format!("{m}-{n}"));
+                actor_ref.port().post(&client, format!("{m}-{n}"));
                 expected_seq += 1;
                 assert_eq!(
                     rx.recv().await.unwrap(),
@@ -1414,42 +1414,42 @@ mod tests {
         let session_id = client.sequencer().session_id();
 
         // Send to handler ports via ActorHandle - seq 1
-        actor_handle.send(&client, "msg1".to_string());
+        actor_handle.post(&client, "msg1".to_string());
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
             SeqInfo::Session { session_id, seq: 1 }
         );
 
         // Send to handler ports via ActorRef - seq 2 (shared with ActorHandle)
-        actor_ref.port().send(&client, "msg2".to_string());
+        actor_ref.port().post(&client, "msg2".to_string());
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
             SeqInfo::Session { session_id, seq: 2 }
         );
 
         // Send to non-handler port - has its own sequence starting at 1
-        non_handler_port_handle.send(&client, ());
+        non_handler_port_handle.post(&client, ());
         assert_eq!(
             non_handler_rx.recv().await.unwrap(),
             Some(SeqInfo::Session { session_id, seq: 1 })
         );
 
         // Send more to handler ports via ActorHandle - seq continues at 3
-        actor_handle.send(&client, "msg3".to_string());
+        actor_handle.post(&client, "msg3".to_string());
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
             SeqInfo::Session { session_id, seq: 3 }
         );
 
         // Send more to non-handler port - its sequence continues at 2
-        non_handler_port_handle.send(&client, ());
+        non_handler_port_handle.post(&client, ());
         assert_eq!(
             non_handler_rx.recv().await.unwrap(),
             Some(SeqInfo::Session { session_id, seq: 2 })
         );
 
         // Send via ActorRef again - seq 4
-        actor_ref.port().send(&client, "msg4".to_string());
+        actor_ref.port().post(&client, "msg4".to_string());
         assert_eq!(
             actor_rx.recv().await.unwrap().1,
             SeqInfo::Session { session_id, seq: 4 }
@@ -1478,7 +1478,7 @@ mod tests {
         assert_ne!(session_id_1, session_id_2);
 
         // Send from client1 via ActorHandle - seq 1 for session_id_1
-        actor_handle.send(&client1, "c1_msg1".to_string());
+        actor_handle.post(&client1, "c1_msg1".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1488,7 +1488,7 @@ mod tests {
         );
 
         // Send from client2 via ActorHandle - seq 1 for session_id_2 (independent)
-        actor_handle.send(&client2, "c2_msg1".to_string());
+        actor_handle.post(&client2, "c2_msg1".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1498,7 +1498,7 @@ mod tests {
         );
 
         // Send from client1 via ActorRef - seq 2 for session_id_1
-        actor_ref.port().send(&client1, "c1_msg2".to_string());
+        actor_ref.port().post(&client1, "c1_msg2".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1508,7 +1508,7 @@ mod tests {
         );
 
         // Send from client2 via ActorRef - seq 2 for session_id_2
-        actor_ref.port().send(&client2, "c2_msg2".to_string());
+        actor_ref.port().post(&client2, "c2_msg2".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1518,7 +1518,7 @@ mod tests {
         );
 
         // Interleave more messages to further verify independence
-        actor_handle.send(&client1, "c1_msg3".to_string());
+        actor_handle.post(&client1, "c1_msg3".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1527,7 +1527,7 @@ mod tests {
             }
         );
 
-        actor_ref.port().send(&client2, "c2_msg3".to_string());
+        actor_ref.port().post(&client2, "c2_msg3".to_string());
         assert_eq!(
             rx.recv().await.unwrap().1,
             SeqInfo::Session {
@@ -1574,11 +1574,11 @@ mod tests {
 
         let (callback_tx, mut callback_rx) = client.open_port();
         // Client sends the 1st message
-        actor_ref.send(&client, Callback(callback_tx.bind()));
+        actor_ref.post(&client, Callback(callback_tx.bind()));
         let msg_port_ref = callback_rx.recv().await.unwrap();
         // client sends the 2nd message. At this time, GetSeqActor is still
         // processing the 1st message, and waiting for the 2nd message.
-        msg_port_ref.send(&client, "finally".to_string());
+        msg_port_ref.post(&client, "finally".to_string());
 
         let session_id = client.sequencer().session_id();
         // passing this assert means GetSeqActor processed the 2nd message.
@@ -1667,7 +1667,7 @@ mod tests {
         let mut messages = expected.clone();
         messages.sort_by_key(|v| v.1);
         for (message, _seq) in messages {
-            actor_ref.send(&remote_client, message);
+            actor_ref.post(&remote_client, message);
         }
         let session_id = remote_client.sequencer().session_id();
         for expect in expected {
@@ -1769,7 +1769,7 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_introspect", actor).unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -1942,7 +1942,7 @@ mod tests {
 
         let child_ref = crate::Addr::Actor(test_proc_id("nonexistent").actor_addr("child"));
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr()).post(
             &client,
             IntrospectMessage::QueryChild {
                 child_ref,
@@ -1990,7 +1990,7 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2029,7 +2029,7 @@ mod tests {
 
         // Query the child — supervisor should be the parent.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&child_handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&child_handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2057,7 +2057,7 @@ mod tests {
         // Query the parent — children should include the child.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
         PortRef::<IntrospectMessage>::attest_handler_port(&parent_handle.actor_addr().clone())
-            .send(
+            .post(
                 &client,
                 IntrospectMessage::Query {
                     view: IntrospectView::Actor,
@@ -2101,7 +2101,7 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2130,11 +2130,11 @@ mod tests {
         let handle = proc.spawn::<EchoActor>("echo_after_msg", actor).unwrap();
 
         // Send a user message and wait for it to be processed.
-        handle.send(&client, 42u64);
+        handle.post(&client, 42u64);
         let _ = rx.recv().await.unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2171,7 +2171,7 @@ mod tests {
 
         // First introspect query.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2182,7 +2182,7 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2344,14 +2344,14 @@ mod tests {
             .unwrap();
 
         // Send a u64 to wedge the actor in its handler.
-        handle.send(&client, 1u64);
+        handle.post(&client, 1u64);
 
         // Wait for the handler to start blocking.
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Send introspect query via the dedicated introspect port.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2389,12 +2389,12 @@ mod tests {
             .unwrap();
 
         // Send a user message and wait for it to be processed.
-        handle.send(&client, 42u64);
+        handle.post(&client, 42u64);
         let _ = rx.recv().await.unwrap();
 
         // First introspect query.
         let (reply_port1, reply_rx1) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2405,7 +2405,7 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        crate::PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr()).send(
+        crate::PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr()).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2440,7 +2440,7 @@ mod tests {
         let actor_id: crate::ActorAddr = handle.actor_addr().clone();
 
         let (reply_port, reply_rx) = bridge.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&actor_id).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&actor_id).post(
             &bridge,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2477,7 +2477,7 @@ mod tests {
         let mailbox_id: crate::ActorAddr = mailbox_handle.actor_addr().clone();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&mailbox_id).send(
+        PortRef::<IntrospectMessage>::attest_handler_port(&mailbox_id).post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,

--- a/hyperactor/src/endpoint.rs
+++ b/hyperactor/src/endpoint.rs
@@ -75,24 +75,24 @@ impl fmt::Display for EndpointLocation {
 ///
 /// This trait abstracts over local actor handles, local port handles, remote
 /// actor refs, remote port refs, and one-shot ports. It is sealed so that
-/// Hyperactor owns the send semantics for each endpoint kind.
+/// Hyperactor owns the post semantics for each endpoint kind.
 pub trait Endpoint<M>: crate::private::Sealed {
     /// The logical location of this endpoint.
     fn endpoint_location(&self) -> EndpointLocation;
 
-    /// Send `message` to this endpoint from `cx`.
-    fn send<C>(self, cx: &C, message: M)
+    /// Post `message` to this endpoint from `cx`.
+    fn post<C>(self, cx: &C, message: M)
     where
         C: context::Actor;
 }
 
 /// A typed endpoint that can receive `M` with message headers.
 ///
-/// `RemoteEndpoint` is implemented only for endpoints whose send path preserves
+/// `RemoteEndpoint` is implemented only for endpoints whose post path preserves
 /// headers.
 pub trait RemoteEndpoint<M>: Endpoint<M> {
-    /// Send `message` and `headers` to this endpoint from `cx`.
-    fn send_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
+    /// Post `message` and `headers` to this endpoint from `cx`.
+    fn post_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
     where
         C: context::Actor;
 }
@@ -129,7 +129,7 @@ mod tests {
     #[async_trait]
     impl Handler<u64> for EchoActor {
         async fn handle(&mut self, cx: &Context<Self>, message: u64) -> anyhow::Result<()> {
-            Endpoint::send(&self.tx, cx, message);
+            Endpoint::post(&self.tx, cx, message);
             Ok(())
         }
     }
@@ -154,7 +154,7 @@ mod tests {
             .spawn("echo", EchoActor { tx: tx.bind() })
             .expect("spawn should succeed");
 
-        Endpoint::send(&handle, &client, 123u64);
+        Endpoint::post(&handle, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -165,7 +165,7 @@ mod tests {
         let (client, _) = proc.instance("client").unwrap();
         let (tx, mut rx) = client.open_port();
 
-        Endpoint::send(&tx, &client, 123u64);
+        Endpoint::post(&tx, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -176,7 +176,7 @@ mod tests {
         let (client, _) = proc.instance("client").unwrap();
         let (tx, rx) = client.open_once_port();
 
-        Endpoint::send(tx, &client, 123u64);
+        Endpoint::post(tx, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -188,7 +188,7 @@ mod tests {
             .attach_actor::<TestBehavior, u64>("remote_actor")
             .expect("attach actor should succeed");
 
-        Endpoint::send(&actor_ref, &client, 123u64);
+        Endpoint::post(&actor_ref, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -200,7 +200,7 @@ mod tests {
         let (tx, mut rx) = client.open_port();
         let port_ref = tx.bind();
 
-        Endpoint::send(&port_ref, &client, 123u64);
+        Endpoint::post(&port_ref, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -212,7 +212,7 @@ mod tests {
         let (tx, rx) = client.open_once_port();
         let port_ref = tx.bind();
 
-        Endpoint::send(port_ref, &client, 123u64);
+        Endpoint::post(port_ref, &client, 123u64);
 
         assert_eq!(rx.recv().await.expect("message should arrive"), 123);
     }
@@ -239,7 +239,7 @@ mod tests {
         let mut headers = Flattrs::new();
         headers.set(ENDPOINT_TEST_HEADER, 456u64);
 
-        RemoteEndpoint::send_with_headers(&port_ref, &client, headers, 123u64);
+        RemoteEndpoint::post_with_headers(&port_ref, &client, headers, 123u64);
 
         assert_eq!(
             observed_rx.recv().await.expect("message should arrive"),

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1361,7 +1361,7 @@ impl<C: context::Actor, M: RemoteMessage> Sink<M> for PortSink<C, M> {
     }
 
     fn start_send(self: Pin<&mut Self>, item: M) -> Result<(), Self::Error> {
-        crate::Endpoint::send(&self.port, &self.cx, item);
+        crate::Endpoint::post(&self.port, &self.cx, item);
         Ok(())
     }
 
@@ -2059,7 +2059,7 @@ where
         self.location().into()
     }
 
-    fn send<C>(self, cx: &C, message: M)
+    fn post<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
@@ -2175,7 +2175,7 @@ where
         EndpointLocation::Port(self.port_id.clone())
     }
 
-    fn send<C>(self, _cx: &C, message: M)
+    fn post<C>(self, _cx: &C, message: M)
     where
         C: context::Actor,
     {
@@ -3428,28 +3428,28 @@ mod tests {
             .open_accum_port(accum::join_semilattice::<accum::Max<i64>>());
 
         for i in -3..4 {
-            port.send(&client, accum::Max(i));
+            port.post(&client, accum::Max(i));
             let received: accum::Max<i64> = receiver.recv().await.unwrap();
             let msg = received.get();
             assert_eq!(msg, &i);
         }
         // Send a smaller or same value. Should still receive the previous max.
         for i in -3..4 {
-            port.send(&client, accum::Max(i));
+            port.post(&client, accum::Max(i));
             assert_eq!(receiver.recv().await.unwrap().get(), &3);
         }
         // send a larger value. Should receive the new max.
-        port.send(&client, accum::Max(4));
+        port.post(&client, accum::Max(4));
         assert_eq!(receiver.recv().await.unwrap().get(), &4);
 
         // Send multiple updates. Should only receive the final change.
         for i in 5..10 {
-            port.send(&client, accum::Max(i));
+            port.post(&client, accum::Max(i));
         }
         assert_eq!(receiver.recv().await.unwrap().get(), &9);
-        port.send(&client, accum::Max(1));
-        port.send(&client, accum::Max(3));
-        port.send(&client, accum::Max(2));
+        port.post(&client, accum::Max(1));
+        port.post(&client, accum::Max(3));
+        port.post(&client, accum::Max(2));
         assert_eq!(receiver.recv().await.unwrap().get(), &9);
     }
 
@@ -3484,7 +3484,7 @@ mod tests {
 
         // let port_id = port.port_addr().clone();
 
-        port.send(&client, 123u64);
+        port.post(&client, 123u64);
         assert_eq!(receiver.recv().await.unwrap(), 123u64);
 
         // // The borrow checker won't let us send again on the port
@@ -3696,7 +3696,7 @@ mod tests {
         let proc = Proc::configured(test_proc_id("0"), BoxedMailboxSender::new(muxer));
         let (client, _) = proc.instance("client").unwrap();
 
-        port.send(&client, 123u64);
+        port.post(&client, 123u64);
         assert_eq!(receiver.recv().await.unwrap(), 123u64);
 
         /*
@@ -3912,10 +3912,10 @@ mod tests {
             Ok(())
         });
 
-        port.send(&client, 10);
-        port.send(&client, 5);
-        port.send(&client, 1);
-        port.send(&client, 0);
+        port.post(&client, 10);
+        port.post(&client, 5);
+        port.post(&client, 1);
+        port.post(&client, 0);
 
         assert_eq!(count.load(Ordering::SeqCst), 16);
     }
@@ -3990,7 +3990,7 @@ mod tests {
             wirevalue::Any::serialize(&1u64).unwrap(),
             Flattrs::new(),
         );
-        return_handle.send(&client, Undeliverable::Message(message));
+        return_handle.post(&client, Undeliverable::Message(message));
 
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
 
@@ -4033,7 +4033,7 @@ mod tests {
         );
         let proc = Proc::isolated();
         let (client, _) = proc.instance("client").unwrap();
-        return_handle.send(&client, Undeliverable::Message(envelope.clone()));
+        return_handle.post(&client, Undeliverable::Message(envelope.clone()));
         // Check we receive the undelivered message.
         assert!(
             tokio::time::timeout(tokio::time::Duration::from_secs(1), return_receiver.recv())
@@ -4781,7 +4781,7 @@ mod tests {
 
         handle
             .contramap(|m| (1, m))
-            .send(&client, "hello".to_string());
+            .post(&client, "hello".to_string());
         assert_eq!(rx.recv().await.unwrap(), (1, "hello".to_string()));
     }
 
@@ -4965,7 +4965,7 @@ mod tests {
         assert!(port_ref.reducer_spec().is_some());
 
         // Send a single value via the bound port
-        port_ref.send(&client, 42);
+        port_ref.post(&client, 42);
 
         // Should receive the value
         let result = receiver.recv().await.unwrap();

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -225,7 +225,7 @@ pub(crate) fn return_undeliverable(
         let client = &CLIENT
             .get_or_init(|| Proc::runtime().instance("global_return_client").unwrap())
             .0;
-        crate::Endpoint::send(&return_handle, client, Undeliverable::message(envelope));
+        crate::Endpoint::post(&return_handle, client, Undeliverable::message(envelope));
     }
 }
 

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -256,7 +256,7 @@ impl<M: Bind> IndexedErasedUnbound<M> {
         let port_handle = mailbox.open_enqueue_port::<IndexedErasedUnbound<M>>({
             move |_, m| {
                 let bound_m = m.downcast()?.bind()?;
-                actor_ref.send(&cx, bound_m);
+                actor_ref.post(&cx, bound_m);
                 Ok(())
             }
         });

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -846,7 +846,7 @@ impl Proc {
     ) {
         let result = match self.state().supervision_coordinator_port.get() {
             Some(port) => {
-                port.send(cx, event.clone());
+                port.post(cx, event.clone());
                 Ok(())
             }
             None => {
@@ -2354,7 +2354,7 @@ impl<A: Actor> Instance<A> {
         let port = self.port();
         tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            port.send(&client, message);
+            port.post(&client, message);
         });
         Ok(())
     }
@@ -3300,7 +3300,7 @@ impl InstanceCell {
             let client = &CLIENT
                 .get_or_init(|| Proc::runtime().instance("global_signal_client").unwrap())
                 .0;
-            signal_port.send(&client, signal);
+            signal_port.post(&client, signal);
             Ok(())
         } else {
             tracing::warn!(
@@ -3327,7 +3327,7 @@ impl InstanceCell {
     ) {
         match &self.inner.actor_loop {
             Some((_, supervision_port)) => {
-                supervision_port.send(child_cx, event.clone());
+                supervision_port.post(child_cx, event.clone());
             }
             None => {
                 if !event.is_error() {
@@ -3864,7 +3864,7 @@ mod tests {
             parent: &ActorHandle<TestActor>,
         ) -> ActorHandle<TestActor> {
             let (tx, rx) = oneshot::channel();
-            parent.send(cx, TestActorMessage::Spawn(tx));
+            parent.post(cx, TestActorMessage::Spawn(tx));
             rx.await.unwrap()
         }
     }
@@ -3899,7 +3899,7 @@ mod tests {
             message: Box<TestActorMessage>,
         ) -> Result<(), anyhow::Error> {
             // TODO: this needn't be async
-            destination.send(cx, *message);
+            destination.post(cx, *message);
             Ok(())
         }
 
@@ -3965,7 +3965,7 @@ mod tests {
         // Send a ping-pong to the actor. Wait for the actor to become idle.
 
         let (tx, rx) = oneshot::channel::<()>();
-        handle.send(&client, TestActorMessage::Reply(tx));
+        handle.post(&client, TestActorMessage::Reply(tx));
         rx.await.unwrap();
 
         state
@@ -3977,7 +3977,7 @@ mod tests {
         let (enter_tx, enter_rx) = oneshot::channel::<()>();
         let (exit_tx, exit_rx) = oneshot::channel::<()>();
 
-        handle.send(&client, TestActorMessage::Wait(enter_tx, exit_rx));
+        handle.post(&client, TestActorMessage::Wait(enter_tx, exit_rx));
         enter_rx.await.unwrap();
         assert_matches!(*state.borrow(), ActorStatus::Processing(instant, _) if instant <= std::time::SystemTime::now());
         exit_tx.send(()).unwrap();
@@ -4000,7 +4000,7 @@ mod tests {
         let second = proc.spawn::<TestActor>("second", TestActor).unwrap();
         let (tx, rx) = oneshot::channel::<()>();
         let reply_message = TestActorMessage::Reply(tx);
-        first.send(
+        first.post(
             &client,
             TestActorMessage::Forward(second, Box::new(reply_message)),
         );
@@ -4553,7 +4553,7 @@ mod tests {
         root.await;
 
         for actor in [root_1, root_2, root_2_1] {
-            actor.send(&client, TestActorMessage::Noop());
+            actor.post(&client, TestActorMessage::Noop());
             assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
         }
     }
@@ -4643,7 +4643,7 @@ mod tests {
 
         // Drain closes runtime-dispatched handler ingress, so new
         // sends to the actor's handler port are rejected.
-        handle.send(&client, ());
+        handle.post(&client, ());
 
         release_stop.notify_one();
         assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
@@ -4662,7 +4662,7 @@ mod tests {
         let root_2 = TestActor::spawn_child(&client, &root).await;
         let root_2_1 = TestActor::spawn_child(&client, &root_2).await;
 
-        root_2.send(
+        root_2.post(
             &client,
             TestActorMessage::Fail(anyhow::anyhow!("some random failure")),
         );
@@ -4701,7 +4701,7 @@ mod tests {
                 cx: &crate::Context<Self>,
                 message: OncePortHandle<PortHandle<usize>>,
             ) -> anyhow::Result<()> {
-                message.send(cx, cx.port());
+                message.post(cx, cx.port());
                 Ok(())
             }
         }
@@ -4724,9 +4724,9 @@ mod tests {
         let handle = proc.spawn::<TestActor>("test", actor).unwrap();
         let (client, _) = proc.instance("client").unwrap();
         let (tx, rx) = client.open_once_port();
-        handle.send(&client, tx);
+        handle.post(&client, tx);
         let usize_handle = rx.recv().await.unwrap();
-        usize_handle.send(&client, 123);
+        usize_handle.post(&client, 123);
 
         handle.drain_and_stop("test").unwrap();
         handle.await;
@@ -4863,12 +4863,12 @@ mod tests {
 
         // fail `root_1_1_1`, the supervision msg should be propagated to
         // `root_1` because `root_1` has set `true` to `handle_supervision_event`.
-        root_1_1_1.send(&client, "some random failure".to_string());
+        root_1_1_1.post(&client, "some random failure".to_string());
 
         // fail `root_2_1`, the supervision msg should be propagated to
         // ProcSupervisionCoordinator.
         let root_2_1_id = root_2_1.actor_addr().clone();
-        root_2_1.send(&client, "some random failure".to_string());
+        root_2_1.post(&client, "some random failure".to_string());
 
         // Wait for root_1 to handle the supervision event from the
         // root_1_1_1 -> root_1_1 -> root_1 chain. The Notify provides
@@ -4902,7 +4902,7 @@ mod tests {
                 cx: &crate::Context<Self>,
                 (message, port): (String, PortRef<String>),
             ) -> anyhow::Result<()> {
-                port.send(cx, message);
+                port.post(cx, message);
                 Ok(())
             }
         }
@@ -4914,7 +4914,7 @@ mod tests {
         let child_actor = TestActor.spawn(&instance).unwrap();
 
         let (port, mut receiver) = instance.open_port();
-        child_actor.send(&instance, ("hello".to_string(), port.bind()));
+        child_actor.post(&instance, ("hello".to_string(), port.bind()));
 
         let message = receiver.recv().await.unwrap();
         assert_eq!(message, "hello");
@@ -4981,7 +4981,7 @@ mod tests {
         impl LoggingActor {
             async fn wait(cx: &impl context::Actor, handle: &ActorHandle<Self>) {
                 let barrier = Arc::new(Barrier::new(2));
-                handle.send(cx, barrier.clone());
+                handle.post(cx, barrier.clone());
                 barrier.wait().await;
             }
         }
@@ -5042,9 +5042,9 @@ mod tests {
             let proc = Proc::isolated();
             let (client, _) = proc.instance("client").unwrap();
             let handle = LoggingActor.spawn_detached().unwrap();
-            handle.send(&client, "hello world".to_string());
-            handle.send(&client, "hello world again".to_string());
-            handle.send(&client, 123u64);
+            handle.post(&client, "hello world".to_string());
+            handle.post(&client, "hello world again".to_string());
+            handle.post(&client, 123u64);
 
             LoggingActor::wait(&client, &handle).await;
 
@@ -5059,7 +5059,7 @@ mod tests {
 
             let stacks = {
                 let barriers = Arc::new((Barrier::new(2), Barrier::new(2)));
-                handle.send(&client, Arc::clone(&barriers));
+                handle.post(&client, Arc::clone(&barriers));
                 barriers.0.wait().await;
                 let stacks = handle.cell().inner.recording.stacks();
                 barriers.1.wait().await;
@@ -5084,7 +5084,7 @@ mod tests {
         actor_handle.drain_and_stop("healthy shutdown").unwrap();
         actor_handle.await;
 
-        handle_for_send.send(&client, TestActorMessage::Noop());
+        handle_for_send.post(&client, TestActorMessage::Noop());
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -5101,13 +5101,13 @@ mod tests {
         let handle_for_send = actor_handle.clone();
 
         // Cause the actor to fail
-        actor_handle.send(
+        actor_handle.post(
             &client,
             TestActorMessage::Fail(anyhow::anyhow!("intentional failure")),
         );
         actor_handle.await;
 
-        handle_for_send.send(&client, TestActorMessage::Noop());
+        handle_for_send.post(&client, TestActorMessage::Noop());
     }
 
     /// Wait for a terminated snapshot to appear for the given actor.
@@ -5196,7 +5196,7 @@ mod tests {
         let actor_id = handle.actor_addr().clone();
 
         // Trigger a failure.
-        handle.send(&client, TestActorMessage::Fail(anyhow::anyhow!("boom")));
+        handle.post(&client, TestActorMessage::Fail(anyhow::anyhow!("boom")));
         handle.await;
 
         let snapshot = wait_for_terminated_snapshot(&proc, &actor_id).await;
@@ -5223,7 +5223,7 @@ mod tests {
         let actor_id = handle.actor_addr().clone();
         let cell = handle.cell().clone();
 
-        handle.send(&client, TestActorMessage::Fail(anyhow::anyhow!("boom")));
+        handle.post(&client, TestActorMessage::Fail(anyhow::anyhow!("boom")));
         handle.await;
 
         let event = cell.supervision_event();
@@ -5332,13 +5332,13 @@ mod tests {
         let parent_cell = parent.cell().clone();
         // Spawn child under parent.
         let (tx, rx) = oneshot::channel();
-        parent.send(&client, TestActorMessage::Spawn(tx));
+        parent.post(&client, TestActorMessage::Spawn(tx));
         let child = rx.await.unwrap();
         let child_id = child.actor_addr().clone();
 
         // Fail the child — parent doesn't handle supervision, so it
         // propagates and terminates too.
-        child.send(
+        child.post(
             &client,
             TestActorMessage::Fail(anyhow::anyhow!("child boom")),
         );
@@ -5397,7 +5397,7 @@ mod tests {
         let handle = proc.spawn::<TestActor>("fail_actor", TestActor).unwrap();
         let actor_id = handle.actor_addr().clone();
 
-        handle.send(&client, TestActorMessage::Fail(anyhow::anyhow!("kaboom")));
+        handle.post(&client, TestActorMessage::Fail(anyhow::anyhow!("kaboom")));
         handle.await;
 
         let snapshot = wait_for_terminated_snapshot(&proc, &actor_id).await;
@@ -5440,11 +5440,11 @@ mod tests {
         let parent_id = parent.actor_addr().clone();
 
         let (tx, rx) = oneshot::channel();
-        parent.send(&client, TestActorMessage::Spawn(tx));
+        parent.post(&client, TestActorMessage::Spawn(tx));
         let child = rx.await.unwrap();
         let child_id = child.actor_addr().clone();
 
-        child.send(
+        child.post(
             &client,
             TestActorMessage::Fail(anyhow::anyhow!("child fail")),
         );

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -103,11 +103,11 @@ where
         EndpointLocation::Actor(self.actor_addr.clone())
     }
 
-    fn send<C>(self, cx: &C, message: M)
+    fn post<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
-        RemoteEndpoint::send_with_headers(self, cx, Flattrs::new(), message)
+        RemoteEndpoint::post_with_headers(self, cx, Flattrs::new(), message)
     }
 }
 
@@ -116,11 +116,11 @@ where
     A: Referable + RemoteHandles<M>,
     M: RemoteMessage,
 {
-    fn send_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
+    fn post_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
     where
         C: context::Actor,
     {
-        RemoteEndpoint::send_with_headers(&self.port(), cx, headers, message)
+        RemoteEndpoint::post_with_headers(&self.port(), cx, headers, message)
     }
 }
 
@@ -348,11 +348,11 @@ where
         EndpointLocation::Port(self.port_addr.clone())
     }
 
-    fn send<C>(self, cx: &C, message: M)
+    fn post<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
-        RemoteEndpoint::send_with_headers(self, cx, Flattrs::new(), message)
+        RemoteEndpoint::post_with_headers(self, cx, Flattrs::new(), message)
     }
 }
 
@@ -360,7 +360,7 @@ impl<M> RemoteEndpoint<M> for &PortRef<M>
 where
     M: RemoteMessage,
 {
-    fn send_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
+    fn post_with_headers<C>(self, cx: &C, headers: Flattrs, message: M)
     where
         C: context::Actor,
     {
@@ -544,11 +544,11 @@ where
         EndpointLocation::Port(self.port_addr.clone())
     }
 
-    fn send<C>(self, cx: &C, message: M)
+    fn post<C>(self, cx: &C, message: M)
     where
         C: context::Actor,
     {
-        RemoteEndpoint::send_with_headers(self, cx, Flattrs::new(), message)
+        RemoteEndpoint::post_with_headers(self, cx, Flattrs::new(), message)
     }
 }
 
@@ -556,7 +556,7 @@ impl<M> RemoteEndpoint<M> for OncePortRef<M>
 where
     M: RemoteMessage,
 {
-    fn send_with_headers<C>(self, cx: &C, mut headers: Flattrs, message: M)
+    fn post_with_headers<C>(self, cx: &C, mut headers: Flattrs, message: M)
     where
         C: context::Actor,
     {

--- a/hyperactor/src/testing/pingpong.rs
+++ b/hyperactor/src/testing/pingpong.rs
@@ -94,7 +94,7 @@ impl Actor for PingPongActor {
         undelivered: crate::mailbox::Undeliverable<crate::mailbox::MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
         match &self.undeliverable_port_ref {
-            Some(port) => port.send(cx, undelivered),
+            Some(port) => port.post(cx, undelivered),
             None => match undelivered {
                 Undeliverable::Message(envelope) => {
                     anyhow::bail!(UndeliverableMessageError::DeliveryFailure { envelope });
@@ -125,13 +125,13 @@ impl Handler<PingPongMessage> for PingPongActor {
             anyhow::bail!("PingPong handler encountered an Error");
         }
         if ttl == 0 {
-            done_port.send(cx, true);
+            done_port.post(cx, true);
         } else {
             if let Some(delay) = self.delay {
                 tokio::time::sleep(delay).await;
             }
             let next_message = PingPongMessage(ttl - 1, cx.bind(), done_port);
-            pong_actor.send(cx, next_message);
+            pong_actor.post(cx, next_message);
         }
         Ok(())
     }

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -757,7 +757,7 @@ pub fn derive_handler(input: TokenStream) -> TokenStream {
                         // This would require Result<Result<..., in order to handle RPC errors.
                         #construct_result_future
                         use hyperactor::Endpoint as _;
-                        #reply_port_arg.send(cx, #result_ident);
+                        #reply_port_arg.post(cx, #result_ident);
                         Ok(())
                     }
                 });
@@ -897,7 +897,7 @@ fn derive_client(input: TokenStream, is_handle: bool) -> TokenStream {
     // The client implementation methods.
     let mut impl_methods = Vec::new();
 
-    let send_message = quote! { hyperactor::Endpoint::send(self, cx, message); };
+    let send_message = quote! { hyperactor::Endpoint::post(self, cx, message); };
     let global_log_level = parse_log_level(&input.attrs).ok().unwrap_or(None);
 
     for message in &messages {

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -79,7 +79,7 @@ where
         cx: &Context<Self>,
         GenericMessage(message): GenericMessage<T>,
     ) -> anyhow::Result<()> {
-        self.forward_port.send(cx, format!("{message:?}"));
+        self.forward_port.post(cx, format!("{message:?}"));
         Ok(())
     }
 }
@@ -90,7 +90,7 @@ struct TestMessage(String);
 #[async_trait]
 impl Handler<TestMessage> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, msg: TestMessage) -> anyhow::Result<()> {
-        self.forward_port.send(cx, msg.0);
+        self.forward_port.post(cx, msg.0);
         Ok(())
     }
 }
@@ -101,7 +101,7 @@ struct MyGeneric<T>(T);
 #[async_trait]
 impl Handler<()> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, _msg: ()) -> anyhow::Result<()> {
-        self.forward_port.send(cx, "()".to_string());
+        self.forward_port.post(cx, "()".to_string());
         Ok(())
     }
 }
@@ -109,7 +109,7 @@ impl Handler<()> for TestActor {
 #[async_trait]
 impl Handler<MyGeneric<()>> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, _msg: MyGeneric<()>) -> anyhow::Result<()> {
-        self.forward_port.send(cx, "MyGeneric<()>".to_string());
+        self.forward_port.post(cx, "MyGeneric<()>".to_string());
         Ok(())
     }
 }
@@ -117,7 +117,7 @@ impl Handler<MyGeneric<()>> for TestActor {
 #[async_trait]
 impl Handler<u64> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, msg: u64) -> anyhow::Result<()> {
-        self.forward_port.send(cx, format!("u64: {msg}"));
+        self.forward_port.post(cx, format!("u64: {msg}"));
         Ok(())
     }
 }
@@ -159,7 +159,7 @@ mod tests {
                 .actor_addr()
                 .port_addr(Port::from(TestMessage::port()));
             let port_ref: reference::PortRef<TestMessage> = reference::PortRef::attest(port_id);
-            port_ref.send(&client, TestMessage("abc".to_string()));
+            port_ref.post(&client, TestMessage("abc".to_string()));
             assert_eq!(rx.recv().await.unwrap(), "abc");
         }
         {
@@ -168,7 +168,7 @@ mod tests {
                 .actor_addr()
                 .port_addr(Port::from(<()>::port()));
             let port_ref: reference::PortRef<()> = reference::PortRef::attest(port_id);
-            port_ref.send(&client, ());
+            port_ref.post(&client, ());
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
         {
@@ -177,7 +177,7 @@ mod tests {
                 .actor_addr()
                 .port_addr(Port::from(<u64>::port()));
             let port_ref: reference::PortRef<u64> = reference::PortRef::attest(port_id);
-            port_ref.send(&client, 987654321);
+            port_ref.post(&client, 987654321);
             assert_eq!(rx.recv().await.unwrap(), "u64: 987654321");
         }
         {
@@ -186,7 +186,7 @@ mod tests {
                 .actor_addr()
                 .port_addr(Port::from(MyGeneric::<()>::port()));
             let port_ref: reference::PortRef<MyGeneric<()>> = reference::PortRef::attest(port_id);
-            port_ref.send(&client, MyGeneric(()));
+            port_ref.post(&client, MyGeneric(()));
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
         }
         {
@@ -200,7 +200,7 @@ mod tests {
                 .port_addr(Port::from(<IndexedErasedUnbound<TestMessage>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<TestMessage>> =
                 reference::PortRef::attest(port_id);
-            port_ref.send(&client, indexed_msg);
+            port_ref.post(&client, indexed_msg);
             assert_eq!(rx.recv().await.unwrap(), "efg");
         }
         {
@@ -213,7 +213,7 @@ mod tests {
                 .port_addr(Port::from(<IndexedErasedUnbound<()>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<()>> =
                 reference::PortRef::attest(port_id);
-            port_ref.send(&client, indexed_msg);
+            port_ref.post(&client, indexed_msg);
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
         {
@@ -226,7 +226,7 @@ mod tests {
                 .port_addr(Port::from(<IndexedErasedUnbound<MyGeneric<()>>>::port()));
             let port_ref: reference::PortRef<IndexedErasedUnbound<MyGeneric<()>>> =
                 reference::PortRef::attest(port_id);
-            port_ref.send(&client, indexed_msg);
+            port_ref.post(&client, indexed_msg);
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
         }
     }
@@ -238,24 +238,24 @@ mod tests {
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
 
-        actor_handle.send(&client, 123u64);
-        actor_handle.send(&client, TestMessage("foo".to_string()));
+        actor_handle.post(&client, 123u64);
+        actor_handle.post(&client, TestMessage("foo".to_string()));
 
         let myref: reference::ActorRef<TestActorAlias> = actor_handle.bind();
-        myref.port().send(&client, MyGeneric(()));
-        myref.port().send(&client, TestMessage("biz".to_string()));
-        myref.port().send(&client, 999u64);
-        myref.port().send(&client, ());
+        myref.port().post(&client, MyGeneric(()));
+        myref.port().post(&client, TestMessage("biz".to_string()));
+        myref.port().post(&client, 999u64);
+        myref.port().post(&client, ());
         {
             let erased_msg =
                 ErasedUnbound::try_from_message(TestMessage("bar".to_string())).unwrap();
             let indexed_msg = IndexedErasedUnbound::<TestMessage>::from(erased_msg);
-            myref.port().send(&client, indexed_msg);
+            myref.port().post(&client, indexed_msg);
         }
         {
             let erased_msg = ErasedUnbound::try_from_message(()).unwrap();
             let indexed_msg = IndexedErasedUnbound::<MyGeneric<()>>::from(erased_msg);
-            myref.port().send(&client, indexed_msg);
+            myref.port().post(&client, indexed_msg);
         }
 
         assert_eq!(rx.recv().await.unwrap(), "u64: 123");
@@ -283,7 +283,7 @@ mod tests {
             .actor_addr()
             .port_addr(Port::from(GenericMessage::<u64>::port()));
         let port_ref: reference::PortRef<GenericMessage<u64>> = reference::PortRef::attest(port_id);
-        port_ref.send(&client, GenericMessage(42));
+        port_ref.post(&client, GenericMessage(42));
         assert_eq!(rx.recv().await.unwrap(), "42");
 
         assert_ne!(

--- a/hyperactor_mesh/benches/bench_actor.rs
+++ b/hyperactor_mesh/benches/bench_actor.rs
@@ -59,7 +59,7 @@ impl Handler<BenchMessage> for BenchActor {
     ) -> Result<(), anyhow::Error> {
         tokio::time::sleep(self.processing_time.clone()).await;
 
-        let _ = msg.reply.send(ctx, msg.step);
+        let _ = msg.reply.post(ctx, msg.step);
         Ok(())
     }
 }

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -124,7 +124,7 @@ impl PhilosopherActor {
         self.waiter
             .get()
             .ok_or(anyhow::anyhow!("uninitialized waiter port"))?
-            .send(
+            .post(
                 cx,
                 WaiterMessage::RequestChopsticks((self.rank, left, right)),
             );
@@ -143,7 +143,7 @@ impl PhilosopherActor {
         self.waiter
             .get()
             .ok_or(anyhow::anyhow!("uninitialized waiter port"))?
-            .send(cx, WaiterMessage::ReleaseChopsticks((left, right)));
+            .post(cx, WaiterMessage::ReleaseChopsticks((left, right)));
         self.chopsticks = (ChopstickStatus::None, ChopstickStatus::None);
         Ok(())
     }

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -93,7 +93,7 @@ impl Handler<NextNumber> for SieveActor {
         }
         match &self.next {
             Some(next) => {
-                next.send(cx, msg);
+                next.post(cx, msg);
             }
             None => {
                 tracing::info!(
@@ -101,7 +101,7 @@ impl Handler<NextNumber> for SieveActor {
                     discovered = msg.number,
                     "new prime discovered, spawning child"
                 );
-                msg.prime_collector.send(cx, msg.number);
+                msg.prime_collector.post(cx, msg.number);
 
                 self.next = Some(
                     SieveActor::new(SieveParams { prime: msg.number }, Flattrs::default())
@@ -207,7 +207,7 @@ async fn main() -> Result<ExitCode> {
 
                 _ = tick.tick() => {
                     sieve_head
-                        .send(
+                        .post(
                             instance,
                             NextNumber {
                                 number: candidate,

--- a/hyperactor_mesh/examples/test_bench.rs
+++ b/hyperactor_mesh/examples/test_bench.rs
@@ -54,7 +54,7 @@ impl Handler<TestMessage> for TestActor {
         message: TestMessage,
     ) -> Result<(), anyhow::Error> {
         match message {
-            TestMessage::Ping(reply) => reply.send(cx, cx.cast_point()),
+            TestMessage::Ping(reply) => reply.post(cx, cx.cast_point()),
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -161,7 +161,7 @@ impl<A: Referable> ActorMesh<A> {
             let id = self.id.resource_id().clone();
             let num_ranks = self.current_ref.region().num_ranks();
             let result: crate::Result<()> = async {
-                controller.send(
+                controller.post(
                     cx,
                     resource::Stop {
                         id: id.clone(),
@@ -178,7 +178,7 @@ impl<A: Referable> ActorMesh<A> {
                 // abort-budget exhaustion). We just need to serialize
                 // behind the Stop handler and read the result.
                 let (port, mut rx) = cx.mailbox().open_port();
-                controller.send(
+                controller.post(
                     cx,
                     resource::GetState::<resource::mesh::State<()>> {
                         id: id.clone(),
@@ -593,7 +593,7 @@ impl<A: Referable> ActorMeshRef<A> {
             let rebound_message = unbound
                 .bind()
                 .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-            actor.send_with_headers(cx, headers, rebound_message);
+            actor.post_with_headers(cx, headers, rebound_message);
         }
         Ok(())
     }
@@ -777,7 +777,7 @@ impl<A: Referable> ActorMeshRef<A> {
             .expect("infallible because CastMessage should not fail for serialization");
 
             // TODO: load balancing instead of always using the first comm actor
-            root_comm_actor.send_with_headers(cx, headers, cast_message);
+            root_comm_actor.post_with_headers(cx, headers, cast_message);
         }
     }
     /// Query the state of all actors in this mesh.
@@ -901,7 +901,7 @@ impl<A: Referable> ActorMeshRef<A> {
     ) {
         let (tx, rx) = cx.mailbox().open_port();
         let tx = tx.bind();
-        controller.send(cx, Subscribe(tx.clone()));
+        controller.post(cx, Subscribe(tx.clone()));
         (tx, into_watch(rx))
     }
 
@@ -985,7 +985,7 @@ impl<A: Referable> ActorMeshRef<A> {
                 let mut port = controller.port();
                 // We don't care if the controller is unreachable for an unsubscribe.
                 port.return_undeliverable(false);
-                let _ = port.send(cx, Unsubscribe(subscriber_port));
+                let _ = port.post(cx, Unsubscribe(subscriber_port));
             }
             // If we successfully got a message back, we can't unsubscribe because
             // the receiver might be shared with other calls to next_supervision_event,
@@ -1279,10 +1279,10 @@ mod tests {
         // exist).
         amr.get(0)
             .expect("rank 0 exists")
-            .send(instance, testactor::GetActorId(port.bind()));
+            .post(instance, testactor::GetActorId(port.bind()));
         amr.get(3)
             .expect("rank 3 exists")
-            .send(instance, testactor::GetActorId(port.bind()));
+            .post(instance, testactor::GetActorId(port.bind()));
         let id_a = tokio::time::timeout(Duration::from_secs(3), rx.recv())
             .await
             .expect("timed out waiting for first reply")
@@ -1774,7 +1774,7 @@ mod tests {
 
         // Verify ping-pong works initially
         let (done_tx, done_rx) = instance.open_once_port();
-        ping_handle.send(
+        ping_handle.post(
             instance,
             PingPongMessage(2, pong_handle.clone(), done_tx.bind()),
         );
@@ -1804,7 +1804,7 @@ mod tests {
         for i in 1..=n {
             let ttl = 66 + i as u64; // Avoid ttl = 66 (which would cause other test behavior)
             let (once_tx, _once_rx) = instance.open_once_port();
-            ping_handle.send(
+            ping_handle.post(
                 instance,
                 PingPongMessage(ttl, pong_handle.clone(), once_tx.bind()),
             );
@@ -1882,7 +1882,7 @@ mod tests {
         // `DrainAndStop` will sit queued in the signal mailbox until this
         // handler completes. Nothing forcibly aborts it.
         for actor_ref in sleep_mesh.values() {
-            actor_ref.send(instance, std::time::Duration::from_secs(5));
+            actor_ref.post(instance, std::time::Duration::from_secs(5));
         }
 
         // Give actors time to start sleeping

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1205,7 +1205,7 @@ impl BootstrapProcHandle {
         // killing the process.
         let mut agent_port = agent.port();
         agent_port.return_undeliverable(false);
-        agent_port.send(
+        agent_port.post(
             cx,
             resource::StopAll {
                 reason: reason.to_string(),
@@ -1745,7 +1745,7 @@ impl BootstrapProcManager {
         if let Some(agent) = handle.agent_ref() {
             let mut agent_port = agent.port();
             agent_port.return_undeliverable(false);
-            let _ = agent_port.send(
+            let _ = agent_port.post(
                 cx,
                 resource::StopAll {
                     reason: reason.to_string(),

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -173,7 +173,7 @@ where
 
     comm_actor_ref
         .port()
-        .send_with_headers(cx, headers, cast_message);
+        .post_with_headers(cx, headers, cast_message);
 
     Ok(())
 }

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -209,7 +209,7 @@ impl Actor for CommActor {
             // original sender of the cast message.
             message_envelope.set_header(CAST_ORIGINATING_SENDER, sender.clone());
 
-            return_port.send(cx, Undeliverable::Message(message_envelope.clone()));
+            return_port.post(cx, Undeliverable::Message(message_envelope.clone()));
             return Ok(());
         }
 
@@ -222,7 +222,7 @@ impl Actor for CommActor {
                 cx.self_addr(),
                 return_port.port_addr(),
             )));
-            return_port.send(cx, Undeliverable::Message(message_envelope.clone()));
+            return_port.post(cx, Undeliverable::Message(message_envelope.clone()));
             return Ok(());
         }
 
@@ -249,9 +249,9 @@ impl CommActor {
         if let Some(cast_actor_mesh_id) = cx.headers().get(CAST_ACTOR_MESH_ID) {
             let mut headers = Flattrs::new();
             headers.set(CAST_ACTOR_MESH_ID, cast_actor_mesh_id);
-            child.send_with_headers(cx, headers, message);
+            child.post_with_headers(cx, headers, message);
         } else {
-            child.send(cx, message);
+            child.post(cx, message);
         }
         Ok(())
     }
@@ -696,9 +696,9 @@ pub mod test_utils {
             // For CastWithUnsplitPort, send a reply so the test can
             // verify that the unsplit port is still directly reachable.
             if let TestMessage::CastWithUnsplitPort { ref reply_to } = msg {
-                reply_to.send(cx, 42);
+                reply_to.post(cx, 42);
             }
-            self.forward_port.send(cx, msg);
+            self.forward_port.post(cx, msg);
             Ok(())
         }
     }
@@ -771,7 +771,7 @@ mod tests {
         let comm_ref = comm_handle.bind::<CommActor>();
         let mut peers = HashMap::new();
         peers.insert(0, comm_ref);
-        comm_handle.send(client, CommMeshConfig::new(0, peers));
+        comm_handle.post(client, CommMeshConfig::new(0, peers));
     }
 
     /// Send a message before config, send config, send another after config,
@@ -785,9 +785,9 @@ mod tests {
         let (client, mut rx, comm_handle, actor_mesh_id, _guards) =
             buffering_fixture(proc_name).await;
 
-        comm_handle.send(&client, make_msg(&client, &actor_mesh_id, "buffered"));
+        comm_handle.post(&client, make_msg(&client, &actor_mesh_id, "buffered"));
         send_config(&client, &comm_handle);
-        comm_handle.send(&client, make_msg(&client, &actor_mesh_id, "direct"));
+        comm_handle.post(&client, make_msg(&client, &actor_mesh_id, "direct"));
 
         assert_eq!(
             rx.recv().await.unwrap(),
@@ -1181,12 +1181,12 @@ mod tests {
                 ranks.iter().zip(reply_tos.iter()).enumerate()
             {
                 let rank_u64 = rank as u64;
-                reply_to1.send(instance, rank_u64);
+                reply_to1.post(instance, rank_u64);
                 let my_reply = MyReply {
                     sender: dest_actor.actor_addr().clone(),
                     value: rank_u64,
                 };
-                reply_to2.send(instance, my_reply.clone());
+                reply_to2.post(instance, my_reply.clone());
 
                 assert_eq!(reply1_rx.recv().await.unwrap(), rank_u64);
                 assert_eq!(reply2_rx.recv().await.unwrap(), my_reply);
@@ -1211,7 +1211,7 @@ mod tests {
                         sender: dest_actor.actor_addr().clone(),
                         value,
                     };
-                    reply_to2.send(instance, my_reply.clone());
+                    reply_to2.post(instance, my_reply.clone());
                     sent2.push(my_reply);
                 }
                 assert!(
@@ -1270,7 +1270,7 @@ mod tests {
         {
             for j in 0..n {
                 let value = (i + j) as u64;
-                reply_to1.send(instance, value);
+                reply_to1.post(instance, value);
                 sum += value;
             }
         }
@@ -1624,7 +1624,7 @@ mod tests {
         // Only the first message will be delivered successfully.
         let num_replies = setup.reply_tos.len();
         for (i, reply_to) in setup.reply_tos.into_iter().enumerate() {
-            reply_to.send(setup.instance, i as u64);
+            reply_to.post(setup.instance, i as u64);
         }
 
         // OncePort receives exactly one value (the first to arrive)
@@ -1661,7 +1661,7 @@ mod tests {
         // Each actor replies with its index
         let mut expected_sum = 0u64;
         for (i, reply_to) in setup.reply_tos.into_iter().enumerate() {
-            reply_to.send(setup.instance, i as u64);
+            reply_to.post(setup.instance, i as u64);
             expected_sum += i as u64;
         }
 

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -173,7 +173,7 @@ impl<C: context::Actor> PinnedDrop for OwnedWriteHalf<C> {
     fn drop(self: Pin<&mut Self>) {
         let this = self.project();
         if !*this.shutdown {
-            let _ = this.port.send(&*this.caps, Io::Eof);
+            let _ = this.port.post(&*this.caps, Io::Eof);
         }
     }
 }
@@ -266,7 +266,7 @@ impl<C: context::Actor> AsyncWrite for OwnedWriteHalf<C> {
                 "write after shutdown",
             )));
         }
-        this.port.send(&*this.caps, Io::Data(buf.into()));
+        this.port.post(&*this.caps, Io::Data(buf.into()));
         Poll::Ready(Ok(buf.len()))
     }
 
@@ -279,7 +279,7 @@ impl<C: context::Actor> AsyncWrite for OwnedWriteHalf<C> {
         _cx: &mut Context<'_>,
     ) -> Poll<Result<(), std::io::Error>> {
         // Send EOF on shutdown.
-        self.port.send(&self.caps, Io::Eof);
+        self.port.post(&self.caps, Io::Eof);
         let mut this = self.project();
         *this.shutdown = true;
         Poll::Ready(Ok(()))
@@ -370,7 +370,7 @@ pub async fn accept<C: context::Actor>(
     message: Connect,
 ) -> Result<ActorConnection<C>> {
     let (tx, rx) = open_port::<Io>(&caps);
-    message.return_conn.send(
+    message.return_conn.post(
         &caps,
         Accept {
             id: self_id,
@@ -424,7 +424,7 @@ mod tests {
         let (client, _) = proc.instance("client")?;
         let (connect, completer) = Connect::allocate(client.self_addr().clone(), client);
         let actor = proc.spawn("actor", EchoActor {})?;
-        actor.send(&completer.caps, connect);
+        actor.post(&completer.caps, connect);
         let (mut rd, mut wr) = completer.complete().await?.into_split();
         let send = [3u8, 4u8, 5u8, 6u8];
         try_join!(

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -285,7 +285,7 @@ impl Actor for GlobalClientActor {
                 );
                 match get_global_supervision_sink() {
                     Some(sink) => {
-                        sink.send(cx, event);
+                        sink.post(cx, event);
                     }
                     None => {
                         tracing::warn!(
@@ -312,7 +312,7 @@ impl Actor for GlobalClientActor {
 
         match get_global_supervision_sink() {
             Some(sink) => {
-                sink.send(cx, event);
+                sink.post(cx, event);
             }
             None => {
                 tracing::warn!(
@@ -566,7 +566,7 @@ mod tests {
         let client_actor_id: hyperactor::ActorAddr = client.self_addr().clone();
         let undeliverable_port =
             PortRef::<Undeliverable<MessageEnvelope>>::attest_handler_port(&client_actor_id);
-        undeliverable_port.send(client, Undeliverable::Message(env));
+        undeliverable_port.post(client, Undeliverable::Message(env));
     }
 
     /// Verifies that creating a `ProcMesh` installs the

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -1703,7 +1703,7 @@ pub mod testing {
             cx: &Context<Self>,
             reply: OncePortRef<ActorAddr>,
         ) -> Result<(), anyhow::Error> {
-            reply.send(cx, cx.self_addr().clone());
+            reply.post(cx, cx.self_addr().clone());
             Ok(())
         }
     }
@@ -1761,7 +1761,7 @@ mod tests {
     #[async_trait]
     impl Handler<SendTo> for UndeliverableCollector {
         async fn handle(&mut self, cx: &Context<Self>, dest: SendTo) -> Result<(), anyhow::Error> {
-            dest.send(cx, "into-the-void".to_string());
+            dest.post(cx, "into-the-void".to_string());
             Ok(())
         }
     }
@@ -1794,7 +1794,7 @@ mod tests {
 
         let (port, mut rx) = instance1.mailbox().open_port();
 
-        port.bind().send(&instance2, "hello".to_string());
+        port.bind().post(&instance2, "hello".to_string());
         assert_eq!(rx.recv().await.unwrap(), "hello".to_string());
 
         // Make sure that the system proc is also wired in correctly.
@@ -1802,7 +1802,7 @@ mod tests {
 
         // system->proc
         port.bind()
-            .send(&system_actor, "hello from the system proc".to_string());
+            .post(&system_actor, "hello from the system proc".to_string());
         assert_eq!(
             rx.recv().await.unwrap(),
             "hello from the system proc".to_string()
@@ -1811,7 +1811,7 @@ mod tests {
         // system->system
         let (port, mut rx) = system_actor.mailbox().open_port();
         port.bind()
-            .send(&system_actor, "hello from the system".to_string());
+            .post(&system_actor, "hello from the system".to_string());
         assert_eq!(
             rx.recv().await.unwrap(),
             "hello from the system".to_string()
@@ -1819,7 +1819,7 @@ mod tests {
 
         // proc->system
         port.bind()
-            .send(&instance1, "hello from the instance1".to_string());
+            .post(&instance1, "hello from the instance1".to_string());
         assert_eq!(
             rx.recv().await.unwrap(),
             "hello from the instance1".to_string()
@@ -1868,7 +1868,7 @@ mod tests {
         .unwrap();
         let (client_inst, _h) = client.instance("test").unwrap();
         let (port, rx) = client_inst.mailbox().open_once_port();
-        echo1.send(&client_inst, port.bind());
+        echo1.post(&client_inst, port.bind());
         let id = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .unwrap()
@@ -1883,7 +1883,7 @@ mod tests {
         // This exercises cross-proc routing between a child and an
         // external client under the same host.
         let (port2, rx2) = client_inst.mailbox().open_once_port();
-        echo2.send(&client_inst, port2.bind());
+        echo2.post(&client_inst, port2.bind());
         let id2 = tokio::time::timeout(Duration::from_secs(5), rx2.recv())
             .await
             .unwrap()
@@ -1902,7 +1902,7 @@ mod tests {
         let (port3, rx3) = client_inst.mailbox().open_once_port();
         // Send from system -> child via a message that ultimately
         // replies to client's port
-        echo1.send(&sys_inst, port3.bind());
+        echo1.post(&sys_inst, port3.bind());
         let id3 = tokio::time::timeout(Duration::from_secs(5), rx3.recv())
             .await
             .unwrap()
@@ -2181,7 +2181,7 @@ mod tests {
         let (remote_port, mut remote_rx) = remote_inst.mailbox().open_port();
         let remote_port = remote_port.bind();
 
-        remote_port.send(&system_inst, "hello-to-remote".to_string());
+        remote_port.post(&system_inst, "hello-to-remote".to_string());
 
         let arrived: String = tokio::time::timeout(Duration::from_secs(5), remote_rx.recv())
             .await
@@ -2194,7 +2194,7 @@ mod tests {
         let (host_port, mut host_rx) = system_inst.mailbox().open_port();
         let host_port = host_port.bind();
 
-        host_port.send(&remote_inst, "hello-from-remote".to_string());
+        host_port.post(&remote_inst, "hello-from-remote".to_string());
 
         let arrived: String = tokio::time::timeout(Duration::from_secs(5), host_rx.recv())
             .await
@@ -2239,7 +2239,7 @@ mod tests {
         let (trigger_inst, _h) = remote_proc.instance("trigger").unwrap();
         collector_ref
             .port::<SendTo>()
-            .send(&trigger_inst, bogus_dest);
+            .post(&trigger_inst, bogus_dest);
 
         let undeliverable = tokio::time::timeout(Duration::from_secs(5), undlv_rx.recv())
             .await
@@ -2293,7 +2293,7 @@ mod tests {
         let (trigger_inst, _h) = host.system_proc().instance("trigger").unwrap();
         collector_ref
             .port::<SendTo>()
-            .send(&trigger_inst, bogus_dest);
+            .post(&trigger_inst, bogus_dest);
 
         let undeliverable = tokio::time::timeout(Duration::from_secs(5), undlv_rx.recv())
             .await
@@ -2338,7 +2338,7 @@ mod tests {
 
         let (remote_port, mut remote_rx) = remote_inst.mailbox().open_port();
         let remote_port = remote_port.bind();
-        remote_port.send(&system_inst, "pre-stop".to_string());
+        remote_port.post(&system_inst, "pre-stop".to_string());
         let arrived: String = tokio::time::timeout(Duration::from_secs(5), remote_rx.recv())
             .await
             .expect("timed out waiting for message on remote rx")
@@ -2403,7 +2403,7 @@ mod tests {
         let reply_port = reply_port.bind();
         echo_ref
             .port::<OncePortRef<ActorAddr>>()
-            .send(&client_inst, reply_port);
+            .post(&client_inst, reply_port);
         let _ = tokio::time::timeout(Duration::from_secs(5), reply_handle.recv())
             .await
             .expect("baseline round-trip timed out")
@@ -2516,7 +2516,7 @@ mod tests {
                     let reply_port = reply_port.bind();
                     echo_ref
                         .port::<OncePortRef<ActorAddr>>()
-                        .send(&client_inst, reply_port);
+                        .post(&client_inst, reply_port);
                     let received =
                         tokio::time::timeout(Duration::from_secs(10), reply_handle.recv())
                             .await
@@ -2590,7 +2590,7 @@ mod tests {
         let reply_port = reply_port.bind();
         echo_ref
             .port::<OncePortRef<ActorAddr>>()
-            .send(&client_inst, reply_port);
+            .post(&client_inst, reply_port);
 
         let received = tokio::time::timeout(Duration::from_secs(10), reply_handle.recv())
             .await

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -349,7 +349,7 @@ async fn push_config_to_host(
     // exact bypass HM-3 prohibits.
     request_port.return_undeliverable(false);
 
-    request_port.send(cx, msg);
+    request_port.post(cx, msg);
 
     match tokio::time::timeout(per_host_timeout, reply_receiver.recv()).await {
         Ok(Ok(())) => Ok(()),
@@ -1362,7 +1362,7 @@ impl HostMeshRef {
                     // If this proc dies or some other issue renders the reply undeliverable,
                     // the reply does not need to be returned to the sender.
                     reply_tx.return_undeliverable(false);
-                    mesh_agent.send(
+                    mesh_agent.post(
                         cx,
                         resource::GetState {
                             id: proc_name.clone(),
@@ -1503,7 +1503,7 @@ impl HostMeshRef {
             // Note that we don't send 1 message per host agent, we send 1 message
             // per proc.
             let host = HostRef(addr);
-            host.mesh_agent().send(
+            host.mesh_agent().post(
                 cx,
                 resource::Stop {
                     id: proc_resource_id.clone(),
@@ -1629,7 +1629,7 @@ impl HostMeshRef {
             if let Some(expires_after) = keepalive {
                 let mut keepalive_port = host.mesh_agent().port();
                 keepalive_port.return_undeliverable(false);
-                keepalive_port.send(
+                keepalive_port.post(
                     cx,
                     resource::KeepaliveGetState {
                         expires_after,
@@ -1637,7 +1637,7 @@ impl HostMeshRef {
                     },
                 );
             } else {
-                send_port.send(cx, get_state);
+                send_port.post(cx, get_state);
             }
         }
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -254,7 +254,7 @@ impl Actor for DrainWorker {
         // Bundle host + ack into DrainComplete so the parent sends the ack
         // AFTER restoring state (prevents race with ShutdownHost).
         if let (Some(host), Some(ack)) = (self.host.take(), self.ack.take()) {
-            let _ = self.done_notify.send(this, DrainComplete { host, ack });
+            let _ = self.done_notify.post(this, DrainComplete { host, ack });
         }
 
         Ok(())
@@ -833,7 +833,7 @@ impl Handler<resource::GetRankStatus> for HostAgent {
             StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
                 .expect("valid single-run overlay")
         };
-        get_rank_status.reply.send(cx, overlay);
+        get_rank_status.reply.post(cx, overlay);
         Ok(())
     }
 }
@@ -864,7 +864,7 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
                 if status >= msg.min_status {
                     let overlay = StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
                         .expect("valid single-run overlay");
-                    let _ = msg.reply.send(cx, overlay);
+                    let _ = msg.reply.post(cx, overlay);
                     return Ok(());
                 }
 
@@ -888,7 +888,7 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
                     Status::Failed(e.to_string()),
                 )])
                 .expect("valid single-run overlay");
-                let _ = msg.reply.send(cx, overlay);
+                let _ = msg.reply.post(cx, overlay);
             }
             None => {
                 // Proc doesn't exist yet. Stash the waiter with a
@@ -941,7 +941,7 @@ impl Handler<ProcStatusChanged> for HostAgent {
                 let overlay =
                     StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
                         .expect("valid single-run overlay");
-                let _ = reply.send(cx, overlay);
+                let _ = reply.post(cx, overlay);
             } else {
                 waiters.push((min_status, rank, reply));
             }
@@ -960,7 +960,7 @@ impl HostAgent {
     fn notify_proc_status_changed(&self, id: &ResourceId) {
         if let Some(port) = &self.proc_status_port {
             let client = Instance::<()>::self_client();
-            let _ = port.send(client, ProcStatusChanged { id: id.clone() });
+            let _ = port.post(client, ProcStatusChanged { id: id.clone() });
         }
     }
 
@@ -1012,13 +1012,13 @@ fn start_proc_watch<S>(
                 Ok(()) => {
                     let status = to_status(&*rx.borrow());
                     let terminated = status.is_terminated();
-                    let _ = port.send(client, ProcStatusChanged { id: id.clone() });
+                    let _ = port.post(client, ProcStatusChanged { id: id.clone() });
                     if terminated {
                         return;
                     }
                 }
                 Err(_) => {
-                    let _ = port.send(client, ProcStatusChanged { id: id.clone() });
+                    let _ = port.post(client, ProcStatusChanged { id: id.clone() });
                     return;
                 }
             }
@@ -1063,7 +1063,7 @@ impl Handler<DrainHost> for HostAgent {
             // Selective drain: stop only procs belonging to the named mesh.
             self.drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
                 .await;
-            msg.ack.send(cx, ());
+            msg.ack.post(cx, ());
             return Ok(());
         }
 
@@ -1073,12 +1073,12 @@ impl Handler<DrainHost> for HostAgent {
             other @ (HostAgentState::Detached(_) | HostAgentState::Draining) => {
                 // Nothing to drain — ack immediately.
                 self.state = other;
-                msg.ack.send(cx, ());
+                msg.ack.post(cx, ());
                 return Ok(());
             }
             HostAgentState::Shutdown => {
                 self.state = HostAgentState::Shutdown;
-                msg.ack.send(cx, ());
+                msg.ack.post(cx, ());
                 return Ok(());
             }
         };
@@ -1113,7 +1113,7 @@ impl Handler<DrainComplete> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainComplete) -> anyhow::Result<()> {
         self.state = HostAgentState::Detached(msg.host);
         self.created.clear();
-        msg.ack.send(cx, ());
+        msg.ack.post(cx, ());
         Ok(())
     }
 }
@@ -1133,7 +1133,7 @@ impl Handler<ShutdownHost> for HostAgent {
 
         // Ack after children are terminated so the caller does not
         // tear down the host's networking prematurely.
-        msg.ack.send(cx, ());
+        msg.ack.post(cx, ());
 
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.
@@ -1235,7 +1235,7 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
             },
         };
 
-        get_state.reply.send(cx, state);
+        get_state.reply.post(cx, state);
         Ok(())
     }
 }
@@ -1299,7 +1299,7 @@ impl Handler<crate::proc_agent::SelfCheck> for HostAgent {
 #[async_trait]
 impl Handler<resource::List> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, list: resource::List) -> anyhow::Result<()> {
-        list.reply.send(cx, self.created.keys().cloned().collect());
+        list.reply.post(cx, self.created.keys().cloned().collect());
         Ok(())
     }
 }
@@ -1381,7 +1381,7 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
         headers.set(crate::proc_agent::STREAM_STATE_SUBSCRIBER, true);
         stream_state
             .subscriber
-            .send_with_headers(cx, headers, state);
+            .post_with_headers(cx, headers, state);
         Ok(())
     }
 }
@@ -1416,7 +1416,7 @@ impl Handler<SetClientConfig> for HostAgent {
             msg.attrs,
         );
         tracing::debug!("installed client config override on host agent");
-        msg.done.send(cx, ());
+        msg.done.post(cx, ());
         Ok(())
     }
 }
@@ -1451,7 +1451,7 @@ impl Handler<GetLocalProc> for HostAgent {
 
         match agent {
             Err(e) => anyhow::bail!("error booting local proc: {}", e),
-            Ok(agent) => proc_mesh_agent.send(cx, agent.clone()),
+            Ok(agent) => proc_mesh_agent.post(cx, agent.clone()),
         };
 
         Ok(())
@@ -1488,7 +1488,7 @@ impl Handler<ConfigDump> for HostAgent {
         message: ConfigDump,
     ) -> Result<(), anyhow::Error> {
         let entries = hyperactor_config::global::config_entries();
-        message.result.send(cx, ConfigDumpResult { entries });
+        message.result.post(cx, ConfigDumpResult { entries });
         Ok(())
     }
 }
@@ -1969,7 +1969,7 @@ mod tests {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(10);
         loop {
             let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-            port.send(
+            port.post(
                 &client,
                 IntrospectMessage::QueryChild {
                     child_ref: Addr::Proc(system_proc.proc_addr().clone()),

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1357,7 +1357,7 @@ impl LogMessageHandler for LogClientActor {
                     self.flush_internal();
                     let reply = self.current_flush_port.take().unwrap();
                     self.current_flush_port = None;
-                    reply.send(cx, ());
+                    reply.post(cx, ());
                 }
             }
         }
@@ -1404,7 +1404,7 @@ impl LogClientMessageHandler for LogClientActor {
         );
         self.current_flush_port = Some(reply.clone());
         self.current_unflushed_procs = expected_procs_flushed;
-        version.send(cx, self.current_flush_version);
+        version.post(cx, self.current_flush_version);
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -403,7 +403,7 @@ async fn query_introspect(
     let (reply_handle, reply_rx) = open_once_port::<IntrospectResult>(cx);
     let mut reply_ref = reply_handle.bind();
     reply_ref.return_undeliverable(false);
-    introspect_port.send(
+    introspect_port.post(
         cx,
         IntrospectMessage::Query {
             view,
@@ -428,7 +428,7 @@ async fn query_child_introspect(
     let (reply_handle, reply_rx) = open_once_port::<IntrospectResult>(cx);
     let mut reply_ref = reply_handle.bind();
     reply_ref.return_undeliverable(false);
-    introspect_port.send(
+    introspect_port.post(
         cx,
         IntrospectMessage::QueryChild {
             child_ref,
@@ -1095,7 +1095,7 @@ impl Handler<MeshAdminMessage> for MeshAdminAgent {
                 let resp = MeshAdminAddrResponse {
                     addr: self.admin_host.clone(),
                 };
-                reply.send(cx, resp);
+                reply.post(cx, resp);
             }
         }
         Ok(())
@@ -1128,7 +1128,7 @@ impl Handler<ResolveReferenceMessage> for MeshAdminAgent {
                         .await
                         .map_err(|e| format!("{:#}", e)),
                 );
-                reply.send(cx, response);
+                reply.post(cx, response);
             }
         }
         Ok(())
@@ -2091,7 +2091,7 @@ async fn probe_actor(
 ) -> Result<bool, ApiError> {
     let port = hyperactor::PortRef::<IntrospectMessage>::attest_handler_port(agent_id);
     let (handle, rx) = open_once_port::<IntrospectResult>(cx);
-    port.send(
+    port.post(
         cx,
         IntrospectMessage::Query {
             view: IntrospectView::Entity,
@@ -2153,8 +2153,8 @@ impl ResolvedProcHandler {
             result: reply_ref,
         };
         match self {
-            Self::Host(r) => r.send(cx, msg),
-            Self::Proc(r) => r.send(cx, msg),
+            Self::Host(r) => r.post(cx, msg),
+            Self::Proc(r) => r.post(cx, msg),
         };
         tokio::time::timeout(timeout, reply_rx.recv())
             .await
@@ -2184,8 +2184,8 @@ impl ResolvedProcHandler {
             result: reply_ref,
         };
         match self {
-            Self::Host(r) => r.send(cx, msg),
-            Self::Proc(r) => r.send(cx, msg),
+            Self::Host(r) => r.post(cx, msg),
+            Self::Proc(r) => r.post(cx, msg),
         };
         tokio::time::timeout(timeout, reply_rx.recv())
             .await
@@ -2211,8 +2211,8 @@ impl ResolvedProcHandler {
         reply_ref.return_undeliverable(false);
         let msg = ConfigDump { result: reply_ref };
         match self {
-            Self::Host(r) => r.send(cx, msg),
-            Self::Proc(r) => r.send(cx, msg),
+            Self::Host(r) => r.post(cx, msg),
+            Self::Proc(r) => r.post(cx, msg),
         };
         tokio::time::timeout(timeout, reply_rx.recv())
             .await
@@ -3494,7 +3494,7 @@ mod tests {
 
         // Spawn a user proc via CreateOrUpdate<ProcSpec>.
         let user_proc_name = ResourceId::unique(Label::new("user-proc").unwrap());
-        host_agent_ref.send(
+        host_agent_ref.post(
             &client,
             resource::CreateOrUpdate {
                 id: user_proc_name.clone(),

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -243,7 +243,7 @@ fn send_subscriber_message(
 ) {
     let mut headers = Flattrs::new();
     headers.set(ACTOR_MESH_SUBSCRIBER_MESSAGE, true);
-    subscriber.send_with_headers(cx, headers, Some(message.clone()));
+    subscriber.post_with_headers(cx, headers, Some(message.clone()));
     tracing::info!(event = %message, "sent supervision failure message to subscriber {}", subscriber.port_addr());
 }
 
@@ -262,7 +262,7 @@ fn send_heartbeat(cx: &impl context::Actor, health_state: &HealthState) {
     for subscriber in health_state.subscribers.iter() {
         let mut headers = Flattrs::new();
         headers.set(ACTOR_MESH_SUBSCRIBER_MESSAGE, true);
-        subscriber.send_with_headers(cx, headers, None);
+        subscriber.post_with_headers(cx, headers, None);
     }
 }
 
@@ -314,7 +314,7 @@ fn send_state_change(
     // told that they were stopped.
     if is_failed {
         if let Some(owner) = &health_state.owner {
-            owner.send(cx, failure_message.clone());
+            owner.post(cx, failure_message.clone());
             tracing::info!(actor_mesh = %mesh_name, %event, "sent supervision failure message to owner {}", owner.port_addr());
         }
     }
@@ -616,7 +616,7 @@ impl<T: Controlled> ResourceController<T> {
             statuses,
             state: (),
         };
-        message.reply.send(
+        message.reply.post(
             cx,
             resource::State {
                 id: message.id,
@@ -864,7 +864,7 @@ where
         cx: &Context<Self>,
         message: GetSubscriberCount,
     ) -> anyhow::Result<()> {
-        message.0.send(cx, self.health_state.subscribers.len());
+        message.0.post(cx, self.health_state.subscribers.len());
         Ok(())
     }
 }
@@ -1280,7 +1280,7 @@ impl Controlled for ProcMeshRef {
         for proc_id in self.proc_ids() {
             let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
             let host = crate::host_mesh::HostRef(proc_id.addr().clone());
-            host.mesh_agent().send(
+            host.mesh_agent().post(
                 cx,
                 resource::StreamState::<Self::StateInner> {
                     id: proc_resource_id,
@@ -1298,7 +1298,7 @@ impl Controlled for ProcMeshRef {
     ) -> anyhow::Result<()> {
         for proc_id in self.proc_ids() {
             let host = crate::host_mesh::HostRef(proc_id.addr().clone());
-            host.mesh_agent().send(cx, msg.clone());
+            host.mesh_agent().post(cx, msg.clone());
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -228,7 +228,7 @@ impl ActorInstanceState {
         for subscriber in &self.subscribers {
             let mut headers = Flattrs::new();
             headers.set(STREAM_STATE_SUBSCRIBER, true);
-            subscriber.send_with_headers(cx, headers, state.clone());
+            subscriber.post_with_headers(cx, headers, state.clone());
         }
 
         // One-shot waiters (predicated).
@@ -239,7 +239,7 @@ impl ActorInstanceState {
                 let overlay =
                     crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
                         .expect("valid single-run overlay");
-                let _ = reply.send(cx, overlay);
+                let _ = reply.post(cx, overlay);
                 false
             } else {
                 true
@@ -831,7 +831,7 @@ impl Handler<ConfigDump> for ProcAgent {
         let entries = hyperactor_config::global::config_entries();
         // Reply is best-effort: the caller may have timed out and dropped
         // the once-port.  That must not crash this actor.
-        let _ = message.result.send(cx, ConfigDumpResult { entries });
+        let _ = message.result.post(cx, ConfigDumpResult { entries });
         Ok(())
     }
 }
@@ -1012,7 +1012,7 @@ impl Handler<resource::GetRankStatus> for ProcAgent {
             StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
                 .expect("valid single-run overlay")
         };
-        get_rank_status.reply.send(cx, overlay);
+        get_rank_status.reply.post(cx, overlay);
         Ok(())
     }
 }
@@ -1040,7 +1040,7 @@ impl Handler<resource::WaitRankStatus> for ProcAgent {
                 StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
                     .expect("valid single-run overlay")
             };
-            let _ = msg.reply.send(cx, overlay);
+            let _ = msg.reply.post(cx, overlay);
             return Ok(());
         }
 
@@ -1071,7 +1071,7 @@ impl Handler<resource::GetState<ActorState>> for ProcAgent {
             },
         };
 
-        get_state.reply.send(cx, state);
+        get_state.reply.post(cx, state);
         Ok(())
     }
 }
@@ -1103,7 +1103,7 @@ impl Handler<resource::StreamState<ActorState>> for ProcAgent {
         headers.set(STREAM_STATE_SUBSCRIBER, true);
         stream_state
             .subscriber
-            .send_with_headers(cx, headers, state);
+            .post_with_headers(cx, headers, state);
         Ok(())
     }
 }
@@ -1150,7 +1150,7 @@ impl Handler<NewClientInstance> for ProcAgent {
         NewClientInstance { client_instance }: NewClientInstance,
     ) -> anyhow::Result<()> {
         let (instance, _handle) = self.proc.instance("client")?;
-        client_instance.send(cx, instance);
+        client_instance.post(cx, instance);
         Ok(())
     }
 }
@@ -1170,7 +1170,7 @@ impl Handler<GetProc> for ProcAgent {
         cx: &Context<Self>,
         GetProc { proc }: GetProc,
     ) -> anyhow::Result<()> {
-        proc.send(cx, self.proc.clone());
+        proc.post(cx, self.proc.clone());
         Ok(())
     }
 }
@@ -1281,7 +1281,7 @@ mod tests {
         // timeout so a misrouted reply fails fast rather than hanging.
         let query = |client: &hyperactor::Instance<()>| {
             let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-            port.send(
+            port.post(
                 client,
                 IntrospectMessage::QueryChild {
                     child_ref: Addr::Proc(proc.proc_addr().clone()),
@@ -1393,7 +1393,7 @@ mod tests {
         let query_task = tokio::spawn(async move {
             loop {
                 let (reply_port, reply_rx) = query_client.open_once_port::<IntrospectResult>();
-                query_port.send(
+                query_port.post(
                     &query_client,
                     IntrospectMessage::QueryChild {
                         child_ref: Addr::Proc(query_proc_id.clone()),
@@ -1450,7 +1450,7 @@ mod tests {
 
         // Final consistency check: QueryChild should still work.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        port.send(
+        port.post(
             &client,
             IntrospectMessage::QueryChild {
                 child_ref: Addr::Proc(proc.proc_addr().clone()),
@@ -1703,7 +1703,7 @@ mod tests {
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
         loop {
             let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-            port.send(
+            port.post(
                 &client,
                 IntrospectMessage::QueryChild {
                     child_ref: Addr::Proc(proc.proc_addr().clone()),

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -239,7 +239,7 @@ impl ProcMesh {
         // Now that we have all of the spawned comm actors, kick them all into
         // mesh mode.
         for (rank, comm_actor) in &address_book {
-            comm_actor.send(cx, CommMeshConfig::new(*rank, address_book.clone()));
+            comm_actor.post(cx, CommMeshConfig::new(*rank, address_book.clone()));
         }
 
         Ok(proc_mesh)
@@ -266,7 +266,7 @@ impl ProcMesh {
     pub async fn stop(&mut self, cx: &impl context::Actor, reason: String) -> anyhow::Result<()> {
         if let Some(controller) = self.controller.take() {
             let id = self.id.resource_id().clone();
-            controller.send(
+            controller.post(
                 cx,
                 resource::Stop {
                     id: id.clone(),
@@ -279,7 +279,7 @@ impl ProcMesh {
             // reflects the outcome of `stop_proc_mesh` (Stopping, Stopped,
             // Failed, or Timeout on `PROC_STOP_MAX_IDLE` exhaustion).
             let (port, mut rx) = cx.mailbox().open_port();
-            controller.send(
+            controller.post(
                 cx,
                 resource::GetState::<resource::mesh::State<()>> {
                     id: id.clone(),

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -567,11 +567,11 @@ impl PySpyWorker {
                     exit_code: None,
                     stderr: format!("failed to spawn pyspy worker: {}", e),
                 };
-                reply_port.send(cx, fail);
+                reply_port.post(cx, fail);
                 return Ok(());
             }
         };
-        worker.send(cx, RunPySpyDump { opts, reply_port });
+        worker.post(cx, RunPySpyDump { opts, reply_port });
         Ok(())
     }
 }
@@ -584,7 +584,7 @@ impl Handler<RunPySpyDump> for PySpyWorker {
         message: RunPySpyDump,
     ) -> Result<(), anyhow::Error> {
         let result = PySpyRunner.dump_self(&message.opts).await;
-        message.reply_port.send(cx, result);
+        message.reply_port.post(cx, result);
         cx.stop("pyspy dump complete")?;
         Ok(())
     }
@@ -620,11 +620,11 @@ impl PySpyProfileWorker {
                 let fail = ProfileExecOutcome::WorkerSpawnFailure {
                     error: e.to_string(),
                 };
-                reply_port.send(cx, PySpyProfileResult::from(fail));
+                reply_port.post(cx, PySpyProfileResult::from(fail));
                 return Ok(());
             }
         };
-        worker.send(
+        worker.post(
             cx,
             RunPySpyProfile {
                 request,
@@ -645,7 +645,7 @@ impl Handler<RunPySpyProfile> for PySpyProfileWorker {
         let outcome = PySpyRunner.profile_self(&message.request).await;
         message
             .reply_port
-            .send(cx, PySpyProfileResult::from(outcome));
+            .post(cx, PySpyProfileResult::from(outcome));
         cx.stop("pyspy profile complete")?;
         Ok(())
     }

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -128,7 +128,7 @@ impl Handler<GetActorId> for TestActor {
         GetActorId(reply): GetActorId,
     ) -> Result<(), anyhow::Error> {
         let seq_info = cx.headers().get(SEQ_INFO);
-        reply.send(cx, (cx.self_addr().clone(), seq_info));
+        reply.post(cx, (cx.self_addr().clone(), seq_info));
         Ok(())
     }
 }
@@ -221,7 +221,7 @@ impl Handler<Forward> for TestActor {
         visited.push(this);
         let next = to_visit.front().cloned();
         anyhow::ensure!(next.is_some(), "unexpected forward chain termination");
-        next.unwrap().send(cx, Forward { to_visit, visited });
+        next.unwrap().post(cx, Forward { to_visit, visited });
         Ok(())
     }
 }
@@ -251,7 +251,7 @@ impl Handler<GetCastInfo> for TestActor {
         cx: &Context<Self>,
         GetCastInfo { cast_info }: GetCastInfo,
     ) -> Result<(), anyhow::Error> {
-        cast_info.send(cx, (cx.cast_point(), cx.bind(), cx.sender().clone()));
+        cast_info.post(cx, (cx.cast_point(), cx.bind(), cx.sender().clone()));
         Ok(())
     }
 }
@@ -307,7 +307,7 @@ impl Handler<GetConfigAttrs> for TestActor {
             hyperactor_config::global::attrs(),
             bincode::config::legacy(),
         )?;
-        reply.send(cx, attrs);
+        reply.post(cx, attrs);
         Ok(())
     }
 }
@@ -396,7 +396,7 @@ impl Handler<NextSupervisionFailure> for WrapperActor {
         let mesh = if let Some(mesh) = self.mesh.as_ref() {
             mesh.deref()
         } else {
-            msg.0.send(cx, None);
+            msg.0.post(cx, None);
             return Ok(());
         };
         let failure = match tokio::time::timeout(
@@ -411,7 +411,7 @@ impl Handler<NextSupervisionFailure> for WrapperActor {
             // If we timeout, send back None.
             Err(_) => None,
         };
-        msg.0.send(cx, failure);
+        msg.0.post(cx, failure);
         Ok(())
     }
 }
@@ -424,7 +424,7 @@ impl Handler<MeshFailure> for WrapperActor {
         tracing::info!("got supervision event from child: {}", msg);
         // Send to a port so the client can view the messages.
         // Ignore the error if there is one.
-        let _ = self.supervisor.send(cx, msg.clone());
+        let _ = self.supervisor.post(cx, msg.clone());
         Ok(())
     }
 }

--- a/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
+++ b/hyperactor_mesh/test/hyperactor_mesh_proxy_test.rs
@@ -79,7 +79,7 @@ pub struct Echo(pub String, pub reference::PortRef<String>);
 impl Handler<Echo> for TestActor {
     async fn handle(&mut self, cx: &Context<Self>, message: Echo) -> Result<(), anyhow::Error> {
         let Echo(message, reply_port) = message;
-        reply_port.send(cx, message);
+        reply_port.post(cx, message);
         Ok(())
     }
 }
@@ -160,8 +160,8 @@ impl Handler<Echo> for ProxyActor {
         let actor = self.actor_mesh.as_ref().unwrap().get(0).unwrap();
 
         let (tx, mut rx) = cx.open_port();
-        actor.send(cx, Echo(message.0, tx.bind()));
-        message.1.send(cx, rx.recv().await.unwrap());
+        actor.post(cx, Echo(message.0, tx.bind()));
+        message.1.post(cx, rx.recv().await.unwrap());
 
         Ok(())
     }
@@ -198,7 +198,7 @@ async fn run_client(exe_path: PathBuf, keep_alive: bool) -> Result<(), anyhow::E
         .await?;
     let proxy_actor = actor_mesh.get(0).unwrap();
     let (tx, mut rx) = instance.mailbox().open_port::<String>();
-    proxy_actor.send(instance, Echo("hello!".to_owned(), tx.bind()));
+    proxy_actor.post(instance, Echo("hello!".to_owned(), tx.bind()));
 
     let msg = rx.recv().await?;
     println!("{}", msg);

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -358,7 +358,7 @@ impl KeepaliveWorker {
     fn send_keepalive(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
         self.generation += 1;
         let generation = self.generation;
-        self.supervisor.send(
+        self.supervisor.post(
             this,
             Keepalive {
                 generation,
@@ -396,7 +396,7 @@ impl Actor for KeepaliveSupervisor {
 impl Handler<Keepalive> for KeepaliveSupervisor {
     async fn handle(&mut self, cx: &Context<Self>, message: Keepalive) -> anyhow::Result<()> {
         self.generation = self.generation.max(message.generation);
-        message.reply.send(
+        message.reply.post(
             cx,
             KeepaliveAck {
                 generation: message.generation,
@@ -485,7 +485,7 @@ mod tests {
             this: &Instance<Self>,
             event: &ActorSupervisionEvent,
         ) -> anyhow::Result<bool> {
-            self.events.send(this, event.clone());
+            self.events.post(this, event.clone());
             Ok(true)
         }
     }
@@ -515,7 +515,7 @@ mod tests {
             .unwrap();
         let (reply, ack_rx) = parent.open_once_port::<KeepaliveAck>();
 
-        supervisor.send(
+        supervisor.post(
             &parent,
             Keepalive {
                 generation: 41,

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -162,7 +162,7 @@ mod tests {
             this: &Instance<Self>,
             event: &ActorSupervisionEvent,
         ) -> anyhow::Result<bool> {
-            self.events.send(this, event.clone());
+            self.events.post(this, event.clone());
             Ok(true)
         }
     }

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -113,7 +113,7 @@ impl Actor for Supervisor {
             .expect("supervisor initialized more than once")
             .spawn_supervisor(this)?;
         self.link_handle = Some(link_handle);
-        self.worker.send(
+        self.worker.post(
             this,
             Link {
                 session_id: self.session_id.clone(),
@@ -210,7 +210,7 @@ impl Supervisor {
         let Some(stop) = self.pending_stop.take() else {
             return Ok(());
         };
-        self.worker.send(
+        self.worker.post(
             cx,
             SupervisedWorker::Stop {
                 session_id: self.session_id.clone(),
@@ -304,7 +304,7 @@ where
             if let Some(session) = &self.session {
                 let supervisor = session.supervisor.clone();
                 let session_id = session.session_id.clone();
-                supervisor.send(
+                supervisor.post(
                     this,
                     WorkerSupervisor::SupervisionEvent {
                         session_id: session_id.into_uid(),
@@ -346,7 +346,7 @@ where
 {
     async fn handle(&mut self, cx: &Context<Self>, message: Link) -> anyhow::Result<()> {
         if self.session.is_some() {
-            let _ = message.supervisor.send(
+            let _ = message.supervisor.post(
                 cx,
                 WorkerSupervisor::LinkRejected {
                     session_id: message.session_id,
@@ -371,7 +371,7 @@ where
             options: message.options,
             link_handle,
         });
-        supervisor.send(
+        supervisor.post(
             cx,
             WorkerSupervisor::Linked {
                 session_id: message.session_id.clone(),
@@ -411,7 +411,7 @@ where
                         OrphanPolicy::Detach => (),
                     }
 
-                    let _ = session.supervisor.send(
+                    let _ = session.supervisor.post(
                         cx,
                         WorkerSupervisor::Unlinked {
                             session_id: session_id.into_uid(),
@@ -485,7 +485,7 @@ impl<C: Actor> Worker<C> {
         let session_id = session.session_id.clone();
         let orphan_policy = session.options.orphan_policy;
         if let Some(child) = &self.child_handle {
-            supervisor.send(
+            supervisor.post(
                 cx,
                 WorkerSupervisor::SupervisionEvent {
                     session_id: session_id.into_uid(),
@@ -565,7 +565,7 @@ mod tests {
     #[async_trait]
     impl Actor for TestChild {
         async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
-            self.ready.send(this, this.self_addr().clone());
+            self.ready.post(this, this.self_addr().clone());
             match self.action.take() {
                 Some(TestChildAction::FailAfter(delay)) => {
                     this.self_message_with_delay(TestChildCommand::Fail, delay)?;
@@ -584,7 +584,7 @@ mod tests {
             mode: StopMode,
             reason: &str,
         ) -> anyhow::Result<()> {
-            self.stopped.send(this, reason.to_string());
+            self.stopped.post(this, reason.to_string());
             this.close();
             match mode {
                 StopMode::Stop => this.exit(reason)?,
@@ -605,7 +605,7 @@ mod tests {
                 TestChildCommand::Fail => cx.kill("test child failed")?,
                 TestChildCommand::Drain(tag) => {
                     if let Some(ref port) = self.drain_observer {
-                        port.send(cx, tag);
+                        port.post(cx, tag);
                     }
                 }
             }
@@ -635,7 +635,7 @@ mod tests {
             this: &Instance<Self>,
             event: &ActorSupervisionEvent,
         ) -> anyhow::Result<bool> {
-            self.events.send(this, event.clone());
+            self.events.post(this, event.clone());
             Ok(true)
         }
     }
@@ -657,7 +657,7 @@ mod tests {
                     .take()
                     .expect("grandparent initialized more than once"),
             )?;
-            self.parent_addr.send(this, parent.actor_addr().clone());
+            self.parent_addr.post(this, parent.actor_addr().clone());
             self.parent_handle = Some(parent);
             Ok(())
         }
@@ -667,7 +667,7 @@ mod tests {
             this: &Instance<Self>,
             event: &ActorSupervisionEvent,
         ) -> anyhow::Result<bool> {
-            self.events.send(this, event.clone());
+            self.events.post(this, event.clone());
             Ok(true)
         }
     }
@@ -772,7 +772,7 @@ mod tests {
     impl Handler<Link> for TestSlowWorker {
         async fn handle(&mut self, cx: &Context<Self>, message: Link) -> anyhow::Result<()> {
             self.session = Some((message.session_id, message.supervisor));
-            self.link_started.send(cx, ());
+            self.link_started.post(cx, ());
             self.release_link.notified().await;
             Ok(())
         }
@@ -793,8 +793,8 @@ mod tests {
                     anyhow::bail!("stop received before link");
                 };
                 anyhow::ensure!(session_id == expected_session_id, "unexpected session id");
-                self.received_stop.send(cx, reason.clone());
-                let _ = supervisor.send(cx, WorkerSupervisor::Unlinked { session_id, reason });
+                self.received_stop.post(cx, reason.clone());
+                let _ = supervisor.post(cx, WorkerSupervisor::Unlinked { session_id, reason });
             }
             Ok(())
         }
@@ -928,7 +928,7 @@ mod tests {
         let _child_addr = ready_rx.recv().await.unwrap();
         let session_id = hyperactor::Uid::instance();
 
-        worker.send(
+        worker.post(
             &client,
             Link {
                 session_id: session_id.clone(),
@@ -956,7 +956,7 @@ mod tests {
         .unwrap();
         worker
             .port::<Undeliverable<MessageEnvelope>>()
-            .send(&client, Undeliverable::Message(envelope));
+            .post(&client, Undeliverable::Message(envelope));
 
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
             .await
@@ -1028,7 +1028,7 @@ mod tests {
         let parent_addr = parent_addr_rx.recv().await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(100)).await;
-        grandparent.send(&client, KillParent);
+        grandparent.post(&client, KillParent);
 
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
             .await
@@ -1086,7 +1086,7 @@ mod tests {
         let _child_addr = ready_rx.recv().await.unwrap();
         let session_id = hyperactor::Uid::instance();
 
-        worker.send(
+        worker.post(
             &inst,
             Link {
                 session_id: session_id.clone(),
@@ -1121,7 +1121,7 @@ mod tests {
         .unwrap();
         worker
             .port::<Undeliverable<MessageEnvelope>>()
-            .send(&inst, Undeliverable::Message(envelope));
+            .post(&inst, Undeliverable::Message(envelope));
 
         // Under `Detach`, the worker clears its session and stops the
         // link, but does NOT stop the child. No message shhould arrive on
@@ -1189,7 +1189,7 @@ mod tests {
         // issuing Unlink.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        worker.send(
+        worker.post(
             &inst,
             SupervisedWorker::Unlink {
                 session_id: session_id.clone(),
@@ -1275,7 +1275,7 @@ mod tests {
         // issuing Unlink.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        worker.send(
+        worker.post(
             &inst,
             SupervisedWorker::Unlink {
                 session_id: session_id.clone(),
@@ -1588,7 +1588,7 @@ mod tests {
         assert_eq!(drained_tag, "child work");
 
         // Now send Stop with DrainAndStop.
-        worker.send(
+        worker.post(
             &inst,
             SupervisedWorker::Stop {
                 session_id: session_id.clone(),
@@ -1655,7 +1655,7 @@ mod tests {
         // issuing Unlink.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        worker.send(
+        worker.post(
             &inst,
             SupervisedWorker::Unlink {
                 session_id: session_id1.clone(),
@@ -1701,7 +1701,7 @@ mod tests {
         // Give the second Link/Linked handshake time to complete.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
-        worker.send(
+        worker.post(
             &inst,
             SupervisedWorker::Unlink {
                 session_id: session_id2.clone(),

--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -229,7 +229,7 @@ impl<C: TokenPeer, J: TokenPeer> Token<C, J> {
         joiner: J,
         result: PortRef<JoinResult<C>>,
     ) -> anyhow::Result<()> {
-        self.rendezvous.send(cx, Join { joiner, result });
+        self.rendezvous.post(cx, Join { joiner, result });
         Ok(())
     }
 
@@ -342,7 +342,7 @@ impl<C: TokenPeer, J: TokenPeer> Actor for Rendezvous<C, J> {}
 impl<C: TokenPeer + Clone, J: TokenPeer> Handler<Join<C, J>> for Rendezvous<C, J> {
     async fn handle(&mut self, cx: &Context<Self>, message: Join<C, J>) -> anyhow::Result<()> {
         if self.options.policy == Policy::Once && self.joined {
-            message.result.send(
+            message.result.post(
                 cx,
                 JoinResult::Rejected {
                     reason: "token already joined".to_string(),
@@ -351,14 +351,14 @@ impl<C: TokenPeer + Clone, J: TokenPeer> Handler<Join<C, J>> for Rendezvous<C, J
             return Ok(());
         }
 
-        self.creator_joined.send(
+        self.creator_joined.post(
             cx,
             Joined {
                 peer: message.joiner,
             },
         );
 
-        message.result.send(
+        message.result.post(
             cx,
             JoinResult::Joined {
                 peer: self.creator.clone(),

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -81,7 +81,7 @@ impl Actor for Parent {
             this.port::<token::Joined<ActorRef<WorkerLike>>>().bind(),
             TokenOptions::default(),
         )?;
-        self.token_out.send(this, token.to_string());
+        self.token_out.post(this, token.to_string());
         Ok(())
     }
 
@@ -90,7 +90,7 @@ impl Actor for Parent {
         this: &Instance<Self>,
         event: &ActorSupervisionEvent,
     ) -> anyhow::Result<bool> {
-        self.events.send(this, event.clone());
+        self.events.post(this, event.clone());
         this.exit("remote supervision event observed")?;
         Ok(true)
     }
@@ -103,7 +103,7 @@ impl Handler<token::Joined<ActorRef<WorkerLike>>> for Parent {
         cx: &Context<Self>,
         message: token::Joined<ActorRef<WorkerLike>>,
     ) -> anyhow::Result<()> {
-        self.linked.send(cx, message.peer.actor_addr().clone());
+        self.linked.post(cx, message.peer.actor_addr().clone());
         cx.spawn(Supervisor::new(
             message.peer,
             KeepaliveLink::new(Duration::from_millis(100), Duration::from_millis(300)),
@@ -156,7 +156,7 @@ impl Handler<ParentControl> for ParentRoot {
             .as_ref()
             .expect("parent must be spawned before control message");
         match message {
-            ParentControl::Exit => parent.send(cx, ParentExit),
+            ParentControl::Exit => parent.post(cx, ParentExit),
             ParentControl::Kill => parent.kill("test parent killed")?,
         }
         Ok(())
@@ -173,7 +173,7 @@ struct SupervisedChild {
 #[async_trait]
 impl Actor for SupervisedChild {
     async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
-        self.ready.send(this, this.self_addr().clone());
+        self.ready.post(this, this.self_addr().clone());
         if let Some(ChildAction::StopAfter(delay)) = self.action.take() {
             this.self_message_with_delay(ChildControl::Stop, delay)?;
         }
@@ -186,7 +186,7 @@ impl Actor for SupervisedChild {
         mode: StopMode,
         reason: &str,
     ) -> anyhow::Result<()> {
-        self.stopped.send(this, reason.to_string());
+        self.stopped.post(this, reason.to_string());
         this.close();
         match mode {
             StopMode::Stop => this.exit(reason)?,
@@ -223,7 +223,7 @@ impl Actor for WorkerRoot {
             stopped: self.child_stopped.clone(),
             action: self.child_action.take(),
         }))?;
-        self.worker_out.send(this, worker.bind::<WorkerLike>());
+        self.worker_out.post(this, worker.bind::<WorkerLike>());
         self.worker = Some(worker);
         Ok(())
     }
@@ -386,7 +386,7 @@ async fn test_token_join_parent_exit_stops_child_first() -> anyhow::Result<()> {
 
     harness
         .parent_root
-        .send(&harness.observer, ParentControl::Exit);
+        .post(&harness.observer, ParentControl::Exit);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
     assert_eq!(reason, "parent stopping");
@@ -405,7 +405,7 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
 
     harness
         .parent_root
-        .send(&harness.observer, ParentControl::Kill);
+        .post(&harness.observer, ParentControl::Kill);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
     assert_eq!(reason, "parent stopping");
@@ -423,7 +423,7 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
 async fn test_token_join_worker_kill_notifies_parent() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
 
-    harness.worker_root.send(&harness.observer, WorkerControl);
+    harness.worker_root.post(&harness.observer, WorkerControl);
 
     let event = recv(&mut harness.parent_events_rx).await?;
     assert!(matches!(event.actor_status, ActorStatus::Failed(_)));

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -764,7 +764,7 @@ impl DatabaseScanner {
                         let msg = QueryResponse {
                             data: Part::from(data),
                         };
-                        dest_ref.send(instance, msg);
+                        dest_ref.post(instance, msg);
                         count += 1;
                     }
                 }

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -174,7 +174,7 @@ impl _Controller {
             tracebacks,
             response_port,
         };
-        hyperactor::Endpoint::send(
+        hyperactor::Endpoint::post(
             &*self.controller_handle.blocking_lock(),
             instance.deref(),
             msg,
@@ -183,7 +183,7 @@ impl _Controller {
     }
 
     fn _drop_refs(&mut self, instance: &PyInstance, refs: Vec<Ref>) -> PyResult<()> {
-        hyperactor::Endpoint::send(
+        hyperactor::Endpoint::post(
             &*self.controller_handle.blocking_lock(),
             instance.deref(),
             ClientToControllerMessage::DropRefs { refs },
@@ -192,7 +192,7 @@ impl _Controller {
     }
 
     fn _sync_at_exit(&mut self, instance: &PyInstance, port: PyPortId) -> PyResult<()> {
-        hyperactor::Endpoint::send(
+        hyperactor::Endpoint::post(
             &*self.controller_handle.blocking_lock(),
             instance.deref(),
             ClientToControllerMessage::SyncAtExit {
@@ -215,7 +215,7 @@ impl _Controller {
             slices.iter().map(|x| x.into()).collect::<Vec<Slice>>()
         };
         let message: WorkerMessage = convert(message)?;
-        hyperactor::Endpoint::send(
+        hyperactor::Endpoint::post(
             &*self.controller_handle.blocking_lock(),
             instance.deref(),
             ClientToControllerMessage::Send { slices, message },
@@ -226,7 +226,7 @@ impl _Controller {
     fn _drain_and_stop(&mut self, py: Python<'_>, instance: &PyInstance) -> PyResult<()> {
         let (stop_worker_port, stop_worker_receiver) = instance.open_once_port();
 
-        hyperactor::Endpoint::send(
+        hyperactor::Endpoint::post(
             &*self.controller_handle.blocking_lock(),
             instance.deref(),
             ClientToControllerMessage::StopWorkers {
@@ -370,10 +370,10 @@ impl Invocation {
                                     .expect("complete runs should not overlap");
                             }
                         }
-                        port.send(sender, overlay.into());
+                        port.post(sender, overlay.into());
                     } else {
                         for result in results {
-                            port.send(sender, result);
+                            port.post(sender, result);
                         }
                     }
                 }
@@ -423,10 +423,10 @@ impl Invocation {
                                             )
                                             .expect("exception runs should not overlap");
                                     }
-                                    port.send(sender, overlay.into());
+                                    port.post(sender, overlay.into());
                                 } else {
                                     for rank in ranks.iter() {
-                                        port.send(
+                                        port.post(
                                             sender,
                                             exception.as_ref().clone().into_rank(rank),
                                         );
@@ -669,7 +669,7 @@ impl History {
                         )
                     }
                 };
-                port.send(sender, result);
+                port.post(sender, result);
                 self.exit_port = None;
             }
         }
@@ -802,7 +802,7 @@ impl MeshControllerActor {
                         let bytes: Vec<u8> =
                             read.call1((requested_size,)).unwrap().extract().unwrap();
 
-                        debugger_actor.send(
+                        debugger_actor.post(
                             this,
                             DebuggerMessage::Action {
                                 action: DebuggerAction::Write { bytes },
@@ -832,7 +832,7 @@ impl MeshControllerActor {
         }
         if self.debugger_active.is_none() {
             self.debugger_active = self.debugger_paused.pop_front().inspect(|pdb_actor| {
-                pdb_actor.send(
+                pdb_actor.post(
                     this,
                     DebuggerMessage::Action {
                         action: DebuggerAction::Attach(),
@@ -983,9 +983,9 @@ impl Handler<ClientToControllerMessage> for MeshControllerActor {
                     .stop(this, "client requested stop".to_string())
                     .await;
                 if worker_stop_result.is_ok() && broker_stop_result.is_ok() {
-                    response_port.send(this, Ok(()));
+                    response_port.post(this, Ok(()));
                 } else {
-                    response_port.send(this, Err(format!("stopping mesh workers failed: tensor worker result: {:?}, broker result: {:?}", worker_stop_result, broker_stop_result)));
+                    response_port.post(this, Err(format!("stopping mesh workers failed: tensor worker result: {:?}, broker result: {:?}", worker_stop_result, broker_stop_result)));
                 }
             }
         }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -375,7 +375,7 @@ impl PythonMessage {
             } => {
                 let broker = BrokerId::new(local_state_broker).resolve(cx).await;
                 let (send, recv) = cx.open_once_port();
-                broker.send(cx, LocalStateBrokerMessage::Get(id, send));
+                broker.post(cx, LocalStateBrokerMessage::Get(id, send));
                 let state = recv.recv().await?;
                 let mut state_it = state.state.into_iter();
                 monarch_with_gil(|py| {
@@ -519,7 +519,7 @@ pub(super) struct PythonActorHandle {
 impl PythonActorHandle {
     // TODO: do the pickling in rust
     fn send(&self, instance: &PyInstance, message: &PythonMessage) -> PyResult<()> {
-        self.inner.send(instance.deref(), message.clone());
+        self.inner.post(instance.deref(), message.clone());
         Ok(())
     }
 
@@ -1592,7 +1592,7 @@ async fn handle_async_endpoint_panic(
                     .unwrap()
             })
             .0;
-        panic_sender.send(&client, Signal::Kill(panic.to_string()));
+        panic_sender.post(&client, Signal::Kill(panic.to_string()));
     }
 
     // Record latency in microseconds
@@ -1625,12 +1625,12 @@ where
 impl LocalPort {
     fn send(&mut self, obj: Py<PyAny>) -> PyResult<()> {
         let port = self.inner.take().expect("use local port once");
-        port.send(self.instance.deref(), Ok(obj));
+        port.post(self.instance.deref(), Ok(obj));
         Ok(())
     }
     fn exception(&mut self, e: Py<PyAny>) -> PyResult<()> {
         let port = self.inner.take().expect("use local port once");
-        port.send(self.instance.deref(), Err(e));
+        port.post(self.instance.deref(), Err(e));
         Ok(())
     }
 }
@@ -1728,7 +1728,7 @@ impl Port {
         );
 
         self.port_ref
-            .send_with_headers(&self.instance, self.reply_headers.clone(), message)
+            .post_with_headers(&self.instance, self.reply_headers.clone(), message)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
@@ -1739,7 +1739,7 @@ impl Port {
         );
 
         self.port_ref
-            .send_with_headers(&self.instance, self.reply_headers.clone(), message)
+            .post_with_headers(&self.instance, self.reply_headers.clone(), message)
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 }

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -405,7 +405,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
 
                     let mut state =
                         crate::pickle::pickle(py, pyerr.into_value(py).into_any(), false, false)?;
-                    let _ = port_ref.send(
+                    let _ = port_ref.post(
                         &instance,
                         PythonMessage::new_from_buf(
                             PythonMessageKind::Exception { rank: Some(0) },
@@ -997,7 +997,7 @@ mod tests {
 
         // Query the subscriber count from the controller.
         let (port, mut rx) = mailbox::open_port::<usize>(instance);
-        controller.send(instance, GetSubscriberCount(port.bind()));
+        controller.post(instance, GetSubscriberCount(port.bind()));
         let initial_count = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .expect("timed out waiting for subscriber count")
@@ -1020,7 +1020,7 @@ mod tests {
         // After 5 calls from the same context, there should be exactly 1
         // subscriber (created lazily on the first call, reused thereafter).
         let (port, mut rx) = mailbox::open_port::<usize>(instance);
-        controller.send(instance, GetSubscriberCount(port.bind()));
+        controller.post(instance, GetSubscriberCount(port.bind()));
         let after_count = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .expect("timed out waiting for subscriber count")
@@ -1041,7 +1041,7 @@ mod tests {
         }
 
         let (port, mut rx) = mailbox::open_port::<usize>(instance);
-        controller.send(instance, GetSubscriberCount(port.bind()));
+        controller.post(instance, GetSubscriberCount(port.bind()));
         let final_count = tokio::time::timeout(Duration::from_secs(5), rx.recv())
             .await
             .expect("timed out waiting for subscriber count")

--- a/monarch_hyperactor/src/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/src/code_sync/auto_reload.rs
@@ -112,7 +112,7 @@ impl Handler<AutoReloadMessage> for AutoReloadActor {
             anyhow::Ok(())
         }
         .await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)));
+        result.post(cx, res.map_err(|e| format!("{:#?}", e)));
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/code_sync/conda_sync.rs
+++ b/monarch_hyperactor/src/code_sync/conda_sync.rs
@@ -88,7 +88,7 @@ impl Handler<CondaSyncMessage> for CondaSyncActor {
         let res = async {
             let workspace = workspace.resolve()?;
             let (connect_msg, completer) = Connect::allocate(cx.self_addr().clone(), cx);
-            connect.send(cx, connect_msg);
+            connect.post(cx, connect_msg);
             let (mut read, mut write) = completer.complete().await?.into_split();
             let path_prefix_replacements = path_prefix_replacements
                 .into_iter()
@@ -110,7 +110,7 @@ impl Handler<CondaSyncMessage> for CondaSyncActor {
             })
         }
         .await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)));
+        result.post(cx, res.map_err(|e| format!("{:#?}", e)));
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -254,7 +254,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
                     // Forward rsync connection port to the RsyncActor, which will do the actual
                     // connection and run the client.
                     let (tx, mut rx) = cx.open_port::<Result<RsyncResult, String>>();
-                    self.get_rsync_actor(cx).await?.send(
+                    self.get_rsync_actor(cx).await?.post(
                         cx,
                         RsyncMessage {
                             connect,
@@ -272,7 +272,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
                     // Forward rsync connection port to the RsyncActor, which will do the actual
                     // connection and run the client.
                     let (tx, mut rx) = cx.open_port::<Result<CondaSyncResult, String>>();
-                    self.get_conda_sync_actor(cx).await?.send(
+                    self.get_conda_sync_actor(cx).await?.post(
                         cx,
                         CondaSyncMessage {
                             connect,
@@ -320,7 +320,7 @@ impl CodeSyncMessageHandler for CodeSyncManager {
             anyhow::Ok(())
         }
         .await;
-        result.send(
+        result.post(
             cx,
             res.map_err(|e| {
                 format!(
@@ -351,12 +351,12 @@ impl CodeSyncMessageHandler for CodeSyncManager {
             let (tx, mut rx) = cx.open_port::<Result<(), String>>();
             self.get_auto_reload_actor(cx)
                 .await?
-                .send(cx, AutoReloadMessage { result: tx.bind() });
+                .post(cx, AutoReloadMessage { result: tx.bind() });
             rx.recv().await?.map_err(anyhow::Error::msg)?;
             anyhow::Ok(())
         }
         .await;
-        result.send(
+        result.post(
             cx,
             res.map_err(|e| {
                 format!(

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -361,7 +361,7 @@ impl Handler<RsyncMessage> for RsyncActor {
                 .resolve()
                 .context("resolving workspace location")?;
             let (connect_msg, completer) = Connect::allocate(cx.self_addr().clone(), cx);
-            connect.send(cx, connect_msg);
+            connect.post(cx, connect_msg);
 
             // some machines (e.g. github CI) do not have ipv6, so try ipv6 then fallback to ipv4
             let ipv6_lo: SocketAddr = "[::1]:0".parse()?;
@@ -381,7 +381,7 @@ impl Handler<RsyncMessage> for RsyncActor {
             anyhow::Ok(rsync_result)
         }
         .await;
-        result.send(cx, res.map_err(|e| format!("{:#?}", e)));
+        result.post(cx, res.map_err(|e| format!("{:#?}", e)));
         Ok(())
     }
 }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -528,7 +528,7 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
         // We don't need the ack, and this temporary proc doesn't have a mailbox
         // receiver set up anyways. Just ignore the message.
         port.return_undeliverable(false);
-        agent.send(
+        agent.post(
             &instance,
             ShutdownHost {
                 timeout: Duration::from_secs(10),

--- a/monarch_hyperactor/src/local_state_broker.rs
+++ b/monarch_hyperactor/src/local_state_broker.rs
@@ -49,7 +49,7 @@ impl Handler<LocalStateBrokerMessage> for LocalStateBrokerActor {
         match message {
             LocalStateBrokerMessage::Set(id, state) => match self.ports.remove_entry(&id) {
                 Some((_, port)) => {
-                    port.send(cx, state);
+                    port.post(cx, state);
                 }
                 None => {
                     self.states.insert(id, state);
@@ -57,7 +57,7 @@ impl Handler<LocalStateBrokerMessage> for LocalStateBrokerActor {
             },
             LocalStateBrokerMessage::Get(id, port) => match self.states.remove_entry(&id) {
                 Some((_, state)) => {
-                    port.send(cx, state);
+                    port.post(cx, state);
                 }
                 None => {
                     self.ports.insert(id, port);

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -238,7 +238,7 @@ impl LoggingMeshClient {
         let (version_tx, version_rx) = cx.instance().open_once_port::<u64>();
 
         // First initialize a sync flush.
-        client_actor.send(
+        client_actor.post(
             cx,
             LogClientMessage::StartSyncFlush {
                 expected_procs: forwarder_mesh.region().num_ranks(),
@@ -423,7 +423,7 @@ impl LoggingMeshClient {
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
         // Always update the client actor's aggregation window.
-        self.client_actor.send(
+        self.client_actor.post(
             instance.deref(),
             LogClientMessage::SetAggregate {
                 aggregate_window_sec,

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -256,7 +256,7 @@ impl PythonPortHandle {
 #[pymethods]
 impl PythonPortHandle {
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {
-        self.inner.send(instance.deref(), message);
+        self.inner.post(instance.deref(), message);
         Ok(())
     }
 
@@ -292,7 +292,7 @@ impl PythonPortRef {
     }
 
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {
-        self.inner.send(instance.deref(), message);
+        self.inner.post(instance.deref(), message);
         Ok(())
     }
 
@@ -441,7 +441,7 @@ impl PythonOncePortHandle {
         let Some(port) = self.inner.take() else {
             return Err(PyErr::new::<PyValueError, _>("OncePort is already used"));
         };
-        port.send(instance.deref(), message);
+        port.post(instance.deref(), message);
         Ok(())
     }
 
@@ -487,7 +487,7 @@ impl PythonOncePortRef {
             return Err(PyErr::new::<PyValueError, _>("OncePortRef is already used"));
         };
         let port_ref: hyperactor::OncePortRef<PythonMessage> = port_ref;
-        port_ref.send(instance.deref(), message);
+        port_ref.post(instance.deref(), message);
         Ok(())
     }
 
@@ -613,31 +613,31 @@ impl EitherPortRef {
         }
     }
 
-    /// Send a message through this port reference.
+    /// Post a message through this port reference.
     /// The message is first resolved for any pending pickle state before sending.
-    pub fn send(
+    pub fn post(
         &mut self,
         cx: &impl hyperactor::context::Actor,
         message: crate::actor::PythonMessage,
     ) -> anyhow::Result<()> {
         match self {
-            EitherPortRef::Unbounded(port_ref) => port_ref.inner.send(cx, message),
+            EitherPortRef::Unbounded(port_ref) => port_ref.inner.post(cx, message),
             EitherPortRef::Once(once_port_ref) => {
                 let port = once_port_ref
                     .inner
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("OncePortRef already used"))?;
-                port.send(cx, message);
+                port.post(cx, message);
             }
         }
         Ok(())
     }
 
-    /// Send a message through this port reference with
+    /// Post a message through this port reference with
     /// caller-supplied envelope headers. Delegates to the underlying
-    /// `PortRef::send_with_headers` /
-    /// `OncePortRef::send_with_headers`.
-    pub fn send_with_headers(
+    /// `PortRef::post_with_headers` /
+    /// `OncePortRef::post_with_headers`.
+    pub fn post_with_headers(
         &mut self,
         cx: &impl hyperactor::context::Actor,
         headers: hyperactor_config::Flattrs,
@@ -645,14 +645,14 @@ impl EitherPortRef {
     ) -> anyhow::Result<()> {
         match self {
             EitherPortRef::Unbounded(port_ref) => {
-                port_ref.inner.send_with_headers(cx, headers, message)
+                port_ref.inner.post_with_headers(cx, headers, message)
             }
             EitherPortRef::Once(once_port_ref) => {
                 let port = once_port_ref
                     .inner
                     .take()
                     .ok_or_else(|| anyhow::anyhow!("OncePortRef already used"))?;
-                port.send_with_headers(cx, headers, message);
+                port.post_with_headers(cx, headers, message);
             }
         }
         Ok(())

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -700,7 +700,7 @@ impl ProcLauncher for ActorProcLauncher {
             message: pickled_args.into(),
         };
 
-        self.spawner.send(&self.instance, message);
+        self.spawner.post(&self.instance, message);
 
         let mut active_procs: tokio::sync::MutexGuard<'_, HashSet<hyperactor::ProcAddr>> =
             self.active_procs.lock().await;
@@ -782,7 +782,7 @@ impl ProcLauncher for ActorProcLauncher {
             message: pickled.into(),
         };
 
-        self.spawner.send(&self.instance, message);
+        self.spawner.post(&self.instance, message);
         Ok(())
     }
 
@@ -822,7 +822,7 @@ impl ProcLauncher for ActorProcLauncher {
             message: pickled.into(),
         };
 
-        self.spawner.send(&self.instance, message);
+        self.spawner.post(&self.instance, message);
         Ok(())
     }
 }

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -107,7 +107,7 @@ CONSTANT = "modified_constant"
 
     // Send AutoReloadMessage to trigger reload
     let (result_tx, mut result_rx) = instance.mailbox().open_port::<Result<(), String>>();
-    actor_ref.send(
+    actor_ref.post(
         instance,
         AutoReloadMessage {
             result: result_tx.bind(),

--- a/monarch_introspection_snapshot/src/integration.rs
+++ b/monarch_introspection_snapshot/src/integration.rs
@@ -141,7 +141,7 @@ pub fn start_periodic_snapshots(
     let actor = SnapshotCaptureActor::new(table_store, admin_ref, interval);
     let handle = proc.spawn("snapshot_capture", actor)?;
     // PT-3: first capture fires at spawn time.
-    handle.send(cx, CaptureSnapshot);
+    handle.post(cx, CaptureSnapshot);
     Ok(())
 }
 

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -445,7 +445,7 @@ impl Handler<InitializeBuffer> for CudaRdmaActor {
             self.rdma_buffer_handle = Some(buffer_handle);
         }
 
-        reply.send(cx, true);
+        reply.post(cx, true);
         Ok(())
     }
 }
@@ -576,7 +576,7 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
                 }
             }
         }
-        reply.send(cx, true);
+        reply.post(cx, true);
         Ok(())
     }
 }
@@ -664,7 +664,7 @@ impl Handler<VerifyBuffer> for CudaRdmaActor {
             }
         }
 
-        reply.send(cx, all_match);
+        reply.post(cx, all_match);
         Ok(())
     }
 }
@@ -686,7 +686,7 @@ impl Handler<GetBufferHandle> for CudaRdmaActor {
             .as_ref()
             .ok_or_else(|| anyhow::anyhow!("Buffer not initialized"))?;
 
-        reply.send(cx, buffer.clone());
+        reply.post(cx, buffer.clone());
         Ok(())
     }
 }
@@ -823,26 +823,26 @@ pub async fn run() -> Result<(), anyhow::Error> {
     let device_1_actor = device_1_actor_mesh.values().next().unwrap();
     let device_2_actor = device_2_actor_mesh.values().next().unwrap();
     let (handle_1, receiver_1) = instance.open_once_port::<bool>();
-    device_1_actor.send(&instance, InitializeBuffer(DATA_VALUE, handle_1.bind()));
+    device_1_actor.post(&instance, InitializeBuffer(DATA_VALUE, handle_1.bind()));
     receiver_1.recv().await?;
 
     // Initialize device 2 buffer with 0
     let (handle_2, receiver_2) = instance.open_once_port::<bool>();
-    device_2_actor.send(&instance, InitializeBuffer(0, handle_2.bind()));
+    device_2_actor.post(&instance, InitializeBuffer(0, handle_2.bind()));
     receiver_2.recv().await?;
 
     // Get the remote buffer handle from device 1
     let (handle_remote, receiver_remote) = instance.open_once_port::<RdmaRemoteBuffer>();
-    device_1_actor.send(&instance, GetBufferHandle(handle_remote.bind()));
+    device_1_actor.post(&instance, GetBufferHandle(handle_remote.bind()));
     let buffer_1 = receiver_remote.recv().await?;
 
     let (handle_remote, receiver_remote) = instance.open_once_port::<RdmaRemoteBuffer>();
-    device_2_actor.send(&instance, GetBufferHandle(handle_remote.bind()));
+    device_2_actor.post(&instance, GetBufferHandle(handle_remote.bind()));
     let buffer_2 = receiver_remote.recv().await?;
     let (handle_1, receiver_1) = instance.open_once_port::<bool>();
 
     let (handle_2, receiver_2) = instance.open_once_port::<bool>();
-    device_2_actor.send(
+    device_2_actor.post(
         &instance,
         PerformPingPong(
             device_1_actor.clone(),
@@ -853,7 +853,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
         ),
     );
     receiver_2.recv().await?;
-    device_1_actor.send(
+    device_1_actor.post(
         &instance,
         PerformPingPong(
             device_2_actor.clone(),
@@ -866,14 +866,14 @@ pub async fn run() -> Result<(), anyhow::Error> {
     receiver_1.recv().await?;
 
     let (handle, receiver) = instance.open_once_port::<bool>();
-    device_2_actor.send(
+    device_2_actor.post(
         &instance,
         VerifyBuffer(expected_data_values.clone(), handle.bind()),
     );
     let verification_result2 = receiver.recv().await?;
 
     let (handle, receiver) = instance.open_once_port::<bool>();
-    device_1_actor.send(
+    device_1_actor.post(
         &instance,
         VerifyBuffer(expected_data_values.clone(), handle.bind()),
     );

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -213,7 +213,7 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
                 grad_buffer_handle
             }
         };
-        reply.send(cx, (weights_handle.clone(), grad_buffer_handle.clone()));
+        reply.post(cx, (weights_handle.clone(), grad_buffer_handle.clone()));
         Ok(())
     }
 }
@@ -233,7 +233,7 @@ impl Handler<PsUpdate> for ParameterServerActor {
             grad.fill(0);
         }
         tracing::info!("[parameter server actor] updated");
-        reply.send(cx, true);
+        reply.post(cx, true);
         Ok(())
     }
 }
@@ -334,7 +334,7 @@ impl Handler<WorkerInit> for WorkerActor {
         tracing::info!("[worker_actor_{}] initializing", rank);
 
         let (handle, receiver) = cx.mailbox().open_once_port();
-        ps_ref.send(cx, PsGetBuffers(rank, handle.bind()));
+        ps_ref.post(cx, PsGetBuffers(rank, handle.bind()));
         let (ps_weights_handle, ps_grad_handle) = receiver.recv().await?;
         self.ps_weights_handle = Some(ps_weights_handle);
         self.ps_grad_handle = Some(ps_grad_handle);
@@ -381,7 +381,7 @@ impl Handler<WorkerStep> for WorkerActor {
 
         self.local_gradients.fill(0);
 
-        reply.send(cx, true);
+        reply.post(cx, true);
         Ok(())
     }
 }
@@ -412,7 +412,7 @@ impl Handler<WorkerUpdate> for WorkerActor {
         ps_weights_handle
             .read_into_local(cx, local_memory, 5)
             .await?;
-        reply.send(cx, true);
+        reply.post(cx, true);
         Ok(())
     }
 }
@@ -572,7 +572,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
         }
 
         let (handle, recv) = instance.mailbox().open_once_port::<bool>();
-        ps_actor.send(instance, PsUpdate(handle.bind()));
+        ps_actor.post(instance, PsUpdate(handle.bind()));
 
         let finished = recv.recv().await.unwrap();
         if !finished {
@@ -592,7 +592,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
         if !results.iter().any(|&result| result) {
             panic!("worker update step did not complete properly.");
         }
-        ps_actor.send(instance, Log {});
+        ps_actor.post(instance, Log {});
     }
     Ok(())
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -849,7 +849,7 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
         let state = match self.ensure_queue_pair_impl(cx, sender, &qp_key) {
             Ok(state) => state,
             Err(e) => {
-                reply.send(cx, PeerInfo(Err(e.to_string())));
+                reply.post(cx, PeerInfo(Err(e.to_string())));
                 return Ok(());
             }
         };
@@ -858,7 +858,7 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
                 info, initializer, ..
             } => {
                 let notify_rts = initializer.bind::<QueuePairInitializer<Self>>().port();
-                reply.send(cx, PeerInfo(Ok((info.clone(), notify_rts))));
+                reply.post(cx, PeerInfo(Ok((info.clone(), notify_rts))));
             }
             QpState::Ready(_) => {
                 // `Ready` means a prior handshake completed and the
@@ -866,7 +866,7 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
                 // initializer ref. Reaching here represents a logic
                 // error (peer is asking us to redo a handshake we've
                 // already finished); surface it as `Err`.
-                reply.send(
+                reply.post(
                     cx,
                     PeerInfo(Err(format!(
                         "EnsureQueuePair on already-Ready entry {qp_key:?}"
@@ -874,7 +874,7 @@ impl Handler<EnsureQueuePair<IbvManagerActor>> for IbvManagerActor {
                 );
             }
             QpState::Failed(error) => {
-                reply.send(cx, PeerInfo(Err(error.clone())));
+                reply.post(cx, PeerInfo(Err(error.clone())));
             }
         }
         Ok(())
@@ -935,14 +935,14 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         let state = match self.ensure_queue_pair_impl(cx, other, &qp_key) {
             Ok(state) => state,
             Err(e) => {
-                reply.send(cx, Err(e.to_string()));
+                reply.post(cx, Err(e.to_string()));
                 return Ok(());
             }
         };
         match state {
             QpState::Pending { waiters, .. } => waiters.push(reply),
-            QpState::Ready(qp) => reply.send(cx, Ok(qp.clone())),
-            QpState::Failed(error) => reply.send(cx, Err(error.clone())),
+            QpState::Ready(qp) => reply.post(cx, Ok(qp.clone())),
+            QpState::Failed(error) => reply.post(cx, Err(error.clone())),
         }
         Ok(())
     }
@@ -966,7 +966,7 @@ impl Handler<QpInitializerDone> for IbvManagerActor {
                 ..
             }) => {
                 for w in waiters {
-                    w.send(cx, Ok(qp.clone()));
+                    w.post(cx, Ok(qp.clone()));
                 }
                 initializer
             }
@@ -1005,7 +1005,7 @@ impl Handler<QpInitializerFailed> for IbvManagerActor {
                 ..
             }) => {
                 for w in waiters {
-                    w.send(cx, Err(error.clone()));
+                    w.post(cx, Err(error.clone()));
                 }
                 initializer
             }

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -145,7 +145,7 @@ where
         let (reply, rx) = cx
             .mailbox()
             .open_once_port::<Result<IbvMemoryRegionView, String>>();
-        self.manager.send(cx, RegisterMr { addr, size, reply });
+        self.manager.post(cx, RegisterMr { addr, size, reply });
         let mrv = rx
             .recv()
             .await
@@ -181,7 +181,7 @@ where
     ) -> Result<OwnedMutexGuard<Qp>, String> {
         if !self.peer_qps.contains_key(qp_key) {
             let (reply, rx) = cx.mailbox().open_once_port::<Result<Qp, String>>();
-            self.manager.send(
+            self.manager.post(
                 cx,
                 RequestQueuePair {
                     qp_key: qp_key.clone(),
@@ -322,7 +322,7 @@ where
             reply,
         } = msg;
         let results = self.process_batch(cx, ops, timeout).await;
-        reply.send(cx, results);
+        reply.post(cx, results);
         Ok(())
     }
 }
@@ -396,7 +396,7 @@ mod tests {
                     _domain: null_domain(),
                 }),
             );
-            msg.reply.send(cx, Ok(mrv));
+            msg.reply.post(cx, Ok(mrv));
             Ok(())
         }
     }
@@ -417,7 +417,7 @@ mod tests {
                 .unwrap()
                 .request_qp_calls
                 .push(msg.qp_key.clone());
-            msg.reply.send(cx, Ok(MockQp));
+            msg.reply.post(cx, Ok(MockQp));
             Ok(())
         }
     }
@@ -517,7 +517,7 @@ mod tests {
         ops: Vec<IbvOp<MockManagerActor>>,
     ) -> Vec<Result<(), String>> {
         let (reply, rx) = harness.client.mailbox().open_once_port();
-        harness.processor.send(
+        harness.processor.post(
             &harness.client,
             SubmitOps {
                 ops,

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1256,7 +1256,7 @@ where
         let timeout = self.timeout;
         let task = tokio::spawn(async move {
             tokio::time::sleep(timeout).await;
-            self_handle.send(Instance::<Self>::self_client(), InitializationFailed);
+            self_handle.post(Instance::<Self>::self_client(), InitializationFailed);
         });
         self.timeout_handle = Some(task);
     }
@@ -1270,7 +1270,7 @@ where
         }
         self.qp = None;
         self.terminal = true;
-        self.owner.send(
+        self.owner.post(
             this,
             QpInitializerFailed {
                 qp_key: self.qp_key.clone(),
@@ -1288,7 +1288,7 @@ where
         }
         let qp = self.qp.take().expect("qp present in done()");
         self.terminal = true;
-        self.owner.send(
+        self.owner.post(
             this,
             QpInitializerDone {
                 qp_key: self.qp_key.clone(),
@@ -1312,7 +1312,7 @@ where
             .expect("qp present pre-terminal")
             .connect(&peer_endpoint)
             .map_err(|e| format!("QpGuard::connect failed: {e}"))?;
-        peer_notify_rts.send(cx, NotifyRts);
+        peer_notify_rts.post(cx, NotifyRts);
         Ok(())
     }
 }
@@ -1329,7 +1329,7 @@ where
         let sender = self.owner.bind();
         let sender_device = self.qp_key.self_device.clone();
         let receiver_device = self.qp_key.other_device.clone();
-        self.other.send(
+        self.other.post(
             this,
             EnsureQueuePair {
                 sender,
@@ -1636,7 +1636,7 @@ mod tests {
             match response {
                 MockResponse::Success(info) => {
                     let notify_rts = cx.bind::<MockManager>().port::<NotifyRts>();
-                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))));
+                    msg.reply.post(cx, PeerInfo(Ok((info, notify_rts))));
                 }
                 MockResponse::SuccessWithBogusNotifyRts(info) => {
                     let bogus = hyperactor::context::Mailbox::mailbox(cx)
@@ -1645,10 +1645,10 @@ mod tests {
                         .actor_addr("bogus")
                         .port_addr(Port::from(0u64));
                     let notify_rts = PortRef::<NotifyRts>::attest(bogus);
-                    msg.reply.send(cx, PeerInfo(Ok((info, notify_rts))));
+                    msg.reply.post(cx, PeerInfo(Ok((info, notify_rts))));
                 }
                 MockResponse::Error(e) => {
-                    msg.reply.send(cx, PeerInfo(Err(e)));
+                    msg.reply.post(cx, PeerInfo(Err(e)));
                 }
                 MockResponse::DropReply => {}
             }
@@ -1797,7 +1797,7 @@ mod tests {
         let harness = Harness::build(qp, MockResponse::Success(info))?;
 
         let (peer, _) = harness.proc.instance("peer")?;
-        harness.init_handle.send(&peer, NotifyRts);
+        harness.init_handle.post(&peer, NotifyRts);
 
         let key = harness.await_done().await;
         assert_eq!(key, harness.qp_key);
@@ -1863,7 +1863,7 @@ mod tests {
         let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
-        harness.init_handle.send(&peer, undeliverable);
+        harness.init_handle.post(&peer, undeliverable);
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
         assert!(
@@ -1905,7 +1905,7 @@ mod tests {
 
         let undeliverable = fake_undeliverable(&harness.proc, "late bounce");
         let (peer, _) = harness.proc.instance("peer").unwrap();
-        harness.init_handle.send(&peer, undeliverable);
+        harness.init_handle.post(&peer, undeliverable);
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(harness.state.lock().unwrap().failed.len(), 1);
     }

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -211,7 +211,7 @@ impl Handler<CudaActorMessage> for CudaActor {
                     .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
                 let rdma_handle = handle.request_buffer(cx, local_memory).await?;
 
-                reply.send(cx, (rdma_handle, dptr));
+                reply.post(cx, (rdma_handle, dptr));
                 Ok(())
             }
             CudaActorMessage::FillBuffer {
@@ -230,7 +230,7 @@ impl Handler<CudaActorMessage> for CudaActor {
                     ));
                 }
 
-                reply.send(cx, ());
+                reply.post(cx, ());
                 Ok(())
             }
             CudaActorMessage::VerifyBuffer {
@@ -249,7 +249,7 @@ impl Handler<CudaActorMessage> for CudaActor {
                     ));
                 }
 
-                reply.send(cx, ());
+                reply.post(cx, ());
                 Ok(())
             }
         }

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -322,7 +322,7 @@ impl TcpManagerActor {
                     let len = std::cmp::min(chunk_size, size - offset);
                     let mut buf = BytesMut::zeroed(len);
                     if let Err(e) = mem.read_at(offset, &mut buf) {
-                        error_port.send(
+                        error_port.post(
                             &instance,
                             TransferError {
                                 message: format!("read_at failed at offset {offset}: {e}"),
@@ -338,7 +338,7 @@ impl TcpManagerActor {
                     };
 
                     if let Err(e) = conn.send(chunk).await {
-                        error_port.send(
+                        error_port.post(
                             &instance,
                             TransferError {
                                 message: format!("failed to send chunk at offset {offset}: {e}"),
@@ -411,7 +411,7 @@ impl Actor for TcpManagerActor {
                             Ok(chunk) => chunk,
                             Err(e) => {
                                 error_port
-                                    .send(
+                                    .post(
                                         &instance,
                                         TransferError {
                                             message: format!(
@@ -446,7 +446,7 @@ impl Actor for TcpManagerActor {
                         let transfer_id = chunk.transfer_id;
                         drop(entry);
                         let (_, state) = transfers.remove(&transfer_id).unwrap();
-                        result_port.send(
+                        result_port.post(
                             &instance,
                             SendTransferResult {
                                 done: state.done,
@@ -461,7 +461,7 @@ impl Actor for TcpManagerActor {
                         let transfer_id = chunk.transfer_id;
                         drop(entry);
                         let (_, state) = transfers.remove(&transfer_id).unwrap();
-                        result_port.send(
+                        result_port.post(
                             &instance,
                             SendTransferResult {
                                 done: state.done,
@@ -589,7 +589,7 @@ impl Handler<RegisterTransferLocal> for TcpManagerActor {
     ) -> Result<(), anyhow::Error> {
         let transfer_id =
             self.register_transfer(message.local_memory, message.total_chunks, message.done);
-        message.reply.send(cx, transfer_id);
+        message.reply.post(cx, transfer_id);
         Ok(())
     }
 }
@@ -618,7 +618,7 @@ impl Handler<SendTransferResult> for TcpManagerActor {
         cx: &Context<Self>,
         message: SendTransferResult,
     ) -> Result<(), anyhow::Error> {
-        message.done.send(cx, message.result);
+        message.done.post(cx, message.result);
         Ok(())
     }
 }
@@ -690,7 +690,7 @@ impl TcpBackend {
         .map_err(|_| anyhow::anyhow!("get_channel_address timed out"))??
         .ok_or_else(|| anyhow::anyhow!("remote does not have parallel channels enabled"))?;
 
-        self.0.send(
+        self.0.post(
             cx,
             ExecuteTransferLocal {
                 transfer_id,
@@ -725,7 +725,7 @@ impl TcpBackend {
 
         let (id_handle, id_rx) = hyperactor::mailbox::open_once_port::<usize>(cx);
 
-        self.0.send(
+        self.0.post(
             cx,
             RegisterTransferLocal {
                 local_memory: op.local_memory.clone(),

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -980,7 +980,7 @@ impl StreamActor {
         let message = LocalStateBrokerMessage::Set(x as usize, state);
 
         let broker = BrokerId::new(params.broker_id).resolve(cx).await;
-        broker.send(cx, message);
+        broker.post(cx, message);
         let result = recv
             .recv()
             .await
@@ -1067,7 +1067,7 @@ impl StreamMessageHandler for StreamActor {
         };
 
         let event = self.cuda_stream().map(|stream| stream.record_event(None));
-        first_use_sender.send(cx, (event, result));
+        first_use_sender.post(cx, (event, result));
         Ok(())
     }
 
@@ -1145,7 +1145,7 @@ impl StreamMessageHandler for StreamActor {
             Err(e) => Err(e),
         };
 
-        last_use_sender.send(cx, (event, tensor));
+        last_use_sender.post(cx, (event, tensor));
         Ok(())
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3920
* __->__ #3919
* #3918
* #3917
* #3916
* #3915

Rename the endpoint-level fire-and-report APIs from `send` to `post`. `Endpoint::send` becomes `Endpoint::post`, and `RemoteEndpoint::send_with_headers` becomes `RemoteEndpoint::post_with_headers`.

Update the endpoint impls, macro-generated clients and replies, and all call sites in the Monarch stack to use the new names. Python-facing methods that are part of the Python API surface keep their existing `send` names, but now delegate to endpoint `post` internally.

This makes the API name match the asynchronous semantics introduced by the previous change: callers post work into the actor runtime, and delivery failures are reported later through the undeliverable path rather than synchronously through the call.

Differential Revision: [D105267803](https://our.internmc.facebook.com/intern/diff/D105267803/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105267803/)!