### PR TITLE
Add `pub fn try_post` to `PortHandle` and `ActorHandle` (#4012)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -782,6 +782,20 @@ impl<A: Actor> ActorHandle<A> {
         self.ports.get()
     }
 
+    /// Post `message` to this actor's handler port for `M`, returning an error
+    /// if delivery fails (the actor has stopped, its mailbox is closed, or the
+    /// underlying channel is disconnected). Unlike [`Endpoint::post`], the
+    /// caller observes the failure instead of having it reported through the
+    /// actor's lost-message channel.
+    pub fn try_post<C, M>(&self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    where
+        C: context::Actor,
+        M: Message,
+        A: Handler<M>,
+    {
+        self.ports.get::<M>().try_post(cx, message)
+    }
+
     /// TEMPORARY: bind...
     /// TODO: we shoudl also have a default binding(?)
     pub fn bind<R: Binds<A>>(&self) -> ActorRef<R> {

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2023,7 +2023,12 @@ impl<M: Message> PortHandle<M> {
         }
     }
 
-    pub(crate) fn try_send<C>(&self, cx: &C, message: M) -> Result<(), MailboxSenderError>
+    /// Post `message` to this port, returning an error if delivery fails (the
+    /// port is closed, its owner has terminated, or its underlying channel is
+    /// disconnected). Unlike [`Endpoint::post`], the caller observes the
+    /// failure instead of having it reported through the actor's lost-message
+    /// channel.
+    pub fn try_post<C>(&self, cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,
     {
@@ -2091,7 +2096,7 @@ where
     where
         C: context::Actor,
     {
-        if let Err(err) = self.try_send(cx, message) {
+        if let Err(err) = self.try_post(cx, message) {
             cx.instance()
                 .report_lost_message(LostMessage::from_send_error::<M>(
                     cx.mailbox().actor_addr().clone(),
@@ -2193,17 +2198,12 @@ impl<M: Message> OncePortHandle<M> {
     pub fn port_addr(&self) -> &PortAddr {
         &self.port_id
     }
-}
 
-impl<M> Endpoint<M> for OncePortHandle<M>
-where
-    M: Message,
-{
-    fn endpoint_location(&self) -> EndpointLocation {
-        EndpointLocation::Port(self.port_id.clone())
-    }
-
-    fn post<C>(self, _cx: &C, message: M)
+    /// Post `message` to this port, returning an error if delivery fails (the
+    /// receiver has been dropped). Unlike [`Endpoint::post`], the caller
+    /// observes the failure instead of having it reported through the actor's
+    /// lost-message channel.
+    pub fn try_post<C>(self, _cx: &C, message: M) -> Result<(), MailboxSenderError>
     where
         C: context::Actor,
     {
@@ -2217,17 +2217,33 @@ where
         );
 
         let actor_id = self.mailbox.actor_addr().clone();
-        let endpoint_location = self.endpoint_location();
-        if let Err(err) = self.sender.send(message).map_err(|_| {
+        self.sender.send(message).map_err(|_| {
             // Here, the value is returned when the port is
             // closed.  We should consider having a similar
             // API for send_once, though arguably it makes less
             // sense in this context.
             MailboxSenderError::new_unbound::<M>(actor_id, MailboxSenderErrorKind::Closed)
-        }) {
-            _cx.instance()
+        })
+    }
+}
+
+impl<M> Endpoint<M> for OncePortHandle<M>
+where
+    M: Message,
+{
+    fn endpoint_location(&self) -> EndpointLocation {
+        EndpointLocation::Port(self.port_id.clone())
+    }
+
+    fn post<C>(self, cx: &C, message: M)
+    where
+        C: context::Actor,
+    {
+        let endpoint_location = self.endpoint_location();
+        if let Err(err) = self.try_post(cx, message) {
+            cx.instance()
                 .report_lost_message(LostMessage::from_send_error::<M>(
-                    _cx.mailbox().actor_addr().clone(),
+                    cx.mailbox().actor_addr().clone(),
                     endpoint_location,
                     &err,
                 ));
@@ -4948,7 +4964,7 @@ mod tests {
 
         mailbox.close(ActorStatus::Stopped("test stop".to_string()));
 
-        let err = port_handle.try_send(&client, 42u64).unwrap_err();
+        let err = port_handle.try_post(&client, 42u64).unwrap_err();
         assert_matches!(
             err.kind(),
             MailboxSenderErrorKind::Mailbox(mailbox_err)
@@ -4972,7 +4988,7 @@ mod tests {
             "test failure".to_string(),
         )));
 
-        let err = port_handle.try_send(&client, 42u64).unwrap_err();
+        let err = port_handle.try_post(&client, 42u64).unwrap_err();
         assert_matches!(
             err.kind(),
             MailboxSenderErrorKind::Mailbox(mailbox_err)

--- a/hyperactor/src/mailbox/undeliverable.rs
+++ b/hyperactor/src/mailbox/undeliverable.rs
@@ -232,7 +232,7 @@ pub(crate) fn return_undeliverable(
             .0;
         let envelope_copy = envelope.clone();
         if return_handle
-            .try_send(client, Undeliverable::message(envelope))
+            .try_post(client, Undeliverable::message(envelope))
             .is_err()
         {
             UndeliverableMailboxSender.post(envelope_copy, /*unused*/ return_handle)

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2311,7 +2311,7 @@ impl<A: Actor> Instance<A> {
         });
 
         if let Err(error) =
-            return_handle.try_send(self, crate::mailbox::Undeliverable::lost(lost.clone()))
+            return_handle.try_post(self, crate::mailbox::Undeliverable::lost(lost.clone()))
         {
             tracing::error!(
                 sender = %lost.sender,
@@ -5037,7 +5037,7 @@ mod tests {
             assert!(
                 actor
                     .port::<TestActorMessage>()
-                    .try_send(&client, TestActorMessage::Noop())
+                    .try_post(&client, TestActorMessage::Noop())
                     .is_err()
             );
             assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
@@ -5129,7 +5129,7 @@ mod tests {
 
         // Drain closes runtime-dispatched handler ingress, so new
         // sends to the actor's handler port are rejected.
-        let err = handle.port::<()>().try_send(&client, ()).unwrap_err();
+        let err = handle.port::<()>().try_post(&client, ()).unwrap_err();
         assert_matches!(err.kind(), crate::mailbox::MailboxSenderErrorKind::Closed);
 
         release_stop.notify_one();
@@ -5652,7 +5652,7 @@ mod tests {
         // Try to send a message to the stopped actor
         let result = handle_for_send
             .port::<TestActorMessage>()
-            .try_send(&client, TestActorMessage::Noop());
+            .try_post(&client, TestActorMessage::Noop());
 
         assert!(result.is_err(), "send should fail when actor is stopped");
         let err = result.unwrap_err();
@@ -5689,7 +5689,7 @@ mod tests {
         // Try to send a message to the failed actor
         let result = handle_for_send
             .port::<TestActorMessage>()
-            .try_send(&client, TestActorMessage::Noop());
+            .try_post(&client, TestActorMessage::Noop());
 
         assert!(result.is_err(), "send should fail when actor has failed");
         let err = result.unwrap_err();


### PR DESCRIPTION
Summary:

Recover some functionality that was lost with the introduction of the `Endpoint` trait. `try_post` allows callers who send messages to handles to observe delivery errors inline rather than waiting for those errors to be propagated asynchronously (and with less context).

Reviewed By: mariusae

Differential Revision: D105991287


