### PR TITLE
enable OSS-aligned clippy lints in PACKAGE

### DIFF
--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -14,5 +14,5 @@ doctest = false
 [dependencies]
 cc = "1.2.60"
 glob = "0.3.2"
-pyo3-build-config = "0.26"
+pyo3-build-config = { version = "0.26", features = ["resolve-config"] }
 which = "8.0.2"

--- a/build_utils/src/lib.rs
+++ b/build_utils/src/lib.rs
@@ -349,10 +349,10 @@ pub fn link_libstdcpp_static() {
                 None
             }
         });
-    if let Some(gcc_lib_path) = gcc_lib_path {
-        if !gcc_lib_path.as_os_str().is_empty() {
-            println!("cargo:rustc-link-search=native={}", gcc_lib_path.display());
-        }
+    if let Some(gcc_lib_path) = gcc_lib_path
+        && !gcc_lib_path.as_os_str().is_empty()
+    {
+        println!("cargo:rustc-link-search=native={}", gcc_lib_path.display());
     }
     println!("cargo:rustc-link-lib=static=stdc++");
 }
@@ -519,9 +519,13 @@ mod tests {
 
     #[test]
     fn test_find_cuda_home_env_var() {
-        env::set_var("CUDA_HOME", "/test/cuda");
+        // SAFETY: this is the only test in the crate that touches CUDA_HOME,
+        // and `find_cuda_home` is not invoked concurrently from any other
+        // test, so no other thread races on the variable.
+        unsafe { env::set_var("CUDA_HOME", "/test/cuda") };
         let result = find_cuda_home();
-        env::remove_var("CUDA_HOME");
+        // SAFETY: same as above.
+        unsafe { env::remove_var("CUDA_HOME") };
         assert_eq!(result, Some("/test/cuda".to_string()));
     }
 

--- a/build_utils/src/rocm.rs
+++ b/build_utils/src/rocm.rs
@@ -29,10 +29,10 @@ use crate::get_env_var_with_rerun;
 /// 3. Finding hipcc in PATH and resolving symlinks
 pub fn validate_rocm_installation() -> Result<String, BuildError> {
     // Try ROCM_PATH environment variable first
-    if let Ok(rocm_path) = get_env_var_with_rerun("ROCM_PATH") {
-        if Path::new(&rocm_path).join("bin/hipcc").exists() {
-            return Ok(rocm_path);
-        }
+    if let Ok(rocm_path) = get_env_var_with_rerun("ROCM_PATH")
+        && Path::new(&rocm_path).join("bin/hipcc").exists()
+    {
+        return Ok(rocm_path);
     }
 
     // Try default location /opt/rocm (handles versioned installs like /opt/rocm-7.1.1 via symlink)
@@ -48,10 +48,10 @@ pub fn validate_rocm_installation() -> Result<String, BuildError> {
     // Try finding hipcc in PATH and resolving symlinks
     if let Ok(hipcc_path) = which("hipcc") {
         // Resolve symlinks to get the real path
-        if let Ok(real_hipcc) = fs::canonicalize(&hipcc_path) {
-            if let Some(rocm_home) = real_hipcc.parent().and_then(|p| p.parent()) {
-                return Ok(rocm_home.to_string_lossy().to_string());
-            }
+        if let Ok(real_hipcc) = fs::canonicalize(&hipcc_path)
+            && let Some(rocm_home) = real_hipcc.parent().and_then(|p| p.parent())
+        {
+            return Ok(rocm_home.to_string_lossy().to_string());
         }
     }
 
@@ -67,17 +67,17 @@ pub fn get_rocm_version(rocm_home: &str) -> Result<(u32, u32), BuildError> {
     if let Ok(content) = fs::read_to_string(&version_file) {
         // Parse version like "6.0.2" or "7.0.0"
         let parts: Vec<&str> = content.trim().split('.').collect();
-        if parts.len() >= 2 {
-            if let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>()) {
-                // Enforce ROCm 7.0+ requirement
-                if major < 7 {
-                    return Err(BuildError::CommandFailed(format!(
-                        "ROCm {}.{} detected, but ROCm 7.0+ is required",
-                        major, minor
-                    )));
-                }
-                return Ok((major, minor));
+        if parts.len() >= 2
+            && let (Ok(major), Ok(minor)) = (parts[0].parse::<u32>(), parts[1].parse::<u32>())
+        {
+            // Enforce ROCm 7.0+ requirement
+            if major < 7 {
+                return Err(BuildError::CommandFailed(format!(
+                    "ROCm {}.{} detected, but ROCm 7.0+ is required",
+                    major, minor
+                )));
             }
+            return Ok((major, minor));
         }
     }
 

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -231,7 +231,7 @@ async fn channel_ping_pong(
         });
 
     let start = Instant::now();
-    let _ = client_handle.await.unwrap().unwrap();
+    client_handle.await.unwrap().unwrap();
     start.elapsed()
 }
 

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -159,7 +159,7 @@ fn bench_message_rates(c: &mut Criterion) {
 
                             response_handlers.push(handle);
 
-                            let delay_ms = if rate > 0 { 1000 / rate } else { 0 };
+                            let delay_ms = 1000_u64.checked_div(rate).unwrap_or(0);
                             let elapsed = start.elapsed().as_millis();
                             let effective_delay = (delay_ms as u128).saturating_sub(elapsed);
                             if effective_delay > 0 {
@@ -328,7 +328,7 @@ fn bench_mailbox_message_rates(c: &mut Criterion) {
 
                         response_handlers.push(handle);
 
-                        let delay_ms = if rate > 0 { 1000 / rate } else { 0 };
+                        let delay_ms = 1000_u64.checked_div(rate).unwrap_or(0);
                         let elapsed = start.elapsed().as_millis();
                         let effective_delay = (delay_ms as u128).saturating_sub(elapsed);
                         if effective_delay > 0 {

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -281,7 +281,7 @@ impl<A: Actor> Handler<Undeliverable<MessageEnvelope>> for A {
     ) -> Result<(), anyhow::Error> {
         let sender = message.0.sender().clone();
         let dest = message.0.dest().clone();
-        let error = message.0.error_msg().unwrap_or(String::new());
+        let error = message.0.error_msg().unwrap_or_default();
         match self.handle_undeliverable_message(cx, message).await {
             Ok(_) => {
                 tracing::debug!(

--- a/hyperactor/src/actor_local.rs
+++ b/hyperactor/src/actor_local.rs
@@ -339,7 +339,7 @@ mod weak_map {
         }
     }
 
-    impl<'a, T: Send + 'static> OccupiedEntry<'a, T> {
+    impl<T: Send + 'static> OccupiedEntry<'_, T> {
         /// Gets a reference to the value in the entry.
         pub fn get(&self) -> &T {
             &self
@@ -821,7 +821,7 @@ pub struct OccupiedEntry<'a, T: Send + 'static>(
     PhantomData<fn() -> T>,
 );
 
-impl<'a, T: Send + 'static> OccupiedEntry<'a, T> {
+impl<T: Send + 'static> OccupiedEntry<'_, T> {
     /// Gets a reference to the value in the entry.
     pub fn get(&self) -> &T {
         self.0

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -215,16 +215,16 @@ impl<M: RemoteMessage> MpscTx<M> {
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for MpscTx<M> {
     fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        if let Err(mpsc::error::SendError(message)) = self.tx.send(message) {
-            if let Some(return_channel) = return_channel {
-                return_channel
-                    .send(SendError {
-                        error: ChannelError::Closed,
-                        message,
-                        reason: None,
-                    })
-                    .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
-            }
+        if let Err(mpsc::error::SendError(message)) = self.tx.send(message)
+            && let Some(return_channel) = return_channel
+        {
+            return_channel
+                .send(SendError {
+                    error: ChannelError::Closed,
+                    message,
+                    reason: None,
+                })
+                .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
         }
     }
 

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -118,16 +118,16 @@ impl<M: RemoteMessage> Tx<M> for LocalTx<M> {
                 return;
             }
         };
-        if self.tx.send(data).is_err() {
-            if let Some(return_channel) = return_channel {
-                return_channel
-                    .send(SendError {
-                        error: ChannelError::Closed,
-                        message,
-                        reason: None,
-                    })
-                    .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
-            }
+        if self.tx.send(data).is_err()
+            && let Some(return_channel) = return_channel
+        {
+            return_channel
+                .send(SendError {
+                    error: ChannelError::Closed,
+                    message,
+                    reason: None,
+                })
+                .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
         }
     }
 

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2765,7 +2765,7 @@ mod tests {
                 server_reader,
                 client_writer,
                 task_coordination_token.clone(),
-                self.debug_log_sampling_rate.clone(),
+                self.debug_log_sampling_rate,
                 /*is_from_client*/ false,
             ));
             let _client_relay_task_handle = tokio::spawn(relay_message::<M>(
@@ -2776,7 +2776,7 @@ mod tests {
                 client_reader,
                 server_writer,
                 task_coordination_token,
-                self.debug_log_sampling_rate.clone(),
+                self.debug_log_sampling_rate,
                 /*is_from_client*/ true,
             ));
 

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -900,6 +900,10 @@ pub(crate) fn listen_with_prebound(
 /// Bind a listener for the given channel address. Returns the listener
 /// and the canonical address callers should advertise (which encodes
 /// the transport — e.g. `ChannelAddr::Tls` for TLS).
+#[expect(
+    dead_code,
+    reason = "canonical listen() entry point; callers currently route through listen_with_prebound"
+)]
 pub(crate) fn listen(addr: ChannelAddr) -> Result<(NetListener, ChannelAddr), ServerError> {
     listen_with_prebound(addr, None)
 }
@@ -2189,6 +2193,11 @@ pub fn try_tls_connector() -> Option<tokio_rustls::TlsConnector> {
 
 #[cfg(test)]
 mod tests {
+    #![expect(
+        clippy::await_holding_invalid_type,
+        reason = "tracing_test::traced_test macro expansion holds tracing::span::Entered across awaits; can't be fixed in our code"
+    )]
+
     use std::assert_matches;
     use std::collections::VecDeque;
     use std::marker::PhantomData;

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -607,10 +607,10 @@ impl<M: RemoteMessage> Unacked<M> {
             message.seq
         );
 
-        if let Some(AckedSeq(largest, _)) = self.largest_acked {
-            if message.seq <= largest {
-                return;
-            }
+        if let Some(AckedSeq(largest, _)) = self.largest_acked
+            && message.seq <= largest
+        {
+            return;
         }
 
         self.deque.push_back(message);

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -375,11 +375,11 @@ impl crate::mailbox::MailboxSender for Gateway {
             }
         }
 
-        if let Some(proc) = proc {
-            if proc.is_local_delivery_target(&dest_proc) {
-                proc.muxer().post(envelope, return_handle);
-                return;
-            }
+        if let Some(proc) = proc
+            && proc.is_local_delivery_target(&dest_proc)
+        {
+            proc.muxer().post(envelope, return_handle);
+            return;
         }
 
         self.inner.forwarder.post(envelope, return_handle)

--- a/hyperactor/src/parse/lex.rs
+++ b/hyperactor/src/parse/lex.rs
@@ -82,7 +82,7 @@ pub(crate) struct Token<'a> {
     pub(crate) span: Span,
 }
 
-impl<'a> Token<'a> {
+impl Token<'_> {
     pub(crate) fn eof(pos: usize) -> Self {
         Self {
             kind: TokenKind::Eof,

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1085,10 +1085,10 @@ impl Proc {
         F: FnMut(&InstanceCell, usize),
     {
         for entry in self.state().instances.iter() {
-            if entry.key().uid().is_singleton() {
-                if let Some(cell) = entry.value().upgrade() {
-                    cell.traverse(f);
-                }
+            if entry.key().uid().is_singleton()
+                && let Some(cell) = entry.value().upgrade()
+            {
+                cell.traverse(f);
             }
         }
     }
@@ -1403,22 +1403,20 @@ impl Proc {
         // events have already been enqueued by this point, and the
         // coordinator's DrainAndStop path drains queued supervision
         // events before exiting.
-        if let Some(ref coord_id) = coordinator_id {
-            if let Some(mut status) = self.stop_actor(coord_id.id(), reason.to_string()) {
-                let stopped = tokio::time::timeout(
-                    timeout,
-                    status.wait_for(|s: &ActorStatus| s.is_terminal()),
-                )
-                .await
-                .is_ok();
-                if stopped {
-                    stopped_actors.push(coord_id.clone());
-                } else {
-                    if let Some(f) = self.abort_root_actor(coord_id.id()) {
-                        f.await;
-                    }
-                    aborted_actors.push(coord_id.clone());
+        if let Some(ref coord_id) = coordinator_id
+            && let Some(mut status) = self.stop_actor(coord_id.id(), reason.to_string())
+        {
+            let stopped =
+                tokio::time::timeout(timeout, status.wait_for(|s: &ActorStatus| s.is_terminal()))
+                    .await
+                    .is_ok();
+            if stopped {
+                stopped_actors.push(coord_id.clone());
+            } else {
+                if let Some(f) = self.abort_root_actor(coord_id.id()) {
+                    f.await;
                 }
+                aborted_actors.push(coord_id.clone());
             }
         }
 

--- a/hyperactor_mesh/benches/bench_actor.rs
+++ b/hyperactor_mesh/benches/bench_actor.rs
@@ -56,7 +56,7 @@ impl Handler<BenchMessage> for BenchActor {
         ctx: &Context<Self>,
         msg: BenchMessage,
     ) -> Result<(), anyhow::Error> {
-        tokio::time::sleep(self.processing_time.clone()).await;
+        tokio::time::sleep(self.processing_time).await;
 
         let _ = msg.reply.send(ctx, msg.step);
         Ok(())

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -1796,10 +1796,10 @@ impl BootstrapProcManager {
             }
 
             // Fall back to launcher-provided tail if we didn't capture.
-            if stderr_tail.is_empty() {
-                if let Some(tail) = exit_result.stderr_tail {
-                    stderr_tail = tail;
-                }
+            if stderr_tail.is_empty()
+                && let Some(tail) = exit_result.stderr_tail
+            {
+                stderr_tail = tail;
             }
 
             let tail_str = if stderr_tail.is_empty() {

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1008,7 +1008,7 @@ mod tests {
             }
 
             for (src, path) in &self.0 {
-                write!(f, "{} -> {}\n", src, vec_to_string(path))?;
+                writeln!(f, "{} -> {}", src, vec_to_string(path))?;
             }
             Ok(())
         }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1218,12 +1218,12 @@ impl HostMeshRef {
                 "per_host dims overlap with existing dims when spawning proc mesh"
             )));
         }
-        if let Some(proc_bind) = proc_bind.as_ref() {
-            if proc_bind.len() != per_host.num_ranks() {
-                return Err(crate::Error::ConfigurationError(anyhow::anyhow!(
-                    "proc_bind length does not match per_host extent"
-                )));
-            }
+        if let Some(proc_bind) = proc_bind.as_ref()
+            && proc_bind.len() != per_host.num_ranks()
+        {
+            return Err(crate::Error::ConfigurationError(anyhow::anyhow!(
+                "proc_bind length does not match per_host extent"
+            )));
         }
 
         let extent = self

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -714,14 +714,12 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
         );
 
         // Transition Detached → Attached on first proc creation.
-        if was_empty {
-            if let HostAgentState::Detached(_) = &self.state {
-                let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
-                    HostAgentState::Detached(h) => h,
-                    _ => unreachable!(),
-                };
-                self.state = HostAgentState::Attached(host);
-            }
+        if was_empty && let HostAgentState::Detached(_) = &self.state {
+            let host = match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
+                HostAgentState::Detached(h) => h,
+                _ => unreachable!(),
+            };
+            self.state = HostAgentState::Attached(host);
         }
 
         // If any WaitRankStatus messages arrived before this proc

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -329,7 +329,7 @@ mod tests {
         assert!(structurally_equal(&actual, &expected));
     }
 
-    #[cfg(FALSE)]
+    #[cfg(false)]
     #[test]
     fn shouldnt_compile() {
         let _ = sel!(foobar);

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1988,7 +1988,7 @@ mod tests {
 
         // Test that result is always between 0.0 and 1.0
         let distance = normalized_edit_distance("completely", "different");
-        assert!(distance >= 0.0 && distance <= 1.0);
+        assert!((0.0..=1.0).contains(&distance));
     }
 
     #[tokio::test]

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -837,23 +837,23 @@ fn build_http_client() -> reqwest::Client {
 
     if let Some(bundle) = hyperactor::channel::try_tls_pem_bundle() {
         let mut ca_bytes = Vec::new();
-        if let Ok(mut reader) = bundle.ca.reader() {
-            if reader.read_to_end(&mut ca_bytes).is_ok() {
-                let (builder, ca_installed) = crate::mesh_admin_client::add_tls(
-                    reqwest::Client::builder(),
-                    &ca_bytes,
-                    None,
-                    None,
-                );
-                if ca_installed {
-                    if let Ok(client) = builder.build() {
-                        return client;
-                    }
-                    tracing::warn!(
-                        "mesh admin: failed to build reqwest client with root CA; \
-                         falling back to default trust store"
-                    );
+        if let Ok(mut reader) = bundle.ca.reader()
+            && reader.read_to_end(&mut ca_bytes).is_ok()
+        {
+            let (builder, ca_installed) = crate::mesh_admin_client::add_tls(
+                reqwest::Client::builder(),
+                &ca_bytes,
+                None,
+                None,
+            );
+            if ca_installed {
+                if let Ok(client) = builder.build() {
+                    return client;
                 }
+                tracing::warn!(
+                    "mesh admin: failed to build reqwest client with root CA; \
+                         falling back to default trust store"
+                );
             }
         }
     }
@@ -1652,11 +1652,11 @@ fn hoist_defs(
     shared: &mut serde_json::Map<String, serde_json::Value>,
 ) {
     if let Some(obj) = schema.as_object_mut() {
-        if let Some(defs) = obj.remove("$defs") {
-            if let Some(defs_map) = defs.as_object() {
-                for (k, v) in defs_map {
-                    shared.insert(k.clone(), v.clone());
-                }
+        if let Some(defs) = obj.remove("$defs")
+            && let Some(defs_map) = defs.as_object()
+        {
+            for (k, v) in defs_map {
+                shared.insert(k.clone(), v.clone());
             }
         }
         // Also remove $schema from embedded schemas — it's
@@ -1672,10 +1672,10 @@ fn hoist_defs(
 fn rewrite_refs(value: &mut serde_json::Value) {
     match value {
         serde_json::Value::Object(map) => {
-            if let Some(serde_json::Value::String(r)) = map.get_mut("$ref") {
-                if r.starts_with("#/$defs/") {
-                    *r = r.replace("#/$defs/", "#/components/schemas/");
-                }
+            if let Some(serde_json::Value::String(r)) = map.get_mut("$ref")
+                && r.starts_with("#/$defs/")
+            {
+                *r = r.replace("#/$defs/", "#/components/schemas/");
             }
             for v in map.values_mut() {
                 rewrite_refs(v);
@@ -2935,18 +2935,19 @@ impl AdminHandle {
             return AdminHandle::Published(PublishedHandle::Mast(addr.to_string()));
         }
         // Strict URL parse — only http/https accepted.
-        if let Ok(parsed) = url::Url::parse(addr) {
-            if matches!(parsed.scheme(), "http" | "https") {
-                return AdminHandle::Url(addr.to_string());
-            }
+        if let Ok(parsed) = url::Url::parse(addr)
+            && matches!(parsed.scheme(), "http" | "https")
+        {
+            return AdminHandle::Url(addr.to_string());
         }
         // Infer https:// for bare host:port inputs (e.g. "myhost:1729").
         // This preserves the TUI's documented --addr behavior.
         let with_scheme = format!("https://{}", addr);
-        if let Ok(parsed) = url::Url::parse(&with_scheme) {
-            if parsed.host_str().is_some() && parsed.port().is_some() {
-                return AdminHandle::Url(with_scheme);
-            }
+        if let Ok(parsed) = url::Url::parse(&with_scheme)
+            && parsed.host_str().is_some()
+            && parsed.port().is_some()
+        {
+            return AdminHandle::Url(with_scheme);
         }
         AdminHandle::Unsupported(addr.to_string())
     }

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -3027,10 +3027,10 @@ mod advertised_host {
 
         // Candidate 2: host IPv6 address (Meta environments).
         #[cfg(fbcode_build)]
-        if let Ok(ip_str) = hyperactor::meta::host_ip::host_ipv6_address() {
-            if let Ok(ip) = ip_str.parse::<IpAddr>() {
-                candidates.push((format!("[{}]", ip), SanIdentity::Ip(ip)));
-            }
+        if let Ok(ip_str) = hyperactor::meta::host_ip::host_ipv6_address()
+            && let Ok(ip) = ip_str.parse::<IpAddr>()
+        {
+            candidates.push((format!("[{}]", ip), SanIdentity::Ip(ip)));
         }
 
         let cert_sans = load_cert_sans();

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -320,21 +320,19 @@ fn send_state_change(
     // Don't send a message to the owner for non-failure events such as "stopped".
     // Those events are always initiated by the owner, who don't need to be
     // told that they were stopped.
-    if is_failed {
-        if let Some(owner) = &health_state.owner {
-            if let Err(error) = owner.send(cx, failure_message.clone()) {
-                tracing::warn!(
-                    name = "SupervisionEvent",
-                    actor_mesh = %mesh_name,
-                    %event,
-                    %error,
-                    "failed to send supervision event to owner {}: {}. dropping event",
-                    owner.port_addr(),
-                    error
-                );
-            } else {
-                tracing::info!(actor_mesh = %mesh_name, %event, "sent supervision failure message to owner {}", owner.port_addr());
-            }
+    if is_failed && let Some(owner) = &health_state.owner {
+        if let Err(error) = owner.send(cx, failure_message.clone()) {
+            tracing::warn!(
+                name = "SupervisionEvent",
+                actor_mesh = %mesh_name,
+                %event,
+                %error,
+                "failed to send supervision event to owner {}: {}. dropping event",
+                owner.port_addr(),
+                error
+            );
+        } else {
+            tracing::info!(actor_mesh = %mesh_name, %event, "sent supervision failure message to owner {}", owner.port_addr());
         }
     }
     // Subscribers get all messages, even for non-failures like Stopped, because

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -514,10 +514,10 @@ impl Actor for ProcAgent {
         this.set_query_child_handler(move |child_ref| {
             use hyperactor::introspect::IntrospectResult;
 
-            if let Addr::Actor(actor_ref) = child_ref {
-                if let Some(snapshot) = proc.terminated_snapshot(actor_ref) {
-                    return snapshot;
-                }
+            if let Addr::Actor(actor_ref) = child_ref
+                && let Some(snapshot) = proc.terminated_snapshot(actor_ref)
+            {
+                return snapshot;
             }
 
             // PA-1 (ProcAgent path): proc-node children used by
@@ -527,107 +527,106 @@ impl Actor for ProcAgent {
             // next QueryChild(Addr::Proc) response without an
             // extra publish event. See
             // test_query_child_proc_returns_live_children.
-            if let Addr::Proc(proc_ref) = child_ref {
-                if *proc_ref == proc.proc_addr() {
-                    let (mut children, mut system_children) = collect_live_children(&proc);
+            if let Addr::Proc(proc_ref) = child_ref
+                && *proc_ref == proc.proc_addr()
+            {
+                let (mut children, mut system_children) = collect_live_children(&proc);
 
-                    let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
-                    for id in proc.all_terminated_actor_ids() {
-                        let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
-                        let node_ref = crate::introspect::NodeRef::Actor(id.clone());
-                        stopped_children.push(node_ref.clone());
-                        if let Some(snapshot) = proc.terminated_snapshot(&id) {
-                            let snapshot_attrs: hyperactor_config::Attrs =
-                                serde_json::from_str(&snapshot.attrs).unwrap_or_default();
-                            if snapshot_attrs
-                                .get(hyperactor::introspect::IS_SYSTEM)
-                                .copied()
-                                .unwrap_or(false)
-                            {
-                                system_children.push(node_ref);
-                            }
-                        }
-                        if !children.contains(&child_ref) {
-                            children.push(child_ref);
+                let mut stopped_children: Vec<crate::introspect::NodeRef> = Vec::new();
+                for id in proc.all_terminated_actor_ids() {
+                    let child_ref = hyperactor::introspect::IntrospectRef::Actor(id.clone());
+                    let node_ref = crate::introspect::NodeRef::Actor(id.clone());
+                    stopped_children.push(node_ref.clone());
+                    if let Some(snapshot) = proc.terminated_snapshot(&id) {
+                        let snapshot_attrs: hyperactor_config::Attrs =
+                            serde_json::from_str(&snapshot.attrs).unwrap_or_default();
+                        if snapshot_attrs
+                            .get(hyperactor::introspect::IS_SYSTEM)
+                            .copied()
+                            .unwrap_or(false)
+                        {
+                            system_children.push(node_ref);
                         }
                     }
-
-                    let stopped_retention_cap = hyperactor_config::global::get(
-                        hyperactor::config::TERMINATED_SNAPSHOT_RETENTION,
-                    );
-
-                    let (is_poisoned, failed_actor_count) = proc
-                        .get_instance(&self_id)
-                        .and_then(|cell| cell.published_attrs())
-                        .map(|attrs| {
-                            let is_poisoned = attrs
-                                .get(crate::introspect::IS_POISONED)
-                                .copied()
-                                .unwrap_or(false);
-                            let failed_actor_count = attrs
-                                .get(crate::introspect::FAILED_ACTOR_COUNT)
-                                .copied()
-                                .unwrap_or(0);
-                            (is_poisoned, failed_actor_count)
-                        })
-                        .unwrap_or((false, 0));
-
-                    // Build attrs for this proc node.
-                    let num_live = children.len();
-                    let mut attrs = hyperactor_config::Attrs::new();
-                    attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
-                    attrs.set(
-                        crate::introspect::PROC_NAME,
-                        proc_ref
-                            .label()
-                            .map(|l| l.as_str().to_string())
-                            .unwrap_or_else(|| proc_ref.id().to_string()),
-                    );
-                    attrs.set(crate::introspect::NUM_ACTORS, num_live);
-                    attrs.set(crate::introspect::SYSTEM_CHILDREN, system_children);
-                    attrs.set(crate::introspect::STOPPED_CHILDREN, stopped_children);
-                    attrs.set(
-                        crate::introspect::STOPPED_RETENTION_CAP,
-                        stopped_retention_cap,
-                    );
-                    attrs.set(crate::introspect::IS_POISONED, is_poisoned);
-                    attrs.set(crate::introspect::FAILED_ACTOR_COUNT, failed_actor_count);
-
-                    // PD-*: include proc debug stats in QueryChild
-                    // to prevent resolution drift from the publish path.
-                    let memory = crate::introspect::ProcessMemoryStats::read_from_procfs();
-                    memory.to_attrs(&mut attrs);
-                    attrs.set(
-                        crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL,
-                        proc.queue_depth_total(),
-                    );
-                    let mut queue_max: u64 = 0;
-                    for aid in proc.all_instance_keys() {
-                        if let Some(cell) = proc.get_instance_by_id(&aid) {
-                            queue_max = queue_max.max(cell.queue_depth());
-                        }
+                    if !children.contains(&child_ref) {
+                        children.push(child_ref);
                     }
-                    attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_MAX, queue_max);
-                    attrs.set(
-                        crate::introspect::ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK,
-                        proc.queue_depth_high_water_mark(),
-                    );
-                    attrs.set(
-                        crate::introspect::LAST_NONZERO_QUEUE_DEPTH_AGE_MS,
-                        proc.last_nonzero_queue_depth_age_ms(),
-                    );
-
-                    let attrs_json =
-                        serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
-
-                    return IntrospectResult {
-                        identity: hyperactor::introspect::IntrospectRef::Proc(proc_ref.clone()),
-                        attrs: attrs_json,
-                        children,
-                        parent: None,
-                        as_of: std::time::SystemTime::now(),
-                    };
                 }
+
+                let stopped_retention_cap = hyperactor_config::global::get(
+                    hyperactor::config::TERMINATED_SNAPSHOT_RETENTION,
+                );
+
+                let (is_poisoned, failed_actor_count) = proc
+                    .get_instance(&self_id)
+                    .and_then(|cell| cell.published_attrs())
+                    .map(|attrs| {
+                        let is_poisoned = attrs
+                            .get(crate::introspect::IS_POISONED)
+                            .copied()
+                            .unwrap_or(false);
+                        let failed_actor_count = attrs
+                            .get(crate::introspect::FAILED_ACTOR_COUNT)
+                            .copied()
+                            .unwrap_or(0);
+                        (is_poisoned, failed_actor_count)
+                    })
+                    .unwrap_or((false, 0));
+
+                // Build attrs for this proc node.
+                let num_live = children.len();
+                let mut attrs = hyperactor_config::Attrs::new();
+                attrs.set(crate::introspect::NODE_TYPE, "proc".to_string());
+                attrs.set(
+                    crate::introspect::PROC_NAME,
+                    proc_ref
+                        .label()
+                        .map(|l| l.as_str().to_string())
+                        .unwrap_or_else(|| proc_ref.id().to_string()),
+                );
+                attrs.set(crate::introspect::NUM_ACTORS, num_live);
+                attrs.set(crate::introspect::SYSTEM_CHILDREN, system_children);
+                attrs.set(crate::introspect::STOPPED_CHILDREN, stopped_children);
+                attrs.set(
+                    crate::introspect::STOPPED_RETENTION_CAP,
+                    stopped_retention_cap,
+                );
+                attrs.set(crate::introspect::IS_POISONED, is_poisoned);
+                attrs.set(crate::introspect::FAILED_ACTOR_COUNT, failed_actor_count);
+
+                // PD-*: include proc debug stats in QueryChild
+                // to prevent resolution drift from the publish path.
+                let memory = crate::introspect::ProcessMemoryStats::read_from_procfs();
+                memory.to_attrs(&mut attrs);
+                attrs.set(
+                    crate::introspect::ACTOR_WORK_QUEUE_DEPTH_TOTAL,
+                    proc.queue_depth_total(),
+                );
+                let mut queue_max: u64 = 0;
+                for aid in proc.all_instance_keys() {
+                    if let Some(cell) = proc.get_instance_by_id(&aid) {
+                        queue_max = queue_max.max(cell.queue_depth());
+                    }
+                }
+                attrs.set(crate::introspect::ACTOR_WORK_QUEUE_DEPTH_MAX, queue_max);
+                attrs.set(
+                    crate::introspect::ACTOR_WORK_QUEUE_DEPTH_HIGH_WATER_MARK,
+                    proc.queue_depth_high_water_mark(),
+                );
+                attrs.set(
+                    crate::introspect::LAST_NONZERO_QUEUE_DEPTH_AGE_MS,
+                    proc.last_nonzero_queue_depth_age_ms(),
+                );
+
+                let attrs_json = serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
+
+                return IntrospectResult {
+                    identity: hyperactor::introspect::IntrospectRef::Proc(proc_ref.clone()),
+                    attrs: attrs_json,
+                    children,
+                    parent: None,
+                    as_of: std::time::SystemTime::now(),
+                };
             }
 
             {
@@ -1214,7 +1213,7 @@ impl Handler<SelfCheck> for ProcAgent {
         let Some(duration) = &self.mesh_orphan_timeout else {
             return Ok(());
         };
-        let duration = duration.clone();
+        let duration = *duration;
         let now = std::time::SystemTime::now();
 
         // Collect expired actors before mutating, since stop_actor borrows &mut self.
@@ -1224,10 +1223,11 @@ impl Handler<SelfCheck> for ProcAgent {
             .filter_map(|(id, state)| {
                 let expiry = state.expiry_time?;
                 // If a stop was already initiated we don't need to do it again.
-                if now > expiry && !state.stop_initiated {
-                    if let Ok(actor_id) = &state.spawn {
-                        return Some((id.clone(), actor_id.clone()));
-                    }
+                if now > expiry
+                    && !state.stop_initiated
+                    && let Ok(actor_id) = &state.spawn
+                {
+                    return Some((id.clone(), actor_id.clone()));
                 }
                 None
             })

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1622,10 +1622,10 @@ mod tests {
             // was still alive.
             let deadline = std::time::Instant::now() + Duration::from_secs(5);
             loop {
-                if let Ok(content) = std::fs::read_to_string(&marker) {
-                    if content.contains("running") {
-                        break;
-                    }
+                if let Ok(content) = std::fs::read_to_string(&marker)
+                    && content.contains("running")
+                {
+                    break;
                 }
                 assert!(
                     std::time::Instant::now() < deadline,

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -666,11 +666,11 @@ impl Handler<RunPySpyProfile> for PySpyProfileWorker {
 /// See PS-3 in `introspect` module doc.
 fn resolve_candidates(pyspy_bin_env: Option<String>) -> Vec<(String, String)> {
     let mut candidates = vec![];
-    if let Some(path) = pyspy_bin_env {
-        if !path.is_empty() {
-            let label = format!("PYSPY_BIN={}", path);
-            candidates.push((path, label));
-        }
+    if let Some(path) = pyspy_bin_env
+        && !path.is_empty()
+    {
+        let label = format!("PYSPY_BIN={}", path);
+        candidates.push((path, label));
     }
     candidates.push(("py-spy".to_string(), "py-spy on PATH".to_string()));
     candidates

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -475,7 +475,7 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            expires_after: self.expires_after.clone(),
+            expires_after: self.expires_after,
             get_state: self.get_state.clone(),
         }
     }

--- a/hyperactor_mesh/src/systemd.rs
+++ b/hyperactor_mesh/src/systemd.rs
@@ -1213,10 +1213,9 @@ mod tests {
                     // for this unit.
                     if let Some((_, expected_marker)) =
                         units.iter().find(|(name, _)| name == &unit_name)
+                        && line.contains(expected_marker)
                     {
-                        if line.contains(expected_marker) {
-                            seen_markers.insert(unit_name.clone(), true);
-                        }
+                        seen_markers.insert(unit_name.clone(), true);
                     }
 
                     // Check if we've seen all markers.

--- a/hyperactor_mesh/src/systemd.rs
+++ b/hyperactor_mesh/src/systemd.rs
@@ -1310,7 +1310,7 @@ mod tests {
             conn: &'a Connection,
             name: String,
         }
-        impl<'a> Cleanup<'a> {
+        impl Cleanup<'_> {
             async fn run(self) {
                 let _ = stop_unit_best_effort(self.conn, &self.name).await;
             }

--- a/hyperactor_mesh/src/value_mesh/rle.rs
+++ b/hyperactor_mesh/src/value_mesh/rle.rs
@@ -162,11 +162,12 @@ pub fn rle_from_value_runs<T: Clone + PartialEq>(
             (table.len() - 1) as u32
         };
         // Coalesce equal-adjacent ids.
-        if let Some((last_r, last_id)) = out.last_mut() {
-            if last_r.end == range.start && *last_id == id {
-                last_r.end = range.end;
-                return;
-            }
+        if let Some((last_r, last_id)) = out.last_mut()
+            && last_r.end == range.start
+            && *last_id == id
+        {
+            last_r.end = range.end;
+            return;
         }
         out.push((range, id));
     };
@@ -200,11 +201,12 @@ pub fn merge_value_runs<T: Eq + Clone>(
     // Local helper that appends a run butg coalesces equal-adjacent
     // (like RankedValues::append)
     let mut append = |range: Range<usize>, value: T| {
-        if let Some((last_r, last_v)) = out.last_mut() {
-            if last_r.end == range.start && *last_v == value {
-                last_r.end = range.end;
-                return;
-            }
+        if let Some((last_r, last_v)) = out.last_mut()
+            && last_r.end == range.start
+            && *last_v == value
+        {
+            last_r.end = range.end;
+            return;
         }
         out.push((range, value));
     };

--- a/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/openapi.rs
@@ -250,10 +250,10 @@ fn escape_pointer_segment(s: &str) -> String {
 fn rewrite_component_refs_to_defs(value: &mut Value) {
     match value {
         Value::Object(map) => {
-            if let Some(Value::String(r)) = map.get_mut("$ref") {
-                if let Some(suffix) = r.strip_prefix("#/components/schemas/") {
-                    *r = format!("#/$defs/{suffix}");
-                }
+            if let Some(Value::String(r)) = map.get_mut("$ref")
+                && let Some(suffix) = r.strip_prefix("#/components/schemas/")
+            {
+                *r = format!("#/$defs/{suffix}");
             }
             for v in map.values_mut() {
                 rewrite_component_refs_to_defs(v);

--- a/hyperactor_mesh_admin_tui/src/client.rs
+++ b/hyperactor_mesh_admin_tui/src/client.rs
@@ -187,12 +187,12 @@ pub(crate) fn build_client(config: &TuiConfig) -> (String, reqwest::Client) {
     // 2. Auto-detect (when no CLI certs were provided).
     // This runs even with an explicit https:// scheme, so the client
     // picks up the mTLS identity from Meta well-known paths.
-    if config.tls_ca.is_none() {
-        if let Some(bundle) = hyperactor::channel::try_tls_pem_bundle() {
-            let (b, ok) = add_tls_from_bundle(builder, &bundle);
-            builder = b;
-            use_tls = use_tls || ok;
-        }
+    if config.tls_ca.is_none()
+        && let Some(bundle) = hyperactor::channel::try_tls_pem_bundle()
+    {
+        let (b, ok) = add_tls_from_bundle(builder, &bundle);
+        builder = b;
+        use_tls = use_tls || ok;
     }
 
     let scheme = if use_tls { "https" } else { "http" };

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -493,8 +493,8 @@ impl<C: Actor> Worker<C> {
         let supervisor = session.supervisor.clone();
         let session_id = session.session_id.clone();
         let orphan_policy = session.options.orphan_policy;
-        if let Some(child) = &self.child_handle {
-            if supervisor
+        if let Some(child) = &self.child_handle
+            && supervisor
                 .send(
                     cx,
                     WorkerSupervisor::SupervisionEvent {
@@ -512,10 +512,9 @@ impl<C: Actor> Worker<C> {
                     },
                 )
                 .is_err()
-            {
-                self.handle_orphaned_supervisor("supervisor session undeliverable")?;
-                return Ok(());
-            }
+        {
+            self.handle_orphaned_supervisor("supervisor session undeliverable")?;
+            return Ok(());
         }
         let session = self
             .session

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -699,10 +699,10 @@ pub fn set_entity_dispatcher(dispatcher: Box<dyn EntityEventDispatcher>) {
                 EntityEventState::Dispatching(_) => Vec::new(),
             };
         for event in buffered {
-            if let EntityEventState::Dispatching(d) = &*state {
-                if let Err(e) = d.dispatch(event) {
-                    tracing::error!("failed to dispatch buffered entity event: {:?}", e);
-                }
+            if let EntityEventState::Dispatching(d) = &*state
+                && let Err(e) = d.dispatch(event)
+            {
+                tracing::error!("failed to dispatch buffered entity event: {:?}", e);
             }
         }
     }

--- a/hyperactor_telemetry/src/recorder.rs
+++ b/hyperactor_telemetry/src/recorder.rs
@@ -399,8 +399,8 @@ impl Recording {
             .collect();
 
         snapshot
-            .iter()
-            .filter_map(|(id, _)| {
+            .keys()
+            .filter_map(|id| {
                 if parents.contains(id) {
                     None
                 } else {

--- a/hyperactor_telemetry/src/recorder.rs
+++ b/hyperactor_telemetry/src/recorder.rs
@@ -149,7 +149,7 @@ impl Entry {
 
     fn set_str(&mut self, name: &'static str, value: &str) {
         self.reset();
-        let mut buf = self.buffer.take().unwrap_or_else(String::new);
+        let mut buf = self.buffer.take().unwrap_or_default();
         buf.clear();
         buf.push_str(value);
         self.name = name;
@@ -158,7 +158,7 @@ impl Entry {
 
     fn set_error(&mut self, name: &'static str, value: &(dyn std::error::Error + 'static)) {
         self.reset();
-        let mut buf = self.buffer.take().unwrap_or_else(String::new);
+        let mut buf = self.buffer.take().unwrap_or_default();
 
         let mut formatter =
             core::fmt::Formatter::new(&mut buf, core::fmt::FormattingOptions::new());
@@ -172,7 +172,7 @@ impl Entry {
 
     fn set_debug(&mut self, name: &'static str, value: &dyn std::fmt::Debug) {
         self.reset();
-        let mut buf = self.buffer.take().unwrap_or_else(String::new);
+        let mut buf = self.buffer.take().unwrap_or_default();
 
         let mut formatter =
             core::fmt::Formatter::new(&mut buf, core::fmt::FormattingOptions::new());
@@ -537,12 +537,12 @@ where
 
         attrs.record(&mut visitor);
 
-        if let Some(keys) = visitor.keys() {
-            if let Some(span) = ctx.span(id) {
-                let mut extensions: tracing_subscriber::registry::ExtensionsMut<'_> =
-                    span.extensions_mut();
-                extensions.insert(keys);
-            }
+        if let Some(keys) = visitor.keys()
+            && let Some(span) = ctx.span(id)
+        {
+            let mut extensions: tracing_subscriber::registry::ExtensionsMut<'_> =
+                span.extensions_mut();
+            extensions.insert(keys);
         }
     }
 

--- a/hyperactor_telemetry/src/sinks/perfetto.rs
+++ b/hyperactor_telemetry/src/sinks/perfetto.rs
@@ -382,7 +382,7 @@ impl PerfettoFileSink {
         track_id
     }
 
-    fn actor_track_name<'a>(fields: &'a TraceFields) -> Option<&'a str> {
+    fn actor_track_name(fields: &TraceFields) -> Option<&str> {
         match get_field(fields, ACTOR_ID_FIELD) {
             Some(FieldValue::Str(actor_id) | FieldValue::Debug(actor_id))
                 if !actor_id.is_empty() =>

--- a/hyperactor_telemetry/src/sqlite.rs
+++ b/hyperactor_telemetry/src/sqlite.rs
@@ -441,10 +441,10 @@ impl Drop for SqliteTracing {
         }
 
         // Delete the temporary file if it exists
-        if let Some(db_path) = &self.db_path {
-            if db_path.exists() {
-                let _ = fs::remove_file(db_path);
-            }
+        if let Some(db_path) = &self.db_path
+            && db_path.exists()
+        {
+            let _ = fs::remove_file(db_path);
         }
     }
 }

--- a/hyperactor_telemetry/src/trace.rs
+++ b/hyperactor_telemetry/src/trace.rs
@@ -17,10 +17,10 @@ const MONARCH_CLIENT_TRACE_ID: &str = "MONARCH_CLIENT_TRACE_ID";
 /// Todo: Eventually use Message Headers to relay this traceid instead of
 /// env vars
 pub fn get_trace_id() -> Option<String> {
-    if let Ok(env_id) = env::var(MONARCH_CLIENT_TRACE_ID) {
-        if !env_id.is_empty() {
-            return Some(env_id);
-        }
+    if let Ok(env_id) = env::var(MONARCH_CLIENT_TRACE_ID)
+        && !env_id.is_empty()
+    {
+        return Some(env_id);
     }
 
     // No trace ID found
@@ -32,10 +32,10 @@ pub fn get_trace_id() -> Option<String> {
 /// The trace ID remains the same as long as it is in the same process.
 /// Use this method only on the client side.
 pub fn get_or_create_trace_id() -> String {
-    if let Ok(existing_trace_id) = std::env::var(MONARCH_CLIENT_TRACE_ID) {
-        if !existing_trace_id.is_empty() {
-            return existing_trace_id;
-        }
+    if let Ok(existing_trace_id) = std::env::var(MONARCH_CLIENT_TRACE_ID)
+        && !existing_trace_id.is_empty()
+    {
+        return existing_trace_id;
     }
 
     let trace_id = execution_id().clone();

--- a/hyperactor_telemetry/src/trace_dispatcher.rs
+++ b/hyperactor_telemetry/src/trace_dispatcher.rs
@@ -302,17 +302,17 @@ impl TraceEventDispatcher {
         }
         let _reset = InSendGuard;
 
-        if let Some(sender) = &self.sender {
-            if let Err(mpsc::TrySendError::Full(_)) = sender.try_send(event) {
-                let dropped = self.dropped_events.fetch_add(1, Ordering::Relaxed) + 1;
+        if let Some(sender) = &self.sender
+            && let Err(mpsc::TrySendError::Full(_)) = sender.try_send(event)
+        {
+            let dropped = self.dropped_events.fetch_add(1, Ordering::Relaxed) + 1;
 
-                if dropped == 1 || dropped.is_multiple_of(1000) {
-                    eprintln!(
-                        "[telemetry]: {}  events and log lines dropped que to full queue (capacity: {})",
-                        dropped, QUEUE_CAPACITY
-                    );
-                    self.send_drop_event(dropped);
-                }
+            if dropped == 1 || dropped.is_multiple_of(1000) {
+                eprintln!(
+                    "[telemetry]: {}  events and log lines dropped que to full queue (capacity: {})",
+                    dropped, QUEUE_CAPACITY
+                );
+                self.send_drop_event(dropped);
             }
         }
     }
@@ -536,14 +536,13 @@ fn worker_loop(
                     None => true,
                 },
                 _ => true,
-            } {
-                if let Err(e) = sink.consume(&event) {
-                    eprintln!(
-                        "[telemetry] sink {} failed to consume event: {}",
-                        sink.name(),
-                        e
-                    );
-                }
+            } && let Err(e) = sink.consume(&event)
+            {
+                eprintln!(
+                    "[telemetry] sink {} failed to consume event: {}",
+                    sink.name(),
+                    e
+                );
             }
         }
     }
@@ -608,10 +607,10 @@ fn worker_loop(
 
 impl Drop for WorkerHandle {
     fn drop(&mut self) {
-        if let Some(handle) = self.join_handle.take() {
-            if let Err(e) = handle.join() {
-                eprintln!("[telemetry] worker thread panicked: {:?}", e);
-            }
+        if let Some(handle) = self.join_handle.take()
+            && let Err(e) = handle.join()
+        {
+            eprintln!("[telemetry] worker thread panicked: {:?}", e);
         }
     }
 }

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -387,8 +387,7 @@ impl DatabaseScanner {
 
         // Build destination PortRef once
         let dest_port_id: reference::PortAddr = dest.clone().into();
-        let dest_ref: reference::PortRef<QueryResponse> =
-            reference::PortRef::attest(dest_port_id.into());
+        let dest_ref: reference::PortRef<QueryResponse> = reference::PortRef::attest(dest_port_id);
 
         // Execute scan, streaming batches directly to destination
         self.execute_scan_streaming(

--- a/monarch_distributed_telemetry/src/query_engine.rs
+++ b/monarch_distributed_telemetry/src/query_engine.rs
@@ -92,15 +92,14 @@ where
 
         loop {
             // Check if we've received all expected batches
-            if let Some(expected) = expected_batches {
-                if batch_count >= expected {
+            if let Some(expected) = expected_batches
+                && batch_count >= expected {
                     tracing::info!(
                         "QueryEngine reader: received all {} expected batches",
                         expected
                     );
                     break;
                 }
-            }
 
             tokio::select! {
                 biased;
@@ -119,11 +118,10 @@ where
                                     for item in iter {
                                         if let Ok(tuple) = item {
                                             // Each item is (rank_dict, count) - get second element
-                                            if let Ok(count_val) = tuple.get_item(1) {
-                                                if let Ok(count) = count_val.extract::<usize>() {
+                                            if let Ok(count_val) = tuple.get_item(1)
+                                                && let Ok(count) = count_val.extract::<usize>() {
                                                     total += count;
                                                 }
-                                            }
                                         }
                                     }
                                 }

--- a/monarch_extension/src/chunked_fuse.rs
+++ b/monarch_extension/src/chunked_fuse.rs
@@ -746,10 +746,10 @@ fn mount_chunked_fuse(
             // Check /proc/mounts directly (authoritative source).
             if let Ok(mounts) = std::fs::read_to_string("/proc/mounts") {
                 for line in mounts.lines() {
-                    if let Some(mp) = line.split_whitespace().nth(1) {
-                        if mp == mount_point {
-                            return Ok(());
-                        }
+                    if let Some(mp) = line.split_whitespace().nth(1)
+                        && mp == mount_point
+                    {
+                        return Ok(());
                     }
                 }
             }

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -440,9 +440,9 @@ impl ClientActor {
     /// or the timeout is reached in which case it will return None
     /// If the actor has been stopped, this returns an error.
     #[pyo3(signature = (*, timeout_msec = None))]
-    fn get_next_message<'py>(
+    fn get_next_message(
         &mut self,
-        py: Python<'py>,
+        py: Python<'_>,
         timeout_msec: Option<u64>,
     ) -> PyResult<Py<PyAny>> {
         let instance = self.instance.clone();

--- a/monarch_extension/src/convert.rs
+++ b/monarch_extension/src/convert.rs
@@ -445,7 +445,7 @@ fn create_map(py: Python) -> HashMap<u64, FnType> {
     m
 }
 
-pub fn convert<'py>(m: Bound<'py, PyAny>) -> PyResult<WorkerMessage> {
+pub fn convert(m: Bound<'_, PyAny>) -> PyResult<WorkerMessage> {
     let converter = {
         let typ = m.get_type().as_ptr() as u64;
         CONVERT_MAP.get_or_init(|| create_map(m.py()))[&typ]

--- a/monarch_extension/src/debugger.rs
+++ b/monarch_extension/src/debugger.rs
@@ -90,7 +90,7 @@ impl PdbActor {
         })
     }
 
-    fn send<'py>(&self, py: Python<'py>, action: DebuggerAction) -> PyResult<()> {
+    fn send(&self, py: Python<'_>, action: DebuggerAction) -> PyResult<()> {
         let controller_actor_ref = self.controller_actor_ref.clone();
         let instance = self.instance.clone();
         let actor_id = instance.blocking_lock().actor_addr().clone();

--- a/monarch_extension/src/fast_pack.rs
+++ b/monarch_extension/src/fast_pack.rs
@@ -83,7 +83,7 @@ pub(crate) fn pack_files_into(buf_ptr: usize, files: &[FileInfo], max_threads: u
     // This prevents all large chunks from landing on a single thread
     // (e.g. 64 x 64 MB data.bin chunks all on thread 0 while threads
     // 1-15 get only tiny .py files).
-    work_units.sort_by(|a, b| b.size.cmp(&a.size));
+    work_units.sort_by_key(|w| std::cmp::Reverse(w.size));
 
     let num_threads = work_units.len().clamp(1, max_threads);
     let mut per_thread: Vec<Vec<&ReadWork>> = vec![Vec::new(); num_threads];

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -659,21 +659,21 @@ impl History {
                 invocation.complete(sender)?;
             }
         }
-        if let Some(port) = &self.exit_port {
-            if self.min_incomplete_seq >= self.seq_lower_bound {
-                let result = match &self.unreported_exception {
-                    Some(exception) => exception.as_ref().clone(),
-                    None => {
-                        // the byte string is just a Python None
-                        PythonMessage::new_from_buf(
-                            PythonMessageKind::Result { rank: None },
-                            b"\x80\x04N.".to_vec(),
-                        )
-                    }
-                };
-                port.send(sender, result)?;
-                self.exit_port = None;
-            }
+        if let Some(port) = &self.exit_port
+            && self.min_incomplete_seq >= self.seq_lower_bound
+        {
+            let result = match &self.unreported_exception {
+                Some(exception) => exception.as_ref().clone(),
+                None => {
+                    // the byte string is just a Python None
+                    PythonMessage::new_from_buf(
+                        PythonMessageKind::Result { rank: None },
+                        b"\x80\x04N.".to_vec(),
+                    )
+                }
+            };
+            port.send(sender, result)?;
+            self.exit_port = None;
         }
         Ok(())
     }

--- a/monarch_extension/src/readonly_fuse.rs
+++ b/monarch_extension/src/readonly_fuse.rs
@@ -437,17 +437,17 @@ impl PathFilesystem for ReadOnlyFs {
         idx += 1;
 
         for (name, maybe_attr) in children {
-            if offset < idx {
-                if let Some(attr) = maybe_attr {
-                    entries.push(Ok(DirectoryEntryPlus {
-                        kind: attr.kind,
-                        name: OsString::from(&name),
-                        offset: idx as i64,
-                        attr,
-                        entry_ttl: TTL,
-                        attr_ttl: TTL,
-                    }));
-                }
+            if offset < idx
+                && let Some(attr) = maybe_attr
+            {
+                entries.push(Ok(DirectoryEntryPlus {
+                    kind: attr.kind,
+                    name: OsString::from(&name),
+                    offset: idx as i64,
+                    attr,
+                    entry_ttl: TTL,
+                    attr_ttl: TTL,
+                }));
             }
             idx += 1;
         }
@@ -620,10 +620,10 @@ fn mount_read_only_filesystem(
 
             if let Ok(mounts) = std::fs::read_to_string("/proc/mounts") {
                 for line in mounts.lines() {
-                    if let Some(mp) = line.split_whitespace().nth(1) {
-                        if mp == mount_point {
-                            return Ok(());
-                        }
+                    if let Some(mp) = line.split_whitespace().nth(1)
+                        && mp == mount_point
+                    {
+                        return Ok(());
                     }
                 }
             }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -491,7 +491,7 @@ impl Bind for PythonMessage {
 impl PythonMessage {
     #[new]
     #[pyo3(signature = (kind, message))]
-    pub fn new<'py>(kind: PythonMessageKind, message: PyRef<'py, FrozenBuffer>) -> PyResult<Self> {
+    pub fn new(kind: PythonMessageKind, message: PyRef<'_, FrozenBuffer>) -> PyResult<Self> {
         Ok(PythonMessage::new_from_buf(kind, message.inner.clone()))
     }
 

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -35,7 +35,7 @@ use crate::runtime::monarch_with_gil;
 #[pyo3(signature = ())]
 pub fn bootstrap_main(py: Python) -> PyResult<Bound<PyAny>> {
     // SAFETY: this is a correct use of this function.
-    let _ = unsafe {
+    unsafe {
         fbinit::perform_init();
     };
 

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -113,9 +113,9 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
 }
 
 #[pyfunction]
-pub fn attach_to_workers<'py>(
+pub fn attach_to_workers(
     instance: &crate::context::PyInstance,
-    workers: Vec<Bound<'py, PyPythonTask>>,
+    workers: Vec<Bound<'_, PyPythonTask>>,
     name: Option<&str>,
 ) -> PyResult<PyPythonTask> {
     let tasks = workers

--- a/monarch_hyperactor/src/buffers.rs
+++ b/monarch_hyperactor/src/buffers.rs
@@ -136,7 +136,7 @@ impl Buffer {
     ///
     /// # Returns
     /// The number of bytes written (always equal to the length of input bytes)
-    fn write<'py>(&mut self, buff: &Bound<'py, PyBytes>) -> usize {
+    fn write(&mut self, buff: &Bound<'_, PyBytes>) -> usize {
         let bytes_written = buff.as_bytes().len();
 
         if bytes_written < self.threshold {
@@ -306,7 +306,7 @@ impl FrozenBuffer {
     /// # Returns
     /// A PyBytes object containing the bytes read from the buffer
     #[pyo3(signature=(size=-1))]
-    fn read<'py>(mut slf: PyRefMut<'py, Self>, size: i64) -> Bound<'py, PyBytes> {
+    fn read(mut slf: PyRefMut<'_, Self>, size: i64) -> Bound<'_, PyBytes> {
         let size = if size <= 0 {
             slf.inner.remaining() as i64
         } else {

--- a/monarch_hyperactor/src/channel.rs
+++ b/monarch_hyperactor/src/channel.rs
@@ -44,7 +44,7 @@ pub enum PyChannelTransport {
 #[pymethods]
 impl PyChannelTransport {
     fn get(&self) -> Self {
-        self.clone()
+        *self
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {

--- a/monarch_hyperactor/src/code_sync/manager.rs
+++ b/monarch_hyperactor/src/code_sync/manager.rs
@@ -419,7 +419,7 @@ pub async fn code_sync_mesh(
             let daemon =
                 RsyncDaemon::spawn(TcpListener::bind(&addrs[..]).await?, &local_workspace).await?;
 
-            let daemon_addr = daemon.addr().clone();
+            let daemon_addr = *daemon.addr();
             let (rsync_conns_tx, rsync_conns_rx) = instance.open_port::<Connect>();
             (
                 Method::Rsync {
@@ -433,7 +433,7 @@ pub async fn code_sync_mesh(
                         .err_into::<anyhow::Error>()
                         .try_for_each_concurrent(None, |connect| async move {
                             let (mut local, mut stream) = try_join!(
-                                TcpStream::connect(daemon_addr.clone()).err_into(),
+                                TcpStream::connect(daemon_addr).err_into(),
                                 accept(instance, instance.self_addr().clone(), connect),
                             )?;
                             tokio::io::copy_bidirectional(&mut local, &mut stream).await?;

--- a/monarch_hyperactor/src/code_sync/rsync.rs
+++ b/monarch_hyperactor/src/code_sync/rsync.rs
@@ -406,7 +406,7 @@ pub async fn rsync_mesh<C: context::Actor + Copy + Unpin>(
             .err_into::<anyhow::Error>()
             .try_for_each_concurrent(None, |connect| async move {
                 let (mut local, mut stream) = try_join!(
-                    TcpStream::connect(daemon_addr.clone()).err_into(),
+                    TcpStream::connect(*daemon_addr).err_into(),
                     accept(cx, cx.instance().self_addr().clone(), connect),
                 )?;
                 tokio::io::copy_bidirectional(&mut local, &mut stream).await?;

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -288,7 +288,7 @@ where
             key.name(),
         ))
     })?;
-    let val: Option<P> = hyperactor_config::global::try_get_cloned(key.clone())
+    let val: Option<P> = hyperactor_config::global::try_get_cloned(*key)
         .map(|v| v.try_into())
         .transpose()?;
     val.map(|v| v.into_py_any(py)).transpose()
@@ -314,7 +314,7 @@ where
     let key = key.downcast_ref::<T>().expect("cannot fail");
     let runtime = hyperactor_config::global::runtime_attrs();
     let val: Option<P> = runtime
-        .get(key.clone())
+        .get(*key)
         .cloned()
         .map(|v| v.try_into())
         .transpose()?;
@@ -334,7 +334,7 @@ fn set_runtime_config_py<T: AttrValue + Debug>(
     // Again, can't fail unless there's a bug in the code in this file.
     let key = key.downcast_ref().expect("cannot fail");
     let mut attrs = Attrs::new();
-    attrs.set(key.clone(), value);
+    attrs.set(*key, value);
     hyperactor_config::global::create_or_merge(Source::Runtime, attrs);
     Ok(())
 }

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -82,7 +82,7 @@ py_global!(
 );
 py_global!(make_future, "monarch._src.actor.future", "Future");
 
-fn unpickle_from_part<'py>(py: Python<'py>, part: Part) -> PyResult<Bound<'py, PyAny>> {
+fn unpickle_from_part(py: Python<'_>, part: Part) -> PyResult<Bound<'_, PyAny>> {
     unpickle(
         py,
         FrozenBuffer {

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -540,10 +540,10 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
 
         // Join the host's mailbox server to flush receive-side acks
         // before the process exits.
-        if let Some(lock) = HOST_SHUTDOWN_HANDLE.get() {
-            if let Some(handle) = lock.lock().await.take() {
-                handle.join().await;
-            }
+        if let Some(lock) = HOST_SHUTDOWN_HANDLE.get()
+            && let Some(handle) = lock.lock().await.take()
+        {
+            handle.join().await;
         }
 
         Ok(())

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -854,12 +854,11 @@ mod tests {
 
             // Await the returned PyPythonTask's future outside the
             // GIL.
-            let flush_result = flush_task
+            flush_task
                 .await_unit()
                 .await
                 .expect("flush failed (forwarding disabled)");
 
-            let _ = flush_result;
             drop(client_py); // See "NOTE ON LIFECYCLE / CLEANUP"
         }
 
@@ -887,12 +886,11 @@ mod tests {
 
             // Await the returned PyPythonTask's future outside the
             // GIL.
-            let flush_result = flush_task
+            flush_task
                 .await_unit()
                 .await
                 .expect("flush failed (forwarding enabled)");
 
-            let _ = flush_result;
             drop(client_py); // See note "NOTE ON LIFECYCLE / CLEANUP"
         }
 

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -523,7 +523,7 @@ impl Drop for LoggingMeshClient {
 
 /// Turns a python exception into a string with a traceback. If the traceback doesn't
 /// exist or can't be formatted, returns just the exception message.
-pub(crate) fn format_traceback<'py>(py: Python<'py>, err: &PyErr) -> String {
+pub(crate) fn format_traceback(py: Python<'_>, err: &PyErr) -> String {
     let traceback = err.traceback(py);
     if traceback.is_some() {
         let inner = || -> PyResult<String> {
@@ -544,8 +544,8 @@ pub(crate) fn format_traceback<'py>(py: Python<'py>, err: &PyErr) -> String {
 }
 
 #[pyfunction]
-fn log_endpoint_exception<'py>(
-    py: Python<'py>,
+fn log_endpoint_exception(
+    py: Python<'_>,
     e: Py<PyAny>,
     endpoint: Py<PyAny>,
     actor_id: PyActorAddr,

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -284,9 +284,7 @@ impl PythonPortRef {
             inner: hyperactor::PortRef::attest(port.inner),
         }
     }
-    fn __reduce__<'py>(
-        slf: Bound<'py, PythonPortRef>,
-    ) -> PyResult<(Bound<'py, PyType>, (PyPortId,))> {
+    fn __reduce__(slf: Bound<'_, PythonPortRef>) -> PyResult<(Bound<'_, PyType>, (PyPortId,))> {
         let id: PyPortId = (*slf.borrow()).inner.port_addr().clone().into();
         Ok((slf.get_type(), (id,)))
     }
@@ -464,9 +462,9 @@ impl PythonOncePortRef {
             inner: port.map(|port| hyperactor::PortRef::attest(port.inner).into_once()),
         }
     }
-    fn __reduce__<'py>(
-        slf: Bound<'py, PythonOncePortRef>,
-    ) -> PyResult<(Bound<'py, PyType>, (Option<PyPortId>,))> {
+    fn __reduce__(
+        slf: Bound<'_, PythonOncePortRef>,
+    ) -> PyResult<(Bound<'_, PyType>, (Option<PyPortId>,))> {
         let id: Option<PyPortId> = (*slf.borrow())
             .inner
             .as_ref()
@@ -687,7 +685,7 @@ struct PythonAccumulator {
 }
 
 impl PythonAccumulator {
-    fn new<'py>(py: Python<'py>, accumulator: Py<PyAny>) -> PyResult<Self> {
+    fn new(py: Python<'_>, accumulator: Py<PyAny>) -> PyResult<Self> {
         let py_reducer = accumulator.getattr(py, "reducer")?;
         let reducer: Option<wirevalue::Any> = if py_reducer.is_none(py) {
             None

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -599,10 +599,10 @@ pub fn pickle(
     Ok(PicklingState { inner: Some(inner) })
 }
 
-pub(crate) fn unpickle<'py>(
-    py: Python<'py>,
+pub(crate) fn unpickle(
+    py: Python<'_>,
     buffer: crate::buffers::FrozenBuffer,
-) -> PyResult<Bound<'py, PyAny>> {
+) -> PyResult<Bound<'_, PyAny>> {
     _unpickle(py).call1((buffer.into_py_any(py)?,))
 }
 

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -444,23 +444,20 @@ fn send_result(
     traceback: Option<Py<PyAny>>,
 ) {
     // a SendErr just means that there are no consumers of the value left.
-    match tx.send(Some(result)) {
-        Err(tokio::sync::watch::error::SendError(Some(Err(pyerr)))) => {
-            monarch_with_gil_blocking(|py| {
-                let tb = if let Some(tb) = traceback {
-                    format_traceback(py, &tb).unwrap()
-                } else {
-                    "None (run with `MONARCH_HYPERACTOR_ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK=1` to see a traceback here)\n".into()
-                };
-                tracing::error!(
-                    "PythonTask errored but is not being awaited; this will not crash your program, but indicates that \
-                    something went wrong.\n{}\nTraceback where the task was created (most recent call last):\n{}",
-                    SerializablePyErr::from(py, &pyerr),
-                    tb
-                );
-            });
-        }
-        _ => {}
+    if let Err(tokio::sync::watch::error::SendError(Some(Err(pyerr)))) = tx.send(Some(result)) {
+        monarch_with_gil_blocking(|py| {
+            let tb = if let Some(tb) = traceback {
+                format_traceback(py, &tb).unwrap()
+            } else {
+                "None (run with `MONARCH_HYPERACTOR_ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK=1` to see a traceback here)\n".into()
+            };
+            tracing::error!(
+                "PythonTask errored but is not being awaited; this will not crash your program, but indicates that \
+                something went wrong.\n{}\nTraceback where the task was created (most recent call last):\n{}",
+                SerializablePyErr::from(py, &pyerr),
+                tb
+            );
+        });
     };
 }
 

--- a/monarch_hyperactor/src/shape.rs
+++ b/monarch_hyperactor/src/shape.rs
@@ -76,7 +76,7 @@ impl PyExtent {
         Ok((slf.getattr("from_bytes")?, (py_bytes,)))
     }
 
-    fn __iter__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+    fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         Ok(self
             .labels()
             .into_bound_py_any(py)?
@@ -94,7 +94,7 @@ impl PyExtent {
         self.inner.len()
     }
 
-    fn keys<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+    fn keys(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         Ok(self.inner.labels().into_bound_py_any(py)?.into())
     }
 
@@ -409,7 +409,7 @@ impl PyPoint {
     fn __len__(&self) -> usize {
         self.extent.len()
     }
-    fn __iter__<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+    fn __iter__(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         Ok(self
             .extent
             .labels()
@@ -467,7 +467,7 @@ impl PyPoint {
         }
     }
 
-    fn keys<'py>(&self, py: Python<'py>) -> PyResult<Py<PyAny>> {
+    fn keys(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         Ok(self.extent.labels().into_bound_py_any(py)?.into())
     }
 }

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -414,10 +414,8 @@ impl ResolvableFunction {
     /// when called.
     pub fn panic_if_requested(&self) {
         match self {
-            Self::FunctionPath(func) => {
-                if func.path == "__test_panic" {
-                    panic!("__test_panic called");
-                }
+            Self::FunctionPath(func) if func.path == "__test_panic" => {
+                panic!("__test_panic called");
             }
             _ => (),
         }

--- a/monarch_record_batch_macros/src/lib.rs
+++ b/monarch_record_batch_macros/src/lib.rs
@@ -156,16 +156,13 @@ impl FieldInfo {
 }
 
 fn extract_option_inner(ty: &Type) -> (&Type, bool) {
-    if let Type::Path(type_path) = ty {
-        if let Some(segment) = type_path.path.segments.last() {
-            if segment.ident == "Option" {
-                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                        return (inner, true);
-                    }
-                }
-            }
-        }
+    if let Type::Path(type_path) = ty
+        && let Some(segment) = type_path.path.segments.last()
+        && segment.ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return (inner, true);
     }
     (ty, false)
 }

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -364,7 +364,7 @@ impl WorkerMessageHandler for WorkerActor {
         let _: Vec<()> = try_join_all(
             sorted_streams
                 .into_iter()
-                .zip(splits.into_iter())
+                .zip(splits)
                 .map(|(stream, split)| stream.init_comm(cx, split)),
         )
         .await?;

--- a/ndslice/src/shape.rs
+++ b/ndslice/src/shape.rs
@@ -260,7 +260,7 @@ pub struct SelectIterator<'a> {
     iter: DimSliceIterator,
 }
 
-impl<'a> Iterator for SelectIterator<'a> {
+impl Iterator for SelectIterator<'_> {
     type Item = Shape;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/ndslice/src/slice.rs
+++ b/ndslice/src/slice.rs
@@ -790,7 +790,7 @@ where
     mapper: F,
 }
 
-impl<'a, T, F> MapSlice<'a, T, F>
+impl<T, F> MapSlice<'_, T, F>
 where
     F: Fn(usize) -> T,
 {

--- a/ndslice/src/view.rs
+++ b/ndslice/src/view.rs
@@ -443,7 +443,7 @@ impl<'a> ExtentPointsIterator<'a> {
     }
 }
 
-impl<'a> Iterator for ExtentPointsIterator<'a> {
+impl Iterator for ExtentPointsIterator<'_> {
     type Item = Point;
 
     /// Advances the iterator and returns the next [`Point`] in
@@ -577,7 +577,7 @@ pub struct CoordIter<'a> {
     axis: usize,
 }
 
-impl<'a> Iterator for CoordIter<'a> {
+impl Iterator for CoordIter<'_> {
     type Item = usize;
 
     /// Computes and returns the coordinate for the current axis, then
@@ -1791,10 +1791,10 @@ pub trait ViewExt: View {
     fn extent(&self) -> Extent;
 
     /// Iterate over all points in this region.
-    fn iter<'a>(&'a self) -> impl Iterator<Item = (Point, Self::Item)> + 'a;
+    fn iter(&self) -> impl Iterator<Item = (Point, Self::Item)> + '_;
 
     /// Iterate over the values in the region.
-    fn values<'a>(&'a self) -> impl Iterator<Item = Self::Item> + 'a;
+    fn values(&self) -> impl Iterator<Item = Self::Item> + '_;
 }
 
 impl<T: View> ViewExt for T {

--- a/serde_multipart/src/de/bincode.rs
+++ b/serde_multipart/src/de/bincode.rs
@@ -77,7 +77,7 @@ where
     }
 }
 
-impl<'de, 'a, R, O> serde::Deserializer<'de> for &'a mut Deserializer<R, O>
+impl<'de, R, O> serde::Deserializer<'de> for &mut Deserializer<R, O>
 where
     R: BincodeRead<'de>,
     O: Options,
@@ -355,7 +355,7 @@ where
     }
 }
 
-impl<'de, 'a, R, O> serde::de::VariantAccess<'de> for &'a mut Deserializer<R, O>
+impl<'de, R, O> serde::de::VariantAccess<'de> for &mut Deserializer<R, O>
 where
     R: BincodeRead<'de>,
     O: Options,

--- a/struct_diff_patch/src/lib.rs
+++ b/struct_diff_patch/src/lib.rs
@@ -456,8 +456,8 @@ mod tests {
         assert_eq!(tuple_value, DerivedTuple("baz".into(), false));
 
         let mut unit = DerivedUnit;
-        let unit_patch = unit.diff(&DerivedUnit);
-        unit_patch.apply(&mut unit).unwrap();
+        unit.diff(&DerivedUnit);
+        ().apply(&mut unit).unwrap();
     }
 
     #[test]

--- a/typeuri_macros/src/lib.rs
+++ b/typeuri_macros/src/lib.rs
@@ -50,35 +50,34 @@ pub fn derive_named(input: TokenStream) -> TokenStream {
     let has_generics = !type_params.is_empty();
 
     for attr in &input.attrs {
-        if attr.path().is_ident("named") {
-            if let Ok(meta) = attr.parse_args_with(
+        if attr.path().is_ident("named")
+            && let Ok(meta) = attr.parse_args_with(
                 syn::punctuated::Punctuated::<Meta, syn::Token![,]>::parse_terminated,
-            ) {
-                for item in meta {
-                    if let Meta::NameValue(MetaNameValue {
-                        path,
-                        value: Expr::Lit(expr_lit),
-                        ..
-                    }) = item
-                    {
-                        if path.is_ident("name") {
-                            if let Lit::Str(name) = expr_lit.lit {
-                                typename = quote! { #name };
-                            } else {
-                                return TokenStream::from(
-                                    syn::Error::new_spanned(path, "invalid name")
-                                        .to_compile_error(),
-                                );
-                            }
+            )
+        {
+            for item in meta {
+                if let Meta::NameValue(MetaNameValue {
+                    path,
+                    value: Expr::Lit(expr_lit),
+                    ..
+                }) = item
+                {
+                    if path.is_ident("name") {
+                        if let Lit::Str(name) = expr_lit.lit {
+                            typename = quote! { #name };
                         } else {
                             return TokenStream::from(
-                                syn::Error::new_spanned(
-                                    path,
-                                    "unsupported attribute (only `name` is supported)",
-                                )
-                                .to_compile_error(),
+                                syn::Error::new_spanned(path, "invalid name").to_compile_error(),
                             );
                         }
+                    } else {
+                        return TokenStream::from(
+                            syn::Error::new_spanned(
+                                path,
+                                "unsupported attribute (only `name` is supported)",
+                            )
+                            .to_compile_error(),
+                        );
                     }
                 }
             }


### PR DESCRIPTION
Summary:
`tools/buckconfigs/fbsource-common.bcfg` globally silences ~46 default-warn clippy lints — including `clippy::collapsible_if`, `clippy::clone_on_copy`, `clippy::needless_lifetimes`, `clippy::elidable_lifetime_names`, and `clippy::unwrap_or_default`. monarch is OSS-first, so contributors running `cargo clippy` see those lints even though `arc rust-clippy` doesn't.  this re-enables the same five via `-W` in `monarch/PACKAGE` so the buck/arc view matches cargo, and CI gates against regressing the cleanups in the parent diff.

these five are exactly the lint categories `cargo clippy --fix` exercised in the parent — picking only those keeps this diff at zero residual warnings; expanding to any of the other ~41 silenced lints would mean a separate cleanup pass first.

source-file edits in this diff are the cleanups those flags surface — mechanical changes (let-chain collapses, `.clone()` removals on `Copy` types, lifetime elisions, `unwrap_or_default` simplifications).

Differential Revision: D105394680
