### PR TITLE
Detect dead peers via TCP keepalive and bound reconnect attempts (#4083)

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -64,6 +64,7 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 signal-hook-tokio = { version = "0.3.1", features = ["futures-v0_3"] }
 smol_str = "0.3.6"
+socket2 = { version = "0.6.3", features = ["all"] }
 strum = { version = "0.27.1", features = ["derive"] }
 thiserror = "2.0.18"
 tokio = { version = "1.52.3", features = ["full", "test-util", "tracing"] }

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -179,6 +179,35 @@ use session::Session;
 use crate::config;
 use crate::metrics;
 
+/// TCP keepalive probe interval after the idle period elapses.
+const TCP_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Number of failed keepalive probes before the kernel marks the
+/// connection dead.
+const TCP_KEEPALIVE_RETRIES: u32 = 3;
+
+/// Enable TCP keepalive on a freshly-created socket so the kernel can
+/// surface peer death on otherwise-idle connections.
+/// [`config::CHANNEL_TCP_KEEPALIVE_IDLE`] is the kernel idle period —
+/// the gap from last activity to the first probe — so on a healthy
+/// idle connection it's also the probe cadence. Total detection time
+/// is `idle + TCP_KEEPALIVE_RETRIES * TCP_KEEPALIVE_INTERVAL`. Logs
+/// and ignores errors: keepalive is best-effort and some test
+/// harnesses use sockets that don't support it.
+fn set_tcp_keepalive(stream: &tokio::net::TcpStream) {
+    let idle = hyperactor_config::global::get(config::CHANNEL_TCP_KEEPALIVE_IDLE);
+
+    let ka = socket2::TcpKeepalive::new()
+        .with_time(idle)
+        .with_interval(TCP_KEEPALIVE_INTERVAL)
+        .with_retries(TCP_KEEPALIVE_RETRIES);
+
+    let sock = socket2::SockRef::from(stream);
+    if let Err(err) = sock.set_tcp_keepalive(&ka) {
+        tracing::warn!(?err, "failed to set TCP keepalive on stream");
+    }
+}
+
 pub(crate) enum LinkStatus {
     NeverConnected,
     Connected(tokio::time::Instant),
@@ -1069,6 +1098,8 @@ pub enum ServerError {
 pub enum ClientError {
     #[error("connection to {0} failed: {1}: {2}")]
     Connect(ChannelAddr, std::io::Error, String),
+    #[error("connection to {0} failed after {1:?} of retries: {2}")]
+    ConnectTimeout(ChannelAddr, Duration, #[source] std::io::Error),
     #[error("unable to resolve address: {0}")]
     Resolve(ChannelAddr),
     #[error("io: {0} {1}")]
@@ -1419,12 +1450,14 @@ pub(crate) mod tcp {
 
         async fn next(&mut self) -> Result<Self::Stream, ClientError> {
             let session_id = self.session_id;
+            let reconnect_timeout =
+                hyperactor_config::global::get(config::CHANNEL_RECONNECT_TIMEOUT);
             let mut backoff = ExponentialBackoffBuilder::new()
                 .with_initial_interval(Duration::from_millis(1))
                 .with_multiplier(2.0)
                 .with_randomization_factor(0.1)
                 .with_max_interval(Duration::from_millis(1000))
-                .with_max_elapsed_time(None)
+                .with_max_elapsed_time(Some(reconnect_timeout))
                 .build();
             loop {
                 match TcpStream::connect(&self.addr).await {
@@ -1436,6 +1469,7 @@ pub(crate) mod tcp {
                                 "cannot disable Nagle algorithm".to_string(),
                             )
                         })?;
+                        set_tcp_keepalive(&stream);
                         write_link_init(&mut stream, session_id, self.stream_id)
                             .await
                             .map_err(|err| ClientError::Io(self.dest(), err))?;
@@ -1443,8 +1477,15 @@ pub(crate) mod tcp {
                     }
                     Err(err) => {
                         tracing::debug!(error = %err, "tcp connect failed, backing off");
-                        if let Some(delay) = backoff.next_backoff() {
-                            tokio::time::sleep(delay).await;
+                        match backoff.next_backoff() {
+                            Some(delay) => tokio::time::sleep(delay).await,
+                            None => {
+                                return Err(ClientError::ConnectTimeout(
+                                    self.dest(),
+                                    reconnect_timeout,
+                                    err,
+                                ));
+                            }
                         }
                     }
                 }
@@ -1472,6 +1513,7 @@ pub(crate) mod tcp {
             stream
                 .set_nodelay(true)
                 .map_err(|err| ServerError::Io(ChannelAddr::Tcp(self.addr), err))?;
+            set_tcp_keepalive(&stream);
             Ok((stream, ChannelAddr::Tcp(peer_addr)))
         }
     }
@@ -1810,12 +1852,14 @@ pub(crate) mod tls {
                     "invalid server name".to_string(),
                 )
             })?;
+            let reconnect_timeout =
+                hyperactor_config::global::get(config::CHANNEL_RECONNECT_TIMEOUT);
             let mut backoff = ExponentialBackoffBuilder::new()
                 .with_initial_interval(Duration::from_millis(1))
                 .with_multiplier(2.0)
                 .with_randomization_factor(0.1)
                 .with_max_interval(Duration::from_millis(1000))
-                .with_max_elapsed_time(None)
+                .with_max_elapsed_time(Some(reconnect_timeout))
                 .build();
             loop {
                 let mut addrs = (self.hostname.as_ref(), self.port)
@@ -1831,6 +1875,7 @@ pub(crate) mod tls {
                                 "cannot disable Nagle algorithm".to_string(),
                             )
                         })?;
+                        set_tcp_keepalive(&stream);
                         let mut tls_stream = self
                             .connector
                             .connect(server_name.clone(), stream)
@@ -1854,8 +1899,15 @@ pub(crate) mod tls {
                     }
                     Err(err) => {
                         tracing::debug!(error = %err, "tls connect failed, backing off");
-                        if let Some(delay) = backoff.next_backoff() {
-                            tokio::time::sleep(delay).await;
+                        match backoff.next_backoff() {
+                            Some(delay) => tokio::time::sleep(delay).await,
+                            None => {
+                                return Err(ClientError::ConnectTimeout(
+                                    self.dest(),
+                                    reconnect_timeout,
+                                    err,
+                                ));
+                            }
                         }
                     }
                 }
@@ -2415,6 +2467,35 @@ mod tests {
                     ..
                 })
             );
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 20)]
+    #[cfg_attr(not(fbcode_build), ignore)]
+    async fn test_tcp_unreachable_peer_surfaces_closed() {
+        // With a bounded reconnect timeout, dialing an unreachable peer must
+        // surface as TxStatus::Closed — not loop forever. The
+        // `async_timed_test` timeout above is the only failure backstop; the
+        // body itself is purely event-driven on the status watch.
+        let config = hyperactor_config::global::lock();
+        // `connect_by` retries `link.next()` until MESSAGE_DELIVERY_TIMEOUT
+        // when an outbound message is pending. Bound both so the test surfaces
+        // Closed within a few seconds rather than the 30s default.
+        let _g1 = config.override_key(config::CHANNEL_RECONNECT_TIMEOUT, Duration::from_secs(1));
+        let _g2 = config.override_key(config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(3));
+
+        // Bind a listener to grab a free local port, then drop it so connects
+        // get ECONNREFUSED.
+        let (addr, rx) =
+            server::serve::<u64>(ChannelAddr::Tcp("[::1]:0".parse().unwrap()), None).unwrap();
+        drop(rx);
+
+        let tx = channel::dial::<u64>(addr.clone()).unwrap();
+        tx.post(123); // primes the send loop so the connect path runs
+
+        let mut status = tx.status().clone();
+        while !status.borrow_and_update().is_closed() {
+            status.changed().await.unwrap();
         }
     }
 

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -188,6 +188,32 @@ declare_attrs! {
     ))
     pub attr CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 
