### PR TITLE
Remove usage of Future.get in async contexts in tests

### DIFF
--- a/python/monarch/_src/actor/logging.py
+++ b/python/monarch/_src/actor/logging.py
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import asyncio
 import logging
 import threading
 import warnings
@@ -23,6 +24,10 @@ logger: logging.Logger = logging.getLogger(__name__)
 
 _global_flush_registered = False
 _global_flush_lock = threading.Lock()
+# Strong references to in-flight async flush tasks scheduled from the
+# post_run_cell callback. The event loop only weak-refs tasks, so without
+# this set a flush task could be garbage-collected mid-execution.
+_pending_flush_tasks: set[asyncio.Task[None]] = set()
 
 FD_READ_CHUNK_SIZE = 4096
 
@@ -34,6 +39,15 @@ def flush_all_proc_mesh_logs() -> None:
     for pm in get_active_proc_meshes():
         if pm._logging_manager._logging_mesh_client is not None:
             pm._logging_manager.flush()
+
+
+async def _flush_all_proc_mesh_logs_async() -> None:
+    """Async counterpart to ``flush_all_proc_mesh_logs``."""
+    from monarch._src.actor.proc_mesh import get_active_proc_meshes
+
+    for pm in get_active_proc_meshes():
+        if pm._logging_manager._logging_mesh_client is not None:
+            await pm._logging_manager.flush_async()
 
 
 class LoggingManager:
@@ -67,10 +81,22 @@ class LoggingManager:
 
                     ipython = get_ipython()
                     assert ipython is not None
-                    ipython.events.register(
-                        "post_run_cell",
-                        lambda _: flush_all_proc_mesh_logs(),
-                    )
+
+                    def _post_run_cell_flush(_: object) -> None:
+                        # For async cells the loop is still running when the
+                        # callback fires; `flush()` would then call
+                        # `Future.get()` inside that loop, which is an error.
+                        # Schedule the async flush on the loop instead.
+                        try:
+                            loop = asyncio.get_running_loop()
+                        except RuntimeError:
+                            flush_all_proc_mesh_logs()
+                        else:
+                            task = loop.create_task(_flush_all_proc_mesh_logs_async())
+                            _pending_flush_tasks.add(task)
+                            task.add_done_callback(_pending_flush_tasks.discard)
+
+                    ipython.events.register("post_run_cell", _post_run_cell_flush)
                     _global_flush_registered = True
 
     def enable_fd_capture_if_in_ipython(self) -> Optional[Tuple[int, int]]:

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -25,6 +25,7 @@ from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.host_mesh import _spawn_admin
+from monarch._src.actor.sync_state import fake_sync_state
 from monarch._src.job.mount_config import Mounts
 
 # note: the jobs api is intended as a library so it should
@@ -471,11 +472,15 @@ class JobTrait(ABC):
         if self._mesh_admin is None or self._admin_url is not None:
             return None
 
-        admin_url, admin_ref = _spawn_admin(
-            host_meshes,
-            admin_addr=self._mesh_admin.admin_addr,
-            telemetry_url=self._telemetry_url,
-        ).get()
+        # state() is a sync API but is commonly called from inside
+        # asyncio.run(...); mask the running loop so the inner .get() does not
+        # trip the Future.get-in-loop check.
+        with fake_sync_state():
+            admin_url, admin_ref = _spawn_admin(
+                host_meshes,
+                admin_addr=self._mesh_admin.admin_addr,
+                telemetry_url=self._telemetry_url,
+            ).get()
         self._admin_url = admin_url
         return admin_ref
 

--- a/python/tests/_monarch/test_logging.py
+++ b/python/tests/_monarch/test_logging.py
@@ -6,8 +6,9 @@
 
 # pyre-strict
 
+import asyncio
 import logging
-from typing import Any
+from typing import Any, Callable
 from unittest import IsolatedAsyncioTestCase, TestCase
 from unittest.mock import Mock, patch
 
@@ -48,6 +49,73 @@ class LoggingManagerTest(TestCase):
         self.assertEqual(args[0], "post_run_cell")
         # Check that the callback is callable
         self.assertTrue(callable(args[1]))
