### PR TITLE
Make `PortHandle::bind()` honor handler ports (#4069)

### DIFF
--- a/hyperactor/src/client.rs
+++ b/hyperactor/src/client.rs
@@ -106,9 +106,7 @@ impl Client {
 
     /// Bind a handler port to this client.
     pub fn bind_handler_port<M: RemoteMessage>(&self) -> (PortHandle<M>, PortReceiver<M>) {
-        let (handle, receiver) = self.instance.open_port();
-        handle.bind_handler_port();
-        (handle, receiver)
+        self.instance.mailbox().bind_handler_port()
     }
 
     /// Bind this client as an actor ref.

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1748,10 +1748,25 @@ impl Mailbox {
     ///      that message to the returned receiver;
     ///   2. mock this message's handler when it is not implemented for this actor
     ///      type, with the returned receiver.
+    ///
+    /// The returned receiver owns the binding. Dropping it removes the handler
+    /// port from the mailbox, so callers that need the handler to stay live
+    /// must retain the receiver.
     pub(crate) fn bind_handler_port<M: RemoteMessage>(&self) -> (PortHandle<M>, PortReceiver<M>) {
-        let (handle, receiver) = self.open_port();
+        let (sender, receiver) = sequenced_unbounded::<SequencedEnvelope<M>>();
+        let port_id = self.inner.actor_id.port_addr(Port::handler::<M>());
+        let handle = PortHandle::new_full_with_target(
+            self.clone(),
+            UnboundedPortSender::Sequenced(sender),
+            PortBindTarget::Handler,
+            None,
+            StreamingReducerOpts::default(),
+        );
         handle.bind_handler_port();
-        (handle, receiver)
+        (
+            handle,
+            PortReceiver::new(receiver, port_id, /*coalesce=*/ false, self.clone()),
+        )
     }
 
     /// Open a new port with an accumulator with default reduce options.
@@ -1808,6 +1823,7 @@ impl Mailbox {
     /// Open a port that accepts M-typed messages, using the provided function
     /// to enqueue.
     // TODO: consider making lifetime bound to Self instead.
+    #[cfg(test)]
     pub(crate) fn open_enqueue_port<M: Message>(
         &self,
         enqueue: impl Fn(Flattrs, M) -> Result<(), anyhow::Error> + Send + Sync + 'static,
@@ -1827,16 +1843,15 @@ impl Mailbox {
         &self,
         enqueue: impl Fn(Flattrs, M) -> Result<(), anyhow::Error> + Send + Sync + 'static,
     ) -> PortHandle<M> {
-        let port_index = self.inner.allocate_port();
         let enqueue = Arc::new(enqueue);
         let sender = Arc::new(HandlerPortSender::new(
             UnboundedPortSender::Func(enqueue),
             self.inner.handler_ingress.clone(),
         ));
-        PortHandle::new_full(
+        PortHandle::new_full_with_target(
             self.clone(),
-            port_index,
             UnboundedPortSender::Handler(sender),
+            PortBindTarget::Handler,
             None,
             StreamingReducerOpts::default(),
         )
@@ -1952,7 +1967,7 @@ impl Mailbox {
         // have handles explicitly staged (unbound, bound).
         let port_ref = self
             .actor_addr()
-            .port_addr(Port::from(handle.inner.port_index));
+            .port_addr(Port::from(handle.inner.bind_target.ephemeral_index()));
         match self.inner.ports.entry(port_ref.port()) {
             Entry::Vacant(entry) => {
                 entry.insert(Arc::new(UnboundedSender::new(
@@ -2309,12 +2324,27 @@ fn port_gone(port: &PortAddr, data: &wirevalue::Any) -> UndeliverableReason {
     ))
 }
 
+#[derive(Debug, Clone, Copy)]
+enum PortBindTarget {
+    Ephemeral(u64),
+    Handler,
+}
+
+impl PortBindTarget {
+    fn ephemeral_index(self) -> u64 {
+        match self {
+            Self::Ephemeral(port_index) => port_index,
+            Self::Handler => panic!("handler port handle has no ephemeral port index"),
+        }
+    }
+}
+
 /// Inner state of a [`PortHandle`], shared via `Arc` to make cloning cheap
 /// (single atomic refcount bump instead of cloning each field).
 struct PortHandleInner<M: Message> {
     mailbox: Mailbox,
-    port_index: u64,
     sender: UnboundedPortSender<M>,
+    bind_target: PortBindTarget,
     // We would like this to be a Arc<RwLock<Option<PortAddr<M>>>>, but we cannot
     // write down the type PortAddr<M> (M: Message), even though we cannot
     // legally construct such a value without M: RemoteMessage. We could consider
@@ -2333,8 +2363,8 @@ impl<M: Message> fmt::Debug for PortHandleInner<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("PortHandleInner")
             .field("mailbox", &self.mailbox)
-            .field("port_index", &self.port_index)
             .field("sender", &self.sender)
+            .field("bind_target", &self.bind_target)
             .field("bound", &self.bound)
             .field("reducer_spec", &self.reducer_spec)
             .field("streaming_opts", &self.streaming_opts)
@@ -2362,11 +2392,27 @@ impl<M: Message> PortHandle<M> {
         reducer_spec: Option<ReducerSpec>,
         streaming_opts: StreamingReducerOpts,
     ) -> Self {
+        Self::new_full_with_target(
+            mailbox,
+            sender,
+            PortBindTarget::Ephemeral(port_index),
+            reducer_spec,
+            streaming_opts,
+        )
+    }
+
+    fn new_full_with_target(
+        mailbox: Mailbox,
+        sender: UnboundedPortSender<M>,
+        bind_target: PortBindTarget,
+        reducer_spec: Option<ReducerSpec>,
+        streaming_opts: StreamingReducerOpts,
+    ) -> Self {
         Self {
             inner: Arc::new(PortHandleInner {
                 mailbox,
-                port_index,
                 sender,
+                bind_target,
                 bound: Arc::new(RwLock::new(None)),
                 reducer_spec,
                 streaming_opts,
@@ -2504,49 +2550,77 @@ impl<M: Message> PortHandle<M> {
 
 impl<M: RemoteMessage> PortHandle<M> {
     /// Bind this port, making it accessible to remote actors.
-    pub fn bind(&self) -> PortRef<M> {
-        let port_ref = {
-            let mut guard = self.inner.bound.write().unwrap();
-            guard
-                .get_or_insert_with(|| self.inner.mailbox.bind(self).into_port_addr())
-                .clone()
-        };
-        PortRef::attest_reducible(
-            port_ref,
-            self.inner.reducer_spec.clone(),
-            self.inner.streaming_opts.clone(),
-        )
-    }
-
-    /// Bind this handle to the handler port for message type `M`. This method
-    /// will panic if the handle is already bound.
     ///
-    /// This is used by [`actor::Binder`] implementations to bind actor refs.
-    /// This is not intended for general use.
-    pub(crate) fn bind_handler_port(&self) {
-        self.bind_to_port(Port::handler::<M>());
-        self.inner.mailbox.bind_to_handler_port(self);
+    /// Ordinary ports bind to their allocated ephemeral port. Handler ports
+    /// bind to the well-known handler port for `M`.
+    pub fn bind(&self) -> PortRef<M> {
+        match self.inner.bind_target {
+            PortBindTarget::Ephemeral(_) => self.bind_ephemeral_port(),
+            PortBindTarget::Handler => self.bind_handler_port(),
+        }
     }
 
-    /// Bind this handle to a control port. This method will panic if the handle
-    /// is already bound.
-    pub(crate) fn bind_control_port(&self, port: ControlPort) {
-        self.bind_to_port(Port::control(port));
-        self.inner.mailbox.bind_to_control_port(self, port);
+    /// Bind this handle to the well-known handler port for message type `M`
+    /// and return a `PortRef` to it.
+    ///
+    /// Binding to the same handler port again returns the existing binding.
+    /// Binding a handle that is already bound to a different port panics.
+    pub(crate) fn bind_handler_port(&self) -> PortRef<M> {
+        self.bind_to_port(Port::handler::<M>(), |mailbox, handle| {
+            mailbox.bind_to_handler_port(handle);
+        })
     }
 
-    fn bind_to_port(&self, port: Port) {
+    /// Bind this handle to a control port and return a `PortRef` to it.
+    ///
+    /// Binding to the same control port again returns the existing binding.
+    /// Binding a handle that is already bound to a different port panics.
+    pub(crate) fn bind_control_port(&self, port: ControlPort) -> PortRef<M> {
+        self.bind_to_port(Port::control(port), |mailbox, handle| {
+            mailbox.bind_to_control_port(handle, port);
+        })
+    }
+
+    fn bind_ephemeral_port(&self) -> PortRef<M> {
+        let port_addr = {
+            let mut guard = self.inner.bound.write().unwrap();
+            match guard.as_ref() {
+                Some(existing) => existing.clone(),
+                None => {
+                    let port_addr = self.inner.mailbox.bind(self).into_port_addr();
+                    *guard = Some(port_addr.clone());
+                    port_addr
+                }
+            }
+        };
+        self.port_ref(port_addr)
+    }
+
+    fn bind_to_port(&self, port: Port, bind: impl FnOnce(&Mailbox, &PortHandle<M>)) -> PortRef<M> {
         let port_id = self.inner.mailbox.actor_addr().port_addr(port);
         {
             let mut guard = self.inner.bound.write().unwrap();
-            if guard.is_some() {
-                panic!(
-                    "could not bind port handle {} as {port_id}: already bound",
-                    self.inner.port_index
-                );
+            match guard.as_ref() {
+                Some(existing) if existing == &port_id => {}
+                Some(existing) => panic!(
+                    "could not bind port handle {:?} as {port_id}: already bound to {existing}",
+                    self.inner.bind_target
+                ),
+                None => {
+                    bind(&self.inner.mailbox, self);
+                    *guard = Some(port_id.clone());
+                }
             }
-            *guard = Some(port_id);
         }
+        self.port_ref(port_id)
+    }
+
+    fn port_ref(&self, port_addr: PortAddr) -> PortRef<M> {
+        PortRef::attest_reducible(
+            port_addr,
+            self.inner.reducer_spec.clone(),
+            self.inner.streaming_opts.clone(),
+        )
     }
 }
 
@@ -4117,40 +4191,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_missing_dropped_handler_port_records_recipient_gone() {
-        let mbox = Mailbox::new(test_actor_id("0", "test"));
-        let (_port, receiver) = mbox.bind_handler_port::<TestMessage>();
-        let dest = mbox.actor_addr().port_addr(Port::handler::<TestMessage>());
-        drop(receiver);
-        let envelope = MessageEnvelope::serialize(
-            mbox.actor_addr().clone(),
-            dest.clone(),
-            &TestMessage,
-            Flattrs::new(),
-        )
-        .expect("serialize");
-        let (return_handle, mut return_rx) = undeliverable::new_undeliverable_port();
-
-        mbox.post(envelope, return_handle);
-
-        let undelivered = tokio::time::timeout(Duration::from_secs(1), return_rx.recv())
-            .await
-            .expect("timed out waiting for undeliverable")
-            .expect("return port closed")
-            .into_message()
-            .expect("expected returned envelope");
-        let root_failure = undelivered
-            .root_delivery_failure()
-            .expect("expected root delivery failure");
-        let DeliveryFailureKind::Undeliverable(UndeliverableReason::PortGone(port_gone)) =
-            &root_failure.kind
-        else {
-            panic!("expected port gone, got {root_failure}");
-        };
-        assert_eq!(port_gone.port, dest);
-    }
-
-    #[tokio::test]
     async fn test_missing_never_allocated_port_records_invalid_reference() {
         let mbox = Mailbox::new(test_actor_id("0", "test"));
         let dest = mbox.actor_addr().port_addr(Port::from(0));
@@ -5101,14 +5141,14 @@ mod tests {
             let dummy_state = State::new(dummy_actor_ref.clone());
             let dummy_port_id = dummy_actor_ref.port_addr(Port::from(0));
             let (sender, receiver) = sequenced_unbounded::<SequencedEnvelope<M>>();
-            let receiver = PortReceiver {
+            let receiver = PortReceiver::new(
                 receiver,
-                port_id: dummy_port_id,
+                dummy_port_id,
                 coalesce,
-                mailbox: Mailbox {
+                Mailbox {
                     inner: Arc::new(dummy_state),
                 },
-            };
+            );
             (sender, receiver)
         }
 
@@ -5892,27 +5932,45 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "already bound")]
-    fn test_bind_port_handle_to_handler_port_twice() {
+    fn test_bind_open_port_uses_ephemeral_port() {
         let mbox = Mailbox::new(test_actor_id("0", "test"));
         let (handle, _rx) = mbox.open_port::<String>();
-        handle.bind_handler_port();
-        handle.bind_handler_port();
+        let ephemeral_port = mbox
+            .actor_addr()
+            .port_addr(Port::from(handle.inner.bind_target.ephemeral_index()));
+        let handler_port = mbox.actor_addr().port_addr(Port::handler::<String>());
+
+        let port_ref = handle.bind();
+
+        assert_eq!(port_ref.port_addr(), &ephemeral_port);
+        assert_ne!(port_ref.port_addr(), &handler_port);
     }
 
     #[test]
-    fn test_bind_port_handle_to_handler_port() {
+    fn test_bind_handler_port_handle_twice_is_idempotent() {
         let mbox = Mailbox::new(test_actor_id("0", "test"));
         let default_port = mbox.actor_addr().port_addr(Port::handler::<String>());
-        let (handle, _rx) = mbox.open_port::<String>();
-        // Handle's port index is allocated by mailbox, not the handler port.
-        assert_ne!(default_port.index(), handle.inner.port_index);
-        // Bind the handle to the handler port.
-        handle.bind_handler_port();
+        let handle = mbox.open_handler_enqueue_port(|_, _message: String| Ok(()));
+        assert_matches!(handle.inner.bind_target, PortBindTarget::Handler);
+
+        let first = handle.bind();
+        let second = handle.bind();
+
+        assert_eq!(first.port_addr(), &default_port);
+        assert_eq!(second.port_addr(), first.port_addr());
         assert_matches!(handle.location(), PortLocation::Bound(port) if port == default_port);
-        // bind() can still be used, just it will not change handle's state.
-        handle.bind();
-        handle.bind();
+    }
+
+    #[test]
+    fn test_bind_handler_port_helper_returns_handler_bound_handle() {
+        let mbox = Mailbox::new(test_actor_id("0", "test"));
+        let default_port = mbox.actor_addr().port_addr(Port::handler::<String>());
+        let (handle, _rx) = mbox.bind_handler_port::<String>();
+        assert_matches!(handle.inner.bind_target, PortBindTarget::Handler);
+
+        let port_ref = handle.bind();
+
+        assert_eq!(port_ref.port_addr(), &default_port);
         assert_matches!(handle.location(), PortLocation::Bound(port) if port == default_port);
     }
 
@@ -5923,8 +5981,8 @@ mod tests {
         let (handle, _rx) = mbox.open_port::<String>();
         // Bound handle to the port allocated by mailbox.
         handle.bind();
-        assert_matches!(handle.location(), PortLocation::Bound(port) if port.index() == handle.inner.port_index);
-        // Since handle is already bound, call bind_to() on it will cause panic.
+        assert_matches!(handle.location(), PortLocation::Bound(port) if port.index() == handle.inner.bind_target.ephemeral_index());
+        // Rebinding the same handle to a different port should panic.
         handle.bind_handler_port();
     }
 

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -253,14 +253,14 @@ impl<M: Bind> IndexedErasedUnbound<M> {
         M: RemoteMessage,
         C: context::Actor + Send + Sync + 'static,
     {
-        let port_handle = mailbox.open_enqueue_port::<IndexedErasedUnbound<M>>({
+        let port_handle = mailbox.open_handler_enqueue_port::<IndexedErasedUnbound<M>>({
             move |_, m| {
                 let bound_m = m.downcast()?.bind()?;
                 (&actor_ref).post(&cx, bound_m);
                 Ok(())
             }
         });
-        port_handle.bind_handler_port();
+        port_handle.bind();
         Ok(())
     }
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -4349,7 +4349,7 @@ impl<A: Actor> HandlerPorts<A> {
         let port = Port::handler::<M>();
         match self.bound.entry(port.clone()) {
             Entry::Vacant(entry) => {
-                self.get::<M>().bind_handler_port();
+                let _ = self.get::<M>().bind();
                 entry.insert(M::typename());
             }
             Entry::Occupied(entry) => {

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -740,27 +740,15 @@ where
 
         // Subscribe to streaming state updates from the underlying agents so
         // the controller receives state changes in real time, complementing
-        // the existing polling loop. Avoid binding the handle here: the
-        // controller's exported ports are bound when the mesh installs the
-        // ActorRef after spawn. Binding the same handle twice panics.
+        // the existing polling loop. Must happen before starting the monitor
+        // so that the first CheckState does not race the initial StreamState
+        // cast.
         //
-        // This must happen before starting the monitor so that the first
-        // CheckState does not race the initial StreamState cast.
-        //
-        // TODO(SF, 2026-03-32, T261106175): follow up in hyperactor on bind
-        // semantics here. `cx.port()` plus later actor-ref export currently
-        // hits `bind()` -> `bind_handler_port()` on the same handle, and
-        // `bind_handler_port()` still panics on an already-bound handle. This
-        // workaround uses `attest_handler_port(...)` to avoid the eager
-        // bind, but the longer-term fix is to clarify whether that bind
-        // path should be idempotent and eliminate the need for attestation
-        // here.
-        let subscriber =
-            hyperactor::PortRef::<resource::State<T::StateInner>>::attest_handler_port(
-                &this.self_addr().clone(),
-            )
-            .unsplit();
-        self.mesh.subscribe_to_stream(this, subscriber)?;
+        // Bind the handler port before handing the `PortRef` to the agent.
+        // The later external bind races against `init`, but both calls bind
+        // the same well-known handler port and are idempotent.
+        self.mesh
+            .subscribe_to_stream(this, this.port().bind().unsplit())?;
 
         // Start the monitor task.
         self.monitor = Some(());


### PR DESCRIPTION
Summary:

`PortHandle::bind()` now uses its recorded bind target. Ordinary mailbox ports carry an ephemeral index, while handler ports from `Instance::port`, `ActorHandle::port`, and handler helpers bind directly to the well-known handler port id.

This makes the `ResourceController::init` race safe without exposing a public `bind_handler_port()` choice: `this.port().bind().unsplit()` and the later external `controller_handle.bind()` both converge on the same handler port. Updated Monarch call sites back to `.bind()` and added regression coverage for ephemeral vs handler binding.

Reviewed By: mariusae

Differential Revision: D106438851


