### PR TITLE
expose instance_id, queue_depth, and inbound_ordering on actor attrs (#4056)

### DIFF
--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -118,6 +118,43 @@
 //!   required keys for that view are missing.
 //! - **AV-3 (unknown-key-tolerance):** Unknown attrs keys must not
 //!   affect successful decode outcome.
+//!
+//! ## Inbound ordering exposure invariants (IO-*)
+//!
+//! - **IO-1 (inbound-ordering tri-state semantics):**
+//!   `ActorAttrsView::inbound_ordering` carries three meaningful states
+//!   that consumers (DTO, TUI, agents) MUST distinguish:
+//!   * `None` -- no snapshot callback was installed. In current code
+//!     this means structural absence: an `InstanceCellState` not built
+//!     through `Instance::new` (hand-built test fixtures, or any future
+//!     code path that bypasses the constructor). Live actors built via
+//!     `Instance::new` always install Some, and terminated-actor
+//!     payloads -- which still go through `live_actor_payload(&cell)`
+//!     while the cell exists -- inherit that Some.
+//!   * `Some({enabled: false, ...})` -- ordered path exists but reorder
+//!     buffering is disabled; `sessions` is empty regardless of traffic.
+//!     Messages flow via `OrderedSender::direct_send`.
+//!   * `Some({enabled: true, ...})` -- buffering active; `sessions`
+//!     is meaningful.
+//!
+//!   `None` is NOT equivalent to `Some({enabled: false, ...})`.
+//! - **IO-2 (inbound-ordering reflects publish-time state):** When
+//!   present, the snapshot is computed at `build_actor_attrs`
+//!   invocation time via `OrderedSender::snapshot`. `last_released_seq`
+//!   etc. are point-in-time. Sessions held by a concurrent `send` show
+//!   up in `skipped_session_count` (never silently omitted);
+//!   `is_complete()` reports the all-clear.
+//! - **IO-3 (queue-depth and inbound-ordering are independent
+//!   diagnostics, no arithmetic contract):**
+//!   * `ACTOR_QUEUE_DEPTH` (per PD-5a/PD-5b in `proc.rs`): accepted
+//!     handler work not yet dequeued by the actor loop.
+//!   * `INBOUND_ORDERING.sessions[*].buffered_count`: messages held by
+//!     `OrderedSender` waiting for a seq gap to fill.
+//!
+//!   These are two independent point-in-time diagnostics. No
+//!   arithmetic or ordering relationship between them is part of the
+//!   API contract; the accounting paths are free to change. Consumers
+//!   must not derive one from the other.
 
 use std::fmt;
 use std::str::FromStr;
@@ -364,6 +401,39 @@ declare_attrs! {
         desc: "Whether the failure was propagated from a child".into(),
     })
     pub attr FAILURE_IS_PROPAGATED: bool = false;
+
+    /// Stable per-instance identifier (`Uuid::now_v7`) assigned at
+    /// `Instance::new`.
+    @meta(INTROSPECT = IntrospectAttr {
+        name: "instance_id".into(),
+        desc: "Stable per-instance Uuid::now_v7() identity assigned at Instance::new".into(),
+    })
+    pub attr INSTANCE_ID: String;
+
+    /// Accepted handler work not yet dequeued by the actor loop (per
+    /// `proc.rs` PD-5a/PD-5b). Independent of `INBOUND_ORDERING`:
+    /// no arithmetic or ordering relationship between the two is part
+    /// of the API contract. See IO-3.
+    @meta(INTROSPECT = IntrospectAttr {
+        name: "queue_depth".into(),
+        desc: "Accepted handler work not yet dequeued by the actor loop (PD-5a/b). Independent of inbound_ordering; no arithmetic contract -- see IO-3.".into(),
+    })
+    pub attr ACTOR_QUEUE_DEPTH: u64 = 0;
+
+    /// Per-session reorder state from `OrderedSender::snapshot`.
+    /// `sessions[*].buffered_count` reports messages held by
+    /// `OrderedSender` waiting for a seq gap to fill. Independent
+    /// diagnostic from `queue_depth`; no arithmetic contract -- see
+    /// IO-3.
+    ///
+    /// Absence (`None` on `ActorAttrsView`) means structural absence
+    /// (no snapshot callback installed). `Some({enabled: false, ...})`
+    /// means the path exists but buffering is disabled. See IO-1.
+    @meta(INTROSPECT = IntrospectAttr {
+        name: "inbound_ordering".into(),
+        desc: "Per-session reorder-buffer state from OrderedSender. Independent diagnostic from queue_depth; no arithmetic contract -- see IO-3. Absence vs Some({enabled: false}) is meaningful -- see IO-1.".into(),
+    })
+    pub attr INBOUND_ORDERING: crate::ordering::OrderingSnapshot;
 }
 
 // See FI-1 through FI-8 in module doc.
@@ -434,6 +504,8 @@ pub struct ActorAttrsView {
     pub status_reason: Option<String>,
     /// Fully-qualified actor type name.
     pub actor_type: String,
+    /// Stable per-instance identifier (`Uuid::now_v7`) as a string.
+    pub instance_id: String,
     /// Number of messages processed.
     pub messages_processed: u64,
     /// When this actor was created.
@@ -442,10 +514,20 @@ pub struct ActorAttrsView {
     pub last_handler: Option<String>,
     /// Total CPU time in message handlers (microseconds).
     pub total_processing_time_us: u64,
+    /// Accepted handler work not yet dequeued by the actor loop
+    /// (PD-5a/b). Independent diagnostic from `inbound_ordering`;
+    /// no arithmetic contract between the two -- see IO-3. Defaults
+    /// to 0 when the attr is absent.
+    pub queue_depth: u64,
     /// Flight recorder JSON, if available.
     pub flight_recorder: Option<String>,
     /// Whether this is a system/infrastructure actor.
     pub is_system: bool,
+    /// Per-session reorder state. `None` means no snapshot callback was
+    /// installed (structural absence per IO-1); `Some({enabled: false, ..})`
+    /// means buffering is disabled; `Some({enabled: true, ..})` means active.
+    /// Consumers must distinguish all three states.
+    pub inbound_ordering: Option<crate::ordering::OrderingSnapshot>,
     /// Failure details, present iff status == "failed".
     pub failure: Option<FailureAttrs>,
 }
@@ -466,12 +548,18 @@ impl ActorAttrsView {
             .get(ACTOR_TYPE)
             .ok_or_else(|| AttrsViewError::missing("actor_type"))?
             .clone();
+        let instance_id = attrs
+            .get(INSTANCE_ID)
+            .ok_or_else(|| AttrsViewError::missing("instance_id"))?
+            .clone();
         let messages_processed = *attrs.get(MESSAGES_PROCESSED).unwrap_or(&0);
         let created_at = attrs.get(CREATED_AT).copied();
         let last_handler = attrs.get(LAST_HANDLER).cloned();
         let total_processing_time_us = *attrs.get(TOTAL_PROCESSING_TIME_US).unwrap_or(&0);
+        let queue_depth = *attrs.get(ACTOR_QUEUE_DEPTH).unwrap_or(&0);
         let flight_recorder = attrs.get(FLIGHT_RECORDER).cloned();
         let is_system = *attrs.get(IS_SYSTEM).unwrap_or(&false);
+        let inbound_ordering = attrs.get(INBOUND_ORDERING).cloned();
 
         // IA-3 (one-sided): status_reason must not be present for
         // non-terminal status. The converse is not enforced —
@@ -540,12 +628,15 @@ impl ActorAttrsView {
             status,
             status_reason,
             actor_type,
+            instance_id,
             messages_processed,
             created_at,
             last_handler,
             total_processing_time_us,
+            queue_depth,
             flight_recorder,
             is_system,
+            inbound_ordering,
             failure,
         })
     }
