### PR TITLE
Resolve CreateOrUpdate rank info from headers (#4122)

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -37,7 +37,6 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Castable;
 use hyperactor::message::ErasedUnbound;
 use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::message::Unbound;
 use hyperactor::port::Port;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
@@ -656,24 +655,13 @@ impl<A: Referable> ActorMeshRef<A> {
         A: RemoteHandles<M>,
         M: Castable + RemoteMessage,
     {
-        let create_rank = point.rank();
         let mut headers = caller_headers.clone();
         multicast::set_cast_info_on_headers(&mut headers, point, cx.instance().self_addr().clone());
 
-        // Make sure that we re-bind ranks, as these may be used for
-        // bootstrapping comm actors.
-        let mut unbound = Unbound::try_from_message(message)
-            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-        unbound
-            .visit_mut::<resource::Rank>(|resource::Rank(rank)| {
-                *rank = Some(create_rank);
-                Ok(())
-            })
-            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-        let rebound_message = unbound
-            .bind()
-            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-        actor.post_with_headers(cx, headers, rebound_message);
+        // Rank is delivery context. Receivers that need it resolve it from
+        // `CAST_POINT` instead of requiring the transport to mutate the payload
+        // before delivery.
+        actor.post_with_headers(cx, headers, message);
         Ok(())
     }
 
@@ -793,18 +781,11 @@ impl<A: Referable> ActorMeshRef<A> {
             .expect("port splitting should not fail");
 
             for rank in 0..num_ranks {
-                let mut rank_data = data.clone();
+                let rank_data = data.clone();
 
                 let cast_point = region
                     .point_of_base_rank(rank)
                     .expect("rank should be valid in region");
-
-                rank_data
-                    .visit_mut::<resource::Rank>(|resource::Rank(r)| {
-                        *r = Some(cast_point.rank());
-                        Ok(())
-                    })
-                    .expect("rank replacement should not fail");
 
                 let mut rank_headers = headers.clone();
                 multicast::set_cast_info_on_headers(&mut rank_headers, cast_point, sender.clone());

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -12,7 +12,6 @@ use crate::comm::multicast::CastEnvelope;
 use crate::comm::multicast::CastMessageV1;
 use crate::comm::multicast::ForwardMessageV1;
 use crate::mesh_id::ActorMeshId;
-use crate::resource;
 pub mod multicast;
 
 use std::cmp::Ordering;
@@ -48,7 +47,6 @@ use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use hyperactor_mesh_macros::sel;
-use ndslice::Point;
 use ndslice::Selection;
 use ndslice::View;
 use ndslice::selection::routing::RoutingFrame;
@@ -369,9 +367,6 @@ impl CommActor {
         config: &CommMeshConfig,
     ) -> anyhow::Result<()> {
         let cast_point = message.cast_point(config)?;
-        // Replace ranks with self ranks.
-        replace_with_self_ranks(&cast_point, message.data_mut())?;
-
         set_cast_info_on_headers(&mut headers, cast_point, message.sender().clone());
 
         // Bind dest ONCE so we can pass to both the stamp helper and the
@@ -456,13 +451,6 @@ fn split_ports(
             Ok(())
         },
     )
-}
-
-fn replace_with_self_ranks(cast_point: &Point, data: &mut ErasedUnbound) -> anyhow::Result<()> {
-    data.visit_mut::<resource::Rank>(|resource::Rank(rank)| {
-        *rank = Some(cast_point.rank());
-        Ok(())
-    })
 }
 
 #[async_trait]

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -73,6 +73,7 @@ use std::time::Duration;
 
 use hyperactor::ActorAddr;
 use hyperactor::ProcAddr;
+use hyperactor::RemoteEndpoint as _;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::context;
 use ndslice::Extent;
@@ -109,7 +110,6 @@ use crate::mesh_id::ResourceId;
 use crate::proc_agent::ProcAgent;
 use crate::proc_mesh::ProcMeshRef;
 use crate::resource;
-use crate::resource::CreateOrUpdateClient;
 use crate::resource::GetRankStatus;
 use crate::resource::GetRankStatusClient;
 use crate::resource::RankedValues;
@@ -1313,20 +1313,23 @@ impl HostMeshRef {
                     proc_bind: bind,
                     host_mesh_id: Some(self.id.clone()),
                 };
-                host.mesh_agent()
-                    .create_or_update(
-                        cx,
-                        proc_name.clone(),
-                        resource::Rank::new(create_rank),
-                        proc_spec,
-                    )
-                    .await
-                    .map_err(|e| {
-                        crate::Error::HostMeshAgentConfigurationError(
-                            host.mesh_agent().actor_addr().clone(),
-                            format!("failed while creating proc: {}", e),
-                        )
-                    })?;
+                let create_point = extent
+                    .point_of_rank(create_rank)
+                    .expect("rank in combined extent");
+                let mut create_headers = hyperactor_config::Flattrs::new();
+                crate::comm::multicast::set_cast_info_on_headers(
+                    &mut create_headers,
+                    create_point,
+                    cx.instance().self_addr().clone(),
+                );
+                host.mesh_agent().post_with_headers(
+                    cx,
+                    create_headers,
+                    resource::CreateOrUpdate {
+                        id: proc_name.clone(),
+                        spec: proc_spec,
+                    },
+                );
                 let mut reply_port = port.bind();
                 // If this proc dies or some other issue renders the reply undeliverable,
                 // the reply does not need to be returned to the sender.

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -679,12 +679,14 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
                 return Ok(());
             }
         };
+        let rank = resource::create_rank_from_headers(cx.headers())
+            .expect("CreateOrUpdate<ProcSpec> must carry CAST_POINT");
         let created = match host {
             HostAgentMode::Process { host, .. } => {
                 host.spawn(
                     create_or_update.id.to_string(),
                     BootstrapProcConfig {
-                        create_rank: create_or_update.rank.unwrap(),
+                        create_rank: rank,
                         client_config_override: create_or_update
                             .spec
                             .client_config_override
@@ -697,8 +699,6 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             }
             HostAgentMode::Local(host) => host.spawn(create_or_update.id.to_string(), ()).await,
         };
-
-        let rank = create_or_update.rank.unwrap();
 
         if let Err(e) = &created {
             tracing::error!("failed to spawn proc {}: {}", create_or_update.id, e);
@@ -1503,9 +1503,32 @@ mod tests {
     use super::*;
     use crate::bootstrap::ProcStatus;
     use crate::mesh_id::ResourceId;
-    use crate::resource::CreateOrUpdateClient;
     use crate::resource::GetStateClient;
     use crate::resource::WaitRankStatusClient;
+
+    fn point_of_rank(rank: usize) -> ndslice::Point {
+        ndslice::Extent::new(vec!["rank".to_string()], vec![rank + 1])
+            .expect("valid extent")
+            .point_of_rank(rank)
+            .expect("valid rank")
+    }
+
+    fn create_proc(
+        host_agent: &ActorHandle<HostAgent>,
+        client: &hyperactor::Client,
+        id: ResourceId,
+        rank: usize,
+        spec: ProcSpec,
+    ) {
+        let mut headers = Flattrs::new();
+        crate::comm::multicast::set_cast_info_on_headers(
+            &mut headers,
+            point_of_rank(rank),
+            client.self_addr().clone(),
+        );
+        let host_agent_ref: ActorRef<HostAgent> = host_agent.bind();
+        host_agent_ref.post_with_headers(client, headers, resource::CreateOrUpdate { id, spec });
+    }
 
     #[tokio::test]
     async fn test_basic() {
@@ -1535,15 +1558,7 @@ mod tests {
 
         // First, create the proc, then query its state:
 
-        host_agent
-            .create_or_update(
-                &client,
-                id.clone(),
-                resource::Rank::new(0),
-                ProcSpec::default(),
-            )
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, id.clone(), 0, ProcSpec::default());
         // The host advertises spawned procs with a
         // `Via(proc_uid, Addr(host_addr))` location so its gateway can
         // peel and forward to the child's serving address. Construct
@@ -1600,15 +1615,7 @@ mod tests {
         let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
-        host_agent
-            .create_or_update(
-                &client,
-                id.clone(),
-                resource::Rank::new(0),
-                ProcSpec::default(),
-            )
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, id.clone(), 0, ProcSpec::default());
 
         // Proc is Running; wait for Running should reply immediately.
         let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
@@ -1650,15 +1657,7 @@ mod tests {
         let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
-        host_agent
-            .create_or_update(
-                &client,
-                id.clone(),
-                resource::Rank::new(0),
-                ProcSpec::default(),
-            )
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, id.clone(), 0, ProcSpec::default());
 
         // Wait for Stopped — should not reply yet.
         let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
@@ -1716,10 +1715,7 @@ mod tests {
 
         // Now create the proc — the stashed waiter should get its
         // sentinel rank fixed and be flushed once the proc is Running.
-        host_agent
-            .create_or_update(&client, id, resource::Rank::new(0), ProcSpec::default())
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, id, 0, ProcSpec::default());
 
         let overlay = tokio::time::timeout(Duration::from_secs(10), rx.recv())
             .await
@@ -1763,20 +1759,14 @@ mod tests {
             host_mesh_id: Some(mesh_a.clone()),
             ..Default::default()
         };
-        host_agent
-            .create_or_update(&client, proc_a_id.clone(), resource::Rank::new(0), spec_a)
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, proc_a_id.clone(), 0, spec_a);
 
         // Create proc_b belonging to mesh_b.
         let spec_b = ProcSpec {
             host_mesh_id: Some(mesh_b.clone()),
             ..Default::default()
         };
-        host_agent
-            .create_or_update(&client, proc_b_id.clone(), resource::Rank::new(1), spec_b)
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, proc_b_id.clone(), 1, spec_b);
 
         // Both should be Running.
         assert_matches!(
@@ -1865,19 +1855,13 @@ mod tests {
             host_mesh_id: Some(mesh_a),
             ..Default::default()
         };
-        host_agent
-            .create_or_update(&client, proc_a_id.clone(), resource::Rank::new(0), spec_a)
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, proc_a_id.clone(), 0, spec_a);
 
         let spec_b = ProcSpec {
             host_mesh_id: Some(mesh_b),
             ..Default::default()
         };
-        host_agent
-            .create_or_update(&client, proc_b_id.clone(), resource::Rank::new(1), spec_b)
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, proc_b_id.clone(), 1, spec_b);
 
         // Drain all (no filter).
         host_agent
@@ -1945,15 +1929,7 @@ mod tests {
         // Spawn a proc so the host_agent processes at least one
         // CreateOrUpdate message, which goes through the work queue.
         let name = ResourceId::instance(Label::new("qd_test_proc").unwrap());
-        host_agent
-            .create_or_update(
-                &client,
-                name.clone(),
-                resource::Rank::new(0),
-                ProcSpec::default(),
-            )
-            .await
-            .unwrap();
+        create_proc(&host_agent, &client, name.clone(), 0, ProcSpec::default());
 
         // The host_agent has now processed messages on the service
         // proc. Query the service proc's introspection.

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -3462,6 +3462,7 @@ mod tests {
         use std::time::Duration;
 
         use hyperactor::Proc;
+        use hyperactor::RemoteEndpoint as _;
         use hyperactor::channel::ChannelTransport;
         use hyperactor::id::Label;
 
@@ -3472,7 +3473,6 @@ mod tests {
         use crate::proc_agent::ProcAgent;
         use crate::resource;
         use crate::resource::ProcSpec;
-        use crate::resource::Rank;
 
         // Stand up a local in-process Host with a HostAgent.
         let spawn: ProcManagerSpawnFn =
@@ -3516,11 +3516,21 @@ mod tests {
 
         // Spawn a user proc via CreateOrUpdate<ProcSpec>.
         let user_proc_name = ResourceId::instance(Label::new("user-proc").unwrap());
-        host_agent_ref.post(
+        let create_point = ndslice::Extent::new(vec!["rank".to_string()], vec![1])
+            .expect("valid extent")
+            .point_of_rank(0)
+            .expect("valid rank");
+        let mut create_headers = hyperactor_config::Flattrs::new();
+        crate::comm::multicast::set_cast_info_on_headers(
+            &mut create_headers,
+            create_point,
+            client.self_addr().clone(),
+        );
+        host_agent_ref.post_with_headers(
             &client,
+            create_headers,
             resource::CreateOrUpdate {
                 id: user_proc_name.clone(),
-                rank: Rank::new(0),
                 spec: ProcSpec::default(),
             },
         );

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -908,7 +908,8 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
             // There is no update.
             return Ok(());
         }
-        let create_rank = create_or_update.rank.unwrap();
+        let create_rank = resource::create_rank_from_headers(cx.headers())
+            .expect("cast CreateOrUpdate<ActorSpec> must carry CAST_POINT");
         // If any actor on this proc has error supervision events,
         // we disallow spawning new actors on it, as this proc may be in an
         // invalid state.
@@ -1277,6 +1278,30 @@ mod tests {
     struct ExtraActor;
     impl hyperactor::Actor for ExtraActor {}
     hyperactor::register_spawnable!(ExtraActor);
+
+    fn point_of_rank(rank: usize) -> ndslice::Point {
+        ndslice::Extent::new(vec!["rank".to_string()], vec![rank + 1])
+            .expect("valid extent")
+            .point_of_rank(rank)
+            .expect("valid rank")
+    }
+
+    fn create_actor(
+        agent_ref: &ActorRef<ProcAgent>,
+        client: &hyperactor::Client,
+        id: ResourceId,
+        rank: usize,
+        spec: ActorSpec,
+    ) {
+        let mut headers = Flattrs::new();
+        crate::comm::multicast::set_cast_info_on_headers(
+            &mut headers,
+            point_of_rank(rank),
+            client.self_addr().clone(),
+        );
+        agent_ref.post_with_headers(client, headers, resource::CreateOrUpdate { id, spec });
+    }
+
     // Verifies that QueryChild(Addr::Proc) on a ProcAgent returns
     // a live IntrospectResult whose children reflect actors spawned
     // directly on the proc — i.e. via proc.spawn_with_label(), which bypasses the
@@ -1514,7 +1539,6 @@ mod tests {
         use hyperactor::actor::ActorStatus;
         use hyperactor::channel::ChannelTransport;
 
-        use crate::resource::CreateOrUpdateClient;
         use crate::resource::GetStateClient;
         use crate::resource::StopClient;
         use crate::resource::StreamStateClient;
@@ -1539,18 +1563,16 @@ mod tests {
         let actor_name = ResourceId::singleton(hyperactor::id::Label::new("test-actor").unwrap());
 
         // 1. Spawn an actor via CreateOrUpdate.
-        agent_ref
-            .create_or_update(
-                &client,
-                actor_name.clone(),
-                resource::Rank::new(0),
-                ActorSpec {
-                    actor_type: actor_type.clone(),
-                    params_data: actor_params.clone(),
-                },
-            )
-            .await
-            .unwrap();
+        create_actor(
+            &agent_ref,
+            &client,
+            actor_name.clone(),
+            0,
+            ActorSpec {
+                actor_type: actor_type.clone(),
+                params_data: actor_params.clone(),
+            },
+        );
 
         // 2. Subscribe to state updates.
         let (sub_port, mut sub_rx) = client.open_port::<resource::State<ActorState>>();
@@ -1580,18 +1602,16 @@ mod tests {
         // 6. Test implicit unsubscription via undeliverable.
         let actor_name_2 =
             ResourceId::singleton(hyperactor::id::Label::new("test-actor-2").unwrap());
-        agent_ref
-            .create_or_update(
-                &client,
-                actor_name_2.clone(),
-                resource::Rank::new(1),
-                ActorSpec {
-                    actor_type: actor_type.clone(),
-                    params_data: actor_params.clone(),
-                },
-            )
-            .await
-            .unwrap();
+        create_actor(
+            &agent_ref,
+            &client,
+            actor_name_2.clone(),
+            1,
+            ActorSpec {
+                actor_type: actor_type.clone(),
+                params_data: actor_params.clone(),
+            },
+        );
 
         let (sub_port_2, mut sub_rx_2) = client.open_port::<resource::State<ActorState>>();
         agent_ref

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -728,7 +728,6 @@ impl ProcMeshRef {
             cx,
             resource::CreateOrUpdate::<proc_agent::ActorSpec> {
                 id: actor_mesh_id.resource_id().clone(),
-                rank: Default::default(),
                 spec: proc_agent::ActorSpec {
                     actor_type: actor_type.clone(),
                     params_data: serialized_params.clone(),

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -35,6 +35,7 @@ use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Bind;
 use hyperactor::message::Bindings;
 use hyperactor::message::Unbind;
+use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
 use ndslice::Region;
 use ndslice::ViewExt;
@@ -156,37 +157,10 @@ impl From<crate::host::LocalProcStatus> for Status {
     }
 }
 
-/// Data type used to communicate ranks.
-/// Implements [`Bind`] and [`Unbind`]; the comm actor replaces
-/// instances with the delivered rank.
-#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq, Default)]
-pub struct Rank(pub Option<usize>);
-wirevalue::register_type!(Rank);
-
-impl Rank {
-    /// Create a new rank with the provided value.
-    pub fn new(rank: usize) -> Self {
-        Self(Some(rank))
-    }
-
-    /// Unwrap the rank; panics if not set.
-    pub fn unwrap(&self) -> usize {
-        self.0.unwrap()
-    }
-}
-
-impl Unbind for Rank {
-    fn unbind(&self, bindings: &mut Bindings) -> anyhow::Result<()> {
-        bindings.push_back(self)
-    }
-}
-
-impl Bind for Rank {
-    fn bind(&mut self, bindings: &mut Bindings) -> anyhow::Result<()> {
-        let bound = bindings.try_pop_front::<Rank>()?;
-        self.0 = bound.0;
-        Ok(())
-    }
+pub(crate) fn create_rank_from_headers(headers: &Flattrs) -> Option<usize> {
+    headers
+        .get(crate::comm::multicast::CAST_POINT)
+        .map(|point| point.rank())
 }
 
 /// Get the status of a resource across the mesh.
@@ -340,9 +314,6 @@ impl<S: Serialize> fmt::Display for State<S> {
 pub struct CreateOrUpdate<S> {
     /// The resource identifier.
     pub id: ResourceId,
-    /// The rank of the resource, when available.
-    #[binding(include)]
-    pub rank: Rank,
     /// The specification of the resource.
     pub spec: S,
 }


### PR DESCRIPTION
Summary:

For `CreateOrUpdate<T>` to work with casts, we will need to resolve the rank from the `CAST_POINT` header instead of the `rank` field. This is because casting can only send an identical message to every node. `CAST_POINT` is able to get around this because it is injected by Cast/Comm Actors when delivering locally. 

To avoid footguns from knowing when to resolve from `.rank` and when to resolve from `CAST_POINT` we just eliminate `.rank` and always resolve from `CAST_POINT` because we are able to stamp it when we need it. When HostMesh sends out `CreateOrUpdate<ProcSpec>`, it iterates through all host agents so this is logically a cast and we can just stamp `CAST_POINT` during iteration

Differential Revision: D107097757


