### PR TITLE
[hyperactor] add current proc action APIs

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -204,6 +204,23 @@ pub use signal_handler::sigpipe_disposition;
 #[doc(inline)]
 pub use signal_handler::unregister_signal_cleanup;
 
+/// Serve the current gateway on the provided channel address.
+pub fn serve(
+    addr: channel::ChannelAddr,
+) -> Result<gateway::GatewayServeHandle, channel::ChannelError> {
+    Gateway::current().serve(addr)
+}
+
+/// Spawn a root actor on the current proc.
+pub fn spawn<A: Actor>(name: &str, actor: A) -> Result<ActorHandle<A>, anyhow::Error> {
+    Proc::current().spawn(name, actor)
+}
+
+/// Create a client actor on the current proc.
+pub fn client(name: &str) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
+    Proc::current().client(name)
+}
+
 mod private {
     /// Public trait in a private module for sealing traits within this crate:
     /// [Sealed trait pattern](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed).


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3955
* #3954
* #3953
* #3952
* __->__ #3951
* #3950

Add top-level hyperactor::serve, hyperactor::spawn, and hyperactor::client wrappers that operate on Gateway::current() and Proc::current(). Keep explicit Proc::current() and Gateway::current() as the accessors instead of adding redundant top-level current accessors.

Differential Revision: [D105707933](https://our.internmc.facebook.com/intern/diff/D105707933/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105707933/)!