### PR TITLE
Apply cargo clippy --fix across workspace

### DIFF
--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 [dependencies]
 cc = "1.2.60"
 glob = "0.3.2"
-pyo3-build-config = "0.26"
+pyo3-build-config = { version = "0.26", features = ["resolve-config"] }
 which = "8.0.2"

--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -349,10 +349,10 @@ pub fn link_libstdcpp_static() {
                 None
             }
         });
-    if let Some(gcc_lib_path) = gcc_lib_path {
-        if !gcc_lib_path.as_os_str().is_empty() {
-            println!("cargo:rustc-link-search=native={}", gcc_lib_path.display());
-        }
+    if let Some(gcc_lib_path) = gcc_lib_path
+        && !gcc_lib_path.as_os_str().is_empty()
+    {
+        println!("cargo:rustc-link-search=native={}", gcc_lib_path.display());
     }
     println!("cargo:rustc-link-lib=static=stdc++");
 }
@@ -519,9 +519,13 @@ mod tests {
 
     #[test]
     fn test_find_cuda_home_env_var() {
-        env::set_var("CUDA_HOME", "/test/cuda");
+        // SAFETY: this is the only test in the crate that touches CUDA_HOME,
+        // and `find_cuda_home` is not invoked concurrently from any other
+        // test, so no other thread races on the variable.
+        unsafe { env::set_var("CUDA_HOME", "/test/cuda") };
         let result = find_cuda_home();
-        env::remove_var("CUDA_HOME");
+        // SAFETY: same as above.
+        unsafe { env::remove_var("CUDA_HOME") };
         assert_eq!(result, Some("/test/cuda".to_string()));
     }
 

--- a/build_utils/src/rocm.rs
+++ b/build_utils/src/rocm.rs
@@ -29,10 +29,10 @@ use crate::get_env_var_with_rerun;
 /// 3. Finding hipcc in PATH and resolving symlinks
 pub fn validate_rocm_installation() -> Result<String, BuildError> {
     // Try ROCM_PATH environment variable first
-    if let Ok(rocm_path) = get_env_var_with_rerun("ROCM_PATH") {
-        if Path::new(&rocm_path).join("bin/hipcc").exists() {
-            return Ok(rocm_path);
-        }
+    if let Ok(rocm_path) = get_env_var_with_rerun("ROCM_PATH")
+        && Path::new(&rocm_path).join("bin/hipcc").exists()
+    {
+        return Ok(rocm_path);
     }
 
     // Try default location /opt/rocm (handles versioned installs like /opt/rocm-7.1.1 via symlink)
@@ -48,10 +48,10 @@ pub fn validate_rocm_installation() -> Result<String, BuildError> {
     // Try finding hipcc in PATH and resolving symlinks
     if let Ok(hipcc_path) = which("hipcc") {
         // Resolve symlinks to get the real path
-        if let Ok(real_hipcc) = fs::canonicalize(&hipcc_path) {
-            if let Some(rocm_home) = real_hipcc.parent().and_then(|p| p.parent()) {
-                return Ok(rocm_home.to_string_lossy().to_string());
-            }
+        if let Ok(real_hipcc) = fs::canonicalize(&hipcc_path)
+            && let Some(rocm_home) = real_hipcc.parent().and_then(|p| p.parent())
+        {
+            return Ok(rocm_home.to_string_lossy().to_string());
         }
     }
 
@@ -67,17 +67,17 @@ pub fn get_rocm_version(rocm_home: &str) -> Result<(u32, u32), BuildError> {
     if let Ok(content) = fs::read_to_string(&version_file) {
         // Parse version like "6.0.2" or "7.0.0"
         let parts: Vec<&str> = content.trim().split('.').collect();
-        if parts.len() >= 2 {
-            if let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
-                // Enforce ROCm 7.0+ requirement
-                if major < 7 {
-                    return Err(BuildError::CommandFailed(format!(
-                        "ROCm {}.{} detected, but ROCm 7.0+ is required",
-                        major, minor
-                    )));
-                }
-                return Ok((major, minor));
+        if parts.len() >= 2
+            && let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>())
+        {
+            // Enforce ROCm 7.0+ requirement
+            if major < 7 {
+                return Err(BuildError::CommandFailed(format!(
+                    "ROCm {}.{} detected, but ROCm 7.0+ is required",
+                    major, minor
+                )));
             }
+            return Ok((major, minor));
         }
     }
 

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -231,7 +231,7 @@ async fn channel_ping_pong(
         });
 
     let start = Instant::now();
-    let _ = client_handle.await.unwrap().unwrap();
+    client_handle.await.unwrap().unwrap();
     start.elapsed()
 }
 

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -281,7 +281,7 @@ impl<A: Actor> Handler<Undeliverable<MessageEnvelope>> for A {
     ) -> Result<(), anyhow::Error> {
         let sender = message.0.sender().clone();
         let dest = message.0.dest().clone();
-        let error = message.0.error_msg().unwrap_or(String::new());
+        let error = message.0.error_msg().unwrap_or_default();
         match self.handle_undeliverable_message(cx, message).await {
             Ok(_) => {
                 tracing::debug!(

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -215,16 +215,16 @@ impl<M: RemoteMessage> MpscTx<M> {
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for MpscTx<M> {
     fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        if let Err(mpsc::error::SendError(message)) = self.tx.send(message) {
-            if let Some(return_channel) = return_channel {
-                return_channel
-                    .send(SendError {
-                        error: ChannelError::Closed,
-                        message,
-                        reason: None,
-                    })
-                    .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
-            }
+        if let Err(mpsc::error::SendError(message)) = self.tx.send(message)
+            && let Some(return_channel) = return_channel
+        {
+            return_channel
+                .send(SendError {
+                    error: ChannelError::Closed,
+                    message,
+                    reason: None,
+                })
+                .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
         }
     }
 

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -118,16 +118,16 @@ impl<M: RemoteMessage> Tx<M> for LocalTx<M> {
                 return;
             }
         };
-        if self.tx.send(data).is_err() {
-            if let Some(return_channel) = return_channel {
-                return_channel
-                    .send(SendError {
-                        error: ChannelError::Closed,
-                        message,
-                        reason: None,
-                    })
-                    .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
-            }
+        if self.tx.send(data).is_err()
+            && let Some(return_channel) = return_channel
+        {
+            return_channel
+                .send(SendError {
+                    error: ChannelError::Closed,
+                    message,
+                    reason: None,
+                })
+                .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
         }
     }
 

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2756,7 +2756,7 @@ mod tests {
                 server_reader,
                 client_writer,
                 task_coordination_token.clone(),
-                self.debug_log_sampling_rate.clone(),
+                self.debug_log_sampling_rate,
                 /*is_from_client*/ false,
             ));
             let _client_relay_task_handle = tokio::spawn(relay_message::<M>(
@@ -2767,7 +2767,7 @@ mod tests {
                 client_reader,
                 server_writer,
                 task_coordination_token,
-                self.debug_log_sampling_rate.clone(),
+                self.debug_log_sampling_rate,
                 /*is_from_client*/ true,
             ));
 

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -607,10 +607,10 @@ impl<M: RemoteMessage> Unacked<M> {
             message.seq
         );
 
-        if let Some(AckedSeq(largest, _)) = self.largest_acked {
-            if message.seq <= largest {
-                return;
-            }
+        if let Some(AckedSeq(largest, _)) = self.largest_acked
+            && message.seq <= largest
+        {
+            return;
         }
 
         self.deque.push_back(message);

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -375,11 +375,11 @@ impl crate::mailbox::MailboxSender for Gateway {
             }
         }
 
-        if let Some(proc) = proc {
-            if proc.is_local_delivery_target(&dest_proc) {
-                proc.muxer().post(envelope, return_handle);
-                return;
-            }
+        if let Some(proc) = proc
+            && proc.is_local_delivery_target(&dest_proc)
+        {
+            proc.muxer().post(envelope, return_handle);
+            return;
         }
 
         self.inner.forwarder.post(envelope, return_handle)

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1085,10 +1085,10 @@ impl Proc {
         F: FnMut(&InstanceCell, usize),
     {
         for entry in self.state().instances.iter() {
-            if entry.key().uid().is_singleton() {
-                if let Some(cell) = entry.value().upgrade() {
-                    cell.traverse(f);
-                }
+            if entry.key().uid().is_singleton()
+                && let Some(cell) = entry.value().upgrade()
+            {
+                cell.traverse(f);
             }
         }
     }
@@ -1403,22 +1403,20 @@ impl Proc {
         // events have already been enqueued by this point, and the
         // coordinator's DrainAndStop path drains queued supervision
         // events before exiting.
-        if let Some(ref coord_id) = coordinator_id {
-            if let Some(mut status) = self.stop_actor(coord_id.id(), reason.to_string()) {
-                let stopped = tokio::time::timeout(
-                    timeout,
-                    status.wait_for(|s: &ActorStatus| s.is_terminal()),
-                )
-                .await
-                .is_ok();
-                if stopped {
-                    stopped_actors.push(coord_id.clone());
-                } else {
-                    if let Some(f) = self.abort_root_actor(coord_id.id()) {
-                        f.await;
-                    }
-                    aborted_actors.push(coord_id.clone());
+        if let Some(ref coord_id) = coordinator_id
+            && let Some(mut status) = self.stop_actor(coord_id.id(), reason.to_string())
+        {
+            let stopped =
+                tokio::time::timeout(timeout, status.wait_for(|s: &ActorStatus| s.is_terminal()))
+                    .await
+                    .is_ok();
+            if stopped {
+                stopped_actors.push(coord_id.clone());
+            } else {
+                if let Some(f) = self.abort_root_actor(coord_id.id()) {
+                    f.await;
                 }
+                aborted_actors.push(coord_id.clone());
             }
         }
 

--- a/hyperactor_mesh/benches/bench_actor.rs
+++ b/hyperactor_mesh/benches/bench_actor.rs
@@ -56,7 +56,7 @@ impl Handler<BenchMessage> for BenchActor {
         ctx: &Context<Self>,
         msg: BenchMessage,
     ) -> Result<(), anyhow::Error> {
-        tokio::time::sleep(self.processing_time.clone()).await;
+        tokio::time::sleep(self.processing_time).await;
 
         let _ = msg.reply.send(ctx, msg.step);
         Ok(())

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1175,34 +1175,7 @@ impl<A: Referable> view::RankedSliceable for ActorMeshRef<A> {
 #[cfg(test)]
 mod tests {
 
-    use std::collections::HashSet;
-    use std::ops::Deref;
-
-    use hyperactor::actor::ActorErrorKind;
-    use hyperactor::actor::ActorStatus;
-    use hyperactor::context::Mailbox as _;
-    use hyperactor::id::Label;
-    use hyperactor::mailbox;
-    use ndslice::Extent;
-    use ndslice::ViewExt;
-    use ndslice::extent;
-    use ndslice::view::Ranked;
-    use timed_test::assert_no_process_leak;
-    use timed_test::async_timed_test;
-    use tokio::time::Duration;
-
-    use super::ActorMesh;
     use crate::ActorMeshRef;
-    use crate::ProcMesh;
-    use crate::host_mesh::GET_PROC_STATE_MAX_IDLE;
-    use crate::host_mesh::PROC_SPAWN_MAX_IDLE;
-    use crate::mesh_controller::SUPERVISION_POLL_FREQUENCY;
-    use crate::mesh_id::ActorMeshId;
-    use crate::proc_mesh::ACTOR_SPAWN_MAX_IDLE;
-    use crate::proc_mesh::GET_ACTOR_STATE_MAX_IDLE;
-    use crate::supervision::MeshFailure;
-    use crate::testactor;
-    use crate::testing;
 
     #[test]
     fn test_actor_mesh_ref_is_send_and_sync() {

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1796,10 +1796,10 @@ impl BootstrapProcManager {
             }
 
             // Fall back to launcher-provided tail if we didn't capture.
-            if stderr_tail.is_empty() {
-                if let Some(tail) = exit_result.stderr_tail {
-                    stderr_tail = tail;
-                }
+            if stderr_tail.is_empty()
+                && let Some(tail) = exit_result.stderr_tail
+            {
+                stderr_tail = tail;
             }
 
             let tail_str = if stderr_tail.is_empty() {

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1008,7 +1008,7 @@ mod tests {
             }
 
             for (src, path) in &self.0 {
-                write!(f, "{} -> {}\n", src, vec_to_string(path))?;
+                writeln!(f, "{} -> {}", src, vec_to_string(path))?;
             }
             Ok(())
         }

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -513,11 +513,8 @@ mod tests {
 
     use hyperactor::testing::ids::test_actor_id;
     use hyperactor_config::Flattrs;
-    use ndslice::view::Extent;
-    use timed_test::async_timed_test;
 
     use super::*;
-    use crate::testing;
 
     /// Helper: send an `Undeliverable<MessageEnvelope>` to the global
     /// root client's well-known undeliverable port via the runtime's

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1218,12 +1218,12 @@ impl HostMeshRef {
                 "per_host dims overlap with existing dims when spawning proc mesh"
             )));
         }
-        if let Some(proc_bind) = proc_bind.as_ref() {
-            if proc_bind.len() != per_host.num_ranks() {
-                return Err(crate::Error::ConfigurationError(anyhow::anyhow!(
-                    "proc_bind length does not match per_host extent"
-                )));
-            }
+        if let Some(proc_bind) = proc_bind.as_ref()
+            && proc_bind.len() != per_host.num_ranks()
+        {
+            return Err(crate::Error::ConfigurationError(anyhow::anyhow!(
+                "proc_bind length does not match per_host extent"
+            )));
         }
 
         let extent = self
@@ -1923,24 +1923,11 @@ impl FromStr for HostMeshRef {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches;
 
-    use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
-    use hyperactor_config::attrs::Attrs;
     use ndslice::ViewExt;
     use ndslice::extent;
-    use timed_test::assert_no_process_leak;
-    use tokio::process::Command;
 
     use super::*;
-    use crate::ActorMesh;
-    use crate::Bootstrap;
-    use crate::bootstrap::MESH_TAIL_LOG_LINES;
-    use crate::comm::ENABLE_NATIVE_V1_CASTING;
-    use crate::resource::Status;
-    use crate::testactor;
-    use crate::testactor::GetConfigAttrs;
-    use crate::testactor::SetConfigAttrs;
     use crate::testing;
 
     #[test]

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -714,14 +714,12 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         );
 
         // Transition Detached → Attached on first proc creation.
-        if was_empty {
-            if let HostAgentState::Detached(_) = &self.state {
-                let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
-                    HostAgentState::Detached(h) => h,
-                    _ => unreachable!(),
-                };
-                self.state = HostAgentState::Attached(host);
-            }
+        if was_empty && let HostAgentState::Detached(_) = &self.state {
+            let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
+                HostAgentState::Detached(h) => h,
+                _ => unreachable!(),
+            };
+            self.state = HostAgentState::Attached(host);
         }
 
         // If any WaitRankStatus messages arrived before this proc
@@ -1528,19 +1526,6 @@ impl Handler<ConfigDump> for HostAgent {
 
 #[cfg(test)]
 mod tests {
-    use std::assert_matches;
-
-    use hyperactor::ActorAddr;
-    use hyperactor::Proc;
-    use hyperactor::channel::ChannelTransport;
-    use hyperactor::id::Label;
-
-    use super::*;
-    use crate::bootstrap::ProcStatus;
-    use crate::mesh_id::ResourceId;
-    use crate::resource::CreateOrUpdateClient;
-    use crate::resource::GetStateClient;
-    use crate::resource::WaitRankStatusClient;
 
     #[tokio::test]
     #[cfg(fbcode_build)]

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -329,7 +329,7 @@ mod tests {
         assert!(structurally_equal(&actual, &expected));
     }
 
-    #[cfg(FALSE)]
+    #[cfg(false)]
     #[test]
     fn shouldnt_compile() {
         let _ = sel!(foobar);

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1988,7 +1988,7 @@ mod tests {
 
         // Test that result is always between 0.0 and 1.0
         let distance = normalized_edit_distance("completely", "different");
-        assert!(distance >= 0.0 && distance <= 1.0);
+        assert!((0.0..=1.0).contains(&distance));
     }
 
     #[tokio::test]

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -837,23 +837,23 @@ fn build_http_client() -> reqwest::Client {
 
     if let Some(bundle) = hyperactor::channel::try_tls_pem_bundle() {
         let mut ca_bytes = Vec::new();
-        if let Ok(mut reader) = bundle.ca.reader() {
-            if reader.read_to_end(&mut ca_bytes).is_ok() {
-                let (builder, ca_installed) = crate::mesh_admin_client::add_tls(
-                    reqwest::Client::builder(),
-                    &ca_bytes,
-                    None,
-                    None,
-                );
-                if ca_installed {
-                    if let Ok(client) = builder.build() {
-                        return client;
-                    }
-                    tracing::warn!(
-                        "mesh admin: failed to build reqwest client with root CA; \
-                         falling back to default trust store"
-                    );
+        if let Ok(mut reader) = bundle.ca.reader()
+            && reader.read_to_end(&mut ca_bytes).is_ok()
+        {
+            let (builder, ca_installed) = crate::mesh_admin_client::add_tls(
+                reqwest::Client::builder(),
+                &ca_bytes,
+                None,
+                None,
+            );
+            if ca_installed {
+                if let Ok(client) = builder.build() {
+                    return client;
                 }
+                tracing::warn!(
+                    "mesh admin: failed to build reqwest client with root CA; \
+                         falling back to default trust store"
+                );
             }
         }
     }
@@ -1652,11 +1652,11 @@ fn hoist_defs(
     shared: &mut serde_json::Map<String, serde_json::Value>,
 ) {
     if let Some(obj) = schema.as_object_mut() {
-        if let Some(defs) = obj.remove("$defs") {
-            if let Some(defs_map) = defs.as_object() {
-                for (k, v) in defs_map {
-                    shared.insert(k.clone(), v.clone());
-                }
+        if let Some(defs) = obj.remove("$defs")
+            && let Some(defs_map) = defs.as_object()
+        {
+            for (k, v) in defs_map {
+                shared.insert(k.clone(), v.clone());
             }
         }
         // Also remove $schema from embedded schemas — it's
@@ -1672,10 +1672,10 @@ fn hoist_defs(
 fn rewrite_refs(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
-            if let Some(serde_json::Value::String(r)) = map.get_mut("$ref") {
-                if r.starts_with("#/$defs/") {
-                    *r = r.replace("#/$defs/", "#/components/schemas/");
-                }
+            if let Some(serde_json::Value::String(r)) = map.get_mut("$ref")
+                && r.starts_with("#/$defs/")
+            {
+                *r = r.replace("#/$defs/", "#/components/schemas/");
             }
             for v in map.values_mut() {
                 rewrite_refs(v);
@@ -2935,18 +2935,19 @@ impl AdminHandle {
             return AdminHandle::Published(PublishedHandle::Mast(addr.to_string()));
         }
         // Strict URL parse — only http/https accepted.
-        if let Ok(parsed) = url::Url::parse(addr) {
-            if matches!(parsed.scheme(), "http" | "https") {
-                return AdminHandle::Url(addr.to_string());
-            }
+        if let Ok(parsed) = url::Url::parse(addr)
+            && matches!(parsed.scheme(), "http" | "https")
+        {
+            return AdminHandle::Url(addr.to_string());
         }
         // Infer https:// for bare host:port inputs (e.g. "myhost:1729").
         // This preserves the TUI's documented --addr behavior.
         let with_scheme = format!("https://{}", addr);
-        if let Ok(parsed) = url::Url::parse(&with_scheme) {
-            if parsed.host_str().is_some() && parsed.port().is_some() {
-                return AdminHandle::Url(with_scheme);
-            }
+        if let Ok(parsed) = url::Url::parse(&with_scheme)
+            && parsed.host_str().is_some()
+            && parsed.port().is_some()
+        {
+            return AdminHandle::Url(with_scheme);
         }
         AdminHandle::Unsupported(addr.to_string())
     }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -320,21 +320,19 @@ fn send_state_change(
     // Don't send a message to the owner for non-failure events such as "stopped".
     // Those events are always initiated by the owner, who don't need to be
     // told that they were stopped.
-    if is_failed {
-        if let Some(owner) = &health_state.owner {
-            if let Err(error) = owner.send(cx, failure_message.clone()) {
-                tracing::warn!(
-                    name = "SupervisionEvent",
-                    actor_mesh = %mesh_name,
-                    %event,
-                    %error,
-                    "failed to send supervision event to owner {}: {}. dropping event",
-                    owner.port_addr(),
-                    error
-                );
-            } else {
-                tracing::info!(actor_mesh = %mesh_name, %event, "sent supervision failure message to owner {}", owner.port_addr());
-            }
+    if is_failed && let Some(owner) = &health_state.owner {
+        if let Err(error) = owner.send(cx, failure_message.clone()) {
+            tracing::warn!(
+                name = "SupervisionEvent",
+                actor_mesh = %mesh_name,
+                %event,
+                %error,
+                "failed to send supervision event to owner {}: {}. dropping event",
+                owner.port_addr(),
+                error
+            );
+        } else {
+            tracing::info!(actor_mesh = %mesh_name, %event, "sent supervision failure message to owner {}", owner.port_addr());
         }
     }
     // Subscribers get all messages, even for non-failures like Stopped, because
@@ -1518,16 +1516,12 @@ mod tests {
     use ndslice::Extent;
     use ndslice::ViewExt;
 
-    use super::SUPERVISION_POLL_FREQUENCY;
     use super::proc_status_to_actor_status;
     use crate::ActorMesh;
     use crate::bootstrap::ProcStatus;
-    use crate::host_mesh::PROC_SPAWN_MAX_IDLE;
     use crate::mesh_id::ActorMeshId;
-    use crate::mesh_id::HostMeshId;
     use crate::proc_agent::MESH_ORPHAN_TIMEOUT;
     use crate::resource;
-    use crate::supervision::MeshFailure;
     use crate::test_utils::local_host_mesh;
     use crate::testactor;
     use crate::testing;

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -514,10 +514,10 @@ impl Actor for ProcAgent {
         this.set_query_child_handler(move |child_ref| {
             use hyperactor::introspect::IntrospectResult;
 
-            if let Addr::Actor(actor_ref) = child_ref {
-                if let Some(snapshot) = proc.terminated_snapshot(actor_ref) {
-                    return snapshot;
-                }
+            if let Addr::Actor(actor_ref) = child_ref
+                && let Some(snapshot) = proc.terminated_snapshot(actor_ref)
+            {
+                return snapshot;
             }
 
             // PA-1 (ProcAgent path): proc-node children used by
@@ -527,107 +527,106 @@ impl Actor for ProcAgent {
             // next QueryChild(Addr::Proc) response without an
             // extra publish event. See
             // test_query_child_proc_returns_live_children.
-            if let Addr::Proc(proc_ref) = child_ref {
-                if *proc_ref == proc.proc_addr() {
-                    let (mut children, mut system_children) = collect_live_children(&proc);
+            if let Addr::Proc(proc_ref) = child_ref
+                && *proc_ref == proc.proc_addr()
+            {
+                let (mut children, mut system_children) = collect_live_children(&proc);
 
-                    let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
-                    for id in proc.all_terminated_actor_ids() {
-                        let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
-                        let node_ref = crate::introspect::NodeRef::Actor(id.clone());
-                        stopped_children.push(node_ref.clone());
-                        if let Some(snapshot) = proc.terminated_snapshot(&id) {
-                            let snapshot_attrs: hyperactor_config::Attrs =
-                                serde_json::from_str(&snapshot.attrs).unwrap_or_default();
-                            if snapshot_attrs
-                                .get(hyperactor::introspect::IS_SYSTEM)
-                                .copied()
-                                .unwrap_or(false)
-                            {
-                                system_children.push(node_ref);
-                            }
-                        }
-                        if !children.contains(&child_ref) {
-                            children.push(child_ref);
+                let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
+                for id in proc.all_terminated_actor_ids() {
+                    let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
+                    let node_ref = crate::introspect::NodeRef::Actor(id.clone());
+                    stopped_children.push(node_ref.clone());
+                    if let Some(snapshot) = proc.terminated_snapshot(&id) {
+                        let snapshot_attrs: hyperactor_config::Attrs =
+                            serde_json::from_str(&snapshot.attrs).unwrap_or_default();
+                        if snapshot_attrs
+                            .get(hyperactor::introspect::IS_SYSTEM)
+                            .copied()
+                            .unwrap_or(false)
+                        {
+                            system_children.push(node_ref);
                         }
                     }
-
-                    let stopped_retention_cap = hyperactor_config::global::get(
-                        hyperactor::config::TERMINATED_SNAPSHOT_RETENTION,
-                    );
-
-                    let (is_poisoned, failed_actor_count) = proc
-                        .get_instance(&self_id)
-                        .and_then(|cell| cell.published_attrs())
-                        .map(|attrs| {
-                            let is_poisoned = attrs
-                                .get(crate::introspect::IS_POISONED)
-                                .copied()
-                                .unwrap_or(false);
-                            let failed_actor_count = attrs
-                                .get(crate::introspect::FAILED_ACTOR_COUNT)
-                                .copied()
-                                .unwrap_or(0);
-                            (is_poisoned, failed_actor_count)
-                        })
-                        .unwrap_or((false, 0));
-
-                    // Build attrs for this proc node.
-                    let num_live = children.len();
-                    let mut attrs = hyperactor_config::Attrs::new();
-                    attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
-                    attrs.set(
-                        crate::introspect::PROC_NAME,
-                        proc_ref
-                            .label()
-                            .map(|l| l.as_str().to_string())
-                            .unwrap_or_else(|| proc_ref.id().to_string()),
-                    );
-                    attrs.set(crate::introspect::NUM_ACTORS, num_live);
-                    attrs.set(crate::introspect::SYSTEM_CHILDREN, system_children);
-                    attrs.set(crate::introspect::STOPPED_CHILDREN, stopped_children);
-                    attrs.set(
-                        crate::introspect::STOPPED_RETENTION_CAP,
-                        stopped_retention_cap,
-                    );
-                    attrs.set(crate::introspect::IS_POISONED, is_poisoned);
-                    attrs.set(crate::introspect::FAILED_ACTOR_COUNT, failed_actor_count);
-
-                    // PD-*: include proc debug stats in QueryChild
-                    // to prevent resolution drift from the publish path.
-                    let memory = crate::introspect::ProcessMemoryStats::read_from_procfs();
-                    memory.to_attrs(&mut attrs);
-                    attrs.set(
-                        crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL,
-                        proc.queue_depth_total(),
-                    );
-                    let mut queue_max: u64 = 0;
-                    for aid in proc.all_instance_keys() {
-                        if let Some(cell) = proc.get_instance_by_id(&aid) {
-                            queue_max = queue_max.max(cell.queue_depth());
-                        }
+                    if !children.contains(&child_ref) {
+                        children.push(child_ref);
                     }
-                    attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_MAX, queue_max);
-                    attrs.set(
-                        crate::introspect::ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK,
-                        proc.queue_depth_high_water_mark(),
-                    );
-                    attrs.set(
-                        crate::introspect::LAST_NONZERO_QUEUE_DEPTH_AGE_MS,
-                        proc.last_nonzero_queue_depth_age_ms(),
-                    );
-
-                    let attrs_json =
-                        serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
-
-                    return IntrospectResult {
-                        identity: hyperactor::introspect::IntrospectRef::Proc(proc_ref.clone()),
-                        attrs: attrs_json,
-                        children,
-                        parent: None,
-                        as_of: std::time::SystemTime::now(),
-                    };
                 }
+
+                let stopped_retention_cap = hyperactor_config::global::get(
+                    hyperactor::config::TERMINATED_SNAPSHOT_RETENTION,
+                );
+
+                let (is_poisoned, failed_actor_count) = proc
+                    .get_instance(&self_id)
+                    .and_then(|cell| cell.published_attrs())
+                    .map(|attrs| {
+                        let is_poisoned = attrs
+                            .get(crate::introspect::IS_POISONED)
+                            .copied()
+                            .unwrap_or(false);
+                        let failed_actor_count = attrs
+                            .get(crate::introspect::FAILED_ACTOR_COUNT)
+                            .copied()
+                            .unwrap_or(0);
+                        (is_poisoned, failed_actor_count)
+                    })
+                    .unwrap_or((false, 0));
+
+                // Build attrs for this proc node.
+                let num_live = children.len();
+                let mut attrs = hyperactor_config::Attrs::new();
+                attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
+                attrs.set(
+                    crate::introspect::PROC_NAME,
+                    proc_ref
+                        .label()
+                        .map(|l| l.as_str().to_string())
+                        .unwrap_or_else(|| proc_ref.id().to_string()),
+                );
+                attrs.set(crate::introspect::NUM_ACTORS, num_live);
+                attrs.set(crate::introspect::SYSTEM_CHILDREN, system_children);
+                attrs.set(crate::introspect::STOPPED_CHILDREN, stopped_children);
+                attrs.set(
+                    crate::introspect::STOPPED_RETENTION_CAP,
+                    stopped_retention_cap,
+                );
+                attrs.set(crate::introspect::IS_POISONED, is_poisoned);
+                attrs.set(crate::introspect::FAILED_ACTOR_COUNT, failed_actor_count);
+
+                // PD-*: include proc debug stats in QueryChild
+                // to prevent resolution drift from the publish path.
+                let memory = crate::introspect::ProcessMemoryStats::read_from_procfs();
+                memory.to_attrs(&mut attrs);
+                attrs.set(
+                    crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL,
+                    proc.queue_depth_total(),
+                );
+                let mut queue_max: u64 = 0;
+                for aid in proc.all_instance_keys() {
+                    if let Some(cell) = proc.get_instance_by_id(&aid) {
+                        queue_max = queue_max.max(cell.queue_depth());
+                    }
+                }
+                attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_MAX, queue_max);
+                attrs.set(
+                    crate::introspect::ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK,
+                    proc.queue_depth_high_water_mark(),
+                );
+                attrs.set(
+                    crate::introspect::LAST_NONZERO_QUEUE_DEPTH_AGE_MS,
+                    proc.last_nonzero_queue_depth_age_ms(),
+                );
+
+                let attrs_json = serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
+
+                return IntrospectResult {
+                    identity: hyperactor::introspect::IntrospectRef::Proc(proc_ref.clone()),
+                    attrs: attrs_json,
+                    children,
+                    parent: None,
+                    as_of: std::time::SystemTime::now(),
+                };
             }
 
             {
@@ -1214,7 +1213,7 @@ impl Handler<SelfCheck> for ProcAgent {
         let Some(duration) = &self.mesh_orphan_timeout else {
             return Ok(());
         };
-        let duration = duration.clone();
+        let duration = *duration;
         let now = std::time::SystemTime::now();
 
         // Collect expired actors before mutating, since stop_actor borrows &mut self.
@@ -1224,10 +1223,11 @@ impl Handler<SelfCheck> for ProcAgent {
             .filter_map(|(id, state)| {
                 let expiry = state.expiry_time?;
                 // If a stop was already initiated we don't need to do it again.
-                if now > expiry && !state.stop_initiated {
-                    if let Ok(actor_id) = &state.spawn {
-                        return Some((id.clone(), actor_id.clone()));
-                    }
+                if now > expiry
+                    && !state.stop_initiated
+                    && let Ok(actor_id) = &state.spawn
+                {
+                    return Some((id.clone(), actor_id.clone()));
                 }
                 None
             })

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1622,10 +1622,10 @@ mod tests {
             // was still alive.
             let deadline = std::time::Instant::now() + Duration::from_secs(5);
             loop {
-                if let Ok(content) = std::fs::read_to_string(&marker) {
-                    if content.contains("running") {
-                        break;
-                    }
+                if let Ok(content) = std::fs::read_to_string(&marker)
+                    && content.contains("running")
+                {
+                    break;
                 }
                 assert!(
                     std::time::Instant::now() < deadline,

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1096,7 +1096,6 @@ fn python_class_from_supervision_name(sdn: &str) -> Option<String> {
 mod tests {
     #[cfg(fbcode_build)]
     use std::ops::Deref;
-    use std::time::Duration;
 
     #[cfg(fbcode_build)]
     use hyperactor::Instance;
@@ -1104,9 +1103,6 @@ mod tests {
     use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
     #[cfg(fbcode_build)]
     use ndslice::ViewExt as _;
-    use ndslice::extent;
-    use timed_test::assert_no_process_leak;
-    use timed_test::async_timed_test;
     #[cfg(fbcode_build)]
     use uuid::Uuid;
 
@@ -1114,11 +1110,6 @@ mod tests {
     use crate::ActorMesh;
     #[cfg(fbcode_build)]
     use crate::comm::ENABLE_NATIVE_V1_CASTING;
-    use crate::host_mesh::PROC_SPAWN_MAX_IDLE;
-    use crate::resource::RankedValues;
-    use crate::resource::Status;
-    use crate::testactor;
-    use crate::testing;
 
     #[cfg(fbcode_build)]
     async fn execute_spawn_actor() {

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -666,11 +666,11 @@ impl Handler<RunPySpyProfile> for PySpyProfileWorker {
 /// See PS-3 in `introspect` module doc.
 fn resolve_candidates(pyspy_bin_env: Option<String>) -> Vec<(String, String)> {
     let mut candidates = vec![];
-    if let Some(path) = pyspy_bin_env {
-        if !path.is_empty() {
-            let label = format!("PYSPY_BIN={}", path);
-            candidates.push((path, label));
-        }
+    if let Some(path) = pyspy_bin_env
+        && !path.is_empty()
+    {
+        let label = format!("PYSPY_BIN={}", path);
+        candidates.push((path, label));
     }
     candidates.push(("py-spy".to_string(), "py-spy on PATH".to_string()));
     candidates

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -475,7 +475,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            expires_after: self.expires_after.clone(),
+            expires_after: self.expires_after,
             get_state: self.get_state.clone(),
         }
     }

--- a/hyperactor_mesh/src/systemd.rs
+++ b/hyperactor_mesh/src/systemd.rs
@@ -1213,10 +1213,9 @@ mod tests {
                     // for this unit.
                     if let Some((_, expected_marker)) =
                         units.iter().find(|(name, _)| name == &unit_name)
+                        && line.contains(expected_marker)
                     {
-                        if line.contains(expected_marker) {
-                            seen_markers.insert(unit_name.clone(), true);
-                        }
+                        seen_markers.insert(unit_name.clone(), true);
                     }
 
                     // Check if we've seen all markers.

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -34,14 +34,9 @@ use hyperactor::channel::ChannelTransport;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::WorkCell;
 use hyperactor::supervision::ActorSupervisionEvent;
-use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
-use crate::Bootstrap;
-use crate::HostMeshRef;
-use crate::host_mesh::HostMesh;
-use crate::host_mesh::HostMeshShutdownGuard;
 use crate::supervision::MeshFailure;
 
 /// Guard that fails the test if it leaves new child processes behind.
@@ -50,6 +45,12 @@ pub struct ChildProcessGuard {
     observed: Arc<Mutex<BTreeSet<u32>>>,
     stop_monitor: Arc<AtomicBool>,
     monitor: Option<std::thread::JoinHandle<()>>,
+}
+
+impl Default for ChildProcessGuard {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl ChildProcessGuard {

--- a/hyperactor_mesh/src/testresource.rs
+++ b/hyperactor_mesh/src/testresource.rs
@@ -8,8 +8,6 @@
 
 #![cfg(test)]
 
-use std::path::PathBuf;
-
 /// Fetch the named (BUCK) named resource, heuristically falling back on
 /// the cargo-built path when possible. Beware! This is not actually a
 /// true cargo dependency, so the binaries have to be built independently.

--- a/hyperactor_mesh/src/value_mesh/rle.rs
+++ b/hyperactor_mesh/src/value_mesh/rle.rs
@@ -162,11 +162,12 @@ pub fn rle_from_value_runs<T: Clone + PartialEq>(
             (table.len() - 1) as u32
         };
         // Coalesce equal-adjacent ids.
-        if let Some((last_r, last_id)) = out.last_mut() {
-            if last_r.end == range.start && *last_id == id {
-                last_r.end = range.end;
-                return;
-            }
+        if let Some((last_r, last_id)) = out.last_mut()
+            && last_r.end == range.start
+            && *last_id == id
+        {
+            last_r.end = range.end;
+            return;
         }
         out.push((range, id));
     };
@@ -200,11 +201,12 @@ pub fn merge_value_runs<T: Eq + Clone>(
     // Local helper that appends a run butg coalesces equal-adjacent
     // (like RankedValues::append)
     let mut append = |range: Range<usize>, value: T| {
-        if let Some((last_r, last_v)) = out.last_mut() {
-            if last_r.end == range.start && *last_v == value {
-                last_r.end = range.end;
-                return;
-            }
+        if let Some((last_r, last_v)) = out.last_mut()
+            && last_r.end == range.start
+            && *last_v == value
+        {
+            last_r.end = range.end;
+            return;
         }
         out.push((range, value));
     };

--- a/hyperactor_mesh_admin_tui/src/client.rs
+++ b/hyperactor_mesh_admin_tui/src/client.rs
@@ -187,12 +187,12 @@ pub(crate) fn build_client(config: &TuiConfig) -> (String, reqwest::Client) {
     // 2. Auto-detect (when no CLI certs were provided).
     // This runs even with an explicit https:// scheme, so the client
     // picks up the mTLS identity from Meta well-known paths.
-    if config.tls_ca.is_none() {
-        if let Some(bundle) = hyperactor::channel::try_tls_pem_bundle() {
-            let (b, ok) = add_tls_from_bundle(builder, &bundle);
-            builder = b;
-            use_tls = use_tls || ok;
-        }
+    if config.tls_ca.is_none()
+        && let Some(bundle) = hyperactor::channel::try_tls_pem_bundle()
+    {
+        let (b, ok) = add_tls_from_bundle(builder, &bundle);
+        builder = b;
+        use_tls = use_tls || ok;
     }
 
     let scheme = if use_tls { "https" } else { "http" };

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -493,8 +493,8 @@ impl<C: Actor> Worker<C> {
         let supervisor = session.supervisor.clone();
         let session_id = session.session_id.clone();
         let orphan_policy = session.options.orphan_policy;
-        if let Some(child) = &self.child_handle {
-            if supervisor
+        if let Some(child) = &self.child_handle
+            && supervisor
                 .send(
                     cx,
                     WorkerSupervisor::SupervisionEvent {
@@ -512,10 +512,9 @@ impl<C: Actor> Worker<C> {
                     },
                 )
                 .is_err()
-            {
-                self.handle_orphaned_supervisor("supervisor session undeliverable")?;
-                return Ok(());
-            }
+        {
+            self.handle_orphaned_supervisor("supervisor session undeliverable")?;
+            return Ok(());
         }
         let session = self
             .session

--- a/hyperactor_telemetry/src/in_memory_reader.rs
+++ b/hyperactor_telemetry/src/in_memory_reader.rs
@@ -104,6 +104,12 @@ pub struct InMemoryMetrics {
     _provider: SdkMeterProvider,
 }
 
+impl Default for InMemoryMetrics {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl InMemoryMetrics {
     // Create a new InMemoryMetrics
     //

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -113,15 +113,12 @@ use tracing_subscriber::fmt::FormatFields;
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::registry::LookupSpan;
 
-use crate::config::ENABLE_OTEL_METRICS;
-use crate::config::ENABLE_OTEL_TRACING;
 use crate::config::ENABLE_RECORDER_TRACING;
 use crate::config::ENABLE_SQLITE_TRACING;
 use crate::config::MONARCH_FILE_LOG_LEVEL;
 use crate::config::MONARCH_LOG_SUFFIX;
 use crate::config::USE_UNIFIED_LAYER;
 use crate::recorder::Recorder;
-use crate::sqlite::get_reloadable_sqlite_layer;
 
 /// Hash any hashable value to a u64 using DefaultHasher.
 pub fn hash_to_u64(value: &impl Hash) -> u64 {
@@ -160,6 +157,12 @@ impl From<crate::meta::sample_buffer::Sample> for TelemetrySample {
 }
 
 #[cfg(not(all(fbcode_build, target_os = "linux")))]
+impl Default for TelemetrySample {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TelemetrySample {
     pub fn new() -> Self {
         Self { fields: Vec::new() }
@@ -699,10 +702,10 @@ pub fn set_entity_dispatcher(dispatcher: Box<dyn EntityEventDispatcher>) {
                 EntityEventState::Dispatching(_) => Vec::new(),
             };
         for event in buffered {
-            if let EntityEventState::Dispatching(d) = &*state {
-                if let Err(e) = d.dispatch(event) {
-                    tracing::error!("failed to dispatch buffered entity event: {:?}", e);
-                }
+            if let EntityEventState::Dispatching(d) = &*state
+                && let Err(e) = d.dispatch(event)
+            {
+                tracing::error!("failed to dispatch buffered entity event: {:?}", e);
             }
         }
     }
@@ -1127,7 +1130,7 @@ pub fn initialize_logging_with_log_prefix_mock_scuba(
 fn initialize_logging_with_log_prefix_impl(
     clock: impl TelemetryClock + Send + 'static,
     prefix_env_var: Option<String>,
-    mock_scuba: bool,
+    _mock_scuba: bool,
 ) -> Box<dyn TelemetryTestHandle> {
     let use_unified = hyperactor_config::global::get(USE_UNIFIED_LAYER);
     let should_install_subscriber = !tracing::dispatcher::has_been_set();

--- a/hyperactor_telemetry/src/recorder.rs
+++ b/hyperactor_telemetry/src/recorder.rs
@@ -149,7 +149,7 @@ impl Entry {
 
     fn set_str(&mut self, name: &'static str, value: &str) {
         self.reset();
-        let mut buf = self.buffer.take().unwrap_or_else(String::new);
+        let mut buf = self.buffer.take().unwrap_or_default();
         buf.clear();
         buf.push_str(value);
         self.name = name;
@@ -158,7 +158,7 @@ impl Entry {
 
     fn set_error(&mut self, name: &'static str, value: &(dyn std::error::Error + 'static)) {
         self.reset();
-        let mut buf = self.buffer.take().unwrap_or_else(String::new);
+        let mut buf = self.buffer.take().unwrap_or_default();
 
         let mut formatter =
             core::fmt::Formatter::new(&mut buf, core::fmt::FormattingOptions::new());
@@ -172,7 +172,7 @@ impl Entry {
 
     fn set_debug(&mut self, name: &'static str, value: &dyn std::fmt::Debug) {
         self.reset();
-        let mut buf = self.buffer.take().unwrap_or_else(String::new);
+        let mut buf = self.buffer.take().unwrap_or_default();
 
         let mut formatter =
             core::fmt::Formatter::new(&mut buf, core::fmt::FormattingOptions::new());
@@ -399,8 +399,8 @@ impl Recording {
             .collect();
 
         snapshot
-            .iter()
-            .filter_map(|(id, _)| {
+            .keys()
+            .filter_map(|id| {
                 if parents.contains(id) {
                     None
                 } else {
@@ -537,12 +537,12 @@ where
 
         attrs.record(&mut visitor);
 
-        if let Some(keys) = visitor.keys() {
-            if let Some(span) = ctx.span(id) {
-                let mut extensions: tracing_subscriber::registry::ExtensionsMut<'_> =
-                    span.extensions_mut();
-                extensions.insert(keys);
-            }
+        if let Some(keys) = visitor.keys()
+            && let Some(span) = ctx.span(id)
+        {
+            let mut extensions: tracing_subscriber::registry::ExtensionsMut<'_> =
+                span.extensions_mut();
+            extensions.insert(keys);
         }
     }
 

--- a/hyperactor_telemetry/src/sinks/perfetto.rs
+++ b/hyperactor_telemetry/src/sinks/perfetto.rs
@@ -382,7 +382,7 @@ impl PerfettoFileSink {
         track_id
     }
 
-    fn actor_track_name<'a>(fields: &'a TraceFields) -> Option<&'a str> {
+    fn actor_track_name(fields: &TraceFields) -> Option<&str> {
         match get_field(fields, ACTOR_ID_FIELD) {
             Some(FieldValue::Str(actor_id) | FieldValue::Debug(actor_id))
                 if !actor_id.is_empty() =>

--- a/hyperactor_telemetry/src/sqlite.rs
+++ b/hyperactor_telemetry/src/sqlite.rs
@@ -441,10 +441,10 @@ impl Drop for SqliteTracing {
         }
 
         // Delete the temporary file if it exists
-        if let Some(db_path) = &self.db_path {
-            if db_path.exists() {
-                let _ = fs::remove_file(db_path);
-            }
+        if let Some(db_path) = &self.db_path
+            && db_path.exists()
+        {
+            let _ = fs::remove_file(db_path);
         }
     }
 }

--- a/hyperactor_telemetry/src/trace.rs
+++ b/hyperactor_telemetry/src/trace.rs
@@ -17,10 +17,10 @@ const MONARCH_CLIENT_TRACE_ID: &str = "MONARCH_CLIENT_TRACE_ID";
 /// Todo: Eventually use Message Headers to relay this traceid instead of
 /// env vars
 pub fn get_trace_id() -> Option<String> {
-    if let Ok(env_id) = env::var(MONARCH_CLIENT_TRACE_ID) {
-        if !env_id.is_empty() {
-            return Some(env_id);
-        }
+    if let Ok(env_id) = env::var(MONARCH_CLIENT_TRACE_ID)
+        && !env_id.is_empty()
+    {
+        return Some(env_id);
     }
 
     // No trace ID found
@@ -32,10 +32,10 @@ pub fn get_trace_id() -> Option<String> {
 /// The trace ID remains the same as long as it is in the same process.
 /// Use this method only on the client side.
 pub fn get_or_create_trace_id() -> String {
-    if let Ok(existing_trace_id) = std::env::var(MONARCH_CLIENT_TRACE_ID) {
-        if !existing_trace_id.is_empty() {
-            return existing_trace_id;
-        }
+    if let Ok(existing_trace_id) = std::env::var(MONARCH_CLIENT_TRACE_ID)
+        && !existing_trace_id.is_empty()
+    {
+        return existing_trace_id;
     }
 
     let trace_id = execution_id().clone();

--- a/hyperactor_telemetry/src/trace_dispatcher.rs
+++ b/hyperactor_telemetry/src/trace_dispatcher.rs
@@ -302,17 +302,17 @@ impl TraceEventDispatcher {
         }
         let _reset = InSendGuard;
 
-        if let Some(sender) = &self.sender {
-            if let Err(mpsc::TrySendError::Full(_)) = sender.try_send(event) {
-                let dropped = self.dropped_events.fetch_add(1, Ordering::Relaxed) + 1;
+        if let Some(sender) = &self.sender
+            && let Err(mpsc::TrySendError::Full(_)) = sender.try_send(event)
+        {
+            let dropped = self.dropped_events.fetch_add(1, Ordering::Relaxed) + 1;
 
-                if dropped == 1 || dropped.is_multiple_of(1000) {
-                    eprintln!(
-                        "[telemetry]: {}  events and log lines dropped que to full queue (capacity: {})",
-                        dropped, QUEUE_CAPACITY
-                    );
-                    self.send_drop_event(dropped);
-                }
+            if dropped == 1 || dropped.is_multiple_of(1000) {
+                eprintln!(
+                    "[telemetry]: {}  events and log lines dropped que to full queue (capacity: {})",
+                    dropped, QUEUE_CAPACITY
+                );
+                self.send_drop_event(dropped);
             }
         }
     }
@@ -536,14 +536,13 @@ fn worker_loop(
                     None => true,
                 },
                 _ => true,
-            } {
-                if let Err(e) = sink.consume(&event) {
-                    eprintln!(
-                        "[telemetry] sink {} failed to consume event: {}",
-                        sink.name(),
-                        e
-                    );
-                }
+            } && let Err(e) = sink.consume(&event)
+            {
+                eprintln!(
+                    "[telemetry] sink {} failed to consume event: {}",
+                    sink.name(),
+                    e
+                );
             }
         }
     }
@@ -608,10 +607,10 @@ fn worker_loop(
 
 impl Drop for WorkerHandle {
     fn drop(&mut self) {
-        if let Some(handle) = self.join_handle.take() {
-            if let Err(e) = handle.join() {
-                eprintln!("[telemetry] worker thread panicked: {:?}", e);
-            }
+        if let Some(handle) = self.join_handle.take()
+            && let Err(e) = handle.join()
+        {
+            eprintln!("[telemetry] worker thread panicked: {:?}", e);
         }
     }
 }

--- a/monarch_conda/src/replace.rs
+++ b/monarch_conda/src/replace.rs
@@ -36,6 +36,12 @@ pub struct ReplacerBuilder<'a> {
     map: HashMap<&'a Path, &'a Path>,
 }
 
+impl<'a> Default for ReplacerBuilder<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> ReplacerBuilder<'a> {
     pub fn new() -> Self {
         Self {

--- a/monarch_conda/src/sync.rs
+++ b/monarch_conda/src/sync.rs
@@ -153,10 +153,10 @@ impl ActionsBuilder {
         match self.state.entry(path) {
             Entry::Occupied(val) => {
                 let (path, (existing_origin, existing_metadata)) = val.remove_entry();
-                if let Some(ignores) = &self.ignores {
-                    if ignores.is_match(path.as_path()) {
-                        return Ok(());
-                    }
+                if let Some(ignores) = &self.ignores
+                    && ignores.is_match(path.as_path())
+                {
+                    return Ok(());
                 }
                 ensure!(existing_origin != origin);
                 let (src, dst) = match origin {
@@ -213,10 +213,10 @@ impl ActionsBuilder {
         for (path, (origin, metadata)) in self.state.into_iter() {
             match origin {
                 Origin::Src => {
-                    if let Some(ignores) = &self.ignores {
-                        if ignores.is_match(path.as_path()) {
-                            continue;
-                        }
+                    if let Some(ignores) = &self.ignores
+                        && ignores.is_match(path.as_path())
+                    {
+                        continue;
                     }
                     actions.insert(
                         path,
@@ -423,7 +423,7 @@ async fn persist(tmp: TempFile, path: &Path) -> Result<(), std::io::Error> {
 /// Helper function to set the FileTime for every file, symlink, and directory in a directory tree
 async fn set_mtime(path: &Path, mtime: SystemTime) -> Result<(), std::io::Error> {
     let mtime = FileTime::from_system_time(mtime);
-    filetime::set_symlink_file_times(path, mtime.clone(), mtime)?;
+    filetime::set_symlink_file_times(path, mtime, mtime)?;
     Ok(())
 }
 

--- a/monarch_cpp_static_libs/build.rs
+++ b/monarch_cpp_static_libs/build.rs
@@ -147,12 +147,12 @@ fn copy_dir(src_dir: &Path, target_dir: &Path) {
 /// that delegates to make). cmake -GNinja requires a real ninja binary.
 fn detect_ninja() -> Option<&'static str> {
     for cmd in &["ninja-build", "ninja"] {
-        if let Ok(output) = Command::new(cmd).arg("--version").output() {
-            if output.status.success() {
-                let version = String::from_utf8_lossy(&output.stdout);
-                println!("cargo:warning=Found {} version: {}", cmd, version.trim());
-                return Some(cmd);
-            }
+        if let Ok(output) = Command::new(cmd).arg("--version").output()
+            && output.status.success()
+        {
+            let version = String::from_utf8_lossy(&output.stdout);
+            println!("cargo:warning=Found {} version: {}", cmd, version.trim());
+            return Some(cmd);
         }
     }
     println!("cargo:warning=ninja not found, will use make (cmake Makefile generator)");

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -387,8 +387,7 @@ impl DatabaseScanner {
 
         // Build destination PortRef once
         let dest_port_id: reference::PortAddr = dest.clone().into();
-        let dest_ref: reference::PortRef<QueryResponse> =
-            reference::PortRef::attest(dest_port_id.into());
+        let dest_ref: reference::PortRef<QueryResponse> = reference::PortRef::attest(dest_port_id);
 
         // Execute scan, streaming batches directly to destination
         self.execute_scan_streaming(

--- a/monarch_distributed_telemetry/src/query_engine.rs
+++ b/monarch_distributed_telemetry/src/query_engine.rs
@@ -92,15 +92,14 @@ where
 
         loop {
             // Check if we've received all expected batches
-            if let Some(expected) = expected_batches {
-                if batch_count >= expected {
+            if let Some(expected) = expected_batches
+                && batch_count >= expected {
                     tracing::info!(
                         "QueryEngine reader: received all {} expected batches",
                         expected
                     );
                     break;
                 }
-            }
 
             tokio::select! {
                 biased;
@@ -119,11 +118,10 @@ where
                                     for item in iter {
                                         if let Ok(tuple) = item {
                                             // Each item is (rank_dict, count) - get second element
-                                            if let Ok(count_val) = tuple.get_item(1) {
-                                                if let Ok(count) = count_val.extract::<usize>() {
+                                            if let Ok(count_val) = tuple.get_item(1)
+                                                && let Ok(count) = count_val.extract::<usize>() {
                                                     total += count;
                                                 }
-                                            }
                                         }
                                     }
                                 }

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -35,7 +35,7 @@ use crate::runtime::monarch_with_gil;
 #[pyo3(signature = ())]
 pub fn bootstrap_main(py: Python) -> PyResult<Bound<PyAny>> {
     // SAFETY: this is a correct use of this function.
-    let _ = unsafe {
+    unsafe {
         fbinit::perform_init();
     };
 

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -44,7 +44,7 @@ pub enum PyChannelTransport {
 #[pymethods]
 impl PyChannelTransport {
     fn get(&self) -> Self {
-        self.clone()
+        *self
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -419,7 +419,7 @@ pub async fn code_sync_mesh(
             let daemon =
                 RsyncDaemon::spawn(TcpListener::bind(&addrs[..]).await?, &local_workspace).await?;
 
-            let daemon_addr = daemon.addr().clone();
+            let daemon_addr = *daemon.addr();
             let (rsync_conns_tx, rsync_conns_rx) = instance.open_port::<Connect>();
             (
                 Method::Rsync {
@@ -433,7 +433,7 @@ pub async fn code_sync_mesh(
                         .err_into::<anyhow::Error>()
                         .try_for_each_concurrent(None, |connect| async move {
                             let (mut local, mut stream) = try_join!(
-                                TcpStream::connect(daemon_addr.clone()).err_into(),
+                                TcpStream::connect(daemon_addr).err_into(),
                                 accept(instance, instance.self_addr().clone(), connect),
                             )?;
                             tokio::io::copy_bidirectional(&mut local, &mut stream).await?;

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -406,7 +406,7 @@ pub async fn rsync_mesh<C: context::Actor + Copy + Unpin>(
             .err_into::<anyhow::Error>()
             .try_for_each_concurrent(None, |connect| async move {
                 let (mut local, mut stream) = try_join!(
-                    TcpStream::connect(daemon_addr.clone()).err_into(),
+                    TcpStream::connect(*daemon_addr).err_into(),
                     accept(cx, cx.instance().self_addr().clone(), connect),
                 )?;
                 tokio::io::copy_bidirectional(&mut local, &mut stream).await?;

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -288,7 +288,7 @@ where
             key.name(),
         ))
     })?;
-    let val: Option<P> = hyperactor_config::global::try_get_cloned(key.clone())
+    let val: Option<P> = hyperactor_config::global::try_get_cloned(*key)
         .map(|v| v.try_into())
         .transpose()?;
     val.map(|v| v.into_py_any(py)).transpose()
@@ -314,7 +314,7 @@ where
     let key = key.downcast_ref::<T>().expect("cannot fail");
     let runtime = hyperactor_config::global::runtime_attrs();
     let val: Option<P> = runtime
-        .get(key.clone())
+        .get(*key)
         .cloned()
         .map(|v| v.try_into())
         .transpose()?;
@@ -334,7 +334,7 @@ fn set_runtime_config_py<T: AttrValue + Debug>(
     // Again, can't fail unless there's a bug in the code in this file.
     let key = key.downcast_ref().expect("cannot fail");
     let mut attrs = Attrs::new();
-    attrs.set(key.clone(), value);
+    attrs.set(*key, value);
     hyperactor_config::global::create_or_merge(Source::Runtime, attrs);
     Ok(())
 }

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -540,10 +540,10 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
 
         // Join the host's mailbox server to flush receive-side acks
         // before the process exits.
-        if let Some(lock) = HOST_SHUTDOWN_HANDLE.get() {
-            if let Some(handle) = lock.lock().await.take() {
-                handle.join().await;
-            }
+        if let Some(lock) = HOST_SHUTDOWN_HANDLE.get()
+            && let Some(handle) = lock.lock().await.take()
+        {
+            handle.join().await;
         }
 
         Ok(())

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -854,12 +854,12 @@ mod tests {
 
             // Await the returned PyPythonTask's future outside the
             // GIL.
-            let flush_result = flush_task
+            flush_task
                 .await_unit()
                 .await
                 .expect("flush failed (forwarding disabled)");
 
-            let _ = flush_result;
+            ();
             drop(client_py); // See "NOTE ON LIFECYCLE / CLEANUP"
         }
 
@@ -887,12 +887,12 @@ mod tests {
 
             // Await the returned PyPythonTask's future outside the
             // GIL.
-            let flush_result = flush_task
+            flush_task
                 .await_unit()
                 .await
                 .expect("flush failed (forwarding enabled)");
 
-            let _ = flush_result;
+            ();
             drop(client_py); // See note "NOTE ON LIFECYCLE / CLEANUP"
         }
 

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -444,23 +444,20 @@ fn send_result(
     traceback: Option<Py<PyAny>>,
 ) {
     // a SendErr just means that there are no consumers of the value left.
-    match tx.send(Some(result)) {
-        Err(tokio::sync::watch::error::SendError(Some(Err(pyerr)))) => {
-            monarch_with_gil_blocking(|py| {
-                let tb = if let Some(tb) = traceback {
-                    format_traceback(py, &tb).unwrap()
-                } else {
-                    "None (run with `MONARCH_HYPERACTOR_ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK=1` to see a traceback here)\n".into()
-                };
-                tracing::error!(
-                    "PythonTask errored but is not being awaited; this will not crash your program, but indicates that \
-                    something went wrong.\n{}\nTraceback where the task was created (most recent call last):\n{}",
-                    SerializablePyErr::from(py, &pyerr),
-                    tb
-                );
-            });
-        }
-        _ => {}
+    if let Err(tokio::sync::watch::error::SendError(Some(Err(pyerr)))) = tx.send(Some(result)) {
+        monarch_with_gil_blocking(|py| {
+            let tb = if let Some(tb) = traceback {
+                format_traceback(py, &tb).unwrap()
+            } else {
+                "None (run with `MONARCH_HYPERACTOR_ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK=1` to see a traceback here)\n".into()
+            };
+            tracing::error!(
+                "PythonTask errored but is not being awaited; this will not crash your program, but indicates that \
+                something went wrong.\n{}\nTraceback where the task was created (most recent call last):\n{}",
+                SerializablePyErr::from(py, &pyerr),
+                tb
+            );
+        });
     };
 }
 

--- a/monarch_record_batch_macros/src/lib.rs
+++ b/monarch_record_batch_macros/src/lib.rs
@@ -156,16 +156,13 @@ impl FieldInfo {
 }
 
 fn extract_option_inner(ty: &Type) -> (&Type, bool) {
-    if let Type::Path(type_path) = ty {
-        if let Some(segment) = type_path.path.segments.last() {
-            if segment.ident == "Option" {
-                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                        return (inner, true);
-                    }
-                }
-            }
-        }
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+        && segment.ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return (inner, true);
     }
     (ty, false)
 }

--- a/serde_multipart/src/de/bincode.rs
+++ b/serde_multipart/src/de/bincode.rs
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<'de, 'a, R, O> serde::Deserializer<'de> for &'a mut Deserializer<R, O>
+impl<'de, R, O> serde::Deserializer<'de> for &mut Deserializer<R, O>
 where
     R: BincodeRead<'de>,
     O: Options,
@@ -355,7 +355,7 @@ where
     }
 }
 
-impl<'de, 'a, R, O> serde::de::VariantAccess<'de> for &'a mut Deserializer<R, O>
+impl<'de, R, O> serde::de::VariantAccess<'de> for &mut Deserializer<R, O>
 where
     R: BincodeRead<'de>,
     O: Options,

--- a/struct_diff_patch/src/lib.rs
+++ b/struct_diff_patch/src/lib.rs
@@ -456,8 +456,8 @@ mod tests {
         assert_eq!(tuple_value, DerivedTuple("baz".into(), false));
 
         let mut unit = DerivedUnit;
-        let unit_patch = unit.diff(&DerivedUnit);
-        unit_patch.apply(&mut unit).unwrap();
+        unit.diff(&DerivedUnit);
+        ().apply(&mut unit).unwrap();
     }
 
     #[test]

--- a/typeuri_macros/src/lib.rs
+++ b/typeuri_macros/src/lib.rs
@@ -50,35 +50,34 @@ pub fn derive_named(input: TokenStream) -> TokenStream {
     let has_generics = !type_params.is_empty();
 
     for attr in &input.attrs {
-        if attr.path().is_ident("named") {
-            if let Ok(meta) = attr.parse_args_with(
+        if attr.path().is_ident("named")
+            && let Ok(meta) = attr.parse_args_with(
                 syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
-            ) {
-                for item in meta {
-                    if let Meta::NameValue(MetaNameValue {
-                        path,
-                        value: Expr::Lit(expr_lit),
-                        ..
-                    }) = item
-                    {
-                        if path.is_ident("name") {
-                            if let Lit::Str(name) = expr_lit.lit {
-                                typename = quote! { #name };
-                            } else {
-                                return TokenStream::from(
-                                    syn::Error::new_spanned(path, "invalid name")
-                                        .to_compile_error(),
-                                );
-                            }
+            )
+        {
+            for item in meta {
+                if let Meta::NameValue(MetaNameValue {
+                    path,
+                    value: Expr::Lit(expr_lit),
+                    ..
+                }) = item
+                {
+                    if path.is_ident("name") {
+                        if let Lit::Str(name) = expr_lit.lit {
+                            typename = quote! { #name };
                         } else {
                             return TokenStream::from(
-                                syn::Error::new_spanned(
-                                    path,
-                                    "unsupported attribute (only `name` is supported)",
-                                )
-                                .to_compile_error(),
+                                syn::Error::new_spanned(path, "invalid name").to_compile_error(),
                             );
                         }
+                    } else {
+                        return TokenStream::from(
+                            syn::Error::new_spanned(
+                                path,
+                                "unsupported attribute (only `name` is supported)",
+                            )
+                            .to_compile_error(),
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Summary:
ran `cargo clippy --workspace --all-targets --fix --allow-dirty --allow-staged` from `fbcode/monarch` on top of the parent's `build_utils` fix, and accepted every suggestion verbatim. excluded the GPU/torch crates that don't build on a CPU laptop — the CI exclude list (`.github/workflows/test-cpu-rust.yml`) plus the workspace members that hang off `monarch_rdma_extension` (`monarch_rdma`, `rdmaxcel-sys`, `monarch_cpp_static_libs`, `torch-sys2`).

most edits collapse nested `if let`/`if` pairs into Rust 2024 let-chains (`clippy::collapsible_if`); the rest are lifetime elision (`clippy::needless_lifetimes`), `.clone()` removal on `Copy` types, `unwrap_or(String::new())` → `unwrap_or_default()`, and unused-import cleanup.

Differential Revision: D105385912
