### PR TITLE
Dashboard server: PAR-safe static dir + OS-assigned port support (#4087)

### DIFF
--- a/monarch_distributed_telemetry/src/lib.rs
+++ b/monarch_distributed_telemetry/src/lib.rs
@@ -28,7 +28,26 @@ use datafusion::arrow::record_batch::RecordBatch;
 pub use entity_batch_sink::EntityBatchSink;
 use hyperactor::Bind;
 use hyperactor::Unbind;
+use monarch_record_batch::RecordBatchBuffer;
+use monarch_telemetry_schema::entity_tables::ACTOR_STATUS_EVENTS;
+use monarch_telemetry_schema::entity_tables::ACTORS;
+use monarch_telemetry_schema::entity_tables::ActorBuffer;
+use monarch_telemetry_schema::entity_tables::ActorStatusEventBuffer;
+use monarch_telemetry_schema::entity_tables::MESHES;
+use monarch_telemetry_schema::entity_tables::MESSAGE_STATUS_EVENTS;
+use monarch_telemetry_schema::entity_tables::MESSAGES;
+use monarch_telemetry_schema::entity_tables::MeshBuffer;
+use monarch_telemetry_schema::entity_tables::MessageBuffer;
+use monarch_telemetry_schema::entity_tables::MessageStatusEventBuffer;
+use monarch_telemetry_schema::entity_tables::SENT_MESSAGES;
+use monarch_telemetry_schema::entity_tables::SentMessageBuffer;
 pub use monarch_telemetry_schema::serialize_batch;
+use monarch_telemetry_schema::trace_tables::EVENTS;
+use monarch_telemetry_schema::trace_tables::EventBuffer;
+use monarch_telemetry_schema::trace_tables::SPAN_EVENTS;
+use monarch_telemetry_schema::trace_tables::SPANS;
+use monarch_telemetry_schema::trace_tables::SpanBuffer;
+use monarch_telemetry_schema::trace_tables::SpanEventBuffer;
 use pyo3::prelude::*;
 pub use pyspy_table::PySpyDump;
 pub use pyspy_table::PySpyFrame;
@@ -115,10 +134,49 @@ fn _start_socket_ingest(scanner: PyRef<'_, DatabaseScanner>, socket_path: &str) 
         .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
 }
 
+/// Register trace and entity schemas with a database scanner.
+#[pyfunction]
+fn _register_trace_entity_schemas(scanner: PyRef<'_, DatabaseScanner>) -> PyResult<()> {
+    register_table_schema::<SpanBuffer>(&scanner, SPANS)?;
+    register_table_schema::<SpanEventBuffer>(&scanner, SPAN_EVENTS)?;
+    register_table_schema::<EventBuffer>(&scanner, EVENTS)?;
+    register_table_schema::<ActorBuffer>(&scanner, ACTORS)?;
+    register_table_schema::<MeshBuffer>(&scanner, MESHES)?;
+    register_table_schema::<ActorStatusEventBuffer>(&scanner, ACTOR_STATUS_EVENTS)?;
+    register_table_schema::<SentMessageBuffer>(&scanner, SENT_MESSAGES)?;
+    register_table_schema::<MessageBuffer>(&scanner, MESSAGES)?;
+    register_table_schema::<MessageStatusEventBuffer>(&scanner, MESSAGE_STATUS_EVENTS)?;
+    Ok(())
+}
+
+fn register_table_schema<B>(scanner: &DatabaseScanner, table_name: &str) -> PyResult<()>
+where
+    B: RecordBatchBuffer + Default,
+{
+    scanner
+        .register_table(
+            table_name,
+            B::default()
+                .drain_to_record_batch()
+                .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))?
+                .schema(),
+        )
+        .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+}
+
+/// Activate the process-global Unix socket telemetry sink.
+#[pyfunction]
+fn _set_unix_socket_sink_path(socket_path: &str) -> PyResult<()> {
+    hyperactor_telemetry::set_unix_socket_sink_path(socket_path)
+        .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
+}
+
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(enable_record_batch_tracing, module)?)?;
     module.add_function(wrap_pyfunction!(get_record_batch_flush_count, module)?)?;
     module.add_function(wrap_pyfunction!(reset_record_batch_flush_count, module)?)?;
     module.add_function(wrap_pyfunction!(_start_socket_ingest, module)?)?;
+    module.add_function(wrap_pyfunction!(_register_trace_entity_schemas, module)?)?;
+    module.add_function(wrap_pyfunction!(_set_unix_socket_sink_path, module)?)?;
     Ok(())
 }

