### PR TITLE
Cast HostMesh shutdown (#4101)

### DIFF
--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -190,24 +190,10 @@ impl HostRef {
         ResourceId::proc_addr_from_name(self.0.clone(), SERVICE_PROC_NAME)
     }
 
-    /// Request an orderly teardown of this host and all procs it
-    /// spawned.
-    ///
-    /// This resolves the per-child grace **timeout** and the maximum
-    /// termination **concurrency** from config and sends a
-    /// [`ShutdownHost`] message to the host's agent. The agent then:
-    ///
-    /// 1) Performs a graceful termination pass over all tracked
-    ///    children (TERM → wait(`timeout`) → KILL), with at most
-    ///    `max_in_flight` running concurrently.
-    /// 2) After the pass completes, **drops the Host**, which also
-    ///    drops the embedded `BootstrapProcManager`. The manager's
-    ///    `Drop` serves as a last-resort safety net (it SIGKILLs
-    ///    anything that somehow remains).
-    ///
-    /// This call returns `Ok(()))` only after the agent has finished
-    /// the termination pass and released the host, so the host is no
-    /// longer reachable when this returns.
+    /// Request an orderly teardown of this host and all procs it spawned:
+    /// send `ShutdownHost` to the host's agent and wait for its single direct
+    /// rank ack. Used by the best-effort Drop-cleanup path; the mesh-wide path
+    /// is `HostMeshRef::cast_shutdown`.
     pub(crate) async fn shutdown(
         &self,
         cx: &impl hyperactor::context::Actor,
@@ -217,9 +203,20 @@ impl HostRef {
             hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_TIMEOUT);
         let max_in_flight =
             hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
+        let (ack, mut rx) = cx.mailbox().open_port::<usize>();
+
         agent
-            .shutdown_host(cx, terminate_timeout, max_in_flight.clamp(1, 256))
+            .shutdown_host(
+                cx,
+                terminate_timeout,
+                max_in_flight.clamp(1, 256),
+                resource::Rank::new(0),
+                ack.bind(),
+            )
             .await?;
+
+        rx.recv().await.map_err(anyhow::Error::from)?;
+
         Ok(())
     }
 }
@@ -666,9 +663,8 @@ impl HostMesh {
     /// Uses a two-phase approach:
     /// 1. Cast `DrainHost` and wait for every host to finish draining
     ///    its user procs while networking stays alive.
-    /// 2. **Shut down hosts** concurrently. No user procs remain, so
-    ///    this is fast and cannot deadlock on cross-host flush
-    ///    timeouts.
+    /// 2. Cast `ShutdownHost` and wait for every host to acknowledge
+    ///    that its local shutdown handler has completed.
     #[hyperactor::instrument(fields(host_mesh=self.id.to_string()))]
     pub async fn shutdown(&mut self, cx: &impl hyperactor::context::Actor) -> anyhow::Result<()> {
         let t0 = std::time::Instant::now();
@@ -685,47 +681,30 @@ impl HostMesh {
                 "failed to cast DrainHost barrier"
             );
         }
-        let phase1_ms = t0.elapsed().as_millis();
+        let drain_ms = t0.elapsed().as_millis();
 
-        // Phase 2: shut down hosts concurrently. No user procs remain.
+        // Phase 2: request host shutdown once the drain barrier has cleared.
         let t1 = std::time::Instant::now();
-        let results = futures::future::join_all(self.current_ref.values().map(|host| async move {
-            let result = host.shutdown(cx).await;
-            (host, result)
-        }))
-        .await;
-        let phase2_ms = t1.elapsed().as_millis();
+        let shutdown_result = self.current_ref.cast_shutdown(cx).await;
+        let shutdown_ack_ms = t1.elapsed().as_millis();
         let total_ms = t0.elapsed().as_millis();
-        let mut failed_hosts = vec![];
-        for (host, result) in &results {
-            if let Err(e) = result {
-                tracing::warn!(
-                    name = "HostMeshStatus",
-                    status = "Shutdown::Host::Failed",
-                    host = %host,
-                    error = %e,
-                    "host shutdown failed"
-                );
-                failed_hosts.push(host);
-            }
-        }
-        if failed_hosts.is_empty() {
+        if let Err(e) = shutdown_result {
+            tracing::warn!(
+                name = "HostMeshStatus",
+                status = "Shutdown::Ack::Failed",
+                drain_ms,
+                shutdown_ack_ms,
+                total_ms,
+                error = %e,
+                "failed waiting for ShutdownHost acknowledgment barrier"
+            );
+        } else {
             tracing::info!(
                 name = "HostMeshStatus",
                 status = "Shutdown::Success",
-                phase1_ms,
-                phase2_ms,
-                total_ms,
-            );
-        } else {
-            tracing::error!(
-                name = "HostMeshStatus",
-                status = "Shutdown::Failed",
-                phase1_ms,
-                phase2_ms,
-                total_ms,
-                "host mesh shutdown failed; check the logs of the failed hosts for details: {:?}",
-                failed_hosts
+                drain_ms,
+                shutdown_ack_ms,
+                total_ms
             );
         }
 
@@ -1175,6 +1154,70 @@ impl HostMeshRef {
                 )
             }
         }
