### PR TITLE
[monarch] Fix pyre-ignore[15] placement for async __cleanup__ override

### DIFF
--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1861,9 +1861,9 @@ class ActorWithAsyncCleanup(Actor):
     async def check(self) -> None:
         pass
 
-    # Cleanup should match the async-ness of the other endpoints.
-    # pyre-ignore[15]: intentionally overrides the sync base with `async def`
+    # Cleanup should match the async-ness of the other endpoints,
     # to exercise the async `__cleanup__` dispatch path.
+    # pyre-ignore[15]: intentionally overrides the sync base with `async def`
     async def __cleanup__(self, exc: Exception | None):
         self.logger.info(f"Calling __cleanup__ on {self}, {exc=}")
         await self.counter.incr.call_one()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #3999

The pyre-ignore[15] comment in test_python_actors.py was separated from the async def __cleanup__ line by an intervening comment line, so Pyre did not apply the suppression. This caused a type error: 'Method __cleanup__ overrides class Actor in an incompatible manner'. Fix by moving pyre-ignore[15] to be the line immediately before the async def

Differential Revision: [D105887402](https://our.internmc.facebook.com/intern/diff/D105887402/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105887402/)!