### PR TITLE
Bootstrap CastActor on proc agents (#4107)

### DIFF
--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -43,10 +43,7 @@ use hyperactor::value_mesh::ValueMesh;
 use hyperactor_config::Flattrs;
 use ndslice::Point;
 use ndslice::Region;
-use ndslice::Shape;
-use ndslice::view::BuildFromRegionIndexed;
 use ndslice::view::MapIntoExt;
-use ndslice::view::Ranked;
 use ndslice::view::View;
 use serde::Deserialize;
 use serde::Serialize;
@@ -111,17 +108,16 @@ impl CastDomainId {
     /// Materialize this domain id over concrete members and return an
     /// addressable domain handle.
     ///
-    /// `members` maps domain rank to member actor address. `shape` describes
-    /// the logical root shape of the domain; tiling and communication are
+    /// `members` maps domain rank to member actor address. `region` describes
+    /// the logical root region of the domain; tiling and communication are
     /// derived internally.
     pub fn materialize(
         self,
         cx: &impl context::Actor,
         members: HashMap<usize, ActorAddr>,
-        shape: Shape,
+        region: Region,
         tiling_policy: TilingPolicy,
     ) -> anyhow::Result<CastDomainRef> {
-        let region = Region::from(shape);
         anyhow::ensure!(
             members.len() == region.num_ranks()
                 && region
@@ -136,7 +132,19 @@ impl CastDomainId {
             .get(&root_rank)
             .expect("members coverage was checked above")
             .clone();
-        let member_mesh = Arc::new(ValueMesh::build_indexed(region.clone(), members)?);
+        let member_mesh = Arc::new(ValueMesh::new(
+            region.clone(),
+            region
+                .slice()
+                .iter()
+                .map(|rank| {
+                    members
+                        .get(&rank)
+                        .expect("members coverage was checked above")
+                        .clone()
+                })
+                .collect(),
+        )?);
 
         let domain_ref = CastDomainRef::from_entry_point(
             self.clone(),
@@ -564,6 +572,10 @@ impl Handler<CreateCastDomain> for CastActor {
             tiling_policy,
             tile,
         } = message;
+        if self.installed_hops.contains_key(&cast_domain_id) {
+            return Ok(());
+        }
+
         let mut next_hops = Vec::new();
 
         for next_tile in next_tiles(tiling_policy, &tile) {
@@ -889,6 +901,8 @@ mod tests {
     use ndslice::Slice;
     use ndslice::ViewExt;
     use ndslice::shape;
+    use ndslice::view::BuildFromRegionIndexed;
+    use ndslice::view::Ranked;
     use proptest::prelude::*;
     use timed_test::async_timed_test;
     use typeuri::Named;
@@ -1308,12 +1322,12 @@ mod tests {
             }
         }
 
-        fn root_domain(&self, shape: Shape) -> CastDomainRef {
+        fn root_domain(&self, region: Region) -> CastDomainRef {
             CastDomainId::new()
                 .materialize(
                     &self.client,
                     self.domain_members(),
-                    shape,
+                    region,
                     TilingPolicy::BlockPartitioning,
                 )
                 .unwrap()
@@ -1325,9 +1339,9 @@ mod tests {
                 .collect()
         }
 
-        fn root_domain_with_policy(&self, shape: Shape, policy: TilingPolicy) -> CastDomainRef {
+        fn root_domain_with_policy(&self, region: Region, policy: TilingPolicy) -> CastDomainRef {
             CastDomainId::new()
-                .materialize(&self.client, self.member_ids.clone(), shape, policy)
+                .materialize(&self.client, self.member_ids.clone(), region, policy)
                 .unwrap()
         }
 
@@ -1454,7 +1468,7 @@ mod tests {
         clear_captured_domains();
 
         let test_mesh = CastTestMesh::new(8);
-        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
         let snapshots = test_mesh
             .wait_for_domain_snapshots(root_domain.domain_id(), 8)
             .await;
@@ -1548,7 +1562,7 @@ mod tests {
         let n = 8;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_delivery_receivers();
-        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
 
         let expected_payloads = vec![
             "hello-0".to_string(),
@@ -1625,7 +1639,7 @@ mod tests {
         let n = 2;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_delivery_receivers();
-        let root_domain = test_mesh.root_domain(shape!(rank = 2));
+        let root_domain = test_mesh.root_domain(shape!(rank = 2).into());
 
         let mut headers = Flattrs::new();
         headers.set(
@@ -1733,7 +1747,7 @@ mod tests {
         clear_captured_domains();
 
         let test_mesh = CastTestMesh::new(8);
-        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
         let domain_id = root_domain.domain_id().clone();
         test_mesh.wait_for_domain_snapshots(&domain_id, 8).await;
 
@@ -1753,7 +1767,7 @@ mod tests {
         let n = 8;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_split_port_receivers();
-        let root_cast_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_cast_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
 
         for (case_name, range, expected_procs) in [
             (
@@ -1797,7 +1811,7 @@ mod tests {
         let n = 4;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_delivery_receivers();
-        let root = test_mesh.root_domain(shape!(rank = 4));
+        let root = test_mesh.root_domain(shape!(rank = 4).into());
 
         let rank_0_to_2 = root
             .materialize_slice(
@@ -2129,7 +2143,7 @@ mod tests {
         let n = 8;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_split_port_receivers();
-        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
 
         let (reply_handle, reply_rx) = context::Mailbox::mailbox(&test_mesh.client)
             .open_reduce_port(TestReplyCountsAccumulator);
@@ -2198,7 +2212,7 @@ mod tests {
 
         let test_mesh = CastTestMesh::new(8);
         let root_domain = test_mesh.root_domain_with_policy(
-            shape!(a = 8),
+            shape!(a = 8).into(),
             TilingPolicy::BoundedFanout {
                 fanout: NonZeroUsize::new(2).unwrap(),
             },
@@ -2263,7 +2277,8 @@ mod tests {
         clear_captured_domains();
 
         let test_mesh = CastTestMesh::new(8);
-        let root_domain = test_mesh.root_domain_with_policy(shape!(a = 8), TilingPolicy::Bisection);
+        let root_domain =
+            test_mesh.root_domain_with_policy(shape!(a = 8).into(), TilingPolicy::Bisection);
         let snapshots = test_mesh
             .wait_for_domain_snapshots(root_domain.domain_id(), 8)
             .await;

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -34,6 +34,7 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hostname = "0.4.2"
 humantime = "2.1"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
+hyperactor_cast = { version = "0.0.0", path = "../hyperactor_cast" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -330,6 +330,12 @@ impl ProcAgent {
         proc: Proc,
         shutdown_tx: Option<tokio::sync::oneshot::Sender<i32>>,
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
+        let cast_handle = proc.spawn_with_uid(
+            Uid::singleton(Label::strip("cast")),
+            hyperactor_cast::cast_actor::CastActor::default(),
+        )?;
+        cast_handle.bind::<hyperactor_cast::cast_actor::CastActor>();
+
         let orphan_timeout = hyperactor_config::global::get(MESH_ORPHAN_TIMEOUT);
         let agent = ProcAgent {
             proc: proc.clone(),


### PR DESCRIPTION
Summary:

Add the `hyperactor_cast` dependency and spawn the well-known `CastActor` from `ProcAgent::boot_v1`. This prepares every proc-agent proc to host cast domains without changing mesh routing yet.

Reviewed By: dulinriley

Differential Revision: D105983201


