### PR TITLE
Wire telemetry sidecar into jobs (#4154)

### DIFF
--- a/python/monarch/_src/job/_telemetry_query_client.py
+++ b/python/monarch/_src/job/_telemetry_query_client.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+class QueryEngineClient:
+    """Parent-process handle to the telemetry sidecar's query API."""
+
+    def __init__(self, base_url: str, timeout: float = 10.0) -> None:
+        self._base_url: str = base_url.rstrip("/")
+        self._timeout: float = timeout
+        # Build an opener with an empty ProxyHandler so requests bypass any
+        # ambient HTTP(S)/no_proxy environment proxies. The sidecar listens
+        # on loopback/localhost; routing through a corporate proxy would fail
+        # or hang, so we force a direct connection.
+        self._opener: urllib.request.OpenerDirector = urllib.request.build_opener(
+            urllib.request.ProxyHandler({})
+        )
+
+    def query(self, sql: str) -> dict[str, Any]:
+        """Run a SQL query through the sidecar API and return its parsed
+        JSON response (``{"columns": [...], "rows": [...]}`` on success)."""
+        payload = json.dumps({"sql": sql}).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._base_url}/api/query",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with self._opener.open(request, timeout=self._timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            # urllib raises HTTPError before the caller can read the body, so
+            # the server's error detail (e.g. a DataFusion parse/plan failure
+            # returned as JSON) would otherwise be lost. Drain the body and
+            # fold it into the reason so the message is actionable, then
+            # re-raise a fresh HTTPError preserving url/code/headers/fp.
+            body = error.read().decode("utf-8", errors="replace")
+            raise urllib.error.HTTPError(
+                error.url,
+                error.code,
+                f"{error.reason}: {body}",
+                error.headers,
+                error.fp,
+            ) from error

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job, MONARCH_BATCH_JOB_ENV
+from monarch._src.job._telemetry_query_client import QueryEngineClient
 from monarch._src.job.job_components import JobComponents, MeshAdminConfig
 from monarch._src.job.job_sidecar import stop_job_sidecar
 from monarch._src.job.telemetry_config import TelemetryConfig
@@ -312,11 +313,13 @@ class JobState:
         self,
         hosts: Dict[str, HostMesh],
         query_engine: Optional[QueryEngine] = None,
+        query_engine_client: Optional[QueryEngineClient] = None,
         telemetry_url: Optional[str] = None,
         admin_url: Optional[str] = None,
     ):
         self._hosts = hosts
         self.query_engine = query_engine
+        self.query_engine_client = query_engine_client
         self.telemetry_url = telemetry_url
         self.admin_url = admin_url
 

--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -37,8 +37,13 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
 from monarch._src.actor.host_mesh import _spawn_admin
 from monarch._src.actor.sync_state import fake_sync_state
+from monarch._src.job._telemetry_query_client import QueryEngineClient
 from monarch._src.job.mount_config import Mounts
-from monarch._src.job.telemetry_config import TelemetryConfig
+from monarch._src.job.telemetry_config import (
+    install_sidecar_socket_sink,
+    Telemetry,
+    TelemetryConfig,
+)
 from monarch.actor import HostMesh
 from monarch.distributed_telemetry.actor import start_telemetry
 from monarch.distributed_telemetry.engine import QueryEngine
@@ -205,6 +210,85 @@ class TelemetryComponent(JobComponent):
         job_state.telemetry_url = self._telemetry_url
 
 
