### PR TITLE
Cast proc spawn with SpawnProcs (#4104)

### DIFF
--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -110,9 +110,7 @@ use crate::mesh_id::ResourceId;
 use crate::proc_agent::ProcAgent;
 use crate::proc_mesh::ProcMeshRef;
 use crate::resource;
-use crate::resource::CreateOrUpdateClient;
 use crate::resource::GetRankStatus;
-use crate::resource::GetRankStatusClient;
 use crate::resource::RankedValues;
 use crate::resource::Status;
 use crate::resource::WaitRankStatusClient;
@@ -1280,8 +1278,9 @@ impl HostMeshRef {
     /// `host_extent ⊕ per_host` extent. Its return value takes
     /// precedence over `self.bootstrap_command` for that proc only.
     ///
-    /// Currently, spawn issues direct calls to each host agent. This will be fixed by
-    /// maintaining a comm actor on the host service procs themselves.
+    /// Spawn is issued as a single `SpawnProcs` cast — each HostAgent spawns all
+    /// of its per-host proc slots — then fenced with an accumulated status
+    /// barrier so returned procs are addressable and ready.
     #[allow(clippy::result_large_err)]
     pub async fn spawn<C: context::Actor>(
         &self,
@@ -1391,69 +1390,19 @@ impl HostMeshRef {
             },
         );
 
-        // Create or update each proc, then fence on receiving status
-        // overlays. This prevents a race where procs become
-        // addressable before their local muxers are ready, which
-        // could make early messages unroutable. A future improvement
-        // would allow buffering in the host-level muxer to eliminate
-        // the need for this synchronization step.
+        // Build each proc's `ProcRef` up front: the caller derives the same
+        // id/rank (`host_agent::proc_name(&proc_mesh_id, create_rank)`) that
+        // each HostAgent will, so the refs are ready before the cast lands. A single
+        // `SpawnProcs` cast (below) then has each HostAgent spawn all of its
+        // per-host slots, replying with status overlays to drive the readiness
+        // barrier.
         let mut proc_names = Vec::new();
         let client_config_override = hyperactor_config::global::propagatable_attrs();
         for (host_rank, host) in self.ranks.iter().enumerate() {
             for per_host_rank in 0..per_host.num_ranks() {
                 let create_rank = per_host.num_ranks() * host_rank + per_host_rank;
-                let proc_name = ResourceId::instance(Label::strip(&format!(
-                    "{}-{}",
-                    proc_mesh_id
-                        .display_label()
-                        .map(|l| l.as_str())
-                        .unwrap_or("unnamed"),
-                    per_host_rank
-                )));
+                let proc_name = host_agent::proc_name(&proc_mesh_id, create_rank);
                 proc_names.push(proc_name.clone());
-                let bind = proc_bind.as_ref().map(|v| v[per_host_rank].clone());
-                let bootstrap_command = match per_rank_bootstrap.as_ref() {
-                    Some(f) => Some(
-                        f(extent
-                            .point_of_rank(create_rank)
-                            .expect("rank in combined extent"))
-                        .map_err(crate::Error::ConfigurationError)?,
-                    ),
-                    None => self.bootstrap_command.clone(),
-                };
-                let proc_spec = resource::ProcSpec {
-                    client_config_override: client_config_override.clone(),
-                    bootstrap_command,
-                    proc_bind: bind,
-                    host_mesh_id: Some(self.id.clone()),
-                };
-                host.mesh_agent()
-                    .create_or_update(
-                        cx,
-                        proc_name.clone(),
-                        resource::Rank::new(create_rank),
-                        proc_spec,
-                    )
-                    .await
-                    .map_err(|e| {
-                        crate::Error::HostMeshAgentConfigurationError(
-                            host.mesh_agent().actor_addr().clone(),
-                            format!("failed while creating proc: {}", e),
-                        )
-                    })?;
-                let mut reply_port = port.bind();
-                // If this proc dies or some other issue renders the reply undeliverable,
-                // the reply does not need to be returned to the sender.
-                reply_port.return_undeliverable(false);
-                host.mesh_agent()
-                    .get_rank_status(cx, proc_name.clone(), reply_port)
-                    .await
-                    .map_err(|e| {
-                        crate::Error::HostMeshAgentConfigurationError(
-                            host.mesh_agent().actor_addr().clone(),
-                            format!("failed while querying proc status: {}", e),
-                        )
-                    })?;
                 let proc_id = host.named_proc(&proc_name);
                 tracing::info!(
                     name = "ProcMeshStatus",
@@ -1472,6 +1421,46 @@ impl HostMeshRef {
                 ));
             }
         }
+
+        let mut reply_port = port.bind();
+
+        reply_port.return_undeliverable(false);
+
+        let total_procs = self.region.num_ranks() * per_host.num_ranks();
+
+        let bootstrap_commands = match per_rank_bootstrap.as_ref() {
+            Some(per_rank_bootstrap) => Some(
+                (0..total_procs)
+                    .map(|create_rank| {
+                        per_rank_bootstrap(
+                            extent
+                                .point_of_rank(create_rank)
+                                .expect("rank in combined extent"),
+                        )
+                        .map(Some)
+                        .map_err(crate::Error::ConfigurationError)
+                    })
+                    .collect::<crate::Result<Vec<_>>>()?,
+            ),
+            None => None,
+        };
+
+        // One cast: each HostAgent spawns all `num_per_host` of its proc slots,
+        // deriving each proc's id/rank from its stamped host rank.
+        self.host_agent_mesh.cast(
+            cx,
+            host_agent::SpawnProcs {
+                rank: resource::Rank::default(),
+                proc_mesh_id: proc_mesh_id.clone(),
+                num_per_host: per_host.num_ranks(),
+                client_config_override,
+                host_mesh_id: Some(self.id.clone()),
+                default_bootstrap_command: self.bootstrap_command.clone(),
+                proc_bind,
+                bootstrap_commands,
+                status_reply: Some(reply_port),
+            },
+        )?;
 
         let start_time = tokio::time::Instant::now();
 
@@ -2149,7 +2138,7 @@ mod tests {
             HostMeshRef::from_hosts(HostMeshId::singleton(Label::new("test").unwrap()), hosts);
 
         let proc_mesh = host_mesh
-            .spawn(&testing::instance(), "test", Extent::unity(), None, None)
+            .spawn(&testing::instance(), "test", extent!(gpus = 4), None, None)
             .await
             .unwrap();
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -16,7 +16,10 @@
 
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::collections::hash_map::DefaultHasher;
 use std::fmt;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::pin::Pin;
 use std::sync::OnceLock;
 
@@ -37,9 +40,11 @@ use hyperactor::Proc;
 use hyperactor::ProcAddr;
 use hyperactor::RefClient;
 use hyperactor::RemoteEndpoint as _;
+use hyperactor::Uid;
 use hyperactor::actor::ActorStatus;
 use hyperactor::context;
 use hyperactor::gateway::GatewayServeHandle;
+use hyperactor::id::Label;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
 use serde::Deserialize;
@@ -47,10 +52,12 @@ use serde::Serialize;
 use tokio::time::Duration;
 use typeuri::Named;
 
+use crate::StatusOverlay;
 use crate::bootstrap;
 use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcConfig;
 use crate::bootstrap::BootstrapProcManager;
+use crate::bootstrap::ProcBind;
 use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
 use crate::host::Host;
@@ -60,6 +67,7 @@ use crate::host::LocalProcManager;
 use crate::host::SERVICE_PROC_NAME;
 use crate::host::SingleTerminate;
 use crate::mesh_id::HostMeshId;
+use crate::mesh_id::ProcMeshId;
 use crate::mesh_id::ResourceId;
 use crate::proc_agent::ProcAgent;
 use crate::pyspy::PySpyDump;
@@ -68,6 +76,7 @@ use crate::pyspy::PySpyProfileWorker;
 use crate::pyspy::PySpyWorker;
 use crate::resource;
 use crate::resource::ProcSpec;
+use crate::resource::Status;
 
 pub(crate) type ProcManagerSpawnFuture =
     Pin<Box<dyn Future<Output = anyhow::Result<ActorHandle<ProcAgent>>> + Send>>;
@@ -169,6 +178,41 @@ impl HostAgentMode {
         match self {
             HostAgentMode::Process { host, .. } => Some(host.manager().command().clone()),
             HostAgentMode::Local(_) => None,
+        }
+    }
+}
+
+/// Derive the proc resource name for the proc at the given mesh `rank`.
+///
+/// `rank` is the proc's absolute rank in the proc mesh — its position in the
+/// `host_extent ⊕ per_host` region, i.e. [`crate::proc_mesh::ProcRef::create_rank`].
+/// This is the proc's first-class, mesh-level identity; the `(host, per-host
+/// slot)` layout is an implementation detail of how procs are placed and is
+/// deliberately NOT part of the name. Both the caller and the receiving
+/// [`HostAgent`] derive the same name from `rank`, so the caller can construct
+/// [`crate::proc_mesh::ProcRef`]s before the casted `CreateOrUpdate<ProcSpec>`
+/// messages arrive. The id is a stable function of the proc mesh id and rank,
+/// so every proc in the mesh has a distinct id.
+pub(crate) fn proc_name(proc_mesh_id: &ProcMeshId, rank: usize) -> ResourceId {
+    let label = Label::strip(&format!(
+        "{}-{}",
+        proc_mesh_id
+            .display_label()
+            .map(|label| label.as_str())
+            .unwrap_or("unnamed"),
+        rank
+    ));
+
+    match proc_mesh_id.uid() {
+        Uid::Singleton(_) => ResourceId::singleton(label),
+        Uid::Instance(_, _) => {
+            let mut hasher = DefaultHasher::new();
+            proc_mesh_id.hash(&mut hasher);
+            rank.hash(&mut hasher);
+            ResourceId::new(
+                Uid::Instance(hasher.finish(), Some(label.clone())),
+                Some(label),
+            )
         }
     }
 }
@@ -287,6 +331,7 @@ impl fmt::Debug for DrainWorker {
 #[hyperactor::export(
     handlers=[
         resource::CreateOrUpdate<ProcSpec>,
+        SpawnProcs,
         resource::Stop,
         resource::GetState<ProcState>,
         resource::KeepaliveGetState<ProcState>,
@@ -690,6 +735,139 @@ impl fmt::Debug for HostAgent {
     }
 }
 
+/// Cast to every HostAgent to spawn a mesh's per-host proc slots in one message.
+/// Identity is positional: each recipient derives its procs' ids/ranks from its
+/// stamped `rank` plus `proc_mesh_id`/`num_per_host`, since a shared cast payload
+/// can't carry a per-host `id` (unlike `CreateOrUpdate`).
+#[derive(
+    Serialize,
+    Deserialize,
+    Clone,
+    Debug,
+    Named,
+    Handler,
+    RefClient,
+    HandleClient
+)]
+pub struct SpawnProcs {
+    /// This host's ordinal within the cast region, stamped by the cast layer.
+    pub rank: resource::Rank,
+    /// Proc mesh id used to deterministically derive per-host proc ids.
+    pub proc_mesh_id: ProcMeshId,
+    /// Number of procs to spawn on this host.
+    pub num_per_host: usize,
+    /// Config values to set on each spawned proc's global config, at the
+    /// `ClientOverride` layer.
+    pub client_config_override: Attrs,
+    /// The HostMesh that owns these procs (used by `DrainHost` for selective
+    /// drain).
+    pub host_mesh_id: Option<HostMeshId>,
+    /// Bootstrap command to use when no per-rank override applies.
+    pub default_bootstrap_command: Option<BootstrapCommand>,
+    /// Optional per-proc CPU/NUMA binding, indexed by per-host slot. `HostMesh::spawn`
+    /// already rejects a length that doesn't match the per-host extent, so the
+    /// handler is deliberately tolerant of a missing slot (including an index
+    /// past the vec's length): it spawns with no binding rather than panicking.
+    pub proc_bind: Option<Vec<ProcBind>>,
+    /// Optional per-rank bootstrap overrides, indexed by absolute proc rank
+    /// (`num_per_host * host_rank + per_host_rank`).
+    pub bootstrap_commands: Option<Vec<Option<BootstrapCommand>>>,
+    /// Spawn ack: the host posts one multi-rank overlay covering all of its
+    /// procs; the caller reduces these per-host overlays into a `StatusMesh`
+    /// barrier.
+    #[serde(default)]
+    pub status_reply: Option<PortRef<crate::StatusOverlay>>,
+}
+wirevalue::register_type!(SpawnProcs);
+
+#[async_trait]
+impl Handler<SpawnProcs> for HostAgent {
+    #[tracing::instrument("HostAgent::SpawnProcs", level = "info", skip_all, fields(host_rank, num = spawn.num_per_host))]
+    async fn handle(&mut self, cx: &Context<Self>, spawn: SpawnProcs) -> anyhow::Result<()> {
+        let host_rank = spawn
+            .rank
+            .0
+            .expect("cast layer stamps the rank before delivery");
+
+        tracing::Span::current().record("host_rank", host_rank);
+
+        let mut spawn_result = Ok(());
+
+        for per_host_rank in 0..spawn.num_per_host {
+            let rank = spawn.num_per_host * host_rank + per_host_rank;
+
+            let id = proc_name(&spawn.proc_mesh_id, rank);
+
+            let bootstrap_command = spawn
+                .bootstrap_commands
+                .as_ref()
+                .and_then(|commands| commands.get(rank).cloned().flatten())
+                .or_else(|| spawn.default_bootstrap_command.clone());
+
+            let proc_bind = spawn
+                .proc_bind
+                .as_ref()
+                .and_then(|binds| binds.get(per_host_rank).cloned());
+
+            if let Err(e) = <Self as Handler<resource::CreateOrUpdate<ProcSpec>>>::handle(
+                self,
+                cx,
+                resource::CreateOrUpdate {
+                    id,
+                    rank: resource::Rank::new(rank),
+                    spec: ProcSpec {
+                        client_config_override: spawn.client_config_override.clone(),
+                        proc_bind,
+                        bootstrap_command,
+                        host_mesh_id: spawn.host_mesh_id.clone(),
+                    },
+                },
+            )
+            .await
+            {
+                // Stop spawning, but fall through to report the result below.
+                spawn_result = Err(e);
+                break;
+            }
+        }
+
+        // Report this host's full rank range in a single multi-rank overlay. The
+        // caller's readiness barrier only completes once *every* rank has moved
+        // off NotExist, so on the error path the ranks we never created are
+        // reported as Failed too — otherwise the caller would wait out its whole
+        // idle timeout instead of failing fast on the error we return below.
+        if let Some(reply) = &spawn.status_reply {
+            let mut runs = Vec::with_capacity(spawn.num_per_host);
+
+            for per_host_rank in 0..spawn.num_per_host {
+                let rank = spawn.num_per_host * host_rank + per_host_rank;
+
+                let id = proc_name(&spawn.proc_mesh_id, rank);
+
+                let status = match self.proc_rank_status(&id).await {
+                    (resolved, status) if resolved != usize::MAX => status,
+                    // Unknown to this host: not yet attempted, or its creation
+                    // errored before being recorded. Mark Failed on the error
+                    // path; on success every rank is created so this is moot.
+                    _ => match &spawn_result {
+                        Err(e) => Status::Failed(e.to_string()),
+                        Ok(()) => continue,
+                    },
+                };
+
+                runs.push((rank..(rank + 1), status));
+            }
+
+            reply.post(cx, crate::StatusOverlay::try_from_runs(runs)?);
+        }
+
+        spawn_result
+    }
+}
+
+// Point-to-point proc spawn by carried `id`. The shared per-proc creation path:
+// invoked directly (e.g. unit/admin tests) and once per slot by the `SpawnProcs`
+// cast handler, which derives each proc's id/rank from the host's stamped rank.
 #[async_trait]
 impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
     #[tracing::instrument("HostAgent::CreateOrUpdate", level = "info", skip_all, fields(id=%create_or_update.id))]
@@ -828,17 +1006,11 @@ impl Handler<resource::Stop> for HostAgent {
     }
 }
 
