### PR TITLE
[hyperactor] add identity constructor aliases

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -300,9 +300,14 @@ impl ActorAddr {
     }
 
     /// Create an ActorAddr for a child actor with a random uid.
-    pub fn unique_child(&self) -> Self {
-        let child_id = id::ActorId::instance(self.id.proc_id().clone());
+    pub fn anonymous_child(&self) -> Self {
+        let child_id = id::ActorId::anonymous(self.id.proc_id().clone());
         Self::new(child_id, self.location.clone())
+    }
+
+    /// Create an ActorAddr for a child actor with a random uid.
+    pub fn unique_child(&self) -> Self {
+        self.anonymous_child()
     }
 
     /// Whether this is a root actor (singleton uid).

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -223,9 +223,14 @@ pub enum UidParseError {
 }
 
 impl Uid {
+    /// Create a fresh instance with a random uid and no display label.
+    pub fn anonymous() -> Self {
+        Uid::Instance(rand::random(), None)
+    }
+
     /// Create a fresh instance with a random uid.
     pub fn instance() -> Self {
-        Uid::Instance(rand::random(), None)
+        Self::anonymous()
     }
 
     /// Create a fresh instance with a random uid and display label.
@@ -622,12 +627,17 @@ impl ActorId {
         }
     }
 
-    /// Create an instance [`ActorId`] with a random uid and no label.
-    pub fn instance(proc_id: ProcId) -> Self {
+    /// Create an anonymous instance [`ActorId`] with a random uid.
+    pub fn anonymous(proc_id: ProcId) -> Self {
         Self {
-            uid: Uid::instance(),
+            uid: Uid::anonymous(),
             proc_id,
         }
+    }
+
+    /// Create an instance [`ActorId`] with a random uid and no label.
+    pub fn instance(proc_id: ProcId) -> Self {
+        Self::anonymous(proc_id)
     }
 
     /// Create an instance [`ActorId`] with a random uid and the given label.

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -101,9 +101,14 @@ impl ResourceId {
         Self(Uid::Singleton(label))
     }
 
+    /// Create an instance [`ResourceId`] with a random uid and the given label.
+    pub fn instance(label: Label) -> Self {
+        Self(Uid::instance_labeled(label))
+    }
+
     /// Create a unique [`ResourceId`] with a random uid and the given label.
     pub fn unique(label: Label) -> Self {
-        Self(Uid::instance_labeled(label))
+        Self::instance(label)
     }
 
     /// Create a resource id from a resource-name string.
@@ -321,9 +326,14 @@ macro_rules! define_mesh_id {
                 Self(ResourceId::singleton(label))
             }
 
+            /// Create an instance mesh id with a random uid and the given label.
+            pub fn instance(label: Label) -> Self {
+                Self(ResourceId::instance(label))
+            }
+
             /// Create a unique mesh id with a random uid and the given label.
             pub fn unique(label: Label) -> Self {
-                Self(ResourceId::unique(label))
+                Self::instance(label)
             }
 
             /// Returns the uid.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3942
* #3941
* #3940
* #3939
* __->__ #3938
* #3937
* #3936
* #3935
* #3934

Add non-conflicting `anonymous` and `instance` constructor aliases across the remaining identity types. This introduces `Uid::anonymous`, `ActorId::anonymous`, `ActorAddr::anonymous_child`, `ResourceId::instance`, and macro-generated mesh id `instance` constructors while keeping the existing names for call-site migration.

Differential Revision: [D105508891](https://our.internmc.facebook.com/intern/diff/D105508891/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508891/)!