+    }
+
+    async fn cast_shutdown(&self, cx: &impl context::Actor) -> anyhow::Result<()> {
+        let num_hosts = self.ranks.len();
+        if num_hosts == 0 {
+            return Ok(());
+        }
+
+        // Each host replies its own rank directly once shutdown work is done.
+        // `ShutdownHost` acks cannot be tree-reduced (hosts exit right after
+        // acking), so we collect one direct reply per host on a plain
+        // multi-receive port rather than a reduced barrier, and track which
+        // ranks acknowledged so we can report the hosts that didn't.
+        let (ack, mut rx) = cx.mailbox().open_port::<usize>();
+        // Bind `.unsplit()`: every `PortRef` becomes a multipart part the cast
+        // split loop would otherwise tree-reduce. `ShutdownHost` acks must reach
+        // the caller directly (hosts exit right after acking), so mark this port
+        // unsplit to keep it out of the reduction tree.
+        let mut ack = ack.bind().unsplit();
+        ack.return_undeliverable(false);
+
+        let terminate_timeout =
+            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_TIMEOUT);
+
+        self.host_agent_mesh.cast(
+            cx,
+            host_agent::ShutdownHost {
+                timeout: terminate_timeout,
+                max_in_flight: hyperactor_config::global::get(
+                    crate::bootstrap::MESH_TERMINATE_CONCURRENCY,
+                )
+                .clamp(1, 256),
+                rank: Default::default(),
+                ack,
+            },
+        )?;
+
+        // Hosts only reply after a (timeout-bounded) termination pass, so the
+        // per-reply wait must exceed the per-host terminate timeout.
+        let barrier_timeout = terminate_timeout.saturating_add(std::time::Duration::from_secs(30));
+
+        let mut acked = std::collections::HashSet::new();
+
+        while acked.len() < num_hosts {
+            match tokio::time::timeout(barrier_timeout, rx.recv()).await {
+                Ok(Ok(rank)) => {
+                    acked.insert(rank);
+                }
+                Ok(Err(err)) => return Err(anyhow::Error::from(err)),
+                Err(_) => {
+                    let missing: Vec<usize> =
+                        (0..num_hosts).filter(|r| !acked.contains(r)).collect();
+
+                    anyhow::bail!(
+                        "ShutdownHost barrier timed out after {:?}; {} of {} hosts did not acknowledge shutdown (host ranks {:?})",
+                        barrier_timeout,
+                        missing.len(),
+                        num_hosts,
+                        missing,
+                    );
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -99,7 +99,6 @@ use crate::bootstrap::ProcBind;
 use crate::host::Host;
 use crate::host::LocalProcManager;
 use crate::host::SERVICE_PROC_NAME;
-use crate::host_mesh::host_agent::DrainHostClient;
 pub use crate::host_mesh::host_agent::HostAgent;
 use crate::host_mesh::host_agent::HostAgentMode;
 use crate::host_mesh::host_agent::ProcManagerSpawnFn;
@@ -220,30 +219,6 @@ impl HostRef {
             hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
         agent
             .shutdown_host(cx, terminate_timeout, max_in_flight.clamp(1, 256))
-            .await?;
-        Ok(())
-    }
-
-    /// Drain all user procs on this host but keep the host, service
-    /// proc, and networking alive. Used during mesh stop/shutdown so
-    /// that forwarder flushes can still reach remote hosts.
-    pub(crate) async fn drain(
-        &self,
-        cx: &impl hyperactor::context::Actor,
-        host_mesh_id: Option<crate::mesh_id::HostMeshId>,
-    ) -> anyhow::Result<()> {
-        let agent = self.mesh_agent();
-        let terminate_timeout =
-            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_TIMEOUT);
-        let max_in_flight =
-            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_CONCURRENCY);
-        agent
-            .drain_host(
-                cx,
-                terminate_timeout,
-                max_in_flight.clamp(1, 256),
-                host_mesh_id,
-            )
             .await?;
         Ok(())
     }
@@ -689,9 +664,8 @@ impl HostMesh {
     /// `HostMesh`.
     ///
     /// Uses a two-phase approach:
-    /// 1. **Terminate children** on every host concurrently. Service
-    ///    infrastructure (host agent, comm proc, networking) stays
-    ///    alive so that forwarder flushes can still reach remote hosts.
+    /// 1. Cast `DrainHost` and wait for every host to finish draining
+    ///    its user procs while networking stays alive.
     /// 2. **Shut down hosts** concurrently. No user procs remain, so
     ///    this is fast and cannot deadlock on cross-host flush
     ///    timeouts.
@@ -700,25 +674,18 @@ impl HostMesh {
         let t0 = std::time::Instant::now();
         tracing::info!(name = "HostMeshStatus", status = "Shutdown::Attempt");
 
-        // Phase 1: terminate all user procs while service infrastructure
-        // stays alive so forwarder flushes can complete across hosts.
-        let results = futures::future::join_all(
-            self.current_ref
-                .values()
-                .map(|host| async move { host.drain(cx, None).await }),
-        )
-        .await;
-        let phase1_ms = t0.elapsed().as_millis();
-        for result in &results {
-            if let Err(e) = result {
-                tracing::warn!(
-                    name = "HostMeshStatus",
-                    status = "Shutdown::Drain::Failed",
-                    error = %e,
-                    "drain failed on a host"
-                );
-            }
+        // Phase 1: terminate all user procs while service infrastructure stays
+        // alive so forwarder flushes can complete across hosts.
+        if let Err(e) = self.current_ref.cast_drain(cx, None).await {
+            tracing::warn!(
+                name = "HostMeshStatus",
+                status = "Shutdown::Drain::Failed",
+                drain_ms = t0.elapsed().as_millis(),
+                error = %e,
+                "failed to cast DrainHost barrier"
+            );
         }
+        let phase1_ms = t0.elapsed().as_millis();
 
         // Phase 2: shut down hosts concurrently. No user procs remain.
         let t1 = std::time::Instant::now();
@@ -782,35 +749,19 @@ impl HostMesh {
         let t0 = std::time::Instant::now();
         tracing::info!(name = "HostMeshStatus", status = "Stop::Attempt");
 
-        let mesh_id = self.id.clone();
-        let results = futures::future::join_all(self.current_ref.values().map(|host| {
-            let mesh_id = Some(mesh_id.clone());
-            async move { host.drain(cx, mesh_id).await }
-        }))
-        .await;
+        let result = self.current_ref.cast_drain(cx, Some(self.id.clone())).await;
         let total_ms = t0.elapsed().as_millis();
-        let mut failed_hosts = vec![];
-        for (i, result) in results.iter().enumerate() {
-            if let Err(e) = result {
-                tracing::warn!(
-                    name = "HostMeshStatus",
-                    status = "Stop::Drain::Failed",
-                    error = %e,
-                    "drain failed on a host"
-                );
-                failed_hosts.push(i);
+        match result {
+            Ok(()) => {
+                tracing::info!(name = "HostMeshStatus", status = "Stop::Success", total_ms,);
             }
-        }
-        if failed_hosts.is_empty() {
-            tracing::info!(name = "HostMeshStatus", status = "Stop::Success", total_ms,);
-        } else {
-            tracing::error!(
+            Err(e) => tracing::warn!(
                 name = "HostMeshStatus",
-                status = "Stop::Failed",
+                status = "Stop::Drain::Failed",
                 total_ms,
-                "host mesh stop failed; check the logs of the failed hosts for details: {:?}",
-                failed_hosts
-            );
+                error = %e,
+                "failed waiting for DrainHost acknowledgment barrier"
+            ),
         }
 
         // Defuse the Drop impl so it doesn't send ShutdownHost to hosts
@@ -1159,6 +1110,71 @@ impl HostMeshRef {
             None,
             members,
         ))
+    }
+
+    async fn cast_drain(
+        &self,
+        cx: &impl context::Actor,
+        host_mesh_id: Option<HostMeshId>,
+    ) -> anyhow::Result<()> {
+        let region = self.region.clone();
+        let num_hosts = region.num_ranks();
+        if num_hosts == 0 {
+            return Ok(());
+        }
+
+        // Each host reports a single-rank `Stopped` overlay once it has
+        // drained; reduce them into a full StatusMesh so we can tell which
+        // hosts (if any) never acknowledged.
+        let (reply, rx) = cx.mailbox().open_accum_port_opts(
+            crate::StatusMesh::from_single(region.clone(), Status::NotExist),
+            StreamingReducerOpts {
+                max_update_interval: Some(std::time::Duration::from_millis(50)),
+                initial_update_interval: None,
+            },
+        );
+        let mut reply = reply.bind();
+        reply.return_undeliverable(false);
+
+        let terminate_timeout =
+            hyperactor_config::global::get(crate::bootstrap::MESH_TERMINATE_TIMEOUT);
+
+        self.host_agent_mesh.cast(
+            cx,
+            host_agent::DrainHost {
+                timeout: terminate_timeout,
+                max_in_flight: hyperactor_config::global::get(
+                    crate::bootstrap::MESH_TERMINATE_CONCURRENCY,
+                )
+                .clamp(1, 256),
+                host_mesh_id,
+                rank: Default::default(),
+                reply,
+            },
+        )?;
+
+        // Hosts only report after a (timeout-bounded) `terminate_children`, so
+        // the barrier's max-idle must exceed the per-host drain timeout.
+        let barrier_timeout = terminate_timeout.saturating_add(std::time::Duration::from_secs(30));
+
+        match GetRankStatus::wait(rx, num_hosts, barrier_timeout, region).await {
+            Ok(_) => Ok(()),
+            Err(partial) => {
+                let missing: Vec<usize> = partial
+                    .values()
+                    .enumerate()
+                    .filter(|(_, status)| status.is_not_exist())
+                    .map(|(rank, _)| rank)
+                    .collect();
+                anyhow::bail!(
+                    "DrainHost barrier timed out after {:?}; {} of {} hosts did not acknowledge (host ranks {:?})",
+                    barrier_timeout,
+                    missing.len(),
+                    num_hosts,
+                    missing,
+                )
+            }
+        }
     }
 
     /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.
@@ -2023,6 +2039,8 @@ mod tests {
     use timed_test::assert_no_process_leak;
     #[cfg(fbcode_build)]
     use tokio::process::Command;
+    #[cfg(fbcode_build)]
+    use tracing_test::traced_test;
 
     use super::*;
     #[cfg(fbcode_build)]
@@ -2144,6 +2162,27 @@ mod tests {
         let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
         let _guard1 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
         execute_extrinsic_allocation(&config).await;
+    }
+
+    /// `HostMesh::shutdown` emits a `Shutdown::Success` status log once every
+    /// host tears down cleanly with no failed hosts (see the `tracing::info!`
+    /// in `HostMesh::shutdown`). Drive the full allocate-then-shutdown path and
+    /// assert that the success log fired.
+    #[expect(
+        clippy::await_holding_invalid_type,
+        reason = "tracing-test's #[traced_test] enters a span whose Entered guard is held across awaits; this is inherent to the macro and harmless in a test"
+    )]
+    #[traced_test]
+    #[tokio::test]
+    #[cfg(fbcode_build)]
+    async fn test_shutdown_succeeds() {
+        let config = hyperactor_config::global::lock();
+        execute_extrinsic_allocation(&config).await;
+
+        assert!(
+            logs_contain("Shutdown::Success"),
+            "Shutdown::Success status log not found after shutting down host mesh"
+        );
     }
 
     #[tokio::test]

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1036,16 +1036,35 @@ fn start_proc_watch<S>(
     });
 }
 
-#[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    Named,
+    Handler,
+    RefClient,
+    HandleClient
+)]
 pub struct ShutdownHost {
     /// Grace window: send SIGTERM and wait this long before
     /// escalating.
     pub timeout: std::time::Duration,
     /// Max number of children to terminate concurrently on this host.
     pub max_in_flight: usize,
-    /// Ack that the agent finished shutdown work (best-effort).
-    #[reply]
-    pub ack: hyperactor::PortRef<()>,
+    /// This host's ordinal within the shutdown cast region, stamped by the
+    /// cast layer. The host echoes it back via `ack` so the caller can tell
+    /// exactly which hosts acknowledged shutdown.
+    pub rank: resource::Rank,
+    /// Direct reply carrying this host's rank once shutdown work is done.
+    ///
+    /// Intentionally must NOT be split/tree-reduced: `ShutdownHost` makes each
+    /// host exit right after acking, so a tree-reduced ack would stall — the
+    /// node that fans in peers' acks tears down before they arrive. Replying
+    /// directly to the caller survives the responders exiting. The caller binds
+    /// this port `.unsplit()` so the cast layer leaves it alone, and collects
+    /// one direct reply per host (see `HostMeshRef::cast_shutdown`).
+    pub ack: PortRef<usize>,
 }
 wirevalue::register_type!(ShutdownHost);
 