+
+    @pytest.mark.oss_skip  # type: ignore: IPython.get_ipython doesn't exist in OSS CI
+    @patch("monarch._src.actor.logging.IN_IPYTHON", True)
+    @patch("IPython.get_ipython")
+    @patch("monarch._src.actor.logging._global_flush_registered", False)
+    @patch("monarch._src.actor.logging._flush_all_proc_mesh_logs_async")
+    @patch("monarch._src.actor.logging.flush_all_proc_mesh_logs")
+    def test_post_run_cell_callback_in_sync_context_calls_sync_flush(
+        self,
+        mock_sync_flush: Mock,
+        mock_async_flush: Mock,
+        mock_get_ipython: Mock,
+    ) -> None:
+        # Setup: register the post_run_cell callback and capture it.
+        mock_ipython = Mock()
+        mock_get_ipython.return_value = mock_ipython
+        self.logging_manager.register_flusher_if_in_ipython()
+        callback = mock_ipython.events.register.call_args[0][1]
+
+        # Execute: fire the callback in a sync context (no running loop).
+        callback(None)
+
+        # Assert: sync flush ran; async helper was not scheduled.
+        mock_sync_flush.assert_called_once()
+        mock_async_flush.assert_not_called()
+
+    @pytest.mark.oss_skip  # type: ignore: IPython.get_ipython doesn't exist in OSS CI
+    @patch("monarch._src.actor.logging.IN_IPYTHON", True)
+    @patch("IPython.get_ipython")
+    @patch("monarch._src.actor.logging._global_flush_registered", False)
+    @patch("monarch._src.actor.logging._flush_all_proc_mesh_logs_async")
+    @patch("monarch._src.actor.logging.flush_all_proc_mesh_logs")
+    def test_post_run_cell_callback_in_async_context_schedules_async_flush(
+        self,
+        mock_sync_flush: Mock,
+        mock_async_flush: Mock,
+        mock_get_ipython: Mock,
+    ) -> None:
+        # Setup: register the post_run_cell callback and capture it.
+        mock_ipython = Mock()
+        mock_get_ipython.return_value = mock_ipython
+
+        # The patched async helper must still produce an awaitable so that
+        # loop.create_task does not complain.
+        async def _coro() -> None:
+            return None
+
+        mock_async_flush.return_value = _coro()
+
+        self.logging_manager.register_flusher_if_in_ipython()
+        callback: Callable[[object], None] = mock_ipython.events.register.call_args[0][
+            1
+        ]
+
+        # Execute: fire the callback from within a running asyncio loop. This
+        # is the path that would raise the RuntimeError landed in D104448236
+        # if the implementation called Future.get() directly.
+        async def driver() -> None:
+            callback(None)
+            # Drain pending tasks so the scheduled coroutine actually runs.
+            await asyncio.sleep(0)
+
+        asyncio.run(driver())
+
+        # Assert: async helper was scheduled; sync flush was not called.
+        mock_async_flush.assert_called_once()
+        mock_sync_flush.assert_not_called()
 
     @patch("monarch._src.actor.logging.IN_IPYTHON", False)
     def test_enable_fd_capture_if_not_in_ipython_returns_none(self) -> None:

--- a/python/tests/test_debugger.py
+++ b/python/tests/test_debugger.py
@@ -157,8 +157,8 @@ async def _test_debug(nested: bool) -> None:
             debugee = proc.spawn("debugee", DebugeeActor)
         else:
             proc = state.hosts.spawn_procs()
