### PR TITLE
[hyperactor] use actor type labels for default spawn

### DIFF
--- a/hyperactor/example/derive.rs
+++ b/hyperactor/example/derive.rs
@@ -130,7 +130,7 @@ hyperactor::behavior!(ShoppingApi, ShoppingList, ClearList, GetItemCount,);
 async fn main() -> Result<(), anyhow::Error> {
     // Spawn our actor on the current proc.
     let shopping_list_actor: hyperactor::ActorHandle<ShoppingListActor> =
-        hyperactor::spawn_with_label("shopping", ShoppingListActor::default());
+        hyperactor::spawn(ShoppingListActor::default());
     let shopping_api: reference::ActorRef<ShoppingApi> = shopping_list_actor.bind();
     let client = hyperactor::client("client");
 

--- a/hyperactor/example/stream.rs
+++ b/hyperactor/example/stream.rs
@@ -81,8 +81,7 @@ impl Handler<u64> for CountClient {
 
 #[tokio::main]
 async fn main() {
-    let counter_actor: ActorHandle<CounterActor> =
-        hyperactor::spawn_with_label("counter", CounterActor::default());
+    let counter_actor: ActorHandle<CounterActor> = hyperactor::spawn(CounterActor::default());
 
     for i in 0..10 {
         // Spawn new "countees". Every time each subscribes, the counter broadcasts

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -133,6 +133,8 @@ pub trait Actor: Sized + Send + 'static {
     }
 
     /// Spawn a child actor, given a spawning capability (usually given by [`Instance`]).
+    ///
+    /// The child gets a fresh uid labeled from the actor type.
     /// The spawned actor will be supervised by the parent (spawning) actor.
     fn spawn(self, cx: &impl context::Actor) -> anyhow::Result<ActorHandle<Self>> {
         cx.instance().spawn(self)
@@ -1058,7 +1060,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo", actor);
+        let handle = proc.spawn(actor);
         handle.post(&client, 123u64);
         handle.drain_and_stop("test").unwrap();
         handle.await;
@@ -1150,7 +1152,7 @@ mod tests {
     async fn test_init() {
         let proc = Proc::isolated();
         let actor = InitActor(false);
-        let handle = proc.spawn_with_label::<InitActor>("init", actor);
+        let handle = proc.spawn(actor);
         let client = proc.client("client");
 
         let (port, receiver) = client.open_once_port();
@@ -1175,7 +1177,7 @@ mod tests {
             let proc = Proc::isolated();
             let values: MultiValues = Arc::new(Mutex::new((0, "".to_string())));
             let actor = MultiActor(values.clone());
-            let handle = proc.spawn_with_label::<MultiActor>("myactor", actor);
+            let handle = proc.spawn(actor);
             let client = proc.client("client");
             Self {
                 proc,
@@ -1292,7 +1294,7 @@ mod tests {
         // Just test that we can round-trip the handle through a downcast.
 
         let proc = Proc::isolated();
-        let handle = proc.spawn_with_label("nothing", NothingActor);
+        let handle = proc.spawn(NothingActor);
         let cell = handle.cell();
 
         // Invalid actor doesn't succeed.
@@ -1353,7 +1355,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
 
-        let actor_handle = proc.spawn_with_label("get_seq", GetSeqActor(tx.bind()));
+        let actor_handle = proc.spawn(GetSeqActor(tx.bind()));
 
         // Verify that unbound handle can send message.
         actor_handle.post(&client, "unbound".to_string());
@@ -1410,7 +1412,7 @@ mod tests {
         // Channel for receiving seq info from non-handler port
         let (non_handler_tx, mut non_handler_rx) = mpsc::unbounded_channel::<Option<SeqInfo>>();
 
-        let actor_handle = proc.spawn_with_label("get_seq", GetSeqActor(actor_tx.bind()));
+        let actor_handle = proc.spawn(GetSeqActor(actor_tx.bind()));
         let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
 
         // Create a non-handler port using open_enqueue_port
@@ -1490,7 +1492,7 @@ mod tests {
         // Port for receiving seq info from actor handler
         let (tx, mut rx) = client1.open_port();
 
-        let actor_handle = proc.spawn_with_label("get_seq", GetSeqActor(tx.bind()));
+        let actor_handle = proc.spawn(GetSeqActor(tx.bind()));
         let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
 
         // Each client should have a different session_id
@@ -1590,7 +1592,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
 
-        let actor_handle = proc.spawn_with_label("get_seq", GetSeqActor(tx.bind()));
+        let actor_handle = proc.spawn(GetSeqActor(tx.bind()));
         let actor_ref: ActorRef<GetSeqActor> = actor_handle.bind();
 
         let (callback_tx, mut callback_rx) = client.open_port();
@@ -1677,7 +1679,7 @@ mod tests {
         let client = local_proc.client("local");
         let (tx, mut rx) = client.open_port();
 
-        let handle = local_proc.spawn_with_label("get_seq", GetSeqActor(tx.bind()));
+        let handle = local_proc.spawn(GetSeqActor(tx.bind()));
         let actor_ref: ActorRef<GetSeqActor> = handle.bind();
 
         let remote_proc = Proc::configured(
@@ -1788,7 +1790,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo_introspect", actor);
+        let handle = proc.spawn(actor);
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
         PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
@@ -1931,7 +1933,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("ia_test", actor);
+        let handle = proc.spawn(actor);
 
         let payload = crate::introspect::live_actor_payload(handle.cell());
 
@@ -1960,7 +1962,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo_qc", actor);
+        let handle = proc.spawn(actor);
 
         let child_ref = crate::Addr::Actor(test_proc_id("nonexistent").actor_addr("child"));
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
@@ -2001,7 +2003,7 @@ mod tests {
 
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let handle = proc.spawn_with_label("custom_introspect", CustomIntrospectActor);
+        let handle = proc.spawn(CustomIntrospectActor);
 
         handle
             .status()
@@ -2109,7 +2111,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo_fresh", actor);
+        let handle = proc.spawn(actor);
 
         // Wait for the actor to finish initialization.
         handle
@@ -2145,7 +2147,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo_after_msg", actor);
+        let handle = proc.spawn(actor);
 
         // Send a user message and wait for it to be processed.
         handle.post(&client, 42u64);
@@ -2179,7 +2181,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo_consec", actor);
+        let handle = proc.spawn(actor);
 
         handle
             .status()
@@ -2238,7 +2240,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo_attrs", actor);
+        let handle = proc.spawn(actor);
 
         // Before publishing, attrs are None.
         assert!(handle.cell().published_attrs().is_none());
@@ -2275,7 +2277,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, _rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo_qch", actor);
+        let handle = proc.spawn(actor);
 
         // Before registering, query_child returns None.
         let test_ref = Addr::Actor(test_proc_id("test").actor_addr("child"));
@@ -2352,7 +2354,7 @@ mod tests {
 
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let handle = proc.spawn_with_label("wedged", WedgedActor);
+        let handle = proc.spawn(WedgedActor);
 
         // Wait for idle before sending the wedging message.
         handle
@@ -2397,7 +2399,7 @@ mod tests {
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port::<u64>();
         let actor = EchoActor(tx.bind());
-        let handle = proc.spawn_with_label::<EchoActor>("echo_no_perturb", actor);
+        let handle = proc.spawn(actor);
 
         // Wait for idle before sending the user message.
         handle

--- a/hyperactor/src/client.rs
+++ b/hyperactor/src/client.rs
@@ -104,7 +104,7 @@ impl Client {
         self.instance.child()
     }
 
-    /// Spawn an actor as this client's child.
+    /// Spawn a child actor with a fresh uid labeled from the actor type.
     pub fn spawn<A: Actor>(&self, actor: A) -> anyhow::Result<ActorHandle<A>> {
         self.instance.spawn(actor)
     }

--- a/hyperactor/src/endpoint.rs
+++ b/hyperactor/src/endpoint.rs
@@ -151,7 +151,7 @@ mod tests {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
-        let handle = proc.spawn_with_label("echo", EchoActor { tx: tx.bind() });
+        let handle = proc.spawn(EchoActor { tx: tx.bind() });
 
         Endpoint::post(&handle, &client, 123u64);
 

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -217,7 +217,7 @@ pub fn serve(
     Gateway::current().serve(addr)
 }
 
-/// Spawn a root actor with a fresh anonymous uid on the current proc.
+/// Spawn a root actor with a fresh uid labeled from the actor type on the current proc.
 pub fn spawn<A: Actor>(actor: A) -> ActorHandle<A> {
     Proc::current().spawn(actor)
 }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -4004,7 +4004,7 @@ mod tests {
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let client = proc.client("client");
 
-        let foo = proc.spawn_with_label("foo", Foo);
+        let foo = proc.spawn(Foo);
         let return_handle = foo.port::<Undeliverable<MessageEnvelope>>();
         let message = MessageEnvelope::new(
             foo.actor_addr().clone(),

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -972,7 +972,7 @@ impl Proc {
 
     /// Attach a mailbox to the proc as a child actor.
     pub fn attach_child(&self, parent_id: &ActorAddr) -> Result<Mailbox, anyhow::Error> {
-        let actor_id: ActorAddr = self.allocate_child_id(parent_id);
+        let actor_id: ActorAddr = self.allocate_anonymous_child_id(parent_id);
         Ok(self.bind_mailbox(actor_id))
     }
 
@@ -1002,9 +1002,9 @@ impl Proc {
         Ok((client, actor_ref, rx))
     }
 
-    /// Spawn a root actor with a fresh anonymous uid.
+    /// Spawn a root actor with a fresh uid labeled from the actor type.
     pub fn spawn<A: Actor>(&self, actor: A) -> ActorHandle<A> {
-        let actor_id: ActorAddr = self.allocate_root_anonymous();
+        let actor_id: ActorAddr = self.allocate_root_type::<A>();
         self.spawn_inner(actor_id, actor, None)
     }
 
@@ -1248,7 +1248,7 @@ impl Proc {
         &self,
         parent: InstanceCell,
     ) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
-        let actor_id = self.allocate_child_id(parent.actor_addr());
+        let actor_id = self.allocate_anonymous_child_id(parent.actor_addr());
         let _ = tracing::debug_span!(
             "child_actor_instance",
             subject = %actor_id.subject(),
@@ -1268,7 +1268,7 @@ impl Proc {
     /// When spawn_child returns, the child has an associated cell and is linked
     /// with its parent.
     pub(crate) fn spawn_child<A: Actor>(&self, parent: InstanceCell, actor: A) -> ActorHandle<A> {
-        let actor_id = self.allocate_child_id(parent.actor_addr());
+        let actor_id = self.allocate_child_id::<A>(parent.actor_addr());
         self.spawn_inner(actor_id, actor, Some(parent))
     }
 
@@ -1530,9 +1530,9 @@ impl Proc {
         self.reserve_root(Uid::singleton(Label::strip(name)))
     }
 
-    /// Create a root allocation with fresh anonymous identity.
-    fn allocate_root_anonymous(&self) -> ActorAddr {
-        self.root_addr(Uid::anonymous())
+    /// Create a root allocation with fresh identity and the actor type label.
+    fn allocate_root_type<A: Actor>(&self) -> ActorAddr {
+        self.root_addr(Uid::instance(default_actor_label::<A>()))
     }
 
     /// Create a root allocation with a display label and fresh identity.
@@ -1570,9 +1570,19 @@ impl Proc {
     }
 
     /// Create a child allocation in the proc.
-    pub(crate) fn allocate_child_id(&self, parent_id: &ActorAddr) -> ActorAddr {
+    pub(crate) fn allocate_anonymous_child_id(&self, parent_id: &ActorAddr) -> ActorAddr {
         assert_eq!(parent_id.proc_id(), self.proc_id());
-        parent_id.anonymous_child()
+        ActorAddr::new(
+            ActorId::anonymous(self.proc_id().clone()),
+            self.default_location(),
+        )
+    }
+
+    /// Create a child allocation in the proc using the actor type label.
+    pub(crate) fn allocate_child_id<A: Actor>(&self, parent_id: &ActorAddr) -> ActorAddr {
+        assert_eq!(parent_id.proc_id(), self.proc_id());
+        let actor_id = ActorId::instance(default_actor_label::<A>(), self.proc_id().clone());
+        ActorAddr::new(actor_id, self.default_location())
     }
 
     /// Ensure that the requested child uid is available in this proc.
@@ -1645,6 +1655,14 @@ fn requires_location_for_local_delivery_identity(proc_id: &ProcId) -> bool {
     // construction paths are assigned instance ids, local delivery for
     // those two ids must keep the old full-address comparison.
     is_legacy_pseudo_singleton_proc_id(proc_id)
+}
+
+fn default_actor_label<A>() -> Label {
+    let type_name = std::any::type_name::<A>();
+    let type_name = type_name
+        .split_once('<')
+        .map_or(type_name, |(base, _)| base);
+    Label::strip(type_name.rsplit("::").next().unwrap_or(type_name))
 }
 
 fn assert_not_legacy_pseudo_singleton_proc_id(proc_id: &ProcId) {
@@ -3207,7 +3225,7 @@ impl<A: Actor> Instance<A> {
         result
     }
 
-    /// Spawn on child on this instance.
+    /// Spawn a child actor with a fresh uid labeled from the actor type.
     pub fn spawn<C: Actor>(&self, actor: C) -> anyhow::Result<ActorHandle<C>> {
         Ok(self.inner.proc.spawn_child(self.inner.cell.clone(), actor))
     }
@@ -4434,6 +4452,63 @@ mod tests {
     }
 
     #[test]
+    fn test_default_actor_label_uses_label_compatible_type_basename() {
+        assert_eq!(default_actor_label::<TestActor>().as_str(), "testactor");
+        assert_eq!(
+            default_actor_label::<std::collections::HashMap<String, u64>>().as_str(),
+            "hashmap"
+        );
+        assert_eq!(default_actor_label::<()>().as_str(), "nil");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_spawn_uses_actor_type_label_for_root_actor() {
+        let proc = Proc::isolated();
+        let handle = proc.spawn(TestActor);
+
+        assert_eq!(
+            handle.actor_addr().label().map(Label::as_str),
+            Some("testactor")
+        );
+        assert!(matches!(
+            handle.actor_addr().uid(),
+            Uid::Instance(_, Some(label)) if label.as_str() == "testactor"
+        ));
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_spawn_uses_actor_type_label_for_child_actor() {
+        let proc = Proc::isolated();
+        let parent = proc.spawn(TestActor);
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DelayedSelfActor {
+                ready: None,
+                fired: None,
+                delay: Duration::from_secs(60),
+            },
+        );
+
+        assert!(!child.actor_addr().is_root());
+        assert_eq!(
+            child.actor_addr().label().map(Label::as_str),
+            Some("delayedselfactor")
+        );
+        assert!(matches!(
+            child.actor_addr().uid(),
+            Uid::Instance(_, Some(label)) if label.as_str() == "delayedselfactor"
+        ));
+
+        child.kill("test").unwrap();
+        child.await;
+        parent.drain_and_stop("test").unwrap();
+        parent.await;
+    }
+
+    #[test]
     fn test_current_proc_uses_stable_global_proc_outside_actor_context() {
         let first = Proc::current();
         let second = Proc::current();
@@ -4537,7 +4612,7 @@ mod tests {
             reply: oneshot::Sender<CurrentProcSnapshot>,
         ) -> Result<(), anyhow::Error> {
             let current = Proc::current();
-            let spawned_handle = crate::spawn_with_label("current_spawned", TestActor);
+            let spawned_handle = crate::spawn(TestActor);
             let client = crate::client("current_client");
             reply
                 .send(CurrentProcSnapshot {
@@ -4555,7 +4630,7 @@ mod tests {
     async fn test_current_proc_tracks_actor_context() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let actor = proc.spawn_with_label::<CurrentProcActor>("current", CurrentProcActor);
+        let actor = proc.spawn(CurrentProcActor);
         let (tx, rx) = oneshot::channel();
 
         crate::Endpoint::post(&actor, &client, CurrentProcMessage::Check(tx));
@@ -4595,7 +4670,7 @@ mod tests {
     async fn test_spawn_actor() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let handle = proc.spawn_with_label("test", TestActor);
+        let handle = proc.spawn(TestActor);
 
         // Check on the join handle.
         assert!(logs_contain(
@@ -5055,9 +5130,9 @@ mod tests {
         let proc = Proc::isolated();
         let client = proc.client("client");
 
-        let target_actor = proc.spawn_with_label::<TestActor>("target", TestActor);
+        let target_actor = proc.spawn(TestActor);
         let target_actor_ref = target_actor.bind();
-        let lookup_actor = proc.spawn_with_label::<LookupTestActor>("lookup", LookupTestActor);
+        let lookup_actor = proc.spawn(LookupTestActor);
 
         assert!(
             lookup_actor
@@ -5253,13 +5328,10 @@ mod tests {
         let proc = Proc::isolated();
         let stop_started = Arc::new(tokio::sync::Notify::new());
         let release_stop = Arc::new(tokio::sync::Notify::new());
-        let handle = proc.spawn_with_label(
-            "deferred_stop",
-            DeferredStopActor {
-                stop_started: Arc::clone(&stop_started),
-                release_stop: Arc::clone(&release_stop),
-            },
-        );
+        let handle = proc.spawn(DeferredStopActor {
+            stop_started: Arc::clone(&stop_started),
+            release_stop: Arc::clone(&release_stop),
+        });
 
         let mut status = handle.status();
         handle.stop("test").unwrap();
@@ -5279,13 +5351,10 @@ mod tests {
         let client = proc.client("client");
         let stop_started = Arc::new(tokio::sync::Notify::new());
         let release_stop = Arc::new(tokio::sync::Notify::new());
-        let handle = proc.spawn_with_label(
-            "deferred_drain_stop",
-            DeferredStopActor {
-                stop_started: Arc::clone(&stop_started),
-                release_stop: Arc::clone(&release_stop),
-            },
-        );
+        let handle = proc.spawn(DeferredStopActor {
+            stop_started: Arc::clone(&stop_started),
+            release_stop: Arc::clone(&release_stop),
+        });
 
         handle.drain_and_stop("test").unwrap();
         stop_started.notified().await;
@@ -5371,7 +5440,7 @@ mod tests {
         let proc = Proc::isolated();
         let state = Arc::new(AtomicUsize::new(0));
         let actor = TestActor(state.clone());
-        let handle = proc.spawn_with_label::<TestActor>("test", actor);
+        let handle = proc.spawn(actor);
         let client = proc.client("client");
         let (tx, rx) = client.open_once_port();
         handle.post(&client, tx);
@@ -5392,14 +5461,11 @@ mod tests {
         let (fired, fired_rx) = client.open_once_port();
         let delay = Duration::from_millis(50);
         let start = tokio::time::Instant::now();
-        let handle = proc.spawn_with_label(
-            "test",
-            DelayedSelfActor {
-                ready: Some(ready.bind()),
-                fired: Some(fired.bind()),
-                delay,
-            },
-        );
+        let handle = proc.spawn(DelayedSelfActor {
+            ready: Some(ready.bind()),
+            fired: Some(fired.bind()),
+            delay,
+        });
 
         ready_rx.recv().await.unwrap();
         fired_rx.recv().await.unwrap();
@@ -5416,13 +5482,10 @@ mod tests {
         let (reply, mut reply_rx) = client.open_port();
         let delay = Duration::from_millis(50);
         let start = tokio::time::Instant::now();
-        let handle = proc.spawn_with_label(
-            "test",
-            DelayedPortActor {
-                reply: Some(reply.bind()),
-                delay,
-            },
-        );
+        let handle = proc.spawn(DelayedPortActor {
+            reply: Some(reply.bind()),
+            delay,
+        });
 
         assert_eq!(reply_rx.recv().await.unwrap(), 123);
         assert!(start.elapsed() >= delay);
@@ -5436,14 +5499,11 @@ mod tests {
         let client = proc.client("client");
         let (ready, ready_rx) = client.open_once_port();
         let (fired, fired_rx) = client.open_once_port();
-        let handle = proc.spawn_with_label(
-            "test",
-            DelayedSelfActor {
-                ready: Some(ready.bind()),
-                fired: Some(fired.bind()),
-                delay: Duration::from_secs(60),
-            },
-        );
+        let handle = proc.spawn(DelayedSelfActor {
+            ready: Some(ready.bind()),
+            fired: Some(fired.bind()),
+            delay: Duration::from_secs(60),
+        });
 
         ready_rx.recv().await.unwrap();
         handle.drain_and_stop("test").unwrap();
@@ -5464,7 +5524,7 @@ mod tests {
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
         let client = proc.client("client");
-        let actor_handle = proc.spawn_with_label("test", TestActor);
+        let actor_handle = proc.spawn(TestActor);
         actor_handle
             .panic(&client, "some random failure".to_string())
             .await
@@ -5788,7 +5848,7 @@ mod tests {
     async fn test_mailbox_closed_with_owner_stopped_reason() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let actor_handle = proc.spawn_with_label("test", TestActor);
+        let actor_handle = proc.spawn(TestActor);
 
         // Clone the handle before awaiting since await consumes the handle
         let handle_for_send = actor_handle.clone();
@@ -5822,7 +5882,7 @@ mod tests {
         // be actor failure(s) in this test which trigger supervision.
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
-        let actor_handle = proc.spawn_with_label("test", TestActor);
+        let actor_handle = proc.spawn(TestActor);
 
         // Clone the handle before awaiting since await consumes the handle
         let handle_for_send = actor_handle.clone();
@@ -5888,7 +5948,7 @@ mod tests {
         let proc = Proc::isolated();
         let _client = proc.client("client");
 
-        let handle = proc.spawn_with_label::<TestActor>("actor", TestActor);
+        let handle = proc.spawn(TestActor);
         let actor_id = handle.actor_addr().clone();
 
         // Actor is live — no terminated snapshot yet.
@@ -5934,7 +5994,7 @@ mod tests {
         // Supervision coordinator required for actor failure handling.
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
-        let handle = proc.spawn_with_label::<TestActor>("fail_actor", TestActor);
+        let handle = proc.spawn(TestActor);
         let actor_id = handle.actor_addr().clone();
 
         // Trigger a failure.
@@ -5961,7 +6021,7 @@ mod tests {
         let client = proc.client("client");
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
-        let handle = proc.spawn_with_label::<TestActor>("fail_actor", TestActor);
+        let handle = proc.spawn(TestActor);
         let actor_id = handle.actor_addr().clone();
         let cell = handle.cell().clone();
 
@@ -5983,7 +6043,7 @@ mod tests {
         let proc = Proc::isolated();
         let _client = proc.client("client");
 
-        let handle = proc.spawn_with_label::<TestActor>("stop_actor", TestActor);
+        let handle = proc.spawn(TestActor);
         let cell = handle.cell().clone();
 
         handle.drain_and_stop("test").unwrap();
@@ -6007,7 +6067,7 @@ mod tests {
         let (mut reported_event, _coordinator_handle) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
-        let handle = proc.spawn_with_label::<TestActor>("stop_actor", TestActor);
+        let handle = proc.spawn(TestActor);
         let actor_id = handle.actor_addr().clone();
 
         handle.drain_and_stop("test").unwrap();
@@ -6107,7 +6167,7 @@ mod tests {
         let proc = Proc::isolated();
         let _client = proc.client("client");
 
-        let handle = proc.spawn_with_label::<TestActor>("target", TestActor);
+        let handle = proc.spawn(TestActor);
         let actor_ref: ActorRef<TestActor> = handle.bind();
 
         // Actor is live — resolve should succeed.
@@ -6134,7 +6194,7 @@ mod tests {
         let client = proc.client("client");
         ProcSupervisionCoordinator::set(&proc).await.unwrap();
 
-        let handle = proc.spawn_with_label::<TestActor>("fail_actor", TestActor);
+        let handle = proc.spawn(TestActor);
         let actor_id = handle.actor_addr().clone();
 
         handle.post(&client, TestActorMessage::Fail(anyhow::anyhow!("kaboom")));
@@ -6333,7 +6393,7 @@ mod tests {
         let proc = Proc::isolated();
         let _client = proc.client("client");
 
-        let handle = proc.spawn_with_label::<TestActor>("stop_actor", TestActor);
+        let handle = proc.spawn(TestActor);
         let actor_id = handle.actor_addr().clone();
 
         handle.drain_and_stop("test").unwrap();

--- a/hyperactor/src/testing/proc_supervison.rs
+++ b/hyperactor/src/testing/proc_supervison.rs
@@ -52,7 +52,7 @@ impl ProcSupervisionCoordinator {
             tx,
             last: last.clone(),
         };
-        let coordinator = proc.spawn_with_label::<ProcSupervisionCoordinator>("coordinator", actor);
+        let coordinator = proc.spawn(actor);
         proc.set_supervision_coordinator(coordinator.port())?;
         Ok((ReportedEvent { rx, last }, coordinator))
     }

--- a/hyperactor_macros/src/lib.rs
+++ b/hyperactor_macros/src/lib.rs
@@ -617,7 +617,7 @@ fn parse_messages(input: DeriveInput) -> Result<Vec<Message>, syn::Error> {
 /// async fn main() -> Result<(), anyhow::Error> {
 ///     // Spawn our actor on the current proc.
 ///     let shopping_list_actor: hyperactor::ActorHandle<ShoppingListActor> =
-///         hyperactor::spawn_with_label("shopping", ShoppingListActor::default())?;
+///         hyperactor::spawn(ShoppingListActor::default());
 ///     let client = hyperactor::client("client");
 ///
 ///     // todo: consider making this a macro to remove the magic names

--- a/hyperactor_macros/tests/basic.rs
+++ b/hyperactor_macros/tests/basic.rs
@@ -184,7 +184,7 @@ mod tests {
     async fn test_client_macros() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let actor_handle = proc.spawn_with_label("foo", TestVariantFormsActor {});
+        let actor_handle = proc.spawn(TestVariantFormsActor {});
 
         assert_eq!(actor_handle.call_struct(&client, 10).await.unwrap(), 10,);
 

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -149,7 +149,7 @@ mod tests {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
-        let actor_handle = proc.spawn_with_label("test", TestActor::new(tx.bind()));
+        let actor_handle = proc.spawn(TestActor::new(tx.bind()));
         //  This will call binds
         actor_handle.bind::<TestActor>();
         // Verify that the ports can be gotten successfully.
@@ -236,7 +236,7 @@ mod tests {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
-        let actor_handle = proc.spawn_with_label("test", TestActor::new(tx.bind()));
+        let actor_handle = proc.spawn(TestActor::new(tx.bind()));
 
         actor_handle.post(&client, 123u64);
         actor_handle.post(&client, TestMessage("foo".to_string()));
@@ -273,7 +273,7 @@ mod tests {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (tx, mut rx) = client.open_port();
-        let actor_handle = proc.spawn_with_label("generic", GenericActor::<u64>::new(tx.bind()));
+        let actor_handle = proc.spawn(GenericActor::<u64>::new(tx.bind()));
 
         actor_handle.bind::<GenericActor<u64>>();
 

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -2479,8 +2479,7 @@ mod tests {
         // Spawn the log client and disable aggregation (immediate
         // print + tap push).
         let log_client_actor = LogClientActor::new((), Flattrs::default()).await.unwrap();
-        let log_client: ActorRef<LogClientActor> =
-            proc.spawn_with_label("log_client", log_client_actor).bind();
+        let log_client: ActorRef<LogClientActor> = proc.spawn(log_client_actor).bind();
         log_client.set_aggregate(&client, None).await.unwrap();
 
         // Spawn the forwarder in this proc (it will serve
@@ -2488,9 +2487,7 @@ mod tests {
         let log_forwarder_actor = LogForwardActor::new(log_client.clone(), Flattrs::default())
             .await
             .unwrap();
-        let _log_forwarder: ActorRef<LogForwardActor> = proc
-            .spawn_with_label("log_forwarder", log_forwarder_actor)
-            .bind();
+        let _log_forwarder: ActorRef<LogForwardActor> = proc.spawn(log_forwarder_actor).bind();
 
         // Dial the channel but don't post until we know the forwarder
         // is receiving.

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -755,7 +755,7 @@ mod tests {
             .unwrap();
         let test_ref: ActorRef<TestActor> = test_handle.bind::<TestActor>();
 
-        let comm_handle = proc.spawn_with_label("comm", CommActor::default());
+        let comm_handle = proc.spawn(CommActor::default());
 
         (
             client,

--- a/hyperactor_mesh/src/connect.rs
+++ b/hyperactor_mesh/src/connect.rs
@@ -423,7 +423,7 @@ mod tests {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (connect, completer) = Connect::allocate(client.self_addr().clone(), client);
-        let actor = proc.spawn_with_label("actor", EchoActor {});
+        let actor = proc.spawn(EchoActor {});
         actor.post(&completer.caps, connect);
         let (mut rd, mut wr) = completer.complete().await?.into_split();
         let send = [3u8, 4u8, 5u8, 6u8];

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -2225,8 +2225,7 @@ mod tests {
 
         // Spawn a collector on the remote proc.
         let (undlv_tx, mut undlv_rx) = mpsc::unbounded_channel();
-        let handle =
-            remote_proc.spawn_with_label("collector", UndeliverableCollector { tx: undlv_tx });
+        let handle = remote_proc.spawn(UndeliverableCollector { tx: undlv_tx });
         let collector_ref = handle.bind::<UndeliverableCollector>();
 
         // Tell the collector to send to a nonexistent actor on the
@@ -2280,7 +2279,7 @@ mod tests {
         let (undlv_tx, mut undlv_rx) = mpsc::unbounded_channel();
         let handle = host
             .system_proc()
-            .spawn_with_label("collector", UndeliverableCollector { tx: undlv_tx });
+            .spawn(UndeliverableCollector { tx: undlv_tx });
         let collector_ref = handle.bind::<UndeliverableCollector>();
 
         // Tell the collector to send to a nonexistent actor on the
@@ -2381,9 +2380,7 @@ mod tests {
         let serve_handle = host.serve().unwrap();
 
         // Spawn an EchoActor and send a request from a simplex client.
-        let echo_handle = host
-            .system_proc()
-            .spawn_with_label::<EchoActor>("echo", EchoActor);
+        let echo_handle = host.system_proc().spawn(EchoActor);
         let echo_ref = echo_handle.bind::<EchoActor>();
 
         let dial_router = DialMailboxRouter::new();
@@ -2478,9 +2475,7 @@ mod tests {
         .unwrap();
         let serve_handle = host.serve().unwrap();
 
-        let echo_handle = host
-            .system_proc()
-            .spawn_with_label::<EchoActor>("echo", EchoActor);
+        let echo_handle = host.system_proc().spawn(EchoActor);
         let echo_ref = echo_handle.bind::<EchoActor>();
         let host_addr = host.addr().clone();
         let echo_actor_id = echo_ref.actor_addr().clone();
@@ -2557,9 +2552,7 @@ mod tests {
         let _serve_handle = host.serve().unwrap();
 
         // Spawn an EchoActor on the host's system_proc.
-        let echo_handle = host
-            .system_proc()
-            .spawn_with_label::<EchoActor>("echo", EchoActor);
+        let echo_handle = host.system_proc().spawn(EchoActor);
         let echo_ref = echo_handle.bind::<EchoActor>();
 
         // Create an external simplex client proc with a dial router

--- a/hyperactor_mesh/src/logging.rs
+++ b/hyperactor_mesh/src/logging.rs
@@ -1602,14 +1602,11 @@ mod tests {
             std::env::set_var(BOOTSTRAP_LOG_CHANNEL, log_channel.to_string());
         }
         let log_client_actor = LogClientActor::new((), Flattrs::default()).await.unwrap();
-        let log_client: ActorRef<LogClientActor> =
-            proc.spawn_with_label("log_client", log_client_actor).bind();
+        let log_client: ActorRef<LogClientActor> = proc.spawn(log_client_actor).bind();
         let log_forwarder_actor = LogForwardActor::new(log_client.clone(), Flattrs::default())
             .await
             .unwrap();
-        let log_forwarder: ActorRef<LogForwardActor> = proc
-            .spawn_with_label("log_forwarder", log_forwarder_actor)
-            .bind();
+        let log_forwarder: ActorRef<LogForwardActor> = proc.spawn(log_forwarder_actor).bind();
 
         // Write some logs that will not be streamed
         let tx: ChannelTx<LogMessage> = channel::dial(log_channel).unwrap();

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -1687,12 +1687,9 @@ mod tests {
 
         // Spawn a blocking actor with a shared gate.
         let gate = Arc::new(tokio::sync::Notify::new());
-        let blocker = proc.spawn_with_label(
-            "blocker",
-            BlockActor {
-                gate: Some(Arc::clone(&gate)),
-            },
-        );
+        let blocker = proc.spawn(BlockActor {
+            gate: Some(Arc::clone(&gate)),
+        });
 
         // Block the actor and queue additional work behind it.
         blocker.block(&client).await.unwrap();

--- a/hyperactor_mesh/test/host_bootstrap.rs
+++ b/hyperactor_mesh/test/host_bootstrap.rs
@@ -17,9 +17,7 @@ async fn main() {
     hyperactor_telemetry::initialize_logging(hyperactor_telemetry::DefaultTelemetryClock {});
 
     let proc = ProcessProcManager::<hyperactor_mesh::host::testing::EchoActor>::boot_proc(
-        |proc| async move {
-            Ok(proc.spawn_with_label("echo", hyperactor_mesh::host::testing::EchoActor))
-        },
+        |proc| async move { Ok(proc.spawn(hyperactor_mesh::host::testing::EchoActor)) },
     )
     .await
     .unwrap();

--- a/hyperactor_remote/example/token_supervision.rs
+++ b/hyperactor_remote/example/token_supervision.rs
@@ -191,18 +191,15 @@ async fn run_parent(args: ParentArgs) -> anyhow::Result<()> {
         ChannelAddr::any(ChannelTransport::Tcp(TcpMode::Localhost)),
         "token_supervision_parent".to_string(),
     )?;
-    let parent = proc.spawn_with_label(
-        "parent",
-        Parent {
-            token_file: args.token_file,
-            ready_file: args.ready_file,
-            event_file: args.event_file,
-            exit_after_link: args.exit_after_link,
-            keepalive_interval: args.keepalive_interval,
-            keepalive_timeout: args.keepalive_timeout,
-            supervisor: None,
-        },
-    );
+    let parent = proc.spawn(Parent {
+        token_file: args.token_file,
+        ready_file: args.ready_file,
+        event_file: args.event_file,
+        exit_after_link: args.exit_after_link,
+        keepalive_interval: args.keepalive_interval,
+        keepalive_timeout: args.keepalive_timeout,
+        supervisor: None,
+    });
     parent.await;
     println!("parent process exiting");
     Ok(())
@@ -215,12 +212,9 @@ async fn run_joiner(args: JoinerArgs) -> anyhow::Result<()> {
         "token_supervision_joiner".to_string(),
     )?;
     let joiner = proc.client("joiner");
-    let worker = proc.spawn_with_label(
-        "worker",
-        Worker::new(DemoChild {
-            stopped_file: args.stopped_file,
-        }),
-    );
+    let worker = proc.spawn(Worker::new(DemoChild {
+        stopped_file: args.stopped_file,
+    }));
     let (result_port, mut result_rx) = joiner.open_port::<token::JoinResult<ActorAddr>>();
 
     token.join(&joiner, worker.bind::<WorkerLike>(), result_port.bind())?;

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -541,13 +541,10 @@ mod tests {
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let supervisor =
             KeepaliveSupervisor::new(KeepaliveSupervisorParams::new(Duration::from_millis(10)));
-        let parent: ActorHandle<ParentActor> = proc.spawn_with_label(
-            "parent",
-            ParentActor {
-                spawn: Some(ParentSpawn::Supervisor(supervisor)),
-                events: events.bind(),
-            },
-        );
+        let parent: ActorHandle<ParentActor> = proc.spawn(ParentActor {
+            spawn: Some(ParentSpawn::Supervisor(supervisor)),
+            events: events.bind(),
+        });
 
         let event = event_rx.recv().await.unwrap();
 
@@ -599,7 +596,7 @@ mod tests {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
-        let supervisor = proc.spawn_with_label("silent_supervisor", SilentSupervisor);
+        let supervisor = proc.spawn(SilentSupervisor);
         let uid = Uid::anonymous();
         let link = KeepaliveWorkerParams::new(
             supervisor.port::<Keepalive>().bind(),
@@ -607,13 +604,10 @@ mod tests {
         )
         .link_spec_uid(uid.clone())
         .unwrap();
-        let parent: ActorHandle<ParentActor> = proc.spawn_with_label(
-            "parent",
-            ParentActor {
-                spawn: Some(ParentSpawn::Link(link)),
-                events: events.bind(),
-            },
-        );
+        let parent: ActorHandle<ParentActor> = proc.spawn(ParentActor {
+            spawn: Some(ParentSpawn::Link(link)),
+            events: events.bind(),
+        });
 
         let event = event_rx.recv().await.unwrap();
 

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -200,13 +200,10 @@ mod tests {
             uid.clone(),
             bincode::serde::encode_to_vec((), bincode::config::legacy()).unwrap(),
         );
-        let parent = proc.spawn_with_label(
-            "parent",
-            TestParentActor {
-                link: Some(link),
-                events: events.bind(),
-            },
-        );
+        let parent = proc.spawn(TestParentActor {
+            link: Some(link),
+            events: events.bind(),
+        });
 
         let event = event_rx.recv().await.unwrap();
 

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -725,26 +725,20 @@ mod tests {
         let (ready, mut ready_rx) = inst.open_port::<ActorAddr>();
         let (stopped, stopped_rx) = inst.open_port::<String>();
         let (events, events_rx) = inst.open_port::<ActorSupervisionEvent>();
-        let worker = proc.spawn_with_label(
-            "worker",
-            Worker::new(test_child(ready, stopped, child_action)),
-        );
+        let worker = proc.spawn(Worker::new(test_child(ready, stopped, child_action)));
         let child_addr = ready_rx.recv().await.unwrap();
         // Spawning Parent starts the link handshake: Parent::init
         // spawns the Supervisor whose own init sends `Link` to the
         // worker.
-        let parent = proc.spawn_with_label(
-            "parent",
-            Parent {
-                supervisor: Some(Supervisor::new_uid(
-                    worker.bind::<WorkerLike>(),
-                    KeepaliveLink::new(Duration::from_millis(5), Duration::from_secs(60)),
-                    options,
-                    session_id,
-                )),
-                events,
-            },
-        );
+        let parent = proc.spawn(Parent {
+            supervisor: Some(Supervisor::new_uid(
+                worker.bind::<WorkerLike>(),
+                KeepaliveLink::new(Duration::from_millis(5), Duration::from_secs(60)),
+                options,
+                session_id,
+            )),
+            events,
+        });
         (child_addr, worker, parent, stopped_rx, events_rx)
     }
 
@@ -914,7 +908,7 @@ mod tests {
         let (stopped, mut stopped_rx) = client.open_port::<String>();
         let (supervisor, mut supervisor_rx) = client.open_port::<WorkerSupervisor>();
         let supervisor_ref = supervisor.bind();
-        let worker = proc.spawn_with_label("worker", Worker::new(test_child(ready, stopped, None)));
+        let worker = proc.spawn(Worker::new(test_child(ready, stopped, None)));
         let (link_handle, link) =
             KeepaliveLink::new(Duration::from_secs(60), Duration::from_secs(60))
                 .spawn_supervisor(&client)
@@ -994,23 +988,20 @@ mod tests {
         let (stopped, mut stopped_rx) = client.open_port::<String>();
         let (events, mut event_rx) = client.open_port::<ActorSupervisionEvent>();
         let (parent_addr, mut parent_addr_rx) = client.open_port::<ActorAddr>();
-        let worker = proc.spawn_with_label("worker", Worker::new(test_child(ready, stopped, None)));
-        let grandparent = proc.spawn_with_label(
-            "grandparent",
-            Grandparent {
-                parent: Some(Parent {
-                    supervisor: Some(Supervisor::new(
-                        worker.bind::<WorkerLike>(),
-                        KeepaliveLink::new(Duration::from_millis(100), Duration::from_millis(300)),
-                        LinkOptions::default(),
-                    )),
-                    events: events.clone(),
-                }),
-                parent_addr,
-                parent_handle: None,
-                events,
-            },
-        );
+        let worker = proc.spawn(Worker::new(test_child(ready, stopped, None)));
+        let grandparent = proc.spawn(Grandparent {
+            parent: Some(Parent {
+                supervisor: Some(Supervisor::new(
+                    worker.bind::<WorkerLike>(),
+                    KeepaliveLink::new(Duration::from_millis(100), Duration::from_millis(300)),
+                    LinkOptions::default(),
+                )),
+                events: events.clone(),
+            }),
+            parent_addr,
+            parent_handle: None,
+            events,
+        });
         let _child_addr = ready_rx.recv().await.unwrap();
         let parent_addr = parent_addr_rx.recv().await.unwrap();
 
@@ -1063,7 +1054,7 @@ mod tests {
         let (stopped, mut stopped_rx) = inst.open_port::<String>();
         let (supervisor, mut supervisor_rx) = inst.open_port::<WorkerSupervisor>();
         let supervisor_ref = supervisor.bind();
-        let worker = proc.spawn_with_label("worker", Worker::new(test_child(ready, stopped, None)));
+        let worker = proc.spawn(Worker::new(test_child(ready, stopped, None)));
         let (keep_alive, link_spec) =
             KeepaliveLink::new(Duration::from_secs(60), Duration::from_secs(60))
                 .spawn_supervisor(&inst)
@@ -1447,28 +1438,22 @@ mod tests {
         let (received_stop, mut received_stop_rx) = inst.open_port::<String>();
         let (events, _events_rx) = inst.open_port::<ActorSupervisionEvent>();
         let release_link = Arc::new(Notify::new());
-        let worker = proc.spawn_with_label(
-            "worker",
-            TestSlowWorker {
-                link_started,
-                release_link: Arc::clone(&release_link),
-                received_stop,
-                session: None,
-            },
-        );
+        let worker = proc.spawn(TestSlowWorker {
+            link_started,
+            release_link: Arc::clone(&release_link),
+            received_stop,
+            session: None,
+        });
         let session_id = Uid::anonymous();
-        let parent = proc.spawn_with_label(
-            "parent",
-            Parent {
-                supervisor: Some(Supervisor::new_uid(
-                    worker.bind::<WorkerLike>(),
-                    KeepaliveLink::new(Duration::from_millis(5), Duration::from_secs(60)),
-                    LinkOptions::default(),
-                    session_id.clone(),
-                )),
-                events,
-            },
-        );
+        let parent = proc.spawn(Parent {
+            supervisor: Some(Supervisor::new_uid(
+                worker.bind::<WorkerLike>(),
+                KeepaliveLink::new(Duration::from_millis(5), Duration::from_secs(60)),
+                LinkOptions::default(),
+                session_id.clone(),
+            )),
+            events,
+        });
 
         // Observe Link receipt - worker is now blocked in Handler<Link>.
         tokio::time::timeout(Duration::from_secs(5), link_started_rx.recv())
@@ -1526,34 +1511,28 @@ mod tests {
         let (stopped, mut stopped_rx) = inst.open_port::<String>();
         let (drained, mut drained_rx) = inst.open_port::<String>();
         let (events, _events_rx) = inst.open_port::<ActorSupervisionEvent>();
-        let worker = proc.spawn_with_label(
-            "worker",
-            Worker::new(
-                test_child(
-                    ready,
-                    stopped,
-                    Some(TestChildAction::DrainAfter(
-                        Duration::from_millis(10),
-                        "child work".to_string(),
-                    )),
-                )
-                .with_drain_observer(drained),
-            ),
-        );
+        let worker = proc.spawn(Worker::new(
+            test_child(
+                ready,
+                stopped,
+                Some(TestChildAction::DrainAfter(
+                    Duration::from_millis(10),
+                    "child work".to_string(),
+                )),
+            )
+            .with_drain_observer(drained),
+        ));
         let _child_addr = ready_rx.recv().await.unwrap();
         let session_id = Uid::anonymous();
-        let parent = proc.spawn_with_label(
-            "parent",
-            Parent {
-                supervisor: Some(Supervisor::new_uid(
-                    worker.bind::<WorkerLike>(),
-                    KeepaliveLink::new(Duration::from_millis(5), Duration::from_secs(60)),
-                    LinkOptions::default(),
-                    session_id.clone(),
-                )),
-                events,
-            },
-        );
+        let parent = proc.spawn(Parent {
+            supervisor: Some(Supervisor::new_uid(
+                worker.bind::<WorkerLike>(),
+                KeepaliveLink::new(Duration::from_millis(5), Duration::from_secs(60)),
+                LinkOptions::default(),
+                session_id.clone(),
+            )),
+            events,
+        });
 
         // Wait for the self-scheduled child work.
         let drained_tag = tokio::time::timeout(Duration::from_secs(5), drained_rx.recv())

--- a/hyperactor_remote/src/token.rs
+++ b/hyperactor_remote/src/token.rs
@@ -649,7 +649,7 @@ mod tests {
     #[tokio::test]
     async fn test_token_serializes_as_single_base64_json_string() {
         let proc = Proc::isolated();
-        let rendezvous = proc.spawn_with_label("rendezvous", RendezvousStub);
+        let rendezvous = proc.spawn(RendezvousStub);
         let token = Token::<CreatorRef, JoinerRef>::new(
             rendezvous.bind::<RendezvousLike<CreatorRef, JoinerRef>>(),
         );
@@ -677,7 +677,7 @@ mod tests {
     #[tokio::test]
     async fn test_token_display_includes_compact_json_suffix() {
         let proc = Proc::isolated();
-        let rendezvous = proc.spawn_with_label("rendezvous", RendezvousStub);
+        let rendezvous = proc.spawn(RendezvousStub);
         let token = Token::<CreatorRef, JoinerRef>::new(
             rendezvous.bind::<RendezvousLike<CreatorRef, JoinerRef>>(),
         );
@@ -694,7 +694,7 @@ mod tests {
     #[tokio::test]
     async fn test_token_from_str_accepts_display_suffix() {
         let proc = Proc::isolated();
-        let rendezvous = proc.spawn_with_label("rendezvous", RendezvousStub);
+        let rendezvous = proc.spawn(RendezvousStub);
         let token = Token::<CreatorRef, JoinerRef>::new(
             rendezvous.bind::<RendezvousLike<CreatorRef, JoinerRef>>(),
         );
@@ -716,7 +716,7 @@ mod tests {
     #[tokio::test]
     async fn test_token_rejects_incompatible_type_parameters() {
         let proc = Proc::isolated();
-        let rendezvous = proc.spawn_with_label("rendezvous", RendezvousStub);
+        let rendezvous = proc.spawn(RendezvousStub);
         let token = Token::<CreatorRef, JoinerRef>::new(
             rendezvous.bind::<RendezvousLike<CreatorRef, JoinerRef>>(),
         );
@@ -746,7 +746,7 @@ mod tests {
     #[tokio::test]
     async fn test_token_from_str_rejects_mismatched_type_uris() {
         let proc = Proc::isolated();
-        let rendezvous = proc.spawn_with_label("rendezvous", RendezvousStub);
+        let rendezvous = proc.spawn(RendezvousStub);
         let token = Token::<CreatorRef, JoinerRef>::new(
             rendezvous.bind::<RendezvousLike<CreatorRef, JoinerRef>>(),
         );
@@ -766,13 +766,10 @@ mod tests {
         let (creator_joined, _creator_joined_rx) = inst.open_port::<Joined<JoinerRef>>();
         let (token_out, mut token_out_rx) = inst.open_port::<Token<CreatorRef, JoinerRef>>();
 
-        let creator_handle = proc.spawn_with_label(
-            "creator",
-            CreatorActor {
-                creator_joined,
-                token_out,
-            },
-        );
+        let creator_handle = proc.spawn(CreatorActor {
+            creator_joined,
+            token_out,
+        });
 
         let token = token_out_rx.recv().await.unwrap();
 

--- a/monarch_introspection_snapshot/src/integration.rs
+++ b/monarch_introspection_snapshot/src/integration.rs
@@ -139,7 +139,7 @@ pub fn start_periodic_snapshots(
     );
     let proc = cx.instance().proc();
     let actor = SnapshotCaptureActor::new(table_store, admin_ref, interval);
-    let handle = proc.spawn_with_label("snapshot_capture", actor);
+    let handle = proc.spawn(actor);
     // PT-3: first capture fires at spawn time.
     handle.post(cx, CaptureSnapshot);
     Ok(())

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -56,7 +56,7 @@
 //!     admin_ref,
 //!     Duration::from_secs(30),
 //! );
-//! proc.spawn_with_label("snapshot_capture", actor)?;
+//! proc.spawn(actor);
 //! // Actor is stopped by framework lifecycle on proc teardown.
 //! ```
 //!

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -485,17 +485,13 @@ mod tests {
         let mgr = MockManagerActor {
             inner: Arc::clone(&mgr_inner),
         };
-        let mgr_handle = proc.spawn_with_label::<MockManagerActor>("mgr", mgr);
+        let mgr_handle = proc.spawn(mgr);
         let processor = IbvProcessorActor::<MockManagerActor, MockQp>::new(
             mgr_handle,
             super::super::primitives::IbvConfig::default(),
             lru_capacity,
         );
-        let processor_handle = proc
-            .spawn_with_label::<IbvProcessorActor<MockManagerActor, MockQp>>(
-                "processor",
-                processor,
-            );
+        let processor_handle = proc.spawn(processor);
         Harness {
             client,
             processor: processor_handle,

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1700,7 +1700,7 @@ mod tests {
                 state: state.clone(),
                 response,
             };
-            let mock_handle = proc.spawn_with_label("mock", mock);
+            let mock_handle = proc.spawn(mock);
             let mock_ref = mock_handle.bind::<MockManager>();
             let qp_key = QpKey {
                 self_device: "mock0".into(),
@@ -1708,7 +1708,7 @@ mod tests {
                 other_device: "mock0".into(),
             };
             let initializer = QueuePairInitializer::new(mock_handle, mock_ref, qp_key.clone(), qp);
-            let init_handle = proc.spawn_with_label("initializer", initializer);
+            let init_handle = proc.spawn(initializer);
             // Bind well-known ports so PeerInfo/NotifyRts can route.
             let _ = init_handle.bind::<QueuePairInitializer<MockManager>>();
             Ok(Harness {

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -570,11 +570,11 @@ impl IbvTestEnv {
         let instance_2 = proc_2.client("client");
 
         let rdma_actor_1 = RdmaManagerActor::new(Some(config1), Flattrs::default()).await?;
-        let rdma_actor_handle_1 = proc_1.spawn_with_label("rdma_manager", rdma_actor_1);
+        let rdma_actor_handle_1 = proc_1.spawn(rdma_actor_1);
         let actor_1: ActorRef<RdmaManagerActor> = rdma_actor_handle_1.bind();
 
         let rdma_actor_2 = RdmaManagerActor::new(Some(config2), Flattrs::default()).await?;
-        let rdma_actor_handle_2 = proc_2.spawn_with_label("rdma_manager", rdma_actor_2);
+        let rdma_actor_handle_2 = proc_2.spawn(rdma_actor_2);
         let actor_2: ActorRef<RdmaManagerActor> = rdma_actor_handle_2.bind();
 
         let mut buf_vec = Vec::new();
@@ -612,7 +612,7 @@ impl IbvTestEnv {
         } else {
             // CUDA case - spawn CudaActor on the same proc
             let cuda_actor = CudaActor::new(parsed_accel1.1 as i32, Flattrs::default()).await?;
-            let cuda_handle = proc_1.spawn_with_label("cuda_init", cuda_actor);
+            let cuda_handle = proc_1.spawn(cuda_actor);
             let cuda_actor_ref_1: ActorRef<CudaActor> = cuda_handle.bind();
 
             let (rdma_buf, dev_ptr) = cuda_actor_ref_1
@@ -659,7 +659,7 @@ impl IbvTestEnv {
         } else {
             // CUDA case - spawn CudaActor on the same proc
             let cuda_actor = CudaActor::new(parsed_accel2.1 as i32, Flattrs::default()).await?;
-            let cuda_handle = proc_2.spawn_with_label("cuda_init", cuda_actor);
+            let cuda_handle = proc_2.spawn(cuda_actor);
             let cuda_actor_ref_2: ActorRef<CudaActor> = cuda_handle.bind();
 
             let (rdma_buf, dev_ptr) = cuda_actor_ref_2

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -1001,7 +1001,7 @@ mod tests {
             let instance = proc.client("client");
 
             let rdma_actor = RdmaManagerActor::new(None, Flattrs::default()).await?;
-            let rdma_handle = proc.spawn_with_label("rdma_manager", rdma_actor);
+            let rdma_handle = proc.spawn(rdma_actor);
 
             let tcp_ref = rdma_handle.get_tcp_actor_ref(&instance).await?;
             let tcp_backend = TcpBackend(
@@ -1591,7 +1591,7 @@ mod tests {
             let instance = proc.client("client");
 
             let rdma_actor = RdmaManagerActor::new(None, Flattrs::default()).await?;
-            let rdma_handle = proc.spawn_with_label("rdma_manager", rdma_actor);
+            let rdma_handle = proc.spawn(rdma_actor);
 
             let tcp_ref = rdma_handle.get_tcp_actor_ref(&instance).await?;
             let tcp_backend = TcpBackend(

--- a/monarch_tensor_worker/src/borrow.rs
+++ b/monarch_tensor_worker/src/borrow.rs
@@ -199,8 +199,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label::<WorkerActor>(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,
@@ -352,8 +351,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label::<WorkerActor>(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,

--- a/monarch_tensor_worker/src/comm.rs
+++ b/monarch_tensor_worker/src/comm.rs
@@ -1024,8 +1024,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let handle = proc.spawn_with_label(
-            "worker",
+        let handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -1134,8 +1134,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,
@@ -1241,8 +1240,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,
@@ -1302,8 +1300,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,
@@ -1374,8 +1371,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,
@@ -1451,8 +1447,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,
@@ -1751,8 +1746,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, _) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,
@@ -1827,8 +1821,7 @@ mod tests {
         let proc = Proc::isolated();
         let (client, controller_ref, mut controller_rx) = proc.attach_actor("controller").unwrap();
 
-        let worker_handle = proc.spawn_with_label(
-            "worker",
+        let worker_handle = proc.spawn(
             WorkerActor::new(
                 WorkerParams {
                     world_size: 1,

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -1976,18 +1976,15 @@ mod tests {
             let client = proc.client("client");
             let (supervision_tx, supervision_rx) = client.open_port();
             proc.set_supervision_coordinator(supervision_tx)?;
-            let stream_actor = proc.spawn_with_label(
-                "stream",
-                StreamActor::new(StreamParams {
-                    world_size,
-                    rank: 0,
-                    creation_mode: StreamCreationMode::UseDefaultStream,
-                    id: 0.into(),
-                    device: Some(CudaDevice::new(0.into())),
-                    controller_actor: controller_actor.clone(),
-                    respond_with_python_message: false,
-                }),
-            );
+            let stream_actor = proc.spawn(StreamActor::new(StreamParams {
+                world_size,
+                rank: 0,
+                creation_mode: StreamCreationMode::UseDefaultStream,
+                id: 0.into(),
+                device: Some(CudaDevice::new(0.into())),
+                controller_actor: controller_actor.clone(),
+                respond_with_python_message: false,
+            }));
 
             Ok(Self {
                 proc,
@@ -2447,8 +2444,7 @@ mod tests {
             .define_recording(&test_setup.client, 0.into())
             .await?;
 
-        let dummy_comm = test_setup.proc.spawn_with_label(
-            "comm",
+        let dummy_comm = test_setup.proc.spawn(
             NcclCommActor::new(CommParams::New {
                 device: CudaDevice::new(0.into()),
                 unique_id: UniqueId::new_nccl()?,


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3983
* #3982
* #3981
* #3980
* #3979
* #3978
* #3974
* #3965
* #3964
* #3963
* #3962
* #3961
* #3960

Change Proc::spawn and child spawn to allocate fresh instance ids with a default label derived from the actor type basename. The basename is sanitized through Label::strip, so generic paths and symbols remain label-compatible. Update call sites that supplied labels already conveyed by the actor type to use spawn directly, while preserving explicit labels that encode roles, ranks, dynamic identities, or test assertions.

Differential Revision: [D105856439](https://our.internmc.facebook.com/intern/diff/D105856439/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105856439/)!