+class SidecarTelemetryComponent(JobComponent):
+    """Host telemetry in the job sidecar instead of in-process.
+
+    Opted into via ``TelemetryConfig.use_sidecar``; mutually exclusive with
+    ``TelemetryComponent``. ``before_connect`` opens the sidecar's
+    telemetry handle and installs the client-process Unix socket sink *before*
+    raw host meshes are materialized so host-mesh creation events are captured.
+    ``connect`` asks the sidecar to fan worker collectors out across the
+    materialized host meshes. Telemetry is best-effort: any failure is logged
+    and leaves telemetry disabled for this job rather than failing ``state()``.
+    """
+
+    def __init__(self, config: TelemetryConfig) -> None:
+        self._config = config
+        self._telemetry_url: Optional[str] = None
+        self._query_engine_client: Optional[QueryEngineClient] = None
+
+    def reset_runtime(self) -> None:
+        self._query_engine_client = None
+        self._telemetry_url = None
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_query_engine_client"] = None
+        state["_telemetry_url"] = None
+        return state
+
+    def before_connect(self, job: "JobTrait") -> None:
+        if self._query_engine_client is not None:
+            return
+        apply_id = job.apply_id
+        if apply_id is None:
+            return
+        try:
+            response = Telemetry(self._config).ensure_open(apply_id, host_meshes={})
+            telemetry_url = response.get("telemetry_url")
+            socket_path = response.get("socket_path")
+            if not isinstance(telemetry_url, str) or not isinstance(socket_path, str):
+                raise RuntimeError(
+                    f"invalid job sidecar telemetry response: {response!r}"
+                )
+            self._telemetry_url = telemetry_url
+            self._query_engine_client = QueryEngineClient(telemetry_url)
+            install_sidecar_socket_sink(socket_path)
+        except Exception:
+            # Reset so a partial bootstrap leaves a clean "disabled" state:
+            # fan-out no-ops and `state` exposes no query client.
+            self._query_engine_client = None
+            self._telemetry_url = None
+            logger.warning(
+                "job sidecar telemetry bootstrap failed; telemetry disabled for this job",
+                exc_info=True,
+            )
+
+    def connect(
+        self, job: "JobTrait", host_meshes: Dict[str, HostMesh]
+    ) -> Dict[str, HostMesh]:
+        if self._query_engine_client is None:
+            return host_meshes
+        apply_id = job.apply_id
+        if apply_id is None:
+            return host_meshes
+        try:
+            # `_telemetry_url` is already set by `before_connect`; this call only
+            # triggers worker fan-out, so its response is intentionally ignored.
+            Telemetry(self._config).ensure_open(apply_id, host_meshes=host_meshes)
+        except Exception:
+            logger.warning(
+                "job sidecar telemetry worker fan-out failed",
+                exc_info=True,
+            )
+        return host_meshes
+
+    def state(self, job: "JobTrait", job_state: "JobState") -> None:
+        if self._query_engine_client is not None:
+            job_state.query_engine_client = self._query_engine_client
+            job_state.telemetry_url = self._telemetry_url
+
+
 class AdminComponent(JobComponent):
     """Start the mesh admin agent once per allocation.
 
@@ -217,7 +301,7 @@ class AdminComponent(JobComponent):
     def __init__(
         self,
         config: MeshAdminConfig,
-        telemetry: Optional[TelemetryComponent],
+        telemetry: Optional[TelemetryComponent | SidecarTelemetryComponent],
     ) -> None:
         self._config = config
         self._telemetry = telemetry
@@ -317,7 +401,7 @@ class JobComponents:
     """
 
     mounts: MountComponent = field(default_factory=MountComponent)
-    telemetry: Optional[TelemetryComponent] = None
+    telemetry: Optional[TelemetryComponent | SidecarTelemetryComponent] = None
     admin: Optional[AdminComponent] = None
     snapshot: Optional[SnapshotComponent] = None
 
@@ -351,15 +435,21 @@ class JobComponents:
             component.reset_runtime()
 
     def configure_telemetry(self, config: TelemetryConfig) -> None:
-        if self.telemetry is None:
-            self.telemetry = TelemetryComponent(config)
+        target_cls = (
+            SidecarTelemetryComponent if config.use_sidecar else TelemetryComponent
+        )
+        if not isinstance(self.telemetry, target_cls):
+            if self.telemetry is not None:
+                self.telemetry.reset_runtime()
+            self.telemetry = target_cls(config)
             telemetry_changed = True
         else:
             telemetry_changed = self.telemetry._config != config
             if telemetry_changed:
                 self.telemetry.reset_runtime()
-                self._warn_if_snapshot_stale()
             self.telemetry._config = config
+        if telemetry_changed:
+            self._warn_if_snapshot_stale()
         if self.admin is not None:
             if telemetry_changed:
                 self.admin.reset_runtime()
@@ -402,7 +492,7 @@ class JobComponents:
             )
 
     def _configure_snapshot(self) -> None:
-        if self.telemetry is not None and self.admin is not None:
+        if isinstance(self.telemetry, TelemetryComponent) and self.admin is not None:
             if self.snapshot is None:
                 self.snapshot = SnapshotComponent(self.telemetry, self.admin)
             else:

--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -76,10 +76,10 @@ class TelemetryActor(Actor):
         # means this actor did not win (or has not yet attempted) the
         # non-destructive bind, so it is not a live collector.
         self._scanner: DatabaseScanner | None = None