-            debugee = proc.spawn("debugee", DebugeeActor).nested.choose().get()
-        name = debugee.name.choose().get()
+            debugee = await proc.spawn("debugee", DebugeeActor).nested.choose()
+        name = await debugee.name.choose()
 
         input_mock = AsyncMock()
         input_mock.side_effect = [
@@ -359,8 +359,8 @@ async def test_debug_multi_actor() -> None:
         proc = state.hosts.spawn_procs(per_host={"gpus": 2})
         debugee_1 = proc.spawn("debugee_1", DebugeeActor)
         debugee_2 = proc.spawn("debugee_2", DebugeeActor)
-        name_1 = debugee_1.name.choose().get()
-        name_2 = debugee_2.name.choose().get()
+        name_1 = await debugee_1.name.choose()
+        name_2 = await debugee_2.name.choose()
 
         input_mock = AsyncMock()
         input_mock.side_effect = [
@@ -789,10 +789,10 @@ async def test_debug_cli():
     with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
         proc = state.hosts.spawn_procs(per_host={"gpus": 2})
         debugee = proc.spawn("debugee", DebugeeActor)
-        name = debugee.name.choose().get()
-        debug_controller = get_or_spawn_controller(
+        name = await debugee.name.choose()
+        debug_controller = await get_or_spawn_controller(
             "debug_controller", DebugControllerForTesting
-        ).get()
+        )
 
         fut = debugee.to_debug.call()
         # Stupidly high timeout because when CI tries to run many instances of this
@@ -809,7 +809,7 @@ async def test_debug_cli():
             assert info.function == "test_debugger._debugee_actor_internal"
             assert info.lineno == cast(int, breakpoints[0].lineno) + 5 * info.rank
 
-        port = debug_controller.server_port.call_one().get()
+        port = await debug_controller.server_port.call_one()
 
         async def create_debug_cli_proc() -> Tuple[
             Optional[asyncio.subprocess.Process],
@@ -1159,7 +1159,7 @@ async def test_debug_with_pickle_by_value():
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         pm = state.hosts.spawn_procs(per_host={"gpus": 1})
         debugee = pm.spawn("debugee", ClosureDebugeeActor)
-        name = debugee.name.choose().get()
+        name = await debugee.name.choose()
 
         input_mock = AsyncMock()
         input_mock.side_effect = [
@@ -1202,16 +1202,16 @@ async def test_debug_with_pickle_by_value():
                 new=output_mock,
             ),
         ):
-            debug_controller = get_or_spawn_controller(
+            debug_controller = await get_or_spawn_controller(
                 "debug_controller", DebugControllerForTesting
-            ).get()
+            )
 
             # Spawn a special source loader that knows how to retrieve the source code
             # for /tmp/monarch_test/class_closure.py and
             # /tmp/monarch_test/function_closure.py
-            get_or_spawn_controller(
+            await get_or_spawn_controller(
                 "source_loader", SourceLoaderControllerWithMockedSource
-            ).get()
+            )
 
             class_closure = load_class_closure()
             func_bp_true, func_bp_false = load_func_closure()
@@ -1221,7 +1221,7 @@ async def test_debug_with_pickle_by_value():
             assert breakpoints[0].function == "class_closure.get_arg"
             assert breakpoints[0].lineno == 14
 
-            debug_controller.blocking_enter.call_one().get()
+            await debug_controller.blocking_enter.call_one()
 
             assert (
                 "> /tmp/monarch_test/class_closure.py(14)get_arg()\n-> return self.arg"
@@ -1235,7 +1235,7 @@ async def test_debug_with_pickle_by_value():
             assert breakpoints[0].function == "class_closure.get_arg"
             assert breakpoints[0].lineno == 14
 
-            debug_controller.blocking_enter.call_one().get()
+            await debug_controller.blocking_enter.call_one()
 
             expected_backtrace = [
                 (
@@ -1259,7 +1259,7 @@ async def test_debug_with_pickle_by_value():
             assert breakpoints[0].function == "function_closure.func"
             assert breakpoints[0].lineno == 5
 
-            debug_controller.blocking_enter.call_one().get()
+            await debug_controller.blocking_enter.call_one()
 
             assert (
                 "> /tmp/monarch_test/function_closure.py(5)func()\n-> return internal().get_arg() + arg"
@@ -1275,13 +1275,13 @@ async def test_debug_with_pickle_by_value():
             assert breakpoints[0].function == "class_closure.__init__"
             assert breakpoints[0].lineno == 10
 
-            debug_controller.blocking_enter.call_one().get()
+            await debug_controller.blocking_enter.call_one()
 
             breakpoints = await _wait_for_breakpoints(debug_controller, 1)
             assert breakpoints[0].function == "class_closure.get_arg"
             assert breakpoints[0].lineno == 14
 
-            debug_controller.blocking_enter.call_one().get()
+            await debug_controller.blocking_enter.call_one()
 
             await _wait_for_breakpoints(debug_controller, 0)
 

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -45,6 +45,7 @@ from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
 from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
+from monarch._src.actor.logging import _pending_flush_tasks
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
 from monarch._src.job.job import LoginJob, ProcessState
 from monarch._src.job.process import ProcessJob
@@ -110,7 +111,7 @@ async def test_choose():
     assert result == result2
 
     v2 = proc.spawn("sync_counter", SyncCounter, v)
-    result3 = v2.value_sync_endpoint.choose().get()
+    result3 = await v2.value_sync_endpoint.choose()
     assert_type(result, int)
     assert result2 == result3
     await proc.stop()
@@ -232,7 +233,7 @@ async def test_rank_string():
     per_host = {"hosts": 1, "gpus": 2}
     proc = this_host().spawn_procs(per_host=per_host)
     r = proc.spawn("runit", RunIt)
-    vm = r.return_current_rank_str.call().get()
+    vm = await r.return_current_rank_str.call()
     r0 = vm.flatten("r").slice(r=0).item()
     r1 = vm.flatten("r").slice(r=1).item()
     assert r0 == "{'hosts': 0/1, 'gpus': 0/2}"
@@ -806,23 +807,37 @@ async def test_flush_called_only_once() -> None:
                 "monarch._src.actor.logging.flush_all_proc_mesh_logs"
             ) as mock_flush,
             unittest.mock.patch(
+                "monarch._src.actor.logging._flush_all_proc_mesh_logs_async"
+            ) as mock_flush_async,
+            unittest.mock.patch(
                 "monarch._src.actor.logging.LoggingManager.enable_fd_capture_if_in_ipython",
                 return_value=None,
             ),
         ):
+
+            async def _coro() -> None:
+                return None
+
+            mock_flush_async.return_value = _coro()
+
             # Create 2 proc meshes with a large aggregation window
             pm1 = this_host().spawn_procs(per_host={"gpus": 2})
             _ = this_host().spawn_procs(per_host={"gpus": 2})
             # flush not yet called unless post_run_cell
             assert mock_flush.call_count == 0
+            assert mock_flush_async.call_count == 0
             assert mock_ipython.events.registers == 0
             await pm1.logging_option(stream_to_client=True, aggregate_window_sec=600)
             assert mock_ipython.events.registers == 1
 
-            # now, flush should be called only once
+            # The callback fires inside the test's running asyncio loop, so it
+            # schedules the async flush rather than calling the sync one. Drain
+            # pending tasks so the scheduled coroutine actually runs.
             mock_ipython.events.trigger("post_run_cell", unittest.mock.MagicMock())
+            await asyncio.sleep(0)
 
-            assert mock_flush.call_count == 1
+            assert mock_flush.call_count == 0
+            assert mock_flush_async.call_count == 1
             await pm1.stop()
 
 
@@ -866,19 +881,18 @@ async def test_flush_logs_ipython() -> None:
                     await am1.print.call("ipython1 test log")
                     await am2.print.call("ipython2 test log")
 
-                # Trigger the post_run_cell event which should flush logs
+                # Trigger the post_run_cell event which should flush logs.
+                # Inside an async loop the callback schedules an async flush
+                # task rather than blocking, so wait for those tasks to finish
+                # before moving on (the next iteration / final assertions rely
+                # on the flush actually having happened).
                 mock_ipython.events.trigger("post_run_cell", unittest.mock.MagicMock())
+                if _pending_flush_tasks:
+                    await asyncio.gather(*list(_pending_flush_tasks))
 
         # We expect to register post_run_cell hook only once per notebook/ipython session
         assert mock_ipython.events.registers == 1
         assert len(mock_ipython.events.callbacks["post_run_cell"]) == 1
-
-        # Flush to ensure all output is written before reading
-        sys.stdout.flush()
-
-        # Read the captured output
-        with open(paths.stdout, "r") as f:
-            stdout_content = f.read()
 
         # We triggered post_run_cell three times; in the current
         # implementation that yields three aggregated groups per
@@ -886,6 +900,24 @@ async def test_flush_logs_ipython() -> None:
         # all 10).
         pattern1 = r"\[\d+ similar log lines\].*ipython1 test log"
         pattern2 = r"\[\d+ similar log lines\].*ipython2 test log"
+
+        # The rust flush task completes via the awaited future, but the
+        # aggregated bytes still have to flow through the FD pipe set up by
+        # enable_fd_capture_if_in_ipython and the pump thread before they
+        # land in the captured temp file. Poll until both patterns appear
+        # the expected number of times, with a deadline.
+        deadline = time.monotonic() + 10
+        stdout_content = ""
+        while time.monotonic() < deadline:
+            sys.stdout.flush()
+            with open(paths.stdout, "r") as f:
+                stdout_content = f.read()
+            if (
+                len(re.findall(pattern1, stdout_content)) >= 3
+                and len(re.findall(pattern2, stdout_content)) >= 3
+            ):
+                break
+            await asyncio.sleep(0.5)
 
         assert len(re.findall(pattern1, stdout_content)) >= 3, stdout_content
         assert len(re.findall(pattern2, stdout_content)) >= 3, stdout_content
@@ -1022,7 +1054,7 @@ async def test_multiple_ongoing_flushes_no_deadlock() -> None:
             )
 
         # The last flush should not block
-        futures[-1].get()
+        await futures[-1]
         await pm.stop()
 
 
@@ -1135,7 +1167,7 @@ async def test_sync_workspace() -> None:
 
         # no file in remote workspace initially
         am = pm.spawn("ls", LsActor, workspace_dst)
-        for item in list(am.ls.call().get()):
+        for item in list(await am.ls.call()):
             assert len(item[1]) == 0
 
         # write a file to local workspace
@@ -1146,7 +1178,7 @@ async def test_sync_workspace() -> None:
 
         # force a sync and it should populate on the dst workspace
         await code_sync_mesh.sync_workspace(config.workspace, auto_reload=True)
-        for item in list(am.ls.call().get()):
+        for item in list(await am.ls.call()):
             assert len(item[1]) == 1
             assert item[1][0] == "new_file"
             file_path = os.path.join(workspace_dst, item[1][0])
@@ -1303,11 +1335,11 @@ async def test_undeliverable_message_with_override() -> None:
         "undeliverable_sender", UndeliverableMessageSenderWithOverride, receiver
     )
     sender.send_undeliverable.call()
-    sender, dest, error_msg = receiver.get_messages.call_one().get()
+    sender, dest, error_msg = await receiver.get_messages.call_one()
     assert sender != ""
     assert "bogus" in dest
     assert error_msg is not None
-    pm.stop().get()
+    await pm.stop()
 
 
 @pytest.mark.timeout(60)
@@ -1319,11 +1351,11 @@ async def test_undeliverable_message_without_override() -> None:
     monarch.actor.unhandled_fault_hook = lambda failure: None
     pm = this_host().spawn_procs(per_host={"gpus": 1})
     sender = pm.spawn("undeliverable_sender", UndeliverableMessageSender)
-    sender.send_undeliverable.call().get()
+    await sender.send_undeliverable.call()
     # Wait a few seconds to ensure that the undeliverable message is processed
     # without crashing anything
     await asyncio.sleep(5)
-    pm.stop().get()
+    await pm.stop()
 
 
 @parametrize_config(actor_queue_dispatch={True, False})
@@ -2016,8 +2048,8 @@ async def test_run_forever_on_init():
     # Fake type, actually ActorMesh[Counter], but necessary for type-checking.
     send, recv = Channel[Counter].open()
     forever = pm.spawn("forever", RunForeverOnInitActor, pm, send)
-    counter = recv.recv().get()
-    assert counter.value.call_one().get() == 42
+    counter = await recv.recv()
+    assert await counter.value.call_one() == 42
     await cast(ActorMesh, forever).stop()
 
 


### PR DESCRIPTION
Summary:
Now that calling Future.get() in an async function is deprecated, clean up some usage
in our tests.

Reviewed By: mariusae

Differential Revision: D105051092


