### PR TITLE
Update `quickcheck` to `1.1.0`

### DIFF
--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -40,7 +40,7 @@ tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "
 whoami = "1.5"
 
 [dev-dependencies]
-quickcheck = "1.0"
+quickcheck = "1.1"
 quickcheck_macros = "1.2.0"
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }
 


### PR DESCRIPTION
Summary: The API in the pinned revision is from_seed, while the offical API in the new version is from_size_and_seed, so I changed the call sites. Changes are obvious/mechanical.

Differential Revision: D106435210
