### PR TITLE
move cfg(fbcode_build) check-cfg to workspace lint inheritance (#3932)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ default-members = [
     "torch-sys-cuda",
     "wirevalue",
 ]
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -16,3 +16,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 
 [dev-dependencies]
 bincode = { version = "2", features = ["serde"] }
+
+[lints]
+workspace = true

--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -16,3 +16,6 @@ cc = "1.2.60"
 glob = "0.3.2"
 pyo3-build-config = { version = "0.26", features = ["resolve-config"] }
 which = "8.0.2"
+
+[lints]
+workspace = true

--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -20,4 +20,4 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 tokio = { version = "1", features = ["full"] }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -92,4 +92,4 @@ default = []
 stdio-write-probe = []
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_config/Cargo.toml
+++ b/hyperactor_config/Cargo.toml
@@ -31,3 +31,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 [dev-dependencies]
 indoc = "2.0.2"
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
+
+[lints]
+workspace = true

--- a/hyperactor_config_macros/Cargo.toml
+++ b/hyperactor_config_macros/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 [dependencies]
 quote = "1.0.45"
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -35,3 +35,6 @@ timed_test = { version = "0.0.0", path = "../timed_test" }
 tokio = { version = "1.37.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
+
+[lints]
+workspace = true

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -75,4 +75,4 @@ proptest = "1.11.0"
 timed_test = { version = "0.0.0", path = "../timed_test" }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_mesh_admin_tui/Cargo.toml
+++ b/hyperactor_mesh_admin_tui/Cargo.toml
@@ -33,4 +33,4 @@ tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 urlencoding = "2.1.0"
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_mesh_macros/Cargo.toml
+++ b/hyperactor_mesh_macros/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 ndslice = { version = "0.0.0", path = "../ndslice" }
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 quote = "1.0.45"
+
+[lints]
+workspace = true

--- a/hyperactor_remote/Cargo.toml
+++ b/hyperactor_remote/Cargo.toml
@@ -28,4 +28,4 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -44,4 +44,4 @@ quickcheck_macros = "1.2.0"
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/monarch_distributed_telemetry/Cargo.toml
+++ b/monarch_distributed_telemetry/Cargo.toml
@@ -26,3 +26,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }
+
+[lints]
+workspace = true

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -53,3 +53,6 @@ distributed_sql_telemetry = ["dep:monarch_distributed_telemetry", "dep:monarch_i
 extension-module = ["pyo3/extension-module"]
 tensor_engine = ["dep:monarch_messages", "dep:monarch_tensor_worker", "dep:torch-sys-cuda"]
 tensor_engine_gpu = ["dep:monarch_cpp_static_libs", "dep:monarch_rdma_extension", "dep:nccl-sys", "dep:rdmaxcel-sys", "monarch_messages/cuda", "monarch_tensor_worker/cuda", "tensor_engine", "torch-sys-cuda/cuda"]
+
+[lints]
+workspace = true

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -63,4 +63,4 @@ default = []
 packaged_rsync = []
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/monarch_introspection_snapshot/Cargo.toml
+++ b/monarch_introspection_snapshot/Cargo.toml
@@ -30,3 +30,6 @@ wirevalue = { version = "0.0.0", path = "../wirevalue" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 tempfile = "3.27.0"
 tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
+
+[lints]
+workspace = true

--- a/monarch_perfetto_trace/Cargo.toml
+++ b/monarch_perfetto_trace/Cargo.toml
@@ -20,3 +20,6 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-perfetto-sdk-schema = "0.13.1"
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
+
+[lints]
+workspace = true

--- a/monarch_record_batch/Cargo.toml
+++ b/monarch_record_batch/Cargo.toml
@@ -10,3 +10,6 @@ license = "BSD-3-Clause"
 [dependencies]
 datafusion = "52.5.0"
 monarch_record_batch_macros = { version = "0.0.0", path = "../monarch_record_batch_macros" }
+
+[lints]
+workspace = true

--- a/monarch_record_batch_macros/Cargo.toml
+++ b/monarch_record_batch_macros/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 quote = "1.0.45"
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -28,3 +28,6 @@ rand = "0.10.1"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
 typeuri = { version = "0.0.0", path = "../typeuri" }
+
+[lints]
+workspace = true

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -13,3 +13,6 @@ tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 [dev-dependencies]
 anyhow = "1.0.102"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
+
+[lints]
+workspace = true


### PR DESCRIPTION
Summary:

each monarch crate's BUCK previously carried its own `cargo_toml_config.lints.rust = {unexpected_cfgs: ...}` block, duplicating the `check-cfg = ['cfg(fbcode_build)']` setting across ~20 generated `Cargo.toml`s.

this hoists the rule to `fbcode/monarch/Cargo.toml`'s new `[workspace.lints.rust]` block (the workspace toml is hand-maintained, not autocargo-generated, so the block survives regen).  per-crate BUCKs now set `lints.workspace = True` so the generated `Cargo.toml`s emit `[lints] workspace = true` and inherit from the workspace.

Differential Revision: D105449600


