### PR TITLE
monarch: drop "early development" warnings from README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,6 @@ The
 [introduction to monarch concepts](https://meta-pytorch.org/monarch/generated/examples/getting_started.html)
 provides an introduction to using these features.
 
-> ⚠️ **Early Development Warning** Monarch is currently in an experimental
-> stage. You should expect bugs, incomplete features, and APIs that may change
-> in future versions. The project welcomes bugfixes, but to make sure things are
-> well coordinated you should discuss any significant change before starting the
-> work. It's recommended that you signal your intention to contribute in the
-> issue tracker, either by filing a new issue or by claiming an existing one.
-
 ## 📖 Documentation
 
 View Monarch's hosted documentation

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -31,13 +31,6 @@ Monarch code imperatively describes how to create processes and actors using a s
     # wait for all trainers to complete
     fut.get()
 
-> ⚠️ **Early Development Warning** Monarch is currently in an experimental
-> stage. You should expect bugs, incomplete features, and APIs that may change
-> in future versions. The project welcomes bugfixes, but to make sure things are
-> well coordinated you should discuss any significant change before starting the
-> work. It's recommended that you signal your intention to contribute in the
-> issue tracker, either by filing a new issue or by claiming an existing one.
-
 Note: Monarch is currently only supported on Linux systems
 
 ## Getting Started

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -28,5 +28,4 @@ If you encounter issues:
 - Check that you're using a compatible version of PyTorch
 - Verify that all dependencies are installed correctly
 - Consult the [GitHub repository](https://github.com/meta-pytorch/monarch) for known issues
-
-Remember that Monarch is currently in an experimental stage, so you may encounter bugs or incomplete features. Contributions and bug reports are welcome!
+- If you don't find an existing issue that matches, please [file a new one](https://github.com/meta-pytorch/monarch/issues/new)

--- a/docs/source/monarch-dashboard.md
+++ b/docs/source/monarch-dashboard.md
@@ -6,8 +6,8 @@ full mesh topology — hosts, processes, actor meshes, and individual actors —
 interactive views with live-updating metrics, message traffic analysis, and a
 full DAG visualization.
 
-> **Beta** — The Monarch Dashboard is in early development. Features may
-> change and rough edges are expected. Feedback is welcome!
+> **Note** — The Monarch Dashboard is in early development and may change
+> significantly between releases.
 
 The dashboard is included in the `torchmonarch` PyPI package. When you call
 `start_telemetry(include_dashboard=True)`, it starts a local web server that


### PR DESCRIPTION
Summary: Monarch is no longer in the early-experimental phase advertised by the warning banners. Remove the "Early Development Warning" blockquote from the top-level `README.md` and from `docs/source/index.md`, and drop the trailing "experimental stage" sentence from `docs/source/installation.md`. The Monarch Dashboard is still pre-1.0, so keep a note on `docs/source/monarch-dashboard.md` but scope it to the dashboard and shorten it to a single sentence about API churn between releases.

Differential Revision: D105952963


