### PR TITLE
add missing HashSet import in ordering tests

### DIFF
--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -469,6 +469,7 @@ impl Sequencer {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
     use std::sync::atomic::Ordering as AtomicOrdering;


### PR DESCRIPTION
Summary: D106411465 used `HashSet` in `ordering::tests` at two sites without importing the type, breaking the build on master.

Differential Revision: D106705548


