### PR TITLE
[hyperactor] add Client caller context

### DIFF
--- a/hyperactor/src/client.rs
+++ b/hyperactor/src/client.rs
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Client caller contexts.
+
+use crate as hyperactor;
+use crate::Actor;
+use crate::ActorAddr;
+use crate::Message;
+use crate::RemoteMessage;
+use crate::actor::Binds;
+use crate::context;
+use crate::context::Mailbox as MailboxContext;
+use crate::mailbox::Mailbox;
+use crate::mailbox::OncePortHandle;
+use crate::mailbox::OncePortReceiver;
+use crate::mailbox::PortHandle;
+use crate::mailbox::PortReceiver;
+use crate::proc::HandlerPorts;
+use crate::proc::Instance;
+
+/// Actor marker type used for client caller contexts.
+#[derive(Debug, Default)]
+#[hyperactor::export]
+pub struct ClientActor;
+
+impl Actor for ClientActor {}
+
+/// A scoped caller context.
+///
+/// Dropping a client closes its mailbox. Messages already accepted into
+/// port receivers remain available; later deliveries to the client's ports
+/// fail as ordinary closed-mailbox deliveries.
+pub struct Client {
+    instance: Instance<ClientActor>,
+}
+
+impl Client {
+    /// This client's actor address.
+    pub fn self_addr(&self) -> &ActorAddr {
+        self.instance.self_addr()
+    }
+
+    /// Open a new port that accepts `M`-typed messages.
+    pub fn open_port<M: Message>(&self) -> (PortHandle<M>, PortReceiver<M>) {
+        self.instance.open_port()
+    }
+
+    /// Open a new one-shot port that accepts an `M`-typed message.
+    pub fn open_once_port<M: Message>(&self) -> (OncePortHandle<M>, OncePortReceiver<M>) {
+        self.instance.open_once_port()
+    }
+
+    /// Bind a handler port to this client.
+    pub fn bind_handler_port<M: RemoteMessage>(&self) -> (PortHandle<M>, PortReceiver<M>) {
+        let (handle, receiver) = self.instance.open_port();
+        handle.bind_handler_port();
+        (handle, receiver)
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        self.instance.close_client("client dropped");
+    }
+}
+
+impl context::Mailbox for Client {
+    fn mailbox(&self) -> &Mailbox {
+        MailboxContext::mailbox(&self.instance)
+    }
+}
+
+impl context::Mailbox for &Client {
+    fn mailbox(&self) -> &Mailbox {
+        MailboxContext::mailbox(&self.instance)
+    }
+}
+
+impl context::Actor for Client {
+    type A = ClientActor;
+
+    fn instance(&self) -> &Instance<ClientActor> {
+        &self.instance
+    }
+}
+
+impl context::Actor for &Client {
+    type A = ClientActor;
+
+    fn instance(&self) -> &Instance<ClientActor> {
+        &self.instance
+    }
+}

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -64,6 +64,7 @@ pub mod actor;
 pub mod actor_local;
 pub mod addr;
 pub mod channel;
+pub mod client;
 pub mod config;
 pub mod context;
 /// Gateway management for proc connectivity.
@@ -121,6 +122,7 @@ pub use addr::AddrParseError;
 pub use addr::Location;
 pub use addr::PortAddr;
 pub use addr::ProcAddr;
+pub use client::Client;
 pub use gateway::Gateway;
 #[doc(inline)]
 pub use hyperactor_macros::Bind;
@@ -231,6 +233,8 @@ mod private {
     impl<A: crate::Actor> Sealed for &crate::proc::Instance<A> {}
     impl<A: crate::Actor> Sealed for crate::proc::Context<'_, A> {}
     impl<A: crate::Actor> Sealed for &crate::proc::Context<'_, A> {}
+    impl Sealed for crate::client::Client {}
+    impl Sealed for &crate::client::Client {}
     impl Sealed for crate::mailbox::Mailbox {}
     impl Sealed for &crate::mailbox::Mailbox {}
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2152,6 +2152,12 @@ impl<A: Actor> Instance<A> {
         self.inner.mailbox.drain();
     }
 
+    pub(crate) fn close_client(&self, reason: &str) {
+        let status = ActorStatus::Stopped(reason.to_string());
+        self.inner.mailbox.close(status.clone());
+        self.change_status(status);
+    }
+
     /// Request immediate actor exit with the provided stop reason.
     pub fn exit(&self, reason: &str) -> Result<(), ActorError> {
         self.inner


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3955
* #3954
* __->__ #3953
* #3952
* #3951
* #3950

Add a hyperactor::client module with ClientActor and Client. Client is a scoped caller context that implements the existing context traits and closes its mailbox on drop so already accepted port messages remain drainable while later deliveries fail normally.

The sets us up to provide a structured client API, whereby the lifetime of the client itself is bound to the `Client` object.

Differential Revision: [D105707938](https://our.internmc.facebook.com/intern/diff/D105707938/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105707938/)!