### PR TITLE
rankspace: test RankSpace::without chains accumulate via union

### DIFF
--- a/rankspace/src/lib.rs
+++ b/rankspace/src/lib.rs
@@ -1479,6 +1479,42 @@ mod tests {
     }
 
     #[test]
+    fn sparse_space_with_empty_mask_matches_dense() {
+        let base = host_gpu_rect(); // sizes [2, 4], valid ranks 0..=7
+        let dense = RankSpace::dense(base.clone());
+        let sparse = RankSpace::sparse(base.clone(), RankMask::Empty);
+
+        // Structural equivalence: both constructors produce the same struct.
+        assert_eq!(dense, sparse);
+
+        // Behavioral equivalence: derived methods agree, and the concrete values
+        // match the expected dense iteration (so a bug producing equally-broken
+        // results on both sides would still be caught).
+        assert_eq!(dense.cardinality(), sparse.cardinality());
+        assert_eq!(dense.cardinality(), 8);
+        let expected = vec![
+            Rank(0),
+            Rank(1),
+            Rank(2),
+            Rank(3),
+            Rank(4),
+            Rank(5),
+            Rank(6),
+            Rank(7),
+        ];
+        assert_eq!(dense.iter_ranks().collect::<Vec<_>>(), expected);
+        assert_eq!(sparse.iter_ranks().collect::<Vec<_>>(), expected);
+        for rank in base.iter_ranks() {
+            assert_eq!(dense.contains_rank(rank), sparse.contains_rank(rank));
+        }
+        // Out-of-base rank: both short-circuit via `base.contains_rank`.
+        assert_eq!(
+            dense.contains_rank(Rank(100)),
+            sparse.contains_rank(Rank(100))
+        );
+    }
+
+    #[test]
     fn sparse_subspaces_keep_masks_in_base_rank_coordinates() {
         let rect = host_gpu_rect();
         let missing_gpu = RankMask::ranks([Rank(5)]);

--- a/rankspace/src/lib.rs
+++ b/rankspace/src/lib.rs
@@ -1515,6 +1515,33 @@ mod tests {
     }
 
     #[test]
+    fn without_chains_accumulate_via_union() {
+        let rect = host_gpu_rect(); // sizes [2, 4], valid ranks 0..=7
+        let mask_a = RankMask::ranks([Rank(2)]);
+        let mask_b = RankMask::ranks([Rank(5)]);
+
+        let space = RankSpace::dense(rect)
+            .without(mask_a.clone())
+            .without(mask_b.clone());
+
+        // Behavioral: both masks are applied — ranks 2 and 5 are hidden.
+        assert!(!space.contains_rank(Rank(2)));
+        assert!(!space.contains_rank(Rank(5)));
+        assert!(space.contains_rank(Rank(0)));
+        assert!(space.contains_rank(Rank(7)));
+        assert!(!space.contains_rank(Rank(100))); // out-of-base
+        assert_eq!(
+            space.iter_ranks().collect::<Vec<_>>(),
+            vec![Rank(0), Rank(1), Rank(3), Rank(4), Rank(6), Rank(7)],
+        );
+        assert_eq!(space.cardinality(), 6);
+
+        // Structural: the chained occlusion equals a direct union of the two masks.
+        let expected_occlusion = RankMask::union([mask_a, mask_b]);
+        assert_eq!(space.occlusion(), &expected_occlusion);
+    }
+
+    #[test]
     fn sparse_subspaces_keep_masks_in_base_rank_coordinates() {
         let rect = host_gpu_rect();
         let missing_gpu = RankMask::ranks([Rank(5)]);

--- a/rankspace/src/lib.rs
+++ b/rankspace/src/lib.rs
@@ -1160,6 +1160,47 @@ mod tests {
     }
 
     #[test]
+    fn coord_of_returns_none_for_ranks_outside_rect() {
+        // Empty rect: `self.is_empty()` short-circuits to None.
+        let empty = RankRect::affine(
+            Extent::new(vec![Dim::new("host", 0)]).unwrap(),
+            Rank(0),
+            vec![1],
+        )
+        .unwrap();
+        assert_eq!(empty.coord_of(Rank(0)), None);
+
+        // Below offset: `rank.0.checked_sub(self.offset.0)` returns None.
+        let offset_rect = RankRect::affine(
+            Extent::new(vec![Dim::new("host", 2), Dim::new("gpu", 4)]).unwrap(),
+            Rank(100),
+            vec![4, 1],
+        )
+        .unwrap();
+        assert_eq!(offset_rect.coord_of(Rank(99)), None);
+        assert_eq!(offset_rect.coord_of(Rank(0)), None);
+
+        // Above max bound on a dense rect: the largest-stride iteration produces
+        // `index >= size`. `host_gpu_rect` has valid ranks 0..=7.
+        let dense = host_gpu_rect();
+        assert_eq!(dense.coord_of(Rank(8)), None);
+        assert_eq!(dense.coord_of(Rank(100)), None);
+
+        // Inside bounds but not on a stride boundary: the decomposition completes
+        // without hitting `index >= size`, but leaves `rest != 0` at the end.
+        // Requires a smallest stride > 1; extent [2] with stride [3] has valid
+        // ranks {0, 3}, so ranks 1 and 2 sit between them and are unreachable.
+        let sparse = RankRect::affine(
+            Extent::new(vec![Dim::new("host", 2)]).unwrap(),
+            Rank(0),
+            vec![3],
+        )
+        .unwrap();
+        assert_eq!(sparse.coord_of(Rank(1)), None);
+        assert_eq!(sparse.coord_of(Rank(2)), None);
+    }
+
+    #[test]
     fn rank_rect_affine_rejects_invalid_strides() {
         let extent =
             |a: usize, b: usize| Extent::new(vec![Dim::new("a", a), Dim::new("b", b)]).unwrap();

--- a/rankspace/src/lib.rs
+++ b/rankspace/src/lib.rs
@@ -1126,6 +1126,40 @@ mod tests {
     }
 
     #[test]
+    fn rank_of_returns_none_for_invalid_coords_and_overflow() {
+        let rect = host_gpu_rect(); // extent [host = 2, gpu = 4]
+
+        // Wrong-length coord (coord.len() != extent.len()).
+        assert_eq!(rect.rank_of([0]), None);
+        assert_eq!(rect.rank_of([0, 0, 0]), None);
+
+        // Out-of-range coord (coord[d] >= sizes[d]).
+        assert_eq!(rect.rank_of([2, 0]), None); // host out of range (size 2)
+        assert_eq!(rect.rank_of([0, 4]), None); // gpu out of range (size 4)
+
+        // Multiply overflow: coord[i] * stride[i] overflows usize.
+        // Direct struct construction bypasses `validate_strides`; this mirrors
+        // the existing `select_reports_rank_arithmetic_overflow` pattern.
+        let overflow_stride = RankRect {
+            extent: Extent::new(vec![Dim::new("host", 3)]).unwrap(),
+            offset: Rank(0),
+            strides: vec![usize::MAX],
+        };
+        assert_eq!(overflow_stride.rank_of([2]), None); // 2 * usize::MAX overflows
+
+        // Add overflow: offset + sum overflows usize. Reachable through the public
+        // constructor — `validate_strides` does not constrain offset, so a near-MAX
+        // offset is admitted.
+        let overflow_offset = RankRect::affine(
+            Extent::new(vec![Dim::new("host", 3)]).unwrap(),
+            Rank(usize::MAX),
+            vec![1],
+        )
+        .unwrap();
+        assert_eq!(overflow_offset.rank_of([1]), None); // usize::MAX + 1 overflows
+    }
+
+    #[test]
     fn rank_rect_affine_rejects_invalid_strides() {
         let extent =
             |a: usize, b: usize| Extent::new(vec![Dim::new("a", a), Dim::new("b", b)]).unwrap();

--- a/rankspace/src/lib.rs
+++ b/rankspace/src/lib.rs
@@ -1162,6 +1162,123 @@ mod tests {
     }
 
     #[test]
+    fn affine_supports_column_major_strides() {
+        // sizes [2, 4] with column-major strides [1, 2]: dim 0 has the smallest
+        // stride, so iter (local row-major over the extent) produces ranks in
+        // interleaved order rather than consecutive.
+        let extent = Extent::new(vec![Dim::new("a", 2), Dim::new("b", 4)]).unwrap();
+        let rect = RankRect::affine(extent, Rank(0), vec![1, 2]).unwrap();
+
+        assert_eq!(
+            rect.iter_ranks().collect::<Vec<_>>(),
+            vec![
+                Rank(0),
+                Rank(2),
+                Rank(4),
+                Rank(6),
+                Rank(1),
+                Rank(3),
+                Rank(5),
+                Rank(7),
+            ],
+        );
+
+        assert_eq!(rect.rank_of([1, 2]), Some(Rank(5)));
+        assert_eq!(rect.coord_of(Rank(5)), Some(Coord::from([1, 2])));
+        assert_eq!(rect.rank_of([0, 3]), Some(Rank(6)));
+        assert_eq!(rect.coord_of(Rank(6)), Some(Coord::from([0, 3])));
+    }
+
+    #[test]
+    fn affine_supports_permuted_strides() {
+        // sizes [2, 3, 4] with strides [4, 8, 1]: the dim with the largest stride
+        // (`b`) is in the middle position, not the outermost. Iteration is still
+        // local row-major over the extent, but the rank arithmetic depends on the
+        // non-canonical stride permutation. Dense (no gaps): the coord_space chain
+        // is 1 -> 4 -> 8 -> 24, exactly matching 2*3*4.
+        let extent =
+            Extent::new(vec![Dim::new("a", 2), Dim::new("b", 3), Dim::new("c", 4)]).unwrap();
+        let rect = RankRect::affine(extent, Rank(0), vec![4, 8, 1]).unwrap();
+
+        for (coord, rank) in [
+            ([0usize, 0, 0], 0usize),
+            ([0, 0, 3], 3),
+            ([0, 1, 0], 8),
+            ([1, 0, 0], 4),
+            ([1, 2, 3], 23),
+        ] {
+            assert_eq!(rect.rank_of(coord), Some(Rank(rank)));
+            assert_eq!(rect.coord_of(Rank(rank)), Some(Coord::from(coord)));
+        }
+
+        // Iteration walks the 24 coords in local row-major over the extent; the
+        // rank stream reflects the permuted strides, not the dim declaration order.
+        assert_eq!(
+            rect.iter_ranks().collect::<Vec<_>>(),
+            vec![
+                Rank(0),
+                Rank(1),
+                Rank(2),
+                Rank(3),
+                Rank(8),
+                Rank(9),
+                Rank(10),
+                Rank(11),
+                Rank(16),
+                Rank(17),
+                Rank(18),
+                Rank(19),
+                Rank(4),
+                Rank(5),
+                Rank(6),
+                Rank(7),
+                Rank(12),
+                Rank(13),
+                Rank(14),
+                Rank(15),
+                Rank(20),
+                Rank(21),
+                Rank(22),
+                Rank(23),
+            ],
+        );
+    }
+
+    #[test]
+    fn affine_supports_gapped_strides() {
+        // sizes [2, 4] with strides [10, 1]: rows are 10 apart, leaving a gap
+        // (ranks 4..=9) between row 0 and row 1 that's not part of the rect.
+        let extent = Extent::new(vec![Dim::new("a", 2), Dim::new("b", 4)]).unwrap();
+        let rect = RankRect::affine(extent, Rank(0), vec![10, 1]).unwrap();
+
+        assert_eq!(
+            rect.iter_ranks().collect::<Vec<_>>(),
+            vec![
+                Rank(0),
+                Rank(1),
+                Rank(2),
+                Rank(3),
+                Rank(10),
+                Rank(11),
+                Rank(12),
+                Rank(13),
+            ],
+        );
+
+        assert_eq!(rect.rank_of([1, 2]), Some(Rank(12)));
+        assert_eq!(rect.coord_of(Rank(12)), Some(Coord::from([1, 2])));
+
+        // Ranks inside the gap are not part of the rect.
+        assert_eq!(rect.coord_of(Rank(4)), None); // immediately after row 0
+        assert_eq!(rect.coord_of(Rank(5)), None);
+        assert_eq!(rect.coord_of(Rank(9)), None);
+
+        // Ranks above the last valid row also return None.
+        assert_eq!(rect.coord_of(Rank(14)), None); // immediately after row 1
+        assert_eq!(rect.coord_of(Rank(20)), None); // where row 2 would start
+    }
+
+    #[test]
     fn rank_rect_with_empty_extent_is_a_single_point() {
         // 0-dim `RankRect`: a "scalar" rect whose one rank is the offset.
         let rect = RankRect::affine(Extent::new(vec![]).unwrap(), Rank(42), vec![]).unwrap();


### PR DESCRIPTION
Summary:
one test pinning that chained `RankSpace::without` calls accumulate occlusions via `RankMask::union`. constructs a `[2, 4]` base, applies `.without(Ranks([Rank(2)])).without(Ranks([Rank(5)]))`, and asserts both behavioral consequences (ranks 2 and 5 hidden, `iter_ranks` yields the remaining 6,  `contains_rank` correct for visible/hidden/out-of-base) and structural equivalence (the resulting occlusion equals `RankMask::union([mask_a, mask_b])` constructed directly).
  
no existing test chains `.without` calls; every sparse-space test applies a single mask. a regression in `RankMask::union`'s accumulation behavior (e.g., dropping the Empty-filter or the 1-mask short-circuit) would survive current coverage as long as single-mask cases keep passing.

Differential Revision: D106127241