+    /// Kernel TCP keepalive idle period: the gap from last activity
+    /// until the kernel sends its first probe on connections created
+    /// by hyperactor's channel layer. On a healthy idle connection
+    /// this is also the probe cadence (each ACK resets the timer).
+    /// Total peer-death detection time is `idle + probe_budget` where
+    /// `probe_budget = TCP_KEEPALIVE_INTERVAL * TCP_KEEPALIVE_RETRIES`
+    /// (private constants in `channel::net`, currently 15s). Larger
+    /// values reduce keepalive ACK traffic at the cost of slower
+    /// peer-death detection.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_CHANNEL_TCP_KEEPALIVE_IDLE".to_string()),
+        Some("channel_tcp_keepalive_idle".to_string()),
+    ))
+    pub attr CHANNEL_TCP_KEEPALIVE_IDLE: Duration = Duration::from_secs(60);
+
+    /// Maximum time `Link::next()` spends retrying a failed connect
+    /// before giving up. Pairs with TCP keepalive: keepalive surfaces
+    /// peer death as an I/O error, then the connect-retry loop quits
+    /// after this bound and the outer NetTx loop terminates the link
+    /// with `TxStatus::Closed`.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_CHANNEL_RECONNECT_TIMEOUT".to_string()),
+        Some("channel_reconnect_timeout".to_string()),
+    ))
+    pub attr CHANNEL_RECONNECT_TIMEOUT: Duration = Duration::from_secs(60);
+
     /// Sampling rate for logging message latency
     /// Set to 0.01 for 1% sampling, 0.1 for 10% sampling, 0.90 for 90% sampling, etc.
     @meta(CONFIG = ConfigAttr::new(


### PR DESCRIPTION
Summary:

A `NetTx` whose peer dies without sending a TCP FIN — typical for a K8s pod that was abruptly killed or partitioned — keeps `TxStatus::Active` forever. The kernel never surfaces an error because the socket has no pending writes, and even if a write does happen, the inner `Link::next()` connect loop retries with unbounded `max_elapsed_time(None)`. The cached `MailboxClient` we just learned to evict on `Closed` thus sits there indefinitely, blocking the new fix from helping the "silent peer death" path.

This change pairs two complementary primitives:

1. **Kernel TCP keepalive** on every `TcpStream` (client `dial` + server `accept`, plain TCP and TLS) via a new helper `set_tcp_keepalive`. `CHANNEL_TCP_KEEPALIVE_IDLE` (default 60s) is passed directly to the kernel as the idle period, so on a healthy idle connection it also sets the probe cadence — roughly one probe + ACK per minute per idle connection. Total peer-death detection time is `idle + probe_budget` where `probe_budget = TCP_KEEPALIVE_INTERVAL * TCP_KEEPALIVE_RETRIES = 15s` (private constants in `channel::net`), so ~75s end-to-end. Each probe is a headers-only TCP segment (~54 B IPv4 wire, ~74 B IPv6); at 1M idle conns/host that's ~22 Mbps of keepalive traffic, well below any meaningful threshold. Uses `socket2::TcpKeepalive` for one cross-platform API.

2. **Bounded `Link::next()` connect retry**. The inner connect loop in `tcp::TcpLink::next` and `tls::TlsLink::next` now uses `with_max_elapsed_time(Some(CHANNEL_RECONNECT_TIMEOUT))` (default 60s). When the backoff exhausts, `next_backoff()` returns `None` and we return `ClientError::ConnectTimeout` to the caller. The outer `NetTx` reconnect loop's existing "session shut down" branch breaks and emits `TxStatus::Closed`, which the `DialMailboxRouter` then evicts.

The two layers compose: keepalive flips an idle dead connection to an I/O error in ~75s; the bounded retry then declares the link dead after another ~60s of failed reconnects, total ~2.25 minutes before a stale cache entry self-clears. Active in-flight messages are still bound by `MESSAGE_DELIVERY_TIMEOUT` as before.

Two new config keys are added: `CHANNEL_TCP_KEEPALIVE_IDLE` (kernel idle period — separate knob from the reconnect timeout so we can tune probe cadence vs. keepalive ACK traffic independently) and `CHANNEL_RECONNECT_TIMEOUT` (reconnect bound). The probe interval and retry count remain private constants in `channel::net` since we don't expect to tune them in production. `Unix` sockets are unaffected — local transports don't have the silent-death problem.

Reviewed By: shayne-fletcher

Differential Revision: D106433787


