### PR TITLE
[hyperactor] port identity constructor call sites

### DIFF
--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -483,7 +483,7 @@ impl ProcId {
     /// Create an anonymous instance [`ProcId`] with a random uid.
     pub fn anonymous() -> Self {
         Self {
-            uid: Uid::instance(),
+            uid: Uid::anonymous(),
         }
     }
 
@@ -1161,8 +1161,8 @@ mod tests {
 
     #[test]
     fn test_unique_uid_generation() {
-        let a = Uid::instance();
-        let b = Uid::instance();
+        let a = Uid::anonymous();
+        let b = Uid::anonymous();
         assert_ne!(a, b);
     }
 
@@ -1395,11 +1395,11 @@ mod tests {
     #[test]
     fn test_actor_id_instance() {
         let proc_id = ProcId::singleton(Label::new("my-proc").unwrap());
-        let aid = ActorId::instance(proc_id.clone());
+        let aid = ActorId::anonymous(proc_id.clone());
         assert!(aid.uid().is_instance());
         assert_eq!(aid.proc_id(), &proc_id);
         assert_eq!(aid.label(), None);
-        let aid2 = ActorId::instance(proc_id);
+        let aid2 = ActorId::anonymous(proc_id);
         assert_ne!(aid, aid2);
     }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1516,7 +1516,7 @@ impl Proc {
         parent_id: &ActorAddr,
     ) -> Result<ActorAddr, anyhow::Error> {
         assert_eq!(parent_id.proc_id(), self.proc_id());
-        Ok(parent_id.unique_child())
+        Ok(parent_id.anonymous_child())
     }
 
     /// Ensure that the requested child uid is available in this proc.
@@ -2784,7 +2784,7 @@ impl<A: Actor> Instance<A> {
     /// The actor type is resolved through the remote spawn registry. The child
     /// receives an empty environment.
     pub async fn gspawn(&self, actor_type: &str, params: Data) -> anyhow::Result<AnyActorHandle> {
-        self.gspawn_uid(actor_type, crate::id::Uid::instance(), params)
+        self.gspawn_uid(actor_type, crate::id::Uid::anonymous(), params)
             .await
     }
 
@@ -4410,7 +4410,7 @@ mod tests {
             !lookup_actor
                 .actor_exists(
                     &client,
-                    ActorRef::attest(target_actor.actor_addr().unique_child())
+                    ActorRef::attest(target_actor.actor_addr().anonymous_child())
                 )
                 .await
                 .unwrap()

--- a/hyperactor/src/spawn.rs
+++ b/hyperactor/src/spawn.rs
@@ -38,7 +38,7 @@ impl LocalSpawner {
 impl CanSpawn for LocalSpawner {
     async fn spawn<A: Actor>(&self, params: A::Params) -> ActorHandle<A::Message> {
         let state = self.0.as_ref().expect("invalid spawner");
-        let actor_id = state.root.unique_child();
+        let actor_id = state.root.anonymous_child();
         A::do_spawn(state.sender.clone(), actor_id.into(), params, self.clone())
             .await
             .unwrap()

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1332,7 +1332,7 @@ mod tests {
             .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
-        let child_name = ActorMeshId::unique(Label::new("child").unwrap());
+        let child_name = ActorMeshId::instance(Label::new("child").unwrap());
 
         // Need to use a wrapper as there's no way to customize the handler for MeshFailure
         // on the client instance. The client would just panic with the message.
@@ -1443,7 +1443,7 @@ mod tests {
             .spawn(instance, "test2", Extent::unity(), None, None)
             .await
             .unwrap();
-        let child_name = ActorMeshId::unique(Label::new("child").unwrap());
+        let child_name = ActorMeshId::instance(Label::new("child").unwrap());
 
         // Need to use a wrapper as there's no way to customize the handler for MeshFailure
         // on the client instance. The client would just panic with the message.
@@ -1542,7 +1542,7 @@ mod tests {
                 .spawn(instance, "test", Extent::unity(), None, None)
                 .await
                 .unwrap();
-            let child_name = ActorMeshId::unique(Label::new("child").unwrap());
+            let child_name = ActorMeshId::instance(Label::new("child").unwrap());
 
             // Need to use a wrapper as there's no way to customize the handler for MeshFailure
             // on the client instance. The client would just panic with the message.

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -766,7 +766,7 @@ mod tests {
         let proc = Proc::direct(ChannelTransport::Unix.any(), proc_name.to_string()).unwrap();
         let (client, client_handle) = proc.client("client").unwrap();
 
-        let actor_mesh_id = crate::mesh_id::ActorMeshId::unique(Label::new("test").unwrap());
+        let actor_mesh_id = crate::mesh_id::ActorMeshId::instance(Label::new("test").unwrap());
 
         let (tx, rx) = open_port(&client);
         let forward_port = tx.bind();
@@ -1340,7 +1340,7 @@ mod tests {
             forward_port: tx.bind(),
         };
         let actor_name =
-            crate::mesh_id::ActorMeshId::unique(hyperactor::id::Label::new("test").unwrap());
+            crate::mesh_id::ActorMeshId::instance(hyperactor::id::Label::new("test").unwrap());
         // Make this actor a "system" actor to avoid spawning a controller actor.
         // This test is verifying the whole comm tree, so we want fewer actors
         // involved.
@@ -1575,7 +1575,7 @@ mod tests {
             forward_port: tx.bind(),
         };
         let actor_name =
-            crate::mesh_id::ActorMeshId::unique(hyperactor::id::Label::new("test").unwrap());
+            crate::mesh_id::ActorMeshId::instance(hyperactor::id::Label::new("test").unwrap());
         // Make this actor a "system" actor to avoid spawning a controller actor.
         let actor_mesh: crate::ActorMesh<TestActor> = proc_mesh
             .spawn_with_name(&instance, actor_name, &params, None, true)
@@ -1732,7 +1732,7 @@ mod tests {
             forward_port: tx.bind(),
         };
         let actor_name =
-            crate::mesh_id::ActorMeshId::unique(hyperactor::id::Label::new("test").unwrap());
+            crate::mesh_id::ActorMeshId::instance(hyperactor::id::Label::new("test").unwrap());
         let actor_mesh: ActorMesh<TestActor> = proc_mesh
             .spawn_with_name(&instance, actor_name, &params, None, true)
             .await

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -477,7 +477,7 @@ impl HostMesh {
 
         let host = HostRef(addr);
         let host_mesh_ref = HostMeshRef::new(
-            HostMeshId::unique(Label::new("local").unwrap()),
+            HostMeshId::instance(Label::new("local").unwrap()),
             extent!(hosts = 1).into(),
             vec![host],
         )?;
@@ -513,7 +513,7 @@ impl HostMesh {
             host_refs.push(Self::create_in_process_host(addr).await?);
         }
         HostMeshRef::new(
-            HostMeshId::unique(Label::new("local").unwrap()),
+            HostMeshId::instance(Label::new("local").unwrap()),
             extent!(hosts = n).into(),
             host_refs,
         )
@@ -576,7 +576,7 @@ impl HostMesh {
         }
 
         let host_mesh_ref = HostMeshRef::new(
-            HostMeshId::unique(Label::new("process").unwrap()),
+            HostMeshId::instance(Label::new("process").unwrap()),
             extent.into(),
             hosts,
         )?;
@@ -1158,7 +1158,7 @@ impl HostMeshRef {
     {
         self.spawn_inner(
             cx,
-            ProcMeshId::unique(Label::strip(name)),
+            ProcMeshId::instance(Label::strip(name)),
             per_host,
             proc_bind,
             per_rank_bootstrap,
@@ -1264,7 +1264,7 @@ impl HostMeshRef {
         for (host_rank, host) in self.ranks.iter().enumerate() {
             for per_host_rank in 0..per_host.num_ranks() {
                 let create_rank = per_host.num_ranks() * host_rank + per_host_rank;
-                let proc_name = ResourceId::unique(Label::strip(&format!(
+                let proc_name = ResourceId::instance(Label::strip(&format!(
                     "{}-{}",
                     proc_mesh_id
                         .display_label()
@@ -2253,7 +2253,7 @@ mod tests {
         // production-shape failure mode.
         let unreachable = free_localhost_addr();
 
-        let id = HostMeshId::unique(Label::new("hm_test").unwrap());
+        let id = HostMeshId::instance(Label::new("hm_test").unwrap());
         let result = HostMesh::attach(instance, id, vec![unreachable.clone()]).await;
 
         // HM-2: attach returns Err on any failed config push.

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1565,7 +1565,7 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.client("client").unwrap();
 
-        let id = ResourceId::unique(Label::new("proc1").unwrap());
+        let id = ResourceId::instance(Label::new("proc1").unwrap());
 
         // First, create the proc, then query its state:
 
@@ -1626,7 +1626,7 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.client("client").unwrap();
 
-        let id = ResourceId::unique(Label::new("proc1").unwrap());
+        let id = ResourceId::instance(Label::new("proc1").unwrap());
         host_agent
             .create_or_update(
                 &client,
@@ -1677,7 +1677,7 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.client("client").unwrap();
 
-        let id = ResourceId::unique(Label::new("proc1").unwrap());
+        let id = ResourceId::instance(Label::new("proc1").unwrap());
         host_agent
             .create_or_update(
                 &client,
@@ -1734,7 +1734,7 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.client("client").unwrap();
 
-        let id = ResourceId::unique(Label::new("proc1").unwrap());
+        let id = ResourceId::instance(Label::new("proc1").unwrap());
 
         // Wait for Running on a proc that doesn't exist yet.
         let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
@@ -1783,10 +1783,10 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.client("client").unwrap();
 
-        let mesh_a = HostMeshId::unique(Label::new("mesh-a").unwrap());
-        let mesh_b = HostMeshId::unique(Label::new("mesh-b").unwrap());
-        let proc_a_id = ResourceId::unique(Label::new("proc-a").unwrap());
-        let proc_b_id = ResourceId::unique(Label::new("proc-b").unwrap());
+        let mesh_a = HostMeshId::instance(Label::new("mesh-a").unwrap());
+        let mesh_b = HostMeshId::instance(Label::new("mesh-b").unwrap());
+        let proc_a_id = ResourceId::instance(Label::new("proc-a").unwrap());
+        let proc_b_id = ResourceId::instance(Label::new("proc-b").unwrap());
 
         // Create proc_a belonging to mesh_a.
         let spec_a = ProcSpec {
@@ -1887,10 +1887,10 @@ mod tests {
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
         let (client, _client_handle) = client_proc.client("client").unwrap();
 
-        let mesh_a = HostMeshId::unique(Label::new("mesh-a").unwrap());
-        let mesh_b = HostMeshId::unique(Label::new("mesh-b").unwrap());
-        let proc_a_id = ResourceId::unique(Label::new("proc-a").unwrap());
-        let proc_b_id = ResourceId::unique(Label::new("proc-b").unwrap());
+        let mesh_a = HostMeshId::instance(Label::new("mesh-a").unwrap());
+        let mesh_b = HostMeshId::instance(Label::new("mesh-b").unwrap());
+        let proc_a_id = ResourceId::instance(Label::new("proc-a").unwrap());
+        let proc_b_id = ResourceId::instance(Label::new("proc-b").unwrap());
 
         let spec_a = ProcSpec {
             host_mesh_id: Some(mesh_a),
@@ -1976,7 +1976,7 @@ mod tests {
 
         // Spawn a proc so the host_agent processes at least one
         // CreateOrUpdate message, which goes through the work queue.
-        let name = ResourceId::unique(Label::new("qd_test_proc").unwrap());
+        let name = ResourceId::instance(Label::new("qd_test_proc").unwrap());
         host_agent
             .create_or_update(
                 &client,

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -3517,7 +3517,7 @@ mod tests {
         let (client, _handle) = client_proc.client("client").unwrap();
 
         // Spawn a user proc via CreateOrUpdate<ProcSpec>.
-        let user_proc_name = ResourceId::unique(Label::new("user-proc").unwrap());
+        let user_proc_name = ResourceId::instance(Label::new("user-proc").unwrap());
         host_agent_ref
             .send(
                 &client,

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1587,7 +1587,7 @@ mod tests {
             .await
             .unwrap();
 
-        let actor_name = ActorMeshId::unique(Label::new("orphan_test").unwrap());
+        let actor_name = ActorMeshId::instance(Label::new("orphan_test").unwrap());
         // Spawn as a system actor so no controller is created. This lets us
         // control keepalive messages directly without the controller
         // interfering.
@@ -1676,7 +1676,7 @@ mod tests {
         }
 
         let host_mesh = crate::HostMeshRef::from_hosts(
-            HostMeshId::unique(Label::new("test").unwrap()),
+            HostMeshId::instance(Label::new("test").unwrap()),
             host_addrs,
         );
         TestHostMesh {
@@ -1723,7 +1723,7 @@ mod tests {
             .await
             .unwrap();
 
-        let child_name = ActorMeshId::unique(Label::new("orphan_child").unwrap());
+        let child_name = ActorMeshId::instance(Label::new("orphan_child").unwrap());
 
         // Supervision port required by WrapperActor params.
         let (supervision_port, _supervision_receiver) = instance.open_port::<MeshFailure>();

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -470,7 +470,7 @@ mod tests {
 
     #[test]
     fn test_resource_id_unique() {
-        let id = ResourceId::unique(Label::new("workers").unwrap());
+        let id = ResourceId::instance(Label::new("workers").unwrap());
         assert!(id.uid().is_instance());
         assert_eq!(id.label().map(|l| l.as_str()), Some("workers"));
     }
@@ -689,11 +689,11 @@ mod tests {
         assert_eq!(host.to_string(), "local");
         assert_eq!(*host.uid(), Uid::Singleton(Label::new("local").unwrap()));
 
-        let proc_ = ProcMeshId::unique(Label::new("workers").unwrap());
+        let proc_ = ProcMeshId::instance(Label::new("workers").unwrap());
         assert!(proc_.uid().is_instance());
         assert_eq!(proc_.label().map(|l| l.as_str()), Some("workers"));
 
-        let actor = ActorMeshId::unique(Label::new("trainers").unwrap());
+        let actor = ActorMeshId::instance(Label::new("trainers").unwrap());
         assert!(actor.uid().is_instance());
         assert_eq!(actor.label().map(|l| l.as_str()), Some("trainers"));
     }
@@ -769,7 +769,7 @@ mod tests {
 
     #[test]
     fn test_mesh_id_resource_id_conversion() {
-        let host = HostMeshId::unique(Label::new("test").unwrap());
+        let host = HostMeshId::instance(Label::new("test").unwrap());
         let resource_id: ResourceId = host.clone().into();
         assert_eq!(host.uid(), resource_id.uid());
         assert_eq!(
@@ -799,8 +799,8 @@ mod tests {
 
     #[test]
     fn test_unique_ids_differ() {
-        let a = ResourceId::unique(Label::new("test").unwrap());
-        let b = ResourceId::unique(Label::new("test").unwrap());
+        let a = ResourceId::instance(Label::new("test").unwrap());
+        let b = ResourceId::instance(Label::new("test").unwrap());
         assert_ne!(a, b);
     }
 

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -629,7 +629,7 @@ impl ProcMeshRef {
         C::A: Handler<MeshFailure>,
     {
         // Spawning from a string is never a system actor.
-        let id = ActorMeshId::unique(Label::strip(name));
+        let id = ActorMeshId::instance(Label::strip(name));
         self.spawn_with_name(cx, id, params, None, false).await
     }
 

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -322,7 +322,9 @@ pub async fn host_mesh(n: usize) -> HostMeshShutdownGuard {
         cmd.spawn().unwrap();
     }
 
-    let host_mesh =
-        HostMeshRef::from_hosts(HostMeshId::unique(Label::new("test").unwrap()), host_addrs);
+    let host_mesh = HostMeshRef::from_hosts(
+        HostMeshId::instance(Label::new("test").unwrap()),
+        host_addrs,
+    );
     HostMesh::take(host_mesh).shutdown_guard()
 }

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -116,7 +116,7 @@ impl KeepaliveLink {
         self,
         this: &Instance<A>,
     ) -> anyhow::Result<(ActorHandle<KeepaliveSupervisor>, LinkSpec)> {
-        self.spawn_supervisor_uid(this, Uid::instance())
+        self.spawn_supervisor_uid(this, Uid::anonymous())
     }
 
     /// Spawn the supervisor side and return the worker-side link spec,
@@ -172,7 +172,7 @@ impl KeepaliveWorkerParams {
 
     /// Create a worker-side link spec for a keepalive worker actor with a fresh uid.
     pub fn link_spec(self) -> anyhow::Result<LinkSpec> {
-        self.link_spec_uid(Uid::instance())
+        self.link_spec_uid(Uid::anonymous())
     }
 
     /// Create a worker-side link spec for a keepalive worker actor with an explicit uid.
@@ -599,7 +599,7 @@ mod tests {
         let (client, _client_handle) = proc.client("client").unwrap();
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let supervisor = proc.spawn("silent_supervisor", SilentSupervisor).unwrap();
-        let uid = Uid::instance();
+        let uid = Uid::anonymous();
         let link = KeepaliveWorkerParams::new(
             supervisor.port::<Keepalive>().bind(),
             KeepaliveParams::new(Duration::from_millis(100), Duration::from_millis(10)),

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -60,7 +60,7 @@ impl LinkSpec {
 
     /// Create a worker-side link spec with a fresh uid.
     pub fn new(actor_type: impl Into<String>, params: Data) -> Self {
-        Self::with_uid(actor_type, Uid::instance(), params)
+        Self::with_uid(actor_type, Uid::anonymous(), params)
     }
 
     /// Create a worker-side link spec with an explicit uid.

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -81,7 +81,7 @@ pub struct Supervisor {
 impl Supervisor {
     /// Create a supervisor proxy for `worker`.
     pub fn new(worker: ActorRef<WorkerLike>, link: KeepaliveLink, options: LinkOptions) -> Self {
-        Self::new_uid(worker, link, options, hyperactor::Uid::instance())
+        Self::new_uid(worker, link, options, hyperactor::Uid::anonymous())
     }
 
     /// Create a supervisor proxy with an explicit session id.
@@ -838,7 +838,7 @@ mod tests {
     async fn test_child_failure_propagates_to_parent() {
         let proc = Proc::isolated();
         let (client, _client_handle) = proc.client("client").unwrap();
-        let session_id = Uid::instance();
+        let session_id = Uid::anonymous();
 
         let (child_addr, worker, parent, _stopped_rx, mut event_rx) = spawn_supervised_pair(
             &proc,
@@ -885,7 +885,7 @@ mod tests {
     async fn test_parent_stop_stops_remote_child_before_parent_finishes() {
         let proc = Proc::isolated();
         let (client, _client_handle) = proc.client("client").unwrap();
-        let session_id = Uid::instance();
+        let session_id = Uid::anonymous();
 
         let (_child_addr, worker, parent, mut stopped_rx, _event_rx) = spawn_supervised_pair(
             &proc,
@@ -943,7 +943,7 @@ mod tests {
                 .spawn_supervisor(&client)
                 .unwrap();
         let _child_addr = ready_rx.recv().await.unwrap();
-        let session_id = hyperactor::Uid::instance();
+        let session_id = hyperactor::Uid::anonymous();
 
         worker
             .send(
@@ -1104,7 +1104,7 @@ mod tests {
                 .spawn_supervisor(&inst)
                 .unwrap();
         let _child_addr = ready_rx.recv().await.unwrap();
-        let session_id = hyperactor::Uid::instance();
+        let session_id = hyperactor::Uid::anonymous();
 
         worker
             .send(
@@ -1197,7 +1197,7 @@ mod tests {
     async fn test_supervised_worker_unlink_stops_child_under_stop_policy() {
         let proc = Proc::isolated();
         let (inst, _inst_hndl) = proc.client("inst").unwrap();
-        let session_id = Uid::instance();
+        let session_id = Uid::anonymous();
 
         let (_child_addr, worker, parent, mut stopped_rx, mut events_rx) = spawn_supervised_pair(
             &proc,
@@ -1282,7 +1282,7 @@ mod tests {
     async fn test_supervised_worker_unlink_leaves_child_running_under_detach_policy() {
         let proc = Proc::isolated();
         let (inst, _inst_hndl) = proc.client("inst").unwrap();
-        let session_id = Uid::instance();
+        let session_id = Uid::anonymous();
 
         let (_child_addr, worker, parent, mut stopped_rx, mut events_rx) = spawn_supervised_pair(
             &proc,
@@ -1381,7 +1381,7 @@ mod tests {
     async fn test_concurrent_link_rejects_second_supervisor() {
         let proc = Proc::isolated();
         let (inst, _inst_hndl) = proc.client("inst").unwrap();
-        let session_id1 = Uid::instance();
+        let session_id1 = Uid::anonymous();
         let (_child_addr, worker, parent1, _stopped_rx, mut events_rx1) = spawn_supervised_pair(
             &proc,
             &inst,
@@ -1399,7 +1399,7 @@ mod tests {
         // Spawn a second parent whose Supervisor targets the same
         // worker with a different session id. Its Link will be
         // rejected.
-        let session_id2 = Uid::instance();
+        let session_id2 = Uid::anonymous();
         let (events2, mut events_rx2) = inst.open_port::<ActorSupervisionEvent>();
         let parent2 = proc
             .spawn(
@@ -1502,7 +1502,7 @@ mod tests {
                 },
             )
             .unwrap();
-        let session_id = Uid::instance();
+        let session_id = Uid::anonymous();
         let parent = proc
             .spawn(
                 "parent",
@@ -1591,7 +1591,7 @@ mod tests {
             )
             .unwrap();
         let _child_addr = ready_rx.recv().await.unwrap();
-        let session_id = Uid::instance();
+        let session_id = Uid::anonymous();
         let parent = proc
             .spawn(
                 "parent",
@@ -1667,7 +1667,7 @@ mod tests {
     async fn test_worker_accepts_relink_after_unlink_under_detach_policy() {
         let proc = Proc::isolated();
         let (inst, _inst_hndl) = proc.client("inst").unwrap();
-        let session_id1 = Uid::instance();
+        let session_id1 = Uid::anonymous();
         let (_child_addr, worker, parent1, mut stopped_rx, mut events_rx1) = spawn_supervised_pair(
             &proc,
             &inst,
@@ -1709,7 +1709,7 @@ mod tests {
             "child should survive unlink under OrphanPolicy::Detach"
         );
 
-        let session_id2 = Uid::instance();
+        let session_id2 = Uid::anonymous();
         let (events2, mut events_rx2) = inst.open_port::<ActorSupervisionEvent>();
         let parent2 = proc
             .spawn(

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1846,7 +1846,7 @@ mod tests {
     fn to_py_error_preserves_proc_creation_message() {
         // State<ProcState> w/ `state.is_none()`
         let state: resource::State<ProcState> = resource::State {
-            id: ResourceId::unique(Label::new("my-proc").unwrap()),
+            id: ResourceId::instance(Label::new("my-proc").unwrap()),
             status: Status::Failed("boom".into()),
             state: None,
             generation: 0,

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -127,7 +127,7 @@ pub fn attach_to_workers(
     // drops illegal characters, falls back to "nil" if empty. Callers pass names
     // derived from experiment / job names that may contain uppercase or punctuation;
     // rejecting them surfaces as an opaque PyException far from the input site.
-    let name = HostMeshId::unique(Label::strip(name.unwrap_or("hosts")));
+    let name = HostMeshId::instance(Label::strip(name.unwrap_or("hosts")));
     let instance = instance.clone();
     PyPythonTask::new(async move {
         let results = try_join_all(tasks).await?;

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -114,7 +114,7 @@ impl PyProcMesh {
             })
             .await?;
 
-            let mesh_name = ActorMeshId::unique(Label::strip(&mesh_base_name));
+            let mesh_name = ActorMeshId::instance(Label::strip(&mesh_base_name));
             let actor_mesh = proc_mesh
                 .spawn_with_name(
                     instance.deref(),

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -763,11 +763,11 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
     // Create separate host meshes for each device to maintain different configs
     let host_mesh_1 = HostMeshRef::from_hosts(
-        HostMeshId::unique(Label::new("cuda-ping-pong-host1").unwrap()),
+        HostMeshId::instance(Label::new("cuda-ping-pong-host1").unwrap()),
         vec![host_addrs[0].clone()],
     );
     let host_mesh_2 = HostMeshRef::from_hosts(
-        HostMeshId::unique(Label::new("cuda-ping-pong-host2").unwrap()),
+        HostMeshId::instance(Label::new("cuda-ping-pong-host2").unwrap()),
         vec![host_addrs[1].clone()],
     );
 

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -487,7 +487,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     let _child = command.spawn().unwrap();
 
     let host_mesh = HostMeshRef::from_hosts(
-        HostMeshId::unique(Label::new("test").unwrap()),
+        HostMeshId::instance(Label::new("test").unwrap()),
         vec![host_addr],
     );
     let ps_proc_mesh = host_mesh


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3942
* #3941
* #3940
* __->__ #3939
* #3938
* #3937
* #3936
* #3935
* #3934

Port call sites to the new non-conflicting identity constructor names. Unlabeled ids now use `anonymous`, child actor addresses use `anonymous_child`, and mesh resource ids use `instance` instead of `unique`.

Differential Revision: [D105508889](https://our.internmc.facebook.com/intern/diff/D105508889/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508889/)!