### PR TITLE
[hyperactor] add explicit proc identity constructors

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -139,18 +139,33 @@ impl ProcAddr {
         self.id.label()
     }
 
-    /// Create a ProcAddr with a unique (random) uid and the given label.
-    pub fn unique(addr: ChannelAddr, base_name: impl AsRef<str>) -> Self {
+    /// Create a ProcAddr with an anonymous instance proc id.
+    pub fn anonymous(addr: ChannelAddr) -> Self {
+        Self::new(id::ProcId::anonymous(), Location::from(addr))
+    }
+
+    /// Create a ProcAddr with an instance proc id and the given display label.
+    pub fn instance(addr: ChannelAddr, base_name: impl AsRef<str>) -> Self {
         let label = Label::strip(base_name.as_ref());
         Self::new(id::ProcId::instance(label), Location::from(addr))
     }
 
-    /// Create a ProcAddr singleton with a label stripped from the given name.
-    pub fn named(addr: ChannelAddr, name: impl AsRef<str>) -> Self {
+    /// Create a ProcAddr with a singleton proc id identified by the given name.
+    pub fn singleton(addr: ChannelAddr, name: impl AsRef<str>) -> Self {
         Self::new(
             id::ProcId::singleton(Label::strip(name.as_ref())),
             Location::from(addr),
         )
+    }
+
+    /// Create a ProcAddr with a unique (random) uid and the given label.
+    pub fn unique(addr: ChannelAddr, base_name: impl AsRef<str>) -> Self {
+        Self::instance(addr, base_name)
+    }
+
+    /// Create a ProcAddr singleton with a label stripped from the given name.
+    pub fn named(addr: ChannelAddr, name: impl AsRef<str>) -> Self {
+        Self::singleton(addr, name)
     }
 
     /// Create an ActorAddr singleton with the provided name within this proc.
@@ -796,6 +811,42 @@ mod tests {
         let loc: Location = ChannelAddr::Local(42).into();
         let pref = ProcAddr::new(pid, loc);
         assert_eq!(pref.to_string(), format!("{}@inproc://42", pref.id()));
+    }
+
+    #[test]
+    fn test_proc_addr_identity_constructors() {
+        let anonymous = ProcAddr::anonymous(ChannelAddr::Local(1));
+        assert!(
+            matches!(anonymous.id().uid(), Uid::Instance(_, None)),
+            "anonymous proc addr must have an unlabeled instance id"
+        );
+        assert_eq!(anonymous.label(), None);
+        assert_eq!(*anonymous.location().addr(), ChannelAddr::Local(1));
+
+        let instance = ProcAddr::instance(ChannelAddr::Local(2), "worker");
+        assert!(
+            matches!(
+                instance.id().uid(),
+                Uid::Instance(_, Some(label)) if label.as_str() == "worker"
+            ),
+            "instance proc addr must have a labeled instance id"
+        );
+        assert_eq!(instance.label().map(|label| label.as_str()), Some("worker"));
+        assert_eq!(*instance.location().addr(), ChannelAddr::Local(2));
+
+        let singleton = ProcAddr::singleton(ChannelAddr::Local(3), "controller");
+        assert!(
+            matches!(
+                singleton.id().uid(),
+                Uid::Singleton(label) if label.as_str() == "controller"
+            ),
+            "singleton proc addr must have a singleton id"
+        );
+        assert_eq!(
+            singleton.label().map(|label| label.as_str()),
+            Some("controller")
+        );
+        assert_eq!(*singleton.location().addr(), ChannelAddr::Local(3));
     }
 
     #[test]

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -475,6 +475,13 @@ impl ProcId {
         }
     }
 
+    /// Create an anonymous instance [`ProcId`] with a random uid.
+    pub fn anonymous() -> Self {
+        Self {
+            uid: Uid::instance(),
+        }
+    }
+
     /// Create a singleton [`ProcId`] identified by the given label.
     pub fn singleton(label: Label) -> Self {
         Self {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -596,7 +596,7 @@ impl<State> Builder<State> {
     }
 
     fn build_proc(proc_id: Option<ProcId>, gateway: Gateway) -> Result<Proc, anyhow::Error> {
-        let proc_id = proc_id.unwrap_or_else(|| ProcId::new(Uid::instance(), None));
+        let proc_id = proc_id.unwrap_or_else(ProcId::anonymous);
         if is_legacy_pseudo_singleton_proc_id(&proc_id) {
             anyhow::bail!(
                 "legacy pseudo-singleton proc id '{}' must be constructed with a dedicated Proc constructor",
@@ -688,27 +688,42 @@ impl Proc {
         )
     }
 
-    /// Create a proc with a random id on the default gateway.
-    pub fn new() -> Self {
+    /// Create a proc with an anonymous instance id on the default gateway.
+    pub fn anonymous() -> Self {
         Self::builder()
             .build()
-            .expect("default proc builder is valid")
+            .expect("anonymous proc builder is valid")
+    }
+
+    /// Create a proc with an instance id and display label on the default gateway.
+    pub fn instance(label: impl AsRef<str>) -> Self {
+        Self::builder()
+            .proc_id(ProcId::instance(Label::strip(label.as_ref())))
+            .build()
+            .expect("instance proc builder is valid")
+    }
+
+    /// Create a proc with a singleton id on the default gateway.
+    pub fn singleton(name: impl AsRef<str>) -> Self {
+        Self::builder()
+            .proc_id(ProcId::singleton(Label::strip(name.as_ref())))
+            .build()
+            .expect("singleton proc builder is valid")
+    }
+
+    /// Create a proc with an anonymous instance id on the default gateway.
+    pub fn new() -> Self {
+        Self::anonymous()
     }
 
     /// Create a proc with a random id and display label on the default gateway.
     pub fn unique(label: impl AsRef<str>) -> Self {
-        Self::builder()
-            .proc_id(ProcId::instance(Label::strip(label.as_ref())))
-            .build()
-            .expect("unique proc builder is valid")
+        Self::instance(label)
     }
 
     /// Create a proc with a singleton id on the default gateway.
     pub fn named(name: impl AsRef<str>) -> Self {
-        Self::builder()
-            .proc_id(ProcId::singleton(Label::strip(name.as_ref())))
-            .build()
-            .expect("named proc builder is valid")
+        Self::singleton(name)
     }
 
     /// Create a proc with a random id on a fresh local-only gateway.
@@ -3813,6 +3828,42 @@ mod tests {
             parent.send(cx, TestActorMessage::Spawn(tx)).unwrap();
             rx.await.unwrap()
         }
+    }
+
+    #[test]
+    fn test_proc_identity_constructors() {
+        let anonymous = Proc::anonymous();
+        assert!(
+            matches!(anonymous.proc_id().uid(), crate::id::Uid::Instance(_, None)),
+            "anonymous proc must have an unlabeled instance id"
+        );
+        assert_eq!(anonymous.proc_id().label(), None);
+
+        let instance = Proc::instance("worker");
+        assert!(
+            matches!(
+                instance.proc_id().uid(),
+                crate::id::Uid::Instance(_, Some(label)) if label.as_str() == "worker"
+            ),
+            "instance proc must have a labeled instance id"
+        );
+        assert_eq!(
+            instance.proc_id().label().map(|label| label.as_str()),
+            Some("worker")
+        );
+
+        let singleton = Proc::singleton("controller");
+        assert!(
+            matches!(
+                singleton.proc_id().uid(),
+                crate::id::Uid::Singleton(label) if label.as_str() == "controller"
+            ),
+            "singleton proc must have a singleton id"
+        );
+        assert_eq!(
+            singleton.proc_id().label().map(|label| label.as_str()),
+            Some("controller")
+        );
     }
 
     #[async_trait]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3942
* #3941
* #3940
* #3939
* #3938
* #3937
* #3936
* __->__ #3935
* #3934

Add explicit `anonymous`, `instance`, and `singleton` constructor names for proc identity construction. `Proc`, `ProcAddr`, and `ProcId` now expose the target vocabulary while the existing `new`, `unique`, and `named` APIs remain as temporary aliases for the next porting diff.

Differential Revision: [D105508885](https://our.internmc.facebook.com/intern/diff/D105508885/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508885/)!