### PR TITLE
wire QueuePairActor into IbvManagerActor + tests

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -34,6 +34,7 @@
 //! `Failed(error)` as a tombstone after a fatal error.
 
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -53,6 +54,8 @@ use hyperactor::HandleClient;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortHandle;
+use hyperactor::OncePortRef;
+use hyperactor::PortHandle;
 use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::actor::Referable;
@@ -72,10 +75,13 @@ use super::primitives::ibverbs_supported;
 use super::primitives::mlx5dv_supported;
 use super::primitives::resolve_qp_type;
 use super::queue_pair::IbvQueuePair;
+use super::queue_pair::OpResult;
 use super::queue_pair::PeerInfo;
 use super::queue_pair::PollTarget;
+use super::queue_pair::ProcessOps;
 use super::queue_pair::QpGuard;
 use super::queue_pair::QpKey;
+use super::queue_pair::QueuePairActor;
 use super::queue_pair::QueuePairInitializer;
 use super::queue_pair::destroy_qp;
 use crate::RdmaOp;
@@ -88,6 +94,10 @@ use crate::rdma_manager_actor::GetIbvActorRefClient;
 use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::validate_execution_context;
 
+// DEPRECATED — replaced by [`CreatePeerQueuePair`] + [`QueuePairActor`].
+// Kept only so [`QueuePairInitializer`] still compiles; the handler
+// on [`IbvManagerActor`] will be removed in a follow-up diff together
+// with the rest of the legacy QP machinery.
 /// Cross-proc message: peer asks for our endpoint, lazily creating
 /// the entry on our side if absent. Generic over the manager actor
 /// type so tests can swap in a mock.
@@ -101,6 +111,46 @@ pub(super) struct EnsureQueuePair<A: Referable> {
 }
 wirevalue::register_type!(EnsureQueuePair<IbvManagerActor>);
 
+/// Cross-proc message: the active side asks the peer's manager to
+/// create and connect a mirror QP for an in-flight [`QueuePairActor`].
+/// Generic over the manager actor type so test code can swap in a
+/// mock.
+#[derive(Debug, Serialize, Deserialize, Named)]
+#[serde(bound(serialize = "", deserialize = ""))]
+pub(super) struct CreatePeerQueuePair<M: Referable> {
+    /// The active side's manager.
+    pub(super) sender: ActorRef<M>,
+    /// Device the active side picked for its QP.
+    pub(super) sender_device: String,
+    /// Device the peer should create its mirror QP on.
+    pub(super) receiver_device: String,
+    /// Active side's endpoint, captured right after QP creation.
+    pub(super) sender_info: IbvQpInfo,
+    /// One-shot reply carrying the peer's endpoint, or an error.
+    pub(super) reply: OncePortRef<Result<IbvQpInfo, String>>,
+}
+wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor>);
+
+/// Local-only message: submit a batch of RDMA ops for end-to-end
+/// execution. The manager iterates the batch, resolves each op's
+/// local MR via [`IbvManagerActor::resolve_local_mr`], looks up
+/// (or spawns) the active-side [`QueuePairActor`] for the op's
+/// [`QpKey`], and immediately dispatches a one-item [`ProcessOps`]
+/// to that QP — so the QP can start posting op `i` while the
+/// manager resolves the MR for op `i+1`.
+///
+/// Per-op completion notifications stream back on `reply` as
+/// [`OpResult`] values.
+pub(super) struct SubmitOps {
+    pub(super) ops: Vec<IbvOp<IbvManagerActor>>,
+    pub(super) reply: PortHandle<OpResult>,
+}
+
+// DEPRECATED — slated for removal in the follow-up diff that deletes
+// the symmetric `QueuePairInitializer` handshake. Active-side
+// queue pairs now live behind [`IbvManagerActor::qp_handles`] (one
+// [`QueuePairActor`] per peer); passive-side mirror QPs live in
+// [`IbvManagerActor::peer_created_qps`].
 /// Per-QpKey state in [`IbvManagerActor::qps`].
 ///
 /// `Pending` covers the entire handshake (an initializer is running);
@@ -108,10 +158,6 @@ wirevalue::register_type!(EnsureQueuePair<IbvManagerActor>);
 /// records the error so subsequent `RequestQueuePair` / `EnsureQueuePair`
 /// calls for the same key surface the same error rather than retrying
 /// or hanging.
