### PR TITLE
KeepaliveLocalMemory: unsafe accessors, drop the RdmaLocalMemory trait (#3922)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -86,8 +86,8 @@ use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
 use monarch_rdma::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
 use monarch_rdma::cu_check;
-use monarch_rdma::local_memory::RdmaLocalMemory;
-use monarch_rdma::local_memory::UnsafeLocalMemory;
+use monarch_rdma::local_memory::Keepalive;
+use monarch_rdma::local_memory::KeepaliveLocalMemory;
 use ndslice::Extent;
 use ndslice::ViewExt;
 use serde::Deserialize;
@@ -143,6 +143,21 @@ pub fn ping_pong(
 
     if result == 0 { Ok(()) } else { Err(result) }
 }
+
+// HACK — `NoKeepalive` keeps nothing alive. The CUDA allocation
+// for this actor's device buffer is leaked for the lifetime of the
+// process; the actor's `Drop` does not free it.
+//
+// We tolerate the lie here *temporarily* because the actual implementation
+// logic is unchanged from the pre-`Keepalive` version. If it was correct
+// before, it's still correct now.
+//
+// TODO(samlurye): replace `NoKeepalive` with a real `CudaAllocation`
+// keepalive (or equivalent) and arrange for the buffer to be released
+// while the CUDA context is still live, e.g., via an explicit
+// shutdown handler on the actor.
+struct NoKeepalive;
+impl Keepalive for NoKeepalive {}
 
 // Constants for default values
 const DEFAULT_BUFFER_SIZE_MB: usize = 32; // `must be multiple of 2MB
@@ -434,8 +449,9 @@ impl Handler<InitializeBuffer> for CudaRdmaActor {
         if self.rdma_buffer_handle.is_none() {
             let addr = self.cu_ptr;
             let size = self.cpu_buffer.len();
-            let local_memory: Arc<dyn RdmaLocalMemory> =
-                Arc::new(UnsafeLocalMemory::new(addr, size));
+            // See the module-level note on `NoKeepalive`.
+            let local_memory: Arc<KeepaliveLocalMemory> =
+                Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(NoKeepalive)));
             let handle = self
                 .rdma_manager
                 .downcast_handle(cx)

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -82,8 +82,8 @@ use monarch_rdma::IbvConfig;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
-use monarch_rdma::local_memory::RdmaLocalMemory;
-use monarch_rdma::local_memory::UnsafeLocalMemory;
+use monarch_rdma::local_memory::Keepalive;
+use monarch_rdma::local_memory::KeepaliveLocalMemory;
 use ndslice::extent;
 use ndslice::view::Ranked;
 use serde::Deserialize;
@@ -93,6 +93,23 @@ use typeuri::Named;
 
 // Constants to control the setup.
 const BUFFER_SIZE: usize = 8;
+
+// HACK — `NoKeepalive` keeps nothing alive. The
+// `Box<[u8]>` fields on `ParameterServerActor` / `WorkerActor`
+// (`weights_data`, `grad_buffer_data`, `local_gradients`) own the
+// backing storage; the `KeepaliveLocalMemory` clones registered with
+// RDMA carry only an empty marker.
+//
+// We tolerate the lie here *temporarily* because the actual implementation
+// logic is unchanged from the pre-`Keepalive` version. If it was correct
+// before, it's still correct now.
+//
+// TODO(samlurye): rework the actor fields so the RDMA-registered
+// buffer is the single source of truth (e.g., `Arc<KeepaliveLocal-
+// Memory>` with a `Box<[u8]>` keepalive), and route the local
+// gradient/weight math through the `KeepaliveLocalMemory` API.
+struct NoKeepalive;
+impl Keepalive for NoKeepalive {}
 
 // Parameter Server Actor
 #[derive(Debug)]
@@ -180,8 +197,9 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
         if self.weights_handle.is_none() {
             let addr = self.weights_data.as_ptr() as usize;
             let size = self.weights_data.len();
-            let local_memory: Arc<dyn RdmaLocalMemory> =
-                Arc::new(UnsafeLocalMemory::new(addr, size));
+            // See the module-level note on `NoKeepalive`.
+            let local_memory: Arc<KeepaliveLocalMemory> =
+                Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(NoKeepalive)));
             let handle = self
                 .owner_ref
                 .downcast_handle(cx)
@@ -200,8 +218,9 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
             std::collections::hash_map::Entry::Vacant(e) => {
                 let addr = self.grad_buffer_data[rank].as_ptr() as usize;
                 let size = self.grad_buffer_data[rank].len();
-                let local_memory: Arc<dyn RdmaLocalMemory> =
-                    Arc::new(UnsafeLocalMemory::new(addr, size));
+                // See the module-level note on `NoKeepalive`.
+                let local_memory: Arc<KeepaliveLocalMemory> =
+                    Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(NoKeepalive)));
                 let handle = self
                     .owner_ref
                     .downcast_handle(cx)
