### PR TITLE
Evict closed clients from DialMailboxRouter sender cache (#4067)

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -116,13 +116,52 @@ impl<M: RemoteMessage> From<SendError<M>> for ChannelError {
     }
 }
 
+/// Reason a [`TxStatus`] transitioned to `Closed`. Callers should branch on
+/// the typed variants for cases they care about (e.g. cache-eviction logic in
+/// `DialMailboxRouter` keys on `SequenceMismatch`); everything else falls
+/// into `Other` and is for display/logging only.
+#[derive(Debug, Clone, PartialEq)]
+pub enum CloseReason {
+    /// The peer rejected our session because our sequence number did not
+    /// match what the peer's dispatcher expected — the K8s "out-of-sequence
+    /// message, expected seq 0, got N" case where the peer GC'd the
+    /// `SessionId` while we still hold an `Outbox.next_seq` past 0.
+    /// Re-dialing produces a fresh session that the peer accepts.
+    SequenceMismatch(String),
+    /// The peer rejected a frame whose length exceeded
+    /// `config::CODEC_MAX_FRAME_LENGTH`. Re-dialing will not help — the
+    /// message itself is the problem.
+    OversizedFrame {
+        /// Actual frame length in bytes.
+        size: usize,
+        /// `CODEC_MAX_FRAME_LENGTH` at the time of rejection.
+        max: usize,
+    },
+    /// Any close reason the transport hasn't classified further. The string
+    /// is for display/logging only — do not parse it. If a caller needs to
+    /// branch on a sub-case, lift it into its own variant on this enum.
+    Other(String),
+}
+
+impl fmt::Display for CloseReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SequenceMismatch(s) => write!(f, "stale session: {}", s),
+            Self::OversizedFrame { size, max } => {
+                write!(f, "oversized frame: len={size} > max={max}")
+            }
+            Self::Other(s) => f.write_str(s),
+        }
+    }
+}
+
 /// The possible states of a `Tx`.
 #[derive(Debug, Clone, PartialEq, EnumAsInner)]
 pub enum TxStatus {
     /// The tx is good.
     Active,
     /// The tx cannot be used for message delivery.
-    Closed(Arc<str>),
+    Closed(CloseReason),
 }
 
 /// The transmit end of an M-typed channel.
@@ -262,9 +301,9 @@ impl<M: RemoteMessage> MpscRx<M> {
 
 impl<M: RemoteMessage> Drop for MpscRx<M> {
     fn drop(&mut self) {
-        let _ = self
-            .status_sender
-            .send(TxStatus::Closed("receiver dropped".into()));
+        let _ = self.status_sender.send(TxStatus::Closed(CloseReason::Other(
+            "receiver dropped".into(),
+        )));
     }
 }
 

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -164,9 +164,9 @@ impl<M: RemoteMessage> Rx<M> for LocalRx<M> {
 
 impl<M: RemoteMessage> Drop for LocalRx<M> {
     fn drop(&mut self) {
-        let _ = self
-            .status_tx
-            .send(TxStatus::Closed("receiver dropped".into()));
+        let _ = self.status_tx.send(TxStatus::Closed(CloseReason::Other(
+            "receiver dropped".into(),
+        )));
         PORTS.lock().unwrap().free(self.port);
     }
 }

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -269,10 +269,33 @@ fn log_send_error(
             );
             true
         }
-        session::SendLoopError::OversizedFrame(reason) => {
-            tracing::error!(dest = %dest, session_id, mode, "oversized frame: {reason}; {link_status}");
+        session::SendLoopError::OversizedFrame { size, max } => {
+            tracing::error!(
+                dest = %dest,
+                session_id,
+                mode,
+                "oversized frame: len={size} > max={max}; {link_status}"
+            );
             true
         }
+    }
+}
+
+/// Map a terminal [`session::SendLoopError`] to a typed [`CloseReason`] for
+/// the `TxStatus` watcher. Variants that callers want to branch on (e.g.
+/// `DialMailboxRouter` keys cache eviction on `SequenceMismatch`) get their
+/// own typed reason; the rest flatten to `Other` carrying the same
+/// `{log_id}: {e}` text used previously for logging.
+fn classify_send_loop_error(error: &session::SendLoopError, log_id: &str) -> CloseReason {
+    match error {
+        session::SendLoopError::Rejected(reason) if reason.contains("out-of-sequence message") => {
+            CloseReason::SequenceMismatch(reason.clone())
+        }
+        session::SendLoopError::OversizedFrame { size, max } => CloseReason::OversizedFrame {
+            size: *size,
+            max: *max,
+        },
+        _ => CloseReason::Other(format!("{log_id}: {error}")),
     }
 }
 
