### PR TITLE
fix build_utils Cargo build

### DIFF
--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 [dependencies]
 cc = "1.2.60"
 glob = "0.3.2"
-pyo3-build-config = "0.26"
+pyo3-build-config = { version = "0.26", features = ["resolve-config"] }
 which = "8.0.2"

--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -349,10 +349,10 @@ pub fn link_libstdcpp_static() {
                 None
             }
         });
-    if let Some(gcc_lib_path) = gcc_lib_path {
-        if !gcc_lib_path.as_os_str().is_empty() {
-            println!("cargo:rustc-link-search=native={}", gcc_lib_path.display());
-        }
+    if let Some(gcc_lib_path) = gcc_lib_path
+        && !gcc_lib_path.as_os_str().is_empty()
+    {
+        println!("cargo:rustc-link-search=native={}", gcc_lib_path.display());
     }
     println!("cargo:rustc-link-lib=static=stdc++");
 }
@@ -519,9 +519,13 @@ mod tests {
 
     #[test]
     fn test_find_cuda_home_env_var() {
-        env::set_var("CUDA_HOME", "/test/cuda");
+        // SAFETY: this is the only test in the crate that touches CUDA_HOME,
+        // and `find_cuda_home` is not invoked concurrently from any other
+        // test, so no other thread races on the variable.
+        unsafe { env::set_var("CUDA_HOME", "/test/cuda") };
         let result = find_cuda_home();
-        env::remove_var("CUDA_HOME");
+        // SAFETY: same as above.
+        unsafe { env::remove_var("CUDA_HOME") };
         assert_eq!(result, Some("/test/cuda".to_string()));
     }
 


### PR DESCRIPTION
Summary:
`cargo clippy --workspace --all-targets` from `fbcode/monarch` fails on `build_utils` with two errors:

1. `pyo3_build_config::get()` is gated behind the `resolve-config` feature, but the autocargo-generated `build_utils/Cargo.toml` carries `pyo3-build-config = "0.26"` with no features.
2. `env::set_var` and `env::remove_var` in  test_find_cuda_home_env_var` require `unsafe` under Rust 2024 edition.

neither surfaces in CI. CI runs `cargo nextest run --workspace`, which only ever compiles `build_utils` as a build-dependency of other crates' `build.rs` files; in that context `pyo3` (also a build-dep) requests `pyo3-build-config = { features = ["resolve-config"] }` and the resolver unifies features within the build-dep graph, so `get()` resolves. `[lib] test = false` plus `unittests = False` in BUCK keep the test module out of every CI lane. the bugs only appear when something selects `build_utils` directly as a normal target, which `cargo clippy --workspace --all-targets` does.

fix: add `autocargo.cargo_toml_config.dependencies_override` in `build_utils/BUCK` to set `features = ["resolve-config"]` on `pyo3-build-config`, regenerate via `autocargo --project monarch`, and wrap the two `env` calls in `unsafe` blocks with `SAFETY` comments.

Differential Revision: D105384318


