### PR TITLE
Disable ROCm CI jobs while ROCm is broken

### DIFF
--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -61,24 +61,21 @@ jobs:
           ROCM_72_PY310='{"name": "rocm7.2", "python-version": "3.10", "docker-image": "pytorch/manylinux2_28-builder:rocm7.2", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/rocm7.2/"}'
 
           # Build matrix:
-          # - ROCm tag: ROCm only (CUDA already built in PR run)
-          # - Push/schedule: CUDA + ROCm
-          # - PR (with or without ciflow/rocm label): CUDA only
-          #   ROCm builds are skipped on PRs so CUDA tests don't wait for them;
-          #   ROCm build failures are caught on push to main.
+          # - ROCm tag: ROCm only (manual opt-in; CUDA already built in PR run)
+          # - Otherwise (PR/push/schedule): CUDA only
+          # ROCm is disabled in normal CI while it is broken. Push a
+          # ciflow/rocm tag to build and test ROCm manually. See
+          # https://github.com/meta-pytorch/monarch/issues/4145 for re-enabling.
           if [[ "$IS_ROCM_TAG" == "true" ]]; then
             BUILD_MATRIX="[$ROCM_71_PY310, $ROCM_72_PY310]"
-          elif [[ "$IS_PUSH" == "true" || "$IS_SCHEDULE" == "true" ]]; then
-            BUILD_MATRIX="[$CUDA_PY310, $CUDA_PY312, $ROCM_71_PY310, $ROCM_72_PY310]"
           else
             BUILD_MATRIX="[$CUDA_PY310, $CUDA_PY312]"
           fi
 
-          # Test matrix: ROCm tested only on push/schedule/tag
+          # Test matrix: ROCm tested only on a manual ciflow/rocm tag; CUDA
+          # otherwise. ROCm is disabled in normal CI while it is broken.
           if [[ "$IS_ROCM_TAG" == "true" ]]; then
             TEST_MATRIX="[$ROCM_71, $ROCM_72]"
-          elif [[ "$IS_PUSH" == "true" || "$IS_SCHEDULE" == "true" ]]; then
-            TEST_MATRIX="[$CUDA, $ROCM_71, $ROCM_72]"
           else
             TEST_MATRIX="[$CUDA]"
           fi


### PR DESCRIPTION
Summary: ROCm GPU CI is currently very broken, so disable it in normal CI. `set-matrix.yaml` now emits CUDA-only build and test matrices for PRs, push, and schedule. ROCm still runs only on a manual `ciflow/rocm` tag push, for iterating on fixes before re-enabling.

Reviewed By: thedavekwon

Differential Revision: D107127116