-        # Other telemetry actors this collector fans queries out to. Empty
-        # for leaf collectors; the query-root collector receives its list via
-        # `set_worker_collectors` once the worker meshes exist.
-        self._worker_collectors: list[Any] = []
+        # Worker actor meshes this collector fans queries out to. Empty for
+        # leaf collectors; the query-root collector receives its list via
+        # `set_worker_collector_meshes` once the worker meshes exist.
+        self._worker_collector_meshes: list[Any] = []
 
     def _scanner_or_raise(self) -> DatabaseScanner:
         scanner = self._scanner
@@ -124,10 +124,10 @@ class TelemetryActor(Actor):
         return self._activate_impl()
 
     @endpoint
-    def set_worker_collectors(self, worker_collectors: List[Any]) -> None:
-        """Replace the client collector's worker fan-out list."""
+    def set_worker_collector_meshes(self, worker_collector_meshes: List[Any]) -> None:
+        """Replace the client collector's worker mesh list."""
         self._scanner_or_raise()
-        self._worker_collectors = list(worker_collectors)
+        self._worker_collector_meshes = list(worker_collector_meshes)
 
     @endpoint
     def table_names(self) -> List[str]:
@@ -163,23 +163,23 @@ class TelemetryActor(Actor):
         limit: Optional[int],
         filter_expr: Optional[str],
     ) -> int:
-        """Scan the local store and configured worker collectors."""
+        """Scan the local store and configured worker collector meshes."""
         # The client collector is the singleton query root: scan its local store
-        # first, then fan out flat to active worker collectors. Worker collectors
-        # have an empty `_worker_collectors` list, so the same endpoint is
-        # leaf-only when invoked on a worker.
+        # first, then fan out flat to active worker collector meshes. Worker
+        # collectors have an empty `_worker_collector_meshes` list, so the same
+        # endpoint is leaf-only when invoked on a worker.
         local_count: int = self._scanner_or_raise().scan(
             dest, table_name, projection, limit, filter_expr
         )
 
         child_futures = []
-        for collector in self._worker_collectors:
+        for collector_mesh in self._worker_collector_meshes:
             try:
                 # Constructing the call can fail if the sidecar holds a stale
                 # actor ref. Treat that as reduced result coverage, matching
                 # the legacy best-effort query behavior.
                 child_futures.append(
-                    collector.scan.call(
+                    collector_mesh.scan.call(
                         dest, table_name, projection, limit, filter_expr
                     )
                 )

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -32,18 +32,19 @@ The parent talks to telemetry via two channels:
 Lifecycle: `Telemetry.ensure_open(apply_id, host_meshes)` is called twice per
 `JobTrait._connect`. The first call (`host_meshes={}`) opens the job sidecar's
 telemetry handle and activates the client process's `UnixSocketSink` *before*
-`_state()` runs `bootstrap_host`, so the host-mesh creation events are
-captured. The second call (with materialised `host_meshes`) triggers worker
-fan-out: the telemetry handle spawns per-host `TelemetryActor` candidates and
-hands the live worker refs to the client collector for query fan-out.
+raw host meshes are materialized, so host-mesh creation events are captured.
+The second call (with materialised `host_meshes`) triggers worker fan-out: the
+telemetry handle spawns per-host `TelemetryActor` candidates and hands the live
+worker refs to the client collector for query fan-out.
 """
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, cast, Mapping, TypedDict
+from typing import Any, Callable, cast, Mapping, TypedDict
 
 from monarch._rust_bindings.monarch_distributed_telemetry import (
     _set_unix_socket_sink_path,
@@ -54,12 +55,15 @@ from monarch._src.job.telemetry_actor import (
     telemetry_socket_path,
     TelemetryActor,
 )
-from monarch.actor import context, HostMesh, shutdown_context
+from monarch.actor import context, HostMesh, ProcMesh, shutdown_context
 from monarch.distributed_telemetry.engine import QueryEngine
 from monarch.monarch_dashboard.server.app import start_dashboard
 from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+_sidecar_socket_path: str | None = None
+_startup_provider_registered: bool = False
 
 
 @dataclass
@@ -81,6 +85,11 @@ class TelemetryConfig:
             (default). When ``include_dashboard`` is True and this is 0,
             it is automatically set to 30s because the dashboard requires
             snapshot data for system actor filtering.
+        use_sidecar: Opt in to telemetry hosted by the job sidecar, which
+            *replaces* the legacy in-process collector for this job (the two
+            never run together). Transitional flag for the migration; defaults
+            to the legacy path. When True, ``state.query_engine`` is None and
+            ``state.query_engine_client`` serves queries instead.
     """
 
     batch_size: int = 1000
@@ -88,6 +97,7 @@ class TelemetryConfig:
     include_dashboard: bool = False
     dashboard_port: int = 8265
     snapshot_interval_secs: float = 0  # 0 = disabled
+    use_sidecar: bool = False
 
     def __post_init__(self) -> None:
         if self.include_dashboard and self.snapshot_interval_secs <= 0:
@@ -113,6 +123,40 @@ def _config_from_wire(config: Mapping[str, object]) -> TelemetryConfig:
         include_dashboard=cast(bool, config["include_dashboard"]),
         dashboard_port=cast(int, config["dashboard_port"]),
     )
