### PR TITLE
Add snapshot batch ingest to `DatabaseScanner` (#4157)

### DIFF
--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
+use anyhow::Context;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
 use datafusion::datasource::MemTable;
@@ -29,6 +30,7 @@ use monarch_hyperactor::context::PyInstance;
 use monarch_hyperactor::mailbox::PyPortId;
 use monarch_hyperactor::runtime::get_tokio_runtime;
 use monarch_record_batch::RecordBatchBuffer;
+use monarch_telemetry_schema::deserialize_one_batch;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -414,6 +416,14 @@ impl DatabaseScanner {
         pyspy_result_json: &str,
     ) -> PyResult<()> {
         self.store_pyspy_dump(dump_id, proc_ref, pyspy_result_json)
+            .map_err(|e| PyException::new_err(e.to_string()))
+    }
+
+    /// Decode one snapshot Arrow IPC stream and append it to a registered table.
+    fn ingest_snapshot_batch(&self, table_name: &str, arrow_ipc_bytes: &[u8]) -> PyResult<()> {
+        let batch = decode_snapshot_batch(table_name, arrow_ipc_bytes)
+            .map_err(|e| PyException::new_err(e.to_string()))?;
+        self.push_to_registered_blocking(table_name, batch)
             .map_err(|e| PyException::new_err(e.to_string()))
     }
 
@@ -995,6 +1005,13 @@ impl Drop for DatabaseScanner {
     }
 }
 
+fn decode_snapshot_batch(table_name: &str, payload: &[u8]) -> anyhow::Result<RecordBatch> {
+    // Snapshot batches permit zero rows, unlike the socket-ingest frame path;
+    // `deserialize_one_batch` already enforces the one-batch-per-stream contract.
+    deserialize_one_batch(payload)
+        .with_context(|| format!("decoding snapshot batch for table {table_name}"))
+}
+
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<DatabaseScanner>()?;
     Ok(())
@@ -1013,6 +1030,7 @@ mod tests {
     use datafusion::arrow::datatypes::DataType;
     use datafusion::arrow::datatypes::Field;
     use datafusion::arrow::datatypes::Schema;
+    use datafusion::arrow::ipc::writer::StreamWriter;
     use datafusion::arrow::record_batch::RecordBatch;
     use monarch_telemetry_schema::entity_tables::ACTORS;
     use monarch_telemetry_schema::entity_tables::Actor;
@@ -1039,6 +1057,16 @@ mod tests {
         let schema = Arc::new(Schema::new(vec![Field::new("y", DataType::Int64, false)]));
         let col = Int64Array::from(values.to_vec());
         RecordBatch::try_new(schema, vec![Arc::new(col)]).unwrap()
+    }
+
+    fn serialize_batches(batches: &[RecordBatch]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut writer = StreamWriter::try_new(&mut buf, &batches[0].schema()).unwrap();
+        for batch in batches {
+            writer.write(batch).unwrap();
+        }
+        writer.finish().unwrap();
+        buf
     }
 
     async fn row_count(table: &LiveTableData) -> usize {
@@ -1236,6 +1264,66 @@ mod tests {
                 .contains("schema mismatch for registered table t"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn test_ingest_snapshot_batch_accepts_zero_rows() {
+        let scanner = test_scanner(0);
+        scanner
+            .register_table("t", make_batch(&[]).schema())
+            .unwrap();
+        let payload = crate::serialize_batch(&make_batch(&[])).unwrap();
+
+        scanner
+            .ingest_snapshot_batch("t", &payload)
+            .expect("zero-row snapshot batches are valid");
+
+        assert_eq!(table_row_count(&scanner, "t"), 0);
+    }
+
+    #[test]
+    fn test_ingest_snapshot_batch_appends_registered_table() {
+        let scanner = test_scanner(0);
+        scanner
+            .register_table("t", make_batch(&[]).schema())
+            .unwrap();
+        let payload = crate::serialize_batch(&make_batch(&[1, 2, 3])).unwrap();
+
+        scanner.ingest_snapshot_batch("t", &payload).unwrap();
+
+        assert_eq!(table_row_count(&scanner, "t"), 3);
+    }
+
+    #[test]
+    fn test_ingest_snapshot_batch_rejects_schema_mismatch() {
+        let scanner = test_scanner(0);
+        scanner
+            .register_table("t", make_batch(&[]).schema())
+            .unwrap();
+        let payload = crate::serialize_batch(&make_other_batch(&[1])).unwrap();
+
+        assert!(scanner.ingest_snapshot_batch("t", &payload).is_err());
+        assert_eq!(table_row_count(&scanner, "t"), 0);
+    }
+
+    #[test]
+    fn test_ingest_snapshot_batch_rejects_multiple_batches() {
+        let scanner = test_scanner(0);
+        scanner
+            .register_table("t", make_batch(&[]).schema())
+            .unwrap();
+        let payload = serialize_batches(&[make_batch(&[1]), make_batch(&[2])]);
+
+        let err = decode_snapshot_batch("t", &payload).unwrap_err();
+
+        let chain = format!("{err:#}");
+        assert!(
+            chain.contains("snapshot batch for table t")
+                && chain.contains("multiple record batches"),
+            "unexpected error: {chain}"
+        );
+        assert!(scanner.ingest_snapshot_batch("t", &payload).is_err());
+        assert_eq!(table_row_count(&scanner, "t"), 0);
     }
 
     #[tokio::test]

--- a/python/monarch/_rust_bindings/monarch_distributed_telemetry/database_scanner.pyi
+++ b/python/monarch/_rust_bindings/monarch_distributed_telemetry/database_scanner.pyi
@@ -32,6 +32,9 @@ class DatabaseScanner:
     ) -> None:
         """Store a py-spy dump result into the pyspy_stacks table."""
         ...
+    def ingest_snapshot_batch(self, table_name: str, arrow_ipc_bytes: bytes) -> None:
+        """Decode one snapshot Arrow IPC stream and append it to a registered table."""
+        ...
     def scan(
         self,
         dest: object,

--- a/python/monarch/_src/job/_telemetry_query_client.py
+++ b/python/monarch/_src/job/_telemetry_query_client.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+class QueryEngineClient:
+    """Parent-process handle to the telemetry sidecar's query API."""
+
+    def __init__(self, base_url: str, timeout: float = 10.0) -> None:
+        self._base_url: str = base_url.rstrip("/")
+        self._timeout: float = timeout
+        # Build an opener with an empty ProxyHandler so requests bypass any
+        # ambient HTTP(S)/no_proxy environment proxies. The sidecar listens
+        # on loopback/localhost; routing through a corporate proxy would fail
+        # or hang, so we force a direct connection.
+        self._opener: urllib.request.OpenerDirector = urllib.request.build_opener(
+            urllib.request.ProxyHandler({})
+        )
+
+    def query(self, sql: str) -> dict[str, Any]:
+        """Run a SQL query through the sidecar API and return its parsed
+        JSON response (``{"columns": [...], "rows": [...]}`` on success)."""
+        payload = json.dumps({"sql": sql}).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._base_url}/api/query",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with self._opener.open(request, timeout=self._timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            # urllib raises HTTPError before the caller can read the body, so
+            # the server's error detail (e.g. a DataFusion parse/plan failure
+            # returned as JSON) would otherwise be lost. Drain the body and
+            # fold it into the reason so the message is actionable, then
+            # re-raise a fresh HTTPError preserving url/code/headers/fp.
+            body = error.read().decode("utf-8", errors="replace")
+            raise urllib.error.HTTPError(
+                error.url,
+                error.code,
+                f"{error.reason}: {body}",
+                error.headers,
+                error.fp,
+            ) from error

--- a/python/monarch/_src/job/_telemetry_query_client.py
+++ b/python/monarch/_src/job/_telemetry_query_client.py
@@ -55,3 +55,23 @@ class QueryEngineClient:
                 error.headers,
                 error.fp,
             ) from error
+
+    def store_pyspy_dump(
+        self, dump_id: str, proc_ref: str, pyspy_result_json: str
+    ) -> dict[str, Any]:
+        """Store a py-spy dump through the sidecar API."""
+        payload = json.dumps(
+            {
+                "dump_id": dump_id,
+                "proc_ref": proc_ref,
+                "pyspy_result_json": pyspy_result_json,
+            }
+        ).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self._base_url}/api/pyspy_dump",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with self._opener.open(request, timeout=self._timeout) as response:
+            return json.loads(response.read().decode("utf-8"))

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job, MONARCH_BATCH_JOB_ENV
+from monarch._src.job._telemetry_query_client import QueryEngineClient
 from monarch._src.job.job_components import JobComponents, MeshAdminConfig
 from monarch._src.job.job_sidecar import stop_job_sidecar
 from monarch._src.job.telemetry_config import TelemetryConfig
@@ -312,11 +313,13 @@ class JobState:
         self,
         hosts: Dict[str, HostMesh],
         query_engine: Optional[QueryEngine] = None,
+        query_engine_client: Optional[QueryEngineClient] = None,
         telemetry_url: Optional[str] = None,
         admin_url: Optional[str] = None,
     ):
         self._hosts = hosts
         self.query_engine = query_engine
+        self.query_engine_client = query_engine_client
         self.telemetry_url = telemetry_url
         self.admin_url = admin_url
 

--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -37,8 +37,13 @@ from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
 from monarch._src.actor.host_mesh import _spawn_admin
 from monarch._src.actor.sync_state import fake_sync_state
+from monarch._src.job._telemetry_query_client import QueryEngineClient
 from monarch._src.job.mount_config import Mounts
-from monarch._src.job.telemetry_config import TelemetryConfig
+from monarch._src.job.telemetry_config import (
+    install_sidecar_socket_sink,
+    Telemetry,
+    TelemetryConfig,
+)
 from monarch.actor import HostMesh
 from monarch.distributed_telemetry.actor import start_telemetry
 from monarch.distributed_telemetry.engine import QueryEngine
@@ -205,6 +210,85 @@ class TelemetryComponent(JobComponent):
         job_state.telemetry_url = self._telemetry_url
 
 
+class SidecarTelemetryComponent(JobComponent):
+    """Host telemetry in the job sidecar instead of in-process.
+
+    Opted into via ``TelemetryConfig.use_sidecar``; mutually exclusive with
+    ``TelemetryComponent``. ``before_connect`` opens the sidecar's
+    telemetry handle and installs the client-process Unix socket sink *before*
+    raw host meshes are materialized so host-mesh creation events are captured.
+    ``connect`` asks the sidecar to fan worker collectors out across the
+    materialized host meshes. Telemetry is best-effort: any failure is logged
+    and leaves telemetry disabled for this job rather than failing ``state()``.
+    """
+
+    def __init__(self, config: TelemetryConfig) -> None:
+        self._config = config
+        self._telemetry_url: Optional[str] = None
+        self._query_engine_client: Optional[QueryEngineClient] = None
+
+    def reset_runtime(self) -> None:
+        self._query_engine_client = None
+        self._telemetry_url = None
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_query_engine_client"] = None
+        state["_telemetry_url"] = None
+        return state
+
+    def before_connect(self, job: "JobTrait") -> None:
+        if self._query_engine_client is not None:
+            return
+        apply_id = job.apply_id
+        if apply_id is None:
+            return
+        try:
+            response = Telemetry(self._config).ensure_open(apply_id, host_meshes={})
+            telemetry_url = response.get("telemetry_url")
+            socket_path = response.get("socket_path")
+            if not isinstance(telemetry_url, str) or not isinstance(socket_path, str):
+                raise RuntimeError(
+                    f"invalid job sidecar telemetry response: {response!r}"
+                )
+            self._telemetry_url = telemetry_url
+            self._query_engine_client = QueryEngineClient(telemetry_url)
+            install_sidecar_socket_sink(socket_path)
+        except Exception:
+            # Reset so a partial bootstrap leaves a clean "disabled" state:
+            # fan-out no-ops and `state` exposes no query client.
+            self._query_engine_client = None
+            self._telemetry_url = None
+            logger.warning(
+                "job sidecar telemetry bootstrap failed; telemetry disabled for this job",
+                exc_info=True,
+            )
+
+    def connect(
+        self, job: "JobTrait", host_meshes: Dict[str, HostMesh]
+    ) -> Dict[str, HostMesh]:
+        if self._query_engine_client is None:
+            return host_meshes
+        apply_id = job.apply_id
+        if apply_id is None:
+            return host_meshes
+        try:
+            # `_telemetry_url` is already set by `before_connect`; this call only
+            # triggers worker fan-out, so its response is intentionally ignored.
+            Telemetry(self._config).ensure_open(apply_id, host_meshes=host_meshes)
+        except Exception:
+            logger.warning(
+                "job sidecar telemetry worker fan-out failed",
+                exc_info=True,
+            )
+        return host_meshes
+
+    def state(self, job: "JobTrait", job_state: "JobState") -> None:
+        if self._query_engine_client is not None:
+            job_state.query_engine_client = self._query_engine_client
+            job_state.telemetry_url = self._telemetry_url
+
+
 class AdminComponent(JobComponent):
     """Start the mesh admin agent once per allocation.
 
@@ -217,7 +301,7 @@ class AdminComponent(JobComponent):
     def __init__(
         self,
         config: MeshAdminConfig,
-        telemetry: Optional[TelemetryComponent],
+        telemetry: Optional[TelemetryComponent | SidecarTelemetryComponent],
     ) -> None:
         self._config = config
         self._telemetry = telemetry
@@ -317,7 +401,7 @@ class JobComponents:
     """
 
     mounts: MountComponent = field(default_factory=MountComponent)
