### PR TITLE
skip ibverbs tests at runtime instead of never generating their test cases (#4136)

### DIFF
--- a/python/tests/rdma_test_utils.py
+++ b/python/tests/rdma_test_utils.py
@@ -8,29 +8,68 @@
 """
 Shared helpers for the RDMA test modules.
 
-``rdma_backends`` is a decorator that runs a test once per available RDMA
-backend. ``ibverbs`` is only collected when the host has compatible hardware;
-``tcp`` always runs, and is forced even on RDMA-capable hosts via
-``rdma_disable_ibverbs=True``.
+``rdma_backends`` runs a test under both RDMA backends: ``ibverbs``
+(``rdma_disable_ibverbs=False``) and ``tcp`` (``rdma_disable_ibverbs=True``,
+which forces TCP even on ibverbs-capable hosts).
 """
 
-from monarch.config import parametrize_config_pointwise
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable
+
+import pytest
+from monarch.config import get_global_config, parametrize_config_pointwise
 from monarch.rdma import is_ibverbs_available
 
 
-RDMA_BACKENDS: list[str] = []
-if is_ibverbs_available():
-    RDMA_BACKENDS.append("ibverbs")
-RDMA_BACKENDS.append("tcp")
+RDMA_BACKENDS: list[str] = ["ibverbs", "tcp"]
 
 
-if is_ibverbs_available():
-    rdma_backends = parametrize_config_pointwise(
+def skip_if_ibverbs_unavailable() -> None:
+    """Skip the running test when no ibverbs device is available on this host."""
+    if not is_ibverbs_available():
+        pytest.skip("ibverbs backend requested but no ibverbs device on this host")
+
+
+def _skip_ibverbs_case_when_unavailable(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap ``fn`` so the ibverbs parametrization is skipped at runtime when the
+    executing host lacks an ibverbs device.
+
+    Runs inside the ``configured(...)`` context that ``parametrize_config_pointwise``
+    applies, so it reads the active backend from the merged config.
+    """
+
+    def _is_ibverbs_case() -> bool:
+        # rdma_disable_ibverbs=False is the ibverbs case.
+        return not get_global_config().get("rdma_disable_ibverbs", False)
+
+    if inspect.iscoroutinefunction(fn):
+
+        @functools.wraps(fn)
+        async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
+            if _is_ibverbs_case():
+                skip_if_ibverbs_unavailable()
+            return await fn(*args, **kwargs)
+
+        return async_wrapper
+
+    @functools.wraps(fn)
+    def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
+        if _is_ibverbs_case():
+            skip_if_ibverbs_unavailable()
+        return fn(*args, **kwargs)
+
+    return sync_wrapper
+
+
+def rdma_backends(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Parametrize a test across the ibverbs and tcp RDMA backends.
+    The ibverbs case is skipped at runtime on hosts without an ibverbs
+    device.
+    """
+    return parametrize_config_pointwise(
         rdma_disable_ibverbs=[True, False],
         rdma_allow_tcp_fallback=[True, False],
-    )
-else:
-    rdma_backends = parametrize_config_pointwise(
-        rdma_disable_ibverbs=[True],
-        rdma_allow_tcp_fallback=[True],
-    )
+    )(_skip_ibverbs_case_when_unavailable(fn))

--- a/python/tests/test_rdma_cpu_no_torch.py
+++ b/python/tests/test_rdma_cpu_no_torch.py
@@ -13,7 +13,7 @@ from isolate_in_subprocess import isolate_in_subprocess
 from monarch.actor import Actor, endpoint, this_host
 from monarch.config import configured
 from monarch.rdma import RDMABuffer
-from rdma_test_utils import RDMA_BACKENDS
+from rdma_test_utils import RDMA_BACKENDS, skip_if_ibverbs_unavailable
 
 
 class CpuActor(Actor):
@@ -59,6 +59,7 @@ async def test_rdma_buffer_cpu_memoryview(rdma_backend):
     if rdma_backend == "tcp":
         cm = configured(rdma_disable_ibverbs=True)
     else:
+        skip_if_ibverbs_unavailable()
         cm = configured(rdma_allow_tcp_fallback=False)
 
     with cm:


### PR DESCRIPTION
Summary:

The ibverbs parametrizations of the rdma tests should always be collected by pytest, even when no ibverbs backend is available on the host; they will be skipped at runtime.

Differential Revision: D107260378


