### PR TITLE
last lints (#3933)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ default-members = [
     "torch-sys-cuda",
     "wirevalue",
 ]
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -16,3 +16,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 
 [dev-dependencies]
 bincode = { version = "2", features = ["serde"] }
+
+[lints]
+workspace = true

--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -16,3 +16,6 @@ cc = "1.2.60"
 glob = "0.3.2"
 pyo3-build-config = { version = "0.26", features = ["resolve-config"] }
 which = "8.0.2"
+
+[lints]
+workspace = true

--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -20,4 +20,4 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 tokio = { version = "1", features = ["full"] }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -92,4 +92,4 @@ default = []
 stdio-write-probe = []
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_config/Cargo.toml
+++ b/hyperactor_config/Cargo.toml
@@ -31,3 +31,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 [dev-dependencies]
 indoc = "2.0.2"
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
+
+[lints]
+workspace = true

--- a/hyperactor_config_macros/Cargo.toml
+++ b/hyperactor_config_macros/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 [dependencies]
 quote = "1.0.45"
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -35,3 +35,6 @@ timed_test = { version = "0.0.0", path = "../timed_test" }
 tokio = { version = "1.37.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
+
+[lints]
+workspace = true

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -75,4 +75,4 @@ proptest = "1.11.0"
 timed_test = { version = "0.0.0", path = "../timed_test" }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_mesh_admin_tui/Cargo.toml
+++ b/hyperactor_mesh_admin_tui/Cargo.toml
@@ -33,4 +33,4 @@ tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 urlencoding = "2.1.0"
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_mesh_macros/Cargo.toml
+++ b/hyperactor_mesh_macros/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 ndslice = { version = "0.0.0", path = "../ndslice" }
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 quote = "1.0.45"
+
+[lints]
+workspace = true

--- a/hyperactor_remote/Cargo.toml
+++ b/hyperactor_remote/Cargo.toml
@@ -28,4 +28,4 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -44,4 +44,4 @@ quickcheck_macros = "1.2.0"
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_telemetry/src/spool.rs
+++ b/hyperactor_telemetry/src/spool.rs
@@ -34,11 +34,7 @@ struct State<T> {
 
 impl<T> Drop for State<T> {
     fn drop(&mut self) {
-        loop {
-            let Some(entry) = self.ring.pop() else {
-                break;
-            };
-
+        while let Some(entry) = self.ring.pop() {
             if !entry.initialized.load(Ordering::Acquire) {
                 continue;
             }

--- a/hyperactor_telemetry/src/task.rs
+++ b/hyperactor_telemetry/src/task.rs
@@ -36,6 +36,9 @@ macro_rules! spawn {
 
 #[cfg(test)]
 mod tests {
+    // #[traced_test] holds a tracing::Entered guard across await points; suppress the false positive.
+    #![allow(clippy::await_holding_invalid_type)]
+
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicUsize;

--- a/monarch_distributed_telemetry/Cargo.toml
+++ b/monarch_distributed_telemetry/Cargo.toml
@@ -26,3 +26,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }
+
+[lints]
+workspace = true

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -53,3 +53,6 @@ distributed_sql_telemetry = ["dep:monarch_distributed_telemetry", "dep:monarch_i
 extension-module = ["pyo3/extension-module"]
 tensor_engine = ["dep:monarch_messages", "dep:monarch_tensor_worker", "dep:torch-sys-cuda"]
 tensor_engine_gpu = ["dep:monarch_cpp_static_libs", "dep:monarch_rdma_extension", "dep:nccl-sys", "dep:rdmaxcel-sys", "monarch_messages/cuda", "monarch_tensor_worker/cuda", "tensor_engine", "torch-sys-cuda/cuda"]
+
+[lints]
+workspace = true

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -63,4 +63,4 @@ default = []
 packaged_rsync = []
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/monarch_introspection_snapshot/Cargo.toml
+++ b/monarch_introspection_snapshot/Cargo.toml
@@ -30,3 +30,6 @@ wirevalue = { version = "0.0.0", path = "../wirevalue" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 tempfile = "3.27.0"
 tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
+
+[lints]
+workspace = true

--- a/monarch_perfetto_trace/Cargo.toml
+++ b/monarch_perfetto_trace/Cargo.toml
@@ -20,3 +20,6 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-perfetto-sdk-schema = "0.13.1"
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
+
+[lints]
+workspace = true

--- a/monarch_record_batch/Cargo.toml
+++ b/monarch_record_batch/Cargo.toml
@@ -10,3 +10,6 @@ license = "BSD-3-Clause"
 [dependencies]
 datafusion = "52.5.0"
 monarch_record_batch_macros = { version = "0.0.0", path = "../monarch_record_batch_macros" }
+
+[lints]
+workspace = true

--- a/monarch_record_batch_macros/Cargo.toml
+++ b/monarch_record_batch_macros/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 quote = "1.0.45"
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/monarch_types/src/python.rs
+++ b/monarch_types/src/python.rs
@@ -24,6 +24,10 @@ use serde::Serialize;
 /// A variant of `pyo3::IntoPyObject` used to wrap unsafe impls and propagates the
 /// unsafety to the caller.
 pub trait TryIntoPyObjectUnsafe<'py, P> {
+    /// # Safety
+    ///
+    /// The caller must ensure self is valid for the duration of the call
+    /// and that the type-erased pointer invariants of the trait are upheld.
     unsafe fn try_to_object_unsafe(self, py: Python<'py>) -> PyResult<Bound<'py, P>>;
 }
 

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -28,3 +28,6 @@ rand = "0.10.1"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
 typeuri = { version = "0.0.0", path = "../typeuri" }
+
+[lints]
+workspace = true

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -13,3 +13,6 @@ tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 [dev-dependencies]
 anyhow = "1.0.102"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
+
+[lints]
+workspace = true

--- a/struct_diff_patch/src/lib.rs
+++ b/struct_diff_patch/src/lib.rs
@@ -339,6 +339,9 @@ impl_tuple_diff_patch!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
 
 #[cfg(test)]
 mod tests {
+    // The Diff derive macro emits a unit expression; suppress the false positive.
+    #![allow(clippy::unused_unit)]
+
     use super::*;
     use crate as struct_diff_patch; // for macros
 

--- a/typeuri/src/lib.rs
+++ b/typeuri/src/lib.rs
@@ -55,6 +55,11 @@ pub trait Named: Sized + 'static {
 
     /// An unsafe version of 'arm', accepting a pointer to the value,
     /// for use in type-erased settings.
+    ///
+    /// # Safety
+    ///
+    /// self_ must be a valid pointer to a Self instance that
+    /// remains alive for the duration of the call.
     unsafe fn arm_unchecked(self_: *const ()) -> Option<&'static str> {
         // SAFETY: This isn't safe. We're passing it on.
         unsafe { &*(self_ as *const Self) }.arm()


### PR DESCRIPTION
Summary:

clippy cleanup following the workspace lint inheritance change: `while let` in `spool::Drop`; `#[allow(clippy::await_holding_invalid_type)]` on `telemetry::task` tests (false positive — `#[traced_test]` holds a `tracing::Entered` across `.await`); `#[allow(clippy::unused_unit)]` on `struct_diff_patch` tests (`Diff` derive emits a unit); `# Safety` docs on `TryIntoPyObjectUnsafe::try_to_object_unsafe` and `Named::arm_unchecked`. 

after this, `cargo clippy --all-targets --workspace` on a CPU laptop (with the GPU/RDMA crates excluded and the current `-A` allow set) reports no lints — a baseline from which the allow flags can be dropped one at a time and the underlying warnings fixed.

Differential Revision: D105500789