--- a/python/monarch/_rust_bindings/monarch_distributed_telemetry/__init__.pyi
+++ b/python/monarch/_rust_bindings/monarch_distributed_telemetry/__init__.pyi
@@ -26,3 +26,13 @@ def _start_socket_ingest(
 ) -> bool:
     """Start Unix-socket ingest for a database scanner."""
     ...
+
+def _register_trace_entity_schemas(
+    scanner: database_scanner.DatabaseScanner,
+) -> None:
+    """Register trace and entity schemas for a database scanner."""
+    ...
+
+def _set_unix_socket_sink_path(socket_path: str) -> None:
+    """Activate the process-global Unix socket sink."""
+    ...

--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -1,0 +1,205 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Host-local telemetry collector actor.
+
+The actor is intentionally a narrow Python control/query shell over the Rust
+`DatabaseScanner`. Hot telemetry frames do not pass through Python: producers
+write framed Arrow IPC over `telemetry.sock`, Rust socket ingest validates and
+decodes those frames, and the scanner owns the in-memory DataFusion tables.
+Python coordinates activation and exposes actor endpoints for query fan-out.
+
+More than one `TelemetryActor` may be started for what turns out to be the
+same host-local socket namespace. That can happen in collocated/local jobs
+(i.e. ProcessJob) where the client-side sidecar collector and a worker-host
+collector resolve the same `/tmp/monarch_<apply_id>/telemetry.sock`, or during
+a sidecar refresh while an existing collector is still alive. This is a deliberate
+design choice. The non-destructive socket bind is the serialization point; the actor
+that binds the socket owns the store, and an actor that observes a live socket
+leaves its scanner unset and acts as an inert candidate.
+
+TODO: consider dedup'ing the worker fan-out by hostname (or job type) so
+ProcessJob / collocated jobs skip the redundant per-host candidate spawns
+instead of relying on each one to lose the bind race and be torn down.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional
+
+from monarch._rust_bindings.monarch_distributed_telemetry import (
+    _register_trace_entity_schemas,
+    _start_socket_ingest,
+)
+from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
+    DatabaseScanner,
+)
+from monarch._rust_bindings.monarch_extension.snapshot_integration import (
+    _pre_register_snapshot_schemas,
+)
+from monarch._rust_bindings.monarch_hyperactor.mailbox import PortId
+from monarch.actor import Actor, current_rank, endpoint
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+_SCAN_WORKER_TIMEOUT_SECS: float = 10.0
+
+
+def telemetry_socket_dir(apply_id: str) -> str:
+    """Return the host-local telemetry socket directory for an apply id."""
+    return os.path.join("/tmp", f"monarch_{apply_id}")
+
+
+def telemetry_socket_path(apply_id: str) -> str:
+    """Return the host-local telemetry socket path for an apply id."""
+    return os.path.join(telemetry_socket_dir(apply_id), "telemetry.sock")
+
+
+class TelemetryActor(Actor):
+    """Host-local telemetry collector actor."""
+
+    def __init__(self, apply_id: str, retention_secs: int) -> None:
+        # Job-instance identifier; namespaces the per-host socket path under
+        # /tmp so concurrent jobs on the same host do not collide.
+        self._apply_id: str = apply_id
+        # Collector-side retention window in seconds for message tables; 0
+        # disables retention. Passed to DataFusion's periodic retention task.
+        self._retention_secs: int = retention_secs
+        # The DataFusion store + socket-ingest pair this actor owns. `None`
+        # means this actor did not win (or has not yet attempted) the
+        # non-destructive bind, so it is not a live collector.
+        self._scanner: DatabaseScanner | None = None
+        # Other telemetry actors this collector fans queries out to. Empty
+        # for leaf collectors; the query-root collector receives its list via
+        # `set_worker_collectors` once the worker meshes exist.
+        self._worker_collectors: list[Any] = []
+
+    def _scanner_or_raise(self) -> DatabaseScanner:
+        scanner = self._scanner
+        if scanner is not None:
+            return scanner
+        raise RuntimeError("not an active telemetry collector")
+
+    def _activate_impl(self) -> bool:
+        """Lazily bind the local socket and stand up the scanner.
+
+        No-op once active. On a previously skipped or failed actor the next
+        call re-attempts activation: the bind is non-destructive, so a retry
+        is safe and may succeed if the prior owner has gone away.
+        """
+        if self._scanner is not None:
+            return True
+
+        # 0o700 keeps the socket dir owner-only under shared /tmp: a co-tenant
+        # without traversal permission on the parent cannot connect to the
+        # socket and inject forged telemetry frames.
+        socket_dir = telemetry_socket_dir(self._apply_id)
+        os.makedirs(socket_dir, mode=0o700, exist_ok=True)
+        os.chmod(socket_dir, 0o700)
+
+        scanner = DatabaseScanner(
+            current_rank().rank,
+            retention_secs=self._retention_secs,
+        )
+        try:
+            _register_trace_entity_schemas(scanner)
+            _pre_register_snapshot_schemas(scanner)
+            if _start_socket_ingest(scanner, telemetry_socket_path(self._apply_id)):
+                self._scanner = scanner
+                return True
+        except Exception as error:
+            logger.warning("telemetry collector activation failed: %s", error)
+        return False
+
+    @endpoint
+    def activate(self) -> bool:
+        """Lazily bind the local socket and stand up the scanner."""
+        return self._activate_impl()
+
+    @endpoint
+    def set_worker_collectors(self, worker_collectors: List[Any]) -> None:
+        """Replace the client collector's worker fan-out list."""
+        self._scanner_or_raise()
+        self._worker_collectors = list(worker_collectors)
+
+    @endpoint
+    def table_names(self) -> List[str]:
+        """Get list of table names available in the local store."""
+        return self._scanner_or_raise().table_names()
+
+    @endpoint
+    def schema_for(self, table: str) -> bytes:
+        """Get schema for a table in Arrow IPC format."""
+        return bytes(self._scanner_or_raise().schema_for(table))
+
+    @endpoint
+    def apply_retention(self, table_name: str, where_clause: str) -> None:
+        """Apply a retention filter to a local table."""
+        self._scanner_or_raise().apply_retention(table_name, where_clause)
+
+    @endpoint
+    def store_pyspy_dump(
+        self, dump_id: str, proc_ref: str, pyspy_result_json: str
+    ) -> bool:
+        """Store py-spy dump data in local tables."""
+        self._scanner_or_raise().store_pyspy_dump_py(
+            dump_id, proc_ref, pyspy_result_json
+        )
+        return True
+
+    @endpoint
+    def scan(
+        self,
+        dest: PortId,
+        table_name: str,
+        projection: Optional[List[int]],
+        limit: Optional[int],
+        filter_expr: Optional[str],
+    ) -> int:
+        """Scan the local store and configured worker collectors."""
+        # The client collector is the singleton query root: scan its local store
+        # first, then fan out flat to active worker collectors. Worker collectors
+        # have an empty `_worker_collectors` list, so the same endpoint is
+        # leaf-only when invoked on a worker.
+        local_count: int = self._scanner_or_raise().scan(
+            dest, table_name, projection, limit, filter_expr
+        )
+
+        child_futures = []
+        for collector in self._worker_collectors:
+            try:
+                # Constructing the call can fail if the sidecar holds a stale
+                # actor ref. Treat that as reduced result coverage, matching
+                # the legacy best-effort query behavior.
+                child_futures.append(
+                    collector.scan.call(
+                        dest, table_name, projection, limit, filter_expr
+                    )
+                )
+            except Exception:
+                logger.info("worker telemetry scan call failed, skipping")
+
+        total_count = local_count
+        for future in child_futures:
+            try:
+                # Worker collectors are independent leaves. A slow or failed
+                # worker should reduce query coverage, not fail the root query.
+                child_results = future.get(timeout=_SCAN_WORKER_TIMEOUT_SECS)
+                for _rank, count in child_results:
+                    total_count += count
+            except TimeoutError:
+                logger.warning(
+                    "worker telemetry scan timed out after %ss",
+                    _SCAN_WORKER_TIMEOUT_SECS,
+                )
+            except Exception:
+                logger.info("worker telemetry scan failed, skipping")
+
+        return total_count