@@ -1159,6 +1178,7 @@ impl Handler<DrainComplete> for HostAgent {
 #[async_trait]
 impl Handler<ShutdownHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: ShutdownHost) -> anyhow::Result<()> {
+        let rank = msg.rank.unwrap();
         // Terminate children BEFORE acking, so the caller's networking
         // stays alive while children flush their forwarders during
         // teardown. If we ack first, the caller proceeds to tear down
@@ -1169,9 +1189,9 @@ impl Handler<ShutdownHost> for HostAgent {
             self.drain(cx, msg.timeout, msg.max_in_flight).await;
         }
 
-        // Ack after children are terminated so the caller does not
-        // tear down the host's networking prematurely.
-        msg.ack.post(cx, ());
+        // Reply this host's rank after children are terminated so the
+        // caller does not tear down the host's networking prematurely.
+        msg.ack.post(cx, rank);
 
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -213,7 +213,11 @@ struct ProcStatusChanged {
 /// Not exported — delivered locally via PortHandle (no serialization).
 struct DrainComplete {
     host: HostAgentMode,
-    ack: PortRef<()>,
+    /// This host's ordinal within the drain cast region.
+    rank: usize,
+    /// Streaming status reply the parent posts the drained overlay to,
+    /// after restoring state.
+    reply: PortRef<crate::StatusOverlay>,
 }
 
 /// Child actor whose only job is to run `host.terminate_children()` in
@@ -225,7 +229,8 @@ struct DrainWorker {
     host: Option<HostAgentMode>,
     timeout: Duration,
     max_in_flight: usize,
-    ack: Option<PortRef<()>>,
+    rank: usize,
+    reply: Option<PortRef<crate::StatusOverlay>>,
     done_notify: PortHandle<DrainComplete>,
 }
 
@@ -250,10 +255,18 @@ impl Actor for DrainWorker {
             }
         }
 
-        // Bundle host + ack into DrainComplete so the parent sends the ack
-        // AFTER restoring state (prevents race with ShutdownHost).
-        if let (Some(host), Some(ack)) = (self.host.take(), self.ack.take()) {
-            let _ = self.done_notify.post(this, DrainComplete { host, ack });
+        // Bundle host + reply into DrainComplete so the parent reports the
+        // drained overlay AFTER restoring state (prevents race with
+        // ShutdownHost).
+        if let (Some(host), Some(reply)) = (self.host.take(), self.reply.take()) {
+            let _ = self.done_notify.post(
+                this,
+                DrainComplete {
+                    host,
+                    rank: self.rank,
+                    reply,
+                },
+            );
         }
 
         Ok(())
@@ -1043,24 +1056,46 @@ wirevalue::register_type!(ShutdownHost);
 /// If `host_mesh_id` is `Some`, only procs belonging to that mesh
 /// are stopped (selective drain). If `None`, all procs are
 /// terminated (full drain).
-#[derive(Serialize, Deserialize, Debug, Named, Handler, RefClient, HandleClient)]
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    Named,
+    Handler,
+    RefClient,
+    HandleClient
+)]
 pub struct DrainHost {
     pub timeout: std::time::Duration,
     pub max_in_flight: usize,
     pub host_mesh_id: Option<HostMeshId>,
-    #[reply]
-    pub ack: hyperactor::PortRef<()>,
+    /// The recipient's ordinal within the drain cast region, stamped by
+    /// the cast layer. Used to position this host's status overlay.
+    pub rank: resource::Rank,
+    /// Streaming status reply. Each host reports a single-rank `Stopped`
+    /// overlay once it has drained; the caller reduces these into a
+    /// `StatusMesh` barrier and can detect hosts that never reported.
+    pub reply: PortRef<crate::StatusOverlay>,
 }
 wirevalue::register_type!(DrainHost);
 
 #[async_trait]
 impl Handler<DrainHost> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainHost) -> anyhow::Result<()> {
+        let rank = msg.rank.unwrap();
+        // This host's drain completion, as a single-rank `Stopped` overlay at
+        // its ordinal. The caller reduces these into a StatusMesh barrier.
+        let drained_overlay = || {
+            crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), resource::Status::Stopped)])
+                .expect("valid single-run overlay")
+        };
+
         if msg.host_mesh_id.is_some() {
             // Selective drain: stop only procs belonging to the named mesh.
             self.drain_by_mesh_name(cx, msg.timeout, msg.host_mesh_id.as_ref())
                 .await;
-            msg.ack.post(cx, ());
+            msg.reply.post(cx, drained_overlay());
             return Ok(());
         }
 
