### PR TITLE
[hyperactor] remove old proc constructor aliases

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -158,16 +158,6 @@ impl ProcAddr {
         )
     }
 
-    /// Create a ProcAddr with a unique (random) uid and the given label.
-    pub fn unique(addr: ChannelAddr, base_name: impl AsRef<str>) -> Self {
-        Self::instance(addr, base_name)
-    }
-
-    /// Create a ProcAddr singleton with a label stripped from the given name.
-    pub fn named(addr: ChannelAddr, name: impl AsRef<str>) -> Self {
-        Self::singleton(addr, name)
-    }
-
     /// Create an ActorAddr singleton with the provided name within this proc.
     pub fn actor_addr(&self, name: impl AsRef<str>) -> ActorAddr {
         let uid = Uid::singleton(Label::strip(name.as_ref()));

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -711,21 +711,6 @@ impl Proc {
             .expect("singleton proc builder is valid")
     }
 
-    /// Create a proc with an anonymous instance id on the default gateway.
-    pub fn new() -> Self {
-        Self::anonymous()
-    }
-
-    /// Create a proc with a random id and display label on the default gateway.
-    pub fn unique(label: impl AsRef<str>) -> Self {
-        Self::instance(label)
-    }
-
-    /// Create a proc with a singleton id on the default gateway.
-    pub fn named(name: impl AsRef<str>) -> Self {
-        Self::singleton(name)
-    }
-
     /// Create a proc with a random id on a fresh local-only gateway.
     pub fn isolated() -> Self {
         Self::builder()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3942
* #3941
* #3940
* #3939
* #3938
* __->__ #3937
* #3936
* #3935
* #3934

Remove the temporary `new`, `unique`, and `named` proc identity constructor aliases after porting internal call sites to `anonymous`, `instance`, and `singleton`.

Differential Revision: [D105508895](https://our.internmc.facebook.com/intern/diff/D105508895/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508895/)!