### PR TITLE
keepalive: per-object types, WeakKeepalive, drop Arc<KeepaliveLocalMemory>

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -157,8 +157,18 @@ pub fn ping_pong(
 // keepalive (or equivalent) and arrange for the buffer to be released
 // while the CUDA context is still live, e.g., via an explicit
 // shutdown handler on the actor.
-struct NoKeepalive;
-impl Keepalive for NoKeepalive {}
+struct NoKeepalive {
+    addr: usize,
+    size: usize,
+}
+impl Keepalive for NoKeepalive {
+    fn addr(&self) -> usize {
+        self.addr
+    }
+    fn size(&self) -> usize {
+        self.size
+    }
+}
 
 // Constants for default values
 const DEFAULT_BUFFER_SIZE_MB: usize = 32; // `must be multiple of 2MB
@@ -451,8 +461,7 @@ impl Handler<InitializeBuffer> for CudaRdmaActor {
             let addr = self.cu_ptr;
             let size = self.cpu_buffer.len();
             // See the module-level note on `NoKeepalive`.
-            let local_memory: Arc<KeepaliveLocalMemory> =
-                Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(NoKeepalive)));
+            let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
             let handle = self
                 .rdma_manager
                 .downcast_handle(cx)

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -109,8 +109,18 @@ const BUFFER_SIZE: usize = 8;
 // buffer is the single source of truth (e.g., `Arc<KeepaliveLocal-
 // Memory>` with a `Box<[u8]>` keepalive), and route the local
 // gradient/weight math through the `KeepaliveLocalMemory` API.
-struct NoKeepalive;
-impl Keepalive for NoKeepalive {}
+struct NoKeepalive {
+    addr: usize,
+    size: usize,
+}
+impl Keepalive for NoKeepalive {
+    fn addr(&self) -> usize {
+        self.addr
+    }
+    fn size(&self) -> usize {
+        self.size
+    }
+}
 
 // Parameter Server Actor
 #[derive(Debug)]
@@ -199,8 +209,7 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
             let addr = self.weights_data.as_ptr() as usize;
             let size = self.weights_data.len();
             // See the module-level note on `NoKeepalive`.
-            let local_memory: Arc<KeepaliveLocalMemory> =
-                Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(NoKeepalive)));
+            let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
             let handle = self
                 .owner_ref
                 .downcast_handle(cx)
@@ -220,8 +229,7 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
                 let addr = self.grad_buffer_data[rank].as_ptr() as usize;
                 let size = self.grad_buffer_data[rank].len();
                 // See the module-level note on `NoKeepalive`.
-                let local_memory: Arc<KeepaliveLocalMemory> =
-                    Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(NoKeepalive)));
+                let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
                 let handle = self
                     .owner_ref
                     .downcast_handle(cx)
@@ -392,11 +400,10 @@ impl Handler<WorkerStep> for WorkerActor {
             .as_ref()
             .expect("worker_actor should be initialized");
         // See the module-level note on `NoKeepalive`.
-        let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
-            self.local_gradients.as_ptr() as usize,
-            self.local_gradients.len(),
-            Arc::new(NoKeepalive),
-        ));
+        let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            addr: self.local_gradients.as_ptr() as usize,
+            size: self.local_gradients.len(),
+        }));
 
         ps_grad_handle.write_from_local(cx, local_memory, 5).await?;
 
@@ -427,11 +434,10 @@ impl Handler<WorkerUpdate> for WorkerActor {
             .as_ref()
             .expect("worker_actor should be initialized");
         // See the module-level note on `NoKeepalive`.
-        let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
-            self.weights_data.as_ptr() as usize,
-            self.weights_data.len(),
-            Arc::new(NoKeepalive),
-        ));
+        let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            addr: self.weights_data.as_ptr() as usize,
+            size: self.weights_data.len(),
+        }));
         ps_weights_handle
             .read_into_local(cx, local_memory, 5)
             .await?;

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -24,15 +24,20 @@ use monarch_rdma::RdmaRemoteBuffer;
 use monarch_rdma::ibverbs_supported;
 use monarch_rdma::local_memory::Keepalive;
 use monarch_rdma::local_memory::KeepaliveLocalMemory;
+use monarch_rdma::local_memory::WeakKeepalive;
+use monarch_rdma::local_memory::WeakLocalMemory;
 use monarch_rdma::rdma_supported;
 use monarch_rdma::register_segment_scanner;
+use monarch_types::py_global;
 use monarch_types::py_module_add_function;
 use pyo3::IntoPyObjectExt;
+use pyo3::buffer::PyBuffer;
 use pyo3::exceptions::PyException;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyAny;
+use pyo3::types::PyMemoryView;
 use pyo3::types::PyTuple;
 use pyo3::types::PyType;
 use typeuri::Named;
@@ -121,13 +126,225 @@ unsafe extern "C" fn pytorch_segment_scanner(
     }
 }
 
