### PR TITLE
[monarch] route Host traffic through a Gateway

### DIFF
--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2381,7 +2381,12 @@ mod tests {
     }
 
     // The message size is limited by CODEC_MAX_FRAME_LENGTH.
-    #[async_timed_test(timeout_secs = 5)]
+    //
+    // Sends a payload of `default_size_in_bytes` (100 MiB) over a TCP
+    // loopback. Real-time wall clock on a loaded build host can take
+    // several seconds; the 30s timeout is comfortable headroom while
+    // still surfacing genuine hangs.
+    #[async_timed_test(timeout_secs = 30)]
     // TODO: OSS: called `Result::unwrap()` on an `Err` value: Listen(Tcp([::1]:0), Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" })
     #[cfg_attr(not(fbcode_build), ignore)]
     async fn test_tcp_message_size() {

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -69,6 +69,81 @@ pub struct Gateway {
     inner: Arc<GatewayState>,
 }
 
+/// A proc attached to a [`Gateway`]. An entry is either:
+///
+/// * `Local`: in-process, identified by a [`WeakProc`] so the gateway
+///   does not extend the proc's lifetime.
+/// * `Remote`: out-of-process (or otherwise not addressable through a
+///   local [`Proc`] handle), reached via a caller-supplied
+///   [`BoxedMailboxSender`].
+///
+/// Use [`Gateway::attach`] with anything that converts into a `ProcEntry`.
+/// Local procs convert via [`From<&Proc>`]; remote attachments
+/// convert via [`From<(ProcId, BoxedMailboxSender)>`] (or are
+/// constructed directly with [`ProcEntry::Remote`]).
+#[derive(Clone)]
+pub enum ProcEntry {
+    /// An in-process proc, held as a weak handle.
+    Local(ProcId, WeakProc),
+    /// A proc reachable through a caller-supplied sender.
+    Remote(ProcId, BoxedMailboxSender),
+}
+
+impl ProcEntry {
+    /// The id of the proc represented by this entry.
+    pub fn proc_id(&self) -> &ProcId {
+        match self {
+            ProcEntry::Local(id, _) | ProcEntry::Remote(id, _) => id,
+        }
+    }
+}
+
+impl From<&Proc> for ProcEntry {
+    fn from(proc: &Proc) -> Self {
+        ProcEntry::Local(proc.proc_id().clone(), proc.downgrade())
+    }
+}
+
+impl From<(ProcId, BoxedMailboxSender)> for ProcEntry {
+    fn from((proc_id, sender): (ProcId, BoxedMailboxSender)) -> Self {
+        ProcEntry::Remote(proc_id, sender)
+    }
+}
+
+/// Handle returned by [`Gateway::attach`] that detaches the proc from
+/// the gateway when dropped. Drop is a no-op if the gateway has already
+/// been dropped, or if the entry has been replaced under the same proc
+/// id since this guard was issued (so we never evict another caller's
+/// attachment).
+pub struct AttachGuard {
+    gateway: Weak<GatewayState>,
+    proc_id: ProcId,
+}
+
+impl fmt::Debug for AttachGuard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AttachGuard")
+            .field("proc_id", &self.proc_id)
+            .finish()
+    }
+}
+
+impl AttachGuard {
+    /// The id of the proc whose attachment this guard owns.
+    pub fn proc_id(&self) -> &ProcId {
+        &self.proc_id
+    }
+}
+
+impl Drop for AttachGuard {
+    fn drop(&mut self) {
+        let Some(state) = self.gateway.upgrade() else {
+            return;
+        };
+        state.procs.write().unwrap().remove(&self.proc_id);
+    }
+}
+
 struct GatewayState {
     /// The location to use when no server is active.
     fallback_location: Location,
@@ -81,7 +156,9 @@ struct GatewayState {
     forwarder: BoxedMailboxSender,
 
     /// Procs attached to this gateway, keyed by runtime identity.
-    procs: RwLock<HashMap<ProcId, WeakProc>>,
+    /// See [`ProcEntry`] for the distinction between local and remote
+    /// attachments.
+    procs: RwLock<HashMap<ProcId, ProcEntry>>,
 
     /// Locations currently served by this gateway. The last location
     /// is the default advertised location.
@@ -111,7 +188,10 @@ impl Gateway {
         GLOBAL_GATEWAY.get_or_init(Self::new)
     }
 
-    pub(crate) fn configured(default_location: Location, forwarder: BoxedMailboxSender) -> Self {
+    /// Create a gateway with an explicit default advertised location
+    /// and outbound forwarder. Inbound traffic for procs not registered
+    /// via [`Gateway::attach`] is handed off to `forwarder`.
+    pub fn configured(default_location: Location, forwarder: BoxedMailboxSender) -> Self {
         Self {
             inner: Arc::new(GatewayState {
                 fallback_location: default_location.clone(),
@@ -142,17 +222,49 @@ impl Gateway {
         &self.inner.forwarder
     }
 
-    pub(crate) fn attach(&self, proc: &Proc) {
-        let proc_id = proc.proc_id().clone();
-        if let Some(existing) = self
+    /// Attach a proc to this gateway.
+    ///
+    /// Accepts anything that converts into a [`ProcEntry`]:
+    ///
+    /// * `&Proc` — attaches an in-process proc by weak handle. The
+    ///   gateway will deliver messages addressed to the proc's id
+    ///   directly to `proc.muxer()` when
+    ///   [`Proc::is_local_delivery_target`] holds.
+    /// * `(ProcId, BoxedMailboxSender)` — attaches a remote proc. The
+    ///   gateway routes envelopes whose destination matches `proc_id`
+    ///   through the supplied sender instead of the gateway's
+    ///   forwarder.
+    ///
+    /// Panics if a live entry with the same id is already attached. A
+    /// dead local entry whose [`WeakProc`] has been dropped is replaced
+    /// silently.
+    ///
+    /// Returns an [`AttachGuard`] that detaches the proc when dropped.
+    /// Callers must keep the guard alive for as long as the registration
+    /// should remain in place; for in-process procs, the guard is held
+    /// inside the [`Proc`] itself so the proc's lifetime drives detach.
+    #[must_use = "the returned AttachGuard detaches the proc when dropped"]
+    pub fn attach(&self, entry: impl Into<ProcEntry>) -> AttachGuard {
+        let entry = entry.into();
+        let proc_id = entry.proc_id().clone();
+        let existing = self
             .inner
             .procs
             .write()
             .unwrap()
-            .insert(proc_id.clone(), proc.downgrade())
-            && existing.upgrade().is_some()
-        {
-            panic!("gateway already has a live proc with id {}", proc_id)
+            .insert(proc_id.clone(), entry);
+        match existing {
+            // No prior entry, or the prior entry was a dead local handle
+            // whose slot is now ours.
+            None => {}
+            Some(ProcEntry::Local(_, weak)) if weak.upgrade().is_none() => {}
+            Some(ProcEntry::Local(_, _)) | Some(ProcEntry::Remote(_, _)) => {
+                panic!("gateway already has a proc with id {}", proc_id)
+            }
+        }
+        AttachGuard {
+            gateway: Arc::downgrade(&self.inner),
+            proc_id,
         }
     }
 
@@ -242,17 +354,25 @@ impl Gateway {
     /// guarantees that each flushed sender observes its usual sender-level
     /// flush semantics at the time it is flushed.
     pub(crate) async fn flush(&self) -> Result<(), anyhow::Error> {
-        let procs = self
-            .inner
-            .procs
-            .read()
-            .unwrap()
-            .values()
-            .filter_map(WeakProc::upgrade)
-            .collect::<Vec<_>>();
-        for proc in procs {
-            proc.muxer().flush().await?;
-        }
+        let (local_procs, remote_senders) = {
+            let procs = self.inner.procs.read().unwrap();
+            let mut local = Vec::with_capacity(procs.len());
+            let mut remote = Vec::with_capacity(procs.len());
+            for entry in procs.values() {
+                match entry {
+                    ProcEntry::Local(_, weak) => {
+                        if let Some(proc) = weak.upgrade() {
+                            local.push(proc);
+                        }
+                    }
+                    ProcEntry::Remote(_, sender) => remote.push(sender.clone()),
+                }
+            }
+            (local, remote)
+        };
+        let proc_flushes = local_procs.iter().map(|proc| proc.muxer().flush());
+        let remote_flushes = remote_senders.iter().map(|sender| sender.flush());
+        futures::future::try_join_all(proc_flushes.chain(remote_flushes)).await?;
         self.inner.forwarder.flush().await
     }
 }
@@ -355,33 +475,41 @@ impl crate::mailbox::MailboxSender for Gateway {
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
         let dest_proc = envelope.dest().actor_addr().proc_addr();
-        let weak_proc = self
+        let entry = self
             .inner
             .procs
             .read()
             .unwrap()
             .get(dest_proc.id())
             .cloned();
-        let proc = weak_proc.as_ref().and_then(WeakProc::upgrade);
-
-        if weak_proc.is_some() && proc.is_none() {
-            let mut procs = self.inner.procs.write().unwrap();
-            if procs
-                .get(dest_proc.id())
-                .and_then(WeakProc::upgrade)
-                .is_none()
-            {
-                procs.remove(dest_proc.id());
+        match entry {
+            Some(ProcEntry::Local(_, weak)) => match weak.upgrade() {
+                Some(proc) if proc.is_local_delivery_target(&dest_proc) => {
+                    proc.muxer().post(envelope, return_handle);
+                    return;
+                }
+                Some(_) => {
+                    // Proc is alive but not a local-delivery target for
+                    // this destination; fall through to the forwarder.
+                }
+                None => {
+                    // Dead local entry. Best-effort cleanup; double-check
+                    // under the write lock so we do not evict a slot that
+                    // another thread has just re-attached.
+                    let mut procs = self.inner.procs.write().unwrap();
+                    if let Some(ProcEntry::Local(_, weak)) = procs.get(dest_proc.id())
+                        && weak.upgrade().is_none()
+                    {
+                        procs.remove(dest_proc.id());
+                    }
+                }
+            },
+            Some(ProcEntry::Remote(_, sender)) => {
+                sender.post(envelope, return_handle);
+                return;
             }
+            None => {}
         }
-
-        if let Some(proc) = proc
-            && proc.is_local_delivery_target(&dest_proc)
-        {
-            proc.muxer().post(envelope, return_handle);
-            return;
-        }
-
         self.inner.forwarder.post(envelope, return_handle)
     }
 
@@ -562,87 +690,12 @@ mod tests {
         );
     }
 
-    /// `Gateway::post_unchecked` removes stale `WeakProc` entries
-    /// lazily on the post path. Dropping a proc leaves a dead
-    /// `WeakProc` in the gateway's `procs` map; the next post to that
-    /// proc's id falls through to the forwarder and removes the stale
-    /// entry.
-    #[tokio::test]
-    async fn test_gateway_post_removes_stale_weak_procs() {
-        #[derive(Clone)]
-        struct CountingSender(Arc<AtomicUsize>);
-
-        #[async_trait]
-        impl MailboxSender for CountingSender {
-            fn post_unchecked(
-                &self,
-                _envelope: MessageEnvelope,
-                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
-            ) {
-                self.0.fetch_add(1, Ordering::SeqCst);
-            }
-        }
-
-        let forwarded = Arc::new(AtomicUsize::new(0));
-        let gateway = Gateway::configured(
-            channel::reserve_local_addr().into(),
-            BoxedMailboxSender::new(CountingSender(forwarded.clone())),
-        );
-
-        let proc = Proc::builder()
-            .proc_id(ProcId::instance(Label::strip("alpha")))
-            .shared_gateway(gateway.clone())
-            .build()
-            .unwrap();
-        let proc_id = proc.proc_id().clone();
-        let dest = proc
-            .proc_addr()
-            .actor_addr("worker")
-            .port_addr(Port::from(0u64));
-
-        // Sanity: proc is attached.
-        assert_eq!(gateway.inner.procs.read().unwrap().len(), 1);
-
-        drop(proc);
-
-        // The entry is still present, but it is now a *stale* WeakProc:
-        // upgrade must fail.
-        {
-            let procs = gateway.inner.procs.read().unwrap();
-            assert_eq!(procs.len(), 1);
-            assert!(
-                procs.get(&proc_id).and_then(WeakProc::upgrade).is_none(),
-                "expected dropped proc to remain only as a stale WeakProc entry",
-            );
-        }
-
-        gateway.post(
-            MessageEnvelope::serialize(
-                test_actor_id("test", "sender"),
-                dest,
-                &42u64,
-                Flattrs::new(),
-            )
-            .unwrap(),
-            monitored_return_handle(),
-        );
-
-        // Envelope fell through to the forwarder; stale entry
-        // removed.
-        assert_eq!(forwarded.load(Ordering::SeqCst), 1);
-        {
-            let procs = gateway.inner.procs.read().unwrap();
-            assert_eq!(procs.len(), 0);
-            assert!(procs.get(&proc_id).is_none());
-        }
-    }
-
     /// `Gateway::attach` panics when a second proc with the same
     /// `ProcId` is built against the same gateway while the first is
     /// still alive. The check is in `Gateway::attach`, invoked from
     /// `Proc::builder().build()` via `Proc::from_parts_unchecked`.
     #[test]
-    #[should_panic(expected = "gateway already has a live proc")]
+    #[should_panic(expected = "gateway already has a proc with id")]
     fn test_gateway_attach_panics_on_duplicate_live_proc() {
         let gateway = Gateway::isolated();
         let proc_id = ProcId::instance(Label::strip("alpha"));
@@ -792,11 +845,12 @@ mod tests {
         );
     }
 
-    /// `Gateway::attach` silently replaces a stale `WeakProc` entry
-    /// (one whose strong reference has dropped). No panic; the new
-    /// proc takes over routing for that `ProcId`.
+    /// Dropping the `Proc` drops its `AttachGuard`, which eagerly
+    /// removes the entry from the gateway's `procs` map. A subsequent
+    /// attach with the same `ProcId` is therefore a fresh insert — no
+    /// panic, no stale entry to replace.
     #[tokio::test]
-    async fn test_gateway_attach_silently_replaces_dead_entry() {
+    async fn test_gateway_attach_after_proc_drop() {
         let gateway = Gateway::isolated();
         let proc_id = ProcId::instance(Label::strip("alpha"));
 
@@ -807,19 +861,11 @@ mod tests {
             .unwrap();
         drop(first);
 
-        // The entry is still present but stale (upgrade fails).
-        {
-            let procs = gateway.inner.procs.read().unwrap();
-            assert_eq!(procs.len(), 1);
-            assert!(
-                procs.get(&proc_id).and_then(WeakProc::upgrade).is_none(),
-                "expected first proc to remain only as a stale WeakProc entry",
-            );
-        }
+        // AttachGuard::drop removed the entry from the map.
+        assert_eq!(gateway.inner.procs.read().unwrap().len(), 0);
 
-        // Attach a second proc with the same id. The dead WeakProc
-        // entry is silently replaced; no panic; map still has exactly
-        // one entry.
+        // The slot is free, so attaching a new proc with the same id
+        // is a fresh insert — no panic.
         let second = Proc::builder()
             .proc_id(proc_id.clone())
             .shared_gateway(gateway.clone())

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -486,6 +486,15 @@ struct ProcState {
     /// gracefully stop the server and join it (flushing receive-side
     /// acks) during shutdown.
     mailbox_server_handle: std::sync::Mutex<Option<crate::mailbox::MailboxServerHandle>>,
+
+    /// Detach guard for this proc's registration with `gateway`. Held
+    /// here so that dropping the proc removes its entry from the
+    /// gateway's proc map without a separate explicit step. Wrapped in
+    /// a `OnceLock` because the guard is constructed *after* the
+    /// `ProcState` Arc exists (so we can pass `&proc` to
+    /// `gateway.attach`); it is set exactly once during construction
+    /// and never read by anyone outside of drop ordering.
+    _attach_guard: OnceLock<crate::gateway::AttachGuard>,
 }
 
 struct TerminatedSnapshot {
@@ -583,8 +592,26 @@ impl Builder<GlobalGateway> {
     }
 
     /// Build the proc.
+    ///
+    /// Procs built on the global gateway must not use legacy
+    /// pseudo-singleton ids — those ids are reserved for in-host
+    /// service/local procs whose location is bound to the host's
+    /// frontend address. Use [`Builder::shared_gateway`] (passing the
+    /// host's gateway) to construct legacy-id procs.
     pub fn build(self) -> Result<Proc, anyhow::Error> {
-        self.build_with_gateway(Gateway::global().clone())
+        let proc_id = self
+            .proc_id
+            .unwrap_or_else(|| ProcId::new(Uid::anonymous(), None));
+        if is_legacy_pseudo_singleton_proc_id(&proc_id) {
+            anyhow::bail!(
+                "legacy pseudo-singleton proc id '{}' is reserved for host-scoped construction; use Builder::shared_gateway",
+                proc_id
+            );
+        }
+        Ok(Proc::from_parts_unchecked(
+            proc_id,
+            Gateway::global().clone(),
+        ))
     }
 }
 
@@ -595,24 +622,16 @@ impl<State> Builder<State> {
         self
     }
 
-    fn build_with_gateway(self, gateway: Gateway) -> Result<Proc, anyhow::Error> {
-        Self::build_proc(self.proc_id, gateway)
-    }
-
     fn build_proc(proc_id: Option<ProcId>, gateway: Gateway) -> Result<Proc, anyhow::Error> {
         let proc_id = proc_id.unwrap_or_else(ProcId::anonymous);
-        if is_legacy_pseudo_singleton_proc_id(&proc_id) {
-            anyhow::bail!(
-                "legacy pseudo-singleton proc id '{}' must be constructed with a dedicated Proc constructor",
-                proc_id
-            );
-        }
         Ok(Proc::from_parts_unchecked(proc_id, gateway))
     }
 }
 
 impl Builder<SharedGateway> {
-    /// Build the proc.
+    /// Build the proc. Accepts any proc id, including legacy
+    /// pseudo-singleton ids, because the caller has explicit control
+    /// over the gateway's default location.
     pub fn build(self) -> Result<Proc, anyhow::Error> {
         let Builder {
             proc_id,
@@ -656,9 +675,17 @@ impl Proc {
                 supervision_coordinator_port: OnceLock::new(),
                 supervision_coordinator_actor_id: OnceLock::new(),
                 mailbox_server_handle: std::sync::Mutex::new(None),
+                _attach_guard: OnceLock::new(),
             }),
         };
-        gateway.attach(&proc);
+        // Attach now that the `Arc<ProcState>` exists; the returned
+        // guard's drop will remove the entry from the gateway's proc
+        // map when the last `Proc` referencing this state is dropped.
+        let guard = gateway.attach(&proc);
+        proc.inner
+            ._attach_guard
+            .set(guard)
+            .expect("fresh ProcState's attach guard slot is empty");
         proc
     }
 
@@ -1635,10 +1662,16 @@ impl MailboxSender for Proc {
     ) {
         let dest_proc = envelope.dest().actor_addr().proc_addr();
         if self.is_local_delivery_target(&dest_proc) {
-            self.state().proc_muxer.post(envelope, return_handle)
-        } else {
-            self.state().gateway.post(envelope, return_handle)
+            self.state().proc_muxer.post(envelope, return_handle);
+            return;
         }
+        // Route through the gateway as a [`MailboxSender`] (not its
+        // raw forwarder) so peers sharing the same gateway —
+        // typically a host's `service_proc` / `local_proc` and any
+        // procs attached via `gateway.attach((proc_id, sender))` —
+        // are reached by an in-gateway lookup rather than bouncing
+        // out through the forwarder.
+        self.state().gateway.post(envelope, return_handle);
     }
 
     async fn flush(&self) -> Result<(), anyhow::Error> {
@@ -4858,6 +4891,76 @@ mod tests {
         assert_eq!(envelope.dest(), &remote_dest);
     }
 
+    #[tokio::test]
+    async fn test_gateway_attach_remote_proc_routes_via_sender() {
+        use tokio::sync::mpsc::UnboundedSender;
+        use tokio::sync::mpsc::unbounded_channel;
+
+        use crate::mailbox::IntoBoxedMailboxSender;
+        use crate::mailbox::MailboxSender as _;
+        use crate::mailbox::monitored_return_handle;
+        use crate::testing::ids::test_actor_id;
+
+        #[derive(Clone)]
+        struct RecordingSender(UnboundedSender<MessageEnvelope>);
+
+        #[async_trait]
+        impl crate::mailbox::MailboxSender for RecordingSender {
+            fn post_unchecked(
+                &self,
+                envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                self.0.send(envelope).unwrap();
+            }
+        }
+
+        let proc = Proc::isolated();
+        let gateway = proc.gateway();
+
+        let remote_proc = ProcAddr::instance(ChannelAddr::Local(1234), "remote");
+        let remote_dest = remote_proc.actor_addr("worker").port_addr(Port::from(0));
+
+        let (tx, mut rx) = unbounded_channel::<MessageEnvelope>();
+        let attach_guard =
+            gateway.attach((remote_proc.id().clone(), RecordingSender(tx).into_boxed()));
+
+        gateway.post(
+            MessageEnvelope::serialize(
+                test_actor_id("sender", "client"),
+                remote_dest.clone(),
+                &42u64,
+                Flattrs::new(),
+            )
+            .unwrap(),
+            monitored_return_handle(),
+        );
+
+        let routed = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("attach did not route envelope before timeout")
+            .expect("recording sender closed unexpectedly");
+        assert_eq!(routed.dest(), &remote_dest);
+
+        drop(attach_guard);
+
+        let (client, _) = proc.client("client").unwrap();
+        let (return_handle, mut undeliverable_rx) =
+            client.open_port::<Undeliverable<MessageEnvelope>>();
+        gateway.post(
+            MessageEnvelope::serialize(
+                test_actor_id("sender", "client"),
+                remote_dest.clone(),
+                &43u64,
+                Flattrs::new(),
+            )
+            .unwrap(),
+            return_handle,
+        );
+        let Undeliverable(envelope) = undeliverable_rx.recv().await.unwrap();
+        assert_eq!(envelope.dest(), &remote_dest);
+    }
+
     #[derive(Debug, Default)]
     #[export]
     struct LookupTestActor;
@@ -5329,8 +5432,13 @@ mod tests {
         }
     }
 
+    // Supervision propagation is deterministic (uses Notify + channel
+    // recv for ordering), but the chain of message passes is sensitive
+    // to tokio runtime scheduling. Under suite-wide CPU contention this
+    // can take well above the natural sub-second runtime; 60s gives
+    // headroom without masking genuine hangs.
     #[cfg_attr(not(target_os = "linux"), ignore = "linux-only")]
-    #[async_timed_test(timeout_secs = 30)]
+    #[async_timed_test(timeout_secs = 60)]
     async fn test_local_supervision_propagation() {
         hyperactor_telemetry::initialize_logging_for_test();
 

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -49,7 +49,6 @@
 //!   when `HostMeshAgent::handle(GetLocalProc)` is first called.
 
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fmt;
 use std::marker::PhantomData;
 use std::str::FromStr;
@@ -64,10 +63,11 @@ use hyperactor::Actor;
 use hyperactor::ActorAddr;
 use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
-use hyperactor::Addr;
 use hyperactor::AttachRequest;
 use hyperactor::BootstrapAssignment;
+use hyperactor::Gateway;
 use hyperactor::Host2Client;
+use hyperactor::Location;
 use hyperactor::PortHandle;
 use hyperactor::Proc;
 use hyperactor::ProcAddr;
@@ -82,18 +82,18 @@ use hyperactor::channel::Rx;
 use hyperactor::channel::ServerError;
 use hyperactor::channel::Tx;
 use hyperactor::context;
-use hyperactor::mailbox::BoxableMailboxSender;
+use hyperactor::gateway::AttachGuard;
 use hyperactor::mailbox::BoxedMailboxSender;
 use hyperactor::mailbox::DialMailboxRouter;
 use hyperactor::mailbox::IntoBoxedMailboxSender as _;
 use hyperactor::mailbox::MailboxClient;
-use hyperactor::mailbox::MailboxRouter;
 use hyperactor::mailbox::MailboxSender;
 use hyperactor::mailbox::MailboxServer;
 use hyperactor::mailbox::MailboxServerError;
 use hyperactor::mailbox::MailboxServerHandle;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
+use hyperactor::proc::LEGACY_LOCAL_PROC_NAME;
 /// Name of the local client proc on a host.
 ///
 /// See LP-1 (lazy activation) in module doc.
@@ -103,6 +103,7 @@ use hyperactor::mailbox::Undeliverable;
 /// throughout the program's lifetime. Code that inspects the local
 /// proc's actors must not assume they exist.
 pub use hyperactor::proc::LEGACY_LOCAL_PROC_NAME as LOCAL_PROC_NAME;
+use hyperactor::proc::LEGACY_SERVICE_PROC_NAME;
 /// Name of the system service proc on a host.
 ///
 /// Hosts the admin actor layer: HostMeshAgent, MeshAdminAgent, and bridge.
@@ -176,15 +177,20 @@ pub enum HostError {
 /// A host, managing the lifecycle of several procs, and their backend
 /// routing, as described in this module's documentation.
 pub struct Host<M> {
-    procs: HashSet<String>,
+    /// Spawned child procs, keyed by name. The stored [`AttachGuard`]
+    /// keeps the gateway entry for the child alive; dropping it
+    /// detaches the child from the gateway (used by
+    /// [`Host::terminate_children`] to free slots).
+    procs: HashMap<String, AttachGuard>,
     frontend_addr: ChannelAddr,
     backend_addr: ChannelAddr,
-    /// Routes messages to known procs (local, attached) by prefix.
-    router: MailboxRouter,
-    /// Addr-based routing for dialed connections (child procs,
-    /// remote hosts); used as the fallback when the prefix router
-    /// has no match.
-    dial_router: DialMailboxRouter,
+    /// Routes incoming traffic addressed to this host. In-process
+    /// procs (system, local) are attached via [`Gateway::attach`] with
+    /// `&Proc`; remote procs anchored to this host (attached clients,
+    /// spawned children) are attached via [`Gateway::attach`] with
+    /// `(ProcId, BoxedMailboxSender)`. Unknown destinations fall
+    /// through to the gateway's forwarder (a `DialMailboxRouter`).
+    gateway: Gateway,
     manager: M,
     service_proc: Proc,
     local_proc: Proc,
@@ -237,41 +243,56 @@ impl<M: ProcManager> Host<M> {
             let (frontend_addr, frontend_rx) = channel::serve_with_listener(addr, listener)?;
             (frontend_addr, Frontend::Simplex(frontend_rx))
         };
-        // We set up a cascade of routers: first, the outer router supports
-        // sending to the the system proc, while the dial router manages dialed
-        // connections.
+        // Outbound dialing to remote hosts and unknown destinations.
+        // Used as the gateway's forwarder fallback when a destination
+        // is not an attached proc.
         let dial_router = match default_sender {
             Some(d) => DialMailboxRouter::new_with_default(d),
             None => DialMailboxRouter::new(),
         };
-        let router = MailboxRouter::new();
 
         // Establish a backend channel on the preferred transport.
         let (backend_addr, backend_rx) = channel::serve(ChannelAddr::any(manager.transport()))?;
 
-        // Set up a system proc. This is often used to manage the host itself.
-        // These use with_name (not unique) because their uniqueness is
-        // guaranteed by the ChannelAddr component, and the Name type's
-        // '-' delimiter must not collide with a hash suffix.
-        let combined = router.fallback(dial_router.boxed());
-        let service_proc =
-            Proc::legacy_service_pseudo_singleton(frontend_addr.clone(), combined.clone());
-        let local_proc = Proc::legacy_local_pseudo_singleton(frontend_addr.clone(), combined);
+        // The host's gateway is the single routing structure for
+        // incoming traffic. In-process procs attach via `attach(&proc)`;
+        // remote procs anchored to this host (attached clients and
+        // spawned children) attach via `attach((proc_id, sender))`.
+        // Anything not registered falls through to `dial_router`.
+        let gateway = Gateway::configured(
+            Location::from(frontend_addr.clone()),
+            dial_router.into_boxed(),
+        );
+
+        // Set up the system proc and the local client proc. The
+        // legacy pseudo-singleton ids carry the frontend address, so
+        // their advertised location matches the host gateway's default
+        // location and other hosts can reach them by name. Building
+        // through `Proc::builder().shared_gateway(..)` makes the
+        // gateway attachment correct-by-construction — no separate
+        // `gateway.attach(&proc)` call is needed because the builder
+        // routes through it internally, and the resulting `Proc` owns
+        // the detach guard so dropping it removes the gateway entry.
+        let service_proc = Proc::builder()
+            .proc_id(
+                ProcAddr::singleton(frontend_addr.clone(), LEGACY_SERVICE_PROC_NAME)
+                    .id()
+                    .clone(),
+            )
+            .shared_gateway(gateway.clone())
+            .build()
+            .expect("legacy service proc builder is valid");
+        let local_proc = Proc::builder()
+            .proc_id(
+                ProcAddr::singleton(frontend_addr.clone(), LEGACY_LOCAL_PROC_NAME)
+                    .id()
+                    .clone(),
+            )
+            .shared_gateway(gateway.clone())
+            .build()
+            .expect("legacy local proc builder is valid");
         let service_proc_id = service_proc.proc_addr().clone();
         let local_proc_id = local_proc.proc_addr().clone();
-
-        // Register the local procs' muxers so the router delivers to
-        // them without dialing. We bind the muxer (not the Proc) to
-        // avoid a flush cycle: Proc.forwarder → MailboxRouter → Proc →
-        // Proc.forwarder → …
-        router.bind(
-            Addr::from(service_proc_id.clone()),
-            service_proc.muxer().clone(),
-        );
-        router.bind(
-            Addr::from(local_proc_id.clone()),
-            local_proc.muxer().clone(),
-        );
 
         tracing::info!(
             frontend_addr = frontend_addr.to_string(),
@@ -282,23 +303,22 @@ impl<M: ProcManager> Host<M> {
         );
 
         let host = Host {
-            procs: HashSet::new(),
+            procs: HashMap::new(),
             frontend_addr,
             backend_addr,
-            router,
-            dial_router,
+            gateway,
             manager,
             service_proc,
             local_proc,
             frontend: Some(frontend),
         };
 
-        // Serve the same router on the backend address. We don't ever need
+        // Serve the gateway on the backend address. We don't ever need
         // to join this handle because the server is used only to receive
         // messages from procs spawned by this host -- if the host is shutting down,
         // then all its procs should have shut down first, and we don't have to worry
         // about any unacked messages.
-        let _backend_handle = host.forwarder().serve(backend_rx);
+        let _backend_handle = host.gateway.clone().serve(backend_rx);
 
         Ok(host)
     }
@@ -314,15 +334,11 @@ impl<M: ProcManager> Host<M> {
     /// resolves.
     pub fn serve(&mut self) -> Result<MailboxServerHandle, HostError> {
         let frontend = self.frontend.take().ok_or(HostError::AlreadyServing)?;
-        let forwarder = self.forwarder();
         Ok(match frontend {
-            Frontend::Duplex(server) => spawn_duplex_accept_loop(
-                server,
-                self.frontend_addr.clone(),
-                self.router.clone(),
-                forwarder,
-            ),
-            Frontend::Simplex(rx) => forwarder.serve(rx),
+            Frontend::Duplex(server) => {
+                spawn_duplex_accept_loop(server, self.frontend_addr.clone(), self.gateway.clone())
+            }
+            Frontend::Simplex(rx) => self.gateway.clone().serve(rx),
         })
     }
 
@@ -359,7 +375,7 @@ impl<M: ProcManager> Host<M> {
         name: String,
         config: M::Config,
     ) -> Result<(ProcAddr, ActorRef<ManagerAgent<M>>), HostError> {
-        if self.procs.contains(&name) {
+        if self.procs.contains_key(&name) {
             return Err(HostError::ProcExists(name));
         }
 
@@ -384,18 +400,26 @@ impl<M: ProcManager> Host<M> {
             HostError::ProcessConfigurationFailure(proc_id.clone(), anyhow::anyhow!("{e:?}"))
         })?;
 
-        self.dial_router
-            .bind(Addr::from(proc_id.clone()), ready.addr().clone());
-        self.procs.insert(name.clone());
+        let child_sender = MailboxClient::dial(ready.addr().clone()).map_err(|e| {
+            HostError::ProcessConfigurationFailure(
+                proc_id.clone(),
+                anyhow::anyhow!("failed to dial spawned proc at {}: {}", ready.addr(), e),
+            )
+        })?;
+        let guard = self
+            .gateway
+            .attach((proc_id.id().clone(), child_sender.into_boxed()));
+        self.procs.insert(name.clone(), guard);
 
         Ok((proc_id, ready.agent_ref().clone()))
     }
 
-    /// A [`MailboxSender`] that first consults the prefix router (for
-    /// local and attached procs) and then falls back to the
-    /// address-based dial router (for child procs and remote hosts).
-    fn forwarder(&self) -> BoxedMailboxSender {
-        self.router.fallback(self.dial_router.boxed())
+    /// The host's [`Gateway`]. All incoming traffic addressed to this
+    /// host's procs is routed through the gateway; remote procs anchored
+    /// to this host (attached clients, spawned children) are attached
+    /// via [`Gateway::attach`] with `(ProcId, BoxedMailboxSender)`.
+    pub fn gateway(&self) -> &Gateway {
+        &self.gateway
     }
 }
 
@@ -406,12 +430,11 @@ impl<M: ProcManager> Host<M> {
 fn spawn_duplex_accept_loop(
     server: channel::duplex::DuplexServer<MessageEnvelope, Host2Client>,
     frontend_addr: ChannelAddr,
-    router: MailboxRouter,
-    forwarder: BoxedMailboxSender,
+    gateway: Gateway,
 ) -> MailboxServerHandle {
     let (stopped_tx, stopped_rx) = watch::channel(false);
     let join_handle = tokio::spawn(async move {
-        duplex_accept_loop(server, frontend_addr, router, forwarder, stopped_rx).await;
+        duplex_accept_loop(server, frontend_addr, gateway, stopped_rx).await;
         Ok::<(), MailboxServerError>(())
     });
     MailboxServerHandle::from_parts(join_handle, stopped_tx)
@@ -490,8 +513,7 @@ impl<R: channel::Rx<MessageEnvelope> + Send> channel::Rx<MessageEnvelope> for Pr
 async fn duplex_accept_loop(
     mut duplex_server: channel::duplex::DuplexServer<MessageEnvelope, Host2Client>,
     frontend_addr: ChannelAddr,
-    router: MailboxRouter,
-    forwarder: BoxedMailboxSender,
+    gateway: Gateway,
     stopped_rx: watch::Receiver<bool>,
 ) {
     let mut tasks = JoinSet::new();
@@ -540,10 +562,10 @@ async fn duplex_accept_loop(
             );
             duplex_tx.post(Host2Client::Bootstrap(assignment));
 
-            router.bind(Addr::from(proc_id.clone()), AttachSender(duplex_tx));
+            let attach_guard =
+                gateway.attach((proc_id.id().clone(), AttachSender(duplex_tx).into_boxed()));
 
-            let mut handle = forwarder.clone().serve(duplex_rx);
-            let cleanup_router = router.clone();
+            let mut handle = gateway.clone().serve(duplex_rx);
             let conn_stop = stopped_rx.clone();
             tasks.spawn(async move {
                 tokio::select! {
@@ -553,7 +575,9 @@ async fn duplex_accept_loop(
                         let _ = handle.await;
                     }
                 }
-                cleanup_router.unbind(&Addr::from(proc_id.clone()));
+                // Drop the guard now (rather than at end-of-scope) so
+                // the route is removed before we log the closure.
+                drop(attach_guard);
                 tracing::info!(
                     proc_id = proc_id.to_string(),
                     "attach connection closed, removed route"
@@ -566,7 +590,7 @@ async fn duplex_accept_loop(
             // the session's outbound channel, which causes the
             // session task to exit and the inbound receiver to
             // close after a single message.
-            let fwd = forwarder.clone();
+            let gw = gateway.clone();
             let conn_stop = stopped_rx.clone();
             tasks.spawn(async move {
                 let _keep_alive = duplex_tx;
@@ -574,7 +598,7 @@ async fn duplex_accept_loop(
                     first: Some(first_msg),
                     inner: duplex_rx,
                 };
-                let mut handle = fwd.serve(rx);
+                let mut handle = gw.serve(rx);
                 tokio::select! {
                     _ = &mut handle => {}
                     () = wait_for_stop(conn_stop) => {
@@ -822,12 +846,9 @@ impl<M: ProcManager + BulkTerminate> Host<M> {
             .manager
             .terminate_all(cx, timeout, max_in_flight, reason)
             .await;
-        // Unbind procs from the router so if new procs are made with the same
-        // names, they can use the same slot.
-        for name in self.procs.drain() {
-            let proc_ref = ResourceId::proc_addr_from_name(self.frontend_addr.clone(), &name);
-            self.dial_router.unbind(&Addr::from(proc_ref));
-        }
+        // Detach procs from the gateway by dropping their attach
+        // guards, freeing the name slots for any future respawns.
+        self.procs.clear();
         summary
     }
 }
@@ -1713,6 +1734,7 @@ mod tests {
 
     use async_trait::async_trait;
     use hyperactor::Actor;
+    use hyperactor::Addr;
     use hyperactor::Context;
     use hyperactor::Endpoint as _;
     use hyperactor::Handler;
@@ -2091,7 +2113,7 @@ mod tests {
 
         let (pid, agent) = host.spawn("ok".into(), ()).await.expect("must succeed");
         assert_eq!(agent.actor_addr().proc_addr(), pid);
-        assert!(host.procs.contains("ok"));
+        assert!(host.procs.contains_key("ok"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3453
* #3153
* #3138
* __->__ #3970

`Host` combined a `MailboxRouter` (prefix routes for local/attached procs) with a `DialMailboxRouter` (fallback for child procs and remote hosts). That role is exactly what the recently-added `Gateway` describes: an advertised location plus a forwarder that multiplexes ingress and routes egress.

This change makes `Host` own a single `Gateway` configured with the frontend address as its default location and the dial router as its forwarder. In-process procs (`service_proc`, `local_proc`) attach via `Gateway::attach(&proc)`; remote procs anchored to this host (attached clients from the duplex accept loop, spawned children) attach via `Gateway::attach((proc_id, sender))`. The polymorphic `attach` accepts anything that converts into a new `ProcEntry` enum (`Local(ProcId, WeakProc) | Remote(ProcId, BoxedMailboxSender)`) and returns an `AttachGuard` so callers do not need to remember to detach explicitly. Unknown destinations fall through to the gateway forwarder.

`Gateway::attach` and `Gateway::configured` are now `pub` so other crates can build host-scoped gateways. The duplex accept loop and `Host::serve` now take a `Gateway` instead of a `(MailboxRouter, BoxedMailboxSender)` pair; `Host::forwarder()` is removed in favor of routing through the gateway.

Dropping a `Proc` drops its `AttachGuard`, which eagerly removes the entry from the gateway's proc map. This replaces the previous lazy "stale `WeakProc` lingers in the map" behavior and is what unblocks the follow-up dynamic-registration work: the gateway can broadcast registration / unregistration over a via duplex on each attach / detach without an explicit cleanup pass.

Differential Revision: [D105349853](https://our.internmc.facebook.com/intern/diff/D105349853/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105349853/)!