### PR TITLE
docs - Adding UV examples to the prebuilt-wheel install docs and updating versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,25 +53,16 @@ View Monarch's hosted documentation
 ### Installing from Pre-built Wheels
 
 Monarch provides pre-built wheels that work regardless of what version of
-PyTorch you have installed:
+PyTorch you have installed.  You can get these with `pip` or `uv`:
 
-#### Stable
-
-```sh
-pip install torchmonarch
-```
-
-#### Nightly
-
-```sh
-pip install --pre torchmonarch
-```
-
-Or install a specific nightly version:
-
-```sh
-pip install torchmonarch==0.3.0.dev20260106
-```
+- **Using PIP**:
+  - stable: `pip install torchmonarch`
+  - nightly: `pip install --pre torchmonarch`
+  - specific: `pip install torchmonarch==v0.6.0.dev20260526`
+- **Using UV** - note, you can also just use `uv pip install ...` and match the above pip commands; but the ones below add monarch to your UV project properly.
+  - stable: `uv add torchmonarch`
+  - nightly: `uv add --prerelease=allow torchmonarch`
+  - specific: `uv add torchmonarch==v0.6.0.dev20260526`
 
 ### Build and Install from Source
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -31,7 +31,9 @@ Monarch code imperatively describes how to create processes and actors using a s
     # wait for all trainers to complete
     fut.get()
 
-Note: Monarch is currently only supported on Linux systems
+Note: Monarch runs on Linux and macOS.
+  - The CPU-only tensor engine works on macOS and on Linux hosts without a GPU
+  - GPU features require Linux with a supported GPU toolchain
 
 ## Getting Started
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -4,9 +4,10 @@
 
 Before installing Monarch, ensure you have:
 
-- A Linux system (Monarch is currently only supported on Linux)
+- Linux or macOS.
+  - The CPU-only tensor engine builds on both; GPU features require Linux with a supported GPU toolchain
 - Python 3.10 or later
-- CUDA-compatible GPU(s)
+- Optional: CUDA-compatible GPU(s) for distributed tensor and RDMA features
 - Basic familiarity with PyTorch
 
 


### PR DESCRIPTION
Summary: Updates the prebuilt wheels installation section with examples for adding monarch to UV projects (it was just PIP).  Also updates the targeted version example to be a recent one.

Differential Revision: D106505977


