### PR TITLE
Move cargo CI timeout from bash to nextest config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -7,6 +7,10 @@ slow-timeout = { period = "30s", terminate-after = 10 }
 fail-fast = false
 # Cap parallelism to reduce contention-induced timeouts on shared CI runners.
 test-threads = 4
+# Timeout for the entire suite, only used in CI to prevent running forever.
+# Use this instead of the shell "timeout" function because this way will exclude
+# build time.
+global-timeout = "15m"
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -55,12 +55,14 @@ jobs:
         free -h || true
         echo "=== end runner spec ==="
         echo "Running CPU Rust tests..."
+        # The CI profile is configured in .config/nextest.toml
+        # It includes individual test timeouts and a timeout for the entire test run.
         # Capture the test exit code so stage_test_artifacts still runs on
         # failure (otherwise set -e would exit before any artifacts are
         # uploaded). Exclude crates that require GPU hardware, CUDA libraries,
         # or torch C++ headers (libtorch) not available on CPU-only runners.
         rc=0
-        CARGO_BUILD_JOBS=${{ matrix.cargo-jobs }} timeout 15m cargo nextest run --workspace --profile ci \
+        CARGO_BUILD_JOBS=${{ matrix.cargo-jobs }} cargo nextest run --workspace --profile ci \
           -E "$(cat .config/nextest-filter.txt)" \
           --exclude monarch_messages \
           --exclude monarch_tensor_worker \

--- a/.github/workflows/test-gpu-rust.yml
+++ b/.github/workflows/test-gpu-rust.yml
@@ -61,6 +61,7 @@ jobs:
         # Uses cargo nextest to run tests in separate processes, which better matches
         # internal buck test behavior.
         # The CI profile is configured in .config/nextest.toml
+        # It includes individual test timeouts and a timeout for the entire test run.
         # Exclude filter is for packages that don't build in Github Actions yet.
         # * monarch_messages: monarch/target/debug/deps/monarch_messages-...:
         #   /lib64/libm.so.6: version `GLIBC_2.29' not found
@@ -69,7 +70,7 @@ jobs:
         # failure (otherwise set -e would exit before any artifacts are
         # uploaded).
         rc=0
-        timeout 12m cargo nextest run --workspace --profile ci \
+        cargo nextest run --workspace --profile ci \
           -E "$(cat .config/nextest-filter.txt)" \
           --exclude monarch_messages \
           --exclude monarch_tensor_worker \


### PR DESCRIPTION
Summary:
Use a nextest timeout config instead of the bash function so that we don't
include build times in the timeout.

Differential Revision: D106685801