-#[async_trait]
-impl Handler<resource::GetRankStatus> for HostAgent {
-    async fn handle(
-        &mut self,
-        cx: &Context<Self>,
-        get_rank_status: resource::GetRankStatus,
-    ) -> anyhow::Result<()> {
-        use crate::StatusOverlay;
-        use crate::resource::Status;
-
-        let (rank, status) = match self.created.get(&get_rank_status.id) {
+impl HostAgent {
+    /// The `(rank, status)` for a created proc, clamped to the host's minimum
+    /// status. `rank == usize::MAX` means the proc is unknown to this host.
+    async fn proc_rank_status(&self, id: &ResourceId) -> (usize, Status) {
+        match self.created.get(id) {
             Some(ProcCreationState {
                 rank,
                 created: Ok((proc_id, _mesh_agent)),
@@ -856,7 +1028,18 @@ impl Handler<resource::GetRankStatus> for HostAgent {
                 ..
             }) => (*rank, Status::Failed(e.to_string())),
             None => (usize::MAX, Status::NotExist),
-        };
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<resource::GetRankStatus> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        get_rank_status: resource::GetRankStatus,
+    ) -> anyhow::Result<()> {
+        let (rank, status) = self.proc_rank_status(&get_rank_status.id).await;
 
         let overlay = if rank == usize::MAX {
             StatusOverlay::new()
@@ -2107,6 +2290,80 @@ mod tests {
                 "timed out waiting for service proc watermark > 0",
             );
             tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
+    /// A single `SpawnProcs` message at host rank 0 fans out into
+    /// `num_per_host` procs, each created under the id derived from
+    /// `proc_name(&proc_mesh_id, rank)`. All of them should come up Running.
+    #[tokio::test]
+    async fn test_spawn_procs_many_per_host() {
+        let host = Host::new(
+            BootstrapProcManager::new(BootstrapCommand::test()).unwrap(),
+            ChannelTransport::Unix.any(),
+        )
+        .await
+        .unwrap();
+
+        let system_proc = host.system_proc().clone();
+        let host_agent = system_proc
+            .spawn_with_uid(
+                Uid::singleton(Label::new(HOST_MESH_AGENT_ACTOR_NAME).unwrap()),
+                HostAgent::new(HostAgentMode::Process {
+                    host,
+                    shutdown_tx: None,
+                }),
+            )
+            .unwrap();
+
+        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
+        let client = client_proc.client("client");
+
+        let proc_mesh_id = ProcMeshId::singleton(Label::new("spawn-many").unwrap());
+        let num_per_host = 4;
+
+        // Send a single point-to-point SpawnProcs (not a cast) to the host
+        // agent at host rank 0.
+        let agent_ref: ActorRef<HostAgent> = host_agent.bind();
+        agent_ref.post(
+            &client,
+            SpawnProcs {
+                rank: resource::Rank::new(0),
+                proc_mesh_id: proc_mesh_id.clone(),
+                num_per_host,
+                client_config_override: Attrs::new(),
+                host_mesh_id: None,
+                default_bootstrap_command: None,
+                proc_bind: None,
+                bootstrap_commands: None,
+                status_reply: None,
+            },
+        );
+
+        // Each of the num_per_host procs should reach Running.
+        for rank in 0..num_per_host {
+            let id = proc_name(&proc_mesh_id, rank);
+            let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
+            host_agent
+                .wait_rank_status(&client, id.clone(), resource::Status::Running, port.bind())
+                .await
+                .unwrap();
+            let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
+                .await
+                .unwrap_or_else(|_| panic!("proc {rank} did not reach Running"))
+                .expect("reply channel closed");
+            assert!(
+                !overlay.is_empty(),
+                "expected non-empty Running overlay for proc {rank}",
+            );
+
+            assert_matches!(
+                host_agent.get_state(&client, id).await.unwrap(),
+                resource::State {
+                    status: resource::Status::Running,
+                    ..
+                }
+            );
         }
     }
 }


### PR DESCRIPTION
Summary:

Use casting for spawning procs with a new `SpawnProcs` message that is sent once per host specifying the number of procs to spawn per host. This will delegate to making n calls to the handler for `CreateOrUpdate<ProcSpec>`

Reviewed By: mariusae

Differential Revision: D106402900