+
+
+def install_sidecar_socket_sink(socket_path: str) -> None:
+    """Install the sidecar telemetry socket sink locally and in future workers."""
+    global _sidecar_socket_path
+    if _sidecar_socket_path not in (None, socket_path):
+        logger.warning(
+            "replacing telemetry data socket path %s with %s",
+            _sidecar_socket_path,
+            socket_path,
+        )
+    _sidecar_socket_path = socket_path
+
+    _ensure_setup_actor_telemetry_provider()
+    _set_unix_socket_sink_path(socket_path)
+
+
+def _unix_socket_sink_startup() -> Callable[[], None] | None:
+    socket_path = _sidecar_socket_path
+    if socket_path is None:
+        return None
+    return functools.partial(_set_unix_socket_sink_path, socket_path)
+
+
+def _ensure_setup_actor_telemetry_provider() -> None:
+    """Install the SetupActor provider that activates worker Unix sinks."""
+    global _startup_provider_registered
+    if _startup_provider_registered:
+        return
+
+    from monarch._src.actor.proc_mesh import SetupActor
+
+    SetupActor.register_startup_function(_unix_socket_sink_startup)
+    _startup_provider_registered = True
 
 
 class Telemetry:
@@ -186,6 +230,9 @@ class _TelemetryHandle:
         self._client_actor: Any | None = None
         self._query_engine: QueryEngine | None = None
         self._dashboard_info: dict[str, object] | None = None
+        # None means worker fan-out has not run yet. An empty list means fan-out
+        # ran, but no worker collectors became active.
+        self._worker_proc_meshes: list[ProcMesh] | None = None
 
     @property
     def client_socket_path(self) -> str:
@@ -204,6 +251,9 @@ class _TelemetryHandle:
             # Config drift is intentionally ignored. Restarting here would drop
             # the in-memory telemetry store and re-bind the data socket.
             logger.warning("telemetry handle config drift ignored")
+
+        if host_meshes and self._worker_proc_meshes is None:
+            self._worker_proc_meshes = self._spawn_telemetry_actors(host_meshes, parsed)
 
         dashboard_info = self._dashboard_info
         if dashboard_info is None:
@@ -253,7 +303,89 @@ class _TelemetryHandle:
         if config.include_dashboard:
             logger.info("Monarch Dashboard: %s", dashboard_info["url"])
 
+    def _spawn_telemetry_actors(
+        self,
+        host_meshes: Mapping[str, HostMesh],
+        config: TelemetryConfig,
+    ) -> list[ProcMesh]:
+        client_actor = self._client_actor
+        if client_actor is None:
+            raise RuntimeError("telemetry sidecar has no client actor")
+
+        worker_proc_meshes: list[ProcMesh] = []
+        worker_collector_meshes: list[Any] = []
+        for host_mesh in host_meshes.values():
+            try:
+                worker = self._start_worker_telemetry_collector(host_mesh, config)
+            except Exception:
+                logger.warning(
+                    "failed to start worker telemetry collector",
+                    exc_info=True,
+                )
+                continue
+            if worker is None:
+                continue
+            proc_mesh, worker_collector_mesh = worker
+            worker_proc_meshes.append(proc_mesh)
+            worker_collector_meshes.append(worker_collector_mesh)
+
+        client_actor.set_worker_collector_meshes.call_one(worker_collector_meshes).get()
+        return worker_proc_meshes
+
+    def _start_worker_telemetry_collector(
+        self,
+        host_mesh: HostMesh,
+        config: TelemetryConfig,
+    ) -> tuple[ProcMesh, Any] | None:
+        proc_mesh = host_mesh.spawn_procs(name="telemetry_hosts")
+        try:
+            worker_collector_mesh = proc_mesh.spawn(
+                "TelemetryActor",
+                TelemetryActor,
+                self._apply_id,
+                config.retention_secs,
+            )
+            active = any(
+                active for _rank, active in worker_collector_mesh.activate.call().get()
+            )
+        except Exception:
+            self._stop_worker_proc_mesh(
+                proc_mesh,
+                "telemetry collector startup failed",
+                "failed to stop failed telemetry worker proc mesh",
+            )
+            raise
+
+        if active:
+            return proc_mesh, worker_collector_mesh
+
+        self._stop_worker_proc_mesh(
+            proc_mesh,
+            "telemetry collector inactive",
+            "failed to stop inactive telemetry worker proc mesh",
+        )
+        return None
+
+    def _stop_worker_proc_mesh(
+        self,
+        proc_mesh: ProcMesh,
+        reason: str,
+        log_message: str,
+    ) -> None:
+        try:
+            proc_mesh.stop(reason).get()
+        except Exception:
+            logger.info(log_message, exc_info=True)
+
     def shutdown(self) -> None:
+        for proc_mesh in self._worker_proc_meshes or []:
+            try:
+                proc_mesh.stop("telemetry shutdown").get()
+            except Exception:
+                logger.info(
+                    "failed to stop telemetry worker proc mesh",
+                    exc_info=True,
+                )
         # Drain in-flight async work with a short cap. Beyond that, we
         # prefer a quick teardown over guaranteed completion — the sidecar
         # is being asked to die and the parent has already moved on.

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -55,6 +55,35 @@ def _telemetry_config(**kwargs: Any) -> TelemetryConfig:
     return TelemetryConfig(**kwargs)
 
 
+def _sidecar_telemetry_config(**kwargs: Any) -> TelemetryConfig:
+    kwargs.setdefault("batch_size", 10)
+    kwargs.setdefault("retention_secs", 0)
+    return _telemetry_config(use_sidecar=True, **kwargs)
+
+
+def _sidecar_query_rows(state, sql: str) -> list[dict[str, Any]]:
+    client = state.query_engine_client
+    assert client is not None
+    return client.query(sql).get("rows", [])
+
+
+def _rows_to_pydict(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    if not rows:
+        return {}
+    return {column: [row.get(column) for row in rows] for column in rows[0].keys()}
+
+
+def _query(state, sql: str) -> dict[str, list[Any]]:
+    deadline = time.monotonic() + 10.0
+    rows: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        rows = _sidecar_query_rows(state, sql)
+        if rows:
+            break
+        time.sleep(0.2)
+    return _rows_to_pydict(rows)
+
+
 def _new_apply_id() -> str:
     return f"test_{uuid.uuid4().hex}"
 
@@ -145,6 +174,37 @@ def test_telemetry_actor_reports_activation_failure() -> None:
         assert actor._scanner is None
     finally:
         _remove_socket_dir(apply_id)
+
+
+@pytest.mark.timeout(180)
+@isolate_in_subprocess
+def test_state_uses_sidecar_query_client_when_opted_in() -> None:
+    # `use_sidecar=True` replaces the legacy in-process collector: the sidecar
+    # serves queries via `query_engine_client` and the legacy `query_engine`
+    # stays None.
+    job = ProcessJob({"hosts": 1}).enable_telemetry(
+        _telemetry_config(batch_size=10, retention_secs=0, use_sidecar=True)
+    )
+    try:
+        state = job.state(cached_path=None)
+        assert state.query_engine is None
+        assert state.query_engine_client is not None
+        assert state.telemetry_url is not None
+
+        rows = []
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            response = state.query_engine_client.query(
+                "SELECT class, COUNT(*) AS count FROM meshes GROUP BY class"
+            )
+            rows = response.get("rows", [])
+            if any(row.get("class") == "Host" for row in rows):
+                break
+            time.sleep(0.2)
+
+        assert any(row.get("class") == "Host" for row in rows), rows
+    finally:
+        job.kill()
 
 
 @pytest.fixture
@@ -632,19 +692,20 @@ def test_actor_status_events_table() -> None:
     """Test that the actor_status_events table is populated when actors change status."""
     # Spawn worker actors — actors go through status transitions during spawn
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        assert state.query_engine is None
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2})
         workers = worker_procs.spawn("status_test_worker", WorkerActor)
         workers.initialized.get()
 
         # Query the actor_status_events table
-        result = engine.query("SELECT * FROM actor_status_events")
-        result_dict = result.to_pydict()
+        result_dict = _query(
+            state,
+            "SELECT * FROM actor_status_events",
+        )
 
         # Verify the schema has the expected columns
         expected_columns = {
@@ -666,12 +727,13 @@ def test_actor_status_events_table() -> None:
             f"Expected at least one actor status event, got {event_count}"
         )
 
