### PR TITLE
Make IbvManagerActor generic over device impl (#4161)

### DIFF
--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -17,6 +17,7 @@ erased-serde = "0.4.10"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
+inventory = "0.3.24"
 rand = "0.10.1"
 rdmaxcel-sys = { path = "../rdmaxcel-sys" }
 regex = "1.12.3"

--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -23,6 +23,7 @@ use crate::RdmaOpType;
 use crate::backend::RdmaBackend;
 use crate::backend::ibverbs::manager_actor::IbvBackend;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
+use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::tcp::manager_actor::TcpBackend;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
@@ -170,8 +171,9 @@ impl RdmaAction {
         // The ibv cell's inner `Option` distinguishes "lookup tried and
         // failed" (`Some(None)`) from "never tried" (cell unset), so the
         // lookup doesn't repeat when the local proc lacks ibverbs.
-        let ibv_cell: tokio::sync::OnceCell<Option<hyperactor::ActorHandle<IbvManagerActor>>> =
-            tokio::sync::OnceCell::new();
+        let ibv_cell: tokio::sync::OnceCell<
+            Option<hyperactor::ActorHandle<IbvManagerActor<MlxDevice>>>,
+        > = tokio::sync::OnceCell::new();
         // The tcp cell needs no such sentinel: the init closure either
         // caches a handle or bails.
         let tcp_cell: tokio::sync::OnceCell<hyperactor::ActorHandle<TcpManagerActor>> =

--- a/monarch_rdma/src/backend.rs
+++ b/monarch_rdma/src/backend.rs
@@ -32,7 +32,7 @@ use crate::RdmaTransportLevel;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RdmaRemoteBackendContext {
     Ibverbs(
-        ActorRef<ibverbs::manager_actor::IbvManagerActor>,
+        ActorRef<ibverbs::manager_actor::IbvManagerActor<ibverbs::mlx_device::MlxDevice>>,
         ibverbs::IbvBuffer,
     ),
     Tcp(ActorRef<tcp::manager_actor::TcpManagerActor>),

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -14,16 +14,17 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-pub(crate) mod device;
+pub mod device;
 pub mod device_selection;
 pub(crate) mod domain;
-pub(crate) mod efa_device;
+pub mod efa_device;
 pub mod manager_actor;
-pub(crate) mod mlx_device;
+pub mod mlx_device;
 pub mod primitives;
 pub mod queue_pair;
 
 use manager_actor::IbvManagerActor;
+use mlx_device::MlxDevice;
 pub use queue_pair::IbvQueuePair;
 pub use queue_pair::PollTarget;
 
@@ -57,7 +58,7 @@ pub struct IbvBuffer {
 /// Generic over the manager actor type so unit tests can swap in a
 /// mock; production code uses the default `IbvOp<IbvManagerActor>`.
 #[derive(Debug, Named)]
-pub struct IbvOp<M: Referable = IbvManagerActor> {
+pub struct IbvOp<M: Referable = IbvManagerActor<MlxDevice>> {
     pub op_type: RdmaOpType,
     pub local_memory: KeepaliveLocalMemory,
     pub remote_buffer: IbvBuffer,

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -14,9 +14,12 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
+pub(crate) mod device;
 pub mod device_selection;
 pub(crate) mod domain;
+pub(crate) mod efa_device;
 pub mod manager_actor;
+pub(crate) mod mlx_device;
 pub mod primitives;
 pub mod queue_pair;
 

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Backend-agnostic ibverbs device abstraction.
+//!
+//! [`IbvDevice`] owns the per-process state for a single opened RDMA
+//! device: an `Arc<IbvContext>`, an [`IbvConfig`], and a map of named
+//! `Arc<IbvDomain>`s allocated against the device.
+//! Per-backend behavior — claiming a device as the backend's,
+//! allocating a domain, and seeding config defaults — is provided by
+//! an [`IbvDeviceImpl`].
+//!
+//! Each [`IbvDeviceImpl`] registers itself via the `inventory` crate
+//! (using [`register_ibv_device_impl!`]). At first access,
+//! [`DEVICE_NAMES_BY_IMPL`] walks the ibverbs device list once and
+//! assigns each device to the first registered impl whose
+//! [`IbvDeviceImpl::is_instance`] claims it, caching the resulting
+//! `typename() → device-infos` map. [`IbvDevice::open`] consults this
+//! map: it returns `None` when `name` is not advertised under
+//! `I::typename()`, and otherwise opens the device using the cached
+//! [`IbvDeviceInfo`].
+
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+use typeuri::Named;
+
+use super::domain::IbvDomain;
+use super::primitives::IbvConfig;
+use super::primitives::IbvDeviceInfo;
+use super::primitives::query_device_info;
+
+/// Per-backend driver for [`IbvDevice`]. Concrete impls register
+/// themselves via [`register_ibv_device_impl!`].
+pub(crate) trait IbvDeviceImpl: Named + Send + Sync + 'static {
+    /// Human-readable display name for the backend this impl
+    /// drives (e.g., `"mellanox"`, `"efa"`). Surfaced in
+    /// diagnostics; not used as a registry key.
+    fn backend_name() -> &'static str;
+
+    /// Returns `true` if `ctx` belongs to this backend. Called
+    /// transiently, once per ibverbs device, while
+    /// [`DEVICE_NAMES_BY_IMPL`] is built.
+    fn is_instance(ctx: Arc<IbvContext>) -> bool;
+
+    /// Allocates a protection domain against `ctx` and wraps it in
+    /// an [`IbvDomain`]. The returned `Arc<IbvDomain>` is the sole
+    /// owner of the PD; the last drop runs `ibv_dealloc_pd`.
+    ///
+    /// The default implementation calls `ibv_alloc_pd` on
+    /// `ctx.as_ptr()` and constructs a plain [`IbvDomain`].
+    /// In a followup, we'll add an `IbvDomainImpl` trait to allow for
+    /// backend-specific domain implementations.
+    fn create_domain(ctx: Arc<IbvContext>) -> anyhow::Result<Arc<IbvDomain>> {
+        // SAFETY: `ctx.as_ptr()` is the non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call.
+        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(ctx.as_ptr()) };
+        if pd.is_null() {
+            anyhow::bail!("ibv_alloc_pd failed: {}", std::io::Error::last_os_error());
+        }
+        // TODO: `IbvDomain` should hold the `Arc<IbvContext>`
+        // itself so the context outlives the PD by construction;
+        // for now we copy the raw pointer and rely on the
+        // surrounding [`IbvDevice`] to keep the context alive.
+        Ok(Arc::new(IbvDomain {
+            context: ctx.as_ptr(),
+            pd,
+        }))
+    }
+
+    /// Seeds an [`IbvConfig`] with backend-appropriate defaults
+    /// (e.g., EFA caps `max_send_sge` at 1).
+    fn apply_config_defaults(config: &mut IbvConfig);
+}
+
+/// Inventory entry submitted by [`register_ibv_device_impl!`] for
+/// each concrete [`IbvDeviceImpl`]. Captures function pointers to
+/// the impl's `typename()`, `backend_name()`, and `is_instance()`,
+/// all erased of the concrete type.
+pub struct IbvDeviceImplRegistration {
+    typename: fn() -> &'static str,
+    backend_name: fn() -> &'static str,
+    is_instance: fn(Arc<IbvContext>) -> bool,
+}
+
+/// Per-impl entry stored in [`DEVICE_NAMES_BY_IMPL`]. Keyed by
+/// `typename()`; carries the human-readable `backend_name` for
+/// diagnostics alongside the impl's device infos.
+#[derive(Debug)]
+struct RegisteredBackend {
+    #[expect(
+        dead_code,
+        reason = "read only via Debug for the IbvDevice::open diagnostic warning"
+    )]
+    backend_name: &'static str,
+    devices: Vec<IbvDeviceInfo>,
+}
+
+inventory::collect!(IbvDeviceImplRegistration);
+
+/// Submits an `inventory` entry for a concrete [`IbvDeviceImpl`].
+///
+/// Place one invocation per impl at module scope. The expansion
+/// references `inventory` and `typeuri` by bare crate name, so the
+/// calling crate must list both as direct dependencies.
+///
+/// ```ignore
+/// register_ibv_device_impl!(StandardImpl);
+/// ```
+#[macro_export]
+macro_rules! register_ibv_device_impl {
+    ($impl_ty:ty) => {
+        inventory::submit! {
+            $crate::backend::ibverbs::device::IbvDeviceImplRegistration::new(
+                <$impl_ty as typeuri::Named>::typename,
+                <$impl_ty as $crate::backend::ibverbs::device::IbvDeviceImpl>::backend_name,
+                <$impl_ty as $crate::backend::ibverbs::device::IbvDeviceImpl>::is_instance,
+            )
+        }
+    };
+}
+
+impl IbvDeviceImplRegistration {
+    /// Construct a registration. Visible to the rest of the crate
+    /// so the [`register_ibv_device_impl!`] macro can call it from
+    /// sibling call sites.
+    pub(crate) const fn new(
+        typename: fn() -> &'static str,
+        backend_name: fn() -> &'static str,
+        is_instance: fn(Arc<IbvContext>) -> bool,
+    ) -> Self {
+        Self {
+            typename,
+            backend_name,
+            is_instance,
+        }
+    }
+}
+
+/// Process-wide map from `IbvDeviceImpl::typename()` to a
+/// [`RegisteredBackend`] holding the impl's display name and the
+/// device infos it claims. Built once on first access by a single
+/// walk of the ibverbs device list, assigning each device to the
+/// first registration whose `is_instance` claims it.
+static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> =
+    LazyLock::new(|| {
+        let registrations: Vec<&IbvDeviceImplRegistration> =
+            inventory::iter::<IbvDeviceImplRegistration>().collect();
+        let mut by_impl: HashMap<&'static str, RegisteredBackend> = registrations
+            .iter()
+            .map(|reg| {
+                (
+                    (reg.typename)(),
+                    RegisteredBackend {
+                        backend_name: (reg.backend_name)(),
+                        devices: Vec::new(),
+                    },
+                )
+            })
+            .collect();
+
+        let mut num_devices = 0i32;
+        // SAFETY: `ibv_get_device_list` populates `num_devices` and
+        // returns either null or a pointer to `num_devices` entries;
+        // we free it before returning.
+        let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+        // A non-null list must be freed even when empty, so only the
+        // null case returns early; the loop below is a no-op at zero
+        // devices and the `ibv_free_device_list` at the end still runs.
+        if device_list.is_null() {
+            return by_impl;
+        }
+        for i in 0..num_devices {
+            // SAFETY: `device_list` is non-null with `num_devices`
+            // valid entries (checked above).
+            let device = unsafe { *device_list.add(i as usize) };
+            if device.is_null() {
+                continue;
+            }
+            // SAFETY: `device` is non-null per the check above.
+            let raw_ctx = unsafe { rdmaxcel_sys::ibv_open_device(device) };
+            if raw_ctx.is_null() {
+                continue;
+            }
+            let ctx = Arc::new(IbvContext(raw_ctx));
+            // Assign the device to the first impl that claims it.
+            if let Some(reg) = registrations
+                .iter()
+                .find(|reg| (reg.is_instance)(Arc::clone(&ctx)))
+            {
+                // SAFETY: `device` and `ctx.as_ptr()` are non-null and
+                // `ctx.as_ptr()` was returned by `ibv_open_device(device)`.
+                if let Some(info) = unsafe { query_device_info(device, ctx.as_ptr()) } {
+                    by_impl
+                        .get_mut((reg.typename)())
+                        .expect("registration typename present in map")
+                        .devices
+                        .push(info);
+                }
+            }
+            // `ctx` drops here, closing the transient context.
+        }
+        // SAFETY: `device_list` was returned by `ibv_get_device_list`
+        // above and has not been freed.
+        unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+        by_impl
+    });
+
+/// RAII owner of a raw `ibv_context*`.
+///
+/// Closes the context in [`Drop`]. Held inside an `Arc` not because
+/// clones are expected to outlive the owning [`IbvDevice`], but so
+/// the raw pointer can be passed around with a lifetime safeguard
+/// where borrow-checked references aren't practical.
+pub(crate) struct IbvContext(*mut rdmaxcel_sys::ibv_context);
+
+// SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
+// operations we perform (allocation, polling, and the final close).
+unsafe impl Send for IbvContext {}
+unsafe impl Sync for IbvContext {}
+
+impl IbvContext {
+    /// Returns the raw `ibv_context*`. The pointer is valid for
+    /// the lifetime of `&self`.
+    pub(crate) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
+        self.0
+    }
+}
+
+impl Drop for IbvContext {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            return;
+        }
+        // SAFETY: `self.0` was returned by `ibv_open_device` in
+        // `IbvDevice::open` and has not been closed elsewhere. The
+        // intended ownership is a single `Arc<IbvContext>`, whose
+        // final `Drop` calls `ibv_close_device` exactly once.
+        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.0) };
+        if result != 0 {
+            tracing::error!(
+                "ibv_close_device failed for context {:p}: error code {}",
+                self.0,
+                result
+            );
+        }
+    }
+}
+
+/// An opened RDMA device.
+///
+/// Owns an `Arc<IbvContext>`, the queried [`IbvDeviceInfo`]
+/// metadata, a device-scoped [`IbvDeviceConfig`], and a map of
+/// named `Arc<IbvDomain>`s allocated against the device (one PD
+/// per name, created lazily by [`Self::get_or_create_domain`]).
+///
+/// `I` is the backend driver type, parameterizing all per-backend
+/// behavior via [`IbvDeviceImpl`].
+///
+/// Field declaration order is significant: `domains` is declared
+/// before `context` so that, on drop, every `Arc<IbvDomain>` in
+/// the map releases its PD before the final `Arc<IbvContext>`
+/// reference closes the context.
+pub(crate) struct IbvDevice<I: IbvDeviceImpl> {
+    domains: HashMap<String, Arc<IbvDomain>>,
+    device_info: IbvDeviceInfo,
+    config: IbvConfig,
+    context: Arc<IbvContext>,
+    _marker: PhantomData<I>,
+}
+
+#[expect(dead_code, reason = "called by manager_actor in follow-up commits")]
+impl<I: IbvDeviceImpl> IbvDevice<I> {
+    /// Opens `name` under impl `I`, storing `config` as-is. Returns
+    /// `None` if `name` is not one of the devices registered for
+    /// `I::typename()`; otherwise returns an `IbvDevice<I>` with the
+    /// device's queried [`IbvDeviceInfo`] and the given [`IbvConfig`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if a registered device cannot be opened — e.g. it
+    /// disappeared from the system between registration and open.
+    /// Such a failure indicates a broken driver invariant rather
+    /// than a runtime condition the caller can recover from.
+    pub(crate) fn open(name: &str, config: IbvConfig) -> Option<Self> {
+        let device_info = DEVICE_NAMES_BY_IMPL
+            .get(I::typename())
+            .and_then(|entry| entry.devices.iter().find(|d| d.name() == name).cloned());
+        let device_info = match device_info {
+            Some(info) => info,
+            None => {
+                tracing::warn!(
+                    "ibv device {} not found under backend {}; available: {:?}",
+                    name,
+                    I::backend_name(),
+                    *DEVICE_NAMES_BY_IMPL,
+                );
+                return None;
+            }
+        };
+
+        // The registry already confirmed `name` belongs to `I`, so
+        // reopen the device by name; a miss here is a broken invariant.
+        let mut num_devices = 0i32;
+        // SAFETY: `ibv_get_device_list` populates `num_devices` and
+        // returns either null or a pointer to `num_devices` entries;
+        // we free it before returning.
+        let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+        assert!(
+            !device_list.is_null(),
+            "RDMA device list was null while opening registered device {}",
+            name,
+        );
+        if num_devices == 0 {
+            // A non-null list must be freed even when empty, per the
+            // libibverbs contract.
+            // SAFETY: `device_list` is non-null (asserted above) and was
+            // returned by `ibv_get_device_list`.
+            unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+            panic!(
+                "no RDMA devices found while opening registered device {}",
+                name
+            );
+        }
+        let mut target = std::ptr::null_mut();
+        for i in 0..num_devices {
+            // SAFETY: `device_list` is non-null with `num_devices`
+            // valid entries (checked above).
+            let device = unsafe { *device_list.add(i as usize) };
+            if device.is_null() {
+                continue;
+            }
+            // SAFETY: `device` is non-null per the check above;
+            // `ibv_get_device_name` returns a null-terminated C string
+            // owned by the device list.
+            let dev_name = unsafe { CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device)) };
+            if dev_name.to_bytes() == name.as_bytes() {
+                target = device;
+                break;
+            }
+        }
+        let mut failure = None;
+        let mut context: *mut crate::rdmaxcel_sys::ibv_context = std::ptr::null_mut();
+        if target.is_null() {
+            failure = Some(format!(
+                "ibv device with name {} not found by ibv_get_device_list",
+                name
+            ));
+        } else {
+            // Open while `target` still points into `device_list`, then free.
+            // SAFETY: `target`, when non-null, is one of `device_list`'s
+            // entries; `ibv_open_device` returns null on failure.
+            context = unsafe { rdmaxcel_sys::ibv_open_device(target) };
+            if context.is_null() {
+                failure = Some(format!(
+                    "registered ibv device {} could not be opened: {}",
+                    name,
+                    std::io::Error::last_os_error(),
+                ));
+            }
+        }
+
+        // SAFETY: `device_list` was returned by `ibv_get_device_list`
+        // above and has not been freed.
+        unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+
+        if let Some(failure) = failure {
+            panic!("{}", failure);
+        }
+
+        Some(Self {
+            domains: HashMap::new(),
+            device_info,
+            config,
+            context: Arc::new(IbvContext(context)),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Returns the `Arc<IbvContext>` for this device.
+    pub(crate) fn context(&self) -> Arc<IbvContext> {
+        Arc::clone(&self.context)
+    }
+
+    /// Returns the queried [`IbvDeviceInfo`] metadata for this
+    /// device.
+    pub(crate) fn device_info(&self) -> &IbvDeviceInfo {
+        &self.device_info
+    }
+
+    /// Returns the [`IbvConfig`] this device was opened with.
+    pub(crate) fn config(&self) -> &IbvConfig {
+        &self.config
+    }
+
+    /// Returns the `Arc<IbvDomain>` registered under `name`,
+    /// creating (and caching) a new one via
+    /// [`IbvDeviceImpl::create_domain`] on first access.
+    pub(crate) fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
+        if let Some(domain) = self.domains.get(name) {
+            return Ok(Arc::clone(domain));
+        }
+        let domain = I::create_domain(Arc::clone(&self.context))?;
+        self.domains.insert(name.to_string(), Arc::clone(&domain));
+        Ok(domain)
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -40,7 +40,7 @@ use super::primitives::query_device_info;
 
 /// Per-backend driver for [`IbvDevice`]. Concrete impls register
 /// themselves via [`register_ibv_device_impl!`].
-pub(crate) trait IbvDeviceImpl: Named + Send + Sync + 'static {
+pub trait IbvDeviceImpl: Named + std::fmt::Debug + Send + Sync + 'static {
     /// Human-readable display name for the backend this impl
     /// drives (e.g., `"mellanox"`, `"efa"`). Surfaced in
     /// diagnostics; not used as a registry key.
@@ -132,7 +132,7 @@ impl IbvDeviceImplRegistration {
     /// Construct a registration. Visible to the rest of the crate
     /// so the [`register_ibv_device_impl!`] macro can call it from
     /// sibling call sites.
-    pub(crate) const fn new(
+    pub const fn new(
         typename: fn() -> &'static str,
         backend_name: fn() -> &'static str,
         is_instance: fn(Arc<IbvContext>) -> bool,
@@ -220,7 +220,8 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
 /// clones are expected to outlive the owning [`IbvDevice`], but so
 /// the raw pointer can be passed around with a lifetime safeguard
 /// where borrow-checked references aren't practical.
-pub(crate) struct IbvContext(*mut rdmaxcel_sys::ibv_context);
+#[derive(Debug)]
+pub struct IbvContext(*mut rdmaxcel_sys::ibv_context);
 
 // SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
 // operations we perform (allocation, polling, and the final close).
@@ -230,7 +231,7 @@ unsafe impl Sync for IbvContext {}
 impl IbvContext {
     /// Returns the raw `ibv_context*`. The pointer is valid for
     /// the lifetime of `&self`.
-    pub(crate) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
+    pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
         self.0
     }
 }
@@ -269,6 +270,7 @@ impl Drop for IbvContext {
 /// before `context` so that, on drop, every `Arc<IbvDomain>` in
 /// the map releases its PD before the final `Arc<IbvContext>`
 /// reference closes the context.
+#[derive(Debug)]
 pub(crate) struct IbvDevice<I: IbvDeviceImpl> {
     domains: HashMap<String, Arc<IbvDomain>>,
     device_info: IbvDeviceInfo,
@@ -290,7 +292,7 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
     /// disappeared from the system between registration and open.
     /// Such a failure indicates a broken driver invariant rather
     /// than a runtime condition the caller can recover from.
-    pub(crate) fn open(name: &str, config: IbvConfig) -> Option<Self> {
+    pub fn open(name: &str, config: IbvConfig) -> Option<Self> {
         let device_info = DEVICE_NAMES_BY_IMPL
             .get(I::typename())
             .and_then(|entry| entry.devices.iter().find(|d| d.name() == name).cloned());
@@ -386,30 +388,46 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
     }
 
     /// Returns the `Arc<IbvContext>` for this device.
-    pub(crate) fn context(&self) -> Arc<IbvContext> {
+    pub fn context(&self) -> Arc<IbvContext> {
         Arc::clone(&self.context)
     }
 
     /// Returns the queried [`IbvDeviceInfo`] metadata for this
     /// device.
-    pub(crate) fn device_info(&self) -> &IbvDeviceInfo {
+    pub fn device_info(&self) -> &IbvDeviceInfo {
         &self.device_info
     }
 
     /// Returns the [`IbvConfig`] this device was opened with.
-    pub(crate) fn config(&self) -> &IbvConfig {
+    pub fn config(&self) -> &IbvConfig {
         &self.config
+    }
+
+    /// Returns the `Arc<IbvDomain>` registered under `name`, if
+    /// one has already been created. Read-only lookup; use
+    /// [`Self::get_or_create_domain`] to create on demand.
+    pub fn domain(&self, name: &str) -> Option<&Arc<IbvDomain>> {
+        self.domains.get(name)
     }
 
     /// Returns the `Arc<IbvDomain>` registered under `name`,
     /// creating (and caching) a new one via
     /// [`IbvDeviceImpl::create_domain`] on first access.
-    pub(crate) fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
+    pub fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
         if let Some(domain) = self.domains.get(name) {
             return Ok(Arc::clone(domain));
         }
         let domain = I::create_domain(Arc::clone(&self.context))?;
         self.domains.insert(name.to_string(), Arc::clone(&domain));
         Ok(domain)
+    }
+
+    /// Whether any device claimed by impl `I` is present on this
+    /// host. Reads the [`DEVICE_NAMES_BY_IMPL`] registry, built on
+    /// first access by a single walk of the ibverbs device list.
+    pub fn available() -> bool {
+        DEVICE_NAMES_BY_IMPL
+            .get(I::typename())
+            .is_some_and(|backend| !backend.devices.is_empty())
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -11,7 +11,7 @@
 
 use std::sync::OnceLock;
 
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 use super::primitives::get_all_devices;
 use crate::device_selection::PCIDevice;
 use crate::device_selection::get_all_rdma_devices;
@@ -24,7 +24,7 @@ use crate::device_selection::parse_pci_topology;
 /// Step 2: Get PCI address from compute device
 /// Step 3: Get PCI address for all RDMA NIC devices
 /// Step 4: Calculate PCI distances and return closest RDMA NIC device
-pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice> {
+pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDeviceInfo> {
     let device_hint = device_hint?;
 
     let (prefix, postfix) = parse_device_string(device_hint)?;
@@ -44,7 +44,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
             };
             let rdma_devices = get_all_rdma_devices();
             if rdma_devices.is_empty() {
-                return IbvDevice::first_available();
+                return IbvDeviceInfo::first_available();
             }
             let pci_devices = parse_pci_topology().ok()?;
             let source_device = pci_devices.get(&source_pci_addr)?;
@@ -68,7 +68,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
             }
 
             // Fallback
-            IbvDevice::first_available()
+            IbvDeviceInfo::first_available()
         }
         _ => {
             // Direct device name lookup for backward compatibility
@@ -85,8 +85,8 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
 ///
 /// Computed at most once per process on the first RDMA operation involving
 /// CUDA memory. CPU-only workloads pay no initialization cost.
-pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDevice>> {
-    static CUDA_DEVICE_TO_IBV: OnceLock<Vec<Option<IbvDevice>>> = OnceLock::new();
+pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDeviceInfo>> {
+    static CUDA_DEVICE_TO_IBV: OnceLock<Vec<Option<IbvDeviceInfo>>> = OnceLock::new();
     CUDA_DEVICE_TO_IBV.get_or_init(|| {
         let count = unsafe {
             let mut c: i32 = 0;
@@ -103,7 +103,7 @@ pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDevice>> {
 ///
 /// Applies auto-detection for default devices, but otherwise
 /// returns the device as-is.
-pub fn resolve_ibv_device(device: &IbvDevice) -> Option<IbvDevice> {
+pub fn resolve_ibv_device(device: &IbvDeviceInfo) -> Option<IbvDeviceInfo> {
     let device_name = device.name();
 
     if device_name.starts_with("mlx") {

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -16,7 +16,7 @@ use std::ffi::CStr;
 use std::io::Error;
 use std::result::Result;
 
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 
 /// Manages RDMA resources including context and protection domain.
 ///
@@ -83,7 +83,7 @@ impl IbvDomain {
     ///
     /// Returns errors if no RDMA devices are found, the specified device cannot be found,
     /// device context creation fails, or protection domain allocation fails.
-    pub fn new(device: IbvDevice) -> Result<Self, anyhow::Error> {
+    pub fn new(device: IbvDeviceInfo) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating IbvDomain for device {}", device.name());
         unsafe {
             let device_name = device.name();

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -31,6 +31,7 @@ use hyperactor_config::Flattrs;
 use super::IbvBuffer;
 use super::manager_actor::IbvManagerActor;
 use super::manager_actor::IbvManagerMessageClient;
+use super::mlx_device::MlxDevice;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::PollTarget;
 use crate::IbvConfig;
@@ -490,13 +491,13 @@ pub struct DoorbellTestEnv {
     pub client_2: hyperactor::Client,
     pub actor_1: ActorRef<RdmaManagerActor>,
     pub actor_2: ActorRef<RdmaManagerActor>,
-    pub ibv_actor_1: ActorRef<IbvManagerActor>,
-    pub ibv_actor_2: ActorRef<IbvManagerActor>,
+    pub ibv_actor_1: ActorRef<IbvManagerActor<MlxDevice>>,
+    pub ibv_actor_2: ActorRef<IbvManagerActor<MlxDevice>>,
     /// In-proc handles for the same actors as `ibv_actor_*`.
     /// Tests that need to call local-only messages such as
     /// `RawQueuePair` go through these.
-    pub ibv_handle_1: ActorHandle<IbvManagerActor>,
-    pub ibv_handle_2: ActorHandle<IbvManagerActor>,
+    pub ibv_handle_1: ActorHandle<IbvManagerActor<MlxDevice>>,
+    pub ibv_handle_2: ActorHandle<IbvManagerActor<MlxDevice>>,
     pub rdma_handle_1: RdmaRemoteBuffer,
     pub rdma_handle_2: RdmaRemoteBuffer,
     pub local_memory_1: KeepaliveLocalMemory,
@@ -684,14 +685,12 @@ impl DoorbellTestEnv {
         let (ibv_actor_2, ibv_buffer_2) = rdma_handle_2
             .resolve_ibv()
             .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 2"))?;
-        let ibv_handle_1: ActorHandle<IbvManagerActor> =
-            ibv_actor_1
-                .downcast_handle(&instance_1)
-                .ok_or_else(|| anyhow::anyhow!("ibv_actor_1 is not in proc_1"))?;
-        let ibv_handle_2: ActorHandle<IbvManagerActor> =
-            ibv_actor_2
-                .downcast_handle(&instance_2)
-                .ok_or_else(|| anyhow::anyhow!("ibv_actor_2 is not in proc_2"))?;
+        let ibv_handle_1: ActorHandle<IbvManagerActor<MlxDevice>> = ibv_actor_1
+            .downcast_handle(&instance_1)
+            .ok_or_else(|| anyhow::anyhow!("ibv_actor_1 is not in proc_1"))?;
+        let ibv_handle_2: ActorHandle<IbvManagerActor<MlxDevice>> = ibv_actor_2
+            .downcast_handle(&instance_2)
+            .ok_or_else(|| anyhow::anyhow!("ibv_actor_2 is not in proc_2"))?;
 
         // Fill buffer1 with test data
         if parsed_accel1.0 == "cuda" {

--- a/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
@@ -25,6 +25,7 @@ mod tests {
     use super::super::doorbell_test_utils::*;
     use super::super::manager_actor::IbvManagerActor;
     use super::super::manager_actor::RawQueuePair;
+    use super::super::mlx_device::MlxDevice;
     use super::super::primitives::get_all_devices;
     use crate::rdma_components::validate_execution_context;
 
@@ -32,16 +33,16 @@ mod tests {
     /// a queue pair via the legacy test path. Replaces the old
     /// `manager_actor::request_queue_pair` helper.
     async fn request_queue_pair(
-        actor: &ActorHandle<IbvManagerActor>,
+        actor: &ActorHandle<IbvManagerActor<MlxDevice>>,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
-        other: ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor<MlxDevice>>,
         self_device: String,
         other_device: String,
     ) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
         let (reply, rx) = Mailbox::mailbox(cx).open_once_port::<Result<IbvQueuePair, String>>();
         actor.try_post(
             cx,
-            RawQueuePair {
+            RawQueuePair::<MlxDevice> {
                 peer: other,
                 self_device,
                 peer_device: other_device,

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! EFA backend for [`IbvDevice`].
+
+use std::sync::Arc;
+
+use typeuri::Named;
+
+use super::device::IbvContext;
+use super::device::IbvDeviceImpl;
+use super::primitives::IbvConfig;
+use crate::register_ibv_device_impl;
+
+/// AWS EFA (Elastic Fabric Adapter) backend.
+#[derive(Named)]
+pub(crate) struct EfaDevice;
+
+impl IbvDeviceImpl for EfaDevice {
+    fn backend_name() -> &'static str {
+        "efa"
+    }
+
+    fn is_instance(ctx: Arc<IbvContext>) -> bool {
+        // SAFETY: `ctx.as_ptr()` is a non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call.
+        unsafe { rdmaxcel_sys::rdmaxcel_is_efa_dev(ctx.as_ptr()) != 0 }
+    }
+
+    fn apply_config_defaults(config: &mut IbvConfig) {
+        config.gid_index = 0;
+        config.max_send_sge = 1;
+        config.max_recv_sge = 1;
+        config.max_dest_rd_atomic = 0;
+        config.max_rd_atomic = 0;
+    }
+}
+
+register_ibv_device_impl!(EfaDevice);

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -18,8 +18,8 @@ use super::primitives::IbvConfig;
 use crate::register_ibv_device_impl;
 
 /// AWS EFA (Elastic Fabric Adapter) backend.
-#[derive(Named)]
-pub(crate) struct EfaDevice;
+#[derive(Debug, Named)]
+pub struct EfaDevice;
 
 impl IbvDeviceImpl for EfaDevice {
     fn backend_name() -> &'static str {

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -48,7 +48,7 @@ use super::IbvBuffer;
 use super::IbvOp;
 use super::domain::IbvDomain;
 use super::primitives::IbvConfig;
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMemoryRegion;
 use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvQpInfo;
@@ -348,7 +348,7 @@ impl IbvManagerActor {
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
-        rdma_device: &IbvDevice,
+        rdma_device: &IbvDeviceInfo,
     ) -> Result<Arc<IbvDomain>, anyhow::Error> {
         if let Some((domain, _)) = self.device_domains.get(device_name) {
             return Ok(Arc::clone(domain));

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -18,6 +18,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Write as _;
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -46,9 +47,11 @@ use typeuri::Named;
 
 use super::IbvBuffer;
 use super::IbvOp;
+use super::device::IbvDevice;
+use super::device::IbvDeviceImpl;
 use super::domain::IbvDomain;
+use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
-use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMemoryRegion;
 use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvQpInfo;
@@ -87,7 +90,7 @@ pub(super) struct CreatePeerQueuePair<M: Referable> {
     /// One-shot reply carrying the peer's endpoint, or an error.
     pub(super) reply: OncePortRef<Result<IbvQpInfo, String>>,
 }
-wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor>);
+wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<MlxDevice>>);
 
 /// Local-only message: submit a batch of RDMA ops for end-to-end
 /// execution. The manager iterates the batch, resolves each op's
@@ -99,8 +102,8 @@ wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor>);
 ///
 /// Per-op completion notifications stream back on `reply` as
 /// [`OpResult`] values.
-pub(super) struct SubmitOps {
-    pub(super) ops: Vec<IbvOp<IbvManagerActor>>,
+pub(super) struct SubmitOps<I: IbvDeviceImpl> {
+    pub(super) ops: Vec<IbvOp<IbvManagerActor<I>>>,
     pub(super) reply: PortHandle<OpResult>,
 }
 
@@ -109,8 +112,8 @@ pub(super) struct SubmitOps {
 /// `peer_device`), and return the connected QP. Lets doorbell tests
 /// and the `cuda_ping_pong` example poke a real QP without going
 /// through [`QueuePairActor`].
-pub struct RawQueuePair {
-    pub peer: ActorRef<IbvManagerActor>,
+pub struct RawQueuePair<I: IbvDeviceImpl> {
+    pub peer: ActorRef<IbvManagerActor<I>>,
     pub self_device: String,
     pub peer_device: String,
     pub reply: OncePortHandle<Result<IbvQueuePair, String>>,
@@ -190,25 +193,33 @@ pub(super) struct SegmentInfo {
     pub(super) rkey: u32,
 }
 
+/// Default key used for the per-device protection domain inside
+/// each [`IbvDevice<I>`] entry of [`IbvManagerActor::devices`].
+const DEFAULT_DOMAIN: &str = "default";
+
 /// Manages all ibverbs-specific RDMA resources and operations.
 ///
 /// This struct handles memory registration, queue pair management,
 /// and connection establishment using the ibverbs API.
+///
+/// Generic over `I: IbvDeviceImpl` so the same actor implementation
+/// drives every concrete backend (`IbvManagerActor<MlxDevice>`,
+/// `IbvManagerActor<EfaDevice>`, ...).
 #[derive(Debug)]
 #[hyperactor::export(
     handlers = [
         IbvManagerMessage,
-        CreatePeerQueuePair<IbvManagerActor>,
+        CreatePeerQueuePair<IbvManagerActor<I>>,
     ],
 )]
-pub struct IbvManagerActor {
+pub struct IbvManagerActor<I: IbvDeviceImpl> {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
     /// Active-side [`QueuePairActor`] children, keyed from this
     /// manager's perspective. Lazily populated on the first
     /// [`SubmitOps`] that targets a new `(self_device, peer,
     /// other_device)` triple.
-    qp_handles: HashMap<QpKey, ActorHandle<QueuePairActor<IbvManagerActor, IbvQueuePair>>>,
+    qp_handles: HashMap<QpKey, ActorHandle<QueuePairActor<IbvManagerActor<I>, IbvQueuePair>>>,
 
     /// Passive-side mirror QPs, created in response to a peer's
     /// [`CreatePeerQueuePair`]. The peer's [`QueuePairActor`] owns
@@ -217,14 +228,13 @@ pub struct IbvManagerActor {
     /// each QP via [`IbvQueuePair`]'s own `Drop`.
     peer_created_qps: HashMap<QpKey, IbvQueuePair>,
 
-    /// Map of RDMA device names to their domains and loopback QPs.
-    /// Created lazily when memory is registered for a specific
-    /// device. `Arc<IbvDomain>` so every `IbvMemoryRegionView`
-    /// registered against the domain can hold a clone and keep the
-    /// PD alive until the last MR is dereg'd. The loopback QP is
+    /// Map of RDMA device names to their opened [`IbvDevice<I>`]
+    /// (which owns the per-device `Arc<IbvContext>` and the
+    /// `DEFAULT_DOMAIN` `Arc<IbvDomain>`) and an optional loopback
+    /// QP used by the CUDA segment scanner. The loopback QP is
     /// owned by this map and destroyed via [`IbvQueuePair`]'s `Drop`
     /// when the entry is removed.
-    device_domains: HashMap<String, (Arc<IbvDomain>, Option<Arc<IbvQueuePair>>)>,
+    devices: HashMap<String, (IbvDevice<I>, Option<IbvQueuePair>)>,
 
     config: IbvConfig,
 
@@ -246,10 +256,12 @@ pub struct IbvManagerActor {
     /// resources are released by the `Arc`s' `Drop`s once no other
     /// holder of those views remains.
     buffer_registrations: HashMap<usize, (IbvBuffer, IbvMemoryRegionView)>,
+
+    _marker: PhantomData<I>,
 }
 
 #[async_trait]
-impl Actor for IbvManagerActor {
+impl<I: IbvDeviceImpl> Actor for IbvManagerActor<I> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         let owner = if let Some(owner) = this.parent_handle() {
             owner
@@ -263,7 +275,7 @@ impl Actor for IbvManagerActor {
     }
 }
 
-impl Drop for IbvManagerActor {
+impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
     fn drop(&mut self) {
         // Drain active-side QP actors. Each child owns its
         // `IbvQueuePair`; `drain_and_stop` schedules the actor to
@@ -274,20 +286,23 @@ impl Drop for IbvManagerActor {
         }
 
         // The remaining fields (`peer_created_qps`,
-        // `buffer_registrations`, `segments_mr`, `device_domains`)
+        // `buffer_registrations`, `segments_mr`, `devices`)
         // free their FFI resources through their elements' `Drop`s
         // when this struct is dropped.
     }
 }
 
-impl IbvManagerActor {
+// `local_handle` ties to `RdmaManagerActor::get_ibv_actor_ref`'s
+// concrete `ActorRef<IbvManagerActor<MlxDevice>>` return type, so it
+// only exists on the `MlxDevice` monomorphization for now.
+impl IbvManagerActor<MlxDevice> {
     /// Construct an [`ActorHandle`] for the [`IbvManagerActor`] co-located
     /// with the caller by querying the local [`RdmaManagerActor`].
     pub async fn local_handle(
         client: &(impl hyperactor::context::Actor + Send + Sync),
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
         let rdma_handle = RdmaManagerActor::local_handle(client);
-        let ibv_ref: ActorRef<IbvManagerActor> = rdma_handle
+        let ibv_ref: ActorRef<IbvManagerActor<MlxDevice>> = rdma_handle
             .get_ibv_actor_ref(client)
             .await?
             .ok_or_else(|| anyhow::anyhow!("local RdmaManagerActor has no ibverbs backend"))?;
@@ -295,7 +310,9 @@ impl IbvManagerActor {
             .downcast_handle(client)
             .ok_or_else(|| anyhow::anyhow!("IbvManagerActor is not in the local process"))
     }
+}
 
+impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     /// Create a new IbvManagerActor with the given configuration.
     pub async fn new(params: Option<IbvConfig>) -> Result<Self, anyhow::Error> {
         if !ibverbs_supported() {
@@ -304,8 +321,16 @@ impl IbvManagerActor {
             ));
         }
 
-        // Use provided config or default if none provided
-        let mut config = params.unwrap_or_default();
+        // Use the caller's config; when none is given, start from the
+        // defaults and let the backend seed its own.
+        let mut config = match params {
+            Some(config) => config,
+            None => {
+                let mut config = IbvConfig::default();
+                I::apply_config_defaults(&mut config);
+                config
+            }
+        };
         tracing::debug!("rdma is enabled, config device hint: {}", config.device);
 
         let mlx5dv_enabled = resolve_qp_type(config.qp_type) == rdmaxcel_sys::RDMA_QP_TYPE_MLX5DV;
@@ -330,34 +355,36 @@ impl IbvManagerActor {
             owner: OnceLock::new(),
             qp_handles: HashMap::new(),
             peer_created_qps: HashMap::new(),
-            device_domains: HashMap::new(),
+            devices: HashMap::new(),
             config,
             mlx5dv_enabled,
             segments_mr: None,
             mrv_id: 0,
             buffer_registrations: HashMap::new(),
+            _marker: PhantomData,
         };
 
         Ok(actor)
     }
 
-    /// Get or create a domain (and its loopback QP, if mlx5dv is
-    /// supported) for the specified RDMA device. The loopback QP is
-    /// kept in [`Self::device_domains`] solely so the CUDA segment
-    /// scanner can hand its raw pointer to `register_segments`.
+    /// Get or create the default domain (and a loopback QP, if
+    /// mlx5dv is supported) for the named RDMA device. The
+    /// loopback QP is kept in [`Self::devices`] solely so
+    /// the CUDA segment scanner can hand its raw pointer to
+    /// `register_segments`.
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
-        rdma_device: &IbvDeviceInfo,
     ) -> Result<Arc<IbvDomain>, anyhow::Error> {
-        if let Some((domain, _)) = self.device_domains.get(device_name) {
-            return Ok(Arc::clone(domain));
+        if let Some((device, _)) = self.devices.get_mut(device_name) {
+            return device.get_or_create_domain(DEFAULT_DOMAIN);
         }
 
-        // Create new domain for this device
-        let domain = Arc::new(IbvDomain::new(rdma_device.clone()).map_err(|e| {
-            anyhow::anyhow!("could not create domain for device {}: {}", device_name, e)
-        })?);
+        let mut device =
+            IbvDevice::<I>::open(device_name, self.config.clone()).ok_or_else(|| {
+                anyhow::anyhow!("{} does not advertise {}", I::backend_name(), device_name,)
+            })?;
+        let domain = device.get_or_create_domain(DEFAULT_DOMAIN)?;
 
         // Print device info if MONARCH_DEBUG_RDMA=1 is set (before initial QP creation)
         crate::print_device_info_if_debug_enabled(domain.context);
@@ -386,13 +413,12 @@ impl IbvManagerActor {
                 )
             })?;
 
-            Some(Arc::new(qp))
+            Some(qp)
         } else {
             None
         };
 
-        self.device_domains
-            .insert(device_name.to_string(), (Arc::clone(&domain), qp));
+        self.devices.insert(device_name.to_string(), (device, qp));
         Ok(domain)
     }
 
@@ -408,15 +434,19 @@ impl IbvManagerActor {
         let mut pds = Vec::with_capacity(cuda_map.len());
         let mut qps = Vec::with_capacity(cuda_map.len());
         for maybe_device in cuda_map {
-            if let Some(device) = maybe_device {
-                if let Some((domain, qp)) = self.device_domains.get(device.name()) {
-                    pds.push(domain.pd);
+            if let Some(info) = maybe_device {
+                if let Some((device, qp)) = self.devices.get(info.name()) {
+                    let pd = device
+                        .domain(DEFAULT_DOMAIN)
+                        .map(|d| d.pd)
+                        .unwrap_or(std::ptr::null_mut());
+                    pds.push(pd);
                     qps.push(
                         qp.as_ref()
                             // SAFETY: the returned pointer is read by
                             // the segment-scan FFI under a separate
                             // call on this same `&self`; the QP lives
-                            // in `device_domains` for the lifetime of
+                            // in `devices` for the lifetime of
                             // this `IbvManagerActor`, so its `Drop`
                             // cannot run while these pointers are in
                             // use.
@@ -485,15 +515,13 @@ impl IbvManagerActor {
                 }
             }
 
-            // Determine the RDMA device to use
-            let rdma_device = if let Some(device) = selected_rdma_device {
-                device
+            // Determine the RDMA device name to use: CUDA-co-located
+            // NIC if available, otherwise the config fallback.
+            let device_name = if let Some(info) = selected_rdma_device {
+                info.name().clone()
             } else {
-                // Fallback to default device from config
-                self.config.device.clone()
+                self.config.device.name().clone()
             };
-
-            let device_name = rdma_device.name().clone();
             tracing::debug!(
                 "Using RDMA device: {} for memory at 0x{:x}",
                 device_name,
@@ -501,7 +529,7 @@ impl IbvManagerActor {
             );
 
             // Get or create domain and loopback QP for this device
-            let domain = self.get_or_create_device_domain(&device_name, &rdma_device)?;
+            let domain = self.get_or_create_device_domain(&device_name)?;
 
             let access = if crate::efa::is_efa_device() {
                 crate::efa::mr_access_flags()
@@ -655,11 +683,7 @@ impl IbvManagerActor {
             anyhow::bail!("peer queue pair already exists for {qp_key:?}");
         }
         let self_device = &qp_key.self_device;
-        let rdma_device = super::primitives::get_all_devices()
-            .into_iter()
-            .find(|d| d.name() == self_device)
-            .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
-        let domain = self.get_or_create_device_domain(self_device, &rdma_device)?;
+        let domain = self.get_or_create_device_domain(self_device)?;
         let mut qp = IbvQueuePair::new(domain, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create peer IbvQueuePair: {}", e))?;
         let local_info = qp
@@ -685,11 +709,7 @@ impl IbvManagerActor {
             return Ok(h.clone());
         }
         let self_device = &qp_key.self_device;
-        let rdma_device = super::primitives::get_all_devices()
-            .into_iter()
-            .find(|d| d.name() == self_device)
-            .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
-        let domain = self.get_or_create_device_domain(self_device, &rdma_device)?;
+        let domain = self.get_or_create_device_domain(self_device)?;
         let qp = IbvQueuePair::new(domain, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair for {qp_key:?}: {}", e))?;
         let local_manager: ActorRef<Self> = cx.bind();
@@ -710,8 +730,7 @@ impl IbvManagerActor {
 }
 
 #[async_trait]
-#[hyperactor::handle(IbvManagerMessage)]
-impl IbvManagerMessageHandler for IbvManagerActor {
+impl<I: IbvDeviceImpl> IbvManagerMessageHandler for IbvManagerActor<I> {
     async fn release_buffer(
         &mut self,
         _cx: &Context<Self>,
@@ -725,9 +744,23 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     }
 }
 
+// `#[hyperactor::handle(IbvManagerMessage)]` would generate a
+// non-generic `impl Handler<...> for IbvManagerActor<I>` that
+// can't see `I`; we write the generic delegation by hand.
 #[async_trait]
-impl Handler<SubmitOps> for IbvManagerActor {
-    async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps) -> Result<(), anyhow::Error> {
+impl<I: IbvDeviceImpl> Handler<IbvManagerMessage> for IbvManagerActor<I> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: IbvManagerMessage,
+    ) -> Result<(), anyhow::Error> {
+        <Self as IbvManagerMessageHandler>::handle(self, cx, message).await
+    }
+}
+
+#[async_trait]
+impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
+    async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps<I>) -> Result<(), anyhow::Error> {
         let SubmitOps { ops, reply } = msg;
 
         // Interleave MR resolution with QP dispatch: as soon as op `i`'s
@@ -779,7 +812,7 @@ impl Handler<SubmitOps> for IbvManagerActor {
     }
 }
 
-impl IbvManagerActor {
+impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     /// Synchronous portion of [`RawQueuePair`] handling: create the
     /// local QP, post `CreatePeerQueuePair` to `peer`, and return the
     /// in-flight reply receiver. The follow-up work (awaiting the
@@ -789,15 +822,11 @@ impl IbvManagerActor {
     fn raw_queue_pair_setup(
         &mut self,
         cx: &Context<'_, Self>,
-        peer: &ActorRef<IbvManagerActor>,
+        peer: &ActorRef<IbvManagerActor<I>>,
         self_device: String,
         peer_device: String,
     ) -> Result<(IbvQueuePair, OncePortReceiver<Result<IbvQpInfo, String>>), anyhow::Error> {
-        let rdma_device = super::primitives::get_all_devices()
-            .into_iter()
-            .find(|d| d.name() == &self_device)
-            .ok_or_else(|| anyhow::anyhow!("RDMA device '{self_device}' not found"))?;
-        let domain = self.get_or_create_device_domain(&self_device, &rdma_device)?;
+        let domain = self.get_or_create_device_domain(&self_device)?;
         let mut qp = IbvQueuePair::new(domain, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {e}"))?;
         let sender_info = qp
@@ -806,7 +835,7 @@ impl IbvManagerActor {
         let (reply, rx) = Mailbox::mailbox(cx).open_once_port::<Result<IbvQpInfo, String>>();
         peer.post(
             cx,
-            CreatePeerQueuePair::<IbvManagerActor> {
+            CreatePeerQueuePair::<IbvManagerActor<I>> {
                 sender: cx.bind(),
                 sender_device: self_device,
                 receiver_device: peer_device,
@@ -819,8 +848,12 @@ impl IbvManagerActor {
 }
 
 #[async_trait]
-impl Handler<RawQueuePair> for IbvManagerActor {
-    async fn handle(&mut self, cx: &Context<Self>, msg: RawQueuePair) -> Result<(), anyhow::Error> {
+impl<I: IbvDeviceImpl> Handler<RawQueuePair<I>> for IbvManagerActor<I> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: RawQueuePair<I>,
+    ) -> Result<(), anyhow::Error> {
         let RawQueuePair {
             peer,
             self_device,
@@ -868,11 +901,11 @@ impl Handler<RawQueuePair> for IbvManagerActor {
 }
 
 #[async_trait]
-impl Handler<CreatePeerQueuePair<IbvManagerActor>> for IbvManagerActor {
+impl<I: IbvDeviceImpl> Handler<CreatePeerQueuePair<IbvManagerActor<I>>> for IbvManagerActor<I> {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
-        msg: CreatePeerQueuePair<IbvManagerActor>,
+        msg: CreatePeerQueuePair<IbvManagerActor<I>>,
     ) -> Result<(), anyhow::Error> {
         let CreatePeerQueuePair {
             sender,
@@ -895,8 +928,7 @@ impl Handler<CreatePeerQueuePair<IbvManagerActor>> for IbvManagerActor {
 }
 
 #[async_trait]
-#[hyperactor::handle(IbvManagerLocalMessage)]
-impl IbvManagerLocalMessageHandler for IbvManagerActor {
+impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
     async fn register_remote_buffer(
         &mut self,
         _cx: &Context<Self>,
@@ -928,22 +960,45 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
     }
 }
 
-/// Wrapper around [`ActorHandle<IbvManagerActor>`] that moves the RDMA
+// `#[hyperactor::handle(IbvManagerLocalMessage)]` analogue, written
+// generically; see the `IbvManagerMessage` block above.
+#[async_trait]
+impl<I: IbvDeviceImpl> Handler<IbvManagerLocalMessage> for IbvManagerActor<I> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: IbvManagerLocalMessage,
+    ) -> Result<(), anyhow::Error> {
+        <Self as IbvManagerLocalMessageHandler>::handle(self, cx, message).await
+    }
+}
+
+/// Wrapper around [`ActorHandle<IbvManagerActor<I>>`] that moves the RDMA
 /// data-plane (post send/recv, poll CQ) off the actor loop while keeping
 /// state-mutating operations (MR registration/deregistration, QP management)
 /// serialized through actor messages.
-#[derive(Debug, Clone)]
-pub struct IbvBackend(pub ActorHandle<IbvManagerActor>);
+#[derive(Debug)]
+pub struct IbvBackend<I: IbvDeviceImpl>(pub ActorHandle<IbvManagerActor<I>>);
 
-impl std::ops::Deref for IbvBackend {
-    type Target = ActorHandle<IbvManagerActor>;
+impl<I: IbvDeviceImpl> Clone for IbvBackend<I> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<I: IbvDeviceImpl> std::ops::Deref for IbvBackend<I> {
+    type Target = ActorHandle<IbvManagerActor<I>>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
+// `submit` builds a `SubmitOps<MlxDevice>` (because `resolve_ibv`
+// returns an `ActorRef<IbvManagerActor<MlxDevice>>`), so the
+// `RdmaBackend` impl is locked to the `MlxDevice` monomorphization
+// for now.
 #[async_trait]
-impl RdmaBackend for IbvBackend {
+impl RdmaBackend for IbvBackend<MlxDevice> {
     type TransportInfo = ();
 
     /// Submit a batch of RDMA operations.
@@ -1085,6 +1140,7 @@ mod tests {
     use serde::Serialize;
     use typeuri::Named;
 
+    use super::super::mlx_device::MlxDevice;
     use super::IbvBackend;
     use super::IbvManagerActor;
     use super::IbvManagerLocalMessageClient;
@@ -1286,7 +1342,7 @@ mod tests {
                     remote: op.remote_buf,
                 });
             }
-            let ibv_handle = IbvManagerActor::local_handle(cx).await?;
+            let ibv_handle = IbvManagerActor::<MlxDevice>::local_handle(cx).await?;
             let mut backend = IbvBackend(ibv_handle);
             let result = backend
                 .submit(cx, rdma_ops, Duration::from_secs(timeout_secs))
@@ -1587,7 +1643,7 @@ mod tests {
     async fn test_register_remote_buffer_fills_mr_slot() -> Result<(), anyhow::Error> {
         require_rdma();
         let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
-        let ibv_handle = IbvManagerActor::local_handle(&env.client).await?;
+        let ibv_handle = IbvManagerActor::<MlxDevice>::local_handle(&env.client).await?;
         let buf: Box<[u8]> = vec![0u8; 1024].into_boxed_slice();
         let local = KeepaliveLocalMemory::new(Arc::new(buf));
         assert!(

--- a/monarch_rdma/src/backend/ibverbs/mlx_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_device.rs
@@ -21,8 +21,8 @@ use crate::register_ibv_device_impl;
 const MELLANOX_VENDOR_ID: u32 = 0x02c9;
 
 /// Mellanox backend.
-#[derive(Named)]
-pub(crate) struct MlxDevice;
+#[derive(Debug, Named)]
+pub struct MlxDevice;
 
 impl IbvDeviceImpl for MlxDevice {
     fn backend_name() -> &'static str {

--- a/monarch_rdma/src/backend/ibverbs/mlx_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_device.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Mellanox backend for [`IbvDevice`].
+
+use std::sync::Arc;
+
+use typeuri::Named;
+
+use super::device::IbvContext;
+use super::device::IbvDeviceImpl;
+use super::primitives::IbvConfig;
+use crate::register_ibv_device_impl;
+
+/// PCI vendor ID for Mellanox Technologies.
+const MELLANOX_VENDOR_ID: u32 = 0x02c9;
+
+/// Mellanox backend.
+#[derive(Named)]
+pub(crate) struct MlxDevice;
+
+impl IbvDeviceImpl for MlxDevice {
+    fn backend_name() -> &'static str {
+        "mellanox"
+    }
+
+    fn is_instance(ctx: Arc<IbvContext>) -> bool {
+        let mut attr = rdmaxcel_sys::ibv_device_attr::default();
+        // SAFETY: `ctx.as_ptr()` is a non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call;
+        // `&mut attr` is a writable, properly aligned
+        // `ibv_device_attr`.
+        let queried = unsafe { rdmaxcel_sys::ibv_query_device(ctx.as_ptr(), &mut attr) } == 0;
+        queried && attr.vendor_id == MELLANOX_VENDOR_ID
+    }
+
+    fn apply_config_defaults(_config: &mut IbvConfig) {}
+}
+
+register_ibv_device_impl!(MlxDevice);

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -17,7 +17,7 @@
 //! - `IbvConfig`: Represents ibverbs specific configurations, holding parameters required to establish and
 //!   manage an RDMA connection, including settings for the RDMA device, queue pair attributes, and other
 //!   connection-specific parameters.
-//! - `IbvDevice`: Represents an RDMA device, i.e. 'mlx5_0'. Contains information about the device, such as:
+//! - `IbvDeviceInfo`: Represents an RDMA device, i.e. 'mlx5_0'. Contains information about the device, such as:
 //!   its name, vendor ID, vendor part ID, hardware version, firmware version, node GUID, and capabilities.
 //! - `IbvPort`: Represents information about the port of an RDMA device, including state, physical state,
 //!   LID (Local Identifier), and GID (Global Identifier) information.
@@ -36,6 +36,8 @@ use serde::Serialize;
 use typeuri::Named;
 
 use super::domain::IbvDomain;
+use crate::backend::ibverbs::device::IbvDeviceImpl;
+use crate::backend::ibverbs::efa_device::EfaDevice;
 
 #[derive(
     Default,
@@ -132,7 +134,7 @@ pub fn resolve_qp_type(qp_type: IbvQpType) -> u32 {
 #[derive(Debug, Named, Clone, Serialize, Deserialize)]
 pub struct IbvConfig {
     /// `device` - The RDMA device to use for the connection.
-    pub device: IbvDevice,
+    pub device: IbvDeviceInfo,
     /// `cq_entries` - The number of completion queue entries.
     pub cq_entries: i32,
     /// `port_num` - The physical port number on the device.
@@ -185,7 +187,7 @@ wirevalue::register_type!(IbvConfig);
 impl Default for IbvConfig {
     fn default() -> Self {
         let mut config = Self {
-            device: IbvDevice::default(),
+            device: IbvDeviceInfo::default(),
             cq_entries: 1024,
             port_num: 1,
             gid_index: 3,
@@ -208,7 +210,7 @@ impl Default for IbvConfig {
             max_sge_override: 0,
         };
         if crate::efa::is_efa_device() {
-            crate::efa::apply_efa_defaults(&mut config);
+            EfaDevice::apply_config_defaults(&mut config);
         }
         config
     }
@@ -295,7 +297,7 @@ impl std::fmt::Display for IbvConfig {
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IbvDevice {
+pub struct IbvDeviceInfo {
     /// `name` - The name of the RDMA device (e.g., "mlx5_0").
     pub name: String,
     /// `vendor_id` - The vendor ID of the device.
@@ -324,14 +326,14 @@ pub struct IbvDevice {
     max_sge: i32,
 }
 
-impl IbvDevice {
+impl IbvDeviceInfo {
     /// Returns the name of the RDMA device.
     pub fn name(&self) -> &String {
         &self.name
     }
 
     /// Returns the first available RDMA device, if any.
-    pub fn first_available() -> Option<IbvDevice> {
+    pub fn first_available() -> Option<IbvDeviceInfo> {
         let devices = get_all_devices();
         if devices.is_empty() {
             None
@@ -401,7 +403,7 @@ impl IbvDevice {
     }
 }
 
-impl Default for IbvDevice {
+impl Default for IbvDeviceInfo {
     fn default() -> Self {
         // Try to get a smart default using device selection logic (defaults to cpu:0)
         if let Some(device) = super::device_selection::select_optimal_ibv_device(Some("cpu:0")) {
@@ -440,7 +442,7 @@ pub struct IbvPort {
     gid_tbl_len: i32,
 }
 
-impl fmt::Display for IbvDevice {
+impl fmt::Display for IbvDeviceInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", self.name)?;
         writeln!(f, "\tNumber of ports: {}", self.ports.len())?;
@@ -578,107 +580,134 @@ pub fn format_gid(gid: &[u8; 16]) -> String {
 ///
 /// # Returns
 ///
-/// A vector of `IbvDevice` structures, each representing an RDMA device in the system.
+/// A vector of `IbvDeviceInfo` structures, each representing an RDMA device in the system.
 /// Returns an empty vector if no devices are found or if there was an error querying
 /// the devices.
-pub fn get_all_devices() -> Vec<IbvDevice> {
+pub fn get_all_devices() -> Vec<IbvDeviceInfo> {
     let mut devices = Vec::new();
-
-    // SAFETY: We are calling several C functions from libibverbs.
-    unsafe {
-        let mut num_devices = 0;
-        let device_list = rdmaxcel_sys::ibv_get_device_list(&mut num_devices);
-        if device_list.is_null() || num_devices == 0 {
-            return devices;
-        }
-
-        for i in 0..num_devices {
-            let device = *device_list.add(i as usize);
-            if device.is_null() {
-                continue;
-            }
-
-            let context = rdmaxcel_sys::ibv_open_device(device);
-            if context.is_null() {
-                continue;
-            }
-
-            let device_name = CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device))
-                .to_string_lossy()
-                .into_owned();
-
-            let mut device_attr = rdmaxcel_sys::ibv_device_attr::default();
-            if rdmaxcel_sys::ibv_query_device(context, &mut device_attr) != 0 {
-                rdmaxcel_sys::ibv_close_device(context);
-                continue;
-            }
-
-            let fw_ver = CStr::from_ptr(device_attr.fw_ver.as_ptr())
-                .to_string_lossy()
-                .into_owned();
-
-            let mut rdma_device = IbvDevice {
-                name: device_name,
-                vendor_id: device_attr.vendor_id,
-                vendor_part_id: device_attr.vendor_part_id,
-                hw_ver: device_attr.hw_ver,
-                fw_ver,
-                node_guid: device_attr.node_guid,
-                ports: Vec::new(),
-                max_qp: device_attr.max_qp,
-                max_cq: device_attr.max_cq,
-                max_mr: device_attr.max_mr,
-                max_pd: device_attr.max_pd,
-                max_qp_wr: device_attr.max_qp_wr,
-                max_sge: device_attr.max_sge,
-            };
-
-            for port_num in 1..=device_attr.phys_port_cnt {
-                let mut port_attr = rdmaxcel_sys::ibv_port_attr::default();
-                if rdmaxcel_sys::ibv_query_port(
-                    context,
-                    port_num,
-                    &mut port_attr as *mut rdmaxcel_sys::ibv_port_attr as *mut _,
-                ) != 0
-                {
-                    continue;
-                }
-                let state = get_port_state_str(port_attr.state);
-                let physical_state = get_port_phy_state_str(port_attr.phys_state);
-
-                let link_layer = get_link_layer_str(port_attr.link_layer);
-
-                let mut gid = rdmaxcel_sys::ibv_gid::default();
-                let gid_str = if rdmaxcel_sys::ibv_query_gid(context, port_num, 0, &mut gid) == 0 {
-                    format_gid(&gid.raw)
-                } else {
-                    "N/A".to_string()
-                };
-
-                let rdma_port = IbvPort {
-                    port_num,
-                    state,
-                    physical_state,
-                    base_lid: port_attr.lid,
-                    lmc: port_attr.lmc,
-                    sm_lid: port_attr.sm_lid,
-                    capability_mask: port_attr.port_cap_flags,
-                    link_layer,
-                    gid: gid_str,
-                    gid_tbl_len: port_attr.gid_tbl_len,
-                };
-
-                rdma_device.ports.push(rdma_port);
-            }
-
-            devices.push(rdma_device);
-            rdmaxcel_sys::ibv_close_device(context);
-        }
-
-        rdmaxcel_sys::ibv_free_device_list(device_list);
+    let mut num_devices = 0;
+    // SAFETY: `ibv_get_device_list` populates `num_devices` and
+    // returns either null or a pointer to `num_devices` entries;
+    // we free it before returning.
+    let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+    if device_list.is_null() {
+        return devices;
     }
-
+    for i in 0..num_devices {
+        // SAFETY: `device_list` is non-null with `num_devices`
+        // valid entries (checked above).
+        let device = unsafe { *device_list.add(i as usize) };
+        if device.is_null() {
+            continue;
+        }
+        // SAFETY: `device` is non-null per the check above.
+        let context = unsafe { rdmaxcel_sys::ibv_open_device(device) };
+        if context.is_null() {
+            continue;
+        }
+        // SAFETY: `device` and `context` are non-null and
+        // `context` was returned by `ibv_open_device(device)`.
+        if let Some(info) = unsafe { query_device_info(device, context) } {
+            devices.push(info);
+        }
+        // SAFETY: `context` was returned by `ibv_open_device`
+        // above and has not been closed elsewhere.
+        unsafe { rdmaxcel_sys::ibv_close_device(context) };
+    }
+    // SAFETY: `device_list` was returned by
+    // `ibv_get_device_list` above and has not been freed.
+    unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
     devices
+}
+
+/// Builds an [`IbvDeviceInfo`] from an already-open
+/// `ibv_context`. Returns `None` if `ibv_query_device` fails.
+///
+/// # Safety
+///
+/// `device` and `context` must both be non-null and valid for
+/// the duration of the call; `context` must be the result of
+/// `ibv_open_device(device)`.
+pub(super) unsafe fn query_device_info(
+    device: *mut rdmaxcel_sys::ibv_device,
+    context: *mut rdmaxcel_sys::ibv_context,
+) -> Option<IbvDeviceInfo> {
+    // SAFETY: `device` is non-null per the caller's contract;
+    // `ibv_get_device_name` returns a null-terminated C string
+    // owned by the device list.
+    let device_name = unsafe { CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device)) }
+        .to_string_lossy()
+        .into_owned();
+    let mut device_attr = rdmaxcel_sys::ibv_device_attr::default();
+    // SAFETY: `context` is a non-null context per the caller's
+    // contract; `&mut device_attr` is a writable, properly
+    // aligned `ibv_device_attr`.
+    if unsafe { rdmaxcel_sys::ibv_query_device(context, &mut device_attr) } != 0 {
+        return None;
+    }
+    // SAFETY: `device_attr.fw_ver` is a null-terminated C buffer
+    // populated by `ibv_query_device`.
+    let fw_ver = unsafe { CStr::from_ptr(device_attr.fw_ver.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
+    let mut info = IbvDeviceInfo {
+        name: device_name,
+        vendor_id: device_attr.vendor_id,
+        vendor_part_id: device_attr.vendor_part_id,
+        hw_ver: device_attr.hw_ver,
+        fw_ver,
+        node_guid: device_attr.node_guid,
+        ports: Vec::new(),
+        max_qp: device_attr.max_qp,
+        max_cq: device_attr.max_cq,
+        max_mr: device_attr.max_mr,
+        max_pd: device_attr.max_pd,
+        max_qp_wr: device_attr.max_qp_wr,
+        max_sge: device_attr.max_sge,
+    };
+    for port_num in 1..=device_attr.phys_port_cnt {
+        let mut port_attr = rdmaxcel_sys::ibv_port_attr::default();
+        // SAFETY: `context` is a valid context; `port_attr` is
+        // a writable, properly aligned `ibv_port_attr`.
+        if unsafe {
+            rdmaxcel_sys::ibv_query_port(
+                context,
+                port_num,
+                &mut port_attr as *mut rdmaxcel_sys::ibv_port_attr as *mut _,
+            )
+        } != 0
+        {
+            continue;
+        }
+        let state = get_port_state_str(port_attr.state);
+        let physical_state = get_port_phy_state_str(port_attr.phys_state);
+        let link_layer = get_link_layer_str(port_attr.link_layer);
+        let mut gid = rdmaxcel_sys::ibv_gid::default();
+        // SAFETY: `context` is a valid context; `&mut gid` is a
+        // writable, properly aligned `ibv_gid`.
+        let gid_str = if unsafe { rdmaxcel_sys::ibv_query_gid(context, port_num, 0, &mut gid) } == 0
+        {
+            // SAFETY: `gid.raw` is a union field that is
+            // always initialized; `ibv_query_gid` filled it.
+            let raw = unsafe { gid.raw };
+            format_gid(&raw)
+        } else {
+            "N/A".to_string()
+        };
+        info.ports.push(IbvPort {
+            port_num,
+            state,
+            physical_state,
+            base_lid: port_attr.lid,
+            lmc: port_attr.lmc,
+            sm_lid: port_attr.sm_lid,
+            capability_mask: port_attr.port_cap_flags,
+            link_layer,
+            gid: gid_str,
+            gid_tbl_len: port_attr.gid_tbl_len,
+        });
+    }
+    Some(info)
 }
 
 /// Cached result of mlx5dv support check.
@@ -1109,7 +1138,7 @@ mod tests {
 
     #[test]
     fn test_device_display() {
-        if let Some(device) = IbvDevice::first_available() {
+        if let Some(device) = IbvDeviceInfo::first_available() {
             let display_output = format!("{}", device);
             assert!(
                 display_output.contains(&device.name),
@@ -1124,7 +1153,7 @@ mod tests {
 
     #[test]
     fn test_port_display() {
-        if let Some(device) = IbvDevice::first_available()
+        if let Some(device) = IbvDeviceInfo::first_available()
             && !device.ports().is_empty()
         {
             let port = &device.ports()[0];

--- a/monarch_rdma/src/efa.rs
+++ b/monarch_rdma/src/efa.rs
@@ -13,8 +13,6 @@
 
 use std::sync::OnceLock;
 
-use crate::backend::ibverbs::primitives::IbvConfig;
-
 /// Cached result of EFA device check.
 static EFA_DEVICE_CACHE: OnceLock<bool> = OnceLock::new();
 
@@ -54,20 +52,6 @@ fn is_efa_device_impl() -> bool {
         rdmaxcel_sys::ibv_free_device_list(device_list);
         found
     }
-}
-
-/// Applies EFA-specific defaults to an `IbvConfig`.
-///
-/// EFA devices have different capabilities than standard InfiniBand/RoCE devices:
-/// - GID index 0 (instead of 3)
-/// - Max 1 SGE per work request
-/// - No RDMA atomics support
-pub fn apply_efa_defaults(config: &mut IbvConfig) {
-    config.gid_index = 0;
-    config.max_send_sge = 1;
-    config.max_recv_sge = 1;
-    config.max_dest_rd_atomic = 0;
-    config.max_rd_atomic = 0;
 }
 
 /// Returns the MR access flags appropriate for EFA devices.

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -57,6 +57,7 @@ use crate::ReleaseBufferClient;
 use crate::backend::RdmaRemoteBackendContext;
 use crate::backend::ibverbs::IbvBuffer;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
+use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
 
@@ -119,7 +120,7 @@ impl RdmaRemoteBuffer {
     ///
     /// Returns `None` if the buffer has no ibverbs backend context
     /// (i.e., the remote side was created without ibverbs).
-    pub fn resolve_ibv(&self) -> Option<(ActorRef<IbvManagerActor>, IbvBuffer)> {
+    pub fn resolve_ibv(&self) -> Option<(ActorRef<IbvManagerActor<MlxDevice>>, IbvBuffer)> {
         self.backends.iter().find_map(|b| match b {
             RdmaRemoteBackendContext::Ibverbs(mgr, buf) => Some((mgr.clone(), buf.clone())),
             _ => None,

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -48,6 +48,7 @@ use crate::backend::RdmaRemoteBackendContext;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
 use crate::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
 use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
+use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::ibverbs::primitives::IbvConfig;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
@@ -100,7 +101,7 @@ wirevalue::register_type!(ReleaseBuffer);
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
 pub struct GetIbvActorRef {
     #[reply]
-    pub reply: OncePortRef<Option<ActorRef<IbvManagerActor>>>,
+    pub reply: OncePortRef<Option<ActorRef<IbvManagerActor<MlxDevice>>>>,
 }
 wirevalue::register_type!(GetIbvActorRef);
 
@@ -154,7 +155,7 @@ impl<A: Actor> RdmaBackendActor<A> {
 pub struct RdmaManagerActor {
     next_remote_buf_id: usize,
     buffers: HashMap<usize, KeepaliveLocalMemory>,
-    ibverbs: Option<RdmaBackendActor<IbvManagerActor>>,
+    ibverbs: Option<RdmaBackendActor<IbvManagerActor<MlxDevice>>>,
     tcp: RdmaBackendActor<TcpManagerActor>,
 }
 
@@ -191,7 +192,7 @@ impl RemoteSpawn for RdmaManagerActor {
                 );
             }
         } else {
-            match IbvManagerActor::new(params).await {
+            match IbvManagerActor::<MlxDevice>::new(params).await {
                 Ok(actor) => Some(RdmaBackendActor::Created(actor)),
                 Err(e) => {
                     if hyperactor_config::global::get(crate::config::RDMA_ALLOW_TCP_FALLBACK) {
@@ -249,7 +250,7 @@ impl GetIbvActorRefHandler for RdmaManagerActor {
     async fn get_ibv_actor_ref(
         &mut self,
         _cx: &Context<Self>,
-    ) -> Result<Option<ActorRef<IbvManagerActor>>, anyhow::Error> {
+    ) -> Result<Option<ActorRef<IbvManagerActor<MlxDevice>>>, anyhow::Error> {
         Ok(self.ibverbs.as_ref().map(|ibv| ibv.handle().bind()))
     }
 }


### PR DESCRIPTION
Summary:

Make `IbvManagerActor<I: IbvDeviceImpl>` generic so a single actor implementation drives any ibverbs backend. Exposes the device abstraction (`pub`) and adds the `IbvDevice::available` / `IbvDevice::domain` accessors the generic actor relies on. Call sites are pinned to `MlxDevice` for now so this change builds on its own.

Reviewed By: zdevito

Differential Revision: D107298525


