### PR TITLE
cargo & buck agree - lint free

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -50,4 +50,5 @@ rustflags = [
     "-Amismatched_lifetime_syntaxes",
     "-Asuspicious_double_ref_op",
     "-Aunused_braces",
+    "-Astable_features"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,3 +77,6 @@ default-members = [
     "torch-sys-cuda",
     "wirevalue",
 ]
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }

--- a/algebra/Cargo.toml
+++ b/algebra/Cargo.toml
@@ -16,3 +16,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 
 [dev-dependencies]
 bincode = { version = "2", features = ["serde"] }
+
+[lints]
+workspace = true

--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -16,3 +16,6 @@ cc = "1.2.60"
 glob = "0.3.2"
 pyo3-build-config = { version = "0.26", features = ["resolve-config"] }
 which = "8.0.2"
+
+[lints]
+workspace = true

--- a/hyper/Cargo.toml
+++ b/hyper/Cargo.toml
@@ -20,4 +20,4 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 tokio = { version = "1", features = ["full"] }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -92,4 +92,4 @@ default = []
 stdio-write-probe = []
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2193,6 +2193,7 @@ pub fn try_tls_connector() -> Option<tokio_rustls::TlsConnector> {
 
 #[cfg(test)]
 mod tests {
+
     #![expect(
         clippy::await_holding_invalid_type,
         reason = "tracing_test::traced_test macro expansion holds tracing::span::Entered across awaits; can't be fixed in our code"

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3888,7 +3888,10 @@ mod tests {
         let (_signal_port, _signal_rx) = client.bind_handler_port::<Signal>();
     }
 
-    #[allow(clippy::await_holding_invalid_type)]
+    #[expect(
+        clippy::await_holding_invalid_type,
+        reason = "tracing_test::traced_test macro expansion holds tracing::span::Entered across awaits; can't be fixed in our code"
+    )]
     #[tracing_test::traced_test]
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_actor() {
@@ -4416,7 +4419,10 @@ mod tests {
         );
     }
 
-    #[allow(clippy::await_holding_invalid_type)]
+    #[expect(
+        clippy::await_holding_invalid_type,
+        reason = "tracing_test::traced_test macro expansion holds tracing::span::Entered across awaits; can't be fixed in our code"
+    )]
     #[tracing_test::traced_test]
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_child() {
@@ -4981,7 +4987,10 @@ mod tests {
 
         #[async_trait]
         impl Handler<Arc<(Barrier, Barrier)>> for LoggingActor {
-            #[allow(clippy::await_holding_invalid_type)]
+            #[expect(
+                clippy::await_holding_invalid_type,
+                reason = "tracing_test::traced_test macro expansion holds tracing::span::Entered across awaits; can't be fixed in our code"
+            )]
             async fn handle(
                 &mut self,
                 _cx: &crate::Context<Self>,

--- a/hyperactor_config/Cargo.toml
+++ b/hyperactor_config/Cargo.toml
@@ -31,3 +31,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 [dev-dependencies]
 indoc = "2.0.2"
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
+
+[lints]
+workspace = true

--- a/hyperactor_config_macros/Cargo.toml
+++ b/hyperactor_config_macros/Cargo.toml
@@ -17,3 +17,6 @@ proc-macro = true
 [dependencies]
 quote = "1.0.45"
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/hyperactor_macros/Cargo.toml
+++ b/hyperactor_macros/Cargo.toml
@@ -35,3 +35,6 @@ timed_test = { version = "0.0.0", path = "../timed_test" }
 tokio = { version = "1.37.0", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
+
+[lints]
+workspace = true

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -75,4 +75,4 @@ proptest = "1.11.0"
 timed_test = { version = "0.0.0", path = "../timed_test" }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1172,7 +1172,7 @@ impl<A: Referable> view::RankedSliceable for ActorMeshRef<A> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, fbcode_build))]
 mod tests {
 
     use std::collections::HashSet;
@@ -1211,7 +1211,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_actor_mesh_ref_lazy_materialization() {
         // 1) Bring up procs and spawn actors.
         let instance = testing::instance();
@@ -1310,7 +1309,6 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 300)]
-    #[cfg(fbcode_build)]
     async fn test_actor_states_with_panic() {
         hyperactor_telemetry::initialize_logging_for_test();
 
@@ -1412,7 +1410,6 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
-    #[cfg(fbcode_build)]
     #[assert_no_process_leak]
     #[async_timed_test(timeout_secs = 300)]
     async fn test_actor_states_with_process_exit() {
@@ -1520,7 +1517,6 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 300)]
-    #[cfg(fbcode_build)]
     async fn test_actor_states_on_sliced_mesh() {
         hyperactor_telemetry::initialize_logging_for_test();
 
@@ -1598,7 +1594,6 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
-    #[cfg(fbcode_build)]
     async fn execute_cast(config: &hyperactor_config::global::ConfigLock) {
         let _guard = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false);
         let _proc_spawn = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
@@ -1642,7 +1637,6 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 60)]
-    #[cfg(fbcode_build)]
     async fn test_cast_with_selection_v1_fallback() {
         use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
         use hyperactor_mesh_macros::sel;
@@ -1705,14 +1699,12 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 30)]
-    #[cfg(fbcode_build)]
     async fn test_cast() {
         let config = hyperactor_config::global::lock();
         execute_cast(&config).await;
     }
 
     #[async_timed_test(timeout_secs = 30)]
