### PR TITLE
[hyperactor] test Client lifecycle semantics

### DIFF
--- a/hyperactor/src/client.rs
+++ b/hyperactor/src/client.rs
@@ -177,3 +177,42 @@ impl context::Actor for &Client {
         &self.instance
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::Proc;
+
+    #[test]
+    fn client_ids_are_fresh_instances() {
+        let proc = Proc::isolated();
+
+        let first = proc.client("caller");
+        let second = proc.client("caller");
+        let anonymous = proc.client("");
+
+        assert!(first.self_addr().id().uid().is_instance());
+        assert!(second.self_addr().id().uid().is_instance());
+        assert!(anonymous.self_addr().id().uid().is_instance());
+        assert_eq!(
+            first.self_addr().id().label().map(|label| label.as_str()),
+            Some("caller")
+        );
+        assert_eq!(anonymous.self_addr().id().label(), None);
+        assert_ne!(first.self_addr().id(), second.self_addr().id());
+    }
+
+    #[tokio::test]
+    async fn dropping_client_closes_mailbox_but_preserves_accepted_messages() {
+        let proc = Proc::isolated();
+        let receiver = proc.client("receiver");
+        let sender = proc.client("sender");
+        let (port, mut rx) = receiver.open_port::<u64>();
+
+        port.send(&sender, 1).unwrap();
+        drop(receiver);
+
+        assert_eq!(rx.recv().await.unwrap(), 1);
+        assert!(port.send(&sender, 2).is_err());
+        assert_eq!(rx.try_recv().unwrap(), None);
+    }
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3955
* #3954
* #3953
* #3952
* #3951
* #3950

Add focused coverage for Client identity and drop behavior. Clients now assert as fresh instance actor ids, repeated labels do not collide, empty labels produce anonymous instances, and dropping a client closes its mailbox while preserving already accepted port messages.

Differential Revision: [D105707936](https://our.internmc.facebook.com/intern/diff/D105707936/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105707936/)!