### PR TITLE
[hyperactor] update identity constructor docs

### DIFF
--- a/docs/source/books/hyperactor-book/src/mailboxes/delivery.md
+++ b/docs/source/books/hyperactor-book/src/mailboxes/delivery.md
@@ -43,9 +43,9 @@ impl MessageEnvelope {
 impl MessageEnvelope {
   fn new_unknown(dest: PortId, data: Serialized) -> Self {
     let unknown_addr = ChannelAddr::any(ChannelTransport::Local);
-    let unknown_proc_id = ProcId::unique(unknown_addr, "unknown");
-    let unknown_actor_id = ActorId::root(unknown_proc_id, "unknown".to_string());
-    Self::new(unknown_actor_id, dest, data)
+    let unknown_proc = ProcAddr::instance(unknown_addr, "unknown");
+    let unknown_actor = ActorAddr::root(unknown_proc, Label::strip("unknown"));
+    Self::new(unknown_actor, dest, data)
   }
 }
 ```

--- a/docs/source/books/hyperactor-book/src/procs/host.md
+++ b/docs/source/books/hyperactor-book/src/procs/host.md
@@ -127,29 +127,29 @@ See [Channel Addresses](../channels/addresses.md) and [Transmits and Receives](.
 
 ### The Service Proc and Local Proc
 
-The host creates two procs, each with a `ProcAddr` combining a fresh instance identity and the frontend location:
+The host creates two procs identified by `ProcId`:
 
 **Service Proc:**
 ```rust
-let service_proc_id = ProcAddr::instance(
+let service_proc_id = ProcId(
     frontend_addr.clone(),
-    "service",
+    "service".to_string()
 );
-let service_proc = Proc::configured(service_proc_id.clone(), router.boxed());
+let service_proc = Proc::configured(service_proc_id, router.boxed());
 ```
 
 **Local Proc:**
 ```rust
-let local_proc_id = ProcAddr::instance(
+let local_proc_id = ProcId(
     frontend_addr.clone(),
-    "local",
+    "local".to_string()
 );
-let local_proc = Proc::configured(local_proc_id.clone(), router.boxed());
+let local_proc = Proc::configured(local_proc_id, router.boxed());
 ```
 
 Both procs:
 - Live within the host process
-- Use `ProcAddr::instance(frontend_addr, name)` as their identity — a fresh instance uid with `name` as display metadata and the frontend channel address as location
+- Use `ProcId(frontend_addr, name)` as their identity
 - Forward outbound messages through the `DialMailboxRouter`
 - The service proc hosts system-level actors that manage proc lifecycle and coordination
 - The local proc hosts user-level actors

--- a/docs/source/books/hyperactor-book/src/procs/host.md
+++ b/docs/source/books/hyperactor-book/src/procs/host.md
@@ -127,29 +127,29 @@ See [Channel Addresses](../channels/addresses.md) and [Transmits and Receives](.
 
 ### The Service Proc and Local Proc
 
-The host creates two procs identified by `ProcId`:
+The host creates two procs, each with a `ProcAddr` combining a fresh instance identity and the frontend location:
 
 **Service Proc:**
 ```rust
-let service_proc_id = ProcId(
+let service_proc_id = ProcAddr::instance(
     frontend_addr.clone(),
-    "service".to_string()
+    "service",
 );
-let service_proc = Proc::configured(service_proc_id, router.boxed());
+let service_proc = Proc::configured(service_proc_id.clone(), router.boxed());
 ```
 
 **Local Proc:**
 ```rust
-let local_proc_id = ProcId(
+let local_proc_id = ProcAddr::instance(
     frontend_addr.clone(),
-    "local".to_string()
+    "local",
 );
-let local_proc = Proc::configured(local_proc_id, router.boxed());
+let local_proc = Proc::configured(local_proc_id.clone(), router.boxed());
 ```
 
 Both procs:
 - Live within the host process
-- Use `ProcId(frontend_addr, name)` as their identity
+- Use `ProcAddr::instance(frontend_addr, name)` as their identity — a fresh instance uid with `name` as display metadata and the frontend channel address as location
 - Forward outbound messages through the `DialMailboxRouter`
 - The service proc hosts system-level actors that manage proc lifecycle and coordination
 - The local proc hosts user-level actors

--- a/docs/source/books/hyperactor-book/src/procs/host.md
+++ b/docs/source/books/hyperactor-book/src/procs/host.md
@@ -71,13 +71,13 @@ impl<M: ProcManager> Host<M> {
 
         let router = DialMailboxRouter::new();
 
-        let service_proc_id = ProcId::unique(
+        let service_proc_id = ProcAddr::instance(
             frontend_addr.clone(),
             "service",
         );
         let service_proc = Proc::configured(service_proc_id.clone(), router.boxed());
 
-        let local_proc_id = ProcId::unique(
+        let local_proc_id = ProcAddr::instance(
             frontend_addr.clone(),
             "local",
         );

--- a/docs/source/books/hyperactor-book/src/references/actor_id.md
+++ b/docs/source/books/hyperactor-book/src/references/actor_id.md
@@ -1,61 +1,56 @@
 # `ActorId`
 
-An `ActorId` uniquely identifies an actor within a proc. It combines the proc the actor lives on and a string name.
+An `ActorId` uniquely identifies an actor within a proc. It combines the owning `ProcId` with an actor uid.
 
 ```rust
 #[derive(
-    Debug,
     Serialize,
     Deserialize,
     Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Hash,
-    Ord,
-    Named
 )]
-pub struct ActorId(ProcId, String);
+pub struct ActorId {
+    uid: Uid,
+    proc_id: ProcId,
+}
 ```
-- The first field is the actor's `ProcId`.
-- The second is the actor's name (used for grouping and logging).
 
 ### Construction
 
 Fields are private; use named constructors:
-```rust
-use hyperactor::reference::{ActorId, ProcId};
 
-let addr = "tcp:127.0.0.1:8080".parse()?;
-let proc = ProcId::from_resource_name(addr, "myproc");
-let actor = ActorId::new(proc.clone(), "worker");
+```rust
+use hyperactor::id::{ActorId, Label, ProcId};
+
+let proc = ProcId::instance(Label::new("myproc").unwrap());
+let anonymous = ActorId::anonymous(proc.clone());
+let worker = ActorId::instance(Label::new("worker").unwrap(), proc.clone());
+let root = ActorId::singleton(Label::new("root").unwrap(), proc);
 ```
 
 ### Methods
 
 ```rust
 impl ActorId {
+    pub fn uid(&self) -> &Uid;
     pub fn proc_id(&self) -> &ProcId;
-    pub fn name(&self) -> &str;
-    pub fn port_id(&self, port: u64) -> PortId;
+    pub fn label(&self) -> Option<&Label>;
 }
 ```
 
-- `.proc_id()` returns the ProcId that owns this actor.
-- `.name()` returns the logical name of the actor (e.g., "worker").
-- `.port_id(port)` returns a `PortId` representing a port on this actor.
+- `.uid()` returns the actor identity uid.
+- `.proc_id()` returns the `ProcId` that owns this actor.
+- `.label()` returns display metadata for instance ids, or the singleton name for singleton ids.
 
 ### Traits
 
 `ActorId` implements:
 
-- `Display` — formats as `addr,proc_name,name`
-- `FromStr` — parses strings like `"tcp:[::1]:1234,myproc,logger"`
+- `Display`
+- `FromStr`
 - `Clone`, `Eq`, `Ord`, `Hash` — useful in maps, sets, and registries
-- `Named` — enables type-based routing, port lookup, and reflection
 
 ## Semantics
 
-- The `name` groups actors logically within a proc (e.g., `"worker"`, `"trainer"`).
-- Most routing and API surfaces operate on actors by name.
-- Port creation is always rooted in an `ActorId`, via `.port_id(...)`.
+- `ActorId::anonymous(proc_id)` creates a fresh unlabeled actor identity.
+- `ActorId::instance(label, proc_id)` creates a fresh actor identity with label metadata.
+- `ActorId::singleton(label, proc_id)` creates an actor identity whose label is the uid identity.

--- a/docs/source/books/hyperactor-book/src/references/proc_id.md
+++ b/docs/source/books/hyperactor-book/src/references/proc_id.md
@@ -2,35 +2,29 @@
 
 A `ProcId` identifies a single runtime instance. All actors exist within a proc, and message routing between actors is scoped by the proc's identity.
 
-Procs are identified by a direct channel address and name:
+Proc identity is separate from proc location. The addressable form is `ProcAddr`, which combines a `ProcId` with a `Location`.
 
 ```rust
 #[derive(
-    Debug,
     Serialize,
     Deserialize,
     Clone,
-    PartialEq,
-    Eq,
-    PartialOrd,
-    Hash,
-    Ord,
-    Named,
 )]
-pub struct ProcId(ChannelAddr, String);
+pub struct ProcId {
+    uid: Uid,
+}
 ```
 
 ## Construction
 
-Construct a `ProcId` with a channel address and proc name. Fields are private; use a named constructor:
-```rust
-use hyperactor::reference::ProcId;
+Fields are private; use named constructors:
 
-let addr = "tcp:127.0.0.1:8080".parse()?;
-// `unique` appends an address hash to make the name globally unique:
-let proc = ProcId::unique(addr.clone(), "service");
-// `with_name` uses the name as-is (for deserialization or already-unique names):
-let proc = ProcId::from_resource_name(addr, "service");
+```rust
+use hyperactor::id::{Label, ProcId};
+
+let anonymous = ProcId::anonymous();
+let worker = ProcId::instance(Label::new("worker").unwrap());
+let service = ProcId::singleton(Label::new("service").unwrap());
 ```
 
 See [Host](../procs/host.md) for how procs are used in the Host architecture.
@@ -39,17 +33,18 @@ See [Host](../procs/host.md) for how procs are used in the Host architecture.
 
 ```rust
 impl ProcId {
-    pub fn name(&self) -> &str;
-    pub fn actor_id(&self, name: impl Into<String>, pid: usize) -> ActorId;
+    pub fn uid(&self) -> &Uid;
+    pub fn label(&self) -> Option<&Label>;
+    pub fn pseudo_uid(&self) -> Uid;
 }
 ```
-- `.name()` returns the proc's name
-- `.actor_id(name, pid)` constructs an `ActorId` for an actor hosted on this proc
+- `.uid()` returns the identity uid.
+- `.label()` returns display metadata for instance ids, or the singleton name for singleton ids.
+- `.pseudo_uid()` returns a stable instance-shaped uid for contexts that need a short local path component.
 
 ## Traits
 
 ProcId implements:
-- `Display` — formatted as `channel_addr,name`
-- `FromStr` — parses from strings like `"tcp:127.0.0.1:8080,service"`
+- `Display`
+- `FromStr`
 - `Ord`, `Eq`, `Hash` — usable in maps and sorted structures
-- `Named` — enables port lookup and type reflection

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-proc-and-instance.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/bootstrapping-proc-and-instance.md
@@ -21,8 +21,8 @@ Under the hood it does (cf. `Proc::direct` in the source):
    - the actual bound address, and
    - a receiver for incoming messages.
 
-2. **Name the proc**
-   It builds a `ProcId::unique(bound_addr, name)`. That's just how this proc identifies itself to the rest of the world: "I am this channel, and my human-ish name is `root`."
+2. **Assign the proc identity and location**
+   It builds a `ProcAddr::instance(bound_addr, name)`. The proc id is a fresh instance uid with `name` as display metadata; the bound channel address is the proc's advertised location.
 
 3. **Create a proc with a dial-able forwarder**
    It does `Proc::configured(proc_id, DialMailboxRouter::new().into_boxed())`. That "dial mailbox router" is the bit that lets this proc send to other procs later — it knows how to connect out.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3942
* #3941
* #3940
* #3939
* #3938
* #3937
* #3936
* #3935
* #3934

Update stale Hyperactor book examples and reference pages to use the current identity constructor vocabulary. The docs now describe `anonymous`, `instance`, and `singleton` semantics and no longer refer to removed `ProcId::unique` or legacy resource-name constructors.

Differential Revision: [D105508886](https://our.internmc.facebook.com/intern/diff/D105508886/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105508886/)!