### PR TITLE
monarch examples: pass use_case="example" to MAST helpers

### DIFF
--- a/examples/rdma_pingpong/rdma_pingpong.py
+++ b/examples/rdma_pingpong/rdma_pingpong.py
@@ -133,6 +133,7 @@ def main(
             useStrictName=True,
             localityConstraints=["region", "gtn"],
             default_transport=ChannelTransport.MetaTlsWithIpV6,
+            use_case="example",
         )
         job.add_mesh("workers", 2)
     elif backend == "k8s":

--- a/examples/remotemount/remoterun.py
+++ b/examples/remotemount/remoterun.py
@@ -76,6 +76,7 @@ def _get_mast_host_mesh(
             "RUST_LOG": "info",
         },
         default_transport=ChannelTransport.MetaTlsWithIpV6,
+        use_case="example",
     )
     t3 = time.time()
     job.add_mesh("workers", num_hosts, host_type=host_type)


### PR DESCRIPTION
Summary: Sweeps `fbcode/monarch/examples/` and adds `use_case="example"` to every direct `MASTJob(...)` constructor and `hyperactor.host_mesh_conda(...)` call. The parameter already existed on `MASTJob.__init__`, `hyperactor.host_mesh`, and `hyperactor.host_mesh_conda`; this just labels these workloads consistently for attribution-tag purposes. `MASTJob.from_torchx(...)` does not accept `use_case`, so those call sites are intentionally left untouched. `examples/meta/tbd/video_processing/mast.py` and `examples/meta/hello_mast_job.py` were already set and are unchanged.

Differential Revision: D105849963