--- a/python/monarch/monarch_dashboard/server/app.py
+++ b/python/monarch/monarch_dashboard/server/app.py
@@ -11,20 +11,47 @@ initialises the database layer pointing at the fake data SQLite file,
 and serves the React frontend build as static files.
 """
 
+import atexit
 import logging
 import os
-import socket
 import ssl
 import threading
+from contextlib import ExitStack
+from importlib.resources import as_file
 
 from flask import Flask, send_from_directory
 from monarch.monarch_dashboard import _PKG
+from werkzeug.serving import make_server
 
 from . import db
 from .db import DBAdapter
 from .routes import api
 
 logger = logging.getLogger(__name__)
+
+
+def _frontend_build_dir() -> str:
+    """Resolve the bundled React build directory to a real filesystem path.
+
+    ``importlib.resources`` exposes packaged data as ``Traversable`` objects
+    whose backing store may be a zip archive (e.g. FastZIP PARs) rather than a
+    real directory; their ``str`` form is not a path that ``os.path`` or
+    Flask's ``static_folder`` can open, and a module ``__file__`` likewise
+    points inside the archive. ``as_file`` materialises the resource on the
+    filesystem -- a no-op when it already lives on disk, an extraction to a
+    temporary directory when it does not -- so the dashboard serves static
+    files correctly under every Buck packaging mode. The materialised copy is
+    retained for the process lifetime and removed at interpreter exit.
+
+    Returns an empty string when the frontend has not been built, in which case
+    the server degrades to API-only.
+    """
+    build = _PKG / "frontend" / "build"
+    if not build.is_dir():
+        return ""
+    stack = ExitStack()
+    atexit.register(stack.close)
+    return str(stack.enter_context(as_file(build)))
 
 
 def create_app(adapter: DBAdapter) -> Flask:
@@ -34,7 +61,7 @@ def create_app(adapter: DBAdapter) -> Flask:
         adapter: A DBAdapter instance for data access (e.g. SQLiteAdapter
             for local dev, QueryEngineAdapter for production).
     """