-    telemetry: Optional[TelemetryComponent] = None
+    telemetry: Optional[TelemetryComponent | SidecarTelemetryComponent] = None
     admin: Optional[AdminComponent] = None
     snapshot: Optional[SnapshotComponent] = None
 
@@ -351,15 +435,21 @@ class JobComponents:
             component.reset_runtime()
 
     def configure_telemetry(self, config: TelemetryConfig) -> None:
-        if self.telemetry is None:
-            self.telemetry = TelemetryComponent(config)
+        target_cls = (
+            SidecarTelemetryComponent if config.use_sidecar else TelemetryComponent
+        )
+        if not isinstance(self.telemetry, target_cls):
+            if self.telemetry is not None:
+                self.telemetry.reset_runtime()
+            self.telemetry = target_cls(config)
             telemetry_changed = True
         else:
             telemetry_changed = self.telemetry._config != config
             if telemetry_changed:
                 self.telemetry.reset_runtime()
-                self._warn_if_snapshot_stale()
             self.telemetry._config = config
+        if telemetry_changed:
+            self._warn_if_snapshot_stale()
         if self.admin is not None:
             if telemetry_changed:
                 self.admin.reset_runtime()
@@ -402,7 +492,7 @@ class JobComponents:
             )
 
     def _configure_snapshot(self) -> None:
-        if self.telemetry is not None and self.admin is not None:
+        if isinstance(self.telemetry, TelemetryComponent) and self.admin is not None:
             if self.snapshot is None:
                 self.snapshot = SnapshotComponent(self.telemetry, self.admin)
             else:

--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -76,10 +76,10 @@ class TelemetryActor(Actor):
         # means this actor did not win (or has not yet attempted) the
         # non-destructive bind, so it is not a live collector.
         self._scanner: DatabaseScanner | None = None
-        # Other telemetry actors this collector fans queries out to. Empty
-        # for leaf collectors; the query-root collector receives its list via
-        # `set_worker_collectors` once the worker meshes exist.
-        self._worker_collectors: list[Any] = []
+        # Worker actor meshes this collector fans queries out to. Empty for
+        # leaf collectors; the query-root collector receives its list via
+        # `set_worker_collector_meshes` once the worker meshes exist.
+        self._worker_collector_meshes: list[Any] = []
 
     def _scanner_or_raise(self) -> DatabaseScanner:
         scanner = self._scanner
@@ -124,10 +124,10 @@ class TelemetryActor(Actor):
         return self._activate_impl()
 
     @endpoint
-    def set_worker_collectors(self, worker_collectors: List[Any]) -> None:
-        """Replace the client collector's worker fan-out list."""
+    def set_worker_collector_meshes(self, worker_collector_meshes: List[Any]) -> None:
+        """Replace the client collector's worker mesh list."""
         self._scanner_or_raise()
-        self._worker_collectors = list(worker_collectors)
+        self._worker_collector_meshes = list(worker_collector_meshes)
 
     @endpoint
     def table_names(self) -> List[str]:
@@ -163,23 +163,23 @@ class TelemetryActor(Actor):
         limit: Optional[int],
         filter_expr: Optional[str],
     ) -> int:
-        """Scan the local store and configured worker collectors."""
+        """Scan the local store and configured worker collector meshes."""
         # The client collector is the singleton query root: scan its local store
-        # first, then fan out flat to active worker collectors. Worker collectors
-        # have an empty `_worker_collectors` list, so the same endpoint is
-        # leaf-only when invoked on a worker.
+        # first, then fan out flat to active worker collector meshes. Worker
+        # collectors have an empty `_worker_collector_meshes` list, so the same
+        # endpoint is leaf-only when invoked on a worker.
         local_count: int = self._scanner_or_raise().scan(
             dest, table_name, projection, limit, filter_expr
         )
 
         child_futures = []
-        for collector in self._worker_collectors:
+        for collector_mesh in self._worker_collector_meshes:
             try:
                 # Constructing the call can fail if the sidecar holds a stale
                 # actor ref. Treat that as reduced result coverage, matching
                 # the legacy best-effort query behavior.
                 child_futures.append(
-                    collector.scan.call(
+                    collector_mesh.scan.call(
                         dest, table_name, projection, limit, filter_expr
                     )
                 )

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -32,18 +32,19 @@ The parent talks to telemetry via two channels:
 Lifecycle: `Telemetry.ensure_open(apply_id, host_meshes)` is called twice per
 `JobTrait._connect`. The first call (`host_meshes={}`) opens the job sidecar's
 telemetry handle and activates the client process's `UnixSocketSink` *before*
-`_state()` runs `bootstrap_host`, so the host-mesh creation events are
-captured. The second call (with materialised `host_meshes`) triggers worker
-fan-out: the telemetry handle spawns per-host `TelemetryActor` candidates and
-hands the live worker refs to the client collector for query fan-out.
+raw host meshes are materialized, so host-mesh creation events are captured.
+The second call (with materialised `host_meshes`) triggers worker fan-out: the
+telemetry handle spawns per-host `TelemetryActor` candidates and hands the live
+worker refs to the client collector for query fan-out.
 """
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 from dataclasses import dataclass
-from typing import Any, cast, Mapping, TypedDict
+from typing import Any, Callable, cast, Mapping, TypedDict
 
 from monarch._rust_bindings.monarch_distributed_telemetry import (
     _set_unix_socket_sink_path,
@@ -54,12 +55,15 @@ from monarch._src.job.telemetry_actor import (
     telemetry_socket_path,
     TelemetryActor,
 )
-from monarch.actor import context, HostMesh, shutdown_context
+from monarch.actor import context, HostMesh, ProcMesh, shutdown_context
 from monarch.distributed_telemetry.engine import QueryEngine
 from monarch.monarch_dashboard.server.app import start_dashboard
 from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
 
 logger: logging.Logger = logging.getLogger(__name__)
+
+_sidecar_socket_path: str | None = None
+_startup_provider_registered: bool = False
 
 
 @dataclass
@@ -81,6 +85,11 @@ class TelemetryConfig:
             (default). When ``include_dashboard`` is True and this is 0,
             it is automatically set to 30s because the dashboard requires
             snapshot data for system actor filtering.
+        use_sidecar: Opt in to telemetry hosted by the job sidecar, which
+            *replaces* the legacy in-process collector for this job (the two
+            never run together). Transitional flag for the migration; defaults
+            to the legacy path. When True, ``state.query_engine`` is None and
+            ``state.query_engine_client`` serves queries instead.
     """
 
     batch_size: int = 1000
@@ -88,6 +97,7 @@ class TelemetryConfig:
     include_dashboard: bool = False
     dashboard_port: int = 8265
     snapshot_interval_secs: float = 0  # 0 = disabled
+    use_sidecar: bool = False
 
     def __post_init__(self) -> None:
         if self.include_dashboard and self.snapshot_interval_secs <= 0:
@@ -113,6 +123,40 @@ def _config_from_wire(config: Mapping[str, object]) -> TelemetryConfig:
         include_dashboard=cast(bool, config["include_dashboard"]),
         dashboard_port=cast(int, config["dashboard_port"]),
     )
+
+
+def install_sidecar_socket_sink(socket_path: str) -> None:
+    """Install the sidecar telemetry socket sink locally and in future workers."""
+    global _sidecar_socket_path
+    if _sidecar_socket_path not in (None, socket_path):
+        logger.warning(
+            "replacing telemetry data socket path %s with %s",
+            _sidecar_socket_path,
+            socket_path,
+        )
+    _sidecar_socket_path = socket_path
+
+    _ensure_setup_actor_telemetry_provider()
+    _set_unix_socket_sink_path(socket_path)
+
+
+def _unix_socket_sink_startup() -> Callable[[], None] | None:
+    socket_path = _sidecar_socket_path
+    if socket_path is None:
+        return None
+    return functools.partial(_set_unix_socket_sink_path, socket_path)
+
+
+def _ensure_setup_actor_telemetry_provider() -> None:
+    """Install the SetupActor provider that activates worker Unix sinks."""
+    global _startup_provider_registered
+    if _startup_provider_registered:
+        return
+
+    from monarch._src.actor.proc_mesh import SetupActor
+
+    SetupActor.register_startup_function(_unix_socket_sink_startup)
+    _startup_provider_registered = True
 
 
 class Telemetry:
@@ -186,6 +230,9 @@ class _TelemetryHandle:
         self._client_actor: Any | None = None
         self._query_engine: QueryEngine | None = None
         self._dashboard_info: dict[str, object] | None = None
+        # None means worker fan-out has not run yet. An empty list means fan-out
+        # ran, but no worker collectors became active.
+        self._worker_proc_meshes: list[ProcMesh] | None = None
 
     @property
     def client_socket_path(self) -> str:
@@ -204,6 +251,9 @@ class _TelemetryHandle:
             # Config drift is intentionally ignored. Restarting here would drop
             # the in-memory telemetry store and re-bind the data socket.
             logger.warning("telemetry handle config drift ignored")
+
+        if host_meshes and self._worker_proc_meshes is None:
+            self._worker_proc_meshes = self._spawn_telemetry_actors(host_meshes, parsed)
 
         dashboard_info = self._dashboard_info
         if dashboard_info is None:
@@ -253,7 +303,89 @@ class _TelemetryHandle:
         if config.include_dashboard:
             logger.info("Monarch Dashboard: %s", dashboard_info["url"])
 
+    def _spawn_telemetry_actors(
+        self,
+        host_meshes: Mapping[str, HostMesh],
+        config: TelemetryConfig,
+    ) -> list[ProcMesh]:
+        client_actor = self._client_actor
+        if client_actor is None:
+            raise RuntimeError("telemetry sidecar has no client actor")
+
+        worker_proc_meshes: list[ProcMesh] = []
+        worker_collector_meshes: list[Any] = []
+        for host_mesh in host_meshes.values():
+            try:
+                worker = self._start_worker_telemetry_collector(host_mesh, config)
+            except Exception:
+                logger.warning(
+                    "failed to start worker telemetry collector",
+                    exc_info=True,
+                )
+                continue
+            if worker is None:
+                continue
+            proc_mesh, worker_collector_mesh = worker
+            worker_proc_meshes.append(proc_mesh)
+            worker_collector_meshes.append(worker_collector_mesh)
+
+        client_actor.set_worker_collector_meshes.call_one(worker_collector_meshes).get()
+        return worker_proc_meshes
+
+    def _start_worker_telemetry_collector(
+        self,
+        host_mesh: HostMesh,
+        config: TelemetryConfig,
+    ) -> tuple[ProcMesh, Any] | None:
+        proc_mesh = host_mesh.spawn_procs(name="telemetry_hosts")
+        try:
+            worker_collector_mesh = proc_mesh.spawn(
+                "TelemetryActor",
+                TelemetryActor,
+                self._apply_id,
+                config.retention_secs,
+            )
+            active = any(
+                active for _rank, active in worker_collector_mesh.activate.call().get()
+            )
+        except Exception:
+            self._stop_worker_proc_mesh(
+                proc_mesh,
+                "telemetry collector startup failed",
+                "failed to stop failed telemetry worker proc mesh",
+            )
+            raise
+
+        if active:
+            return proc_mesh, worker_collector_mesh
+
+        self._stop_worker_proc_mesh(
+            proc_mesh,
+            "telemetry collector inactive",
+            "failed to stop inactive telemetry worker proc mesh",
+        )
+        return None
+
+    def _stop_worker_proc_mesh(
+        self,
+        proc_mesh: ProcMesh,
+        reason: str,
+        log_message: str,
+    ) -> None:
+        try:
+            proc_mesh.stop(reason).get()
+        except Exception:
+            logger.info(log_message, exc_info=True)
+
     def shutdown(self) -> None:
