### PR TITLE
[hyperactor] remove old identity constructor aliases

### DIFF
--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -305,11 +305,6 @@ impl ActorAddr {
         Self::new(child_id, self.location.clone())
     }
 
-    /// Create an ActorAddr for a child actor with a random uid.
-    pub fn unique_child(&self) -> Self {
-        self.anonymous_child()
-    }
-
     /// Whether this is a root actor (singleton uid).
     pub fn is_root(&self) -> bool {
         self.id.uid().is_singleton()

--- a/hyperactor_mesh/src/mesh_id.rs
+++ b/hyperactor_mesh/src/mesh_id.rs
@@ -106,11 +106,6 @@ impl ResourceId {
         Self(Uid::instance(label))
     }
 
-    /// Create a unique [`ResourceId`] with a random uid and the given label.
-    pub fn unique(label: Label) -> Self {
-        Self::instance(label)
-    }
-
     /// Create a resource id from a resource-name string.
     ///
     /// This accepts the mesh resource-id grammar, falling back to a stripped
@@ -331,11 +326,6 @@ macro_rules! define_mesh_id {
                 Self(ResourceId::instance(label))
             }
 
-            /// Create a unique mesh id with a random uid and the given label.
-            pub fn unique(label: Label) -> Self {
-                Self::instance(label)
-            }
-
             /// Returns the uid.
             pub fn uid(&self) -> &Uid {
                 self.0.uid()
@@ -469,7 +459,7 @@ mod tests {
     }
 
     #[test]
-    fn test_resource_id_unique() {
+    fn test_resource_id_instance() {
         let id = ResourceId::instance(Label::new("workers").unwrap());
         assert!(id.uid().is_instance());
         assert_eq!(id.label().map(|l| l.as_str()), Some("workers"));
@@ -798,7 +788,7 @@ mod tests {
     }
 
     #[test]
-    fn test_unique_ids_differ() {
+    fn test_instance_ids_differ() {
         let a = ResourceId::instance(Label::new("test").unwrap());
         let b = ResourceId::instance(Label::new("test").unwrap());
         assert_ne!(a, b);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3942
* __->__ #3941
* #3940
* #3939
* #3938
* #3937
* #3936
* #3935
* #3934

Remove the remaining old `unique` identity aliases after porting call sites to the explicit constructor vocabulary. `ActorAddr::unique_child`, `ResourceId::unique`, and macro-generated mesh id `unique` constructors are gone.

Differential Revision: [D105508883](https://our.internmc.facebook.com/intern/diff/D105508883/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508883/)!