### PR TITLE
Bump nightlies to 0.6.0

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -89,7 +89,7 @@ jobs:
         if [ -n "${{ inputs.version }}" ]; then
           export MONARCH_VERSION="${{ inputs.version }}"
         else
-          export MONARCH_VERSION=0.5.0.dev$(date +'%Y%m%d')
+          export MONARCH_VERSION=0.6.0.dev$(date +'%Y%m%d')
         fi
         python setup.py bdist_wheel
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -69,7 +69,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             export MONARCH_VERSION="${{ inputs.version }}"
           else
-            export MONARCH_VERSION=0.5.0.dev$(date +'%Y%m%d')
+            export MONARCH_VERSION=0.6.0.dev$(date +'%Y%m%d')
           fi
 
           python setup.py bdist_wheel

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -116,7 +116,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Get tag for publishing
-        run: echo "DOCKER_TAG=0.5.0.dev$(date +'%Y%m%d')-cuda12.6" >> $GITHUB_ENV
+        run: echo "DOCKER_TAG=0.6.0.dev$(date +'%Y%m%d')-cuda12.6" >> $GITHUB_ENV
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/setup.py
+++ b/setup.py
@@ -505,7 +505,7 @@ class BuildPyWithFrontend(build_py):
 
 # Actual Setup
 package_name = os.environ.get("MONARCH_PACKAGE_NAME", "torchmonarch")
-package_version = os.environ.get("MONARCH_VERSION", "0.5.0.dev0")
+package_version = os.environ.get("MONARCH_VERSION", "0.6.0.dev0")
 
 setup(
     name=package_name,


### PR DESCRIPTION
Summary: Now that 0.5.0 is cut, bump nightly build versions to 0.6.0

Differential Revision: D105759264