@@ -1068,14 +1103,14 @@ impl Handler<DrainHost> for HostAgent {
         let host = match std::mem::replace(&mut self.state, HostAgentState::Draining) {
             HostAgentState::Attached(h) => h,
             other @ (HostAgentState::Detached(_) | HostAgentState::Draining) => {
-                // Nothing to drain — ack immediately.
+                // Nothing to drain — report immediately.
                 self.state = other;
-                msg.ack.post(cx, ());
+                msg.reply.post(cx, drained_overlay());
                 return Ok(());
             }
             HostAgentState::Shutdown => {
                 self.state = HostAgentState::Shutdown;
-                msg.ack.post(cx, ());
+                msg.reply.post(cx, drained_overlay());
                 return Ok(());
             }
         };
@@ -1096,7 +1131,8 @@ impl Handler<DrainHost> for HostAgent {
                 host: Some(host),
                 timeout: msg.timeout,
                 max_in_flight: msg.max_in_flight,
-                ack: Some(msg.ack),
+                rank,
+                reply: Some(msg.reply),
                 done_notify: done_port,
             },
         );
@@ -1110,7 +1146,12 @@ impl Handler<DrainComplete> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: DrainComplete) -> anyhow::Result<()> {
         self.state = HostAgentState::Detached(msg.host);
         self.created.clear();
-        msg.ack.post(cx, ());
+        let overlay = crate::StatusOverlay::try_from_runs(vec![(
+            msg.rank..(msg.rank + 1),
+            resource::Status::Stopped,
+        )])
+        .expect("valid single-run overlay");
+        msg.reply.post(cx, overlay);
         Ok(())
     }
 }
