### PR TITLE
Fix publish_release Docker build: use cuda12.6 base for pytorch 2.12.0

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           VERSION="${{ github.event.inputs.version }}"
           PRERELEASE="${{ github.event.inputs.is_prerelease }}"
-          TAGS="ghcr.io/${{ github.repository }}:${VERSION}-cuda12.8"
+          TAGS="ghcr.io/${{ github.repository }}:${VERSION}-cuda12.6"
           if [[ "$PRERELEASE" == "false" ]]; then
             TAGS="$TAGS,ghcr.io/${{ github.repository }}:latest"
           fi
@@ -118,7 +118,7 @@ jobs:
           push: true # Push the image to the registry
           tags: ${{ steps.determine-tags.outputs.tags }}
           build-args: |
-            PYTORCH_TAG=2.12.0-cuda12.8-cudnn9-runtime
+            PYTORCH_TAG=2.12.0-cuda12.6-cudnn9-runtime
             MONARCH_VERSION=${{ github.event.inputs.version }}
 
   create-docs-branch:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -116,7 +116,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Get tag for publishing
-        run: echo "DOCKER_TAG=0.5.0.dev$(date +'%Y%m%d')-cuda12.8" >> $GITHUB_ENV
+        run: echo "DOCKER_TAG=0.5.0.dev$(date +'%Y%m%d')-cuda12.6" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Override on build from CI.
-ARG PYTORCH_TAG=2.12.0-cuda12.8-cudnn9-runtime
+ARG PYTORCH_TAG=2.12.0-cuda12.6-cudnn9-runtime
 
 # Build from latest pytorch stable image; should be relatively in sync with torchmonarch and pytorch.
 FROM ghcr.io/pytorch/pytorch:${PYTORCH_TAG}


### PR DESCRIPTION
Summary: The `publish_release` workflow was failing because `ghcr.io/pytorch/pytorch:2.12.0-cuda12.8-cudnn9-runtime` does not exist — only the `cuda12.6` variant is published for the 2.12.0 release. Switch the Dockerfile default and the CI `PYTORCH_TAG` build-arg to `2.12.0-cuda12.6-cudnn9-runtime`. Update the resulting Docker image tag suffixes in `publish_release.yml` and `wheels.yml` from `-cuda12.8` to `-cuda12.6` so the tag reflects the actual CUDA runtime in the image. The wheel build path (cu128 index, `pytorch/manylinux*-builder:cuda12.8`) is unchanged.

Differential Revision: D105369175


