### PR TITLE
Derive actor telemetry IDs from ActorId (#4121)

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2181,7 +2181,7 @@ impl MailboxSender for Mailbox {
             return_undeliverable,
         } = metadata;
 
-        let to_actor_id = hash_to_u64(&dest);
+        let to_actor_id = hash_to_u64(dest.actor_addr().id());
         let message_id = hyperactor_telemetry::generate_message_id(to_actor_id);
         headers.set(crate::mailbox::headers::TELEMETRY_MESSAGE_ID, message_id);
         // Only set sender hash if not already present (cast path
@@ -2189,7 +2189,7 @@ impl MailboxSender for Mailbox {
         if !headers.contains_key(crate::mailbox::headers::SENDER_ACTOR_ID_HASH) {
             headers.set(
                 crate::mailbox::headers::SENDER_ACTOR_ID_HASH,
-                hash_to_u64(&sender),
+                hash_to_u64(sender.id()),
             );
         }
         headers.set(crate::mailbox::headers::TELEMETRY_PORT_ID, dest.index());

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -31,7 +31,7 @@ declare_attrs! {
     /// The rust type of the message.
     pub attr RUST_MESSAGE_TYPE: String;
 
-    /// Hashed ActorAddr of the message sender, injected in post_unchecked().
+    /// Hashed ActorId of the message sender, injected in post_unchecked().
     pub attr SENDER_ACTOR_ID_HASH: u64;
 
     /// Full ActorAddr of the session owner — the actor whose Sequencer

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2293,7 +2293,7 @@ impl<A: Actor> Instance<A> {
                 caller = %PanicLocation::caller(),
                 change_reason,
             );
-            let actor_id = hash_to_u64(self.self_addr());
+            let actor_id = hash_to_u64(self.self_addr().id());
             notify_actor_status_changed(ActorStatusEvent {
                 id: generate_actor_status_event_id(actor_id),
                 timestamp: std::time::SystemTime::now(),
@@ -3155,7 +3155,7 @@ impl<A: Actor> Instance<A> {
             let from_actor_id = headers
                 .get(crate::mailbox::headers::SENDER_ACTOR_ID_HASH)
                 .unwrap_or(0);
-            let to_actor_id = hash_to_u64(self.self_addr());
+            let to_actor_id = hash_to_u64(self.self_addr().id());
             let port_id = headers.get(crate::mailbox::headers::TELEMETRY_PORT_ID);
 
             notify_message(hyperactor_telemetry::MessageEvent {

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -598,7 +598,7 @@ impl<A: Referable> ActorMeshRef<A> {
     fn emit_sent_message_telemetry(&self, cx: &impl context::Actor, region: &Region) {
         hyperactor_telemetry::notify_sent_message(hyperactor_telemetry::SentMessageEvent {
             timestamp: std::time::SystemTime::now(),
-            sender_actor_id: hyperactor_telemetry::hash_to_u64(cx.mailbox().actor_addr()),
+            sender_actor_id: hyperactor_telemetry::hash_to_u64(cx.mailbox().actor_addr().id()),
             actor_mesh_id: hyperactor_telemetry::hash_to_u64(&self.id.to_string()),
             view_json: serde_json::to_string(region).unwrap_or_default(),
             shape_json: {

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -371,7 +371,7 @@ pub fn set_cast_info_on_headers(headers: &mut Flattrs, cast_point: Point, sender
     // CAST_ORIGINATING_SENDER -- they carry overlapping sender identity.
     headers.set(
         hyperactor::mailbox::headers::SENDER_ACTOR_ID_HASH,
-        hyperactor_telemetry::hash_to_u64(&sender),
+        hyperactor_telemetry::hash_to_u64(sender.id()),
     );
     headers.set(CAST_POINT, cast_point);
     headers.set(CAST_ORIGINATING_SENDER, sender);

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -432,7 +432,7 @@ impl HostMesh {
         for (rank, host) in self.current_ref.hosts().iter().enumerate() {
             let actor = host.mesh_agent();
             hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                id: hyperactor_telemetry::hash_to_u64(&actor.actor_addr()),
+                id: hyperactor_telemetry::hash_to_u64(actor.actor_addr().id()),
                 timestamp: now,
                 mesh_id: mesh_id_hash,
                 rank: rank as u64,

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -206,14 +206,14 @@ impl ProcMesh {
             // These are skipped in Proc::spawn_inner. mesh_id directly points to proc mesh.
             let now = std::time::SystemTime::now();
             for rank in current_ref.ranks.iter() {
-                let actor_id = rank.agent.actor_addr();
+                let actor_addr = rank.agent.actor_addr();
 
                 hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                    id: hyperactor_telemetry::hash_to_u64(&actor_id),
+                    id: hyperactor_telemetry::hash_to_u64(actor_addr.id()),
                     timestamp: now,
                     mesh_id: mesh_id_hash,
                     rank: rank.create_rank as u64,
-                    full_name: actor_id.to_string(),
+                    full_name: actor_addr.to_string(),
                     display_name: None,
                 });
             }
@@ -884,13 +884,13 @@ impl ProcMeshRef {
                     let point = self.region().extent().point_of_rank(rank).unwrap();
                     crate::actor_display_name(sdn, &point)
                 });
-                let actor_id = proc_ref.actor_addr(&actor_mesh_id);
+                let actor_addr = proc_ref.actor_addr(&actor_mesh_id);
                 hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                    id: hyperactor_telemetry::hash_to_u64(&actor_id),
+                    id: hyperactor_telemetry::hash_to_u64(actor_addr.id()),
                     timestamp: now,
                     mesh_id: mesh_id_hash,
                     rank: rank as u64,
-                    full_name: actor_id.to_string(),
+                    full_name: actor_addr.to_string(),
                     display_name,
                 });
             }

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -111,6 +111,7 @@ use crate::config::ENABLE_RECORDER_TRACING;
 use crate::config::ENABLE_SQLITE_TRACING;
 use crate::config::MONARCH_LOG_SUFFIX;
 use crate::recorder::Recorder;
+
 /// Hash any hashable value to a u64 using DefaultHasher.
 pub fn hash_to_u64(value: &impl Hash) -> u64 {
     let mut hasher = DefaultHasher::new();
@@ -335,11 +336,11 @@ pub fn end_user_span(id: u64) {
 /// Event data for actor creation.
 #[derive(Debug, Clone)]
 pub struct ActorEvent {
-    /// Unique identifier for this actor (hashed from ActorAddr)
+    /// Unique identifier for this actor, hashed from ActorId.
     pub id: u64,
     /// Timestamp when the actor was created
     pub timestamp: SystemTime,
-    /// ID of the mesh this actor belongs to (hashed from actor_name)
+    /// ID of the mesh this actor belongs to, matching `MeshEvent.id`.
     pub mesh_id: u64,
     /// Rank index into the mesh shape
     pub rank: u64,
@@ -407,7 +408,7 @@ pub fn notify_actor_status_changed(event: ActorStatusEvent) {
 #[derive(Debug, Clone)]
 pub struct SentMessageEvent {
     pub timestamp: SystemTime,
-    /// Hash of the sending actor's [`ActorAddr`].
+    /// Hash of the sending actor's ActorId.
     pub sender_actor_id: u64,
     /// Hash of the target actor mesh's name.
     pub actor_mesh_id: u64,
@@ -432,9 +433,9 @@ pub struct MessageEvent {
     pub timestamp: SystemTime,
     /// Unique identifier for this received message.
     pub id: u64,
-    /// Hash of sender's ActorAddr.
+    /// Hash of sender's ActorId.
     pub from_actor_id: u64,
-    /// Hash of receiver's ActorAddr.
+    /// Hash of receiver's ActorId.
     pub to_actor_id: u64,
     /// Endpoint name if this message targets a specific actor endpoint
     pub endpoint: Option<String>,

--- a/monarch_distributed_telemetry/src/socket_ingest.rs
+++ b/monarch_distributed_telemetry/src/socket_ingest.rs
@@ -37,6 +37,7 @@ use std::time::Duration;
 use anyhow::Context;
 use datafusion::arrow::ipc::reader::StreamReader;
 use datafusion::arrow::record_batch::RecordBatch;
+use monarch_hyperactor::runtime::get_tokio_runtime;
 use monarch_telemetry_schema::MAX_FRAME_LEN;
 use monarch_telemetry_schema::MAX_TABLE_NAME_LEN;
 use tokio::io::AsyncRead;
@@ -107,8 +108,12 @@ pub fn run_ingest_server(
     // serving connections. Tokio requires the fd to be nonblocking before
     // `from_std`.
     listener.set_nonblocking(true)?;
+    // Called from a PyO3 thread with no ambient Tokio runtime. Use monarch's
+    // shared runtime.
+    let runtime = get_tokio_runtime();
+    let _guard = runtime.enter();
     let listener = UnixListener::from_std(listener)?;
-    let task = tokio::spawn(async move {
+    let task = runtime.spawn(async move {
         loop {
             match listener.accept().await {
                 Ok((stream, _addr)) => {

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -428,13 +428,13 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
                 parent_view_json: None,
             });
 
-            let host_agent_id = host_mesh_agent.actor_addr();
+            let host_agent_addr = host_mesh_agent.actor_addr();
             hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                id: hyperactor_telemetry::hash_to_u64(host_agent_id),
+                id: hyperactor_telemetry::hash_to_u64(host_agent_addr.id()),
                 timestamp: now,
                 mesh_id: host_mesh_id,
                 rank: 0,
-                full_name: host_agent_id.to_string(),
+                full_name: host_agent_addr.to_string(),
                 display_name: None,
             });
 
@@ -456,13 +456,13 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
                 parent_view_json: None,
             });
 
-            let proc_agent_id = local_proc_agent.actor_addr();
+            let proc_agent_addr = local_proc_agent.actor_addr();
             hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                id: hyperactor_telemetry::hash_to_u64(proc_agent_id),
+                id: hyperactor_telemetry::hash_to_u64(proc_agent_addr.id()),
                 timestamp: now,
                 mesh_id: proc_mesh_id,
                 rank: 0,
-                full_name: proc_agent_id.to_string(),
+                full_name: proc_agent_addr.to_string(),
                 display_name: None,
             });
 
@@ -480,7 +480,7 @@ fn bootstrap_host(bootstrap_cmd: Option<PyBootstrapCommand>) -> PyResult<PyPytho
             });
 
             hyperactor_telemetry::notify_actor_created(hyperactor_telemetry::ActorEvent {
-                id: hyperactor_telemetry::hash_to_u64(instance.self_addr()),
+                id: hyperactor_telemetry::hash_to_u64(instance.self_addr().id()),
                 timestamp: now,
                 mesh_id: client_mesh_id,
                 rank: 0,

--- a/python/monarch/_src/job/_job_sidecar_worker.py
+++ b/python/monarch/_src/job/_job_sidecar_worker.py
@@ -6,16 +6,16 @@
 
 # pyre-unsafe
 
-"""Entry point for the background mount process.
+"""Entry point for the background job sidecar process.
 
-Launched by :func:`~monarch._src.job.mount_config.Mounts.ensure_open`.
+Launched by :func:`~monarch._src.job.job_sidecar.create_job_sidecar`.
 Receives the socket path and lock fd as arguments. Binds the socket
-immediately to signal readiness, then serves refresh/shutdown requests.
-The first ``refresh`` initialises the mounts; subsequent ones refresh them.
+immediately to signal readiness, then serves job-scoped refresh/shutdown
+requests.
 
 Usage::
 
-    python -m monarch._src.job._mount_worker <socket_path> <lock_fd>
+    python -m monarch._src.job._job_sidecar_worker <socket_path> <lock_fd>
 """
 
 import sys
@@ -25,9 +25,9 @@ def main() -> None:
     socket_path = sys.argv[1]
     int(sys.argv[2])  # keep fd open to hold the flock for the process lifetime
 
-    from monarch._src.job.mount_config import _run_mount_process
+    from monarch._src.job.job_sidecar import _run_job_sidecar
 
-    _run_mount_process(socket_path)
+    _run_job_sidecar(socket_path)
 
 
 if __name__ == "__main__":

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -26,6 +26,7 @@ from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.host_mesh import _spawn_admin
 from monarch._src.actor.sync_state import fake_sync_state
+from monarch._src.job.job_sidecar import stop_job_sidecar
 from monarch._src.job.mount_config import Mounts
 
 # note: the jobs api is intended as a library so it should
@@ -670,7 +671,7 @@ class JobTrait(ABC):
         apply_id = self.apply_id
         running = self._running
         if apply_id is not None and running is not None:
-            self._mounts.ensure_open(running)
+            self._mounts.ensure_open(apply_id, raw._hosts)
         hosts = {}
         for mesh_name, mesh in raw._hosts.items():
             exe = self._python_executables.get(mesh_name, self._default_python_exe)
@@ -743,8 +744,9 @@ class JobTrait(ABC):
         return pickle.dumps(self)
 
     def kill(self):
-        if self._apply_id is not None:
-            self._mounts.ensure_stopped(self._apply_id)
+        apply_id = self.apply_id
+        if apply_id is not None:
+            stop_job_sidecar(apply_id)
         running = self._running
         if running is not None:
             running._kill()

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -28,6 +28,7 @@ from monarch._src.actor.host_mesh import _spawn_admin
 from monarch._src.actor.sync_state import fake_sync_state
 from monarch._src.job.job_sidecar import stop_job_sidecar
 from monarch._src.job.mount_config import Mounts
+from monarch._src.job.telemetry_config import TelemetryConfig
 
 # note: the jobs api is intended as a library so it should
 # only be importing _public_ monarch API functions.
@@ -295,38 +296,6 @@ class BashActor(Actor):
             sel.close()
             proc.wait()
         output_port.send(f"{my_rank}:rc:{proc.returncode}")
-
-
-@dataclass
-class TelemetryConfig:
-    """Configuration for automatic telemetry startup.
-
-    When passed to a job constructor, telemetry (and optionally a dashboard)
-    is started automatically when ``state()`` is called.
-
-    Args:
-        batch_size: Number of rows to buffer before flushing to a RecordBatch.
-        retention_secs: Retention window in seconds for message tables.
-            0 disables retention.
-        include_dashboard: Whether to start the monarch dashboard web server.
-        dashboard_port: Preferred port for the dashboard.
-        snapshot_interval_secs: Interval in seconds between periodic mesh
-            introspection snapshots. Snapshots capture the mesh topology
-            into the telemetry query surface. 0 disables periodic capture
-            (default). When ``include_dashboard`` is True and this is 0,
-            it is automatically set to 30s because the dashboard requires
-            snapshot data for system actor filtering.
-    """
-
-    batch_size: int = 1000
-    retention_secs: int = 600
-    include_dashboard: bool = False
-    dashboard_port: int = 8265
-    snapshot_interval_secs: float = 0  # 0 = disabled
-
-    def __post_init__(self) -> None:
-        if self.include_dashboard and self.snapshot_interval_secs <= 0:
-            self.snapshot_interval_secs = 30.0
 
 
 @dataclass

--- a/python/monarch/_src/job/job_sidecar.py
+++ b/python/monarch/_src/job/job_sidecar.py
@@ -21,7 +21,17 @@ import traceback
 from dataclasses import dataclass
 from typing import Any
 
+from monarch._src.job.process_guard import find_process, ProcessGuard
 from monarch.actor import HostMesh
+
+_JOB_SIDECAR_WORKER_MODULE = "monarch._src.job._job_sidecar_worker"
+
+try:
+    from __manifest__ import fbmake  # noqa
+
+    _IN_PAR: bool = bool(fbmake.get("par_style"))
+except ImportError:
+    _IN_PAR = False
 
 
 def job_sidecar_lock_path(apply_id: str) -> str:
@@ -29,21 +39,30 @@ def job_sidecar_lock_path(apply_id: str) -> str:
     return f"/tmp/monarch_job_sidecar_{apply_id}.lock"
 
 
-def create_job_sidecar(apply_id: str) -> Any:
-    """Ensure the per-job sidecar process is running and return its guard."""
-    from monarch._src.job.process_guard import ProcessGuard
+def spawn_module(lock_path: str, config_key: object, module_name: str) -> ProcessGuard:
+    """Launch a Python module as a ``ProcessGuard``-managed background process."""
+    if _IN_PAR:
+        command = [sys.argv[0]]
+        env: dict[str, str] | None = {"PAR_MAIN_OVERRIDE": module_name}
+    else:
+        if not sys.executable:
+            raise RuntimeError("no python executable available")
+        command = [sys.executable, "-m", module_name]
+        env = None
+    return ProcessGuard.create(lock_path, config_key, command, env=env)
 
-    return ProcessGuard.create(
+
+def create_job_sidecar(apply_id: str) -> ProcessGuard:
+    """Ensure the per-job sidecar process is running and return its guard."""
+    return spawn_module(
         job_sidecar_lock_path(apply_id),
         apply_id,
-        [sys.executable, "-m", "monarch._src.job._job_sidecar_worker"],
+        _JOB_SIDECAR_WORKER_MODULE,
     )
 
 
-def find_job_sidecar(apply_id: str) -> Any | None:
+def find_job_sidecar(apply_id: str) -> ProcessGuard | None:
     """Return the per-job sidecar process guard if it exists."""
-    from monarch._src.job.process_guard import find_process
-
     return find_process(job_sidecar_lock_path(apply_id))
 
 
@@ -67,12 +86,23 @@ class MountsRequest:
     host_meshes: dict[str, HostMesh]
 
 
+@dataclass
+class TelemetryRequest:
+    """Open or refresh the job sidecar's telemetry state."""
+
+    apply_id: str
+    config: dict[str, object]
+    host_meshes: dict[str, HostMesh]
+
+
 class _JobSidecarState:
     """State owned by the background job sidecar process."""
 
     def __init__(self) -> None:
         self._mounts_handle: Any | None = None
         self._mounts_key: bytes | None = None
+        self._telemetry_handle: Any | None = None
+        self._apply_id: str | None = None
 
     def handle_mounts(self, request: MountsRequest) -> str:
         # The request carries declarative mount config. Compare that serialized
@@ -109,8 +139,26 @@ class _JobSidecarState:
             self._mounts_key = None
         return "ok"
 
+    def handle_telemetry(self, request: TelemetryRequest) -> object:
+        from monarch._src.job.telemetry_config import _TelemetryHandle
+
+        if self._telemetry_handle is None:
+            self._telemetry_handle = _TelemetryHandle(request.apply_id)
+            self._apply_id = request.apply_id
+        elif self._apply_id != request.apply_id:
+            raise RuntimeError(f"job sidecar already owns apply id {self._apply_id}")
+
+        return self._telemetry_handle.open_or_refresh(
+            request.host_meshes,
+            request.config,
+        )
+
     def shutdown(self) -> None:
         self.clear_mounts()
+        if self._telemetry_handle is not None:
+            self._telemetry_handle.shutdown()
+            self._telemetry_handle = None
+            self._apply_id = None
 
 
 def _dbg(msg: str) -> None:
@@ -164,6 +212,12 @@ def _run_job_sidecar(socket_path: str) -> None:
                         response = state.handle_mounts(msg)
                     elif isinstance(msg, ClearMountsRequest):
                         response = state.clear_mounts()
+                    elif isinstance(msg, TelemetryRequest):
+                        try:
+                            response = state.handle_telemetry(msg)
+                        except Exception:
+                            # TODO: Centralize sidecar error.
+                            response = {"error": traceback.format_exc()}
                     else:
                         raise RuntimeError(f"unexpected job sidecar request: {msg!r}")
                 except Exception:

--- a/python/monarch/_src/job/job_sidecar.py
+++ b/python/monarch/_src/job/job_sidecar.py
@@ -1,0 +1,185 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Per-job sidecar command server.
+
+The sidecar process is keyed by a job ``apply_id`` and kept alive by ``ProcessGuard``.
+"""
+
+import os
+import pickle
+import socket
+import sys
+import threading
+import time
+import traceback
+from dataclasses import dataclass
+from typing import Any
+
+from monarch.actor import HostMesh
+
+
+def job_sidecar_lock_path(apply_id: str) -> str:
+    """Return the lock path for the per-job sidecar process."""
+    return f"/tmp/monarch_job_sidecar_{apply_id}.lock"
+
+
+def create_job_sidecar(apply_id: str) -> Any:
+    """Ensure the per-job sidecar process is running and return its guard."""
+    from monarch._src.job.process_guard import ProcessGuard
+
+    return ProcessGuard.create(
+        job_sidecar_lock_path(apply_id),
+        apply_id,
+        [sys.executable, "-m", "monarch._src.job._job_sidecar_worker"],
+    )
+
+
+def find_job_sidecar(apply_id: str) -> Any | None:
+    """Return the per-job sidecar process guard if it exists."""
+    from monarch._src.job.process_guard import find_process
+
+    return find_process(job_sidecar_lock_path(apply_id))
+
+
+def stop_job_sidecar(apply_id: str) -> None:
+    """Shut down the per-job sidecar process for an apply id if it exists."""
+    guard = find_job_sidecar(apply_id)
+    if guard is not None:
+        guard.shutdown()
+
+
+@dataclass
+class ClearMountsRequest:
+    """Clear the job sidecar's mount state."""
+
+
+@dataclass
+class MountsRequest:
+    """Refresh the job sidecar's mount state."""
+
+    mounts: Any
+    host_meshes: dict[str, HostMesh]
+
+
+class _JobSidecarState:
+    """State owned by the background job sidecar process."""
+
+    def __init__(self) -> None:
+        self._mounts_handle: Any | None = None
+        self._mounts_key: bytes | None = None
+
+    def handle_mounts(self, request: MountsRequest) -> str:
+        # The request carries declarative mount config. Compare that serialized
+        # config so edited mounts replace the live handles, while unchanged
+        # config refreshes existing remote mounts in-place.
+        # @lint-ignore PYTHONPICKLEISBAD
+        mounts_key = pickle.dumps(request.mounts)
+        t0 = time.time()
+        if self._mounts_handle is None:
+            _dbg("initialising mounts")
+            self._mounts_handle = request.mounts.open(request.host_meshes)
+            self._mounts_key = mounts_key
+            _dbg(f"mounts opened in {time.time() - t0:.2f}s")
+            return "ok"
+
+        if mounts_key != self._mounts_key:
+            _dbg("replacing mounts")
+            self._mounts_handle.close()
+            self._mounts_handle = request.mounts.open(request.host_meshes)
+            self._mounts_key = mounts_key
+            _dbg(f"mounts replaced in {time.time() - t0:.2f}s")
+            return "ok"
+
+        _dbg("refreshing mounts")
+        self._mounts_handle.refresh()
+        _dbg(f"refresh complete in {time.time() - t0:.2f}s")
+        return "ok"
+
+    def clear_mounts(self) -> str:
+        """Close any live mounts and reset mount state."""
+        if self._mounts_handle is not None:
+            self._mounts_handle.close()
+            self._mounts_handle = None
+            self._mounts_key = None
+        return "ok"
+
+    def shutdown(self) -> None:
+        self.clear_mounts()
+
+
+def _dbg(msg: str) -> None:
+    print(f"[job_sidecar pid={os.getpid()}] {msg}", file=sys.stderr, flush=True)
+
+
+def _run_job_sidecar(socket_path: str) -> None:
+    """Run in the child process: bind socket then serve refresh/shutdown requests."""
+    import signal as _signal
+
+    # Signal handlers are process-global and only legal from the main thread.
+    if threading.current_thread() is threading.main_thread():
+        _signal.signal(_signal.SIGINT, _signal.SIG_DFL)
+        _signal.signal(_signal.SIGTERM, _signal.SIG_DFL)
+
+    from monarch._src.job.process_guard import _Shutdown
+
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(socket_path)
+    server.listen(5)
+    _dbg(f"listening on {socket_path}")
+
+    state = _JobSidecarState()
+
+    while True:
+        try:
+            conn, _ = server.accept()
+        except OSError:
+            break
+        try:
+            f = conn.makefile("rb")
+            while True:
+                try:
+                    # @lint-ignore PYTHONPICKLEISBAD
+                    msg = pickle.load(f)
+                except EOFError:
+                    break  # client disconnected (e.g. readiness probe)
+                if isinstance(msg, _Shutdown):
+                    _dbg("received shutdown")
+                    state.shutdown()
+                    conn.close()
+                    server.close()
+                    try:
+                        os.unlink(socket_path)
+                    except OSError:
+                        pass
+                    _dbg("exiting")
+                    return
+                try:
+                    if isinstance(msg, MountsRequest):
+                        response = state.handle_mounts(msg)
+                    elif isinstance(msg, ClearMountsRequest):
+                        response = state.clear_mounts()
+                    else:
+                        raise RuntimeError(f"unexpected job sidecar request: {msg!r}")
+                except Exception:
+                    _dbg(
+                        "ERROR during job sidecar operation:\n" + traceback.format_exc()
+                    )
+                    response = "ok"
+                # @lint-ignore PYTHONPICKLEISBAD
+                conn.sendall(pickle.dumps(response))
+        except Exception:
+            _dbg("ERROR handling connection:\n" + traceback.format_exc())
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    server.close()
+    _dbg("exiting")

--- a/python/monarch/_src/job/mount_config.py
+++ b/python/monarch/_src/job/mount_config.py
@@ -8,15 +8,18 @@
 
 import logging
 import os
-import pickle
-import socket
 import sys
-import time
 import traceback
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional
 
-from monarch._src.job.job_state import JobState
+from monarch._src.job.job_sidecar import (
+    ClearMountsRequest,
+    create_job_sidecar,
+    find_job_sidecar,
+    MountsRequest,
+)
+from monarch.actor import HostMesh
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -30,7 +33,7 @@ class RemoteMountEntry:
     meshes: Optional[List[str]] = None
     kwargs: dict = field(default_factory=dict)
 
-    def apply(self, raw_state: JobState) -> "list[Any]":
+    def apply(self, host_meshes: Mapping[str, HostMesh]) -> "list[Any]":
         """Open the remote mount for each targeted mesh. Returns handles.
 
         If ``mntpoint`` contains ``$SUBDIR`` it is replaced with the mesh name,
@@ -39,7 +42,7 @@ class RemoteMountEntry:
         from monarch.remotemount.remotemount import remotemount as _remotemount
 
         handles = []
-        for mesh_name, raw_mesh in raw_state._hosts.items():
+        for mesh_name, raw_mesh in host_meshes.items():
             if self.meshes is not None and mesh_name not in self.meshes:
                 continue
             handler = _remotemount(
@@ -58,7 +61,7 @@ class GatherMountEntry:
     local_mount_point: str
     meshes: Optional[List[str]] = None
 
-    def apply(self, raw_state: JobState) -> "list[Any]":
+    def apply(self, host_meshes: Mapping[str, HostMesh]) -> "list[Any]":
         """Start the gather mount for each targeted mesh. Returns handles.
 
         Single targeted mesh: mounts directly at ``local_mount_point``.
@@ -68,7 +71,7 @@ class GatherMountEntry:
 
         target_meshes = [
             (mesh_name, raw_mesh)
-            for mesh_name, raw_mesh in raw_state._hosts.items()
+            for mesh_name, raw_mesh in host_meshes.items()
             if self.meshes is None or mesh_name in self.meshes
         ]
         multi = len(target_meshes) > 1
@@ -88,8 +91,8 @@ class Mounts:
     """Declarative mount configuration for a job.
 
     Call :meth:`remote_mount` and :meth:`gather_mount` to register mounts.
-    The live handles are managed by :class:`MountsHandle` in the background
-    mount process.
+    The live handles are managed by :class:`MountsHandle` in the background job
+    sidecar process.
     """
 
     def __init__(self) -> None:
@@ -125,56 +128,37 @@ class Mounts:
             )
         )
 
-    def ensure_stopped(self, apply_id: str) -> None:
-        """Shut down the background mount process for *apply_id*, if running.
+    def open(self, host_meshes: Mapping[str, HostMesh]) -> "MountsHandle":
+        """Open all mounts against *host_meshes* and return the live handle."""
+        return MountsHandle(self, host_meshes)
 
-        Does nothing if no mounts are configured or no process is found.
+    def ensure_open(self, apply_id: str, host_meshes: Mapping[str, HostMesh]) -> None:
+        """Ensure a background job sidecar is running for this configuration.
+
+        Keyed on ``apply_id``: reuses an existing process, then sends a refresh
+        so the sidecar picks up any mount config changes. Clears existing mount
+        state when no mounts are configured.
         """
-        from monarch._src.job.process_guard import find_process
-
-        lock_path = f"/tmp/monarch_mounts_{apply_id}.lock"
-        guard = find_process(lock_path)
-        if guard is not None:
-            guard.shutdown()
-
-    def open(self, job: "Any") -> "MountsHandle":
-        """Open all mounts against *job* and return the live handle."""
-        return MountsHandle(self, job._state())
-
-    def ensure_open(self, job: "Any") -> None:
-        """Ensure a background mount process is running for this configuration.
-
-        Keyed on ``(apply_id, mounts)``: reuses an existing process with the
-        same config, otherwise shuts down the old one and launches a new one.
-        Always sends a refresh so the mount process picks up any changes.
-        Does nothing if no mounts are configured.
-        """
-        apply_id = job.apply_id
         if not self._remote_entries and not self._gather_entries:
-            self.ensure_stopped(apply_id)
+            guard = find_job_sidecar(apply_id)
+            if guard is not None:
+                guard.send(ClearMountsRequest()).get()
             return
 
-        from monarch._src.job.process_guard import ProcessGuard
-
-        lock_path = f"/tmp/monarch_mounts_{apply_id}.lock"
-        guard = ProcessGuard.create(
-            lock_path,
-            (apply_id, self),
-            [sys.executable, "-m", "monarch._src.job._mount_worker"],
-        )
-        guard.send((self, job)).get()
+        guard = create_job_sidecar(apply_id)
+        guard.send(MountsRequest(self, dict(host_meshes))).get()
 
 
 class MountsHandle:
-    """Live mount handles for a running background mount process."""
+    """Live mount handles for a running background job sidecar."""
 
-    def __init__(self, mounts: Mounts, raw_state: JobState) -> None:
+    def __init__(self, mounts: Mounts, host_meshes: Mapping[str, HostMesh]) -> None:
         self._active_remote: list[Any] = []
         self._active_gather: list[Any] = []
         for entry in mounts._remote_entries:
-            self._active_remote.extend(entry.apply(raw_state))
+            self._active_remote.extend(entry.apply(host_meshes))
         for entry in mounts._gather_entries:
-            self._active_gather.extend(entry.apply(raw_state))
+            self._active_gather.extend(entry.apply(host_meshes))
 
     def refresh(self) -> None:
         """Refresh remote mounts in-place; gather mounts are unaffected."""
@@ -204,76 +188,5 @@ class MountsHandle:
                 _dbg("close: ERROR closing gather mount:\n" + traceback.format_exc())
 
 
-# ── Background mount process ──────────────────────────────────────────────────
-
-
 def _dbg(msg: str) -> None:
-    print(f"[mount_process pid={os.getpid()}] {msg}", file=sys.stderr, flush=True)
-
-
-def _run_mount_process(socket_path: str) -> None:
-    """Run in the child process: bind socket then serve refresh/shutdown requests."""
-    import signal as _signal
-
-    _signal.signal(_signal.SIGINT, _signal.SIG_DFL)
-    _signal.signal(_signal.SIGTERM, _signal.SIG_DFL)
-
-    from monarch._src.job.process_guard import _Shutdown
-
-    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    server.bind(socket_path)
-    server.listen(5)
-    _dbg(f"listening on {socket_path}")
-
-    handle: "MountsHandle | None" = None
-
-    while True:
-        try:
-            conn, _ = server.accept()
-        except OSError:
-            break
-        try:
-            f = conn.makefile("rb")
-            while True:
-                try:
-                    # @lint-ignore PYTHONPICKLEISBAD
-                    msg = pickle.load(f)
-                except EOFError:
-                    break  # client disconnected (e.g. readiness probe)
-                if isinstance(msg, _Shutdown):
-                    _dbg("received shutdown")
-                    if handle is not None:
-                        handle.close()
-                    conn.close()
-                    server.close()
-                    try:
-                        os.unlink(socket_path)
-                    except OSError:
-                        pass
-                    _dbg("exiting")
-                    return
-                mounts, job = msg
-                try:
-                    t0 = time.time()
-                    if handle is None:
-                        _dbg("initialising mounts")
-                        handle = mounts.open(job)
-                        _dbg(f"mounts opened in {time.time() - t0:.2f}s")
-                    else:
-                        _dbg("refreshing mounts")
-                        handle.refresh()
-                        _dbg(f"refresh complete in {time.time() - t0:.2f}s")
-                except Exception:
-                    _dbg("ERROR during mount operation:\n" + traceback.format_exc())
-                # @lint-ignore PYTHONPICKLEISBAD
-                conn.sendall(pickle.dumps("ok"))
-        except Exception:
-            _dbg("ERROR handling connection:\n" + traceback.format_exc())
-        finally:
-            try:
-                conn.close()
-            except Exception:
-                pass
-
-    server.close()
-    _dbg("exiting")
+    print(f"[job_sidecar pid={os.getpid()}] {msg}", file=sys.stderr, flush=True)

--- a/python/monarch/_src/job/process_guard.py
+++ b/python/monarch/_src/job/process_guard.py
@@ -162,7 +162,7 @@ def _wait_for_socket(socket_path: str, pid: int = 0, timeout: float = 60.0) -> N
                 os.kill(pid, 0)
             except ProcessLookupError:
                 raise RuntimeError(
-                    f"Mount process (pid {pid}) exited before the socket "
+                    f"Guarded process (pid {pid}) exited before the socket "
                     f"{socket_path!r} became ready."
                 )
         try:

--- a/python/monarch/_src/job/process_guard.py
+++ b/python/monarch/_src/job/process_guard.py
@@ -55,6 +55,7 @@ class ProcessGuard:
         lock_path: str,
         config_key: object,
         subprocess_args: "list[str]",
+        env: "dict[str, str] | None" = None,
     ) -> "ProcessGuard":
         """Ensure a background process is running with the given config.
 
@@ -73,9 +74,11 @@ class ProcessGuard:
             if acquired:
                 socket_path = tempfile.mktemp(suffix=".sock", prefix="monarch_")
                 _write_record(fd, _LockRecord(new_key_bytes, 0, socket_path))
+                proc_env = None if env is None else {**os.environ, **env}
 
                 proc = subprocess.Popen(
                     [*subprocess_args, socket_path, str(fd)],
+                    env=proc_env,
                     pass_fds=(fd,),
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
@@ -99,7 +102,7 @@ class ProcessGuard:
                 # Config differs — shut down old process and retry.
                 if rec is not None:
                     cls(rec.socket_path, rec.pid).shutdown()
-                return cls.create(lock_path, config_key, subprocess_args)
+                return cls.create(lock_path, config_key, subprocess_args, env=env)
 
         finally:
             if fd != -1:

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -1,0 +1,267 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Telemetry state hosted by the per-job sidecar.
+
+The job sidecar is a separate Python process keyed on the job's `apply_id`.
+Telemetry reuses that process to host the client-side `TelemetryActor`
+(collector + scanner + dashboard), ingest telemetry frames over a per-host
+Unix socket, and serve the dashboard's HTTP query API. Decoupling it from the
+parent job process means:
+
+- Telemetry state (in-memory DataFusion store) survives across `state()`
+  calls and parent-process refreshes, so query results are stable across
+  job restarts.
+- The dashboard server keeps running without the parent needing an event
+  loop.
+- Producers on the same host write into one collector via a stable socket
+  path, regardless of how many parent processes come and go.
+
+The parent talks to telemetry via two channels:
+
+- The job sidecar command socket: pickled `TelemetryRequest` control messages.
+- The telemetry data socket (`/tmp/monarch_<apply_id>/telemetry.sock`):
+  framed Arrow IPC from producers, decoded by Rust socket ingest into the
+  collector's scanner.
+
+Lifecycle: `Telemetry.ensure_open(apply_id, host_meshes)` is called twice per
+`JobTrait._connect`. The first call (`host_meshes={}`) opens the job sidecar's
+telemetry handle and activates the client process's `UnixSocketSink` *before*
+`_state()` runs `bootstrap_host`, so the host-mesh creation events are
+captured. The second call (with materialised `host_meshes`) triggers worker
+fan-out: the telemetry handle spawns per-host `TelemetryActor` candidates and
+hands the live worker refs to the client collector for query fan-out.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, cast, Mapping, TypedDict
+
+from monarch._rust_bindings.monarch_distributed_telemetry import (
+    _set_unix_socket_sink_path,
+)
+from monarch._src.job.job_sidecar import create_job_sidecar, TelemetryRequest
+from monarch._src.job.telemetry_actor import (
+    telemetry_socket_dir,
+    telemetry_socket_path,
+    TelemetryActor,
+)
+from monarch.actor import context, HostMesh, shutdown_context
+from monarch.distributed_telemetry.engine import QueryEngine
+from monarch.monarch_dashboard.server.app import start_dashboard
+from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TelemetryConfig:
+    """Configuration for automatic telemetry startup.
+
+    When passed to a job constructor, telemetry (and optionally a dashboard)
+    is started automatically when ``state()`` is called.
+
+    Args:
+        batch_size: Number of rows to buffer before flushing to a RecordBatch.
+        retention_secs: Retention window in seconds for message tables.
+            0 disables retention.
+        include_dashboard: Whether to start the monarch dashboard web server.
+        dashboard_port: Preferred port for the dashboard.
+        snapshot_interval_secs: Interval in seconds between periodic mesh
+            introspection snapshots. Snapshots capture the mesh topology
+            into the telemetry query surface. 0 disables periodic capture
+            (default). When ``include_dashboard`` is True and this is 0,
+            it is automatically set to 30s because the dashboard requires
+            snapshot data for system actor filtering.
+    """
+
+    batch_size: int = 1000
+    retention_secs: int = 600
+    include_dashboard: bool = False
+    dashboard_port: int = 8265
+    snapshot_interval_secs: float = 0  # 0 = disabled
+
+    def __post_init__(self) -> None:
+        if self.include_dashboard and self.snapshot_interval_secs <= 0:
+            self.snapshot_interval_secs = 30.0
+
+
+# Successful response from the telemetry handle's `open_or_refresh` control message,
+# pickled back over the command socket. The error case rides on the same
+# wire as `{"error": traceback_str}` and is narrowed away by `ensure_open`
+# before the cast.
+class _TelemetryResponse(TypedDict):
+    telemetry_url: str
+    dashboard_url: str
+    socket_path: str
+
+
+def _config_from_wire(config: Mapping[str, object]) -> TelemetryConfig:
+    """Rebuild a `TelemetryConfig` from the pickled wire dict. Only the three
+    fields the telemetry handle acts on cross the wire; the rest take their
+    defaults."""
+    return TelemetryConfig(
+        retention_secs=cast(int, config["retention_secs"]),
+        include_dashboard=cast(bool, config["include_dashboard"]),
+        dashboard_port=cast(int, config["dashboard_port"]),
+    )
+
+
+class Telemetry:
+    """Parent-process client for telemetry hosted by the job sidecar.
+
+    Uses `create_job_sidecar` so the job sidecar gets launched on first call
+    and reused on subsequent calls (keyed on `apply_id`, not on config —
+    config edits do not restart the sidecar). `ensure_open` is the single
+    interaction point: it opens or refreshes the telemetry handle and forwards
+    the host meshes for worker fan-out.
+    """
+
+    def __init__(self, config: TelemetryConfig) -> None:
+        self._config: TelemetryConfig = config
+
+    def ensure_open(
+        self,
+        apply_id: str,
+        host_meshes: Mapping[str, HostMesh] | None = None,
+    ) -> _TelemetryResponse:
+        """Ensure the job sidecar's telemetry handle is open and refreshed."""
+        if not isinstance(apply_id, str):
+            raise RuntimeError("telemetry requires an active apply_id")
+
+        socket_dir = telemetry_socket_dir(apply_id)
+        os.makedirs(socket_dir, mode=0o700, exist_ok=True)
+        os.chmod(socket_dir, 0o700)
+        # `create_job_sidecar` is idempotent and keyed on `apply_id`: the
+        # second call for the same job reuses the existing job sidecar rather
+        # than relaunching. That is what makes the two-phase bootstrap to
+        # fan-out flow safe to invoke from any of JobTrait's `_connect` branches.
+        guard = create_job_sidecar(apply_id)
+        response = guard.send(
+            TelemetryRequest(
+                apply_id=apply_id,
+                config={
+                    "retention_secs": self._config.retention_secs,
+                    "include_dashboard": self._config.include_dashboard,
+                    "dashboard_port": self._config.dashboard_port,
+                },
+                host_meshes=dict(host_meshes or {}),
+            )
+        ).get()
+        if not isinstance(response, dict):
+            raise RuntimeError(f"unexpected telemetry handle response: {response!r}")
+        # The wire carries either a `_TelemetryResponse` shape or an
+        # `{"error": traceback_str}` envelope from the sidecar's exception
+        # handler; re-raise on the parent side so failures surface here.
+        error = response.get("error")
+        if isinstance(error, str):
+            raise RuntimeError(error)
+        return cast(_TelemetryResponse, response)
+
+
+class _TelemetryHandle:
+    """Live telemetry resources hosted inside the job sidecar worker.
+
+    Owns the client `TelemetryActor` (which owns the scanner), the
+    `QueryEngine` that backs the dashboard's `/api/query` route, and the
+    dashboard server info. The job sidecar control loop drives
+    `open_or_refresh` and `shutdown`.
+    """
+
+    def __init__(self, apply_id: str) -> None:
+        self._apply_id: str = apply_id
+        # `None` until the first `open_or_refresh` runs `_bootstrap`; serves as
+        # the recorded config for drift detection. We intentionally do NOT restart
+        # on drift — that would drop the in-memory store and re-bind the data socket,
+        # defeating the point of the sidecar surviving across parent restarts.
+        self._first_config: TelemetryConfig | None = None
+        self._client_actor: Any | None = None
+        self._query_engine: QueryEngine | None = None
+        self._dashboard_info: dict[str, object] | None = None
+
+    @property
+    def client_socket_path(self) -> str:
+        return telemetry_socket_path(self._apply_id)
+
+    def open_or_refresh(
+        self,
+        host_meshes: Mapping[str, HostMesh],
+        config: Mapping[str, object],
+    ) -> _TelemetryResponse:
+        parsed = _config_from_wire(config)
+        if self._first_config is None:
+            self._bootstrap(parsed)
+            self._first_config = parsed
+        elif parsed != self._first_config:
+            # Config drift is intentionally ignored. Restarting here would drop
+            # the in-memory telemetry store and re-bind the data socket.
+            logger.warning("telemetry handle config drift ignored")
+
+        dashboard_info = self._dashboard_info
+        if dashboard_info is None:
+            raise RuntimeError("telemetry handle is not open")
+        local_url = dashboard_info["local_url"]
+        url = dashboard_info["url"]
+        if not isinstance(local_url, str) or not isinstance(url, str):
+            raise RuntimeError(f"invalid dashboard info: {dashboard_info!r}")
+        return {
+            "telemetry_url": local_url,
+            "dashboard_url": url,
+            "socket_path": self.client_socket_path,
+        }
+
+    def _bootstrap(self, config: TelemetryConfig) -> None:
+        # Reach the Python-wrapped `ProcMesh` via `monarch.actor.context()`.
+        # The raw `PyProcMesh_Ref` returned by `bootstrap_host()` lacks
+        # `.spawn`, so we cannot use it directly.
+        actor_context = context()
+        proc_mesh = actor_context.actor_instance.proc_mesh
+        client_actor = proc_mesh.spawn(
+            "telemetry",
+            TelemetryActor,
+            self._apply_id,
+            config.retention_secs,
+        )
+        # `activate` is the actor's bind decision: triggers the
+        # non-destructive Unix-socket bind and stands up the scanner. We
+        # do not branch on the return — failures stay scannerless and the
+        # scan endpoint surfaces them as best-effort empty results.
+        client_actor.activate.call_one().get()
+
+        query_engine = QueryEngine(client_actor)
+        dashboard_info = start_dashboard(
+            adapter=QueryEngineAdapter(query_engine),
+            port=config.dashboard_port,
+        )
+        # Self-activate the sidecar process's own `UnixSocketSink` against
+        # the client socket so telemetry emitted *by* the sidecar (dashboard
+        # logs, query handler traces) flows into the same collector. Without
+        # this the sidecar would be deaf to its own events.
+        _set_unix_socket_sink_path(self.client_socket_path)
+
+        self._client_actor = client_actor
+        self._query_engine = query_engine
+        self._dashboard_info = dashboard_info
+        if config.include_dashboard:
+            logger.info("Monarch Dashboard: %s", dashboard_info["url"])
+
+    def shutdown(self) -> None:
+        # Drain in-flight async work with a short cap. Beyond that, we
+        # prefer a quick teardown over guaranteed completion — the sidecar
+        # is being asked to die and the parent has already moved on.
+        try:
+            shutdown_context().get(timeout=5.0)
+        except TimeoutError:
+            logger.info("telemetry handle shutdown timed out")
+        try:
+            os.unlink(self.client_socket_path)
+        except OSError:
+            pass

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -668,6 +668,17 @@ def test_actor_status_events_table() -> None:
             f"Expected at least one actor status event, got {event_count}"
         )
 
+        joined = engine.query(
+            "SELECT ase.id FROM actor_status_events ase "
+            "INNER JOIN actors a ON ase.actor_id = a.id "
+            "WHERE a.display_name LIKE '%status_test_worker%'"
+        )
+        joined_count = len(joined.to_pydict().get("id", []))
+        assert joined_count > 0, (
+            "Expected actor_status_events.actor_id to join actors.id for "
+            f"status_test_worker, got {joined_count} joined rows"
+        )
+
         # Verify new_status values are valid ActorStatus arm names
         valid_statuses = {
             "Unknown",
@@ -795,7 +806,7 @@ def test_sent_messages_table(
     All send paths (call, call_one, broadcast, choose) go through
     cast_with_selection in actor_mesh.rs, which calls notify_sent_message
     with a SentMessageEvent containing:
-      - sender_actor_id: hash of the sending actor's ActorAddr
+      - sender_actor_id: hash of the sending actor's ActorId
       - actor_mesh_id: hash of the target actor mesh name
       - view_json: serialized ndslice::Region of the current view
       - shape_json: serialized ndslice::Shape (converted from the Region)

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -7,12 +7,17 @@
 # pyre-unsafe
 
 import os
+import pickle
+import socket
 import subprocess
 import sys
 import tempfile
+import threading
+from dataclasses import dataclass
 from typing import cast, Dict, Optional, Sequence
 from unittest.mock import MagicMock, patch
 
+import monarch._src.job.job_sidecar as js
 import pytest
 
 # Import directly from _src since job module isn't properly exposed
@@ -25,7 +30,63 @@ from monarch._src.job.job import (
     MeshAdminConfig,
     TelemetryConfig,
 )
+from monarch._src.job.mount_config import Mounts
+from monarch._src.job.process_guard import _Shutdown, _wait_for_socket
 from monarch.actor import HostMesh
+
+
+def _append_line(path: str, line: str) -> None:
+    with open(path, "a") as f:
+        f.write(line + "\n")
+
+
+@dataclass
+class _RecordingJob:
+    name: str
+
+
+@dataclass
+class _RecordingMountHandle:
+    name: str
+    log_path: str
+
+    def refresh(self) -> None:
+        _append_line(self.log_path, f"refresh:{self.name}")
+
+    def close(self) -> None:
+        _append_line(self.log_path, f"close:{self.name}")
+
+
+@dataclass
+class _RecordingMounts:
+    name: str
+    log_path: str
+
+    def open(self, job: _RecordingJob) -> _RecordingMountHandle:
+        _append_line(self.log_path, f"open:{self.name}:{job.name}")
+        return _RecordingMountHandle(self.name, self.log_path)
+
+
+def _send_sidecar_request(socket_path: str, message: object) -> object:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        client.connect(socket_path)
+        # @lint-ignore PYTHONPICKLEISBAD
+        client.sendall(pickle.dumps(message))
+        # @lint-ignore PYTHONPICKLEISBAD
+        return pickle.load(client.makefile("rb"))
+    finally:
+        client.close()
+
+
+def _send_sidecar_shutdown(socket_path: str) -> None:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        client.connect(socket_path)
+        # @lint-ignore PYTHONPICKLEISBAD
+        client.sendall(pickle.dumps(_Shutdown()))
+    finally:
+        client.close()
 
 
 class MockJobTrait(JobTrait):
@@ -89,6 +150,108 @@ class MockJobTrait(JobTrait):
     def _kill(self):
         """Mock implementation that tracks the kill call."""
         self.kill_called = True
+
+
+def test_create_job_sidecar_uses_job_sidecar_worker():
+    """The sidecar launcher should use the renamed job sidecar worker."""
+    with patch("monarch._src.job.process_guard.ProcessGuard.create") as create:
+        js.create_job_sidecar("apply_id")
+
+    lock_path, config_key, command = create.call_args.args
+    assert lock_path == js.job_sidecar_lock_path("apply_id")
+    assert config_key == "apply_id"
+    assert command == [
+        sys.executable,
+        "-m",
+        "monarch._src.job._job_sidecar_worker",
+    ]
+
+
+def test_mounts_ensure_open_clears_existing_sidecar_when_empty():
+    """Empty mount config should clear stale mount state on an existing sidecar."""
+    guard = MagicMock()
+    with patch(
+        "monarch._src.job.mount_config.find_job_sidecar", return_value=guard
+    ) as find_sidecar:
+        Mounts().ensure_open("apply_id", {})
+
+    find_sidecar.assert_called_once_with("apply_id")
+    request = guard.send.call_args.args[0]
+    assert isinstance(request, js.ClearMountsRequest)
+    guard.send.return_value.get.assert_called_once_with()
+
+
+def test_mounts_ensure_open_does_not_create_sidecar_when_empty():
+    """Empty mount config should not start a sidecar just to clear no state."""
+    with (
+        patch(
+            "monarch._src.job.mount_config.find_job_sidecar", return_value=None
+        ) as find_sidecar,
+        patch("monarch._src.job.mount_config.create_job_sidecar") as create_sidecar,
+    ):
+        Mounts().ensure_open("apply_id", {})
+
+    find_sidecar.assert_called_once_with("apply_id")
+    create_sidecar.assert_not_called()
+
+
+def test_run_job_sidecar_manages_mount_lifecycle():
+    """Mount requests open once, refresh unchanged config, replace drift, and
+    clear stale state."""
+    with tempfile.TemporaryDirectory(prefix="monarch_sidecar_", dir="/tmp") as tempdir:
+        socket_path = os.path.join(tempdir, "cmd.sock")
+        log_path = os.path.join(tempdir, "events.log")
+        thread = threading.Thread(
+            target=js._run_job_sidecar,
+            args=(socket_path,),
+            daemon=True,
+        )
+
+        with patch("signal.signal"):
+            thread.start()
+            _wait_for_socket(socket_path, timeout=10.0)
+
+        try:
+            job = _RecordingJob("job")
+            assert (
+                _send_sidecar_request(
+                    socket_path,
+                    js.MountsRequest(_RecordingMounts("one", log_path), job),
+                )
+                == "ok"
+            )
+            assert (
+                _send_sidecar_request(
+                    socket_path,
+                    js.MountsRequest(_RecordingMounts("one", log_path), job),
+                )
+                == "ok"
+            )
+            assert (
+                _send_sidecar_request(
+                    socket_path,
+                    js.MountsRequest(_RecordingMounts("two", log_path), job),
+                )
+                == "ok"
+            )
+            assert _send_sidecar_request(socket_path, js.ClearMountsRequest()) == "ok"
+            assert _send_sidecar_request(socket_path, js.ClearMountsRequest()) == "ok"
+        finally:
+            try:
+                _send_sidecar_shutdown(socket_path)
+            except OSError:
+                pass
+            thread.join(timeout=10.0)
+
+        assert not thread.is_alive(), "job sidecar did not exit on shutdown"
+        with open(log_path) as f:
+            assert f.read().splitlines() == [
+                "open:one:job",
+                "refresh:one",
+                "close:one",
+                "open:two:job",
+                "close:two",
+            ]
 
 
 def test_apply():
@@ -302,14 +465,17 @@ def test_kill():
     """Test the kill method."""
     job = MockJobTrait()
     job.apply()
+    apply_id = job.apply_id
+    assert apply_id is not None
     # Kill shouldn't have been called yet
     assert not job.kill_called
 
-    # Call kill
-    job.kill()
+    with patch("monarch._src.job.job.stop_job_sidecar") as stop_sidecar:
+        job.kill()
 
     # kill_called should now be True
     assert job.kill_called
+    stop_sidecar.assert_called_once_with(apply_id)
 
 
 def test_state_query_engine_none_without_telemetry():

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -152,19 +152,46 @@ class MockJobTrait(JobTrait):
         self.kill_called = True
 
 
-def test_create_job_sidecar_uses_job_sidecar_worker():
-    """The sidecar launcher should use the renamed job sidecar worker."""
-    with patch("monarch._src.job.process_guard.ProcessGuard.create") as create:
-        js.create_job_sidecar("apply_id")
+def test_spawn_module_uses_module_command_outside_par():
+    with (
+        patch.object(js, "_IN_PAR", False),
+        patch("monarch._src.job.process_guard.ProcessGuard.create") as create,
+    ):
+        js.spawn_module("lock", "key", "monarch.fake_module")
 
     lock_path, config_key, command = create.call_args.args
-    assert lock_path == js.job_sidecar_lock_path("apply_id")
-    assert config_key == "apply_id"
-    assert command == [
-        sys.executable,
-        "-m",
+    assert lock_path == "lock"
+    assert config_key == "key"
+    assert command == [sys.executable, "-m", "monarch.fake_module"]
+    assert create.call_args.kwargs == {"env": None}
+
+
+def test_spawn_module_reenters_parent_binary_inside_par():
+    with (
+        patch.object(js, "_IN_PAR", True),
+        patch.object(sys, "argv", ["/tmp/parent.par"]),
+        patch("monarch._src.job.process_guard.ProcessGuard.create") as create,
+    ):
+        js.spawn_module("lock", "key", "monarch.fake_module")
+
+    lock_path, config_key, command = create.call_args.args
+    assert lock_path == "lock"
+    assert config_key == "key"
+    assert command == ["/tmp/parent.par"]
+    assert create.call_args.kwargs == {
+        "env": {"PAR_MAIN_OVERRIDE": "monarch.fake_module"}
+    }
+
+
+def test_create_job_sidecar_spawns_job_sidecar_worker_module():
+    with patch.object(js, "spawn_module") as spawn_module:
+        js.create_job_sidecar("apply_id")
+
+    spawn_module.assert_called_once_with(
+        js.job_sidecar_lock_path("apply_id"),
+        "apply_id",
         "monarch._src.job._job_sidecar_worker",
-    ]
+    )
 
 
 def test_mounts_ensure_open_clears_existing_sidecar_when_empty():

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -1,0 +1,239 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Unit tests for telemetry hosted by the job sidecar."""
+
+import json
+import os
+import pickle
+import shutil
+import socket
+import threading
+import urllib.request
+import uuid
+from typing import cast
+from unittest.mock import patch
+
+import monarch._src.job.job_sidecar as js
+import monarch._src.job.telemetry_config as tc
+import pytest
+from monarch._src.job.process_guard import _Shutdown, _wait_for_socket
+from monarch._src.job.telemetry_actor import telemetry_socket_dir, telemetry_socket_path
+from monarch.job import TelemetryConfig
+
+
+def _new_apply_id() -> str:
+    return f"test_{uuid.uuid4().hex}"
+
+
+def _remove_socket_dir(apply_id: str) -> None:
+    shutil.rmtree(telemetry_socket_dir(apply_id), ignore_errors=True)
+
+
+def _post_json(url: str, payload: dict[str, object]) -> dict[str, object]:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=10.0) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _cfg_dict(**overrides):
+    base = {"retention_secs": 0, "include_dashboard": False, "dashboard_port": 0}
+    base.update(overrides)
+    return base
+
+
+class _FakeTelemetryHandle:
+    """Stand-in for `_TelemetryHandle` so the job sidecar command loop can be
+    driven without bootstrapping a real actor system / dashboard."""
+
+    def __init__(self) -> None:
+        self.calls = []
+        self.shutdown_called = False
+
+    def open_or_refresh(self, host_meshes, config):
+        self.calls.append((host_meshes, config))
+        return {
+            "telemetry_url": "http://telemetry",
+            "dashboard_url": "http://dashboard",
+            "socket_path": "/tmp/fake.sock",
+        }
+
+    def shutdown(self) -> None:
+        self.shutdown_called = True
+
+
+# ── job sidecar command loop ──────────────────────────────────────────────────
+
+
+@pytest.mark.timeout(30)
+def test_run_job_sidecar_survives_broken_connection(tmp_path) -> None:
+    """A connection that sends garbage (or breaks mid-request) must drop only
+    that connection, not tear down the job sidecar."""
+    socket_path = str(tmp_path / "cmd.sock")
+    fake = _FakeTelemetryHandle()
+
+    with patch.object(tc, "_TelemetryHandle", return_value=fake):
+        thread = threading.Thread(
+            target=js._run_job_sidecar,
+            args=(socket_path,),
+            daemon=True,
+        )
+        thread.start()
+        try:
+            _wait_for_socket(socket_path, timeout=10.0)
+
+            # 1) Unparseable pickle: pickle.load raises (not EOFError), which
+            #    must be caught at the connection level, not kill the loop.
+            bad = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            bad.connect(socket_path)
+            bad.sendall(b"\xff")  # invalid pickle opcode → UnpicklingError
+            bad.close()
+
+            # 2) A valid request still gets served → proves the job sidecar lived.
+            good = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            good.connect(socket_path)
+            good.sendall(
+                pickle.dumps(
+                    js.TelemetryRequest(
+                        apply_id="apply",
+                        config={},
+                        host_meshes={},
+                    )
+                )
+            )
+            response = pickle.load(good.makefile("rb"))
+            good.close()
+
+            assert response["telemetry_url"] == "http://telemetry"
+            assert len(fake.calls) == 1
+        finally:
+            stop = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            try:
+                stop.connect(socket_path)
+                stop.sendall(pickle.dumps(_Shutdown()))
+                stop.close()
+            except OSError:
+                pass
+            thread.join(timeout=10)
+
+    assert not thread.is_alive(), "job sidecar did not exit on _Shutdown"
+    assert fake.shutdown_called
+
+
+# ── _TelemetryHandle.open_or_refresh (bootstrap-once + drift) ─────────────────
+
+
+def test_open_or_refresh_bootstraps_once_and_ignores_drift() -> None:
+    handle = tc._TelemetryHandle("apply")
+    bootstrap_calls = []
+
+    def fake_bootstrap(config) -> None:
+        bootstrap_calls.append(config)
+        handle._dashboard_info = {"local_url": "http://local", "url": "http://ext"}
+
+    with patch.object(handle, "_bootstrap", side_effect=fake_bootstrap):
+        expected = {
+            "telemetry_url": "http://local",
+            "dashboard_url": "http://ext",
+            "socket_path": telemetry_socket_path("apply"),
+        }
+
+        # First call bootstraps and returns the urls.
+        assert handle.open_or_refresh({}, _cfg_dict()) == expected
+        assert len(bootstrap_calls) == 1
+
+        # Same config: reuse, no re-bootstrap.
+        assert handle.open_or_refresh({}, _cfg_dict()) == expected
+        assert len(bootstrap_calls) == 1
+
+        # Drifted config: still no re-bootstrap, first config retained.
+        assert handle.open_or_refresh({}, _cfg_dict(retention_secs=600)) == expected
+        assert len(bootstrap_calls) == 1
+        assert handle._first_config is not None
+        assert handle._first_config.retention_secs == 0
+
+
+def test_open_or_refresh_raises_when_not_open() -> None:
+    """If bootstrap fails to stand up the dashboard, open_or_refresh surfaces
+    a clear error rather than returning a malformed response."""
+    handle = tc._TelemetryHandle("apply")
+    with patch.object(handle, "_bootstrap", lambda config: None):
+        with pytest.raises(RuntimeError, match="not open"):
+            handle.open_or_refresh({}, _cfg_dict())
+
+
+# ── Telemetry.ensure_open ─────────────────────────────────────────────────────
+
+
+def test_ensure_open_requires_apply_id() -> None:
+    tel = tc.Telemetry(TelemetryConfig())
+    with pytest.raises(RuntimeError, match="apply_id"):
+        tel.ensure_open(cast(str, None))
+
+
+def test_ensure_open_reraises_sidecar_error() -> None:
+    apply_id = _new_apply_id()
+    tel = tc.Telemetry(TelemetryConfig())
+    try:
+        with patch.object(tc, "create_job_sidecar") as create_sidecar:
+            create_sidecar.return_value.send.return_value.get.return_value = {
+                "error": "boom"
+            }
+            with pytest.raises(RuntimeError, match="boom"):
+                tel.ensure_open(apply_id)
+    finally:
+        _remove_socket_dir(apply_id)
+
+
+# ── End-to-end: real job sidecar subprocess ───────────────────────────────────
+
+
+@pytest.mark.timeout(120)
+def test_job_sidecar_hosts_telemetry_query_api() -> None:
+    """Launch the real job sidecar process, open telemetry over the command
+    socket, and confirm the data socket is bound and the query API answers."""
+    apply_id = _new_apply_id()
+    socket_dir = telemetry_socket_dir(apply_id)
+    _remove_socket_dir(apply_id)
+    os.makedirs(socket_dir, mode=0o700)
+    try:
+        response = tc.Telemetry(
+            TelemetryConfig(
+                retention_secs=0,
+                include_dashboard=False,
+                dashboard_port=0,
+            )
+        ).ensure_open(
+            apply_id,
+            host_meshes={},
+        )
+        assert isinstance(response, dict)
+        telemetry_url = response["telemetry_url"]
+        socket_path = response["socket_path"]
+        assert isinstance(telemetry_url, str)
+        assert socket_path == telemetry_socket_path(apply_id)
+
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+            client.connect(socket_path)
+        finally:
+            client.close()
+
+        query_response = _post_json(
+            f"{telemetry_url}/api/query",
+            {"sql": "SELECT COUNT(*) AS count FROM spans"},
+        )
+        assert "rows" in query_response
+    finally:
+        js.stop_job_sidecar(apply_id)
+        _remove_socket_dir(apply_id)


### PR DESCRIPTION
Summary:

Actor telemetry IDs should use runtime actor identity, not routable actor addresses (changed in D102822047) This updates actor rows, sender IDs, receiver IDs, and actor status IDs to hash `ActorId` while keeping `ActorAddr` strings only for display/debug fields. This prevents location changes from changing the telemetry actor join key.

Reviewed By: mariusae

Differential Revision: D107156872
