### PR TITLE
Add annotation support in Kubernetes.add_mesh

### DIFF
--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -125,6 +125,7 @@ class KubernetesJob(JobTrait):
         port: int = _DEFAULT_MONARCH_PORT,
         pod_template: client.V1PodTemplateSpec | None = None,
         labels: dict[str, str] | None = None,
+        annotations: dict[str, str] | None = None,
     ) -> None:
         """
         Add a mesh specification.
@@ -149,6 +150,12 @@ class KubernetesJob(JobTrait):
             pod_template: ``V1PodTemplateSpec`` for advanced provisioning (e.g. custom volumes, sidecars,
                           pod-level labels/annotations). Mutually exclusive with ``image_spec``.
             labels: Optional labels to apply to the MonarchMesh CRD metadata.
+                    Propagated by the operator to the StatefulSet metadata. To set
+                    labels on the worker pods, use ``pod_template.metadata.labels``.
+                    Only used when provisioning (``image_spec`` or ``pod_template`` supplied).
+            annotations: Optional annotations to apply to the MonarchMesh CRD metadata.
+                    Propagated by the operator to the StatefulSet metadata. To set
+                    annotations on the worker pods, use ``pod_template.metadata.annotations``.
                     Only used when provisioning (``image_spec`` or ``pod_template`` supplied).
 
         Raises:
@@ -183,6 +190,8 @@ class KubernetesJob(JobTrait):
             raise ValueError("'pod_rank_label' cannot be customized when provisioning.")
         if not provisioned and labels is not None:
             raise ValueError("'labels' can only be set when provisioning.")
+        if not provisioned and annotations is not None:
+            raise ValueError("'annotations' can only be set when provisioning.")
 
         mesh_entry: Dict[str, Any] = {
             "label_selector": label_selector
@@ -195,6 +204,9 @@ class KubernetesJob(JobTrait):
 
         if labels is not None:
             mesh_entry["labels"] = labels
+
+        if annotations is not None:
+            mesh_entry["annotations"] = annotations
 
         if image_spec is not None:
             mesh_entry["pod_template"] = self._build_worker_pod_template(
@@ -248,6 +260,8 @@ class KubernetesJob(JobTrait):
             }
             if "labels" in mesh_config:
                 metadata["labels"] = mesh_config["labels"]
+            if "annotations" in mesh_config:
+                metadata["annotations"] = mesh_config["annotations"]
 
             body: Dict[str, Any] = {
                 "apiVersion": f"{_MONARCHMESH_GROUP}/{_MONARCHMESH_VERSION}",

--- a/python/tests/_src/job/test_kubernetes.py
+++ b/python/tests/_src/job/test_kubernetes.py
@@ -234,6 +234,31 @@ class TestAddMesh(unittest.TestCase):
         job.add_mesh("workers", num_replicas=1, image_spec=ImageSpec("img"))
         self.assertNotIn("labels", job._meshes["workers"])
 
+    # -- annotations -----------------------------------------------------------
+
+    def test_annotations_stored_when_provisioning(self) -> None:
+        job = self._make_job()
+        annotations = {"team": "infra", "scheduler": "kueue"}
+        job.add_mesh(
+            "workers",
+            num_replicas=1,
+            image_spec=ImageSpec("img"),
+            annotations=annotations,
+        )
+        self.assertEqual(job._meshes["workers"]["annotations"], annotations)
+
+    def test_annotations_forbidden_without_provisioning(self) -> None:
+        job = self._make_job()
+        with self.assertRaises(
+            ValueError, msg="annotations can only be set when provisioning"
+        ):
+            job.add_mesh("workers", num_replicas=1, annotations={"team": "infra"})
+
+    def test_no_annotations_by_default(self) -> None:
+        job = self._make_job()
+        job.add_mesh("workers", num_replicas=1, image_spec=ImageSpec("img"))
+        self.assertNotIn("annotations", job._meshes["workers"])
+
 
 class TestCreate(unittest.TestCase):
     """Tests for KubernetesJob._create guards."""
@@ -334,6 +359,52 @@ class TestCreate(unittest.TestCase):
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         self.assertEqual(body["metadata"]["labels"], labels)
+
+    @patch("monarch._src.job.kubernetes.client.ApiClient")
+    @patch("monarch._src.job.kubernetes.client.CustomObjectsApi")
+    @patch("monarch._src.job.kubernetes.config.load_incluster_config")
+    def test_create_includes_annotations_in_crd(
+        self,
+        mock_load_config: MagicMock,
+        mock_custom_api_cls: MagicMock,
+        mock_api_client_cls: MagicMock,
+    ) -> None:
+        job = self._make_job()
+        annotations = {"kueue.x-k8s.io/queue-name": "my-queue", "owner": "team"}
+        job.add_mesh(
+            "workers",
+            num_replicas=1,
+            image_spec=ImageSpec("img"),
+            annotations=annotations,
+        )
+
+        mock_api = MagicMock()
+        mock_custom_api_cls.return_value = mock_api
+
+        job._create(None)
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertEqual(body["metadata"]["annotations"], annotations)
+
+    @patch("monarch._src.job.kubernetes.client.ApiClient")
+    @patch("monarch._src.job.kubernetes.client.CustomObjectsApi")
+    @patch("monarch._src.job.kubernetes.config.load_incluster_config")
+    def test_create_omits_annotations_when_not_set(
+        self,
+        mock_load_config: MagicMock,
+        mock_custom_api_cls: MagicMock,
+        mock_api_client_cls: MagicMock,
+    ) -> None:
+        job = self._make_job()
+        job.add_mesh("workers", num_replicas=1, image_spec=ImageSpec("img"))
+
+        mock_api = MagicMock()
+        mock_custom_api_cls.return_value = mock_api
+
+        job._create(None)
+
+        body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
+        self.assertNotIn("annotations", body["metadata"])
 
     @patch("monarch._src.job.kubernetes.client.ApiClient")
     @patch("monarch._src.job.kubernetes.client.CustomObjectsApi")


### PR DESCRIPTION
Summary:
* and clarify you should use podtemplatespec for label and annotation for pods

intenral:
added support in D104882357 from the operator side

Differential Revision: D105620428


