### PR TITLE
Separate type checking in CI from tests (#4032)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,17 @@ jobs:
     with:
       artifact-name: monarch-cpu-${{ github.sha }}-py3.10
 
+  # Runs pyright as its own check so type errors surface as a separate
+  # signal. This job is intentionally omitted from status-check.needs so type
+  # failures never gate test results or merging.
+  type-check-python:
+    name: Type Check Python
+    if: ${{ !startsWith(github.ref, 'refs/tags/ciflow/rocm/') }}
+    needs: build-cpu
+    uses: ./.github/workflows/type-check-python.yml
+    with:
+      artifact-name: monarch-cpu-${{ github.sha }}-py3.10
+
   test-gpu-python:
     name: Test GPU Python
     needs: build-gpu

--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -54,10 +54,6 @@ jobs:
         # Install the built wheel from artifact
         install_wheel_from_artifact
 
-        # tests the type_assert statements in test_python_actor are correct
-        # pyre currently does not check these assertions
-        pyright python/tests/test_python_actors.py
-
         # run_test_groups disables errexit internally and leaks `set +e`,
         # so capture its exit code before `stage_test_artifacts` runs;
         # otherwise stage_test_artifacts's exit 0 masks a test failure.

--- a/.github/workflows/type-check-python.yml
+++ b/.github/workflows/type-check-python.yml
@@ -1,0 +1,50 @@
+name: Type Check Python
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Wheel artifact name from build workflow'
+        required: true
+        type: string
+      python-version:
+        description: 'Python version to type-check with'
+        type: string
+        default: '3.10'
+      runner:
+        description: 'Linux runner to use for type checking (small by default; bump if pyright OOMs indexing torch)'
+        type: string
+        default: 'linux.large'
+
+concurrency:
+  group: type-check-python-${{ inputs.runner }}-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  type-check-python:
+    name: Type Check Python (pyright)
+    uses: pytorch/test-infra/.github/workflows/linux_job_v2.yml@main
+    with:
+      timeout: 30
+      runner: ${{ inputs.runner }}
+      submodules: recursive
+      download-artifact: ${{ inputs.artifact-name }}
+      script: |
+        # Source common setup functions
+        source scripts/common-setup.sh
+
+        # Setup Python environment with the same dependencies as test jobs.
+        setup_test_environment "${{ inputs.python-version }}"
+
+        # Disable tensor engine for CPU wheel
+        export USE_TENSOR_ENGINE=0
+
+        # Install PyTorch nightly (CPU) so monarch imports resolve for pyright
+        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+
+        # Install the built wheel from artifact
+        install_wheel_from_artifact
+
+        # Type-check the type_assert statements in test_python_actors;
+        # pyre currently does not check these assertions.
+        pyright python/tests/test_python_actors.py


### PR DESCRIPTION
Summary:

In the case where type checking fails, we don't want to hide all other CI signal.
Separate into a second job. Host this job on a smaller runner machine so it's easier
to schedule fast. It doesn't need the tensor engine or GPU setup to typecheck the python
parts correctly.

Reviewed By: pzhan9

Differential Revision: D105984796