@@ -501,7 +524,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
         }
 
         let reason = format!("{log_id}: dispatcher closed");
-        let _ = notify.send(TxStatus::Closed(reason.into()));
+        let _ = notify.send(TxStatus::Closed(CloseReason::Other(reason)));
     });
 
     tx
@@ -536,12 +559,16 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
                         error = %err,
                         "failed to push message to outbox"
                     );
-                    let _ = notify.send(TxStatus::Closed("failed to push to outbox".into()));
+                    let _ = notify.send(TxStatus::Closed(CloseReason::Other(
+                        "failed to push to outbox".into(),
+                    )));
                     return;
                 }
             }
             None => {
-                let _ = notify.send(TxStatus::Closed("sender dropped".into()));
+                let _ = notify.send(TxStatus::Closed(CloseReason::Other(
+                    "sender dropped".into(),
+                )));
                 return;
             }
         }
@@ -556,7 +583,7 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
 
         let mut link_status = LinkStatus::NeverConnected;
 
-        let reason: String = 'outer: loop {
+        let reason: CloseReason = 'outer: loop {
             let connected = match deliveries.expiry_time() {
                 Some(deadline) => match session.connect_by(deadline).await {
                     Ok(s) => s,
@@ -574,12 +601,12 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
                         tracing::error!(
                             dest = %dest, session_id = session_id.0, "{}", error_msg
                         );
-                        break 'outer format!("{log_id}: {error_msg}");
+                        break 'outer CloseReason::Other(format!("{log_id}: {error_msg}"));
                     }
                 },
                 None => match session.connect().await {
                     Ok(s) => s,
-                    Err(_) => break 'outer "session shut down".into(),
+                    Err(_) => break 'outer CloseReason::Other("session shut down".into()),
                 },
             };
 
@@ -637,7 +664,7 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
                 }
                 Err(ref e) => {
                     if log_send_error(e, &dest, session_id.0, "simplex", &link_status) {
-                        break 'outer format!("{log_id}: {e}");
+                        break 'outer classify_send_loop_error(e, &log_id);
                     }
                     // Recoverable error — reconnect after backoff.
                     if let Some(delay) = reconnect_backoff.next_backoff() {
@@ -658,22 +685,23 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
             dest = %dest, session_id = session_id.0, "NetTx closing: {reason}"
         );
 
+        let reason_str = reason.to_string();
         receiver.close();
         deliveries
             .unacked
             .deque
             .drain(..)
             .chain(deliveries.outbox.deque.drain(..))
-            .for_each(|queued| queued.try_return(Some(reason.clone())));
+            .for_each(|queued| queued.try_return(Some(reason_str.clone())));
         while let Ok((msg, return_channel, _)) = receiver.try_recv() {
             let _ = return_channel.send(SendError {
                 error: ChannelError::Closed,
                 message: msg,
-                reason: Some(reason.clone()),
+                reason: Some(reason_str.clone()),
             });
         }
 
-        let _ = notify.send(TxStatus::Closed(reason.into()));
+        let _ = notify.send(TxStatus::Closed(reason));
     });
     tx
 }

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -54,6 +54,7 @@ use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
 use crate::channel::ChannelTransport;
+use crate::channel::CloseReason;
 use crate::channel::Rx;
 use crate::channel::SendError;
 use crate::channel::Tx;
@@ -595,7 +596,9 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
     // fails after the link's receiver above is dropped.
     sessions.remove(&session_id);
 
-    let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
+    let _ = notify.send(TxStatus::Closed(CloseReason::Other(
+        "duplex session ended".into(),
+    )));
 }
 
 /// Establish a duplex (bidirectional) session over the given link.