-        joined = engine.query(
+        joined = _query(
+            state,
             "SELECT ase.id FROM actor_status_events ase "
             "INNER JOIN actors a ON ase.actor_id = a.id "
-            "WHERE a.display_name LIKE '%status_test_worker%'"
+            "WHERE a.display_name LIKE '%status_test_worker%'",
         )
-        joined_count = len(joined.to_pydict().get("id", []))
+        joined_count = len(joined.get("id", []))
         assert joined_count > 0, (
             "Expected actor_status_events.actor_id to join actors.id for "
             f"status_test_worker, got {joined_count} joined rows"

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import contextlib
 import os
 import pickle
 import socket
@@ -13,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import types
 from dataclasses import dataclass
 from typing import cast, Dict, Optional, Sequence
 from unittest.mock import MagicMock, patch
@@ -118,17 +120,20 @@ class MockJobTrait(JobTrait):
 
     def _state(self) -> JobState:
         """Return a mock job state with fake host meshes."""
-        # Create a mock host mesh for each host name
         mock_hosts: Dict[str, HostMesh] = {}
+
+        class MockHostMesh:
+            def __init__(self, name, python_executable=None):
+                self.name = name
+                self.python_executable = python_executable
+
+            def __repr__(self):
+                return f"MockHostMesh({self.name})"
+
+            def with_python_executable(self, python_executable):
+                return MockHostMesh(self.name, python_executable)
+
         for name in self._host_names:
-            # Using a simple object that mimics HostMesh for testing
-            class MockHostMesh:
-                def __init__(self, name):
-                    self.name = name
-
-                def __repr__(self):
-                    return f"MockHostMesh({self.name})"
-
             mock_hosts[name] = cast("HostMesh", MockHostMesh(name))
 
         return JobState(mock_hosts)
@@ -1004,6 +1009,170 @@ def test_batch_job_shares_component_runtime_with_wrapped_job(mock_start, mock_sp
     assert job_state.admin_url == "http://localhost:1729"
     mock_start.assert_called_once()
     mock_spawn.assert_called_once()
+
+
+@contextlib.contextmanager
+def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
+    with (
+        patch("monarch._src.job.job_components.Telemetry") as telemetry_cls,
+        patch(
+            "monarch._src.job.job_components.install_sidecar_socket_sink"
+        ) as install_sink,
+        patch("monarch._src.job.job_components.QueryEngineClient") as qec_cls,
+        patch("monarch._src.job.job_components.start_telemetry") as start_legacy,
+    ):
+        start_legacy.return_value = (MagicMock(), "http://legacy", MagicMock())
+        ensure_open = telemetry_cls.return_value.ensure_open
+        if ensure_open_side_effect is not None:
+            ensure_open.side_effect = ensure_open_side_effect
+        else:
+            ensure_open.return_value = ensure_open_return or {
+                "telemetry_url": "http://sidecar",
+                "socket_path": "/tmp/telemetry.sock",
+            }
+        yield types.SimpleNamespace(
+            ensure_open=ensure_open,
+            install_sink=install_sink,
+            query_engine_client_cls=qec_cls,
+            start_legacy=start_legacy,
+        )
+
+
+def test_mesh_admin_receives_sidecar_telemetry_url():
+    """Admin links to sidecar telemetry when the sidecar path is configured."""
+    with (
+        _patched_sidecar() as m,
+        patch("monarch._src.job.job_components._spawn_admin") as mock_spawn,
+    ):
+        mock_future = MagicMock()
+        mock_admin_ref = MagicMock()
+        mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
+        mock_spawn.return_value = mock_future
+
+        job = (
+            MockJobTrait(host_names=["hosts"])
+            .enable_telemetry(TelemetryConfig(use_sidecar=True))
+            .enable_admin(MeshAdminConfig())
+        )
+        state = job.state(cached_path=None)
+
+    m.start_legacy.assert_not_called()
+    _, kwargs = mock_spawn.call_args
+    assert kwargs.get("telemetry_url") == "http://sidecar"
+    assert state.telemetry_url == "http://sidecar"
+    assert state.admin_url == "http://localhost:1729"
+
+
+def test_sidecar_replaces_legacy_when_opted_in():
+    """use_sidecar=True exposes the sidecar query client and skips the legacy
+    in-process collector (the two are mutually exclusive)."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)
+
+    # Legacy path skipped; sidecar client exposed instead.
+    m.start_legacy.assert_not_called()
+    assert state.query_engine is None
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
+    assert state.telemetry_url == "http://sidecar"
+    m.query_engine_client_cls.assert_called_once_with("http://sidecar")
+    m.install_sink.assert_called_once_with("/tmp/telemetry.sock")
+
+
+def test_sidecar_bootstrap_then_fanout_carry_host_meshes():
+    """state() bootstraps the sidecar with empty host_meshes, then fans out
+    workers with the materialized host meshes."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        job.state(cached_path=None)
+
+    assert m.ensure_open.call_count == 2
+    bootstrap_kwargs = m.ensure_open.call_args_list[0].kwargs
+    fanout_kwargs = m.ensure_open.call_args_list[1].kwargs
+    assert bootstrap_kwargs["host_meshes"] == {}
+    assert set(fanout_kwargs["host_meshes"].keys()) == {"hosts"}
+
+
+def test_sidecar_worker_fanout_uses_configured_host_meshes():
+    """Worker fan-out should spawn telemetry collectors from the same host
+    mesh configuration that state() returns to user code."""
+    python_exe = "/mnt/app/.venv/bin/python"
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        job._components.mounts._default_python_exe = python_exe
+        state = job.state(cached_path=None)
+
+    fanout_hosts = m.ensure_open.call_args_list[1].kwargs["host_meshes"]
+    assert fanout_hosts["hosts"].python_executable == python_exe
+    assert state.hosts.python_executable == python_exe
+
+
+def test_sidecar_bootstrap_failure_is_isolated():
+    """A sidecar bootstrap failure disables telemetry and never fails state()."""
+    with _patched_sidecar(ensure_open_side_effect=RuntimeError("boom")) as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)  # must not raise
+
+    assert state.query_engine_client is None
+    assert state.query_engine is None  # legacy stays skipped under use_sidecar
+    m.query_engine_client_cls.assert_not_called()
+
+
+def test_sidecar_worker_fanout_failure_is_isolated():
+    """A fan-out failure after a successful bootstrap is swallowed; the client
+    from bootstrap stays exposed."""
+    good = {"telemetry_url": "http://sidecar", "socket_path": "/tmp/telemetry.sock"}
+    with _patched_sidecar(
+        ensure_open_side_effect=[good, RuntimeError("fanout boom")]
+    ) as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)  # must not raise
+
+    assert m.ensure_open.call_count == 2
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
+
+
+def test_sidecar_not_bootstrapped_without_opt_in():
+    """Default (use_sidecar=False) never touches the sidecar; legacy runs."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
+        state = job.state(cached_path=None)
+
+    m.ensure_open.assert_not_called()
+    m.query_engine_client_cls.assert_not_called()
+    assert state.query_engine_client is None
+    m.start_legacy.assert_called_once()  # legacy collector ran instead
+    assert state.query_engine is not None
+
+
+def test_sidecar_query_client_dropped_on_pickle():
+    """The sidecar query client is dropped on pickle and re-bootstrapped on the
+    next state() (mirrors the legacy query_engine behavior)."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)
+        assert state.query_engine_client is m.query_engine_client_cls.return_value
+
+        # __getstate__ drops live handles; the deserialized job is clean.
+        loaded = job_loads(job.dumps())
+        assert loaded._components.telemetry is not None
+        assert loaded._components.telemetry._telemetry_url is None
+
+        # Next state() re-bootstraps the sidecar.
+        state = loaded.state(cached_path=None)
+        assert state.query_engine_client is m.query_engine_client_cls.return_value
 
 
 # Tests for LocalJob implementation

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -17,7 +17,7 @@ import threading
 import urllib.request
 import uuid
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import monarch._src.job.job_sidecar as js
 import monarch._src.job.telemetry_config as tc
@@ -172,7 +172,161 @@ def test_open_or_refresh_raises_when_not_open() -> None:
             handle.open_or_refresh({}, _cfg_dict())
 
 
-# ── Telemetry.ensure_open ─────────────────────────────────────────────────────
+def test_open_or_refresh_spawns_telemetry_actors_once_with_no_active_workers() -> None:
+    sidecar = tc._TelemetryHandle("apply")
+
+    def fake_bootstrap(config) -> None:
+        sidecar._dashboard_info = {"local_url": "http://local", "url": "http://ext"}
+
+    with (
+        patch.object(sidecar, "_bootstrap", side_effect=fake_bootstrap),
+        patch.object(sidecar, "_spawn_telemetry_actors", return_value=[]) as spawn,
+    ):
+        sidecar.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
+        sidecar.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
+
+    spawn.assert_called_once()
+    assert sidecar._worker_proc_meshes == []
+
+
+def test_spawn_telemetry_actors_registers_workers_and_stops_on_shutdown() -> None:
+    """Spawning creates a collector mesh, registers it with the client
+    collector, retains it, and stops its proc mesh on shutdown."""
+    actor_mesh = MagicMock()
+    proc_mesh = MagicMock()
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    sidecar = tc._TelemetryHandle("fanout_test")
+    sidecar._client_actor = client_actor
+
+    proc_mesh.spawn.return_value = actor_mesh
+    host_mesh.spawn_procs.return_value = proc_mesh
+    actor_mesh.activate.call.return_value.get.return_value = [(0, True)]
+
+    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
+    proc_mesh.spawn.assert_called_once_with(
+        "TelemetryActor",
+        tc.TelemetryActor,
+        "fanout_test",
+        0,
+    )
+    actor_mesh.activate.call.return_value.get.assert_called_once_with()
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with(
+        [actor_mesh]
+    )
+    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
+
+    assert worker_proc_meshes == [proc_mesh]
+    sidecar._worker_proc_meshes = worker_proc_meshes
+    with patch.object(tc, "shutdown_context") as shutdown_context:
+        sidecar.shutdown()
+    proc_mesh.stop.assert_called_once_with("telemetry shutdown")
+    proc_mesh.stop.return_value.get.assert_called_once_with()
+    shutdown_context.return_value.get.assert_called_once_with(timeout=5.0)
+
+
+def test_spawn_telemetry_actors_drops_inactive_worker_collectors() -> None:
+    actor_mesh = MagicMock()
+    proc_mesh = MagicMock()
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    sidecar = tc._TelemetryHandle("fanout_test")
+    sidecar._client_actor = client_actor
+
+    proc_mesh.spawn.return_value = actor_mesh
+    host_mesh.spawn_procs.return_value = proc_mesh
+    actor_mesh.activate.call.return_value.get.return_value = [(0, False)]
+
+    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+    )
+
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
+    assert worker_proc_meshes == []
+    proc_mesh.stop.assert_called_once_with("telemetry collector inactive")
+    proc_mesh.stop.return_value.get.assert_called_once_with()
+
+
+def test_spawn_telemetry_actors_noops_when_setup_raises() -> None:
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    sidecar = tc._TelemetryHandle("fanout_test")
+    sidecar._client_actor = client_actor
+
+    host_mesh.spawn_procs.side_effect = RuntimeError("boom")
+
+    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
+    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
+    assert worker_proc_meshes == []
+
+
+@pytest.mark.parametrize("failure_point", ["spawn", "activate"])
+def test_spawn_telemetry_actors_stops_partially_started_proc_mesh(
+    failure_point: str,
+) -> None:
+    actor_mesh = MagicMock()
+    proc_mesh = MagicMock()
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    sidecar = tc._TelemetryHandle("fanout_test")
+    sidecar._client_actor = client_actor
+
+    host_mesh.spawn_procs.return_value = proc_mesh
+    if failure_point == "spawn":
+        proc_mesh.spawn.side_effect = RuntimeError("spawn boom")
+    else:
+        proc_mesh.spawn.return_value = actor_mesh
+        actor_mesh.activate.call.return_value.get.side_effect = RuntimeError(
+            "activate boom"
+        )
+
+    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
+    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
+    assert worker_proc_meshes == []
+    proc_mesh.stop.assert_called_once_with("telemetry collector startup failed")
+    proc_mesh.stop.return_value.get.assert_called_once_with()
 
 
 def test_ensure_open_requires_apply_id() -> None:


