### PR TITLE
fix: add missing HashSet import in ordering.rs test module

### DIFF
--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -469,6 +469,7 @@ impl Sequencer {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering as AtomicOrdering;


### PR DESCRIPTION
## Summary

The chaos test added in #4064 (`add end-to-end OrderedSender chaos test`) uses `HashSet<Uuid>` at line 1545 of `hyperactor/src/ordering.rs` inside the `#[cfg(test)] mod tests` block, but `HashSet` is not imported in that module. The parent module has `use std::collections::HashSet;` but that is a private binding and is not pulled in by `use super::*`.

This causes a compile error on both x86_64 and arm64:
```
error[E0425]: cannot find value `HashSet` in this scope
  --> hyperactor/src/ordering.rs:1545:32
   |
1545|         let distinct_sessions: HashSet<Uuid> = sender_session.values().copied().collect();
   |                                ^^^^^^^  not found in this scope
```

**Fix:** add `use std::collections::HashSet;` to the test module's imports.

## Test plan

- CI build passes (no more E0425 compile error)