### PR TITLE
[hyperactor] rename Proc::instance to Proc::client

### DIFF
--- a/docs/source/books/hyperactor-book/src/macros/behavior.md
+++ b/docs/source/books/hyperactor-book/src/macros/behavior.md
@@ -51,7 +51,7 @@ After spawning the real actor, re-type its id as the behavior:
 let mut proc = Proc::isolated();
 let shopping_list_actor: ActorHandle<ShoppingListActor> =
     proc.spawn("shopping", ()).await?;
-let (client, _) = proc.instance("client").unwrap();
+let (client, _) = proc.client("client").unwrap();
 
 // Re-type the reference as ActorRef<ShoppingApi>.
 // We use `attest` here for demonstration, because we know this id

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-appendix-canonical-test.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-appendix-canonical-test.md
@@ -16,7 +16,7 @@ async fn bootstrap_canonical_simple() {
         .unwrap();
 
     // 2) Create an actor instance we'll use to send and receive messages.
-    let (instance, _handle) = proc.instance("client").unwrap();
+    let (instance, _handle) = proc.client("client").unwrap();
 
     // 3) Configure a ProcessAllocator with the bootstrap binary.
     let mut allocator = ProcessAllocator::new(Command::new(crate::testresource::get(

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-from-python.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-from-python.md
@@ -119,7 +119,7 @@ pub fn global_root_client() -> &'static Instance<()> {
         ).unwrap();
 
         // 2. Start an actual actor instance in that proc, called "client".
-        let (client, handle) = client_proc.instance("client").expect("root instance create");
+        let (client, handle) = client_proc.client("client").expect("root instance create");
 
         (client, handle)
     }).0

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-proc-and-instance.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-proc-and-instance.md
@@ -5,7 +5,7 @@ We begin in a process that can already run hyperactor code and create an instanc
 ```rust
 let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string())
     .unwrap();
-let (instance, _handle) = proc.instance("client").unwrap();
+let (instance, _handle) = proc.client("client").unwrap();
 ```
 
 This gives us a proc + mailbox we can use to tell the mesh to do things. That's two separate things happening, so let's spell them out.
@@ -35,20 +35,20 @@ Under the hood it does (cf. `Proc::direct` in the source):
 **Why we start with this:** it's the simplest shape — "one OS process, one hyperactor proc, reachable on a real address."
 
 
-## 1.2 What `proc.instance("client")` does
+## 1.2 What `proc.client("client")` does
 
 Once we have a proc (from `Proc::direct(...)` or otherwise), we usually want "a handle into that proc" that we can drive from plain Rust code. That's what
 
 ```rust
-let (instance, handle) = proc.instance("client")?;
+let (instance, handle) = proc.client("client")?;
 ```
 
 gives you.
 
-Here's what that actually does, based on the `Proc::instance(...)` implementation.
+Here's what that actually does, based on the `Proc::client(...)` implementation.
 
 1. **Allocates a root actor id on that proc**
-   The proc keeps a map of root names. Calling `instance("client")` says: "reserve the name `client` on this proc and give me an `ActorId` for it."
+   The proc keeps a map of root names. Calling `client("client")` says: "reserve the name `client` on this proc and give me an `ActorId` for it."
    That becomes something like:
 
    ```text
@@ -65,7 +65,7 @@ Here's what that actually does, based on the `Proc::instance(...)` implementatio
    - can create children
    - can be turned into a real running actor later
 
-   Because this is `proc.instance(...)` (not `proc.spawn(...)`), it does **not** start an actor loop. The instance is in the "client" shape.
+   Because this is `proc.client(...)` (not `proc.spawn(...)`), it does **not** start an actor loop. The instance is in the "client" shape.
 
 3. **Returns both the instance and a handle**
    You get:
@@ -79,17 +79,17 @@ In the bootstrapping flow we're describing, we often need "a proc-local, control
 - send messages to actors in the mesh (once hosts/procs are up)
 - hand out ports that mesh actors can use to talk back to us
 
-`proc.instance("…")` gives us exactly that: an addressable actor slot on this proc that we control from code.
+`proc.client("…")` gives us exactly that: an addressable actor slot on this proc that we control from code.
 
 Important: this instance is created in "client" / detached mode — there's no actor task running for it - so nothing will automatically read and handle incoming messages. If you open ports on this instance, mesh actors can send to them, but **you** (the calling code) are responsible for receiving/draining those messages.
 
-`proc.instance("client")` is the cheapest way to get that: you get an actor-shaped participant inside the proc without having to define a whole actor type up front.
+`proc.client("client")` is the cheapest way to get that: you get an actor-shaped participant inside the proc without having to define a whole actor type up front.
 
 So this pattern:
 
 ```rust
 let proc = Proc::direct(...).await?;
-let (instance, _handle) = proc.instance("client")?;
+let (instance, _handle) = proc.client("client")?;
 ```
 
 means:

--- a/hyperactor/example/derive.rs
+++ b/hyperactor/example/derive.rs
@@ -137,7 +137,7 @@ async fn main() -> Result<(), anyhow::Error> {
         proc.spawn("shopping", ShoppingListActor::default())?;
     let shopping_api: reference::ActorRef<ShoppingApi> = shopping_list_actor.bind();
     // We join the system, so that we can send messages to actors.
-    let (client, _) = proc.instance("client").unwrap();
+    let (client, _) = proc.client("client").unwrap();
 
     // todo: consider making this a macro to remove the magic names
 

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -224,7 +224,7 @@ pub fn handle_stop<A: Actor>(
 }
 
 /// An actor that does nothing. It is used to represent "client only" actors,
-/// returned by [`Proc::instance`].
+/// returned by [`Proc::client`].
 #[async_trait]
 impl Actor for () {}
 
@@ -1021,7 +1021,7 @@ mod tests {
     #[tokio::test]
     async fn test_server_basic() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, mut rx) = client.open_port();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo", actor).unwrap();
@@ -1035,7 +1035,7 @@ mod tests {
     #[tokio::test]
     async fn test_ping_pong() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (undeliverable_msg_tx, _) = client.open_port();
 
         let ping_actor = PingPongActor::new(Some(undeliverable_msg_tx.bind()), None, None);
@@ -1058,7 +1058,7 @@ mod tests {
     #[tokio::test]
     async fn test_ping_pong_on_handler_error() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (undeliverable_msg_tx, _) = client.open_port();
 
         // Need to set a supervison coordinator for this Proc because there will
@@ -1121,7 +1121,7 @@ mod tests {
         let proc = Proc::isolated();
         let actor = InitActor(false);
         let handle = proc.spawn::<InitActor>("init", actor).unwrap();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         let (port, receiver) = client.open_once_port();
         handle.send(&client, port).unwrap();
@@ -1147,7 +1147,7 @@ mod tests {
             let values: MultiValues = Arc::new(Mutex::new((0, "".to_string())));
             let actor = MultiActor(values.clone());
             let handle = proc.spawn::<MultiActor>("myactor", actor).unwrap();
-            let (client, client_handle) = proc.instance("client").unwrap();
+            let (client, client_handle) = proc.client("client").unwrap();
             Self {
                 proc,
                 values,
@@ -1322,7 +1322,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_actor_handle_basic() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, mut rx) = client.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
@@ -1374,7 +1374,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_mixed_handler_and_non_handler_ports() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         // Port for receiving seq info from actor handler
         let (actor_tx, mut actor_rx) = client.open_port();
@@ -1456,8 +1456,8 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_multiple_clients() {
         let proc = Proc::isolated();
-        let (client1, _) = proc.instance("client1").unwrap();
-        let (client2, _) = proc.instance("client2").unwrap();
+        let (client1, _) = proc.client("client1").unwrap();
+        let (client2, _) = proc.client("client2").unwrap();
 
         // Port for receiving seq info from actor handler
         let (tx, mut rx) = client1.open_port();
@@ -1568,7 +1568,7 @@ mod tests {
         let _guard = config.override_key(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
 
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, mut rx) = client.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
@@ -1656,7 +1656,7 @@ mod tests {
 
     async fn assert_out_of_order_delivery(expected: Vec<(String, u64)>, relay_orders: Vec<usize>) {
         let local_proc: Proc = Proc::isolated();
-        let (client, _) = local_proc.instance("local").unwrap();
+        let (client, _) = local_proc.client("local").unwrap();
         let (tx, mut rx) = client.open_port();
 
         let handle = local_proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
@@ -1666,7 +1666,7 @@ mod tests {
             test_proc_id("remote_0"),
             DelayedMailboxSender::new(local_proc.clone(), relay_orders).boxed(),
         );
-        let (remote_client, _) = remote_proc.instance("remote").unwrap();
+        let (remote_client, _) = remote_proc.client("remote").unwrap();
         // Send the messages out in the order of their expected sequence numbers.
         let mut messages = expected.clone();
         messages.sort_by_key(|v| v.1);
@@ -1767,7 +1767,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_query_default_payload() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_introspect", actor).unwrap();
@@ -1912,7 +1912,7 @@ mod tests {
     #[tokio::test]
     async fn test_ia1_ia4_running_actor_attrs() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("ia_test", actor).unwrap();
@@ -1941,7 +1941,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_query_child_not_found() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_qc", actor).unwrap();
@@ -1986,7 +1986,7 @@ mod tests {
         impl Actor for CustomIntrospectActor {}
 
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let handle = proc
             .spawn("custom_introspect", CustomIntrospectActor)
             .unwrap();
@@ -2023,7 +2023,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_query_supervision_child() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         // Spawn parent.
         let (tx_parent, _rx_parent) = client.open_port::<u64>();
@@ -2101,7 +2101,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_fresh_actor_status() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_fresh", actor).unwrap();
@@ -2139,7 +2139,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_after_user_message() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, mut rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_after_msg", actor).unwrap();
@@ -2175,7 +2175,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_consecutive_queries() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_consec", actor).unwrap();
@@ -2238,7 +2238,7 @@ mod tests {
         }
 
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_attrs", actor).unwrap();
@@ -2275,7 +2275,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_child_handler_round_trip() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_qch", actor).unwrap();
@@ -2354,7 +2354,7 @@ mod tests {
         }
 
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let handle = proc.spawn("wedged", WedgedActor).unwrap();
 
         // Wait for idle before sending the wedging message.
@@ -2399,7 +2399,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_no_perturbation() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, mut rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_no_perturb", actor).unwrap();
@@ -2456,7 +2456,7 @@ mod tests {
 
     /// Exercises CI-1 (see `proc` module doc).
     ///
-    /// Unlike a plain `instance()`, which drops the introspect
+    /// Unlike a plain `client()`, which drops the introspect
     /// receiver so queries are silently discarded, an
     /// `introspectable_instance` has a live `serve_introspect` task
     /// and is fully navigable in admin tooling.
@@ -2491,9 +2491,9 @@ mod tests {
         assert_eq!(actor_type, "()", "CI-1: actor_type must be \"()\"");
     }
 
-    /// Contrast with CI-1: a plain `instance()` does NOT respond to
+    /// Contrast with CI-1: a plain `client()` does NOT respond to
     /// `IntrospectMessage::Query`. Its introspect receiver is dropped
-    /// in `Proc::instance()`, so the message is silently discarded
+    /// in `Proc::client()`, so the message is silently discarded
     /// and the reply port never receives a value.
     ///
     /// Callers that need TUI visibility must use
@@ -2501,8 +2501,8 @@ mod tests {
     #[tokio::test]
     async fn test_instance_does_not_respond_to_query() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
-        let (_mailbox, mailbox_handle) = proc.instance("mailbox").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
+        let (_mailbox, mailbox_handle) = proc.client("mailbox").unwrap();
         let mailbox_id: crate::ActorAddr = mailbox_handle.actor_addr().clone();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
@@ -2516,12 +2516,12 @@ mod tests {
             )
             .unwrap();
 
-        // The introspect receiver was dropped in `instance()`, so the
+        // The introspect receiver was dropped in `client()`, so the
         // message is silently discarded and the reply never arrives.
         let result = tokio::time::timeout(Duration::from_millis(100), reply_rx.recv()).await;
         assert!(
             result.is_err(),
-            "instance() must not respond to IntrospectMessage (introspect receiver dropped)"
+            "client() must not respond to IntrospectMessage (introspect receiver dropped)"
         );
     }
 

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -286,7 +286,7 @@ mod tests {
     #[tokio::test]
     async fn test_instance_gspawn_child_returns_erased_handle() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let (parent, _parent_handle) = proc.client("parent").unwrap();
 
         let child = parent
             .gspawn(
@@ -307,7 +307,7 @@ mod tests {
     #[tokio::test]
     async fn test_instance_gspawn_uid_uses_explicit_uid() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let (parent, _parent_handle) = proc.client("parent").unwrap();
         let uid = Uid::instance_labeled(Label::new("child").unwrap());
 
         let child = parent
@@ -328,7 +328,7 @@ mod tests {
     #[tokio::test]
     async fn test_instance_gspawn_uid_rejects_duplicate_uid() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let (parent, _parent_handle) = proc.client("parent").unwrap();
         let uid = Uid::instance_labeled(Label::new("child").unwrap());
 
         let child = parent

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -451,13 +451,13 @@ mod tests {
             .build()
             .unwrap();
 
-        let (alpha_client, _) = alpha.instance("client").unwrap();
+        let (alpha_client, _) = alpha.client("client").unwrap();
         let (alpha_port, mut alpha_rx) = alpha_client.bind_handler_port::<u64>();
         let PortLocation::Bound(alpha_dest) = alpha_port.location() else {
             panic!("alpha handler port must be bound");
         };
 
-        let (beta_client, _) = beta.instance("client").unwrap();
+        let (beta_client, _) = beta.client("client").unwrap();
         let (beta_port, mut beta_rx) = beta_client.bind_handler_port::<u64>();
         let PortLocation::Bound(beta_dest) = beta_port.location() else {
             panic!("beta handler port must be bound");
@@ -531,7 +531,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let (client, _) = alpha.instance("client").unwrap();
+        let (client, _) = alpha.client("client").unwrap();
         let (undeliverable_msg_tx, mut undeliverable_rx) =
             client.open_port::<Undeliverable<MessageEnvelope>>();
 
@@ -752,7 +752,7 @@ mod tests {
 
         // Scratch proc just to host the return port.
         let scratch = Proc::isolated();
-        let (scratch_client, _) = scratch.instance("return").unwrap();
+        let (scratch_client, _) = scratch.client("return").unwrap();
         let (return_handle, mut return_rx) =
             scratch_client.open_port::<Undeliverable<MessageEnvelope>>();
 
@@ -825,7 +825,7 @@ mod tests {
         assert_eq!(gateway.inner.procs.read().unwrap().len(), 1);
 
         // Verify the new proc is reachable via the gateway.
-        let (client, _) = second.instance("client").unwrap();
+        let (client, _) = second.client("client").unwrap();
         let (port, mut rx) = client.bind_handler_port::<u64>();
         let dest = port.bind().port_addr().clone();
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -21,7 +21,7 @@
 //! # use hyperactor::{ActorAddr, ProcAddr};
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::isolated();
-//! # let (client, _) = proc.instance("client").unwrap();
+//! # let (client, _) = proc.client("client").unwrap();
 //! # let actor_id = proc.proc_addr().actor_addr("actor");
 //! let mbox = Mailbox::new(actor_id);
 //! let (port, mut receiver) = mbox.open_port::<u64>();
@@ -40,7 +40,7 @@
 //! # use hyperactor::{ActorAddr, ProcAddr};
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::isolated();
-//! # let (client, _) = proc.instance("client").unwrap();
+//! # let (client, _) = proc.client("client").unwrap();
 //! # let actor_id = proc.proc_addr().actor_addr("actor");
 //! let mbox = Mailbox::new(actor_id);
 //!
@@ -1072,7 +1072,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                 ))
                 .build()
                 .expect("mailbox server proc builder is valid");
-            let (client, _) = proc.instance("undeliverable_supervisor").unwrap();
+            let (client, _) = proc.client("undeliverable_supervisor").unwrap();
             while let Ok(Undeliverable(mut envelope)) = undeliverable_rx.recv().await {
                 if let Ok(Undeliverable(e)) =
                     envelope.deserialized::<Undeliverable<MessageEnvelope>>()
@@ -3370,7 +3370,7 @@ mod tests {
     #[tokio::test]
     async fn test_mailbox_accum() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (port, mut receiver) = client
             .mailbox()
             .open_accum_port(accum::join_semilattice::<accum::Max<i64>>());
@@ -3426,7 +3426,7 @@ mod tests {
     #[ignore] // error behavior changed, but we will bring it back
     async fn test_mailbox_once() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         let (port, receiver) = client.open_once_port::<u64>();
 
@@ -3638,7 +3638,7 @@ mod tests {
         let (port, receiver) = mbox0.open_once_port::<u64>();
 
         let proc = Proc::configured(test_proc_id("0"), BoxedMailboxSender::new(muxer));
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         port.send(&client, 123u64).unwrap();
         assert_eq!(receiver.recv().await.unwrap(), 123u64);
@@ -3847,7 +3847,7 @@ mod tests {
     #[tokio::test]
     async fn test_enqueue_port() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         let count = Arc::new(AtomicUsize::new(0));
         let count_clone = count.clone();
@@ -3924,7 +3924,7 @@ mod tests {
         let proc_id = test_proc_id("quux_0");
         let mut proc = Proc::configured(proc_id.clone(), proc_forwarder);
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         let foo = proc.spawn("foo", Foo).unwrap();
         let return_handle = foo.port::<Undeliverable<MessageEnvelope>>();
@@ -3976,7 +3976,7 @@ mod tests {
             Flattrs::new(),
         );
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         return_handle
             .send(&client, Undeliverable(envelope.clone()))
             .unwrap();
@@ -4169,8 +4169,8 @@ mod tests {
         reducer_mode: ReducerMode,
     ) -> Setup {
         let proc = Proc::isolated();
-        let (actor0, actor0_handle) = proc.instance("actor0").unwrap();
-        let (actor1, actor1_handle) = proc.instance("actor1").unwrap();
+        let (actor0, actor0_handle) = proc.client("actor0").unwrap();
+        let (actor1, actor1_handle) = proc.client("actor1").unwrap();
 
         // Open a port on actor0
         let (port_handle, receiver) = actor0.open_port::<u64>();
@@ -4300,7 +4300,7 @@ mod tests {
         let _config_guard =
             config.override_key(crate::config::SPLIT_MAX_BUFFER_AGE, Duration::from_mins(10));
         let proc = Proc::isolated();
-        let (actor, _actor_handle) = proc.instance("actor").unwrap();
+        let (actor, _actor_handle) = proc.client("actor").unwrap();
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
         // Split it
@@ -4423,7 +4423,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_split_port_once_mode_basic() {
         let proc = Proc::isolated();
-        let (actor, _actor_handle) = proc.instance("actor").unwrap();
+        let (actor, _actor_handle) = proc.client("actor").unwrap();
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
 
@@ -4451,7 +4451,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_split_port_once_mode_teardown() {
         let proc = Proc::isolated();
-        let (actor, _actor_handle) = proc.instance("actor").unwrap();
+        let (actor, _actor_handle) = proc.client("actor").unwrap();
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
 
@@ -4715,7 +4715,7 @@ mod tests {
     #[tokio::test]
     async fn test_port_contramap() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (handle, mut rx) = client.open_port();
 
         handle
@@ -4848,7 +4848,7 @@ mod tests {
 
         let (port_handle, _rx) = mailbox.open_port::<u64>();
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         mailbox.close(ActorStatus::Stopped("test stop".to_string()));
 
@@ -4873,7 +4873,7 @@ mod tests {
 
         let (port_handle, _rx) = mailbox.open_port::<u64>();
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         mailbox.close(ActorStatus::Failed(ActorErrorKind::Generic(
             "test failure".to_string(),
@@ -4893,7 +4893,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_open_reduce_port() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         // Open an accumulator port with sum reducer
         let (port_handle, receiver) = client.mailbox().open_reduce_port(accum::sum::<u64>());
@@ -4913,7 +4913,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_open_reduce_port_reducer_spec_preserved() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         // Test that different accumulators produce different reducer_specs
         let (sum_handle, _) = client.mailbox().open_reduce_port(accum::sum::<u64>());

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -145,7 +145,7 @@ pub(crate) fn return_undeliverable(
         // A global client for returning undeliverable messages.
         static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
         let client = &CLIENT
-            .get_or_init(|| Proc::runtime().instance("global_return_client").unwrap())
+            .get_or_init(|| Proc::runtime().client("global_return_client").unwrap())
             .0;
         let envelope_copy = envelope.clone();
         if (return_handle.send(client, Undeliverable(envelope))).is_err() {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -968,7 +968,7 @@ impl Proc {
         M: RemoteMessage,
         R: Referable + RemoteHandles<M>,
     {
-        let (instance, _handle) = self.instance(name)?;
+        let (instance, _handle) = self.client(name)?;
         let (_handle, rx) = instance.bind_handler_port::<M>();
         let actor_ref = ActorRef::attest(instance.self_addr().clone());
         Ok((instance, actor_ref, rx))
@@ -1010,7 +1010,7 @@ impl Proc {
     /// introspect task).  This is safe to call outside a Tokio
     /// runtime — unlike [`actor_instance`], it never calls
     /// `tokio::spawn`.
-    pub fn instance(&self, name: &str) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
+    pub fn client(&self, name: &str) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
         let actor_id: ActorAddr = self.allocate_root_id(name)?;
         let (instance, _receivers) = Instance::new(self.clone(), actor_id, false, None);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
@@ -1021,8 +1021,8 @@ impl Proc {
     /// Create a lightweight client instance that handles
     /// [`IntrospectMessage`].
     ///
-    /// Like [`instance`](Self::instance), this creates a client-mode
-    /// instance with no actor message loop. Unlike `instance`, it
+    /// Like [`client`](Self::client), this creates a client-mode
+    /// instance with no actor message loop. Unlike `client`, it
     /// spawns a dedicated introspect task, so the instance responds
     /// to `IntrospectMessage::Query` and is visible and navigable in
     /// admin tooling such as the mesh TUI.
@@ -2250,7 +2250,7 @@ impl<A: Actor> Instance<A> {
     pub fn self_client() -> &'static Instance<()> {
         static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
         &CLIENT
-            .get_or_init(|| Proc::runtime().instance("self_message_client").unwrap())
+            .get_or_init(|| Proc::runtime().client("self_message_client").unwrap())
             .0
     }
 
@@ -3228,7 +3228,7 @@ impl InstanceCell {
             // A global signal client is used to send signals to the actor.
             static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
             let client = &CLIENT
-                .get_or_init(|| Proc::runtime().instance("global_signal_client").unwrap())
+                .get_or_init(|| Proc::runtime().client("global_signal_client").unwrap())
                 .0;
             signal_port.send(&client, signal).map_err(ActorError::from)
         } else {
@@ -3258,7 +3258,7 @@ impl InstanceCell {
                         // send are silently dropped. This happens when a child
                         // stops after the parent's mailbox has been closed or its
                         // supervision port receiver has been dropped (e.g. client
-                        // instances created via Proc::instance()).
+                        // instances created via Proc::client()).
                         tracing::debug!(
                             "{}: dropping non-error supervision event {}: {:?}",
                             self.actor_addr(),
@@ -3883,7 +3883,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_instance_can_bind_signal_port() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         let (_signal_port, _signal_rx) = client.bind_handler_port::<Signal>();
     }
@@ -3893,7 +3893,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_actor() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let handle = proc.spawn("test", TestActor).unwrap();
 
         // Check on the join handle.
@@ -3943,7 +3943,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_proc_actors_messaging() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let first = proc.spawn::<TestActor>("first", TestActor).unwrap();
         let second = proc.spawn::<TestActor>("second", TestActor).unwrap();
         let (tx, rx) = oneshot::channel::<()>();
@@ -4129,7 +4129,7 @@ mod tests {
         use crate::testing::ids::test_actor_id;
 
         let proc = Proc::isolated();
-        let (instance, _) = proc.instance("worker").unwrap();
+        let (instance, _) = proc.client("worker").unwrap();
         let (port, mut receiver) = instance.bind_handler_port::<u64>();
 
         let PortLocation::Bound(default_dest) = port.location() else {
@@ -4156,7 +4156,7 @@ mod tests {
     fn test_default_location_changes_new_bindings_not_lookup() {
         let proc = Proc::isolated();
         let gateway = proc.gateway();
-        let (_instance, handle) = proc.instance("worker").unwrap();
+        let (_instance, handle) = proc.client("worker").unwrap();
 
         let first_ref: ActorRef<()> = handle.bind();
         let new_location = ChannelAddr::Local(9876).into();
@@ -4224,7 +4224,7 @@ mod tests {
         let proc = Proc::isolated();
         let gateway = proc.gateway();
         let initial_location = proc.default_location();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (port, mut receiver) = client.bind_handler_port::<u64>();
         let PortLocation::Bound(default_dest) = port.location() else {
             panic!("handler port must be bound");
@@ -4307,7 +4307,7 @@ mod tests {
         use crate::testing::ids::test_actor_id;
 
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (return_handle, mut undeliverable_rx) =
             client.open_port::<Undeliverable<MessageEnvelope>>();
         let remote_proc = ProcAddr::unique(ChannelAddr::Local(1234), "remote");
@@ -4354,7 +4354,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_actor_lookup() {
         let proc = Proc::isolated();
-        let (client, _handle) = proc.instance("client").unwrap();
+        let (client, _handle) = proc.client("client").unwrap();
 
         let target_actor = proc.spawn::<TestActor>("target", TestActor).unwrap();
         let target_actor_ref = target_actor.bind();
@@ -4421,7 +4421,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_child() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         let first = proc.spawn::<TestActor>("first", TestActor).unwrap();
         let second = TestActor::spawn_child(&client, &first).await;
@@ -4490,7 +4490,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_child_lifecycle() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let root_1 = TestActor::spawn_child(&client, &root).await;
@@ -4573,7 +4573,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_drain_and_stop_closes_handler_ingress() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let stop_started = Arc::new(tokio::sync::Notify::new());
         let release_stop = Arc::new(tokio::sync::Notify::new());
         let handle = proc
@@ -4601,7 +4601,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_parent_failure() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         // Need to set a supervison coordinator for this Proc because there will
         // be actor failure(s) in this test which trigger supervision.
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -4673,7 +4673,7 @@ mod tests {
         let state = Arc::new(AtomicUsize::new(0));
         let actor = TestActor(state.clone());
         let handle = proc.spawn::<TestActor>("test", actor).unwrap();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, rx) = client.open_once_port();
         handle.send(&client, tx).unwrap();
         let usize_handle = rx.recv().await.unwrap();
@@ -4695,7 +4695,7 @@ mod tests {
         // be actor failure(s) in this test which trigger supervision.
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
-        let (client, _handle) = proc.instance("client").unwrap();
+        let (client, _handle) = proc.client("client").unwrap();
         let actor_handle = proc.spawn("test", TestActor).unwrap();
         actor_handle
             .panic(&client, "some random failure".to_string())
@@ -4771,7 +4771,7 @@ mod tests {
         };
 
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (mut reported_event, _coordinator) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -4864,7 +4864,7 @@ mod tests {
 
         let proc = Proc::isolated();
 
-        let (instance, handle) = proc.instance("my_test_actor").unwrap();
+        let (instance, handle) = proc.client("my_test_actor").unwrap();
 
         let child_actor = TestActor.spawn(&instance).unwrap();
 
@@ -4901,7 +4901,7 @@ mod tests {
             // should cause the process to terminate.
             // ProcSupervisionCoordinator::set(&proc).await.unwrap();
             let root = proc.spawn("root", TestActor).unwrap();
-            let (client, _handle) = proc.instance("client").unwrap();
+            let (client, _handle) = proc.client("client").unwrap();
             root.fail(&client, anyhow::anyhow!("some random failure"))
                 .await
                 .unwrap();
@@ -4997,7 +4997,7 @@ mod tests {
 
         trace_and_block(async {
             let proc = Proc::isolated();
-            let (client, _) = proc.instance("client").unwrap();
+            let (client, _) = proc.client("client").unwrap();
             let handle = LoggingActor.spawn_detached().unwrap();
             handle.send(&client, "hello world".to_string()).unwrap();
             handle
@@ -5037,7 +5037,7 @@ mod tests {
         use crate::mailbox::MailboxSenderErrorKind;
 
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let actor_handle = proc.spawn("test", TestActor).unwrap();
 
         // Clone the handle before awaiting since await consumes the handle
@@ -5070,7 +5070,7 @@ mod tests {
         use crate::mailbox::MailboxSenderErrorKind;
 
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         // Need to set a supervison coordinator for this Proc because there will
         // be actor failure(s) in this test which trigger supervision.
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -5139,7 +5139,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_stored_on_stop() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.instance("client").unwrap();
+        let (_client, _client_handle) = proc.client("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("actor", TestActor).unwrap();
         let actor_id = handle.actor_addr().clone();
@@ -5183,7 +5183,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_stored_on_failure() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         // Supervision coordinator required for actor failure handling.
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5213,7 +5213,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_stored_on_failure() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let handle = proc.spawn::<TestActor>("fail_actor", TestActor).unwrap();
@@ -5238,7 +5238,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_on_clean_stop() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.instance("client").unwrap();
+        let (_client, _client_handle) = proc.client("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("stop_actor", TestActor).unwrap();
         let cell = handle.cell().clone();
@@ -5260,7 +5260,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_coordinator_receives_clean_stop() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.instance("client").unwrap();
+        let (_client, _client_handle) = proc.client("client").unwrap();
         let (mut reported_event, _coordinator_handle) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5283,7 +5283,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_coordinator_shuts_down_last_during_destroy() {
         let mut proc = Proc::isolated();
-        let (_client, _client_handle) = proc.instance("client").unwrap();
+        let (_client, _client_handle) = proc.client("client").unwrap();
         let (mut reported_event, _coordinator_handle) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5324,7 +5324,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_on_propagated_failure() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let parent = proc.spawn::<TestActor>("parent", TestActor).unwrap();
@@ -5366,7 +5366,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_resolve_actor_ref_none_for_terminal_actor() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.instance("client").unwrap();
+        let (_client, _client_handle) = proc.client("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("target", TestActor).unwrap();
         let actor_ref: ActorRef<TestActor> = handle.bind();
@@ -5392,7 +5392,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_has_failure_info() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let handle = proc.spawn::<TestActor>("fail_actor", TestActor).unwrap();
@@ -5436,7 +5436,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_propagated_failure_info() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let parent = proc.spawn::<TestActor>("parent", TestActor).unwrap();
@@ -5619,7 +5619,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_stopped_snapshot_has_no_failure_info() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.instance("client").unwrap();
+        let (_client, _client_handle) = proc.client("client").unwrap();
 
         let handle = proc.spawn::<TestActor>("stop_actor", TestActor).unwrap();
         let actor_id = handle.actor_addr().clone();
@@ -5655,7 +5655,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 10)]
     async fn test_queue_depth_increment_decrement() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let handle = proc.spawn("qd_test", TestActor).unwrap();
         let actor_ref: crate::ActorRef<TestActor> = handle.bind();
         let actor_id = actor_ref.actor_addr().clone();
@@ -5710,7 +5710,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 10)]
     async fn test_proc_queue_depth_aggregation_under_pressure() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
 
         // Spawn two actors.
         let h1 = proc.spawn("a1", TestActor).unwrap();
@@ -5800,7 +5800,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 10)]
     async fn test_retained_queue_stats_burst_then_drain() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let h = proc.spawn("ret_test", TestActor).unwrap();
 
         // Block the actor.

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -183,7 +183,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_client_macros() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let actor_handle = proc.spawn("foo", TestVariantFormsActor {}).unwrap();
 
         assert_eq!(actor_handle.call_struct(&client, 10).await.unwrap(), 10,);

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -145,7 +145,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_binds() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
         //  This will call binds
@@ -234,7 +234,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ref_alias() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
 
@@ -276,7 +276,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_generic_export() {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc
             .spawn("generic", GenericActor::<u64>::new(tx.bind()))

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2464,7 +2464,7 @@ mod tests {
         proc.clone().serve(proc_rx);
         let proc_ref: ProcAddr = test_proc_id("client_0");
         router.bind(proc_ref, proc_addr.clone());
-        let (client, _handle) = proc.instance("client").unwrap();
+        let (client, _handle) = proc.client("client").unwrap();
 
         let (tap_tx, mut tap_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         test_tap::install(tap_tx);
@@ -3004,7 +3004,7 @@ mod tests {
         // Create a root direct-addressed proc + client instance.
         let root =
             hyperactor::Proc::direct(ChannelTransport::Unix.any(), "root".to_string()).unwrap();
-        let (instance, _handle) = root.instance("client").unwrap();
+        let (instance, _handle) = root.client("client").unwrap();
 
         let mgr = BootstrapProcManager::new(BootstrapCommand::test()).unwrap();
         let (proc_id, backend_addr) = make_proc_id_and_backend_addr(&instance, "t_term").await;
@@ -3071,7 +3071,7 @@ mod tests {
         // Root proc + client instance (so the child can dial back).
         let root =
             hyperactor::Proc::direct(ChannelTransport::Unix.any(), "root".to_string()).unwrap();
-        let (instance, _handle) = root.instance("client").unwrap();
+        let (instance, _handle) = root.client("client").unwrap();
 
         let mgr = BootstrapProcManager::new(BootstrapCommand::test()).unwrap();
 
@@ -3125,7 +3125,7 @@ mod tests {
         // Create a local instance just to call the local bootstrap actor.
         // We should find a way to avoid this for local handles.
         let temp_proc = Proc::isolated();
-        let (temp_instance, _) = temp_proc.instance("temp").unwrap();
+        let (temp_instance, _) = temp_proc.client("temp").unwrap();
 
         let handle = host(
             ChannelAddr::any(ChannelTransport::Unix),

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -764,7 +764,7 @@ mod tests {
         use hyperactor::id::Label;
 
         let proc = Proc::direct(ChannelTransport::Unix.any(), proc_name.to_string()).unwrap();
-        let (client, client_handle) = proc.instance("client").unwrap();
+        let (client, client_handle) = proc.client("client").unwrap();
 
         let actor_mesh_id = crate::mesh_id::ActorMeshId::unique(Label::new("test").unwrap());
 

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -426,7 +426,7 @@ mod tests {
     #[tokio::test]
     async fn test_simple_connection() -> Result<()> {
         let proc = Proc::isolated();
-        let (client, _) = proc.instance("client")?;
+        let (client, _) = proc.client("client")?;
         let (connect, completer) = Connect::allocate(client.self_addr().clone(), client);
         let actor = proc.spawn("actor", EchoActor {})?;
         actor.send(&completer.caps, connect)?;
@@ -451,7 +451,7 @@ mod tests {
     #[tokio::test]
     async fn test_connection_close_on_drop() -> Result<()> {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client")?;
+        let (client, _client_handle) = proc.client("client")?;
 
         let (connect, completer) =
             Connect::allocate(client.self_addr().clone(), client.clone_for_py());
@@ -478,7 +478,7 @@ mod tests {
     #[tokio::test]
     async fn test_no_eof_on_drop_after_shutdown() -> Result<()> {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client")?;
+        let (client, _client_handle) = proc.client("client")?;
 
         let (connect, completer) =
             Connect::allocate(client.self_addr().clone(), client.clone_for_py());

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -379,7 +379,7 @@ async fn bootstrap_host() -> GlobalState {
     // reasoning about the bootstrap sequence.
     let temp_proc = Proc::isolated();
     let (bootstrap_cx, _guard) = temp_proc
-        .instance("bootstrap")
+        .client("bootstrap")
         .expect("failed to create bootstrap instance");
     let local_proc_agent: ActorHandle<ProcAgent> = host_agent
         .get_local_proc(&bootstrap_cx)

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -1784,8 +1784,8 @@ mod tests {
         let proc2 = procs.lock().await.get(&proc_id2).unwrap().clone();
 
         // Make sure they can talk to each other:
-        let (instance1, _handle) = proc1.instance("client").unwrap();
-        let (instance2, _handle) = proc2.instance("client").unwrap();
+        let (instance1, _handle) = proc1.client("client").unwrap();
+        let (instance2, _handle) = proc2.client("client").unwrap();
 
         let (port, mut rx) = instance1.mailbox().open_port();
 
@@ -1793,7 +1793,7 @@ mod tests {
         assert_eq!(rx.recv().await.unwrap(), "hello".to_string());
 
         // Make sure that the system proc is also wired in correctly.
-        let (system_actor, _handle) = host.system_proc().instance("test").unwrap();
+        let (system_actor, _handle) = host.system_proc().client("test").unwrap();
 
         // system->proc
         port.bind()
@@ -1864,7 +1864,7 @@ mod tests {
             "test".to_string(),
         )
         .unwrap();
-        let (client_inst, _h) = client.instance("test").unwrap();
+        let (client_inst, _h) = client.client("test").unwrap();
         let (port, rx) = client_inst.mailbox().open_once_port();
         echo1.send(&client_inst, port.bind()).unwrap();
         let id = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -1896,7 +1896,7 @@ mod tests {
         //        client port.
         // Because `client_inst` runs in its own proc, the reply
         // traverses the host (not local delivery within proc1).
-        let (sys_inst, _h) = host.system_proc().instance("sys-client").unwrap();
+        let (sys_inst, _h) = host.system_proc().client("sys-client").unwrap();
         let (port3, rx3) = client_inst.mailbox().open_once_port();
         // Send from system -> child via a message that ultimately
         // replies to client's port
@@ -2173,8 +2173,8 @@ mod tests {
 
         // (1) Host -> remote: open a port on the remote proc, send from
         //     the system instance.
-        let (system_inst, _h) = host.system_proc().instance("test-sender").unwrap();
-        let (remote_inst, _rh) = remote_proc.instance("remote-client").unwrap();
+        let (system_inst, _h) = host.system_proc().client("test-sender").unwrap();
+        let (remote_inst, _rh) = remote_proc.client("remote-client").unwrap();
 
         let (remote_port, mut remote_rx) = remote_inst.mailbox().open_port();
         let remote_port = remote_port.bind();
@@ -2238,7 +2238,7 @@ mod tests {
         let bogus_port = bogus_actor.port_addr(Port::from(0u64));
         let bogus_dest = PortRef::<String>::attest(bogus_port);
 
-        let (trigger_inst, _h) = remote_proc.instance("trigger").unwrap();
+        let (trigger_inst, _h) = remote_proc.client("trigger").unwrap();
         collector_ref
             .port::<SendTo>()
             .send(&trigger_inst, bogus_dest)
@@ -2286,7 +2286,7 @@ mod tests {
         let bogus_port = bogus_actor.port_addr(Port::from(0u64));
         let bogus_dest = PortRef::<String>::attest(bogus_port);
 
-        let (trigger_inst, _h) = host.system_proc().instance("trigger").unwrap();
+        let (trigger_inst, _h) = host.system_proc().client("trigger").unwrap();
         collector_ref
             .port::<SendTo>()
             .send(&trigger_inst, bogus_dest)
@@ -2323,8 +2323,8 @@ mod tests {
 
         let remote_proc = Proc::attach_to_host(host.addr().clone()).await.unwrap();
 
-        let (system_inst, _h) = host.system_proc().instance("teardown-sender").unwrap();
-        let (remote_inst, _rh) = remote_proc.instance("teardown-client").unwrap();
+        let (system_inst, _h) = host.system_proc().client("teardown-sender").unwrap();
+        let (remote_inst, _rh) = remote_proc.client("teardown-client").unwrap();
 
         let (remote_port, mut remote_rx) = remote_inst.mailbox().open_port();
         let remote_port = remote_port.bind();
@@ -2390,7 +2390,7 @@ mod tests {
         let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
         let _client_handle = client_proc.clone().serve(client_rx);
 
-        let (client_inst, _h) = client_proc.instance("requester").unwrap();
+        let (client_inst, _h) = client_proc.client("requester").unwrap();
         let (reply_port, reply_handle) = client_inst.mailbox().open_once_port::<ActorAddr>();
         let reply_port = reply_port.bind();
         echo_ref
@@ -2503,7 +2503,7 @@ mod tests {
                 let echo_ref = ActorRef::<EchoActor>::attest(echo_actor_id);
 
                 for ri in 0..M_REQUESTS {
-                    let (client_inst, _h) = client_proc.instance(&format!("req-{}", ri)).unwrap();
+                    let (client_inst, _h) = client_proc.client(&format!("req-{}", ri)).unwrap();
                     let (reply_port, reply_handle) =
                         client_inst.mailbox().open_once_port::<ActorAddr>();
                     let reply_port = reply_port.bind();
@@ -2575,7 +2575,7 @@ mod tests {
         let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
         let _client_handle = client_proc.clone().serve(client_rx);
 
-        let (client_inst, _client_h) = client_proc.instance("requester").unwrap();
+        let (client_inst, _client_h) = client_proc.client("requester").unwrap();
 
         // Send a request to the echo actor on the host. The reply
         // travels back through the host's dial router → simplex dial

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -863,7 +863,7 @@ impl Drop for HostMeshShutdownGuard {
                                  relying on PDEATHSIG/manager Drop"
                             );
                         }
-                        Ok(proc) => match proc.instance("drop") {
+                        Ok(proc) => match proc.client("drop") {
                             Err(e) => {
                                 tracing::warn!(
                                     error = %e,

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1563,7 +1563,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         let id = ResourceId::unique(Label::new("proc1").unwrap());
 
@@ -1624,7 +1624,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         let id = ResourceId::unique(Label::new("proc1").unwrap());
         host_agent
@@ -1675,7 +1675,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         let id = ResourceId::unique(Label::new("proc1").unwrap());
         host_agent
@@ -1732,7 +1732,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         let id = ResourceId::unique(Label::new("proc1").unwrap());
 
@@ -1781,7 +1781,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         let mesh_a = HostMeshId::unique(Label::new("mesh-a").unwrap());
         let mesh_b = HostMeshId::unique(Label::new("mesh-b").unwrap());
@@ -1885,7 +1885,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         let mesh_a = HostMeshId::unique(Label::new("mesh-a").unwrap());
         let mesh_b = HostMeshId::unique(Label::new("mesh-b").unwrap());
@@ -1972,7 +1972,7 @@ mod tests {
 
         let client_proc =
             Proc::direct(ChannelTransport::Unix.any(), "qd_client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         // Spawn a proc so the host_agent processes at least one
         // CreateOrUpdate message, which goes through the work queue.

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1600,7 +1600,7 @@ mod tests {
         proc.clone().serve(client_rx);
         let proc_ref: ProcAddr = test_proc_id("client_0");
         router.bind(proc_ref, proc_addr.clone());
-        let (client, _handle) = proc.instance("client").unwrap();
+        let (client, _handle) = proc.client("client").unwrap();
 
         // Spin up both the forwarder and the client
         let log_channel = ChannelAddr::any(ChannelTransport::Unix);

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -455,7 +455,7 @@ pub const MESH_ADMIN_ACTOR_NAME: &str = "mesh_admin";
 /// proc identity so they can open one-shot reply ports
 /// (`open_once_port`) to receive responses from `MeshAdminAgent`.
 ///
-/// Unlike a plain `instance()`, this uses
+/// Unlike a plain `client()`, this uses
 /// `Proc::introspectable_instance()` so the bridge responds to
 /// `IntrospectMessage::Query` and appears as a navigable node in the
 /// mesh TUI rather than causing a 504 when selected.
@@ -3349,7 +3349,7 @@ mod tests {
         // Only a mailbox is needed for reply ports — no actor message
         // loop required.
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.instance("client").unwrap();
+        let (client, _handle) = client_proc.client("client").unwrap();
 
         // -- 4. Resolve "root" --
         let root_resp = admin_ref
@@ -3514,7 +3514,7 @@ mod tests {
 
         // Create a bare client instance for sending messages.
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.instance("client").unwrap();
+        let (client, _handle) = client_proc.client("client").unwrap();
 
         // Spawn a user proc via CreateOrUpdate<ProcSpec>.
         let user_proc_name = ResourceId::unique(Label::new("user-proc").unwrap());
@@ -3676,7 +3676,7 @@ mod tests {
         // Client for sending messages.
         let client_proc =
             hyperactor::Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.instance("client").unwrap();
+        let (client, _handle) = client_proc.client("client").unwrap();
 
         // Resolve "root" — should contain only the host.
         let root_resp = admin_ref
@@ -3829,7 +3829,7 @@ mod tests {
         let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.instance("client").unwrap();
+        let (client, _handle) = client_proc.client("client").unwrap();
 
         // Walk the tree breadth-first, checking the invariant at every node.
         // Each entry is (reference_string, expected_parent_identity).
@@ -3935,7 +3935,7 @@ mod tests {
 
         // -- 3. Create a bare client instance for sending messages --
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.instance("client").unwrap();
+        let (client, _handle) = client_proc.client("client").unwrap();
 
         // -- 4. Resolve the host to get its children --
         let host_ref_str =
@@ -4151,7 +4151,7 @@ mod tests {
         // 2. Create a separate caller proc with an actor instance.
         let caller_proc = Proc::direct(ChannelTransport::Unix.any(), "caller".to_string()).unwrap();
         let _supervision = ProcSupervisionCoordinator::set(&caller_proc).await.unwrap();
-        let (caller_cx, _caller_handle) = caller_proc.instance("caller").unwrap();
+        let (caller_cx, _caller_handle) = caller_proc.client("caller").unwrap();
 
         // 3. Call the real public entrypoint.
         let admin_ref = crate::host_mesh::spawn_admin(
@@ -4266,7 +4266,7 @@ mod tests {
         let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         // Resolve the user proc via MeshAdminAgent. HostMeshAgent
         // returns Error for QueryChild → fallback to proc_agent[0]

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -1176,7 +1176,7 @@ impl Handler<NewClientInstance> for ProcAgent {
         cx: &Context<Self>,
         NewClientInstance { client_instance }: NewClientInstance,
     ) -> anyhow::Result<()> {
-        let (instance, _handle) = self.proc.instance("client")?;
+        let (instance, _handle) = self.proc.client("client")?;
         client_instance.send(cx, instance)?;
         Ok(())
     }
@@ -1300,7 +1300,7 @@ mod tests {
 
         // Client instance for opening reply ports.
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_handler_port(&agent_id);
@@ -1406,7 +1406,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_handler_port(&agent_id);
@@ -1414,7 +1414,7 @@ mod tests {
         // Concurrent query task: send QueryChild(Proc) every 10ms.
         let query_client_proc =
             Proc::direct(ChannelTransport::Unix.any(), "query_client".to_string()).unwrap();
-        let (query_client, _qc_handle) = query_client_proc.instance("qc").unwrap();
+        let (query_client, _qc_handle) = query_client_proc.client("qc").unwrap();
         let query_port = port.clone();
         let query_proc_id = proc.proc_addr().clone();
         let query_count = Arc::new(AtomicUsize::new(0));
@@ -1524,7 +1524,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         let agent_ref: ActorRef<ProcAgent> = agent_handle.bind();
 
         let actor_type = hyperactor::actor::remote::Remote::collect()
@@ -1709,7 +1709,7 @@ mod tests {
 
         let client_proc =
             Proc::direct(ChannelTransport::Unix.any(), "qd_client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.instance("client").unwrap();
+        let (client, _client_handle) = client_proc.client("client").unwrap();
 
         // Spawn a blocking actor with a shared gate.
         let gate = Arc::new(tokio::sync::Notify::new());

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1192,7 +1192,7 @@ mod tests {
 
         let (instance, _) = cx
             .proc()
-            .instance(&format!("random_casts_{}", Uuid::now_v7()))
+            .client(&format!("random_casts_{}", Uuid::now_v7()))
             .unwrap();
         let n = 1;
         for _ in 0..n {

--- a/hyperactor_remote/example/token_supervision.rs
+++ b/hyperactor_remote/example/token_supervision.rs
@@ -214,7 +214,7 @@ async fn run_joiner(args: JoinerArgs) -> anyhow::Result<()> {
         ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Localhost)),
         "token_supervision_joiner".to_string(),
     )?;
-    let (joiner, _joiner_handle) = proc.instance("joiner")?;
+    let (joiner, _joiner_handle) = proc.client("joiner")?;
     let worker = proc.spawn(
         "worker",
         Worker::new(DemoChild {

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -506,7 +506,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_supervisor_replies_to_keepalive() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let (parent, _parent_handle) = proc.client("parent").unwrap();
         let supervisor = parent
             .spawn(KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(
                 Duration::from_secs(60),
@@ -534,7 +534,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_supervisor_failure_propagates_to_parent() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let supervisor =
             KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(Duration::from_millis(10)));
@@ -564,7 +564,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_worker_sends_keepalives() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let (parent, _parent_handle) = proc.client("parent").unwrap();
         let supervisor = parent
             .spawn(KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(
                 Duration::from_secs(60),
@@ -596,7 +596,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_worker_failure_propagates_to_parent() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let supervisor = proc.spawn("silent_supervisor", SilentSupervisor).unwrap();
         let uid = Uid::instance();
@@ -634,7 +634,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_link_spawn_mints_shared_worker_spec() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let (parent, _parent_handle) = proc.client("parent").unwrap();
 
         let (supervisor, worker_link) =
             KeepaliveLink::new(Duration::from_secs(60), Duration::from_secs(60))

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -169,7 +169,7 @@ mod tests {
     #[tokio::test]
     async fn test_link_spec_spawns_supervised_child() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.instance("parent").unwrap();
+        let (parent, _parent_handle) = proc.client("parent").unwrap();
         let uid = Uid::instance_labeled(Label::new("link").unwrap());
 
         let link = LinkSpec::for_actor_uid::<TestLinkActor>(
@@ -189,7 +189,7 @@ mod tests {
     #[tokio::test]
     async fn test_link_actor_failure_propagates_to_parent() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let uid = Uid::instance_labeled(Label::new("link").unwrap());
         let link = LinkSpec::for_actor_uid::<TestLinkActor>(

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -837,7 +837,7 @@ mod tests {
     #[tokio::test]
     async fn test_child_failure_propagates_to_parent() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         let session_id = Uid::instance();
 
         let (child_addr, worker, parent, _stopped_rx, mut event_rx) = spawn_supervised_pair(
@@ -884,7 +884,7 @@ mod tests {
     #[tokio::test]
     async fn test_parent_stop_stops_remote_child_before_parent_finishes() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         let session_id = Uid::instance();
 
         let (_child_addr, worker, parent, mut stopped_rx, _event_rx) = spawn_supervised_pair(
@@ -930,7 +930,7 @@ mod tests {
     #[tokio::test]
     async fn test_worker_undeliverable_supervisor_session_stops_child() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         let (ready, mut ready_rx) = client.open_port::<ActorAddr>();
         let (stopped, mut stopped_rx) = client.open_port::<String>();
         let (supervisor, mut supervisor_rx) = client.open_port::<WorkerSupervisor>();
@@ -1015,7 +1015,7 @@ mod tests {
     #[tokio::test]
     async fn test_parent_kill_stops_remote_child() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.instance("client").unwrap();
+        let (client, _client_handle) = proc.client("client").unwrap();
         let (ready, mut ready_rx) = client.open_port::<ActorAddr>();
         let (stopped, mut stopped_rx) = client.open_port::<String>();
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
@@ -1091,7 +1091,7 @@ mod tests {
     #[tokio::test]
     async fn test_detach_orphan_policy_leaves_child_running_on_supervisor_loss() {
         let proc = Proc::isolated();
-        let (inst, _client_handle) = proc.instance("inst").unwrap();
+        let (inst, _client_handle) = proc.client("inst").unwrap();
         let (ready, mut ready_rx) = inst.open_port::<ActorAddr>();
         let (stopped, mut stopped_rx) = inst.open_port::<String>();
         let (supervisor, mut supervisor_rx) = inst.open_port::<WorkerSupervisor>();
@@ -1196,7 +1196,7 @@ mod tests {
     #[tokio::test]
     async fn test_supervised_worker_unlink_stops_child_under_stop_policy() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.instance("inst").unwrap();
+        let (inst, _inst_hndl) = proc.client("inst").unwrap();
         let session_id = Uid::instance();
 
         let (_child_addr, worker, parent, mut stopped_rx, mut events_rx) = spawn_supervised_pair(
@@ -1281,7 +1281,7 @@ mod tests {
     #[tokio::test]
     async fn test_supervised_worker_unlink_leaves_child_running_under_detach_policy() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.instance("inst").unwrap();
+        let (inst, _inst_hndl) = proc.client("inst").unwrap();
         let session_id = Uid::instance();
 
         let (_child_addr, worker, parent, mut stopped_rx, mut events_rx) = spawn_supervised_pair(
@@ -1380,7 +1380,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_link_rejects_second_supervisor() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.instance("inst").unwrap();
+        let (inst, _inst_hndl) = proc.client("inst").unwrap();
         let session_id1 = Uid::instance();
         let (_child_addr, worker, parent1, _stopped_rx, mut events_rx1) = spawn_supervised_pair(
             &proc,
@@ -1486,7 +1486,7 @@ mod tests {
     #[tokio::test]
     async fn test_stop_before_linked_propagates_via_pending_stop() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.instance("inst").unwrap();
+        let (inst, _inst_hndl) = proc.client("inst").unwrap();
         let (link_started, mut link_started_rx) = inst.open_port::<()>();
         let (received_stop, mut received_stop_rx) = inst.open_port::<String>();
         let (events, _events_rx) = inst.open_port::<ActorSupervisionEvent>();
@@ -1569,7 +1569,7 @@ mod tests {
     #[tokio::test]
     async fn test_drain_and_stop_propagates_through_worker_after_child_work() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.instance("inst").unwrap();
+        let (inst, _inst_hndl) = proc.client("inst").unwrap();
         let (ready, mut ready_rx) = inst.open_port::<ActorAddr>();
         let (stopped, mut stopped_rx) = inst.open_port::<String>();
         let (drained, mut drained_rx) = inst.open_port::<String>();
@@ -1666,7 +1666,7 @@ mod tests {
     #[tokio::test]
     async fn test_worker_accepts_relink_after_unlink_under_detach_policy() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.instance("inst").unwrap();
+        let (inst, _inst_hndl) = proc.client("inst").unwrap();
         let session_id1 = Uid::instance();
         let (_child_addr, worker, parent1, mut stopped_rx, mut events_rx1) = spawn_supervised_pair(
             &proc,

--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -533,7 +533,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_delivers_join_to_both_sides() {
         let proc = Proc::isolated();
-        let (creator, _creator_handle) = proc.instance("creator").unwrap();
+        let (creator, _creator_handle) = proc.client("creator").unwrap();
         let (creator_joined, mut creator_joined_rx) = creator.open_port::<Joined<JoinerRef>>();
         let token = create(
             &creator,
@@ -542,7 +542,7 @@ mod tests {
             Options::default(),
         )
         .unwrap();
-        let (joiner, _joiner_handle) = proc.instance("joiner").unwrap();
+        let (joiner, _joiner_handle) = proc.client("joiner").unwrap();
         let (join_result, mut join_result_rx) = joiner.open_port::<JoinResult<CreatorRef>>();
 
         token.join(&joiner, JoinerRef, join_result.bind()).unwrap();
@@ -557,7 +557,7 @@ mod tests {
     #[tokio::test]
     async fn test_once_token_rejects_later_joins() {
         let proc = Proc::isolated();
-        let (creator, _creator_handle) = proc.instance("creator").unwrap();
+        let (creator, _creator_handle) = proc.client("creator").unwrap();
         let (creator_joined, mut creator_joined_rx) = creator.open_port::<Joined<JoinerRef>>();
         let token = create(
             &creator,
@@ -568,7 +568,7 @@ mod tests {
             },
         )
         .unwrap();
-        let (joiner, _joiner_handle) = proc.instance("joiner").unwrap();
+        let (joiner, _joiner_handle) = proc.client("joiner").unwrap();
         let (first_result, mut first_result_rx) = joiner.open_port::<JoinResult<CreatorRef>>();
         let (second_result, mut second_result_rx) = joiner.open_port::<JoinResult<CreatorRef>>();
 
@@ -593,7 +593,7 @@ mod tests {
     #[tokio::test]
     async fn test_multi_token_accepts_every_join() {
         let proc = Proc::isolated();
-        let (creator, _creator_hndl) = proc.instance("creator").unwrap();
+        let (creator, _creator_hndl) = proc.client("creator").unwrap();
         let (creator_joined, mut creator_joined_rx) = creator.open_port::<Joined<MultiJoinerRef>>();
         let token = create(
             &creator,
@@ -605,9 +605,9 @@ mod tests {
         )
         .unwrap();
 
-        let (joiner1, _joiner1_handle) = proc.instance("joiner1").unwrap();
-        let (joiner2, _joiner2_handle) = proc.instance("joiner2").unwrap();
-        let (joiner3, _joiner3_handle) = proc.instance("joiner3").unwrap();
+        let (joiner1, _joiner1_handle) = proc.client("joiner1").unwrap();
+        let (joiner2, _joiner2_handle) = proc.client("joiner2").unwrap();
+        let (joiner3, _joiner3_handle) = proc.client("joiner3").unwrap();
 
         let (r1, mut r1_rx) = joiner1.open_port::<JoinResult<CreatorRef>>();
         let (r2, mut r2_rx) = joiner2.open_port::<JoinResult<CreatorRef>>();
@@ -769,7 +769,7 @@ mod tests {
     #[tokio::test]
     async fn test_join_fails_after_creator_stops() {
         let proc = Proc::isolated();
-        let (inst, _inst_handle) = proc.instance("inst").unwrap();
+        let (inst, _inst_handle) = proc.client("inst").unwrap();
         let (creator_joined, _creator_joined_rx) = inst.open_port::<Joined<JoinerRef>>();
         let (token_out, mut token_out_rx) = inst.open_port::<Token<CreatorRef, JoinerRef>>();
 
@@ -792,7 +792,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (joiner, _joiner_handle) = proc.instance("joiner").unwrap();
+        let (joiner, _joiner_handle) = proc.client("joiner").unwrap();
         let (result, mut result_rx) = joiner.open_port::<JoinResult<CreatorRef>>();
         token.join(&joiner, JoinerRef, result.bind()).unwrap();
 

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -264,7 +264,7 @@ impl Harness {
         let observer_proc = local_proc("observer")?;
         let parent_proc = local_proc("parent")?;
         let worker_proc = local_proc("worker")?;
-        let (observer, _observer_handle) = observer_proc.instance("observer")?;
+        let (observer, _observer_handle) = observer_proc.client("observer")?;
         let (token_out, mut token_out_rx) = observer.open_port::<String>();
         let (parent_linked, mut parent_linked_rx) = observer.open_port::<ActorAddr>();
         let (parent_events, parent_events_rx) = observer.open_port::<ActorSupervisionEvent>();

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1577,11 +1577,7 @@ async fn handle_async_endpoint_panic(
         ENDPOINT_ACTOR_ERROR.add(1, attributes);
         static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
         let client = &CLIENT
-            .get_or_init(|| {
-                get_proc_runtime()
-                    .instance("async_endpoint_handler")
-                    .unwrap()
-            })
+            .get_or_init(|| get_proc_runtime().client("async_endpoint_handler").unwrap())
             .0;
         panic_sender
             .send(&client, Signal::Kill(panic.to_string()))

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -376,7 +376,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
         // We require a temporary instance to make a call to the host/proc agent.
         let temp_proc = Proc::isolated();
         let (temp_instance, _) = temp_proc
-            .instance("temp")
+            .client("temp")
             .map_err(|e| PyException::new_err(e.to_string()))?;
 
         let local_proc_agent: hyperactor::ActorHandle<hyperactor_mesh::proc_agent::ProcAgent> =
@@ -515,7 +515,7 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
         // Create a temporary instance to send the shutdown message
         let temp_proc = hyperactor::Proc::isolated();
         let (instance, _) = temp_proc
-            .instance("shutdown_requester")
+            .client("shutdown_requester")
             .map_err(|e| PyException::new_err(e.to_string()))?;
 
         tracing::info!(

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -333,7 +333,7 @@ pub struct InstanceWrapper<M: RemoteMessage> {
 
 impl<M: RemoteMessage> InstanceWrapper<M> {
     pub fn new(proc: &PyProc, actor_name: &str) -> Result<Self> {
-        let instance = proc.inner.instance(actor_name)?.0;
+        let instance = proc.inner.client(actor_name)?.0;
         // TEMPORARY: remove after using fixed handler ports.
         let (_handler_port, message_receiver) = instance.bind_handler_port::<M>();
 

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -542,7 +542,7 @@ use py::import_cloudpickle;
 /// [`ProcLauncher`] methods don't take a context parameter, but
 /// sending actor messages does. This launcher stores an
 /// [`Instance<()>`] ("client-only" actor) to use as the send context.
-/// The instance is created via [`Proc::instance()`] and must remain
+/// The instance is created via [`Proc::client()`] and must remain
 /// valid for the lifetime of the launcher.
 #[derive(Debug)]
 pub struct ActorProcLauncher {
@@ -557,7 +557,7 @@ pub struct ActorProcLauncher {
     /// Client-only actor instance used as the send context for all
     /// messages to `spawner`.
     ///
-    /// Created via `Proc::instance()`. The `()` type indicates this
+    /// Created via `Proc::client()`. The `()` type indicates this
     /// is not a real actor—just a sending context. Must outlive the
     /// launcher.
     instance: Instance<()>,
@@ -578,7 +578,7 @@ impl ActorProcLauncher {
     ///   `ProcLauncher` ABC.
     /// * `mailbox` - Mailbox used to create one-shot exit ports.
     /// * `instance` - Send context for `ActorHandle::send` (typically
-    ///   from `Proc::instance()`). Any valid instance granting send
+    ///   from `Proc::client()`). Any valid instance granting send
     ///   capability is sufficient; it need not be
     ///   `Instance<PythonActor>`. Must remain valid for the
     ///   launcher's lifetime.

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -502,7 +502,7 @@ mod tests {
 
     async fn setup_with_lru(lru_capacity: usize) -> Harness {
         let proc = Proc::new();
-        let (client, _) = proc.instance("client").unwrap();
+        let (client, _) = proc.client("client").unwrap();
         let mgr_inner = Arc::new(StdMutex::new(MockManagerInner::default()));
         let mgr = MockManagerActor {
             inner: Arc::clone(&mgr_inner),

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1798,7 +1798,7 @@ mod tests {
         };
         let harness = Harness::build(qp, MockResponse::Success(info))?;
 
-        let (peer, _) = harness.proc.instance("peer")?;
+        let (peer, _) = harness.proc.client("peer")?;
         harness.init_handle.send(&peer, NotifyRts)?;
 
         let key = harness.await_done().await;
@@ -1864,7 +1864,7 @@ mod tests {
     async fn test_undeliverable_in_awaiting_transitions_to_failed() {
         let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
-        let (peer, _) = harness.proc.instance("peer").unwrap();
+        let (peer, _) = harness.proc.client("peer").unwrap();
         harness.init_handle.send(&peer, undeliverable).unwrap();
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
@@ -1906,7 +1906,7 @@ mod tests {
         let _ = harness.await_failed().await;
 
         let undeliverable = fake_undeliverable(&harness.proc, "late bounce");
-        let (peer, _) = harness.proc.instance("peer").unwrap();
+        let (peer, _) = harness.proc.client("peer").unwrap();
         harness.init_handle.send(&peer, undeliverable).unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(harness.state.lock().unwrap().failed.len(), 1);

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -549,8 +549,8 @@ impl IbvTestEnv {
             format!("rdma_test_{id}_b"),
         )?;
 
-        let (instance_1, _client_handle_1) = proc_1.instance("client")?;
-        let (instance_2, _client_handle_2) = proc_2.instance("client")?;
+        let (instance_1, _client_handle_1) = proc_1.client("client")?;
+        let (instance_2, _client_handle_2) = proc_2.client("client")?;
 
         let rdma_actor_1 = RdmaManagerActor::new(Some(config1), Flattrs::default()).await?;
         let rdma_actor_handle_1 = proc_1.spawn("rdma_manager", rdma_actor_1)?;

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -304,7 +304,7 @@ impl TcpManagerActor {
                     hyperactor_mesh::shortuuid::ShortUuid::generate()
                 );
                 let (instance, _handle) = proc
-                    .instance(&sender_name)
+                    .client(&sender_name)
                     .expect("failed to create sender instance");
 
                 loop {
@@ -406,7 +406,7 @@ impl Actor for TcpManagerActor {
 
             tokio::spawn(async move {
                 let (instance, _handle) = proc
-                    .instance(&receiver_name.to_string())
+                    .client(&receiver_name.to_string())
                     .expect("failed to create receiver instance");
 
                 loop {
@@ -993,7 +993,7 @@ mod tests {
                 ChannelAddr::any(hyperactor::channel::ChannelTransport::Unix),
                 format!("tcp_test_{id}"),
             )?;
-            let (instance, _) = proc.instance("client")?;
+            let (instance, _) = proc.client("client")?;
 
             let rdma_actor = RdmaManagerActor::new(None, Flattrs::default()).await?;
             let rdma_handle = proc.spawn("rdma_manager", rdma_actor)?;
@@ -1026,7 +1026,7 @@ mod tests {
             buffer_size: usize,
         ) -> anyhow::Result<Self> {
             let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-            let (instance, _) = proc.instance(&format!("client_{id}"))?;
+            let (instance, _) = proc.client(&format!("client_{id}"))?;
 
             let (local_memory, rdma_remote_buf) =
                 Self::alloc_cpu_buffer(&instance, rdma_handle, buffer_size).await?;
@@ -1565,7 +1565,7 @@ mod tests {
                 ChannelAddr::any(hyperactor::channel::ChannelTransport::Unix),
                 format!("tcp_gpu_test_{id}"),
             )?;
-            let (instance, _) = proc.instance("client")?;
+            let (instance, _) = proc.client("client")?;
 
             let rdma_actor = RdmaManagerActor::new(None, Flattrs::default()).await?;
             let rdma_handle = proc.spawn("rdma_manager", rdma_actor)?;

--- a/monarch_tensor_worker/src/comm.rs
+++ b/monarch_tensor_worker/src/comm.rs
@@ -437,7 +437,7 @@ mod tests {
     async fn all_reduce() {
         test_setup().unwrap();
         let proc = Proc::isolated();
-        let (client, _handle) = proc.instance("client").unwrap();
+        let (client, _handle) = proc.client("client").unwrap();
 
         let unique_id = UniqueId::new_nccl().unwrap();
         let device0 = CudaDevice::new(DeviceIndex(0));
@@ -504,7 +504,7 @@ mod tests {
     async fn group_send_recv() {
         test_setup().unwrap();
         let proc = Proc::isolated();
-        let (client, _handle) = proc.instance("client").unwrap();
+        let (client, _handle) = proc.client("client").unwrap();
 
         let unique_id = UniqueId::new_nccl().unwrap();
         let device0 = CudaDevice::new(DeviceIndex(0));
@@ -579,7 +579,7 @@ mod tests {
     async fn reduce() -> Result<()> {
         test_setup()?;
         let proc = Proc::isolated();
-        let (client, _handle) = proc.instance("client")?;
+        let (client, _handle) = proc.client("client")?;
 
         let unique_id = UniqueId::new_nccl()?;
         let device0 = CudaDevice::new(DeviceIndex(0));

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -1984,7 +1984,7 @@ mod tests {
             let proc = Proc::isolated();
             let (_, controller_actor, controller_rx) =
                 proc.attach_actor::<ControllerActor, ControllerMessage>("controller")?;
-            let (client, _handle) = proc.instance("client")?;
+            let (client, _handle) = proc.client("client")?;
             let (supervision_tx, supervision_rx) = client.open_port();
             proc.set_supervision_coordinator(supervision_tx)?;
             let stream_actor = proc.spawn(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3942
* #3941
* #3940
* #3939
* #3938
* #3937
* #3936
* #3935
* __->__ #3934

Rename the existing lightweight client-instance constructor from `Proc::instance` to `Proc::client`, and update call sites and docs across Monarch. This is the first step toward separating client-root construction from the upcoming consistent proc identity constructor API.

Differential Revision: [D105508890](https://our.internmc.facebook.com/intern/diff/D105508890/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508890/)!