### PR TITLE
test Gateway::flush concurrent with proc attach/detach (#4046)

### DIFF
--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -406,6 +406,7 @@ mod tests {
 
     use async_trait::async_trait;
     use hyperactor_config::Flattrs;
+    use timed_test::async_timed_test;
     use tokio::time;
 
     use super::*;
@@ -741,6 +742,93 @@ mod tests {
         assert_eq!(alpha_flushed.load(Ordering::SeqCst), 1);
         assert_eq!(beta_flushed.load(Ordering::SeqCst), 1);
         assert_eq!(forwarder_flushed.load(Ordering::SeqCst), 1);
+    }
+
+    /// Driving `Gateway::flush` concurrently with proc attach + drop must
+    /// not panic, deadlock, or leave the gateway in a torn state. The
+    /// flush impl snapshots the live proc set before awaiting, so
+    /// attaches/drops during flush should be invisible to the flush in
+    /// flight.
+    #[async_timed_test(timeout_secs = 10)]
+    async fn test_gateway_flush_concurrent_with_attach_and_drop() {
+        #[derive(Clone)]
+        struct NoopSender;
+
+        #[async_trait]
+        impl MailboxSender for NoopSender {
+            fn post_unchecked(
+                &self,
+                _envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                // Defensive no-op: this test shouldn't route messages.
+            }
+
+            async fn flush(&self) -> Result<(), anyhow::Error> {
+                Ok(())
+            }
+        }
+
+        let gateway = Gateway::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(NoopSender),
+        );
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let flushes = {
+            let gateway = gateway.clone();
+            let barrier = barrier.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                for _ in 0..100 {
+                    gateway.flush().await.unwrap();
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        let attach_drop = {
+            let gateway = gateway.clone();
+            let barrier = barrier.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                for i in 0..100 {
+                    let proc = Proc::builder()
+                        .proc_id(ProcId::instance(Label::strip(&format!("p{i}"))))
+                        .shared_gateway(gateway.clone())
+                        .build()
+                        .unwrap();
+                    // Hold the proc across at least one yield so it's
+                    // attached for an observable window before drop.
+                    tokio::task::yield_now().await;
+                    drop(proc);
+                }
+            })
+        };
+
+        flushes.await.unwrap();
+        attach_drop.await.unwrap();
+
+        // No torn state: a final flush succeeds.
+        gateway.flush().await.unwrap();
+
+        // All procs dropped — no weak entries should still upgrade. Stale
+        // weak entries may remain in the map (replaced on next attach with
+        // same id), so we don't assert on `len()`; we assert on live
+        // entries only.
+        assert_eq!(
+            gateway
+                .inner
+                .procs
+                .read()
+                .unwrap()
+                .values()
+                .filter_map(WeakProc::upgrade)
+                .count(),
+            0,
+            "no procs should still be live after attach_drop task completes",
+        );
     }
 
     /// After the gateway is dropped, `WeakGateway::post_unchecked`


### PR DESCRIPTION
Summary:

one race-focused test pinning that driving `Gateway::flush` concurrently with proc attach + drop doesn't panic, deadlock, or tear state. the flush impl snapshots the live proc set before awaiting (`gateway.rs:244`), so concurrent attaches/drops should be invisible to the flush in flight. 
  
uses a multi-threaded runtime (`worker_threads = 2`), a `tokio::sync::Barrier(2)` to align the start of the racing tasks, and `yield_now().await` inside both loops so iterations actually interleave. each `Proc` is held across a yield before drop, so the attach is observable. joined awaits are wrapped in a 10s `time::timeout` — a deadlock would otherwise hang until the test harness timeout.
  
final asserts: a `flush()` after the race succeeds, and no `WeakProc` values in the gateway's proc map still upgrade (live count is 0; stale weak entries may remain, so `len()` isn't asserted).

___

Reviewed By: pzhan9

Differential Revision: D106129731


