### PR TITLE
test concurrent set_default_location and bind (#4047)

### DIFF
--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -406,6 +406,7 @@ mod tests {
 
     use async_trait::async_trait;
     use hyperactor_config::Flattrs;
+    use timed_test::async_timed_test;
     use tokio::time;
 
     use super::*;
@@ -741,6 +742,93 @@ mod tests {
         assert_eq!(alpha_flushed.load(Ordering::SeqCst), 1);
         assert_eq!(beta_flushed.load(Ordering::SeqCst), 1);
         assert_eq!(forwarder_flushed.load(Ordering::SeqCst), 1);
+    }
+
+    /// Driving `Gateway::flush` concurrently with proc attach + drop must
+    /// not panic, deadlock, or leave the gateway in a torn state. The
+    /// flush impl snapshots the live proc set before awaiting, so
+    /// attaches/drops during flush should be invisible to the flush in
+    /// flight.
+    #[async_timed_test(timeout_secs = 10)]
+    async fn test_gateway_flush_concurrent_with_attach_and_drop() {
+        #[derive(Clone)]
+        struct NoopSender;
+
+        #[async_trait]
+        impl MailboxSender for NoopSender {
+            fn post_unchecked(
+                &self,
+                _envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                // Defensive no-op: this test shouldn't route messages.
+            }
+
+            async fn flush(&self) -> Result<(), anyhow::Error> {
+                Ok(())
+            }
+        }
+
+        let gateway = Gateway::configured(
+            channel::reserve_local_addr().into(),
+            BoxedMailboxSender::new(NoopSender),
+        );
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(2));
+
+        let flushes = {
+            let gateway = gateway.clone();
+            let barrier = barrier.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                for _ in 0..100 {
+                    gateway.flush().await.unwrap();
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        let attach_drop = {
+            let gateway = gateway.clone();
+            let barrier = barrier.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                for i in 0..100 {
+                    let proc = Proc::builder()
+                        .proc_id(ProcId::instance(Label::strip(&format!("p{i}"))))
+                        .shared_gateway(gateway.clone())
+                        .build()
+                        .unwrap();
+                    // Hold the proc across at least one yield so it's
+                    // attached for an observable window before drop.
+                    tokio::task::yield_now().await;
+                    drop(proc);
+                }
+            })
+        };
+
+        flushes.await.unwrap();
+        attach_drop.await.unwrap();
+
+        // No torn state: a final flush succeeds.
+        gateway.flush().await.unwrap();
+
+        // All procs dropped — no weak entries should still upgrade. Stale
+        // weak entries may remain in the map (replaced on next attach with
+        // same id), so we don't assert on `len()`; we assert on live
+        // entries only.
+        assert_eq!(
+            gateway
+                .inner
+                .procs
+                .read()
+                .unwrap()
+                .values()
+                .filter_map(WeakProc::upgrade)
+                .count(),
+            0,
+            "no procs should still be live after attach_drop task completes",
+        );
     }
 
     /// After the gateway is dropped, `WeakGateway::post_unchecked`

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -5126,6 +5126,87 @@ mod tests {
         assert!(proc.get_instance(second_ref.actor_addr()).is_some());
     }
 
+    /// Concurrent `set_default_location` and `handle.bind()` must not
+    /// corrupt the bindings. Every bound ref carries one of the racing
+    /// locations, and every bound ref is still resolvable via
+    /// `get_instance` (which keys on identity, not location).
+    #[async_timed_test(timeout_secs = 10)]
+    async fn test_default_location_concurrent_with_bind() {
+        let proc = Proc::isolated();
+        let gateway = proc.gateway();
+        let handle = proc.client("worker");
+
+        let loc_a: Location = ChannelAddr::Local(40001).into();
+        let loc_b: Location = ChannelAddr::Local(40002).into();
+
+        // Pre-set to loc_a so binds never observe the initial default
+        // location. Without this, a bind that runs before the setter's
+        // first write could see the initial location and fail the
+        // "one of two locations" assertion.
+        gateway.set_default_location(loc_a.clone());
+
+        let barrier = std::sync::Arc::new(Barrier::new(2));
+
+        let setter = {
+            let gateway = gateway.clone();
+            let loc_a = loc_a.clone();
+            let loc_b = loc_b.clone();
+            let barrier = barrier.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                for i in 0..100 {
+                    let loc = if i % 2 == 0 {
+                        loc_a.clone()
+                    } else {
+                        loc_b.clone()
+                    };
+                    gateway.set_default_location(loc);
+                    tokio::task::yield_now().await;
+                }
+            })
+        };
+
+        let binder = {
+            // Clone `handle` into the binder so the outer `handle` stays
+            // alive after the spawned task finishes. Without this, the
+            // only strong reference to the client's instance drops when
+            // the binder task ends and the `proc.get_instance(...)` checks
+            // below return None.
+            let handle = handle.clone();
+            let barrier = barrier.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                let mut refs = Vec::with_capacity(100);
+                for _ in 0..100 {
+                    refs.push(handle.bind::<()>());
+                    tokio::task::yield_now().await;
+                }
+                refs
+            })
+        };
+
+        setter.await.unwrap();
+        let refs = binder.await.unwrap();
+
+        // Every ref carries one of the two racing locations.
+        for r in &refs {
+            let loc = r.actor_addr().location();
+            assert!(
+                loc == &loc_a || loc == &loc_b,
+                "ref location {loc:?} is neither {loc_a:?} nor {loc_b:?}",
+            );
+        }
+
+        // Every ref is still resolvable via get_instance (identity-based).
+        for r in &refs {
+            assert!(
+                proc.get_instance(r.actor_addr()).is_some(),
+                "ref {:?} no longer resolves",
+                r.actor_addr(),
+            );
+        }
+    }
+
     #[test]
     fn test_builder_procs_can_share_gateway_with_distinct_ids() {
         let gateway = Gateway::new();


### PR DESCRIPTION
Summary:

one race-focused test pinning that concurrent `Gateway::set_default_location` and `handle.bind()` calls don't corrupt bindings. every bound ref carries one of the racing locations (the gateway's `RwLock` keeps the read/write sequence atomic), and every bound ref is still resolvable via `get_instance` (which keys on identity, not on the location captured at bind time).
  
the test pre-sets the gateway to `loc_a` before spawning the racing tasks — otherwise a bind that ran before the setter's first write could observe the proc's initial default location and fail the "one of two locations" assertion. uses a multi-threaded runtime (`worker_threads = 2`), a `tokio::sync::Barrier(2)` to align the start, and `yield_now().await` inside both loops so iterations actually interleave. joined awaits are wrapped in a 10s `time::timeout`.
  
the single-threaded variant (`test_default_location_changes_new_bindings_not_lookup` at `proc.rs:4684`) pins the asymmetry but doesn't exercise racing; this  test extends that coverage.

Reviewed By: pzhan9

Differential Revision: D106131001


