### PR TITLE
[hyperactor] return Client from proc clients

### DIFF
--- a/hyperactor/example/derive.rs
+++ b/hyperactor/example/derive.rs
@@ -137,7 +137,7 @@ async fn main() -> Result<(), anyhow::Error> {
         proc.spawn("shopping", ShoppingListActor::default())?;
     let shopping_api: reference::ActorRef<ShoppingApi> = shopping_list_actor.bind();
     // We join the system, so that we can send messages to actors.
-    let (client, _) = proc.client("client").unwrap();
+    let client = proc.client("client");
 
     // todo: consider making this a macro to remove the magic names
 

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -34,6 +34,8 @@ use typeuri::Named;
 use crate as hyperactor; // for macros
 use crate::ActorAddr;
 use crate::ActorRef;
+#[cfg(test)]
+use crate::Client;
 use crate::Data;
 use crate::Message;
 use crate::RemoteMessage;
@@ -1021,7 +1023,7 @@ mod tests {
     #[tokio::test]
     async fn test_server_basic() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo", actor).unwrap();
@@ -1035,7 +1037,7 @@ mod tests {
     #[tokio::test]
     async fn test_ping_pong() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (undeliverable_msg_tx, _) = client.open_port();
 
         let ping_actor = PingPongActor::new(Some(undeliverable_msg_tx.bind()), None, None);
@@ -1058,7 +1060,7 @@ mod tests {
     #[tokio::test]
     async fn test_ping_pong_on_handler_error() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (undeliverable_msg_tx, _) = client.open_port();
 
         // Need to set a supervison coordinator for this Proc because there will
@@ -1121,7 +1123,7 @@ mod tests {
         let proc = Proc::isolated();
         let actor = InitActor(false);
         let handle = proc.spawn::<InitActor>("init", actor).unwrap();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let (port, receiver) = client.open_once_port();
         handle.send(&client, port).unwrap();
@@ -1137,8 +1139,7 @@ mod tests {
         proc: Proc,
         values: MultiValues,
         handle: ActorHandle<MultiActor>,
-        client: Instance<()>,
-        _client_handle: ActorHandle<()>,
+        client: Client,
     }
 
     impl MultiValuesTest {
@@ -1147,13 +1148,12 @@ mod tests {
             let values: MultiValues = Arc::new(Mutex::new((0, "".to_string())));
             let actor = MultiActor(values.clone());
             let handle = proc.spawn::<MultiActor>("myactor", actor).unwrap();
-            let (client, client_handle) = proc.client("client").unwrap();
+            let client = proc.client("client");
             Self {
                 proc,
                 values,
                 handle,
                 client,
-                _client_handle: client_handle,
             }
         }
 
@@ -1322,7 +1322,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_actor_handle_basic() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
@@ -1374,7 +1374,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_mixed_handler_and_non_handler_ports() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         // Port for receiving seq info from actor handler
         let (actor_tx, mut actor_rx) = client.open_port();
@@ -1456,8 +1456,8 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_sequencing_multiple_clients() {
         let proc = Proc::isolated();
-        let (client1, _) = proc.client("client1").unwrap();
-        let (client2, _) = proc.client("client2").unwrap();
+        let client1 = proc.client("client1");
+        let client2 = proc.client("client2");
 
         // Port for receiving seq info from actor handler
         let (tx, mut rx) = client1.open_port();
@@ -1568,7 +1568,7 @@ mod tests {
         let _guard = config.override_key(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
 
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
 
         let actor_handle = proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
@@ -1656,7 +1656,7 @@ mod tests {
 
     async fn assert_out_of_order_delivery(expected: Vec<(String, u64)>, relay_orders: Vec<usize>) {
         let local_proc: Proc = Proc::isolated();
-        let (client, _) = local_proc.client("local").unwrap();
+        let client = local_proc.client("local");
         let (tx, mut rx) = client.open_port();
 
         let handle = local_proc.spawn("get_seq", GetSeqActor(tx.bind())).unwrap();
@@ -1666,7 +1666,7 @@ mod tests {
             test_proc_id("remote_0"),
             DelayedMailboxSender::new(local_proc.clone(), relay_orders).boxed(),
         );
-        let (remote_client, _) = remote_proc.client("remote").unwrap();
+        let remote_client = remote_proc.client("remote");
         // Send the messages out in the order of their expected sequence numbers.
         let mut messages = expected.clone();
         messages.sort_by_key(|v| v.1);
@@ -1767,7 +1767,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_query_default_payload() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_introspect", actor).unwrap();
@@ -1912,7 +1912,7 @@ mod tests {
     #[tokio::test]
     async fn test_ia1_ia4_running_actor_attrs() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("ia_test", actor).unwrap();
@@ -1941,7 +1941,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_query_child_not_found() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_qc", actor).unwrap();
@@ -1986,7 +1986,7 @@ mod tests {
         impl Actor for CustomIntrospectActor {}
 
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let handle = proc
             .spawn("custom_introspect", CustomIntrospectActor)
             .unwrap();
@@ -2023,7 +2023,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_query_supervision_child() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         // Spawn parent.
         let (tx_parent, _rx_parent) = client.open_port::<u64>();
@@ -2101,7 +2101,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_fresh_actor_status() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_fresh", actor).unwrap();
@@ -2139,7 +2139,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_after_user_message() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, mut rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_after_msg", actor).unwrap();
@@ -2175,7 +2175,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_consecutive_queries() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_consec", actor).unwrap();
@@ -2238,7 +2238,7 @@ mod tests {
         }
 
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_attrs", actor).unwrap();
@@ -2275,7 +2275,7 @@ mod tests {
     #[tokio::test]
     async fn test_query_child_handler_round_trip() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_qch", actor).unwrap();
@@ -2354,7 +2354,7 @@ mod tests {
         }
 
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let handle = proc.spawn("wedged", WedgedActor).unwrap();
 
         // Wait for idle before sending the wedging message.
@@ -2399,7 +2399,7 @@ mod tests {
     #[tokio::test]
     async fn test_introspect_no_perturbation() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, mut rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
         let handle = proc.spawn::<EchoActor>("echo_no_perturb", actor).unwrap();
@@ -2501,9 +2501,9 @@ mod tests {
     #[tokio::test]
     async fn test_instance_does_not_respond_to_query() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
-        let (_mailbox, mailbox_handle) = proc.client("mailbox").unwrap();
-        let mailbox_id: crate::ActorAddr = mailbox_handle.actor_addr().clone();
+        let client = proc.client("client");
+        let mailbox = proc.client("mailbox");
+        let mailbox_id: crate::ActorAddr = mailbox.self_addr().clone();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
         PortRef::<IntrospectMessage>::attest_handler_port(&mailbox_id)

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -286,7 +286,7 @@ mod tests {
     #[tokio::test]
     async fn test_instance_gspawn_child_returns_erased_handle() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.client("parent").unwrap();
+        let parent = proc.client("parent");
 
         let child = parent
             .gspawn(
@@ -307,7 +307,7 @@ mod tests {
     #[tokio::test]
     async fn test_instance_gspawn_uid_uses_explicit_uid() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.client("parent").unwrap();
+        let parent = proc.client("parent");
         let uid = Uid::instance(Label::new("child").unwrap());
 
         let child = parent
@@ -328,7 +328,7 @@ mod tests {
     #[tokio::test]
     async fn test_instance_gspawn_uid_rejects_duplicate_uid() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.client("parent").unwrap();
+        let parent = proc.client("parent");
         let uid = Uid::instance(Label::new("child").unwrap());
 
         let child = parent

--- a/hyperactor/src/client.rs
+++ b/hyperactor/src/client.rs
@@ -8,21 +8,31 @@
 
 //! Client caller contexts.
 
+use std::fmt;
+
 use crate as hyperactor;
 use crate::Actor;
 use crate::ActorAddr;
+use crate::ActorRef;
+use crate::Data;
 use crate::Message;
 use crate::RemoteMessage;
+use crate::actor::ActorHandle;
+use crate::actor::ActorStatus;
+use crate::actor::AnyActorHandle;
 use crate::actor::Binds;
 use crate::context;
 use crate::context::Mailbox as MailboxContext;
+use crate::id::Uid;
 use crate::mailbox::Mailbox;
 use crate::mailbox::OncePortHandle;
 use crate::mailbox::OncePortReceiver;
 use crate::mailbox::PortHandle;
 use crate::mailbox::PortReceiver;
+use crate::ordering::Sequencer;
 use crate::proc::HandlerPorts;
 use crate::proc::Instance;
+use crate::proc::Proc;
 
 /// Actor marker type used for client caller contexts.
 #[derive(Debug, Default)]
@@ -30,6 +40,10 @@ use crate::proc::Instance;
 pub struct ClientActor;
 
 impl Actor for ClientActor {}
+
+impl Binds<ClientActor> for () {
+    fn bind(_ports: &HandlerPorts<ClientActor>) {}
+}
 
 /// A scoped caller context.
 ///
@@ -40,10 +54,27 @@ pub struct Client {
     instance: Instance<ClientActor>,
 }
 
+impl fmt::Debug for Client {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Client")
+            .field("self_addr", self.self_addr())
+            .finish()
+    }
+}
+
 impl Client {
+    pub(crate) fn new(instance: Instance<ClientActor>) -> Self {
+        Self { instance }
+    }
+
     /// This client's actor address.
     pub fn self_addr(&self) -> &ActorAddr {
         self.instance.self_addr()
+    }
+
+    /// The proc that owns this client.
+    pub fn proc(&self) -> &Proc {
+        self.instance.proc()
     }
 
     /// Open a new port that accepts `M`-typed messages.
@@ -61,6 +92,55 @@ impl Client {
         let (handle, receiver) = self.instance.open_port();
         handle.bind_handler_port();
         (handle, receiver)
+    }
+
+    /// Bind this client as an actor ref.
+    pub fn bind<R: Binds<ClientActor>>(&self) -> ActorRef<R> {
+        self.instance.bind()
+    }
+
+    /// Create a new direct child instance.
+    pub fn child(&self) -> anyhow::Result<(Instance<()>, ActorHandle<()>)> {
+        self.instance.child()
+    }
+
+    /// Spawn an actor as this client's child.
+    pub fn spawn<A: Actor>(&self, actor: A) -> anyhow::Result<ActorHandle<A>> {
+        self.instance.spawn(actor)
+    }
+
+    /// Spawn a named actor as this client's child.
+    pub fn spawn_with_name<A: Actor>(
+        &self,
+        name: &str,
+        actor: A,
+    ) -> anyhow::Result<ActorHandle<A>> {
+        self.instance.spawn_with_name(name, actor)
+    }
+
+    /// Spawn a registered actor as this client's child.
+    pub async fn gspawn(&self, actor_type: &str, params: Data) -> anyhow::Result<AnyActorHandle> {
+        self.instance.gspawn(actor_type, params).await
+    }
+
+    /// Spawn a registered actor as this client's child using an explicit uid.
+    pub async fn gspawn_uid(
+        &self,
+        actor_type: &str,
+        uid: Uid,
+        params: Data,
+    ) -> anyhow::Result<AnyActorHandle> {
+        self.instance.gspawn_uid(actor_type, uid, params).await
+    }
+
+    /// Return this client's sequencer.
+    pub fn sequencer(&self) -> &Sequencer {
+        self.instance.sequencer()
+    }
+
+    /// The client's lifecycle status.
+    pub fn status(&self) -> tokio::sync::watch::Receiver<ActorStatus> {
+        self.instance.status()
     }
 }
 

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -458,13 +458,13 @@ mod tests {
             .build()
             .unwrap();
 
-        let (alpha_client, _) = alpha.client("client").unwrap();
+        let alpha_client = alpha.client("client");
         let (alpha_port, mut alpha_rx) = alpha_client.bind_handler_port::<u64>();
         let PortLocation::Bound(alpha_dest) = alpha_port.location() else {
             panic!("alpha handler port must be bound");
         };
 
-        let (beta_client, _) = beta.client("client").unwrap();
+        let beta_client = beta.client("client");
         let (beta_port, mut beta_rx) = beta_client.bind_handler_port::<u64>();
         let PortLocation::Bound(beta_dest) = beta_port.location() else {
             panic!("beta handler port must be bound");
@@ -538,7 +538,7 @@ mod tests {
             .build()
             .unwrap();
 
-        let (client, _) = alpha.client("client").unwrap();
+        let client = alpha.client("client");
         let (undeliverable_msg_tx, mut undeliverable_rx) =
             client.open_port::<Undeliverable<MessageEnvelope>>();
 
@@ -759,7 +759,7 @@ mod tests {
 
         // Scratch proc just to host the return port.
         let scratch = Proc::isolated();
-        let (scratch_client, _) = scratch.client("return").unwrap();
+        let scratch_client = scratch.client("return");
         let (return_handle, mut return_rx) =
             scratch_client.open_port::<Undeliverable<MessageEnvelope>>();
 
@@ -832,7 +832,7 @@ mod tests {
         assert_eq!(gateway.inner.procs.read().unwrap().len(), 1);
 
         // Verify the new proc is reachable via the gateway.
-        let (client, _) = second.client("client").unwrap();
+        let client = second.client("client");
         let (port, mut rx) = client.bind_handler_port::<u64>();
         let dest = port.bind().port_addr().clone();
 

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -219,7 +219,7 @@ pub fn spawn<A: Actor>(name: &str, actor: A) -> Result<ActorHandle<A>, anyhow::E
 }
 
 /// Create a client actor on the current proc.
-pub fn client(name: &str) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
+pub fn client(name: &str) -> Client {
     Proc::current().client(name)
 }
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -21,7 +21,7 @@
 //! # use hyperactor::{ActorAddr, ProcAddr};
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::isolated();
-//! # let (client, _) = proc.client("client").unwrap();
+//! # let client = proc.client("client");
 //! # let actor_id = proc.proc_addr().actor_addr("actor");
 //! let mbox = Mailbox::new(actor_id);
 //! let (port, mut receiver) = mbox.open_port::<u64>();
@@ -40,7 +40,7 @@
 //! # use hyperactor::{ActorAddr, ProcAddr};
 //! # tokio_test::block_on(async {
 //! # let proc = Proc::isolated();
-//! # let (client, _) = proc.client("client").unwrap();
+//! # let client = proc.client("client");
 //! # let actor_id = proc.proc_addr().actor_addr("actor");
 //! let mbox = Mailbox::new(actor_id);
 //!
@@ -1072,7 +1072,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
                 ))
                 .build()
                 .expect("mailbox server proc builder is valid");
-            let (client, _) = proc.client("undeliverable_supervisor").unwrap();
+            let client = proc.client("undeliverable_supervisor");
             while let Ok(Undeliverable(mut envelope)) = undeliverable_rx.recv().await {
                 if let Ok(Undeliverable(e)) =
                     envelope.deserialized::<Undeliverable<MessageEnvelope>>()
@@ -3283,8 +3283,6 @@ mod tests {
 
     use super::*;
     use crate::Actor;
-    use crate::ActorHandle;
-    use crate::Instance;
     use crate::accum;
     use crate::accum::ReducerMode;
     use crate::channel::ChannelTransport;
@@ -3370,7 +3368,7 @@ mod tests {
     #[tokio::test]
     async fn test_mailbox_accum() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (port, mut receiver) = client
             .mailbox()
             .open_accum_port(accum::join_semilattice::<accum::Max<i64>>());
@@ -3426,7 +3424,7 @@ mod tests {
     #[ignore] // error behavior changed, but we will bring it back
     async fn test_mailbox_once() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let (port, receiver) = client.open_once_port::<u64>();
 
@@ -3638,7 +3636,7 @@ mod tests {
         let (port, receiver) = mbox0.open_once_port::<u64>();
 
         let proc = Proc::configured(test_proc_id("0"), BoxedMailboxSender::new(muxer));
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         port.send(&client, 123u64).unwrap();
         assert_eq!(receiver.recv().await.unwrap(), 123u64);
@@ -3847,7 +3845,7 @@ mod tests {
     #[tokio::test]
     async fn test_enqueue_port() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let count = Arc::new(AtomicUsize::new(0));
         let count_clone = count.clone();
@@ -3924,7 +3922,7 @@ mod tests {
         let proc_id = test_proc_id("quux_0");
         let mut proc = Proc::configured(proc_id.clone(), proc_forwarder);
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let foo = proc.spawn("foo", Foo).unwrap();
         let return_handle = foo.port::<Undeliverable<MessageEnvelope>>();
@@ -3976,7 +3974,7 @@ mod tests {
             Flattrs::new(),
         );
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         return_handle
             .send(&client, Undeliverable(envelope.clone()))
             .unwrap();
@@ -4154,10 +4152,8 @@ mod tests {
 
     struct Setup {
         receiver: PortReceiver<u64>,
-        actor0: Instance<()>,
-        actor1: Instance<()>,
-        _actor0_handle: ActorHandle<()>,
-        _actor1_handle: ActorHandle<()>,
+        actor0: crate::Client,
+        actor1: crate::Client,
         port_id: PortAddr,
         port_id1: PortAddr,
         port_id2: PortAddr,
@@ -4169,8 +4165,8 @@ mod tests {
         reducer_mode: ReducerMode,
     ) -> Setup {
         let proc = Proc::isolated();
-        let (actor0, actor0_handle) = proc.client("actor0").unwrap();
-        let (actor1, actor1_handle) = proc.client("actor1").unwrap();
+        let actor0 = proc.client("actor0");
+        let actor1 = proc.client("actor1");
 
         // Open a port on actor0
         let (port_handle, receiver) = actor0.open_port::<u64>();
@@ -4193,8 +4189,6 @@ mod tests {
             receiver,
             actor0,
             actor1,
-            _actor0_handle: actor0_handle,
-            _actor1_handle: actor1_handle,
             port_id,
             port_id1,
             port_id2,
@@ -4300,7 +4294,7 @@ mod tests {
         let _config_guard =
             config.override_key(crate::config::SPLIT_MAX_BUFFER_AGE, Duration::from_mins(10));
         let proc = Proc::isolated();
-        let (actor, _actor_handle) = proc.client("actor").unwrap();
+        let actor = proc.client("actor");
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
         // Split it
@@ -4423,7 +4417,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_split_port_once_mode_basic() {
         let proc = Proc::isolated();
-        let (actor, _actor_handle) = proc.client("actor").unwrap();
+        let actor = proc.client("actor");
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
 
@@ -4451,7 +4445,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_split_port_once_mode_teardown() {
         let proc = Proc::isolated();
-        let (actor, _actor_handle) = proc.client("actor").unwrap();
+        let actor = proc.client("actor");
         let (port_handle, mut receiver) = actor.open_port::<u64>();
         let port_id = port_handle.bind().port_addr().clone();
 
@@ -4715,7 +4709,7 @@ mod tests {
     #[tokio::test]
     async fn test_port_contramap() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (handle, mut rx) = client.open_port();
 
         handle
@@ -4848,7 +4842,7 @@ mod tests {
 
         let (port_handle, _rx) = mailbox.open_port::<u64>();
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         mailbox.close(ActorStatus::Stopped("test stop".to_string()));
 
@@ -4873,7 +4867,7 @@ mod tests {
 
         let (port_handle, _rx) = mailbox.open_port::<u64>();
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         mailbox.close(ActorStatus::Failed(ActorErrorKind::Generic(
             "test failure".to_string(),
@@ -4893,7 +4887,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_open_reduce_port() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         // Open an accumulator port with sum reducer
         let (port_handle, receiver) = client.mailbox().open_reduce_port(accum::sum::<u64>());
@@ -4913,7 +4907,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_open_reduce_port_reducer_spec_preserved() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         // Test that different accumulators produce different reducer_specs
         let (sum_handle, _) = client.mailbox().open_reduce_port(accum::sum::<u64>());

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -52,8 +52,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use thiserror::Error;
 
-use crate::ActorHandle;
-use crate::Instance;
+use crate::Client;
 // for macros
 use crate::Message;
 use crate::Proc;
@@ -143,10 +142,8 @@ pub(crate) fn return_undeliverable(
 ) {
     if envelope.return_undeliverable() {
         // A global client for returning undeliverable messages.
-        static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
-        let client = &CLIENT
-            .get_or_init(|| Proc::global().client("global_return_client").unwrap())
-            .0;
+        static CLIENT: OnceLock<Client> = OnceLock::new();
+        let client = CLIENT.get_or_init(|| Proc::global().client("global_return_client"));
         let envelope_copy = envelope.clone();
         if (return_handle.send(client, Undeliverable(envelope))).is_err() {
             UndeliverableMailboxSender.post(envelope_copy, /*unused*/ return_handle)

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -164,6 +164,8 @@ use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
 #[cfg(test)]
 use crate::channel::ChannelTransport;
+use crate::client::Client;
+use crate::client::ClientActor;
 use crate::config;
 use crate::context;
 use crate::context::Mailbox as _;
@@ -982,15 +984,15 @@ impl Proc {
     pub fn attach_actor<R, M>(
         &self,
         name: &str,
-    ) -> Result<(Instance<()>, ActorRef<R>, PortReceiver<M>), anyhow::Error>
+    ) -> Result<(Client, ActorRef<R>, PortReceiver<M>), anyhow::Error>
     where
         M: RemoteMessage,
         R: Referable + RemoteHandles<M>,
     {
-        let (instance, _handle) = self.client(name)?;
-        let (_handle, rx) = instance.bind_handler_port::<M>();
-        let actor_ref = ActorRef::attest(instance.self_addr().clone());
-        Ok((instance, actor_ref, rx))
+        let client = self.client(name);
+        let (_handle, rx) = client.bind_handler_port::<M>();
+        let actor_ref = ActorRef::attest(client.self_addr().clone());
+        Ok((client, actor_ref, rx))
     }
 
     /// Spawn a named (root) actor on this proc. The name of the actor must be
@@ -1029,12 +1031,12 @@ impl Proc {
     /// introspect task).  This is safe to call outside a Tokio
     /// runtime — unlike [`actor_instance`], it never calls
     /// `tokio::spawn`.
-    pub fn client(&self, name: &str) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
-        let actor_id: ActorAddr = self.allocate_root_id(name)?;
-        let (instance, _receivers) = Instance::new(self.clone(), actor_id, false, None);
-        let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
+    pub fn client(&self, label: &str) -> Client {
+        let actor_id = self.allocate_client_id(label);
+        let (instance, _receivers) =
+            Instance::<ClientActor>::new(self.clone(), actor_id, false, None);
         instance.change_status(ActorStatus::Client);
-        Ok((instance, handle))
+        Client::new(instance)
     }
 
     /// Create a lightweight client instance that handles
@@ -1518,6 +1520,15 @@ impl Proc {
     /// Create a root allocation in the proc from an explicit uid.
     fn allocate_root_uid(&self, uid: Uid) -> Result<ActorAddr, anyhow::Error> {
         self.reserve_root(uid)
+    }
+
+    fn allocate_client_id(&self, label: &str) -> ActorAddr {
+        let actor_id = if label.is_empty() {
+            ActorId::anonymous(self.proc_id().clone())
+        } else {
+            ActorId::instance(Label::strip(label), self.proc_id().clone())
+        };
+        ActorAddr::new(actor_id, self.default_location())
     }
 
     fn reserve_root(&self, uid: Uid) -> Result<ActorAddr, anyhow::Error> {
@@ -2152,6 +2163,10 @@ impl<A: Actor> Instance<A> {
         self.inner.mailbox.drain();
     }
 
+    pub(crate) fn status(&self) -> watch::Receiver<ActorStatus> {
+        self.inner.status_tx.subscribe()
+    }
+
     pub(crate) fn close_client(&self, reason: &str) {
         let status = ActorStatus::Stopped(reason.to_string());
         self.inner.mailbox.close(status.clone());
@@ -2272,11 +2287,9 @@ impl<A: Actor> Instance<A> {
     /// (e.g. from background tokio tasks).
     // TODO: replace with a proper mechanism for sending to port
     // handles without an actor context.
-    pub fn self_client() -> &'static Instance<()> {
-        static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
-        &CLIENT
-            .get_or_init(|| Proc::global().client("self_message_client").unwrap())
-            .0
+    pub fn self_client() -> &'static Client {
+        static CLIENT: OnceLock<Client> = OnceLock::new();
+        CLIENT.get_or_init(|| Proc::global().client("self_message_client"))
     }
 
     /// Send a message to the actor itself with a delay usually to trigger some event.
@@ -2290,7 +2303,7 @@ impl<A: Actor> Instance<A> {
         let self_id = self.self_addr().clone();
         tokio::spawn(async move {
             tokio::time::sleep(delay).await;
-            if let Err(e) = port.send(&client, message) {
+            if let Err(e) = port.send(client, message) {
                 // TODO: this is a fire-n-forget thread. We need to
                 // handle errors in a better way.
                 tracing::info!("{}: error sending delayed message: {}", self_id, e);
@@ -3263,11 +3276,9 @@ impl InstanceCell {
     pub fn signal(&self, signal: Signal) -> Result<(), ActorError> {
         if let Some((signal_port, _)) = &self.inner.actor_loop {
             // A global signal client is used to send signals to the actor.
-            static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
-            let client = &CLIENT
-                .get_or_init(|| Proc::global().client("global_signal_client").unwrap())
-                .0;
-            signal_port.send(&client, signal).map_err(ActorError::from)
+            static CLIENT: OnceLock<Client> = OnceLock::new();
+            let client = CLIENT.get_or_init(|| Proc::global().client("global_signal_client"));
+            signal_port.send(client, signal).map_err(ActorError::from)
         } else {
             tracing::warn!(
                 "{}: attempted to send signal {} to detached actor",
@@ -3993,13 +4004,13 @@ mod tests {
         ) -> Result<(), anyhow::Error> {
             let current = Proc::current();
             let spawned_handle = crate::spawn("current_spawned", TestActor)?;
-            let (_client_instance, client_handle) = crate::client("current_client")?;
+            let client = crate::client("current_client");
             reply
                 .send(CurrentProcSnapshot {
                     current_proc_id: current.proc_id().clone(),
                     current_gateway_proc_addr: Gateway::current().proc_addr(current.proc_id()),
                     spawned_handle,
-                    client_proc_id: client_handle.actor_addr().proc_id().clone(),
+                    client_proc_id: client.self_addr().proc_id().clone(),
                 })
                 .unwrap();
             Ok(())
@@ -4009,7 +4020,7 @@ mod tests {
     #[tokio::test]
     async fn test_current_proc_tracks_actor_context() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let actor = proc
             .spawn::<CurrentProcActor>("current", CurrentProcActor)
             .unwrap();
@@ -4038,7 +4049,7 @@ mod tests {
     #[tokio::test]
     async fn test_client_instance_can_bind_signal_port() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let (_signal_port, _signal_rx) = client.bind_handler_port::<Signal>();
     }
@@ -4051,7 +4062,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_actor() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let handle = proc.spawn("test", TestActor).unwrap();
 
         // Check on the join handle.
@@ -4101,7 +4112,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_proc_actors_messaging() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let first = proc.spawn::<TestActor>("first", TestActor).unwrap();
         let second = proc.spawn::<TestActor>("second", TestActor).unwrap();
         let (tx, rx) = oneshot::channel::<()>();
@@ -4287,7 +4298,7 @@ mod tests {
         use crate::testing::ids::test_actor_id;
 
         let proc = Proc::isolated();
-        let (instance, _) = proc.client("worker").unwrap();
+        let instance = proc.client("worker");
         let (port, mut receiver) = instance.bind_handler_port::<u64>();
 
         let PortLocation::Bound(default_dest) = port.location() else {
@@ -4314,12 +4325,12 @@ mod tests {
     fn test_default_location_changes_new_bindings_not_lookup() {
         let proc = Proc::isolated();
         let gateway = proc.gateway();
-        let (_instance, handle) = proc.client("worker").unwrap();
+        let client = proc.client("worker");
 
-        let first_ref: ActorRef<()> = handle.bind();
+        let first_ref: ActorRef<()> = client.bind();
         let new_location = ChannelAddr::Local(9876).into();
         gateway.set_default_location(new_location);
-        let second_ref: ActorRef<()> = handle.bind();
+        let second_ref: ActorRef<()> = client.bind();
 
         assert_eq!(first_ref.actor_addr().id(), second_ref.actor_addr().id());
         assert_ne!(
@@ -4382,7 +4393,7 @@ mod tests {
         let proc = Proc::isolated();
         let gateway = proc.gateway();
         let initial_location = proc.default_location();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (port, mut receiver) = client.bind_handler_port::<u64>();
         let PortLocation::Bound(default_dest) = port.location() else {
             panic!("handler port must be bound");
@@ -4465,7 +4476,7 @@ mod tests {
         use crate::testing::ids::test_actor_id;
 
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (return_handle, mut undeliverable_rx) =
             client.open_port::<Undeliverable<MessageEnvelope>>();
         let remote_proc = ProcAddr::instance(ChannelAddr::Local(1234), "remote");
@@ -4512,7 +4523,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_actor_lookup() {
         let proc = Proc::isolated();
-        let (client, _handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let target_actor = proc.spawn::<TestActor>("target", TestActor).unwrap();
         let target_actor_ref = target_actor.bind();
@@ -4582,7 +4593,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_spawn_child() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let first = proc.spawn::<TestActor>("first", TestActor).unwrap();
         let second = TestActor::spawn_child(&client, &first).await;
@@ -4651,7 +4662,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_child_lifecycle() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let root = proc.spawn::<TestActor>("root", TestActor).unwrap();
         let root_1 = TestActor::spawn_child(&client, &root).await;
@@ -4734,7 +4745,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_drain_and_stop_closes_handler_ingress() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let stop_started = Arc::new(tokio::sync::Notify::new());
         let release_stop = Arc::new(tokio::sync::Notify::new());
         let handle = proc
@@ -4762,7 +4773,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_parent_failure() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         // Need to set a supervison coordinator for this Proc because there will
         // be actor failure(s) in this test which trigger supervision.
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -4834,7 +4845,7 @@ mod tests {
         let state = Arc::new(AtomicUsize::new(0));
         let actor = TestActor(state.clone());
         let handle = proc.spawn::<TestActor>("test", actor).unwrap();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, rx) = client.open_once_port();
         handle.send(&client, tx).unwrap();
         let usize_handle = rx.recv().await.unwrap();
@@ -4856,7 +4867,7 @@ mod tests {
         // be actor failure(s) in this test which trigger supervision.
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
-        let (client, _handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let actor_handle = proc.spawn("test", TestActor).unwrap();
         actor_handle
             .panic(&client, "some random failure".to_string())
@@ -4932,7 +4943,7 @@ mod tests {
         };
 
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (mut reported_event, _coordinator) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5025,13 +5036,14 @@ mod tests {
 
         let proc = Proc::isolated();
 
-        let (instance, handle) = proc.client("my_test_actor").unwrap();
+        let client = proc.client("my_test_actor");
+        let status = client.status();
 
-        let child_actor = TestActor.spawn(&instance).unwrap();
+        let child_actor = TestActor.spawn(&client).unwrap();
 
-        let (port, mut receiver) = instance.open_port();
+        let (port, mut receiver) = client.open_port();
         child_actor
-            .send(&instance, ("hello".to_string(), port.bind()))
+            .send(&client, ("hello".to_string(), port.bind()))
             .unwrap();
 
         let message = receiver.recv().await.unwrap();
@@ -5040,10 +5052,9 @@ mod tests {
         child_actor.drain_and_stop("test").unwrap();
         child_actor.await;
 
-        assert_eq!(*handle.status().borrow(), ActorStatus::Client);
-        drop(instance);
-        assert_matches!(*handle.status().borrow(), ActorStatus::Stopped(_));
-        handle.await;
+        assert_eq!(*status.borrow(), ActorStatus::Client);
+        drop(client);
+        assert_matches!(*status.borrow(), ActorStatus::Stopped(_));
     }
 
     // Tokio's I/O driver is not fork-safe on macOS, and this test intentionally
@@ -5062,7 +5073,7 @@ mod tests {
             // should cause the process to terminate.
             // ProcSupervisionCoordinator::set(&proc).await.unwrap();
             let root = proc.spawn("root", TestActor).unwrap();
-            let (client, _handle) = proc.client("client").unwrap();
+            let client = proc.client("client");
             root.fail(&client, anyhow::anyhow!("some random failure"))
                 .await
                 .unwrap();
@@ -5161,7 +5172,7 @@ mod tests {
 
         trace_and_block(async {
             let proc = Proc::isolated();
-            let (client, _) = proc.client("client").unwrap();
+            let client = proc.client("client");
             let handle = LoggingActor.spawn_detached().unwrap();
             handle.send(&client, "hello world".to_string()).unwrap();
             handle
@@ -5201,7 +5212,7 @@ mod tests {
         use crate::mailbox::MailboxSenderErrorKind;
 
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let actor_handle = proc.spawn("test", TestActor).unwrap();
 
         // Clone the handle before awaiting since await consumes the handle
@@ -5234,7 +5245,7 @@ mod tests {
         use crate::mailbox::MailboxSenderErrorKind;
 
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         // Need to set a supervison coordinator for this Proc because there will
         // be actor failure(s) in this test which trigger supervision.
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
@@ -5303,7 +5314,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_stored_on_stop() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.client("client").unwrap();
+        let _client = proc.client("client");
 
         let handle = proc.spawn::<TestActor>("actor", TestActor).unwrap();
         let actor_id = handle.actor_addr().clone();
@@ -5347,7 +5358,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_stored_on_failure() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         // Supervision coordinator required for actor failure handling.
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5377,7 +5388,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_stored_on_failure() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let handle = proc.spawn::<TestActor>("fail_actor", TestActor).unwrap();
@@ -5402,7 +5413,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_on_clean_stop() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.client("client").unwrap();
+        let _client = proc.client("client");
 
         let handle = proc.spawn::<TestActor>("stop_actor", TestActor).unwrap();
         let cell = handle.cell().clone();
@@ -5424,7 +5435,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_coordinator_receives_clean_stop() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.client("client").unwrap();
+        let _client = proc.client("client");
         let (mut reported_event, _coordinator_handle) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5447,7 +5458,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_coordinator_shuts_down_last_during_destroy() {
         let mut proc = Proc::isolated();
-        let (_client, _client_handle) = proc.client("client").unwrap();
+        let _client = proc.client("client");
         let (mut reported_event, _coordinator_handle) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
@@ -5488,7 +5499,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_supervision_event_on_propagated_failure() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let parent = proc.spawn::<TestActor>("parent", TestActor).unwrap();
@@ -5530,7 +5541,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_resolve_actor_ref_none_for_terminal_actor() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.client("client").unwrap();
+        let _client = proc.client("client");
 
         let handle = proc.spawn::<TestActor>("target", TestActor).unwrap();
         let actor_ref: ActorRef<TestActor> = handle.bind();
@@ -5556,7 +5567,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_terminated_snapshot_has_failure_info() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let handle = proc.spawn::<TestActor>("fail_actor", TestActor).unwrap();
@@ -5600,7 +5611,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_propagated_failure_info() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let parent = proc.spawn::<TestActor>("parent", TestActor).unwrap();
@@ -5783,7 +5794,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 60)]
     async fn test_stopped_snapshot_has_no_failure_info() {
         let proc = Proc::isolated();
-        let (_client, _client_handle) = proc.client("client").unwrap();
+        let _client = proc.client("client");
 
         let handle = proc.spawn::<TestActor>("stop_actor", TestActor).unwrap();
         let actor_id = handle.actor_addr().clone();
@@ -5819,7 +5830,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 10)]
     async fn test_queue_depth_increment_decrement() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let handle = proc.spawn("qd_test", TestActor).unwrap();
         let actor_ref: crate::ActorRef<TestActor> = handle.bind();
         let actor_id = actor_ref.actor_addr().clone();
@@ -5874,7 +5885,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 10)]
     async fn test_proc_queue_depth_aggregation_under_pressure() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         // Spawn two actors.
         let h1 = proc.spawn("a1", TestActor).unwrap();
@@ -5964,7 +5975,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 10)]
     async fn test_retained_queue_stats_burst_then_drain() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let h = proc.spawn("ret_test", TestActor).unwrap();
 
         // Block the actor.

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -183,7 +183,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_client_macros() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let actor_handle = proc.spawn("foo", TestVariantFormsActor {}).unwrap();
 
         assert_eq!(actor_handle.call_struct(&client, 10).await.unwrap(), 10,);

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -145,7 +145,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_binds() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
         //  This will call binds
@@ -234,7 +234,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_ref_alias() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc.spawn("test", TestActor::new(tx.bind())).unwrap();
 
@@ -276,7 +276,7 @@ mod tests {
     #[async_timed_test(timeout_secs = 30)]
     async fn test_generic_export() {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
         let actor_handle = proc
             .spawn("generic", GenericActor::<u64>::new(tx.bind()))

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2464,7 +2464,7 @@ mod tests {
         proc.clone().serve(proc_rx);
         let proc_ref: ProcAddr = test_proc_id("client_0");
         router.bind(proc_ref, proc_addr.clone());
-        let (client, _handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let (tap_tx, mut tap_rx) = tokio::sync::mpsc::unbounded_channel::<String>();
         test_tap::install(tap_tx);
@@ -2981,7 +2981,7 @@ mod tests {
     ///   so its messages route via the host.
     #[cfg(fbcode_build)]
     async fn make_proc_id_and_backend_addr(
-        instance: &hyperactor::Instance<()>,
+        instance: &hyperactor::Client,
         _tag: &str,
     ) -> (ProcAddr, ChannelAddr) {
         // Serve a Unix channel as the "backend_addr" and hook it into
@@ -3005,7 +3005,7 @@ mod tests {
         // Create a root direct-addressed proc + client instance.
         let root =
             hyperactor::Proc::direct(ChannelTransport::Unix.any(), "root".to_string()).unwrap();
-        let (instance, _handle) = root.client("client").unwrap();
+        let instance = root.client("client");
 
         let mgr = BootstrapProcManager::new(BootstrapCommand::test()).unwrap();
         let (proc_id, backend_addr) = make_proc_id_and_backend_addr(&instance, "t_term").await;
@@ -3072,7 +3072,7 @@ mod tests {
         // Root proc + client instance (so the child can dial back).
         let root =
             hyperactor::Proc::direct(ChannelTransport::Unix.any(), "root".to_string()).unwrap();
-        let (instance, _handle) = root.client("client").unwrap();
+        let instance = root.client("client");
 
         let mgr = BootstrapProcManager::new(BootstrapCommand::test()).unwrap();
 
@@ -3126,7 +3126,7 @@ mod tests {
         // Create a local instance just to call the local bootstrap actor.
         // We should find a way to avoid this for local handles.
         let temp_proc = Proc::isolated();
-        let (temp_instance, _) = temp_proc.client("temp").unwrap();
+        let temp_instance = temp_proc.client("temp");
 
         let handle = host(
             ChannelAddr::any(ChannelTransport::Unix),

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -747,16 +747,12 @@ mod tests {
     async fn buffering_fixture(
         proc_name: &str,
     ) -> (
-        Instance<()>,
+        hyperactor::Client,
         hyperactor::mailbox::PortReceiver<TestMessage>,
         hyperactor::ActorHandle<CommActor>,
         crate::mesh_id::ActorMeshId,
-        // Drop guards: client handle, test actor handle, test actor ref.
-        (
-            hyperactor::ActorHandle<()>,
-            hyperactor::ActorHandle<TestActor>,
-            ActorRef<TestActor>,
-        ),
+        // Drop guards: test actor handle, test actor ref.
+        (hyperactor::ActorHandle<TestActor>, ActorRef<TestActor>),
     ) {
         use hyperactor::Proc;
         use hyperactor::RemoteSpawn;
@@ -764,7 +760,7 @@ mod tests {
         use hyperactor::id::Label;
 
         let proc = Proc::direct(ChannelTransport::Unix.any(), proc_name.to_string()).unwrap();
-        let (client, client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let actor_mesh_id = crate::mesh_id::ActorMeshId::instance(Label::new("test").unwrap());
 
@@ -785,12 +781,12 @@ mod tests {
             rx,
             comm_handle,
             actor_mesh_id,
-            (client_handle, test_handle, test_ref),
+            (test_handle, test_ref),
         )
     }
 
     /// Send CommMeshConfig (single-rank mesh pointing at self).
-    fn send_config(client: &Instance<()>, comm_handle: &hyperactor::ActorHandle<CommActor>) {
+    fn send_config(client: &hyperactor::Client, comm_handle: &hyperactor::ActorHandle<CommActor>) {
         let comm_ref = comm_handle.bind::<CommActor>();
         let mut peers = HashMap::new();
         peers.insert(0, comm_ref);
@@ -803,7 +799,7 @@ mod tests {
     /// and verify both are delivered in order.
     async fn assert_buffered_and_replayed<M: hyperactor::Message>(
         proc_name: &str,
-        mut make_msg: impl FnMut(&Instance<()>, &crate::mesh_id::ActorMeshId, &str) -> M,
+        mut make_msg: impl FnMut(&hyperactor::Client, &crate::mesh_id::ActorMeshId, &str) -> M,
     ) where
         CommActor: hyperactor::Handler<M>,
     {

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -426,7 +426,7 @@ mod tests {
     #[tokio::test]
     async fn test_simple_connection() -> Result<()> {
         let proc = Proc::isolated();
-        let (client, _) = proc.client("client")?;
+        let client = proc.client("client");
         let (connect, completer) = Connect::allocate(client.self_addr().clone(), client);
         let actor = proc.spawn("actor", EchoActor {})?;
         actor.send(&completer.caps, connect)?;
@@ -451,13 +451,13 @@ mod tests {
     #[tokio::test]
     async fn test_connection_close_on_drop() -> Result<()> {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client")?;
+        let client = proc.client("client");
+        let client_addr = client.self_addr().clone();
+        let server = proc.client("server");
+        let server_addr = server.self_addr().clone();
 
-        let (connect, completer) =
-            Connect::allocate(client.self_addr().clone(), client.clone_for_py());
-        let (mut rd, _) = accept(client.clone_for_py(), client.self_addr().clone(), connect)
-            .await?
-            .into_split();
+        let (connect, completer) = Connect::allocate(client_addr, client);
+        let (mut rd, _) = accept(server, server_addr, connect).await?.into_split();
         let (_, mut wr) = completer.complete().await?.into_split();
 
         // Write some data
@@ -478,13 +478,13 @@ mod tests {
     #[tokio::test]
     async fn test_no_eof_on_drop_after_shutdown() -> Result<()> {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client")?;
+        let client = proc.client("client");
+        let client_addr = client.self_addr().clone();
+        let server = proc.client("server");
+        let server_addr = server.self_addr().clone();
 
-        let (connect, completer) =
-            Connect::allocate(client.self_addr().clone(), client.clone_for_py());
-        let (mut rd, _) = accept(client.clone_for_py(), client.self_addr().clone(), connect)
-            .await?
-            .into_split();
+        let (connect, completer) = Connect::allocate(client_addr, client);
+        let (mut rd, _) = accept(server, server_addr, connect).await?.into_split();
         let (_, mut wr) = completer.complete().await?.into_split();
 
         // Write some data

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -378,9 +378,7 @@ async fn bootstrap_host() -> GlobalState {
     // — intentionally acceptable for cross-language symmetry and easier
     // reasoning about the bootstrap sequence.
     let temp_proc = Proc::isolated();
-    let (bootstrap_cx, _guard) = temp_proc
-        .client("bootstrap")
-        .expect("failed to create bootstrap instance");
+    let bootstrap_cx = temp_proc.client("bootstrap");
     let local_proc_agent: ActorHandle<ProcAgent> = host_agent
         .get_local_proc(&bootstrap_cx)
         .await

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -1784,8 +1784,8 @@ mod tests {
         let proc2 = procs.lock().await.get(&proc_id2).unwrap().clone();
 
         // Make sure they can talk to each other:
-        let (instance1, _handle) = proc1.client("client").unwrap();
-        let (instance2, _handle) = proc2.client("client").unwrap();
+        let instance1 = proc1.client("client");
+        let instance2 = proc2.client("client");
 
         let (port, mut rx) = instance1.mailbox().open_port();
 
@@ -1793,7 +1793,7 @@ mod tests {
         assert_eq!(rx.recv().await.unwrap(), "hello".to_string());
 
         // Make sure that the system proc is also wired in correctly.
-        let (system_actor, _handle) = host.system_proc().client("test").unwrap();
+        let system_actor = host.system_proc().client("test");
 
         // system->proc
         port.bind()
@@ -1864,7 +1864,7 @@ mod tests {
             "test".to_string(),
         )
         .unwrap();
-        let (client_inst, _h) = client.client("test").unwrap();
+        let client_inst = client.client("test");
         let (port, rx) = client_inst.mailbox().open_once_port();
         echo1.send(&client_inst, port.bind()).unwrap();
         let id = tokio::time::timeout(Duration::from_secs(5), rx.recv())
@@ -1896,7 +1896,7 @@ mod tests {
         //        client port.
         // Because `client_inst` runs in its own proc, the reply
         // traverses the host (not local delivery within proc1).
-        let (sys_inst, _h) = host.system_proc().client("sys-client").unwrap();
+        let sys_inst = host.system_proc().client("sys-client");
         let (port3, rx3) = client_inst.mailbox().open_once_port();
         // Send from system -> child via a message that ultimately
         // replies to client's port
@@ -2173,8 +2173,8 @@ mod tests {
 
         // (1) Host -> remote: open a port on the remote proc, send from
         //     the system instance.
-        let (system_inst, _h) = host.system_proc().client("test-sender").unwrap();
-        let (remote_inst, _rh) = remote_proc.client("remote-client").unwrap();
+        let system_inst = host.system_proc().client("test-sender");
+        let remote_inst = remote_proc.client("remote-client");
 
         let (remote_port, mut remote_rx) = remote_inst.mailbox().open_port();
         let remote_port = remote_port.bind();
@@ -2238,7 +2238,7 @@ mod tests {
         let bogus_port = bogus_actor.port_addr(Port::from(0u64));
         let bogus_dest = PortRef::<String>::attest(bogus_port);
 
-        let (trigger_inst, _h) = remote_proc.client("trigger").unwrap();
+        let trigger_inst = remote_proc.client("trigger");
         collector_ref
             .port::<SendTo>()
             .send(&trigger_inst, bogus_dest)
@@ -2286,7 +2286,7 @@ mod tests {
         let bogus_port = bogus_actor.port_addr(Port::from(0u64));
         let bogus_dest = PortRef::<String>::attest(bogus_port);
 
-        let (trigger_inst, _h) = host.system_proc().client("trigger").unwrap();
+        let trigger_inst = host.system_proc().client("trigger");
         collector_ref
             .port::<SendTo>()
             .send(&trigger_inst, bogus_dest)
@@ -2323,8 +2323,8 @@ mod tests {
 
         let remote_proc = Proc::attach_to_host(host.addr().clone()).await.unwrap();
 
-        let (system_inst, _h) = host.system_proc().client("teardown-sender").unwrap();
-        let (remote_inst, _rh) = remote_proc.client("teardown-client").unwrap();
+        let system_inst = host.system_proc().client("teardown-sender");
+        let remote_inst = remote_proc.client("teardown-client");
 
         let (remote_port, mut remote_rx) = remote_inst.mailbox().open_port();
         let remote_port = remote_port.bind();
@@ -2390,7 +2390,7 @@ mod tests {
         let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
         let _client_handle = client_proc.clone().serve(client_rx);
 
-        let (client_inst, _h) = client_proc.client("requester").unwrap();
+        let client_inst = client_proc.client("requester");
         let (reply_port, reply_handle) = client_inst.mailbox().open_once_port::<ActorAddr>();
         let reply_port = reply_port.bind();
         echo_ref
@@ -2503,7 +2503,7 @@ mod tests {
                 let echo_ref = ActorRef::<EchoActor>::attest(echo_actor_id);
 
                 for ri in 0..M_REQUESTS {
-                    let (client_inst, _h) = client_proc.client(&format!("req-{}", ri)).unwrap();
+                    let client_inst = client_proc.client(&format!("req-{}", ri));
                     let (reply_port, reply_handle) =
                         client_inst.mailbox().open_once_port::<ActorAddr>();
                     let reply_port = reply_port.bind();
@@ -2575,7 +2575,7 @@ mod tests {
         let client_proc = Proc::configured(client_proc_id, dial_router.into_boxed());
         let _client_handle = client_proc.clone().serve(client_rx);
 
-        let (client_inst, _client_h) = client_proc.client("requester").unwrap();
+        let client_inst = client_proc.client("requester");
 
         // Send a request to the echo actor on the host. The reply
         // travels back through the host's dial router → simplex dial

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -863,40 +863,29 @@ impl Drop for HostMeshShutdownGuard {
                                  relying on PDEATHSIG/manager Drop"
                             );
                         }
-                        Ok(proc) => match proc.client("drop") {
-                            Err(e) => {
-                                tracing::warn!(
-                                    error = %e,
-                                    "failed to create ephemeral instance for drop-cleanup; \
-                                     relying on PDEATHSIG/manager Drop"
-                                );
-                            }
-                            Ok((instance, _guard)) => {
-                                let mut attempted = 0usize;
-                                let mut ok = 0usize;
-                                let mut err = 0usize;
+                        Ok(proc) => {
+                            let client = proc.client("drop");
+                            let mut attempted = 0usize;
+                            let mut ok = 0usize;
+                            let mut err = 0usize;
 
-                                for host in hosts {
-                                    attempted += 1;
-                                    tracing::debug!(host = %host, "drop-cleanup: shutdown start");
-                                    match host.shutdown(&instance).await {
-                                        Ok(()) => {
-                                            ok += 1;
-                                            tracing::debug!(host = %host, "drop-cleanup: shutdown ok");
-                                        }
-                                        Err(e) => {
-                                            err += 1;
-                                            tracing::warn!(host = %host, error = %e, "drop-cleanup: shutdown failed");
-                                        }
+                            for host in hosts {
+                                attempted += 1;
+                                tracing::debug!(host = %host, "drop-cleanup: shutdown start");
+                                match host.shutdown(&client).await {
+                                    Ok(()) => {
+                                        ok += 1;
+                                        tracing::debug!(host = %host, "drop-cleanup: shutdown ok");
+                                    }
+                                    Err(e) => {
+                                        err += 1;
+                                        tracing::warn!(host = %host, error = %e, "drop-cleanup: shutdown failed");
                                     }
                                 }
-
-                                tracing::info!(
-                                    attempted, ok, err,
-                                    "hostmesh drop-cleanup summary"
-                                );
                             }
-                        },
+
+                            tracing::info!(attempted, ok, err, "hostmesh drop-cleanup summary");
+                        }
                     }
                 }
                 .instrument(span),

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1562,7 +1562,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
 
@@ -1622,7 +1622,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
         host_agent
@@ -1672,7 +1672,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
         host_agent
@@ -1728,7 +1728,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
 
@@ -1776,7 +1776,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         let mesh_a = HostMeshId::instance(Label::new("mesh-a").unwrap());
         let mesh_b = HostMeshId::instance(Label::new("mesh-b").unwrap());
@@ -1879,7 +1879,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         let mesh_a = HostMeshId::instance(Label::new("mesh-a").unwrap());
         let mesh_b = HostMeshId::instance(Label::new("mesh-b").unwrap());
@@ -1965,7 +1965,7 @@ mod tests {
 
         let client_proc =
             Proc::direct(ChannelTransport::Unix.any(), "qd_client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         // Spawn a proc so the host_agent processes at least one
         // CreateOrUpdate message, which goes through the work queue.

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1600,7 +1600,7 @@ mod tests {
         proc.clone().serve(client_rx);
         let proc_ref: ProcAddr = test_proc_id("client_0");
         router.bind(proc_ref, proc_addr.clone());
-        let (client, _handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         // Spin up both the forwarder and the client
         let log_channel = ChannelAddr::any(ChannelTransport::Unix);

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -3349,7 +3349,7 @@ mod tests {
         // Only a mailbox is needed for reply ports — no actor message
         // loop required.
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         // -- 4. Resolve "root" --
         let root_resp = admin_ref
@@ -3514,7 +3514,7 @@ mod tests {
 
         // Create a bare client instance for sending messages.
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         // Spawn a user proc via CreateOrUpdate<ProcSpec>.
         let user_proc_name = ResourceId::instance(Label::new("user-proc").unwrap());
@@ -3676,7 +3676,7 @@ mod tests {
         // Client for sending messages.
         let client_proc =
             hyperactor::Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         // Resolve "root" — should contain only the host.
         let root_resp = admin_ref
@@ -3829,7 +3829,7 @@ mod tests {
         let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         // Walk the tree breadth-first, checking the invariant at every node.
         // Each entry is (reference_string, expected_parent_identity).
@@ -3935,7 +3935,7 @@ mod tests {
 
         // -- 3. Create a bare client instance for sending messages --
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         // -- 4. Resolve the host to get its children --
         let host_ref_str =
@@ -4151,7 +4151,7 @@ mod tests {
         // 2. Create a separate caller proc with an actor instance.
         let caller_proc = Proc::direct(ChannelTransport::Unix.any(), "caller".to_string()).unwrap();
         let _supervision = ProcSupervisionCoordinator::set(&caller_proc).await.unwrap();
-        let (caller_cx, _caller_handle) = caller_proc.client("caller").unwrap();
+        let caller_cx = caller_proc.client("caller");
 
         // 3. Call the real public entrypoint.
         let admin_ref = crate::host_mesh::spawn_admin(
@@ -4266,7 +4266,7 @@ mod tests {
         let admin_ref: ActorRef<MeshAdminAgent> = admin_handle.bind();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         // Resolve the user proc via MeshAdminAgent. HostMeshAgent
         // returns Error for QueryChild → fallback to proc_agent[0]

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -23,6 +23,7 @@ use hyperactor::ActorAddr;
 use hyperactor::ActorHandle;
 use hyperactor::Addr;
 use hyperactor::Bind;
+use hyperactor::Client;
 use hyperactor::Context;
 use hyperactor::Data;
 use hyperactor::Handler;
@@ -1166,7 +1167,7 @@ impl Handler<resource::KeepaliveGetState<ActorState>> for ProcAgent {
 #[derive(Debug, hyperactor::Handler, hyperactor::HandleClient)]
 pub struct NewClientInstance {
     #[reply]
-    pub client_instance: PortHandle<Instance<()>>,
+    pub client_instance: PortHandle<Client>,
 }
 
 #[async_trait]
@@ -1176,8 +1177,8 @@ impl Handler<NewClientInstance> for ProcAgent {
         cx: &Context<Self>,
         NewClientInstance { client_instance }: NewClientInstance,
     ) -> anyhow::Result<()> {
-        let (instance, _handle) = self.proc.client("client")?;
-        client_instance.send(cx, instance)?;
+        let client = self.proc.client("client");
+        client_instance.send(cx, client)?;
         Ok(())
     }
 }
@@ -1300,14 +1301,14 @@ mod tests {
 
         // Client instance for opening reply ports.
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_handler_port(&agent_id);
 
         // Helper: send QueryChild(Proc) and return the payload with a
         // timeout so a misrouted reply fails fast rather than hanging.
-        let query = |client: &hyperactor::Instance<()>| {
+        let query = |client: &hyperactor::Client| {
             let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
             port.send(
                 client,
@@ -1406,7 +1407,7 @@ mod tests {
             .unwrap();
 
         let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
         let port = PortRef::<IntrospectMessage>::attest_handler_port(&agent_id);
@@ -1414,7 +1415,7 @@ mod tests {
         // Concurrent query task: send QueryChild(Proc) every 10ms.
         let query_client_proc =
             Proc::direct(ChannelTransport::Unix.any(), "query_client".to_string()).unwrap();
-        let (query_client, _qc_handle) = query_client_proc.client("qc").unwrap();
+        let query_client = query_client_proc.client("qc");
         let query_port = port.clone();
         let query_proc_id = proc.proc_addr().clone();
         let query_count = Arc::new(AtomicUsize::new(0));
@@ -1524,7 +1525,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let agent_ref: ActorRef<ProcAgent> = agent_handle.bind();
 
         let actor_type = hyperactor::actor::remote::Remote::collect()
@@ -1709,7 +1710,7 @@ mod tests {
 
         let client_proc =
             Proc::direct(ChannelTransport::Unix.any(), "qd_client".to_string()).unwrap();
-        let (client, _client_handle) = client_proc.client("client").unwrap();
+        let client = client_proc.client("client");
 
         // Spawn a blocking actor with a shared gate.
         let gate = Arc::new(tokio::sync::Notify::new());

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1199,10 +1199,9 @@ mod tests {
         let actor_mesh: ActorMesh<testactor::TestActor> =
             proc_mesh.spawn(cx, "test", &()).await.unwrap();
 
-        let (instance, _) = cx
+        let instance = cx
             .proc()
-            .client(&format!("random_casts_{}", Uuid::now_v7()))
-            .unwrap();
+            .client(&format!("random_casts_{}", Uuid::now_v7()));
         let n = 1;
         for _ in 0..n {
             actor_mesh.cast(&instance, ()).unwrap();

--- a/hyperactor_remote/example/token_supervision.rs
+++ b/hyperactor_remote/example/token_supervision.rs
@@ -214,7 +214,7 @@ async fn run_joiner(args: JoinerArgs) -> anyhow::Result<()> {
         ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Localhost)),
         "token_supervision_joiner".to_string(),
     )?;
-    let (joiner, _joiner_handle) = proc.client("joiner")?;
+    let joiner = proc.client("joiner");
     let worker = proc.spawn(
         "worker",
         Worker::new(DemoChild {

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -50,6 +50,7 @@ use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::Uid;
 use hyperactor::Unbind;
+use hyperactor::context;
 use hyperactor_config::Flattrs;
 use serde::Deserialize;
 use serde::Serialize;
@@ -112,9 +113,9 @@ impl KeepaliveLink {
     }
 
     /// Spawn the supervisor side and return the worker-side link spec.
-    pub fn spawn_supervisor<A: Actor>(
+    pub fn spawn_supervisor<C: context::Actor>(
         self,
-        this: &Instance<A>,
+        this: &C,
     ) -> anyhow::Result<(ActorHandle<KeepaliveSupervisor>, LinkSpec)> {
         self.spawn_supervisor_uid(this, Uid::anonymous())
     }
@@ -125,15 +126,17 @@ impl KeepaliveLink {
     /// The passed uid determines the uid of the worker side implementation
     /// actor; it is specified by the supervisor to enable efficient group-style
     /// supervision.
-    pub fn spawn_supervisor_uid<A: Actor>(
+    pub fn spawn_supervisor_uid<C: context::Actor>(
         self,
-        this: &Instance<A>,
+        this: &C,
         uid: Uid,
     ) -> anyhow::Result<(ActorHandle<KeepaliveSupervisor>, LinkSpec)> {
         let params = self.0;
-        let supervisor = this.spawn(KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(
-            params.timeout,
-        )))?;
+        let supervisor =
+            this.instance()
+                .spawn(KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(
+                    params.timeout,
+                )))?;
         let worker = KeepaliveWorkerParams::new(supervisor.port::<Keepalive>().bind(), params)
             .link_spec_uid(uid)?;
         Ok((supervisor, worker))
@@ -506,7 +509,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_supervisor_replies_to_keepalive() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.client("parent").unwrap();
+        let parent = proc.client("parent");
         let supervisor = parent
             .spawn(KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(
                 Duration::from_secs(60),
@@ -534,7 +537,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_supervisor_failure_propagates_to_parent() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let supervisor =
             KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(Duration::from_millis(10)));
@@ -564,7 +567,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_worker_sends_keepalives() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.client("parent").unwrap();
+        let parent = proc.client("parent");
         let supervisor = parent
             .spawn(KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(
                 Duration::from_secs(60),
@@ -596,7 +599,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_worker_failure_propagates_to_parent() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let supervisor = proc.spawn("silent_supervisor", SilentSupervisor).unwrap();
         let uid = Uid::anonymous();
@@ -634,7 +637,7 @@ mod tests {
     #[tokio::test]
     async fn test_keepalive_link_spawn_mints_shared_worker_spec() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.client("parent").unwrap();
+        let parent = proc.client("parent");
 
         let (supervisor, worker_link) =
             KeepaliveLink::new(Duration::from_secs(60), Duration::from_secs(60))

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -17,9 +17,11 @@ use hyperactor::Actor;
 use hyperactor::AnyActorHandle;
 use hyperactor::Bind;
 use hyperactor::Data;
+#[cfg(test)]
 use hyperactor::Instance;
 use hyperactor::Uid;
 use hyperactor::Unbind;
+use hyperactor::context;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -88,11 +90,12 @@ impl LinkSpec {
     }
 
     /// Spawn the worker-side link actor as a supervised child of `parent`.
-    pub async fn spawn_worker<A: Actor>(
+    pub async fn spawn_worker<C: context::Actor>(
         self,
-        parent: &Instance<A>,
+        parent: &C,
     ) -> anyhow::Result<AnyActorHandle> {
         parent
+            .instance()
             .gspawn_uid(&self.actor_type, self.uid, self.params)
             .await
     }
@@ -169,7 +172,7 @@ mod tests {
     #[tokio::test]
     async fn test_link_spec_spawns_supervised_child() {
         let proc = Proc::isolated();
-        let (parent, _parent_handle) = proc.client("parent").unwrap();
+        let parent = proc.client("parent");
         let uid = Uid::instance(Label::new("link").unwrap());
 
         let link = LinkSpec::for_actor_uid::<TestLinkActor>(
@@ -189,7 +192,7 @@ mod tests {
     #[tokio::test]
     async fn test_link_actor_failure_propagates_to_parent() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let uid = Uid::instance(Label::new("link").unwrap());
         let link = LinkSpec::for_actor_uid::<TestLinkActor>(

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -726,7 +726,7 @@ mod tests {
     // depends on it.
     async fn spawn_supervised_pair(
         proc: &Proc,
-        inst: &Instance<()>,
+        inst: &hyperactor::Client,
         session_id: hyperactor::Uid,
         options: LinkOptions,
         child_action: Option<TestChildAction>,
@@ -837,7 +837,7 @@ mod tests {
     #[tokio::test]
     async fn test_child_failure_propagates_to_parent() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let session_id = Uid::anonymous();
 
         let (child_addr, worker, parent, _stopped_rx, mut event_rx) = spawn_supervised_pair(
@@ -884,7 +884,7 @@ mod tests {
     #[tokio::test]
     async fn test_parent_stop_stops_remote_child_before_parent_finishes() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let session_id = Uid::anonymous();
 
         let (_child_addr, worker, parent, mut stopped_rx, _event_rx) = spawn_supervised_pair(
@@ -930,7 +930,7 @@ mod tests {
     #[tokio::test]
     async fn test_worker_undeliverable_supervisor_session_stops_child() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (ready, mut ready_rx) = client.open_port::<ActorAddr>();
         let (stopped, mut stopped_rx) = client.open_port::<String>();
         let (supervisor, mut supervisor_rx) = client.open_port::<WorkerSupervisor>();
@@ -1015,7 +1015,7 @@ mod tests {
     #[tokio::test]
     async fn test_parent_kill_stops_remote_child() {
         let proc = Proc::isolated();
-        let (client, _client_handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let (ready, mut ready_rx) = client.open_port::<ActorAddr>();
         let (stopped, mut stopped_rx) = client.open_port::<String>();
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
@@ -1091,7 +1091,7 @@ mod tests {
     #[tokio::test]
     async fn test_detach_orphan_policy_leaves_child_running_on_supervisor_loss() {
         let proc = Proc::isolated();
-        let (inst, _client_handle) = proc.client("inst").unwrap();
+        let inst = proc.client("inst");
         let (ready, mut ready_rx) = inst.open_port::<ActorAddr>();
         let (stopped, mut stopped_rx) = inst.open_port::<String>();
         let (supervisor, mut supervisor_rx) = inst.open_port::<WorkerSupervisor>();
@@ -1196,7 +1196,7 @@ mod tests {
     #[tokio::test]
     async fn test_supervised_worker_unlink_stops_child_under_stop_policy() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.client("inst").unwrap();
+        let inst = proc.client("inst");
         let session_id = Uid::anonymous();
 
         let (_child_addr, worker, parent, mut stopped_rx, mut events_rx) = spawn_supervised_pair(
@@ -1281,7 +1281,7 @@ mod tests {
     #[tokio::test]
     async fn test_supervised_worker_unlink_leaves_child_running_under_detach_policy() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.client("inst").unwrap();
+        let inst = proc.client("inst");
         let session_id = Uid::anonymous();
 
         let (_child_addr, worker, parent, mut stopped_rx, mut events_rx) = spawn_supervised_pair(
@@ -1380,7 +1380,7 @@ mod tests {
     #[tokio::test]
     async fn test_concurrent_link_rejects_second_supervisor() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.client("inst").unwrap();
+        let inst = proc.client("inst");
         let session_id1 = Uid::anonymous();
         let (_child_addr, worker, parent1, _stopped_rx, mut events_rx1) = spawn_supervised_pair(
             &proc,
@@ -1486,7 +1486,7 @@ mod tests {
     #[tokio::test]
     async fn test_stop_before_linked_propagates_via_pending_stop() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.client("inst").unwrap();
+        let inst = proc.client("inst");
         let (link_started, mut link_started_rx) = inst.open_port::<()>();
         let (received_stop, mut received_stop_rx) = inst.open_port::<String>();
         let (events, _events_rx) = inst.open_port::<ActorSupervisionEvent>();
@@ -1569,7 +1569,7 @@ mod tests {
     #[tokio::test]
     async fn test_drain_and_stop_propagates_through_worker_after_child_work() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.client("inst").unwrap();
+        let inst = proc.client("inst");
         let (ready, mut ready_rx) = inst.open_port::<ActorAddr>();
         let (stopped, mut stopped_rx) = inst.open_port::<String>();
         let (drained, mut drained_rx) = inst.open_port::<String>();
@@ -1666,7 +1666,7 @@ mod tests {
     #[tokio::test]
     async fn test_worker_accepts_relink_after_unlink_under_detach_policy() {
         let proc = Proc::isolated();
-        let (inst, _inst_hndl) = proc.client("inst").unwrap();
+        let inst = proc.client("inst");
         let session_id1 = Uid::anonymous();
         let (_child_addr, worker, parent1, mut stopped_rx, mut events_rx1) = spawn_supervised_pair(
             &proc,

--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -46,10 +46,12 @@ use hyperactor::Bind;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
+#[cfg(test)]
 use hyperactor::Instance;
 use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::Unbind;
+use hyperactor::context;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -190,7 +192,7 @@ hyperactor::behavior!(RendezvousLike<C, J>, Join<C, J>);
 /// The creator receives [`Joined`] notifications on `creator_joined`; joiners
 /// receive [`JoinResult`] on the result port they pass to [`Token::join`].
 pub fn create<A, C, J>(
-    this: &Instance<A>,
+    this: &impl context::Actor<A = A>,
     creator: C,
     creator_joined: PortRef<Joined<J>>,
     options: Options,
@@ -200,7 +202,9 @@ where
     C: TokenPeer + Clone,
     J: TokenPeer,
 {
-    let rendezvous = this.spawn(Rendezvous::new(creator, creator_joined, options))?;
+    let rendezvous = this
+        .instance()
+        .spawn(Rendezvous::new(creator, creator_joined, options))?;
     Ok(Token::new(rendezvous.bind::<RendezvousLike<C, J>>()))
 }
 
@@ -533,7 +537,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_delivers_join_to_both_sides() {
         let proc = Proc::isolated();
-        let (creator, _creator_handle) = proc.client("creator").unwrap();
+        let creator = proc.client("creator");
         let (creator_joined, mut creator_joined_rx) = creator.open_port::<Joined<JoinerRef>>();
         let token = create(
             &creator,
@@ -542,7 +546,7 @@ mod tests {
             Options::default(),
         )
         .unwrap();
-        let (joiner, _joiner_handle) = proc.client("joiner").unwrap();
+        let joiner = proc.client("joiner");
         let (join_result, mut join_result_rx) = joiner.open_port::<JoinResult<CreatorRef>>();
 
         token.join(&joiner, JoinerRef, join_result.bind()).unwrap();
@@ -557,7 +561,7 @@ mod tests {
     #[tokio::test]
     async fn test_once_token_rejects_later_joins() {
         let proc = Proc::isolated();
-        let (creator, _creator_handle) = proc.client("creator").unwrap();
+        let creator = proc.client("creator");
         let (creator_joined, mut creator_joined_rx) = creator.open_port::<Joined<JoinerRef>>();
         let token = create(
             &creator,
@@ -568,7 +572,7 @@ mod tests {
             },
         )
         .unwrap();
-        let (joiner, _joiner_handle) = proc.client("joiner").unwrap();
+        let joiner = proc.client("joiner");
         let (first_result, mut first_result_rx) = joiner.open_port::<JoinResult<CreatorRef>>();
         let (second_result, mut second_result_rx) = joiner.open_port::<JoinResult<CreatorRef>>();
 
@@ -593,7 +597,7 @@ mod tests {
     #[tokio::test]
     async fn test_multi_token_accepts_every_join() {
         let proc = Proc::isolated();
-        let (creator, _creator_hndl) = proc.client("creator").unwrap();
+        let creator = proc.client("creator");
         let (creator_joined, mut creator_joined_rx) = creator.open_port::<Joined<MultiJoinerRef>>();
         let token = create(
             &creator,
@@ -605,9 +609,9 @@ mod tests {
         )
         .unwrap();
 
-        let (joiner1, _joiner1_handle) = proc.client("joiner1").unwrap();
-        let (joiner2, _joiner2_handle) = proc.client("joiner2").unwrap();
-        let (joiner3, _joiner3_handle) = proc.client("joiner3").unwrap();
+        let joiner1 = proc.client("joiner1");
+        let joiner2 = proc.client("joiner2");
+        let joiner3 = proc.client("joiner3");
 
         let (r1, mut r1_rx) = joiner1.open_port::<JoinResult<CreatorRef>>();
         let (r2, mut r2_rx) = joiner2.open_port::<JoinResult<CreatorRef>>();
@@ -769,7 +773,7 @@ mod tests {
     #[tokio::test]
     async fn test_join_fails_after_creator_stops() {
         let proc = Proc::isolated();
-        let (inst, _inst_handle) = proc.client("inst").unwrap();
+        let inst = proc.client("inst");
         let (creator_joined, _creator_joined_rx) = inst.open_port::<Joined<JoinerRef>>();
         let (token_out, mut token_out_rx) = inst.open_port::<Token<CreatorRef, JoinerRef>>();
 
@@ -792,7 +796,7 @@ mod tests {
             .await
             .unwrap();
 
-        let (joiner, _joiner_handle) = proc.client("joiner").unwrap();
+        let joiner = proc.client("joiner");
         let (result, mut result_rx) = joiner.open_port::<JoinResult<CreatorRef>>();
         token.join(&joiner, JoinerRef, result.bind()).unwrap();
 

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -248,7 +248,7 @@ impl Handler<WorkerControl> for WorkerRoot {
 }
 
 struct Harness {
-    observer: Instance<()>,
+    observer: hyperactor::Client,
     parent_root: hyperactor::ActorHandle<ParentRoot>,
     worker_root: hyperactor::ActorHandle<WorkerRoot>,
     child_stopped_rx: PortReceiver<String>,
@@ -264,7 +264,7 @@ impl Harness {
         let observer_proc = local_proc("observer")?;
         let parent_proc = local_proc("parent")?;
         let worker_proc = local_proc("worker")?;
-        let (observer, _observer_handle) = observer_proc.client("observer")?;
+        let observer = observer_proc.client("observer");
         let (token_out, mut token_out_rx) = observer.open_port::<String>();
         let (parent_linked, mut parent_linked_rx) = observer.open_port::<ActorAddr>();
         let (parent_events, parent_events_rx) = observer.open_port::<ActorSupervisionEvent>();

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -15,6 +15,7 @@ use std::sync::OnceLock;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
+use hyperactor::Client;
 use hyperactor::Context;
 use hyperactor::Handler;
 use hyperactor::Instance;
@@ -1575,12 +1576,10 @@ async fn handle_async_endpoint_panic(
     } {
         // Record error and panic metrics
         ENDPOINT_ACTOR_ERROR.add(1, attributes);
-        static CLIENT: OnceLock<(Instance<()>, ActorHandle<()>)> = OnceLock::new();
-        let client = &CLIENT
-            .get_or_init(|| get_proc_runtime().client("async_endpoint_handler").unwrap())
-            .0;
+        static CLIENT: OnceLock<Client> = OnceLock::new();
+        let client = CLIENT.get_or_init(|| get_proc_runtime().client("async_endpoint_handler"));
         panic_sender
-            .send(&client, Signal::Kill(panic.to_string()))
+            .send(client, Signal::Kill(panic.to_string()))
             .expect("unable to send panic message");
     }
 

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -375,9 +375,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
 
         // We require a temporary instance to make a call to the host/proc agent.
         let temp_proc = Proc::isolated();
-        let (temp_instance, _) = temp_proc
-            .client("temp")
-            .map_err(|e| PyException::new_err(e.to_string()))?;
+        let temp_instance = temp_proc.client("temp");
 
         let local_proc_agent: hyperactor::ActorHandle<hyperactor_mesh::proc_agent::ProcAgent> =
             host_mesh_agent
@@ -514,9 +512,7 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
     PyPythonTask::new(async move {
         // Create a temporary instance to send the shutdown message
         let temp_proc = hyperactor::Proc::isolated();
-        let (instance, _) = temp_proc
-            .client("shutdown_requester")
-            .map_err(|e| PyException::new_err(e.to_string()))?;
+        let instance = temp_proc.client("shutdown_requester");
 
         tracing::info!(
             "sending shutdown_host request to agent {}",

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -12,11 +12,11 @@ use std::hash::Hasher;
 use std::time::Duration;
 
 use anyhow::Result;
+use hyperactor::Client;
 use hyperactor::RemoteMessage;
 use hyperactor::actor::Signal;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::mailbox::PortReceiver;
-use hyperactor::proc::Instance;
 use hyperactor::proc::Proc;
 use monarch_types::PickledPyObject;
 use pyo3::exceptions::PyRuntimeError;
@@ -324,7 +324,7 @@ impl PySerialized {
 /// a python actor. This helps by allowing users to specialize the actor to the
 /// message type they want to handle.
 pub struct InstanceWrapper<M: RemoteMessage> {
-    instance: Instance<()>,
+    instance: Client,
     message_receiver: PortReceiver<M>,
     signal_receiver: PortReceiver<Signal>,
     status: InstanceStatus,
@@ -333,7 +333,7 @@ pub struct InstanceWrapper<M: RemoteMessage> {
 
 impl<M: RemoteMessage> InstanceWrapper<M> {
     pub fn new(proc: &PyProc, actor_name: &str) -> Result<Self> {
-        let instance = proc.inner.client(actor_name)?.0;
+        let instance = proc.inner.client(actor_name);
         // TEMPORARY: remove after using fixed handler ports.
         let (_handler_port, message_receiver) = instance.bind_handler_port::<M>();
 
@@ -451,7 +451,7 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
         Ok(messages)
     }
 
-    pub fn instance(&self) -> &Instance<()> {
+    pub fn instance(&self) -> &Client {
         &self.instance
     }
 

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -488,14 +488,14 @@ mod tests {
     }
 
     struct Harness {
-        client: hyperactor::Instance<()>,
+        client: hyperactor::Client,
         processor: ActorHandle<IbvProcessorActor<MockManagerActor, MockQp>>,
         mgr_inner: Arc<StdMutex<MockManagerInner>>,
     }
 
     async fn setup_with_lru(lru_capacity: usize) -> Harness {
         let proc = Proc::anonymous();
-        let (client, _) = proc.client("client").unwrap();
+        let client = proc.client("client");
         let mgr_inner = Arc::new(StdMutex::new(MockManagerInner::default()));
         let mgr = MockManagerActor {
             inner: Arc::clone(&mgr_inner),

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1798,7 +1798,7 @@ mod tests {
         };
         let harness = Harness::build(qp, MockResponse::Success(info))?;
 
-        let (peer, _) = harness.proc.client("peer")?;
+        let peer = harness.proc.client("peer");
         harness.init_handle.send(&peer, NotifyRts)?;
 
         let key = harness.await_done().await;
@@ -1864,7 +1864,7 @@ mod tests {
     async fn test_undeliverable_in_awaiting_transitions_to_failed() {
         let harness = Harness::build(QpGuard::new(fake_qp()), MockResponse::DropReply).unwrap();
         let undeliverable = fake_undeliverable(&harness.proc, "simulated bounce");
-        let (peer, _) = harness.proc.client("peer").unwrap();
+        let peer = harness.proc.client("peer");
         harness.init_handle.send(&peer, undeliverable).unwrap();
         let (key, error) = harness.await_failed().await;
         assert_eq!(key, harness.qp_key);
@@ -1906,7 +1906,7 @@ mod tests {
         let _ = harness.await_failed().await;
 
         let undeliverable = fake_undeliverable(&harness.proc, "late bounce");
-        let (peer, _) = harness.proc.client("peer").unwrap();
+        let peer = harness.proc.client("peer");
         harness.init_handle.send(&peer, undeliverable).unwrap();
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(harness.state.lock().unwrap().failed.len(), 1);

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -18,7 +18,6 @@ use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
-use hyperactor::Instance;
 use hyperactor::OncePortRef;
 use hyperactor::Proc;
 use hyperactor::RefClient;
@@ -477,8 +476,8 @@ pub async fn wait_for_completion_gpu(
 pub struct IbvTestEnv {
     buffer_1: Buffer,
     buffer_2: Buffer,
-    pub client_1: Instance<()>,
-    pub client_2: Instance<()>,
+    pub client_1: hyperactor::Client,
+    pub client_2: hyperactor::Client,
     pub actor_1: ActorRef<RdmaManagerActor>,
     pub actor_2: ActorRef<RdmaManagerActor>,
     pub ibv_actor_1: ActorRef<IbvManagerActor>,
@@ -566,8 +565,8 @@ impl IbvTestEnv {
             format!("rdma_test_{id}_b"),
         )?;
 
-        let (instance_1, _client_handle_1) = proc_1.client("client")?;
-        let (instance_2, _client_handle_2) = proc_2.client("client")?;
+        let instance_1 = proc_1.client("client");
+        let instance_2 = proc_2.client("client");
 
         let rdma_actor_1 = RdmaManagerActor::new(Some(config1), Flattrs::default()).await?;
         let rdma_actor_handle_1 = proc_1.spawn("rdma_manager", rdma_actor_1)?;

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -303,9 +303,7 @@ impl TcpManagerActor {
                     "tcp_chunk_sender_{}",
                     hyperactor_mesh::shortuuid::ShortUuid::generate()
                 );
-                let (instance, _handle) = proc
-                    .client(&sender_name)
-                    .expect("failed to create sender instance");
+                let instance = proc.client(&sender_name);
 
                 loop {
                     if cancel.is_cancelled() {
@@ -407,9 +405,7 @@ impl Actor for TcpManagerActor {
             self.receiver_done = Some(done_rx);
 
             tokio::spawn(async move {
-                let (instance, _handle) = proc
-                    .client(&receiver_name.to_string())
-                    .expect("failed to create receiver instance");
+                let instance = proc.client(&receiver_name.to_string());
 
                 loop {
                     let chunk = tokio::select! {
@@ -980,7 +976,7 @@ mod tests {
     struct TcpTestProcEnv {
         proc: Proc,
         rdma_handle: ActorHandle<RdmaManagerActor>,
-        instance: hyperactor::Instance<()>,
+        instance: hyperactor::Client,
         tcp_backend: TcpBackend,
         rdma_remote_buf: crate::RdmaRemoteBuffer,
         local_memory: Arc<KeepaliveLocalMemory>,
@@ -1011,7 +1007,7 @@ mod tests {
                 ChannelAddr::any(hyperactor::channel::ChannelTransport::Unix),
                 format!("tcp_test_{id}"),
             )?;
-            let (instance, _) = proc.client("client")?;
+            let instance = proc.client("client");
 
             let rdma_actor = RdmaManagerActor::new(None, Flattrs::default()).await?;
             let rdma_handle = proc.spawn("rdma_manager", rdma_actor)?;
@@ -1044,7 +1040,7 @@ mod tests {
             buffer_size: usize,
         ) -> anyhow::Result<Self> {
             let id = COUNTER.fetch_add(1, Ordering::Relaxed);
-            let (instance, _) = proc.client(&format!("client_{id}"))?;
+            let instance = proc.client(&format!("client_{id}"));
 
             let (local_memory, rdma_remote_buf) =
                 Self::alloc_cpu_buffer(&instance, rdma_handle, buffer_size).await?;
@@ -1060,7 +1056,7 @@ mod tests {
         }
 
         async fn alloc_cpu_buffer(
-            instance: &hyperactor::Instance<()>,
+            instance: &hyperactor::Client,
             rdma_handle: &ActorHandle<RdmaManagerActor>,
             buffer_size: usize,
         ) -> anyhow::Result<(Arc<KeepaliveLocalMemory>, crate::RdmaRemoteBuffer)> {
@@ -1601,7 +1597,7 @@ mod tests {
                 ChannelAddr::any(hyperactor::channel::ChannelTransport::Unix),
                 format!("tcp_gpu_test_{id}"),
             )?;
-            let (instance, _) = proc.client("client")?;
+            let instance = proc.client("client");
 
             let rdma_actor = RdmaManagerActor::new(None, Flattrs::default()).await?;
             let rdma_handle = proc.spawn("rdma_manager", rdma_actor)?;

--- a/monarch_tensor_worker/src/comm.rs
+++ b/monarch_tensor_worker/src/comm.rs
@@ -437,7 +437,7 @@ mod tests {
     async fn all_reduce() {
         test_setup().unwrap();
         let proc = Proc::isolated();
-        let (client, _handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let unique_id = UniqueId::new_nccl().unwrap();
         let device0 = CudaDevice::new(DeviceIndex(0));
@@ -504,7 +504,7 @@ mod tests {
     async fn group_send_recv() {
         test_setup().unwrap();
         let proc = Proc::isolated();
-        let (client, _handle) = proc.client("client").unwrap();
+        let client = proc.client("client");
 
         let unique_id = UniqueId::new_nccl().unwrap();
         let device0 = CudaDevice::new(DeviceIndex(0));
@@ -579,7 +579,7 @@ mod tests {
     async fn reduce() -> Result<()> {
         test_setup()?;
         let proc = Proc::isolated();
-        let (client, _handle) = proc.client("client")?;
+        let client = proc.client("client");
 
         let unique_id = UniqueId::new_nccl()?;
         let device0 = CudaDevice::new(DeviceIndex(0));

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -1961,7 +1961,7 @@ mod tests {
     struct TestSetup {
         proc: Proc,
         stream_actor: ActorHandle<StreamActor>,
-        client: Instance<()>,
+        client: reference::Client,
         // Unused, but necessary, because proc needs a supervision
         // port -- otherwise an actor failure will cause a crash.
         #[allow(dead_code)]
@@ -1984,7 +1984,7 @@ mod tests {
             let proc = Proc::isolated();
             let (_, controller_actor, controller_rx) =
                 proc.attach_actor::<ControllerActor, ControllerMessage>("controller")?;
-            let (client, _handle) = proc.client("client")?;
+            let client = proc.client("client");
             let (supervision_tx, supervision_rx) = client.open_port();
             proc.set_supervision_coordinator(supervision_tx)?;
             let stream_actor = proc.spawn(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3955
* __->__ #3954
* #3953
* #3952
* #3951
* #3950

Change Proc::client and hyperactor::client to return the explicit Client caller context instead of an Instance/ActorHandle pair. Client construction is infallible and allocates fresh instance actor ids from labels, with an empty label producing an anonymous instance. Port call sites to use Client as the caller context and update helper APIs that were typed as Instance<()> only because they needed send/open-port/spawn context capabilities.

Differential Revision: [D105707932](https://our.internmc.facebook.com/intern/diff/D105707932/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105707932/)!