### PR TITLE
[hyperactor] port proc constructor call sites

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -1166,7 +1166,7 @@ mod tests {
 
     #[test]
     fn test_reference_prefix_relationships() {
-        let proc_ref = ProcAddr::named(ChannelAddr::Local(42), "service");
+        let proc_ref = ProcAddr::singleton(ChannelAddr::Local(42), "service");
         let actor_ref = proc_ref.actor_addr("host_agent");
         let port_ref = actor_ref.port_addr(Port::from(7u64));
 

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -489,7 +489,7 @@ mod tests {
         assert_eq!(received, 222);
         assert_eq!(forwarded.load(Ordering::SeqCst), 0);
 
-        let stranger_proc = ProcAddr::unique(ChannelAddr::Local(9999), "stranger");
+        let stranger_proc = ProcAddr::instance(ChannelAddr::Local(9999), "stranger");
         let stranger_dest = stranger_proc
             .actor_addr("ghost")
             .port_addr(Port::from(0u64));
@@ -759,7 +759,7 @@ mod tests {
         // Fabricate a destination — its contents don't matter; the
         // bounce happens at WeakGateway::upgrade before any demux
         // would run.
-        let dest_proc = ProcAddr::unique(ChannelAddr::Local(1234), "stranger");
+        let dest_proc = ProcAddr::instance(ChannelAddr::Local(1234), "stranger");
         let dest = dest_proc.actor_addr("ghost").port_addr(Port::from(0u64));
         let envelope = MessageEnvelope::serialize(
             test_actor_id("test", "sender"),

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -1073,7 +1073,7 @@ mod tests {
     }
 
     fn test_actor_id(proc_name: &str, actor_name: &str) -> ActorAddr {
-        ProcAddr::named(ChannelAddr::Local(0), proc_name).actor_addr(actor_name)
+        ProcAddr::singleton(ChannelAddr::Local(0), proc_name).actor_addr(actor_name)
     }
 
     fn failed_actor_attrs() -> Attrs {
@@ -1209,7 +1209,7 @@ mod tests {
     /// integration coverage.
     #[test]
     fn test_fi7_fi8_propagated_stopped_child() {
-        let proc_id = ProcAddr::named(ChannelAddr::Local(0), "test_proc");
+        let proc_id = ProcAddr::singleton(ChannelAddr::Local(0), "test_proc");
         let child_id = proc_id.actor_addr("proc_agent");
         let parent_id = proc_id.actor_addr("mesh_actor");
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -285,7 +285,7 @@ impl MessageEnvelope {
     pub(crate) fn new_unknown(dest: impl Into<PortAddr>, data: wirevalue::Any) -> Self {
         // Create a synthetic "unknown" actor ID for messages with no known sender
         let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
-        let unknown_proc_ref = ProcAddr::unique(unknown_addr, "unknown");
+        let unknown_proc_ref = ProcAddr::instance(unknown_addr, "unknown");
         let unknown_actor_ref =
             ActorAddr::root(unknown_proc_ref, crate::id::Label::strip("unknown"));
         Self::new(unknown_actor_ref, dest, data, Flattrs::new())
@@ -1059,7 +1059,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
             static NEXT_RANK: AtomicUsize = AtomicUsize::new(0);
             let rank = NEXT_RANK.fetch_add(1, Ordering::Relaxed);
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = ProcAddr::unique(addr, format!("mailbox_server_{}", rank));
+            let proc_id = ProcAddr::instance(addr, format!("mailbox_server_{}", rank));
             // Use this mailbox server as the forwarder, so we can use it to
             // return message back to the sender.
             //
@@ -3737,7 +3737,7 @@ mod tests {
         // The actor must be on unix:@4 so that after unbinding, the prefix
         // route for world1_1 (unix!@3) is the fallback, not world1_1/actor1 (unix!@4).
         let direct_actor_ref: ActorAddr =
-            ProcAddr::named("unix:@4".parse().unwrap(), "my_proc").actor_addr("my_actor");
+            ProcAddr::singleton("unix:@4".parse().unwrap(), "my_proc").actor_addr("my_actor");
         router.bind(
             Addr::Actor(direct_actor_ref.clone()),
             "unix:@5".parse().unwrap(),

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -681,7 +681,7 @@ impl Proc {
         name: &'static str,
         forwarder: BoxedMailboxSender,
     ) -> Self {
-        let proc_addr = ProcAddr::named(addr, name);
+        let proc_addr = ProcAddr::singleton(addr, name);
         Self::from_parts_unchecked(
             proc_addr.id().clone(),
             Gateway::configured(proc_addr.location().clone(), forwarder),
@@ -754,7 +754,7 @@ impl Proc {
     /// independent instances, so each one receives a unique proc id.
     pub fn direct(addr: ChannelAddr, name: String) -> Result<Self, ChannelError> {
         let (addr, rx) = channel::serve(addr)?;
-        let proc_id = ProcAddr::unique(addr, name);
+        let proc_id = ProcAddr::instance(addr, name);
         let proc = Self::builder()
             .proc_id(proc_id.id().clone())
             .shared_gateway(Gateway::configured(
@@ -790,7 +790,7 @@ impl Proc {
         // envelope ever escapes into the forwarder: it should be
         // dropped, not bounced to the fake sender.
         let signal_actor_id = ActorAddr::root(
-            ProcAddr::named(ChannelAddr::any(channel::ChannelTransport::Local), "attach"),
+            ProcAddr::singleton(ChannelAddr::any(channel::ChannelTransport::Local), "attach"),
             crate::id::Label::strip("attach"),
         );
         let signal_port = signal_actor_id.port_addr(crate::port::Port::from(0u64));
@@ -946,7 +946,7 @@ impl Proc {
         static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
         RUNTIME_PROC.get_or_init(|| {
             let addr = ChannelAddr::any(ChannelTransport::Local);
-            let proc_id = ProcAddr::unique(addr, "hyperactor_runtime");
+            let proc_id = ProcAddr::instance(addr, "hyperactor_runtime");
             Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
         })
     }
@@ -4036,10 +4036,10 @@ mod tests {
         let local_addr = ChannelAddr::Local(1);
         let remote_addr = ChannelAddr::Local(2);
 
-        let proc_local = ProcAddr::unique(local_addr.clone(), "shared");
+        let proc_local = ProcAddr::instance(local_addr.clone(), "shared");
         let proc_same_id_other_location =
             ProcAddr::new(proc_local.id().clone(), remote_addr.into());
-        let proc_other_id_same_location = ProcAddr::unique(local_addr, "other");
+        let proc_other_id_same_location = ProcAddr::instance(local_addr, "other");
         assert_eq!(
             proc_local.id(),
             proc_same_id_other_location.id(),
@@ -4105,8 +4105,8 @@ mod tests {
     #[test]
     fn test_local_delivery_service_and_local_compare_full_proc_addr() {
         for name in [LEGACY_SERVICE_PROC_NAME, LEGACY_LOCAL_PROC_NAME] {
-            let local = ProcAddr::named(ChannelAddr::Local(1), name);
-            let same_id_other_location = ProcAddr::named(ChannelAddr::Local(2), name);
+            let local = ProcAddr::singleton(ChannelAddr::Local(1), name);
+            let same_id_other_location = ProcAddr::singleton(ChannelAddr::Local(2), name);
             let proc = match name {
                 LEGACY_SERVICE_PROC_NAME => Proc::legacy_service_pseudo_singleton(
                     ChannelAddr::Local(1),
@@ -4124,15 +4124,15 @@ mod tests {
             assert!(!proc.is_local_delivery_target(&same_id_other_location));
         }
 
-        let shared = ProcAddr::named(ChannelAddr::Local(1), "shared");
-        let shared_other_location = ProcAddr::named(ChannelAddr::Local(2), "shared");
+        let shared = ProcAddr::singleton(ChannelAddr::Local(1), "shared");
+        let shared_other_location = ProcAddr::singleton(ChannelAddr::Local(2), "shared");
         let proc = Proc::configured(
             shared.clone(),
             BoxedMailboxSender::new(PanickingMailboxSender),
         );
         assert!(proc.is_local_delivery_target(&shared_other_location));
 
-        let service_instance = ProcAddr::unique(ChannelAddr::Local(1), "service");
+        let service_instance = ProcAddr::instance(ChannelAddr::Local(1), "service");
         let service_instance_other_location =
             ProcAddr::new(service_instance.id().clone(), ChannelAddr::Local(2).into());
         let proc = Proc::configured(
@@ -4147,7 +4147,7 @@ mod tests {
         for name in [LEGACY_SERVICE_PROC_NAME, LEGACY_LOCAL_PROC_NAME] {
             let result = std::panic::catch_unwind(|| {
                 Proc::configured(
-                    ProcAddr::named(ChannelAddr::Local(1), name),
+                    ProcAddr::singleton(ChannelAddr::Local(1), name),
                     BoxedMailboxSender::new(PanickingMailboxSender),
                 );
             });
@@ -4361,7 +4361,7 @@ mod tests {
         let (client, _) = proc.client("client").unwrap();
         let (return_handle, mut undeliverable_rx) =
             client.open_port::<Undeliverable<MessageEnvelope>>();
-        let remote_proc = ProcAddr::unique(ChannelAddr::Local(1234), "remote");
+        let remote_proc = ProcAddr::instance(ChannelAddr::Local(1234), "remote");
         let remote_dest = remote_proc.actor_addr("worker").port_addr(Port::from(0));
 
         proc.post(

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -245,7 +245,7 @@ mod tests {
     use crate::channel::ChannelAddr;
 
     fn test_event(name: &str, status: ActorStatus) -> ActorSupervisionEvent {
-        let proc_id = ProcAddr::named(ChannelAddr::Local(0), "test_proc");
+        let proc_id = ProcAddr::singleton(ChannelAddr::Local(0), "test_proc");
         ActorSupervisionEvent::new(
             proc_id.actor_addr(name),
             Some(name.to_string()),
@@ -259,7 +259,7 @@ mod tests {
         addr: ChannelAddr,
         status: ActorStatus,
     ) -> ActorSupervisionEvent {
-        let proc_id = ProcAddr::named(addr, "test_proc");
+        let proc_id = ProcAddr::singleton(addr, "test_proc");
         ActorSupervisionEvent::new(proc_id.actor_addr(name), None, status, None)
     }
 
@@ -573,7 +573,7 @@ mod tests {
     /// root cause for structured failure attribution.
     #[test]
     fn test_sv1_actually_failing_actor_returns_stopped_child() {
-        let proc_id = ProcAddr::named(ChannelAddr::Local(0), "test_proc");
+        let proc_id = ProcAddr::singleton(ChannelAddr::Local(0), "test_proc");
         let child_id = proc_id.actor_addr("proc_agent");
         let parent_id = proc_id.actor_addr("controller");
 

--- a/hyperactor/src/testing/ids.rs
+++ b/hyperactor/src/testing/ids.rs
@@ -19,7 +19,7 @@ use crate::channel::ChannelTransport;
 
 /// Create a test `ProcAddr` with a local channel address and name `"test_{name}"`.
 pub fn test_proc_id(name: &str) -> ProcAddr {
-    ProcAddr::named(
+    ProcAddr::singleton(
         ChannelAddr::any(ChannelTransport::Local),
         format!("test_{name}"),
     )
@@ -27,7 +27,7 @@ pub fn test_proc_id(name: &str) -> ProcAddr {
 
 /// Create a test `ProcAddr` with a custom address and name `"test_{name}"`.
 pub fn test_proc_id_with_addr(addr: ChannelAddr, name: &str) -> ProcAddr {
-    ProcAddr::named(addr, format!("test_{name}"))
+    ProcAddr::singleton(addr, format!("test_{name}"))
 }
 
 /// Create a test `ActorAddr`.

--- a/hyperactor_mesh/src/bootstrap/mailbox.rs
+++ b/hyperactor_mesh/src/bootstrap/mailbox.rs
@@ -130,9 +130,9 @@ mod tests {
     async fn test_proc_dialer() {
         let dir = tempfile::tempdir().unwrap();
         let local_addr: ChannelAddr = "tcp:3.4.5.6:123".parse().unwrap();
-        let first = hyperactor::ProcAddr::unique(local_addr.clone(), "first");
-        let second = hyperactor::ProcAddr::unique(local_addr.clone(), "second");
-        let third = hyperactor::ProcAddr::unique(local_addr.clone(), "third");
+        let first = hyperactor::ProcAddr::instance(local_addr.clone(), "first");
+        let second = hyperactor::ProcAddr::instance(local_addr.clone(), "second");
+        let third = hyperactor::ProcAddr::instance(local_addr.clone(), "third");
         let (first_serve, _) = local_proc_addr(dir.path(), first.id()).unwrap();
         let (_first_addr, mut first_rx) = channel::serve::<MessageEnvelope>(first_serve).unwrap();
         let (second_serve, _) = local_proc_addr(dir.path(), second.id()).unwrap();

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -529,7 +529,7 @@ async fn duplex_accept_loop(
             // `remote` label so procs attached to different host
             // generations sharing a frontend address (e.g., after
             // restart on the same ip:port) cannot collide.
-            let proc_id = ProcAddr::unique(frontend_addr.clone(), "remote");
+            let proc_id = ProcAddr::instance(frontend_addr.clone(), "remote");
 
             let assignment = BootstrapAssignment {
                 proc_id: proc_id.clone(),

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -166,7 +166,7 @@ impl PyActorAddr {
             PyValueError::new_err(format!("Failed to parse channel address '{}': {}", addr, e))
         })?;
         Ok(Self {
-            inner: hyperactor::ProcAddr::named(addr, proc_name).actor_addr(actor_name),
+            inner: hyperactor::ProcAddr::singleton(addr, proc_name).actor_addr(actor_name),
         })
     }
 

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -100,7 +100,7 @@ pub(crate) fn get_proc_runtime() -> &'static Proc {
     static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
     RUNTIME_PROC.get_or_init(|| {
         let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = hyperactor::ProcAddr::unique(addr, "monarch_hyperactor_runtime");
+        let proc_id = hyperactor::ProcAddr::instance(addr, "monarch_hyperactor_runtime");
         Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
     })
 }

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -501,7 +501,7 @@ mod tests {
     }
 
     async fn setup_with_lru(lru_capacity: usize) -> Harness {
-        let proc = Proc::new();
+        let proc = Proc::anonymous();
         let (client, _) = proc.client("client").unwrap();
         let mgr_inner = Arc::new(StdMutex::new(MockManagerInner::default()));
         let mgr = MockManagerActor {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1696,7 +1696,7 @@ mod tests {
 
     impl Harness {
         fn build(qp: QpGuard, response: MockResponse) -> Result<Self> {
-            let proc = Proc::new();
+            let proc = Proc::anonymous();
             let state = Arc::new(Mutex::new(MockState::default()));
             let mock = MockManager {
                 state: state.clone(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3942
* #3941
* #3940
* #3939
* #3938
* #3937
* __->__ #3936
* #3935
* #3934

Port internal Monarch call sites from the temporary `new`, `unique`, and `named` proc identity constructors to the explicit `anonymous`, `instance`, and `singleton` vocabulary. This leaves the old aliases in place for the final cleanup diff.

Differential Revision: [D105508892](https://our.internmc.facebook.com/intern/diff/D105508892/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508892/)!