@@ -810,7 +813,9 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
             }
         }
 
-        let _ = notify.send(TxStatus::Closed("duplex session ended".into()));
+        let _ = notify.send(TxStatus::Closed(CloseReason::Other(
+            "duplex session ended".into(),
+        )));
     });
     let tx = DuplexTx::new(outbound_tx, addr.clone(), status);
     let rx = DuplexRx::new(inbound_rx, addr.clone());

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -945,8 +945,8 @@ pub(super) enum SendLoopError {
     ServerClosed,
     /// Delivery timeout on oldest unacked message.
     DeliveryTimeout,
-    /// Frame exceeds maximum allowed size.
-    OversizedFrame(String),
+    /// Frame `size` exceeded `max` (= `CODEC_MAX_FRAME_LENGTH`).
+    OversizedFrame { size: usize, max: usize },
 }
 
 impl fmt::Display for SendLoopError {
@@ -957,7 +957,11 @@ impl fmt::Display for SendLoopError {
             Self::Rejected(r) => write!(f, "rejected: {r}"),
             Self::ServerClosed => write!(f, "server closed"),
             Self::DeliveryTimeout => write!(f, "delivery timeout"),
-            Self::OversizedFrame(r) => write!(f, "oversized frame: {r}"),
+            Self::OversizedFrame { size, max } => write!(
+                f,
+                "oversized frame: rejecting oversize frame: len={size} > max={max}. \
+                 ack will not arrive before timeout; increase CODEC_MAX_FRAME_LENGTH to allow."
+            ),
         }
     }
 }
@@ -1327,17 +1331,13 @@ where
             let len = deliveries.outbox.front_size().expect("not empty");
             let max = stream.max_frame_len();
             if len > max {
-                let reason = format!(
-                    "rejecting oversize frame: len={} > max={}. \
-                    ack will not arrive before timeout; increase CODEC_MAX_FRAME_LENGTH to allow.",
-                    len, max
-                );
+                let err = SendLoopError::OversizedFrame { size: len, max };
                 deliveries
                     .outbox
                     .pop_front()
                     .expect("not empty")
-                    .try_return(Some(reason.clone()));
-                return Err(SendLoopError::OversizedFrame(reason));
+                    .try_return(Some(err.to_string()));
+                return Err(err);
             }
             let message = deliveries.outbox.front_message().expect("not empty");
             pending = Some(stream.write(message.framed()));

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -156,6 +156,7 @@ use crate::channel;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
 use crate::channel::ChannelTransport;
+use crate::channel::CloseReason;
 use crate::channel::SendError;
 use crate::channel::TxStatus;
 use crate::context;
@@ -1210,6 +1211,10 @@ pub struct MailboxClient {
     completed: Arc<AtomicUsize>,
     // Notifies flush waiters when `completed` changes.
     completed_notify: Arc<tokio::sync::Notify>,
+
+    // Watcher exposing the underlying Tx's health. Callers can peek to detect
+    // a closed client before submitting, e.g. for routing-cache eviction.
+    tx_status: watch::Receiver<TxStatus>,
 }
 
 impl fmt::Debug for MailboxClient {
@@ -1273,9 +1278,17 @@ impl MailboxClient {
             submitted: Arc::new(AtomicUsize::new(0)),
             completed,
             completed_notify,
+            tx_status: tx_status.clone(),
         };
         Self::monitor_tx_health(tx_status, tx_monitoring, addr);
         this
+    }
+
+    /// A means to monitor the health of the underlying [`channel::Tx`]. The
+    /// watcher transitions to [`TxStatus::Closed`] when the tx is no longer
+    /// usable for message delivery (e.g. peer rejected the session).
+    pub fn tx_status(&self) -> &watch::Receiver<TxStatus> {
+        &self.tx_status
     }
 
     /// Convenience constructor, to set up a mailbox client that forwards messages
@@ -3125,6 +3138,19 @@ impl MailboxSender for WeakMailboxRouter {
     }
 }
 
