### PR TITLE
stamp SENDER_ACTOR_ID alongside SEQ_INFO (#4052)

### DIFF
--- a/hyperactor/src/context.rs
+++ b/hyperactor/src/context.rs
@@ -164,6 +164,15 @@ impl<T: Actor + Send + Sync> MailboxExt for T {
             // without worrying about rollback.
             let sequencer = self.instance().sequencer();
             let seq_info = sequencer.assign_seq(&dest);
+            // Pair the SENDER_ACTOR_ID stamp with the seq we just assigned.
+            // Helper applies the (seq<=4 || stale) gate, the handler-port +
+            // non-bypass guard, and the framework-owned overwrite semantics.
+            crate::mailbox::headers::stamp_sender_actor_id(
+                &mut headers,
+                &seq_info,
+                &dest,
+                self.mailbox().actor_addr(),
+            );
             headers.set(SEQ_INFO, seq_info);
         }
 

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2052,6 +2052,17 @@ impl<M: Message> PortHandle<M> {
             let sequencer = cx.instance().sequencer();
             let bound_ref: PortAddr = bound_port.clone();
             let seq_info = sequencer.assign_seq(&bound_ref);
+            // Pair SENDER_ACTOR_ID stamp with SEQ_INFO. PortHandle::try_post
+            // starts with Flattrs::new(), so there's no caller-supplied stale
+            // header to defend against — use the simpler "fresh" helper.
+            if let SeqInfo::Session { seq, .. } = &seq_info {
+                crate::mailbox::headers::stamp_sender_actor_id_fresh(
+                    &mut headers,
+                    *seq,
+                    &bound_ref,
+                    cx.mailbox().actor_addr(),
+                );
+            }
             headers.set(SEQ_INFO, seq_info);
         } else {
             // Because the port is not bound, messages can only be sent through

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -19,7 +19,11 @@ use hyperactor_config::attrs::OPERATION_CONTEXT_HEADER;
 use hyperactor_config::attrs::declare_attrs;
 use hyperactor_config::global;
 
+use crate::ActorAddr;
+use crate::PortAddr;
 use crate::metrics::MESSAGE_LATENCY_MICROS;
+use crate::ordering::SeqInfo;
+use crate::ordering::is_bypass_workq_actor_port;
 
 declare_attrs! {
     /// Send timestamp for message latency tracking
@@ -30,6 +34,22 @@ declare_attrs! {
 
     /// Hashed ActorAddr of the message sender, injected in post_unchecked().
     pub attr SENDER_ACTOR_ID_HASH: u64;
+
+    /// Full ActorAddr of the session owner — the actor whose Sequencer
+    /// assigned this message's SEQ_INFO. Stamped at SEQ_INFO
+    /// assignment/install sites: MailboxExt::post, PortHandle::try_post,
+    /// and CommActor::deliver_to_dest (after V1 installs SEQ_INFO).
+    /// Paired with the SEQ_INFO value.
+    ///
+    /// Framework-owned: stamping sites OVERWRITE caller-supplied values
+    /// (do not trust callers to know who owns the session). This attr
+    /// must never be propagated by handlers via verbatim header
+    /// forwarding; the framework will overwrite stale forwards on the
+    /// next ordered send through a trusted site.
+    ///
+    /// Larger than SENDER_ACTOR_ID_HASH (~50-100 bytes vs 8); both kept
+    /// so the hash remains available for high-cardinality OTel labels.
+    pub attr SENDER_ACTOR_ID: ActorAddr;
 
     /// Telemetry message ID for correlating lifecycle events, injected in post_unchecked().
     pub attr TELEMETRY_MESSAGE_ID: u64;
@@ -78,6 +98,49 @@ pub fn set_rust_message_type<M>(headers: &mut Flattrs) {
     headers.set(RUST_MESSAGE_TYPE, type_name::<M>().to_string());
 }
 
+/// Stamp `SENDER_ACTOR_ID` into `headers` if the gate conditions are met.
+/// Framework-owned: overwrites existing values, never "sets if absent".
+///
+/// Gate: stamp when (early-session OR caller-set-stale) AND ordered handler
+/// traffic. `caller_set_stale` defends against handlers that forward inbound
+/// headers verbatim.
+///
+/// Callable from cross-crate sites (CommActor::deliver_to_dest in
+/// hyperactor_mesh), so visibility is `pub` with `#[doc(hidden)]` to keep
+/// it out of the public API surface.
+#[doc(hidden)]
+pub fn stamp_sender_actor_id(
+    headers: &mut Flattrs,
+    seq_info: &SeqInfo,
+    dest: &PortAddr,
+    owner: &ActorAddr,
+) {
+    if let SeqInfo::Session { seq, .. } = seq_info {
+        let early_session = *seq <= 4;
+        let caller_set_stale = headers.contains_key(SENDER_ACTOR_ID);
+        if (early_session || caller_set_stale)
+            && dest.is_handler_port()
+            && !is_bypass_workq_actor_port(dest.index())
+        {
+            headers.set(SENDER_ACTOR_ID, owner.clone());
+        }
+    }
+}
+
+/// Simpler stamping for paths where headers start fresh (no caller-supplied
+/// stale value to defend against). Used only within the hyperactor crate by
+/// PortHandle::try_post.
+pub(crate) fn stamp_sender_actor_id_fresh(
+    headers: &mut Flattrs,
+    seq: u64,
+    dest: &PortAddr,
+    owner: &ActorAddr,
+) {
+    if seq <= 4 && dest.is_handler_port() && !is_bypass_workq_actor_port(dest.index()) {
+        headers.set(SENDER_ACTOR_ID, owner.clone());
+    }
+}
+
 /// This function checks the configured sampling rate and, if the random sample passes,
 /// calculates the latency between the send timestamp and the current time, then records
 /// the latency metric with the associated actor ID.
@@ -103,4 +166,132 @@ pub fn log_message_latency_if_sampling(headers: &Flattrs, actor_id: String) {
     let now = std::time::SystemTime::now();
     let latency = now.duration_since(send_timestamp).unwrap_or_default();
     MESSAGE_LATENCY_MICROS.record(latency.as_micros() as f64, metric_pairs);
+}
+
+#[cfg(test)]
+mod tests {
+    use typeuri::Named;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::actor::Signal;
+    use crate::port::Port;
+    use crate::testing::ids::test_actor_id;
+
+    fn session(seq: u64) -> SeqInfo {
+        SeqInfo::Session {
+            session_id: Uuid::now_v7(),
+            seq,
+        }
+    }
+
+    fn handler_port(actor_name: &str) -> (ActorAddr, PortAddr) {
+        let addr: ActorAddr = test_actor_id(actor_name, "worker");
+        // Use a fabricated handler-port index (high bit set) by going through
+        // the existing Signal::port() / IntrospectMessage::port() — they're
+        // bypass ports though, so for a NON-bypass handler port we'll use
+        // an explicit message type. Easier: spin up via Port::from of any
+        // u64 with the handler bit set. Since the test util test_actor_id
+        // already returns an ActorAddr, and the only requirement is that
+        // .is_handler_port() is true, we construct a PortAddr that points
+        // to a known handler port — for headers tests we can use
+        // Signal::port() (a bypass handler port — gate should skip it) or
+        // a fabricated non-bypass handler. Use TestHandlerMsg below.
+        let port = addr.port_addr(Port::from(TestHandlerMsg::port()));
+        (addr, port)
+    }
+
+    fn non_handler_port(actor_name: &str) -> (ActorAddr, PortAddr) {
+        let addr: ActorAddr = test_actor_id(actor_name, "worker");
+        // Non-handler port: a plain Port::from(integer), without the handler
+        // bit. Per the ordering tests (test_sequencer_non_handler_ports_*),
+        // Port::from(N) for small N is a non-handler port.
+        let port = addr.port_addr(Port::from(1));
+        (addr, port)
+    }
+
+    fn bypass_port(actor_name: &str) -> (ActorAddr, PortAddr) {
+        let addr: ActorAddr = test_actor_id(actor_name, "worker");
+        let port = addr.port_addr(Port::from(Signal::port()));
+        (addr, port)
+    }
+
+    // A test handler-port message type. Named with handler-port semantics
+    // so its port is a handler port distinct from bypass ports.
+    #[derive(typeuri::Named)]
+    struct TestHandlerMsg;
+
+    #[test]
+    fn test_stamp_helper_sets_sender_on_seq_1() {
+        let (owner, dest) = handler_port("test_0");
+        let mut headers = Flattrs::new();
+        stamp_sender_actor_id(&mut headers, &session(1), &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), Some(owner));
+    }
+
+    #[test]
+    fn test_stamp_helper_sets_sender_on_seq_4() {
+        let (owner, dest) = handler_port("test_0");
+        let mut headers = Flattrs::new();
+        stamp_sender_actor_id(&mut headers, &session(4), &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), Some(owner));
+    }
+
+    #[test]
+    fn test_stamp_helper_skips_seq_5_no_stale() {
+        let (owner, dest) = handler_port("test_0");
+        let mut headers = Flattrs::new();
+        stamp_sender_actor_id(&mut headers, &session(5), &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), None);
+    }
+
+    #[test]
+    fn test_stamp_helper_overwrites_stale_at_seq_5() {
+        let (owner, dest) = handler_port("test_0");
+        let fake_owner: ActorAddr = test_actor_id("fake_0", "imposter");
+        let mut headers = Flattrs::new();
+        headers.set(SENDER_ACTOR_ID, fake_owner.clone());
+        stamp_sender_actor_id(&mut headers, &session(5), &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), Some(owner));
+    }
+
+    #[test]
+    fn test_stamp_helper_skips_non_handler_port() {
+        let (owner, dest) = non_handler_port("test_0");
+        let mut headers = Flattrs::new();
+        stamp_sender_actor_id(&mut headers, &session(1), &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), None);
+    }
+
+    #[test]
+    fn test_stamp_helper_skips_bypass_port() {
+        let (owner, dest) = bypass_port("test_0");
+        let mut headers = Flattrs::new();
+        stamp_sender_actor_id(&mut headers, &session(1), &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), None);
+    }
+
+    #[test]
+    fn test_stamp_helper_skips_seq_info_direct() {
+        let (owner, dest) = handler_port("test_0");
+        let mut headers = Flattrs::new();
+        stamp_sender_actor_id(&mut headers, &SeqInfo::Direct, &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), None);
+    }
+
+    #[test]
+    fn test_stamp_fresh_helper_sets_on_seq_4() {
+        let (owner, dest) = handler_port("test_0");
+        let mut headers = Flattrs::new();
+        stamp_sender_actor_id_fresh(&mut headers, 4, &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), Some(owner));
+    }
+
+    #[test]
+    fn test_stamp_fresh_helper_skips_on_seq_5() {
+        let (owner, dest) = handler_port("test_0");
+        let mut headers = Flattrs::new();
+        stamp_sender_actor_id_fresh(&mut headers, 5, &dest, &owner);
+        assert_eq!(headers.get(SENDER_ACTOR_ID), None);
+    }
 }

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -76,6 +76,13 @@ struct BufferState<T> {
     ///
     /// Map's key is seq_no, value is msg.
     buffer: HashMap<u64, T>,
+    /// Sender ActorAddr, populated by **first non-None wins**: any
+    /// arrival carrying a sender claims the slot if it's still None.
+    /// Captured before the seq-ordering match, so even messages that are
+    /// buffered (not delivered) or rejected as duplicate still record the
+    /// sender. None when the originating send bypassed the normal
+    /// `MailboxExt::post` / `PortHandle::try_post` / cast-leaf path (rare).
+    sender: Option<ActorAddr>,
 }
 
 impl<T> Default for BufferState<T> {
@@ -83,6 +90,7 @@ impl<T> Default for BufferState<T> {
         Self {
             last_seq: 0,
             buffer: HashMap::new(),
+            sender: None,
         }
     }
 }
