### PR TITLE
[hyperactor] rename labeled identity constructors

### DIFF
--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -262,7 +262,7 @@ mod tests {
             .gspawn(
                 &Proc::isolated(),
                 "hyperactor::actor::remote::tests::MyActor",
-                Uid::instance_labeled(Label::new("actor").unwrap()),
+                Uid::instance(Label::new("actor").unwrap()),
                 bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
                 Flattrs::default(),
             )
@@ -273,7 +273,7 @@ mod tests {
             .gspawn(
                 &Proc::isolated(),
                 "hyperactor::actor::remote::tests::MyActor",
-                Uid::instance_labeled(Label::new("actor").unwrap()),
+                Uid::instance(Label::new("actor").unwrap()),
                 bincode::serde::encode_to_vec(false, bincode::config::legacy()).unwrap(),
                 Flattrs::default(),
             )
@@ -308,7 +308,7 @@ mod tests {
     async fn test_instance_gspawn_uid_uses_explicit_uid() {
         let proc = Proc::isolated();
         let (parent, _parent_handle) = proc.client("parent").unwrap();
-        let uid = Uid::instance_labeled(Label::new("child").unwrap());
+        let uid = Uid::instance(Label::new("child").unwrap());
 
         let child = parent
             .gspawn_uid(
@@ -329,7 +329,7 @@ mod tests {
     async fn test_instance_gspawn_uid_rejects_duplicate_uid() {
         let proc = Proc::isolated();
         let (parent, _parent_handle) = proc.client("parent").unwrap();
-        let uid = Uid::instance_labeled(Label::new("child").unwrap());
+        let uid = Uid::instance(Label::new("child").unwrap());
 
         let child = parent
             .gspawn_uid(

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -228,13 +228,8 @@ impl Uid {
         Uid::Instance(rand::random(), None)
     }
 
-    /// Create a fresh instance with a random uid.
-    pub fn instance() -> Self {
-        Self::anonymous()
-    }
-
     /// Create a fresh instance with a random uid and display label.
-    pub fn instance_labeled(label: Label) -> Self {
+    pub fn instance(label: Label) -> Self {
         Uid::Instance(rand::random(), Some(label))
     }
 
@@ -497,7 +492,7 @@ impl ProcId {
     /// Create an instance [`ProcId`] with a random uid and the given label.
     pub fn instance(label: Label) -> Self {
         Self {
-            uid: Uid::instance_labeled(label),
+            uid: Uid::instance(label),
         }
     }
 
@@ -635,15 +630,10 @@ impl ActorId {
         }
     }
 
-    /// Create an instance [`ActorId`] with a random uid and no label.
-    pub fn instance(proc_id: ProcId) -> Self {
-        Self::anonymous(proc_id)
-    }
-
     /// Create an instance [`ActorId`] with a random uid and the given label.
-    pub fn instance_labeled(label: Label, proc_id: ProcId) -> Self {
+    pub fn instance(label: Label, proc_id: ProcId) -> Self {
         Self {
-            uid: Uid::instance_labeled(label),
+            uid: Uid::instance(label),
             proc_id,
         }
     }
@@ -1393,7 +1383,7 @@ mod tests {
     }
 
     #[test]
-    fn test_actor_id_instance() {
+    fn test_actor_id_anonymous() {
         let proc_id = ProcId::singleton(Label::new("my-proc").unwrap());
         let aid = ActorId::anonymous(proc_id.clone());
         assert!(aid.uid().is_instance());
@@ -1404,14 +1394,14 @@ mod tests {
     }
 
     #[test]
-    fn test_actor_id_instance_labeled() {
+    fn test_actor_id_instance() {
         let label = Label::new("my-actor").unwrap();
         let proc_id = ProcId::singleton(Label::new("my-proc").unwrap());
-        let aid = ActorId::instance_labeled(label.clone(), proc_id.clone());
+        let aid = ActorId::instance(label.clone(), proc_id.clone());
         assert!(aid.uid().is_instance());
         assert_eq!(aid.proc_id(), &proc_id);
         assert_eq!(aid.label(), Some(&label));
-        let aid2 = ActorId::instance_labeled(label, proc_id);
+        let aid2 = ActorId::instance(label, proc_id);
         assert_ne!(aid, aid2);
     }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1542,7 +1542,7 @@ impl Proc {
     ) -> Result<ActorAddr, anyhow::Error> {
         assert_eq!(parent_id.proc_id(), self.proc_id());
         let proc_id = self.proc_id().clone();
-        let actor_id = crate::id::ActorId::instance_labeled(crate::id::Label::strip(name), proc_id);
+        let actor_id = crate::id::ActorId::instance(crate::id::Label::strip(name), proc_id);
         Ok(ActorAddr::new(actor_id, self.default_location()))
     }
 

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -103,7 +103,7 @@ impl ResourceId {
 
     /// Create an instance [`ResourceId`] with a random uid and the given label.
     pub fn instance(label: Label) -> Self {
-        Self(Uid::instance_labeled(label))
+        Self(Uid::instance(label))
     }
 
     /// Create a unique [`ResourceId`] with a random uid and the given label.

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -170,7 +170,7 @@ mod tests {
     async fn test_link_spec_spawns_supervised_child() {
         let proc = Proc::isolated();
         let (parent, _parent_handle) = proc.client("parent").unwrap();
-        let uid = Uid::instance_labeled(Label::new("link").unwrap());
+        let uid = Uid::instance(Label::new("link").unwrap());
 
         let link = LinkSpec::for_actor_uid::<TestLinkActor>(
             uid.clone(),
@@ -191,7 +191,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, _client_handle) = proc.client("client").unwrap();
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
-        let uid = Uid::instance_labeled(Label::new("link").unwrap());
+        let uid = Uid::instance(Label::new("link").unwrap());
         let link = LinkSpec::for_actor_uid::<TestLinkActor>(
             uid.clone(),
             bincode::serde::encode_to_vec((), bincode::config::legacy()).unwrap(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3942
* #3941
* __->__ #3940
* #3939
* #3938
* #3937
* #3936
* #3935
* #3934

Give labeled identity constructors the final `instance(label)` spelling now that anonymous call sites use `anonymous()`. This replaces `Uid::instance_labeled` and `ActorId::instance_labeled` with `Uid::instance` and `ActorId::instance`.

Differential Revision: [D105508884](https://our.internmc.facebook.com/intern/diff/D105508884/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508884/)!