### PR TITLE
Add doc string to Future.get

### DIFF
--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -107,6 +107,38 @@ class Future(Generic[R]):
         )
 
     def get(self, timeout: Optional[float] = None) -> R:
+        """Get the result of the Future.
+
+        Caveats:
+
+        This method is designed to be used in places where event loops are not available. Besides that, you should
+        avoid using this method if possible. Instead, use `await`. This is because when Future.get() is called from
+        within an active event loop, it blocks synchronously and does not yield control. That may degrade performance
+        by preventing other tasks from running, and can potentially cause deadlocks if this future depends on them.
+
+        examples:
+
+        This is not recommended because `fut.get()` blocks the event loop and might lead to issues explained above.
+        ```
+        def inner_func(fut):
+            result = fut.get()
+            # ...
+
+        async def out_func(fut):
+            inner_func(fut)
+        ```
+
+        This is okay because everything is running synchronously.
+        ```
+        def inner_func(fut):
+            result = fut.get()
+            # ...
+
+        def main():
+            # ...
+            inner_func(fut)
+        ```
+        """
         in_asyncio = asyncio._get_running_loop() is not None
         in_tokio = is_tokio_thread()
         if in_asyncio or in_tokio:


### PR DESCRIPTION
Summary:
Using `Future.get` in an async event loop can cause issues, and we are recommending users to avoid using it. But it is still confusing to the user on when is a good time to use `Future.get()`. For example I got [this question](https://github.com/pytorch/torchtitan/pull/3449#discussion_r3320177292).

This diff adds a doc string to this method with a verbose instruction.

Differential Revision: D106826000


