### PR TITLE
Avoid per-chunk waits in RDMA TCP fallback (#4066)

### DIFF
--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -130,7 +130,7 @@ struct SendTransferResult {
     result: Result<(), String>,
 }
 
-/// Fatal error from the receive loop.
+/// Fatal error from a transfer background task.
 ///
 /// The handler logs the error and returns `Err`, which triggers a
 /// supervision event and crashes the actor.
@@ -300,11 +300,13 @@ impl TcpManagerActor {
             let cancel = cancel.clone();
 
             tokio::spawn(async move {
+                let mut chunks_sent = 0usize;
                 let sender_name = format!(
                     "tcp_chunk_sender_{}",
                     hyperactor_mesh::shortuuid::ShortUuid::generate()
                 );
                 let instance = proc.client(&sender_name);
+                let instance = Arc::new(instance);
 
                 loop {
                     if cancel.is_cancelled() {
@@ -323,7 +325,7 @@ impl TcpManagerActor {
                     // component writes the target byte range concurrently.
                     if let Err(e) = unsafe { mem.read_at(offset, &mut buf) } {
                         error_port.post(
-                            &instance,
+                            &*instance,
                             TransferError {
                                 message: format!("read_at failed at offset {offset}: {e}"),
                             },
@@ -337,14 +339,36 @@ impl TcpManagerActor {
                         data: Part::from(buf.freeze()),
                     };
 
-                    if let Err(e) = conn.send(chunk).await {
-                        error_port.post(
-                            &instance,
-                            TransferError {
-                                message: format!("failed to send chunk at offset {offset}: {e}"),
-                            },
-                        );
-                        return;
+                    let (return_tx, return_rx) = tokio::sync::oneshot::channel();
+                    conn.try_post(chunk, return_tx);
+
+                    {
+                        let error_port = error_port.clone();
+                        let instance = instance.clone();
+                        let cancel = cancel.clone();
+
+                        tokio::spawn(async move {
+                            let result = tokio::select! {
+                                _ = cancel.cancelled() => return,
+                                result = return_rx => result,
+                            };
+
+                            if let Ok(e) = result {
+                                error_port.post(
+                                    &*instance,
+                                    TransferError {
+                                        message: format!(
+                                            "parallel channel send failed for transfer {transfer_id}, chunk {idx} at offset {offset}: {e}"
+                                        ),
+                                    },
+                                );
+                            }
+                        });
+                    }
+                    chunks_sent += 1;
+
+                    if chunks_sent.is_multiple_of(8) {
+                        tokio::task::yield_now().await;
                     }
                 }
             });


### PR DESCRIPTION
Summary:

The TCP fallback parallel sender used `conn.send(chunk).await` for every 1 MB data chunk. `Tx::send` waits for Hyperactor delivery acknowledgment, so transfers were throttled by the channel ack cadence even though the RDMA TCP fallback already waits for the receiver-side transfer completion port. Use `post` for data chunks and periodically yield so the data plane can pipeline chunks while preserving the existing transfer-level completion wait.

# Monarch RDMA TCP Fallback Fix: Distilled Repro Report

Date: 2026-05-25
Client: GPU-less EAG devvm
Worker: MAST `h100`, default PCI locality
Benchmark shape: `direction=oneway`, `buffer_type=memoryview`, 8 streams, checksum validated
Benchmark diff/changeset: `da27e751912177490b664afe3339bf966222db9a`
Fix changeset: `2285821485addcef3d2cdb7b441e5b6b86ac1a42`

## Summary

The fix brings Monarch RDMA TCP fallback into roughly the same performance band as the minimal custom TCP benchmark (`cbench`) added in `da27e751912177490b664afe3339bf966222db9a` for the key 4 GB transfer case.

The important 40-iteration fixed results are:

| Case | Median | Mean | p10-p90 |
| --- | ---: | ---: | ---: |
| RDMA TCP fallback, 1 GB, 8 streams | `2.74 GB/s` | `2.69 GB/s` | `2.66-2.82 GB/s` |
| RDMA TCP fallback, 4 GB, 8 streams | `2.91 GB/s` | `2.88 GB/s` | `2.71-3.15 GB/s` |
| `cbench`, 4 GB, 8 streams | `3.11 GB/s` | `2.94 GB/s` | `2.38-3.25 GB/s` |

For the key 4 GB / 8-stream point, fixed RDMA fallback is about 7% below `cbench` on median (`2.91` vs `3.11 GB/s`), with overlapping spread. This is effectively parity for the purpose of validating that the fallback path is no longer dramatically underperforming.

## Fix Ablation

The ablation was run by rebuilding/reinstalling Monarch after reverting the fix. The relevant TCP fallback send path returned to:

```rust
conn.send(chunk).await
```

With the fix reverted, the key 4 GB / 8-stream RDMA TCP fallback control produced:

| Case | Samples | Median |
| --- | --- | ---: |
| RDMA TCP fallback, 4 GB, 8 streams, no fix | `0.99, 1.24, 1.23, 1.22, 1.22 GB/s` | `1.22 GB/s` |

That matches the bad-path result reported in `da27e751912177490b664afe3339bf966222db9a`, which was around `1.26 GB/s` for the same important 4 GB case.

With the fix installed, the same 4 GB / 8-stream case measured:

| Case | Samples / stats | Median |
| --- | --- | ---: |
| RDMA TCP fallback, 4 GB, 8 streams, fixed, initial 5-it run | `1.54, 3.15, 3.13, 2.78, 2.89 GB/s` | `2.89 GB/s` |
| RDMA TCP fallback, 4 GB, 8 streams, fixed, 40-it run | p10-p90 `2.71-3.15 GB/s` | `2.91 GB/s` |

So the fix moves the 4 GB / 8-stream fallback path from about `1.22 GB/s` to about `2.9 GB/s`, a roughly `2.4x` median improvement in this repro.

## Context

The benchmark in `da27e751912177490b664afe3339bf966222db9a` showed that Monarch's RDMA TCP fallback underperformed a minimal custom TCP solution. The suspected cause was the fallback send loop using actor-channel `send(...).await` semantics for each chunk, which effectively waited on delivery acknowledgements and throttled throughput.

The fix in `2285821485addcef3d2cdb7b441e5b6b86ac1a42` changes the fallback sender to post chunks without waiting for per-chunk delivery acknowledgement, while yielding periodically to keep the async runtime fair. In source terms, the fixed path replaces the old `conn.send(chunk).await` behavior with the non-blocking `conn.post(chunk)` path plus periodic `tokio::task::yield_now().await`.

The key validation question was not whether the fixed path beats `cbench`, but whether it stops being dramatically worse. The 40-iteration data says yes: fixed RDMA TCP fallback is close to `cbench` for 4 GB / 8 streams.

## Repro Details

The client devvm had no GPU and no NVIDIA driver library. To build and run the RDMA-enabled wheel on this GPU-less client, I had to do two non-verbatim setup steps:

1. Build Monarch with CUDA/RDMA bindings using pip-provided CUDA compiler/toolkit bits and in-repo rdma-core source.
2. Use a local `libcuda.so.1` stub so rdmaxcel's CPU `memoryview` pointer probe returned "not CUDA memory" instead of aborting on missing driver library.

The local stub only affects pointer classification on the GPU-less client. The benchmark uses CPU `memoryview` buffers and forced TCP fallback.

Benchmark environment knobs:

```bash
MONARCH_RDMA_ALLOW_TCP_FALLBACK=1
MONARCH_RDMA_DISABLE_IBVERBS=1
MONARCH_RDMA_TCP_FALLBACK_PARALLELISM=8
```

For `cbench`, the comparison used:

```bash
--transport=cbench --n_streams=8
```

All runs used `--backend=mast --host_type=h100 --direction=oneway --buffer_type=memoryview`.

The helper defaults `h100` jobs to PCI region locality. Observed worker hostnames and MAST status also showed PCI placements.

## Caveats

- The GPU-less client required the local `libcuda.so.1` stub, so this is not a perfectly verbatim repro of the original benchmark environment.
- The 40-iteration fixed runs reduce within-placement noise, but they do not fully characterize placement-to-placement variance.
- `cbench` showed visible low outliers in the 40-iteration run; its median remained slightly higher than RDMA fallback, but the two are close enough to call parity for this investigation.
- The no-fix ablation used 5 iterations, not 40. It was still very close to the bad number reported in the benchmark diff and far below the fixed 40-iteration result.

## Raw Artifacts

Longer report:

```text
/home/thomasywang/monarch_rdma_repro_report.md
```

Raw fixed stream sweep:

```text
/home/thomasywang/monarch_stream_sweep_4gb_fixed.log
```

Raw fixed 40-iteration key runs:

```text
/home/thomasywang/monarch_key_40iter_fixed.log
```

Relevant MAST jobs:

- No-fix 4 GB / 8-stream control: `monarch_rdma_reverted_4gb_thomasywang_1779718728193070841`
- Fixed RDMA 1 GB / 8 streams / 40 iterations: `monarch_rdma_fixed_1gb_s8_40it_thomasywang_1779726192748674478`
- Fixed RDMA 4 GB / 8 streams / 40 iterations: `monarch_rdma_fixed_4gb_s8_40it_thomasywang_1779726514106814622`
- Fixed `cbench` 4 GB / 8 streams / 40 iterations: `monarch_cbench_fixed_4gb_s8_40it_thomasywang_1779726940975409289`

Differential Revision: D106306879


