### PR TITLE
Add releasenotes URL pointing to github (#3977)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,10 +140,11 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://meta-pytorch.org/monarch/"
-Documentation = "https://meta-pytorch.org/monarch/"
-Repository = "https://github.com/meta-pytorch/monarch"
-Issues = "https://github.com/meta-pytorch/monarch/issues"
+homepage = "https://meta-pytorch.org/monarch/"
+documentation = "https://meta-pytorch.org/monarch/"
+source = "https://github.com/meta-pytorch/monarch"
+issues = "https://github.com/meta-pytorch/monarch/issues"
+releasenotes = "https://github.com/meta-pytorch/monarch/releases"
 
 [project.scripts]
 monarch = "monarch.tools.cli:main"


### PR DESCRIPTION
Summary:

Add `releasenotes` to well known pyproject fields, and have it point to
https://github.com/meta-pytorch/monarch/releases
where we publish curated release notes.

Note that `changelog` also exists and is not an alias, but is supposed to be the comprehensive list of all changes. I'm not sure if that's valuable to have so I am
sticking with just releases.

These URLs are displayed on the PyPI web page automatically.

Aside: changed format to the formal labels listed in https://packaging.python.org/en/latest/specifications/well-known-project-urls/
these are normalized anyways but "ReleaseNotes" would've looked a bit odd

Reviewed By: thedavekwon

Differential Revision: D105852781


