### PR TITLE
[monarch] Fix Pyright error for async __cleanup__ override in test

### DIFF
--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1861,10 +1861,9 @@ class ActorWithAsyncCleanup(Actor):
     async def check(self) -> None:
         pass
 
-    # Cleanup should match the async-ness of the other endpoints,
+    # Cleanup should match the async-ness of the other endpoints
     # to exercise the async `__cleanup__` dispatch path.
-    # pyre-ignore[15]: intentionally overrides the sync base with `async def`
-    async def __cleanup__(self, exc: Exception | None):
+    async def __cleanup__(self, exc: Exception | None):  # type: ignore[override]
         self.logger.info(f"Calling __cleanup__ on {self}, {exc=}")
         await self.counter.incr.call_one()
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4011

The CI type checker is Pyright (not Pyre), so the # pyre-ignore[15] suppression added in D105887402 has no effect. Pyright reports reportIncompatibleMethodOverride because the async def __cleanup__ override returns CoroutineType instead of None. Fix by replacing pyre-ignore with # type: ignore[override], which Pyright respects.

Differential Revision: [D105975678](https://our.internmc.facebook.com/intern/diff/D105975678/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D105975678/)!