### PR TITLE
Backend-agnostic ibverbs device abstraction (#4162)

### DIFF
--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -17,6 +17,7 @@ erased-serde = "0.4.10"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
+inventory = "0.3.24"
 rand = "0.10.1"
 rdmaxcel-sys = { path = "../rdmaxcel-sys" }
 regex = "1.12.3"

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -14,9 +14,12 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
+pub(crate) mod device;
 pub mod device_selection;
 pub(crate) mod domain;
+pub(crate) mod efa_device;
 pub mod manager_actor;
+pub(crate) mod mlx_device;
 pub mod primitives;
 pub mod queue_pair;
 

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Backend-agnostic ibverbs device abstraction.
+//!
+//! [`IbvDevice`] owns the per-process state for a single opened RDMA
+//! device: an `Arc<IbvContext>`, an [`IbvConfig`], and a map of named
+//! `Arc<IbvDomain>`s allocated against the device.
+//! Per-backend behavior — claiming a device as the backend's,
+//! allocating a domain, and seeding config defaults — is provided by
+//! an [`IbvDeviceImpl`].
+//!
+//! Each [`IbvDeviceImpl`] registers itself via the `inventory` crate
+//! (using [`register_ibv_device_impl!`]). At first access,
+//! [`DEVICE_NAMES_BY_IMPL`] walks the ibverbs device list once and
+//! assigns each device to the first registered impl whose
+//! [`IbvDeviceImpl::is_instance`] claims it, caching the resulting
+//! `typename() → device-infos` map. [`IbvDevice::open`] consults this
+//! map: it returns `None` when `name` is not advertised under
+//! `I::typename()`, and otherwise opens the device using the cached
+//! [`IbvDeviceInfo`].
+
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+use typeuri::Named;
+
+use super::domain::IbvDomain;
+use super::primitives::IbvConfig;
+use super::primitives::IbvDeviceInfo;
+use super::primitives::query_device_info;
+
+/// Per-backend driver for [`IbvDevice`]. Concrete impls register
+/// themselves via [`register_ibv_device_impl!`].
+pub(crate) trait IbvDeviceImpl: Named + Send + Sync + 'static {
+    /// Human-readable display name for the backend this impl
+    /// drives (e.g., `"mellanox"`, `"efa"`). Surfaced in
+    /// diagnostics; not used as a registry key.
+    fn backend_name() -> &'static str;
+
+    /// Returns `true` if `ctx` belongs to this backend. Called
+    /// transiently, once per ibverbs device, while
+    /// [`DEVICE_NAMES_BY_IMPL`] is built.
+    fn is_instance(ctx: Arc<IbvContext>) -> bool;
+
+    /// Allocates a protection domain against `ctx` and wraps it in
+    /// an [`IbvDomain`]. The returned `Arc<IbvDomain>` is the sole
+    /// owner of the PD; the last drop runs `ibv_dealloc_pd`.
+    ///
+    /// The default implementation calls `ibv_alloc_pd` on
+    /// `ctx.as_ptr()` and constructs a plain [`IbvDomain`].
+    /// In a followup, we'll add an `IbvDomainImpl` trait to allow for
+    /// backend-specific domain implementations.
+    fn create_domain(ctx: Arc<IbvContext>) -> anyhow::Result<Arc<IbvDomain>> {
+        // SAFETY: `ctx.as_ptr()` is the non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call.
+        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(ctx.as_ptr()) };
+        if pd.is_null() {
+            anyhow::bail!("ibv_alloc_pd failed: {}", std::io::Error::last_os_error());
+        }
+        // TODO: `IbvDomain` should hold the `Arc<IbvContext>`
+        // itself so the context outlives the PD by construction;
+        // for now we copy the raw pointer and rely on the
+        // surrounding [`IbvDevice`] to keep the context alive.
+        Ok(Arc::new(IbvDomain {
+            context: ctx.as_ptr(),
+            pd,
+        }))
+    }
+
+    /// Seeds an [`IbvConfig`] with backend-appropriate defaults
+    /// (e.g., EFA caps `max_send_sge` at 1).
+    fn apply_config_defaults(config: &mut IbvConfig);
+}
+
+/// Inventory entry submitted by [`register_ibv_device_impl!`] for
+/// each concrete [`IbvDeviceImpl`]. Captures function pointers to
+/// the impl's `typename()`, `backend_name()`, and `is_instance()`,
+/// all erased of the concrete type.
+pub struct IbvDeviceImplRegistration {
+    typename: fn() -> &'static str,
+    backend_name: fn() -> &'static str,
+    is_instance: fn(Arc<IbvContext>) -> bool,
+}
+
+/// Per-impl entry stored in [`DEVICE_NAMES_BY_IMPL`]. Keyed by
+/// `typename()`; carries the human-readable `backend_name` for
+/// diagnostics alongside the impl's device infos.
+#[derive(Debug)]
+struct RegisteredBackend {
+    #[expect(
+        dead_code,
+        reason = "read only via Debug for the IbvDevice::open diagnostic warning"
+    )]
+    backend_name: &'static str,
+    devices: Vec<IbvDeviceInfo>,
+}
+
+inventory::collect!(IbvDeviceImplRegistration);
+
+/// Submits an `inventory` entry for a concrete [`IbvDeviceImpl`].
+///
+/// Place one invocation per impl at module scope. The expansion
+/// references `inventory` and `typeuri` by bare crate name, so the
+/// calling crate must list both as direct dependencies.
+///
+/// ```ignore
+/// register_ibv_device_impl!(StandardImpl);
+/// ```
+#[macro_export]
+macro_rules! register_ibv_device_impl {
+    ($impl_ty:ty) => {
+        inventory::submit! {
+            $crate::backend::ibverbs::device::IbvDeviceImplRegistration::new(
+                <$impl_ty as typeuri::Named>::typename,
+                <$impl_ty as $crate::backend::ibverbs::device::IbvDeviceImpl>::backend_name,
+                <$impl_ty as $crate::backend::ibverbs::device::IbvDeviceImpl>::is_instance,
+            )
+        }
+    };
+}
+
+impl IbvDeviceImplRegistration {
+    /// Construct a registration. Visible to the rest of the crate
+    /// so the [`register_ibv_device_impl!`] macro can call it from
+    /// sibling call sites.
+    pub(crate) const fn new(
+        typename: fn() -> &'static str,
+        backend_name: fn() -> &'static str,
+        is_instance: fn(Arc<IbvContext>) -> bool,
+    ) -> Self {
+        Self {
+            typename,
+            backend_name,
+            is_instance,
+        }
+    }
+}
+
+/// Process-wide map from `IbvDeviceImpl::typename()` to a
+/// [`RegisteredBackend`] holding the impl's display name and the
+/// device infos it claims. Built once on first access by a single
+/// walk of the ibverbs device list, assigning each device to the
+/// first registration whose `is_instance` claims it.
+static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> =
+    LazyLock::new(|| {
+        let registrations: Vec<&IbvDeviceImplRegistration> =
+            inventory::iter::<IbvDeviceImplRegistration>().collect();
+        let mut by_impl: HashMap<&'static str, RegisteredBackend> = registrations
+            .iter()
+            .map(|reg| {
+                (
+                    (reg.typename)(),
+                    RegisteredBackend {
+                        backend_name: (reg.backend_name)(),
+                        devices: Vec::new(),
+                    },
+                )
+            })
+            .collect();
+
+        let mut num_devices = 0i32;
+        // SAFETY: `ibv_get_device_list` populates `num_devices` and
+        // returns either null or a pointer to `num_devices` entries;
+        // we free it before returning.
+        let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+        // A non-null list must be freed even when empty, so only the
+        // null case returns early; the loop below is a no-op at zero
+        // devices and the `ibv_free_device_list` at the end still runs.
+        if device_list.is_null() {
+            return by_impl;
+        }
+        for i in 0..num_devices {
+            // SAFETY: `device_list` is non-null with `num_devices`
+            // valid entries (checked above).
+            let device = unsafe { *device_list.add(i as usize) };
+            if device.is_null() {
+                continue;
+            }
+            // SAFETY: `device` is non-null per the check above.
+            let raw_ctx = unsafe { rdmaxcel_sys::ibv_open_device(device) };
+            if raw_ctx.is_null() {
+                continue;
+            }
+            let ctx = Arc::new(IbvContext(raw_ctx));
+            // Assign the device to the first impl that claims it.
+            if let Some(reg) = registrations
+                .iter()
+                .find(|reg| (reg.is_instance)(Arc::clone(&ctx)))
+            {
+                // SAFETY: `device` and `ctx.as_ptr()` are non-null and
+                // `ctx.as_ptr()` was returned by `ibv_open_device(device)`.
+                if let Some(info) = unsafe { query_device_info(device, ctx.as_ptr()) } {
+                    by_impl
+                        .get_mut((reg.typename)())
+                        .expect("registration typename present in map")
+                        .devices
+                        .push(info);
+                }
+            }
+            // `ctx` drops here, closing the transient context.
+        }
+        // SAFETY: `device_list` was returned by `ibv_get_device_list`
+        // above and has not been freed.
+        unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+        by_impl
+    });
+
+/// RAII owner of a raw `ibv_context*`.
+///
+/// Closes the context in [`Drop`]. Held inside an `Arc` not because
+/// clones are expected to outlive the owning [`IbvDevice`], but so
+/// the raw pointer can be passed around with a lifetime safeguard
+/// where borrow-checked references aren't practical.
+pub(crate) struct IbvContext(*mut rdmaxcel_sys::ibv_context);
+
+// SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
+// operations we perform (allocation, polling, and the final close).
+unsafe impl Send for IbvContext {}
+unsafe impl Sync for IbvContext {}
+
+impl IbvContext {
+    /// Returns the raw `ibv_context*`. The pointer is valid for
+    /// the lifetime of `&self`.
+    pub(crate) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
+        self.0
+    }
+}
+
+impl Drop for IbvContext {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            return;
+        }
+        // SAFETY: `self.0` was returned by `ibv_open_device` in
+        // `IbvDevice::open` and has not been closed elsewhere. The
+        // intended ownership is a single `Arc<IbvContext>`, whose
+        // final `Drop` calls `ibv_close_device` exactly once.
+        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.0) };
+        if result != 0 {
+            tracing::error!(
+                "ibv_close_device failed for context {:p}: error code {}",
+                self.0,
+                result
+            );
+        }
+    }
+}
+
+/// An opened RDMA device.
+///
+/// Owns an `Arc<IbvContext>`, the queried [`IbvDeviceInfo`]
+/// metadata, a device-scoped [`IbvDeviceConfig`], and a map of
+/// named `Arc<IbvDomain>`s allocated against the device (one PD
+/// per name, created lazily by [`Self::get_or_create_domain`]).
+///
+/// `I` is the backend driver type, parameterizing all per-backend
+/// behavior via [`IbvDeviceImpl`].
+///
+/// Field declaration order is significant: `domains` is declared
+/// before `context` so that, on drop, every `Arc<IbvDomain>` in
+/// the map releases its PD before the final `Arc<IbvContext>`
+/// reference closes the context.
+pub(crate) struct IbvDevice<I: IbvDeviceImpl> {
+    domains: HashMap<String, Arc<IbvDomain>>,
+    device_info: IbvDeviceInfo,
+    config: IbvConfig,
+    context: Arc<IbvContext>,
+    _marker: PhantomData<I>,
+}
+
+#[expect(dead_code, reason = "called by manager_actor in follow-up commits")]
+impl<I: IbvDeviceImpl> IbvDevice<I> {
+    /// Opens `name` under impl `I`, storing `config` as-is. Returns
+    /// `None` if `name` is not one of the devices registered for
+    /// `I::typename()`; otherwise returns an `IbvDevice<I>` with the
+    /// device's queried [`IbvDeviceInfo`] and the given [`IbvConfig`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if a registered device cannot be opened — e.g. it
+    /// disappeared from the system between registration and open.
+    /// Such a failure indicates a broken driver invariant rather
+    /// than a runtime condition the caller can recover from.
+    pub(crate) fn open(name: &str, config: IbvConfig) -> Option<Self> {
+        let device_info = DEVICE_NAMES_BY_IMPL
+            .get(I::typename())
+            .and_then(|entry| entry.devices.iter().find(|d| d.name() == name).cloned());
+        let device_info = match device_info {
+            Some(info) => info,
+            None => {
+                tracing::warn!(
+                    "ibv device {} not found under backend {}; available: {:?}",
+                    name,
+                    I::backend_name(),
+                    *DEVICE_NAMES_BY_IMPL,
+                );
+                return None;
+            }
+        };
+
+        // The registry already confirmed `name` belongs to `I`, so
+        // reopen the device by name; a miss here is a broken invariant.
+        let mut num_devices = 0i32;
+        // SAFETY: `ibv_get_device_list` populates `num_devices` and
+        // returns either null or a pointer to `num_devices` entries;
+        // we free it before returning.
+        let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+        assert!(
+            !device_list.is_null(),
+            "RDMA device list was null while opening registered device {}",
+            name,
+        );
+        if num_devices == 0 {
+            // A non-null list must be freed even when empty, per the
+            // libibverbs contract.
+            // SAFETY: `device_list` is non-null (asserted above) and was
+            // returned by `ibv_get_device_list`.
+            unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+            panic!(
+                "no RDMA devices found while opening registered device {}",
+                name
+            );
+        }
+        let mut target = std::ptr::null_mut();
+        for i in 0..num_devices {
+            // SAFETY: `device_list` is non-null with `num_devices`
+            // valid entries (checked above).
+            let device = unsafe { *device_list.add(i as usize) };
+            if device.is_null() {
+                continue;
+            }
+            // SAFETY: `device` is non-null per the check above;
+            // `ibv_get_device_name` returns a null-terminated C string
+            // owned by the device list.
+            let dev_name = unsafe { CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device)) };
+            if dev_name.to_bytes() == name.as_bytes() {
+                target = device;
+                break;
+            }
+        }
+        let mut failure = None;
+        let mut context: *mut crate::rdmaxcel_sys::ibv_context = std::ptr::null_mut();
+        if target.is_null() {
+            failure = Some(format!(
+                "ibv device with name {} not found by ibv_get_device_list",
+                name
+            ));
+        } else {
+            // Open while `target` still points into `device_list`, then free.
+            // SAFETY: `target`, when non-null, is one of `device_list`'s
+            // entries; `ibv_open_device` returns null on failure.
+            context = unsafe { rdmaxcel_sys::ibv_open_device(target) };
+            if context.is_null() {
+                failure = Some(format!(
+                    "registered ibv device {} could not be opened: {}",
+                    name,
+                    std::io::Error::last_os_error(),
+                ));
+            }
+        }
+
+        // SAFETY: `device_list` was returned by `ibv_get_device_list`
+        // above and has not been freed.
+        unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+
+        if let Some(failure) = failure {
+            panic!("{}", failure);
+        }
+
+        Some(Self {
+            domains: HashMap::new(),
+            device_info,
+            config,
+            context: Arc::new(IbvContext(context)),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Returns the `Arc<IbvContext>` for this device.
+    pub(crate) fn context(&self) -> Arc<IbvContext> {
+        Arc::clone(&self.context)
+    }
+
+    /// Returns the queried [`IbvDeviceInfo`] metadata for this
+    /// device.
+    pub(crate) fn device_info(&self) -> &IbvDeviceInfo {
+        &self.device_info
+    }
+
+    /// Returns the [`IbvConfig`] this device was opened with.
+    pub(crate) fn config(&self) -> &IbvConfig {
+        &self.config
+    }
+
+    /// Returns the `Arc<IbvDomain>` registered under `name`,
+    /// creating (and caching) a new one via
+    /// [`IbvDeviceImpl::create_domain`] on first access.
+    pub(crate) fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
+        if let Some(domain) = self.domains.get(name) {
+            return Ok(Arc::clone(domain));
+        }
+        let domain = I::create_domain(Arc::clone(&self.context))?;
+        self.domains.insert(name.to_string(), Arc::clone(&domain));
+        Ok(domain)
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -11,7 +11,7 @@
 
 use std::sync::OnceLock;
 
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 use super::primitives::get_all_devices;
 use crate::device_selection::PCIDevice;
 use crate::device_selection::get_all_rdma_devices;
@@ -24,7 +24,7 @@ use crate::device_selection::parse_pci_topology;
 /// Step 2: Get PCI address from compute device
 /// Step 3: Get PCI address for all RDMA NIC devices
 /// Step 4: Calculate PCI distances and return closest RDMA NIC device
-pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice> {
+pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDeviceInfo> {
     let device_hint = device_hint?;
 
     let (prefix, postfix) = parse_device_string(device_hint)?;
@@ -44,7 +44,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
             };
             let rdma_devices = get_all_rdma_devices();
             if rdma_devices.is_empty() {
-                return IbvDevice::first_available();
+                return IbvDeviceInfo::first_available();
             }
             let pci_devices = parse_pci_topology().ok()?;
             let source_device = pci_devices.get(&source_pci_addr)?;
@@ -68,7 +68,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
             }
 
             // Fallback
-            IbvDevice::first_available()
+            IbvDeviceInfo::first_available()
         }
         _ => {
             // Direct device name lookup for backward compatibility
@@ -85,8 +85,8 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
 ///
 /// Computed at most once per process on the first RDMA operation involving
 /// CUDA memory. CPU-only workloads pay no initialization cost.
-pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDevice>> {
-    static CUDA_DEVICE_TO_IBV: OnceLock<Vec<Option<IbvDevice>>> = OnceLock::new();
+pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDeviceInfo>> {
+    static CUDA_DEVICE_TO_IBV: OnceLock<Vec<Option<IbvDeviceInfo>>> = OnceLock::new();
     CUDA_DEVICE_TO_IBV.get_or_init(|| {
         let count = unsafe {
             let mut c: i32 = 0;
@@ -103,7 +103,7 @@ pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDevice>> {
 ///
 /// Applies auto-detection for default devices, but otherwise
 /// returns the device as-is.
-pub fn resolve_ibv_device(device: &IbvDevice) -> Option<IbvDevice> {
+pub fn resolve_ibv_device(device: &IbvDeviceInfo) -> Option<IbvDeviceInfo> {
     let device_name = device.name();
 
     if device_name.starts_with("mlx") {

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -16,7 +16,7 @@ use std::ffi::CStr;
 use std::io::Error;
 use std::result::Result;
 
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 
 /// Manages RDMA resources including context and protection domain.
 ///
@@ -83,7 +83,7 @@ impl IbvDomain {
     ///
     /// Returns errors if no RDMA devices are found, the specified device cannot be found,
     /// device context creation fails, or protection domain allocation fails.
-    pub fn new(device: IbvDevice) -> Result<Self, anyhow::Error> {
+    pub fn new(device: IbvDeviceInfo) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating IbvDomain for device {}", device.name());
         unsafe {
             let device_name = device.name();

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! EFA backend for [`IbvDevice`].
+
+use std::sync::Arc;
+
+use typeuri::Named;
+
+use super::device::IbvContext;
+use super::device::IbvDeviceImpl;
+use super::primitives::IbvConfig;
+use crate::register_ibv_device_impl;
+
+/// AWS EFA (Elastic Fabric Adapter) backend.
+#[derive(Named)]
+pub(crate) struct EfaDevice;
+
+impl IbvDeviceImpl for EfaDevice {
+    fn backend_name() -> &'static str {
+        "efa"
+    }
+
+    fn is_instance(ctx: Arc<IbvContext>) -> bool {
+        // SAFETY: `ctx.as_ptr()` is a non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call.
+        unsafe { rdmaxcel_sys::rdmaxcel_is_efa_dev(ctx.as_ptr()) != 0 }
+    }
+
+    fn apply_config_defaults(config: &mut IbvConfig) {
+        config.gid_index = 0;
+        config.max_send_sge = 1;
+        config.max_recv_sge = 1;
+        config.max_dest_rd_atomic = 0;
+        config.max_rd_atomic = 0;
+    }
+}
+
+register_ibv_device_impl!(EfaDevice);

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -48,7 +48,7 @@ use super::IbvBuffer;
 use super::IbvOp;
 use super::domain::IbvDomain;
 use super::primitives::IbvConfig;
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMemoryRegion;
 use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvQpInfo;
@@ -348,7 +348,7 @@ impl IbvManagerActor {
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
-        rdma_device: &IbvDevice,
+        rdma_device: &IbvDeviceInfo,
     ) -> Result<Arc<IbvDomain>, anyhow::Error> {
         if let Some((domain, _)) = self.device_domains.get(device_name) {
             return Ok(Arc::clone(domain));

--- a/monarch_rdma/src/backend/ibverbs/mlx_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_device.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Mellanox backend for [`IbvDevice`].
+
+use std::sync::Arc;
+
+use typeuri::Named;
+
+use super::device::IbvContext;
+use super::device::IbvDeviceImpl;
+use super::primitives::IbvConfig;
+use crate::register_ibv_device_impl;
+
+/// PCI vendor ID for Mellanox Technologies.
+const MELLANOX_VENDOR_ID: u32 = 0x02c9;
+
+/// Mellanox backend.
+#[derive(Named)]
+pub(crate) struct MlxDevice;
+
+impl IbvDeviceImpl for MlxDevice {
+    fn backend_name() -> &'static str {
+        "mellanox"
+    }
+
+    fn is_instance(ctx: Arc<IbvContext>) -> bool {
+        let mut attr = rdmaxcel_sys::ibv_device_attr::default();
+        // SAFETY: `ctx.as_ptr()` is a non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call;
+        // `&mut attr` is a writable, properly aligned
+        // `ibv_device_attr`.
+        let queried = unsafe { rdmaxcel_sys::ibv_query_device(ctx.as_ptr(), &mut attr) } == 0;
+        queried && attr.vendor_id == MELLANOX_VENDOR_ID
+    }
+
+    fn apply_config_defaults(_config: &mut IbvConfig) {}
+}
+
+register_ibv_device_impl!(MlxDevice);

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -17,7 +17,7 @@
 //! - `IbvConfig`: Represents ibverbs specific configurations, holding parameters required to establish and
 //!   manage an RDMA connection, including settings for the RDMA device, queue pair attributes, and other
 //!   connection-specific parameters.
-//! - `IbvDevice`: Represents an RDMA device, i.e. 'mlx5_0'. Contains information about the device, such as:
+//! - `IbvDeviceInfo`: Represents an RDMA device, i.e. 'mlx5_0'. Contains information about the device, such as:
 //!   its name, vendor ID, vendor part ID, hardware version, firmware version, node GUID, and capabilities.
 //! - `IbvPort`: Represents information about the port of an RDMA device, including state, physical state,
 //!   LID (Local Identifier), and GID (Global Identifier) information.
@@ -36,6 +36,8 @@ use serde::Serialize;
 use typeuri::Named;
 
 use super::domain::IbvDomain;
+use crate::backend::ibverbs::device::IbvDeviceImpl;
+use crate::backend::ibverbs::efa_device::EfaDevice;
 
 #[derive(
     Default,
@@ -132,7 +134,7 @@ pub fn resolve_qp_type(qp_type: IbvQpType) -> u32 {
 #[derive(Debug, Named, Clone, Serialize, Deserialize)]
 pub struct IbvConfig {
     /// `device` - The RDMA device to use for the connection.
-    pub device: IbvDevice,
+    pub device: IbvDeviceInfo,
     /// `cq_entries` - The number of completion queue entries.
     pub cq_entries: i32,
     /// `port_num` - The physical port number on the device.
@@ -185,7 +187,7 @@ wirevalue::register_type!(IbvConfig);
 impl Default for IbvConfig {
     fn default() -> Self {
         let mut config = Self {
-            device: IbvDevice::default(),
+            device: IbvDeviceInfo::default(),
             cq_entries: 1024,
             port_num: 1,
             gid_index: 3,
@@ -208,7 +210,7 @@ impl Default for IbvConfig {
             max_sge_override: 0,
         };
         if crate::efa::is_efa_device() {
-            crate::efa::apply_efa_defaults(&mut config);
+            EfaDevice::apply_config_defaults(&mut config);
         }
         config
     }
@@ -295,7 +297,7 @@ impl std::fmt::Display for IbvConfig {
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IbvDevice {
+pub struct IbvDeviceInfo {
     /// `name` - The name of the RDMA device (e.g., "mlx5_0").
     pub name: String,
     /// `vendor_id` - The vendor ID of the device.
@@ -324,14 +326,14 @@ pub struct IbvDevice {
     max_sge: i32,
 }
 
-impl IbvDevice {
+impl IbvDeviceInfo {
     /// Returns the name of the RDMA device.
     pub fn name(&self) -> &String {
         &self.name
     }
 
     /// Returns the first available RDMA device, if any.
-    pub fn first_available() -> Option<IbvDevice> {
+    pub fn first_available() -> Option<IbvDeviceInfo> {
         let devices = get_all_devices();
         if devices.is_empty() {
             None
@@ -401,7 +403,7 @@ impl IbvDevice {
     }
 }
 
-impl Default for IbvDevice {
+impl Default for IbvDeviceInfo {
     fn default() -> Self {
         // Try to get a smart default using device selection logic (defaults to cpu:0)
         if let Some(device) = super::device_selection::select_optimal_ibv_device(Some("cpu:0")) {
@@ -440,7 +442,7 @@ pub struct IbvPort {
     gid_tbl_len: i32,
 }
 
-impl fmt::Display for IbvDevice {
+impl fmt::Display for IbvDeviceInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", self.name)?;
         writeln!(f, "\tNumber of ports: {}", self.ports.len())?;
@@ -578,107 +580,134 @@ pub fn format_gid(gid: &[u8; 16]) -> String {
 ///
 /// # Returns
 ///
-/// A vector of `IbvDevice` structures, each representing an RDMA device in the system.
+/// A vector of `IbvDeviceInfo` structures, each representing an RDMA device in the system.
 /// Returns an empty vector if no devices are found or if there was an error querying
 /// the devices.
-pub fn get_all_devices() -> Vec<IbvDevice> {
+pub fn get_all_devices() -> Vec<IbvDeviceInfo> {
     let mut devices = Vec::new();
-
-    // SAFETY: We are calling several C functions from libibverbs.
-    unsafe {
-        let mut num_devices = 0;
-        let device_list = rdmaxcel_sys::ibv_get_device_list(&mut num_devices);
-        if device_list.is_null() || num_devices == 0 {
-            return devices;
-        }
-
-        for i in 0..num_devices {
-            let device = *device_list.add(i as usize);
-            if device.is_null() {
-                continue;
-            }
-
-            let context = rdmaxcel_sys::ibv_open_device(device);
-            if context.is_null() {
-                continue;
-            }
-
-            let device_name = CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device))
-                .to_string_lossy()
-                .into_owned();
-
-            let mut device_attr = rdmaxcel_sys::ibv_device_attr::default();
-            if rdmaxcel_sys::ibv_query_device(context, &mut device_attr) != 0 {
-                rdmaxcel_sys::ibv_close_device(context);
-                continue;
-            }
-
-            let fw_ver = CStr::from_ptr(device_attr.fw_ver.as_ptr())
-                .to_string_lossy()
-                .into_owned();
-
-            let mut rdma_device = IbvDevice {
-                name: device_name,
-                vendor_id: device_attr.vendor_id,
-                vendor_part_id: device_attr.vendor_part_id,
-                hw_ver: device_attr.hw_ver,
-                fw_ver,
-                node_guid: device_attr.node_guid,
-                ports: Vec::new(),
-                max_qp: device_attr.max_qp,
-                max_cq: device_attr.max_cq,
-                max_mr: device_attr.max_mr,
-                max_pd: device_attr.max_pd,
-                max_qp_wr: device_attr.max_qp_wr,
-                max_sge: device_attr.max_sge,
-            };
-
-            for port_num in 1..=device_attr.phys_port_cnt {
-                let mut port_attr = rdmaxcel_sys::ibv_port_attr::default();
-                if rdmaxcel_sys::ibv_query_port(
-                    context,
-                    port_num,
-                    &mut port_attr as *mut rdmaxcel_sys::ibv_port_attr as *mut _,
-                ) != 0
-                {
-                    continue;
-                }
-                let state = get_port_state_str(port_attr.state);
-                let physical_state = get_port_phy_state_str(port_attr.phys_state);
-
-                let link_layer = get_link_layer_str(port_attr.link_layer);
-
-                let mut gid = rdmaxcel_sys::ibv_gid::default();
-                let gid_str = if rdmaxcel_sys::ibv_query_gid(context, port_num, 0, &mut gid) == 0 {
-                    format_gid(&gid.raw)
-                } else {
-                    "N/A".to_string()
-                };
-
-                let rdma_port = IbvPort {
-                    port_num,
-                    state,
-                    physical_state,
-                    base_lid: port_attr.lid,
-                    lmc: port_attr.lmc,
-                    sm_lid: port_attr.sm_lid,
-                    capability_mask: port_attr.port_cap_flags,
-                    link_layer,
-                    gid: gid_str,
-                    gid_tbl_len: port_attr.gid_tbl_len,
-                };
-
-                rdma_device.ports.push(rdma_port);
-            }
-
-            devices.push(rdma_device);
-            rdmaxcel_sys::ibv_close_device(context);
-        }
-
-        rdmaxcel_sys::ibv_free_device_list(device_list);
+    let mut num_devices = 0;
+    // SAFETY: `ibv_get_device_list` populates `num_devices` and
+    // returns either null or a pointer to `num_devices` entries;
+    // we free it before returning.
+    let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+    if device_list.is_null() {
+        return devices;
     }
-
+    for i in 0..num_devices {
+        // SAFETY: `device_list` is non-null with `num_devices`
+        // valid entries (checked above).
+        let device = unsafe { *device_list.add(i as usize) };
+        if device.is_null() {
+            continue;
+        }
+        // SAFETY: `device` is non-null per the check above.
+        let context = unsafe { rdmaxcel_sys::ibv_open_device(device) };
+        if context.is_null() {
+            continue;
+        }
+        // SAFETY: `device` and `context` are non-null and
+        // `context` was returned by `ibv_open_device(device)`.
+        if let Some(info) = unsafe { query_device_info(device, context) } {
+            devices.push(info);
+        }
+        // SAFETY: `context` was returned by `ibv_open_device`
+        // above and has not been closed elsewhere.
+        unsafe { rdmaxcel_sys::ibv_close_device(context) };
+    }
+    // SAFETY: `device_list` was returned by
+    // `ibv_get_device_list` above and has not been freed.
+    unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
     devices
+}
+
+/// Builds an [`IbvDeviceInfo`] from an already-open
+/// `ibv_context`. Returns `None` if `ibv_query_device` fails.
+///
+/// # Safety
+///
+/// `device` and `context` must both be non-null and valid for
+/// the duration of the call; `context` must be the result of
+/// `ibv_open_device(device)`.
+pub(super) unsafe fn query_device_info(
+    device: *mut rdmaxcel_sys::ibv_device,
+    context: *mut rdmaxcel_sys::ibv_context,
+) -> Option<IbvDeviceInfo> {
+    // SAFETY: `device` is non-null per the caller's contract;
+    // `ibv_get_device_name` returns a null-terminated C string
+    // owned by the device list.
+    let device_name = unsafe { CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device)) }
+        .to_string_lossy()
+        .into_owned();
+    let mut device_attr = rdmaxcel_sys::ibv_device_attr::default();
+    // SAFETY: `context` is a non-null context per the caller's
+    // contract; `&mut device_attr` is a writable, properly
+    // aligned `ibv_device_attr`.
+    if unsafe { rdmaxcel_sys::ibv_query_device(context, &mut device_attr) } != 0 {
+        return None;
+    }
+    // SAFETY: `device_attr.fw_ver` is a null-terminated C buffer
+    // populated by `ibv_query_device`.
+    let fw_ver = unsafe { CStr::from_ptr(device_attr.fw_ver.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
+    let mut info = IbvDeviceInfo {
+        name: device_name,
+        vendor_id: device_attr.vendor_id,
+        vendor_part_id: device_attr.vendor_part_id,
+        hw_ver: device_attr.hw_ver,
+        fw_ver,
+        node_guid: device_attr.node_guid,
+        ports: Vec::new(),
+        max_qp: device_attr.max_qp,
+        max_cq: device_attr.max_cq,
+        max_mr: device_attr.max_mr,
+        max_pd: device_attr.max_pd,
+        max_qp_wr: device_attr.max_qp_wr,
+        max_sge: device_attr.max_sge,
+    };
+    for port_num in 1..=device_attr.phys_port_cnt {
+        let mut port_attr = rdmaxcel_sys::ibv_port_attr::default();
+        // SAFETY: `context` is a valid context; `port_attr` is
+        // a writable, properly aligned `ibv_port_attr`.
+        if unsafe {
+            rdmaxcel_sys::ibv_query_port(
+                context,
+                port_num,
+                &mut port_attr as *mut rdmaxcel_sys::ibv_port_attr as *mut _,
+            )
+        } != 0
+        {
+            continue;
+        }
+        let state = get_port_state_str(port_attr.state);
+        let physical_state = get_port_phy_state_str(port_attr.phys_state);
+        let link_layer = get_link_layer_str(port_attr.link_layer);
+        let mut gid = rdmaxcel_sys::ibv_gid::default();
+        // SAFETY: `context` is a valid context; `&mut gid` is a
+        // writable, properly aligned `ibv_gid`.
+        let gid_str = if unsafe { rdmaxcel_sys::ibv_query_gid(context, port_num, 0, &mut gid) } == 0
+        {
+            // SAFETY: `gid.raw` is a union field that is
+            // always initialized; `ibv_query_gid` filled it.
+            let raw = unsafe { gid.raw };
+            format_gid(&raw)
+        } else {
+            "N/A".to_string()
+        };
+        info.ports.push(IbvPort {
+            port_num,
+            state,
+            physical_state,
+            base_lid: port_attr.lid,
+            lmc: port_attr.lmc,
+            sm_lid: port_attr.sm_lid,
+            capability_mask: port_attr.port_cap_flags,
+            link_layer,
+            gid: gid_str,
+            gid_tbl_len: port_attr.gid_tbl_len,
+        });
+    }
+    Some(info)
 }
 
 /// Cached result of mlx5dv support check.
@@ -1109,7 +1138,7 @@ mod tests {
 
     #[test]
     fn test_device_display() {
-        if let Some(device) = IbvDevice::first_available() {
+        if let Some(device) = IbvDeviceInfo::first_available() {
             let display_output = format!("{}", device);
             assert!(
                 display_output.contains(&device.name),
@@ -1124,7 +1153,7 @@ mod tests {
 
     #[test]
     fn test_port_display() {
-        if let Some(device) = IbvDevice::first_available()
+        if let Some(device) = IbvDeviceInfo::first_available()
             && !device.ports().is_empty()
         {
             let port = &device.ports()[0];

--- a/monarch_rdma/src/efa.rs
+++ b/monarch_rdma/src/efa.rs
@@ -13,8 +13,6 @@
 
 use std::sync::OnceLock;
 
-use crate::backend::ibverbs::primitives::IbvConfig;
-
 /// Cached result of EFA device check.
 static EFA_DEVICE_CACHE: OnceLock<bool> = OnceLock::new();
 
@@ -54,20 +52,6 @@ fn is_efa_device_impl() -> bool {
         rdmaxcel_sys::ibv_free_device_list(device_list);
         found
     }
-}
-
-/// Applies EFA-specific defaults to an `IbvConfig`.
-///
-/// EFA devices have different capabilities than standard InfiniBand/RoCE devices:
-/// - GID index 0 (instead of 3)
-/// - Max 1 SGE per work request
-/// - No RDMA atomics support
-pub fn apply_efa_defaults(config: &mut IbvConfig) {
-    config.gid_index = 0;
-    config.max_send_sge = 1;
-    config.max_recv_sge = 1;
-    config.max_dest_rd_atomic = 0;
-    config.max_rd_atomic = 0;
 }
 
 /// Returns the MR access flags appropriate for EFA devices.


### PR DESCRIPTION
Summary:

Introduce `IbvDeviceImpl`, a trait that abstracts per-backend ibverbs behavior — device detection, context open, domain allocation, and config defaults — behind a single `IbvDevice` type. Impls register themselves through the `inventory` crate; Mellanox and EFA impls are added.

Reviewed By: zdevito

Differential Revision: D107298526