-///
-/// TODO: add recovery — allow retries via an explicit message or after
-/// a backoff. For now the entry stays `Failed` for the life of the
-/// manager.
 #[derive(Debug)]
 enum QpState {
     Pending {
@@ -165,6 +211,11 @@ pub enum IbvManagerLocalMessage {
         #[reply]
         reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
+    /// DEPRECATED — slated for removal in the follow-up diff. Callers
+    /// now submit ops directly via [`SubmitOps`]; per-peer QPs are
+    /// managed internally by [`IbvManagerActor`] through
+    /// [`QueuePairActor`].
+    ///
     /// User-facing entry point: get a connected `IbvQueuePair` for
     /// `(self_device, other actor's id, other_device)`. Lazily creates
     /// the QP + initializer if absent; if a handshake is in flight,
@@ -182,6 +233,7 @@ pub enum IbvManagerLocalMessage {
     },
 }
 
+// DEPRECATED — slated for removal in the follow-up diff.
 /// Local-only handshake-success report. The initializer sends this
 /// to its owning manager once both sides have reached RTS, handing
 /// over the freshly-connected [`QpGuard`].
@@ -191,6 +243,7 @@ pub(super) struct QpInitializerDone {
     pub(super) qp: QpGuard,
 }
 
+// DEPRECATED — slated for removal in the follow-up diff.
 /// Local-only handshake-failure report. The initializer sends this
 /// to its owning manager when the handshake aborted; the underlying
 /// QP has already been dropped on the initializer side.
@@ -200,6 +253,9 @@ pub(super) struct QpInitializerFailed {
     pub(super) error: String,
 }
 
+/// DEPRECATED — slated for removal in the follow-up diff together
+/// with [`IbvBackend::execute_op`] and [`IbvBackend::wait_for_completion`].
+///
 /// Adaptive wait between completion polls.
 ///
 /// While the elapsed time since [`Self::yield_now`] was first called
@@ -319,13 +375,29 @@ pub(super) struct SegmentInfo {
     handlers = [
         IbvManagerMessage,
         EnsureQueuePair<IbvManagerActor>,
+        CreatePeerQueuePair<IbvManagerActor>,
     ],
 )]
 pub struct IbvManagerActor {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
+    /// DEPRECATED — slated for removal in the follow-up diff together
+    /// with the rest of the legacy QP machinery.
+    ///
     /// Per-QP state, keyed from this manager's perspective. See [`QpKey`].
     qps: HashMap<QpKey, QpState>,
+
+    /// Active-side [`QueuePairActor`] children, keyed from this
+    /// manager's perspective. Lazily populated on the first
+    /// [`SubmitOps`] that targets a new `(self_device, peer,
+    /// other_device)` triple.
+    qp_handles: HashMap<QpKey, ActorHandle<QueuePairActor<IbvManagerActor, IbvQueuePair>>>,
+
+    /// Passive-side mirror QPs, created in response to a peer's
+    /// [`CreatePeerQueuePair`]. The peer's [`QueuePairActor`] owns
+    /// the active side; we hold the connected mirror here so the
+    /// peer can read/write our memory.
+    peer_created_qps: HashMap<QpKey, IbvQueuePair>,
 
     /// Map of RDMA device names to their domains and loopback QPs.
     /// Created lazily when memory is registered for a specific
@@ -369,14 +441,35 @@ impl Actor for IbvManagerActor {
             .expect("owner should only be set once during init");
         Ok(())
     }
+
+    /// Absorb `Undeliverable::Lost` for per-op [`OpResult`] replies —
+    /// the typical case is that the submitting caller dropped its
+    /// receiver mid-batch (e.g. test teardown, `IbvBackend::submit`
+    /// timing out) and we just want to drop those replies on the
+    /// floor rather than letting the default impl kill the actor.
+    /// Everything else (including any other lost message type or any
+    /// `Undeliverable::Message`) falls through to the default which
+    /// bails into supervision.
+    async fn handle_undeliverable_message(
+        &mut self,
+        this: &Instance<Self>,
+        undeliverable: hyperactor::mailbox::Undeliverable<hyperactor::mailbox::MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        if let hyperactor::mailbox::Undeliverable::Lost(lost) = &undeliverable
+            && lost.message_type.as_deref() == Some(std::any::type_name::<OpResult>())
+        {
+            return Ok(());
+        }
+        hyperactor::actor::handle_undeliverable_message(this, undeliverable)
+    }
 }
 
 impl Drop for IbvManagerActor {
     fn drop(&mut self) {
-        // 1. Clean up QPs. `Pending` entries hold the qp via the
-        // initializer; signal the initializer to stop and let the
-        // runtime tear it down. `Failed` is a tombstone with no
-        // resources. Pending waiters won't be answered and their
+        // 1. DEPRECATED legacy QP state. `Pending` entries hold the
+        // qp via the initializer; signal the initializer to stop and
+        // let the runtime tear it down. `Failed` is a tombstone with
+        // no resources. Pending waiters won't be answered and their
         // callers will observe the dropped reply ports as `Err(_)`.
         for (_key, state) in self.qps.drain() {
             match state {
@@ -392,19 +485,38 @@ impl Drop for IbvManagerActor {
             }
         }
 
-        // 2. Drop buffer registrations. Each entry's
+        // 2. Drain active-side QP actors. Each child owns its
+        // `IbvQueuePair`; `drain_and_stop` schedules the actor to
+        // finish in-flight ops and exit. The owned `IbvQueuePair`
+        // currently leaks on actor drop because the type is still
+        // `Clone` — same TODO as `QpState::Ready` above; the
+        // follow-up diff that makes `IbvQueuePair: !Clone` fixes both.
+        for (_key, handle) in self.qp_handles.drain() {
+            let _ = handle.drain_and_stop("IbvManagerActor dropped");
+        }
+
+        // 3. Destroy passive-side mirror QPs. The manager is their
+        // sole owner.
+        for (_key, qp) in self.peer_created_qps.drain() {
+            // SAFETY: We just drained `peer_created_qps`; the
+            // manager is being dropped and no other code holds a
+            // clone of this QP's `rdmaxcel_qp_t` pointer.
+            unsafe { destroy_qp(&qp) };
+        }
+
+        // 4. Drop buffer registrations. Each entry's
         // `IbvMemoryRegionView` carries the only manager-side
         // reference to that MR's `Arc<IbvMemoryRegion>` and its
         // `Arc<IbvDomain>`. They run their FFI cleanup from their
         // `Drop`s once no surviving view holds a clone.
         self.buffer_registrations.clear();
 
-        // 3. Drop the segments-owner Arc. `deregister_segments`
+        // 5. Drop the segments-owner Arc. `deregister_segments`
         // runs from `IbvMemoryRegion::Segments::Drop` when the last
         // segment-backed view also goes away.
         self.segments_mr.take();
 
-        // 4. Drop device domains (PDs + loopback QPs). Loopback QPs
+        // 6. Drop device domains (PDs + loopback QPs). Loopback QPs
         // are tied to this map only; destroy them explicitly. PD
         // teardown waits on the last `Arc<IbvDomain>` clone (held
         // by any outstanding view) to drop.
@@ -469,6 +581,8 @@ impl IbvManagerActor {
         let actor = Self {
             owner: OnceLock::new(),
             qps: HashMap::new(),
+            qp_handles: HashMap::new(),
+            peer_created_qps: HashMap::new(),
             device_domains: HashMap::new(),
             config,
             mlx5dv_enabled,
@@ -763,6 +877,97 @@ impl IbvManagerActor {
         }
     }
 
+    /// Resolve `mem` to an [`IbvMemoryRegionView`] using the slot
+    /// shared by every clone of `mem`. On a cold slot, calls
+    /// [`Self::register_mr_impl`] and installs the result; on a warm
+    /// slot, returns the previously-installed view.
+    fn resolve_local_mr(
+        &mut self,
+        mem: &KeepaliveLocalMemory,
+    ) -> Result<IbvMemoryRegionView, anyhow::Error> {
+        if let Some(mrv) = mem.mr_slot().get() {
+            return Ok(mrv.clone());
+        }
+        let (mrv, _device_name) = self.register_mr_impl(mem.addr(), mem.size())?;
+        Ok(mem.mr_slot().get_or_init(|| mrv).clone())
+    }
+
+    /// Build a passive-side mirror QP for `qp_key`, connect it to
+    /// `sender_info`, and store it in [`Self::peer_created_qps`].
+    /// Returns the local endpoint the active side needs to finish
+    /// its own `connect`. Called from
+    /// [`Handler<CreatePeerQueuePair>`].
+    fn create_peer_qp(
+        &mut self,
+        qp_key: &QpKey,
+        sender_info: &IbvQpInfo,
+    ) -> Result<IbvQpInfo, anyhow::Error> {
+        if self.peer_created_qps.contains_key(qp_key) {
+            anyhow::bail!("peer queue pair already exists for {qp_key:?}");
+        }
+        let self_device = &qp_key.self_device;
+        let rdma_device = super::primitives::get_all_devices()
+            .into_iter()
+            .find(|d| d.name() == self_device)
+            .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
+        let (domain, _) = self.get_or_create_device_domain(self_device, &rdma_device)?;
+        // The `QpGuard` here destroys the underlying `rdmaxcel_qp_t`
+        // on early returns from `get_qp_info` / `connect`. Once
+        // `IbvQueuePair` becomes single-owner (with its own `Drop`)
+        // in a follow-up diff, the guard goes away.
+        let mut qp = QpGuard::new(
+            IbvQueuePair::new(domain.context, domain.pd, self.config.clone())
+                .map_err(|e| anyhow::anyhow!("could not create peer IbvQueuePair: {}", e))?,
+        );
+        let local_info = qp
+            .get_qp_info()
+            .map_err(|e| anyhow::anyhow!("could not extract peer QP info: {}", e))?;
+        qp.connect(sender_info)
+            .map_err(|e| anyhow::anyhow!("could not connect peer QP: {}", e))?;
+        self.peer_created_qps
+            .insert(qp_key.clone(), qp.into_inner());
+        Ok(local_info)
+    }
+
+    /// Lazy active-side QP actor: if `qp_key` is absent from
+    /// [`Self::qp_handles`], create an [`IbvQueuePair`] on the
+    /// requested device and spawn a [`QueuePairActor`] to drive its
+    /// handshake + data path. Returns a clone of the actor handle.
+    fn ensure_qp_actor(
+        &mut self,
+        cx: &Context<'_, Self>,
+        qp_key: &QpKey,
+        peer_manager: ActorRef<Self>,
+    ) -> Result<ActorHandle<QueuePairActor<Self, IbvQueuePair>>, anyhow::Error> {
+        if let Some(h) = self.qp_handles.get(qp_key) {
+            return Ok(h.clone());
+        }
+        let self_device = &qp_key.self_device;
+        let rdma_device = super::primitives::get_all_devices()
+            .into_iter()
+            .find(|d| d.name() == self_device)
+            .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
+        let (domain, _) = self.get_or_create_device_domain(self_device, &rdma_device)?;
+        let qp = IbvQueuePair::new(domain.context, domain.pd, self.config.clone())
+            .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair for {qp_key:?}: {}", e))?;
+        let local_manager: ActorRef<Self> = cx.bind();
+        let is_loopback = local_manager.actor_addr() == peer_manager.actor_addr()
+            && qp_key.self_device == qp_key.other_device;
+        let actor = cx.spawn(QueuePairActor::new(
+            qp_key.clone(),
+            local_manager,
+            peer_manager,
+            qp,
+            is_loopback,
+            self.config.max_send_wr,
+            self.config.max_rd_atomic as u32,
+        ));
+        self.qp_handles.insert(qp_key.clone(), actor.clone());
+        Ok(actor)
+    }
+
+    /// DEPRECATED — slated for removal in the follow-up diff.
+    ///
     /// Lazy QP creation: if `qp_key` is absent, create the local
     /// `IbvQueuePair`, capture its `IbvQpInfo`, and spawn a
     /// `QueuePairInitializer` to drive the handshake. Returns the
@@ -826,6 +1031,87 @@ impl IbvManagerMessageHandler for IbvManagerActor {
         // the view's MR and PD; FFI cleanup happens via their `Drop`s
         // once the last referencing view is gone.
         self.buffer_registrations.remove(&remote_buf_id);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<SubmitOps> for IbvManagerActor {
+    async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps) -> Result<(), anyhow::Error> {
+        let SubmitOps { ops, reply } = msg;
+
+        // Interleave MR resolution with QP dispatch: as soon as op `i`'s
+        // local MR is resolved and its QP actor is in place, ship a
+        // one-item `ProcessOps` to that QP. The QP can then post and
+        // poll op `i` while we run `resolve_local_mr` for op `i+1`.
+        for (i, op) in ops.into_iter().enumerate() {
+            let mrv = match self.resolve_local_mr(&op.local_memory) {
+                Ok(mrv) => mrv,
+                Err(e) => {
+                    reply.post(
+                        cx,
+                        OpResult {
+                            op_idx: i,
+                            result: Err(e.to_string()),
+                        },
+                    );
+                    continue;
+                }
+            };
+            let qp_key = QpKey {
+                self_device: mrv.device_name.clone(),
+                other_id: op.remote_manager.actor_addr().id().clone(),
+                other_device: op.remote_buffer.device_name.clone(),
+            };
+            let peer_manager = op.remote_manager.clone();
+            let handle = match self.ensure_qp_actor(cx, &qp_key, peer_manager) {
+                Ok(h) => h,
+                Err(e) => {
+                    reply.post(
+                        cx,
+                        OpResult {
+                            op_idx: i,
+                            result: Err(e.to_string()),
+                        },
+                    );
+                    continue;
+                }
+            };
+            handle.post(
+                cx,
+                ProcessOps {
+                    items: vec![(i, op, mrv)],
+                    reply: reply.clone(),
+                },
+            );
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<CreatePeerQueuePair<IbvManagerActor>> for IbvManagerActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: CreatePeerQueuePair<IbvManagerActor>,
+    ) -> Result<(), anyhow::Error> {
+        let CreatePeerQueuePair {
+            sender,
+            sender_device,
+            receiver_device,
+            sender_info,
+            reply,
+        } = msg;
+        let qp_key = QpKey {
+            self_device: receiver_device,
+            other_id: sender.actor_addr().id().clone(),
+            other_device: sender_device,
+        };
+        match self.create_peer_qp(&qp_key, &sender_info) {
+            Ok(local_info) => reply.post(cx, Ok(local_info)),
+            Err(e) => reply.post(cx, Err(e.to_string())),
+        }
         Ok(())
     }
 }
@@ -1030,6 +1316,8 @@ impl Handler<QpInitializerFailed> for IbvManagerActor {
     }
 }
 
+/// DEPRECATED — slated for removal in the follow-up diff.
+///
 /// Free helper around [`IbvManagerLocalMessage::RequestQueuePair`] — opens
 /// a `OncePortHandle` for the reply, sends the message, and awaits the
 /// answer. Exists because `RequestQueuePair` doesn't use `#[reply]`
@@ -1067,7 +1355,10 @@ impl std::ops::Deref for IbvBackend {
     }
 }
 
+#[expect(dead_code, reason = "DEPRECATED, removed in the follow-up diff")]
 impl IbvBackend {
+    /// DEPRECATED — replaced by [`QueuePairActor`]-driven CQ polling.
+    ///
     /// Waits for the completion of RDMA operations.
     ///
     /// Polls the completion queue until all specified work requests complete
@@ -1133,6 +1424,9 @@ impl IbvBackend {
         ))
     }
 
+    /// DEPRECATED — replaced by [`SubmitOps`] dispatch into per-peer
+    /// [`QueuePairActor`]s.
+    ///
     /// Core submit logic: registers a local MR via actor message,
     /// resolves the remote `IbvBuffer` lazily, and executes the op.
     /// `local_mrv` is kept in scope for the duration of the op so
@@ -1190,8 +1484,16 @@ impl RdmaBackend for IbvBackend {
 
     /// Submit a batch of RDMA operations.
     ///
-    /// Resolves ibv ops, then executes each directly — registering/deregistering
-    /// MRs via actor messages, while performing QP put/get and CQ polling locally.
+    /// Translates each `RdmaOp` to an `IbvOp`, then ships the whole
+    /// batch to [`IbvManagerActor`] via [`SubmitOps`]. The manager
+    /// interleaves local-MR resolution with per-op dispatch: each
+    /// op is sent to its [`QueuePairActor`] as a one-item
+    /// [`ProcessOps`] the moment its MR is ready, so QP work on
+    /// op `i` overlaps MR registration for op `i+1`.
+    ///
+    /// Always waits for exactly `ops.len()` per-op replies before
+    /// returning. Per-op failures are collected and formatted into a single
+    /// multi-line `Err` listing each `op_idx` and its error message.
     async fn submit(
         &mut self,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
@@ -1210,16 +1512,63 @@ impl RdmaBackend for IbvBackend {
                 remote_manager,
             });
         }
+        let n = ibv_ops.len();
 
-        let deadline = Instant::now() + timeout;
-        for op in ibv_ops {
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                return Err(anyhow::anyhow!("submit timed out"));
+        let (reply, mut reply_rx) = cx.mailbox().open_port::<OpResult>();
+
+        self.0.post(
+            cx,
+            SubmitOps {
+                ops: ibv_ops,
+                reply,
+            },
+        );
+
+        let mut failures: Vec<(usize, String)> = Vec::with_capacity(n);
+        let mut received = 0usize;
+        let mut terminal: Option<String> = None;
+        let deadline = tokio::time::Instant::now() + timeout;
+        while received < n {
+            tokio::select! {
+                () = tokio::time::sleep_until(deadline) => {
+                    terminal = Some(format!(
+                        "submit timed out after {received}/{n} replies with {} failures",
+                        failures.len()
+                    ));
+                    break;
+                }
+                recv = reply_rx.recv() => {
+                    match recv {
+                        Ok(OpResult { result: Ok(()), .. }) => received += 1,
+                        Ok(OpResult { op_idx, result: Err(e) }) => {
+                            received += 1;
+                            failures.push((op_idx, e));
+                        }
+                        Err(e) => {
+                            terminal = Some(format!(
+                                "SubmitOps reply port closed after {received}/{n} replies with {} failures: {e}",
+                                failures.len()
+                            ));
+                            break;
+                        }
+                    }
+                }
             }
-            self.execute_op(cx, op, remaining).await?;
         }
-        Ok(())
+
+        if terminal.is_none() && failures.is_empty() {
+            return Ok(());
+        }
+
+        failures.sort_by_key(|(idx, _)| *idx);
+        let mut msg = terminal.unwrap_or_else(|| format!("{}/{n} ops failed", failures.len()));
+        if !failures.is_empty() {
+            msg.push(':');
+            for (idx, err) in &failures {
+                write!(msg, "\n  op {idx}: {err}").expect("infallible String write");
+            }
+        }
+        Err(anyhow::anyhow!(msg))
     }
 
     fn transport_level(&self) -> RdmaTransportLevel {
@@ -1228,5 +1577,1103 @@ impl RdmaBackend for IbvBackend {
 
     fn transport_info(&self) -> Option<Self::TransportInfo> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end coverage of the [`SubmitOps`] → [`ProcessOps`] →
+    //! [`QueuePairActor`] data path.
+    //!
+    //! Each test stands up two RDMA participants in two
+    //! [`Proc::direct`] procs in the test process. Each proc hosts an
+    //! [`RdmaManagerActor`] and a [`BufferHelperActor`]. Tests
+    //! allocate buffers on either side via the helpers, drive RDMA
+    //! through [`IbvBackend::submit`] (called inside the helper
+    //! actor), and verify by reading back local contents through
+    //! [`BufferHelperMessage::ReadContents`]. The
+    //! [`BufferHelperActor::cleanup`] impl releases any CUDA
+    //! allocations when the actor stops; [`TestEnv::shutdown`]
+    //! explicitly drains both procs.
+
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use hyperactor::Actor;
+    use hyperactor::ActorRef;
+    use hyperactor::Context;
+    use hyperactor::Handler;
+    use hyperactor::Instance;
+    use hyperactor::Label;
+    use hyperactor::OncePortRef;
+    use hyperactor::Proc;
+    use hyperactor::RefClient;
+    use hyperactor::RemoteSpawn;
+    use hyperactor::Uid;
+    use hyperactor::actor::ActorError;
+    use hyperactor::channel::ChannelAddr;
+    use hyperactor::channel::ChannelTransport;
+    use hyperactor_config::Flattrs;
+    use serde::Deserialize;
+    use serde::Serialize;
+    use typeuri::Named;
+
+    use super::IbvBackend;
+    use super::IbvManagerActor;
+    use crate::IbvConfig;
+    use crate::RdmaManagerActor;
+    use crate::RdmaManagerMessageClient;
+    use crate::RdmaOp;
+    use crate::RdmaOpType;
+    use crate::RdmaRemoteBuffer;
+    use crate::backend::RdmaBackend;
+    use crate::backend::cuda_test_utils::CudaAllocation;
+    use crate::backend::cuda_test_utils::CudaAllocator;
+    use crate::backend::ibverbs::primitives::IbvQpType;
+    use crate::backend::ibverbs::primitives::get_all_devices;
+    use crate::local_memory::KeepaliveLocalMemory;
+
+    // ====================================================================
+    // BufferHelperActor
+    // ====================================================================
+
+    /// Device a test buffer is allocated on.
+    #[derive(Debug, Clone, Copy, Serialize, Deserialize, Named)]
+    pub enum BufferDevice {
+        Cpu,
+        Cuda(i32),
+    }
+
+    /// One op for [`BufferHelperMessage::Submit`]. The helper looks up
+    /// the local memory behind `local_buf` (registered earlier via
+    /// `Allocate`) and pairs it with `remote_buf` to form an
+    /// [`RdmaOp`].
+    #[derive(Debug, Clone, Serialize, Deserialize, Named)]
+    pub struct BufferHelperOp {
+        op_type: RdmaOpType,
+        local_buf: RdmaRemoteBuffer,
+        remote_buf: RdmaRemoteBuffer,
+    }
+
+    /// Test helper that owns local buffers (CPU or CUDA) and drives
+    /// [`IbvBackend::submit`] against its own [`RdmaManagerActor`].
+    #[hyperactor::export(handlers = [BufferHelperMessage])]
+    #[hyperactor::spawnable]
+    #[derive(Debug)]
+    pub struct BufferHelperActor {
+        rdma_manager: ActorRef<RdmaManagerActor>,
+        /// CUDA allocations tracked for cleanup. Each is also held as
+        /// `Keepalive` inside the registered `KeepaliveLocalMemory`;
+        /// both clones must drop before the FFI memory is released.
+        cuda_allocs: Vec<CudaAllocation>,
+    }
+
+    #[async_trait]
+    impl Actor for BufferHelperActor {
+        async fn cleanup(
+            &mut self,
+            _this: &Instance<Self>,
+            _err: Option<&ActorError>,
+        ) -> Result<(), anyhow::Error> {
+            for alloc in self.cuda_allocs.drain(..) {
+                alloc.try_free();
+            }
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl RemoteSpawn for BufferHelperActor {
+        type Params = ActorRef<RdmaManagerActor>;
+
+        async fn new(
+            rdma_manager: ActorRef<RdmaManagerActor>,
+            _env: Flattrs,
+        ) -> Result<Self, anyhow::Error> {
+            Ok(Self {
+                rdma_manager,
+                cuda_allocs: Vec::new(),
+            })
+        }
+    }
+
+    #[derive(Handler, RefClient, Named, Serialize, Deserialize, Debug)]
+    pub enum BufferHelperMessage {
+        /// Allocate `size` bytes on `device`, pre-fill with `pattern`,
+        /// register with the local `RdmaManagerActor`, and reply with
+        /// the resulting `RdmaRemoteBuffer`.
+        Allocate {
+            size: usize,
+            device: BufferDevice,
+            pattern: u8,
+            #[reply]
+            reply: OncePortRef<RdmaRemoteBuffer>,
+        },
+        /// Look up the local memory behind `remote.id` and reply with
+        /// the byte range `[offset, offset + len)`. Tests use this to
+        /// sample buffers too large to ship over a single actor
+        /// message in one piece.
+        ReadContents {
+            remote: RdmaRemoteBuffer,
+            offset: usize,
+            len: usize,
+            #[reply]
+            reply: OncePortRef<Vec<u8>>,
+        },
+        /// Drive a batch of RDMA ops through `IbvBackend::submit`.
+        /// Each op's `local_buf` is resolved against this helper's
+        /// `RdmaManagerActor`; `remote_buf` is shipped as-is to the
+        /// peer.
+        Submit {
+            ops: Vec<BufferHelperOp>,
+            timeout_secs: u64,
+            #[reply]
+            reply: OncePortRef<Result<(), String>>,
+        },
+    }
+
+    impl BufferHelperActor {
+        async fn allocate_impl(
+            &mut self,
+            cx: &Context<'_, Self>,
+            size: usize,
+            device: BufferDevice,
+            pattern: u8,
+        ) -> Result<RdmaRemoteBuffer, anyhow::Error> {
+            let local = match device {
+                BufferDevice::Cpu => {
+                    let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
+                    let addr = buf.as_ptr() as usize;
+                    Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(buf)))
+                }
+                BufferDevice::Cuda(device_id) => {
+                    let alloc = CudaAllocator::get().allocate(device_id, size, size);
+                    let addr = alloc.ptr();
+                    let local = Arc::new(KeepaliveLocalMemory::new(
+                        addr,
+                        size,
+                        Arc::new(alloc.clone()),
+                    ));
+                    self.cuda_allocs.push(alloc);
+                    let fill = vec![pattern; size];
+                    // SAFETY: `local` is freshly constructed; no other
+                    // holder touches this CUDA range yet.
+                    unsafe { local.write_at(0, &fill) }?;
+                    local
+                }
+            };
+            let handle = self
+                .rdma_manager
+                .downcast_handle(cx)
+                .ok_or_else(|| anyhow::anyhow!("rdma_manager not local to BufferHelperActor"))?;
+            handle.request_buffer(cx, local).await
+        }
+
+        async fn read_contents_impl(
+            &mut self,
+            cx: &Context<'_, Self>,
+            remote: RdmaRemoteBuffer,
+            offset: usize,
+            len: usize,
+        ) -> Result<Vec<u8>, anyhow::Error> {
+            let handle = self
+                .rdma_manager
+                .downcast_handle(cx)
+                .ok_or_else(|| anyhow::anyhow!("rdma_manager not local"))?;
+            let local = handle
+                .request_local_memory(cx, remote.id)
+                .await?
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "no local memory registered on this side for remote_buf_id={}",
+                        remote.id,
+                    )
+                })?;
+            let mut out = vec![0u8; len];
+            // SAFETY: by convention the caller has ensured all RDMA
+            // ops against this buffer have completed before invoking
+            // ReadContents.
+            unsafe { local.read_at(offset, &mut out)? };
+            Ok(out)
+        }
+
+        async fn submit_impl(
+            &mut self,
+            cx: &Context<'_, Self>,
+            ops: Vec<BufferHelperOp>,
+            timeout_secs: u64,
+        ) -> Result<Result<(), String>, anyhow::Error> {
+            let handle = self
+                .rdma_manager
+                .downcast_handle(cx)
+                .ok_or_else(|| anyhow::anyhow!("rdma_manager not local"))?;
+            let mut rdma_ops = Vec::with_capacity(ops.len());
+            for (i, op) in ops.into_iter().enumerate() {
+                let local = handle
+                    .request_local_memory(cx, op.local_buf.id)
+                    .await?
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "op {i}: no local memory registered for remote_buf_id={}",
+                            op.local_buf.id,
+                        )
+                    })?;
+                rdma_ops.push(RdmaOp {
+                    op_type: op.op_type,
+                    local,
+                    remote: op.remote_buf,
+                });
+            }
+            let ibv_handle = IbvManagerActor::local_handle(cx).await?;
+            let mut backend = IbvBackend(ibv_handle);
+            let result = backend
+                .submit(cx, rdma_ops, Duration::from_secs(timeout_secs))
+                .await;
+            Ok(result.map_err(|e| format!("{e}")))
+        }
+    }
+
+    #[async_trait]
+    #[hyperactor::handle(BufferHelperMessage)]
+    impl BufferHelperMessageHandler for BufferHelperActor {
+        async fn allocate(
+            &mut self,
+            cx: &Context<Self>,
+            size: usize,
+            device: BufferDevice,
+            pattern: u8,
+        ) -> Result<RdmaRemoteBuffer, anyhow::Error> {
+            self.allocate_impl(cx, size, device, pattern).await
+        }
+
+        async fn read_contents(
+            &mut self,
+            cx: &Context<Self>,
+            remote: RdmaRemoteBuffer,
+            offset: usize,
+            len: usize,
+        ) -> Result<Vec<u8>, anyhow::Error> {
+            self.read_contents_impl(cx, remote, offset, len).await
+        }
+
+        async fn submit(
+            &mut self,
+            cx: &Context<Self>,
+            ops: Vec<BufferHelperOp>,
+            timeout_secs: u64,
+        ) -> Result<Result<(), String>, anyhow::Error> {
+            self.submit_impl(cx, ops, timeout_secs).await
+        }
+    }
+
+    // ====================================================================
+    // TestEnv
+    // ====================================================================
+
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// Two-sided test environment.
+    ///
+    /// Each side is a `Proc::direct` in the test process hosting its
+    /// own `RdmaManagerActor` and `BufferHelperActor`. A client minted
+    /// from `proc_b` drives both helpers through their `ActorRef`s.
+    struct TestEnv {
+        client: hyperactor::Client,
+        proc_a: Proc,
+        helper_a: ActorRef<BufferHelperActor>,
+        proc_b: Proc,
+        helper_b: ActorRef<BufferHelperActor>,
+    }
+
+    impl TestEnv {
+        /// Asymmetric setup: side A uses `config_a`, side B uses `config_b`.
+        async fn new(config_a: IbvConfig, config_b: IbvConfig) -> Result<Self, anyhow::Error> {
+            let id = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let proc_a = Proc::direct(
+                ChannelAddr::any(ChannelTransport::Unix),
+                format!("rdma_side_a_{id}"),
+            )?;
+            let helper_a = Self::spawn_side(&proc_a, config_a).await?;
+            let proc_b = Proc::direct(
+                ChannelAddr::any(ChannelTransport::Unix),
+                format!("rdma_side_b_{id}"),
+            )?;
+            let helper_b = Self::spawn_side(&proc_b, config_b).await?;
+            let client = proc_b.client("test_client");
+            Ok(Self {
+                client,
+                proc_a,
+                helper_a,
+                proc_b,
+                helper_b,
+            })
+        }
+
+        /// Symmetric setup: both sides use `config`.
+        async fn same_config(config: IbvConfig) -> Result<Self, anyhow::Error> {
+            Self::new(config.clone(), config).await
+        }
+
+        /// Spawn an `RdmaManagerActor` + `BufferHelperActor` on `proc`
+        /// and return the helper's `ActorRef`.
+        async fn spawn_side(
+            proc: &Proc,
+            config: IbvConfig,
+        ) -> Result<ActorRef<BufferHelperActor>, anyhow::Error> {
+            let rdma_actor = RdmaManagerActor::new(Some(config), Flattrs::default()).await?;
+            // Must match `RdmaManagerActor::local_handle`'s singleton lookup of "rdma_manager".
+            let rdma_handle =
+                proc.spawn_with_uid(Uid::singleton(Label::strip("rdma_manager")), rdma_actor)?;
+            let rdma: ActorRef<RdmaManagerActor> = rdma_handle.bind();
+            let helper_actor = BufferHelperActor::new(rdma, Flattrs::default()).await?;
+            let helper_handle = proc.spawn_with_label("helper", helper_actor);
+            Ok(helper_handle.bind())
+        }
+
+        async fn shutdown(mut self) -> Result<(), anyhow::Error> {
+            let _ = self
+                .proc_a
+                .destroy_and_wait(Duration::from_secs(10), "TestEnv shutdown proc_a")
+                .await?;
+            let _ = self
+                .proc_b
+                .destroy_and_wait(Duration::from_secs(10), "TestEnv shutdown proc_b")
+                .await?;
+            Ok(())
+        }
+    }
+
+    // ====================================================================
+    // Shared test bodies
+    // ====================================================================
+
+    async fn assert_remote_pattern(
+        helper: &ActorRef<BufferHelperActor>,
+        cx: &hyperactor::Client,
+        remote: RdmaRemoteBuffer,
+        size: usize,
+        pattern: u8,
+    ) -> Result<(), anyhow::Error> {
+        let got = helper.read_contents(cx, remote, 0, size).await?;
+        assert_eq!(got, vec![pattern; size]);
+        Ok(())
+    }
+
+    /// Drive a single write from side A's buffer into side B's buffer
+    /// and assert the destination now matches the pattern.
+    async fn run_cross_actor_write(
+        env: &TestEnv,
+        src_dev: BufferDevice,
+        dst_dev: BufferDevice,
+        size: usize,
+        pattern: u8,
+        timeout_secs: u64,
+    ) -> Result<(), anyhow::Error> {
+        let src = env
+            .helper_a
+            .allocate(&env.client, size, src_dev, pattern)
+            .await?;
+        let dst = env.helper_b.allocate(&env.client, size, dst_dev, 0).await?;
+        env.helper_a
+            .submit(
+                &env.client,
+                vec![BufferHelperOp {
+                    op_type: RdmaOpType::WriteFromLocal,
+                    local_buf: src,
+                    remote_buf: dst.clone(),
+                }],
+                timeout_secs,
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
+        assert_remote_pattern(&env.helper_b, &env.client, dst, size, pattern).await
+    }
+
+    /// Drive a single read from side B's buffer into side A's buffer
+    /// and assert the destination now matches the pattern.
+    async fn run_cross_actor_read(
+        env: &TestEnv,
+        dst_dev: BufferDevice,
+        src_dev: BufferDevice,
+        size: usize,
+        pattern: u8,
+        timeout_secs: u64,
+    ) -> Result<(), anyhow::Error> {
+        let dst = env.helper_a.allocate(&env.client, size, dst_dev, 0).await?;
+        let src = env
+            .helper_b
+            .allocate(&env.client, size, src_dev, pattern)
+            .await?;
+        env.helper_a
+            .submit(
+                &env.client,
+                vec![BufferHelperOp {
+                    op_type: RdmaOpType::ReadIntoLocal,
+                    local_buf: dst.clone(),
+                    remote_buf: src,
+                }],
+                timeout_secs,
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
+        assert_remote_pattern(&env.helper_a, &env.client, dst, size, pattern).await
+    }
+
+    /// Drive both a write and a read in a single
+    /// `IbvBackend::submit` batch — both ops target the same peer
+    /// QP and so resolve to a single `ProcessOps` group. After the
+    /// batch completes, side B's `write_dst` and side A's `read_dst`
+    /// both contain their respective patterns.
+    async fn run_multi_op_same_qp(
+        env: &TestEnv,
+        dev_a: BufferDevice,
+        dev_b: BufferDevice,
+        size: usize,
+        timeout_secs: u64,
+    ) -> Result<(), anyhow::Error> {
+        const WRITE_PATTERN: u8 = 0xa1;
+        const READ_PATTERN: u8 = 0xb2;
+        let write_src = env
+            .helper_a
+            .allocate(&env.client, size, dev_a, WRITE_PATTERN)
+            .await?;
+        let write_dst = env.helper_b.allocate(&env.client, size, dev_b, 0).await?;
+        let read_dst = env.helper_a.allocate(&env.client, size, dev_a, 0).await?;
+        let read_src = env
+            .helper_b
+            .allocate(&env.client, size, dev_b, READ_PATTERN)
+            .await?;
+        env.helper_a
+            .submit(
+                &env.client,
+                vec![
+                    BufferHelperOp {
+                        op_type: RdmaOpType::WriteFromLocal,
+                        local_buf: write_src,
+                        remote_buf: write_dst.clone(),
+                    },
+                    BufferHelperOp {
+                        op_type: RdmaOpType::ReadIntoLocal,
+                        local_buf: read_dst.clone(),
+                        remote_buf: read_src,
+                    },
+                ],
+                timeout_secs,
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
+        assert_remote_pattern(&env.helper_b, &env.client, write_dst, size, WRITE_PATTERN).await?;
+        assert_remote_pattern(&env.helper_a, &env.client, read_dst, size, READ_PATTERN).await
+    }
+
+    /// Drive a write + read between two buffers registered with the
+    /// *same* `RdmaManagerActor` on the *same* device. Exercises the
+    /// loopback path (`is_loopback = true`) where the active actor
+    /// connects its QP to its own endpoint and skips the
+    /// `CreatePeerQueuePair` round trip.
+    async fn run_true_loopback(
+        env: &TestEnv,
+        dev: BufferDevice,
+        size: usize,
+    ) -> Result<(), anyhow::Error> {
+        const PATTERN: u8 = 0x5d;
+        let src = env
+            .helper_a
+            .allocate(&env.client, size, dev, PATTERN)
+            .await?;
+        let dst = env.helper_a.allocate(&env.client, size, dev, 0).await?;
+        env.helper_a
+            .submit(
+                &env.client,
+                vec![BufferHelperOp {
+                    op_type: RdmaOpType::WriteFromLocal,
+                    local_buf: src,
+                    remote_buf: dst.clone(),
+                }],
+                5,
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
+        assert_remote_pattern(&env.helper_a, &env.client, dst, size, PATTERN).await
+    }
+
+    // ====================================================================
+    // Helpers
+    // ====================================================================
+
+    fn require_rdma() {
+        if get_all_devices().is_empty() {
+            panic!("SKIPPED: no RDMA devices available");
+        }
+    }
+
+    fn require_cuda() {
+        if !crate::is_cuda_available() {
+            panic!("SKIPPED: CUDA not available");
+        }
+    }
+
+    // ====================================================================
+    // Tests
+    // ====================================================================
+
+    /// Cross-actor RDMA write over a single device (both sides target
+    /// `cpu:0`). The two `RdmaManagerActor`s differ — this exercises
+    /// the asymmetric `CreatePeerQueuePair` handshake even though the
+    /// underlying device is shared.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cross_actor_same_device_write() -> Result<(), anyhow::Error> {
+        require_rdma();
+        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        run_cross_actor_write(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, 0xa5, 5).await?;
+        env.shutdown().await
+    }
+
+    /// Cross-actor RDMA read over a single device.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cross_actor_same_device_read() -> Result<(), anyhow::Error> {
+        require_rdma();
+        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        run_cross_actor_read(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, 0x3c, 5).await?;
+        env.shutdown().await
+    }
+
+    /// True loopback write: both buffers registered with the same
+    /// `RdmaManagerActor` on the same device. The `QueuePairActor`
+    /// sees `is_loopback = true` and connects its QP to its own
+    /// endpoint without going through `CreatePeerQueuePair`.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_loopback_write() -> Result<(), anyhow::Error> {
+        require_rdma();
+        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        run_true_loopback(&env, BufferDevice::Cpu, 32).await?;
+        env.shutdown().await
+    }
+
+    /// Cross-device write (cpu:0 → cpu:1).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cross_device_write() -> Result<(), anyhow::Error> {
+        require_rdma();
+        let env =
+            TestEnv::new(IbvConfig::targeting("cpu:0"), IbvConfig::targeting("cpu:1")).await?;
+        run_cross_actor_write(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, 0x77, 5).await?;
+        env.shutdown().await
+    }
+
+    /// Cross-device read (cpu:0 ← cpu:1).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cross_device_read() -> Result<(), anyhow::Error> {
+        require_rdma();
+        let env =
+            TestEnv::new(IbvConfig::targeting("cpu:0"), IbvConfig::targeting("cpu:1")).await?;
+        run_cross_actor_read(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, 0x88, 5).await?;
+        env.shutdown().await
+    }
+
+    /// One write + one read in a single `IbvBackend::submit` batch.
+    /// Both ops share the same `QpKey` so the manager groups them
+    /// into a single `ProcessOps` dispatched to one `QueuePairActor`.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_multi_op_same_qp_cpu() -> Result<(), anyhow::Error> {
+        require_rdma();
+        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        run_multi_op_same_qp(&env, BufferDevice::Cpu, BufferDevice::Cpu, 64, 5).await?;
+        env.shutdown().await
+    }
+
+    /// Same as `test_multi_op_same_qp_cpu` but with 2 MiB CUDA buffers,
+    /// pulled apart into a separate test because the buffer-size +
+    /// device split is the only thing that differs.
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_multi_op_same_qp_cuda() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 2 * 1024 * 1024;
+        let env = TestEnv::new(
+            IbvConfig::targeting("cuda:0"),
+            IbvConfig::targeting("cuda:1"),
+        )
+        .await?;
+        run_multi_op_same_qp(&env, BufferDevice::Cuda(0), BufferDevice::Cuda(1), SIZE, 10).await?;
+        env.shutdown().await
+    }
+
+    /// CUDA → CPU write.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cuda_to_cpu_write() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 2 * 1024 * 1024;
+        let env = TestEnv::new(
+            IbvConfig::targeting("cuda:0"),
+            IbvConfig::targeting("cpu:1"),
+        )
+        .await?;
+        run_cross_actor_write(
+            &env,
+            BufferDevice::Cuda(0),
+            BufferDevice::Cpu,
+            SIZE,
+            0x9b,
+            10,
+        )
+        .await?;
+        env.shutdown().await
+    }
+
+    /// CUDA → CPU read (source is the CUDA side).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cuda_to_cpu_read() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 2 * 1024 * 1024;
+        let env = TestEnv::new(
+            IbvConfig::targeting("cpu:0"),
+            IbvConfig::targeting("cuda:1"),
+        )
+        .await?;
+        run_cross_actor_read(
+            &env,
+            BufferDevice::Cpu,
+            BufferDevice::Cuda(1),
+            SIZE,
+            0x37,
+            10,
+        )
+        .await?;
+        env.shutdown().await
+    }
+
+    /// CPU → CUDA write.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cpu_to_cuda_write() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 2 * 1024 * 1024;
+        let env = TestEnv::new(
+            IbvConfig::targeting("cpu:0"),
+            IbvConfig::targeting("cuda:1"),
+        )
+        .await?;
+        run_cross_actor_write(
+            &env,
+            BufferDevice::Cpu,
+            BufferDevice::Cuda(1),
+            SIZE,
+            0x5a,
+            10,
+        )
+        .await?;
+        env.shutdown().await
+    }
+
+    /// CPU → CUDA read (source is the CPU side).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cpu_to_cuda_read() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 2 * 1024 * 1024;
+        let env = TestEnv::new(
+            IbvConfig::targeting("cuda:0"),
+            IbvConfig::targeting("cpu:1"),
+        )
+        .await?;
+        run_cross_actor_read(
+            &env,
+            BufferDevice::Cuda(0),
+            BufferDevice::Cpu,
+            SIZE,
+            0x4e,
+            10,
+        )
+        .await?;
+        env.shutdown().await
+    }
+
+    /// CUDA → CUDA write.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cuda_to_cuda_write() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 2 * 1024 * 1024;
+        let env = TestEnv::new(
+            IbvConfig::targeting("cuda:0"),
+            IbvConfig::targeting("cuda:1"),
+        )
+        .await?;
+        run_cross_actor_write(
+            &env,
+            BufferDevice::Cuda(0),
+            BufferDevice::Cuda(1),
+            SIZE,
+            0xee,
+            10,
+        )
+        .await?;
+        env.shutdown().await
+    }
+
+    /// CUDA → CUDA read.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_cuda_to_cuda_read() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 2 * 1024 * 1024;
+        let env = TestEnv::new(
+            IbvConfig::targeting("cuda:0"),
+            IbvConfig::targeting("cuda:1"),
+        )
+        .await?;
+        run_cross_actor_read(
+            &env,
+            BufferDevice::Cuda(0),
+            BufferDevice::Cuda(1),
+            SIZE,
+            0x42,
+            10,
+        )
+        .await?;
+        env.shutdown().await
+    }
+
+    /// CUDA buffers with `IbvQpType::Standard` (no mlx5dv).
+    /// Exercises the per-buffer dmabuf MR-registration path: without
+    /// mlx5dv the manager cannot use indirect mkeys via segment
+    /// scanning and instead registers each buffer as a standalone
+    /// dmabuf MR (`ibv_reg_dmabuf_mr`).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_standard_qp_cuda_dmabuf_fallback() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 16 * 1024 * 1024;
+        let mut config_a = IbvConfig::targeting("cuda:0");
+        config_a.qp_type = IbvQpType::Standard;
+        let mut config_b = IbvConfig::targeting("cuda:1");
+        config_b.qp_type = IbvQpType::Standard;
+        let env = TestEnv::new(config_a, config_b).await?;
+        run_cross_actor_write(
+            &env,
+            BufferDevice::Cuda(0),
+            BufferDevice::Cuda(1),
+            SIZE,
+            0x33,
+            10,
+        )
+        .await?;
+        env.shutdown().await
+    }
+
+    /// Two `IbvBackend::submit` calls back-to-back through the same
+    /// helper. The second batch reuses the cached `QueuePairActor`
+    /// from the first (the manager's `qp_handles` entry persists
+    /// across submits).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_multi_batch_same_qp() -> Result<(), anyhow::Error> {
+        require_rdma();
+        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let src1 = env
+            .helper_a
+            .allocate(&env.client, 32, BufferDevice::Cpu, 0xa1)
+            .await?;
+        let dst1 = env
+            .helper_b
+            .allocate(&env.client, 32, BufferDevice::Cpu, 0)
+            .await?;
+        env.helper_a
+            .submit(
+                &env.client,
+                vec![BufferHelperOp {
+                    op_type: RdmaOpType::WriteFromLocal,
+                    local_buf: src1,
+                    remote_buf: dst1.clone(),
+                }],
+                5,
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
+        assert_remote_pattern(&env.helper_b, &env.client, dst1, 32, 0xa1).await?;
+
+        let src2 = env
+            .helper_a
+            .allocate(&env.client, 32, BufferDevice::Cpu, 0xb2)
+            .await?;
+        let dst2 = env
+            .helper_b
+            .allocate(&env.client, 32, BufferDevice::Cpu, 0)
+            .await?;
+        env.helper_a
+            .submit(
+                &env.client,
+                vec![BufferHelperOp {
+                    op_type: RdmaOpType::WriteFromLocal,
+                    local_buf: src2,
+                    remote_buf: dst2.clone(),
+                }],
+                5,
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
+        assert_remote_pattern(&env.helper_b, &env.client, dst2, 32, 0xb2).await?;
+        env.shutdown().await
+    }
+
+    /// Single submit batch with ops landing on multiple `QpKey`
+    /// groups: loopback (helper_a → helper_a), cross-actor cpu↔cpu,
+    /// cpu↔cuda, cuda↔cpu, cuda↔cuda. Exercises the manager's
+    /// per-QP slicing and concurrent multi-QP dispatch.
+    #[timed_test::async_timed_test(timeout_secs = 120)]
+    async fn test_multi_op_multi_qp() -> Result<(), anyhow::Error> {
+        require_rdma();
+        require_cuda();
+        const SIZE: usize = 2 * 1024 * 1024;
+
+        let env = TestEnv::same_config(IbvConfig::default()).await?;
+
+        const LOOPBACK_PAT: u8 = 0x11;
+        let lb_src = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, LOOPBACK_PAT)
+            .await?;
+        let lb_dst = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0)
+            .await?;
+
+        const CC_PAT: u8 = 0x22;
+        let cc_src = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, CC_PAT)
+            .await?;
+        let cc_dst = env
+            .helper_b
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0)
+            .await?;
+
+        const CG_PAT: u8 = 0x33;
+        let cg_src = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, CG_PAT)
+            .await?;
+        let cg_dst = env
+            .helper_b
+            .allocate(&env.client, SIZE, BufferDevice::Cuda(1), 0)
+            .await?;
+
+        const GC_PAT: u8 = 0x44;
+        let gc_src = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cuda(0), GC_PAT)
+            .await?;
+        let gc_dst = env
+            .helper_b
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0)
+            .await?;
+
+        const GG_PAT: u8 = 0x55;
+        let gg_src = env
+            .helper_b
+            .allocate(&env.client, SIZE, BufferDevice::Cuda(1), GG_PAT)
+            .await?;
+        let gg_dst = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cuda(0), 0)
+            .await?;
+
+        env.helper_a
+            .submit(
+                &env.client,
+                vec![
+                    BufferHelperOp {
+                        op_type: RdmaOpType::WriteFromLocal,
+                        local_buf: lb_src,
+                        remote_buf: lb_dst.clone(),
+                    },
+                    BufferHelperOp {
+                        op_type: RdmaOpType::WriteFromLocal,
+                        local_buf: cc_src,
+                        remote_buf: cc_dst.clone(),
+                    },
+                    BufferHelperOp {
+                        op_type: RdmaOpType::WriteFromLocal,
+                        local_buf: cg_src,
+                        remote_buf: cg_dst.clone(),
+                    },
+                    BufferHelperOp {
+                        op_type: RdmaOpType::WriteFromLocal,
+                        local_buf: gc_src,
+                        remote_buf: gc_dst.clone(),
+                    },
+                    BufferHelperOp {
+                        op_type: RdmaOpType::ReadIntoLocal,
+                        local_buf: gg_dst.clone(),
+                        remote_buf: gg_src,
+                    },
+                ],
+                30,
+            )
+            .await?
+            .map_err(|e| anyhow::anyhow!(e))?;
+
+        assert_remote_pattern(&env.helper_a, &env.client, lb_dst, SIZE, LOOPBACK_PAT).await?;
+        assert_remote_pattern(&env.helper_b, &env.client, cc_dst, SIZE, CC_PAT).await?;
+        assert_remote_pattern(&env.helper_b, &env.client, cg_dst, SIZE, CG_PAT).await?;
+        assert_remote_pattern(&env.helper_b, &env.client, gc_dst, SIZE, GC_PAT).await?;
+        assert_remote_pattern(&env.helper_a, &env.client, gg_dst, SIZE, GG_PAT).await?;
+
+        env.shutdown().await
+    }
+
+    /// Force the timeout branch in `IbvBackend::submit`. A near-zero
+    /// timeout fires before any per-op replies arrive, so the
+    /// aggregated error reports the timeout terminal cause.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_submit_timeout() -> Result<(), anyhow::Error> {
+        require_rdma();
+        const SIZE: usize = 1024 * 1024;
+        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let src = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0x77)
+            .await?;
+        let dst = env
+            .helper_b
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0)
+            .await?;
+        let result = env
+            .helper_a
+            .submit(
+                &env.client,
+                vec![BufferHelperOp {
+                    op_type: RdmaOpType::WriteFromLocal,
+                    local_buf: src,
+                    remote_buf: dst,
+                }],
+                0,
+            )
+            .await?;
+        let err = result.expect_err("expected submit to time out");
+        assert!(
+            err.contains("submit timed out"),
+            "unexpected error message: {err}",
+        );
+        env.shutdown().await
+    }
+
+    /// Submit a batch with a bogus op in the middle. RC
+    /// completions fire in posting order, so the good op before it
+    /// completes normally, the bogus op fails with `REM_ACCESS_ERR`
+    /// (it puts the QP into error state), and the good op after it
+    /// gets flushed with `WC_WR_FLUSH_ERR`. Verifies (a) op 0 is
+    /// absent from the aggregated error and its bytes transferred,
+    /// (b) ops 1 and 2 both appear in the error, and (c) op 2's
+    /// destination was *not* written (the flush meant nothing was
+    /// transferred).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn test_partial_failure_batch() -> Result<(), anyhow::Error> {
+        use crate::backend::RdmaRemoteBackendContext;
+
+        require_rdma();
+        const SIZE: usize = 32;
+        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+
+        const GOOD_PAT: u8 = 0xc3;
+        const POST_FLUSH_PAT: u8 = 0xde;
+
+        let good_src_0 = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, GOOD_PAT)
+            .await?;
+        let good_dst_0 = env
+            .helper_b
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0)
+            .await?;
+
+        let bogus_src = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0xee)
+            .await?;
+        let real_remote = env
+            .helper_b
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0)
+            .await?;
+        let mut bogus_remote = real_remote.clone();
+        for backend in bogus_remote.backends.iter_mut() {
+            if let RdmaRemoteBackendContext::Ibverbs(_, buf) = backend {
+                buf.rkey = 0xdead_beef;
+                buf.addr = 0xdead_0000;
+            }
+        }
+
+        let post_flush_src = env
+            .helper_a
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, POST_FLUSH_PAT)
+            .await?;
+        let post_flush_dst = env
+            .helper_b
+            .allocate(&env.client, SIZE, BufferDevice::Cpu, 0)
+            .await?;
+
+        let result = env
+            .helper_a
+            .submit(
+                &env.client,
+                vec![
+                    BufferHelperOp {
+                        op_type: RdmaOpType::WriteFromLocal,
+                        local_buf: good_src_0,
+                        remote_buf: good_dst_0.clone(),
+                    },
+                    BufferHelperOp {
+                        op_type: RdmaOpType::WriteFromLocal,
+                        local_buf: bogus_src,
+                        remote_buf: bogus_remote,
+                    },
+                    BufferHelperOp {
+                        op_type: RdmaOpType::WriteFromLocal,
+                        local_buf: post_flush_src,
+                        remote_buf: post_flush_dst.clone(),
+                    },
+                ],
+                10,
+            )
+            .await?;
+        let err = result.expect_err("expected at least one op to fail");
+        let rem_access = format!(
+            "status={:?}",
+            rdmaxcel_sys::ibv_wc_status::IBV_WC_REM_ACCESS_ERR,
+        );
+        let wr_flush = format!(
+            "status={:?}",
+            rdmaxcel_sys::ibv_wc_status::IBV_WC_WR_FLUSH_ERR,
+        );
+        assert!(
+            !err.contains("op 0:"),
+            "op 0 should not appear in error: {err}",
+        );
+        let op1 = err
+            .split("\n  ")
+            .find(|line| line.starts_with("op 1:"))
+            .unwrap_or_else(|| panic!("expected op 1 line in error: {err}"));
+        assert!(
+            op1.contains("Completion status not successful") && op1.contains(&rem_access),
+            "expected op 1 to fail with REM_ACCESS_ERR: {op1}",
+        );
+        let op2 = err
+            .split("\n  ")
+            .find(|line| line.starts_with("op 2:"))
+            .unwrap_or_else(|| panic!("expected op 2 line in error: {err}"));
+        assert!(
+            op2.contains("Completion status not successful") && op2.contains(&wr_flush),
+            "expected op 2 to be flushed with WR_FLUSH_ERR: {op2}",
+        );
+
+        assert_remote_pattern(&env.helper_b, &env.client, good_dst_0, SIZE, GOOD_PAT).await?;
+        // The flushed op was never transferred; destination stays zero.
+        assert_remote_pattern(&env.helper_b, &env.client, post_flush_dst, SIZE, 0).await?;
+
+        env.shutdown().await
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -73,7 +73,6 @@ use super::primitives::mlx5dv_supported;
 use super::primitives::resolve_qp_type;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::PeerInfo;