### PR DESCRIPTION
Summary:

Add `TelemetryConfig(use_sidecar=True)`, hosting telemetry in the job sidecar through `SidecarTelemetryComponent` rather than in-process.

Non-obvious:
- Sidecar and in-process telemetry are mutually exclusive; selecting one resets and replaces the other in the telemetry component slot.
- Two-phase bootstrap: `before_connect` opens the sidecar and installs the client-process Unix socket sink before raw host meshes materialize, so host-mesh creation events are captured; `connect` then fans worker collectors out across the materialized host meshes.
- The socket sink is reinstalled in future workers via a `SetupActor` startup function, not only in the client process.
- `state` exposes only a `QueryEngineClient` and the telemetry URL; the in-process `query_engine` stays None on the sidecar path.
- Telemetry is best-effort: a bootstrap or fan-out failure logs and disables telemetry for the job instead of failing `state()`, and a partial bootstrap is reset to a clean disabled state.
- `QueryEngineClient` forces a direct connection with an empty `ProxyHandler` because the sidecar listens on loopback, and folds the HTTP error body into the raised reason so server-side query errors stay actionable.
- Inactive worker collectors are dropped and their proc meshes stopped; `worker_collectors` is renamed `worker_collector_meshes` to reflect that the query root fans out to actor meshes.

Differential Revision: D107343038