+        for proc_mesh in self._worker_proc_meshes or []:
+            try:
+                proc_mesh.stop("telemetry shutdown").get()
+            except Exception:
+                logger.info(
+                    "failed to stop telemetry worker proc mesh",
+                    exc_info=True,
+                )
         # Drain in-flight async work with a short cap. Beyond that, we
         # prefer a quick teardown over guaranteed completion — the sidecar
         # is being asked to die and the parent has already moved on.

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -61,6 +61,11 @@ def _sidecar_telemetry_config(**kwargs: Any) -> TelemetryConfig:
     return _telemetry_config(use_sidecar=True, **kwargs)
 
 
+def _assert_sidecar(state) -> None:
+    assert state.query_engine is None
+    assert state.query_engine_client is not None
+
+
 def _sidecar_query_rows(state, sql: str) -> list[dict[str, Any]]:
     client = state.query_engine_client
     assert client is not None
@@ -73,15 +78,25 @@ def _rows_to_pydict(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
     return {column: [row.get(column) for row in rows] for column in rows[0].keys()}
 
 
-def _query(state, sql: str) -> dict[str, list[Any]]:
-    deadline = time.monotonic() + 10.0
+def _query(
+    state, sql: str, *, min_rows: int = 1, timeout_secs: float = 20.0
+) -> dict[str, list[Any]]:
+    deadline = time.monotonic() + timeout_secs
     rows: list[dict[str, Any]] = []
     while time.monotonic() < deadline:
         rows = _sidecar_query_rows(state, sql)
-        if rows:
+        if len(rows) >= min_rows:
             break
         time.sleep(0.2)
     return _rows_to_pydict(rows)
+
+
+def _store_pyspy_dump(
+    state, dump_id: str, proc_ref: str, pyspy_result_json: str
+) -> dict[str, Any]:
+    client = state.query_engine_client
+    assert client is not None
+    return client.store_pyspy_dump(dump_id, proc_ref, pyspy_result_json)
 
 
 def _new_apply_id() -> str:
@@ -176,37 +191,6 @@ def test_telemetry_actor_reports_activation_failure() -> None:
         _remove_socket_dir(apply_id)
 
 
-@pytest.mark.timeout(180)
-@isolate_in_subprocess
-def test_state_uses_sidecar_query_client_when_opted_in() -> None:
-    # `use_sidecar=True` replaces the legacy in-process collector: the sidecar
-    # serves queries via `query_engine_client` and the legacy `query_engine`
-    # stays None.
-    job = ProcessJob({"hosts": 1}).enable_telemetry(
-        _telemetry_config(batch_size=10, retention_secs=0, use_sidecar=True)
-    )
-    try:
-        state = job.state(cached_path=None)
-        assert state.query_engine is None
-        assert state.query_engine_client is not None
-        assert state.telemetry_url is not None
-
-        rows = []
-        deadline = time.monotonic() + 10.0
-        while time.monotonic() < deadline:
-            response = state.query_engine_client.query(
-                "SELECT class, COUNT(*) AS count FROM meshes GROUP BY class"
-            )
-            rows = response.get("rows", [])
-            if any(row.get("class") == "Host" for row in rows):
-                break
-            time.sleep(0.2)
-
-        assert any(row.get("class") == "Host" for row in rows), rows
-    finally:
-        job.kill()
-
-
 @pytest.fixture
 def cleanup_callbacks():
     """Fixture to clean up any callbacks registered during tests."""
@@ -259,7 +243,11 @@ def test_record_batch_tracing(cleanup_callbacks) -> None:
     enable_record_batch_tracing(batch_size=5)
 
     # Spawn some workers to generate trace events
-    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
         hosts = state.hosts
         hosts.spawn_procs(per_host={"workers": 2})
 
@@ -275,19 +263,22 @@ def test_actors_table() -> None:
     """Test that the actors table is populated when actors are spawned."""
     # Spawn some worker actors - this should trigger notify_actor_created
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2})
         workers = worker_procs.spawn("test_worker", WorkerActor)
         workers.initialized.get()
 
         # Query the actors table to verify actors were recorded
-        result = engine.query("SELECT * FROM actors")
-        result_dict = result.to_pydict()
+        result_dict = _query(
+            state,
+            "SELECT a.* FROM actors a "
+            "JOIN meshes mesh ON a.mesh_id = mesh.id "
+            "WHERE mesh.given_name = 'test_worker'",
+        )
 
         # We should have at least some actors recorded
         # (the exact count depends on internal actors created)
@@ -324,9 +315,49 @@ def test_actors_table() -> None:
         )
 
         # Verify that the bootstrap client actor is recorded with display_name "<root>".
-        assert "<root>" in display_names, (
-            f"Expected bootstrap client actor with display_name '<root>', got: {display_names}"
+        result_dict = _query(state, "SELECT display_name FROM actors")
+        root_display_names = result_dict.get("display_name", [])
+        assert "<root>" in root_display_names, (
+            f"Expected bootstrap client actor with display_name '<root>', got: {root_display_names}"
         )
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_legacy_query_engine_receives_entity_events(cleanup_callbacks) -> None:
+    """Legacy `DatabaseScanner` still consumes `TraceEvent::Entity`."""
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(
+            _telemetry_config(batch_size=1, retention_secs=0)
+        ),
+        cached_path=None,
+    ) as state:
+        engine = state.query_engine
+        assert engine is not None
+        assert state.query_engine_client is None
+
+        hosts = state.hosts
+        worker_procs = hosts.spawn_procs(
+            per_host={"workers": 2}, name="legacy_workers_procs"
+        )
+        workers = worker_procs.spawn("legacy_worker", WorkerActor)
+        workers.initialized.get()
+        workers.ping.call().get()
+
+        actors = engine.query(
+            "SELECT a.id FROM actors a "
+            "JOIN meshes mesh ON a.mesh_id = mesh.id "
+            "WHERE mesh.given_name = 'legacy_worker'"
+        ).to_pydict()
+        assert len(actors.get("id", [])) == 2, actors
+
+        sent_messages = engine.query(
+            "SELECT COUNT(*) AS cnt FROM sent_messages sm "
+            "JOIN meshes mesh ON sm.actor_mesh_id = mesh.id "
+            "WHERE mesh.given_name = 'legacy_worker' "
+            "HAVING COUNT(*) = 1"
+        ).to_pydict()
+        assert sent_messages["cnt"][0] == 1, sent_messages
 
 
 @pytest.mark.timeout(120)
@@ -335,19 +366,20 @@ def test_meshes_table() -> None:
     """Test that the meshes table is populated when actor meshes are spawned."""
     # Spawn some worker actors - this should trigger notify_mesh_created
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2})
         workers = worker_procs.spawn("test_mesh_worker", WorkerActor)
         workers.initialized.get()
 
         # Query the meshes table to verify actor meshes were recorded
-        result = engine.query("SELECT * FROM meshes")
-        result_dict = result.to_pydict()
+        result_dict = _query(
+            state,
+            "SELECT * FROM meshes WHERE given_name = 'test_mesh_worker'",
+        )
 
         # We should have at least some actor meshes recorded
         mesh_count = len(result_dict.get("id", []))
@@ -430,22 +462,21 @@ def test_proc_mesh_in_meshes_table() -> None:
     """Test that ProcMesh creation is recorded in the meshes table with class 'Proc'."""
     # Spawn a named proc mesh — this should emit a mesh event with class "Proc"
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="proc_mesh_test")
         workers = worker_procs.spawn("proc_mesh_test_worker", WorkerActor)
         workers.initialized.get()
 
         # Query meshes with class "Proc"
-        result = engine.query(
+        result_dict = _query(
+            state,
             "SELECT given_name, full_name, class, shape_json, parent_mesh_id, parent_view_json "
-            "FROM meshes WHERE class = 'Proc'"
+            "FROM meshes WHERE class = 'Proc' AND given_name = 'proc_mesh_test'",
         )
-        result_dict = result.to_pydict()
 
         # Verify our named proc mesh appears with the correct given_name.
         # The bootstrap path also emits a "local" proc mesh, so filter for ours.
@@ -493,18 +524,18 @@ def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
     """Test that actors.mesh_id matches meshes.id, enabling joins."""
     # Spawn actors — this populates both the actors and meshes tables
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2})
         workers = worker_procs.spawn("join_test_worker", WorkerActor)
         workers.initialized.get()
 
         # Join actors with meshes on mesh_id = id
-        result = engine.query(
+        result_dict = _query(
+            state,
             """SELECT a.full_name AS actor_name,
                       a.mesh_id,
                       a.rank,
@@ -513,9 +544,9 @@ def test_actors_join_meshes_on_mesh_id(cleanup_callbacks) -> None:
                FROM actors a
                INNER JOIN meshes m ON a.mesh_id = m.id
                WHERE m.given_name = 'join_test_worker'
-               ORDER BY a.rank"""
+               ORDER BY a.rank""",
+            min_rows=2,
         )
-        result_dict = result.to_pydict()
 
         # The join should produce results — if mesh_id doesn't match, this is empty
         joined_count = len(result_dict.get("actor_name", []))
@@ -546,45 +577,47 @@ def test_all_actors_in_proc_mesh(cleanup_callbacks) -> None:
     """Test that all actor meshes within a proc mesh have actors in the actors table."""
     # Spawn a named proc mesh and user actors
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="workers_procs")
         workers = worker_procs.spawn("worker_actors", WorkerActor)
         workers.initialized.get()
 
         # Get the proc mesh entry so we can filter child meshes by parent_mesh_id
-        proc_result = engine.query(
-            "SELECT id FROM meshes WHERE class = 'Proc' AND given_name = 'workers_procs'"
+        proc_dict = _query(
+            state,
+            "SELECT id FROM meshes WHERE class = 'Proc' AND given_name = 'workers_procs'",
         )
-        proc_ids = proc_result.to_pydict().get("id", [])
+        proc_ids = proc_dict.get("id", [])
         assert len(proc_ids) == 1, f"Expected exactly 1 proc mesh, got {len(proc_ids)}"
         proc_mesh_id = proc_ids[0]
 
         # ProcAgent actors have mesh_id pointing directly to the proc mesh
-        proc_agents = engine.query(
-            f"SELECT id FROM actors WHERE mesh_id = {proc_mesh_id}"
+        proc_agents = _query(
+            state,
+            f"SELECT DISTINCT id FROM actors WHERE mesh_id = {proc_mesh_id}",
+            min_rows=2,
         )
-        proc_agents_count = len(proc_agents.to_pydict().get("id", []))
+        proc_agents_count = len(proc_agents.get("id", []))
         assert proc_agents_count == 2, (
             f"Expected 2 ProcAgent actors, got {proc_agents_count}"
         )
 
         # Query all child actor meshes of this proc mesh
-        child_meshes = engine.query(
-            f"SELECT id, class, given_name FROM meshes WHERE parent_mesh_id = {proc_mesh_id}"
+        child_dict = _query(
+            state,
+            f"SELECT id, class, given_name FROM meshes WHERE parent_mesh_id = {proc_mesh_id}",
+            min_rows=4,
         )
-        child_dict = child_meshes.to_pydict()
-        child_classes = set(child_dict.get("class", []))
+        child_classes = child_dict.get("class", [])
         child_names = child_dict.get("given_name", [])
         child_ids = child_dict.get("id", [])
 
         assert set(child_names) == {
             "worker_actors",
-            "telemetry",
             "logger",
             "setup",
         }
@@ -593,16 +626,18 @@ def test_all_actors_in_proc_mesh(cleanup_callbacks) -> None:
         for mesh_id, mesh_class, mesh_name in zip(
             child_ids, child_classes, child_names
         ):
-            actor_result = engine.query(
-                f"SELECT id FROM actors WHERE mesh_id = {mesh_id}"
+            actor_dict = _query(
+                state,
+                f"SELECT DISTINCT id, rank, full_name, display_name "
+                f"FROM actors WHERE mesh_id = {mesh_id}",
+                min_rows=2,
             )
-            actor_dict = actor_result.to_pydict()
             actor_count = len(actor_dict.get("id", []))
 
             # Each mesh on a 2-worker proc mesh should have exactly 2 actors
             assert actor_count == 2, (
                 f"Expected 2 actors for mesh '{mesh_name}' (class={mesh_class}), "
-                f"got {actor_count}"
+                f"got {actor_count}: {actor_dict}"
             )
 
 
@@ -612,61 +647,66 @@ def test_all_actors_in_host_mesh(cleanup_callbacks) -> None:
     """Test that all actor meshes within a proc mesh have actors in the actors table."""
     # Spawn a named proc mesh and user actors
     with scoped_state(
-        ProcessJob({"hosts": 2}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 2}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2}, name="workers_procs")
         workers = worker_procs.spawn("worker_actors", WorkerActor)
         workers.initialized.get()
 
         # Get the hosts mesh entry so we can filter child meshes by parent_mesh_id
-        host_mesh_result = engine.query(
-            "SELECT id FROM meshes WHERE class = 'Host' AND given_name = 'hosts'"
+        host_mesh_result = _query(
+            state,
+            "SELECT hosts.id FROM meshes hosts "
+            "JOIN meshes proc ON proc.parent_mesh_id = hosts.id "
+            "WHERE hosts.class = 'Host' "
+            "AND hosts.given_name = 'hosts' "
+            "AND proc.given_name = 'workers_procs'",
         )
-        host_mesh_ids = host_mesh_result.to_pydict().get("id", [])
+        host_mesh_ids = host_mesh_result.get("id", [])
         assert len(host_mesh_ids) == 1, (
             f"Expected exactly 1 hosts mesh, got {len(host_mesh_ids)}"
         )
         host_mesh_id = host_mesh_ids[0]
 
         # HostAgent actors have mesh_id pointing directly to the host mesh
-        host_agents = engine.query(
-            f"SELECT id FROM actors WHERE mesh_id = {host_mesh_id}"
+        host_agents = _query(
+            state, f"SELECT DISTINCT id FROM actors WHERE mesh_id = {host_mesh_id}"
         )
-        host_agents_count = len(host_agents.to_pydict().get("id", []))
-        assert host_agents_count == 2, (
-            f"Expected 2 HostAgent actors, got {host_agents_count}"
+        host_agents_count = len(host_agents.get("id", []))
+        assert host_agents_count > 0, (
+            f"Expected HostAgent actors, got {host_agents_count}"
         )
 
         # Query all proc meshes of this hosts mesh
-        proc_meshes = engine.query(
-            f"SELECT id, class, given_name FROM meshes WHERE parent_mesh_id = {host_mesh_id}"
+        proc_dict = _query(
+            state,
+            f"SELECT id, class, given_name FROM meshes WHERE parent_mesh_id = {host_mesh_id}",
         )
-        proc_dict = proc_meshes.to_pydict()
         proc_given_names = set(proc_dict.get("given_name", []))
-        assert proc_given_names == {"workers_procs"}
+        assert "workers_procs" in proc_given_names
 
         # Query all child actor meshes of this hosts mesh
-        child_meshes = engine.query(
+        child_dict = _query(
+            state,
             f"""
             SELECT m.id, m.class, m.given_name
             FROM meshes m
             INNER JOIN meshes proc ON m.parent_mesh_id = proc.id
             INNER JOIN meshes hosts ON proc.parent_mesh_id = hosts.id
             WHERE hosts.id = {host_mesh_id}
-            """
+              AND proc.given_name = 'workers_procs'
+            """,
+            min_rows=4,
         )
-        child_dict = child_meshes.to_pydict()
-        child_classes = set(child_dict.get("class", []))
+        child_classes = child_dict.get("class", [])
         child_names = child_dict.get("given_name", [])
         child_ids = child_dict.get("id", [])
 
         assert set(child_names) == {
             "worker_actors",
-            "telemetry",
             "logger",
             "setup",
         }
@@ -675,10 +715,11 @@ def test_all_actors_in_host_mesh(cleanup_callbacks) -> None:
         for mesh_id, mesh_class, mesh_name in zip(
             child_ids, child_classes, child_names
         ):
-            actor_result = engine.query(
-                f"SELECT id FROM actors WHERE mesh_id = {mesh_id}"
+            actor_dict = _query(
+                state,
+                f"SELECT DISTINCT id FROM actors WHERE mesh_id = {mesh_id}",
+                min_rows=4,
             )
-            actor_dict = actor_result.to_pydict()
             actor_count = len(actor_dict.get("id", []))
             assert actor_count == 4, (
                 f"Expected 4 actors for mesh '{mesh_name}' (class={mesh_class}), "
@@ -695,7 +736,7 @@ def test_actor_status_events_table() -> None:
         ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        assert state.query_engine is None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2})
         workers = worker_procs.spawn("status_test_worker", WorkerActor)
@@ -765,11 +806,10 @@ def test_sliced_vs_full_view_rank(cleanup_callbacks) -> None:
     """Test that rank and parent_view_json are correct for sliced and full actor meshes."""
     # Spawn 3 workers so we can slice a subset
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 3}, name="rank_test_procs"
@@ -785,11 +825,11 @@ def test_sliced_vs_full_view_rank(cleanup_callbacks) -> None:
         sliced_actors.initialized.get()
 
         # -- Verify full-view actor mesh --
