### PR TITLE
make glog.rs logging single line

### DIFF
--- a/hyperactor_telemetry/src/sinks/glog.rs
+++ b/hyperactor_telemetry/src/sinks/glog.rs
@@ -210,17 +210,9 @@ impl GlogSink {
                     write!(&mut self.line_buffer, "event")?;
                 }
 
-                let max_key_len = fields
-                    .iter()
-                    .filter(|(k, _)| *k != "message" && *k != crate::SUBJECT_KEY)
-                    .map(|(k, _)| k.len())
-                    .max()
-                    .unwrap_or(0);
-
                 for (k, v) in fields.iter() {
                     if *k != "message" && *k != crate::SUBJECT_KEY {
-                        let pad = max_key_len - k.len() + 1;
-                        write!(&mut self.line_buffer, "\n    {k}:{:pad$}", "")?;
+                        write!(&mut self.line_buffer, ", {k}: ")?;
                         match v {
                             FieldValue::Bool(b) => write!(&mut self.line_buffer, "{}", b)?,
                             FieldValue::I64(i) => write!(&mut self.line_buffer, "{}", i)?,


### PR DESCRIPTION
Summary:
Reformat GlogSink event output as a single line: emit each non-message field as `, key: value` after the message instead of writing each field on its own indented line with aligned padding. Single-line output makes log lines greppable and easier to process with standard text tools at the cost of some human readability.

Closes T272341970.

Differential Revision: D105904605