@@ -371,9 +390,11 @@ impl Handler<WorkerStep> for WorkerActor {
             .ps_grad_handle
             .as_ref()
             .expect("worker_actor should be initialized");
-        let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(UnsafeLocalMemory::new(
+        // See the module-level note on `NoKeepalive`.
+        let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
             self.local_gradients.as_ptr() as usize,
             self.local_gradients.len(),
+            Arc::new(NoKeepalive),
         ));
 
         ps_grad_handle.write_from_local(cx, local_memory, 5).await?;
@@ -404,9 +425,11 @@ impl Handler<WorkerUpdate> for WorkerActor {
             .ps_weights_handle
             .as_ref()
             .expect("worker_actor should be initialized");
-        let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(UnsafeLocalMemory::new(
+        // See the module-level note on `NoKeepalive`.
+        let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
             self.weights_data.as_ptr() as usize,
             self.weights_data.len(),
+            Arc::new(NoKeepalive),
         ));
         ps_weights_handle
             .read_into_local(cx, local_memory, 5)

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -22,7 +22,6 @@ use monarch_rdma::RdmaRemoteBuffer;
 use monarch_rdma::ibverbs_supported;
 use monarch_rdma::local_memory::Keepalive;
 use monarch_rdma::local_memory::KeepaliveLocalMemory;
-use monarch_rdma::local_memory::RdmaLocalMemory;
 use monarch_rdma::rdma_supported;
 use monarch_rdma::register_segment_scanner;
 use monarch_types::py_module_add_function;
@@ -161,13 +160,22 @@ impl PyLocalMemoryHandle {
 
     fn read_at(&self, offset: usize, size: usize) -> PyResult<Vec<u8>> {
         let mut buf = vec![0u8; size];
-        RdmaLocalMemory::read_at(&self.inner, offset, &mut buf)
+        // SAFETY: `self.inner`'s `AccessLock` is shared with every
+        // clone derived from it (including any held by an
+        // `RdmaManagerActor` after `create_rdma_buffer`), so intra-
+        // handle races are already excluded. The Python caller is
+        // responsible for ensuring no *external* view of the same
+        // allocation (e.g., a torch tensor whose data pointer was
+        // wrapped, or a C extension running with the GIL released)
+        // mutates the byte range while this call runs.
+        unsafe { self.inner.read_at(offset, &mut buf) }
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
         Ok(buf)
     }
 
     fn write_at(&self, offset: usize, data: &[u8]) -> PyResult<()> {
-        RdmaLocalMemory::write_at(&self.inner, offset, data)
+        // SAFETY: see `read_at`.
+        unsafe { self.inner.write_at(offset, data) }
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
@@ -193,7 +201,7 @@ async fn create_rdma_buffer(
 ) -> PyResult<PyRdmaBuffer> {
     let owner_handle = RdmaManagerActor::local_handle(client.deref());
 
-    let local: Arc<dyn RdmaLocalMemory> = Arc::new(local.inner);
+    let local: Arc<KeepaliveLocalMemory> = Arc::new(local.inner);
     let buffer = owner_handle
         .request_buffer(client.deref(), local)
         .await
@@ -251,7 +259,7 @@ impl PyRdmaBuffer {
         let buffer = self.buffer.clone();
 
         PyPythonTask::new(async move {
-            let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(dst.inner);
+            let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(dst.inner);
 
             buffer
                 .read_into_local(client.deref(), local_memory, timeout)
@@ -278,7 +286,7 @@ impl PyRdmaBuffer {
         let buffer = self.buffer.clone();
 
         PyPythonTask::new(async move {
-            let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(src.inner);
+            let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(src.inner);
 
             buffer
                 .write_from_local(client.deref(), local_memory, timeout)

--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -30,7 +30,6 @@ use crate::RdmaManagerMessageClient;
 use crate::RdmaRemoteBuffer;
 use crate::local_memory::Keepalive;
 use crate::local_memory::KeepaliveLocalMemory;
-use crate::local_memory::RdmaLocalMemory;
 use crate::register_segment_scanner;
 
 /// One physical chunk mapped into an expandable segment's VA
@@ -572,7 +571,7 @@ impl SenderMessageHandler for SenderActor {
 
         let mut remotes = Vec::with_capacity(buffers.len());
         for &(offset, size) in &buffers {
-            let local: Arc<dyn RdmaLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
+            let local: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
                 alloc.ptr() + offset,
                 size,
                 Arc::new(alloc.clone()),
@@ -580,7 +579,10 @@ impl SenderMessageHandler for SenderActor {
             // Pre-fill so reads return a known sequence; write_at
             // routes to the GPU path for CUDA-backed memory.
             let fill = vec![pattern; size];
-            local.write_at(0, &fill)?;
+            // SAFETY: `local` is freshly constructed and not yet
+            // registered, so no other thread holds a view of this
+            // sub-range of `alloc` while we initialize it.
+            unsafe { local.write_at(0, &fill) }?;
             remotes.push(handle.request_buffer(cx, local).await?);
         }
 
@@ -660,7 +662,7 @@ impl ReceiverMessageHandler for ReceiverActor {
         // read.
         let buf: Box<[u8]> = vec![!expected_pattern; size].into_boxed_slice();
         let addr = buf.as_ptr() as usize;
-        let local: Arc<dyn RdmaLocalMemory> =
+        let local: Arc<KeepaliveLocalMemory> =
             Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(buf)));
 
         let read_result = remote
@@ -673,7 +675,10 @@ impl ReceiverMessageHandler for ReceiverActor {
         }
 
         let mut got = vec![0u8; size];
-        if let Err(e) = local.read_at(0, &mut got) {
+        // SAFETY: `local` is the sole handle to this fresh CPU
+        // allocation; the `read_into_local` call above has already
+        // completed.
+        if let Err(e) = unsafe { local.read_at(0, &mut got) } {
             return Ok(Err(format!("post-read inspect failed: {e}")));
         }
         if let Some(idx) = got.iter().position(|&b| b != expected_pattern) {
@@ -696,7 +701,7 @@ impl ReceiverMessageHandler for ReceiverActor {
     ) -> Result<Result<(), String>, anyhow::Error> {
         let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
         let addr = buf.as_ptr() as usize;
-        let local: Arc<dyn RdmaLocalMemory> =
+        let local: Arc<KeepaliveLocalMemory> =
             Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(buf)));
 
         let result = remote

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -35,7 +35,7 @@ mod mlx5dv_tests;
 mod test_utils;
 
 use crate::RdmaOpType;
-use crate::local_memory::RdmaLocalMemory;
+use crate::local_memory::KeepaliveLocalMemory;
 
 /// Lazily-initialized ibverbs transport details for a registered memory
 /// region. Retrieved on demand from the [`IbvManagerActor`] via
@@ -59,7 +59,7 @@ pub struct IbvBuffer {
 #[derive(Debug, Named)]
 pub struct IbvOp<M: Referable = IbvManagerActor> {
     pub op_type: RdmaOpType,
-    pub local_memory: Arc<dyn RdmaLocalMemory>,
+    pub local_memory: Arc<KeepaliveLocalMemory>,
     pub remote_buffer: IbvBuffer,
     pub remote_manager: ActorRef<M>,
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -82,7 +82,7 @@ use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
-use crate::local_memory::RdmaLocalMemory;
+use crate::local_memory::KeepaliveLocalMemory;
 use crate::rdma_components::get_registered_cuda_segments;
 use crate::rdma_manager_actor::GetIbvActorRefClient;
 use crate::rdma_manager_actor::RdmaManagerActor;
@@ -161,7 +161,7 @@ pub enum IbvManagerLocalMessage {
     /// is deregistered on [`IbvManagerMessage::ReleaseBuffer`].
     RegisterRemoteBuffer {
         remote_buf_id: usize,
-        local: Arc<dyn RdmaLocalMemory>,
+        local: Arc<KeepaliveLocalMemory>,
         #[reply]
         reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
@@ -896,7 +896,7 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         &mut self,
         _cx: &Context<Self>,
         remote_buf_id: usize,
-        local: Arc<dyn RdmaLocalMemory>,
+        local: Arc<KeepaliveLocalMemory>,
     ) -> Result<Result<IbvBuffer, String>, anyhow::Error> {
         if let Some((buf, _)) = self.buffer_registrations.get(&remote_buf_id) {
             return Ok(Ok(buf.clone()));

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -362,7 +362,8 @@ mod tests {
     use super::super::primitives::IbvMemoryRegion;
     use super::*;
     use crate::RdmaOpType;
-    use crate::local_memory::RdmaLocalMemory;
+    use crate::local_memory::Keepalive;
+    use crate::local_memory::KeepaliveLocalMemory;
 
     fn null_domain() -> Arc<IbvDomain> {
         Arc::new(IbvDomain {
@@ -437,25 +438,17 @@ mod tests {
         }
     }
 
-    #[derive(Debug)]
-    struct FakeLocalMemory {
-        addr: usize,
-        size: usize,
-    }
+    /// No-op [`Keepalive`] for tests that mint a [`KeepaliveLocalMemory`]
+    /// from a fake address never actually read or written through.
+    struct FakeKeepalive;
+    impl Keepalive for FakeKeepalive {}
 
-    impl RdmaLocalMemory for FakeLocalMemory {
-        fn addr(&self) -> usize {
-            self.addr
-        }
-        fn size(&self) -> usize {
-            self.size
-        }
-        fn read_at(&self, _offset: usize, _dst: &mut [u8]) -> anyhow::Result<()> {
-            unimplemented!("test stub")
-        }
-        fn write_at(&self, _offset: usize, _src: &[u8]) -> anyhow::Result<()> {
-            unimplemented!("test stub")
-        }
+    fn fake_local_memory(addr: usize, size: usize) -> Arc<KeepaliveLocalMemory> {
+        Arc::new(KeepaliveLocalMemory::new(
+            addr,
+            size,
+            Arc::new(FakeKeepalive),
+        ))
     }
 
     fn fake_remote_ref(label: &str, uid: u64) -> ActorRef<MockManagerActor> {
@@ -472,7 +465,7 @@ mod tests {
     ) -> IbvOp<MockManagerActor> {
         IbvOp {
             op_type: RdmaOpType::WriteFromLocal,
-            local_memory: Arc::new(FakeLocalMemory { addr, size }),
+            local_memory: fake_local_memory(addr, size),
             remote_buffer: IbvBuffer {
                 mr_id: 1,
                 lkey: 0,

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -34,10 +34,23 @@ use super::queue_pair::PollTarget;
 use crate::IbvConfig;
 use crate::RdmaManagerMessageClient;
 use crate::RdmaRemoteBuffer;
-use crate::local_memory::RdmaLocalMemory;
-use crate::local_memory::UnsafeLocalMemory;
+use crate::local_memory::Keepalive;
+use crate::local_memory::KeepaliveLocalMemory;
 use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::validate_execution_context;
+
+// HACK — `NoKeepalive` keeps nothing alive. Test buffers are
+// either CPU `Box<[u8]>`s owned by `IbvTestEnv` (which lives across
+// the whole test) or raw CUDA allocations leaked by `CudaActor` for
+// the lifetime of the process.
+//
+// We tolerate the lie here *temporarily* because the actual implementation
+// logic is unchanged from the pre-`Keepalive` version. If it was correct
+// before, it's still correct now.
+//
+// TODO(samlurye): use real `Keepalive` implementations for test buffers.
+struct NoKeepalive;
+impl Keepalive for NoKeepalive {}
 
 #[derive(Debug)]
 struct SendSyncCudaContext(rdmaxcel_sys::CUcontext);
@@ -203,8 +216,12 @@ impl Handler<CudaActorMessage> for CudaActor {
                 };
 
                 // Register via RdmaManagerActor request_buffer.
-                let local_memory: Arc<dyn RdmaLocalMemory> =
-                    Arc::new(UnsafeLocalMemory::new(dptr, padded_size));
+                // See the module-level note on `NoKeepalive`.
+                let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
+                    dptr,
+                    padded_size,
+                    Arc::new(NoKeepalive),
+                ));
                 let handle = rdma_actor
                     .downcast_handle(cx)
                     .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -473,8 +490,8 @@ pub struct IbvTestEnv {
     pub ibv_handle_2: ActorHandle<IbvManagerActor>,
     pub rdma_handle_1: RdmaRemoteBuffer,
     pub rdma_handle_2: RdmaRemoteBuffer,
-    pub local_memory_1: Arc<dyn RdmaLocalMemory>,
-    pub local_memory_2: Arc<dyn RdmaLocalMemory>,
+    pub local_memory_1: Arc<KeepaliveLocalMemory>,
+    pub local_memory_2: Arc<KeepaliveLocalMemory>,
     pub ibv_buffer_1: IbvBuffer,
     pub ibv_buffer_2: IbvBuffer,
     cuda_actor_1: Option<ActorRef<CudaActor>>,
@@ -568,8 +585,8 @@ impl IbvTestEnv {
 
         let rdma_handle_1;
         let rdma_handle_2;
-        let local_memory_1: Arc<dyn RdmaLocalMemory>;
-        let local_memory_2: Arc<dyn RdmaLocalMemory>;
+        let local_memory_1: Arc<KeepaliveLocalMemory>;
+        let local_memory_2: Arc<KeepaliveLocalMemory>;
 
         // Process first accelerator
         if parsed_accel1.0 == "cpu" {
@@ -580,7 +597,12 @@ impl IbvTestEnv {
                 len: buffer.len(),
                 cpu_ref: Some(buffer),
             });
-            local_memory_1 = Arc::new(UnsafeLocalMemory::new(ptr as usize, buffer_size));
+            // See the module-level note on `NoKeepalive`.
+            local_memory_1 = Arc::new(KeepaliveLocalMemory::new(
+                ptr as usize,
+                buffer_size,
+                Arc::new(NoKeepalive),
+            ));
             let handle_1 = actor_1
                 .downcast_handle(&instance_1)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -598,7 +620,12 @@ impl IbvTestEnv {
                 .await?;
             rdma_handle_1 = rdma_buf;
             device_ptr_1 = Some(dev_ptr);
-            local_memory_1 = Arc::new(UnsafeLocalMemory::new(dev_ptr, buffer_size));
+            // See the module-level note on `NoKeepalive`.
+            local_memory_1 = Arc::new(KeepaliveLocalMemory::new(
+                dev_ptr,
+                buffer_size,
+                Arc::new(NoKeepalive),
+            ));
 
             buf_vec.push(Buffer {
                 ptr: dev_ptr as u64,
@@ -617,7 +644,12 @@ impl IbvTestEnv {
                 len: buffer.len(),
                 cpu_ref: Some(buffer),
             });
-            local_memory_2 = Arc::new(UnsafeLocalMemory::new(ptr as usize, buffer_size));
+            // See the module-level note on `NoKeepalive`.
+            local_memory_2 = Arc::new(KeepaliveLocalMemory::new(
+                ptr as usize,
+                buffer_size,
+                Arc::new(NoKeepalive),
+            ));
             let handle_2 = actor_2
                 .downcast_handle(&instance_2)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -635,7 +667,12 @@ impl IbvTestEnv {
                 .await?;
             rdma_handle_2 = rdma_buf;
             device_ptr_2 = Some(dev_ptr);
-            local_memory_2 = Arc::new(UnsafeLocalMemory::new(dev_ptr, buffer_size));
+            // See the module-level note on `NoKeepalive`.
+            local_memory_2 = Arc::new(KeepaliveLocalMemory::new(
+                dev_ptr,
+                buffer_size,
+                Arc::new(NoKeepalive),
+            ));
 
             buf_vec.push(Buffer {
                 ptr: dev_ptr as u64,

--- a/monarch_rdma/src/backend/tcp.rs
+++ b/monarch_rdma/src/backend/tcp.rs
@@ -19,14 +19,14 @@ use std::sync::Arc;
 use hyperactor::ActorRef;
 use manager_actor::TcpManagerActor;
 
-use crate::RdmaLocalMemory;
 use crate::RdmaOpType;
+use crate::local_memory::KeepaliveLocalMemory;
 
 /// A single operation for the [`TcpBackend`](manager_actor::TcpBackend).
 #[derive(Debug)]
 pub struct TcpOp {
     pub op_type: RdmaOpType,
-    pub local_memory: Arc<dyn RdmaLocalMemory>,
+    pub local_memory: Arc<KeepaliveLocalMemory>,
     pub remote_tcp_manager: ActorRef<TcpManagerActor>,
     pub remote_buf_id: usize,
 }

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -51,11 +51,11 @@ use tokio_util::sync::CancellationToken;
 use typeuri::Named;
 
 use super::TcpOp;
-use crate::RdmaLocalMemory;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
+use crate::local_memory::KeepaliveLocalMemory;
 use crate::rdma_manager_actor::GetTcpActorRefClient;
 use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::rdma_manager_actor::RdmaManagerMessageClient;
@@ -86,7 +86,7 @@ wirevalue::register_type!(TcpDataChunk);
 #[derive(Debug)]
 struct TransferState {
     /// Buffer backing this transfer, provided at construction.
-    local_memory: Arc<dyn RdmaLocalMemory>,
+    local_memory: Arc<KeepaliveLocalMemory>,
 
     /// Number of chunks received so far.
     chunks_received: usize,
@@ -102,7 +102,7 @@ struct TransferState {
 impl TransferState {
     fn new(
         total_chunks: usize,
-        local_memory: Arc<dyn RdmaLocalMemory>,
+        local_memory: Arc<KeepaliveLocalMemory>,
         done: OncePortRef<Result<(), String>>,
     ) -> Self {
         Self {
@@ -142,7 +142,7 @@ struct TransferError {
 /// a remote TcpManagerActor.
 #[derive(Debug)]
 struct RegisterTransferLocal {
-    local_memory: Arc<dyn RdmaLocalMemory>,
+    local_memory: Arc<KeepaliveLocalMemory>,
     total_chunks: usize,
     done: OncePortRef<Result<(), String>>,
     // The transfer ID
@@ -154,7 +154,7 @@ struct RegisterTransferLocal {
 #[derive(Debug)]
 struct ExecuteTransferLocal {
     transfer_id: usize,
-    local_memory: Arc<dyn RdmaLocalMemory>,
+    local_memory: Arc<KeepaliveLocalMemory>,
     chunk_size: usize,
     dest_addr: ChannelAddr,
 }
@@ -247,7 +247,7 @@ impl TcpManagerActor {
 
     fn register_transfer(
         &mut self,
-        local_memory: Arc<dyn RdmaLocalMemory>,
+        local_memory: Arc<KeepaliveLocalMemory>,
         total_chunks: usize,
         done: OncePortRef<Result<(), String>>,
     ) -> usize {
@@ -264,7 +264,7 @@ impl TcpManagerActor {
         &mut self,
         cx: &Context<Self>,
         transfer_id: usize,
-        local_memory: Arc<dyn RdmaLocalMemory>,
+        local_memory: Arc<KeepaliveLocalMemory>,
         chunk_size: usize,
         dest_addr: ChannelAddr,
     ) -> Result<()> {
@@ -320,7 +320,9 @@ impl TcpManagerActor {
                     let offset = idx * chunk_size;
                     let len = std::cmp::min(chunk_size, size - offset);
                     let mut buf = BytesMut::zeroed(len);
-                    if let Err(e) = mem.read_at(offset, &mut buf) {
+                    // SAFETY: the caller is responsible for ensuring that no other
+                    // component writes the target byte range concurrently.
+                    if let Err(e) = unsafe { mem.read_at(offset, &mut buf) } {
                         error_port
                             .send(
                                 &instance,
@@ -444,7 +446,9 @@ impl Actor for TcpManagerActor {
                     let mut write_offset = chunk.offset;
                     let fragments = chunk.data.into_inner();
                     let write_err = fragments.iter().find_map(|fragment| {
-                        let result = entry.local_memory.write_at(write_offset, fragment);
+                        // SAFETY: the caller is responsible for ensuring that no other
+                        // component reads or writes the target byte range concurrently.
+                        let result = unsafe { entry.local_memory.write_at(write_offset, fragment) };
                         write_offset += fragment.len();
                         result.err()
                     });
@@ -519,7 +523,11 @@ impl TcpManagerMessageHandler for TcpManagerActor {
         };
 
         let bytes = data.into_bytes();
-        if let Err(e) = mem.write_at(offset, &bytes) {
+        // SAFETY: the remote peer that issued this `WriteChunk` had to
+        // register the buffer locally first; its caller is responsible
+        // for ensuring no other component reads or writes the target byte
+        // range concurrently.
+        if let Err(e) = unsafe { mem.write_at(offset, &bytes) } {
             return Ok(Err(e.to_string()));
         }
 
@@ -541,7 +549,11 @@ impl TcpManagerMessageHandler for TcpManagerActor {
         };
 
         let mut buf = BytesMut::zeroed(size);
-        if let Err(e) = mem.read_at(offset, &mut buf) {
+        // SAFETY: the remote peer that issued this `ReadChunk` had to
+        // register the buffer locally first; its caller is responsible
+        // for ensuring no other component writes the target byte range
+        // concurrently.
+        if let Err(e) = unsafe { mem.read_at(offset, &mut buf) } {
             return Ok(Err(e.to_string()));
         }
         Ok(Ok(TcpChunk(Part::from(buf.freeze()))))
@@ -799,7 +811,10 @@ impl TcpBackend {
             let len = std::cmp::min(chunk_size, size - offset);
 
             let mut buf = vec![0u8; len];
-            op.local_memory.read_at(offset, &mut buf)?;
+            // SAFETY: `op.local_memory` is the caller's buffer; that
+            // caller is responsible for excluding external writers
+            // while the `write_from_local` operation is in flight.
+            unsafe { op.local_memory.read_at(offset, &mut buf) }?;
             let data = Part::from(Bytes::from(buf));
 
             tokio_timeout(
@@ -853,7 +868,11 @@ impl TcpBackend {
                 data.len()
             );
 
-            op.local_memory.write_at(offset, &data)?;
+            // SAFETY: `op.local_memory` is the caller's buffer; that
+            // caller is responsible for excluding external readers
+            // and writers while the `read_into_local` operation is in
+            // flight.
+            unsafe { op.local_memory.write_at(offset, &data) }?;
 
             offset += len;
         }
@@ -953,7 +972,6 @@ mod tests {
     use crate::RdmaOpType;
     use crate::backend::RdmaBackend;
     use crate::local_memory::KeepaliveLocalMemory;
-    use crate::local_memory::RdmaLocalMemory;
     use crate::rdma_manager_actor::GetTcpActorRefClient;
     use crate::rdma_manager_actor::RdmaManagerActor;
 
@@ -965,7 +983,7 @@ mod tests {
         instance: hyperactor::Instance<()>,
         tcp_backend: TcpBackend,
         rdma_remote_buf: crate::RdmaRemoteBuffer,
-        local_memory: Arc<dyn RdmaLocalMemory>,
+        local_memory: Arc<KeepaliveLocalMemory>,
     }
 
     impl Drop for TcpTestProcEnv {
@@ -1045,10 +1063,10 @@ mod tests {
             instance: &hyperactor::Instance<()>,
             rdma_handle: &ActorHandle<RdmaManagerActor>,
             buffer_size: usize,
-        ) -> anyhow::Result<(Arc<dyn RdmaLocalMemory>, crate::RdmaRemoteBuffer)> {
+        ) -> anyhow::Result<(Arc<KeepaliveLocalMemory>, crate::RdmaRemoteBuffer)> {
             let cpu_buf = vec![0u8; buffer_size].into_boxed_slice();
             let ptr = cpu_buf.as_ptr() as usize;
-            let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
+            let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
                 ptr,
                 buffer_size,
                 Arc::new(cpu_buf),
@@ -1097,6 +1115,24 @@ mod tests {
 
     // --- Shared test helpers ---
 
+    /// Test-only wrapper around [`KeepaliveLocalMemory::write_at`].
+    ///
+    /// Every [`TcpTestProcEnv`] owns a distinct CPU buffer that no
+    /// other thread accesses outside of explicit, serialized test
+    /// operations, so the safety obligation of `write_at` is trivially
+    /// satisfied across the whole module.
+    fn test_write(mem: &KeepaliveLocalMemory, offset: usize, src: &[u8]) -> anyhow::Result<()> {
+        // SAFETY: see the function-level comment.
+        unsafe { mem.write_at(offset, src) }
+    }
+
+    /// Test-only wrapper around [`KeepaliveLocalMemory::read_at`]. See
+    /// [`test_write`] for the safety rationale.
+    fn test_read(mem: &KeepaliveLocalMemory, offset: usize, dst: &mut [u8]) -> anyhow::Result<()> {
+        // SAFETY: see the function-level comment.
+        unsafe { mem.read_at(offset, dst) }
+    }
+
     /// Fill envs[0], write to envs[1], verify.
     async fn do_write_test(
         envs: &mut [TcpTestProcEnv],
@@ -1107,7 +1143,7 @@ mod tests {
         for (i, byte) in src.iter_mut().enumerate() {
             *byte = (i % 256) as u8;
         }
-        envs[0].local_memory.write_at(0, &src)?;
+        test_write(&envs[0].local_memory, 0, &src)?;
 
         let remote = envs[1].rdma_remote_buf.clone();
         let env = &mut envs[0];
@@ -1124,7 +1160,7 @@ mod tests {
             .await?;
 
         let mut dst = vec![0u8; buf_size];
-        envs[1].local_memory.read_at(0, &mut dst)?;
+        test_read(&envs[1].local_memory, 0, &mut dst)?;
         for (i, byte) in dst.iter().enumerate() {
             assert_eq!(*byte, (i % 256) as u8, "mismatch at offset {i} after write");
         }
@@ -1141,7 +1177,7 @@ mod tests {
         for (i, byte) in src.iter_mut().enumerate() {
             *byte = ((i * 7 + 3) % 256) as u8;
         }
-        envs[1].local_memory.write_at(0, &src)?;
+        test_write(&envs[1].local_memory, 0, &src)?;
 
         let remote = envs[1].rdma_remote_buf.clone();
         let env = &mut envs[0];
@@ -1158,7 +1194,7 @@ mod tests {
             .await?;
 
         let mut dst = vec![0u8; buf_size];
-        envs[0].local_memory.read_at(0, &mut dst)?;
+        test_read(&envs[0].local_memory, 0, &mut dst)?;
         for (i, byte) in dst.iter().enumerate() {
             assert_eq!(
                 *byte,
@@ -1179,7 +1215,7 @@ mod tests {
         for (i, byte) in src.iter_mut().enumerate() {
             *byte = ((i * 13 + 5) % 256) as u8;
         }
-        envs[0].local_memory.write_at(0, &src)?;
+        test_write(&envs[0].local_memory, 0, &src)?;
 
         let remote = envs[1].rdma_remote_buf.clone();
         let env = &mut envs[0];
@@ -1195,7 +1231,7 @@ mod tests {
             )
             .await?;
 
-        envs[0].local_memory.write_at(0, &vec![0u8; buf_size])?;
+        test_write(&envs[0].local_memory, 0, &vec![0u8; buf_size])?;
 
         let env = &mut envs[0];
         env.tcp_backend
@@ -1211,7 +1247,7 @@ mod tests {
             .await?;
 
         let mut dst = vec![0u8; buf_size];
-        envs[0].local_memory.read_at(0, &mut dst)?;
+        test_read(&envs[0].local_memory, 0, &mut dst)?;
         for (i, byte) in dst.iter().enumerate() {
             assert_eq!(
                 *byte,
@@ -1268,7 +1304,7 @@ mod tests {
         for (i, byte) in src.iter_mut().enumerate() {
             *byte = (i % 251) as u8;
         }
-        envs[0].local_memory.write_at(0, &src)?;
+        test_write(&envs[0].local_memory, 0, &src)?;
 
         let remote = envs[1].rdma_remote_buf.clone();
         let env = &mut envs[0];
@@ -1285,7 +1321,7 @@ mod tests {
             .await?;
 
         let mut dst = vec![0u8; buf_size];
-        envs[1].local_memory.read_at(0, &mut dst)?;
+        test_read(&envs[1].local_memory, 0, &mut dst)?;
         for (i, byte) in dst.iter().enumerate() {
             assert_eq!(*byte, (i % 251) as u8, "mismatch at offset {i}");
         }
@@ -1307,7 +1343,7 @@ mod tests {
         for (i, byte) in src.iter_mut().enumerate() {
             *byte = ((i * 3 + 17) % 256) as u8;
         }
-        envs[1].local_memory.write_at(0, &src)?;
+        test_write(&envs[1].local_memory, 0, &src)?;
 
         let remote = envs[1].rdma_remote_buf.clone();
         let env = &mut envs[0];
@@ -1324,7 +1360,7 @@ mod tests {
             .await?;
 
         let mut dst = vec![0u8; buf_size];
-        envs[0].local_memory.read_at(0, &mut dst)?;
+        test_read(&envs[0].local_memory, 0, &mut dst)?;
         for (i, byte) in dst.iter().enumerate() {
             assert_eq!(*byte, ((i * 3 + 17) % 256) as u8, "mismatch at offset {i}");
         }
@@ -1346,7 +1382,7 @@ mod tests {
         for (i, byte) in src.iter_mut().enumerate() {
             *byte = ((i * 41 + 7) % 256) as u8;
         }
-        envs[0].local_memory.write_at(0, &src)?;
+        test_write(&envs[0].local_memory, 0, &src)?;
 
         let remote = envs[1].rdma_remote_buf.clone();
         let env = &mut envs[0];
@@ -1362,7 +1398,7 @@ mod tests {
             )
             .await?;
 
-        envs[0].local_memory.write_at(0, &vec![0u8; buf_size])?;
+        test_write(&envs[0].local_memory, 0, &vec![0u8; buf_size])?;
 
         let env = &mut envs[0];
         env.tcp_backend
@@ -1378,7 +1414,7 @@ mod tests {
             .await?;
 
         let mut dst = vec![0u8; buf_size];
-        envs[0].local_memory.read_at(0, &mut dst)?;
+        test_read(&envs[0].local_memory, 0, &mut dst)?;
         for (i, byte) in dst.iter().enumerate() {
             assert_eq!(
                 *byte,
@@ -1421,7 +1457,7 @@ mod tests {
         for (i, byte) in src.iter_mut().enumerate() {
             *byte = (i % 256) as u8;
         }
-        envs[0].local_memory.write_at(0, &src)?;
+        test_write(&envs[0].local_memory, 0, &src)?;
 
         // Normal write should succeed.
         let remote = envs[1].rdma_remote_buf.clone();
@@ -1578,7 +1614,7 @@ mod tests {
             );
 
             let alloc = CudaAllocator::get().allocate(device, buffer_size, buffer_size);
-            let local_memory: Arc<dyn RdmaLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
+            let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
                 alloc.ptr(),
                 buffer_size,
                 Arc::new(alloc),
@@ -1672,7 +1708,7 @@ mod tests {
         for (i, byte) in src.iter_mut().enumerate() {
             *byte = (i % 256) as u8;
         }
-        envs[0].local_memory.write_at(0, &src)?;
+        test_write(&envs[0].local_memory, 0, &src)?;
         let remote = envs[1].rdma_remote_buf.clone();
         let env = &mut envs[0];
         env.tcp_backend
@@ -1783,12 +1819,12 @@ mod tests {
         for (i, byte) in src0.iter_mut().enumerate() {
             *byte = (i % 256) as u8;
         }
-        envs[0].local_memory.write_at(0, &src0)?;
+        test_write(&envs[0].local_memory, 0, &src0)?;
         let mut src2 = vec![0u8; buf_size];
         for (i, byte) in src2.iter_mut().enumerate() {
             *byte = ((i * 3 + 7) % 256) as u8;
         }
-        envs[2].local_memory.write_at(0, &src2)?;
+        test_write(&envs[2].local_memory, 0, &src2)?;
 
         // Pair 1: envs[0] -> envs[1], Pair 2: envs[2] -> envs[3].
         let remote_1 = envs[1].rdma_remote_buf.clone();
@@ -1823,12 +1859,12 @@ mod tests {
         r2?;
 
         let mut dst1 = vec![0u8; buf_size];
-        envs[1].local_memory.read_at(0, &mut dst1)?;
+        test_read(&envs[1].local_memory, 0, &mut dst1)?;
         for (i, byte) in dst1.iter().enumerate() {
             assert_eq!(*byte, (i % 256) as u8, "pair 1 mismatch at offset {i}");
         }
         let mut dst3 = vec![0u8; buf_size];
-        envs[3].local_memory.read_at(0, &mut dst3)?;
+        test_read(&envs[3].local_memory, 0, &mut dst3)?;
         for (i, byte) in dst3.iter().enumerate() {
             assert_eq!(
                 *byte,
@@ -1856,12 +1892,12 @@ mod tests {
         for (i, byte) in src1.iter_mut().enumerate() {
             *byte = ((i * 11 + 3) % 256) as u8;
         }
-        envs[1].local_memory.write_at(0, &src1)?;
+        test_write(&envs[1].local_memory, 0, &src1)?;
         let mut src3 = vec![0u8; buf_size];
         for (i, byte) in src3.iter_mut().enumerate() {
             *byte = ((i * 5 + 13) % 256) as u8;
         }
-        envs[3].local_memory.write_at(0, &src3)?;
+        test_write(&envs[3].local_memory, 0, &src3)?;
 
         // Pair 1: envs[0] <- envs[1], Pair 2: envs[2] <- envs[3].
         let remote_1 = envs[1].rdma_remote_buf.clone();
@@ -1896,7 +1932,7 @@ mod tests {
         r2?;
 
         let mut dst0 = vec![0u8; buf_size];
-        envs[0].local_memory.read_at(0, &mut dst0)?;
+        test_read(&envs[0].local_memory, 0, &mut dst0)?;
         for (i, byte) in dst0.iter().enumerate() {
             assert_eq!(
                 *byte,
@@ -1905,7 +1941,7 @@ mod tests {
             );
         }
         let mut dst2 = vec![0u8; buf_size];
-        envs[2].local_memory.read_at(0, &mut dst2)?;
+        test_read(&envs[2].local_memory, 0, &mut dst2)?;
         for (i, byte) in dst2.iter().enumerate() {
             assert_eq!(
                 *byte,
@@ -1933,12 +1969,12 @@ mod tests {
         for (i, byte) in src0.iter_mut().enumerate() {
             *byte = (i % 256) as u8;
         }
-        envs[0].local_memory.write_at(0, &src0)?;
+        test_write(&envs[0].local_memory, 0, &src0)?;
         let mut src3 = vec![0u8; buf_size];
         for (i, byte) in src3.iter_mut().enumerate() {
             *byte = ((i * 7 + 13) % 256) as u8;
         }
-        envs[3].local_memory.write_at(0, &src3)?;
+        test_write(&envs[3].local_memory, 0, &src3)?;
 
         // Write envs[0] -> envs[1], read envs[2] <- envs[3] concurrently.
         let remote_1 = envs[1].rdma_remote_buf.clone();
@@ -1973,12 +2009,12 @@ mod tests {
         read_result?;
 
         let mut dst1 = vec![0u8; buf_size];
-        envs[1].local_memory.read_at(0, &mut dst1)?;
+        test_read(&envs[1].local_memory, 0, &mut dst1)?;
         for (i, byte) in dst1.iter().enumerate() {
             assert_eq!(*byte, (i % 256) as u8, "write mismatch at offset {i}");
         }
         let mut dst2 = vec![0u8; buf_size];
-        envs[2].local_memory.read_at(0, &mut dst2)?;
+        test_read(&envs[2].local_memory, 0, &mut dst2)?;
         for (i, byte) in dst2.iter().enumerate() {
             assert_eq!(
                 *byte,

--- a/monarch_rdma/src/lib.rs
+++ b/monarch_rdma/src/lib.rs
@@ -11,7 +11,7 @@
 
 use std::sync::Arc;
 
-use local_memory::RdmaLocalMemory;
+use local_memory::KeepaliveLocalMemory;
 use serde::Deserialize;
 use serde::Serialize;
 
@@ -56,7 +56,7 @@ pub enum RdmaOpType {
 #[derive(Debug)]
 pub struct RdmaOp {
     pub op_type: RdmaOpType,
-    pub local: Arc<dyn RdmaLocalMemory>,
+    pub local: Arc<KeepaliveLocalMemory>,
     pub remote: RdmaRemoteBuffer,
 }
 

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -8,19 +8,13 @@
 
 //! Local memory abstractions for RDMA operations.
 //!
-//! This module defines the [`RdmaLocalMemory`] trait and its implementations:
-//!
-//! - [`KeepaliveLocalMemory`] – wraps a raw pointer with a keepalive guard
-//!   and dispatches reads/writes to CPU or CUDA paths.
-//! - [`UnsafeLocalMemory`] – raw pointer-based handle where the caller is
-//!   responsible for lifetime management.
+//! [`KeepaliveLocalMemory`] wraps a raw pointer with a [`Keepalive`]
+//! guard and dispatches reads/writes to CPU or CUDA paths.
 
 use std::fmt::Debug;
 use std::sync::Arc;
-use std::sync::RwLock;
-
-use serde::Deserialize;
-use serde::Serialize;
+use std::sync::Condvar;
+use std::sync::Mutex;
 
 /// Returns `true` when `addr` is a CUDA device pointer.
 ///
@@ -131,24 +125,6 @@ pub(crate) unsafe fn set_ctx_for_ptr(addr: usize) -> Result<CudaCtxGuard, anyhow
     })
 }
 
-/// Handle to a contiguous region of local memory.
-///
-/// Implementations must guarantee the underlying allocation is valid for the
-/// lifetime of the implementor.
-pub trait RdmaLocalMemory: Send + Sync + Debug {
-    /// Starting virtual address of the memory region.
-    fn addr(&self) -> usize;
-
-    /// Size of the memory region in bytes.
-    fn size(&self) -> usize;
-
-    /// Copy `dst.len()` bytes from this memory region starting at `offset` into `dst`.
-    fn read_at(&self, offset: usize, dst: &mut [u8]) -> Result<(), anyhow::Error>;
-
-    /// Copy `src.len()` bytes from `src` into this memory region starting at `offset`.
-    fn write_at(&self, offset: usize, src: &[u8]) -> Result<(), anyhow::Error>;
-}
-
 /// Verify that an access at `offset` with `len` bytes fits within `size`.
 fn check_bounds(offset: usize, len: usize, size: usize) -> Result<(), anyhow::Error> {
     anyhow::ensure!(
@@ -226,6 +202,134 @@ unsafe fn write_gpu(addr: usize, offset: usize, src: &[u8]) -> Result<(), anyhow
     Ok(())
 }
 
+/// Three-mode access lock used by [`KeepaliveLocalMemory`] to coordinate
+/// concurrent reads, exclusive writes, and parallel "disjoint" writes
+/// (writers that the caller has promised target disjoint ranges).
+///
+/// - [`AccessLock::read`] returns when no exclusive writer and no
+///   disjoint writer is active. Multiple readers are permitted to hold
+///   the lock at the same time.
+/// - [`AccessLock::disjoint_write`] returns when no reader and no
+///   exclusive writer is active. Multiple disjoint writers are
+///   permitted to hold the lock at the same time.
+/// - [`AccessLock::exclusive`] returns only when no one else holds the
+///   lock.
+///
+/// Read mode and disjoint-write mode are mutually exclusive, which is
+/// what gives readers a torn-free view of memory in the presence of
+/// disjoint parallel writers.
+#[derive(Debug, Default)]
+struct AccessLock {
+    state: Mutex<AccessState>,
+    cond: Condvar,
+}
+
+#[derive(Debug, Default)]
+enum AccessState {
+    #[default]
+    Idle,
+    Reading(usize),
+    DisjointWriting(usize),
+    Exclusive,
+}
+
+impl AccessLock {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn read(&self) -> AccessReadGuard<'_> {
+        let mut state = self.state.lock().expect("AccessLock poisoned");
+        loop {
+            match &mut *state {
+                AccessState::Idle => {
+                    *state = AccessState::Reading(1);
+                    return AccessReadGuard(self);
+                }
+                AccessState::Reading(n) => {
+                    *n += 1;
+                    return AccessReadGuard(self);
+                }
+                AccessState::DisjointWriting(_) | AccessState::Exclusive => {
+                    state = self.cond.wait(state).expect("AccessLock poisoned");
+                }
+            }
+        }
+    }
+
+    fn disjoint_write(&self) -> AccessDisjointWriteGuard<'_> {
+        let mut state = self.state.lock().expect("AccessLock poisoned");
+        loop {
+            match &mut *state {
+                AccessState::Idle => {
+                    *state = AccessState::DisjointWriting(1);
+                    return AccessDisjointWriteGuard(self);
+                }
+                AccessState::DisjointWriting(n) => {
+                    *n += 1;
+                    return AccessDisjointWriteGuard(self);
+                }
+                AccessState::Reading(_) | AccessState::Exclusive => {
+                    state = self.cond.wait(state).expect("AccessLock poisoned");
+                }
+            }
+        }
+    }
+
+    fn exclusive(&self) -> AccessExclusiveGuard<'_> {
+        let mut state = self.state.lock().expect("AccessLock poisoned");
+        loop {
+            if matches!(*state, AccessState::Idle) {
+                *state = AccessState::Exclusive;
+                return AccessExclusiveGuard(self);
+            }
+            state = self.cond.wait(state).expect("AccessLock poisoned");
+        }
+    }
+}
+
+struct AccessReadGuard<'a>(&'a AccessLock);
+impl Drop for AccessReadGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock().expect("AccessLock poisoned");
+        match &mut *state {
+            AccessState::Reading(1) => {
+                *state = AccessState::Idle;
+                self.0.cond.notify_all();
+            }
+            AccessState::Reading(n) => *n -= 1,
+            other => unreachable!("AccessReadGuard dropped in non-Reading state: {other:?}"),
+        }
+    }
+}
+
+struct AccessDisjointWriteGuard<'a>(&'a AccessLock);
+impl Drop for AccessDisjointWriteGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock().expect("AccessLock poisoned");
+        match &mut *state {
+            AccessState::DisjointWriting(1) => {
+                *state = AccessState::Idle;
+                self.0.cond.notify_all();
+            }
+            AccessState::DisjointWriting(n) => *n -= 1,
+            other => unreachable!(
+                "AccessDisjointWriteGuard dropped in non-DisjointWriting state: {other:?}"
+            ),
+        }
+    }
+}
+
+struct AccessExclusiveGuard<'a>(&'a AccessLock);
+impl Drop for AccessExclusiveGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.0.state.lock().expect("AccessLock poisoned");
+        debug_assert!(matches!(*state, AccessState::Exclusive));
+        *state = AccessState::Idle;
+        self.0.cond.notify_all();
+    }
+}
+
 /// Marker trait: the implementor keeps a backing memory allocation alive.
 ///
 /// As long as a value implementing this trait exists, the memory region
@@ -240,6 +344,15 @@ impl Keepalive for Box<[u8]> {}
 ///
 /// Detects at construction time whether the address is a CUDA device
 /// pointer and dispatches `read_at`/`write_at` accordingly.
+///
+/// All three access methods are `unsafe`: the [`Keepalive`] only
+/// guarantees the allocation stays mapped, not that this handle has
+/// unique ownership. The internal [`AccessLock`] coordinates concurrent
+/// callers that share the same clone of this handle (readers run in
+/// parallel, exclusive writers run alone, disjoint writers run in
+/// parallel with one another but exclude readers and exclusive
+/// writers), but callers must additionally rule out concurrent access
+/// through other views of the same allocation.
 ///
 /// The `direct_access_host_bandwidth` and `direct_access_device_bandwidth`
 /// fields indicate the speed of reading the memory via pointer dereference
@@ -256,7 +369,9 @@ pub struct KeepaliveLocalMemory {
     /// `None` if the memory is not device-accessible.
     direct_access_device_bandwidth: Option<u64>,
     _keepalive: Arc<dyn Keepalive>,
-    guard: Arc<RwLock<()>>,
+    /// Coordinates concurrent reads, exclusive writes, and parallel
+    /// disjoint writes against this region.
+    access: Arc<AccessLock>,
 }
 
 impl Debug for KeepaliveLocalMemory {
@@ -293,25 +408,46 @@ impl KeepaliveLocalMemory {
             direct_access_host_bandwidth: host_bw,
             direct_access_device_bandwidth: device_bw,
             _keepalive: keepalive,
-            guard: Arc::new(RwLock::new(())),
+            access: Arc::new(AccessLock::new()),
         }
     }
-}
 
-impl RdmaLocalMemory for KeepaliveLocalMemory {
-    fn addr(&self) -> usize {
+    /// Starting virtual address of the memory region.
+    pub fn addr(&self) -> usize {
         self.addr
     }
 
-    fn size(&self) -> usize {
+    /// Size of the memory region in bytes.
+    pub fn size(&self) -> usize {
         self.size
     }
 
-    fn read_at(&self, offset: usize, dst: &mut [u8]) -> Result<(), anyhow::Error> {
-        let _lock = self.guard.read().expect("lock poisoned");
+    /// Copy `dst.len()` bytes from this memory region starting at `offset`
+    /// into `dst`.
+    ///
+    /// Mutually exclusive with both `write_at` and `write_at_disjoint`
+    /// *across clones of this handle*: the [`AccessLock`] guarantees a
+    /// reader and any writer (exclusive or disjoint) that share the
+    /// same lock never observe each other's partial state. Multiple
+    /// concurrent `read_at` calls on shared clones are permitted and
+    /// run in parallel.
+    ///
+    /// # Safety
+    ///
+    /// The [`Keepalive`] guarantees the allocation stays mapped, but it
+    /// does *not* imply unique ownership: another component may hold its
+    /// own view of the same allocation and read or write it concurrently
+    /// outside this handle's [`AccessLock`]. The caller must ensure that
+    /// no such external access produces a torn read of
+    /// `offset..offset + dst.len()` for the duration of this call.
+    pub unsafe fn read_at(&self, offset: usize, dst: &mut [u8]) -> Result<(), anyhow::Error> {
+        let _guard = self.access.read();
         check_bounds(offset, dst.len(), self.size)?;
-        // SAFETY: The keepalive guard guarantees the allocation is live, and
-        // check_bounds verified the access is in range.
+        // SAFETY: the `_keepalive` field keeps the allocation live, the
+        // read guard above excludes concurrent exclusive and disjoint
+        // writers that share this lock, `check_bounds` verified the access
+        // is in range, and the caller upholds the no-external-writer
+        // obligation documented on this method.
         unsafe {
             if self.direct_access_host_bandwidth.is_some() {
                 read_cpu(self.addr, offset, dst);
@@ -322,11 +458,28 @@ impl RdmaLocalMemory for KeepaliveLocalMemory {
         }
     }
 
-    fn write_at(&self, offset: usize, src: &[u8]) -> Result<(), anyhow::Error> {
-        let _lock = self.guard.write().expect("lock poisoned");
+    /// Copy `src.len()` bytes from `src` into this memory region starting
+    /// at `offset`.
+    ///
+    /// Mutually exclusive with every other read and write against this
+    /// region *across clones of this handle*: the [`AccessLock`] blocks
+    /// concurrent readers and writers that share the same lock. Use
+    /// [`KeepaliveLocalMemory::write_at_disjoint`] when multiple writers
+    /// can be proven to target disjoint byte ranges.
+    ///
+    /// # Safety
+    ///
+    /// See [`KeepaliveLocalMemory::read_at`]. The [`Keepalive`] guarantee
+    /// covers liveness only; the caller must ensure no concurrent
+    /// external reader or writer observes an overlapping byte range.
+    pub unsafe fn write_at(&self, offset: usize, src: &[u8]) -> Result<(), anyhow::Error> {
+        let _guard = self.access.exclusive();
         check_bounds(offset, src.len(), self.size)?;
-        // SAFETY: The keepalive guard guarantees the allocation is live, and
-        // check_bounds verified the access is in range.
+        // SAFETY: the `_keepalive` field keeps the allocation live, the
+        // exclusive guard above excludes every other reader and writer
+        // that shares this lock, `check_bounds` verified the access is
+        // in range, and the caller upholds the no-external-access
+        // obligation documented on this method.
         unsafe {
             if self.direct_access_host_bandwidth.is_some() {
                 write_cpu(self.addr, offset, src);
@@ -336,59 +489,35 @@ impl RdmaLocalMemory for KeepaliveLocalMemory {
             }
         }
     }
-}
 
-/// Raw pointer-based local memory handle that supports both CPU and GPU memory.
-///
-/// Wraps a virtual address and size. The caller is responsible for
-/// ensuring the underlying allocation outlives this handle. Uses
-/// `is_device_ptr` to dispatch reads/writes to the appropriate CPU or CUDA
-/// path, just like [`KeepaliveLocalMemory`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct UnsafeLocalMemory {
-    pub addr: usize,
-    pub size: usize,
-}
-
-impl UnsafeLocalMemory {
-    pub fn new(addr: usize, size: usize) -> Self {
-        Self { addr, size }
-    }
-}
-
-impl RdmaLocalMemory for UnsafeLocalMemory {
-    fn addr(&self) -> usize {
-        self.addr
-    }
-
-    fn size(&self) -> usize {
-        self.size
-    }
-
-    fn read_at(&self, offset: usize, dst: &mut [u8]) -> Result<(), anyhow::Error> {
-        check_bounds(offset, dst.len(), self.size)?;
-        // SAFETY: The caller is responsible for ensuring the allocation is
-        // live; check_bounds verified the access is in range.
-        unsafe {
-            if is_device_ptr(self.addr) {
-                read_gpu(self.addr, offset, dst)
-            } else {
-                read_cpu(self.addr, offset, dst);
-                Ok(())
-            }
-        }
-    }
-
-    fn write_at(&self, offset: usize, src: &[u8]) -> Result<(), anyhow::Error> {
+    /// Like [`KeepaliveLocalMemory::write_at`], but allows other
+    /// concurrent `write_at_disjoint` calls (across clones of this
+    /// handle) to proceed in parallel. Still mutually exclusive with
+    /// `read_at` and `write_at` through the [`AccessLock`].
+    ///
+    /// # Safety
+    ///
+    /// In addition to the obligations of
+    /// [`KeepaliveLocalMemory::write_at`] (no external concurrent
+    /// reader or writer of the same byte range), the caller must
+    /// ensure that no other concurrent call to this method targets a
+    /// byte range that overlaps `offset..offset + src.len()`. Disjoint
+    /// byte ranges across concurrent disjoint callers are sound.
+    pub unsafe fn write_at_disjoint(&self, offset: usize, src: &[u8]) -> Result<(), anyhow::Error> {
+        let _guard = self.access.disjoint_write();
         check_bounds(offset, src.len(), self.size)?;
-        // SAFETY: The caller is responsible for ensuring the allocation is
-        // live; check_bounds verified the access is in range.
+        // SAFETY: the `_keepalive` field keeps the allocation live, the
+        // disjoint-write guard above excludes concurrent readers and
+        // exclusive writers that share this lock, `check_bounds`
+        // verified the access is in range, and the caller upholds both
+        // safety obligations documented on this method (no external access,
+        // no overlap with other concurrent disjoint writers).
         unsafe {
-            if is_device_ptr(self.addr) {
-                write_gpu(self.addr, offset, src)
-            } else {
+            if self.direct_access_host_bandwidth.is_some() {
                 write_cpu(self.addr, offset, src);
                 Ok(())
+            } else {
+                write_gpu(self.addr, offset, src)
             }
         }
     }
@@ -410,16 +539,21 @@ mod tests {
     fn keepalive_host_read_at() {
         let mem = host_keepalive_mem(Box::from([1, 2, 3, 4, 5]));
         let mut buf = [0u8; 3];
-        mem.read_at(1, &mut buf).unwrap();
+        // SAFETY: `mem` is the sole handle to the allocation, no other
+        // thread or component holds a view of it.
+        unsafe { mem.read_at(1, &mut buf) }.unwrap();
         assert_eq!(buf, [2, 3, 4]);
     }
 
     #[test]
     fn keepalive_host_write_then_read() {
         let mem = host_keepalive_mem(vec![0; 5].into_boxed_slice());
-        mem.write_at(1, &[7, 8, 9]).unwrap();
+        // SAFETY: `mem` is the sole handle to the allocation, no other
+        // thread or component holds a view of it.
+        unsafe { mem.write_at(1, &[7, 8, 9]) }.unwrap();
         let mut buf = [0u8; 5];
-        mem.read_at(0, &mut buf).unwrap();
+        // SAFETY: same as above.
+        unsafe { mem.read_at(0, &mut buf) }.unwrap();
         assert_eq!(buf, [0, 7, 8, 9, 0]);
     }
 
@@ -427,7 +561,10 @@ mod tests {
     fn keepalive_host_out_of_bounds() {
         let mem = host_keepalive_mem(vec![0; 3].into_boxed_slice());
         let mut buf = [0u8; 3];
-        assert!(mem.read_at(1, &mut buf).is_err());
-        assert!(mem.write_at(1, &[7, 8, 9]).is_err());
+        // SAFETY: `mem` is the sole handle to the allocation; the
+        // bounds check fires before any pointer dereference.
+        assert!(unsafe { mem.read_at(1, &mut buf) }.is_err());
+        // SAFETY: same as above.
+        assert!(unsafe { mem.write_at(1, &[7, 8, 9]) }.is_err());
     }
 }

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -63,7 +63,7 @@ use crate::backend::ibverbs::manager_actor::IbvBackend;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
 use crate::backend::tcp::manager_actor::TcpBackend;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
-use crate::local_memory::RdmaLocalMemory;
+use crate::local_memory::KeepaliveLocalMemory;
 
 /// Lightweight handle representing a registered RDMA buffer.
 ///
@@ -138,7 +138,7 @@ impl RdmaRemoteBuffer {
     pub async fn write_from_local(
         &self,
         client: &(impl context::Actor + Send + Sync),
-        local: Arc<dyn RdmaLocalMemory>,
+        local: Arc<KeepaliveLocalMemory>,
         timeout: u64,
     ) -> Result<bool, anyhow::Error> {
         let mut backend = self.choose_backend(client).await?;
@@ -160,7 +160,7 @@ impl RdmaRemoteBuffer {
     pub async fn read_into_local(
         &self,
         client: &(impl context::Actor + Send + Sync),
-        local: Arc<dyn RdmaLocalMemory>,
+        local: Arc<KeepaliveLocalMemory>,
         timeout: u64,
     ) -> Result<bool, anyhow::Error> {
         let mut backend = self.choose_backend(client).await?;

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -15,7 +15,7 @@
 //! ## Responsibilities
 //!
 //! - Assigns a unique `remote_buf_id` to each registered local memory handle
-//!   and stores the `Arc<dyn RdmaLocalMemory>` for later retrieval.
+//!   and stores the `Arc<KeepaliveLocalMemory>` for later retrieval.
 //! - Produces [`RdmaRemoteBuffer`] tokens that can be sent to remote peers so
 //!   they can address this buffer over RDMA.
 //! - Delegates MR registration, QP management, and data movement to the
@@ -51,7 +51,7 @@ use crate::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
 use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
 use crate::backend::ibverbs::primitives::IbvConfig;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
-use crate::local_memory::RdmaLocalMemory;
+use crate::local_memory::KeepaliveLocalMemory;
 use crate::rdma_components::RdmaRemoteBuffer;
 
 /// Helper function to get detailed error messages from RDMAXCEL error codes
@@ -66,14 +66,14 @@ pub fn get_rdmaxcel_error_message(error_code: i32) -> String {
 
 /// Local-only messages for the [`RdmaManagerActor`].
 ///
-/// These messages carry `Arc<dyn RdmaLocalMemory>` and are therefore
+/// These messages carry `Arc<KeepaliveLocalMemory>` and are therefore
 /// not serializable -- they can only be sent within the same process.
 #[derive(Handler, HandleClient, Debug)]
 pub enum RdmaManagerMessage {
     /// Register a local memory handle and return a [`RdmaRemoteBuffer`] that
     /// remote peers can use to address this buffer over RDMA.
     RequestBuffer {
-        local: Arc<dyn RdmaLocalMemory>,
+        local: Arc<KeepaliveLocalMemory>,
         #[reply]
         reply: OncePortHandle<RdmaRemoteBuffer>,
     },
@@ -82,7 +82,7 @@ pub enum RdmaManagerMessage {
     RequestLocalMemory {
         remote_buf_id: usize,
         #[reply]
-        reply: OncePortHandle<Option<Arc<dyn RdmaLocalMemory>>>,
+        reply: OncePortHandle<Option<Arc<KeepaliveLocalMemory>>>,
     },
 }
 
@@ -154,7 +154,7 @@ impl<A: Actor> RdmaBackendActor<A> {
 #[hyperactor::spawnable]
 pub struct RdmaManagerActor {
     next_remote_buf_id: usize,
-    buffers: HashMap<usize, Arc<dyn RdmaLocalMemory>>,
+    buffers: HashMap<usize, Arc<KeepaliveLocalMemory>>,
     ibverbs: Option<RdmaBackendActor<IbvManagerActor>>,
     tcp: RdmaBackendActor<TcpManagerActor>,
 }
@@ -284,7 +284,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     async fn request_buffer(
         &mut self,
         cx: &Context<Self>,
-        local: Arc<dyn RdmaLocalMemory>,
+        local: Arc<KeepaliveLocalMemory>,
     ) -> Result<RdmaRemoteBuffer, anyhow::Error> {
         let remote_buf_id = self.next_remote_buf_id;
         self.next_remote_buf_id += 1;
@@ -320,7 +320,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         &mut self,
         _cx: &Context<Self>,
         remote_buf_id: usize,
-    ) -> Result<Option<Arc<dyn RdmaLocalMemory>>, anyhow::Error> {
+    ) -> Result<Option<Arc<KeepaliveLocalMemory>>, anyhow::Error> {
         Ok(self.buffers.get(&remote_buf_id).cloned())
     }
 }


### PR DESCRIPTION
Summary:

Make `KeepaliveLocalMemory` the only local-memory handle and tighten its concurrency contract.

The `RdmaLocalMemory` trait and `UnsafeLocalMemory` are gone. Every RDMA path in `monarch_rdma` takes `Arc<KeepaliveLocalMemory>` directly; this removes the dyn-dispatch indirection and gives the implementation a single concrete handle to reason about. In fact, the correctness of the RDMA implementation *already* relied on the assumption of keepalive behavior -- this commit merely makes it explicit.

`KeepaliveLocalMemory` gains an inherent two-layer concurrency model:

- An internal `AccessLock` (three modes: shared reads, shared "disjoint" writes, exclusive writes) coordinates concurrent callers across clones of the same handle. Read and disjoint-write modes are mutually exclusive, which is what gives readers a torn-free view in the presence of parallel writers.
- `read_at`/`write_at`/`write_at_disjoint` are all `unsafe fn`. The `Keepalive` only guarantees the allocation stays mapped — it does not imply unique ownership — so the caller must additionally rule out concurrent external access through any other view of the same byte range. SAFETY comments at every callsite pin that obligation on the appropriate actor (RDMA buffer registrant, Python caller under the GIL, test harness).

`write_at_disjoint` is a new method exposing the parallel-disjoint-writer mode through the AccessLock; the receive side of the TCP backend can adopt it for fragmented writes (no functional change in this commit; the TCP receive loop still uses `write_at`).

The `monarch_rdma` examples (`parameter_server`, `cuda_ping_pong`) and `ibverbs/test_utils.rs` retain a transient `NoKeepalive` marker that satisfies the trait's lifetime slot without actually owning the allocation. Each site carries a loud `HACK` comment and a `TODO(samlurye)` to convert it to a real keepalive soon. The actual implementations remain unchanged, so if they were correct before, then they are still correct now; refactoring them to use true `Keepalive` implementations would make this PR too large.

Differential Revision: D105381660


