### PR TITLE
short-circuit RankSpace cardinality, rank_at, and local_index_of when unoccluded (#4159)

### DIFF
--- a/rankspace/src/lib.rs
+++ b/rankspace/src/lib.rs
@@ -1365,6 +1365,20 @@ impl RankMask {
             RankMask::Union(masks) => masks.iter().all(|mask| self.contains_mask(mask)),
         }
     }
+
+    /// Returns true if the mask contains no ranks.
+    ///
+    /// Unlike `matches!(self, RankMask::Empty)`, this also reports the
+    /// semantically-empty non-`Empty` forms: a zero-cardinality `Rect`, an
+    /// empty `Ranks` set, or a `Union` whose children are all empty.
+    pub fn is_empty(&self) -> bool {
+        match self {
+            RankMask::Empty => true,
+            RankMask::Rect(rect) => rect.is_empty(),
+            RankMask::Ranks(ranks) => ranks.is_empty(),
+            RankMask::Union(masks) => masks.iter().all(|mask| mask.is_empty()),
+        }
+    }
 }
 
 /// A possibly sparse rank space: a dense base rectangle minus occluded ranks.
@@ -1406,6 +1420,12 @@ impl RankSpace {
 
     /// Returns the number of visible ranks.
     pub fn cardinality(&self) -> usize {
+        // With no occlusion every base rank is visible, so the visible count is
+        // just the base rectangle's cardinality (O(ndim)) — no O(N) `iter_ranks`
+        // walk needed.
+        if self.occlusion.is_empty() {
+            return self.base.cardinality();
+        }
         self.iter_ranks().count()
     }
 
@@ -1590,6 +1610,12 @@ impl RankSpace {
     /// `self.rank_at(index) == Some(rank)`, then
     /// `self.local_index_of(rank) == Some(index)`.
     pub fn rank_at(&self, local_index: usize) -> Option<Rank> {
+        // With no occlusion the visible order is the base rectangle's row-major
+        // order, so `base.rank_at` (O(ndim)) returns the same rank as walking
+        // `iter_ranks`.
+        if self.occlusion.is_empty() {
+            return self.base.rank_at(local_index);
+        }
         self.iter_ranks().nth(local_index)
     }
 
@@ -1601,6 +1627,13 @@ impl RankSpace {
     /// `self.local_index_of(rank) == Some(index)`, then
     /// `self.rank_at(index) == Some(rank)`.
     pub fn local_index_of(&self, rank: Rank) -> Option<usize> {
+        // With no occlusion the visible order is the base rectangle's row-major
+        // order, so `base.local_index_of` (O(ndim)) gives the same index; it
+        // already returns None for ranks outside the rect, so the `contains_rank`
+        // guard below isn't needed on this path.
+        if self.occlusion.is_empty() {
+            return self.base.local_index_of(rank);
+        }
         if !self.contains_rank(rank) {
             return None;
         }
@@ -1888,6 +1921,37 @@ mod tests {
 
     fn host_gpu_rect() -> RankRect {
         rankrect!(host = 2, gpu = 4)
+    }
+
+    #[test]
+    fn rank_mask_is_empty_reports_semantic_emptiness() {
+        // Canonical empty.
+        assert!(RankMask::Empty.is_empty());
+
+        // Non-canonical empties, built as raw variants (not the smart ctors)
+        // so the cases survive any future constructor normalization.
+        assert!(RankMask::Rect(rankrect!(x = 0)).is_empty());
+        assert!(RankMask::Ranks(BTreeSet::new()).is_empty());
+        assert!(RankMask::Union(vec![]).is_empty());
+        assert!(RankMask::Union(vec![RankMask::Empty, RankMask::Empty]).is_empty());
+        assert!(
+            RankMask::Union(vec![
+                RankMask::Rect(rankrect!(x = 0)),
+                RankMask::Ranks(BTreeSet::new()),
+            ])
+            .is_empty()
+        );
+
+        // Non-empty masks.
+        assert!(!RankMask::Rect(rankrect!(x = 2)).is_empty());
+        assert!(!RankMask::Ranks([Rank(1)].into_iter().collect()).is_empty());
+        assert!(
+            !RankMask::Union(vec![
+                RankMask::Empty,
+                RankMask::Ranks([Rank(1)].into_iter().collect()),
+            ])
+            .is_empty()
+        );
     }
 
     #[test]

--- a/rankspace/src/proptests.rs
+++ b/rankspace/src/proptests.rs
@@ -478,6 +478,27 @@ proptest! {
     }
 
     #[test]
+    fn dense_space_fast_path_matches_iteration(rect in gen_scaled_rect(1..=4, 8, 32, 4)) {
+        // Theorem: for every rect, an unoccluded `RankSpace::dense(rect)` is
+        // observationally equivalent to the general iteration path. Over the
+        // visible ranks in `iter_ranks()` order:
+        //   - `cardinality()` equals the number of visible ranks;
+        //   - `rank_at(i)` is the i-th visible rank, with `local_index_of` its
+        //     inverse (the index <-> rank round-trip holds);
+        //   - `rank_at(cardinality())` is `None` (one past the last index).
+        // I.e. the O(ndim) base-delegating shortcut returns exactly the O(N)
+        // iteration result.
+        let space = RankSpace::dense(rect);
+
+        prop_assert_eq!(space.cardinality(), space.iter_ranks().count());
+        for (index, rank) in space.iter_ranks().enumerate() {
+            prop_assert_eq!(space.rank_at(index), Some(rank));
+            prop_assert_eq!(space.local_index_of(rank), Some(index));
+        }
+        prop_assert_eq!(space.rank_at(space.cardinality()), None);
+    }
+
+    #[test]
     fn base_and_compact_views_agree_on_visible_ranks(
         (space, _) in gen_sparse_space(1..=4, 8)
     ) {


### PR DESCRIPTION
Summary:

`RankSpace::cardinality`, `rank_at`, and `local_index_of` each walked `iter_ranks()` unconditionally — O(N) in the visible-rank count — even when the space has no occlusion, where the base `RankRect` already answers all three in O(ndim). this adds an `occlusion == RankMask::Empty` fast path to each, delegating to the base rectangle. with no occlusion the visible ranks are exactly the base rectangle's ranks in the same row-major order, so the results are identical and the sparse path is unchanged.

it removes a quadratic edge for unoccluded consumers — `CompactView::get_rank` resolves through `local_index_of`, so per-rank access over an unoccluded view was O(N) per lookup. a new proptest (`dense_space_fast_path_matches_iteration`) checks the fast path agrees with iterating the visible ranks across offset/strided rects.

Reviewed By: mariusae

Differential Revision: D107421978


