### PR TITLE
Use CastDomain for actor meshes (#4098)

### DIFF
--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -131,6 +131,7 @@ impl CastDomainId {
         members: HashMap<usize, ActorAddr>,
         region: Region,
         tiling_policy: TilingPolicy,
+        headers: Flattrs,
     ) -> anyhow::Result<CastDomainRef> {
         anyhow::ensure!(
             members.len() == region.num_ranks()
@@ -168,8 +169,9 @@ impl CastDomainId {
         let root_tile =
             MaterializedTile::from_value_mesh_with_tile(Tile::from_view(&region), member_mesh);
 
-        domain_ref.entry_point.post(
+        domain_ref.entry_point.port().post_with_headers(
             cx,
+            headers,
             CreateCastDomain {
                 cast_domain_id: self,
                 region,
@@ -1360,6 +1362,7 @@ mod tests {
                     self.domain_members(),
                     region,
                     TilingPolicy::BlockPartitioning,
+                    Flattrs::new(),
                 )
                 .unwrap()
         }
@@ -1372,7 +1375,13 @@ mod tests {
 
         fn root_domain_with_policy(&self, region: Region, policy: TilingPolicy) -> CastDomainRef {
             CastDomainId::new()
-                .materialize(&self.client, self.member_ids.clone(), region, policy)
+                .materialize(
+                    &self.client,
+                    self.member_ids.clone(),
+                    region,
+                    policy,
+                    Flattrs::new(),
+                )
                 .unwrap()
         }
 

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -50,7 +50,7 @@ use uuid::Uuid;
 
 use crate::tile::MaterializedTile;
 use crate::tile::Tile;
-use crate::tile::TilingPolicy;
+pub use crate::tile::TilingPolicy;
 
 hyperactor_config::declare_attrs! {
     /// Header stamped on each locally delivered message with the
@@ -80,6 +80,22 @@ hyperactor_config::declare_attrs! {
     /// recipient.
     pub attr CAST_LINEAGE: Vec<usize>;
 }
+
+/// Wire-compatible mirror of `hyperactor_mesh::resource::RankRepr`.
+///
+/// `hyperactor_cast` cannot depend on `hyperactor_mesh` without creating a
+/// crate cycle, but cast delivery still needs to stamp the rank multipart part
+/// for messages whose handlers read rank from the payload. The part is tagged
+/// with `RankRepr`'s typename, so this mirror must match it exactly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ResourceRankRepr(Option<usize>);
+
+impl Named for ResourceRankRepr {
+    fn typename() -> &'static str {
+        "hyperactor_mesh::resource::RankRepr"
+    }
+}
+
 /// Pure, data-only identifier for a cast domain.
 ///
 /// This type contains no runtime references (e.g. `ActorRef`) and can
@@ -677,6 +693,7 @@ fn split_ports(
 
     Ok(())
 }
+
 /// Test-only forwarding path metadata.
 ///
 /// In production this is zero-sized and optimized away. In tests, each
@@ -779,6 +796,17 @@ impl Handler<CastMessage> for CastActor {
 
         // Deliver to destination actor.
         {
+            let mut local_data = data.clone();
+
+            let rank = domain.point_in_domain.rank();
+
+            local_data.visit_multipart_parts_mut::<ResourceRankRepr, anyhow::Error>(
+                |ResourceRankRepr(resource_rank)| {
+                    *resource_rank = Some(rank);
+                    Ok(())
+                },
+            )?;
+
             let seq = *message
                 .seqs
                 .get_by_base_rank(domain.base_rank_in_domain)
@@ -809,7 +837,7 @@ impl Handler<CastMessage> for CastActor {
                 &dest,
                 &message.sender,
             );
-            cx.post_with_external_seq_info(dest, headers, data.clone().erase_encoding());
+            cx.post_with_external_seq_info(dest, headers, local_data.erase_encoding());
         }
 
         for next_hop in &domain.next_hops {

--- a/hyperactor_cast/src/lib.rs
+++ b/hyperactor_cast/src/lib.rs
@@ -15,3 +15,5 @@
 
 pub mod cast_actor;
 mod tile;
+
+pub use tile::TilingPolicy;

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -8,18 +8,29 @@
 
 //! ## Actor mesh invariants (AM-*)
 //!
-//! - **AM-1 (rank-space):** `proc_mesh` and any view derived from
-//!   it share the same dense rank space.
+//! - **AM-1 (rank-space):** `ActorMeshRef` uses its `CastDomainRef` as
+//!   the source of truth for actor addresses. The cast domain stores
+//!   members in the same dense rank order as the mesh `Region`, so a
+//!   rank can be materialized by indexing the cast-domain member map
+//!   directly; the reference does not need to retain the `ProcMeshRef`
+//!   that created it.
+//! - **AM-2 (slice materialization):** `RankedSliceable::sliced` has no
+//!   caller context, so it carries only a raw cast-domain descriptor. The first
+//!   cast through that ref materializes the descriptor with the caller context
+//!   before sending the cast message, sequencing setup and delivery on the same
+//!   sender stream.
 
 use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
+use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::OnceLock as OnceCell;
 use std::time::Duration;
 
+use hyperactor::ActorAddr;
 use hyperactor::ActorLocal;
 use hyperactor::ActorRef;
 use hyperactor::Endpoint as _;
@@ -36,14 +47,15 @@ use hyperactor::context;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::port::Port;
 use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_cast::TilingPolicy;
+use hyperactor_cast::cast_actor::CastDomainId;
+use hyperactor_cast::cast_actor::CastDomainRef;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
-use ndslice::Selection;
 use ndslice::ViewExt as _;
 use ndslice::view;
-use ndslice::view::MapIntoExt;
 use ndslice::view::Region;
 use ndslice::view::View;
 use serde::Deserialize;
@@ -52,14 +64,11 @@ use serde::Serialize;
 use serde::Serializer;
 use tokio::sync::watch;
 
-use crate::CommActor;
 use crate::Error;
 use crate::ProcMeshRef;
 use crate::ValueMesh;
-use crate::casting;
 use crate::comm::multicast;
-use crate::comm::multicast::CastMessageV1;
-use crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD;
+use crate::config::MAX_CAST_FANOUT;
 use crate::host_mesh::GET_PROC_STATE_MAX_IDLE;
 use crate::host_mesh::mesh_to_rankedvalues_with_default;
 use crate::mesh_controller::ActorMeshController;
@@ -67,7 +76,7 @@ use crate::mesh_controller::SUPERVISION_POLL_FREQUENCY;
 use crate::mesh_controller::Subscribe;
 use crate::mesh_controller::Unsubscribe;
 use crate::mesh_id::ActorMeshId;
-use crate::metrics;
+use crate::mesh_id::ProcMeshId;
 use crate::proc_mesh::GET_ACTOR_STATE_MAX_IDLE;
 use crate::proc_mesh::telemetry_actor_mesh_id;
 use crate::resource;
@@ -113,12 +122,14 @@ impl<A: Referable> ActorMesh<A> {
         proc_mesh: ProcMeshRef,
         id: ActorMeshId,
         controller: Option<ActorRef<ActorMeshController<A>>>,
+        members: Arc<ValueMesh<ActorAddr>>,
     ) -> Self {
-        let current_ref = ActorMeshRef::with_page_size(
+        let current_ref = ActorMeshRef::new(
             id.clone(),
-            proc_mesh.clone(),
-            DEFAULT_PAGE,
+            Some(proc_mesh.id().clone()),
+            proc_mesh.region().clone(),
             controller.clone(),
+            members,
         );
 
         Self {
@@ -355,6 +366,117 @@ impl<M: Send + Sync + Clone + Default + 'static> Default for MessageOrFailure<M>
     }
 }
 
+fn default_cast_tiling_policy() -> TilingPolicy {
+    TilingPolicy::BoundedFanout {
+        fanout: NonZeroUsize::new(hyperactor_config::global::get(MAX_CAST_FANOUT))
+            .expect("MAX_CAST_FANOUT must be > 0"),
+    }
+}
+
+#[derive(Clone)]
+struct ActorMeshCastDomain {
+    id: CastDomainId,
+    members: Arc<ValueMesh<ActorAddr>>,
+    region: Region,
+    tiling_policy: TilingPolicy,
+    cast_domain: ActorLocal<CastDomainRef>,
+}
+
+impl std::fmt::Debug for ActorMeshCastDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ActorMeshCastDomain")
+            .field("id", &self.id)
+            .field("members", &self.members)
+            .field("region", &self.region)
+            .field("tiling_policy", &self.tiling_policy)
+            .finish_non_exhaustive()
+    }
+}
+
+impl ActorMeshCastDomain {
+    fn new(members: Arc<ValueMesh<ActorAddr>>, region: Region) -> Self {
+        Self {
+            id: CastDomainId::new(),
+            members,
+            region,
+            tiling_policy: default_cast_tiling_policy(),
+            cast_domain: ActorLocal::new(),
+        }
+    }
+
+    fn ensure_materialized(
+        &self,
+        cx: &impl context::Actor,
+        headers: &Flattrs,
+    ) -> anyhow::Result<CastDomainRef> {
+        if let hyperactor::actor_local::Entry::Occupied(cast_domain) = self.cast_domain.entry(cx) {
+            return Ok(cast_domain.get().clone());
+        }
+
+        let members =
+            self.region
+                .slice()
+                .iter()
+                .map(|rank| {
+                    let member = self.members.get_by_base_rank(rank).ok_or_else(|| {
+                        anyhow::anyhow!("missing cast-domain member for rank {rank}")
+                    })?;
+                    Ok((rank, member.clone()))
+                })
+                .collect::<anyhow::Result<HashMap<_, _>>>()?;
+
+        let cast_domain = self.id.clone().materialize(
+            cx,
+            members,
+            self.region.clone(),
+            self.tiling_policy,
+            headers.clone(),
+        )?;
+
+        self.cast_domain.entry(cx).or_insert(cast_domain.clone());
+
+        Ok(cast_domain)
+    }
+
+    fn members(&self) -> &ValueMesh<ActorAddr> {
+        &self.members
+    }
+
+    fn region(&self) -> &Region {
+        &self.region
+    }
+}
+
+impl Serialize for ActorMeshCastDomain {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        (&self.id, &self.members, &self.region, self.tiling_policy).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ActorMeshCastDomain {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let (id, members, region, tiling_policy) = <(
+            CastDomainId,
+            Arc<ValueMesh<ActorAddr>>,
+            Region,
+            TilingPolicy,
+        )>::deserialize(deserializer)?;
+        Ok(Self {
+            id,
+            members,
+            region,
+            tiling_policy,
+            cast_domain: ActorLocal::new(),
+        })
+    }
+}
+
 /// Turn the single-owner PortReceiver into a watch receiver, which can be
 /// cloned and subscribed to. Requires a default message to pre-populate with.
 /// Option can be used as M to provide a default of None.
@@ -411,8 +533,12 @@ fn into_watch<M: Send + Sync + Clone + Default + 'static>(
 /// A reference to a stable snapshot of an [`ActorMesh`].
 #[derive(typeuri::Named)]
 pub struct ActorMeshRef<A: Referable> {
-    proc_mesh: ProcMeshRef,
     id: ActorMeshId,
+    /// Id of the proc mesh backing this actor mesh, if any. Retained as a
+    /// lightweight id (not the `ProcMeshRef`) so telemetry can derive the same
+    /// mesh id as creation time without holding proc-mesh state. `None` for
+    /// meshes not backed by a user proc mesh (e.g. the host-agent mesh).
+    proc_mesh_id: Option<ProcMeshId>,
     /// Reference to a remote controller actor living on the proc that spawned
     /// the actors in this ref. If None, the actor mesh was already stopped, or
     /// this is a mesh ref to a "system actor" which has no controller and should
@@ -421,6 +547,13 @@ pub struct ActorMeshRef<A: Referable> {
     /// stopped.
     controller: Option<ActorRef<ActorMeshController<A>>>,
 
+    /// Cast-domain handle for this mesh view.
+    ///
+    /// A cast domain is the `hyperactor_cast` routing state used to deliver a
+    /// mesh-wide cast without iterating over every destination actor. The
+    /// descriptor can be carried by pure slices; routing setup is fenced by the
+    /// first cast from the caller that uses this ref.
+    cast_domain: ActorMeshCastDomain,
     /// Recorded health issues with the mesh, to quickly consult before sending
     /// out any casted messages. This is a locally updated copy of the authoritative
     /// state stored on the ActorMeshController.
@@ -489,24 +622,130 @@ impl<A: Referable> ActorMeshRef<A> {
         self.check_cached_failure(cx)?;
         self.emit_sent_message_telemetry(cx, view::Ranked::region(self));
 
-        if let Some(root_comm_actor) = self.proc_mesh.root_comm_actor() {
-            if casting::v1_casting_enabled() {
-                self.cast_v1(cx, message, root_comm_actor, caller_headers);
+        let mut headers = caller_headers.clone();
+        headers.set(
+            multicast::CAST_ORIGINATING_SENDER,
+            cx.instance().self_addr().clone(),
+        );
+        headers.set(crate::casting::CAST_ACTOR_MESH_ID, self.id.clone());
+
+        let threshold =
+            hyperactor_config::global::get(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD);
+
+        let num_ranks = self.len();
+
+        match num_ranks {
+            0 => Ok(()),
+            1 if threshold >= 1 => {
+                // Avoid paying tax of conversion to IndexedErasedUnbound and port splitting
+                // when the threshold enables direct singleton sends.
+                let point = self
+                    .cast_domain
+                    .region()
+                    .extent()
+                    .point_of_rank(0)
+                    .map_err(|err| Error::CastingError(self.id.clone(), err.into()))?;
+
+                let actor = self.materialize(0).ok_or_else(|| {
+                    Error::CastingError(
+                        self.id.clone(),
+                        anyhow::anyhow!("missing actor for rank 0"),
+                    )
+                })?;
+
+                self.post_cast_direct(cx, point, actor, message, &headers)
+            }
+            n if threshold > 0 && n < threshold => {
+                // Point-to-point: send directly to each destination actor,
+                // bypassing the comm actor tree for lower latency when fanout
+                // is small.
+                let sender = cx.instance().self_addr().clone();
+                let dest_port = M::port();
+                let mut data =
+                    wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message)
+                        .expect("cast message serialization should not fail");
+
+                // Split ports for N destinations, matching the comm tree's
+                // split_ports behavior.
+                data.visit_multipart_parts_mut::<PortRefRepr, anyhow::Error>(|port| {
+                    if port.unsplit() {
+                        return Ok(());
+                    }
+                    let split = port.port_addr().split(
+                        cx,
+                        port.reducer_spec().clone(),
+                        ReducerMode::Streaming(port.streaming_opts().clone()),
+                        port.get_return_undeliverable(),
+                    )?;
+                    port.update_port_addr(split);
+                    Ok(())
+                })
+                .map_err(|e| Error::CastingError(self.id.clone(), e))?;
+
+                data.visit_multipart_parts_mut::<OncePortRefRepr, anyhow::Error>(|port| {
+                    if port.unsplit() || port.reducer_spec().is_none() {
+                        // Once ports without reducers pass through. If used more
+                        // than once, only one destination can reply.
+                        return Ok(());
+                    }
+                    let split = port.port_addr().split(
+                        cx,
+                        port.reducer_spec().clone(),
+                        ReducerMode::Once(n),
+                        port.get_return_undeliverable(),
+                    )?;
+                    port.update_port_addr(split);
+                    Ok(())
+                })
+                .map_err(|e| Error::CastingError(self.id.clone(), e))?;
+
+                for rank in 0..n {
+                    let point = self
+                        .cast_domain
+                        .region()
+                        .extent()
+                        .point_of_rank(rank)
+                        .map_err(|err| Error::CastingError(self.id.clone(), err.into()))?;
+
+                    let actor = self.materialize(rank).ok_or_else(|| {
+                        Error::CastingError(
+                            self.id.clone(),
+                            anyhow::anyhow!("missing actor for rank {rank}"),
+                        )
+                    })?;
+
+                    let mut rank_data = data.clone();
+
+                    rank_data
+                        .visit_multipart_parts_mut::<resource::RankRepr, anyhow::Error>(
+                            |resource::RankRepr(rank)| {
+                                *rank = Some(point.rank());
+                                Ok(())
+                            },
+                        )
+                        .map_err(|e| Error::CastingError(self.id.clone(), e))?;
+
+                    let mut rank_headers = headers.clone();
+
+                    multicast::set_cast_info_on_headers(&mut rank_headers, point, sender.clone());
+
+                    cx.instance().post(
+                        actor
+                            .actor_addr()
+                            .port_addr(Port::handler_id(dest_port, None)),
+                        rank_headers,
+                        rank_data.erase_encoding(),
+                    );
+                }
+
                 Ok(())
-            } else {
-                self.cast_v0(
-                    cx,
-                    message,
-                    ndslice::selection::dsl::true_(),
-                    root_comm_actor,
-                    caller_headers,
-                )
             }
-        } else {
-            for (point, actor) in self.iter() {
-                self.post_cast_direct(cx, point, &actor, message.clone(), caller_headers)?;
-            }
-            Ok(())
+            _ => self
+                .cast_domain
+                .ensure_materialized(cx, &headers)
+                .map_err(|e| Error::CastingError(self.id.clone(), e))?
+                .cast(cx, headers, message)
+                .map_err(|e| Error::CastingError(self.id.clone(), e)),
         }
     }
 
@@ -533,47 +772,29 @@ impl<A: Referable> ActorMeshRef<A> {
             ),
         );
 
-        if !casting::v1_casting_enabled()
-            && let Some(root_comm_actor) = self.proc_mesh.root_comm_actor()
-        {
-            self.cast_v0(
-                cx,
-                message,
-                ndslice::selection::dsl::any(ndslice::selection::dsl::true_()),
-                root_comm_actor,
-                caller_headers,
-            )
-        } else {
-            self.cast_choose_direct(cx, message, caller_headers)
+        let num_ranks = self.cast_domain.region().num_ranks();
+
+        if num_ranks == 0 {
+            return Ok(());
         }
-    }
 
-    /// Cast a message to the actors in this mesh according to the provided selection.
-    /// This should *only* be used for temporary support for selections in the tensor
-    /// engine. If you use this for anything else, you will be fired (you too, OSS
-    /// contributor).
-    #[allow(clippy::result_large_err)]
-    pub fn cast_for_tensor_engine_only_do_not_use<M>(
-        &self,
-        cx: &impl context::Actor,
-        sel: Selection,
-        message: M,
-    ) -> crate::Result<()>
-    where
-        A: RemoteHandles<M>,
-        M: RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
-    {
-        self.check_cached_failure(cx)?;
-        self.emit_sent_message_telemetry(cx, view::Ranked::region(self));
+        let rank_index = rand::random::<u64>() as usize % num_ranks;
 
-        let Some(root_comm_actor) = self.proc_mesh.root_comm_actor() else {
-            return Err(Error::CastingError(
+        let point = self
+            .cast_domain
+            .region()
+            .extent()
+            .point_of_rank(rank_index)
+            .map_err(|err| Error::CastingError(self.id.clone(), err.into()))?;
+
+        let actor = self.materialize(rank_index).ok_or_else(|| {
+            Error::CastingError(
                 self.id.clone(),
-                anyhow::anyhow!("tensor-engine selection casts require a root CommActor"),
-            ));
-        };
+                anyhow::anyhow!("missing actor for chosen rank {rank_index}"),
+            )
+        })?;
 
-        self.cast_v0(cx, message, sel, root_comm_actor, &Flattrs::new())
+        self.post_cast_direct(cx, point, actor, message, caller_headers)
     }
 
     #[allow(clippy::result_large_err)]
@@ -596,48 +817,18 @@ impl<A: Referable> ActorMeshRef<A> {
         hyperactor_telemetry::notify_sent_message(hyperactor_telemetry::SentMessageEvent {
             timestamp: std::time::SystemTime::now(),
             sender_actor_id: hyperactor_telemetry::hash_to_u64(cx.mailbox().actor_addr().id()),
-            actor_mesh_id: telemetry_actor_mesh_id(self.proc_mesh.id(), &self.id),
+            actor_mesh_id: match &self.proc_mesh_id {
+                Some(proc_mesh_id) => telemetry_actor_mesh_id(proc_mesh_id, &self.id),
+                // No backing proc mesh (e.g. the host-agent mesh): key telemetry
+                // on the actor mesh id alone.
+                None => hyperactor_telemetry::hash_to_u64(&self.id),
+            },
             view_json: serde_json::to_string(region).unwrap_or_default(),
             shape_json: {
                 let shape: ndslice::Shape = region.into();
                 serde_json::to_string(&shape).unwrap_or_default()
             },
         });
-    }
-
-    #[allow(clippy::result_large_err)]
-    fn cast_choose_direct<M>(
-        &self,
-        cx: &impl context::Actor,
-        message: M,
-        caller_headers: &Flattrs,
-    ) -> crate::Result<()>
-    where
-        A: RemoteHandles<M>,
-        M: RemoteMessage,
-    {
-        let region = view::Ranked::region(self);
-
-        let num_ranks = region.num_ranks();
-        if num_ranks == 0 {
-            return Ok(());
-        }
-
-        let rank_index = rand::random::<u64>() as usize % num_ranks;
-
-        let point = region
-            .extent()
-            .point_of_rank(rank_index)
-            .map_err(|err| Error::CastingError(self.id.clone(), err.into()))?;
-
-        let actor = view::Ranked::get(self, point.rank()).ok_or_else(|| {
-            Error::CastingError(
-                self.id.clone(),
-                anyhow::anyhow!("missing actor for chosen rank {}", point.rank()),
-            )
-        })?;
-
-        self.post_cast_direct(cx, point, actor, message, caller_headers)
     }
 
     #[allow(clippy::result_large_err)]
@@ -672,200 +863,17 @@ impl<A: Referable> ActorMeshRef<A> {
             .deserialized_unchecked()
             .map_err(|e| Error::CastingError(self.id.clone(), e.into()))?;
         actor.post_with_headers(cx, headers, rebound_message);
-
         Ok(())
     }
 
-    #[allow(clippy::result_large_err)]
-    fn cast_v0<M>(
-        &self,
-        cx: &impl context::Actor,
-        message: M,
-        sel: Selection,
-        root_comm_actor: &ActorRef<CommActor>,
-        caller_headers: &Flattrs,
-    ) -> crate::Result<()>
-    where
-        A: RemoteHandles<M>,
-        M: RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
-    {
-        let cast_mesh_shape = view::Ranked::region(self).into();
-        let actor_mesh_id = self.id.clone();
-        match &self.proc_mesh.root_region {
-            Some(root_region) => {
-                let root_mesh_shape = root_region.into();
-                casting::cast_to_sliced_mesh::<A, M>(
-                    cx,
-                    actor_mesh_id,
-                    root_comm_actor,
-                    &sel,
-                    message,
-                    &cast_mesh_shape,
-                    &root_mesh_shape,
-                    caller_headers,
-                )
-                .map_err(|e| Error::CastingError(self.id.clone(), e.into()))
-            }
-            None => casting::actor_mesh_cast::<A, M>(
-                cx,
-                actor_mesh_id,
-                root_comm_actor,
-                sel,
-                &cast_mesh_shape,
-                &cast_mesh_shape,
-                message,
-                caller_headers,
-            )
-            .map_err(|e| Error::CastingError(self.id.clone(), e.into())),
-        }
-    }
-
-    fn cast_v1<M>(
-        &self,
-        cx: &impl context::Actor,
-        message: M,
-        root_comm_actor: &ActorRef<CommActor>,
-        caller_headers: &Flattrs,
-    ) where
-        A: RemoteHandles<M>,
-        M: RemoteMessage,
-    {
-        let _ = metrics::ACTOR_MESH_CAST_DURATION.start(hyperactor::kv_pairs!(
-            "message_type" => <M as typeuri::Named>::typename(),
-            "message_variant" => message.arm().unwrap_or_default(),
-        ));
-
-        let actor_ids: ValueMesh<_> = self.proc_mesh.map_into(|proc| proc.actor_addr(&self.id));
-
-        let mut headers = caller_headers.clone();
-        headers.set(
-            multicast::CAST_ORIGINATING_SENDER,
-            cx.instance().self_addr().clone(),
-        );
-        // Set CAST_ACTOR_MESH_ID temporarily to support supervision's
-        // v0 transition. Should be removed once supervision is migrated
-        // and ActorMeshId is deleted.
-        headers.set(casting::CAST_ACTOR_MESH_ID, self.id.clone());
-
-        let region = view::Ranked::region(self).clone();
-        let num_ranks = region.num_ranks();
-        let threshold = hyperactor_config::global::get(V1_CAST_POINT_TO_POINT_THRESHOLD);
-
-        if threshold > 0 && num_ranks < threshold {
-            // Point-to-point: send directly to each destination actor,
-            // bypassing the comm actor tree for lower latency when fanout
-            // is small.
-            let sender = cx.instance().self_addr().clone();
-            let dest_port = M::port();
-
-            let mut data = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message)
-                .expect("cast message serialization should not fail");
-
-            // Split ports for N destinations, matching the comm tree's
-            // split_ports behavior.
-            data.visit_multipart_parts_mut::<PortRefRepr, anyhow::Error>(|port| {
-                if port.unsplit() {
-                    return Ok(());
-                }
-                let split = port.port_addr().split(
-                    cx,
-                    port.reducer_spec().clone(),
-                    ReducerMode::Streaming(port.streaming_opts().clone()),
-                    port.get_return_undeliverable(),
-                )?;
-                port.update_port_addr(split);
-                Ok(())
-            })
-            .expect("port splitting should not fail");
-
-            data.visit_multipart_parts_mut::<OncePortRefRepr, anyhow::Error>(|port| {
-                if port.unsplit() || port.reducer_spec().is_none() {
-                    // Once ports without reducers pass through, same as the comm
-                    // tree's split_ports.
-                    return Ok(());
-                }
-                let split = port.port_addr().split(
-                    cx,
-                    port.reducer_spec().clone(),
-                    ReducerMode::Once(num_ranks),
-                    true,
-                )?;
-                port.update_port_addr(split);
-                Ok(())
-            })
-            .expect("once port splitting should not fail");
-
-            for rank in 0..num_ranks {
-                let mut rank_data = data.clone();
-
-                let cast_point = region
-                    .point_of_base_rank(rank)
-                    .expect("rank should be valid in region");
-
-                rank_data
-                    .visit_multipart_parts_mut::<resource::RankRepr, anyhow::Error>(
-                        |resource::RankRepr(r)| {
-                            *r = Some(cast_point.rank());
-                            Ok(())
-                        },
-                    )
-                    .expect("rank replacement should not fail");
-
-                let mut rank_headers = headers.clone();
-                multicast::set_cast_info_on_headers(&mut rank_headers, cast_point, sender.clone());
-
-                let port_id = actor_ids
-                    .get(rank)
-                    .expect("mismatched actor_ids and dest_region")
-                    .port_addr(Port::handler_id(dest_port, None));
-
-                cx.instance()
-                    .post(port_id, rank_headers, rank_data.erase_encoding());
-            }
-        } else {
-            // Tree path: route through the comm actor tree.
-            // Pre-compute sequence numbers — this block is infallible so
-            // rollback is not a concern.
-            let sequencer = cx.instance().sequencer();
-            let seqs: ValueMesh<u64> = actor_ids.map_into(|actor_id| {
-                let hyperactor::ordering::SeqInfo::Session { seq, .. } =
-                    sequencer.assign_seq(&actor_id.port_addr(Port::handler::<M>()))
-                else {
-                    unreachable!("assign_seq always returns SeqInfo::Session")
-                };
-                seq
-            });
-
-            let mut headers = caller_headers.clone();
-            headers.set(
-                multicast::CAST_ORIGINATING_SENDER,
-                cx.instance().self_addr().clone(),
-            );
-            // Set CAST_ACTOR_MESH_ID temporarily to support supervision's
-            // v0 transition. Should be removed once supervision is migrated
-            // and ActorMeshId is deleted.
-            headers.set(casting::CAST_ACTOR_MESH_ID, self.id.clone());
-            let cast_message = CastMessageV1::new::<A, M>(
-                cx.instance().self_addr().clone(),
-                &self.id,
-                region,
-                headers.clone(),
-                message,
-                sequencer.session_id(),
-                seqs,
-            )
-            .expect("infallible because CastMessage should not fail for serialization");
-
-            // TODO: load balancing instead of always using the first comm actor
-            root_comm_actor.post_with_headers(cx, headers, cast_message);
-        }
-    }
     pub(crate) fn new(
         id: ActorMeshId,
-        proc_mesh: ProcMeshRef,
+        proc_mesh_id: Option<ProcMeshId>,
+        region: Region,
         controller: Option<ActorRef<ActorMeshController<A>>>,
+        members: Arc<ValueMesh<ActorAddr>>,
     ) -> Self {
-        Self::with_page_size(id, proc_mesh, DEFAULT_PAGE, controller)
+        Self::with_page_size(id, proc_mesh_id, region, DEFAULT_PAGE, controller, members)
     }
 
     pub fn id(&self) -> &ActorMeshId {
@@ -874,14 +882,33 @@ impl<A: Referable> ActorMeshRef<A> {
 
     pub(crate) fn with_page_size(
         id: ActorMeshId,
-        proc_mesh: ProcMeshRef,
+        proc_mesh_id: Option<ProcMeshId>,
+        region: Region,
         page_size: usize,
         controller: Option<ActorRef<ActorMeshController<A>>>,
+        members: Arc<ValueMesh<ActorAddr>>,
+    ) -> Self {
+        Self::with_cast_domain(
+            id,
+            proc_mesh_id,
+            controller,
+            ActorMeshCastDomain::new(members, region),
+            page_size,
+        )
+    }
+
+    fn with_cast_domain(
+        id: ActorMeshId,
+        proc_mesh_id: Option<ProcMeshId>,
+        controller: Option<ActorRef<ActorMeshController<A>>>,
+        cast_domain: ActorMeshCastDomain,
+        page_size: usize,
     ) -> Self {
         Self {
-            proc_mesh,
             id,
+            proc_mesh_id,
             controller,
+            cast_domain,
             health_state: ActorLocal::new(),
             receiver: ActorLocal::new(),
             pages: OnceCell::new(),
@@ -889,13 +916,9 @@ impl<A: Referable> ActorMeshRef<A> {
         }
     }
 
-    pub fn proc_mesh(&self) -> &ProcMeshRef {
-        &self.proc_mesh
-    }
-
     #[inline]
     fn len(&self) -> usize {
-        view::Ranked::region(&self.proc_mesh).num_ranks()
+        self.cast_domain.region().num_ranks()
     }
 
     pub fn controller(&self) -> &Option<ActorRef<ActorMeshController<A>>> {
@@ -917,6 +940,7 @@ impl<A: Referable> ActorMeshRef<A> {
         if rank >= len {
             return None;
         }
+        let cast_domain = &self.cast_domain;
         let p = self.page_size;
         let page_ix = rank / p;
         let local_ix = rank % p;
@@ -931,20 +955,14 @@ impl<A: Referable> ActorMeshRef<A> {
         });
 
         Some(page.slots[local_ix].get_or_init(|| {
-            // AM-1: see module doc.
-            //   - ranks are contiguous [0, self.len()) with no gaps
-            //     or reordering
-            //   - for every rank r, `proc_mesh.get(r)` is Some(..)
-            // Therefore we can index `proc_mesh` with `rank`
-            // directly.
+            // AM-1: see module doc. The cast domain member map is in the
+            // same dense local-rank order as this mesh ref's region.
             debug_assert!(rank < self.len(), "rank must be within [0, len)");
-            debug_assert!(
-                ndslice::view::Ranked::get(&self.proc_mesh, rank).is_some(),
-                "proc_mesh must be dense/aligned with this view"
-            );
-            let proc_ref =
-                ndslice::view::Ranked::get(&self.proc_mesh, rank).expect("rank in-bounds");
-            proc_ref.attest(&self.id)
+            ActorRef::attest(
+                view::Ranked::get(cast_domain.members(), rank)
+                    .expect("rank must be present in cast-domain member map")
+                    .clone(),
+            )
         }))
     }
 
@@ -1094,9 +1112,10 @@ impl<A: Referable> ActorMeshRef<A> {
     /// Will have a separate cache.
     pub fn clone_with_supervision_receiver(&self) -> Self {
         Self {
-            proc_mesh: self.proc_mesh.clone(),
             id: self.id.clone(),
+            proc_mesh_id: self.proc_mesh_id.clone(),
             controller: self.controller.clone(),
+            cast_domain: self.cast_domain.clone(),
             health_state: self.health_state.clone(),
             receiver: self.receiver.clone(),
             // Cache does not support Clone at this time.
@@ -1109,9 +1128,10 @@ impl<A: Referable> ActorMeshRef<A> {
 impl<A: Referable> Clone for ActorMeshRef<A> {
     fn clone(&self) -> Self {
         Self {
-            proc_mesh: self.proc_mesh.clone(),
             id: self.id.clone(),
+            proc_mesh_id: self.proc_mesh_id.clone(),
             controller: self.controller.clone(),
+            cast_domain: self.cast_domain.clone(),
             // Cloning should not use the same health state or receiver, because
             // it should make a new subscriber.
             health_state: ActorLocal::new(),
@@ -1124,20 +1144,29 @@ impl<A: Referable> Clone for ActorMeshRef<A> {
 
 impl<A: Referable> fmt::Display for ActorMeshRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}@{}", self.id, A::typename(), self.proc_mesh)
+        write!(
+            f,
+            "{}:{}@{}",
+            self.id,
+            A::typename(),
+            self.cast_domain.region()
+        )
     }
 }
 
 impl<A: Referable> PartialEq for ActorMeshRef<A> {
     fn eq(&self, other: &Self) -> bool {
-        self.proc_mesh == other.proc_mesh && self.id == other.id
+        self.cast_domain.region() == other.cast_domain.region()
+            && self.cast_domain.id.domain_id() == other.cast_domain.id.domain_id()
+            && self.id == other.id
     }
 }
 impl<A: Referable> Eq for ActorMeshRef<A> {}
 
 impl<A: Referable> Hash for ActorMeshRef<A> {
     fn hash<H: Hasher>(&self, state: &mut H) {
-        self.proc_mesh.hash(state);
+        self.cast_domain.region().hash(state);
+        self.cast_domain.id.domain_id().hash(state);
         self.id.hash(state);
     }
 }
@@ -1145,7 +1174,7 @@ impl<A: Referable> Hash for ActorMeshRef<A> {
 impl<A: Referable> fmt::Debug for ActorMeshRef<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ActorMeshRef")
-            .field("proc_mesh", &self.proc_mesh)
+            .field("region", self.cast_domain.region())
             .field("id", &self.id)
             .field("page_size", &self.page_size)
             .finish_non_exhaustive() // No print cache.
@@ -1158,7 +1187,14 @@ impl<A: Referable> Serialize for ActorMeshRef<A> {
     where
         S: Serializer,
     {
-        (&self.proc_mesh, &self.id, &self.controller).serialize(serializer)
+        // Serialize only the fields that don't depend on A.
+        (
+            &self.id,
+            &self.proc_mesh_id,
+            &self.controller,
+            &self.cast_domain,
+        )
+            .serialize(serializer)
     }
 }
 
@@ -1168,16 +1204,18 @@ impl<'de, A: Referable> Deserialize<'de> for ActorMeshRef<A> {
     where
         D: Deserializer<'de>,
     {
-        let (proc_mesh, id, controller) = <(
-            ProcMeshRef,
+        let (id, proc_mesh_id, controller, cast_domain) = <(
             ActorMeshId,
+            Option<ProcMeshId>,
             Option<ActorRef<ActorMeshController<A>>>,
+            ActorMeshCastDomain,
         )>::deserialize(deserializer)?;
-        Ok(ActorMeshRef::with_page_size(
+        Ok(Self::with_cast_domain(
             id,
-            proc_mesh,
-            DEFAULT_PAGE,
+            proc_mesh_id,
             controller,
+            cast_domain,
+            DEFAULT_PAGE,
         ))
     }
 }
@@ -1187,7 +1225,7 @@ impl<A: Referable> view::Ranked for ActorMeshRef<A> {
 
     #[inline]
     fn region(&self) -> &Region {
-        view::Ranked::region(&self.proc_mesh)
+        self.cast_domain.region()
     }
 
     #[inline]
@@ -1197,17 +1235,26 @@ impl<A: Referable> view::Ranked for ActorMeshRef<A> {
 }
 
 impl<A: Referable> view::RankedSliceable for ActorMeshRef<A> {
+    /// Return a pure slice of this actor mesh.
+    ///
+    /// This method cannot install routing state because the trait has no caller
+    /// context. Instead it carries a lazy cast-domain descriptor. The first cast
+    /// through the returned ref posts setup from that caller before sending the
+    /// cast message, preserving normal sender-side stream ordering.
     fn sliced(&self, region: Region) -> Self {
         // Slices inherit cached failures that were already observed on the parent
         // mesh ref so new sub-slices do not race the controller replay path.
         // The supervision receiver stays independent because each slice applies
         // its own region filter to future updates.
         debug_assert!(region.is_subset(view::Ranked::region(self)));
-        let proc_mesh = self.proc_mesh.subset(region).unwrap();
         Self {
-            proc_mesh,
             id: self.id.clone(),
+            proc_mesh_id: self.proc_mesh_id.clone(),
             controller: self.controller.clone(),
+            cast_domain: ActorMeshCastDomain::new(
+                Arc::new(self.cast_domain.members().sliced(region.clone())),
+                region.clone(),
+            ),
             health_state: self.health_state.clone(),
             receiver: ActorLocal::new(),
             pages: OnceCell::new(),
@@ -1222,6 +1269,7 @@ mod tests {
     use std::collections::HashMap;
     use std::collections::HashSet;
     use std::ops::Deref;
+    use std::sync::Arc;
 
     use hyperactor::Endpoint as _;
     use hyperactor::actor::ActorErrorKind;
@@ -1276,8 +1324,14 @@ mod tests {
         // force multiple pages:
         // page 0: ranks [0,1], page 1: [2,3], page 2: [4,5]
         let page_size = 2;
-        let amr: ActorMeshRef<testactor::TestActor> =
-            ActorMeshRef::with_page_size(am.id.clone(), pm.clone(), page_size, None);
+        let amr: ActorMeshRef<testactor::TestActor> = ActorMeshRef::with_page_size(
+            am.id.clone(),
+            am.deref().proc_mesh_id.clone(),
+            am.region().clone(),
+            page_size,
+            None,
+            Arc::clone(&am.deref().cast_domain.members),
+        );
         assert_eq!(amr.extent(), extent!(hosts = 2, gpus = 2));
         assert_eq!(amr.region().num_ranks(), 4);
 
@@ -1315,6 +1369,10 @@ mod tests {
         // (RankedSliceable::sliced)
         let sliced = amr.range("hosts", 0..2).expect("slice should be valid"); // leaves 4 ranks
         assert_eq!(sliced.region().num_ranks(), 4);
+        assert!(
+            sliced.get(0).is_some(),
+            "RankedSliceable::sliced preserves a lazy cast-domain descriptor"
+        );
         // First access materializes a new cache for the sliced view.
         let sp0_a = sliced.get(0).unwrap() as *const _;
         let sp0_b = sliced.get(0).unwrap() as *const _;
@@ -1801,6 +1859,7 @@ mod tests {
                 members,
                 Region::from(ndslice::shape!(rank = 2)),
                 hyperactor_cast::cast_actor::TilingPolicy::BlockPartitioning,
+                hyperactor_config::Flattrs::new(),
             )
             .unwrap();
 

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1219,6 +1219,7 @@ impl<A: Referable> view::RankedSliceable for ActorMeshRef<A> {
 #[cfg(all(test, fbcode_build))]
 mod tests {
 
+    use std::collections::HashMap;
     use std::collections::HashSet;
     use std::ops::Deref;
 
@@ -1744,6 +1745,87 @@ mod tests {
         assert_eq!(all_ranks, HashSet::from([0, 1]));
 
         let _ = host_mesh.shutdown(instance).await;
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_cast_domain_stamps_resource_rank_binding() {
+        let client_proc = hyperactor::proc::Proc::direct(
+            hyperactor::channel::ChannelTransport::Unix.any(),
+            "client_proc".into(),
+        )
+        .unwrap();
+
+        let client = client_proc.client("client");
+
+        let mut procs = Vec::new();
+
+        let members = (0..2)
+            .map(|rank| {
+                let proc = hyperactor::proc::Proc::direct(
+                    hyperactor::channel::ChannelTransport::Unix.any(),
+                    format!("proc_{rank}"),
+                )
+                .unwrap();
+
+                let cast_handle = proc
+                    .spawn_with_uid(
+                        hyperactor::Uid::singleton(Label::strip("cast")),
+                        hyperactor_cast::cast_actor::CastActor::default(),
+                    )
+                    .unwrap();
+
+                let _: hyperactor::ActorRef<hyperactor_cast::cast_actor::CastActor> =
+                    cast_handle.bind();
+
+                let receiver_handle = proc
+                    .spawn_with_uid(
+                        hyperactor::Uid::singleton(Label::strip("receiver")),
+                        testactor::TestActor,
+                    )
+                    .unwrap();
+
+                let _: hyperactor::ActorRef<testactor::TestActor> = receiver_handle.bind();
+
+                let actor_addr =
+                    hyperactor::ActorAddr::root(proc.proc_addr().clone(), Label::strip("receiver"));
+
+                procs.push(proc);
+
+                (rank, actor_addr)
+            })
+            .collect::<HashMap<_, _>>();
+
+        let cast_domain = hyperactor_cast::cast_actor::CastDomainId::new()
+            .materialize(
+                &client,
+                members,
+                Region::from(ndslice::shape!(rank = 2)),
+                hyperactor_cast::cast_actor::TilingPolicy::BlockPartitioning,
+            )
+            .unwrap();
+
+        let (rank_port, mut rank_rx) = client.mailbox().open_port();
+
+        cast_domain
+            .cast(
+                &client,
+                hyperactor_config::Flattrs::new(),
+                testactor::GetResourceRank {
+                    rank: crate::resource::Rank::default(),
+                    reply: rank_port.bind(),
+                },
+            )
+            .unwrap();
+
+        let mut received_ranks = HashSet::new();
+
+        for _ in 0..2 {
+            let (_point, rank) = rank_rx.recv().await.unwrap();
+
+            received_ranks.insert(rank);
+        }
+
+        assert_eq!(received_ranks, HashSet::from([Some(0), Some(1)]));
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -1178,14 +1178,6 @@ mod tests {
         assert!(envelope.root_delivery_failure().is_none());
     }
 
-    // Helper to look up the rank for a given actor ID using the rank_lookup table.
-    fn lookup_rank(actor_id: &ActorAddr, rank_lookup: &HashMap<ProcAddr, usize>) -> usize {
-        let proc_id = actor_id.proc_addr();
-        *rank_lookup
-            .get(&proc_id)
-            .unwrap_or_else(|| panic!("proc rank not found for {}", proc_id))
-    }
-
     struct Edge<T> {
         from: T,
         to: T,
@@ -1314,55 +1306,6 @@ mod tests {
         assert_eq!(paths.0, expected);
     }
 
-    //  Given a port tree,
-    //     * remove the client port, i.e. the 1st element of the path;
-    //     * verify all remaining ports are comm handler ports;
-    //     * remove the actor information and return a rank-based tree representation.
-    //
-    //  The rank-based tree representation is what [collect_commactor_routing_tree] returns.
-    //  This conversion enables us to compare the path against [collect_commactor_routing_tree]'s result.
-    //
-    //      For example, for a 2x2 slice, the port tree could look like:
-    //      dest[0].comm[0][1028] -> [client[0].client_user[0][1025], dest[0].comm[0][1028]]
-    //      dest[1].comm[0][1028] -> [client[0].client_user[0][1025], dest[0].comm[0][1028], dest[1].comm[0][1028]]
-    //      dest[2].comm[0][1028] -> [client[0].client_user[0][1025], dest[0].comm[0][1028], dest[2].comm[0][1028]]
-    //      dest[3].comm[0][1028] -> [client[0].client_user[0][1025], dest[0].comm[0][1028], dest[2].comm[0][1028], dest[3].comm[0][1028]]
-    //
-    //     The result should be:
-    //     0 -> 0
-    //     1 -> 0, 1
-    //     2 -> 0, 2
-    //     3 -> 0, 2, 3
-    fn get_ranks(
-        paths: PathToLeaves<PortAddr>,
-        client_reply: &PortAddr,
-        rank_lookup: &HashMap<ProcAddr, usize>,
-    ) -> PathToLeaves<Index> {
-        let ranks = paths
-            .0
-            .into_iter()
-            .map(|(dst, mut path): (PortAddr, Vec<PortAddr>)| {
-                let first = path.remove(0);
-                // The first PortId is the client's reply port.
-                assert_eq!(&first, client_reply);
-                // Other ports's actor ID must be dest[?].comm[0], where ? is
-                // the rank we want to extract here.
-                assert!(dst.actor_addr().label().unwrap().as_str().contains("comm"));
-                let actor_path = path
-                    .into_iter()
-                    .map(|p: PortAddr| {
-                        assert!(p.actor_addr().label().unwrap().as_str().contains("comm"));
-                        let actor_ref = p.actor_addr();
-                        lookup_rank(&actor_ref, rank_lookup)
-                    })
-                    .collect();
-                let dst_actor_ref = dst.actor_addr();
-                (lookup_rank(&dst_actor_ref, rank_lookup), actor_path)
-            })
-            .collect();
-        PathToLeaves(ranks)
-    }
-
     struct NoneAccumulator;
 
     impl Accumulator for NoneAccumulator {
@@ -1380,51 +1323,6 @@ mod tests {
         fn reducer_spec(&self) -> Option<ReducerSpec> {
             unimplemented!()
         }
-    }
-
-    // Verify the split port paths are the same as the casting paths.
-    fn verify_split_port_paths(
-        selection: &Selection,
-        extent: &Extent,
-        reply_port_ref1: &PortRef<u64>,
-        reply_port_ref2: &PortRef<MyReply>,
-        rank_lookup: &HashMap<ProcAddr, usize>,
-    ) {
-        // Get the paths used in casting
-        let sel_paths = PathToLeaves(
-            collect_commactor_routing_tree(selection, &extent.to_slice())
-                .delivered
-                .into_iter()
-                .collect(),
-        );
-
-        // Get the split port paths collected in SPLIT_PORT_TREE during casting
-        let (reply1_paths, reply2_paths) = {
-            let tree = SPLIT_PORT_TREE
-                .get()
-                .expect("not initialized; are Hosts in the same process as SPLIT_PORT_TREE?");
-            let edges = tree.lock().unwrap();
-            let (reply1, reply2): (BTreeMap<_, _>, BTreeMap<_, _>) = build_paths(&edges)
-                .0
-                .into_iter()
-                .partition(|(_dst, path)| path[0] == *reply_port_ref1.port_addr());
-            (
-                get_ranks(
-                    PathToLeaves(reply1),
-                    reply_port_ref1.port_addr(),
-                    rank_lookup,
-                ),
-                get_ranks(
-                    PathToLeaves(reply2),
-                    reply_port_ref2.port_addr(),
-                    rank_lookup,
-                ),
-            )
-        };
-
-        // split port paths should be the same as casting paths
-        assert_eq!(sel_paths, reply1_paths);
-        assert_eq!(sel_paths, reply2_paths);
     }
 
     async fn execute_cast_and_reply(
@@ -1615,61 +1513,12 @@ mod tests {
                     // ports have been replaced by split ports.
                     assert_ne!(reply_to1, reply_port_ref1);
                     assert_ne!(reply_to2, reply_port_ref2);
-                    let p2p_threshold = hyperactor_config::global::get(
-                        crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD,
-                    );
-                    if p2p_threshold == 0 {
-                        // Tree path: split ports belong to comm actors.
-                        assert!(
-                            reply_to1
-                                .port_addr()
-                                .actor_id()
-                                .label()
-                                .unwrap()
-                                .as_str()
-                                .contains("comm")
-                        );
-                        assert!(
-                            reply_to2
-                                .port_addr()
-                                .actor_id()
-                                .label()
-                                .unwrap()
-                                .as_str()
-                                .contains("comm")
-                        );
-                    }
                     reply_tos.push((reply_to1, reply_to2));
                 }
                 _ => {
                     panic!("unexpected message: {:?}", msg);
                 }
             }
-        }
-
-        // verify_split_port_paths only applies to the tree path;
-        // in point-to-point mode no comm actors are involved.
-        let p2p_threshold =
-            hyperactor_config::global::get(crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD);
-        if p2p_threshold == 0 {
-            // [collect_commactor_routing_tree] only returns ranks, so we need
-            // to map proc IDs collected in SPLIT_PORT_TREE to ranks.
-            let rank_lookup = proc_mesh
-                .ranks()
-                .iter()
-                .enumerate()
-                .map(|(i, r)| (r.proc_addr().clone(), i))
-                .collect::<HashMap<ProcAddr, usize>>();
-
-            // v1 always uses sel!(*) when casting to a mesh.
-            let selection = sel!(*);
-            verify_split_port_paths(
-                &selection,
-                &proc_mesh.extent(),
-                &reply_port_ref1,
-                &reply_port_ref2,
-                &rank_lookup,
-            );
         }
 
         MeshSetupV1 {
@@ -1836,21 +1685,6 @@ mod tests {
                     if has_reducer {
                         // With reducer: port is split.
                         assert_ne!(reply_to, reply_port_ref);
-                        let p2p_threshold = hyperactor_config::global::get(
-                            crate::config::V1_CAST_POINT_TO_POINT_THRESHOLD,
-                        );
-                        if p2p_threshold == 0 {
-                            // Tree path: split port belongs to a comm actor.
-                            assert!(
-                                reply_to
-                                    .port_addr()
-                                    .actor_id()
-                                    .label()
-                                    .unwrap()
-                                    .as_str()
-                                    .contains("comm")
-                            );
-                        }
                     } else {
                         // Without reducer: port is passed through unchanged.
                         assert_eq!(reply_to, reply_port_ref);
@@ -2121,44 +1955,6 @@ mod tests {
             let captured = setup.rx.recv().await.unwrap();
             assert_eq!(captured, expected);
         }
-
-        let _ = setup.host_mesh.shutdown(setup.instance).await;
-    }
-
-    /// V0 legacy cast: SENDER_ACTOR_ID at the receiver names the local
-    /// CommActor (session owner), NOT the caster. V0 doesn't propagate
-    /// SEQ_INFO from origin; deliver_to_dest skips its stamp-if-present
-    /// branch; MailboxExt::post on cx assigns SEQ_INFO via the CommActor's
-    /// Sequencer and stamps with the CommActor's actor_addr.
-    ///
-    /// V0 invariant: when V0 is retired this test can be deleted with no
-    /// loss of coverage.
-    #[async_timed_test(timeout_secs = 60)]
-    async fn test_v0_legacy_sender_actor_id() {
-        let config = hyperactor_config::global::lock();
-        let _g1 = config.override_key(ENABLE_NATIVE_V1_CASTING, false);
-        let _g2 = config.override_key(
-            hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER,
-            false,
-        );
-
-        let mut setup = setup_sender_capture_mesh(1).await;
-        setup
-            .actor_mesh
-            .cast(setup.instance, SenderCaptureMsg())
-            .unwrap();
-
-        let captured = setup.rx.recv().await.unwrap();
-        let captured_addr = captured.0.as_ref().expect("sender was stamped");
-        assert_ne!(
-            captured_addr,
-            setup.instance.self_addr(),
-            "V0 cast is relay-owned, not origin-owned",
-        );
-        assert!(
-            captured_addr.label().unwrap().as_str().contains("comm"),
-            "session owner should be structurally a comm actor; got {captured_addr:?}",
-        );
 
         let _ = setup.host_mesh.shutdown(setup.instance).await;
     }

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -16,7 +16,6 @@ use hyperactor::RemoteMessage;
 use hyperactor::actor::Referable;
 use hyperactor::id::Uid;
 use hyperactor_config::Flattrs;
-use hyperactor_config::attrs::declare_attrs;
 use ndslice::Extent;
 use ndslice::Point;
 use ndslice::Region;
@@ -314,6 +313,7 @@ impl CastEnvelope for CastMessageV1 {
     }
 }
 
+#[cfg(test)]
 impl CastMessageV1 {
     /// Create a new CastMessageEnvelope.
     pub(crate) fn new<A, M>(
@@ -353,13 +353,8 @@ pub(super) struct ForwardMessageV1 {
     pub(super) message: CastMessageV1,
 }
 
-declare_attrs! {
-    /// Used inside headers to store the originating sender of a cast.
-    pub attr CAST_ORIGINATING_SENDER: ActorAddr;
-
-    /// The point in the casted region that this message was sent to.
-    pub attr CAST_POINT: Point;
-}
+pub use hyperactor_cast::cast_actor::CAST_ORIGINATING_SENDER;
+pub use hyperactor_cast::cast_actor::CAST_POINT;
 
 pub fn set_cast_info_on_headers(headers: &mut Flattrs, cast_point: Point, sender: ActorAddr) {
     // Pre-set the telemetry sender hash to the originating actor,

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -273,4 +273,11 @@ declare_attrs! {
         Some("v1_cast_point_to_point_threshold".to_string()),
     ))
     pub attr V1_CAST_POINT_TO_POINT_THRESHOLD: usize = 0;
+
+
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_MESH_MAX_CAST_FANOUT".to_string()),
+        Some("max_cast_fanout".to_string()),
+    ))
+    pub attr MAX_CAST_FANOUT: usize = 16;
 }

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -456,7 +456,8 @@ async fn bootstrap_host() -> GlobalState {
             0,
             local_proc_agent.bind(),
         ),
-    );
+    )
+    .expect("failed to create proc mesh ref");
     let actor_instance = local_proc
         .actor_instance::<GlobalClientActor>("client")
         .expect("failed to create root client instance");

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -24,7 +24,6 @@ use hyperactor::RemoteMessage;
 use hyperactor::RemoteSpawn;
 use hyperactor::accum::StreamingReducerOpts;
 use hyperactor::actor::ActorStatus;
-use hyperactor::actor::Referable;
 use hyperactor::actor::remote::Remote;
 use hyperactor::context;
 use hyperactor::id::Label;
@@ -119,12 +118,6 @@ impl ProcRef {
 
     pub(crate) fn actor_addr(&self, id: &ActorMeshId) -> ActorAddr {
         self.proc_id.actor_addr_uid(id.uid().clone())
-    }
-
-    /// Generic bound: `A: Referable` - required because we return
-    /// an `ActorRef<A>`.
-    pub(crate) fn attest<A: Referable>(&self, id: &ActorMeshId) -> ActorRef<A> {
-        ActorRef::attest(self.actor_addr(id))
     }
 }
 
@@ -330,11 +323,6 @@ impl ProcMesh {
             .map(|_| ())
             .map_err(anyhow::Error::from)
     }
-
-    #[cfg(test)]
-    pub(crate) fn ranks(&self) -> Arc<Vec<ProcRef>> {
-        Arc::clone(&self.current_ref.ranks)
-    }
 }
 
 impl fmt::Display for ProcMesh {
@@ -367,11 +355,25 @@ impl Drop for ProcMesh {
 ///
 /// ProcMeshes can be sliced to create new ProcMeshes with a subset of the
 /// original ranks.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Named, Serialize, Deserialize)]
+///
+/// `ProcMeshRef::sliced` is intentionally pure. A sliced proc mesh can still
+/// expose dense `ProcRef`s, while the backing `ProcAgent` `ActorMeshRef`
+/// carries a lazy cast-domain descriptor that installs itself on first cast.
+#[derive(Debug, Clone, Named, Serialize, Deserialize)]
 pub struct ProcMeshRef {
     id: ProcMeshId,
     region: Region,
     ranks: Arc<Vec<ProcRef>>,
+    /// Actor mesh for the `ProcAgent`s backing this proc mesh view.
+    ///
+    /// `ProcMeshRef::sliced` derives a sliced agent mesh with a lazy cast
+    /// descriptor. The first cast through that view installs the descriptor on
+    /// the caller's sender stream.
+    ///
+    /// The `ProcMeshRef` itself keeps dense `ProcRef`s so it can later
+    /// materialize this field from the current view without consulting the
+    /// parent mesh or using a temporary proc.
+    proc_agent_mesh: ActorMeshRef<ProcAgent>,
     // Some if this was spawned from a host mesh, else none.
     host_mesh: Option<HostMeshRef>,
     // Temporary: used to fit v1 ActorMesh with v0's casting implementation. This
@@ -386,6 +388,32 @@ pub struct ProcMeshRef {
 }
 wirevalue::register_type!(ProcMeshRef);
 
+// The proc-agent actor mesh is derived from `ranks`, so it is not part of
+// `ProcMeshRef` identity.
+impl PartialEq for ProcMeshRef {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.region == other.region
+            && self.ranks == other.ranks
+            && self.host_mesh == other.host_mesh
+            && self.root_region == other.root_region
+            && self.root_comm_actor == other.root_comm_actor
+    }
+}
+
+impl Eq for ProcMeshRef {}
+
+impl std::hash::Hash for ProcMeshRef {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.id.hash(state);
+        self.region.hash(state);
+        self.ranks.hash(state);
+        self.host_mesh.hash(state);
+        self.root_region.hash(state);
+        self.root_comm_actor.hash(state);
+    }
+}
+
 impl ProcMeshRef {
     /// Create a new ProcMeshRef from the given id, region, ranks, and so on.
     #[allow(clippy::result_large_err)]
@@ -397,16 +425,23 @@ impl ProcMeshRef {
         root_region: Option<Region>,
         root_comm_actor: Option<ActorRef<CommActor>>,
     ) -> crate::Result<Self> {
+        if ranks.is_empty() {
+            return Err(crate::Error::ConfigurationError(anyhow::anyhow!(
+                "empty proc meshes are not supported"
+            )));
+        }
         if region.num_ranks() != ranks.len() {
             return Err(crate::Error::InvalidRankCardinality {
                 expected: region.num_ranks(),
                 actual: ranks.len(),
             });
         }
+        let proc_agent_mesh = Self::proc_agent_mesh_ref(&id, &region, &ranks)?;
         Ok(Self {
             id,
             region,
             ranks,
+            proc_agent_mesh,
             host_mesh,
             root_region,
             root_comm_actor,
@@ -416,19 +451,19 @@ impl ProcMeshRef {
     /// Create a singleton ProcMeshRef, given the provided ProcRef and id.
     /// This is used to support creating local singleton proc meshes to support `this_proc()`
     /// in python client actors.
-    pub fn new_singleton(id: ProcMeshId, proc_ref: ProcRef) -> Self {
-        Self {
+    pub fn new_singleton(id: ProcMeshId, proc_ref: ProcRef) -> crate::Result<Self> {
+        let region: Region = Extent::unity().into();
+        let ranks = Arc::new(vec![proc_ref]);
+        let proc_agent_mesh = Self::proc_agent_mesh_ref(&id, &region, &ranks)?;
+        Ok(Self {
             id,
-            region: Extent::unity().into(),
-            ranks: Arc::new(vec![proc_ref]),
+            region,
+            ranks,
+            proc_agent_mesh,
             host_mesh: None,
             root_region: None,
             root_comm_actor: None,
-        }
-    }
-
-    pub(crate) fn root_comm_actor(&self) -> Option<&ActorRef<CommActor>> {
-        self.root_comm_actor.as_ref()
+        })
     }
 
     pub fn id(&self) -> &ProcMeshId {
@@ -444,9 +479,16 @@ impl ProcMeshRef {
         self.host_mesh.as_ref()
     }
 
-    pub(crate) fn agent_mesh(&self) -> ActorMeshRef<ProcAgent> {
-        let agent_label = self
-            .ranks
+    pub(crate) fn agent_mesh(&self) -> &ActorMeshRef<ProcAgent> {
+        &self.proc_agent_mesh
+    }
+
+    fn proc_agent_mesh_ref(
+        proc_mesh_id: &ProcMeshId,
+        region: &Region,
+        ranks: &[ProcRef],
+    ) -> crate::Result<ActorMeshRef<ProcAgent>> {
+        let agent_label = ranks
             .first()
             .unwrap()
             .agent
@@ -455,7 +497,22 @@ impl ProcMeshRef {
             .cloned()
             .unwrap_or_else(|| Label::new(proc_agent::PROC_AGENT_ACTOR_NAME).unwrap());
         let id = ActorMeshId::singleton(agent_label);
-        ActorMeshRef::new(id, self.clone(), None)
+
+        let members = Arc::new(
+            ranks
+                .iter()
+                .map(|rank| rank.agent.actor_addr().clone())
+                .collect_mesh::<ValueMesh<_>>(region.clone())
+                .map_err(|error| crate::Error::ConfigurationError(error.into()))?,
+        );
+
+        Ok(ActorMeshRef::new(
+            id,
+            Some(proc_mesh_id.clone()),
+            region.clone(),
+            None,
+            members,
+        ))
     }
 
     /// Query the state of all actors in this mesh matching the given id.
@@ -478,7 +535,6 @@ impl ProcMeshRef {
         id: ActorMeshId,
         keepalive: Option<std::time::SystemTime>,
     ) -> crate::Result<ValueMesh<resource::State<ActorState>>> {
-        let agent_mesh = self.agent_mesh();
         let (port, mut rx) = cx.mailbox().open_port::<resource::State<ActorState>>();
         let mut port = port.bind();
         // If this proc dies or some other issue renders the reply undeliverable,
@@ -491,7 +547,7 @@ impl ProcMeshRef {
             reply: port,
         };
         if let Some(expires_after) = keepalive {
-            agent_mesh.cast(
+            self.proc_agent_mesh.cast(
                 cx,
                 resource::KeepaliveGetState {
                     expires_after,
@@ -499,7 +555,7 @@ impl ProcMeshRef {
                 },
             )?;
         } else {
-            agent_mesh.cast(cx, get_state)?;
+            self.proc_agent_mesh.cast(cx, get_state)?;
         }
         let expected = self.ranks.len();
         let mut states = Vec::with_capacity(expected);
@@ -526,7 +582,7 @@ impl ProcMeshRef {
                 tracing::error!(
                     "timeout waiting for a message after {:?} from proc mesh agent in mesh {}",
                     timeout,
-                    agent_mesh
+                    self.proc_agent_mesh
                 );
                 // Timeout error, stop reading from the receiver and send back what we have so far,
                 // padding with failed states.
@@ -538,7 +594,7 @@ impl ProcMeshRef {
                     let rank = *leftover_ranks
                         .pop()
                         .expect("leftover ranks should not be empty");
-                    let agent = agent_mesh.get(rank).expect("agent should exist");
+                    let agent = self.proc_agent_mesh.get(rank).expect("agent should exist");
                     let agent_id = agent.actor_addr().clone();
                     states.push((
                         // We populate with any ranks leftover at the time of the timeout.
@@ -728,9 +784,7 @@ impl ProcMeshRef {
             .to_string();
 
         let serialized_params = bincode::serde::encode_to_vec(params, bincode::config::legacy())?;
-        let agent_mesh = self.agent_mesh();
-
-        agent_mesh.cast(
+        self.proc_agent_mesh.cast(
             cx,
             resource::CreateOrUpdate::<proc_agent::ActorSpec> {
                 id: actor_mesh_id.resource_id().clone(),
@@ -768,7 +822,7 @@ impl ProcMeshRef {
         reply.return_undeliverable(false);
         // Send a message to all ranks. They reply with overlays to
         // `port`.
-        agent_mesh.cast(
+        self.proc_agent_mesh.cast(
             cx,
             resource::GetRankStatus {
                 id: actor_mesh_id.resource_id().clone(),
@@ -786,7 +840,7 @@ impl ProcMeshRef {
         // overlays are applied, it emits a new StatusMesh snapshot.
         // `wait()` loops on it, deciding when the stream is
         // "complete" (no more NotExist) or times out.
-        let (statuses, mut mesh) = match GetRankStatus::wait(
+        let statuses = match GetRankStatus::wait(
             rx,
             self.ranks.len(),
             hyperactor_config::global::get(ACTOR_SPAWN_MAX_IDLE),
@@ -800,10 +854,7 @@ impl ProcMeshRef {
                 // `first_terminating().is_none()` semantics.
                 let has_terminating = statuses.values().any(|s| s.is_terminating());
                 if !has_terminating {
-                    Ok((
-                        statuses,
-                        ActorMesh::new(self.clone(), actor_mesh_id.clone(), None),
-                    ))
+                    Ok(statuses)
                 } else {
                     let legacy = mesh_to_rankedvalues_with_default(
                         &statuses,
@@ -827,6 +878,21 @@ impl ProcMeshRef {
                 Err(Error::ActorSpawnError { statuses: legacy })
             }
         }?;
+
+        let actor_mesh_members = Arc::new(
+            self.ranks
+                .iter()
+                .map(|rank| rank.actor_addr(&actor_mesh_id))
+                .collect_mesh::<ValueMesh<_>>(self.region().clone())
+                .map_err(|error| crate::Error::ConfigurationError(error.into()))?,
+        );
+
+        let mut mesh = ActorMesh::new(
+            self.clone(),
+            actor_mesh_id.clone(),
+            None,
+            actor_mesh_members,
+        );
         // We don't need controllers for a system actor like the CommActor.
         if !is_system_actor {
             // Spawn a unique mesh manager for each actor mesh, so the type of the
@@ -937,8 +1003,7 @@ impl ProcMeshRef {
         reason: String,
     ) -> crate::Result<ValueMesh<Status>> {
         let region = self.region().clone();
-        let agent_mesh = self.agent_mesh();
-        agent_mesh.cast(
+        self.proc_agent_mesh.cast(
             cx,
             resource::Stop {
                 id: actor_mesh_id.resource_id().clone(),
@@ -967,7 +1032,7 @@ impl ProcMeshRef {
         // Use WaitRankStatus instead of GetRankStatus so agents defer
         // their reply until the actor reaches terminal state, rather
         // than replying immediately with Stopping.
-        agent_mesh.cast(
+        self.proc_agent_mesh.cast(
             cx,
             resource::WaitRankStatus {
                 id: actor_mesh_id.resource_id().clone(),
@@ -1038,6 +1103,10 @@ impl view::Ranked for ProcMeshRef {
 }
 
 impl view::RankedSliceable for ProcMeshRef {
+    /// Return a pure slice of this proc mesh.
+    ///
+    /// The returned `ProcMeshRef` contains the selected dense `ProcRef`s, and
+    /// its `proc_agent_mesh` carries a lazy actor-mesh slice descriptor.
     fn sliced(&self, region: Region) -> Self {
         debug_assert!(region.is_subset(view::Ranked::region(self)));
         let ranks = self
@@ -1045,16 +1114,17 @@ impl view::RankedSliceable for ProcMeshRef {
             .remap(&region)
             .unwrap()
             .map(|index| self.get(index).unwrap().clone())
-            .collect();
-        Self::new(
-            self.id.clone(),
+            .collect::<Vec<_>>();
+
+        Self {
+            id: self.id.clone(),
+            proc_agent_mesh: self.proc_agent_mesh.sliced(region.clone()),
             region,
-            Arc::new(ranks),
-            self.host_mesh.clone(),
-            Some(self.root_region.as_ref().unwrap_or(&self.region).clone()),
-            self.root_comm_actor.clone(),
-        )
-        .unwrap()
+            ranks: Arc::new(ranks),
+            host_mesh: self.host_mesh.clone(),
+            root_region: Some(self.root_region.as_ref().unwrap_or(&self.region).clone()),
+            root_comm_actor: self.root_comm_actor.clone(),
+        }
     }
 }
 
@@ -1403,6 +1473,52 @@ mod tests {
             statuses,
             RankedValues::from((0..1, Status::Failed("test failure".to_string()))),
         );
+
+        let _ = hm.shutdown(instance).await;
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    #[cfg(fbcode_build)]
+    async fn test_spawn_actor_on_proc_mesh_slice_only_spawns_slice_members() {
+        let instance = testing::instance();
+
+        let mut hm = testing::host_mesh(2).await;
+        let proc_mesh = hm
+            .spawn(&instance, "test", extent!(gpus = 2), None, None)
+            .await
+            .unwrap();
+        let host1 = proc_mesh.range("hosts", 1..2).unwrap();
+        let actor_name = crate::mesh_id::ActorMeshId::instance(
+            hyperactor::id::Label::new("slice_only").unwrap(),
+        );
+
+        let actor_mesh = host1
+            .spawn_with_name::<testactor::TestActor, _>(
+                instance,
+                actor_name.clone(),
+                &(),
+                None,
+                false,
+            )
+            .await
+            .unwrap();
+        testactor::assert_casting_correctness(&actor_mesh, instance, None).await;
+
+        let slice_states = host1
+            .actor_states(instance, actor_name.clone())
+            .await
+            .unwrap();
+        assert_eq!(slice_states.extent(), host1.extent());
+
+        let err = proc_mesh
+            .actor_states(instance, actor_name.clone())
+            .await
+            .unwrap_err();
+        let expected_name = actor_name.into();
+        match err {
+            crate::Error::NotExist(name) if name == expected_name => {}
+            other => panic!("expected NotExist for {expected_name}, got {other:?}"),
+        }
 
         let _ = hm.shutdown(instance).await;
     }

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -272,14 +272,15 @@ impl GetRankStatus {
 
             alarm.arm(max_idle_time);
 
-            // Completion: once every rank (among the first
-            // `num_ranks`) has reported at least something (i.e.
-            // moved off NotExist).
-            if snapshot
+            // Completion: once every expected rank has reported at least
+            // something (i.e. moved off NotExist). Sliced meshes may report at
+            // non-zero base ranks, so do not assume the relevant ranks occupy
+            // the first `num_ranks` dense slots.
+            let reported = snapshot
                 .values()
-                .take(num_ranks)
-                .all(|s| !matches!(s, crate::resource::Status::NotExist))
-            {
+                .filter(|s| !matches!(s, crate::resource::Status::NotExist))
+                .count();
+            if reported >= num_ranks {
                 break Ok(snapshot);
             }
         }

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -58,6 +58,7 @@ use crate::testing;
     (),
     GetActorId,
     GetCastInfo,
+    GetResourceRank,
     CauseSupervisionEvent,
     Forward,
     GetConfigAttrs,
@@ -238,6 +239,25 @@ impl Handler<GetCastInfo> for TestActor {
         GetCastInfo { cast_info }: GetCastInfo,
     ) -> Result<(), anyhow::Error> {
         cast_info.post(cx, (cx.cast_point(), cx.bind(), cx.sender().clone()));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Named, Serialize, Deserialize)]
+pub struct GetResourceRank {
+    pub rank: crate::resource::Rank,
+    pub reply: hyperactor::PortRef<(Point, Option<usize>)>,
+}
+
+#[async_trait]
+impl Handler<GetResourceRank> for TestActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        GetResourceRank { rank, reply }: GetResourceRank,
+    ) -> Result<(), anyhow::Error> {
+        reply.post(cx, (cx.cast_point(), rank.0));
+
         Ok(())
     }
 }

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -36,6 +36,7 @@ use hyperactor::context;
 use hyperactor::mailbox::MailboxSenderError;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::ActorMesh;
+use hyperactor_mesh::ActorMeshRef;
 use hyperactor_mesh::ProcMeshRef;
 use hyperactor_mesh::supervision::MeshFailure;
 use hyperactor_mesh::value_mesh::ValueOverlay;
@@ -61,10 +62,11 @@ use monarch_messages::worker::WorkerMessage;
 use monarch_messages::worker::WorkerParams;
 use monarch_tensor_worker::AssignRankMessage;
 use monarch_tensor_worker::WorkerActor;
+use ndslice::Region;
 use ndslice::Slice;
 use ndslice::ViewExt;
-use ndslice::selection::ReifySlice;
 use ndslice::view::Ranked;
+use ndslice::view::RankedSliceable as _;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
@@ -724,6 +726,7 @@ enum ClientToControllerMessage {
 struct MeshControllerActor {
     proc_mesh_ref: ProcMeshRef,
     workers: Option<ActorMesh<WorkerActor>>,
+    worker_slice_cache: HashMap<Region, ActorMeshRef<WorkerActor>>,
     brokers: Option<ActorMesh<LocalStateBrokerActor>>,
     history: History,
     id: usize,
@@ -750,6 +753,7 @@ impl MeshControllerActor {
         MeshControllerActor {
             proc_mesh_ref,
             workers: None,
+            worker_slice_cache: HashMap::new(),
             brokers: None,
             history: History::new(world_size),
             id,
@@ -763,8 +767,69 @@ impl MeshControllerActor {
         self.workers.as_ref().unwrap()
     }
 
+    fn worker_slice(&mut self, region: Region) -> ActorMeshRef<WorkerActor> {
+        if let Some(slice) = self.worker_slice_cache.get(&region) {
+            return slice.clone();
+        }
+
+        let slice = self.workers().deref().sliced(region.clone());
+        self.worker_slice_cache.insert(region, slice.clone());
+        slice
+    }
+
     fn workers_mut(&mut self) -> &mut ActorMesh<WorkerActor> {
         self.workers.as_mut().unwrap()
+    }
+
+    fn cast_to_worker_slices(
+        &mut self,
+        this: &Context<'_, Self>,
+        slices: Vec<Slice>,
+        message: WorkerMessage,
+    ) -> anyhow::Result<()> {
+        let worker_region = Ranked::region(self.workers().deref()).clone();
+
+        let mut seen = HashSet::new();
+        for slice in slices {
+            let ranks = slice.iter().collect::<Vec<_>>();
+            if ranks.is_empty() {
+                continue;
+            }
+
+            let labels = if worker_region.labels().len() == slice.num_dim() {
+                worker_region.labels().to_vec()
+            } else {
+                (0..slice.num_dim())
+                    .map(|dim| format!("rank_{dim}"))
+                    .collect()
+            };
+            let region = Region::new(labels, slice);
+            anyhow::ensure!(
+                region.is_subset(&worker_region),
+                "worker send target must be a subset of the worker mesh"
+            );
+
+            // `Vec<Slice>` represents a union. Preserve the common efficient case
+            // by casting whole non-overlapping slices, but avoid duplicate delivery
+            // if later slices overlap earlier ones.
+            if ranks.iter().all(|rank| !seen.contains(rank)) {
+                seen.extend(ranks);
+                self.worker_slice(region).cast(this, message.clone())?;
+                continue;
+            }
+
+            for rank in ranks {
+                if !seen.insert(rank) {
+                    continue;
+                }
+                let singleton = Region::new(
+                    Vec::new(),
+                    Slice::new(rank, Vec::new(), Vec::new()).map_err(anyhow::Error::from)?,
+                );
+                self.worker_slice(singleton).cast(this, message.clone())?;
+            }
+        }
+        Ok(())
     }
 
     fn brokers_mut(&mut self) -> &mut ActorMesh<LocalStateBrokerActor> {
@@ -944,11 +1009,7 @@ impl Handler<ClientToControllerMessage> for MeshControllerActor {
     ) -> anyhow::Result<()> {
         match message {
             ClientToControllerMessage::Send { slices, message } => {
-                let workers = self.workers();
-                let sel = Ranked::region(workers.deref())
-                    .slice()
-                    .reify_slices(slices)?;
-                workers.cast_for_tensor_engine_only_do_not_use(this, sel, message)?;
+                self.cast_to_worker_slices(this, slices, message)?;
             }
             ClientToControllerMessage::Node {
                 seq,

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -397,7 +397,8 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
                 0,
                 local_proc_agent.bind(),
             ),
-        );
+        )
+        .map_err(|e| PyException::new_err(e.to_string()))?;
 
         let local_proc = local_proc_agent
             .get_proc(&temp_instance)


### PR DESCRIPTION
Summary:


Use Cast Actors instead of Comm Actors for `ActorMeshRef`s. 

`ActorMeshRef`s are created with a materialized `CastDomainRef` that is used to cast to its Actors.

`ActorMeshRef`s have an actor-local `ActorMeshCastDomain`. The purpose of this is so that the first time an `Actor` casts a message, it will also send (or possibly resend) an `CreateCastDomain` message on the same stream is sends `CastMessage`, ensuring that the `CastMessage` will never race ahead `CreateCastDomain`. `CreateCastDomain` is idempotent.

`ProcMeshRef` casts to `ProcAgent`s via `CommActor`s so it needs to migrate to `CastActor`s in this commit as well by holding an `ActorMeshRef<ProcAgent>`.

A special case is `MeshController` which can cast to arbitrary selections. This is what the old `cast_for_tensor_engine_do_not_use` was for. The use case for multiple slices was for casting a message to 2 slices to send tensors with 1 being the sending slice and the other being the receiving. Cast Domains are static rather than accepting arbitrary selections so our workaround is to just cache CastDomainRefs to slices it casts to, materializing if cache misses. The old code has union semantics so we iterate point to point if any slices have ranks to have overlap with another slice being casted to. This shouldn't usually be the case if the usage is to send from some slices to other slices

Reviewed By: mariusae

Differential Revision: D105983258