-use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
 use super::queue_pair::QpGuard;
 use super::queue_pair::QpKey;
@@ -1091,10 +1090,19 @@ impl IbvBackend {
                 return Ok(());
             }
 
-            let wr_ids_to_poll: Vec<u64> = remaining.iter().copied().collect();
-            match qp.poll_completion(poll_target, &wr_ids_to_poll) {
+            match qp.poll_completion(poll_target, &remaining) {
                 Ok(completions) => {
-                    for (wr_id, _wc) in completions {
+                    for (wr_id, wc_result) in completions {
+                        if let Err(e) = wc_result {
+                            return Err(anyhow::anyhow!(
+                                "RDMA polling completion failed: {} [lkey={}, rkey={}, addr=0x{:x}, size={}]",
+                                e,
+                                local_buf.lkey,
+                                local_buf.rkey,
+                                local_buf.addr,
+                                local_buf.size,
+                            ));
+                        }
                         remaining.remove(&wr_id);
                     }
                     if remaining.is_empty() {
@@ -1103,37 +1111,13 @@ impl IbvBackend {
                     poll_policy.yield_now().await;
                 }
                 Err(e) => {
-                    // When the returned error is WR_FLUSH_ERR, which is generally a
-                    // secondary error, drain the remaining completions to find the
-                    // original root cause error. WR_FLUSH_ERR means the QP entered
-                    // error state due to a DIFFERENT WR's failure, so the actual root
-                    // cause may be cached or still in the CQ.
-                    let mut root_cause: Option<PollCompletionError> = None;
-                    if e.is_wr_flush_err() {
-                        for &wr_id in &wr_ids_to_poll {
-                            if let Err(inner_err) = qp.poll_completion(poll_target, &[wr_id]) {
-                                if !inner_err.is_wr_flush_err() {
-                                    root_cause = Some(inner_err);
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    let error_detail = if let Some(cause) = root_cause {
-                        format!(
-                            "RDMA polling completion failed: {} (root cause: {})",
-                            e, cause
-                        )
-                    } else {
-                        format!("RDMA polling completion failed: {}", e)
-                    };
                     return Err(anyhow::anyhow!(
-                        "{} [lkey={}, rkey={}, addr=0x{:x}, size={}]",
-                        error_detail,
+                        "RDMA CQ poll failed: {} [lkey={}, rkey={}, addr=0x{:x}, size={}]",
+                        e,
                         local_buf.lkey,
                         local_buf.rkey,
                         local_buf.addr,
-                        local_buf.size
+                        local_buf.size,
                     ));
                 }
             }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1040,6 +1040,24 @@ impl IbvWc {
     pub fn is_valid(&self) -> bool {
         self.valid
     }
+
+    #[cfg(test)]
+    pub(super) fn for_test(wr_id: u64, valid: bool) -> Self {
+        Self {
+            wr_id,
+            len: 0,
+            valid,
+            error: None,
+            opcode: rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RDMA_WRITE,
+            bytes: None,
+            qp_num: 0,
+            src_qp: 0,
+            pkey_index: 0,
+            slid: 0,
+            sl: 0,
+            dlid_path_bits: 0,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -35,7 +35,6 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
-use hyperactor::OncePortRef;
 use hyperactor::PortHandle;
 use hyperactor::PortRef;
 use hyperactor::actor::Binds;
@@ -50,6 +49,7 @@ use typeuri::Named;
 
 use super::IbvBuffer;
 use super::IbvOp;
+use super::manager_actor::CreatePeerQueuePair;
 use super::manager_actor::EnsureQueuePair;
 use super::manager_actor::QpInitializerDone;
 use super::manager_actor::QpInitializerFailed;
@@ -1459,28 +1459,8 @@ pub(super) unsafe fn destroy_qp(qp: &IbvQueuePair) {
 // peer later wants to RDMA us, it spawns its own `QueuePairActor`
 // locally, which creates a fresh pair the same way.
 
-/// Cross-proc message: the active side asks the peer's manager to
-/// create and connect a mirror QP for an in-flight `QueuePairActor`.
-/// Generic over the manager actor type so test code can swap in a
-/// mock.
-#[derive(Debug, Serialize, Deserialize, Named)]
-#[serde(bound(serialize = "", deserialize = ""))]
-pub(super) struct CreatePeerQueuePair<M: Referable> {
-    /// The active side's manager.
-    pub(super) sender: ActorRef<M>,
-    /// Device the active side picked for its QP.
-    pub(super) sender_device: String,
-    /// Device the peer should create its mirror QP on.
-    pub(super) receiver_device: String,
-    /// Active side's endpoint, captured right after QP creation.
-    pub(super) sender_info: IbvQpInfo,
-    /// One-shot reply carrying the peer's endpoint, or an error.
-    pub(super) reply: OncePortRef<Result<IbvQpInfo, String>>,
-}
-
 /// Operations a [`QueuePairActor`] performs on its QP. Implemented
 /// on the real [`IbvQueuePair`] and on mocks in `#[cfg(test)]` code.
-#[allow(dead_code)] // not yet referenced by IbvManagerActor
 pub(super) trait QueuePair: std::fmt::Debug + Send + Sync + 'static {
     /// Returns the local endpoint other peers need in order to
     /// connect to this QP.
@@ -1594,7 +1574,6 @@ impl PollSleepPolicy {
 
 /// Bundle of trait bounds for an actor type that can serve as the
 /// peer manager — i.e. the recipient of [`CreatePeerQueuePair`].
-#[allow(dead_code)] // not yet referenced by IbvManagerActor
 pub(super) trait Manager:
     Actor + Referable + RemoteHandles<CreatePeerQueuePair<Self>>
 {
@@ -1624,7 +1603,6 @@ pub(super) struct OpResult {
 /// successfully, otherwise `Err` carrying the first per-WR error
 /// observed (held back until the op's other WRs also report, so the
 /// MR registration outlives the data path).
-#[allow(dead_code)] // not yet referenced by IbvManagerActor
 #[derive(Debug)]
 pub(super) struct ProcessOps<M: Referable> {
     pub(super) items: Vec<(usize, IbvOp<M>, IbvMemoryRegionView)>,
@@ -1672,7 +1650,6 @@ struct PostedOpEntry {
 /// RDMA hardware). The QP is constructed by the spawning manager
 /// and handed in as a spawn param; the actor owns it for life and
 /// drops it when the actor stops.
-#[allow(dead_code)] // not yet referenced by IbvManagerActor
 #[derive(Debug)]
 pub(super) struct QueuePairActor<M: Manager, Qp: QueuePair> {
     qp_key: QpKey,
@@ -1720,7 +1697,6 @@ pub(super) struct QueuePairActor<M: Manager, Qp: QueuePair> {
 }
 
 impl<M: Manager, Qp: QueuePair> QueuePairActor<M, Qp> {
-    #[allow(dead_code)] // not yet referenced by IbvManagerActor
     pub(super) fn new(
         qp_key: QpKey,
         local_manager: ActorRef<M>,

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -15,6 +15,7 @@
 /// Maximum size for a single RDMA operation in bytes (1 GiB).
 const MAX_RDMA_MSG_SIZE: usize = 1024 * 1024 * 1024;
 
+use std::collections::HashSet;
 use std::io::Error;
 use std::result::Result;
 use std::time::Duration;
@@ -945,22 +946,25 @@ impl IbvQueuePair {
         }
     }
 
-    /// Polls for work completions by wr_ids.
-    ///
-    /// # Arguments
-    ///
-    /// * `target` - Which completion queue to poll (Send, Receive)
-    /// * `expected_wr_ids` - Slice of work request IDs to wait for
+    /// Polls for work completions for each of `expected_wr_ids`.
     ///
     /// # Returns
     ///
-    /// * `Ok(Vec<(u64, IbvWc)>)` - Vector of (wr_id, completion) pairs found
-    /// * `Err(e)` - An error occurred
+    /// * Outer `Ok` — the CQ poll itself succeeded. Each element is
+    ///   `(wr_id, Ok(IbvWc))` for a completed WR or `(wr_id,
+    ///   Err(PollCompletionError))` for a WR whose completion landed
+    ///   with a non-success status (per-WR failure; the QP may or may
+    ///   not be in error state). wr_ids that have no completion yet
+    ///   are omitted.
+    /// * Outer `Err` — the CQ itself is unusable (`ibv_poll_cq`
+    ///   returned a negative value, i.e. `RDMAXCEL_CQ_POLL_FAILED`,
+    ///   or some other non-classifiable rdmaxcel return code). The
+    ///   QP should be treated as poisoned.
     pub fn poll_completion(
         &mut self,
         target: PollTarget,
-        expected_wr_ids: &[u64],
-    ) -> Result<Vec<(u64, IbvWc)>, PollCompletionError> {
+        expected_wr_ids: &HashSet<u64>,
+    ) -> Result<Vec<(u64, Result<IbvWc, PollCompletionError>)>, PollCompletionError> {
         if expected_wr_ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -1000,55 +1004,67 @@ impl IbvQueuePair {
                         if !wc.is_valid()
                             && let Some((status, vendor_err)) = wc.error()
                         {
-                            return Err(PollCompletionError {
-                                status: Some(status),
-                                vendor_err: Some(vendor_err),
-                                message: format!(
-                                    "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
-                                    cq_type, expected_wr_id, status, vendor_err,
-                                ),
-                            });
+                            results.push((
+                                expected_wr_id,
+                                Err(PollCompletionError {
+                                    status: Some(status),
+                                    vendor_err: Some(vendor_err),
+                                    message: format!(
+                                        "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
+                                        cq_type, expected_wr_id, status, vendor_err,
+                                    ),
+                                }),
+                            ));
+                        } else {
+                            results.push((expected_wr_id, Ok(IbvWc::from(wc))));
                         }
-                        results.push((expected_wr_id, IbvWc::from(wc)));
                     }
                     0 => {
                         // Not found yet
                     }
+                    // RDMAXCEL_COMPLETION_FAILED: per-WR completion landed
+                    // with a non-success status. Surface as an inner Err
+                    // so the caller can report the failure for this op
+                    // without poisoning the QP.
                     -17 => {
                         let error_msg =
                             std::ffi::CStr::from_ptr(rdmaxcel_sys::rdmaxcel_error_string(ret))
                                 .to_str()
                                 .unwrap_or("Unknown error");
-                        if let Some((status, vendor_err)) = wc.error() {
-                            return Err(PollCompletionError {
-                                status: Some(status),
-                                vendor_err: Some(vendor_err),
-                                message: format!(
-                                    "Failed to poll {} CQ for wr_id={}: {} [status={:?}, vendor_err={}, qp_num={}, byte_len={}]",
-                                    cq_type,
-                                    expected_wr_id,
-                                    error_msg,
-                                    status,
-                                    vendor_err,
-                                    wc.qp_num,
-                                    wc.len(),
-                                ),
-                            });
-                        } else {
-                            return Err(PollCompletionError {
-                                status: None,
-                                vendor_err: None,
-                                message: format!(
-                                    "Failed to poll {} CQ for wr_id={}: {} [qp_num={}, byte_len={}]",
-                                    cq_type,
-                                    expected_wr_id,
-                                    error_msg,
-                                    wc.qp_num,
-                                    wc.len(),
-                                ),
-                            });
-                        }
+                        let (status, vendor_err) =
+                            wc.error().map_or((None, None), |(s, v)| (Some(s), Some(v)));
+                        let message = match (status, vendor_err) {
+                            (Some(s), Some(v)) => format!(
+                                "{} wr_id={} completed with non-success status: {} [status={:?}, vendor_err={}, qp_num={}, byte_len={}]",
+                                cq_type,
+                                expected_wr_id,
+                                error_msg,
+                                s,
+                                v,
+                                wc.qp_num,
+                                wc.len(),
+                            ),
+                            _ => format!(
+                                "{} wr_id={} completed with non-success status: {} [qp_num={}, byte_len={}]",
+                                cq_type,
+                                expected_wr_id,
+                                error_msg,
+                                wc.qp_num,
+                                wc.len(),
+                            ),
+                        };
+                        results.push((
+                            expected_wr_id,
+                            Err(PollCompletionError {
+                                status,
+                                vendor_err,
+                                message,
+                            }),
+                        ));
                     }
+                    // RDMAXCEL_CQ_POLL_FAILED (-16) and any other
+                    // non-classifiable rdmaxcel return code: fatal at
+                    // the CQ level; the QP is no longer pollable.
                     _ => {
                         let error_msg =
                             std::ffi::CStr::from_ptr(rdmaxcel_sys::rdmaxcel_error_string(ret))
@@ -1058,8 +1074,8 @@ impl IbvQueuePair {
                             status: None,
                             vendor_err: None,
                             message: format!(
-                                "Failed to poll {} CQ for wr_id={}: {}",
-                                cq_type, expected_wr_id, error_msg,
+                                "{} CQ poll failed (ret={}) while looking up wr_id={}: {}",
+                                cq_type, ret, expected_wr_id, error_msg,
                             ),
                         });
                     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -28,10 +28,12 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::OncePortRef;
 use hyperactor::PortRef;
 use hyperactor::actor::Binds;
 use hyperactor::actor::Referable;
 use hyperactor::actor::RemoteHandles;
+use hyperactor::context::Mailbox;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use serde::Deserialize;
@@ -995,17 +997,17 @@ impl IbvQueuePair {
 
                 match ret {
                     1 => {
-                        if !wc.is_valid() {
-                            if let Some((status, vendor_err)) = wc.error() {
-                                return Err(PollCompletionError {
-                                    status: Some(status),
-                                    vendor_err: Some(vendor_err),
-                                    message: format!(
-                                        "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
-                                        cq_type, expected_wr_id, status, vendor_err,
-                                    ),
-                                });
-                            }
+                        if !wc.is_valid()
+                            && let Some((status, vendor_err)) = wc.error()
+                        {
+                            return Err(PollCompletionError {
+                                status: Some(status),
+                                vendor_err: Some(vendor_err),
+                                message: format!(
+                                    "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
+                                    cq_type, expected_wr_id, status, vendor_err,
+                                ),
+                            });
                         }
                         results.push((expected_wr_id, IbvWc::from(wc)));
                     }
@@ -1406,6 +1408,183 @@ pub(super) unsafe fn destroy_qp(qp: &IbvQueuePair) {
             let rdmaxcel_qp = qp.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
             rdmaxcel_sys::rdmaxcel_qp_destroy(rdmaxcel_qp);
         }
+    }
+}
+
+// =====================================================================
+// QueuePairActor
+// =====================================================================
+//
+// Owns one simplex queue pair to a peer. Replaces the symmetric
+// `QueuePairInitializer` handshake — in which each side drives its
+// own QP — with an asymmetric one: the active side spawns a
+// `QueuePairActor` that owns and operates the local QP; the peer's
+// manager eagerly creates its mirror QP during the handshake, stores
+// it as a passive endpoint, and never wraps it in an actor. If the
+// peer later wants to RDMA us, it spawns its own `QueuePairActor`
+// locally, which creates a fresh pair the same way.
+
+/// Cross-proc message: the active side asks the peer's manager to
+/// create and connect a mirror QP for an in-flight `QueuePairActor`.
+/// Generic over the manager actor type so test code can swap in a
+/// mock.
+#[derive(Debug, Serialize, Deserialize, Named)]
+#[serde(bound(serialize = "", deserialize = ""))]
+pub(super) struct CreatePeerQueuePair<M: Referable> {
+    /// The active side's manager.
+    pub(super) sender: ActorRef<M>,
+    /// Device the active side picked for its QP.
+    pub(super) sender_device: String,
+    /// Device the peer should create its mirror QP on.
+    pub(super) receiver_device: String,
+    /// Active side's endpoint, captured right after QP creation.
+    pub(super) sender_info: IbvQpInfo,
+    /// One-shot reply carrying the peer's endpoint, or an error.
+    pub(super) reply: OncePortRef<Result<IbvQpInfo, String>>,
+}
+
+/// Operations a [`QueuePairActor`] performs on its QP. Implemented
+/// on the real [`IbvQueuePair`] and on mocks in `#[cfg(test)]` code.
+///
+/// Today only [`Self::get_qp_info`] and [`Self::connect`] are used;
+/// data-path methods will be added alongside op processing.
+#[allow(dead_code)] // not yet referenced by IbvManagerActor
+pub(super) trait QueuePair: std::fmt::Debug + Send + Sync + 'static {
+    /// Returns the local endpoint other peers need in order to
+    /// connect to this QP.
+    fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error>;
+
+    /// Transitions the QP through `INIT -> RTR -> RTS`, connected to
+    /// `info`.
+    fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error>;
+}
+
+/// Bundle of trait bounds for an actor type that can serve as the
+/// peer manager — i.e. the recipient of [`CreatePeerQueuePair`].
+#[allow(dead_code)] // not yet referenced by IbvManagerActor
+pub(super) trait Manager:
+    Actor + Referable + RemoteHandles<CreatePeerQueuePair<Self>>
+{
+}
+
+impl<T> Manager for T where T: Actor + Referable + RemoteHandles<CreatePeerQueuePair<T>> {}
+
+/// Per-peer queue-pair actor.
+///
+/// Generic over the manager actor type `M` (so tests can swap in a
+/// mock) and the queue-pair type `Qp` (so unit tests run without
+/// RDMA hardware). The QP is constructed by the spawning manager
+/// and handed in as a spawn param; the actor owns it for life and
+/// drops it when the actor stops.
+#[allow(dead_code)] // not yet referenced by IbvManagerActor
+#[derive(Debug)]
+pub(super) struct QueuePairActor<M: Manager, Qp: QueuePair> {
+    qp_key: QpKey,
+    /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
+    /// build its own [`QpKey`] from our identity.
+    local_manager: ActorRef<M>,
+    /// Recipient of [`CreatePeerQueuePair`].
+    peer_manager: ActorRef<M>,
+    qp: Qp,
+    /// `true` when the peer QP is colocated with this actor's QP —
+    /// i.e. both endpoints live in the same `IbvManagerActor` *and*
+    /// target the same RDMA device. In that case `init` connects
+    /// the QP to its own endpoint and skips the cross-actor
+    /// handshake.
+    is_loopback: bool,
+    init_timeout: Duration,
+}
+
+impl<M: Manager, Qp: QueuePair> QueuePairActor<M, Qp> {
+    #[allow(dead_code)] // not yet referenced by IbvManagerActor
+    pub(super) fn new(
+        qp_key: QpKey,
+        local_manager: ActorRef<M>,
+        peer_manager: ActorRef<M>,
+        qp: Qp,
+        is_loopback: bool,
+    ) -> Self {
+        let init_timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
+        Self {
+            qp_key,
+            local_manager,
+            peer_manager,
+            qp,
+            is_loopback,
+            init_timeout,
+        }
+    }
+}
+
+#[async_trait]
+impl<M: Manager, Qp: QueuePair> Actor for QueuePairActor<M, Qp> {
+    async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        let local_info = self.qp.get_qp_info().map_err(|e| {
+            tracing::error!(qp_key = ?self.qp_key, error = %e, "QueuePairActor init: get_qp_info failed");
+            anyhow::anyhow!("could not extract local QP info: {e}")
+        })?;
+
+        let peer_info = if self.is_loopback {
+            // The "peer" is ourselves; skip the round-trip and
+            // connect to our own endpoint.
+            local_info.clone()
+        } else {
+            let (reply, rx) = this.mailbox().open_once_port::<Result<IbvQpInfo, String>>();
+            self.peer_manager.post(
+                this,
+                CreatePeerQueuePair {
+                    sender: self.local_manager.clone(),
+                    sender_device: self.qp_key.self_device.clone(),
+                    receiver_device: self.qp_key.other_device.clone(),
+                    sender_info: local_info,
+                    reply: reply.bind(),
+                },
+            );
+            match tokio::time::timeout(self.init_timeout, rx.recv()).await {
+                Ok(Ok(Ok(info))) => info,
+                Ok(Ok(Err(e))) => {
+                    tracing::error!(
+                        qp_key = ?self.qp_key,
+                        peer_manager = ?self.peer_manager,
+                        error = %e,
+                        "QueuePairActor init: peer manager rejected CreatePeerQueuePair",
+                    );
+                    return Err(anyhow::anyhow!("peer manager rejected QP request: {e}"));
+                }
+                Ok(Err(e)) => {
+                    tracing::error!(
+                        qp_key = ?self.qp_key,
+                        peer_manager = ?self.peer_manager,
+                        error = %e,
+                        "QueuePairActor init: peer reply port closed",
+                    );
+                    return Err(anyhow::anyhow!("peer reply port closed: {e}"));
+                }
+                Err(_) => {
+                    tracing::error!(
+                        qp_key = ?self.qp_key,
+                        peer_manager = ?self.peer_manager,
+                        timeout = ?self.init_timeout,
+                        "QueuePairActor init: timed out waiting for peer reply",
+                    );
+                    return Err(anyhow::anyhow!(
+                        "QP initialization timed out after {:?}",
+                        self.init_timeout
+                    ));
+                }
+            }
+        };
+
+        self.qp.connect(&peer_info).map_err(|e| {
+            tracing::error!(
+                qp_key = ?self.qp_key,
+                peer_info = ?peer_info,
+                error = %e,
+                "QueuePairActor init: connect failed",
+            );
+            anyhow::anyhow!("could not connect QP to peer: {e}")
+        })?;
+        Ok(())
     }
 }
 
@@ -1908,5 +2087,428 @@ mod tests {
         harness.init_handle.post(&peer, undeliverable);
         tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(harness.state.lock().unwrap().failed.len(), 1);
+    }
+
+    // =================================================================
+    // QueuePairActor init handshake
+    // =================================================================
+
+    /// Captured fields from a `CreatePeerQueuePair` message; we
+    /// can't keep the original because the `reply` port is consumed
+    /// to send the response.
+    #[derive(Debug, Clone)]
+    struct CreateCapture {
+        sender_id: hyperactor::ActorId,
+        sender_device: String,
+        receiver_device: String,
+        sender_qp_num: u32,
+    }
+
+    #[derive(Debug)]
+    struct QpaMockState {
+        creates: Vec<CreateCapture>,
+        response: Option<Result<IbvQpInfo, String>>,
+        /// Forwards every supervision event the parent receives to
+        /// the test.
+        supervision_tx: Option<
+            tokio::sync::mpsc::UnboundedSender<hyperactor::supervision::ActorSupervisionEvent>,
+        >,
+    }
+
+    /// Mock manager used by `QueuePairActor` tests.
+    ///
+    /// Plays two roles:
+    /// 1. As the *parent*, it spawns `QueuePairActor` children via
+    ///    [`SpawnQpaChild`].
+    /// 2. As the *peer*, it handles `CreatePeerQueuePair`.
+    #[derive(Debug)]
+    #[hyperactor::export(handlers = [CreatePeerQueuePair<QpaMockManager>])]
+    struct QpaMockManager {
+        state: Arc<Mutex<QpaMockState>>,
+    }
+
+    #[async_trait]
+    impl Actor for QpaMockManager {
+        async fn handle_supervision_event(
+            &mut self,
+            _this: &Instance<Self>,
+            event: &hyperactor::supervision::ActorSupervisionEvent,
+        ) -> Result<bool> {
+            let tx = self.state.lock().unwrap().supervision_tx.clone();
+            let Some(tx) = tx else {
+                return Ok(!event.is_error());
+            };
+            tx.send(event.clone())
+                .map_err(|e| anyhow::anyhow!("supervision_tx send failed: {e}"))?;
+            Ok(true)
+        }
+    }
+
+    #[async_trait]
+    impl Handler<CreatePeerQueuePair<QpaMockManager>> for QpaMockManager {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: CreatePeerQueuePair<QpaMockManager>,
+        ) -> Result<()> {
+            let response = {
+                let mut state = self.state.lock().unwrap();
+                state.creates.push(CreateCapture {
+                    sender_id: msg.sender.actor_addr().id().clone(),
+                    sender_device: msg.sender_device.clone(),
+                    receiver_device: msg.receiver_device.clone(),
+                    sender_qp_num: msg.sender_info.qp_num,
+                });
+                state.response.take()
+            };
+            if let Some(response) = response {
+                msg.reply.post(cx, response);
+            }
+            // None → drop reply intentionally to test the timeout path.
+            Ok(())
+        }
+    }
+
+    /// Local message that spawns a `QueuePairActor` as a child of
+    /// this manager so supervision events route here. The reply
+    /// carries the resulting `ActorHandle` so the test can observe
+    /// lifecycle transitions.
+    #[derive(Debug)]
+    struct SpawnQpaChild {
+        qp_key: QpKey,
+        peer_manager: ActorRef<QpaMockManager>,
+        qp: MockQp,
+        is_loopback: bool,
+        reply: hyperactor::OncePortHandle<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>>,
+    }
+
+    #[async_trait]
+    impl Handler<SpawnQpaChild> for QpaMockManager {
+        async fn handle(&mut self, cx: &Context<Self>, msg: SpawnQpaChild) -> Result<()> {
+            let local_manager = cx.bind::<QpaMockManager>();
+            let actor = QueuePairActor::new(
+                msg.qp_key,
+                local_manager,
+                msg.peer_manager,
+                msg.qp,
+                msg.is_loopback,
+            );
+            let handle = cx.spawn(actor);
+            msg.reply.post(cx, handle);
+            Ok(())
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct MockQpInner {
+        connect_calls: Vec<IbvQpInfo>,
+    }
+
+    /// Minimal `QueuePair` impl used by the init-handshake tests.
+    /// Records every `connect` call so the test can assert what the
+    /// actor passed in.
+    #[derive(Debug, Clone)]
+    struct MockQp {
+        info: IbvQpInfo,
+        inner: Arc<Mutex<MockQpInner>>,
+    }
+
+    impl MockQp {
+        fn new(qp_num: u32, psn: u32) -> Self {
+            Self {
+                info: IbvQpInfo {
+                    qp_num,
+                    lid: 0,
+                    gid: None,
+                    psn,
+                },
+                inner: Arc::new(Mutex::new(MockQpInner::default())),
+            }
+        }
+
+        fn connect_calls(&self) -> Vec<IbvQpInfo> {
+            self.inner.lock().unwrap().connect_calls.clone()
+        }
+    }
+
+    impl QueuePair for MockQp {
+        fn get_qp_info(&mut self) -> Result<IbvQpInfo> {
+            Ok(self.info.clone())
+        }
+
+        fn connect(&mut self, info: &IbvQpInfo) -> Result<()> {
+            self.inner.lock().unwrap().connect_calls.push(info.clone());
+            Ok(())
+        }
+    }
+
+    struct QpaHarness {
+        proc: Proc,
+        parent: ActorHandle<QpaMockManager>,
+        peer: ActorHandle<QpaMockManager>,
+        peer_state: Arc<Mutex<QpaMockState>>,
+        client: hyperactor::Client,
+        supervision_rx:
+            tokio::sync::mpsc::UnboundedReceiver<hyperactor::supervision::ActorSupervisionEvent>,
+    }
+
+    impl QpaHarness {
+        fn build() -> Result<Self> {
+            let proc = Proc::anonymous();
+            let (supervision_tx, supervision_rx) = tokio::sync::mpsc::unbounded_channel();
+            let parent = proc.spawn_with_label(
+                "parent",
+                QpaMockManager {
+                    state: Arc::new(Mutex::new(QpaMockState {
+                        creates: Vec::new(),
+                        response: None,
+                        supervision_tx: Some(supervision_tx),
+                    })),
+                },
+            );
+            let peer_state = Arc::new(Mutex::new(QpaMockState {
+                creates: Vec::new(),
+                response: None,
+                supervision_tx: None,
+            }));
+            let peer = proc.spawn_with_label(
+                "peer",
+                QpaMockManager {
+                    state: Arc::clone(&peer_state),
+                },
+            );
+            let client = proc.client("client");
+            Ok(Self {
+                proc,
+                parent,
+                peer,
+                peer_state,
+                client,
+                supervision_rx,
+            })
+        }
+
+        fn peer_id(&self) -> hyperactor::ActorId {
+            self.peer.actor_addr().id().clone()
+        }
+
+        fn parent_id(&self) -> hyperactor::ActorId {
+            self.parent.actor_addr().id().clone()
+        }
+
+        /// Await the next forwarded child-error supervision event.
+        async fn next_supervision_failure(
+            &mut self,
+        ) -> hyperactor::supervision::ActorSupervisionEvent {
+            tokio::time::timeout(Duration::from_secs(5), self.supervision_rx.recv())
+                .await
+                .expect("timed out waiting for child failure event")
+                .expect("supervision channel closed")
+        }
+
+        /// Destroys the proc, closes the supervision channel, drains
+        /// every remaining event, and asserts none are unexpected.
+        async fn teardown(mut self) {
+            self.supervision_rx.close();
+            self.proc
+                .destroy_and_wait(Duration::from_secs(30), "test teardown")
+                .await
+                .expect("destroy_and_wait failed");
+            let mut leftover = Vec::new();
+            while let Some(event) = self.supervision_rx.recv().await {
+                leftover.push(event);
+            }
+            assert!(
+                leftover.is_empty(),
+                "unexpected supervision events at teardown: {leftover:?}",
+            );
+        }
+
+        async fn spawn_actor(
+            &self,
+            qp_key: QpKey,
+            peer_manager: ActorRef<QpaMockManager>,
+            qp: MockQp,
+            is_loopback: bool,
+        ) -> Result<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>> {
+            let (reply, rx) = self.client.mailbox().open_once_port();
+            self.parent.post(
+                &self.client,
+                SpawnQpaChild {
+                    qp_key,
+                    peer_manager,
+                    qp,
+                    is_loopback,
+                    reply,
+                },
+            );
+            Ok(rx.recv().await?)
+        }
+    }
+
+    async fn await_status(
+        handle: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
+        expected: impl Fn(&hyperactor::actor::ActorStatus) -> bool,
+    ) -> hyperactor::actor::ActorStatus {
+        let mut status = handle.status();
+        status.wait_for(|s| expected(s)).await.unwrap();
+        status.borrow().clone()
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_init_succeeds_via_peer() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let peer_info = IbvQpInfo {
+            qp_num: 0xbeef,
+            lid: 0,
+            gid: None,
+            psn: 0xc0ffee,
+        };
+        harness.peer_state.lock().unwrap().response = Some(Ok(peer_info.clone()));
+
+        let qp = MockQp::new(0x1234, 0xdead);
+        let qp_key = QpKey {
+            self_device: "mlx5_0".into(),
+            other_id: harness.peer_id(),
+            other_device: "mlx5_1".into(),
+        };
+        let handle = harness
+            .spawn_actor(
+                qp_key.clone(),
+                harness.peer.bind::<QpaMockManager>(),
+                qp.clone(),
+                false,
+            )
+            .await?;
+
+        await_status(&handle, |s| {
+            matches!(s, hyperactor::actor::ActorStatus::Idle)
+        })
+        .await;
+
+        let creates = harness.peer_state.lock().unwrap().creates.clone();
+        assert_eq!(creates.len(), 1);
+        assert_eq!(creates[0].sender_device, "mlx5_0");
+        assert_eq!(creates[0].receiver_device, "mlx5_1");
+        assert_eq!(creates[0].sender_qp_num, 0x1234);
+        // The sender ref carries the local manager's identity so the
+        // receiver can build its own `QpKey`.
+        assert_eq!(creates[0].sender_id, harness.parent_id());
+
+        let connects = qp.connect_calls();
+        assert_eq!(connects.len(), 1);
+        assert_eq!(connects[0].qp_num, peer_info.qp_num);
+        assert_eq!(connects[0].psn, peer_info.psn);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_init_loopback_skips_peer_round_trip() -> Result<()> {
+        let harness = QpaHarness::build()?;
+
+        let qp = MockQp::new(0xaaa, 0xbbb);
+        let qp_key = QpKey {
+            self_device: "mlx5_0".into(),
+            other_id: harness.parent_id(),
+            other_device: "mlx5_0".into(),
+        };
+        let handle = harness
+            .spawn_actor(
+                qp_key,
+                harness.peer.bind::<QpaMockManager>(),
+                qp.clone(),
+                true,
+            )
+            .await?;
+
+        await_status(&handle, |s| {
+            matches!(s, hyperactor::actor::ActorStatus::Idle)
+        })
+        .await;
+        assert!(harness.peer_state.lock().unwrap().creates.is_empty());
+
+        let connects = qp.connect_calls();
+        assert_eq!(connects.len(), 1);
+        assert_eq!(connects[0].qp_num, 0xaaa);
+        assert_eq!(connects[0].psn, 0xbbb);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_init_peer_error_fails_actor() -> Result<()> {
+        let mut harness = QpaHarness::build()?;
+        harness.peer_state.lock().unwrap().response =
+            Some(Err("peer rejected, no domain on receiver_device".into()));
+
+        let qp_key = QpKey {
+            self_device: "mlx5_0".into(),
+            other_id: harness.peer_id(),
+            other_device: "mlx5_99".into(),
+        };
+        let handle = harness
+            .spawn_actor(
+                qp_key,
+                harness.peer.bind::<QpaMockManager>(),
+                MockQp::new(1, 2),
+                false,
+            )
+            .await?;
+
+        let event = harness.next_supervision_failure().await;
+        assert_eq!(&event.actor_id, handle.actor_addr());
+        let report = event.failure_report().expect("event should be a failure");
+        assert!(
+            report.contains("peer rejected"),
+            "failure report should surface the peer's error string; got: {report}"
+        );
+        let status = await_status(&handle, |s| {
+            matches!(s, hyperactor::actor::ActorStatus::Failed(_))
+        })
+        .await;
+        assert!(matches!(status, hyperactor::actor::ActorStatus::Failed(_)));
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_init_timeout_fails_actor() -> Result<()> {
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(
+            crate::config::RDMA_QP_INIT_TIMEOUT,
+            Duration::from_millis(100),
+        );
+
+        let mut harness = QpaHarness::build()?;
+
+        let qp_key = QpKey {
+            self_device: "mlx5_0".into(),
+            other_id: harness.peer_id(),
+            other_device: "mlx5_1".into(),
+        };
+        let handle = harness
+            .spawn_actor(
+                qp_key,
+                harness.peer.bind::<QpaMockManager>(),
+                MockQp::new(1, 2),
+                false,
+            )
+            .await?;
+
+        let event = harness.next_supervision_failure().await;
+        assert_eq!(&event.actor_id, handle.actor_addr());
+        let report = event.failure_report().expect("event should be a failure");
+        assert!(
+            report.contains("timed out"),
+            "failure report should mention timeout; got: {report}"
+        );
+        let status = await_status(&handle, |s| {
+            matches!(s, hyperactor::actor::ActorStatus::Failed(_))
+        })
+        .await;
+        assert!(matches!(status, hyperactor::actor::ActorStatus::Failed(_)));
+        harness.teardown().await;
+        Ok(())
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -15,12 +15,18 @@
 /// Maximum size for a single RDMA operation in bytes (1 GiB).
 const MAX_RDMA_MSG_SIZE: usize = 1024 * 1024 * 1024;
 
+use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::VecDeque;
 use std::io::Error;
 use std::result::Result;
 use std::time::Duration;
+use std::time::Instant;
 
 use async_trait::async_trait;
+use backoff::ExponentialBackoff;
+use backoff::ExponentialBackoffBuilder;
+use backoff::backoff::Backoff;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
 use hyperactor::ActorId;
@@ -30,6 +36,7 @@ use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::OncePortRef;
+use hyperactor::PortHandle;
 use hyperactor::PortRef;
 use hyperactor::actor::Binds;
 use hyperactor::actor::Referable;
@@ -42,15 +49,18 @@ use serde::Serialize;
 use typeuri::Named;
 
 use super::IbvBuffer;
+use super::IbvOp;
 use super::manager_actor::EnsureQueuePair;
 use super::manager_actor::QpInitializerDone;
 use super::manager_actor::QpInitializerFailed;
 use super::primitives::Gid;
 use super::primitives::IbvConfig;
+use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvOperation;
 use super::primitives::IbvQpInfo;
 use super::primitives::IbvWc;
 use super::primitives::resolve_qp_type;
+use crate::RdmaOpType;
 
 /// A structured error from [`IbvQueuePair::poll_completion`].
 ///
@@ -77,6 +87,15 @@ impl PollCompletionError {
     /// error state due to a different work request's failure.
     pub fn is_wr_flush_err(&self) -> bool {
         self.status == Some(rdmaxcel_sys::ibv_wc_status::IBV_WC_WR_FLUSH_ERR)
+    }
+
+    #[cfg(test)]
+    pub(super) fn for_test(message: &str) -> Self {
+        Self {
+            message: message.to_string(),
+            status: None,
+            vendor_err: None,
+        }
     }
 }
 
@@ -1461,9 +1480,6 @@ pub(super) struct CreatePeerQueuePair<M: Referable> {
 
 /// Operations a [`QueuePairActor`] performs on its QP. Implemented
 /// on the real [`IbvQueuePair`] and on mocks in `#[cfg(test)]` code.
-///
-/// Today only [`Self::get_qp_info`] and [`Self::connect`] are used;
-/// data-path methods will be added alongside op processing.
 #[allow(dead_code)] // not yet referenced by IbvManagerActor
 pub(super) trait QueuePair: std::fmt::Debug + Send + Sync + 'static {
     /// Returns the local endpoint other peers need in order to
@@ -1473,6 +1489,107 @@ pub(super) trait QueuePair: std::fmt::Debug + Send + Sync + 'static {
     /// Transitions the QP through `INIT -> RTR -> RTS`, connected to
     /// `info`.
     fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error>;
+
+    /// Post an RDMA WRITE from `lhandle` to `rhandle`. Returns one
+    /// wr_id per `MAX_RDMA_MSG_SIZE` chunk the QP issues.
+    fn put(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> Result<Vec<u64>, anyhow::Error>;
+
+    /// Post an RDMA READ from `rhandle` into `lhandle`. Returns one
+    /// wr_id per chunk.
+    fn get(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> Result<Vec<u64>, anyhow::Error>;
+
+    /// Poll for completions of every wr_id in `expected_wr_ids`. See
+    /// [`IbvQueuePair::poll_completion`] for the outer/inner `Result`
+    /// semantics.
+    fn poll_completion(
+        &mut self,
+        target: PollTarget,
+        expected_wr_ids: &HashSet<u64>,
+    ) -> Result<Vec<(u64, Result<IbvWc, PollCompletionError>)>, PollCompletionError>;
+}
+
+impl QueuePair for IbvQueuePair {
+    fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
+        IbvQueuePair::get_qp_info(self)
+    }
+    fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
+        IbvQueuePair::connect(self, info)
+    }
+    fn put(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> Result<Vec<u64>, anyhow::Error> {
+        IbvQueuePair::put(self, lhandle, rhandle)
+    }
+    fn get(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> Result<Vec<u64>, anyhow::Error> {
+        IbvQueuePair::get(self, lhandle, rhandle)
+    }
+    fn poll_completion(
+        &mut self,
+        target: PollTarget,
+        expected_wr_ids: &HashSet<u64>,
+    ) -> Result<Vec<(u64, Result<IbvWc, PollCompletionError>)>, PollCompletionError> {
+        IbvQueuePair::poll_completion(self, target, expected_wr_ids)
+    }
+}
+
+/// Adaptive backoff for the scheduler's `Tick` self-message. Use
+/// [`Self::next_interval`] to ask "how long should I wait before the
+/// next poll attempt?"; call [`Self::reset`] whenever the previous
+/// poll observed completions (so the actor stays tight while work
+/// is making progress).
+///
+/// While the elapsed time since the first non-zero interval is below
+/// `yield_window`, the policy returns `Duration::ZERO` so the actor
+/// just re-sends `Tick` to itself with no delay — keeping latency
+/// tight when WRs are about to complete. Past the window, it walks
+/// an exponential backoff (1ms initial, doubling, capped at 10ms)
+/// so a long-running op doesn't keep the runtime spinning. When
+/// `yield_window` is `None` (the default for
+/// `RDMA_CQ_BUSY_POLL_WINDOW`) the policy always returns
+/// `Duration::ZERO`.
+#[derive(Debug)]
+struct PollSleepPolicy {
+    yield_window: Option<Duration>,
+    started_at: Option<Instant>,
+    backoff: Option<ExponentialBackoff>,
+}
+
+impl PollSleepPolicy {
+    fn new() -> Self {
+        let yield_window = hyperactor_config::global::get(crate::config::RDMA_CQ_BUSY_POLL_WINDOW);
+        Self {
+            yield_window,
+            started_at: None,
+            backoff: None,
+        }
+    }
+
+    /// Forget all accumulated backoff state. Called after a poll
+    /// returns completions, so the next idle stretch starts fresh.
+    fn reset(&mut self) {
+        self.started_at = None;
+        self.backoff = None;
+    }
+
+    /// Suggested delay before the next `Tick`. `Duration::ZERO`
+    /// means "send `Tick` immediately".
+    fn next_interval(&mut self) -> Duration {
+        let Some(window) = self.yield_window else {
+            return Duration::ZERO;
+        };
+        let started = *self.started_at.get_or_insert_with(Instant::now);
+        if started.elapsed() < window {
+            return Duration::ZERO;
+        }
+        let backoff = self.backoff.get_or_insert_with(|| {
+            ExponentialBackoffBuilder::new()
+                .with_initial_interval(Duration::from_millis(1))
+                .with_max_interval(Duration::from_millis(10))
+                .with_multiplier(2.0)
+                .with_randomization_factor(0.0)
+                .with_max_elapsed_time(None)
+                .build()
+        });
+        backoff.next_backoff().unwrap_or(Duration::ZERO)
+    }
 }
 
 /// Bundle of trait bounds for an actor type that can serve as the
@@ -1484,6 +1601,69 @@ pub(super) trait Manager:
 }
 
 impl<T> Manager for T where T: Actor + Referable + RemoteHandles<CreatePeerQueuePair<T>> {}
+
+/// Per-op completion reply emitted by [`QueuePairActor`] back to the
+/// manager via [`ProcessOps::reply`]. A named newtype (rather than a
+/// raw `(usize, Result<…>)` tuple) so the manager can identify
+/// undeliverable `OpResult`s by type name in
+/// `handle_undeliverable_message` and absorb them when the original
+/// caller has gone away (typical at test teardown).
+#[allow(dead_code)] // not yet referenced by IbvManagerActor
+#[derive(Debug)]
+pub(super) struct OpResult {
+    pub(super) op_idx: usize,
+    pub(super) result: Result<(), String>,
+}
+
+/// Local-only message: enqueue a batch of ops on this QP. As each
+/// op resolves the actor sends one `(op_idx, result)` tuple on
+/// `reply` — `op_idx` is the original index of the op in the
+/// user-facing `IbvManagerActor::submit_ops` request, so the receiver
+/// can correlate replies across batches that were sliced per-QP. The
+/// inner `Result` is `Ok(())` if every WR for the op completed
+/// successfully, otherwise `Err` carrying the first per-WR error
+/// observed (held back until the op's other WRs also report, so the
+/// MR registration outlives the data path).
+#[allow(dead_code)] // not yet referenced by IbvManagerActor
+#[derive(Debug)]
+pub(super) struct ProcessOps<M: Referable> {
+    pub(super) items: Vec<(usize, IbvOp<M>, IbvMemoryRegionView)>,
+    pub(super) reply: PortHandle<OpResult>,
+}
+
+/// Local-only self-message that drives one round of the scheduler.
+#[derive(Debug)]
+struct Tick;
+
+/// An op accepted by the actor but not yet posted to the QP.
+#[derive(Debug)]
+struct PendingOp<M: Referable> {
+    op_idx: usize,
+    op: IbvOp<M>,
+    mrv: IbvMemoryRegionView,
+    reply: PortHandle<OpResult>,
+    /// WR count this op will issue when posted, computed once at
+    /// construction so retries from a credit head-block don't redo
+    /// the work.
+    wrs: u32,
+    is_read: bool,
+}
+
+/// State of an op whose WRs are in flight on the QP.
+#[derive(Debug)]
+struct PostedOpEntry {
+    op_idx: usize,
+    pending_wrs: HashSet<u64>,
+    is_read: bool,
+    /// Kept alive so the MR registration outlives every in-flight
+    /// WR touching it. Field is intentionally unread.
+    _mrv: IbvMemoryRegionView,
+    reply: PortHandle<OpResult>,
+    /// First per-WR error observed for this op. The op's final
+    /// reply is held back until `pending_wrs.is_empty()` so we don't
+    /// release the MR while remaining WRs are still in flight.
+    first_error: Option<String>,
+}
 
 /// Per-peer queue-pair actor.
 ///
@@ -1509,6 +1689,34 @@ pub(super) struct QueuePairActor<M: Manager, Qp: QueuePair> {
     /// handshake.
     is_loopback: bool,
     init_timeout: Duration,
+    /// QP-wide cap on outstanding send-queue WRs (reads + writes).
+    max_send_wr: u32,
+    /// QP-wide cap on outstanding RDMA-READ WRs at the initiator.
+    max_rd_atomic: u32,
+    /// Single FIFO of ops awaiting their first post attempt. If the
+    /// head op bumps against either credit cap, ops queued behind
+    /// it stall — a write stuck behind a credit-blocked read is the
+    /// known consequence; smarter interleaving is future work.
+    queue: VecDeque<PendingOp<M>>,
+    /// op-id → entry, for tracking WR completion. op-ids are local
+    /// to this actor (monotonic counter); they exist so we can
+    /// route per-WR completions to the right `PostedOpEntry`
+    /// without making any assumptions about uniqueness of `op_idx`
+    /// across batches.
+    posted: HashMap<u64, PostedOpEntry>,
+    /// wr_id → local op-id.
+    wr_to_op: HashMap<u64, u64>,
+    /// Mirrors `wr_to_op.keys()` exactly, maintained incrementally
+    /// so each tick can hand it straight to `poll_completion`
+    /// without rebuilding.
+    to_poll: HashSet<u64>,
+    next_op_id: u64,
+    in_flight_reads: u32,
+    in_flight_writes: u32,
+    /// `true` while a `Tick` self-message is already in flight; the
+    /// flag prevents stacking redundant ticks.
+    tick_armed: bool,
+    poll_policy: PollSleepPolicy,
 }
 
 impl<M: Manager, Qp: QueuePair> QueuePairActor<M, Qp> {
@@ -1519,6 +1727,8 @@ impl<M: Manager, Qp: QueuePair> QueuePairActor<M, Qp> {
         peer_manager: ActorRef<M>,
         qp: Qp,
         is_loopback: bool,
+        max_send_wr: u32,
+        max_rd_atomic: u32,
     ) -> Self {
         let init_timeout = hyperactor_config::global::get(crate::config::RDMA_QP_INIT_TIMEOUT);
         Self {
@@ -1528,7 +1738,226 @@ impl<M: Manager, Qp: QueuePair> QueuePairActor<M, Qp> {
             qp,
             is_loopback,
             init_timeout,
+            max_send_wr,
+            max_rd_atomic,
+            queue: VecDeque::new(),
+            posted: HashMap::new(),
+            wr_to_op: HashMap::new(),
+            to_poll: HashSet::new(),
+            next_op_id: 0,
+            in_flight_reads: 0,
+            in_flight_writes: 0,
+            tick_armed: false,
+            poll_policy: PollSleepPolicy::new(),
         }
+    }
+
+    /// Number of WRs the QP will issue for an op that targets
+    /// `local_size` bytes. The QP splits large transfers into
+    /// `MAX_RDMA_MSG_SIZE`-bound chunks; a zero-byte op still
+    /// consumes one WR.
+    fn wr_count(local_size: usize) -> u32 {
+        local_size.div_ceil(MAX_RDMA_MSG_SIZE).max(1) as u32
+    }
+
+    /// Try to post the head of `queue`.
+    ///
+    /// * `Ok(true)` — head was either posted or rejected with a
+    ///   per-op error (e.g. op too large for this QP); caller
+    ///   should attempt the next head.
+    /// * `Ok(false)` — head can't be posted because the QP is at
+    ///   either `max_send_wr` or, for a head read, `max_rd_atomic`.
+    ///   The op stays at the head; caller should stop walking.
+    /// * `Err(_)` — `qp.put`/`qp.get` failed (e.g. the QP is in
+    ///   error state). Fatal: the actor's handler returns this,
+    ///   which raises a supervision event.
+    fn try_post_head(&mut self, cx: &Instance<Self>) -> Result<bool, anyhow::Error> {
+        let pending = self.queue.pop_front().expect("non-empty queue");
+        let PendingOp {
+            op_idx,
+            op,
+            mrv,
+            reply,
+            wrs,
+            is_read,
+        } = pending;
+
+        let local_buf = IbvBuffer {
+            mr_id: mrv.id,
+            lkey: mrv.lkey,
+            rkey: mrv.rkey,
+            addr: mrv.rdma_addr,
+            size: mrv.size,
+            device_name: mrv.device_name.clone(),
+        };
+
+        // 1. Per-op fatal: op alone exceeds the QP's capacity.
+        if wrs > self.max_send_wr {
+            let err = format!(
+                "op too large for this QP [op_idx={}, qp_key={:?}, op_type={:?}, wrs={}, max_send_wr={}, local: {:?}, remote: {:?}]",
+                op_idx, self.qp_key, op.op_type, wrs, self.max_send_wr, local_buf, op.remote_buffer,
+            );
+            reply.post(
+                cx,
+                OpResult {
+                    op_idx,
+                    result: Err(err),
+                },
+            );
+            return Ok(true);
+        }
+        if is_read && wrs > self.max_rd_atomic {
+            let err = format!(
+                "read op too large for this QP [op_idx={}, qp_key={:?}, wrs={}, max_rd_atomic={}, local: {:?}, remote: {:?}]",
+                op_idx, self.qp_key, wrs, self.max_rd_atomic, local_buf, op.remote_buffer,
+            );
+            reply.post(
+                cx,
+                OpResult {
+                    op_idx,
+                    result: Err(err),
+                },
+            );
+            return Ok(true);
+        }
+
+        // 2. Credit gating. Every op consumes a send-queue slot;
+        //    reads additionally consume read credits. A read at the
+        //    head that hits either cap stalls the whole queue.
+        let projected_total = self.in_flight_reads + self.in_flight_writes + wrs;
+        if projected_total > self.max_send_wr
+            || (is_read && self.in_flight_reads + wrs > self.max_rd_atomic)
+        {
+            self.queue.push_front(PendingOp {
+                op_idx,
+                op,
+                mrv,
+                reply,
+                wrs,
+                is_read,
+            });
+            return Ok(false);
+        }
+
+        // 3. Post.
+        let post_result = match op.op_type {
+            RdmaOpType::WriteFromLocal => self.qp.put(local_buf.clone(), op.remote_buffer.clone()),
+            RdmaOpType::ReadIntoLocal => self.qp.get(local_buf.clone(), op.remote_buffer.clone()),
+        };
+        let wr_ids = post_result.map_err(|e| {
+            anyhow::anyhow!(
+                "qp.{} failed [op_idx={}, qp_key={:?}, local: {:?}, remote: {:?}]: {e}",
+                if is_read { "get" } else { "put" },
+                op_idx,
+                self.qp_key,
+                local_buf,
+                op.remote_buffer,
+            )
+        })?;
+
+        // 4. Track in-flight state.
+        let op_id = self.next_op_id;
+        self.next_op_id += 1;
+        let mut pending_wrs = HashSet::with_capacity(wr_ids.len());
+        for id in &wr_ids {
+            self.wr_to_op.insert(*id, op_id);
+            self.to_poll.insert(*id);
+            pending_wrs.insert(*id);
+        }
+        if is_read {
+            self.in_flight_reads += wr_ids.len() as u32;
+        } else {
+            self.in_flight_writes += wr_ids.len() as u32;
+        }
+        self.posted.insert(
+            op_id,
+            PostedOpEntry {
+                op_idx,
+                pending_wrs,
+                is_read,
+                _mrv: mrv,
+                reply,
+                first_error: None,
+            },
+        );
+        Ok(true)
+    }
+
+    /// One scheduler round: post everything that fits, poll for
+    /// completions, emit replies for finished ops, and re-arm
+    /// `Tick` if work remains. Returns `Err` for fatal QP-level
+    /// failures; the surrounding handler propagates the error so
+    /// supervision tears the actor down.
+    fn advance(&mut self, cx: &Instance<Self>) -> Result<(), anyhow::Error> {
+        // 1. Post from the queue head until either it's empty or
+        //    the head is credit-blocked.
+        while !self.queue.is_empty() {
+            if !self.try_post_head(cx)? {
+                break;
+            }
+        }
+
+        // 2. Poll for completions.
+        let mut progressed = false;
+        if !self.to_poll.is_empty() {
+            let completions = self
+                .qp
+                .poll_completion(PollTarget::Send, &self.to_poll)
+                .map_err(|e| anyhow::anyhow!("CQ poll failed for qp_key={:?}: {e}", self.qp_key))?;
+            progressed = !completions.is_empty();
+            for (wr_id, wc_result) in completions {
+                self.to_poll.remove(&wr_id);
+                let op_id = self
+                    .wr_to_op
+                    .remove(&wr_id)
+                    .expect("completed wr_id missing from wr_to_op");
+                let entry = self
+                    .posted
+                    .get_mut(&op_id)
+                    .expect("op_id missing from posted");
+                entry.pending_wrs.remove(&wr_id);
+                if entry.is_read {
+                    self.in_flight_reads -= 1;
+                } else {
+                    self.in_flight_writes -= 1;
+                }
+                if let Err(per_wr) = wc_result
+                    && entry.first_error.is_none()
+                {
+                    entry.first_error = Some(per_wr.to_string());
+                }
+                if entry.pending_wrs.is_empty() {
+                    let entry = self.posted.remove(&op_id).expect("just verified");
+                    let result = match entry.first_error {
+                        Some(err) => Err(err),
+                        None => Ok(()),
+                    };
+                    entry.reply.post(
+                        cx,
+                        OpResult {
+                            op_idx: entry.op_idx,
+                            result,
+                        },
+                    );
+                }
+            }
+        }
+        if progressed {
+            self.poll_policy.reset();
+        }
+
+        // 3. Re-arm Tick if any work remains.
+        let pending_work = !self.queue.is_empty() || !self.posted.is_empty();
+        if pending_work && !self.tick_armed {
+            self.tick_armed = true;
+            let interval = self.poll_policy.next_interval();
+            if interval.is_zero() {
+                cx.handle().post(cx, Tick);
+            } else {
+                cx.post_after(cx, Tick, interval);
+            }
+        }
+        Ok(())
     }
 }
 
@@ -1600,6 +2029,43 @@ impl<M: Manager, Qp: QueuePair> Actor for QueuePairActor<M, Qp> {
             );
             anyhow::anyhow!("could not connect QP to peer: {e}")
         })?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<M: Manager, Qp: QueuePair> Handler<ProcessOps<M>> for QueuePairActor<M, Qp> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: ProcessOps<M>,
+    ) -> Result<(), anyhow::Error> {
+        for (op_idx, op, mrv) in msg.items.into_iter() {
+            let wrs = Self::wr_count(op.local_memory.size());
+            let is_read = matches!(op.op_type, RdmaOpType::ReadIntoLocal);
+            self.queue.push_back(PendingOp {
+                op_idx,
+                op,
+                mrv,
+                reply: msg.reply.clone(),
+                wrs,
+                is_read,
+            });
+        }
+        // If a tick is already armed it will pick up the new ops on
+        // its next round; advancing here would just duplicate work.
+        if !self.tick_armed {
+            self.advance(cx)?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<M: Manager, Qp: QueuePair> Handler<Tick> for QueuePairActor<M, Qp> {
+    async fn handle(&mut self, cx: &Context<Self>, _msg: Tick) -> Result<(), anyhow::Error> {
+        self.tick_armed = false;
+        self.advance(cx)?;
         Ok(())
     }
 }
@@ -2195,6 +2661,8 @@ mod tests {
         peer_manager: ActorRef<QpaMockManager>,
         qp: MockQp,
         is_loopback: bool,
+        max_send_wr: u32,
+        max_rd_atomic: u32,
         reply: hyperactor::OncePortHandle<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>>,
     }
 
@@ -2208,6 +2676,8 @@ mod tests {
                 msg.peer_manager,
                 msg.qp,
                 msg.is_loopback,
+                msg.max_send_wr,
+                msg.max_rd_atomic,
             );
             let handle = cx.spawn(actor);
             msg.reply.post(cx, handle);
@@ -2215,14 +2685,43 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Default)]
-    struct MockQpInner {
-        connect_calls: Vec<IbvQpInfo>,
+    /// One `put` or `get` call recorded by the mock, surfaced to the
+    /// test via the `posted_rx` channel returned alongside the QP.
+    #[derive(Debug)]
+    enum PostedOp {
+        Put {
+            lhandle: IbvBuffer,
+            rhandle: IbvBuffer,
+            wr_ids: Vec<u64>,
+        },
+        Get {
+            lhandle: IbvBuffer,
+            rhandle: IbvBuffer,
+            wr_ids: Vec<u64>,
+        },
     }
 
-    /// Minimal `QueuePair` impl used by the init-handshake tests.
-    /// Records every `connect` call so the test can assert what the
-    /// actor passed in.
+    #[derive(Debug)]
+    struct MockQpInner {
+        connect_calls: Vec<IbvQpInfo>,
+        next_wr_id: u64,
+        /// Every `put`/`get` call is forwarded here in order, so the
+        /// test body can `await` rather than poll.
+        posted_tx: tokio::sync::mpsc::UnboundedSender<PostedOp>,
+        /// FIFO of completions the next `poll_completion` will hand
+        /// back (after filtering by `expected_wr_ids`). Each entry
+        /// is either `Ok(IbvWc)` (success) or `Err(...)` (per-WR
+        /// completion failure).
+        pending_completions: VecDeque<(u64, std::result::Result<IbvWc, PollCompletionError>)>,
+        /// One-shot CQ-level error; cleared after the next poll consumes it.
+        poll_error: Option<PollCompletionError>,
+        /// One-shot error for the next `put` or `get` call.
+        post_error: Option<String>,
+    }
+
+    /// `QueuePair` mock used by `QueuePairActor` tests. Cloning is
+    /// cheap (shared `Arc<Mutex<...>>`); the test typically holds
+    /// one clone while handing another to the actor.
     #[derive(Debug, Clone)]
     struct MockQp {
         info: IbvQpInfo,
@@ -2230,20 +2729,64 @@ mod tests {
     }
 
     impl MockQp {
-        fn new(qp_num: u32, psn: u32) -> Self {
-            Self {
+        /// Returns the mock QP and the receiver that observes its
+        /// posts. Tests that don't care about post events can drop
+        /// the receiver.
+        fn new(qp_num: u32, psn: u32) -> (Self, tokio::sync::mpsc::UnboundedReceiver<PostedOp>) {
+            let (posted_tx, posted_rx) = tokio::sync::mpsc::unbounded_channel();
+            let qp = Self {
                 info: IbvQpInfo {
                     qp_num,
                     lid: 0,
                     gid: None,
                     psn,
                 },
-                inner: Arc::new(Mutex::new(MockQpInner::default())),
-            }
+                inner: Arc::new(Mutex::new(MockQpInner {
+                    connect_calls: Vec::new(),
+                    next_wr_id: 0,
+                    posted_tx,
+                    pending_completions: VecDeque::new(),
+                    poll_error: None,
+                    post_error: None,
+                })),
+            };
+            (qp, posted_rx)
         }
 
         fn connect_calls(&self) -> Vec<IbvQpInfo> {
             self.inner.lock().unwrap().connect_calls.clone()
+        }
+
+        /// Queue a successful WC for `wr_id`. The next poll whose
+        /// `expected_wr_ids` contains `wr_id` returns it.
+        fn queue_completion(&self, wr_id: u64) {
+            self.inner
+                .lock()
+                .unwrap()
+                .pending_completions
+                .push_back((wr_id, Ok(IbvWc::for_test(wr_id, true))));
+        }
+
+        /// Queue a per-WR completion failure for `wr_id` — the actor
+        /// receives it as the inner `Err` from `poll_completion` and
+        /// should fail just that op (not poison the QP).
+        fn queue_per_wr_error(&self, wr_id: u64, message: &str) {
+            self.inner
+                .lock()
+                .unwrap()
+                .pending_completions
+                .push_back((wr_id, Err(PollCompletionError::for_test(message))));
+        }
+
+        /// Queue a CQ-level poll error (one-shot). The next poll
+        /// returns this as the outer `Err`, simulating a poisoned QP.
+        fn queue_poll_error(&self, err: PollCompletionError) {
+            self.inner.lock().unwrap().poll_error = Some(err);
+        }
+
+        /// Make the next `put`/`get` return this error (one-shot).
+        fn queue_post_error(&self, message: &str) {
+            self.inner.lock().unwrap().post_error = Some(message.to_string());
         }
     }
 
@@ -2255,6 +2798,69 @@ mod tests {
         fn connect(&mut self, info: &IbvQpInfo) -> Result<()> {
             self.inner.lock().unwrap().connect_calls.push(info.clone());
             Ok(())
+        }
+
+        fn put(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> Result<Vec<u64>> {
+            let mut inner = self.inner.lock().unwrap();
+            if let Some(msg) = inner.post_error.take() {
+                return Err(anyhow::anyhow!(msg));
+            }
+            let wrs = lhandle.size.div_ceil(MAX_RDMA_MSG_SIZE).max(1);
+            let mut wr_ids = Vec::with_capacity(wrs);
+            for _ in 0..wrs {
+                wr_ids.push(inner.next_wr_id);
+                inner.next_wr_id += 1;
+            }
+            let _ = inner.posted_tx.send(PostedOp::Put {
+                lhandle,
+                rhandle,
+                wr_ids: wr_ids.clone(),
+            });
+            Ok(wr_ids)
+        }
+
+        fn get(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> Result<Vec<u64>> {
+            let mut inner = self.inner.lock().unwrap();
+            if let Some(msg) = inner.post_error.take() {
+                return Err(anyhow::anyhow!(msg));
+            }
+            let wrs = lhandle.size.div_ceil(MAX_RDMA_MSG_SIZE).max(1);
+            let mut wr_ids = Vec::with_capacity(wrs);
+            for _ in 0..wrs {
+                wr_ids.push(inner.next_wr_id);
+                inner.next_wr_id += 1;
+            }
+            let _ = inner.posted_tx.send(PostedOp::Get {
+                lhandle,
+                rhandle,
+                wr_ids: wr_ids.clone(),
+            });
+            Ok(wr_ids)
+        }
+
+        fn poll_completion(
+            &mut self,
+            _target: PollTarget,
+            expected_wr_ids: &HashSet<u64>,
+        ) -> std::result::Result<
+            Vec<(u64, std::result::Result<IbvWc, PollCompletionError>)>,
+            PollCompletionError,
+        > {
+            let mut inner = self.inner.lock().unwrap();
+            if let Some(err) = inner.poll_error.take() {
+                return Err(err);
+            }
+            let mut matched = Vec::new();
+            let mut remaining = VecDeque::new();
+            while let Some((wr_id, wc)) = inner.pending_completions.pop_front() {
+                if expected_wr_ids.contains(&wr_id) {
+                    matched.push((wr_id, wc));
+                } else {
+                    remaining.push_back((wr_id, wc));
+                }
+            }
+            inner.pending_completions = remaining;
+            Ok(matched)
         }
     }
 
@@ -2347,6 +2953,19 @@ mod tests {
             qp: MockQp,
             is_loopback: bool,
         ) -> Result<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>> {
+            self.spawn_actor_with_caps(qp_key, peer_manager, qp, is_loopback, 4, 2)
+                .await
+        }
+
+        async fn spawn_actor_with_caps(
+            &self,
+            qp_key: QpKey,
+            peer_manager: ActorRef<QpaMockManager>,
+            qp: MockQp,
+            is_loopback: bool,
+            max_send_wr: u32,
+            max_rd_atomic: u32,
+        ) -> Result<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>> {
             let (reply, rx) = self.client.mailbox().open_once_port();
             self.parent.post(
                 &self.client,
@@ -2355,6 +2974,8 @@ mod tests {
                     peer_manager,
                     qp,
                     is_loopback,
+                    max_send_wr,
+                    max_rd_atomic,
                     reply,
                 },
             );
@@ -2382,7 +3003,7 @@ mod tests {
         };
         harness.peer_state.lock().unwrap().response = Some(Ok(peer_info.clone()));
 
-        let qp = MockQp::new(0x1234, 0xdead);
+        let (qp, _posted_rx) = MockQp::new(0x1234, 0xdead);
         let qp_key = QpKey {
             self_device: "mlx5_0".into(),
             other_id: harness.peer_id(),
@@ -2423,7 +3044,7 @@ mod tests {
     async fn qpa_init_loopback_skips_peer_round_trip() -> Result<()> {
         let harness = QpaHarness::build()?;
 
-        let qp = MockQp::new(0xaaa, 0xbbb);
+        let (qp, _posted_rx) = MockQp::new(0xaaa, 0xbbb);
         let qp_key = QpKey {
             self_device: "mlx5_0".into(),
             other_id: harness.parent_id(),
@@ -2463,13 +3084,9 @@ mod tests {
             other_id: harness.peer_id(),
             other_device: "mlx5_99".into(),
         };
+        let (qp, _posted_rx) = MockQp::new(1, 2);
         let handle = harness
-            .spawn_actor(
-                qp_key,
-                harness.peer.bind::<QpaMockManager>(),
-                MockQp::new(1, 2),
-                false,
-            )
+            .spawn_actor(qp_key, harness.peer.bind::<QpaMockManager>(), qp, false)
             .await?;
 
         let event = harness.next_supervision_failure().await;
@@ -2479,11 +3096,10 @@ mod tests {
             report.contains("peer rejected"),
             "failure report should surface the peer's error string; got: {report}"
         );
-        let status = await_status(&handle, |s| {
+        await_status(&handle, |s| {
             matches!(s, hyperactor::actor::ActorStatus::Failed(_))
         })
         .await;
-        assert!(matches!(status, hyperactor::actor::ActorStatus::Failed(_)));
         harness.teardown().await;
         Ok(())
     }
@@ -2503,13 +3119,9 @@ mod tests {
             other_id: harness.peer_id(),
             other_device: "mlx5_1".into(),
         };
+        let (qp, _posted_rx) = MockQp::new(1, 2);
         let handle = harness
-            .spawn_actor(
-                qp_key,
-                harness.peer.bind::<QpaMockManager>(),
-                MockQp::new(1, 2),
-                false,
-            )
+            .spawn_actor(qp_key, harness.peer.bind::<QpaMockManager>(), qp, false)
             .await?;
 
         let event = harness.next_supervision_failure().await;
@@ -2519,11 +3131,679 @@ mod tests {
             report.contains("timed out"),
             "failure report should mention timeout; got: {report}"
         );
-        let status = await_status(&handle, |s| {
+        await_status(&handle, |s| {
             matches!(s, hyperactor::actor::ActorStatus::Failed(_))
         })
         .await;
-        assert!(matches!(status, hyperactor::actor::ActorStatus::Failed(_)));
+        harness.teardown().await;
+        Ok(())
+    }
+
+    // =================================================================
+    // QueuePairActor op processing
+    // =================================================================
+
+    use crate::backend::ibverbs::primitives::IbvMemoryRegion;
+    use crate::local_memory::Keepalive;
+    use crate::local_memory::KeepaliveLocalMemory;
+
+    fn null_domain() -> Arc<IbvDomain> {
+        Arc::new(IbvDomain {
+            context: std::ptr::null_mut(),
+            pd: std::ptr::null_mut(),
+        })
+    }
+
+    /// No-op [`Keepalive`] for tests that mint a [`KeepaliveLocalMemory`]
+    /// from a fake address never actually read or written through.
+    struct FakeKeepalive;
+    impl Keepalive for FakeKeepalive {}
+
+    fn fake_local_memory(addr: usize, size: usize) -> Arc<KeepaliveLocalMemory> {
+        Arc::new(KeepaliveLocalMemory::new(
+            addr,
+            size,
+            Arc::new(FakeKeepalive),
+        ))
+    }
+
+    fn fake_mrv(id: usize, addr: usize, size: usize) -> IbvMemoryRegionView {
+        IbvMemoryRegionView::new(
+            id,
+            addr,
+            addr,
+            size,
+            0x1234,
+            0x5678,
+            "dev0".to_string(),
+            Arc::new(IbvMemoryRegion::Direct {
+                mr: std::ptr::null_mut(),
+                _domain: null_domain(),
+            }),
+        )
+    }
+
+    /// Build a `QpaMockManager` ref attested to an unrelated proc;
+    /// only used to populate `IbvOp::remote_manager` (the actor
+    /// never sends to it during op processing — it just reads
+    /// `op.remote_buffer`).
+    fn fake_remote_ref() -> ActorRef<QpaMockManager> {
+        let proc_id = hyperactor::id::ProcId::new(
+            hyperactor::id::Uid::Instance(0xc0ffee, None),
+            Some(hyperactor::id::Label::new("remote").unwrap()),
+        );
+        let proc_addr =
+            hyperactor::ProcAddr::new(proc_id, hyperactor::channel::ChannelAddr::Local(1).into());
+        ActorRef::attest(proc_addr.actor_addr("remote-mgr"))
+    }
+
+    fn make_op(op_type: RdmaOpType, addr: usize, size: usize) -> IbvOp<QpaMockManager> {
+        IbvOp {
+            op_type,
+            local_memory: fake_local_memory(addr, size),
+            remote_buffer: IbvBuffer {
+                mr_id: 1,
+                lkey: 0,
+                rkey: 0,
+                addr: 0x4000_0000,
+                size,
+                device_name: "remote_dev".to_string(),
+            },
+            remote_manager: fake_remote_ref(),
+        }
+    }
+
+    impl QpaHarness {
+        /// Spawn a `QueuePairActor` in loopback mode (no peer round
+        /// trip) so init completes immediately; await it reaching
+        /// `Idle`. Returns the actor handle along with the mock QP
+        /// the test can drive.
+        async fn spawn_ready_actor(
+            &self,
+            max_send_wr: u32,
+            max_rd_atomic: u32,
+        ) -> Result<(
+            ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
+            MockQp,
+            tokio::sync::mpsc::UnboundedReceiver<PostedOp>,
+        )> {
+            let (qp, posted_rx) = MockQp::new(0x1, 0x2);
+            let qp_key = QpKey {
+                self_device: "mlx5_0".into(),
+                other_id: self.parent_id(),
+                other_device: "mlx5_0".into(),
+            };
+            let handle = self
+                .spawn_actor_with_caps(
+                    qp_key,
+                    self.peer.bind::<QpaMockManager>(),
+                    qp.clone(),
+                    true,
+                    max_send_wr,
+                    max_rd_atomic,
+                )
+                .await?;
+            await_status(&handle, |s| {
+                matches!(s, hyperactor::actor::ActorStatus::Idle)
+            })
+            .await;
+            Ok((handle, qp, posted_rx))
+        }
+    }
+
+    /// Await the next `PostedOp` from the mock; panics on timeout.
+    async fn recv_posted(rx: &mut tokio::sync::mpsc::UnboundedReceiver<PostedOp>) -> PostedOp {
+        tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("timed out waiting for post on MockQp")
+            .expect("MockQp post channel closed")
+    }
+
+    /// Assert that no further `PostedOp` arrives in `wait`. Used to
+    /// pin down a credit-blocked state.
+    async fn assert_no_post(
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<PostedOp>,
+        wait: Duration,
+    ) {
+        if let Ok(Some(p)) = tokio::time::timeout(wait, rx.recv()).await {
+            panic!("unexpected post on MockQp: {p:?}");
+        }
+    }
+
+    fn expect_put(p: PostedOp) -> (IbvBuffer, IbvBuffer, Vec<u64>) {
+        match p {
+            PostedOp::Put {
+                lhandle,
+                rhandle,
+                wr_ids,
+            } => (lhandle, rhandle, wr_ids),
+            other => panic!("expected Put, got {other:?}"),
+        }
+    }
+
+    fn expect_get(p: PostedOp) -> (IbvBuffer, IbvBuffer, Vec<u64>) {
+        match p {
+            PostedOp::Get {
+                lhandle,
+                rhandle,
+                wr_ids,
+            } => (lhandle, rhandle, wr_ids),
+            other => panic!("expected Get, got {other:?}"),
+        }
+    }
+
+    /// Open a multi-shot port and send a `ProcessOps` batch. Returns
+    /// the receiver so the caller can await per-op results.
+    fn submit_ops(
+        harness: &QpaHarness,
+        actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
+        items: Vec<(usize, IbvOp<QpaMockManager>, IbvMemoryRegionView)>,
+    ) -> Result<hyperactor::mailbox::PortReceiver<OpResult>> {
+        let (reply, rx) = harness.client.mailbox().open_port::<OpResult>();
+        actor.post(&harness.client, ProcessOps { items, reply });
+        Ok(rx)
+    }
+
+    /// Collect exactly `n` replies with a per-recv timeout, sorted
+    /// by op_idx for deterministic comparison.
+    async fn collect_replies(
+        rx: &mut hyperactor::mailbox::PortReceiver<OpResult>,
+        n: usize,
+    ) -> Vec<(usize, Result<(), String>)> {
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            let m = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+                .await
+                .expect("timed out waiting for ProcessOps reply")
+                .expect("ProcessOps reply port closed");
+            out.push((m.op_idx, m.result));
+        }
+        out.sort_by_key(|(i, _)| *i);
+        out
+    }
+
+    /// Try to recv with a short timeout, returning `None` on timeout
+    /// so callers can assert "no reply yet".
+    async fn try_recv(
+        rx: &mut hyperactor::mailbox::PortReceiver<OpResult>,
+        wait: Duration,
+    ) -> Option<(usize, Result<(), String>)> {
+        match tokio::time::timeout(wait, rx.recv()).await {
+            Ok(Ok(m)) => Some((m.op_idx, m.result)),
+            Ok(Err(e)) => panic!("ProcessOps reply port closed: {e}"),
+            Err(_) => None,
+        }
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_processes_single_write() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
+
+        let items = vec![(
+            7usize,
+            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
+            fake_mrv(1, 0x1000, 4096),
+        )];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        // wr_ids start at 0 (fresh MockQp), so the single WR is wr 0.
+        let (lhandle, rhandle, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(wr_ids, vec![0]);
+        assert_eq!(lhandle.addr, 0x1000);
+        assert_eq!(lhandle.size, 4096);
+        assert_eq!(lhandle.lkey, 0x1234);
+        assert_eq!(lhandle.rkey, 0x5678);
+        assert_eq!(lhandle.device_name, "dev0");
+        assert_eq!(rhandle.addr, 0x4000_0000);
+        assert_eq!(rhandle.size, 4096);
+        assert_eq!(rhandle.device_name, "remote_dev");
+
+        qp.queue_completion(0);
+        let replies = collect_replies(&mut rx, 1).await;
+        assert_eq!(replies, vec![(7, Ok(()))]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_chunked_op_waits_for_all_wrs() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8, 4).await?;
+
+        // A 3-chunk write (3 * MAX_RDMA_MSG_SIZE) splits into 3 WRs;
+        // the op's reply must be held back until all 3 complete.
+        let items = vec![(
+            11usize,
+            make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+            fake_mrv(1, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+        )];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(wr_ids, vec![0, 1, 2]);
+
+        // Complete the first two — no reply yet.
+        qp.queue_completion(wr_ids[0]);
+        qp.queue_completion(wr_ids[1]);
+        assert!(
+            try_recv(&mut rx, Duration::from_millis(100))
+                .await
+                .is_none(),
+            "op should not be reported until every WR has completed",
+        );
+
+        // Complete the third — now the op resolves.
+        qp.queue_completion(wr_ids[2]);
+        let replies = collect_replies(&mut rx, 1).await;
+        assert_eq!(replies, vec![(11, Ok(()))]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_per_wr_error_held_until_all_wrs_complete() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8, 4).await?;
+
+        // 3-WR write: simulate the second WR failing first; the op's
+        // Err must not fire until the other 2 WRs have also reported
+        // so the MR registration outlives every in-flight WR.
+        let items = vec![(
+            42usize,
+            make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+            fake_mrv(1, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+        )];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        let (_, _, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(wr_ids.len(), 3);
+
+        // Deliver the per-WR error first.
+        qp.queue_per_wr_error(wr_ids[1], "simulated WR fail");
+        assert!(
+            try_recv(&mut rx, Duration::from_millis(100))
+                .await
+                .is_none(),
+            "op error must wait for the other WRs to drain",
+        );
+
+        // The remaining WRs complete (flush-style or otherwise) and
+        // finally the op's Err is reported.
+        qp.queue_completion(wr_ids[0]);
+        qp.queue_completion(wr_ids[2]);
+
+        let replies = collect_replies(&mut rx, 1).await;
+        assert_eq!(replies.len(), 1);
+        assert_eq!(replies[0].0, 42);
+        let err = replies[0]
+            .1
+            .as_ref()
+            .expect_err("op should fail because one WR errored");
+        assert!(
+            err.contains("simulated WR fail"),
+            "op error should surface the per-WR error: {err}",
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_per_wr_error_isolates_to_failing_op() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8, 4).await?;
+
+        // Two writes share a batch: op_idx 0 is multi-WR (3 chunks),
+        // op_idx 1 is single-WR. One of op_idx 0's WRs fails;
+        // op_idx 1's WR succeeds independently.
+        let items = vec![
+            (
+                0usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+                fake_mrv(1, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+            ),
+            (
+                1usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
+                fake_mrv(2, 0x2000, 4096),
+            ),
+        ];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        let (_, _, big_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        let (_, _, small_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(big_wrs, vec![0, 1, 2]);
+        assert_eq!(small_wrs, vec![3]);
+
+        // op_idx 1 completes successfully on its own.
+        qp.queue_completion(small_wrs[0]);
+        // op_idx 0: middle WR fails, others succeed.
+        qp.queue_per_wr_error(big_wrs[1], "isolated per-WR fail");
+        qp.queue_completion(big_wrs[0]);
+        qp.queue_completion(big_wrs[2]);
+
+        let replies = collect_replies(&mut rx, 2).await;
+        assert_eq!(replies.len(), 2);
+        assert_eq!(replies[0].0, 0);
+        let err = replies[0]
+            .1
+            .as_ref()
+            .expect_err("op_idx 0 should fail because one WR errored");
+        assert!(
+            err.contains("isolated per-WR fail"),
+            "op_idx 0 error should name the per-WR error: {err}",
+        );
+        assert_eq!(replies[1], (1usize, Ok(())));
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_read_credit_gating() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        // max_rd_atomic=2 lets at most 2 RDMA_READs sit on the QP.
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8, 2).await?;
+
+        let items = (0..3usize)
+            .map(|i| {
+                (
+                    i,
+                    make_op(RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096),
+                    fake_mrv(i + 1, 0x1000 + i * 0x1000, 4096),
+                )
+            })
+            .collect();
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        // Only the first two reads make it onto the wire; the third
+        // stays parked at the queue head.
+        let (_, _, r0_wrs) = expect_get(recv_posted(&mut posted_rx).await);
+        let (_, _, r1_wrs) = expect_get(recv_posted(&mut posted_rx).await);
+        assert_eq!(r0_wrs, vec![0]);
+        assert_eq!(r1_wrs, vec![1]);
+        assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
+
+        // Complete the first read; the third should post.
+        qp.queue_completion(r0_wrs[0]);
+        let (_, _, r2_wrs) = expect_get(recv_posted(&mut posted_rx).await);
+        assert_eq!(r2_wrs, vec![2]);
+
+        qp.queue_completion(r1_wrs[0]);
+        qp.queue_completion(r2_wrs[0]);
+        let replies = collect_replies(&mut rx, 3).await;
+        assert_eq!(replies, vec![(0, Ok(())), (1, Ok(())), (2, Ok(()))]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_write_slot_gating() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        // max_send_wr=2 caps total in-flight WRs; submit 4 writes.
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(2, 8).await?;
+
+        let items = (0..4usize)
+            .map(|i| {
+                (
+                    i,
+                    make_op(RdmaOpType::WriteFromLocal, 0x1000 + i * 0x1000, 4096),
+                    fake_mrv(i + 1, 0x1000 + i * 0x1000, 4096),
+                )
+            })
+            .collect();
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        let (_, _, w0_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        let (_, _, w1_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(w0_wrs, vec![0]);
+        assert_eq!(w1_wrs, vec![1]);
+        assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
+
+        // Complete one — the third write should post; one slot still busy.
+        qp.queue_completion(w0_wrs[0]);
+        let (_, _, w2_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(w2_wrs, vec![2]);
+        assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
+
+        // Complete another — the fourth write posts.
+        qp.queue_completion(w1_wrs[0]);
+        let (_, _, w3_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(w3_wrs, vec![3]);
+
+        qp.queue_completion(w2_wrs[0]);
+        qp.queue_completion(w3_wrs[0]);
+        let replies = collect_replies(&mut rx, 4).await;
+        assert_eq!(
+            replies,
+            vec![(0, Ok(())), (1, Ok(())), (2, Ok(())), (3, Ok(()))],
+        );
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_blocked_until_one_read_and_one_write_complete() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        // max_send_wr=4, max_rd_atomic=2. The trailing 2-WR read
+        // needs *both* a free read credit (only 1 in use) and a free
+        // slot (currently full at 4) — so it sits parked until one
+        // read AND one write complete.
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
+
+        let items = vec![
+            (
+                0usize,
+                make_op(RdmaOpType::ReadIntoLocal, 0x1000, 4096),
+                fake_mrv(1, 0x1000, 4096),
+            ),
+            (
+                1usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
+                fake_mrv(2, 0x2000, 4096),
+            ),
+            (
+                2usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x3000, 4096),
+                fake_mrv(3, 0x3000, 4096),
+            ),
+            (
+                3usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x4000, 4096),
+                fake_mrv(4, 0x4000, 4096),
+            ),
+            (
+                4usize,
+                make_op(RdmaOpType::ReadIntoLocal, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
+                fake_mrv(5, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
+            ),
+        ];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        // First four post: 1 read WR (op 0) + 3 write WRs (ops 1-3).
+        let (_, _, r0_wrs) = expect_get(recv_posted(&mut posted_rx).await);
+        let (_, _, w1_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        let (_, _, w2_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        let (_, _, w3_wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(r0_wrs, vec![0]);
+        assert_eq!(w1_wrs, vec![1]);
+        assert_eq!(w2_wrs, vec![2]);
+        assert_eq!(w3_wrs, vec![3]);
+        // The 2-WR read at op_idx 4 stays parked.
+        assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
+
+        // Completing just the in-flight read frees a read credit but
+        // doesn't free a slot — op 4 still blocks.
+        qp.queue_completion(r0_wrs[0]);
+        let first_reply = collect_replies(&mut rx, 1).await;
+        assert_eq!(first_reply, vec![(0, Ok(()))]);
+        assert_no_post(&mut posted_rx, Duration::from_millis(50)).await;
+
+        // Completing one write frees the last slot needed; op 4 posts.
+        qp.queue_completion(w1_wrs[0]);
+        let second_reply = collect_replies(&mut rx, 1).await;
+        assert_eq!(second_reply, vec![(1, Ok(()))]);
+        let (_, _, r4_wrs) = expect_get(recv_posted(&mut posted_rx).await);
+        assert_eq!(r4_wrs, vec![4, 5]);
+
+        // Drain everything else.
+        qp.queue_completion(w2_wrs[0]);
+        qp.queue_completion(w3_wrs[0]);
+        for &id in &r4_wrs {
+            qp.queue_completion(id);
+        }
+        let rest = collect_replies(&mut rx, 3).await;
+        assert_eq!(rest, vec![(2, Ok(())), (3, Ok(())), (4, Ok(()))]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_multiple_batches_share_credit() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
+
+        // Batch A: 2 writes with op_idx 10, 11.
+        let batch_a = vec![
+            (
+                10usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
+                fake_mrv(1, 0x1000, 4096),
+            ),
+            (
+                11usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
+                fake_mrv(2, 0x2000, 4096),
+            ),
+        ];
+        let mut rx_a = submit_ops(&harness, &actor, batch_a)?;
+
+        // Batch B: 2 writes with op_idx 20, 21. Shares the QP with
+        // Batch A — together they sit at 4/4 max_send_wr.
+        let batch_b = vec![
+            (
+                20usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x3000, 4096),
+                fake_mrv(3, 0x3000, 4096),
+            ),
+            (
+                21usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x4000, 4096),
+                fake_mrv(4, 0x4000, 4096),
+            ),
+        ];
+        let mut rx_b = submit_ops(&harness, &actor, batch_b)?;
+
+        // Collect 4 post events (one per write).
+        let mut all_wr_ids = Vec::new();
+        for _ in 0..4 {
+            let (_, _, wrs) = expect_put(recv_posted(&mut posted_rx).await);
+            all_wr_ids.extend(wrs);
+        }
+        for &id in &all_wr_ids {
+            qp.queue_completion(id);
+        }
+
+        let replies_a = collect_replies(&mut rx_a, 2).await;
+        assert_eq!(replies_a, vec![(10, Ok(())), (11, Ok(()))]);
+        let replies_b = collect_replies(&mut rx_b, 2).await;
+        assert_eq!(replies_b, vec![(20, Ok(())), (21, Ok(()))]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_op_too_large_for_qp() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        // max_send_wr=1 with a 2-chunk write → can never fit.
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(1, 1).await?;
+
+        let items = vec![
+            (
+                0usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
+                fake_mrv(1, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
+            ),
+            (
+                1usize,
+                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
+                fake_mrv(2, 0x2000, 4096),
+            ),
+        ];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        // Only op_idx 1 reaches the wire (op_idx 0 was rejected).
+        let (_, _, wrs) = expect_put(recv_posted(&mut posted_rx).await);
+        assert_eq!(wrs, vec![0]);
+        qp.queue_completion(0);
+
+        let replies = collect_replies(&mut rx, 2).await;
+        // op_idx 0 must report a "too large" error; op_idx 1 succeeds.
+        assert_eq!(replies.len(), 2);
+        assert_eq!(replies[0].0, 0);
+        let err = replies[0]
+            .1
+            .as_ref()
+            .expect_err("op_idx 0 should fail as too large");
+        assert!(err.contains("too large"), "expected too-large error: {err}");
+        assert_eq!(replies[1], (1usize, Ok(())));
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_poll_error_kills_actor_via_supervision() -> Result<()> {
+        let mut harness = QpaHarness::build()?;
+        let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
+
+        // Post one op so the next poll has something to look at.
+        let items = vec![(
+            0usize,
+            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
+            fake_mrv(1, 0x1000, 4096),
+        )];
+        let _rx = submit_ops(&harness, &actor, items)?;
+        let _ = recv_posted(&mut posted_rx).await;
+        qp.queue_poll_error(PollCompletionError::for_test("simulated CQ poison"));
+
+        let event = harness.next_supervision_failure().await;
+        assert_eq!(&event.actor_id, actor.actor_addr());
+        let report = event.failure_report().expect("event should be a failure");
+        assert!(
+            report.contains("CQ poll failed") && report.contains("simulated CQ poison"),
+            "supervision report should name the poll failure: {report}",
+        );
+        await_status(&actor, |s| {
+            matches!(s, hyperactor::actor::ActorStatus::Failed(_))
+        })
+        .await;
+        harness.teardown().await;
+        Ok(())
+    }
+
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_post_error_kills_actor_via_supervision() -> Result<()> {
+        let mut harness = QpaHarness::build()?;
+        let (actor, qp, _posted_rx) = harness.spawn_ready_actor(4, 2).await?;
+
+        qp.queue_post_error("simulated post failure");
+        let items = vec![(
+            0usize,
+            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
+            fake_mrv(1, 0x1000, 4096),
+        )];
+        let _rx = submit_ops(&harness, &actor, items)?;
+
+        let event = harness.next_supervision_failure().await;
+        assert_eq!(&event.actor_id, actor.actor_addr());
+        let report = event.failure_report().expect("event should be a failure");
+        assert!(
+            report.contains("qp.put failed") && report.contains("simulated post failure"),
+            "supervision report should name the post failure: {report}",
+        );
+        await_status(&actor, |s| {
+            matches!(s, hyperactor::actor::ActorStatus::Failed(_))
+        })
+        .await;
         harness.teardown().await;
         Ok(())
     }

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -303,10 +303,12 @@ pub async fn wait_for_completion(
             return Ok(true);
         }
 
-        let wr_ids_to_poll: Vec<u64> = remaining.iter().copied().collect();
-        match qp.poll_completion(poll_target, &wr_ids_to_poll) {
+        match qp.poll_completion(poll_target, &remaining) {
             Ok(completions) => {
-                for (wr_id, _wc) in completions {
+                for (wr_id, wc_result) in completions {
+                    if let Err(e) = wc_result {
+                        return Err(anyhow::anyhow!("WR {} completion failed: {}", wr_id, e));
+                    }
                     remaining.remove(&wr_id);
                 }
                 if remaining.is_empty() {
@@ -315,7 +317,7 @@ pub async fn wait_for_completion(
                 tokio::time::sleep(Duration::from_millis(1)).await;
             }
             Err(e) => {
-                return Err(anyhow::anyhow!(e));
+                return Err(anyhow::anyhow!("CQ poll failed: {}", e));
             }
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/test_utils.rs
@@ -19,10 +19,12 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
+use hyperactor::Label;
 use hyperactor::OncePortRef;
 use hyperactor::Proc;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
+use hyperactor::Uid;
 use hyperactor::channel::ChannelAddr;
 use hyperactor_config::Flattrs;
 
@@ -571,12 +573,15 @@ impl IbvTestEnv {
         let instance_1 = proc_1.client("client");
         let instance_2 = proc_2.client("client");
 
+        // Must match `RdmaManagerActor::local_handle`'s singleton lookup of "rdma_manager".
         let rdma_actor_1 = RdmaManagerActor::new(Some(config1), Flattrs::default()).await?;
-        let rdma_actor_handle_1 = proc_1.spawn(rdma_actor_1);
+        let rdma_actor_handle_1 =
+            proc_1.spawn_with_uid(Uid::singleton(Label::strip("rdma_manager")), rdma_actor_1)?;
         let actor_1: ActorRef<RdmaManagerActor> = rdma_actor_handle_1.bind();
 
         let rdma_actor_2 = RdmaManagerActor::new(Some(config2), Flattrs::default()).await?;
-        let rdma_actor_handle_2 = proc_2.spawn(rdma_actor_2);
+        let rdma_actor_handle_2 =
+            proc_2.spawn_with_uid(Uid::singleton(Label::strip("rdma_manager")), rdma_actor_2)?;
         let actor_2: ActorRef<RdmaManagerActor> = rdma_actor_handle_2.bind();
 
         let mut buf_vec = Vec::new();

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -15,6 +15,9 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
+use std::sync::OnceLock;
+
+use crate::backend::ibverbs::primitives::IbvMemoryRegionView;
 
 /// Returns `true` when `addr` is a CUDA device pointer.
 ///
@@ -339,6 +342,55 @@ pub trait Keepalive: Send + Sync {}
 
 impl Keepalive for Box<[u8]> {}
 
+/// Backing state of a [`KeepaliveLocalMemory`].
+///
+/// Holds the addressing/bandwidth metadata, the access-coordination
+/// lock, and a single-slot home for an [`IbvMemoryRegionView`]
+/// registered against this region. Cloning shares the slot and the
+/// access lock by `Arc`, so every handle derived from the same
+/// allocation observes the same registered MR and the same
+/// reader/writer coordination.
+///
+/// All access goes through methods on [`KeepaliveLocalMemory`];
+/// nothing outside the module pokes at these fields directly.
+#[derive(Clone)]
+pub(crate) struct LocalMemoryInner {
+    addr: usize,
+    size: usize,
+    /// Bandwidth (bytes/s) for direct host-thread pointer access, or `None`
+    /// if the memory is not host-accessible.
+    direct_access_host_bandwidth: Option<u64>,
+    /// Bandwidth (bytes/s) for direct device-thread pointer access, or
+    /// `None` if the memory is not device-accessible.
+    direct_access_device_bandwidth: Option<u64>,
+    /// Per-allocation slot for the [`IbvMemoryRegionView`] registered
+    /// against this region. Populated lazily by
+    /// `IbvManagerActor::resolve_local_mr` on first use.
+    mr_slot: Arc<OnceLock<IbvMemoryRegionView>>,
+    /// Coordinates concurrent reads, exclusive writes, and parallel
+    /// disjoint writes against this region.
+    access: Arc<AccessLock>,
+}
+
+impl LocalMemoryInner {
+    fn new(addr: usize, size: usize) -> Self {
+        // TODO(slurye): Using placeholder values for now. Fill in with real values.
+        let (host_bw, device_bw) = if is_device_ptr(addr) {
+            (None, Some(1))
+        } else {
+            (Some(1), None)
+        };
+        Self {
+            addr,
+            size,
+            direct_access_host_bandwidth: host_bw,
+            direct_access_device_bandwidth: device_bw,
+            mr_slot: Arc::new(OnceLock::new()),
+            access: Arc::new(AccessLock::new()),
+        }
+    }
+}
+
 /// Local memory handle that keeps its backing allocation alive via an
 /// [`Arc<dyn Keepalive>`].
 ///
@@ -360,32 +412,22 @@ impl Keepalive for Box<[u8]> {}
 /// memory is not directly accessible from that context.
 #[derive(Clone)]
 pub struct KeepaliveLocalMemory {
-    addr: usize,
-    size: usize,
-    /// Bandwidth (bytes/s) for direct host-thread pointer access, or `None`
-    /// if the memory is not host-accessible.
-    direct_access_host_bandwidth: Option<u64>,
-    /// Bandwidth (bytes/s) for direct device-thread pointer access, or
-    /// `None` if the memory is not device-accessible.
-    direct_access_device_bandwidth: Option<u64>,
+    inner: LocalMemoryInner,
     _keepalive: Arc<dyn Keepalive>,
-    /// Coordinates concurrent reads, exclusive writes, and parallel
-    /// disjoint writes against this region.
-    access: Arc<AccessLock>,
 }
 
 impl Debug for KeepaliveLocalMemory {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("KeepaliveLocalMemory")
-            .field("addr", &self.addr)
-            .field("size", &self.size)
+            .field("addr", &self.inner.addr)
+            .field("size", &self.inner.size)
             .field(
                 "direct_access_host_bandwidth",
-                &self.direct_access_host_bandwidth,
+                &self.inner.direct_access_host_bandwidth,
             )
             .field(
                 "direct_access_device_bandwidth",
-                &self.direct_access_device_bandwidth,
+                &self.inner.direct_access_device_bandwidth,
             )
             .finish_non_exhaustive()
     }
@@ -396,30 +438,29 @@ impl KeepaliveLocalMemory {
     /// `addr` is a device pointer and sets the bandwidth fields
     /// accordingly.
     pub fn new(addr: usize, size: usize, keepalive: Arc<dyn Keepalive>) -> Self {
-        // TODO(slurye): Using placeholder values for now. Fill in with real values.
-        let (host_bw, device_bw) = if is_device_ptr(addr) {
-            (None, Some(1))
-        } else {
-            (Some(1), None)
-        };
         Self {
-            addr,
-            size,
-            direct_access_host_bandwidth: host_bw,
-            direct_access_device_bandwidth: device_bw,
+            inner: LocalMemoryInner::new(addr, size),
             _keepalive: keepalive,
-            access: Arc::new(AccessLock::new()),
         }
     }
 
     /// Starting virtual address of the memory region.
     pub fn addr(&self) -> usize {
-        self.addr
+        self.inner.addr
     }
 
     /// Size of the memory region in bytes.
     pub fn size(&self) -> usize {
-        self.size
+        self.inner.size
+    }
+
+    /// Shared slot for the [`IbvMemoryRegionView`] registered against
+    /// this region. Populated lazily by
+    /// [`IbvManagerActor::resolve_local_mr`] on first use; the slot
+    /// is cloned `Arc` so every handle derived from the same
+    /// allocation sees the same registered MR.
+    pub fn mr_slot(&self) -> &Arc<OnceLock<IbvMemoryRegionView>> {
+        &self.inner.mr_slot
     }
 
     /// Copy `dst.len()` bytes from this memory region starting at `offset`
@@ -441,19 +482,19 @@ impl KeepaliveLocalMemory {
     /// no such external access produces a torn read of
     /// `offset..offset + dst.len()` for the duration of this call.
     pub unsafe fn read_at(&self, offset: usize, dst: &mut [u8]) -> Result<(), anyhow::Error> {
-        let _guard = self.access.read();
-        check_bounds(offset, dst.len(), self.size)?;
+        let _guard = self.inner.access.read();
+        check_bounds(offset, dst.len(), self.inner.size)?;
         // SAFETY: the `_keepalive` field keeps the allocation live, the
         // read guard above excludes concurrent exclusive and disjoint
         // writers that share this lock, `check_bounds` verified the access
         // is in range, and the caller upholds the no-external-writer
         // obligation documented on this method.
         unsafe {
-            if self.direct_access_host_bandwidth.is_some() {
-                read_cpu(self.addr, offset, dst);
+            if self.inner.direct_access_host_bandwidth.is_some() {
+                read_cpu(self.inner.addr, offset, dst);
                 Ok(())
             } else {
-                read_gpu(self.addr, offset, dst)
+                read_gpu(self.inner.addr, offset, dst)
             }
         }
     }
@@ -473,19 +514,19 @@ impl KeepaliveLocalMemory {
     /// covers liveness only; the caller must ensure no concurrent
     /// external reader or writer observes an overlapping byte range.
     pub unsafe fn write_at(&self, offset: usize, src: &[u8]) -> Result<(), anyhow::Error> {
-        let _guard = self.access.exclusive();
-        check_bounds(offset, src.len(), self.size)?;
+        let _guard = self.inner.access.exclusive();
+        check_bounds(offset, src.len(), self.inner.size)?;
         // SAFETY: the `_keepalive` field keeps the allocation live, the
         // exclusive guard above excludes every other reader and writer
         // that shares this lock, `check_bounds` verified the access is
         // in range, and the caller upholds the no-external-access
         // obligation documented on this method.
         unsafe {
-            if self.direct_access_host_bandwidth.is_some() {
-                write_cpu(self.addr, offset, src);
+            if self.inner.direct_access_host_bandwidth.is_some() {
+                write_cpu(self.inner.addr, offset, src);
                 Ok(())
             } else {
-                write_gpu(self.addr, offset, src)
+                write_gpu(self.inner.addr, offset, src)
             }
         }
     }
@@ -504,8 +545,8 @@ impl KeepaliveLocalMemory {
     /// byte range that overlaps `offset..offset + src.len()`. Disjoint
     /// byte ranges across concurrent disjoint callers are sound.
     pub unsafe fn write_at_disjoint(&self, offset: usize, src: &[u8]) -> Result<(), anyhow::Error> {
-        let _guard = self.access.disjoint_write();
-        check_bounds(offset, src.len(), self.size)?;
+        let _guard = self.inner.access.disjoint_write();
+        check_bounds(offset, src.len(), self.inner.size)?;
         // SAFETY: the `_keepalive` field keeps the allocation live, the
         // disjoint-write guard above excludes concurrent readers and
         // exclusive writers that share this lock, `check_bounds`
@@ -513,11 +554,11 @@ impl KeepaliveLocalMemory {
         // safety obligations documented on this method (no external access,
         // no overlap with other concurrent disjoint writers).
         unsafe {
-            if self.direct_access_host_bandwidth.is_some() {
-                write_cpu(self.addr, offset, src);
+            if self.inner.direct_access_host_bandwidth.is_some() {
+                write_cpu(self.inner.addr, offset, src);
                 Ok(())
             } else {
-                write_gpu(self.addr, offset, src)
+                write_gpu(self.inner.addr, offset, src)
             }
         }
     }


### PR DESCRIPTION
Summary:
End-to-end wire-up of the new `QueuePairActor` data path into `IbvManagerActor`.

`Handler<SubmitOps>` walks the incoming `Vec<RdmaOp>` and for each op resolves the local MR, derives the `QpKey { self_device, other_id, other_device }`, looks up (or spawns on demand) the corresponding `QueuePairActor`, and posts a single-item `ProcessOps` to it. `.post(ProcessOps)` returns as soon as the message lands in the QP actor's mailbox, so resolving the MR for op `i+1` overlaps with the QP actor's post/poll work for op `i`. Spawning a new `QueuePairActor` drives a `CreatePeerQueuePair` round trip on the peer manager to initialize the passive-side QP; loopback short-circuits the round trip.

Per-op completions travel back through the original `SubmitOps.reply` port as `OpResult { op_idx, result }`, where `op_idx` is the op's position in the caller's `Vec<RdmaOp>`. That lets `IbvBackend::submit` correlate completions back to the original submit even though each op flows through its own per-QP actor.

The legacy `QueuePairInitializer` data path stays compiled but is no longer reached by `Handler<SubmitOps>`; it is deleted in the follow-up diff so this wire-up stays reviewable on its own.

New integration tests use a `BufferHelperActor` to drive CPU/CUDA buffers across a `HostMesh::local` side and a `Proc::direct` in-process side, covering same-device, cross-device, loopback, multiple ops sharing one QP, multiple ops fanning across distinct QPs, every CPU↔CUDA permutation, the `IbvQpType::Standard` per-buffer dmabuf fallback, and a 2 GiB CUDA transfer.

Reviewed By: zdevito

Differential Revision: D105904433


