### PR TITLE
Fix bug with run_worker_loop_forever on an alias address (#4160)

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -740,6 +740,12 @@ pub enum ChannelAddr {
     /// address, yet the server is bound to a private IP address or simply
     /// INADDR_ANY. Traffic to the public IP address is mapped to the private
     /// IP address through network address translation (NAT).
+    ///
+    /// `Alias` is serve-side syntax. [`serve`] consumes it by binding to
+    /// `bind_to` and advertising `dial_to`; identity-bearing values such as
+    /// proc addresses, actor addresses, host references, and routing keys
+    /// should store only `dial_to`. Dial helpers canonicalize aliases the same
+    /// way.
     Alias {
         /// The address to which the client should dial to.
         dial_to: Box<ChannelAddr>,
@@ -956,6 +962,19 @@ pub(crate) fn normalize_host(host: &str) -> String {
 }
 
 impl ChannelAddr {
+    /// Return the canonical address that remote peers should dial.
+    ///
+    /// For regular addresses this is the address itself. For aliases, this
+    /// recursively consumes the alias and returns its `dial_to` address. Use
+    /// this before storing an address in identity-bearing state; aliases are
+    /// intended as input to [`serve`].
+    pub fn into_dial_addr(self) -> Self {
+        match self {
+            Self::Alias { dial_to, .. } => (*dial_to).into_dial_addr(),
+            addr => addr,
+        }
+    }
+
     /// Parse ZMQ-style URL format: scheme://address
     /// Supports:
     /// - tcp://hostname:port or tcp://*:port (wildcard binding)
@@ -966,6 +985,10 @@ impl ChannelAddr {
     /// - metaquic://hostname:port or metaquic://*:port
     /// - Alias format: dial_to_url@bind_to_url (e.g., tcp://host:port@tcp://host:port)
     ///   Note: Alias format is currently only supported for TCP addresses
+    ///
+    /// Alias format is meant for serving. Callers that will dial or store the
+    /// result as an identity should canonicalize it with
+    /// [`ChannelAddr::into_dial_addr`].
     pub fn from_zmq_url(address: &str) -> Result<Self, anyhow::Error> {
         let (addr, _listener) = Self::from_zmq_url_with_listener(address)?;
         Ok(addr)
@@ -1227,6 +1250,7 @@ impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
 #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
 #[track_caller]
 pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, ChannelError> {
+    let addr = addr.into_dial_addr();
     tracing::debug!(name = "dial", caller = %Location::caller(), %addr, "dialing channel {}", addr);
     let inner = match addr {
         ChannelAddr::Local(port) => ChannelTxKind::Local(local::dial(port)?),
@@ -1238,7 +1262,7 @@ pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, Channel
         | ChannelAddr::MetaQuic(_) => {
             ChannelTxKind::Net(net::spawn(net::link(addr, net::SessionId::random(), 0)?))
         }
-        ChannelAddr::Alias { dial_to, .. } => dial(*dial_to)?.inner,
+        ChannelAddr::Alias { .. } => unreachable!("aliases are canonicalized before dialing"),
     };
     Ok(ChannelTx { inner })
 }
@@ -1298,6 +1322,7 @@ pub mod unordered {
         num_streams: usize,
     ) -> Result<ChannelTx<M>, ChannelError> {
         assert!(num_streams > 0);
+        let addr = addr.into_dial_addr();
         let session_id = net::SessionId::random();
         let links: Vec<net::NetLink> = (1..=num_streams)
             .map(|i| net::link(addr.clone(), session_id, i as u8))
@@ -1376,7 +1401,11 @@ fn serve_inner<M: RemoteMessage>(
         | ChannelAddr::Tls(_)
         | ChannelAddr::MetaTls(_)
         | ChannelAddr::Quic(_)
-        | ChannelAddr::MetaQuic(_) => {
+        | ChannelAddr::MetaQuic(_)
+        // The `Alias` variant binds on its `bind_to` address but advertises
+        // `dial_to`; `listen_with_prebound` resolves this, so it routes through
+        // the same net serve path as the other TCP-based transports.
+        | ChannelAddr::Alias { .. } => {
             let (addr, rx) = net::server::serve::<M>(addr, listener)?;
             Ok((addr, ChannelRxKind::Net(rx)))
         }
@@ -1392,14 +1421,6 @@ fn serve_inner<M: RemoteMessage>(
             ChannelAddr::Local(a),
             ChannelRxKind::Local(local::bind::<M>(a)?),
         )),
-        ChannelAddr::Alias { dial_to, bind_to } => {
-            let (bound_addr, rx) = serve_inner::<M>(*bind_to, listener)?;
-            let alias_addr = ChannelAddr::Alias {
-                dial_to,
-                bind_to: Box::new(bound_addr),
-            };
-            Ok((alias_addr, rx))
-        }
     }
 }
 
@@ -1856,6 +1877,42 @@ mod tests {
             tx.post(123);
             assert_eq!(rx.recv().await.unwrap(), 123);
         }
+    }
+
+    #[tokio::test]
+    // TODO: OSS: called `Result::unwrap()` on an `Err` value: Server(Listen(Tcp([::1]:0), Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" }))
+    #[cfg_attr(not(fbcode_build), ignore)]
+    async fn test_serve_alias_advertises_dial_to() {
+        // Reserve an ephemeral port, then release it so the alias can bind to
+        // it via `bind_to`.
+        let probe = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = probe.local_addr().unwrap().port();
+        drop(probe);
+
+        // `dial_to` advertises a reachable loopback address; `bind_to` listens
+        // on the wildcard interface (the case that matters where the dial
+        // address cannot be bound directly, e.g. behind NAT).
+        let alias =
+            ChannelAddr::from_zmq_url(&format!("tcp://127.0.0.1:{port}@tcp://0.0.0.0:{port}"))
+                .unwrap();
+        assert_matches!(alias, ChannelAddr::Alias { .. });
+
+        let (listen_addr, mut rx) = crate::channel::serve::<i32>(alias).unwrap();
+
+        // Serving an alias consumes it: the advertised address is the plain
+        // `dial_to`. Remote peers independently construct this same `Tcp`
+        // address from the dial string, so the proc namespace derived from it
+        // must match. If serving left the address an `Alias`, that match would
+        // fail and messages would not route to the server.
+        assert_eq!(
+            listen_addr,
+            ChannelAddr::Tcp(format!("127.0.0.1:{port}").parse().unwrap()),
+            "serving an alias must advertise dial_to, not the alias itself"
+        );
+
+        let tx = crate::channel::dial(listen_addr).unwrap();
+        tx.post(123);
+        assert_eq!(rx.recv().await.unwrap(), 123);
     }
 
     #[tokio::test]

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -995,7 +995,14 @@ pub(crate) fn listen_with_prebound(
             Ok((NetListener::Quic(listener), bound_addr))
         }
         ChannelAddr::Alias { dial_to, bind_to } => {
-            let (listener, _bound_addr) = listen(*bind_to)?;
+            // Bind the socket on `bind_to` (e.g. a wildcard interface), but
+            // advertise `dial_to` as the canonical address. Callers refer to
+            // this server by its dial address; the listener merely needs to
+            // accept the connections that `dial_to` is routed to (e.g. via
+            // NAT). The alias is fully consumed here -- everything downstream,
+            // including the proc namespace derived from this address, uses
+            // `dial_to`, which is what remote peers independently construct.
+            let (listener, _bound_addr) = listen_with_prebound(*bind_to, prebound)?;
             Ok((listener, *dial_to))
         }
         other => Err(ServerError::Listen(
@@ -1003,13 +1010,6 @@ pub(crate) fn listen_with_prebound(
             std::io::Error::other(format!("unsupported transport: {}", other)),
         )),
     }
-}
-
-/// Bind a listener for the given channel address. Returns the listener
-/// and the canonical address callers should advertise (which encodes
-/// the transport — e.g. `ChannelAddr::Tls` for TLS).
-pub(crate) fn listen(addr: ChannelAddr) -> Result<(NetListener, ChannelAddr), ServerError> {
-    listen_with_prebound(addr, None)
 }
 
 /// Frames are the messages sent between clients and servers over sessions.

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -3597,6 +3597,7 @@ impl DialMailboxRouter {
     /// cache to ensure fresh routing on next use.
     pub fn bind(&self, dest: impl Into<Addr>, addr: ChannelAddr) {
         let dest = dest.into();
+        let addr = addr.into_dial_addr();
         if let Ok(mut w) = self.address_book.write() {
             if let Some(old_addr) = w.insert(dest.clone(), addr.clone())
                 && old_addr != addr
@@ -3643,9 +3644,9 @@ impl DialMailboxRouter {
         if let Some((key, addr)) = found
             && key.is_prefix_of(&reference)
         {
-            Some(addr.clone())
+            Some(addr.clone().into_dial_addr())
         } else {
-            let addr = actor_ref.addr().clone();
+            let addr = actor_ref.addr().clone().into_dial_addr();
             if self.direct_addressed_remote_only {
                 addr.transport().is_remote().then_some(addr)
             } else {
@@ -4700,6 +4701,24 @@ mod tests {
                 .unwrap(),
             fallback,
         );
+    }
+
+    #[test]
+    fn test_dial_mailbox_router_canonicalizes_alias_addresses() {
+        let router = DialMailboxRouter::new();
+        let dial_to = ChannelAddr::from_zmq_url("tcp://127.0.0.1:9000").unwrap();
+        let alias = ChannelAddr::from_zmq_url("tcp://127.0.0.1:9000@tcp://0.0.0.0:9000").unwrap();
+
+        router.bind(test_proc_ref("world_alias"), alias.clone());
+        assert_eq!(
+            router
+                .lookup_addr(&test_actor_id("world_alias", "actor"))
+                .unwrap(),
+            dial_to
+        );
+
+        let direct_actor_ref = ProcAddr::singleton(alias, "direct_alias").actor_addr("actor");
+        assert_eq!(router.lookup_addr(&direct_actor_ref).unwrap(), dial_to);
     }
 
     #[tokio::test]

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -160,9 +160,8 @@ declare_attrs! {
     ///
     /// When attaching to pre-existing workers (simple bootstrap), the
     /// client pushes its propagatable config to each host agent and
-    /// waits for confirmation. If the barrier does not complete within
-    /// this duration, a warning is logged and attach continues without
-    /// blocking — config push is best-effort.
+    /// waits for confirmation. If the barrier does not complete
+    /// within this duration, attach fails closed.
     @meta(CONFIG = ConfigAttr::new(
         Some("HYPERACTOR_MESH_ATTACH_CONFIG_TIMEOUT".to_string()),
         Some("mesh_attach_config_timeout".to_string()),

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -147,11 +147,21 @@ declare_attrs! {
 }
 
 /// A reference to a single host.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Named, Serialize, Deserialize)]
-pub struct HostRef(pub(crate) ChannelAddr);
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Named, Serialize)]
+pub struct HostRef(ChannelAddr);
 wirevalue::register_type!(HostRef);
 
 impl HostRef {
+    /// Create a host reference from a channel address.
+    ///
+    /// `ChannelAddr::Alias` is a socket setup convenience, not a host
+    /// identity. The host consumes the alias when serving and advertises the
+    /// `dial_to` address, so remote references must use that same address in
+    /// proc and actor identities.
+    pub(crate) fn new(addr: ChannelAddr) -> Self {
+        Self(addr.into_dial_addr())
+    }
+
     /// The host mesh agent associated with this host.
     pub(crate) fn mesh_agent(&self) -> ActorRef<HostAgent> {
         ActorRef::attest(
@@ -235,12 +245,21 @@ impl HostRef {
     }
 }
 
+impl<'de> Deserialize<'de> for HostRef {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Self::new(ChannelAddr::deserialize(deserializer)?))
+    }
+}
+
 impl TryFrom<ActorRef<HostAgent>> for HostRef {
     type Error = crate::Error;
 
     fn try_from(value: ActorRef<HostAgent>) -> Result<Self, crate::Error> {
         let proc_id = value.actor_addr().proc_addr();
-        Ok(HostRef(proc_id.addr().clone()))
+        Ok(Self::new(proc_id.addr().clone()))
     }
 }
 
@@ -254,7 +273,7 @@ impl FromStr for HostRef {
     type Err = <ChannelAddr as FromStr>::Err;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(HostRef(ChannelAddr::from_str(s)?))
+        Ok(Self::new(ChannelAddr::from_str(s)?))
     }
 }
 
@@ -487,7 +506,7 @@ impl HostMesh {
             .map_err(crate::Error::SingletonActorSpawnError)?;
         host_mesh_agent.bind::<HostAgent>();
 
-        let host = HostRef(addr);
+        let host = HostRef::new(addr);
         let host_mesh_ref = HostMeshRef::new(
             HostMeshId::instance(Label::new("local").unwrap()),
             extent!(hosts = 1).into(),
@@ -551,7 +570,7 @@ impl HostMesh {
             )
             .map_err(crate::Error::SingletonActorSpawnError)?;
         host_mesh_agent.bind::<HostAgent>();
-        Ok(HostRef(addr))
+        Ok(HostRef::new(addr))
     }
 
     /// Create a new process-based host mesh. Each host is represented by a local process,
@@ -588,7 +607,7 @@ impl HostMesh {
             let mut cmd = command.new();
             bootstrap.to_env(&mut cmd);
             cmd.spawn()?;
-            hosts.push(HostRef(addr));
+            hosts.push(HostRef::new(addr));
         }
 
         let host_mesh_ref = HostMeshRef::new(
@@ -1021,7 +1040,7 @@ impl HostMeshRef {
         Self {
             id,
             region: extent!(hosts = hosts.len()).into(),
-            ranks: Arc::new(hosts.into_iter().map(HostRef).collect()),
+            ranks: Arc::new(hosts.into_iter().map(HostRef::new).collect()),
             bootstrap_command: None,
         }
     }
@@ -1503,7 +1522,7 @@ impl HostMeshRef {
 
             // Note that we don't send 1 message per host agent, we send 1 message
             // per proc.
-            let host = HostRef(addr);
+            let host = HostRef::new(addr);
             host.mesh_agent().post(
                 cx,
                 resource::Stop {
@@ -1611,7 +1630,7 @@ impl HostMeshRef {
 
             // Note that we don't send 1 message per host agent, we send 1 message
             // per proc.
-            let host = HostRef(addr);
+            let host = HostRef::new(addr);
             let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
             proc_names.push(proc_resource_id.clone());
             let mut reply = tx.bind();
@@ -2273,7 +2292,7 @@ mod tests {
         let (failed_host, _failure) = &push_err.failures[0];
         assert_eq!(
             failed_host,
-            &HostRef(unreachable),
+            &HostRef::new(unreachable),
             "HM-4: failure entry must identify the unreachable host"
         );
         // Intentionally do NOT pin the `_failure` variant — the
@@ -2287,6 +2306,23 @@ mod tests {
         // root-client's default delivery-failure handling would
         // surface an `UndeliverableMessageError::DeliveryFailure`,
         // supervision would fire, and we wouldn't be here.
+    }
+
+    #[test]
+    fn test_host_refs_canonicalize_alias_to_dial_addr() {
+        let dial_to = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600").unwrap();
+        let alias = ChannelAddr::from_zmq_url("tcp://127.0.0.1:26600@tcp://0.0.0.0:26600").unwrap();
+
+        let mesh = HostMeshRef::from_hosts(
+            HostMeshId::singleton(Label::new("alias").unwrap()),
+            vec![alias],
+        );
+
+        assert_eq!(mesh.hosts(), &[HostRef::new(dial_to.clone())]);
+        assert_eq!(
+            mesh.hosts()[0].mesh_agent().actor_addr().proc_addr().addr(),
+            &dial_to
+        );
     }
 
     #[tokio::test]
@@ -2316,8 +2352,8 @@ mod tests {
         let addr_a: ChannelAddr = "tcp:127.0.0.1:2001".parse().unwrap();
         let addr_b: ChannelAddr = "tcp:127.0.0.1:2002".parse().unwrap();
 
-        let ref_a = HostRef(addr_a.clone()).mesh_agent();
-        let ref_b = HostRef(addr_b.clone()).mesh_agent();
+        let ref_a = HostRef::new(addr_a.clone()).mesh_agent();
+        let ref_b = HostRef::new(addr_b.clone()).mesh_agent();
 
         let mut set = HostSet::new();
         set.insert(addr_a.to_string(), ref_a.clone());
@@ -2385,7 +2421,7 @@ mod tests {
         );
 
         // Client host entry overlaps with addr_a.
-        let client_ref = HostRef(addr_a.clone()).mesh_agent();
+        let client_ref = HostRef::new(addr_a.clone()).mesh_agent();
         let client_entries = vec![("client_addr".to_string(), client_ref)];
 
         let result = aggregate_hosts(&[&mesh], Some(client_entries));

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1359,7 +1359,7 @@ impl Controlled for ProcMeshRef {
         // Send one StreamState per proc to its host agent.
         for proc_id in self.proc_ids() {
             let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
-            let host = crate::host_mesh::HostRef(proc_id.addr().clone());
+            let host = crate::host_mesh::HostRef::new(proc_id.addr().clone());
             host.mesh_agent().post(
                 cx,
                 resource::StreamState::<Self::StateInner> {
@@ -1377,7 +1377,7 @@ impl Controlled for ProcMeshRef {
         msg: resource::WaitRankStatus,
     ) -> anyhow::Result<()> {
         for proc_id in self.proc_ids() {
-            let host = crate::host_mesh::HostRef(proc_id.addr().clone());
+            let host = crate::host_mesh::HostRef::new(proc_id.addr().clone());
             host.mesh_agent().post(cx, msg.clone());
         }
         Ok(())

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -138,7 +138,7 @@ pub fn attach_to_workers(
                 .into_iter()
                 .map(|result| {
                     let url_str: String = result.bind(py).extract()?;
-                    ChannelAddr::from_zmq_url(&url_str)
+                    Ok(ChannelAddr::from_zmq_url(&url_str)?.into_dial_addr())
                 })
                 .collect()
         })

--- a/python/monarch/_src/actor/bootstrap.py
+++ b/python/monarch/_src/actor/bootstrap.py
@@ -60,7 +60,9 @@ def run_worker_loop_forever(
     The server binds to ``tcp://0.0.0.0:4444`` so any local interface can
     accept connections (e.g. ``localhost`` for ``kubectl port-forward``)
     while peers still address the worker by its routable FQDN. Without the
-    ``@``-suffix, bind address equals advertised address.
+    ``@``-suffix, bind address equals advertised address. The ``@`` form is
+    only for serving: after the worker starts, its host identity is the
+    advertised address to the left of ``@``.
 
     The server will accept a connection to a new root client and enable it to
     use this machine as a host. If the client disconnects or cannot be contacted, this server
@@ -105,6 +107,12 @@ def attach_to_workers(
     used to decide if we have successfully connected to all hosts. Workers are specified with the same zmq-style
     specifier strings described in `run_worker_loop_forever`. They may be specified as monarch.actor.Future objects
     so that an implementation can do some asynchronous work to discover where to connect.
+
+    If a worker string uses the alias form ``dial_to@bind_to``,
+    ``attach_to_workers`` treats it as a reference to an already-serving
+    worker and stores only ``dial_to`` in the host mesh. The ``bind_to`` half
+    is a serve-side detail and is not part of the host, proc, or actor
+    identity.
 
 
     private_key is a tls private key file loaded as bytes used to establish secure connections.

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -9,7 +9,9 @@
 import os
 import pathlib
 import shutil
+import socket
 import stat
+import subprocess
 import sys
 import tempfile
 import textwrap
@@ -23,6 +25,7 @@ import pytest
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, context
+from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.host_mesh import HostMesh, this_host
 from monarch._src.actor.pickle import flatten, unflatten
@@ -147,6 +150,60 @@ def test_shutdown_host_mesh() -> None:
         am = pm.spawn("actor", RankActor)
         am.get_rank.choose().get()
         hm.shutdown().get()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_alias_bootstrap() -> None:
+    """A worker started with an alias address (dial_to@bind_to) is reachable.
+
+    The alias format `tcp://PUBLIC:PORT@tcp://0.0.0.0:PORT` lets a worker
+    advertise a dialable address while binding to a wildcard interface. This
+    is required where binding directly to the advertised address is not
+    possible (e.g. behind NAT, where only `0.0.0.0` can be bound).
+    """
+    procs = []
+    workers = []
+    for _i in range(2):
+        # Reserve an ephemeral port, then release it so the worker can bind
+        # to it via the alias's bind_to address.
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+
+        env = {**os.environ}
+        if "FB_XAR_INVOKED_NAME" in os.environ:
+            env["PYTHONPATH"] = ":".join(sys.path)
+
+        # dial_to advertises a reachable address; bind_to listens on the
+        # wildcard interface.
+        addr = f"tcp://127.0.0.1:{port}@tcp://0.0.0.0:{port}"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import sys; from monarch.actor import run_worker_loop_forever; "
+                f'run_worker_loop_forever(address={addr!r}, ca="trust_all_connections")',
+            ],
+            env=env,
+        )
+        procs.append(proc)
+        # Pass the full alias through attach_to_workers. The attach path must
+        # canonicalize this to dial_to before using it as host identity.
+        workers.append(addr)
+
+    try:
+        # pyrefly: ignore [bad-argument-type]
+        hosts = attach_to_workers(ca="trust_all_connections", workers=workers)
+        am = hosts.spawn_procs(per_host={"gpus": 1}).spawn("rank", RankActor)
+        ranks = sorted(v for _, v in am.get_rank.call().get().items())
+        assert ranks == [0, 1]
+        hosts.shutdown().get()
+    finally:
+        for proc in procs:
+            proc.kill()
+            proc.wait()
 
 
 @pytest.mark.timeout(60)


### PR DESCRIPTION
Summary:

`run_worker_loop_forever` accepts a ZMQ-style alias address (`tcp://DIAL@tcp://BIND`) so a worker can bind one address, often `0.0.0.0`, while advertising another address that clients can dial. The alias path was broken because the worker bind path and the identities derived from the advertised address disagreed.

The first issue was binding. TCP workers are served through the duplex net path, and `listen_with_prebound()` did not handle `ChannelAddr::Alias`, so an alias could fall through as `unsupported transport` instead of binding `bind_to`.

The second issue was identity. Serving an alias re-wrapped the advertised address as `Alias { dial_to, bind_to }`, while clients independently constructed the host reference from only `dial_to`. Proc addresses, actor addresses, host refs, and mailbox routing keys are identity-bearing values, so `Tcp(127.0.0.1:port)` and `Alias { dial_to: Tcp(127.0.0.1:port), ... }` did not match even though they describe the same endpoint.

This change treats aliases as serve-side input only. Net serving binds `bind_to` and advertises canonical `dial_to`; dialing canonicalizes aliases before constructing links; `HostRef` construction and deserialization canonicalize stored host addresses; and mailbox routing canonicalizes address fields before comparing or storing identity. The Python bootstrap path preserves the original alias string for worker startup while using the dial address where clients need to route messages.

Reviewed By: shayne-fletcher

Differential Revision: D107425190


