### PR TITLE
Drop InstanceWrapper's detached-client signal port (#3975)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -239,13 +239,6 @@ pub trait Handler<M>: Actor {
 /// in [crate::ordering::Sequencer::assign_seq] and the registry of bypass types
 /// in [crate::ordering::is_bypass_workq_type_id].
 #[async_trait]
-impl<A: Actor> Handler<Signal> for A {
-    async fn handle(&mut self, _cx: &Context<Self>, _message: Signal) -> Result<(), anyhow::Error> {
-        unimplemented!("signal handler should not be called directly")
-    }
-}
-
-#[async_trait]
 impl<A: Actor> Handler<crate::introspect::IntrospectMessage> for A {
     async fn handle(
         &mut self,
@@ -446,6 +439,11 @@ pub enum ActorErrorKind {
     /// The actor was explicitly aborted with the provided reason.
     #[error("actor explicitly aborted due to: {0}")]
     Aborted(String),
+
+    /// The actor's signal channel was closed before the actor loop exited
+    /// normally.
+    #[error("signal channel closed")]
+    SignalChannelClosed,
 }
 
 impl ActorErrorKind {
@@ -557,7 +555,6 @@ pub enum Signal {
     /// hierarchy.
     Kill(String),
 }
-wirevalue::register_type!(Signal);
 
 impl fmt::Display for Signal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -174,7 +174,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
-    use crate::actor::Signal;
+    use crate::introspect::IntrospectMessage;
     use crate::port::Port;
     use crate::testing::ids::test_actor_id;
 
@@ -188,15 +188,15 @@ mod tests {
     fn handler_port(actor_name: &str) -> (ActorAddr, PortAddr) {
         let addr: ActorAddr = test_actor_id(actor_name, "worker");
         // Use a fabricated handler-port index (high bit set) by going through
-        // the existing Signal::port() / IntrospectMessage::port() — they're
-        // bypass ports though, so for a NON-bypass handler port we'll use
-        // an explicit message type. Easier: spin up via Port::from of any
-        // u64 with the handler bit set. Since the test util test_actor_id
-        // already returns an ActorAddr, and the only requirement is that
-        // .is_handler_port() is true, we construct a PortAddr that points
-        // to a known handler port — for headers tests we can use
-        // Signal::port() (a bypass handler port — gate should skip it) or
-        // a fabricated non-bypass handler. Use TestHandlerMsg below.
+        // the existing IntrospectMessage::port() — it's a bypass port though,
+        // so for a NON-bypass handler port we'll use an explicit message
+        // type. Easier: spin up via Port::from of any u64 with the handler
+        // bit set. Since the test util test_actor_id already returns an
+        // ActorAddr, and the only requirement is that .is_handler_port() is
+        // true, we construct a PortAddr that points to a known handler port
+        // — for headers tests we can use IntrospectMessage::port() (a bypass
+        // handler port — gate should skip it) or a fabricated non-bypass
+        // handler. Use TestHandlerMsg below.
         let port = addr.port_addr(Port::from(TestHandlerMsg::port()));
         (addr, port)
     }
@@ -212,7 +212,7 @@ mod tests {
 
     fn bypass_port(actor_name: &str) -> (ActorAddr, PortAddr) {
         let addr: ActorAddr = test_actor_id(actor_name, "worker");
-        let port = addr.port_addr(Port::from(Signal::port()));
+        let port = addr.port_addr(Port::from(IntrospectMessage::port()));
         (addr, port)
     }
 

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -11,11 +11,9 @@
 
 use std::any::TypeId;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fmt;
 use std::ops::DerefMut;
 use std::sync::Arc;
-use std::sync::LazyLock;
 use std::sync::Mutex;
 
 use dashmap::DashMap;
@@ -30,40 +28,31 @@ use uuid::Uuid;
 
 use crate::ActorAddr;
 use crate::PortAddr;
-use crate::actor::Signal;
 use crate::introspect::IntrospectMessage;
 
-// Bypass-actor-workq registry: message types whose receivers are delivered via
+// Bypass-actor-workq: message types whose receivers are delivered via
 // dedicated channels rather than the actor's work queue.
 //
-// Types in this registry share two invariants that the framework must honor:
-//   1. Their actor port is pre-registered via `Ports::open_message_port` in
-//      `Instance::new`; `Ports::get` rejects them via `is_bypass_workq_type_id` so
-//      they can't accidentally be wired to the work queue.
-//   2. Their sender-side sequence numbers must NOT share the per-actor seq
+// The bypass-workq message type shares two invariants that the framework
+// must honor:
+//   1. Its actor port is pre-registered via `Ports::open_message_port` in
+//      `Instance::new`; `Ports::get` rejects it via `is_bypass_workq_type_id`
+//      so it can't accidentally be wired to the work queue.
+//   2. Its sender-side sequence numbers must NOT share the per-actor seq
 //      counter (`SeqKey::Actor`), because the work queue never observes them
 //      and would otherwise see seq gaps that buffer subsequent workq messages
-//      indefinitely. `Sequencer::assign_seq` uses `SeqKey::Port` for these.
-//
-// When adding a new bypass-channel actor-port message type, update both lists.
-// A future move to `inventory`-driven registration can collapse them.
-
-static BYPASS_TYPE_IDS: LazyLock<HashSet<TypeId>> =
-    LazyLock::new(|| HashSet::from([TypeId::of::<Signal>(), TypeId::of::<IntrospectMessage>()]));
-
-static BYPASS_ACTOR_PORTS: LazyLock<HashSet<u64>> =
-    LazyLock::new(|| HashSet::from([Signal::port(), IntrospectMessage::port()]));
+//      indefinitely. `Sequencer::assign_seq` uses `SeqKey::Port` for them.
 
 /// Returns true if `id` is the `TypeId` of a bypass-channel message type
 /// (i.e. one that must not be wired through `Ports::get`).
 pub(crate) fn is_bypass_workq_type_id(id: TypeId) -> bool {
-    BYPASS_TYPE_IDS.contains(&id)
+    id == TypeId::of::<IntrospectMessage>()
 }
 
 /// Returns true if `port` is the actor-port index of a bypass-channel
 /// message type (i.e. the sequencer must use `SeqKey::Port` for it).
 pub(crate) fn is_bypass_workq_actor_port(port: u64) -> bool {
-    BYPASS_ACTOR_PORTS.contains(&port)
+    port == IntrospectMessage::port()
 }
 
 /// A client's re-ordering buffer state.
@@ -772,18 +761,6 @@ mod tests {
     fn bypass_registry_introspect_message() {
         assert!(is_bypass_workq_type_id(TypeId::of::<IntrospectMessage>()));
         assert!(is_bypass_workq_actor_port(IntrospectMessage::port()));
-    }
-
-    #[test]
-    fn bypass_registry_signal() {
-        assert!(is_bypass_workq_type_id(TypeId::of::<Signal>()));
-        assert!(is_bypass_workq_actor_port(Signal::port()));
-    }
-
-    #[test]
-    fn bypass_registry_lists_have_matching_lengths() {
-        // If this fails, BYPASS_TYPE_IDS and BYPASS_ACTOR_PORTS have drifted.
-        assert_eq!(BYPASS_TYPE_IDS.len(), BYPASS_ACTOR_PORTS.len());
     }
 
     #[test]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -550,7 +550,7 @@ pub struct ActorInstance<A: Actor> {
     /// Supervision events delivered to this actor.
     pub supervision: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
     /// Control signals for the actor.
-    pub signal: PortReceiver<Signal>,
+    pub signal: mpsc::UnboundedReceiver<Signal>,
     /// Primary work queue for handler dispatch.
     pub work: mpsc::UnboundedReceiver<WorkCell<A>>,
 }
@@ -2189,7 +2189,7 @@ pub struct InstanceReceivers<A: Actor> {
     /// Signal and supervision receivers for the actor loop. `None`
     /// for detached/client instances that don't run an actor loop.
     actor_loop: Option<(
-        PortReceiver<Signal>,
+        mpsc::UnboundedReceiver<Signal>,
         mpsc::UnboundedReceiver<ActorSupervisionEvent>,
     )>,
     /// Work queue for dispatching messages to actor handlers.
@@ -2230,11 +2230,11 @@ impl<A: Actor> Instance<A> {
         let actor_loop_ports = if detached {
             None
         } else {
-            let (signal_port, signal_receiver) = mailbox.open_port::<Signal>();
+            let (signal_tx, signal_receiver) = mpsc::unbounded_channel::<Signal>();
             let (supervision_tx, supervision_receiver) =
                 mpsc::unbounded_channel::<ActorSupervisionEvent>();
             Some((
-                (signal_port, supervision_tx),
+                (signal_tx, supervision_tx),
                 (signal_receiver, supervision_receiver),
             ))
         };
@@ -2604,10 +2604,10 @@ impl<A: Actor> Instance<A> {
         self.inner.mailbox.open_once_port()
     }
 
-    /// Return this actor's runtime signal port.
+    /// Return this actor's runtime signal sender.
     #[doc(hidden)]
-    pub fn signal_port(&self) -> PortHandle<Signal> {
-        self.inner.cell.signal_port()
+    pub fn signal_sender(&self) -> mpsc::UnboundedSender<Signal> {
+        self.inner.cell.signal_sender()
     }
 
     /// Get the per-instance local storage.
@@ -2769,7 +2769,7 @@ impl<A: Actor> Instance<A> {
         mut self,
         mut actor: A,
         actor_loop_receivers: (
-            PortReceiver<Signal>,
+            mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
         mut work_rx: mpsc::UnboundedReceiver<WorkCell<A>>,
@@ -2864,7 +2864,7 @@ impl<A: Actor> Instance<A> {
         &mut self,
         actor: &mut A,
         mut actor_loop_receivers: (
-            PortReceiver<Signal>,
+            mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
         work_rx: &mut mpsc::UnboundedReceiver<WorkCell<A>>,
@@ -2923,10 +2923,19 @@ impl<A: Actor> Instance<A> {
         let (mut signal_receiver, _) = actor_loop_receivers;
         while self.inner.cell.child_count() > 0 {
             match tokio::time::timeout(Duration::from_millis(500), signal_receiver.recv()).await {
-                Ok(signal) => {
-                    if let Signal::ChildStopped(uid) = signal? {
-                        assert!(self.inner.cell.get_child(&uid).is_none());
-                    }
+                Ok(Some(Signal::ChildStopped(uid))) => {
+                    assert!(self.inner.cell.get_child(&uid).is_none());
+                }
+                // Drain only tracks child termination; other signals are
+                // intentionally swallowed here.
+                Ok(Some(_)) => {}
+                Ok(None) => {
+                    // Signal channel closed: no further ChildStopped will
+                    // arrive, so we can no longer track child termination.
+                    // Drop remaining links and exit the drain loop, mirroring
+                    // the timeout branch below.
+                    self.inner.cell.unlink_all();
+                    break;
                 }
                 Err(_) => {
                     tracing::warn!(
@@ -2991,7 +3000,7 @@ impl<A: Actor> Instance<A> {
         &mut self,
         actor: &mut A,
         actor_loop_receivers: &mut (
-            PortReceiver<Signal>,
+            mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
         work_rx: &mut mpsc::UnboundedReceiver<WorkCell<A>>,
@@ -3014,9 +3023,11 @@ impl<A: Actor> Instance<A> {
             tokio::select! {
                 biased;
                 signal = signal_receiver.recv() => {
-                    let signal = signal.map_err(ActorError::from);
+                    let signal = signal.ok_or_else(|| {
+                        ActorError::new(self.self_addr(), ActorErrorKind::SignalChannelClosed)
+                    })?;
                     tracing::debug!("received signal {signal:?}");
-                    match signal? {
+                    match signal {
                         Signal::Stop(reason) => {
                             self.change_status(ActorStatus::Stopping);
                             self.inner
@@ -3582,9 +3593,9 @@ struct InstanceCellState {
     /// The proc in which the actor is running.
     proc: Proc,
 
-    /// Control port handles to the actor loop, if one is running.
+    /// Control plane message senders to the actor loop, if one is running.
     actor_loop: Option<(
-        PortHandle<Signal>,
+        mpsc::UnboundedSender<Signal>,
         mpsc::UnboundedSender<ActorSupervisionEvent>,
     )>,
 
@@ -3755,7 +3766,7 @@ impl InstanceCell {
         actor_type: ActorType,
         proc: Proc,
         actor_loop: Option<(
-            PortHandle<Signal>,
+            mpsc::UnboundedSender<Signal>,
             mpsc::UnboundedSender<ActorSupervisionEvent>,
         )>,
         status: watch::Receiver<ActorStatus>,
@@ -3840,22 +3851,20 @@ impl InstanceCell {
         self.inner.supervision_event.lock().unwrap().clone()
     }
 
-    fn signal_port(&self) -> PortHandle<Signal> {
+    fn signal_sender(&self) -> mpsc::UnboundedSender<Signal> {
         self.inner
             .actor_loop
             .as_ref()
-            .map(|(signal_port, _)| signal_port.clone())
-            .unwrap_or_else(|| panic!("{} has no runtime signal port", self.actor_addr()))
+            .map(|(signal_tx, _)| signal_tx.clone())
+            .unwrap_or_else(|| panic!("{} has no runtime signal sender", self.actor_addr()))
     }
 
     /// Send a signal to the actor.
     pub fn signal(&self, signal: Signal) -> Result<(), ActorError> {
-        if let Some((signal_port, _)) = &self.inner.actor_loop {
-            // A global signal client is used to send signals to the actor.
-            static CLIENT: OnceLock<Client> = OnceLock::new();
-            let client = CLIENT.get_or_init(|| Proc::global().client("global_signal_client"));
-            signal_port.post(client, signal);
-            Ok(())
+        if let Some((signal_tx, _)) = &self.inner.actor_loop {
+            signal_tx.send(signal).map_err(|_| {
+                ActorError::new(self.actor_addr(), ActorErrorKind::SignalChannelClosed)
+            })
         } else {
             tracing::warn!(
                 "{}: attempted to send signal {} to detached actor",
@@ -4138,12 +4147,6 @@ impl InstanceCell {
     /// We should find some (better) way to consolidate the two.
     pub(crate) fn bind<A: Actor, R: Binds<A>>(&self, ports: &HandlerPorts<A>) -> ActorRef<R> {
         <R as Binds<A>>::bind(ports);
-        // Signal: registered directly in Instance::new() and handled
-        // by the actor loop's select!. The port remains unbound
-        // because runtime signals are sent through InstanceCell's
-        // stored PortHandle, not as externally addressable actor
-        // messages.
-        //
         // Undeliverable: dispatched through the work queue to the
         // actor's Handler<Undeliverable<MessageEnvelope>>.
         //
@@ -4832,14 +4835,6 @@ mod tests {
         snapshot.spawned_handle.await;
         actor.drain_and_stop("test complete").unwrap();
         actor.await;
-    }
-
-    #[tokio::test]
-    async fn test_client_instance_can_bind_signal_port() {
-        let proc = Proc::isolated();
-        let client = proc.client("client");
-
-        let (_signal_port, _signal_rx) = client.bind_handler_port::<Signal>();
     }
 
     #[expect(

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -69,7 +69,6 @@ use hyperactor::id::Label;
 use hyperactor::id::Uid;
 use hyperactor::mailbox::DeliveryError;
 use hyperactor::mailbox::MessageEnvelope;
-use hyperactor::mailbox::PortReceiver;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::proc::Proc;
 use hyperactor::proc::WorkCell;
@@ -173,7 +172,7 @@ fn get_global_supervision_sink() -> Option<PortRef<ActorSupervisionEvent>> {
 #[hyperactor::export(handlers = [MeshFailure])]
 pub struct GlobalClientActor {
     /// Control signals for the actor's proc (shutdown, etc.).
-    signal_rx: PortReceiver<Signal>,
+    signal_rx: mpsc::UnboundedReceiver<Signal>,
     /// Supervision events delivered to this actor instance.
     ///
     /// The root client is a monitor, so it should process these
@@ -208,7 +207,7 @@ impl GlobalClientActor {
                             };
                         }
                     }
-                    _ = self.signal_rx.recv() => {
+                    Some(_) = self.signal_rx.recv() => {
                         // TODO: do we need any signal handling for the root client?
                     }
                     Some(supervision_event) = self.supervision_rx.recv() => {

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -31,7 +31,6 @@ use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Signal;
 use hyperactor::channel::ChannelTransport;
-use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::WorkCell;
 use hyperactor::supervision::ActorSupervisionEvent;
 #[cfg(fbcode_build)]
@@ -186,7 +185,7 @@ fn process_name(pid: u32) -> Option<String> {
 
 #[derive(Debug)]
 pub struct TestRootClient {
-    signal_rx: PortReceiver<Signal>,
+    signal_rx: mpsc::UnboundedReceiver<Signal>,
     supervision_rx: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
     work_rx: mpsc::UnboundedReceiver<WorkCell<Self>>,
 }
@@ -223,7 +222,7 @@ impl TestRootClient {
                             };
                         }
                     }
-                    _ = self.signal_rx.recv() => {
+                    Some(_) = self.signal_rx.recv() => {
                         // TODO: do we need any signal handling for the root client?
                     }
                     Some(supervision_event) = self.supervision_rx.recv() => {

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -15,13 +15,11 @@ use std::sync::OnceLock;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::Client;
 use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
-use hyperactor::PortHandle;
 use hyperactor::Proc;
 use hyperactor::RemoteSpawn;
 use hyperactor::actor::ActorError;
@@ -60,6 +58,7 @@ use pyo3::types::PyType;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_multipart::Part;
+use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use typeuri::Named;
 
@@ -71,7 +70,6 @@ use crate::local_state_broker::BrokerId;
 use crate::local_state_broker::LocalStateBrokerMessage;
 use crate::mailbox::EitherPortRef;
 use crate::mailbox::PyMailbox;
-use crate::mailbox::PythonPortHandle;
 use crate::mailbox::PythonUndeliverableMessageEnvelope;
 use crate::metrics::ENDPOINT_ACTOR_COUNT;
 use crate::metrics::ENDPOINT_ACTOR_ERROR;
@@ -81,7 +79,6 @@ use crate::pickle::pickle_to_part;
 use crate::proc::PyActorAddr;
 use crate::pympsc;
 use crate::pytokio::PythonTask;
-use crate::runtime::get_proc_runtime;
 use crate::runtime::get_tokio_runtime;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
@@ -773,19 +770,23 @@ impl PythonActor {
                         }
                     }
                     signal = signal_rx.recv() => {
-                        let signal = signal.map_err(ActorError::from);
                         tracing::info!(actor_id = %instance.self_addr(), "client received signal {signal:?}");
                         match signal {
-                            Ok(signal@(Signal::Stop(_) | Signal::DrainAndStop(_))) => {
+                            Some(signal@(Signal::Stop(_) | Signal::DrainAndStop(_))) => {
                                 need_drain = matches!(signal, Signal::DrainAndStop(_));
                                 break None;
                             },
-                            Ok(Signal::ExitRequested(_)) => break None,
-                            Ok(Signal::ChildStopped(_)) => {},
-                            Ok(Signal::Kill(reason)) => {
+                            Some(Signal::ExitRequested(_)) => break None,
+                            Some(Signal::ChildStopped(_)) => {},
+                            Some(Signal::Kill(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
                             },
-                            Err(err) => break Some(err),
+                            None => {
+                                break Some(ActorError {
+                                    actor_id: Box::new(instance.self_addr().clone()),
+                                    kind: Box::new(ActorErrorKind::SignalChannelClosed),
+                                })
+                            },
                         }
                     }
                     Some(supervision_event) = supervision_rx.recv() => {
@@ -895,36 +896,15 @@ impl Actor for PythonActor {
         if let PythonActorDispatchMode::Queue { receiver, .. } = &mut self.dispatch_mode {
             let receiver = receiver.take().unwrap();
 
-            // Create an error port that converts PythonMessage to an abort signal.
-            // This allows Python to send errors that trigger actor supervision.
-            let error_port: hyperactor::PortHandle<PythonMessage> =
-                this.signal_port().contramap(|msg: PythonMessage| {
-                    monarch_with_gil_blocking(|py| {
-                        let err = match msg.kind {
-                            PythonMessageKind::Exception { .. } => {
-                                // Deserialize the error from the message
-                                let cloudpickle = py.import("cloudpickle").unwrap();
-                                let err_obj = cloudpickle
-                                    .call_method1("loads", (msg.message.to_bytes().as_ref(),))
-                                    .unwrap();
-                                let py_err = pyo3::PyErr::from_value(err_obj);
-                                SerializablePyErr::from(py, &py_err)
-                            }
-                            _ => {
-                                let py_err = PyRuntimeError::new_err(format!(
-                                    "expected Exception, got {:?}",
-                                    msg.kind
-                                ));
-                                SerializablePyErr::from(py, &py_err)
-                            }
-                        };
-                        Signal::Kill(err.to_string())
-                    })
-                });
-
-            let error_port_handle = PythonPortHandle::new(error_port);
-
             monarch_with_gil(|py| {
+                let self_instance = self
+                    .instance
+                    .get_or_insert_with(|| {
+                        let inst: crate::context::PyInstance = this.into();
+                        inst.into_pyobject(py).unwrap().into()
+                    })
+                    .clone_ref(py);
+
                 let tl = self
                     .task_locals
                     .as_ref()
@@ -932,7 +912,7 @@ impl Actor for PythonActor {
                 let awaitable = self.actor.call_method(
                     py,
                     "_dispatch_loop",
-                    (receiver, error_port_handle),
+                    (receiver, self_instance),
                     None,
                 )?;
                 let future =
@@ -1321,7 +1301,7 @@ impl PythonActor {
 
         // Spawn a child actor to await the Python handler method.
         tokio::spawn(handle_async_endpoint_panic(
-            cx.signal_port(),
+            cx.signal_sender(),
             PythonTask::new(future)?,
             receiver,
             cx.self_addr().to_string(),
@@ -1532,7 +1512,7 @@ impl Handler<MeshFailure> for PythonActor {
 }
 
 async fn handle_async_endpoint_panic(
-    panic_sender: PortHandle<Signal>,
+    panic_sender: mpsc::UnboundedSender<Signal>,
     task: PythonTask,
     side_channel: oneshot::Receiver<Py<PyAny>>,
     actor_id: String,
@@ -1585,9 +1565,9 @@ async fn handle_async_endpoint_panic(
     } {
         // Record error and panic metrics
         ENDPOINT_ACTOR_ERROR.add(1, attributes);
-        static CLIENT: OnceLock<Client> = OnceLock::new();
-        let client = CLIENT.get_or_init(|| get_proc_runtime().client("async_endpoint_handler"));
-        panic_sender.post(client, Signal::Kill(panic.to_string()));
+        if panic_sender.send(Signal::Kill(panic.to_string())).is_err() {
+            tracing::warn!("dropped panic signal: actor already stopped: {panic}");
+        }
     }
 
     // Record latency in microseconds

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -849,7 +849,6 @@ mod tests {
     use hyperactor::actor::Signal;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::mailbox;
-    use hyperactor::mailbox::PortReceiver;
     use hyperactor::proc::WorkCell;
     use hyperactor::supervision::ActorSupervisionEvent;
     use hyperactor_mesh::host_mesh::HostMesh;
@@ -868,7 +867,7 @@ mod tests {
     /// Handles MeshFailure by panicking (test failure).
     #[derive(Debug)]
     struct TestClient {
-        signal_rx: PortReceiver<Signal>,
+        signal_rx: mpsc::UnboundedReceiver<Signal>,
         supervision_rx: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         work_rx: mpsc::UnboundedReceiver<WorkCell<Self>>,
     }
@@ -899,7 +898,7 @@ mod tests {
                                 None => break,
                             }
                         }
-                        _ = self.signal_rx.recv() => {}
+                        Some(_) = self.signal_rx.recv() => {}
                         Some(event) = self.supervision_rx.recv() => {
                             let _ = instance
                                 .handle_supervision_event(&mut self, event)

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -90,6 +90,12 @@ impl PyInstance {
     }
 
     #[pyo3(signature = (reason = None))]
+    fn kill(&self, reason: Option<&str>) -> PyResult<()> {
+        let reason = reason.unwrap_or("(no reason provided)");
+        Ok(self.inner.kill(reason).map_err(anyhow::Error::from)?)
+    }
+
+    #[pyo3(signature = (reason = None))]
     fn stop(&self, reason: Option<&str>) -> PyResult<()> {
         tracing::info!(actor_id = %self.inner.self_addr(), "stopping PyInstance");
         let reason = reason.unwrap_or("(no reason provided)");

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -247,12 +247,6 @@ pub(crate) struct PythonPortHandle {
     inner: PortHandle<PythonMessage>,
 }
 
-impl PythonPortHandle {
-    pub(crate) fn new(inner: PortHandle<PythonMessage>) -> Self {
-        Self { inner }
-    }
-}
-
 #[pymethods]
 impl PythonPortHandle {
     fn send(&self, instance: &PyInstance, message: PythonMessage) -> PyResult<()> {

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -14,7 +14,6 @@ use std::time::Duration;
 use anyhow::Result;
 use hyperactor::Client;
 use hyperactor::RemoteMessage;
-use hyperactor::actor::Signal;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::Proc;
@@ -323,7 +322,6 @@ impl PySerialized {
 pub struct InstanceWrapper<M: RemoteMessage> {
     instance: Client,
     message_receiver: PortReceiver<M>,
-    signal_receiver: PortReceiver<Signal>,
     status: InstanceStatus,
     actor_id: hyperactor::ActorAddr,
 }
@@ -334,14 +332,11 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
         // TEMPORARY: remove after using fixed handler ports.
         let (_handler_port, message_receiver) = instance.bind_handler_port::<M>();
 
-        let (_signal_port, signal_receiver) = instance.bind_handler_port::<Signal>();
-
         let actor_id = instance.self_addr().clone();
 
         Ok(Self {
             instance,
             message_receiver,
-            signal_receiver,
             status: InstanceStatus::Running,
             actor_id,
         })
@@ -364,29 +359,12 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
         Ok(())
     }
 
-    /// Make sure the actor is running in detached mode and is alive.
-    fn ensure_detached_and_alive(&mut self) -> Result<()> {
+    /// Make sure the actor is still alive (in the `Running` state).
+    fn ensure_alive(&self) -> Result<()> {
         anyhow::ensure!(
             self.status == InstanceStatus::Running,
             "actor is not running"
         );
-
-        // This is a little weird as we are potentially stopping before responding to messages
-        // but in reality if we receive stop signal and not stop and drain in most cases its
-        // probably ok to stop early.
-        // Also an implicit assumption here is that is the signal is stop and drain we allow things
-        // to continue as there will hopefully not be new messages coming in. But need a proper draining
-        // flow for this.
-        // TODO: T208289078
-        let signals = self.signal_receiver.drain();
-        if signals
-            .into_iter()
-            .any(|sig| matches!(sig, Signal::Stop(_)))
-        {
-            self.status = InstanceStatus::Stopped;
-            anyhow::bail!("actor has been stopped");
-        }
-
         Ok(())
     }
 
@@ -405,7 +383,7 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
                 Some(0) => "polling",
                 Some(_) => "blocking_with_timeout",
             }));
-        self.ensure_detached_and_alive()?;
+        self.ensure_alive()?;
         match timeout_msec {
             // Blocking wait for next message.
             None => {
@@ -441,7 +419,7 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
     /// Put the actor in stopped mode and return any messages that were received.
     #[hyperactor::instrument(fields(actor_id=hyperactor::internal_macro_support::tracing::field::display(self.actor_addr())))]
     pub fn drain_and_stop(&mut self) -> Result<Vec<M>> {
-        self.ensure_detached_and_alive()?;
+        self.ensure_alive()?;
         let messages: Vec<M> = self.message_receiver.drain().into_iter().collect();
         tracing::info!("stopping the client actor in Python client");
         self.status = InstanceStatus::Stopped;

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -15,11 +15,6 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Result;
-use hyperactor::Proc;
-use hyperactor::channel::ChannelAddr;
-use hyperactor::channel::ChannelTransport;
-use hyperactor::mailbox::BoxedMailboxSender;
-use hyperactor::mailbox::PanickingMailboxSender;
 use once_cell::sync::Lazy;
 use once_cell::unsync::OnceCell as UnsyncOnceCell;
 use pyo3::PyResult;
@@ -93,16 +88,6 @@ pub fn shutdown_tokio_runtime(py: Python<'_>) {
         };
         rt.shutdown_timeout(Duration::from_secs(1));
     });
-}
-
-/// A global runtime proc used by this crate.
-pub(crate) fn get_proc_runtime() -> &'static Proc {
-    static RUNTIME_PROC: OnceLock<Proc> = OnceLock::new();
-    RUNTIME_PROC.get_or_init(|| {
-        let addr = ChannelAddr::any(ChannelTransport::Local);
-        let proc_id = hyperactor::ProcAddr::instance(addr, "monarch_hyperactor_runtime");
-        Proc::configured(proc_id, BoxedMailboxSender::new(PanickingMailboxSender))
-    })
 }
 
 /// Stores the native thread ID of the main Python thread.

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -99,10 +99,7 @@ if TYPE_CHECKING:
         QueuedMessage,
     )
     from monarch._rust_bindings.monarch_hyperactor.actor_mesh import ActorMeshProtocol
-    from monarch._rust_bindings.monarch_hyperactor.mailbox import (
-        PortHandle,
-        PortReceiverBase,
-    )
+    from monarch._rust_bindings.monarch_hyperactor.mailbox import PortReceiverBase
     from monarch._src.actor.proc_mesh import _ControllerController, DeviceMesh, ProcMesh
 
     def _assert_implements_endpoint(x: Endpoint[..., Any]) -> None: ...
@@ -229,6 +226,14 @@ class Instance(abc.ABC):
         """
         Abort the current actor. This will cause the actor to terminate
         with a failure, and a supervision error will propagate to its creator.
+        """
+        ...
+
+    @abstractmethod
+    def kill(self, reason: Optional[str] = None) -> None:
+        """
+        Terminate the current actor with a failure. A supervision error
+        propagates to its creator.
         """
         ...
 
@@ -1443,29 +1448,23 @@ class _Actor:
     async def _dispatch_loop(
         self,
         receiver: "Receiver[QueuedMessage]",
-        error_port: "PortHandle",
+        self_instance: "Instance",
     ) -> None:
         """
         Message loop for queue-dispatch mode. Called from Rust Actor::init.
 
         Args:
             receiver: Channel receiver for queued messages
-            error_port: Port to send errors to for actor supervision
+            self_instance: The actor's own Instance, used to kill self on
+                an unhandled exception.
         """
         while True:
             msg = await receiver.recv()
             try:
                 await self._handle_queued_message(msg)
             except BaseException as e:
-                state = pickle(
-                    e, allow_pending_pickles=False, allow_tensor_engine_references=False
-                )
-                error_msg = PythonMessage(
-                    # pyrefly: ignore [bad-argument-type, unexpected-keyword]
-                    PythonMessageKind.Exception(rank=None),
-                    state.buffer(),
-                )
-                error_port.send(msg.context.actor_instance, error_msg)
+                reason = "".join(TracebackException.from_exception(e).format())
+                self_instance.kill(reason)
                 raise
 
     async def _handle_queued_message(self, msg: "QueuedMessage") -> None:


### PR DESCRIPTION
Summary:

Follow-up to D105396332. I do not think we need this signal port for `InstanceWrapper` either. remove it.

Reviewed By: mariusae

Differential Revision: D105780014


