### PR TITLE
[monarch] downgrade Future.get() in-loop warning to UserWarning

### DIFF
--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -112,8 +112,8 @@ class Future(Generic[R]):
         if in_asyncio or in_tokio:
             warnings.warn(
                 "Future.get() called from within an active event loop blocks it; "
-                "use 'await' instead. This will become a RuntimeError in monarch v0.6.",
-                DeprecationWarning,
+                "use 'await' instead.",
+                UserWarning,
                 stacklevel=2,
             )
             # Forward the event directly to Rust tracing so we capture it in

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1855,10 +1855,9 @@ def test_context_propagated_through_python_task_spawn_blocking():
 
 @pytest.mark.timeout(15)
 def test_future_get_inside_async_loop_warns():
-    """Calling Future.get() from inside an active asyncio loop is deprecated:
-    it blocks the surrounding loop. Verify a DeprecationWarning fires while
-    the call still completes for backward compatibility; this will become a
-    RuntimeError in monarch v0.6.
+    """Calling Future.get() from inside an active asyncio loop blocks the
+    surrounding loop. Verify a UserWarning fires while the call still
+    completes for backward compatibility.
     """
 
     async def runner() -> int:
@@ -1866,7 +1865,7 @@ def test_future_get_inside_async_loop_warns():
             return 1
 
         f: Future[int] = Future(coro=inner())
-        with pytest.warns(DeprecationWarning, match="event loop"):
+        with pytest.warns(UserWarning, match="event loop"):
             return f.get()
 
     assert asyncio.run(runner()) == 1


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #3985
* __->__ #4075
* #3984

There are legitimate cases where a caller needs to bridge `Future.get()` into non-async code and doesn't mind blocking the surrounding loop, so we are not promoting the in-loop check to a hard `RuntimeError`. This commit keeps the warning behavior introduced in the previous commit but tones it down:

- Change the warning class from `DeprecationWarning` to `UserWarning`. `DeprecationWarning` carries an implicit promise of future removal that we no longer want to make.
- Drop the "This will become a RuntimeError in monarch v0.6." text from the message. The check is staying as a warning indefinitely.

The companion `log_with_tracing` call is unchanged so the event still shows up in Rust-side tracing for non-actor driver processes.

Differential Revision: [D104448236](https://our.internmc.facebook.com/intern/diff/D104448236/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D104448236/)!