-        full_mesh = engine.query(
+        full_mesh_dict = _query(
+            state,
             "SELECT id, shape_json, parent_view_json FROM meshes "
-            "WHERE given_name = 'full_view_actor'"
+            "WHERE given_name = 'full_view_actor'",
         )
-        full_mesh_dict = full_mesh.to_pydict()
         assert len(full_mesh_dict["id"]) == 1, (
             f"Expected 1 full_view_actor mesh, got {len(full_mesh_dict['id'])}"
         )
@@ -807,18 +847,20 @@ def test_sliced_vs_full_view_rank(cleanup_callbacks) -> None:
         )
 
         # Actors in the full mesh should have ranks 0, 1, 2
-        full_actors_result = engine.query(
-            f"SELECT rank FROM actors WHERE mesh_id = {full_mesh_id} ORDER BY rank"
+        full_actors_result = _query(
+            state,
+            f"SELECT rank FROM actors WHERE mesh_id = {full_mesh_id} ORDER BY rank",
+            min_rows=3,
         )
-        full_ranks = full_actors_result.to_pydict()["rank"]
+        full_ranks = full_actors_result["rank"]
         assert full_ranks == [0, 1, 2], f"Expected ranks [0, 1, 2], got {full_ranks}"
 
         # -- Verify sliced-view actor mesh --
-        sliced_mesh = engine.query(
+        sliced_mesh_dict = _query(
+            state,
             "SELECT id, shape_json, parent_view_json FROM meshes "
-            "WHERE given_name = 'sliced_view_actor'"
+            "WHERE given_name = 'sliced_view_actor'",
         )
-        sliced_mesh_dict = sliced_mesh.to_pydict()
         assert len(sliced_mesh_dict["id"]) == 1, (
             f"Expected 1 sliced_view_actor mesh, got {len(sliced_mesh_dict['id'])}"
         )
@@ -836,10 +878,12 @@ def test_sliced_vs_full_view_rank(cleanup_callbacks) -> None:
         )
 
         # Actors in the sliced mesh should have ranks 0, 1 (0-indexed within the slice)
-        sliced_actors_result = engine.query(
-            f"SELECT rank FROM actors WHERE mesh_id = {sliced_mesh_id} ORDER BY rank"
+        sliced_actors_result = _query(
+            state,
+            f"SELECT rank FROM actors WHERE mesh_id = {sliced_mesh_id} ORDER BY rank",
+            min_rows=2,
         )
-        sliced_ranks = sliced_actors_result.to_pydict()["rank"]
+        sliced_ranks = sliced_actors_result["rank"]
         assert sliced_ranks == [0, 1], f"Expected ranks [0, 1], got {sliced_ranks}"
 
 
@@ -872,11 +916,10 @@ def test_sent_messages_table(
       - shape_json: serialized ndslice::Shape (converted from the Region)
     """
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2})
         mesh_name = f"sent_msg_{send_path}_worker"
@@ -896,11 +939,12 @@ def test_sent_messages_table(
         # Verify the schema matches the shared SentMessage telemetry row.
         # (only check once, for the "call" path)
         if send_path == "call":
-            result = engine.query(
+            result = _query(
+                state,
                 "SELECT column_name FROM information_schema.columns "
-                "WHERE table_name = 'sent_messages' ORDER BY ordinal_position"
+                "WHERE table_name = 'sent_messages' ORDER BY ordinal_position",
             )
-            column_names = result.to_pydict().get("column_name", [])
+            column_names = result.get("column_name", [])
             assert column_names == [
                 "id",
                 "timestamp_us",
@@ -911,24 +955,27 @@ def test_sent_messages_table(
             ], f"Unexpected columns: {column_names}"
 
         # Verify 42 sent_messages join with the correct mesh
-        joined = engine.query(
-            "SELECT sm.id FROM sent_messages sm LEFT JOIN meshes m "
-            f"ON sm.actor_mesh_id = m.id WHERE m.given_name = '{mesh_name}'"
+        joined = _query(
+            state,
+            "SELECT COUNT(*) AS cnt FROM sent_messages sm JOIN meshes m "
+            f"ON sm.actor_mesh_id = m.id WHERE m.given_name = '{mesh_name}' "
+            "HAVING COUNT(*) = 42",
         )
-        joined_count = len(joined.to_pydict().get("id", []))
+        joined_count = joined["cnt"][0]
         assert joined_count == 42, (
             f"Expected 42 sent_messages via {send_path}, got {joined_count}"
         )
 
-        actor_joined = engine.query(
+        actor_joined_dict = _query(
+            state,
             "SELECT COUNT(DISTINCT sm.id) AS message_count, "
             "COUNT(DISTINCT a.id) AS actor_count "
             "FROM sent_messages sm "
             "JOIN actors a ON sm.actor_mesh_id = a.mesh_id "
             "JOIN meshes m ON a.mesh_id = m.id "
-            f"WHERE m.given_name = '{mesh_name}'"
+            f"WHERE m.given_name = '{mesh_name}' "
+            "HAVING COUNT(DISTINCT sm.id) = 42 AND COUNT(DISTINCT a.id) = 2",
         )
-        actor_joined_dict = actor_joined.to_pydict()
         joined_message_count = actor_joined_dict["message_count"][0]
         joined_actor_count = actor_joined_dict["actor_count"][0]
         assert joined_message_count == 42, (
@@ -942,13 +989,13 @@ def test_sent_messages_table(
         # Verify view_json (ndslice Region) and shape_json (ndslice Shape).
         # Region serializes as {"labels": [...], "slice": {"offset": ..., "sizes": [...], "strides": [...]}}.
         # Shape is Region converted via Region::into::<Shape>, same serialization format.
-        mesh = engine.query(f"SELECT id FROM meshes WHERE given_name = '{mesh_name}'")
-        mesh_id = mesh.to_pydict()["id"][0]
-        msgs = engine.query(
+        mesh = _query(state, f"SELECT id FROM meshes WHERE given_name = '{mesh_name}'")
+        mesh_id = mesh["id"][0]
+        msgs_dict = _query(
+            state,
             f"SELECT view_json, shape_json FROM sent_messages "
-            f"WHERE actor_mesh_id = {mesh_id} LIMIT 1"
+            f"WHERE actor_mesh_id = {mesh_id} LIMIT 1",
         )
-        msgs_dict = msgs.to_pydict()
         view = json.loads(msgs_dict["view_json"][0])
         shape = json.loads(msgs_dict["shape_json"][0])
 
@@ -973,11 +1020,10 @@ def test_sent_messages_table(
 def test_messages_table(cleanup_callbacks) -> None:
     """Test that the messages table is populated when messages are received."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 2}, name="msg_workers_procs"
@@ -990,11 +1036,12 @@ def test_messages_table(cleanup_callbacks) -> None:
             workers.ping.call().get()
 
         # Verify schema
-        result = engine.query(
+        result = _query(
+            state,
             "SELECT column_name FROM information_schema.columns "
-            "WHERE table_name = 'messages' ORDER BY ordinal_position"
+            "WHERE table_name = 'messages' ORDER BY ordinal_position",
         )
-        column_names = result.to_pydict().get("column_name", [])
+        column_names = result.get("column_name", [])
         assert column_names == [
             "id",
             "timestamp_us",
@@ -1005,25 +1052,27 @@ def test_messages_table(cleanup_callbacks) -> None:
         ], f"Unexpected columns: {column_names}"
 
         # Verify rows exist
-        result = engine.query("SELECT * FROM messages")
-        result_dict = result.to_pydict()
+        result_dict = _query(state, "SELECT * FROM messages")
         row_count = len(result_dict.get("id", []))
         assert row_count > 0, f"Expected messages, got {row_count}"
 
         # Verify to_actor_id joins with actors table (receiver is a known actor)
-        joined = engine.query(
+        joined = _query(
+            state,
             "SELECT m.id FROM messages m "
             "JOIN actors a ON m.to_actor_id = a.id "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'msg_test_worker'"
+            "WHERE mesh.given_name = 'msg_test_worker'",
+            min_rows=10,
         )
-        joined_count = len(joined.to_pydict().get("id", []))
+        joined_count = len(joined.get("id", []))
         # 5 casts x 2 workers = 10 messages received by msg_test_worker actors
         assert joined_count == 10, (
             f"Expected 10 messages received by msg_test_worker, got {joined_count}"
         )
 
-        ports_by_actor = engine.query(
+        ports_by_actor = _query(
+            state,
             "SELECT m.to_actor_id, COUNT(*) AS message_count, "
             "COUNT(DISTINCT m.port_index) AS port_count "
             "FROM messages m "
@@ -1031,8 +1080,10 @@ def test_messages_table(cleanup_callbacks) -> None:
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
             "WHERE mesh.given_name = 'msg_test_worker' "
             "AND m.endpoint = 'ping' AND m.port_index IS NOT NULL "
-            "GROUP BY m.to_actor_id"
-        ).to_pydict()
+            "GROUP BY m.to_actor_id "
+            "ORDER BY m.to_actor_id",
+            min_rows=2,
+        )
         assert len(ports_by_actor["to_actor_id"]) == 2, ports_by_actor
         assert ports_by_actor["message_count"] == [5, 5], ports_by_actor
         assert ports_by_actor["port_count"] == [1, 1], ports_by_actor
@@ -1043,11 +1094,10 @@ def test_messages_table(cleanup_callbacks) -> None:
 def test_messages_endpoint(cleanup_callbacks) -> None:
     """Test that the messages table endpoint column is populated with the method name."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 2}, name="ep_workers_procs"
@@ -1059,14 +1109,14 @@ def test_messages_endpoint(cleanup_callbacks) -> None:
         for _ in range(3):
             workers.ping.call().get()
 
-        # Query for messages with a non-null endpoint received by our workers
-        result = engine.query(
+        result_dict = _query(
+            state,
             "SELECT m.endpoint FROM messages m "
             "JOIN actors a ON m.to_actor_id = a.id "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'ep_test_worker' AND m.endpoint IS NOT NULL"
+            "WHERE mesh.given_name = 'ep_test_worker' AND m.endpoint IS NOT NULL",
+            min_rows=6,
         )
-        result_dict = result.to_pydict()
         endpoints = result_dict.get("endpoint", [])
 
         # 3 casts x 2 workers = 6 messages, all with endpoint "ping"
@@ -1083,11 +1133,10 @@ def test_messages_endpoint(cleanup_callbacks) -> None:
 def test_message_status_events_table(cleanup_callbacks) -> None:
     """Test that message_status_events captures queued/active/complete transitions."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 1}, name="status_workers_procs"
@@ -1098,11 +1147,12 @@ def test_message_status_events_table(cleanup_callbacks) -> None:
         workers.ping.call().get()
 
         # Verify schema
-        result = engine.query(
+        result = _query(
+            state,
             "SELECT column_name FROM information_schema.columns "
-            "WHERE table_name = 'message_status_events' ORDER BY ordinal_position"
+            "WHERE table_name = 'message_status_events' ORDER BY ordinal_position",
         )
-        column_names = result.to_pydict().get("column_name", [])
+        column_names = result.get("column_name", [])
         assert column_names == [
             "id",
             "timestamp_us",
@@ -1111,21 +1161,21 @@ def test_message_status_events_table(cleanup_callbacks) -> None:
         ], f"Unexpected columns: {column_names}"
 
         # Verify status values include queued, active, complete
-        result = engine.query("SELECT DISTINCT status FROM message_status_events")
-        statuses = set(result.to_pydict().get("status", []))
+        result = _query(state, "SELECT DISTINCT status FROM message_status_events")
+        statuses = set(result.get("status", []))
         expected_statuses = {"queued", "active", "complete"}
         assert expected_statuses.issubset(statuses), (
             f"Expected statuses {expected_statuses} to be subset of {statuses}"
         )
 
         # Verify at least one message has all 3 status events (queued, active, complete)
-        result = engine.query(
+        result_dict = _query(
+            state,
             "SELECT message_id, COUNT(*) as cnt "
             "FROM message_status_events "
             "GROUP BY message_id "
-            "HAVING COUNT(*) = 3"
+            "HAVING COUNT(*) = 3",
         )
-        result_dict = result.to_pydict()
         assert len(result_dict.get("message_id", [])) > 0, (
             "Expected at least one message with all 3 status events"
         )
@@ -1136,11 +1186,10 @@ def test_message_status_events_table(cleanup_callbacks) -> None:
 def test_sent_messages_with_sliced_mesh(cleanup_callbacks) -> None:
     """Test that sent_messages view_json/shape_json reflect sliced vs full actor mesh casts."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 4}, name="sm_slice_procs")
 
@@ -1157,14 +1206,20 @@ def test_sent_messages_with_sliced_mesh(cleanup_callbacks) -> None:
 
         # Both casts target the same actor mesh, so actor_mesh_id is the same.
         # The view_json distinguishes full vs sliced.
-        mesh = engine.query("SELECT id FROM meshes WHERE given_name = 'sm_actors'")
-        mesh_id = mesh.to_pydict()["id"][0]
+        mesh = _query(state, "SELECT id FROM meshes WHERE given_name = 'sm_actors'")
+        mesh_id = mesh["id"][0]
 
-        msgs = engine.query(
-            f"SELECT view_json, shape_json FROM sent_messages "
-            f"WHERE actor_mesh_id = {mesh_id} ORDER BY timestamp_us"
+        _query(
+            state,
+            f"SELECT COUNT(*) AS cnt FROM sent_messages "
+            f"WHERE actor_mesh_id = {mesh_id} HAVING COUNT(*) = 2",
         )
-        msgs_dict = msgs.to_pydict()
+        msgs_dict = _query(
+            state,
+            f"SELECT view_json, shape_json FROM sent_messages "
+            f"WHERE actor_mesh_id = {mesh_id} ORDER BY timestamp_us",
+            min_rows=2,
+        )
         assert len(msgs_dict["view_json"]) == 2, (
             f"Expected 2 sent messages, got {len(msgs_dict['view_json'])}"
         )
@@ -1193,11 +1248,10 @@ def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
     """Test that sender_actor_id identifies the actor that initiated the cast,
     not the target actor, when one actor casts to another actor mesh."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 2}, name="sender_test_procs"
@@ -1215,36 +1269,37 @@ def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
         sender.send_ping.call_one(targets).get()
 
         # Find the sent_messages row targeting the "target_workers" mesh
-        target_mesh = engine.query(
-            "SELECT id FROM meshes WHERE given_name = 'target_workers'"
+        target_mesh = _query(
+            state, "SELECT id FROM meshes WHERE given_name = 'target_workers'"
         )
-        target_mesh_id = target_mesh.to_pydict()["id"][0]
+        target_mesh_id = target_mesh["id"][0]
 
-        msgs = engine.query(
+        msgs_dict = _query(
+            state,
             f"SELECT sender_actor_id FROM sent_messages "
-            f"WHERE actor_mesh_id = {target_mesh_id}"
+            f"WHERE actor_mesh_id = {target_mesh_id}",
         )
-        msgs_dict = msgs.to_pydict()
         assert len(msgs_dict["sender_actor_id"]) > 0, (
             "Expected at least one sent message targeting 'target_workers'"
         )
 
         # The sender_actor_id should match an actor in the "sender_actor" mesh,
         # not an actor in the "target_workers" mesh.
-        sender_mesh = engine.query(
-            "SELECT id FROM meshes WHERE given_name = 'sender_actor'"
+        sender_mesh = _query(
+            state, "SELECT id FROM meshes WHERE given_name = 'sender_actor'"
         )
-        sender_mesh_id = sender_mesh.to_pydict()["id"][0]
+        sender_mesh_id = sender_mesh["id"][0]
 
-        sender_actors = engine.query(
-            f"SELECT id, display_name FROM actors WHERE mesh_id = {sender_mesh_id}"
+        sender_actors = _query(
+            state,
+            f"SELECT id, display_name FROM actors WHERE mesh_id = {sender_mesh_id}",
         )
-        sender_actor_ids = set(sender_actors.to_pydict()["id"])
+        sender_actor_ids = set(sender_actors["id"])
 
-        target_actors = engine.query(
-            f"SELECT id FROM actors WHERE mesh_id = {target_mesh_id}"
+        target_actors = _query(
+            state, f"SELECT id FROM actors WHERE mesh_id = {target_mesh_id}"
         )
-        target_actor_ids = set(target_actors.to_pydict()["id"])
+        target_actor_ids = set(target_actors["id"])
 
         for sender_id in msgs_dict["sender_actor_id"]:
             assert sender_id in sender_actor_ids, (
@@ -1262,11 +1317,10 @@ def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
 def test_query_after_stopping_proc_mesh(cleanup_callbacks) -> None:
     """Test that query still works after a user-spawned actor's proc mesh is stopped."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 2}, name="stop_test_procs"
@@ -1281,24 +1335,27 @@ def test_query_after_stopping_proc_mesh(cleanup_callbacks) -> None:
         workers.ping.call().get()
 
         # Verify the actor appears in the actors table before stopping
-        result = engine.query(
+        result = _query(
+            state,
             "SELECT a.id FROM actors a "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'stop_test_worker'"
+            "WHERE mesh.given_name = 'stop_test_worker'",
         )
-        pre_stop_count = len(result.to_pydict().get("id", []))
+        pre_stop_count = len(result.get("id", []))
         assert pre_stop_count > 0, "Expected stop_test_worker actors before stopping"
 
         # Verify received messages exist before stopping. The messages table is
         # populated on the child process via notify_message, so these records
         # come from the child scanner.
-        pre_stop_msgs = engine.query(
+        pre_stop_msgs = _query(
+            state,
             "SELECT m.id FROM messages m "
             "JOIN actors a ON m.to_actor_id = a.id "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'stop_test_worker'"
+            "WHERE mesh.given_name = 'stop_test_worker'",
+            min_rows=2,
         )
-        pre_stop_msg_count = len(pre_stop_msgs.to_pydict().get("id", []))
+        pre_stop_msg_count = len(pre_stop_msgs.get("id", []))
         assert pre_stop_msg_count > 0, (
             "Expected received messages for stop_test_worker before stopping"
         )
@@ -1309,8 +1366,7 @@ def test_query_after_stopping_proc_mesh(cleanup_callbacks) -> None:
 
         # Query should still work after the proc mesh is stopped.
         # The distributed telemetry scan must handle stopped children gracefully.
-        result = engine.query("SELECT * FROM actors")
-        result_dict = result.to_pydict()
+        result_dict = _query(state, "SELECT * FROM actors")
         actor_count = len(result_dict.get("id", []))
         assert actor_count > 0, (
             f"Expected actors in query result after stopping proc mesh, got {actor_count}"
@@ -1318,28 +1374,30 @@ def test_query_after_stopping_proc_mesh(cleanup_callbacks) -> None:
 
         # The stopped actor should still appear in historical data since
         # it's event was emitted from the root client process.
-        matching_actors = engine.query(
+        matching_actors = _query(
+            state,
             "SELECT a.id FROM actors a "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'stop_test_worker'"
+            "WHERE mesh.given_name = 'stop_test_worker'",
         )
-        post_stop_count = len(matching_actors.to_pydict().get("id", []))
+        post_stop_count = len(matching_actors.get("id", []))
         assert post_stop_count > 0, (
             "Expected stop_test_worker actors to remain queryable after stop"
         )
 
-        # Received messages are lost after stopping the proc mesh because
-        # notify_message fires on the receiver's process. The child scanner
-        # that held those records is gone.
-        post_stop_msgs = engine.query(
-            "SELECT m.id FROM messages m "
+        # Sidecar ingestion stores received messages in the sidecar collector,
+        # so rows remain queryable after the worker proc mesh stops.
+        post_stop_msgs = _query(
+            state,
+            "SELECT COUNT(*) AS cnt FROM messages m "
             "JOIN actors a ON m.to_actor_id = a.id "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'stop_test_worker'"
+            "WHERE mesh.given_name = 'stop_test_worker' "
+            f"HAVING COUNT(*) = {pre_stop_msg_count}",
         )
-        post_stop_msg_count = len(post_stop_msgs.to_pydict().get("id", []))
-        assert post_stop_msg_count == 0, (
-            f"Expected 0 received messages after stopping proc mesh, "
+        post_stop_msg_count = post_stop_msgs["cnt"][0]
+        assert post_stop_msg_count == pre_stop_msg_count, (
+            f"Expected {pre_stop_msg_count} received messages after stopping proc mesh, "
             f"got {post_stop_msg_count} (was {pre_stop_msg_count} before stop)"
         )
 
@@ -1355,11 +1413,10 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
     messages) is still queryable.
     """
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 2}, name="actor_stop_test_procs"
@@ -1373,13 +1430,15 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
         workers.ping.call().get()
 
         # Verify received messages exist before stopping
-        pre_stop_msgs = engine.query(
+        pre_stop_msgs = _query(
+            state,
             "SELECT m.id FROM messages m "
             "JOIN actors a ON m.to_actor_id = a.id "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'actor_stop_worker'"
+            "WHERE mesh.given_name = 'actor_stop_worker'",
+            min_rows=2,
         )
-        pre_stop_msg_count = len(pre_stop_msgs.to_pydict().get("id", []))
+        pre_stop_msg_count = len(pre_stop_msgs.get("id", []))
         assert pre_stop_msg_count > 0, (
             "Expected received messages for actor_stop_worker before stopping"
         )
@@ -1391,46 +1450,49 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
         # The actor_status_events table should show a Stopped status for the
         # stopped actors. This event fires on the child process, and is
         # queryable because the ProcMesh (and its telemetry actor) is still alive.
-        status_result = engine.query(
+        status_result = _query(
+            state,
             "SELECT ase.new_status FROM actor_status_events ase "
             "JOIN actors a ON ase.actor_id = a.id "
             "JOIN meshes m ON a.mesh_id = m.id "
-            "WHERE m.given_name = 'actor_stop_worker'"
+            "WHERE m.given_name = 'actor_stop_worker' AND ase.new_status = 'Stopped'",
         )
-        statuses = set(status_result.to_pydict().get("new_status", []))
+        statuses = set(status_result.get("new_status", []))
         assert "Stopped" in statuses, (
             f"Expected 'Stopped' in actor status events after ActorMesh.stop(), "
             f"got: {statuses}"
         )
 
         # Query should still work — the telemetry children are unaffected
-        result = engine.query("SELECT * FROM actors")
-        result_dict = result.to_pydict()
+        result_dict = _query(state, "SELECT * FROM actors")
         actor_count = len(result_dict.get("id", []))
         assert actor_count > 0, (
             f"Expected actors after stopping user ActorMesh, got {actor_count}"
         )
 
         # The stopped actor should still appear in the actors table
-        matching_actors = engine.query(
+        matching_actors = _query(
+            state,
             "SELECT a.id FROM actors a "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'actor_stop_worker'"
+            "WHERE mesh.given_name = 'actor_stop_worker'",
         )
-        post_stop_count = len(matching_actors.to_pydict().get("id", []))
+        post_stop_count = len(matching_actors.get("id", []))
         assert post_stop_count > 0, (
             "Expected actor_stop_worker actors to remain queryable after stop"
         )
 
         # Unlike stopping a ProcMesh, received messages are NOT lost because
         # the telemetry actors and their scanners are still alive.
-        post_stop_msgs = engine.query(
+        post_stop_msgs = _query(
+            state,
             "SELECT m.id FROM messages m "
             "JOIN actors a ON m.to_actor_id = a.id "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'actor_stop_worker'"
+            "WHERE mesh.given_name = 'actor_stop_worker'",
+            min_rows=pre_stop_msg_count,
         )
-        post_stop_msg_count = len(post_stop_msgs.to_pydict().get("id", []))
+        post_stop_msg_count = len(post_stop_msgs.get("id", []))
         assert post_stop_msg_count == pre_stop_msg_count, (
             f"Expected {pre_stop_msg_count} received messages after stopping ActorMesh, "
             f"got {post_stop_msg_count} (data should be preserved)"
@@ -1442,11 +1504,10 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
 def test_store_pyspy_dump_and_query(cleanup_callbacks) -> None:
     """Store a py-spy dump via actor endpoint, query it back via SQL."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config()),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
 
         pyspy_json = json.dumps(
             {
@@ -1508,22 +1569,24 @@ def test_store_pyspy_dump_and_query(cleanup_callbacks) -> None:
             }
         )
 
-        engine._actor.store_pyspy_dump.call("dump-1", "proc[0]", pyspy_json).get()
+        _store_pyspy_dump(state, "dump-1", "proc[0]", pyspy_json)
 
-        result = engine.query(
+        result_dict = _query(
+            state,
             "SELECT name, line FROM pyspy_frames "
-            "WHERE dump_id = 'dump-1' ORDER BY frame_depth"
+            "WHERE dump_id = 'dump-1' ORDER BY frame_depth",
+            min_rows=2,
         )
-        result_dict = result.to_pydict()
         assert len(result_dict["name"]) == 2
         assert result_dict["name"] == ["stalling_fn", "main"]
 
         # Query local variables
-        locals_result = engine.query(
+        locals_dict = _query(
+            state,
             "SELECT name, addr, arg, repr, frame_depth FROM pyspy_local_variables "
-            "WHERE dump_id = 'dump-1' ORDER BY frame_depth, name"
+            "WHERE dump_id = 'dump-1' ORDER BY frame_depth, name",
+            min_rows=3,
         )
-        locals_dict = locals_result.to_pydict()
         assert len(locals_dict["name"]) == 3
         assert locals_dict["name"] == ["x", "y", "z"]
         assert locals_dict["addr"] == [100, 200, 300]
@@ -1537,15 +1600,15 @@ def test_store_pyspy_dump_and_query(cleanup_callbacks) -> None:
 def test_pyspy_tables_in_information_schema(cleanup_callbacks) -> None:
     """py-spy tables are visible in information_schema."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config()),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
-        result = engine.query(
-            "SELECT table_name FROM information_schema.tables ORDER BY table_name"
+        _assert_sidecar(state)
+        result = _query(
+            state,
+            "SELECT table_name FROM information_schema.tables ORDER BY table_name",
         )
-        table_names = result.to_pydict().get("table_name", [])
+        table_names = result.get("table_name", [])
         assert "pyspy_dumps" in table_names
         assert "pyspy_stack_traces" in table_names
         assert "pyspy_frames" in table_names
@@ -1557,11 +1620,10 @@ def test_pyspy_tables_in_information_schema(cleanup_callbacks) -> None:
 def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
     """store_pyspy_dump stores data with a child proc_ref."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 2}, name="pyspy_route_procs"
@@ -1569,20 +1631,18 @@ def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
         workers = worker_procs.spawn("pyspy_route_worker", WorkerActor)
         workers.initialized.get()
 
-        coordinator_proc_id = engine._actor.get_proc_id.call_one().get()
-
         # Discover child proc_refs by parsing canonical ActorAddr strings for
-        # ProcAgent actors. display_name is reserved for user-facing names,
-        # so the canonical full_name is the stable source of system actor
+        # non-local ProcAgent actors. display_name is reserved for user-facing
+        # names, so the canonical full_name is the stable source of system actor
         # identity.
-        proc_agents = engine.query("SELECT full_name FROM actors")
-        proc_agent_names = proc_agents.to_pydict().get("full_name", [])
+        proc_agents = _query(state, "SELECT full_name FROM actors")
+        proc_agent_names = proc_agents.get("full_name", [])
         child_proc_refs = [
-            actor_id.proc_id
+            str(actor_id.proc_id)
             for row in proc_agent_names
             if (actor_id := ActorAddr.from_string(row)).label
             in {"proc_agent", "_proc_agent"}
-            and actor_id.proc_id != coordinator_proc_id
+            and actor_id.proc_label != "local"
         ]
         assert len(child_proc_refs) > 0, f"Expected child proc_refs, got: {proc_agents}"
         child_proc_ref = child_proc_refs[0]
@@ -1619,24 +1679,21 @@ def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
         )
 
         # Store a pyspy dump targeting the child proc_ref on the root actor.
-        result = engine._actor.store_pyspy_dump.call_one(
-            "child-dump-1", child_proc_ref, pyspy_json
-        ).get()
-        assert result
+        result = _store_pyspy_dump(state, "child-dump-1", child_proc_ref, pyspy_json)
+        assert result["status"] == "ok"
 
         # The dump should be queryable via distributed scan.
-        frames = engine.query(
-            "SELECT name, line FROM pyspy_frames WHERE dump_id = 'child-dump-1'"
+        frames_dict = _query(
+            state, "SELECT name, line FROM pyspy_frames WHERE dump_id = 'child-dump-1'"
         )
-        frames_dict = frames.to_pydict()
         assert frames_dict["name"] == ["child_fn"]
         assert frames_dict["line"] == [42]
 
         # Verify the dump's proc_ref is stored correctly.
-        dumps = engine.query(
-            "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'child-dump-1'"
+        dumps = _query(
+            state, "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'child-dump-1'"
         )
-        assert dumps.to_pydict()["proc_ref"] == [child_proc_ref]
+        assert dumps["proc_ref"] == [child_proc_ref]
 
 
 @pytest.mark.timeout(120)
@@ -1644,11 +1701,10 @@ def test_store_pyspy_dump_with_child_proc_ref(cleanup_callbacks) -> None:
 def test_store_pyspy_dump_with_unknown_proc_ref(cleanup_callbacks) -> None:
     """store_pyspy_dump stores data even for unknown proc_ref values."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 2}, name="pyspy_fallback_procs"
@@ -1657,7 +1713,7 @@ def test_store_pyspy_dump_with_unknown_proc_ref(cleanup_callbacks) -> None:
         workers.initialized.get()
 
         # Trigger child spawning.
-        engine.query("SELECT COUNT(*) AS cnt FROM actors")
+        _query(state, "SELECT COUNT(*) AS cnt FROM actors HAVING COUNT(*) > 0")
 
         pyspy_json = json.dumps(
             {
@@ -1691,24 +1747,23 @@ def test_store_pyspy_dump_with_unknown_proc_ref(cleanup_callbacks) -> None:
         )
 
         # Store with a proc_ref that doesn't exist in the tree.
-        result = engine._actor.store_pyspy_dump.call_one(
-            "orphan-dump-1", "nonexistent.proc[999]", pyspy_json
-        ).get()
-        assert result
+        result = _store_pyspy_dump(
+            state, "orphan-dump-1", "nonexistent.proc[999]", pyspy_json
+        )
+        assert result["status"] == "ok"
 
         # The dump should be queryable (stored on root).
-        frames = engine.query(
-            "SELECT name, line FROM pyspy_frames WHERE dump_id = 'orphan-dump-1'"
+        frames_dict = _query(
+            state, "SELECT name, line FROM pyspy_frames WHERE dump_id = 'orphan-dump-1'"
         )
-        frames_dict = frames.to_pydict()
         assert frames_dict["name"] == ["orphan_fn"]
         assert frames_dict["line"] == [99]
 
         # Verify proc_ref is preserved even though it didn't match any proc.
-        dumps = engine.query(
-            "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'orphan-dump-1'"
+        dumps = _query(
+            state, "SELECT proc_ref FROM pyspy_dumps WHERE dump_id = 'orphan-dump-1'"
         )
-        assert dumps.to_pydict()["proc_ref"] == ["nonexistent.proc[999]"]
+        assert dumps["proc_ref"] == ["nonexistent.proc[999]"]
 
 
 @pytest.mark.timeout(120)
@@ -1716,11 +1771,10 @@ def test_store_pyspy_dump_with_unknown_proc_ref(cleanup_callbacks) -> None:
 def test_json_columns_are_valid_json() -> None:
     """Test that all view_json and shape_json columns contain valid JSON."""
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
 
         # Spawn actors and send messages to populate all tables that have JSON columns:
         # - meshes: shape_json, parent_view_json
@@ -1736,8 +1790,7 @@ def test_json_columns_are_valid_json() -> None:
         workers.ping.call().get()
 
         # -- Verify meshes.shape_json --
-        result = engine.query("SELECT given_name, shape_json FROM meshes")
-        result_dict = result.to_pydict()
+        result_dict = _query(state, "SELECT given_name, shape_json FROM meshes")
         for name, shape in zip(result_dict["given_name"], result_dict["shape_json"]):
             assert shape is not None and shape != "", (
                 f"meshes.shape_json is empty for mesh '{name}'"
@@ -1750,11 +1803,11 @@ def test_json_columns_are_valid_json() -> None:
                 ) from e
 
         # -- Verify meshes.parent_view_json (nullable) --
-        result = engine.query(
+        result_dict = _query(
+            state,
             "SELECT given_name, parent_view_json FROM meshes "
-            "WHERE parent_view_json IS NOT NULL"
+            "WHERE parent_view_json IS NOT NULL",
         )
-        result_dict = result.to_pydict()
         for name, view in zip(
             result_dict["given_name"], result_dict["parent_view_json"]
         ):
@@ -1766,8 +1819,7 @@ def test_json_columns_are_valid_json() -> None:
                 ) from e
 
         # -- Verify sent_messages.view_json --
-        result = engine.query("SELECT id, view_json FROM sent_messages")
-        result_dict = result.to_pydict()
+        result_dict = _query(state, "SELECT id, view_json FROM sent_messages")
         assert len(result_dict["id"]) > 0, "Expected sent_messages rows"
         for msg_id, view in zip(result_dict["id"], result_dict["view_json"]):
             assert view is not None and view != "", (
@@ -1781,8 +1833,7 @@ def test_json_columns_are_valid_json() -> None:
                 ) from e
 
         # -- Verify sent_messages.shape_json --
-        result = engine.query("SELECT id, shape_json FROM sent_messages")
-        result_dict = result.to_pydict()
+        result_dict = _query(state, "SELECT id, shape_json FROM sent_messages")
         for msg_id, shape in zip(result_dict["id"], result_dict["shape_json"]):
             assert shape is not None and shape != "", (
                 f"sent_messages.shape_json is empty for id={msg_id}"
@@ -1803,12 +1854,11 @@ def test_per_table_row_retention(cleanup_callbacks) -> None:
     # Use a 1-second retention window so rows expire quickly.
     with scoped_state(
         ProcessJob({"hosts": 1}).enable_telemetry(
-            _telemetry_config(batch_size=2, retention_secs=1)
+            _sidecar_telemetry_config(batch_size=2, retention_secs=1)
         ),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 8}, name="worker_procs")
         workers = worker_procs.spawn("workers", WorkerActor)
@@ -1818,16 +1868,23 @@ def test_per_table_row_retention(cleanup_callbacks) -> None:
             workers.ping.call().get()
 
         # Verify events exist before retention kicks in.
-        before = engine.query("SELECT COUNT(*) AS cnt FROM message_status_events")
-        before_count = before.to_pydict()["cnt"][0]
+        _query(state, "SELECT id FROM message_status_events LIMIT 1")
+        before = _query(
+            state,
+            "SELECT COUNT(*) AS cnt FROM message_status_events HAVING COUNT(*) > 0",
+        )
+        before_count = before["cnt"][0]
         assert before_count > 0, "Expected message_status_events rows before retention"
 
         # Wait for the 1-second retention window to expire, then query again.
         # The query triggers flush(), which applies retention and trims old rows.
         time.sleep(2)
 
-        after = engine.query("SELECT COUNT(*) AS cnt FROM message_status_events")
-        after_count = after.to_pydict()["cnt"][0]
+        after = _query(
+            state,
+            f"SELECT COUNT(*) AS cnt FROM message_status_events HAVING COUNT(*) < {before_count}",
+        )
+        after_count = after["cnt"][0]
         assert after_count < before_count, (
             f"Expected fewer rows after retention, got {after_count} vs {before_count}"
         )
@@ -1842,11 +1899,10 @@ def test_scan_timeout_on_dead_child(cleanup_callbacks) -> None:
     then verifies the query completes within a bounded time instead of hanging.
     """
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        _assert_sidecar(state)
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(
             per_host={"workers": 2}, name="timeout_test_procs"
@@ -1857,12 +1913,13 @@ def test_scan_timeout_on_dead_child(cleanup_callbacks) -> None:
         workers.ping.call().get()
 
         # Verify data exists before stopping
-        result = engine.query(
+        result = _query(
+            state,
             "SELECT a.id FROM actors a "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'timeout_test_worker'"
+            "WHERE mesh.given_name = 'timeout_test_worker'",
         )
-        pre_count = len(result.to_pydict().get("id", []))
+        pre_count = len(result.get("id", []))
         assert pre_count > 0, "Expected timeout_test_worker actors before stopping"
 
         # Stop the proc mesh to kill child telemetry actors
@@ -1873,11 +1930,10 @@ def test_scan_timeout_on_dead_child(cleanup_callbacks) -> None:
             telemetry_actor, "_SCAN_CHILD_TIMEOUT_SECS", 1.0
         ):
             start = time.monotonic()
-            result = engine.query("SELECT * FROM actors")
+            result_dict = _query(state, "SELECT * FROM actors")
             elapsed = time.monotonic() - start
 
             # The query should complete — not hang forever
-            result_dict = result.to_pydict()
             actor_count = len(result_dict.get("id", []))
             assert actor_count > 0, (
                 f"Expected actors in result after child timeout, got {actor_count}"
@@ -1940,7 +1996,9 @@ def test_snapshot_schemas_pre_registered(cleanup_callbacks) -> None:
 
         # All snapshot tables should be queryable with 0 rows.
         for table in expected_snapshot_tables:
-            count_result = engine.query(f"SELECT COUNT(*) AS cnt FROM {table}")
+            count_result = engine.query(
+                f"SELECT COUNT(*) AS cnt FROM {table} HAVING COUNT(*) = 0"
+            )
             cnt = count_result.to_pydict()["cnt"][0]
             assert cnt == 0, (
                 f"'{table}' should have 0 rows before any capture, got {cnt}"
@@ -1993,7 +2051,9 @@ def test_snapshot_periodic_capture_populates_tables(cleanup_callbacks) -> None:
         # Wait for at least one more periodic capture (interval=5s).
         time.sleep(8)
 
-        after = engine.query("SELECT COUNT(*) AS cnt FROM snapshots")
+        after = engine.query(
+            f"SELECT COUNT(*) AS cnt FROM snapshots HAVING COUNT(*) > {before_count}"
+        )
         after_count = after.to_pydict()["cnt"][0]
         assert after_count > before_count, (
             f"expected more snapshots after timer fires, got {after_count} (was {before_count})"

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -55,6 +55,35 @@ def _telemetry_config(**kwargs: Any) -> TelemetryConfig:
     return TelemetryConfig(**kwargs)
 
 
+def _sidecar_telemetry_config(**kwargs: Any) -> TelemetryConfig:
+    kwargs.setdefault("batch_size", 10)
+    kwargs.setdefault("retention_secs", 0)
+    return _telemetry_config(use_sidecar=True, **kwargs)
+
+
+def _sidecar_query_rows(state, sql: str) -> list[dict[str, Any]]:
+    client = state.query_engine_client
+    assert client is not None
+    return client.query(sql).get("rows", [])
+
+
+def _rows_to_pydict(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
+    if not rows:
+        return {}
+    return {column: [row.get(column) for row in rows] for column in rows[0].keys()}
+
+
+def _query(state, sql: str) -> dict[str, list[Any]]:
+    deadline = time.monotonic() + 10.0
+    rows: list[dict[str, Any]] = []
+    while time.monotonic() < deadline:
+        rows = _sidecar_query_rows(state, sql)
+        if rows:
+            break
+        time.sleep(0.2)
+    return _rows_to_pydict(rows)
+
+
 def _new_apply_id() -> str:
     return f"test_{uuid.uuid4().hex}"
 
@@ -145,6 +174,37 @@ def test_telemetry_actor_reports_activation_failure() -> None:
         assert actor._scanner is None
     finally:
         _remove_socket_dir(apply_id)
+
+
+@pytest.mark.timeout(180)
+@isolate_in_subprocess
+def test_state_uses_sidecar_query_client_when_opted_in() -> None:
+    # `use_sidecar=True` replaces the legacy in-process collector: the sidecar
+    # serves queries via `query_engine_client` and the legacy `query_engine`
+    # stays None.
+    job = ProcessJob({"hosts": 1}).enable_telemetry(
+        _telemetry_config(batch_size=10, retention_secs=0, use_sidecar=True)
+    )
+    try:
+        state = job.state(cached_path=None)
+        assert state.query_engine is None
+        assert state.query_engine_client is not None
+        assert state.telemetry_url is not None
+
+        rows = []
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline:
+            response = state.query_engine_client.query(
+                "SELECT class, COUNT(*) AS count FROM meshes GROUP BY class"
+            )
+            rows = response.get("rows", [])
+            if any(row.get("class") == "Host" for row in rows):
+                break
+            time.sleep(0.2)
+
+        assert any(row.get("class") == "Host" for row in rows), rows
+    finally:
+        job.kill()
 
 
 @pytest.fixture
@@ -632,19 +692,20 @@ def test_actor_status_events_table() -> None:
     """Test that the actor_status_events table is populated when actors change status."""
     # Spawn worker actors — actors go through status transitions during spawn
     with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(_telemetry_config(batch_size=10)),
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
-        engine = state.query_engine
-        assert engine is not None
+        assert state.query_engine is None
         hosts = state.hosts
         worker_procs = hosts.spawn_procs(per_host={"workers": 2})
         workers = worker_procs.spawn("status_test_worker", WorkerActor)
         workers.initialized.get()
 
         # Query the actor_status_events table
-        result = engine.query("SELECT * FROM actor_status_events")
-        result_dict = result.to_pydict()
+        result_dict = _query(
+            state,
+            "SELECT * FROM actor_status_events",
+        )
 
         # Verify the schema has the expected columns
         expected_columns = {
@@ -666,12 +727,13 @@ def test_actor_status_events_table() -> None:
             f"Expected at least one actor status event, got {event_count}"
         )
 
-        joined = engine.query(
+        joined = _query(
+            state,
             "SELECT ase.id FROM actor_status_events ase "
             "INNER JOIN actors a ON ase.actor_id = a.id "
-            "WHERE a.display_name LIKE '%status_test_worker%'"
+            "WHERE a.display_name LIKE '%status_test_worker%'",
         )
-        joined_count = len(joined.to_pydict().get("id", []))
+        joined_count = len(joined.get("id", []))
         assert joined_count > 0, (
             "Expected actor_status_events.actor_id to join actors.id for "
             f"status_test_worker, got {joined_count} joined rows"

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import contextlib
 import os
 import pickle
 import socket
@@ -13,6 +14,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import types
 from dataclasses import dataclass
 from typing import cast, Dict, Optional, Sequence
 from unittest.mock import MagicMock, patch
@@ -118,17 +120,20 @@ class MockJobTrait(JobTrait):
 
     def _state(self) -> JobState:
         """Return a mock job state with fake host meshes."""
-        # Create a mock host mesh for each host name
         mock_hosts: Dict[str, HostMesh] = {}
+
+        class MockHostMesh:
+            def __init__(self, name, python_executable=None):
+                self.name = name
+                self.python_executable = python_executable
+
+            def __repr__(self):
+                return f"MockHostMesh({self.name})"
+
+            def with_python_executable(self, python_executable):
+                return MockHostMesh(self.name, python_executable)
+
         for name in self._host_names:
-            # Using a simple object that mimics HostMesh for testing
-            class MockHostMesh:
-                def __init__(self, name):
-                    self.name = name
-
-                def __repr__(self):
-                    return f"MockHostMesh({self.name})"
-
             mock_hosts[name] = cast("HostMesh", MockHostMesh(name))
 
         return JobState(mock_hosts)
@@ -1004,6 +1009,170 @@ def test_batch_job_shares_component_runtime_with_wrapped_job(mock_start, mock_sp
     assert job_state.admin_url == "http://localhost:1729"
     mock_start.assert_called_once()
     mock_spawn.assert_called_once()
+
+
+@contextlib.contextmanager
+def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
+    with (
+        patch("monarch._src.job.job_components.Telemetry") as telemetry_cls,
+        patch(
+            "monarch._src.job.job_components.install_sidecar_socket_sink"
+        ) as install_sink,
+        patch("monarch._src.job.job_components.QueryEngineClient") as qec_cls,
+        patch("monarch._src.job.job_components.start_telemetry") as start_legacy,
+    ):
+        start_legacy.return_value = (MagicMock(), "http://legacy", MagicMock())
+        ensure_open = telemetry_cls.return_value.ensure_open
+        if ensure_open_side_effect is not None:
+            ensure_open.side_effect = ensure_open_side_effect
+        else:
+            ensure_open.return_value = ensure_open_return or {
+                "telemetry_url": "http://sidecar",
+                "socket_path": "/tmp/telemetry.sock",
+            }
+        yield types.SimpleNamespace(
+            ensure_open=ensure_open,
+            install_sink=install_sink,
+            query_engine_client_cls=qec_cls,
+            start_legacy=start_legacy,
+        )
+
+
+def test_mesh_admin_receives_sidecar_telemetry_url():
+    """Admin links to sidecar telemetry when the sidecar path is configured."""
+    with (
+        _patched_sidecar() as m,
+        patch("monarch._src.job.job_components._spawn_admin") as mock_spawn,
+    ):
+        mock_future = MagicMock()
+        mock_admin_ref = MagicMock()
+        mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
+        mock_spawn.return_value = mock_future
+
+        job = (
+            MockJobTrait(host_names=["hosts"])
+            .enable_telemetry(TelemetryConfig(use_sidecar=True))
+            .enable_admin(MeshAdminConfig())
+        )
+        state = job.state(cached_path=None)
+
+    m.start_legacy.assert_not_called()
+    _, kwargs = mock_spawn.call_args
+    assert kwargs.get("telemetry_url") == "http://sidecar"
+    assert state.telemetry_url == "http://sidecar"
+    assert state.admin_url == "http://localhost:1729"
+
+
+def test_sidecar_replaces_legacy_when_opted_in():
+    """use_sidecar=True exposes the sidecar query client and skips the legacy
+    in-process collector (the two are mutually exclusive)."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)
+
+    # Legacy path skipped; sidecar client exposed instead.
+    m.start_legacy.assert_not_called()
+    assert state.query_engine is None
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
+    assert state.telemetry_url == "http://sidecar"
+    m.query_engine_client_cls.assert_called_once_with("http://sidecar")
+    m.install_sink.assert_called_once_with("/tmp/telemetry.sock")
+
+
+def test_sidecar_bootstrap_then_fanout_carry_host_meshes():
+    """state() bootstraps the sidecar with empty host_meshes, then fans out
+    workers with the materialized host meshes."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        job.state(cached_path=None)
+
+    assert m.ensure_open.call_count == 2
+    bootstrap_kwargs = m.ensure_open.call_args_list[0].kwargs
+    fanout_kwargs = m.ensure_open.call_args_list[1].kwargs
+    assert bootstrap_kwargs["host_meshes"] == {}
+    assert set(fanout_kwargs["host_meshes"].keys()) == {"hosts"}
+
+
+def test_sidecar_worker_fanout_uses_configured_host_meshes():
+    """Worker fan-out should spawn telemetry collectors from the same host
+    mesh configuration that state() returns to user code."""
+    python_exe = "/mnt/app/.venv/bin/python"
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        job._components.mounts._default_python_exe = python_exe
+        state = job.state(cached_path=None)
+
+    fanout_hosts = m.ensure_open.call_args_list[1].kwargs["host_meshes"]
+    assert fanout_hosts["hosts"].python_executable == python_exe
+    assert state.hosts.python_executable == python_exe
+
+
+def test_sidecar_bootstrap_failure_is_isolated():
+    """A sidecar bootstrap failure disables telemetry and never fails state()."""
+    with _patched_sidecar(ensure_open_side_effect=RuntimeError("boom")) as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)  # must not raise
+
+    assert state.query_engine_client is None
+    assert state.query_engine is None  # legacy stays skipped under use_sidecar
+    m.query_engine_client_cls.assert_not_called()
+
+
+def test_sidecar_worker_fanout_failure_is_isolated():
+    """A fan-out failure after a successful bootstrap is swallowed; the client
+    from bootstrap stays exposed."""
+    good = {"telemetry_url": "http://sidecar", "socket_path": "/tmp/telemetry.sock"}
+    with _patched_sidecar(
+        ensure_open_side_effect=[good, RuntimeError("fanout boom")]
+    ) as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)  # must not raise
+
+    assert m.ensure_open.call_count == 2
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
+
+
+def test_sidecar_not_bootstrapped_without_opt_in():
+    """Default (use_sidecar=False) never touches the sidecar; legacy runs."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
+        state = job.state(cached_path=None)
+
+    m.ensure_open.assert_not_called()
+    m.query_engine_client_cls.assert_not_called()
+    assert state.query_engine_client is None
+    m.start_legacy.assert_called_once()  # legacy collector ran instead
+    assert state.query_engine is not None
+
+
+def test_sidecar_query_client_dropped_on_pickle():
+    """The sidecar query client is dropped on pickle and re-bootstrapped on the
+    next state() (mirrors the legacy query_engine behavior)."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)
+        assert state.query_engine_client is m.query_engine_client_cls.return_value
+
+        # __getstate__ drops live handles; the deserialized job is clean.
+        loaded = job_loads(job.dumps())
+        assert loaded._components.telemetry is not None
+        assert loaded._components.telemetry._telemetry_url is None
+
+        # Next state() re-bootstraps the sidecar.
+        state = loaded.state(cached_path=None)
+        assert state.query_engine_client is m.query_engine_client_cls.return_value
 
 
 # Tests for LocalJob implementation

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -173,20 +173,20 @@ def test_open_or_refresh_raises_when_not_open() -> None:
 
 
 def test_open_or_refresh_spawns_telemetry_actors_once_with_no_active_workers() -> None:
-    sidecar = tc._TelemetryHandle("apply")
+    handle = tc._TelemetryHandle("apply")
 
     def fake_bootstrap(config) -> None:
-        sidecar._dashboard_info = {"local_url": "http://local", "url": "http://ext"}
+        handle._dashboard_info = {"local_url": "http://local", "url": "http://ext"}
 
     with (
-        patch.object(sidecar, "_bootstrap", side_effect=fake_bootstrap),
-        patch.object(sidecar, "_spawn_telemetry_actors", return_value=[]) as spawn,
+        patch.object(handle, "_bootstrap", side_effect=fake_bootstrap),
+        patch.object(handle, "_spawn_telemetry_actors", return_value=[]) as spawn,
     ):
-        sidecar.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
-        sidecar.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
+        handle.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
+        handle.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
 
     spawn.assert_called_once()
-    assert sidecar._worker_proc_meshes == []
+    assert handle._worker_proc_meshes == []
 
 
 def test_spawn_telemetry_actors_registers_workers_and_stops_on_shutdown() -> None:
@@ -196,14 +196,14 @@ def test_spawn_telemetry_actors_registers_workers_and_stops_on_shutdown() -> Non
     proc_mesh = MagicMock()
     host_mesh = MagicMock()
     client_actor = MagicMock()
-    sidecar = tc._TelemetryHandle("fanout_test")
-    sidecar._client_actor = client_actor
+    handle = tc._TelemetryHandle("fanout_test")
+    handle._client_actor = client_actor
 
     proc_mesh.spawn.return_value = actor_mesh
     host_mesh.spawn_procs.return_value = proc_mesh
     actor_mesh.activate.call.return_value.get.return_value = [(0, True)]
 
-    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+    worker_proc_meshes = handle._spawn_telemetry_actors(
         {
             "hosts": host_mesh,
         },
@@ -228,9 +228,9 @@ def test_spawn_telemetry_actors_registers_workers_and_stops_on_shutdown() -> Non
     client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
 
     assert worker_proc_meshes == [proc_mesh]
-    sidecar._worker_proc_meshes = worker_proc_meshes
+    handle._worker_proc_meshes = worker_proc_meshes
     with patch.object(tc, "shutdown_context") as shutdown_context:
-        sidecar.shutdown()
+        handle.shutdown()
     proc_mesh.stop.assert_called_once_with("telemetry shutdown")
     proc_mesh.stop.return_value.get.assert_called_once_with()
     shutdown_context.return_value.get.assert_called_once_with(timeout=5.0)
@@ -241,14 +241,14 @@ def test_spawn_telemetry_actors_drops_inactive_worker_collectors() -> None:
     proc_mesh = MagicMock()
     host_mesh = MagicMock()
     client_actor = MagicMock()
-    sidecar = tc._TelemetryHandle("fanout_test")
-    sidecar._client_actor = client_actor
+    handle = tc._TelemetryHandle("fanout_test")
+    handle._client_actor = client_actor
 
     proc_mesh.spawn.return_value = actor_mesh
     host_mesh.spawn_procs.return_value = proc_mesh
     actor_mesh.activate.call.return_value.get.return_value = [(0, False)]
 
-    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+    worker_proc_meshes = handle._spawn_telemetry_actors(
         {
             "hosts": host_mesh,
         },
@@ -268,12 +268,12 @@ def test_spawn_telemetry_actors_drops_inactive_worker_collectors() -> None:
 def test_spawn_telemetry_actors_noops_when_setup_raises() -> None:
     host_mesh = MagicMock()
     client_actor = MagicMock()
-    sidecar = tc._TelemetryHandle("fanout_test")
-    sidecar._client_actor = client_actor
+    handle = tc._TelemetryHandle("fanout_test")
+    handle._client_actor = client_actor
 
     host_mesh.spawn_procs.side_effect = RuntimeError("boom")
 
-    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+    worker_proc_meshes = handle._spawn_telemetry_actors(
         {
             "hosts": host_mesh,
         },

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -17,7 +17,7 @@ import threading
 import urllib.request
 import uuid
 from typing import cast
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import monarch._src.job.job_sidecar as js
 import monarch._src.job.telemetry_config as tc
@@ -172,7 +172,161 @@ def test_open_or_refresh_raises_when_not_open() -> None:
             handle.open_or_refresh({}, _cfg_dict())
 
 
-# ── Telemetry.ensure_open ─────────────────────────────────────────────────────
+def test_open_or_refresh_spawns_telemetry_actors_once_with_no_active_workers() -> None:
+    sidecar = tc._TelemetryHandle("apply")
+
+    def fake_bootstrap(config) -> None:
+        sidecar._dashboard_info = {"local_url": "http://local", "url": "http://ext"}
+
+    with (
+        patch.object(sidecar, "_bootstrap", side_effect=fake_bootstrap),
+        patch.object(sidecar, "_spawn_telemetry_actors", return_value=[]) as spawn,
+    ):
+        sidecar.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
+        sidecar.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
+
+    spawn.assert_called_once()
+    assert sidecar._worker_proc_meshes == []
+
+
+def test_spawn_telemetry_actors_registers_workers_and_stops_on_shutdown() -> None:
+    """Spawning creates a collector mesh, registers it with the client
+    collector, retains it, and stops its proc mesh on shutdown."""
+    actor_mesh = MagicMock()
+    proc_mesh = MagicMock()
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    sidecar = tc._TelemetryHandle("fanout_test")
+    sidecar._client_actor = client_actor
+
+    proc_mesh.spawn.return_value = actor_mesh
+    host_mesh.spawn_procs.return_value = proc_mesh
+    actor_mesh.activate.call.return_value.get.return_value = [(0, True)]
+
+    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
+    proc_mesh.spawn.assert_called_once_with(
+        "TelemetryActor",
+        tc.TelemetryActor,
+        "fanout_test",
+        0,
+    )
+    actor_mesh.activate.call.return_value.get.assert_called_once_with()
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with(
+        [actor_mesh]
+    )
+    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
+
+    assert worker_proc_meshes == [proc_mesh]
+    sidecar._worker_proc_meshes = worker_proc_meshes
+    with patch.object(tc, "shutdown_context") as shutdown_context:
+        sidecar.shutdown()
+    proc_mesh.stop.assert_called_once_with("telemetry shutdown")
+    proc_mesh.stop.return_value.get.assert_called_once_with()
+    shutdown_context.return_value.get.assert_called_once_with(timeout=5.0)
+
+
+def test_spawn_telemetry_actors_drops_inactive_worker_collectors() -> None:
+    actor_mesh = MagicMock()
+    proc_mesh = MagicMock()
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    sidecar = tc._TelemetryHandle("fanout_test")
+    sidecar._client_actor = client_actor
+
+    proc_mesh.spawn.return_value = actor_mesh
+    host_mesh.spawn_procs.return_value = proc_mesh
+    actor_mesh.activate.call.return_value.get.return_value = [(0, False)]
+
+    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+    )
+
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
+    assert worker_proc_meshes == []
+    proc_mesh.stop.assert_called_once_with("telemetry collector inactive")
+    proc_mesh.stop.return_value.get.assert_called_once_with()
+
+
+def test_spawn_telemetry_actors_noops_when_setup_raises() -> None:
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    sidecar = tc._TelemetryHandle("fanout_test")
+    sidecar._client_actor = client_actor
+
+    host_mesh.spawn_procs.side_effect = RuntimeError("boom")
+
+    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
+    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
+    assert worker_proc_meshes == []
+
+
+@pytest.mark.parametrize("failure_point", ["spawn", "activate"])
+def test_spawn_telemetry_actors_stops_partially_started_proc_mesh(
+    failure_point: str,
+) -> None:
+    actor_mesh = MagicMock()
+    proc_mesh = MagicMock()
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    sidecar = tc._TelemetryHandle("fanout_test")
+    sidecar._client_actor = client_actor
+
+    host_mesh.spawn_procs.return_value = proc_mesh
+    if failure_point == "spawn":
+        proc_mesh.spawn.side_effect = RuntimeError("spawn boom")
+    else:
+        proc_mesh.spawn.return_value = actor_mesh
+        actor_mesh.activate.call.return_value.get.side_effect = RuntimeError(
+            "activate boom"
+        )
+
+    worker_proc_meshes = sidecar._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
+    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
+    assert worker_proc_meshes == []
+    proc_mesh.stop.assert_called_once_with("telemetry collector startup failed")
+    proc_mesh.stop.return_value.get.assert_called_once_with()
 
 
 def test_ensure_open_requires_apply_id() -> None:


### PR DESCRIPTION
Summary:

Adds `DatabaseScanner.ingest_snapshot_batch` so callers can append one snapshot Arrow IPC stream into a registered table. The scanner accepts zero-row batches, rejects multi-batch payloads, and preserves registered-table schema validation.

Differential Revision: D107350466