-    build_dir = str(_PKG / "frontend" / "build")
+    build_dir = _frontend_build_dir()
 
     app = Flask(
         __name__,
@@ -96,20 +123,6 @@ def start_dashboard(
     Raises:
         OSError: If the port is already in use.
     """
-    # Check port availability before starting the thread so failures
-    # are raised to the caller instead of silently killing the thread.
-    # Resolve host to the correct address family so IPv4 ("127.0.0.1"),
-    # IPv6 ("::"), and hostname forms all work.
-    family, _, _, _, sockaddr = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)[
-        0
-    ]
-    with socket.socket(family, socket.SOCK_STREAM) as s:
-        try:
-            s.bind(sockaddr)
-        except OSError:
-            logger.error("Dashboard failed to start: port %d is unavailable", port)
-            raise
-
     ssl_ctx: ssl.SSLContext | None = None
     tls_hostname: str | None = None
     try:
@@ -124,22 +137,33 @@ def start_dashboard(
     except ImportError:
         pass
 
-    if ssl_ctx is not None and tls_hostname is not None:
-        # pyrefly: ignore [unbound-name]
-        url = nest_dev_proxy_url(tls_hostname, port)
-        local_url = f"https://{tls_hostname}:{port}"
-    else:
-        url = f"http://localhost:{port}"
-        local_url = url
-
     app = create_app(adapter)
     # Suppress per-request werkzeug logs (they are noisy in production).
     logging.getLogger("werkzeug").setLevel(logging.WARNING)
 
+    try:
+        server = make_server(
+            host,
+            port,
+            app,
+            threaded=True,
+            ssl_context=ssl_ctx,
+        )
+    except OSError:
+        logger.exception("dashboard failed to start on %s:%s", host, port)
+        raise
+
+    actual_port = server.server_port
+    if ssl_ctx is not None and tls_hostname is not None:
+        # pyrefly: ignore [unbound-name]
+        url = nest_dev_proxy_url(tls_hostname, actual_port)
+        local_url = f"https://{tls_hostname}:{actual_port}"
+    else:
+        url = f"http://localhost:{actual_port}"
+        local_url = url
+
     thread = threading.Thread(
-        target=lambda: app.run(
-            host=host, port=port, debug=False, use_reloader=False, ssl_context=ssl_ctx
-        ),
+        target=server.serve_forever,
         daemon=True,
         name="monarch-dashboard",
     )
@@ -149,7 +173,7 @@ def start_dashboard(
     return {
         "url": url,
         "local_url": local_url,
-        "port": port,
+        "port": actual_port,
         "pid": None,
         "handle": thread,
     }

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -9,10 +9,15 @@
 """Tests for distributed telemetry with automatic callback registration."""
 
 import json
+import os
+import shutil
 import time
+import types
 import unittest.mock
+import uuid
 from typing import Any, cast
 
+import monarch._src.job.telemetry_actor as job_telemetry_actor
 import monarch.distributed_telemetry.actor as telemetry_actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
@@ -48,6 +53,98 @@ class SenderActor(Actor):
 def _telemetry_config(**kwargs: Any) -> TelemetryConfig:
     kwargs.setdefault("dashboard_port", 0)
     return TelemetryConfig(**kwargs)
+
+
+def _new_apply_id() -> str:
+    return f"test_{uuid.uuid4().hex}"
+
+
+def _remove_socket_dir(apply_id: str) -> None:
+    shutil.rmtree(
+        job_telemetry_actor.telemetry_socket_dir(apply_id), ignore_errors=True
+    )
+
+
+@pytest.mark.timeout(30)
+def test_telemetry_actor_starts_local_socket_collector() -> None:
+    apply_id = _new_apply_id()
+    _remove_socket_dir(apply_id)
+    try:
+        actor = job_telemetry_actor.TelemetryActor(apply_id, retention_secs=0)
+        with (
+            unittest.mock.patch.object(
+                job_telemetry_actor,
+                "current_rank",
+                return_value=types.SimpleNamespace(rank=0),
+            ),
+            unittest.mock.patch.object(
+                job_telemetry_actor,
+                "_start_socket_ingest",
+                return_value=True,
+            ) as start_ingest,
+        ):
+            assert actor._activate_impl()
+            assert actor._scanner is not None
+            # Second call is a no-op.
+            assert actor._activate_impl()
+
+        socket_dir = job_telemetry_actor.telemetry_socket_dir(apply_id)
+        socket_path = job_telemetry_actor.telemetry_socket_path(apply_id)
+        assert os.stat(socket_dir).st_mode & 0o777 == 0o700
+        start_ingest.assert_called_once()
+        assert start_ingest.call_args.args[1] == socket_path
+    finally:
+        _remove_socket_dir(apply_id)
+
+
+@pytest.mark.timeout(30)
+def test_telemetry_actor_skips_active_existing_collector() -> None:
+    apply_id = _new_apply_id()
+    _remove_socket_dir(apply_id)
+    try:
+        actor = job_telemetry_actor.TelemetryActor(apply_id, retention_secs=0)
+        with (
+            unittest.mock.patch.object(
+                job_telemetry_actor,
+                "current_rank",
+                return_value=types.SimpleNamespace(rank=0),
+            ),
+            unittest.mock.patch.object(
+                job_telemetry_actor,
+                "_start_socket_ingest",
+                return_value=False,
+            ),
+        ):
+            assert not actor._activate_impl()
+        assert actor._scanner is None
+        with pytest.raises(RuntimeError, match="not an active telemetry collector"):
+            actor._scanner_or_raise()
+    finally:
+        _remove_socket_dir(apply_id)
+
+
+@pytest.mark.timeout(30)
+def test_telemetry_actor_reports_activation_failure() -> None:
+    apply_id = _new_apply_id()
+    _remove_socket_dir(apply_id)
+    try:
+        actor = job_telemetry_actor.TelemetryActor(apply_id, retention_secs=0)
+        with (
+            unittest.mock.patch.object(
+                job_telemetry_actor,
+                "current_rank",
+                return_value=types.SimpleNamespace(rank=0),
+            ),
+            unittest.mock.patch.object(
+                job_telemetry_actor,
+                "_start_socket_ingest",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            assert not actor._activate_impl()
+        assert actor._scanner is None
+    finally:
+        _remove_socket_dir(apply_id)
 
 
 @pytest.fixture


### PR DESCRIPTION
Summary:

Two improvements to `start_dashboard` that make it robust under contexts the in-process dashboard does not usually hit but the upcoming sidecar will. (1) Resolve the React build dir with `importlib.resources.as_file(_PKG / "frontend" / "build")`, retaining the materialized path for the process lifetime via an `ExitStack` closed at interpreter exit. `importlib.resources.files(...)` returns a `Traversable` whose `str(...)` form is not a filesystem path under zip-based packaging, so the earlier `str(...)` usage caused frontend static files to 404 when the dashboard ran from a PAR; `os.path.dirname(__file__)` would have the same problem under FastZIP, where `__file__` points inside the archive rather than at a real directory. `as_file` returns the directory unchanged when the package lives on disk (pip installs, extracted PARs, mounted XARs) and extracts it to a temporary directory when the package is served from a zip, so Flask's `static_folder` and `os.path` always see an openable path regardless of Buck packaging mode. (2) Bind the HTTP server via `werkzeug.serving.make_server(host, port, app)` and return `server.server_port` instead of `app.run(port=port)` and the requested port. With `make_server`, a `port=0` request is bound to an OS-assigned ephemeral port and the resolved port is read back from the server object, so callers get back a real URL instead of `http://localhost:0`. Drops the pre-bind socket-availability probe (TOCTOU dance) because `make_server` raises `OSError` synchronously on bind failure.

Reviewed By: dulinriley

Differential Revision: D106687761