@@ -558,6 +649,7 @@ impl ActorAttrsView {
             attrs.set(STATUS_REASON, reason.clone());
         }
         attrs.set(ACTOR_TYPE, self.actor_type.clone());
+        attrs.set(INSTANCE_ID, self.instance_id.clone());
         attrs.set(MESSAGES_PROCESSED, self.messages_processed);
         if let Some(t) = self.created_at {
             attrs.set(CREATED_AT, t);
@@ -566,10 +658,14 @@ impl ActorAttrsView {
             attrs.set(LAST_HANDLER, handler.clone());
         }
         attrs.set(TOTAL_PROCESSING_TIME_US, self.total_processing_time_us);
+        attrs.set(ACTOR_QUEUE_DEPTH, self.queue_depth);
         if let Some(fr) = &self.flight_recorder {
             attrs.set(FLIGHT_RECORDER, fr.clone());
         }
         attrs.set(IS_SYSTEM, self.is_system);
+        if let Some(snapshot) = &self.inbound_ordering {
+            attrs.set(INBOUND_ORDERING, snapshot.clone());
+        }
         if let Some(fi) = &self.failure {
             attrs.set(FAILURE_ERROR_MESSAGE, fi.error_message.clone());
             attrs.set(FAILURE_ROOT_CAUSE_ACTOR, fi.root_cause_actor.clone());
@@ -738,6 +834,15 @@ fn build_actor_attrs(cell: &crate::InstanceCell, snap: &ActorSnapshot) -> String
     attrs.set(CREATED_AT, cell.created_at());
     attrs.set(TOTAL_PROCESSING_TIME_US, cell.total_processing_time_us());
     attrs.set(IS_SYSTEM, snap.is_system);
+    attrs.set(INSTANCE_ID, cell.instance_id().to_string());
+    attrs.set(ACTOR_QUEUE_DEPTH, cell.queue_depth());
+
+    if let Some(snapshot) = cell.inbound_ordering_snapshot() {
+        // TODO: truncation / filtering of long session lists belongs at
+        // the API/DTO layer, not here. `build_actor_attrs` returns the
+        // full per-actor snapshot verbatim so consumers can decide.
+        attrs.set(INBOUND_ORDERING, snapshot);
+    }
 
     if let Some(handler) = &snap.last_handler {
         attrs.set(LAST_HANDLER, handler.clone());
@@ -994,6 +1099,9 @@ mod tests {
             ("failure_root_cause_name", FAILURE_ROOT_CAUSE_NAME.attrs()),
             ("failure_occurred_at", FAILURE_OCCURRED_AT.attrs()),
             ("failure_is_propagated", FAILURE_IS_PROPAGATED.attrs()),
+            ("instance_id", INSTANCE_ID.attrs()),
+            ("queue_depth", ACTOR_QUEUE_DEPTH.attrs()),
+            ("inbound_ordering", INBOUND_ORDERING.attrs()),
         ];
 
         for (expected_name, meta) in &cases {
@@ -1066,6 +1174,7 @@ mod tests {
         let mut attrs = Attrs::new();
         attrs.set(STATUS, "running".to_string());
         attrs.set(ACTOR_TYPE, "MyActor".to_string());
+        attrs.set(INSTANCE_ID, uuid::Uuid::from_u128(0xfeed_face).to_string());
         attrs.set(MESSAGES_PROCESSED, 42u64);
         attrs.set(CREATED_AT, SystemTime::UNIX_EPOCH);
         attrs.set(IS_SYSTEM, false);
@@ -1095,6 +1204,10 @@ mod tests {
         assert_eq!(view.status, "running");
         assert_eq!(view.actor_type, "MyActor");
         assert_eq!(view.messages_processed, 42);
+        // Default values for the new fields when not set in the
+        // running_actor_attrs() fixture.
+        assert_eq!(view.queue_depth, 0);
+        assert!(view.inbound_ordering.is_none());
         assert!(view.failure.is_none());
 
         let round_tripped = ActorAttrsView::from_attrs(&view.to_attrs()).unwrap();
@@ -1130,6 +1243,65 @@ mod tests {
         attrs.set(STATUS, "running".to_string());
         let err = ActorAttrsView::from_attrs(&attrs).unwrap_err();
         assert_eq!(err, AttrsViewError::MissingKey { key: "actor_type" });
+    }
+
+    /// AV-2: `instance_id` is a required key on the actor view --
+    /// every live actor's attrs bag carries one.
+    #[test]
+    fn test_actor_view_missing_instance_id() {
+        let mut attrs = Attrs::new();
+        attrs.set(STATUS, "running".to_string());
+        attrs.set(ACTOR_TYPE, "X".to_string());
+        let err = ActorAttrsView::from_attrs(&attrs).unwrap_err();
+        assert_eq!(err, AttrsViewError::MissingKey { key: "instance_id" });
+    }
+
+    /// AV-1 + IO-1: round-trip with inbound_ordering = Some(...).
+    /// Pins that the typed `OrderingSnapshot` survives the
+    /// Attrs encode/decode boundary.
+    #[test]
+    fn test_actor_view_round_trip_with_inbound_ordering() {
+        use crate::ordering::OrderingSessionSnapshot;
+        use crate::ordering::OrderingSnapshot;
+
+        let session_addr = test_actor_id("sender_proc", "sender_actor");
+        let snapshot = OrderingSnapshot {
+            enabled: true,
+            sessions: vec![OrderingSessionSnapshot {
+                session_id: uuid::Uuid::from_u128(7),
+                sender: Some(session_addr),
+                last_released_seq: 3,
+                expected_next_seq: 4,
+                buffered_count: 2,
+                oldest_buffered_seq: Some(5),
+                newest_buffered_seq: Some(6),
+            }],
+            skipped_session_count: 0,
+        };
+
+        let mut attrs = running_actor_attrs();
+        attrs.set(ACTOR_QUEUE_DEPTH, 7u64);
+        attrs.set(INBOUND_ORDERING, snapshot.clone());
+
+        let view = ActorAttrsView::from_attrs(&attrs).unwrap();
+        assert_eq!(view.queue_depth, 7);
+        assert_eq!(view.inbound_ordering.as_ref(), Some(&snapshot));
+
+        let round_tripped = ActorAttrsView::from_attrs(&view.to_attrs()).unwrap();
+        assert_eq!(round_tripped, view);
+    }
+
+    /// AV-1 + IO-1: round-trip with inbound_ordering = None survives
+    /// cleanly. Pins the "structural absence" semantics: round-tripping
+    /// the view does not invent a Some({enabled: false}) value.
+    #[test]
+    fn test_actor_view_round_trip_without_inbound_ordering() {
+        let view = ActorAttrsView::from_attrs(&running_actor_attrs()).unwrap();
+        assert!(view.inbound_ordering.is_none());
+
+        let round_tripped = ActorAttrsView::from_attrs(&view.to_attrs()).unwrap();
+        assert!(round_tripped.inbound_ordering.is_none());
+        assert_eq!(round_tripped, view);
     }
 
     #[test]

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -95,13 +95,15 @@ impl<T> Default for BufferState<T> {
     }
 }
 
-/// A sender that ensures messages are delivered in per-client sequence order.
+/// The sending half of an ordered channel; internally tracks one ordering
+/// stream per remote sender session.
 pub(crate) struct OrderedSender<T> {
     tx: mpsc::UnboundedSender<T>,
-    /// Map's key is session ID, and value is the buffer state of that session.
+    /// Per-session reorder state keyed by `SeqInfo::Session.session_id`; one
+    /// entry corresponds to one logical sender stream.
     states: Arc<DashMap<Uuid, Arc<Mutex<BufferState<T>>>>>,
     pub(crate) enable_buffering: bool,
-    /// The identify of this object, which is used to distiguish it in debugging.
+    /// The identity of this object, used to distinguish it in debugging.
     log_id: String,
 }
 
@@ -233,6 +235,140 @@ impl<T> OrderedSender<T> {
 
     pub(crate) fn direct_send(&self, msg: T) -> Result<(), SendError<T>> {
         self.tx.send(msg)
+    }
+
+    /// Out-of-band snapshot of per-session ordering state. Reads each
+    /// session's state via `try_lock`; sessions held by a concurrent
+    /// `send` are counted in `skipped_session_count`, not silently
+    /// dropped. Returned `sessions` are sorted by `session_id` so output
+    /// is stable across calls and across DashMap iteration order.
+    #[allow(dead_code)]
+    pub(crate) fn snapshot(&self) -> OrderingSnapshot {
+        let mut sessions = Vec::new();
+        let mut skipped = 0usize;
+        for entry in self.states.iter() {
+            let session_id = *entry.key();
+            match entry.value().try_lock() {
+                Ok(state) => {
+                    let oldest = state.buffer.keys().min().copied();
+                    let newest = state.buffer.keys().max().copied();
+                    sessions.push(OrderingSessionSnapshot {
+                        session_id,
+                        sender: state.sender.clone(),
+                        last_released_seq: state.last_seq,
+                        expected_next_seq: state.last_seq.saturating_add(1),
+                        buffered_count: state.buffer.len(),
+                        oldest_buffered_seq: oldest,
+                        newest_buffered_seq: newest,
+                    });
+                }
+                Err(_) => skipped += 1,
+            }
+        }
+        // DashMap iter is nondeterministic; sort by session_id for
+        // stable output.
+        sessions.sort_by_key(|s| s.session_id);
+        OrderingSnapshot {
+            enabled: self.enable_buffering,
+            sessions,
+            skipped_session_count: skipped,
+        }
+    }
+}
+
+/// Per-session ordering snapshot. Read out-of-band from `OrderedSender`;
+/// does not lock the work queue or hold per-session mutexes across awaits.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Named, AttrValue)]
+pub struct OrderingSessionSnapshot {
+    /// Identifier of the session whose ordering state this snapshot
+    /// describes; matches `SeqInfo::Session { session_id, .. }` on the
+    /// wire and the DashMap key in `OrderedSender::states`.
+    pub session_id: Uuid,
+
+    /// Sender `ActorAddr` captured by `BufferState`'s first-non-None-wins
+    /// rule. `None` when every message in this session bypassed the
+    /// normal stamping sites (rare: test fixtures, non-handler routes).
+    pub sender: Option<ActorAddr>,
+
+    /// Highest seq released from the reorder buffer into the actor work
+    /// queue. NOT "handler processed" -- that's downstream of the queue.
+    pub last_released_seq: u64,
+
+    /// `last_released_seq + 1` -- the seq the next contiguous send must
+    /// carry for delivery without further buffering.
+    pub expected_next_seq: u64,
+
+    /// Number of messages currently sitting in the reorder buffer waiting
+    /// for a seq gap to be filled. Zero on healthy in-order sessions.
+    pub buffered_count: usize,
+
+    /// Lowest seq currently buffered. `None` when `buffered_count == 0`.
+    pub oldest_buffered_seq: Option<u64>,
+
+    /// Highest seq currently buffered. `None` when `buffered_count == 0`.
+    pub newest_buffered_seq: Option<u64>,
+}
+
+/// Diagnostic projection of an `OrderedSender`.
+///
+/// `OrderedSender` is the sending half of an ordered channel for one actor
+/// work queue, but it multiplexes many remote sender sessions internally.
+/// Each `OrderingSessionSnapshot` corresponds to one `BufferState` entry,
+/// keyed by `SeqInfo::Session.session_id`. Sequence progress here means
+/// "released into the actor work queue", not "processed by the actor handler".
+///
+/// Carries completeness metadata so callers can distinguish "no stalled
+/// sessions" from "snapshot was partial" from "buffering is disabled".
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Named, AttrValue)]
+pub struct OrderingSnapshot {
+    /// Whether reorder buffering is enabled for this sender. When
+    /// `false`, messages flow via `direct_send` and `sessions` is empty
+    /// even under load. Sourced from `OrderedSender::enable_buffering`.
+    pub enabled: bool,
+
+    /// Per-session entries, sorted by `session_id` for stable output.
+    /// Includes idle (drained) sessions with `buffered_count == 0`.
+    pub sessions: Vec<OrderingSessionSnapshot>,
+
+    /// Sessions whose mutex was held by a concurrent send when we tried
+    /// to snapshot. NOT in `sessions`. Zero means the snapshot is
+    /// complete.
+    pub skipped_session_count: usize,
+}
+
+impl OrderingSnapshot {
+    /// True when no session was skipped due to a concurrent send -- i.e.,
+    /// every live session's state was successfully captured in
+    /// `sessions`.
+    pub fn is_complete(&self) -> bool {
+        self.skipped_session_count == 0
+    }
+}
+
+impl fmt::Display for OrderingSessionSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Infallible for this struct (all fields serialize cleanly).
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl std::str::FromStr for OrderingSessionSnapshot {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl fmt::Display for OrderingSnapshot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", serde_json::to_string(self).unwrap())
+    }
+}
+
+impl std::str::FromStr for OrderingSnapshot {
+    type Err = serde_json::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        serde_json::from_str(s)
     }
 }
 
@@ -730,7 +866,7 @@ mod tests {
     }
 
     /// Sender is captured even for messages that are buffered (not yet
-    /// delivered) — capture runs before the seq match.
+    /// delivered) -- capture runs before the seq match.
     #[test]
     fn test_ordered_send_sender_capture_runs_before_seq_match() {
         let session_id = Uuid::now_v7();
@@ -771,5 +907,144 @@ mod tests {
 
         // Next assignment is seq 4, not 2.
         assert_eq!(get_seq(sequencer.assign_seq(&dest)), 4);
+    }
+
+    // --------------------------------------------------------------------
+    // OrderedSender::snapshot accessor tests.
+
+    #[test]
+    fn test_snapshot_empty() {
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+        let snap = tx.snapshot();
+        assert!(snap.enabled);
+        assert!(snap.sessions.is_empty());
+        assert_eq!(snap.skipped_session_count, 0);
+        assert!(snap.is_complete());
+    }
+
+    #[test]
+    fn test_snapshot_in_order() {
+        let addr: ActorAddr = test_actor_id("sender_actor", "client");
+        let session_id = Uuid::from_u128(1);
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+        for s in 1..=3u64 {
+            tx.send(session_id, s, Some(addr.clone()), s).unwrap();
+        }
+
+        let snap = tx.snapshot();
+        assert_eq!(snap.sessions.len(), 1);
+        let session = &snap.sessions[0];
+        assert_eq!(session.session_id, session_id);
+        assert_eq!(session.sender, Some(addr));
+        assert_eq!(session.last_released_seq, 3);
+        assert_eq!(session.expected_next_seq, 4);
+        assert_eq!(session.buffered_count, 0);
+        assert_eq!(session.oldest_buffered_seq, None);
+        assert_eq!(session.newest_buffered_seq, None);
+    }
+
+    #[test]
+    fn test_snapshot_out_of_order() {
+        let addr: ActorAddr = test_actor_id("sender_actor", "client");
+        let session_id = Uuid::from_u128(1);
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+
+        tx.send(session_id, 1, Some(addr.clone()), 1).unwrap();
+        tx.send(session_id, 3, None, 3).unwrap();
+        tx.send(session_id, 5, None, 5).unwrap();
+
+        let snap = tx.snapshot();
+        assert_eq!(snap.sessions.len(), 1);
+        let session = &snap.sessions[0];
+        assert_eq!(session.last_released_seq, 1);
+        assert_eq!(session.expected_next_seq, 2);
+        assert_eq!(session.buffered_count, 2);
+        assert_eq!(session.oldest_buffered_seq, Some(3));
+        assert_eq!(session.newest_buffered_seq, Some(5));
+        assert_eq!(session.sender, Some(addr));
+    }
+
+    /// The sender captured in `BufferState` during `OrderedSender::send`
+    /// flows out through the snapshot accessor's `sender` field.
+    #[test]
+    fn test_snapshot_includes_sender() {
+        let addr: ActorAddr = test_actor_id("captured", "client");
+        let session_id = Uuid::from_u128(1);
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+        tx.send(session_id, 1, Some(addr.clone()), 1).unwrap();
+
+        let snap = tx.snapshot();
+        assert_eq!(snap.sessions[0].sender, Some(addr));
+    }
+
+    #[test]
+    fn test_snapshot_completeness_under_concurrent_send() {
+        let session_a = Uuid::from_u128(1);
+        let session_b = Uuid::from_u128(2);
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+        tx.send(session_a, 1, None, 1).unwrap();
+        tx.send(session_b, 1, None, 1).unwrap();
+
+        // Hold session_a's mutex; snapshot's try_lock on this session
+        // should fail and be counted as skipped.
+        let state_a = tx.states.get(&session_a).unwrap().value().clone();
+        let _guard = state_a.lock().unwrap();
+
+        let snap = tx.snapshot();
+        assert_eq!(snap.skipped_session_count, 1);
+        assert!(!snap.is_complete());
+        // session_b's mutex is free; it should still appear in `sessions`.
+        assert_eq!(snap.sessions.len(), 1);
+        assert_eq!(snap.sessions[0].session_id, session_b);
+    }
+
+    #[test]
+    fn test_snapshot_disabled_buffering() {
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), false);
+        let snap = tx.snapshot();
+        assert!(!snap.enabled);
+        assert!(snap.sessions.is_empty());
+    }
+
+    /// Pins the `sort_by_key(|s| s.session_id)` guarantee. Uses fixed
+    /// UUIDs (not `Uuid::now_v7()`) so the test is independent of
+    /// timestamp ordering. Sends `session_hi` first, then `session_lo`,
+    /// then asserts the snapshot orders them low -> high.
+    #[test]
+    fn test_snapshot_sorted_by_session_id() {
+        let session_lo = Uuid::from_u128(1);
+        let session_hi = Uuid::from_u128(2);
+        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
+        tx.send(session_hi, 1, None, 1).unwrap();
+        tx.send(session_lo, 1, None, 1).unwrap();
+
+        let snap = tx.snapshot();
+        assert_eq!(snap.sessions.len(), 2);
+        assert_eq!(snap.sessions[0].session_id, session_lo);
+        assert_eq!(snap.sessions[1].session_id, session_hi);
+    }
+
+    /// Pins the exact `AttrValue` contract used by `declare_attrs!`
+    /// storage: `AttrValue::display(&self) -> String` then
+    /// `AttrValue::parse(&str) -> Result<Self, _>`.
+    #[test]
+    fn test_snapshot_attr_roundtrip() {
+        let addr: ActorAddr = test_actor_id("a", "client");
+        let snap = OrderingSnapshot {
+            enabled: true,
+            sessions: vec![OrderingSessionSnapshot {
+                session_id: Uuid::from_u128(42),
+                sender: Some(addr),
+                last_released_seq: 7,
+                expected_next_seq: 8,
+                buffered_count: 2,
+                oldest_buffered_seq: Some(9),
+                newest_buffered_seq: Some(11),
+            }],
+            skipped_session_count: 3,
+        };
+        let s = AttrValue::display(&snap);
+        let parsed = <OrderingSnapshot as AttrValue>::parse(&s).unwrap();
+        assert_eq!(snap, parsed);
     }
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -48,10 +48,16 @@
 //!
 //! ## Queue depth accounting invariants (PD-5*)
 //!