@@ -146,6 +154,7 @@ impl<T> OrderedSender<T> {
         &self,
         session_id: Uuid,
         seq_no: u64,
+        sender: Option<ActorAddr>,
         msg: T,
     ) -> Result<(), OrderedSenderError<T>> {
         use std::cmp::Ordering;
@@ -158,7 +167,21 @@ impl<T> OrderedSender<T> {
         // Make sure only this session's state is locked, not all states.
         let state = self.states.entry(session_id).or_default().value().clone();
         let mut state_guard = state.lock().unwrap();
-        let BufferState { last_seq, buffer } = state_guard.deref_mut();
+
+        // Capture sender BEFORE the seq match: first non-None wins.
+        // Ensures sender is recorded even when the message is buffered
+        // (not delivered) or rejected as duplicate.
+        if state_guard.sender.is_none()
+            && let Some(addr) = sender
+        {
+            state_guard.sender = Some(addr);
+        }
+
+        let BufferState {
+            last_seq,
+            buffer,
+            sender: _,
+        } = state_guard.deref_mut();
 
         match seq_no.cmp(&(*last_seq + 1)) {
             Ordering::Less => {
@@ -356,7 +379,7 @@ mod tests {
         let session_id_a = Uuid::now_v7();
         let (tx, mut rx) = ordered_channel::<u64>("test".to_string(), true);
         for s in 1..=10 {
-            tx.send(session_id_a, s, s).unwrap();
+            tx.send(session_id_a, s, None, s).unwrap();
             let got = drain_try_recv(&mut rx);
             assert_eq!(got, vec![s]);
         }
@@ -369,12 +392,12 @@ mod tests {
 
         // Send 2 to 4 in descending order: all should buffer until 1 arrives.
         for s in (2..=4).rev() {
-            tx.send(session_id_a, s, s).unwrap();
+            tx.send(session_id_a, s, None, s).unwrap();
         }
 
         // Send 7 to 9 in descending order: all should buffer until 1 - 6 arrives.
         for s in (7..=9).rev() {
-            tx.send(session_id_a, s, s).unwrap();
+            tx.send(session_id_a, s, None, s).unwrap();
         }
 
         assert!(
@@ -383,19 +406,19 @@ mod tests {
         );
 
         // Now send 1: should deliver 1 then flush 2 - 4.
-        tx.send(session_id_a, 1, 1).unwrap();
+        tx.send(session_id_a, 1, None, 1).unwrap();
         assert_eq!(drain_try_recv(&mut rx), vec![1, 2, 3, 4]);
 
         // Now send 5: should deliver immediately but not flush 7 - 9.
-        tx.send(session_id_a, 5, 5).unwrap();
+        tx.send(session_id_a, 5, None, 5).unwrap();
         assert_eq!(drain_try_recv(&mut rx), vec![5]);
 
         // Now send 6: should deliver 6 then flush 7 - 9.
-        tx.send(session_id_a, 6, 6).unwrap();
+        tx.send(session_id_a, 6, None, 6).unwrap();
         assert_eq!(drain_try_recv(&mut rx), vec![6, 7, 8, 9]);
 
         // Send 10: should deliver immediately.
-        tx.send(session_id_a, 10, 10).unwrap();
+        tx.send(session_id_a, 10, None, 10).unwrap();
         let got = drain_try_recv(&mut rx);
         assert_eq!(got, vec![10]);
     }
@@ -407,22 +430,22 @@ mod tests {
         let (tx, mut rx) = ordered_channel::<(Uuid, u64)>("test".to_string(), true);
 
         // A1 -> deliver
-        tx.send(session_id_a, 1, (session_id_a, 1)).unwrap();
+        tx.send(session_id_a, 1, None, (session_id_a, 1)).unwrap();
         assert_eq!(drain_try_recv(&mut rx), vec![(session_id_a, 1)]);
         // B1 -> deliver
-        tx.send(session_id_b, 1, (session_id_b, 1)).unwrap();
+        tx.send(session_id_b, 1, None, (session_id_b, 1)).unwrap();
         assert_eq!(drain_try_recv(&mut rx), vec![(session_id_b, 1)]);
         for s in (3..=5).rev() {
             // A3-5 -> buffer (waiting for A2)
-            tx.send(session_id_a, s, (session_id_a, s)).unwrap();
+            tx.send(session_id_a, s, None, (session_id_a, s)).unwrap();
             // B3-5 -> buffer (waiting for B2)
-            tx.send(session_id_b, s, (session_id_b, s)).unwrap();
+            tx.send(session_id_b, s, None, (session_id_b, s)).unwrap();
         }
         for s in (7..=9).rev() {
             // A7-9 -> buffer (waiting for A1-6)
-            tx.send(session_id_a, s, (session_id_a, s)).unwrap();
+            tx.send(session_id_a, s, None, (session_id_a, s)).unwrap();
             // B7-9 -> buffer (waiting for B1-6)
-            tx.send(session_id_b, s, (session_id_b, s)).unwrap();
+            tx.send(session_id_b, s, None, (session_id_b, s)).unwrap();
         }
         assert!(
             drain_try_recv(&mut rx).is_empty(),
@@ -430,7 +453,7 @@ mod tests {
         );
 
         // A2 -> deliver A2 then flush A3
-        tx.send(session_id_a, 2, (session_id_a, 2)).unwrap();
+        tx.send(session_id_a, 2, None, (session_id_a, 2)).unwrap();
         assert_eq!(
             drain_try_recv(&mut rx),
             vec![
@@ -441,7 +464,7 @@ mod tests {
             ]
         );
         // B2 -> deliver B2 then flush B3
-        tx.send(session_id_b, 2, (session_id_b, 2)).unwrap();
+        tx.send(session_id_b, 2, None, (session_id_b, 2)).unwrap();
         assert_eq!(
             drain_try_recv(&mut rx),
             vec![
@@ -453,7 +476,7 @@ mod tests {
         );
 
         // A6 -> should deliver immediately and flush A7-9
-        tx.send(session_id_a, 6, (session_id_a, 6)).unwrap();
+        tx.send(session_id_a, 6, None, (session_id_a, 6)).unwrap();
         assert_eq!(
             drain_try_recv(&mut rx),
             vec![
@@ -464,7 +487,7 @@ mod tests {
             ]
         );
         // B6 -> should deliver immediately and flush B7-9
-        tx.send(session_id_b, 6, (session_id_b, 6)).unwrap();
+        tx.send(session_id_b, 6, None, (session_id_b, 6)).unwrap();
         assert_eq!(
             drain_try_recv(&mut rx),
             vec![
@@ -487,22 +510,24 @@ mod tests {
 
         let (tx, mut rx) = ordered_channel::<(Uuid, u64)>("test".to_string(), true);
         // A1 -> deliver
-        tx.send(session_id_a, 1, (session_id_a, 1)).unwrap();
+        tx.send(session_id_a, 1, None, (session_id_a, 1)).unwrap();
         assert_eq!(drain_try_recv(&mut rx), vec![(session_id_a, 1)]);
         verify_empty_buffers(&tx.states);
         // duplicate A1 -> drop even if the message is different.
-        tx.send(session_id_a, 1, (session_id_a, 1_000)).unwrap();
+        tx.send(session_id_a, 1, None, (session_id_a, 1_000))
+            .unwrap();
         assert!(
             drain_try_recv(&mut rx).is_empty(),
             "nothing should be delivered yet"
         );
         verify_empty_buffers(&tx.states);
         // A2 -> deliver
-        tx.send(session_id_a, 2, (session_id_a, 2)).unwrap();
+        tx.send(session_id_a, 2, None, (session_id_a, 2)).unwrap();
         assert_eq!(drain_try_recv(&mut rx), vec![(session_id_a, 2)]);
         verify_empty_buffers(&tx.states);
         // late A1 duplicate -> drop
-        tx.send(session_id_a, 1, (session_id_a, 1_001)).unwrap();
+        tx.send(session_id_a, 1, None, (session_id_a, 1_001))
+            .unwrap();
         assert!(
             drain_try_recv(&mut rx).is_empty(),
             "nothing should be delivered yet"
@@ -643,5 +668,108 @@ mod tests {
         // And continue independently.
         assert_eq!(get_seq(sequencer.assign_seq(&introspect_port)), 2);
         assert_eq!(get_seq(sequencer.assign_seq(&regular_actor_port)), 2);
+    }
+
+    // --- SENDER_ACTOR_ID capture tests ---
+
+    /// First send carrying a sender populates BufferState.sender.
+    #[test]
+    fn test_ordered_send_records_sender_on_first_with_addr() {
+        let session_id = Uuid::now_v7();
+        let addr: ActorAddr = test_actor_id("sender_0", "client");
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+
+        tx.send(session_id, 1, Some(addr.clone()), 1).unwrap();
+
+        let state = tx.states.get(&session_id).unwrap().value().clone();
+        assert_eq!(state.lock().unwrap().sender, Some(addr));
+    }
+
+    /// First-non-None wins: a None arrival doesn't claim the slot; a
+    /// subsequent Some arrival does.
+    #[test]
+    fn test_ordered_send_first_non_none_wins() {
+        let session_id = Uuid::now_v7();
+        let addr: ActorAddr = test_actor_id("sender_0", "client");
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+
+        tx.send(session_id, 1, None, 1).unwrap();
+        tx.send(session_id, 2, Some(addr.clone()), 2).unwrap();
+
+        let state = tx.states.get(&session_id).unwrap().value().clone();
+        assert_eq!(state.lock().unwrap().sender, Some(addr));
+    }
+
+    /// Second non-None arrival does NOT overwrite the first. Pathological
+    /// (shouldn't happen in production); documents the invariant.
+    #[test]
+    fn test_ordered_send_second_addr_does_not_overwrite() {
+        let session_id = Uuid::now_v7();
+        let addr1: ActorAddr = test_actor_id("first_0", "client");
+        let addr2: ActorAddr = test_actor_id("second_0", "client");
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+
+        tx.send(session_id, 1, Some(addr1.clone()), 1).unwrap();
+        tx.send(session_id, 2, Some(addr2), 2).unwrap();
+
+        let state = tx.states.get(&session_id).unwrap().value().clone();
+        assert_eq!(state.lock().unwrap().sender, Some(addr1));
+    }
+
+    /// All sends with None sender produce BufferState.sender = None; no panic.
+    #[test]
+    fn test_ordered_send_sender_absent() {
+        let session_id = Uuid::now_v7();
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+
+        tx.send(session_id, 1, None, 1).unwrap();
+        tx.send(session_id, 2, None, 2).unwrap();
+
+        let state = tx.states.get(&session_id).unwrap().value().clone();
+        assert_eq!(state.lock().unwrap().sender, None);
+    }
+
+    /// Sender is captured even for messages that are buffered (not yet
+    /// delivered) — capture runs before the seq match.
+    #[test]
+    fn test_ordered_send_sender_capture_runs_before_seq_match() {
+        let session_id = Uuid::now_v7();
+        let addr: ActorAddr = test_actor_id("sender_0", "client");
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+
+        // Send seq 5 first: seq 1 is missing, so this gets buffered.
+        // Sender capture must still happen before the buffer insert.
+        tx.send(session_id, 5, Some(addr.clone()), 5).unwrap();
+
+        let state = tx.states.get(&session_id).unwrap().value().clone();
+        let guard = state.lock().unwrap();
+        assert_eq!(guard.sender, Some(addr));
+        // Confirm the message was buffered (not delivered): last_seq stays 0
+        // and the buffer holds the message.
+        assert_eq!(guard.last_seq, 0);
+        assert!(guard.buffer.contains_key(&5));
+    }
+
+    /// Sequencer-level test for the debug-skip helper's underlying behavior:
+    /// `assign_seq` called `count` times advances the per-(actor,dest)
+    /// counter, so a subsequent `assign_seq` returns `count + 1` not 1.
+    /// The `Instance<A>::debug_skip_next_ordering_seq` method is a tiny
+    /// for-loop of `assign_seq` calls; its correctness reduces to this.
+    #[test]
+    fn test_sequencer_skip_advances_counter() {
+        let sequencer = Sequencer::new(Uuid::now_v7());
+        let actor_ref: ActorAddr = test_actor_id("test_0", "test");
+        let dest = actor_ref.port_addr(Port::from(TestMsg1::port()));
+
+        // Assign once: seq 1.
+        assert_eq!(get_seq(sequencer.assign_seq(&dest)), 1);
+
+        // Skip 2 (the helper would loop assign_seq).
+        for _ in 0..2 {
+            let _ = sequencer.assign_seq(&dest);
+        }
+
+        // Next assignment is seq 4, not 2.
+        assert_eq!(get_seq(sequencer.assign_seq(&dest)), 4);
     }
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3342,6 +3342,22 @@ impl<A: Actor> Instance<A> {
         &self.inner.sequencer
     }
 
+    /// Reserve (consume) the next `count` ordering sequence numbers for
+    /// the given destination without posting any messages. Subsequent
+    /// normal sends to this destination pick up at `last_reserved + 1`,
+    /// creating a deterministic gap from the receiver's perspective.
+    ///
+    /// Test/demo only. Production code should not call this; misuse will
+    /// produce stalled receivers. Marked `#[doc(hidden)]`; review
+    /// discipline is the misuse defense.
+    #[doc(hidden)]
+    pub fn debug_skip_next_ordering_seq(&self, dest: &PortAddr, count: u64) {
+        let sequencer = self.sequencer();
+        for _ in 0..count {
+            let _ = sequencer.assign_seq(dest);
+        }
+    }
+
     /// Return this instance's ID.
     pub fn instance_id(&self) -> Uuid {
         self.inner.id
@@ -4222,7 +4238,12 @@ impl<A: Actor> HandlerPorts<A> {
                 // considered drainable accepted work; after draining begins,
                 // that missing future sequence is rejected.
                 let enqueue = move |headers: Flattrs, msg: M| {
+                    // Extract values from headers BEFORE they're moved into
+                    // WorkCell — Flattrs::get returns owned typed values, so
+                    // these bindings don't borrow from `headers` and `headers`
+                    // can be moved into WorkCell freely.
                     let seq_info = headers.get(SEQ_INFO);
+                    let sender = headers.get(crate::mailbox::headers::SENDER_ACTOR_ID);
 
                     let work = WorkCell::new(move |actor: &mut A, instance: &Instance<A>| {
                         Box::pin(async move {
@@ -4246,7 +4267,7 @@ impl<A: Actor> HandlerPorts<A> {
                             Some(SeqInfo::Session { session_id, seq }) => {
                                 // TODO: return the message contained in the error instead of dropping them when converting
                                 // to anyhow::Error. In that way, the message can be picked up by mailbox and returned to sender.
-                                workq.send(session_id, seq, work).map_err(|e| match e {
+                                workq.send(session_id, seq, sender, work).map_err(|e| match e {
                                     OrderedSenderError::InvalidZeroSeq(_) => {
                                         let error_msg = format!(
                                             "in enqueue func for {}, got seq 0 for message type {}",
@@ -4912,6 +4933,74 @@ mod tests {
             monitored_return_handle(),
         );
         assert_eq!(forwarded.load(Ordering::SeqCst), 1);
+    }
+
+    /// `Instance::post` (-> `MailboxExt::post`) must stamp `SENDER_ACTOR_ID`
+    /// alongside the `SEQ_INFO` it assigns when the destination is a handler
+    /// port. Verified by forwarding to a different `ProcId` and capturing the
+    /// outbound envelope.
+    #[tokio::test]
+    async fn test_mailbox_ext_post_stamps_sender_actor_id() {
+        use typeuri::Named;
+
+        use crate::mailbox::headers::SENDER_ACTOR_ID;
+
+        #[derive(typeuri::Named)]
+        struct DestHandlerMsg;
+
+        #[derive(Clone, Default)]
+        struct CapturingSender(Arc<Mutex<Vec<MessageEnvelope>>>);
+
+        #[async_trait]
+        impl MailboxSender for CapturingSender {
+            fn post_unchecked(
+                &self,
+                envelope: MessageEnvelope,
+                _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+            ) {
+                self.0.lock().unwrap().push(envelope);
+            }
+        }
+
+        let proc_addr = ProcAddr::instance(ChannelAddr::Local(1), "stamping_test");
+        let captured: Arc<Mutex<Vec<MessageEnvelope>>> = Arc::new(Mutex::new(Vec::new()));
+        let proc = Proc::configured(
+            proc_addr,
+            BoxedMailboxSender::new(CapturingSender(captured.clone())),
+        );
+
+        let client = proc.client("client");
+        let client_addr = client.mailbox().actor_addr().clone();
+
+        // Distinct ProcId so the envelope routes through the configured
+        // forwarder (CapturingSender), where we can inspect the headers.
+        let remote_dest = ProcAddr::instance(ChannelAddr::Local(2), "remote")
+            .actor_addr("worker")
+            .port_addr(Port::from(DestHandlerMsg::port()));
+
+        // UFCS to select MailboxExt::post over Endpoint::post (also in
+        // scope at module level via `use ... as _`). Client implements
+        // `context::Actor` so the MailboxExt blanket impl applies.
+        <Client as context::MailboxExt>::post(
+            &client,
+            remote_dest,
+            Flattrs::new(),
+            wirevalue::Any::serialize(&1u64).unwrap(),
+            false,
+            context::SeqInfoPolicy::AssignNew,
+        );
+
+        let captured = captured.lock().unwrap();
+        assert_eq!(
+            captured.len(),
+            1,
+            "exactly one envelope should be forwarded"
+        );
+        assert_eq!(
+            captured[0].headers().get(SENDER_ACTOR_ID),
+            Some(client_addr),
+            "MailboxExt::post must stamp SENDER_ACTOR_ID with the client's actor_addr"
+        );
     }
 
     #[test]

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -313,14 +313,31 @@ impl CommActor {
         replace_with_self_ranks(&cast_point, message.data_mut())?;
 
         set_cast_info_on_headers(&mut headers, cast_point, message.sender().clone());
-        cx.post_with_external_seq_info(
-            cx.self_addr()
-                .proc_addr()
-                .actor_addr_uid(message.dest_port().actor_uid().clone())
-                .port_addr(hyperactor::port::Port::from(message.dest_port().port())),
-            headers,
-            wirevalue::Any::serialize(message.data())?,
-        );
+
+        // Bind dest ONCE so we can pass to both the stamp helper and the
+        // post call.
+        let dest = cx
+            .self_addr()
+            .proc_addr()
+            .actor_addr_uid(message.dest_port().actor_uid().clone())
+            .port_addr(hyperactor::port::Port::from(message.dest_port().port()));
+
+        // Stamp SENDER_ACTOR_ID when headers already carry SEQ_INFO (V1
+        // path). V0 path leaves SEQ_INFO absent here; MailboxExt::post will
+        // assign it and stamp via its own helper call later. Flattrs::get
+        // returns an owned typed value, so seq_info isn't borrowed from
+        // headers and we can pass &mut headers to the helper without
+        // a borrow-checker conflict.
+        if let Some(seq_info) = headers.get(SEQ_INFO) {
+            hyperactor::mailbox::headers::stamp_sender_actor_id(
+                &mut headers,
+                &seq_info,
+                &dest,
+                message.sender(),
+            );
+        }
+
+        cx.post_with_external_seq_info(dest, headers, wirevalue::Any::serialize(message.data())?);
 
         Ok(())
     }


### PR DESCRIPTION
Summary:

adds a `SENDER_ACTOR_ID` header attr stamped alongside `SEQ_INFO` at the three framework-owned ordered-send sites: `MailboxExt::post`, `PortHandle::try_post`, and `CommActor::deliver_to_dest` (V1 leaf). helpers in `mailbox/headers.rs` gate on `seq <= 4 || caller-set-stale` and skip non-handler / bypass ports; framework-owned semantics mean handlers cannot poison the header by forwarding stale values.

`OrderedSender` captures the first non-None `ActorAddr` per session into `BufferState`, so the sender survives buffering and duplicate rejection.

Differential Revision: D106202757


