### PR TITLE
docs: note macOS support in installation and index

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -31,7 +31,9 @@ Monarch code imperatively describes how to create processes and actors using a s
     # wait for all trainers to complete
     fut.get()
 
-Note: Monarch is currently only supported on Linux systems
+Note: Monarch runs on Linux and macOS.
+  - The CPU-only tensor engine works on macOS and on Linux hosts without a GPU
+  - GPU features require Linux with a supported GPU toolchain
 
 ## Getting Started
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -4,9 +4,10 @@
 
 Before installing Monarch, ensure you have:
 
-- A Linux system (Monarch is currently only supported on Linux)
+- Linux or macOS.
+  - The CPU-only tensor engine builds on both; GPU features require Linux with a supported GPU toolchain
 - Python 3.10 or later
-- CUDA-compatible GPU(s)
+- Optional: CUDA-compatible GPU(s) for distributed tensor and RDMA features
 - Basic familiarity with PyTorch
 
 


### PR DESCRIPTION
Summary: The README already documents macOS support, but `docs/source/installation.md` and `docs/source/index.md` still claimed Monarch was "currently only supported on Linux".   Updated both to note mac is supported and to call out the limitations.

Differential Revision: D106368730