-//! - **PD-5a:** Per-actor queue depth counts work items enqueued for
-//!   handler execution but not yet received from `work_rx`.
-//! - **PD-5b:** Queue depth is incremented exactly once on every
-//!   enqueue into the actor work queue (in `HandlerPorts::get`).
+//! - **PD-5a:** Per-actor queue depth counts accepted handler work
+//!   not yet dequeued by the actor loop. Accounting increments in
+//!   `HandlerPorts::get`'s enqueue closure *before* the reorder-buffer
+//!   decision, so this counter includes both in-order messages waiting
+//!   in `work_rx` AND out-of-order messages held in the
+//!   `OrderedSender` reorder buffer. (Reflected at the introspection
+//!   layer in IO-3 of the `introspect` module doc.)
+//! - **PD-5b:** Queue depth is incremented exactly once per accepted
+//!   message in the enqueue closure of `HandlerPorts::get`, before
+//!   the in-order / out-of-order branch.
 //! - **PD-5c:** Queue depth is decremented exactly once on every
 //!   dequeue from `work_rx` (in the actor `run` loop).
 //! - **PD-5d:** Queue depth is intended to be non-negative; tests
@@ -2244,8 +2250,20 @@ impl<A: Actor> Instance<A> {
         let (introspect_port, introspect_receiver) = mailbox.open_port::<IntrospectMessage>();
         introspect_port.bind_handler_port();
 
+        let instance_id = Uuid::now_v7();
+
+        // Type-erased snapshot callback: captures `Arc<HandlerPorts<A>>::clone()`
+        // (the typed Arc), which lets `InstanceCellState` invoke
+        // `OrderedSender::snapshot` from non-generic code. Only the typed
+        // ports are captured; nothing cyclic (no Instance, no InstanceCell).
+        let workq_ports = ports.clone();
+        let inbound_ordering_snapshot: Option<
+            Box<dyn Fn() -> crate::ordering::OrderingSnapshot + Send + Sync>,
+        > = Some(Box::new(move || workq_ports.workq.snapshot()));
+
         let cell = InstanceCell::new(
             actor_id,
+            instance_id,
             actor_type,
             proc.clone(),
             actor_loop,
@@ -2253,8 +2271,8 @@ impl<A: Actor> Instance<A> {
             parent,
             ports.clone(),
             queue_depth,
+            inbound_ordering_snapshot,
         );
-        let instance_id = Uuid::now_v7();
         let inner = Arc::new(InstanceState {
             proc,
             cell,
@@ -3545,6 +3563,11 @@ struct InstanceCellState {
     /// The actor's id.
     actor_id: ActorAddr,
 
+    /// The actor instance's `Uuid::now_v7()` identity. Stable for the
+    /// lifetime of this instance; surfaced via `InstanceCell::instance_id`
+    /// and the `INSTANCE_ID` introspection attr.
+    instance_id: Uuid,
+
     /// Actor info contains the actor's type information.
     actor_type: ActorType,
 
@@ -3631,6 +3654,23 @@ struct InstanceCellState {
     /// A type-erased reference to HandlerPorts<A>, which allows us to
     /// recover an ActorHandle<A> by downcasting.
     ports: Arc<dyn Any + Send + Sync>,
+
+    /// Type-erased snapshot callback for inbound ordering state.
+    /// Captured at `Instance::new` from the typed `Arc<HandlerPorts<A>>`
+    /// (where `A` is in scope), erased to `dyn Fn() -> OrderingSnapshot`
+    /// so non-generic code in `InstanceCellState` can invoke it.
+    ///
+    /// Hygiene: the closure captures ONLY `Arc<HandlerPorts<A>>::clone()`
+    /// — never `Instance<A>` or `InstanceCell` — to avoid cyclic refs
+    /// back to the cell that holds this callback. Body is a single
+    /// `workq.snapshot()` call; bounded work, `try_lock`-based, never
+    /// blocks. See IO-1/IO-2 in `introspect` module doc.
+    ///
+    /// `None` only for hand-built fixtures or future code paths that
+    /// construct an `InstanceCellState` without going through
+    /// `Instance::new`; production live actors always install Some.
+    inbound_ordering_snapshot:
+        Option<Box<dyn Fn() -> crate::ordering::OrderingSnapshot + Send + Sync>>,
 }
 
 impl InstanceCellState {
@@ -3700,8 +3740,10 @@ fn select_eviction_candidates(
 impl InstanceCell {
     /// Creates a new instance cell with the provided internal state. If a parent
     /// is provided, it is linked to this cell.
+    #[allow(clippy::too_many_arguments)]
     fn new(
         actor_id: ActorAddr,
+        instance_id: Uuid,
         actor_type: ActorType,
         proc: Proc,
         actor_loop: Option<(
@@ -3712,12 +3754,16 @@ impl InstanceCell {
         parent: Option<InstanceCell>,
         ports: Arc<dyn Any + Send + Sync>,
         queue_depth: Arc<AtomicU64>,
+        inbound_ordering_snapshot: Option<
+            Box<dyn Fn() -> crate::ordering::OrderingSnapshot + Send + Sync>,
+        >,
     ) -> Self {
         let is_root = parent.is_none();
         let _ais = actor_id.to_string();
         let cell = Self {
             inner: Arc::new(InstanceCellState {
                 actor_id: actor_id.clone(),
+                instance_id,
                 actor_type,
                 proc: proc.clone(),
                 actor_loop,
@@ -3737,6 +3783,7 @@ impl InstanceCell {
                 supervision_event: std::sync::Mutex::new(None),
                 is_system: AtomicBool::new(false),
                 ports,
+                inbound_ordering_snapshot,
             }),
         };
         cell.maybe_link_parent();
@@ -3954,6 +4001,20 @@ impl InstanceCell {
     /// Current actor work-queue depth (PD-5).
     pub fn queue_depth(&self) -> u64 {
         self.inner.queue_depth.load(Ordering::Relaxed)
+    }
+
+    /// Stable per-instance identifier (`Uuid::now_v7`) assigned at
+    /// `Instance::new` and threaded through to the cell at construction.
+    pub fn instance_id(&self) -> Uuid {
+        self.inner.instance_id
+    }
+
+    /// Out-of-band inbound ordering snapshot. Returns `None` when no
+    /// snapshot callback was installed (see IO-1 in `introspect` module
+    /// doc). The callback uses `OrderedSender::snapshot` (`try_lock`,
+    /// non-blocking) and never perturbs ordering state.
+    pub fn inbound_ordering_snapshot(&self) -> Option<crate::ordering::OrderingSnapshot> {
+        self.inner.inbound_ordering_snapshot.as_ref().map(|f| f())
     }
 
     /// Get parent instance cell, if it exists.
@@ -6654,6 +6715,130 @@ mod tests {
             depth, 0,
             "queue depth should return to 0 after all messages handled"
         );
+    }
+
+    // Test-only Named message + dedicated actor with explicit handler
+    // export, so the integration test can bind the BufferTestMsg
+    // handler port (`handle.bind()`) and drive ordered traffic through
+    // `OrderedSender`. Without the bind, `PortHandle::try_post` stamps
+    // `SeqInfo::Direct` and the enqueue closure takes the `direct_send`
+    // branch -- which never populates `OrderedSender::states`, leaving
+    // the snapshot empty.
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, typeuri::Named)]
+    struct BufferTestMsg;
+
+    #[derive(Debug, Default)]
+    #[hyperactor::export(handlers = [BufferTestMsg])]
+    struct BufferTestActor;
+
+    #[async_trait]
+    impl Actor for BufferTestActor {}
+
+    #[async_trait]
+    impl Handler<BufferTestMsg> for BufferTestActor {
+        async fn handle(
+            &mut self,
+            _cx: &crate::Context<Self>,
+            _msg: BufferTestMsg,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Exercises IO-1 ("active" branch: snapshot is `Some({enabled:
+    /// true, ...})`), IO-2 (publish-time state via `try_lock` populates
+    /// the session's buffered fields), and IO-3 (asserts `queue_depth`
+    /// is a propagated `u64` but makes NO arithmetic claim relating it
+    /// to `buffered_count`). End-to-end wiring proof: `Instance::new`
+    /// installs the snapshot callback, `InstanceCell::inbound_ordering_snapshot()`
+    /// invokes it, the resulting snapshot includes the buffered session
+    /// with its sender, `expected_next_seq`, and `buffered_count`, AND
+    /// `build_actor_attrs` (via `live_actor_payload`) publishes
+    /// `INBOUND_ORDERING` so it round-trips through `ActorAttrsView`.
+    /// The attrs-publish assertion catches accidental removal of the
+    /// `attrs.set(INBOUND_ORDERING, snapshot)` call site. Drives a
+    /// deterministic gap via `debug_skip_next_ordering_seq` so the test
+    /// is not timing-sensitive.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_inbound_ordering_snapshot_callback_publishes_session() {
+        use typeuri::Named;
+
+        // Pin reorder buffering ON regardless of any global config
+        // overrides set by other tests in the same binary. Without this
+        // guard the snapshot would observe `enabled = false` and the
+        // assertions below would fail when tests run in interleaved
+        // order.
+        let config = hyperactor_config::global::lock();
+        let _g = config.override_key(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
+
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let handle = proc.spawn_with_label("a", BufferTestActor);
+        let actor_id = handle.actor_addr().clone();
+
+        // Bind the handler ports so `handle.post` uses `SeqInfo::Session`
+        // (not `SeqInfo::Direct`). This is the equivalent of asking
+        // for a typed actor reference; for our purposes we only need
+        // the side effect of binding handler ports.
+        let _actor_ref: crate::ActorRef<BufferTestActor> = handle.bind();
+
+        // Reserve seq 1 on the actor's BufferTestMsg handler port so
+        // subsequent client posts get seqs 2..=N which then buffer
+        // (waiting for seq 1, which will never arrive).
+        let handler_port = actor_id.port_addr(Port::from(BufferTestMsg::port()));
+        // Reserve one seq directly on the client's sequencer. Equivalent
+        // to `Instance::debug_skip_next_ordering_seq(dest, 1)`, but
+        // inlined here so the test does not depend on a Client-side
+        // convenience method.
+        let _ = client.sequencer().assign_seq(&handler_port);
+
+        // Post three messages. These flow through MailboxExt::post ->
+        // HandlerPorts enqueue closure -> OrderedSender::send, where
+        // they buffer (out of order from seq 1's perspective).
+        for _ in 0..3 {
+            handle.post(&client, BufferTestMsg);
+        }
+        // Let the enqueues propagate to the buffer.
+        tokio::task::yield_now().await;
+
+        // Direct accessor: cell.inbound_ordering_snapshot() invokes the
+        // type-erased callback installed at Instance::new.
+        let cell = proc.get_instance(&actor_id).expect("actor exists");
+        let snapshot = cell
+            .inbound_ordering_snapshot()
+            .expect("snapshot callback should be installed for live actors");
+
+        assert!(snapshot.enabled, "buffering enabled by override");
+        assert_eq!(snapshot.sessions.len(), 1, "one client session expected");
+        let session = &snapshot.sessions[0];
+        assert_eq!(session.expected_next_seq, 1);
+        assert_eq!(session.buffered_count, 3);
+        assert_eq!(session.oldest_buffered_seq, Some(2));
+        assert_eq!(session.newest_buffered_seq, Some(4));
+        assert_eq!(
+            session.sender.as_ref(),
+            Some(client.mailbox().actor_addr()),
+            "session owner should be the posting client",
+        );
+
+        // Attrs-publish wiring: build_actor_attrs (via live_actor_payload)
+        // must call attrs.set(INBOUND_ORDERING, snapshot). Round-trip
+        // through ActorAttrsView and assert the same session.
+        let payload = crate::introspect::live_actor_payload(&cell);
+        let attrs: hyperactor_config::Attrs =
+            serde_json::from_str(&payload.attrs).expect("payload.attrs is well-formed JSON");
+        let view = crate::introspect::ActorAttrsView::from_attrs(&attrs)
+            .expect("attrs decode through ActorAttrsView");
+        let view_snapshot = view
+            .inbound_ordering
+            .as_ref()
+            .expect("INBOUND_ORDERING attr should be set by build_actor_attrs");
+        assert_eq!(view_snapshot, &snapshot);
+
+        // queue_depth scalar is propagated (no arithmetic relation to
+        // buffered_count asserted; IO-3 in introspect module doc).
+        let _: u64 = cell.queue_depth();
+        let _: u64 = view.queue_depth;
     }
 
     // PD-4/PD-5: proc-level queue pressure aggregation reports

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -723,6 +723,57 @@ pub mod test_utils {
             Ok(())
         }
     }
+
+    // SENDER_ACTOR_ID capture fixture for the cast-correctness matrix tests.
+    // Kept in test_utils so #[hyperactor::spawnable]'s inventory::submit!
+    // registration is reliably picked up by Remote::collect() at runtime;
+    // #[doc(hidden)] because this is a test fixture, not API.
+
+    #[doc(hidden)]
+    #[derive(Debug, Clone, Serialize, Deserialize, Named, Bind, Unbind)]
+    pub struct SenderCaptureMsg();
+
+    #[doc(hidden)]
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
+    pub struct CapturedSender(pub Option<ActorAddr>);
+
+    #[doc(hidden)]
+    #[derive(Debug)]
+    #[hyperactor::export(SenderCaptureMsg { cast = true })]
+    #[hyperactor::spawnable]
+    pub struct SenderCapturingActor {
+        forward_port: PortRef<CapturedSender>,
+    }
+
+    #[doc(hidden)]
+    #[derive(Debug, Clone, Named, Serialize, Deserialize)]
+    pub struct SenderCapturingActorParams {
+        pub forward_port: PortRef<CapturedSender>,
+    }
+
+    #[async_trait]
+    impl Actor for SenderCapturingActor {}
+
+    #[async_trait]
+    impl hyperactor::RemoteSpawn for SenderCapturingActor {
+        type Params = SenderCapturingActorParams;
+
+        async fn new(params: Self::Params, _environment: Flattrs) -> Result<Self> {
+            let Self::Params { forward_port } = params;
+            Ok(Self { forward_port })
+        }
+    }
+
+    #[async_trait]
+    impl Handler<SenderCaptureMsg> for SenderCapturingActor {
+        async fn handle(&mut self, cx: &Context<Self>, _: SenderCaptureMsg) -> anyhow::Result<()> {
+            let sender = cx
+                .headers()
+                .get(hyperactor::mailbox::headers::SENDER_ACTOR_ID);
+            self.forward_port.post(cx, CapturedSender(sender));
+            Ok(())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -906,6 +957,7 @@ mod tests {
 
     use hyperactor::ActorAddr;
     use hyperactor::ActorRef;
+    use hyperactor::Endpoint as _;
     use hyperactor::Index;
     use hyperactor::OncePortRef;
     use hyperactor::PortAddr;
@@ -932,6 +984,7 @@ mod tests {
 
     use super::*;
     use crate::ActorMesh;
+    use crate::ProcMesh;
     use crate::host_mesh::HostMesh;
     use crate::test_utils::local_host_mesh;
     use crate::testing;
@@ -1758,5 +1811,167 @@ mod tests {
             assert_eq!(val, 42);
         }
         let _ = host_mesh.shutdown(instance).await;
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Cast correctness matrix: SENDER_ACTOR_ID stamping invariant verified at
+    // the receiver across direct, V1 native p2p, V1 native tree, and V0 legacy
+    // paths. Invariant: SENDER_ACTOR_ID == session owner (the actor whose
+    // Sequencer assigned the SEQ_INFO for this session).
+
+    struct SenderCaptureSetup {
+        instance: &'static Instance<testing::TestRootClient>,
+        host_mesh: HostMesh,
+        proc_mesh: ProcMesh,
+        actor_mesh: ActorMesh<SenderCapturingActor>,
+        rx: hyperactor::mailbox::PortReceiver<CapturedSender>,
+    }
+
+    async fn setup_sender_capture_mesh(num_ranks: usize) -> SenderCaptureSetup {
+        let instance = crate::testing::instance();
+        let host_mesh = local_host_mesh(num_ranks).await;
+        let proc_mesh = host_mesh
+            .spawn(
+                instance,
+                "sender_capture",
+                extent!(gpu = num_ranks),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+        let (tx, rx) = hyperactor::mailbox::open_port(instance);
+        let params = SenderCapturingActorParams {
+            forward_port: tx.bind(),
+        };
+        let actor_name = crate::mesh_id::ActorMeshId::instance(
+            hyperactor::id::Label::new("sender_capture").unwrap(),
+        );
+        let actor_mesh: ActorMesh<SenderCapturingActor> = proc_mesh
+            .spawn_with_name(&instance, actor_name, &params, None, true)
+            .await
+            .unwrap();
+        SenderCaptureSetup {
+            instance,
+            host_mesh,
+            proc_mesh,
+            actor_mesh,
+            rx,
+        }
+    }
+
+    /// Direct send: SENDER_ACTOR_ID at the receiver equals the caller's
+    /// `actor_addr` (MailboxExt::post stamps via the caller's Sequencer).
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_direct_send_sender_actor_id() {
+        let mut setup = setup_sender_capture_mesh(1).await;
+
+        let actor_ref = setup.actor_mesh.values().next().unwrap();
+        actor_ref.post(setup.instance, SenderCaptureMsg());
+
+        let captured = setup.rx.recv().await.unwrap();
+        assert_eq!(
+            captured,
+            CapturedSender(Some(setup.instance.self_addr().clone())),
+        );
+
+        let _ = setup.host_mesh.shutdown(setup.instance).await;
+    }
+
+    /// V1 native p2p cast: SENDER_ACTOR_ID at the receiver equals the
+    /// caster's `actor_addr`. SEQ_INFO is assigned at the cast origin's
+    /// Sequencer; CommActor::deliver_to_dest stamps from message.sender()
+    /// (which is the origin) on the leaf.
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_v1_native_p2p_sender_actor_id() {
+        let config = hyperactor_config::global::lock();
+        let _g1 = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+        let _g2 = config.override_key(
+            hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER,
+            true,
+        );
+        let _g3 = config.override_key(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD, 1024);
+
+        let mut setup = setup_sender_capture_mesh(1).await;
+        setup
+            .actor_mesh
+            .cast(setup.instance, SenderCaptureMsg())
+            .unwrap();
+
+        let captured = setup.rx.recv().await.unwrap();
+        assert_eq!(
+            captured,
+            CapturedSender(Some(setup.instance.self_addr().clone())),
+        );
+
+        let _ = setup.host_mesh.shutdown(setup.instance).await;
+    }
+
+    /// V1 native tree cast: SENDER_ACTOR_ID at every receiver equals the
+    /// caster's `actor_addr`. Origin propagates through the comm-tree
+    /// because each leaf's deliver_to_dest stamps from message.sender()
+    /// when SEQ_INFO is present on headers.
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_v1_native_tree_sender_actor_id() {
+        let config = hyperactor_config::global::lock();
+        let _g1 = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+        let _g2 = config.override_key(
+            hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER,
+            true,
+        );
+        let _g3 = config.override_key(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD, 0);
+
+        let mut setup = setup_sender_capture_mesh(8).await;
+        setup
+            .actor_mesh
+            .cast(setup.instance, SenderCaptureMsg())
+            .unwrap();
+
+        let num_points = setup.proc_mesh.extent().points().count();
+        let expected = CapturedSender(Some(setup.instance.self_addr().clone()));
+        for _ in 0..num_points {
+            let captured = setup.rx.recv().await.unwrap();
+            assert_eq!(captured, expected);
+        }
+
+        let _ = setup.host_mesh.shutdown(setup.instance).await;
+    }
+
+    /// V0 legacy cast: SENDER_ACTOR_ID at the receiver names the local
+    /// CommActor (session owner), NOT the caster. V0 doesn't propagate
+    /// SEQ_INFO from origin; deliver_to_dest skips its stamp-if-present
+    /// branch; MailboxExt::post on cx assigns SEQ_INFO via the CommActor's
+    /// Sequencer and stamps with the CommActor's actor_addr.
+    ///
+    /// V0 invariant: when V0 is retired this test can be deleted with no
+    /// loss of coverage.
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_v0_legacy_sender_actor_id() {
+        let config = hyperactor_config::global::lock();
+        let _g1 = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
+        let _g2 = config.override_key(
+            hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER,
+            false,
+        );
+
+        let mut setup = setup_sender_capture_mesh(1).await;
+        setup
+            .actor_mesh
+            .cast(setup.instance, SenderCaptureMsg())
+            .unwrap();
+
+        let captured = setup.rx.recv().await.unwrap();
+        let captured_addr = captured.0.as_ref().expect("sender was stamped");
+        assert_ne!(
+            captured_addr,
+            setup.instance.self_addr(),
+            "V0 cast is relay-owned, not origin-owned",
+        );
+        assert!(
+            captured_addr.label().unwrap().as_str().contains("comm"),
+            "session owner should be structurally a comm actor; got {captured_addr:?}",
+        );
+
+        let _ = setup.host_mesh.shutdown(setup.instance).await;
     }
 }

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -1551,12 +1551,14 @@ mod tests {
     #[test]
     fn test_derive_properties_valid_actor() {
         use hyperactor::introspect::ACTOR_TYPE;
+        use hyperactor::introspect::INSTANCE_ID;
         use hyperactor::introspect::MESSAGES_PROCESSED;
         use hyperactor::introspect::STATUS;
 
         let mut attrs = Attrs::new();
         attrs.set(STATUS, "running".into());
         attrs.set(ACTOR_TYPE, "TestActor".into());
+        attrs.set(INSTANCE_ID, "01900000-0000-7000-8000-000000000001".into());
         attrs.set(MESSAGES_PROCESSED, 7u64);
         let json = serde_json::to_string(&attrs).unwrap();
         let props = derive_properties(&json);
@@ -1613,11 +1615,13 @@ mod tests {
     #[test]
     fn test_ia6_actor_ignores_unknown_keys() {
         use hyperactor::introspect::ACTOR_TYPE;
+        use hyperactor::introspect::INSTANCE_ID;
         use hyperactor::introspect::STATUS;
 
         let mut attrs = Attrs::new();
         attrs.set(STATUS, "running".into());
         attrs.set(ACTOR_TYPE, "TestActor".into());
+        attrs.set(INSTANCE_ID, "01900000-0000-7000-8000-000000000001".into());
         let json = inject_unknown_key(&attrs);
         let props = derive_properties(&json);
         assert!(matches!(props, NodeProperties::Actor { .. }));


### PR DESCRIPTION
Summary:

adds three actor-introspection fields through the existing `Attrs` pipeline:

- `instance_id` (`String`): the actor's `Uuid::now_v7` identity, previously created in `Instance::new` but not exposed. requires moving the UUID creation earlier so `InstanceCell::new` receives it; threaded through to `InstanceCellState` with an `InstanceCell::instance_id()` accessor.
- `queue_depth` (`u64`): accepted handler work not yet dequeued by the actor loop (per PD-5a/b in `proc.rs`). pure exposure of the existing `InstanceCell::queue_depth()` counter; no accounting changes. `proc.rs` PD-5* docs updated to match the wording.
- `inbound_ordering` (`Option<OrderingSnapshot>`): per-session reorder state from `OrderedSender::snapshot`. plumbed through a type-erased callback (`Box<dyn Fn() -> OrderingSnapshot + Send + Sync>`) captured at `Instance::new` where the actor type is in scope, stashed on `InstanceCellState`, and invoked from non-generic `build_actor_attrs` at attrs-build time. callback captures only `Arc<HandlerPorts<A>>::clone()` -- no `Instance` or `InstanceCell`, nothing cyclic.

three-state semantics for `inbound_ordering` (new invariant **IO-1**): `None` means no snapshot callback was installed (an `InstanceCellState` not built through `Instance::new`); `Some({enabled: false, ...})` means the ordered path exists but reorder buffering is off; `Some({enabled: true, ...})` means active. consumers must distinguish all three.

related new invariants pinned in the `introspect.rs` registry: **IO-2** (snapshot reflects publish-time state via `try_lock`; partial sessions are counted in `skipped_session_count`, not silently omitted), **IO-3** (`queue_depth` and `inbound_ordering.sessions[*].buffered_count` are independent point-in-time diagnostics; no arithmetic or ordering relationship between them is part of the API contract). attr descriptions and the `ActorAttrsView` field docs reinforce the no-contract rule.

Differential Revision: D106202755


