### PR TITLE
monarch: bump Development Status classifier from Alpha to Beta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ authors = [
     {name = "Meta", email = "oncall+monarch@xmail.facebook.com"}
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Operating System :: POSIX :: Linux",


### PR DESCRIPTION
Summary:
Now that the "early development" warning banners are gone from `README.md` and the docs (D105952963), bump the PyPI Trove classifier in `pyproject.toml` from `Development Status :: 3 - Alpha` to `Development Status :: 4 - Beta`. This matches Monarch's current posture — past the experimental phase, but not yet promising a stable API. The other language classifiers (full `Python :: 3.x` ladder and `Rust`) match the convention used by other Python+Rust PyPI packages and stay as-is.

Reference: PyPI Trove classifier list at https://pypi.org/classifiers/ ("Development Status" section).

___

Differential Revision: D105993645