-/// Wrapper implementing [`Keepalive`] for a Python object reference.
-///
-/// Prevents garbage collection of the backing Python object while RDMA
-/// operations are in flight.
-struct PyKeepalive(#[allow(dead_code)] Py<PyAny>);
+/// Resolve a Python `weakref.ref` to a strong [`Py<PyAny>`], or
+/// `None` if the referent has gone away. Caller must hold the GIL.
+fn upgrade_weakref(py: Python<'_>, weak: &Py<PyAny>) -> Option<Py<PyAny>> {
+    let obj = weak.call0(py).ok()?;
+    if obj.bind(py).is_none() {
+        return None;
+    }
+    Some(obj)
+}
 
-impl Keepalive for PyKeepalive {}
+py_global!(weakref_ref, "weakref", "ref");
+
+/// Build a `weakref.ref(obj)`. Returns `None` for objects that
+/// don't carry a `__weakref__` slot (`bytes`, `bytearray`, ...).
+fn make_weakref(py: Python<'_>, obj: &Py<PyAny>) -> Option<Py<PyAny>> {
+    let weak_ref = weakref_ref(py).call1((obj.bind(py),)).ok()?;
+    Some(weak_ref.unbind())
+}
+
+/// Read the current `(addr, size)` of a `memoryview` via the buffer
+/// protocol. Returns `None` if the buffer can't be acquired.
+fn memoryview_addr_size(py: Python<'_>, mv: &Py<PyAny>) -> Option<(usize, usize)> {
+    let buffer = PyBuffer::<u8>::get(mv.bind(py)).ok()?;
+    Some((buffer.buf_ptr() as usize, buffer.len_bytes()))
+}
+
+/// Whether `obj` is a torch tensor, without importing torch: if torch
+/// has not been imported, no object can be a tensor.
+fn is_torch_tensor(py: Python<'_>, obj: &Bound<'_, PyAny>) -> PyResult<bool> {
+    let torch = py
+        .import("sys")?
+        .getattr("modules")?
+        .call_method1("get", ("torch",))?;
+    if torch.is_none() {
+        return Ok(false);
+    }
+    obj.is_instance(&torch.getattr("Tensor")?)
+}
+
+/// `ValueError` describing the supported-input contract, mirroring the
+/// message the Python wrapper historically raised.
+fn unsupported_buffer_error(buf: &Bound<'_, PyAny>) -> PyErr {
+    let repr = buf
+        .str()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|_| "<unrepresentable>".to_string());
+    PyValueError::new_err(format!(
+        "RDMABuffer only supports 1d contiguous torch.Tensor or 1d c-contiguous memoryview. Got: {}",
+        repr
+    ))
+}
+
+/// Validate that `buf` is a 1d contiguous torch tensor or a 1d
+/// c-contiguous memoryview, raising `ValueError` otherwise. The
+/// local-memory handle constructors derive `(addr, size)` assuming this
+/// layout, so a non-contiguous or multi-dimensional input would yield a
+/// region that misrepresents the data.
+#[pyfunction]
+fn _assert_1d_contiguous(py: Python<'_>, buf: &Bound<'_, PyAny>) -> PyResult<()> {
+    if is_torch_tensor(py, buf)? {
+        let dim: usize = buf.call_method0("dim")?.extract()?;
+        let contiguous: bool = buf.call_method0("is_contiguous")?.extract()?;
+        if dim != 1 || !contiguous {
+            return Err(unsupported_buffer_error(buf));
+        }
+    } else if buf.is_instance_of::<PyMemoryView>() {
+        let ndim: usize = buf.getattr("ndim")?.extract()?;
+        let c_contiguous: bool = buf.getattr("c_contiguous")?.extract()?;
+        if ndim != 1 || !c_contiguous {
+            return Err(unsupported_buffer_error(buf));
+        }
+    } else {
+        return Err(unsupported_buffer_error(buf));
+    }
+    Ok(())
+}
+
+/// Compute the `(addr, size)` of a torch tensor's data: the storage
+/// pointer offset by `storage_offset`, and `element_size * numel`.
+/// Assumes a 1d contiguous tensor (see [`_assert_1d_contiguous`]).
+#[pyfunction]
+fn _get_tensor_addr_and_size(tensor: &Bound<'_, PyAny>) -> PyResult<(usize, usize)> {
+    let base_addr: usize = tensor
+        .call_method0("untyped_storage")?
+        .call_method0("data_ptr")?
+        .extract()?;
+    let storage_offset: usize = tensor.call_method0("storage_offset")?.extract()?;
+    let element_size: usize = tensor.call_method0("element_size")?.extract()?;
+    let numel: usize = tensor.call_method0("numel")?.extract()?;
+    Ok((
+        base_addr + storage_offset * element_size,
+        element_size * numel,
+    ))
+}
+
+/// Compute the `(addr, size)` of a `memoryview` via the buffer protocol.
+#[pyfunction]
+fn _get_memoryview_addr_and_size(
+    py: Python<'_>,
+    mv: &Bound<'_, PyAny>,
+) -> PyResult<(usize, usize)> {
+    memoryview_addr_size(py, &mv.clone().unbind())
+        .ok_or_else(|| PyRuntimeError::new_err("failed to acquire memoryview buffer"))
+}
+
+/// [`Keepalive`] for a Python `memoryview`. Holding the memoryview
+/// keeps its buffer exporter pinned for the lifetime of this value.
+/// Caches the `(addr, size)` read at construction so the
+/// [`Keepalive::addr`] / [`Keepalive::size`]
+/// implementations don't re-enter the buffer protocol.
+struct PyMemoryViewKeepalive {
+    mv: Py<PyAny>,
+    addr: usize,
+    size: usize,
+}
+
+impl Keepalive for PyMemoryViewKeepalive {
+    fn addr(&self) -> usize {
+        self.addr
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+
+    fn downgrade(&self) -> Option<Arc<dyn WeakKeepalive>> {
+        monarch_with_gil_blocking(|py| {
+            let weak = make_weakref(py, &self.mv)?;
+            Some(Arc::new(PyMemoryViewWeakKeepalive { weak }) as Arc<dyn WeakKeepalive>)
+        })
+    }
+}
+
+/// [`WeakKeepalive`] for a `memoryview`. Upgrades by re-acquiring the
+/// memoryview via the weakref and re-reading `(addr, size)` from the
+/// buffer protocol; a retargeted memoryview will produce a strong
+/// keepalive whose cached values no longer match the paired
+/// [`WeakLocalMemory`], so [`WeakLocalMemory::upgrade`] fails.
+struct PyMemoryViewWeakKeepalive {
+    weak: Py<PyAny>,
+}
+
+impl WeakKeepalive for PyMemoryViewWeakKeepalive {
+    fn upgrade(&self) -> Option<Arc<dyn Keepalive>> {
+        monarch_with_gil_blocking(|py| {
+            let mv = upgrade_weakref(py, &self.weak)?;
+            let (addr, size) = memoryview_addr_size(py, &mv)?;
+            Some(Arc::new(PyMemoryViewKeepalive { mv, addr, size }) as Arc<dyn Keepalive>)
+        })
+    }
+}
+
+/// [`Keepalive`] for a torch tensor's `UntypedStorage`. Pinning the
+/// storage (rather than any specific tensor view onto it) keeps the
+/// backing allocation alive across temporary views like
+/// `tensor.view(...).flatten()` — those views can be dropped while
+/// the storage outlives them. `(addr, size)` are recomputed from the
+/// cached shape components so they remain correct on upgrade.
+struct PyTorchUntypedStorageKeepalive {
+    storage: Py<PyAny>,
+    base_addr: usize,
+    storage_offset: usize,
+    element_size: usize,
+    numel: usize,
+}
+
+impl Keepalive for PyTorchUntypedStorageKeepalive {
+    fn addr(&self) -> usize {
+        self.base_addr + self.storage_offset * self.element_size
+    }
+
+    fn size(&self) -> usize {
+        self.element_size * self.numel
+    }
+
+    fn downgrade(&self) -> Option<Arc<dyn WeakKeepalive>> {
+        monarch_with_gil_blocking(|py| {
+            let weak = make_weakref(py, &self.storage)?;
+            Some(Arc::new(PyTorchUntypedStorageWeakKeepalive {
+                weak,
+                storage_offset: self.storage_offset,
+                element_size: self.element_size,
+                numel: self.numel,
+            }) as Arc<dyn WeakKeepalive>)
+        })
+    }
+}
+
+/// [`WeakKeepalive`] for a `UntypedStorage`. Upgrades by re-acquiring
+/// the storage via the weakref and re-reading its `data_ptr()`; a
+/// fresh `base_addr` combined with the cached shape components
+/// reproduces the original `(addr, size)`.
+struct PyTorchUntypedStorageWeakKeepalive {
+    weak: Py<PyAny>,
+    storage_offset: usize,
+    element_size: usize,
+    numel: usize,
+}
+
+impl WeakKeepalive for PyTorchUntypedStorageWeakKeepalive {
+    fn upgrade(&self) -> Option<Arc<dyn Keepalive>> {
+        monarch_with_gil_blocking(|py| {
+            let storage = upgrade_weakref(py, &self.weak)?;
+            let base_addr: usize = storage
+                .bind(py)
+                .call_method0("data_ptr")
+                .ok()?
+                .extract()
+                .ok()?;
+            Some(Arc::new(PyTorchUntypedStorageKeepalive {
+                storage,
+                base_addr,
+                storage_offset: self.storage_offset,
+                element_size: self.element_size,
+                numel: self.numel,
+            }) as Arc<dyn Keepalive>)
+        })
+    }
+}
 
 /// Local memory handle exposed to Python.
 ///
@@ -140,13 +357,34 @@ pub struct PyLocalMemoryHandle {
     inner: KeepaliveLocalMemory,
 }
 
+/// Catch-all [`Keepalive`] for a Python object the caller has
+/// already inspected to obtain `(addr, size)`. Holds the object
+/// strongly to pin the underlying allocation while the
+/// [`KeepaliveLocalMemory`] is in use.
+struct PyKeepalive {
+    #[expect(dead_code, reason = "held only to pin the Python object alive")]
+    obj: Py<PyAny>,
+    addr: usize,
+    size: usize,
+}
+
+impl Keepalive for PyKeepalive {
+    fn addr(&self) -> usize {
+        self.addr
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+}
+
 #[pymethods]
 impl PyLocalMemoryHandle {
     #[new]
     fn new(obj: Py<PyAny>, addr: usize, size: usize) -> Self {
-        let keepalive: Arc<dyn Keepalive> = Arc::new(PyKeepalive(obj));
+        let keepalive: Arc<dyn Keepalive> = Arc::new(PyKeepalive { obj, addr, size });
         Self {
-            inner: KeepaliveLocalMemory::new(addr, size, keepalive),
+            inner: KeepaliveLocalMemory::new(keepalive),
         }
     }
 
@@ -181,6 +419,16 @@ impl PyLocalMemoryHandle {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
+    /// Pair off a [`PyWeakLocalMemoryHandle`] sharing this handle's
+    /// MR slot and access lock. Returns `None` when the backing
+    /// keepalive (e.g. a memoryview over a non-weak-referenceable
+    /// object like `bytes` or `bytearray`) has no weak form.
+    fn downgrade(&self) -> Option<PyWeakLocalMemoryHandle> {
+        self.inner
+            .downgrade()
+            .map(|inner| PyWeakLocalMemoryHandle { inner })
+    }
+
     #[pyo3(name = "__repr__")]
     fn repr(&self) -> String {
         format!(
@@ -189,6 +437,102 @@ impl PyLocalMemoryHandle {
             self.inner.size()
         )
     }
+}
+
+/// Weak counterpart of [`PyLocalMemoryHandle`]. Holds the shared
+/// MR slot but only a weak reference to the backing Python object,
+/// so caching this handle does not pin the allocation. `upgrade()`
+/// returns a fresh strong handle if the referent is still alive.
+#[pyclass(
+    name = "_WeakLocalMemoryHandle",
+    module = "monarch._rust_bindings.rdma"
+)]
+#[derive(Clone)]
+pub struct PyWeakLocalMemoryHandle {
+    inner: WeakLocalMemory,
+}
+
+#[pymethods]
+impl PyWeakLocalMemoryHandle {
+    #[getter]
+    fn addr(&self) -> usize {
+        self.inner.addr()
+    }
+
+    #[getter]
+    fn size(&self) -> usize {
+        self.inner.size()
+    }
+
+    /// Try to re-acquire a strong [`PyLocalMemoryHandle`] for the
+    /// same allocation. Returns `None` if the backing object has
+    /// been garbage-collected.
+    fn upgrade(&self) -> Option<PyLocalMemoryHandle> {
+        self.inner
+            .upgrade()
+            .map(|inner| PyLocalMemoryHandle { inner })
+    }
+
+    #[pyo3(name = "__repr__")]
+    fn repr(&self) -> String {
+        format!(
+            "<WeakLocalMemoryHandle addr={:#x} size={}>",
+            self.inner.addr(),
+            self.inner.size()
+        )
+    }
+}
+
+/// Construct a [`PyLocalMemoryHandle`] from a Python `memoryview`.
+/// The strong keepalive holds the memoryview (pinning the buffer
+/// export); `(addr, size)` come from the buffer protocol and are
+/// cached on the keepalive.
+#[pyfunction]
+fn _make_local_memory_handle_from_memoryview(
+    py: Python<'_>,
+    mv: &Bound<'_, PyAny>,
+) -> PyResult<PyLocalMemoryHandle> {
+    _assert_1d_contiguous(py, mv)?;
+    let mv_owned = mv.clone().unbind();
+    let (addr, size) = memoryview_addr_size(py, &mv_owned)
+        .ok_or_else(|| PyRuntimeError::new_err("failed to acquire memoryview buffer"))?;
+    let keepalive: Arc<dyn Keepalive> = Arc::new(PyMemoryViewKeepalive {
+        mv: mv_owned,
+        addr,
+        size,
+    });
+    Ok(PyLocalMemoryHandle {
+        inner: KeepaliveLocalMemory::new(keepalive),
+    })
+}
+
+/// Construct a [`PyLocalMemoryHandle`] from a torch tensor. Extracts
+/// the tensor's underlying `UntypedStorage` and the shape components
+/// needed to compute `(addr, size)`; the keepalive pins the storage
+/// (not the input tensor view), so a transient view like
+/// `t.view(...).flatten()` can be dropped without invalidating
+/// cached weak handles.
+#[pyfunction]
+fn _make_local_memory_handle_from_tensor(
+    py: Python<'_>,
+    tensor: &Bound<'_, PyAny>,
+) -> PyResult<PyLocalMemoryHandle> {
+    _assert_1d_contiguous(py, tensor)?;
+    let storage = tensor.call_method0("untyped_storage")?;
+    let base_addr: usize = storage.call_method0("data_ptr")?.extract()?;
+    let storage_offset: usize = tensor.call_method0("storage_offset")?.extract()?;
+    let element_size: usize = tensor.call_method0("element_size")?.extract()?;
+    let numel: usize = tensor.call_method0("numel")?.extract()?;
+    let keepalive: Arc<dyn Keepalive> = Arc::new(PyTorchUntypedStorageKeepalive {
+        storage: storage.unbind(),
+        base_addr,
+        storage_offset,
+        element_size,
+        numel,
+    });
+    Ok(PyLocalMemoryHandle {
+        inner: KeepaliveLocalMemory::new(keepalive),
+    })
 }
 
 #[pyclass(name = "_RdmaBuffer", module = "monarch._rust_bindings.rdma")]
@@ -232,7 +576,7 @@ impl PyRdmaAction {
         local: PyLocalMemoryHandle,
     ) -> PyResult<()> {
         self.try_lock_sync()?
-            .add_read_into_local(remote.buffer, Arc::new(local.inner))
+            .add_read_into_local(remote.buffer, local.inner)
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
         Ok(())
     }
@@ -243,7 +587,7 @@ impl PyRdmaAction {
         local: PyLocalMemoryHandle,
     ) -> PyResult<()> {
         self.try_lock_sync()?
-            .add_write_from_local(remote.buffer, Arc::new(local.inner))
+            .add_write_from_local(remote.buffer, local.inner)
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
         Ok(())
     }
@@ -272,9 +616,8 @@ async fn create_rdma_buffer(
 ) -> PyResult<PyRdmaBuffer> {
     let owner_handle = RdmaManagerActor::local_handle(client.deref());
 
-    let local: Arc<KeepaliveLocalMemory> = Arc::new(local.inner);
     let buffer = owner_handle
-        .request_buffer(client.deref(), local)
+        .request_buffer(client.deref(), local.inner)
         .await
         .map_err(|e| PyException::new_err(format!("failed to request buffer: {}", e)))?;
 
@@ -330,10 +673,8 @@ impl PyRdmaBuffer {
         let buffer = self.buffer.clone();
 
         PyPythonTask::new(async move {
-            let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(dst.inner);
-
             buffer
-                .read_into_local(client.deref(), local_memory, timeout)
+                .read_into_local(client.deref(), dst.inner, timeout)
                 .await
                 .map_err(|e| PyException::new_err(format!("failed to read into buffer: {}", e)))?;
 
@@ -357,10 +698,8 @@ impl PyRdmaBuffer {
         let buffer = self.buffer.clone();
 
         PyPythonTask::new(async move {
-            let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(src.inner);
-
             buffer
-                .write_from_local(client.deref(), local_memory, timeout)
+                .write_from_local(client.deref(), src.inner, timeout)
                 .await
                 .map_err(|e| PyException::new_err(format!("failed to write from buffer: {}", e)))?;
 
@@ -472,6 +811,7 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     register_segment_scanner(Some(pytorch_segment_scanner));
 
     module.add_class::<PyLocalMemoryHandle>()?;
+    module.add_class::<PyWeakLocalMemoryHandle>()?;
     module.add_class::<PyRdmaBuffer>()?;
     module.add_class::<PyRdmaAction>()?;
     module.add_class::<PyRdmaManager>()?;
@@ -481,5 +821,26 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
         is_ibverbs_available_py
     );
     py_module_add_function!(module, "monarch._rust_bindings.rdma", rdma_supported_py);
+    py_module_add_function!(
+        module,
+        "monarch._rust_bindings.rdma",
+        _make_local_memory_handle_from_memoryview
+    );
+    py_module_add_function!(
+        module,
+        "monarch._rust_bindings.rdma",
+        _make_local_memory_handle_from_tensor
+    );
+    py_module_add_function!(module, "monarch._rust_bindings.rdma", _assert_1d_contiguous);
+    py_module_add_function!(
+        module,
+        "monarch._rust_bindings.rdma",
+        _get_tensor_addr_and_size
+    );
+    py_module_add_function!(
+        module,
+        "monarch._rust_bindings.rdma",
+        _get_memoryview_addr_and_size
+    );
     Ok(())
 }

--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -14,7 +14,6 @@
 //! across the available backends in parallel on [`RdmaAction::submit`].
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::time::Duration;
 
 use hyperactor::context;
@@ -73,7 +72,7 @@ impl RdmaAction {
     pub fn add_read_into_local(
         &mut self,
         remote: RdmaRemoteBuffer,
-        local: Arc<KeepaliveLocalMemory>,
+        local: KeepaliveLocalMemory,
     ) -> Result<&mut Self, anyhow::Error> {
         if local.size() < remote.size {
             anyhow::bail!(
@@ -96,7 +95,7 @@ impl RdmaAction {
     pub fn add_write_from_local(
         &mut self,
         remote: RdmaRemoteBuffer,
-        local: Arc<KeepaliveLocalMemory>,
+        local: KeepaliveLocalMemory,
     ) -> Result<&mut Self, anyhow::Error> {
         if local.size() > remote.size {
             anyhow::bail!(

--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -205,7 +205,34 @@ impl CudaAllocation {
     }
 }
 
-impl Keepalive for CudaAllocation {}
+impl Keepalive for CudaAllocation {
+    fn addr(&self) -> usize {
+        self.ptr()
+    }
+
+    fn size(&self) -> usize {
+        self.size()
+    }
+}
+
+/// Keepalive for a sub-range of a [`CudaAllocation`]. Used by tests
+/// that register several non-overlapping buffers within one mapped
+/// CUDA region.
+struct CudaAllocationSlice {
+    alloc: CudaAllocation,
+    offset: usize,
+    size: usize,
+}
+
+impl Keepalive for CudaAllocationSlice {
+    fn addr(&self) -> usize {
+        self.alloc.ptr() + self.offset
+    }
+
+    fn size(&self) -> usize {
+        self.size
+    }
+}
 
 pub struct CudaAllocator {
     allocations: Mutex<HashMap<usize, Weak<CudaAllocationInner>>>,
@@ -571,11 +598,11 @@ impl SenderMessageHandler for SenderActor {
 
         let mut remotes = Vec::with_capacity(buffers.len());
         for &(offset, size) in &buffers {
-            let local: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
-                alloc.ptr() + offset,
+            let local = KeepaliveLocalMemory::new(Arc::new(CudaAllocationSlice {
+                alloc: alloc.clone(),
+                offset,
                 size,
-                Arc::new(alloc.clone()),
-            ));
+            }));
             // Pre-fill so reads return a known sequence; write_at
             // routes to the GPU path for CUDA-backed memory.
             let fill = vec![pattern; size];
@@ -661,12 +688,10 @@ impl ReceiverMessageHandler for ReceiverActor {
         // unwritten destination is distinguishable from a successful
         // read.
         let buf: Box<[u8]> = vec![!expected_pattern; size].into_boxed_slice();
-        let addr = buf.as_ptr() as usize;
-        let local: Arc<KeepaliveLocalMemory> =
-            Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(buf)));
+        let local = KeepaliveLocalMemory::new(Arc::new(buf));
 
         let read_result = remote
-            .read_into_local(cx, Arc::clone(&local), timeout_secs)
+            .read_into_local(cx, local.clone(), timeout_secs)
             .await
             .map(|_| ())
             .map_err(|e| e.to_string());
@@ -700,9 +725,7 @@ impl ReceiverMessageHandler for ReceiverActor {
         timeout_secs: u64,
     ) -> Result<Result<(), String>, anyhow::Error> {
         let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
-        let addr = buf.as_ptr() as usize;
-        let local: Arc<KeepaliveLocalMemory> =
-            Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(buf)));
+        let local = KeepaliveLocalMemory::new(Arc::new(buf));
 
         let result = remote
             .write_from_local(cx, local, timeout_secs)

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -8,8 +8,6 @@
 
 //! ibverbs backend implementation for RDMA operations.
 
-use std::sync::Arc;
-
 use hyperactor::ActorRef;
 use hyperactor::actor::Referable;
 use serde::Deserialize;
@@ -59,7 +57,7 @@ pub struct IbvBuffer {
 #[derive(Debug, Named)]
 pub struct IbvOp<M: Referable = IbvManagerActor> {
     pub op_type: RdmaOpType,
-    pub local_memory: Arc<KeepaliveLocalMemory>,
+    pub local_memory: KeepaliveLocalMemory,
     pub remote_buffer: IbvBuffer,
     pub remote_manager: ActorRef<M>,
 }
@@ -70,7 +68,7 @@ impl<M: Referable> Clone for IbvOp<M> {
     fn clone(&self) -> Self {
         Self {
             op_type: self.op_type,
-            local_memory: Arc::clone(&self.local_memory),
+            local_memory: self.local_memory.clone(),
             remote_buffer: self.remote_buffer.clone(),
             remote_manager: self.remote_manager.clone(),
         }

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -51,8 +51,18 @@ use crate::validate_execution_context;
 // before, it's still correct now.
 //
 // TODO(samlurye): use real `Keepalive` implementations for test buffers.
-struct NoKeepalive;
-impl Keepalive for NoKeepalive {}
+struct NoKeepalive {
+    addr: usize,
+    size: usize,
+}
+impl Keepalive for NoKeepalive {
+    fn addr(&self) -> usize {
+        self.addr
+    }
+    fn size(&self) -> usize {
+        self.size
+    }
+}
 
 #[derive(Debug)]
 struct SendSyncCudaContext(rdmaxcel_sys::CUcontext);
@@ -221,11 +231,10 @@ impl Handler<CudaActorMessage> for CudaActor {
 
                 // Register via RdmaManagerActor request_buffer.
                 // See the module-level note on `NoKeepalive`.
-                let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
-                    dptr,
-                    padded_size,
-                    Arc::new(NoKeepalive),
-                ));
+                let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+                    addr: dptr,
+                    size: padded_size,
+                }));
                 let handle = rdma_actor
                     .downcast_handle(cx)
                     .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -490,8 +499,8 @@ pub struct DoorbellTestEnv {
     pub ibv_handle_2: ActorHandle<IbvManagerActor>,
     pub rdma_handle_1: RdmaRemoteBuffer,
     pub rdma_handle_2: RdmaRemoteBuffer,
-    pub local_memory_1: Arc<KeepaliveLocalMemory>,
-    pub local_memory_2: Arc<KeepaliveLocalMemory>,
+    pub local_memory_1: KeepaliveLocalMemory,
+    pub local_memory_2: KeepaliveLocalMemory,
     pub ibv_buffer_1: IbvBuffer,
     pub ibv_buffer_2: IbvBuffer,
     cuda_actor_1: Option<ActorRef<CudaActor>>,
@@ -584,8 +593,8 @@ impl DoorbellTestEnv {
 
         let rdma_handle_1;
         let rdma_handle_2;
-        let local_memory_1: Arc<KeepaliveLocalMemory>;
-        let local_memory_2: Arc<KeepaliveLocalMemory>;
+        let local_memory_1: KeepaliveLocalMemory;
+        let local_memory_2: KeepaliveLocalMemory;
 
         if parsed_accel1.0 == "cpu" {
             let mut buffer = vec![0u8; buffer_size].into_boxed_slice();
@@ -595,11 +604,10 @@ impl DoorbellTestEnv {
                 len: buffer.len(),
                 cpu_ref: Some(buffer),
             });
-            local_memory_1 = Arc::new(KeepaliveLocalMemory::new(
-                ptr as usize,
-                buffer_size,
-                Arc::new(NoKeepalive),
-            ));
+            local_memory_1 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+                addr: ptr as usize,
+                size: buffer_size,
+            }));
             let handle_1 = actor_1
                 .downcast_handle(&instance_1)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -616,11 +624,10 @@ impl DoorbellTestEnv {
                 .await?;
             rdma_handle_1 = rdma_buf;
             device_ptr_1 = Some(dev_ptr);
-            local_memory_1 = Arc::new(KeepaliveLocalMemory::new(
-                dev_ptr,
-                buffer_size,
-                Arc::new(NoKeepalive),
-            ));
+            local_memory_1 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+                addr: dev_ptr,
+                size: buffer_size,
+            }));
 
             buf_vec.push(Buffer {
                 ptr: dev_ptr as u64,
@@ -638,11 +645,10 @@ impl DoorbellTestEnv {
                 len: buffer.len(),
                 cpu_ref: Some(buffer),
             });
-            local_memory_2 = Arc::new(KeepaliveLocalMemory::new(
-                ptr as usize,
-                buffer_size,
-                Arc::new(NoKeepalive),
-            ));
+            local_memory_2 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+                addr: ptr as usize,
+                size: buffer_size,
+            }));
             let handle_2 = actor_2
                 .downcast_handle(&instance_2)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -659,11 +665,10 @@ impl DoorbellTestEnv {
                 .await?;
             rdma_handle_2 = rdma_buf;
             device_ptr_2 = Some(dev_ptr);
-            local_memory_2 = Arc::new(KeepaliveLocalMemory::new(
-                dev_ptr,
-                buffer_size,
-                Arc::new(NoKeepalive),
-            ));
+            local_memory_2 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+                addr: dev_ptr,
+                size: buffer_size,
+            }));
 
             buf_vec.push(Buffer {
                 ptr: dev_ptr as u64,

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -144,7 +144,7 @@ pub enum IbvManagerLocalMessage {
     /// is deregistered on [`IbvManagerMessage::ReleaseBuffer`].
     RegisterRemoteBuffer {
         remote_buf_id: usize,
-        local: Arc<KeepaliveLocalMemory>,
+        local: KeepaliveLocalMemory,
         #[reply]
         reply: OncePortHandle<Result<IbvBuffer, String>>,
     },
@@ -922,7 +922,7 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
         &mut self,
         _cx: &Context<Self>,
         remote_buf_id: usize,
-        local: Arc<KeepaliveLocalMemory>,
+        local: KeepaliveLocalMemory,
     ) -> Result<Result<IbvBuffer, String>, anyhow::Error> {
         if let Some((buf, _)) = self.buffer_registrations.get(&remote_buf_id) {
             return Ok(Ok(buf.clone()));
@@ -1227,17 +1227,11 @@ mod tests {
             let local = match device {
                 BufferDevice::Cpu => {
                     let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
-                    let addr = buf.as_ptr() as usize;
-                    Arc::new(KeepaliveLocalMemory::new(addr, size, Arc::new(buf)))
+                    KeepaliveLocalMemory::new(Arc::new(buf))
                 }
                 BufferDevice::Cuda(device_id) => {
                     let alloc = CudaAllocator::get().allocate(device_id, size, size);
-                    let addr = alloc.ptr();
-                    let local = Arc::new(KeepaliveLocalMemory::new(
-                        addr,
-                        size,
-                        Arc::new(alloc.clone()),
-                    ));
+                    let local = KeepaliveLocalMemory::new(Arc::new(alloc.clone()));
                     self.cuda_allocs.push(alloc);
                     let fill = vec![pattern; size];
                     // SAFETY: `local` is freshly constructed; no other

--- a/monarch_rdma/src/backend/ibverbs/processor_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/processor_actor.rs
@@ -425,15 +425,21 @@ mod tests {
 
     /// No-op [`Keepalive`] for tests that mint a [`KeepaliveLocalMemory`]
     /// from a fake address never actually read or written through.
-    struct FakeKeepalive;
-    impl Keepalive for FakeKeepalive {}
+    struct FakeKeepalive {
+        addr: usize,
+        size: usize,
+    }
+    impl Keepalive for FakeKeepalive {
+        fn addr(&self) -> usize {
+            self.addr
+        }
+        fn size(&self) -> usize {
+            self.size
+        }
+    }
 
-    fn fake_local_memory(addr: usize, size: usize) -> Arc<KeepaliveLocalMemory> {
-        Arc::new(KeepaliveLocalMemory::new(
-            addr,
-            size,
-            Arc::new(FakeKeepalive),
-        ))
+    fn fake_local_memory(addr: usize, size: usize) -> KeepaliveLocalMemory {
+        KeepaliveLocalMemory::new(Arc::new(FakeKeepalive { addr, size }))
     }
 
     fn fake_remote_ref(label: &str, uid: u64) -> ActorRef<MockManagerActor> {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -2396,15 +2396,21 @@ mod tests {
 
     /// No-op [`Keepalive`] for tests that mint a [`KeepaliveLocalMemory`]
     /// from a fake address never actually read or written through.
-    struct FakeKeepalive;
-    impl Keepalive for FakeKeepalive {}
+    struct FakeKeepalive {
+        addr: usize,
+        size: usize,
+    }
+    impl Keepalive for FakeKeepalive {
+        fn addr(&self) -> usize {
+            self.addr
+        }
+        fn size(&self) -> usize {
+            self.size
+        }
+    }
 
-    fn fake_local_memory(addr: usize, size: usize) -> Arc<KeepaliveLocalMemory> {
-        Arc::new(KeepaliveLocalMemory::new(
-            addr,
-            size,
-            Arc::new(FakeKeepalive),
-        ))
+    fn fake_local_memory(addr: usize, size: usize) -> KeepaliveLocalMemory {
+        KeepaliveLocalMemory::new(Arc::new(FakeKeepalive { addr, size }))
     }
 
     fn fake_mrv(id: usize, addr: usize, size: usize) -> IbvMemoryRegionView {

--- a/monarch_rdma/src/backend/tcp.rs
+++ b/monarch_rdma/src/backend/tcp.rs
@@ -14,8 +14,6 @@
 
 pub mod manager_actor;
 
-use std::sync::Arc;
-
 use hyperactor::ActorRef;
 use manager_actor::TcpManagerActor;
 
@@ -26,7 +24,7 @@ use crate::local_memory::KeepaliveLocalMemory;
 #[derive(Debug)]
 pub struct TcpOp {
     pub op_type: RdmaOpType,
-    pub local_memory: Arc<KeepaliveLocalMemory>,
+    pub local_memory: KeepaliveLocalMemory,
     pub remote_tcp_manager: ActorRef<TcpManagerActor>,
     pub remote_buf_id: usize,
 }

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -87,7 +87,7 @@ wirevalue::register_type!(TcpDataChunk);
 #[derive(Debug)]
 struct TransferState {
     /// Buffer backing this transfer, provided at construction.
-    local_memory: Arc<KeepaliveLocalMemory>,
+    local_memory: KeepaliveLocalMemory,
 
     /// Number of chunks received so far.
     chunks_received: usize,
@@ -103,7 +103,7 @@ struct TransferState {
 impl TransferState {
     fn new(
         total_chunks: usize,
-        local_memory: Arc<KeepaliveLocalMemory>,
+        local_memory: KeepaliveLocalMemory,
         done: OncePortRef<Result<(), String>>,
     ) -> Self {
         Self {
@@ -143,7 +143,7 @@ struct TransferError {
 /// a remote TcpManagerActor.
 #[derive(Debug)]
 struct RegisterTransferLocal {
-    local_memory: Arc<KeepaliveLocalMemory>,
+    local_memory: KeepaliveLocalMemory,
     total_chunks: usize,
     done: OncePortRef<Result<(), String>>,
     // The transfer ID
@@ -155,7 +155,7 @@ struct RegisterTransferLocal {
 #[derive(Debug)]
 struct ExecuteTransferLocal {
     transfer_id: usize,
-    local_memory: Arc<KeepaliveLocalMemory>,
+    local_memory: KeepaliveLocalMemory,
     chunk_size: usize,
     dest_addr: ChannelAddr,
 }
@@ -248,7 +248,7 @@ impl TcpManagerActor {
 
     fn register_transfer(
         &mut self,
-        local_memory: Arc<KeepaliveLocalMemory>,
+        local_memory: KeepaliveLocalMemory,
         total_chunks: usize,
         done: OncePortRef<Result<(), String>>,
     ) -> usize {
@@ -265,7 +265,7 @@ impl TcpManagerActor {
         &mut self,
         cx: &Context<Self>,
         transfer_id: usize,
-        local_memory: Arc<KeepaliveLocalMemory>,
+        local_memory: KeepaliveLocalMemory,
         chunk_size: usize,
         dest_addr: ChannelAddr,
     ) -> Result<()> {
@@ -970,7 +970,7 @@ mod tests {
         instance: hyperactor::Client,
         tcp_backend: TcpBackend,
         rdma_remote_buf: crate::RdmaRemoteBuffer,
-        local_memory: Arc<KeepaliveLocalMemory>,
+        local_memory: KeepaliveLocalMemory,
     }
 
     impl Drop for TcpTestProcEnv {
@@ -1050,14 +1050,9 @@ mod tests {
             instance: &hyperactor::Client,
             rdma_handle: &ActorHandle<RdmaManagerActor>,
             buffer_size: usize,
-        ) -> anyhow::Result<(Arc<KeepaliveLocalMemory>, crate::RdmaRemoteBuffer)> {
+        ) -> anyhow::Result<(KeepaliveLocalMemory, crate::RdmaRemoteBuffer)> {
             let cpu_buf = vec![0u8; buffer_size].into_boxed_slice();
-            let ptr = cpu_buf.as_ptr() as usize;
-            let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
-                ptr,
-                buffer_size,
-                Arc::new(cpu_buf),
-            ));
+            let local_memory = KeepaliveLocalMemory::new(Arc::new(cpu_buf));
             let rdma_remote_buf = rdma_handle
                 .request_buffer(instance, local_memory.clone())
                 .await?;
@@ -1601,11 +1596,7 @@ mod tests {
             );
 
             let alloc = CudaAllocator::get().allocate(device, buffer_size, buffer_size);
-            let local_memory: Arc<KeepaliveLocalMemory> = Arc::new(KeepaliveLocalMemory::new(
-                alloc.ptr(),
-                buffer_size,
-                Arc::new(alloc),
-            ));
+            let local_memory = KeepaliveLocalMemory::new(Arc::new(alloc));
             let rdma_remote_buf = rdma_handle
                 .request_buffer(&instance, local_memory.clone())
                 .await?;

--- a/monarch_rdma/src/lib.rs
+++ b/monarch_rdma/src/lib.rs
@@ -9,8 +9,6 @@
 // RDMA requires frequent unsafe code blocks
 #![allow(clippy::undocumented_unsafe_blocks)]
 
-use std::sync::Arc;
-
 use local_memory::KeepaliveLocalMemory;
 use serde::Deserialize;
 use serde::Serialize;
@@ -58,7 +56,7 @@ pub enum RdmaOpType {
 #[derive(Debug)]
 pub struct RdmaOp {
     pub op_type: RdmaOpType,
-    pub local: Arc<KeepaliveLocalMemory>,
+    pub local: KeepaliveLocalMemory,
     pub remote: RdmaRemoteBuffer,
 }
 

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -333,14 +333,43 @@ impl Drop for AccessExclusiveGuard<'_> {
     }
 }
 
-/// Marker trait: the implementor keeps a backing memory allocation alive.
+/// Trait for values that keep a backing memory allocation alive and
+/// know its address and size.
 ///
 /// As long as a value implementing this trait exists, the memory region
-/// described by the containing [`KeepaliveLocalMemory`] is guaranteed to
-/// remain valid.
-pub trait Keepalive: Send + Sync {}
+/// it describes is guaranteed to remain valid.
+pub trait Keepalive: Send + Sync {
+    /// Start address of the memory region this keepalive pins.
+    fn addr(&self) -> usize;
 
-impl Keepalive for Box<[u8]> {}
+    /// Size in bytes of the memory region this keepalive pins.
+    fn size(&self) -> usize;
+
+    /// Produce a [`WeakKeepalive`] pointing at the same underlying
+    /// resource. Defaults to `None` for impls with no weak form.
+    fn downgrade(&self) -> Option<Arc<dyn WeakKeepalive>> {
+        None
+    }
+}
+
+/// Counterpart to [`Keepalive`]: a non-pinning reference to the same
+/// underlying resource that can be re-promoted to a [`Keepalive`] as
+/// long as the resource is still alive.
+pub trait WeakKeepalive: Send + Sync {
+    /// Re-acquire a strong [`Keepalive`] for the underlying resource,
+    /// or `None` if the referent has gone away.
+    fn upgrade(&self) -> Option<Arc<dyn Keepalive>>;
+}
+
+impl Keepalive for Box<[u8]> {
+    fn addr(&self) -> usize {
+        self.as_ptr() as usize
+    }
+
+    fn size(&self) -> usize {
+        self.len()
+    }
+}
 
 /// Backing state of a [`KeepaliveLocalMemory`].
 ///
@@ -434,10 +463,14 @@ impl Debug for KeepaliveLocalMemory {
 }
 
 impl KeepaliveLocalMemory {
-    /// Create a new handle. Probes the CUDA driver to determine whether
-    /// `addr` is a device pointer and sets the bandwidth fields
-    /// accordingly.
-    pub fn new(addr: usize, size: usize, keepalive: Arc<dyn Keepalive>) -> Self {
+    /// Create a new handle. Derives `addr` and `size` from the
+    /// `keepalive` via [`Keepalive::addr`] /
+    /// [`Keepalive::size`], then probes the CUDA driver to
+    /// determine whether the address is a device pointer and sets the
+    /// bandwidth fields accordingly.
+    pub fn new(keepalive: Arc<dyn Keepalive>) -> Self {
+        let addr = keepalive.addr();
+        let size = keepalive.size();
         Self {
             inner: LocalMemoryInner::new(addr, size),
             _keepalive: keepalive,
@@ -562,6 +595,69 @@ impl KeepaliveLocalMemory {
             }
         }
     }
+
+    /// Pair off a [`WeakLocalMemory`] that shares this handle's
+    /// [`LocalMemoryInner`] (and therefore the same MR slot and
+    /// access lock). Returns `None` when the underlying [`Keepalive`]
+    /// does not provide a weak form.
+    pub fn downgrade(&self) -> Option<WeakLocalMemory> {
+        let weak_keepalive = self._keepalive.downgrade()?;
+        Some(WeakLocalMemory {
+            inner: self.inner.clone(),
+            weak_keepalive,
+        })
+    }
+}
+
+/// Non-pinning counterpart of [`KeepaliveLocalMemory`].
+///
+/// Holds the shared [`LocalMemoryInner`] (so a re-promoted strong
+/// handle sees the same MR slot and access lock) plus a
+/// [`WeakKeepalive`] that can be upgraded to a fresh
+/// [`Arc<dyn Keepalive>`] as long as the referent is still alive.
+#[derive(Clone)]
+pub struct WeakLocalMemory {
+    inner: LocalMemoryInner,
+    weak_keepalive: Arc<dyn WeakKeepalive>,
+}
+
+impl WeakLocalMemory {
+    /// Starting virtual address of the memory region.
+    pub fn addr(&self) -> usize {
+        self.inner.addr
+    }
+
+    /// Size of the memory region in bytes.
+    pub fn size(&self) -> usize {
+        self.inner.size
+    }
+
+    /// Materialize a strong [`KeepaliveLocalMemory`] sharing this
+    /// handle's [`LocalMemoryInner`]. Returns `None` if the
+    /// referent has gone away **or** if its currently-computed
+    /// `(addr, size)` no longer matches the values stored on this
+    /// handle — the latter guarding against the live referent
+    /// describing a different memory region than the one this weak
+    /// handle was paired with at downgrade time.
+    pub fn upgrade(&self) -> Option<KeepaliveLocalMemory> {
+        let keepalive = self.weak_keepalive.upgrade()?;
+        let new_addr = keepalive.addr();
+        let new_size = keepalive.size();
+        if new_addr != self.inner.addr || new_size != self.inner.size {
+            tracing::warn!(
+                expected_addr = self.inner.addr,
+                actual_addr = new_addr,
+                expected_size = self.inner.size,
+                actual_size = new_size,
+                "WeakLocalMemory upgrade rejected: backing keepalive's (addr, size) changed since downgrade",
+            );
+            return None;
+        }
+        Some(KeepaliveLocalMemory {
+            inner: self.inner.clone(),
+            _keepalive: keepalive,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -571,9 +667,7 @@ mod tests {
     // -- KeepaliveLocalMemory (host) --
 
     fn host_keepalive_mem(data: Box<[u8]>) -> KeepaliveLocalMemory {
-        let addr = data.as_ptr() as usize;
-        let size = data.len();
-        KeepaliveLocalMemory::new(addr, size, Arc::new(data))
+        KeepaliveLocalMemory::new(Arc::new(data))
     }
 
     #[test]

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -43,7 +43,6 @@
 /// Maximum size for a single RDMA operation in bytes (1 GiB)
 use std::fs;
 use std::result::Result;
-use std::sync::Arc;
 use std::time::Duration;
 
 use hyperactor::ActorRef;
@@ -138,7 +137,7 @@ impl RdmaRemoteBuffer {
     pub async fn write_from_local(
         &self,
         client: &(impl context::Actor + Send + Sync),
-        local: Arc<KeepaliveLocalMemory>,
+        local: KeepaliveLocalMemory,
         timeout: u64,
     ) -> Result<bool, anyhow::Error> {
         let mut action = RdmaAction::new();
@@ -151,7 +150,7 @@ impl RdmaRemoteBuffer {
     pub async fn read_into_local(
         &self,
         client: &(impl context::Actor + Send + Sync),
-        local: Arc<KeepaliveLocalMemory>,
+        local: KeepaliveLocalMemory,
         timeout: u64,
     ) -> Result<bool, anyhow::Error> {
         let mut action = RdmaAction::new();

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -15,7 +15,7 @@
 //! ## Responsibilities
 //!
 //! - Assigns a unique `remote_buf_id` to each registered local memory handle
-//!   and stores the `Arc<KeepaliveLocalMemory>` for later retrieval.
+//!   and stores the [`KeepaliveLocalMemory`] for later retrieval.
 //! - Produces [`RdmaRemoteBuffer`] tokens that can be sent to remote peers so
 //!   they can address this buffer over RDMA.
 //! - Delegates MR registration, QP management, and data movement to the
@@ -24,7 +24,6 @@
 //! - Handles remote [`ReleaseBuffer`] requests to clean up registrations.
 
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
@@ -66,14 +65,14 @@ pub fn get_rdmaxcel_error_message(error_code: i32) -> String {
 
 /// Local-only messages for the [`RdmaManagerActor`].
 ///
-/// These messages carry `Arc<KeepaliveLocalMemory>` and are therefore
-/// not serializable -- they can only be sent within the same process.
+/// These messages carry [`KeepaliveLocalMemory`] and are therefore not
+/// serializable -- they can only be sent within the same process.
 #[derive(Handler, HandleClient, Debug)]
 pub enum RdmaManagerMessage {
     /// Register a local memory handle and return a [`RdmaRemoteBuffer`] that
     /// remote peers can use to address this buffer over RDMA.
     RequestBuffer {
-        local: Arc<KeepaliveLocalMemory>,
+        local: KeepaliveLocalMemory,
         #[reply]
         reply: OncePortHandle<RdmaRemoteBuffer>,
     },
@@ -82,7 +81,7 @@ pub enum RdmaManagerMessage {
     RequestLocalMemory {
         remote_buf_id: usize,
         #[reply]
-        reply: OncePortHandle<Option<Arc<KeepaliveLocalMemory>>>,
+        reply: OncePortHandle<Option<KeepaliveLocalMemory>>,
     },
 }
 
@@ -154,7 +153,7 @@ impl<A: Actor> RdmaBackendActor<A> {
 #[hyperactor::spawnable]
 pub struct RdmaManagerActor {
     next_remote_buf_id: usize,
-    buffers: HashMap<usize, Arc<KeepaliveLocalMemory>>,
+    buffers: HashMap<usize, KeepaliveLocalMemory>,
     ibverbs: Option<RdmaBackendActor<IbvManagerActor>>,
     tcp: RdmaBackendActor<TcpManagerActor>,
 }
@@ -284,7 +283,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
     async fn request_buffer(
         &mut self,
         cx: &Context<Self>,
-        local: Arc<KeepaliveLocalMemory>,
+        local: KeepaliveLocalMemory,
     ) -> Result<RdmaRemoteBuffer, anyhow::Error> {
         let remote_buf_id = self.next_remote_buf_id;
         self.next_remote_buf_id += 1;
@@ -320,7 +319,7 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         &mut self,
         _cx: &Context<Self>,
         remote_buf_id: usize,
-    ) -> Result<Option<Arc<KeepaliveLocalMemory>>, anyhow::Error> {
+    ) -> Result<Option<KeepaliveLocalMemory>, anyhow::Error> {
         Ok(self.buffers.get(&remote_buf_id).cloned())
     }
 }


### PR DESCRIPTION
Summary:
Reshape the keepalive interface so the strong handle owns `(addr, size)`, introduce a `WeakKeepalive` counterpart for non-pinning references, give every supported Python object type its own strong + weak Keepalive pair, and drop the redundant `Arc` wrapper around `KeepaliveLocalMemory` from the data path.

1. **`Keepalive` gains `addr()` / `size()` / `downgrade()`; new `WeakKeepalive` trait.** `Keepalive` was a marker trait; it now also owns the address and size of the resource it pins, plus a `downgrade()` that returns `Option<Arc<dyn WeakKeepalive>>`. `WeakKeepalive::upgrade()` re-acquires a strong `Keepalive` while the referent is still alive. `KeepaliveLocalMemory::new` takes only the keepalive and derives `(addr, size)` from it. The new `WeakLocalMemory` is the weak counterpart of `KeepaliveLocalMemory`; its `upgrade()` returns `None` either when the referent is gone or when the live referent's `(addr, size)` no longer matches what was recorded at downgrade time.

2. **`KeepaliveLocalMemory` is `Clone`; the data path takes it by value.** The handle is a thin `(addr, size, slot, Arc<dyn Keepalive>)` aggregate where the slot is itself an `Arc<Mutex<…>>`, so the outer `Arc<KeepaliveLocalMemory>` wrapper was always redundant. All callsites (ibverbs / TCP manager actors, op records, buffer maps, parameter-server / cuda-ping-pong examples, integration-test helpers) take `KeepaliveLocalMemory` directly.

3. **Python keepalives split per object type with weak counterparts.** The opaque `PyKeepalive(Py<PyAny>)` is replaced with one strong + one weak class per supported object type (memoryview, torch tensor). Each strong type caches `(addr, size)` at construction; the weak counterpart's `upgrade()` re-reads them via `weakref.ref` + the buffer protocol / `storage.data_ptr()`. Construction goes through per-type `pyfunction`s (`_make_local_memory_handle_from_memoryview`, `_make_local_memory_handle_from_tensor`); `PyWeakLocalMemoryHandle` is exposed so the Python side can hold weak handles directly.

4. **Contiguity validation and `(addr, size)` extraction exposed as `pyfunction`s.** Adds `_assert_1d_contiguous`, which rejects anything that is not a 1d contiguous torch tensor or 1d c-contiguous memoryview with a `ValueError`. It runs at the top of both `_make_local_memory_handle_from_memoryview` and `_make_local_memory_handle_from_tensor`, so a non-contiguous or multi-dimensional buffer is caught at the binding boundary instead of registering a region that misrepresents the tensor's layout (this addresses review feedback that the tensor constructor's `element_size * numel` / `storage_offset` math silently assumes contiguity). Also exposes `_get_tensor_addr_and_size` and `_get_memoryview_addr_and_size`, the Rust versions of the `(addr, size)` introspection helpers the Python wrapper previously implemented; the child diff removes the Python copies and calls these instead. Separately, the catch-all `PyKeepalive`'s pin-only `obj` field moves from `#[allow(dead_code)]` to `#[expect(dead_code, reason = …)]` per the Rust style guide.

Reviewed By: zdevito

Differential Revision: D106407986


