### PR TITLE
Narrow selection types for casts (#4109)

### DIFF
--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -43,10 +43,7 @@ use hyperactor::value_mesh::ValueMesh;
 use hyperactor_config::Flattrs;
 use ndslice::Point;
 use ndslice::Region;
-use ndslice::Shape;
-use ndslice::view::BuildFromRegionIndexed;
 use ndslice::view::MapIntoExt;
-use ndslice::view::Ranked;
 use ndslice::view::View;
 use serde::Deserialize;
 use serde::Serialize;
@@ -111,17 +108,16 @@ impl CastDomainId {
     /// Materialize this domain id over concrete members and return an
     /// addressable domain handle.
     ///
-    /// `members` maps domain rank to member actor address. `shape` describes
-    /// the logical root shape of the domain; tiling and communication are
+    /// `members` maps domain rank to member actor address. `region` describes
+    /// the logical root region of the domain; tiling and communication are
     /// derived internally.
     pub fn materialize(
         self,
         cx: &impl context::Actor,
         members: HashMap<usize, ActorAddr>,
-        shape: Shape,
+        region: Region,
         tiling_policy: TilingPolicy,
     ) -> anyhow::Result<CastDomainRef> {
-        let region = Region::from(shape);
         anyhow::ensure!(
             members.len() == region.num_ranks()
                 && region
@@ -136,7 +132,19 @@ impl CastDomainId {
             .get(&root_rank)
             .expect("members coverage was checked above")
             .clone();
-        let member_mesh = Arc::new(ValueMesh::build_indexed(region.clone(), members)?);
+        let member_mesh = Arc::new(ValueMesh::new(
+            region.clone(),
+            region
+                .slice()
+                .iter()
+                .map(|rank| {
+                    members
+                        .get(&rank)
+                        .expect("members coverage was checked above")
+                        .clone()
+                })
+                .collect(),
+        )?);
 
         let domain_ref = CastDomainRef::from_entry_point(
             self.clone(),
@@ -564,6 +572,10 @@ impl Handler<CreateCastDomain> for CastActor {
             tiling_policy,
             tile,
         } = message;
+        if self.installed_hops.contains_key(&cast_domain_id) {
+            return Ok(());
+        }
+
         let mut next_hops = Vec::new();
 
         for next_tile in next_tiles(tiling_policy, &tile) {
@@ -889,6 +901,8 @@ mod tests {
     use ndslice::Slice;
     use ndslice::ViewExt;
     use ndslice::shape;
+    use ndslice::view::BuildFromRegionIndexed;
+    use ndslice::view::Ranked;
     use proptest::prelude::*;
     use timed_test::async_timed_test;
     use typeuri::Named;
@@ -1308,12 +1322,12 @@ mod tests {
             }
         }
 
-        fn root_domain(&self, shape: Shape) -> CastDomainRef {
+        fn root_domain(&self, region: Region) -> CastDomainRef {
             CastDomainId::new()
                 .materialize(
                     &self.client,
                     self.domain_members(),
-                    shape,
+                    region,
                     TilingPolicy::BlockPartitioning,
                 )
                 .unwrap()
@@ -1325,9 +1339,9 @@ mod tests {
                 .collect()
         }
 
-        fn root_domain_with_policy(&self, shape: Shape, policy: TilingPolicy) -> CastDomainRef {
+        fn root_domain_with_policy(&self, region: Region, policy: TilingPolicy) -> CastDomainRef {
             CastDomainId::new()
-                .materialize(&self.client, self.member_ids.clone(), shape, policy)
+                .materialize(&self.client, self.member_ids.clone(), region, policy)
                 .unwrap()
         }
 
@@ -1454,7 +1468,7 @@ mod tests {
         clear_captured_domains();
 
         let test_mesh = CastTestMesh::new(8);
-        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
         let snapshots = test_mesh
             .wait_for_domain_snapshots(root_domain.domain_id(), 8)
             .await;
@@ -1548,7 +1562,7 @@ mod tests {
         let n = 8;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_delivery_receivers();
-        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
 
         let expected_payloads = vec![
             "hello-0".to_string(),
@@ -1625,7 +1639,7 @@ mod tests {
         let n = 2;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_delivery_receivers();
-        let root_domain = test_mesh.root_domain(shape!(rank = 2));
+        let root_domain = test_mesh.root_domain(shape!(rank = 2).into());
 
         let mut headers = Flattrs::new();
         headers.set(
@@ -1733,7 +1747,7 @@ mod tests {
         clear_captured_domains();
 
         let test_mesh = CastTestMesh::new(8);
-        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
         let domain_id = root_domain.domain_id().clone();
         test_mesh.wait_for_domain_snapshots(&domain_id, 8).await;
 
@@ -1753,7 +1767,7 @@ mod tests {
         let n = 8;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_split_port_receivers();
-        let root_cast_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_cast_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
 
         for (case_name, range, expected_procs) in [
             (
@@ -1797,7 +1811,7 @@ mod tests {
         let n = 4;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_delivery_receivers();
-        let root = test_mesh.root_domain(shape!(rank = 4));
+        let root = test_mesh.root_domain(shape!(rank = 4).into());
 
         let rank_0_to_2 = root
             .materialize_slice(
@@ -2129,7 +2143,7 @@ mod tests {
         let n = 8;
         let mut test_mesh = CastTestMesh::new(n);
         test_mesh.spawn_split_port_receivers();
-        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2));
+        let root_domain = test_mesh.root_domain(shape!(a = 2, b = 2, c = 2).into());
 
         let (reply_handle, reply_rx) = context::Mailbox::mailbox(&test_mesh.client)
             .open_reduce_port(TestReplyCountsAccumulator);
@@ -2198,7 +2212,7 @@ mod tests {
 
         let test_mesh = CastTestMesh::new(8);
         let root_domain = test_mesh.root_domain_with_policy(
-            shape!(a = 8),
+            shape!(a = 8).into(),
             TilingPolicy::BoundedFanout {
                 fanout: NonZeroUsize::new(2).unwrap(),
             },
@@ -2263,7 +2277,8 @@ mod tests {
         clear_captured_domains();
 
         let test_mesh = CastTestMesh::new(8);
-        let root_domain = test_mesh.root_domain_with_policy(shape!(a = 8), TilingPolicy::Bisection);
+        let root_domain =
+            test_mesh.root_domain_with_policy(shape!(a = 8).into(), TilingPolicy::Bisection);
         let snapshots = test_mesh
             .wait_for_domain_snapshots(root_domain.domain_id(), 8)
             .await;

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -34,6 +34,7 @@ futures = { version = "0.3.31", features = ["async-await", "compat"] }
 hostname = "0.4.2"
 humantime = "2.1"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
+hyperactor_cast = { version = "0.0.0", path = "../hyperactor_cast" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -44,7 +44,6 @@ use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
-use hyperactor_mesh_macros::sel;
 use ndslice::Selection;
 use ndslice::ViewExt as _;
 use ndslice::view;
@@ -470,7 +469,7 @@ impl<A: Referable> ActorMeshRef<A> {
         A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
-        self.cast_with_selection(cx, sel!(*), message, &Flattrs::new())
+        self.cast_with_headers(cx, &Flattrs::new(), message)
     }
 
     /// Cast a message to all the actors in this mesh, merging
@@ -490,7 +489,66 @@ impl<A: Referable> ActorMeshRef<A> {
         A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
         M: Castable + RemoteMessage + Clone,
     {
-        self.cast_with_selection(cx, sel!(*), message, caller_headers)
+        self.check_cached_failure(cx)?;
+        self.emit_sent_message_telemetry(cx, view::Ranked::region(self));
+
+        if let Some(root_comm_actor) = self.proc_mesh.root_comm_actor() {
+            if casting::v1_casting_enabled() {
+                self.cast_v1(cx, message, root_comm_actor, caller_headers);
+                Ok(())
+            } else {
+                self.cast_v0(
+                    cx,
+                    message,
+                    ndslice::selection::dsl::true_(),
+                    root_comm_actor,
+                    caller_headers,
+                )
+            }
+        } else {
+            for (point, actor) in self.iter() {
+                self.post_cast_direct(cx, point, &actor, message.clone(), caller_headers)?;
+            }
+            Ok(())
+        }
+    }
+
+    /// Cast a message to one randomly chosen actor in this mesh, merging
+    /// caller-supplied `caller_headers` into the outgoing envelope.
+    #[allow(clippy::result_large_err)]
+    pub fn cast_choose_with_headers<M>(
+        &self,
+        cx: &impl context::Actor,
+        caller_headers: &Flattrs,
+        message: M,
+    ) -> crate::Result<()>
+    where
+        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        M: Castable + RemoteMessage + Clone,
+    {
+        self.check_cached_failure(cx)?;
+        self.emit_sent_message_telemetry(
+            cx,
+            &Region::new(
+                Vec::new(),
+                ndslice::Slice::new(0, Vec::new(), Vec::new())
+                    .expect("zero-dimensional slice is valid"),
+            ),
+        );
+
+        if !casting::v1_casting_enabled()
+            && let Some(root_comm_actor) = self.proc_mesh.root_comm_actor()
+        {
+            self.cast_v0(
+                cx,
+                message,
+                ndslice::selection::dsl::any(ndslice::selection::dsl::true_()),
+                root_comm_actor,
+                caller_headers,
+            )
+        } else {
+            self.cast_choose_direct(cx, message, caller_headers)
+        }
     }
 
     /// Cast a message to the actors in this mesh according to the provided selection.
@@ -508,21 +566,21 @@ impl<A: Referable> ActorMeshRef<A> {
         A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
-        self.cast_with_selection(cx, sel, message, &Flattrs::new())
+        self.check_cached_failure(cx)?;
+        self.emit_sent_message_telemetry(cx, view::Ranked::region(self));
+
+        let Some(root_comm_actor) = self.proc_mesh.root_comm_actor() else {
+            return Err(Error::CastingError(
+                self.id.clone(),
+                anyhow::anyhow!("tensor-engine selection casts require a root CommActor"),
+            ));
+        };
+
+        self.cast_v0(cx, message, sel, root_comm_actor, &Flattrs::new())
     }
 
     #[allow(clippy::result_large_err)]
-    fn cast_with_selection<M>(
-        &self,
-        cx: &impl context::Actor,
-        sel: Selection,
-        message: M,
-        caller_headers: &Flattrs,
-    ) -> crate::Result<()>
-    where
-        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
-        M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
-    {
+    fn check_cached_failure(&self, cx: &impl context::Actor) -> crate::Result<()> {
         // First check if the mesh is already dead before sending out any messages
         // to a possibly undeliverable actor.
         if let Some(failure) = self.cached_failure(cx) {
@@ -534,66 +592,88 @@ impl<A: Referable> ActorMeshRef<A> {
             return Err(crate::Error::Supervision(Box::new(failure)));
         }
 
+        Ok(())
+    }
+
+    fn emit_sent_message_telemetry(&self, cx: &impl context::Actor, region: &Region) {
         hyperactor_telemetry::notify_sent_message(hyperactor_telemetry::SentMessageEvent {
             timestamp: std::time::SystemTime::now(),
             sender_actor_id: hyperactor_telemetry::hash_to_u64(cx.mailbox().actor_addr()),
             actor_mesh_id: hyperactor_telemetry::hash_to_u64(&self.id.to_string()),
-            view_json: serde_json::to_string(view::Ranked::region(self)).unwrap_or_default(),
+            view_json: serde_json::to_string(region).unwrap_or_default(),
             shape_json: {
-                let shape: ndslice::Shape = view::Ranked::region(self).into();
+                let shape: ndslice::Shape = region.into();
                 serde_json::to_string(&shape).unwrap_or_default()
             },
         });
+    }
 
-        // Now that we know these ranks are active, send out the actual messages.
-        if let Some(root_comm_actor) = self.proc_mesh.root_comm_actor() {
-            if casting::v1_casting_enabled() {
-                if Selection::is_equivalent_to_true(&sel) {
-                    self.cast_v1(cx, message, root_comm_actor, caller_headers);
-                    return Ok(());
-                }
-                // V1 does not support non-* selections yet; fall back to
-                // the iteration path below.
-            } else {
-                return self.cast_v0(cx, message, sel, root_comm_actor, caller_headers);
-            }
+    #[allow(clippy::result_large_err)]
+    fn cast_choose_direct<M>(
+        &self,
+        cx: &impl context::Actor,
+        message: M,
+        caller_headers: &Flattrs,
+    ) -> crate::Result<()>
+    where
+        A: RemoteHandles<M>,
+        M: Castable + RemoteMessage,
+    {
+        let region = view::Ranked::region(self);
+
+        let num_ranks = region.num_ranks();
+        if num_ranks == 0 {
+            return Ok(());
         }
 
-        let selected_ranks: std::collections::HashSet<usize> = sel
-            .eval(
-                &ndslice::selection::EvalOpts::lenient(),
-                view::Ranked::region(self).slice(),
+        let rank_index = rand::random::<u64>() as usize % num_ranks;
+
+        let point = region
+            .extent()
+            .point_of_rank(rank_index)
+            .map_err(|err| Error::CastingError(self.id.clone(), err.into()))?;
+
+        let actor = view::Ranked::get(self, point.rank()).ok_or_else(|| {
+            Error::CastingError(
+                self.id.clone(),
+                anyhow::anyhow!("missing actor for chosen rank {}", point.rank()),
             )
-            .map_err(|e| Error::CastingError(self.id.clone(), e.into()))?
-            .collect();
+        })?;
 
-        for (point, actor) in self.iter() {
-            if !selected_ranks.contains(&point.rank()) {
-                continue;
-            }
-            let create_rank = point.rank();
-            let mut headers = caller_headers.clone();
-            multicast::set_cast_info_on_headers(
-                &mut headers,
-                point,
-                cx.instance().self_addr().clone(),
-            );
+        self.post_cast_direct(cx, point, actor, message, caller_headers)
+    }
 
-            // Make sure that we re-bind ranks, as these may be used for
-            // bootstrapping comm actors.
-            let mut unbound = Unbound::try_from_message(message.clone())
-                .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-            unbound
-                .visit_mut::<resource::Rank>(|resource::Rank(rank)| {
-                    *rank = Some(create_rank);
-                    Ok(())
-                })
-                .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-            let rebound_message = unbound
-                .bind()
-                .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-            actor.post_with_headers(cx, headers, rebound_message);
-        }
+    #[allow(clippy::result_large_err)]
+    fn post_cast_direct<M>(
+        &self,
+        cx: &impl context::Actor,
+        point: ndslice::Point,
+        actor: &ActorRef<A>,
+        message: M,
+        caller_headers: &Flattrs,
+    ) -> crate::Result<()>
+    where
+        A: RemoteHandles<M>,
+        M: Castable + RemoteMessage,
+    {
+        let create_rank = point.rank();
+        let mut headers = caller_headers.clone();
+        multicast::set_cast_info_on_headers(&mut headers, point, cx.instance().self_addr().clone());
+
+        // Make sure that we re-bind ranks, as these may be used for
+        // bootstrapping comm actors.
+        let mut unbound = Unbound::try_from_message(message)
+            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
+        unbound
+            .visit_mut::<resource::Rank>(|resource::Rank(rank)| {
+                *rank = Some(create_rank);
+                Ok(())
+            })
+            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
+        let rebound_message = unbound
+            .bind()
+            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
+        actor.post_with_headers(cx, headers, rebound_message);
         Ok(())
     }
 
@@ -1148,9 +1228,12 @@ mod tests {
     use hyperactor::id::Label;
     use hyperactor::mailbox;
     use ndslice::Extent;
+    use ndslice::Region;
+    use ndslice::Slice;
     use ndslice::ViewExt;
     use ndslice::extent;
     use ndslice::view::Ranked;
+    use ndslice::view::RankedSliceable;
     use timed_test::assert_no_process_leak;
     use timed_test::async_timed_test;
     use tokio::time::Duration;
@@ -1599,10 +1682,8 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 60)]
-    async fn test_cast_with_selection_v1_fallback() {
+    async fn test_sliced_actor_mesh_cast_v1_reaches_slice_members() {
         use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
-        use hyperactor_mesh_macros::sel;
-        use ndslice::Selection;
 
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(crate::bootstrap::MESH_BOOTSTRAP_ENABLE_PDEATHSIG, false);
@@ -1620,15 +1701,19 @@ mod tests {
             .spawn(instance, "test", Extent::unity(), None, None)
             .await
             .unwrap();
-        let actor_mesh: ActorMesh<testactor::TestActor> =
+        let root_actor_mesh: ActorMesh<testactor::TestActor> =
             proc_mesh.spawn(instance, "test", &()).await.unwrap();
 
-        // Cast with sel!(0:1) — should only reach host 0.
+        // Cast through a sliced mesh — `cast` still means all, but all is
+        // scoped to the immutable sliced rank space.
+        let actor_mesh = root_actor_mesh.sliced(Region::new(
+            vec!["rank".to_string()],
+            Slice::new(0, vec![1], vec![1]).unwrap(),
+        ));
         let (cast_info, mut cast_info_rx) = instance.mailbox().open_port();
         actor_mesh
-            .cast_for_tensor_engine_only_do_not_use(
+            .cast(
                 instance,
-                sel!(0:1),
                 testactor::GetCastInfo {
                     cast_info: cast_info.bind(),
                 },
@@ -1639,9 +1724,9 @@ mod tests {
         let received_ranks = HashSet::from([point.rank()]);
         assert_eq!(received_ranks, HashSet::from([0]));
 
-        // Also cast with sel!(*) — all ranks should be reached via V1.
+        // Also cast the root mesh — all ranks should be reached via V1.
         let (cast_info2, mut cast_info_rx2) = instance.mailbox().open_port();
-        actor_mesh
+        root_actor_mesh
             .cast(
                 instance,
                 testactor::GetCastInfo {

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -330,6 +330,12 @@ impl ProcAgent {
         proc: Proc,
         shutdown_tx: Option<tokio::sync::oneshot::Sender<i32>>,
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
+        let cast_handle = proc.spawn_with_uid(
+            Uid::singleton(Label::strip("cast")),
+            hyperactor_cast::cast_actor::CastActor::default(),
+        )?;
+        cast_handle.bind::<hyperactor_cast::cast_actor::CastActor>();
+
         let orphan_timeout = hyperactor_config::global::get(MESH_ORPHAN_TIMEOUT);
         let agent = ProcAgent {
             proc: proc.clone(),

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -402,7 +402,7 @@ pub fn notify_actor_status_changed(event: ActorStatusEvent) {
 
 /// Event fired when a message is sent to an actor mesh.
 ///
-/// Emitted from `cast_with_selection` in `actor_mesh.rs`, which is the common
+/// Emitted from `cast_all_or_choose` in `actor_mesh.rs`, which is the common
 /// path for all Python send methods: `call`, `call_one`, `broadcast`, and `choose`.
 #[derive(Debug, Clone)]
 pub struct SentMessageEvent {

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -21,13 +21,8 @@ use hyperactor::Instance;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_mesh::actor_mesh::ActorMesh;
 use hyperactor_mesh::actor_mesh::ActorMeshRef;
-use hyperactor_mesh::sel;
 use monarch_types::py_global;
 use monarch_types::py_module_add_function;
-use ndslice::Region;
-use ndslice::Slice;
-use ndslice::selection::Selection;
-use ndslice::selection::structurally_equal;
 use ndslice::view::Ranked;
 use ndslice::view::RankedSliceable;
 use pyo3::IntoPyObjectExt;
@@ -67,6 +62,26 @@ py_global!(
     "Shared"
 );
 
+/// Closed actor-mesh selection surface used by public send APIs.
+///
+/// Public Python APIs expose only `"all"` and `"choose"`. Keep that
+/// invariant explicit here so arbitrary `ndslice::Selection` values stay out
+/// of the public mesh-casting surface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AllOrChoose {
+    All,
+    Choose,
+}
+
+impl AllOrChoose {
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::All => "all",
+            Self::Choose => "choose",
+        }
+    }
+}
+
 /// Trait defining the common interface for actor mesh, mesh ref and actor mesh implementations.
 /// This corresponds to the Python ActorMeshProtocol ABC.
 pub(crate) trait ActorMeshProtocol: Send + Sync {
@@ -74,7 +89,7 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
     fn cast(
         &self,
         message: PythonMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()>;
 
@@ -87,7 +102,7 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
     fn cast_with_headers(
         &self,
         message: PythonMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
         _caller_headers: hyperactor_config::Flattrs,
     ) -> PyResult<()> {
@@ -101,7 +116,7 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
     fn cast_unresolved(
         &self,
         message: PendingMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
         let message = get_tokio_runtime().block_on(message.resolve())?;
@@ -115,7 +130,7 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
     fn cast_unresolved_with_headers(
         &self,
         message: PendingMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
         caller_headers: hyperactor_config::Flattrs,
     ) -> PyResult<()> {
@@ -178,10 +193,10 @@ impl PythonActorMesh {
     }
 }
 
-pub(crate) fn to_hy_sel(selection: &str) -> PyResult<Selection> {
+pub(crate) fn to_all_or_choose(selection: &str) -> PyResult<AllOrChoose> {
     match selection {
-        "choose" => Ok(sel!(?)),
-        "all" => Ok(sel!(*)),
+        "choose" => Ok(AllOrChoose::Choose),
+        "all" => Ok(AllOrChoose::All),
         _ => Err(PyErr::new::<PyValueError, _>(format!(
             "Invalid selection: {}",
             selection
@@ -199,7 +214,7 @@ impl PythonActorMesh {
         selection: &str,
         instance: &PyInstance,
     ) -> PyResult<()> {
-        let sel = to_hy_sel(selection)?;
+        let sel = to_all_or_choose(selection)?;
         self.inner.cast(message.clone(), sel, instance.deref())
     }
 
@@ -210,7 +225,7 @@ impl PythonActorMesh {
         selection: &str,
         instance: &PyInstance,
     ) -> PyResult<()> {
-        let sel = to_hy_sel(selection)?;
+        let sel = to_all_or_choose(selection)?;
         let message = message.take()?;
         self.inner.cast_unresolved(message, sel, instance)
     }
@@ -333,7 +348,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
     fn cast(
         &self,
         _message: PythonMessage,
-        _selection: Selection,
+        _selection: AllOrChoose,
         _instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
         panic!("not implemented")
@@ -342,7 +357,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
     fn cast_unresolved(
         &self,
         message: PendingMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
         self.cast_unresolved_with_headers(
@@ -356,7 +371,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
     fn cast_unresolved_with_headers(
         &self,
         message: PendingMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
         caller_headers: hyperactor_config::Flattrs,
     ) -> PyResult<()> {
@@ -566,7 +581,7 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
     fn cast(
         &self,
         message: PythonMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
         <ActorMeshRef<PythonActor> as ActorMeshProtocol>::cast(
@@ -580,7 +595,7 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
     fn cast_with_headers(
         &self,
         message: PythonMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
         caller_headers: hyperactor_config::Flattrs,
     ) -> PyResult<()> {
@@ -641,7 +656,7 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
     fn cast(
         &self,
         message: PythonMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
         <Self as ActorMeshProtocol>::cast_with_headers(
@@ -656,44 +671,26 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
     fn cast_with_headers(
         &self,
         message: PythonMessage,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
         caller_headers: hyperactor_config::Flattrs,
     ) -> PyResult<()> {
-        if structurally_equal(&selection, &Selection::All(Box::new(Selection::True))) {
-            ActorMeshRef::<PythonActor>::cast_with_headers(
+        match selection {
+            AllOrChoose::All => ActorMeshRef::<PythonActor>::cast_with_headers(
                 self,
                 instance,
                 &caller_headers,
-                message.clone(),
+                message,
             )
-            .map_err(cast_error_to_py_error)?;
-        } else if structurally_equal(&selection, &Selection::Any(Box::new(Selection::True))) {
-            let region = Ranked::region(self);
-            let random_rank = fastrand::usize(0..region.num_ranks());
-            let offset = region
-                .slice()
-                .get(random_rank)
-                .map_err(anyhow::Error::from)?;
-            let singleton_region = Region::new(
-                Vec::new(),
-                Slice::new(offset, Vec::new(), Vec::new()).map_err(anyhow::Error::from)?,
-            );
-            ActorMeshRef::<PythonActor>::cast_with_headers(
-                &self.sliced(singleton_region),
+            .map_err(cast_error_to_py_error),
+            AllOrChoose::Choose => ActorMeshRef::<PythonActor>::cast_choose_with_headers(
+                self,
                 instance,
                 &caller_headers,
-                message.clone(),
+                message,
             )
-            .map_err(cast_error_to_py_error)?;
-        } else {
-            return Err(PyRuntimeError::new_err(format!(
-                "invalid selection: {:?}",
-                selection
-            )));
+            .map_err(cast_error_to_py_error),
         }
-
-        Ok(())
     }
 
     /// Stop the actor mesh asynchronously.

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -19,12 +19,10 @@ use hyperactor::accum::ReducerFactory;
 use hyperactor::accum::ReducerSpec;
 use hyperactor::mailbox::OncePortReceiver;
 use hyperactor::mailbox::PortReceiver;
-use hyperactor_mesh::sel;
 use hyperactor_mesh::value_mesh::ValueOverlay;
 use hyperactor_mesh::value_mesh::rle;
 use monarch_types::py_global;
 use ndslice::Extent;
-use ndslice::Selection;
 use ndslice::Shape;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
@@ -37,9 +35,10 @@ use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
 use crate::actor::PythonMessageKind;
 use crate::actor::PythonResponseMessage;
+use crate::actor_mesh::AllOrChoose;
 use crate::actor_mesh::PythonActorMesh;
 use crate::actor_mesh::SupervisableActorMesh;
-use crate::actor_mesh::to_hy_sel;
+use crate::actor_mesh::to_all_or_choose;
 use crate::buffers::FrozenBuffer;
 use crate::context::PyInstance;
 use crate::mailbox::EitherPortRef;
@@ -577,7 +576,7 @@ pub(crate) trait Endpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
         port_ref: Option<EitherPortRef>,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()>;
 
@@ -591,7 +590,7 @@ pub(crate) trait Endpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
         port_ref: Option<EitherPortRef>,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
         _caller_headers: hyperactor_config::Flattrs,
     ) -> PyResult<()> {
@@ -683,7 +682,7 @@ pub(crate) trait Endpoint {
             args,
             kwargs,
             Some(EitherPortRef::Once(port_ref)),
-            sel!(*),
+            AllOrChoose::All,
             &instance,
             caller_headers,
         )?;
@@ -723,7 +722,7 @@ pub(crate) trait Endpoint {
             args,
             kwargs,
             Some(EitherPortRef::Unbounded(port_ref)),
-            sel!(?),
+            AllOrChoose::Choose,
             &instance,
             caller_headers,
         )?;
@@ -767,7 +766,7 @@ pub(crate) trait Endpoint {
             args,
             kwargs,
             Some(EitherPortRef::Unbounded(port_ref)),
-            sel!(*),
+            AllOrChoose::All,
             &instance,
             caller_headers,
         )?;
@@ -804,7 +803,7 @@ pub(crate) trait Endpoint {
             args,
             kwargs,
             Some(EitherPortRef::Unbounded(port_ref)),
-            sel!(*),
+            AllOrChoose::All,
             &instance,
             caller_headers,
         )?;
@@ -848,7 +847,7 @@ pub(crate) trait Endpoint {
             "method" => method_name.to_string()
         );
 
-        match self.send_message(py, args, kwargs, None, sel!(*), &instance) {
+        match self.send_message(py, args, kwargs, None, AllOrChoose::All, &instance) {
             Ok(()) => {
                 ENDPOINT_BROADCAST_THROUGHPUT.add(1, attributes);
                 Ok(())
@@ -922,7 +921,7 @@ impl Endpoint for ActorEndpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
         port_ref: Option<EitherPortRef>,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
         let message = self.create_message(py, args, kwargs, port_ref)?;
@@ -935,7 +934,7 @@ impl Endpoint for ActorEndpoint {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
         port_ref: Option<EitherPortRef>,
-        selection: Selection,
+        selection: AllOrChoose,
         instance: &Instance<PythonActor>,
         caller_headers: hyperactor_config::Flattrs,
     ) -> PyResult<()> {
@@ -1149,7 +1148,7 @@ impl ActorEndpoint {
         selection: &str,
     ) -> PyResult<()> {
         let instance = self.get_current_instance(py)?;
-        let sel = to_hy_sel(selection)?;
+        let sel = to_all_or_choose(selection)?;
         self.send_message(py, args, Some(kwargs), port, sel, &instance)
     }
 }
@@ -1183,7 +1182,7 @@ impl Endpoint for Remote {
         args: &Bound<'py, PyTuple>,
         kwargs: Option<&Bound<'py, PyDict>>,
         port_ref: Option<EitherPortRef>,
-        selection: Selection,
+        selection: AllOrChoose,
         _instance: &Instance<PythonActor>,
     ) -> PyResult<()> {
         let send_kwargs = PyDict::new(py);
@@ -1192,15 +1191,7 @@ impl Endpoint for Remote {
             None => send_kwargs.set_item("port", py.None())?,
         }
 
-        let selection_str = match selection {
-            Selection::All(inner) if matches!(*inner, Selection::True) => "all",
-            Selection::Any(inner) if matches!(*inner, Selection::True) => "choose",
-            _ => {
-                panic!("only sel!(*) and sel!(?) should be provided as selection for send_message")
-            }
-        };
-
-        send_kwargs.set_item("selection", selection_str)?;
+        send_kwargs.set_item("selection", selection.as_str())?;
 
         let kwargs_dict = kwargs.map_or_else(|| PyDict::new(py), |d| d.clone());
         self.inner
@@ -1494,7 +1485,7 @@ mod tests {
             _args: &Bound<'py, PyTuple>,
             _kwargs: Option<&Bound<'py, PyDict>>,
             _port_ref: Option<EitherPortRef>,
-            _selection: Selection,
+            _selection: AllOrChoose,
             _instance: &Instance<PythonActor>,
         ) -> PyResult<()> {
             unreachable!()


### PR DESCRIPTION
Summary:

Only tensor-engine casts need arbitrary Selection values. Regular actor-mesh casts only support all and choose, so this narrows the regular cast path to an explicit AllOrChoose selector while keeping the tensor-engine escape hatch separate. This lets regular actor-mesh casting rely on the invariant that it only handles the public "all" / "choose" surface. This also naturally eliminates the awkward "equivalent to True" and "equivalent to Any(True)" checks

This split is needed before migrating ActorMeshRef to CastActor: the new CastActor path casts to all actors in the mesh, so non-all behavior must either be represented as the dedicated choose path or remain isolated behind the tensor-engine-only arbitrary-selection API

Differential Revision: D106402899