-    #[cfg(fbcode_build)]
     async fn test_cast_p2p() {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(crate::comm::ENABLE_NATIVE_V1_CASTING, true);
@@ -1728,7 +1720,6 @@ mod tests {
     ///
     /// This is the V1 version of the test from
     /// hyperactor_multiprocess/src/proc_actor.rs::test_undeliverable_message_return.
-    #[cfg(fbcode_build)]
     #[assert_no_process_leak]
     #[async_timed_test(timeout_secs = 60)]
     async fn test_undeliverable_message_return() {
@@ -1864,7 +1855,6 @@ mod tests {
     /// continue running in the background: no code path in the mesh layer
     /// forcibly aborts them via `JoinHandle::abort()`.
     #[async_timed_test(timeout_secs = 30)]
-    #[cfg(fbcode_build)]
     async fn test_actor_mesh_stop_timeout() {
         hyperactor_telemetry::initialize_logging_for_test();
 
@@ -1962,7 +1952,6 @@ mod tests {
     /// equivalent of
     /// hyperactor_multiprocess/src/proc_actor.rs::test_stop
     #[async_timed_test(timeout_secs = 60)]
-    #[cfg(fbcode_build)]
     async fn test_actor_mesh_stop_graceful() {
         hyperactor_telemetry::initialize_logging_for_test();
 

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2979,6 +2979,7 @@ mod tests {
     /// - `backend_addr`: a mailbox address served by the **parent
     ///   (host) proc** here; the spawned bootstrap process dials this
     ///   so its messages route via the host.
+    #[cfg(fbcode_build)]
     async fn make_proc_id_and_backend_addr(
         instance: &hyperactor::Instance<()>,
         _tag: &str,
@@ -3168,6 +3169,7 @@ mod tests {
     }
 
     impl DummyLauncher {
+        #[allow(dead_code)]
         fn new(marker: u64) -> Self {
             Self { marker }
         }

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -513,10 +513,13 @@ mod tests {
 
     use hyperactor::testing::ids::test_actor_id;
     use hyperactor_config::Flattrs;
+    #[cfg(fbcode_build)]
     use ndslice::view::Extent;
+    #[cfg(fbcode_build)]
     use timed_test::async_timed_test;
 
     use super::*;
+    #[cfg(fbcode_build)]
     use crate::testing;
 
     /// Helper: send an `Undeliverable<MessageEnvelope>` to the global

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1923,23 +1923,36 @@ impl FromStr for HostMeshRef {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(fbcode_build)]
     use std::assert_matches;
 
+    #[cfg(fbcode_build)]
     use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
+    #[cfg(fbcode_build)]
     use hyperactor_config::attrs::Attrs;
     use ndslice::ViewExt;
     use ndslice::extent;
+    #[cfg(fbcode_build)]
     use timed_test::assert_no_process_leak;
+    #[cfg(fbcode_build)]
     use tokio::process::Command;
 
     use super::*;
+    #[cfg(fbcode_build)]
     use crate::ActorMesh;
+    #[cfg(fbcode_build)]
     use crate::Bootstrap;
+    #[cfg(fbcode_build)]
     use crate::bootstrap::MESH_TAIL_LOG_LINES;
+    #[cfg(fbcode_build)]
     use crate::comm::ENABLE_NATIVE_V1_CASTING;
+    #[cfg(fbcode_build)]
     use crate::resource::Status;
+    #[cfg(fbcode_build)]
     use crate::testactor;
+    #[cfg(fbcode_build)]
     use crate::testactor::GetConfigAttrs;
+    #[cfg(fbcode_build)]
     use crate::testactor::SetConfigAttrs;
     use crate::testing;
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1524,7 +1524,7 @@ impl Handler<ConfigDump> for HostAgent {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, fbcode_build))]
 mod tests {
     use std::assert_matches;
 
@@ -1541,7 +1541,6 @@ mod tests {
     use crate::resource::WaitRankStatusClient;
 
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_basic() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
@@ -1603,7 +1602,6 @@ mod tests {
 
     /// WaitRankStatus on a running proc replies immediately with Running.
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_wait_rank_status_already_running() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
@@ -1654,7 +1652,6 @@ mod tests {
     /// WaitRankStatus for Stopped, then stop the proc — reply should
     /// arrive only after the proc actually stops.
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_wait_rank_status_stop() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
@@ -1711,7 +1708,6 @@ mod tests {
     /// WaitRankStatus sent before the proc is created — the waiter is
     /// stashed and replied to once CreateOrUpdate runs.
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_wait_rank_status_before_proc_exists() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
@@ -1760,7 +1756,6 @@ mod tests {
     /// DrainHost with a host_mesh_id filter only stops procs
     /// belonging to that mesh; procs from other meshes are unaffected.
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_drain_scoped_to_host_mesh_id() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
@@ -1864,7 +1859,6 @@ mod tests {
     /// DrainHost with host_mesh_id=None drains all procs regardless
     /// of their mesh affiliation (backwards compatibility).
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_drain_none_drains_all() {
         let host = Host::new(
             BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
@@ -1939,7 +1933,6 @@ mod tests {
     // defaulted queue stats to zero because it predated Proc-level
     // queue accessors.
     #[tokio::test]
-    #[cfg(fbcode_build)]
     async fn test_service_proc_query_child_has_queue_stats() {
         use hyperactor::actor::ActorStatus;
         use hyperactor::introspect::IntrospectMessage;

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1516,15 +1516,19 @@ mod tests {
     use ndslice::Extent;
     use ndslice::ViewExt;
 
+    #[cfg(fbcode_build)]
     use super::SUPERVISION_POLL_FREQUENCY;
     use super::proc_status_to_actor_status;
     use crate::ActorMesh;
     use crate::bootstrap::ProcStatus;
+    #[cfg(fbcode_build)]
     use crate::host_mesh::PROC_SPAWN_MAX_IDLE;
     use crate::mesh_id::ActorMeshId;
+    #[cfg(fbcode_build)]
     use crate::mesh_id::HostMeshId;
     use crate::proc_agent::MESH_ORPHAN_TIMEOUT;
     use crate::resource;
+    #[cfg(fbcode_build)]
     use crate::supervision::MeshFailure;
     use crate::test_utils::local_host_mesh;
     use crate::testactor;

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1096,6 +1096,7 @@ fn python_class_from_supervision_name(sdn: &str) -> Option<String> {
 mod tests {
     #[cfg(fbcode_build)]
     use std::ops::Deref;
+    #[cfg(fbcode_build)]
     use std::time::Duration;
 
     #[cfg(fbcode_build)]
@@ -1104,8 +1105,11 @@ mod tests {
     use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
     #[cfg(fbcode_build)]
     use ndslice::ViewExt as _;
+    #[cfg(fbcode_build)]
     use ndslice::extent;
+    #[cfg(fbcode_build)]
     use timed_test::assert_no_process_leak;
+    #[cfg(fbcode_build)]
     use timed_test::async_timed_test;
     #[cfg(fbcode_build)]
     use uuid::Uuid;
@@ -1114,10 +1118,15 @@ mod tests {
     use crate::ActorMesh;
     #[cfg(fbcode_build)]
     use crate::comm::ENABLE_NATIVE_V1_CASTING;
+    #[cfg(fbcode_build)]
     use crate::host_mesh::PROC_SPAWN_MAX_IDLE;
+    #[cfg(fbcode_build)]
     use crate::resource::RankedValues;
+    #[cfg(fbcode_build)]
     use crate::resource::Status;
+    #[cfg(fbcode_build)]
     use crate::testactor;
+    #[cfg(fbcode_build)]
     use crate::testing;
 
     #[cfg(fbcode_build)]

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -34,13 +34,18 @@ use hyperactor::channel::ChannelTransport;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::WorkCell;
 use hyperactor::supervision::ActorSupervisionEvent;
+#[cfg(fbcode_build)]
 use tokio::process::Command;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 
+#[cfg(fbcode_build)]
 use crate::Bootstrap;
+#[cfg(fbcode_build)]
 use crate::HostMeshRef;
+#[cfg(fbcode_build)]
 use crate::host_mesh::HostMesh;
+#[cfg(fbcode_build)]
 use crate::host_mesh::HostMeshShutdownGuard;
 use crate::supervision::MeshFailure;
 

--- a/hyperactor_mesh/src/testresource.rs
+++ b/hyperactor_mesh/src/testresource.rs
@@ -8,6 +8,7 @@
 
 #![cfg(test)]
 
+#[cfg(fbcode_build)]
 use std::path::PathBuf;
 
 /// Fetch the named (BUCK) named resource, heuristically falling back on

--- a/hyperactor_mesh_admin_tui/Cargo.toml
+++ b/hyperactor_mesh_admin_tui/Cargo.toml
@@ -33,4 +33,4 @@ tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 urlencoding = "2.1.0"
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_mesh_macros/Cargo.toml
+++ b/hyperactor_mesh_macros/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 ndslice = { version = "0.0.0", path = "../ndslice" }
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 quote = "1.0.45"
+
+[lints]
+workspace = true

--- a/hyperactor_remote/Cargo.toml
+++ b/hyperactor_remote/Cargo.toml
@@ -28,4 +28,4 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 wirevalue = { version = "0.0.0", path = "../wirevalue" }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -44,4 +44,4 @@ quickcheck_macros = "1.2.0"
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -113,7 +113,9 @@ use tracing_subscriber::fmt::FormatFields;
 use tracing_subscriber::fmt::format::Writer;
 use tracing_subscriber::registry::LookupSpan;
 
+#[cfg(all(fbcode_build, target_os = "linux"))]
 use crate::config::ENABLE_OTEL_METRICS;
+#[cfg(all(fbcode_build, target_os = "linux"))]
 use crate::config::ENABLE_OTEL_TRACING;
 use crate::config::ENABLE_RECORDER_TRACING;
 use crate::config::ENABLE_SQLITE_TRACING;
@@ -121,6 +123,7 @@ use crate::config::MONARCH_FILE_LOG_LEVEL;
 use crate::config::MONARCH_LOG_SUFFIX;
 use crate::config::USE_UNIFIED_LAYER;
 use crate::recorder::Recorder;
+#[cfg(all(fbcode_build, target_os = "linux"))]
 use crate::sqlite::get_reloadable_sqlite_layer;
 
 /// Hash any hashable value to a u64 using DefaultHasher.
@@ -830,7 +833,7 @@ pub struct TimerGuard<'a> {
     start: Instant,
 }
 
-impl<'a> Drop for TimerGuard<'a> {
+impl Drop for TimerGuard<'_> {
     fn drop(&mut self) {
         let now = Instant::now();
         let dur = now.duration_since(self.start);
@@ -1129,6 +1132,9 @@ fn initialize_logging_with_log_prefix_impl(
     prefix_env_var: Option<String>,
     mock_scuba: bool,
 ) -> Box<dyn TelemetryTestHandle> {
+    #[cfg(not(all(fbcode_build, target_os = "linux")))]
+    let _ = mock_scuba;
+
     let use_unified = hyperactor_config::global::get(USE_UNIFIED_LAYER);
     let should_install_subscriber = !tracing::dispatcher::has_been_set();
 

--- a/hyperactor_telemetry/src/spool.rs
+++ b/hyperactor_telemetry/src/spool.rs
@@ -34,11 +34,7 @@ struct State<T> {
 
 impl<T> Drop for State<T> {
     fn drop(&mut self) {
-        loop {
-            let Some(entry) = self.ring.pop() else {
-                break;
-            };
-
+        while let Some(entry) = self.ring.pop() {
             if !entry.initialized.load(Ordering::Acquire) {
                 continue;
             }

--- a/hyperactor_telemetry/src/task.rs
+++ b/hyperactor_telemetry/src/task.rs
@@ -37,7 +37,10 @@ macro_rules! spawn {
 #[cfg(test)]
 mod tests {
     // #[traced_test] holds a tracing::Entered guard across await points; suppress the false positive.
-    #![allow(clippy::await_holding_invalid_type)]
+    #![expect(
+        clippy::await_holding_invalid_type,
+        reason = "tracing_test::traced_test macro expansion holds tracing::span::Entered across awaits; can't be fixed in our code"
+    )]
 
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;

--- a/hyperactor_telemetry/src/task.rs
+++ b/hyperactor_telemetry/src/task.rs
@@ -36,6 +36,9 @@ macro_rules! spawn {
 
 #[cfg(test)]
 mod tests {
+    // #[traced_test] holds a tracing::Entered guard across await points; suppress the false positive.
+    #![allow(clippy::await_holding_invalid_type)]
+
     use std::sync::Arc;
     use std::sync::atomic::AtomicBool;
     use std::sync::atomic::AtomicUsize;

--- a/hyperactor_telemetry/src/trace_dispatcher.rs
+++ b/hyperactor_telemetry/src/trace_dispatcher.rs
@@ -476,7 +476,7 @@ where
 
 struct FieldVisitor<'a>(&'a mut TraceFields);
 
-impl<'a> tracing::field::Visit for FieldVisitor<'a> {
+impl tracing::field::Visit for FieldVisitor<'_> {
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
         self.0.push((field.name(), FieldValue::Bool(value)));
     }

--- a/monarch_conda/src/sync.rs
+++ b/monarch_conda/src/sync.rs
@@ -153,10 +153,10 @@ impl ActionsBuilder {
         match self.state.entry(path) {
             Entry::Occupied(val) => {
                 let (path, (existing_origin, existing_metadata)) = val.remove_entry();
-                if let Some(ignores) = &self.ignores {
-                    if ignores.is_match(path.as_path()) {
-                        return Ok(());
-                    }
+                if let Some(ignores) = &self.ignores
+                    && ignores.is_match(path.as_path())
+                {
+                    return Ok(());
                 }
                 ensure!(existing_origin != origin);
                 let (src, dst) = match origin {
@@ -213,10 +213,10 @@ impl ActionsBuilder {
         for (path, (origin, metadata)) in self.state.into_iter() {
             match origin {
                 Origin::Src => {
-                    if let Some(ignores) = &self.ignores {
-                        if ignores.is_match(path.as_path()) {
-                            continue;
-                        }
+                    if let Some(ignores) = &self.ignores
+                        && ignores.is_match(path.as_path())
+                    {
+                        continue;
                     }
                     actions.insert(
                         path,
@@ -423,7 +423,7 @@ async fn persist(tmp: TempFile, path: &Path) -> Result<(), std::io::Error> {
 /// Helper function to set the FileTime for every file, symlink, and directory in a directory tree
 async fn set_mtime(path: &Path, mtime: SystemTime) -> Result<(), std::io::Error> {
     let mtime = FileTime::from_system_time(mtime);
-    filetime::set_symlink_file_times(path, mtime.clone(), mtime)?;
+    filetime::set_symlink_file_times(path, mtime, mtime)?;
     Ok(())
 }
 

--- a/monarch_distributed_telemetry/Cargo.toml
+++ b/monarch_distributed_telemetry/Cargo.toml
@@ -26,3 +26,6 @@ typeuri = { version = "0.0.0", path = "../typeuri" }
 
 [build-dependencies]
 build_utils = { path = "../build_utils" }
+
+[lints]
+workspace = true

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -53,3 +53,6 @@ distributed_sql_telemetry = ["dep:monarch_distributed_telemetry", "dep:monarch_i
 extension-module = ["pyo3/extension-module"]
 tensor_engine = ["dep:monarch_messages", "dep:monarch_tensor_worker", "dep:torch-sys-cuda"]
 tensor_engine_gpu = ["dep:monarch_cpp_static_libs", "dep:monarch_rdma_extension", "dep:nccl-sys", "dep:rdmaxcel-sys", "monarch_messages/cuda", "monarch_tensor_worker/cuda", "tensor_engine", "torch-sys-cuda/cuda"]
+
+[lints]
+workspace = true

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -63,4 +63,4 @@ default = []
 packaged_rsync = []
 
 [lints]
-rust = { unexpected_cfgs = { check-cfg = ["cfg(fbcode_build)"], level = "warn" } }
+workspace = true

--- a/monarch_introspection_snapshot/Cargo.toml
+++ b/monarch_introspection_snapshot/Cargo.toml
@@ -30,3 +30,6 @@ wirevalue = { version = "0.0.0", path = "../wirevalue" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 tempfile = "3.27.0"
 tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
+
+[lints]
+workspace = true

--- a/monarch_perfetto_trace/Cargo.toml
+++ b/monarch_perfetto_trace/Cargo.toml
@@ -20,3 +20,6 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 tracing-perfetto-sdk-schema = "0.13.1"
 tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "json", "local-time", "parking_lot", "registry"] }
+
+[lints]
+workspace = true

--- a/monarch_record_batch/Cargo.toml
+++ b/monarch_record_batch/Cargo.toml
@@ -10,3 +10,6 @@ license = "BSD-3-Clause"
 [dependencies]
 datafusion = "52.5.0"
 monarch_record_batch_macros = { version = "0.0.0", path = "../monarch_record_batch_macros" }
+
+[lints]
+workspace = true

--- a/monarch_record_batch_macros/Cargo.toml
+++ b/monarch_record_batch_macros/Cargo.toml
@@ -16,3 +16,6 @@ proc-macro = true
 proc-macro2 = { version = "1.0.106", features = ["span-locations"] }
 quote = "1.0.45"
 syn = { version = "2.0.117", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+
+[lints]
+workspace = true

--- a/monarch_types/src/python.rs
+++ b/monarch_types/src/python.rs
@@ -24,6 +24,10 @@ use serde::Serialize;
 /// A variant of `pyo3::IntoPyObject` used to wrap unsafe impls and propagates the
 /// unsafety to the caller.
 pub trait TryIntoPyObjectUnsafe<'py, P> {
+    /// # Safety
+    ///
+    /// The caller must ensure self is valid for the duration of the call
+    /// and that the type-erased pointer invariants of the trait are upheld.
     unsafe fn try_to_object_unsafe(self, py: Python<'py>) -> PyResult<Bound<'py, P>>;
 }
 

--- a/ndslice/Cargo.toml
+++ b/ndslice/Cargo.toml
@@ -28,3 +28,6 @@ rand = "0.10.1"
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
 typeuri = { version = "0.0.0", path = "../typeuri" }
+
+[lints]
+workspace = true

--- a/preempt_rwlock/Cargo.toml
+++ b/preempt_rwlock/Cargo.toml
@@ -13,3 +13,6 @@ tokio = { version = "1.52.1", features = ["full", "test-util", "tracing"] }
 [dev-dependencies]
 anyhow = "1.0.102"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
+
+[lints]
+workspace = true

--- a/struct_diff_patch/src/lib.rs
+++ b/struct_diff_patch/src/lib.rs
@@ -339,6 +339,9 @@ impl_tuple_diff_patch!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
 
 #[cfg(test)]
 mod tests {
+    // The Diff derive macro emits a unit expression; suppress the false positive.
+    #![allow(clippy::unused_unit)]
+
     use super::*;
     use crate as struct_diff_patch; // for macros
 

--- a/typeuri/src/lib.rs
+++ b/typeuri/src/lib.rs
@@ -55,6 +55,11 @@ pub trait Named: Sized + 'static {
 
     /// An unsafe version of 'arm', accepting a pointer to the value,
     /// for use in type-erased settings.
+    ///
+    /// # Safety
+    ///
+    /// self_ must be a valid pointer to a Self instance that
+    /// remains alive for the duration of the call.
     unsafe fn arm_unchecked(self_: *const ()) -> Option<&'static str> {
         // SAFETY: This isn't safe. We're passing it on.
         unsafe { &*(self_ as *const Self) }.arm()


### PR DESCRIPTION
Summary: brings `cargo clippy --all-targets --workspace` on a CPU laptop (with GPU/RDMA exclusions) to a clean baseline. the `clippy.toml` adds the  `await-holding-invalid-types` entries that buck's merged config already has, so existing `#[expect(clippy::await_holding_invalid_type)]` sites are fulfilled under cargo; remaining `#[allow]`s in `hyperactor/src/proc.rs` and `hyperactor_telemetry/src/task.rs` flipped to `#[expect]` per the Meta `#[expect]`-only rule. the `#[cfg(fbcode_build)]` gating in `hyperactor_mesh` test modules and their imports is because those tests use BUCK-only bootstrap infra and don't compile under cargo. lifetime elision (`TimerGuard`, `FieldVisitor`) and let-chain collapses in `hyperactor_telemetry::meta::*` and `monarch_conda::sync` are incidental — clippy fires on them regardless of config. with this baseline, the `-A` allow set can come down one at a time.

Differential Revision: D105568354