+/// Returns true if `status` is `Closed` with a typed reason identifying a
+/// stale session — the K8s "out-of-sequence message, expected seq 0, got N"
+/// case where the peer's dispatcher GC'd the `SessionId` but our cached
+/// `NetTx` still holds an `Outbox.next_seq` past 0. Re-dialing produces a
+/// fresh session that the peer accepts.
+///
+/// Other close reasons (oversized frame, codec errors, etc.) intentionally
+/// do not match: the message or peer is the problem and re-dialing would
+/// just hit the same failure.
+fn is_stale_session_close(status: &TxStatus) -> bool {
+    matches!(status, TxStatus::Closed(CloseReason::SequenceMismatch(_)))
+}
+
 /// A dynamic mailbox router that supports remote delivery.
 ///
 /// `DialMailboxRouter` maintains a runtime address book mapping
@@ -3276,21 +3302,45 @@ impl DialMailboxRouter {
         addr: &ChannelAddr,
         actor_ref: &ActorAddr,
     ) -> Result<Arc<MailboxClient>, MailboxSenderError> {
-        // Get the sender. Create it if needed. Do not send the
-        // messages inside this block so we do not hold onto the
-        // reference of the dashmap entries.
-        match self.sender_cache.entry(addr.clone()) {
-            Entry::Occupied(entry) => Ok(entry.get().clone()),
-            Entry::Vacant(entry) => {
-                let tx = channel::dial(addr.clone()).map_err(|err| {
-                    MailboxSenderError::new_unbound_type(
-                        actor_ref.clone(),
-                        MailboxSenderErrorKind::Channel(err),
-                        "unknown",
-                    )
-                })?;
-                let sender = MailboxClient::new(tx);
-                Ok(entry.insert(Arc::new(sender)).value().clone())
+        // The cache must self-heal when a peer rejects a stale session
+        // (e.g. its dispatcher GC'd the SessionId after the prior connection
+        // ended, but our cached NetTx has an Outbox.next_seq past 0). Without
+        // eviction, the cached client is dead-on-arrival forever, since the
+        // server rejects every reconnect with "out-of-sequence message,
+        // expected seq 0, got N".
+        //
+        // Eviction is narrowly gated on this exact close reason. Re-dialing
+        // a client closed for any other reason (oversized frame, codec
+        // error, etc.) just produces a fresh session that fails the same
+        // way and would turn the cache into an unbounded redial loop under
+        // upstream retry. Other reasons stay cached so the existing
+        // closed-channel fast-fail path can drain the retry budget cleanly.
+        loop {
+            match self.sender_cache.entry(addr.clone()) {
+                Entry::Occupied(entry) => {
+                    let status = entry.get().tx_status().borrow().clone();
+                    if is_stale_session_close(&status) {
+                        tracing::info!(
+                            ?addr,
+                            reason = ?status.as_closed(),
+                            "evicting stale-session MailboxClient from DialMailboxRouter cache"
+                        );
+                        entry.remove();
+                        continue;
+                    }
+                    return Ok(entry.get().clone());
+                }
+                Entry::Vacant(entry) => {
+                    let tx = channel::dial(addr.clone()).map_err(|err| {
+                        MailboxSenderError::new_unbound_type(
+                            actor_ref.clone(),
+                            MailboxSenderErrorKind::Channel(err),
+                            "unknown",
+                        )
+                    })?;
+                    let sender = Arc::new(MailboxClient::new(tx));
+                    return Ok(entry.insert(sender).value().clone());
+                }
             }
         }
     }
@@ -3931,6 +3981,67 @@ mod tests {
                 assert_eq!(receiver.recv().await.unwrap(), 123u64);
             }
         }
+    }
+
+    #[test]
+    fn test_is_stale_session_close() {
+        // Only the typed SequenceMismatch variant identifies a stale session.
+        let stale = TxStatus::Closed(CloseReason::SequenceMismatch(
+            "out-of-sequence message, expected seq 0, got 7".into(),
+        ));
+        assert!(is_stale_session_close(&stale));
+
+        // Other close reasons must NOT match — re-dialing would just hit the
+        // same failure and create an unbounded evict/redial loop.
+        let oversize = TxStatus::Closed(CloseReason::OversizedFrame {
+            size: 55_001_392,
+            max: 50_000_000,
+        });
+        assert!(!is_stale_session_close(&oversize));
+
+        let generic = TxStatus::Closed(CloseReason::Other("test teardown".into()));
+        assert!(!is_stale_session_close(&generic));
+
+        // Active is never stale.
+        assert!(!is_stale_session_close(&TxStatus::Active));
+    }
+
+    #[tokio::test]
+    async fn test_dial_router_keeps_client_closed_for_non_stale_reason() {
+        // A client closed for any reason other than the K8s sequence-mismatch
+        // pattern must stay cached — re-dialing on, say, an oversize-frame
+        // rejection would just produce a fresh session that fails the same
+        // way under upstream retry, turning the cache into an unbounded
+        // evict/redial loop. The closed entry sticks; upstream retries
+        // fast-fail via the existing channel-closed path.
+        let mbox = Mailbox::new(test_actor_id("non_stale_close_0", "actor0"));
+        let (addr, rx) =
+            channel::serve::<MessageEnvelope>(ChannelAddr::any(ChannelTransport::Local)).unwrap();
+        let h = mbox.clone().serve(rx);
+
+        let router = DialMailboxRouter::new();
+        router.bind(Addr::from(mbox.actor_addr().clone()), addr.clone());
+
+        let client1 = router.dial(&addr, mbox.actor_addr()).unwrap();
+        let mut status = client1.tx_status().clone();
+
+        // LocalRx::drop closes the watcher with a non-stale reason — the
+        // string never contains "out-of-sequence message", so it must not
+        // trigger eviction.
+        h.stop("test teardown");
+        let _ = h.await;
+        while !status.borrow_and_update().is_closed() {
+            status.changed().await.unwrap();
+        }
+        assert!(!is_stale_session_close(&status.borrow()));
+
+        let client2 = router.dial(&addr, mbox.actor_addr()).unwrap();
+        assert!(
+            Arc::ptr_eq(&client1, &client2),
+            "router must not evict a client closed for a non-stale reason"
+        );
+        let client3 = router.dial(&addr, mbox.actor_addr()).unwrap();
+        assert!(Arc::ptr_eq(&client1, &client3));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Summary:

`DialMailboxRouter::sender_cache` is a process-wide singleton mapping `ChannelAddr` to cached `Arc<MailboxClient>`. It had no eviction when the underlying `NetTx` closed — so after a peer rejected a stale session for a sequence mismatch (`out-of-sequence message, expected seq 0, got N`), the cached client was dead-on-arrival forever. The receiver already sends `NetRxResponse::Reject` on `SequenceError` and the client classifies that as terminal, transitioning its `TxStatus` watch to `Closed`; the missing wire was the cache observing that transition.

This change makes `DialMailboxRouter::dial` evict the cached entry on a cache hit when its `tx_status` is `Closed` *and* the close reason identifies the K8s stale-session case, then re-dials. To make that decision robust, the close-reason payload of `TxStatus::Closed` is promoted from a free-form `Arc<str>` to a typed `CloseReason` enum with three variants: `SequenceMismatch(String)` (the K8s pattern we evict on), `OversizedFrame { size, max }` (typed numeric fields threaded all the way from `session::SendLoopError::OversizedFrame` — no string parsing), and `Other(String)` for everything else (display-only). The eviction predicate is `matches!(status, TxStatus::Closed(CloseReason::SequenceMismatch(_)))`, so new close reasons added later default to "do not evict" unless explicitly opted in. `MailboxClient` now retains its `tx_status` and exposes it via `pub fn tx_status(&self)`.

This narrow gating fixes a regression an earlier version of this diff introduced: evicting on every `Closed` status caused an unbounded evict/redial loop when the close came from a message-level error (e.g. an oversized frame) — every fresh client failed the same way under upstream retry. With the typed predicate, only sessions the peer rejected for a sequence mismatch trigger re-dial; all other close reasons leave the cached entry in place so the existing channel-closed fast-fail path drains the retry budget cleanly.

Reviewed By: shayne-fletcher

Differential Revision: D106429694