@@ -1791,10 +1832,20 @@ mod tests {
         );
 
         // Drain only mesh_a.
+        let (drain_reply, mut drain_rx) = client.open_port::<crate::StatusOverlay>();
         host_agent
-            .drain_host(&client, Duration::from_secs(5), 16, Some(mesh_a.clone()))
+            .drain_host(
+                &client,
+                Duration::from_secs(5),
+                16,
+                Some(mesh_a.clone()),
+                resource::Rank::new(0),
+                drain_reply.bind(),
+            )
             .await
             .unwrap();
+        // Wait for the host to report drained before asserting.
+        drain_rx.recv().await.unwrap();
 
         // proc_a should be gone (removed from created).
         assert_matches!(
@@ -1870,10 +1921,20 @@ mod tests {
             .unwrap();
 
         // Drain all (no filter).
+        let (drain_reply, mut drain_rx) = client.open_port::<crate::StatusOverlay>();
         host_agent
-            .drain_host(&client, Duration::from_secs(5), 16, None)
+            .drain_host(
+                &client,
+                Duration::from_secs(5),
+                16,
+                None,
+                resource::Rank::new(0),
+                drain_reply.bind(),
+            )
             .await
             .unwrap();
+        // Wait for the host to report drained before asserting.
+        drain_rx.recv().await.unwrap();
 
         // Both should be gone.
         assert_matches!(

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -531,7 +531,7 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
         // - MESH_TERMINATE_TIMEOUT = 10 seconds
         // - MESH_TERMINATE_CONCURRENCY = 16
 
-        let (port, _) = instance.open_port();
+        let (port, _) = instance.open_port::<usize>();
         let mut port = port.bind();
         // We don't need the ack, and this temporary proc doesn't have a mailbox
         // receiver set up anyways. Just ignore the message.
@@ -541,6 +541,7 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
             ShutdownHost {
                 timeout: Duration::from_secs(10),
                 max_in_flight: 16,
+                rank: hyperactor_mesh::resource::Rank::new(0),
                 ack: port,
             },
         );


### PR DESCRIPTION
Summary:

Use the materialized HostAgent cast domain for `ShutdownHost`. These messages now implement `Bind`/`Unbind` and use `OncePortRef<()>` replies so they can be carried through `CastDomainRef::cast` and acknowledged through the unit accumulator.

Reviewed By: mariusae

Differential Revision: D105983256


