### PR TITLE
Route RDMA over Mlx/Efa NIC backends (#4171)

### DIFF
--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -17,6 +17,7 @@ erased-serde = "0.4.10"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
+inventory = "0.3.24"
 rand = "0.10.1"
 rdmaxcel-sys = { path = "../rdmaxcel-sys" }
 regex = "1.12.3"

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -13,6 +13,7 @@ async-trait = "0.1.86"
 backoff = { version = "0.4.0", features = ["futures", "tokio"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 dashmap = { version = "6.2.1", features = ["rayon", "serde"] }
+enum-as-inner = "0.6.1"
 erased-serde = "0.4.10"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -531,13 +531,15 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
             cu_check!(rdmaxcel_sys::rdmaxcel_cuCtxSetCurrent(context));
         }
 
-        // Extract IbvManagerActor refs and IbvBuffers from backends
+        // Extract IbvManagerActor refs and IbvBuffers from backends.
         let (local_ibv_manager, local_ibv) = local_buffer
-            .resolve_ibv()
-            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for local buffer"))?;
+            .resolve_nic()
+            .and_then(|ctx| ctx.into_mlx().ok())
+            .ok_or_else(|| anyhow::anyhow!("Mellanox backend not found for local buffer"))?;
         let (remote_ibv_manager, remote_ibv) = remote_buffer
-            .resolve_ibv()
-            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for remote buffer"))?;
+            .resolve_nic()
+            .and_then(|ctx| ctx.into_mlx().ok())
+            .ok_or_else(|| anyhow::anyhow!("Mellanox backend not found for remote buffer"))?;
 
         let local_ibv_manager_handle = local_ibv_manager
             .downcast_handle(cx)

--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -23,6 +23,7 @@ use crate::RdmaOpType;
 use crate::backend::RdmaBackend;
 use crate::backend::ibverbs::manager_actor::IbvBackend;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
+use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::tcp::manager_actor::TcpBackend;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
@@ -170,8 +171,9 @@ impl RdmaAction {
         // The ibv cell's inner `Option` distinguishes "lookup tried and
         // failed" (`Some(None)`) from "never tried" (cell unset), so the
         // lookup doesn't repeat when the local proc lacks ibverbs.
-        let ibv_cell: tokio::sync::OnceCell<Option<hyperactor::ActorHandle<IbvManagerActor>>> =
-            tokio::sync::OnceCell::new();
+        let ibv_cell: tokio::sync::OnceCell<
+            Option<hyperactor::ActorHandle<IbvManagerActor<MlxDevice>>>,
+        > = tokio::sync::OnceCell::new();
         // The tcp cell needs no such sentinel: the init closure either
         // caches a handle or bails.
         let tcp_cell: tokio::sync::OnceCell<hyperactor::ActorHandle<TcpManagerActor>> =

--- a/monarch_rdma/src/action.rs
+++ b/monarch_rdma/src/action.rs
@@ -18,15 +18,15 @@ use std::time::Duration;
 
 use hyperactor::context;
 
+use crate::RdmaManagerActor;
+use crate::RdmaManagerMessageClient;
 use crate::RdmaOp;
 use crate::RdmaOpType;
 use crate::backend::RdmaBackend;
-use crate::backend::ibverbs::manager_actor::IbvBackend;
-use crate::backend::ibverbs::manager_actor::IbvManagerActor;
-use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::tcp::manager_actor::TcpBackend;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
+use crate::nic::NicBackendHandle;
 use crate::rdma_components::RdmaRemoteBuffer;
 
 /// A batch of RDMA operations submitted as a single unit.
@@ -155,7 +155,7 @@ impl RdmaAction {
     }
 
     /// Submit all queued ops. Ops are grouped by their local backend
-    /// (ibverbs or TCP); each group is submitted in parallel. Safe to
+    /// (NIC or TCP); each group is submitted in parallel. Safe to
     /// call more than once on the same action — the queued ops and
     /// overlap claims are left intact.
     ///
@@ -168,18 +168,17 @@ impl RdmaAction {
         client: &(impl context::Actor + Send + Sync),
         timeout: Duration,
     ) -> Result<(), anyhow::Error> {
-        // The ibv cell's inner `Option` distinguishes "lookup tried and
+        // The nic cell's inner `Option` distinguishes "lookup tried and
         // failed" (`Some(None)`) from "never tried" (cell unset), so the
-        // lookup doesn't repeat when the local proc lacks ibverbs.
-        let ibv_cell: tokio::sync::OnceCell<
-            Option<hyperactor::ActorHandle<IbvManagerActor<MlxDevice>>>,
-        > = tokio::sync::OnceCell::new();
+        // lookup doesn't repeat when the local proc lacks a NIC.
+        let nic_cell: tokio::sync::OnceCell<Option<NicBackendHandle>> =
+            tokio::sync::OnceCell::new();
         // The tcp cell needs no such sentinel: the init closure either
         // caches a handle or bails.
         let tcp_cell: tokio::sync::OnceCell<hyperactor::ActorHandle<TcpManagerActor>> =
             tokio::sync::OnceCell::new();
 
-        let mut ibv_ops: Vec<RdmaOp> = Vec::new();
+        let mut nic_ops: Vec<RdmaOp> = Vec::new();
         let mut tcp_ops: Vec<RdmaOp> = Vec::new();
 
         for entry in &self.entries {
@@ -188,38 +187,47 @@ impl RdmaAction {
                 local: entry.local.clone(),
                 remote: entry.remote.clone(),
             };
-            if entry.remote.has_ibverbs_backend() {
-                let ibv = ibv_cell
-                    .get_or_init(|| async { IbvManagerActor::local_handle(client).await.ok() })
+            // Route over the NIC only when the remote advertises a NIC
+            // backend and the local proc runs a compatible one.
+            if let Some(backend_ctx) = entry.remote.resolve_nic() {
+                let nic = nic_cell
+                    .get_or_init(|| async {
+                        RdmaManagerActor::local_handle(client)
+                            .get_nic_backend_handle(client)
+                            .await
+                            .ok()
+                            .flatten()
+                    })
                     .await;
-                if ibv.is_some() {
-                    ibv_ops.push(op);
+                if nic
+                    .as_ref()
+                    .is_some_and(|h| backend_ctx.is_compatible_with(h))
+                {
+                    nic_ops.push(op);
                     continue;
                 }
             }
-            // Either the remote lacks an ibverbs backend, or the local
-            // proc has no `IbvManagerActor`. Fall back to TCP — refusing
-            // if fallback is disabled by configuration.
+            // Fall back to TCP — refusing if fallback is disabled.
             tcp_cell
                 .get_or_try_init(|| async {
                     if !hyperactor_config::global::get(crate::config::RDMA_ALLOW_TCP_FALLBACK) {
                         anyhow::bail!(
-                            "no usable ibverbs backend, and TCP fallback is disabled; \
+                            "no usable NIC backend, and TCP fallback is disabled; \
                              enable it with monarch.configure(rdma_allow_tcp_fallback=True)"
                         );
                     }
-                    tracing::warn!("falling back to TCP transport (no usable ibverbs backend)");
+                    tracing::warn!("falling back to TCP transport (no usable NIC backend)");
                     TcpManagerActor::local_handle(client).await
                 })
                 .await?;
             tcp_ops.push(op);
         }
 
-        let ibv_fut = async {
-            match ibv_cell.into_inner().flatten() {
-                Some(h) => IbvBackend(h).submit(client, ibv_ops, timeout).await,
+        let nic_fut = async {
+            match nic_cell.into_inner().flatten() {
+                Some(h) => h.submit(client, nic_ops, timeout).await,
                 None => {
-                    assert!(ibv_ops.is_empty());
+                    assert!(nic_ops.is_empty());
                     Ok(())
                 }
             }
@@ -233,8 +241,8 @@ impl RdmaAction {
                 }
             }
         };
-        let (ibv_res, tcp_res) = tokio::join!(ibv_fut, tcp_fut);
-        ibv_res?;
+        let (nic_res, tcp_res) = tokio::join!(nic_fut, tcp_fut);
+        nic_res?;
         tcp_res?;
         Ok(())
     }

--- a/monarch_rdma/src/backend.rs
+++ b/monarch_rdma/src/backend.rs
@@ -24,6 +24,7 @@ use serde::Serialize;
 
 use crate::RdmaOp;
 use crate::RdmaTransportLevel;
+use crate::nic::NicRemoteBackendContext;
 
 /// Backend-specific context for a remote buffer.
 ///
@@ -31,10 +32,7 @@ use crate::RdmaTransportLevel;
 /// using that backend on a particular buffer.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RdmaRemoteBackendContext {
-    Ibverbs(
-        ActorRef<ibverbs::manager_actor::IbvManagerActor<ibverbs::mlx_device::MlxDevice>>,
-        ibverbs::IbvBuffer,
-    ),
+    Nic(NicRemoteBackendContext),
     Tcp(ActorRef<tcp::manager_actor::TcpManagerActor>),
 }
 

--- a/monarch_rdma/src/backend.rs
+++ b/monarch_rdma/src/backend.rs
@@ -32,7 +32,7 @@ use crate::RdmaTransportLevel;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum RdmaRemoteBackendContext {
     Ibverbs(
-        ActorRef<ibverbs::manager_actor::IbvManagerActor>,
+        ActorRef<ibverbs::manager_actor::IbvManagerActor<ibverbs::mlx_device::MlxDevice>>,
         ibverbs::IbvBuffer,
     ),
     Tcp(ActorRef<tcp::manager_actor::TcpManagerActor>),

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -14,16 +14,17 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-pub(crate) mod device;
+pub mod device;
 pub mod device_selection;
 pub(crate) mod domain;
-pub(crate) mod efa_device;
+pub mod efa_device;
 pub mod manager_actor;
-pub(crate) mod mlx_device;
+pub mod mlx_device;
 pub mod primitives;
 pub mod queue_pair;
 
 use manager_actor::IbvManagerActor;
+use mlx_device::MlxDevice;
 pub use queue_pair::IbvQueuePair;
 pub use queue_pair::PollTarget;
 
@@ -57,7 +58,7 @@ pub struct IbvBuffer {
 /// Generic over the manager actor type so unit tests can swap in a
 /// mock; production code uses the default `IbvOp<IbvManagerActor>`.
 #[derive(Debug, Named)]
-pub struct IbvOp<M: Referable = IbvManagerActor> {
+pub struct IbvOp<M: Referable = IbvManagerActor<MlxDevice>> {
     pub op_type: RdmaOpType,
     pub local_memory: KeepaliveLocalMemory,
     pub remote_buffer: IbvBuffer,

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -14,9 +14,12 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
+pub(crate) mod device;
 pub mod device_selection;
 pub(crate) mod domain;
+pub(crate) mod efa_device;
 pub mod manager_actor;
+pub(crate) mod mlx_device;
 pub mod primitives;
 pub mod queue_pair;
 

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -1,0 +1,415 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Backend-agnostic ibverbs device abstraction.
+//!
+//! [`IbvDevice`] owns the per-process state for a single opened RDMA
+//! device: an `Arc<IbvContext>`, an [`IbvConfig`], and a map of named
+//! `Arc<IbvDomain>`s allocated against the device.
+//! Per-backend behavior — claiming a device as the backend's,
+//! allocating a domain, and seeding config defaults — is provided by
+//! an [`IbvDeviceImpl`].
+//!
+//! Each [`IbvDeviceImpl`] registers itself via the `inventory` crate
+//! (using [`register_ibv_device_impl!`]). At first access,
+//! [`DEVICE_NAMES_BY_IMPL`] walks the ibverbs device list once and
+//! assigns each device to the first registered impl whose
+//! [`IbvDeviceImpl::is_instance`] claims it, caching the resulting
+//! `typename() → device-infos` map. [`IbvDevice::open`] consults this
+//! map: it returns `None` when `name` is not advertised under
+//! `I::typename()`, and otherwise opens the device using the cached
+//! [`IbvDeviceInfo`].
+
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::marker::PhantomData;
+use std::sync::Arc;
+use std::sync::LazyLock;
+
+use typeuri::Named;
+
+use super::domain::IbvDomain;
+use super::primitives::IbvConfig;
+use super::primitives::IbvDeviceInfo;
+use super::primitives::query_device_info;
+
+/// Per-backend driver for [`IbvDevice`]. Concrete impls register
+/// themselves via [`register_ibv_device_impl!`].
+pub(crate) trait IbvDeviceImpl: Named + Send + Sync + 'static {
+    /// Human-readable display name for the backend this impl
+    /// drives (e.g., `"mellanox"`, `"efa"`). Surfaced in
+    /// diagnostics; not used as a registry key.
+    fn backend_name() -> &'static str;
+
+    /// Returns `true` if `ctx` belongs to this backend. Called
+    /// transiently, once per ibverbs device, while
+    /// [`DEVICE_NAMES_BY_IMPL`] is built.
+    fn is_instance(ctx: Arc<IbvContext>) -> bool;
+
+    /// Allocates a protection domain against `ctx` and wraps it in
+    /// an [`IbvDomain`]. The returned `Arc<IbvDomain>` is the sole
+    /// owner of the PD; the last drop runs `ibv_dealloc_pd`.
+    ///
+    /// The default implementation calls `ibv_alloc_pd` on
+    /// `ctx.as_ptr()` and constructs a plain [`IbvDomain`].
+    /// In a followup, we'll add an `IbvDomainImpl` trait to allow for
+    /// backend-specific domain implementations.
+    fn create_domain(ctx: Arc<IbvContext>) -> anyhow::Result<Arc<IbvDomain>> {
+        // SAFETY: `ctx.as_ptr()` is the non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call.
+        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(ctx.as_ptr()) };
+        if pd.is_null() {
+            anyhow::bail!("ibv_alloc_pd failed: {}", std::io::Error::last_os_error());
+        }
+        // TODO: `IbvDomain` should hold the `Arc<IbvContext>`
+        // itself so the context outlives the PD by construction;
+        // for now we copy the raw pointer and rely on the
+        // surrounding [`IbvDevice`] to keep the context alive.
+        Ok(Arc::new(IbvDomain {
+            context: ctx.as_ptr(),
+            pd,
+        }))
+    }
+
+    /// Seeds an [`IbvConfig`] with backend-appropriate defaults
+    /// (e.g., EFA caps `max_send_sge` at 1).
+    fn apply_config_defaults(config: &mut IbvConfig);
+}
+
+/// Inventory entry submitted by [`register_ibv_device_impl!`] for
+/// each concrete [`IbvDeviceImpl`]. Captures function pointers to
+/// the impl's `typename()`, `backend_name()`, and `is_instance()`,
+/// all erased of the concrete type.
+pub struct IbvDeviceImplRegistration {
+    typename: fn() -> &'static str,
+    backend_name: fn() -> &'static str,
+    is_instance: fn(Arc<IbvContext>) -> bool,
+}
+
+/// Per-impl entry stored in [`DEVICE_NAMES_BY_IMPL`]. Keyed by
+/// `typename()`; carries the human-readable `backend_name` for
+/// diagnostics alongside the impl's device infos.
+#[derive(Debug)]
+struct RegisteredBackend {
+    #[expect(
+        dead_code,
+        reason = "read only via Debug for the IbvDevice::open diagnostic warning"
+    )]
+    backend_name: &'static str,
+    devices: Vec<IbvDeviceInfo>,
+}
+
+inventory::collect!(IbvDeviceImplRegistration);
+
+/// Submits an `inventory` entry for a concrete [`IbvDeviceImpl`].
+///
+/// Place one invocation per impl at module scope. The expansion
+/// references `inventory` and `typeuri` by bare crate name, so the
+/// calling crate must list both as direct dependencies.
+///
+/// ```ignore
+/// register_ibv_device_impl!(StandardImpl);
+/// ```
+#[macro_export]
+macro_rules! register_ibv_device_impl {
+    ($impl_ty:ty) => {
+        inventory::submit! {
+            $crate::backend::ibverbs::device::IbvDeviceImplRegistration::new(
+                <$impl_ty as typeuri::Named>::typename,
+                <$impl_ty as $crate::backend::ibverbs::device::IbvDeviceImpl>::backend_name,
+                <$impl_ty as $crate::backend::ibverbs::device::IbvDeviceImpl>::is_instance,
+            )
+        }
+    };
+}
+
+impl IbvDeviceImplRegistration {
+    /// Construct a registration. Visible to the rest of the crate
+    /// so the [`register_ibv_device_impl!`] macro can call it from
+    /// sibling call sites.
+    pub(crate) const fn new(
+        typename: fn() -> &'static str,
+        backend_name: fn() -> &'static str,
+        is_instance: fn(Arc<IbvContext>) -> bool,
+    ) -> Self {
+        Self {
+            typename,
+            backend_name,
+            is_instance,
+        }
+    }
+}
+
+/// Process-wide map from `IbvDeviceImpl::typename()` to a
+/// [`RegisteredBackend`] holding the impl's display name and the
+/// device infos it claims. Built once on first access by a single
+/// walk of the ibverbs device list, assigning each device to the
+/// first registration whose `is_instance` claims it.
+static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> =
+    LazyLock::new(|| {
+        let registrations: Vec<&IbvDeviceImplRegistration> =
+            inventory::iter::<IbvDeviceImplRegistration>().collect();
+        let mut by_impl: HashMap<&'static str, RegisteredBackend> = registrations
+            .iter()
+            .map(|reg| {
+                (
+                    (reg.typename)(),
+                    RegisteredBackend {
+                        backend_name: (reg.backend_name)(),
+                        devices: Vec::new(),
+                    },
+                )
+            })
+            .collect();
+
+        let mut num_devices = 0i32;
+        // SAFETY: `ibv_get_device_list` populates `num_devices` and
+        // returns either null or a pointer to `num_devices` entries;
+        // we free it before returning.
+        let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+        // A non-null list must be freed even when empty, so only the
+        // null case returns early; the loop below is a no-op at zero
+        // devices and the `ibv_free_device_list` at the end still runs.
+        if device_list.is_null() {
+            return by_impl;
+        }
+        for i in 0..num_devices {
+            // SAFETY: `device_list` is non-null with `num_devices`
+            // valid entries (checked above).
+            let device = unsafe { *device_list.add(i as usize) };
+            if device.is_null() {
+                continue;
+            }
+            // SAFETY: `device` is non-null per the check above.
+            let raw_ctx = unsafe { rdmaxcel_sys::ibv_open_device(device) };
+            if raw_ctx.is_null() {
+                continue;
+            }
+            let ctx = Arc::new(IbvContext(raw_ctx));
+            // Assign the device to the first impl that claims it.
+            if let Some(reg) = registrations
+                .iter()
+                .find(|reg| (reg.is_instance)(Arc::clone(&ctx)))
+            {
+                // SAFETY: `device` and `ctx.as_ptr()` are non-null and
+                // `ctx.as_ptr()` was returned by `ibv_open_device(device)`.
+                if let Some(info) = unsafe { query_device_info(device, ctx.as_ptr()) } {
+                    by_impl
+                        .get_mut((reg.typename)())
+                        .expect("registration typename present in map")
+                        .devices
+                        .push(info);
+                }
+            }
+            // `ctx` drops here, closing the transient context.
+        }
+        // SAFETY: `device_list` was returned by `ibv_get_device_list`
+        // above and has not been freed.
+        unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+        by_impl
+    });
+
+/// RAII owner of a raw `ibv_context*`.
+///
+/// Closes the context in [`Drop`]. Held inside an `Arc` not because
+/// clones are expected to outlive the owning [`IbvDevice`], but so
+/// the raw pointer can be passed around with a lifetime safeguard
+/// where borrow-checked references aren't practical.
+pub(crate) struct IbvContext(*mut rdmaxcel_sys::ibv_context);
+
+// SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
+// operations we perform (allocation, polling, and the final close).
+unsafe impl Send for IbvContext {}
+unsafe impl Sync for IbvContext {}
+
+impl IbvContext {
+    /// Returns the raw `ibv_context*`. The pointer is valid for
+    /// the lifetime of `&self`.
+    pub(crate) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
+        self.0
+    }
+}
+
+impl Drop for IbvContext {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            return;
+        }
+        // SAFETY: `self.0` was returned by `ibv_open_device` in
+        // `IbvDevice::open` and has not been closed elsewhere. The
+        // intended ownership is a single `Arc<IbvContext>`, whose
+        // final `Drop` calls `ibv_close_device` exactly once.
+        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.0) };
+        if result != 0 {
+            tracing::error!(
+                "ibv_close_device failed for context {:p}: error code {}",
+                self.0,
+                result
+            );
+        }
+    }
+}
+
+/// An opened RDMA device.
+///
+/// Owns an `Arc<IbvContext>`, the queried [`IbvDeviceInfo`]
+/// metadata, a device-scoped [`IbvDeviceConfig`], and a map of
+/// named `Arc<IbvDomain>`s allocated against the device (one PD
+/// per name, created lazily by [`Self::get_or_create_domain`]).
+///
+/// `I` is the backend driver type, parameterizing all per-backend
+/// behavior via [`IbvDeviceImpl`].
+///
+/// Field declaration order is significant: `domains` is declared
+/// before `context` so that, on drop, every `Arc<IbvDomain>` in
+/// the map releases its PD before the final `Arc<IbvContext>`
+/// reference closes the context.
+pub(crate) struct IbvDevice<I: IbvDeviceImpl> {
+    domains: HashMap<String, Arc<IbvDomain>>,
+    device_info: IbvDeviceInfo,
+    config: IbvConfig,
+    context: Arc<IbvContext>,
+    _marker: PhantomData<I>,
+}
+
+#[expect(dead_code, reason = "called by manager_actor in follow-up commits")]
+impl<I: IbvDeviceImpl> IbvDevice<I> {
+    /// Opens `name` under impl `I`, storing `config` as-is. Returns
+    /// `None` if `name` is not one of the devices registered for
+    /// `I::typename()`; otherwise returns an `IbvDevice<I>` with the
+    /// device's queried [`IbvDeviceInfo`] and the given [`IbvConfig`].
+    ///
+    /// # Panics
+    ///
+    /// Panics if a registered device cannot be opened — e.g. it
+    /// disappeared from the system between registration and open.
+    /// Such a failure indicates a broken driver invariant rather
+    /// than a runtime condition the caller can recover from.
+    pub(crate) fn open(name: &str, config: IbvConfig) -> Option<Self> {
+        let device_info = DEVICE_NAMES_BY_IMPL
+            .get(I::typename())
+            .and_then(|entry| entry.devices.iter().find(|d| d.name() == name).cloned());
+        let device_info = match device_info {
+            Some(info) => info,
+            None => {
+                tracing::warn!(
+                    "ibv device {} not found under backend {}; available: {:?}",
+                    name,
+                    I::backend_name(),
+                    *DEVICE_NAMES_BY_IMPL,
+                );
+                return None;
+            }
+        };
+
+        // The registry already confirmed `name` belongs to `I`, so
+        // reopen the device by name; a miss here is a broken invariant.
+        let mut num_devices = 0i32;
+        // SAFETY: `ibv_get_device_list` populates `num_devices` and
+        // returns either null or a pointer to `num_devices` entries;
+        // we free it before returning.
+        let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+        assert!(
+            !device_list.is_null(),
+            "RDMA device list was null while opening registered device {}",
+            name,
+        );
+        if num_devices == 0 {
+            // A non-null list must be freed even when empty, per the
+            // libibverbs contract.
+            // SAFETY: `device_list` is non-null (asserted above) and was
+            // returned by `ibv_get_device_list`.
+            unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+            panic!(
+                "no RDMA devices found while opening registered device {}",
+                name
+            );
+        }
+        let mut target = std::ptr::null_mut();
+        for i in 0..num_devices {
+            // SAFETY: `device_list` is non-null with `num_devices`
+            // valid entries (checked above).
+            let device = unsafe { *device_list.add(i as usize) };
+            if device.is_null() {
+                continue;
+            }
+            // SAFETY: `device` is non-null per the check above;
+            // `ibv_get_device_name` returns a null-terminated C string
+            // owned by the device list.
+            let dev_name = unsafe { CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device)) };
+            if dev_name.to_bytes() == name.as_bytes() {
+                target = device;
+                break;
+            }
+        }
+        let mut failure = None;
+        let mut context: *mut crate::rdmaxcel_sys::ibv_context = std::ptr::null_mut();
+        if target.is_null() {
+            failure = Some(format!(
+                "ibv device with name {} not found by ibv_get_device_list",
+                name
+            ));
+        } else {
+            // Open while `target` still points into `device_list`, then free.
+            // SAFETY: `target`, when non-null, is one of `device_list`'s
+            // entries; `ibv_open_device` returns null on failure.
+            context = unsafe { rdmaxcel_sys::ibv_open_device(target) };
+            if context.is_null() {
+                failure = Some(format!(
+                    "registered ibv device {} could not be opened: {}",
+                    name,
+                    std::io::Error::last_os_error(),
+                ));
+            }
+        }
+
+        // SAFETY: `device_list` was returned by `ibv_get_device_list`
+        // above and has not been freed.
+        unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
+
+        if let Some(failure) = failure {
+            panic!("{}", failure);
+        }
+
+        Some(Self {
+            domains: HashMap::new(),
+            device_info,
+            config,
+            context: Arc::new(IbvContext(context)),
+            _marker: PhantomData,
+        })
+    }
+
+    /// Returns the `Arc<IbvContext>` for this device.
+    pub(crate) fn context(&self) -> Arc<IbvContext> {
+        Arc::clone(&self.context)
+    }
+
+    /// Returns the queried [`IbvDeviceInfo`] metadata for this
+    /// device.
+    pub(crate) fn device_info(&self) -> &IbvDeviceInfo {
+        &self.device_info
+    }
+
+    /// Returns the [`IbvConfig`] this device was opened with.
+    pub(crate) fn config(&self) -> &IbvConfig {
+        &self.config
+    }
+
+    /// Returns the `Arc<IbvDomain>` registered under `name`,
+    /// creating (and caching) a new one via
+    /// [`IbvDeviceImpl::create_domain`] on first access.
+    pub(crate) fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
+        if let Some(domain) = self.domains.get(name) {
+            return Ok(Arc::clone(domain));
+        }
+        let domain = I::create_domain(Arc::clone(&self.context))?;
+        self.domains.insert(name.to_string(), Arc::clone(&domain));
+        Ok(domain)
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -40,7 +40,7 @@ use super::primitives::query_device_info;
 
 /// Per-backend driver for [`IbvDevice`]. Concrete impls register
 /// themselves via [`register_ibv_device_impl!`].
-pub(crate) trait IbvDeviceImpl: Named + Send + Sync + 'static {
+pub trait IbvDeviceImpl: Named + std::fmt::Debug + Send + Sync + 'static {
     /// Human-readable display name for the backend this impl
     /// drives (e.g., `"mellanox"`, `"efa"`). Surfaced in
     /// diagnostics; not used as a registry key.
@@ -132,7 +132,7 @@ impl IbvDeviceImplRegistration {
     /// Construct a registration. Visible to the rest of the crate
     /// so the [`register_ibv_device_impl!`] macro can call it from
     /// sibling call sites.
-    pub(crate) const fn new(
+    pub const fn new(
         typename: fn() -> &'static str,
         backend_name: fn() -> &'static str,
         is_instance: fn(Arc<IbvContext>) -> bool,
@@ -220,7 +220,8 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
 /// clones are expected to outlive the owning [`IbvDevice`], but so
 /// the raw pointer can be passed around with a lifetime safeguard
 /// where borrow-checked references aren't practical.
-pub(crate) struct IbvContext(*mut rdmaxcel_sys::ibv_context);
+#[derive(Debug)]
+pub struct IbvContext(*mut rdmaxcel_sys::ibv_context);
 
 // SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
 // operations we perform (allocation, polling, and the final close).
@@ -230,7 +231,7 @@ unsafe impl Sync for IbvContext {}
 impl IbvContext {
     /// Returns the raw `ibv_context*`. The pointer is valid for
     /// the lifetime of `&self`.
-    pub(crate) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
+    pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
         self.0
     }
 }
@@ -269,6 +270,7 @@ impl Drop for IbvContext {
 /// before `context` so that, on drop, every `Arc<IbvDomain>` in
 /// the map releases its PD before the final `Arc<IbvContext>`
 /// reference closes the context.
+#[derive(Debug)]
 pub(crate) struct IbvDevice<I: IbvDeviceImpl> {
     domains: HashMap<String, Arc<IbvDomain>>,
     device_info: IbvDeviceInfo,
@@ -290,7 +292,7 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
     /// disappeared from the system between registration and open.
     /// Such a failure indicates a broken driver invariant rather
     /// than a runtime condition the caller can recover from.
-    pub(crate) fn open(name: &str, config: IbvConfig) -> Option<Self> {
+    pub fn open(name: &str, config: IbvConfig) -> Option<Self> {
         let device_info = DEVICE_NAMES_BY_IMPL
             .get(I::typename())
             .and_then(|entry| entry.devices.iter().find(|d| d.name() == name).cloned());
@@ -386,30 +388,46 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
     }
 
     /// Returns the `Arc<IbvContext>` for this device.
-    pub(crate) fn context(&self) -> Arc<IbvContext> {
+    pub fn context(&self) -> Arc<IbvContext> {
         Arc::clone(&self.context)
     }
 
     /// Returns the queried [`IbvDeviceInfo`] metadata for this
     /// device.
-    pub(crate) fn device_info(&self) -> &IbvDeviceInfo {
+    pub fn device_info(&self) -> &IbvDeviceInfo {
         &self.device_info
     }
 
     /// Returns the [`IbvConfig`] this device was opened with.
-    pub(crate) fn config(&self) -> &IbvConfig {
+    pub fn config(&self) -> &IbvConfig {
         &self.config
+    }
+
+    /// Returns the `Arc<IbvDomain>` registered under `name`, if
+    /// one has already been created. Read-only lookup; use
+    /// [`Self::get_or_create_domain`] to create on demand.
+    pub fn domain(&self, name: &str) -> Option<&Arc<IbvDomain>> {
+        self.domains.get(name)
     }
 
     /// Returns the `Arc<IbvDomain>` registered under `name`,
     /// creating (and caching) a new one via
     /// [`IbvDeviceImpl::create_domain`] on first access.
-    pub(crate) fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
+    pub fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
         if let Some(domain) = self.domains.get(name) {
             return Ok(Arc::clone(domain));
         }
         let domain = I::create_domain(Arc::clone(&self.context))?;
         self.domains.insert(name.to_string(), Arc::clone(&domain));
         Ok(domain)
+    }
+
+    /// Whether any device claimed by impl `I` is present on this
+    /// host. Reads the [`DEVICE_NAMES_BY_IMPL`] registry, built on
+    /// first access by a single walk of the ibverbs device list.
+    pub fn available() -> bool {
+        DEVICE_NAMES_BY_IMPL
+            .get(I::typename())
+            .is_some_and(|backend| !backend.devices.is_empty())
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -11,7 +11,7 @@
 
 use std::sync::OnceLock;
 
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 use super::primitives::get_all_devices;
 use crate::device_selection::PCIDevice;
 use crate::device_selection::get_all_rdma_devices;
@@ -24,7 +24,7 @@ use crate::device_selection::parse_pci_topology;
 /// Step 2: Get PCI address from compute device
 /// Step 3: Get PCI address for all RDMA NIC devices
 /// Step 4: Calculate PCI distances and return closest RDMA NIC device
-pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice> {
+pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDeviceInfo> {
     let device_hint = device_hint?;
 
     let (prefix, postfix) = parse_device_string(device_hint)?;
@@ -44,7 +44,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
             };
             let rdma_devices = get_all_rdma_devices();
             if rdma_devices.is_empty() {
-                return IbvDevice::first_available();
+                return IbvDeviceInfo::first_available();
             }
             let pci_devices = parse_pci_topology().ok()?;
             let source_device = pci_devices.get(&source_pci_addr)?;
@@ -68,7 +68,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
             }
 
             // Fallback
-            IbvDevice::first_available()
+            IbvDeviceInfo::first_available()
         }
         _ => {
             // Direct device name lookup for backward compatibility
@@ -85,8 +85,8 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDevice>
 ///
 /// Computed at most once per process on the first RDMA operation involving
 /// CUDA memory. CPU-only workloads pay no initialization cost.
-pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDevice>> {
-    static CUDA_DEVICE_TO_IBV: OnceLock<Vec<Option<IbvDevice>>> = OnceLock::new();
+pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDeviceInfo>> {
+    static CUDA_DEVICE_TO_IBV: OnceLock<Vec<Option<IbvDeviceInfo>>> = OnceLock::new();
     CUDA_DEVICE_TO_IBV.get_or_init(|| {
         let count = unsafe {
             let mut c: i32 = 0;
@@ -103,7 +103,7 @@ pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDevice>> {
 ///
 /// Applies auto-detection for default devices, but otherwise
 /// returns the device as-is.
-pub fn resolve_ibv_device(device: &IbvDevice) -> Option<IbvDevice> {
+pub fn resolve_ibv_device(device: &IbvDeviceInfo) -> Option<IbvDeviceInfo> {
     let device_name = device.name();
 
     if device_name.starts_with("mlx") {

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -16,7 +16,7 @@ use std::ffi::CStr;
 use std::io::Error;
 use std::result::Result;
 
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 
 /// Manages RDMA resources including context and protection domain.
 ///
@@ -83,7 +83,7 @@ impl IbvDomain {
     ///
     /// Returns errors if no RDMA devices are found, the specified device cannot be found,
     /// device context creation fails, or protection domain allocation fails.
-    pub fn new(device: IbvDevice) -> Result<Self, anyhow::Error> {
+    pub fn new(device: IbvDeviceInfo) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating IbvDomain for device {}", device.name());
         unsafe {
             let device_name = device.name();

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -31,6 +31,7 @@ use hyperactor_config::Flattrs;
 use super::IbvBuffer;
 use super::manager_actor::IbvManagerActor;
 use super::manager_actor::IbvManagerMessageClient;
+use super::mlx_device::MlxDevice;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::PollTarget;
 use crate::IbvConfig;
@@ -490,13 +491,13 @@ pub struct DoorbellTestEnv {
     pub client_2: hyperactor::Client,
     pub actor_1: ActorRef<RdmaManagerActor>,
     pub actor_2: ActorRef<RdmaManagerActor>,
-    pub ibv_actor_1: ActorRef<IbvManagerActor>,
-    pub ibv_actor_2: ActorRef<IbvManagerActor>,
+    pub ibv_actor_1: ActorRef<IbvManagerActor<MlxDevice>>,
+    pub ibv_actor_2: ActorRef<IbvManagerActor<MlxDevice>>,
     /// In-proc handles for the same actors as `ibv_actor_*`.
     /// Tests that need to call local-only messages such as
     /// `RawQueuePair` go through these.
-    pub ibv_handle_1: ActorHandle<IbvManagerActor>,
-    pub ibv_handle_2: ActorHandle<IbvManagerActor>,
+    pub ibv_handle_1: ActorHandle<IbvManagerActor<MlxDevice>>,
+    pub ibv_handle_2: ActorHandle<IbvManagerActor<MlxDevice>>,
     pub rdma_handle_1: RdmaRemoteBuffer,
     pub rdma_handle_2: RdmaRemoteBuffer,
     pub local_memory_1: KeepaliveLocalMemory,
@@ -684,14 +685,12 @@ impl DoorbellTestEnv {
         let (ibv_actor_2, ibv_buffer_2) = rdma_handle_2
             .resolve_ibv()
             .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 2"))?;
-        let ibv_handle_1: ActorHandle<IbvManagerActor> =
-            ibv_actor_1
-                .downcast_handle(&instance_1)
-                .ok_or_else(|| anyhow::anyhow!("ibv_actor_1 is not in proc_1"))?;
-        let ibv_handle_2: ActorHandle<IbvManagerActor> =
-            ibv_actor_2
-                .downcast_handle(&instance_2)
-                .ok_or_else(|| anyhow::anyhow!("ibv_actor_2 is not in proc_2"))?;
+        let ibv_handle_1: ActorHandle<IbvManagerActor<MlxDevice>> = ibv_actor_1
+            .downcast_handle(&instance_1)
+            .ok_or_else(|| anyhow::anyhow!("ibv_actor_1 is not in proc_1"))?;
+        let ibv_handle_2: ActorHandle<IbvManagerActor<MlxDevice>> = ibv_actor_2
+            .downcast_handle(&instance_2)
+            .ok_or_else(|| anyhow::anyhow!("ibv_actor_2 is not in proc_2"))?;
 
         // Fill buffer1 with test data
         if parsed_accel1.0 == "cuda" {

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -680,11 +680,15 @@ impl DoorbellTestEnv {
         }
 
         let (ibv_actor_1, ibv_buffer_1) = rdma_handle_1
-            .resolve_ibv()
-            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 1"))?;
+            .resolve_nic()
+            .expect("buffer 1 has a NIC backend")
+            .into_mlx()
+            .expect("buffer 1 is Mellanox");
         let (ibv_actor_2, ibv_buffer_2) = rdma_handle_2
-            .resolve_ibv()
-            .ok_or_else(|| anyhow::anyhow!("ibverbs backend not found for buffer 2"))?;
+            .resolve_nic()
+            .expect("buffer 2 has a NIC backend")
+            .into_mlx()
+            .expect("buffer 2 is Mellanox");
         let ibv_handle_1: ActorHandle<IbvManagerActor<MlxDevice>> = ibv_actor_1
             .downcast_handle(&instance_1)
             .ok_or_else(|| anyhow::anyhow!("ibv_actor_1 is not in proc_1"))?;

--- a/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
@@ -25,6 +25,7 @@ mod tests {
     use super::super::doorbell_test_utils::*;
     use super::super::manager_actor::IbvManagerActor;
     use super::super::manager_actor::RawQueuePair;
+    use super::super::mlx_device::MlxDevice;
     use super::super::primitives::get_all_devices;
     use crate::rdma_components::validate_execution_context;
 
@@ -32,16 +33,16 @@ mod tests {
     /// a queue pair via the legacy test path. Replaces the old
     /// `manager_actor::request_queue_pair` helper.
     async fn request_queue_pair(
-        actor: &ActorHandle<IbvManagerActor>,
+        actor: &ActorHandle<IbvManagerActor<MlxDevice>>,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
-        other: ActorRef<IbvManagerActor>,
+        other: ActorRef<IbvManagerActor<MlxDevice>>,
         self_device: String,
         other_device: String,
     ) -> Result<Result<IbvQueuePair, String>, anyhow::Error> {
         let (reply, rx) = Mailbox::mailbox(cx).open_once_port::<Result<IbvQueuePair, String>>();
         actor.try_post(
             cx,
-            RawQueuePair {
+            RawQueuePair::<MlxDevice> {
                 peer: other,
                 self_device,
                 peer_device: other_device,

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! EFA backend for [`IbvDevice`].
+
+use std::sync::Arc;
+
+use typeuri::Named;
+
+use super::device::IbvContext;
+use super::device::IbvDeviceImpl;
+use super::primitives::IbvConfig;
+use crate::register_ibv_device_impl;
+
+/// AWS EFA (Elastic Fabric Adapter) backend.
+#[derive(Named)]
+pub(crate) struct EfaDevice;
+
+impl IbvDeviceImpl for EfaDevice {
+    fn backend_name() -> &'static str {
+        "efa"
+    }
+
+    fn is_instance(ctx: Arc<IbvContext>) -> bool {
+        // SAFETY: `ctx.as_ptr()` is a non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call.
+        unsafe { rdmaxcel_sys::rdmaxcel_is_efa_dev(ctx.as_ptr()) != 0 }
+    }
+
+    fn apply_config_defaults(config: &mut IbvConfig) {
+        config.gid_index = 0;
+        config.max_send_sge = 1;
+        config.max_recv_sge = 1;
+        config.max_dest_rd_atomic = 0;
+        config.max_rd_atomic = 0;
+    }
+}
+
+register_ibv_device_impl!(EfaDevice);

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -18,8 +18,8 @@ use super::primitives::IbvConfig;
 use crate::register_ibv_device_impl;
 
 /// AWS EFA (Elastic Fabric Adapter) backend.
-#[derive(Named)]
-pub(crate) struct EfaDevice;
+#[derive(Debug, Named)]
+pub struct EfaDevice;
 
 impl IbvDeviceImpl for EfaDevice {
     fn backend_name() -> &'static str {

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -50,6 +50,7 @@ use super::IbvOp;
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
 use super::domain::IbvDomain;
+use super::efa_device::EfaDevice;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
 use super::primitives::IbvMemoryRegion;
@@ -67,8 +68,8 @@ use crate::RdmaOp;
 use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
 use crate::local_memory::KeepaliveLocalMemory;
+use crate::nic::NicRemoteBackendContext;
 use crate::rdma_components::get_registered_cuda_segments;
-use crate::rdma_manager_actor::GetIbvActorRefClient;
 use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::validate_execution_context;
 
@@ -91,6 +92,7 @@ pub(super) struct CreatePeerQueuePair<M: Referable> {
     pub(super) reply: OncePortRef<Result<IbvQpInfo, String>>,
 }
 wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<MlxDevice>>);
+wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<EfaDevice>>);
 
 /// Local-only message: submit a batch of RDMA ops for end-to-end
 /// execution. The manager iterates the batch, resolves each op's
@@ -289,26 +291,6 @@ impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
         // `buffer_registrations`, `segments_mr`, `devices`)
         // free their FFI resources through their elements' `Drop`s
         // when this struct is dropped.
-    }
-}
-
-// `local_handle` ties to `RdmaManagerActor::get_ibv_actor_ref`'s
-// concrete `ActorRef<IbvManagerActor<MlxDevice>>` return type, so it
-// only exists on the `MlxDevice` monomorphization for now.
-impl IbvManagerActor<MlxDevice> {
-    /// Construct an [`ActorHandle`] for the [`IbvManagerActor`] co-located
-    /// with the caller by querying the local [`RdmaManagerActor`].
-    pub async fn local_handle(
-        client: &(impl hyperactor::context::Actor + Send + Sync),
-    ) -> Result<ActorHandle<Self>, anyhow::Error> {
-        let rdma_handle = RdmaManagerActor::local_handle(client);
-        let ibv_ref: ActorRef<IbvManagerActor<MlxDevice>> = rdma_handle
-            .get_ibv_actor_ref(client)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("local RdmaManagerActor has no ibverbs backend"))?;
-        ibv_ref
-            .downcast_handle(client)
-            .ok_or_else(|| anyhow::anyhow!("IbvManagerActor is not in the local process"))
     }
 }
 
@@ -993,12 +975,37 @@ impl<I: IbvDeviceImpl> std::ops::Deref for IbvBackend<I> {
     }
 }
 
-// `submit` builds a `SubmitOps<MlxDevice>` (because `resolve_ibv`
-// returns an `ActorRef<IbvManagerActor<MlxDevice>>`), so the
-// `RdmaBackend` impl is locked to the `MlxDevice` monomorphization
-// for now.
+/// Extracts the `(manager ref, buffer)` for device impl `I` from a
+/// remote backend context, or `None` if the context targets a
+/// different backend.
+trait ResolveIbv<I: IbvDeviceImpl> {
+    fn resolve(&self) -> Option<(ActorRef<IbvManagerActor<I>>, IbvBuffer)>;
+}
+
+impl ResolveIbv<MlxDevice> for NicRemoteBackendContext {
+    fn resolve(&self) -> Option<(ActorRef<IbvManagerActor<MlxDevice>>, IbvBuffer)> {
+        match self {
+            NicRemoteBackendContext::Mlx(mgr, buf) => Some((mgr.clone(), buf.clone())),
+            _ => None,
+        }
+    }
+}
+
+impl ResolveIbv<EfaDevice> for NicRemoteBackendContext {
+    fn resolve(&self) -> Option<(ActorRef<IbvManagerActor<EfaDevice>>, IbvBuffer)> {
+        match self {
+            NicRemoteBackendContext::Efa(mgr, buf) => Some((mgr.clone(), buf.clone())),
+            _ => None,
+        }
+    }
+}
+
 #[async_trait]
-impl RdmaBackend for IbvBackend<MlxDevice> {
+impl<I> RdmaBackend for IbvBackend<I>
+where
+    I: IbvDeviceImpl,
+    NicRemoteBackendContext: ResolveIbv<I>,
+{
     type TransportInfo = ();
 
     /// Submit a batch of RDMA operations.
@@ -1021,9 +1028,13 @@ impl RdmaBackend for IbvBackend<MlxDevice> {
     ) -> Result<(), anyhow::Error> {
         let mut ibv_ops = Vec::with_capacity(ops.len());
         for op in ops {
-            let (remote_manager, remote_buffer) = op.remote.resolve_ibv().ok_or_else(|| {
-                anyhow::anyhow!("ibverbs backend not found for buffer: {:?}", op.remote)
-            })?;
+            let (remote_manager, remote_buffer) = op
+                .remote
+                .resolve_nic()
+                .and_then(|ctx| <NicRemoteBackendContext as ResolveIbv<I>>::resolve(&ctx))
+                .ok_or_else(|| {
+                    anyhow::anyhow!("no compatible NIC backend for buffer: {:?}", op.remote)
+                })?;
             ibv_ops.push(IbvOp {
                 op_type: op.op_type,
                 local_memory: op.local.clone(),
@@ -1140,17 +1151,12 @@ mod tests {
     use serde::Serialize;
     use typeuri::Named;
 
-    use super::super::mlx_device::MlxDevice;
-    use super::IbvBackend;
-    use super::IbvManagerActor;
-    use super::IbvManagerLocalMessageClient;
     use crate::IbvConfig;
     use crate::RdmaManagerActor;
     use crate::RdmaManagerMessageClient;
     use crate::RdmaOp;
     use crate::RdmaOpType;
     use crate::RdmaRemoteBuffer;
-    use crate::backend::RdmaBackend;
     use crate::backend::cuda_test_utils::CudaAllocation;
     use crate::backend::cuda_test_utils::CudaAllocator;
     use crate::backend::ibverbs::primitives::IbvQpType;
@@ -1342,9 +1348,11 @@ mod tests {
                     remote: op.remote_buf,
                 });
             }
-            let ibv_handle = IbvManagerActor::<MlxDevice>::local_handle(cx).await?;
-            let mut backend = IbvBackend(ibv_handle);
-            let result = backend
+            let nic = RdmaManagerActor::local_handle(cx)
+                .get_nic_backend_handle(cx)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("no NIC backend on this proc"))?;
+            let result = nic
                 .submit(cx, rdma_ops, Duration::from_secs(timeout_secs))
                 .await;
             Ok(result.map_err(|e| format!("{e}")))
@@ -1643,17 +1651,18 @@ mod tests {
     async fn test_register_remote_buffer_fills_mr_slot() -> Result<(), anyhow::Error> {
         require_rdma();
         let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
-        let ibv_handle = IbvManagerActor::<MlxDevice>::local_handle(&env.client).await?;
+        let nic = RdmaManagerActor::local_handle(&env.client)
+            .get_nic_backend_handle(&env.client)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("no NIC backend on this proc"))?;
         let buf: Box<[u8]> = vec![0u8; 1024].into_boxed_slice();
         let local = KeepaliveLocalMemory::new(Arc::new(buf));
         assert!(
             local.mr_slot().get().is_none(),
             "MR slot should be empty before registration",
         );
-        ibv_handle
-            .register_remote_buffer(&env.client, 0, local.clone())
-            .await?
-            .map_err(|e| anyhow::anyhow!(e))?;
+        nic.register_remote_buffer(&env.client, 0, local.clone())
+            .await?;
         assert!(
             local.mr_slot().get().is_some(),
             "register_remote_buffer should populate the MR slot",
@@ -2114,6 +2123,7 @@ mod tests {
     /// transferred).
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_partial_failure_batch() -> Result<(), anyhow::Error> {
+        use super::NicRemoteBackendContext;
         use crate::backend::RdmaRemoteBackendContext;
 
         require_rdma();
@@ -2142,7 +2152,10 @@ mod tests {
             .await?;
         let mut bogus_remote = real_remote.clone();
         for backend in bogus_remote.backends.iter_mut() {
-            if let RdmaRemoteBackendContext::Ibverbs(_, buf) = backend {
+            if let RdmaRemoteBackendContext::Nic(
+                NicRemoteBackendContext::Mlx(_, buf) | NicRemoteBackendContext::Efa(_, buf),
+            ) = backend
+            {
                 buf.rkey = 0xdead_beef;
                 buf.addr = 0xdead_0000;
             }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -48,7 +48,7 @@ use super::IbvBuffer;
 use super::IbvOp;
 use super::domain::IbvDomain;
 use super::primitives::IbvConfig;
-use super::primitives::IbvDevice;
+use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMemoryRegion;
 use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvQpInfo;
@@ -348,7 +348,7 @@ impl IbvManagerActor {
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
-        rdma_device: &IbvDevice,
+        rdma_device: &IbvDeviceInfo,
     ) -> Result<Arc<IbvDomain>, anyhow::Error> {
         if let Some((domain, _)) = self.device_domains.get(device_name) {
             return Ok(Arc::clone(domain));

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -18,6 +18,7 @@
 
 use std::collections::HashMap;
 use std::fmt::Write as _;
+use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -46,9 +47,11 @@ use typeuri::Named;
 
 use super::IbvBuffer;
 use super::IbvOp;
+use super::device::IbvDevice;
+use super::device::IbvDeviceImpl;
 use super::domain::IbvDomain;
+use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
-use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMemoryRegion;
 use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvQpInfo;
@@ -87,7 +90,7 @@ pub(super) struct CreatePeerQueuePair<M: Referable> {
     /// One-shot reply carrying the peer's endpoint, or an error.
     pub(super) reply: OncePortRef<Result<IbvQpInfo, String>>,
 }
-wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor>);
+wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<MlxDevice>>);
 
 /// Local-only message: submit a batch of RDMA ops for end-to-end
 /// execution. The manager iterates the batch, resolves each op's
@@ -99,8 +102,8 @@ wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor>);
 ///
 /// Per-op completion notifications stream back on `reply` as
 /// [`OpResult`] values.
-pub(super) struct SubmitOps {
-    pub(super) ops: Vec<IbvOp<IbvManagerActor>>,
+pub(super) struct SubmitOps<I: IbvDeviceImpl> {
+    pub(super) ops: Vec<IbvOp<IbvManagerActor<I>>>,
     pub(super) reply: PortHandle<OpResult>,
 }
 
@@ -109,8 +112,8 @@ pub(super) struct SubmitOps {
 /// `peer_device`), and return the connected QP. Lets doorbell tests
 /// and the `cuda_ping_pong` example poke a real QP without going
 /// through [`QueuePairActor`].
-pub struct RawQueuePair {
-    pub peer: ActorRef<IbvManagerActor>,
+pub struct RawQueuePair<I: IbvDeviceImpl> {
+    pub peer: ActorRef<IbvManagerActor<I>>,
     pub self_device: String,
     pub peer_device: String,
     pub reply: OncePortHandle<Result<IbvQueuePair, String>>,
@@ -190,25 +193,33 @@ pub(super) struct SegmentInfo {
     pub(super) rkey: u32,
 }
 
+/// Default key used for the per-device protection domain inside
+/// each [`IbvDevice<I>`] entry of [`IbvManagerActor::devices`].
+const DEFAULT_DOMAIN: &str = "default";
+
 /// Manages all ibverbs-specific RDMA resources and operations.
 ///
 /// This struct handles memory registration, queue pair management,
 /// and connection establishment using the ibverbs API.
+///
+/// Generic over `I: IbvDeviceImpl` so the same actor implementation
+/// drives every concrete backend (`IbvManagerActor<MlxDevice>`,
+/// `IbvManagerActor<EfaDevice>`, ...).
 #[derive(Debug)]
 #[hyperactor::export(
     handlers = [
         IbvManagerMessage,
-        CreatePeerQueuePair<IbvManagerActor>,
+        CreatePeerQueuePair<IbvManagerActor<I>>,
     ],
 )]
-pub struct IbvManagerActor {
+pub struct IbvManagerActor<I: IbvDeviceImpl> {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
     /// Active-side [`QueuePairActor`] children, keyed from this
     /// manager's perspective. Lazily populated on the first
     /// [`SubmitOps`] that targets a new `(self_device, peer,
     /// other_device)` triple.
-    qp_handles: HashMap<QpKey, ActorHandle<QueuePairActor<IbvManagerActor, IbvQueuePair>>>,
+    qp_handles: HashMap<QpKey, ActorHandle<QueuePairActor<IbvManagerActor<I>, IbvQueuePair>>>,
 
     /// Passive-side mirror QPs, created in response to a peer's
     /// [`CreatePeerQueuePair`]. The peer's [`QueuePairActor`] owns
@@ -217,14 +228,13 @@ pub struct IbvManagerActor {
     /// each QP via [`IbvQueuePair`]'s own `Drop`.
     peer_created_qps: HashMap<QpKey, IbvQueuePair>,
 
-    /// Map of RDMA device names to their domains and loopback QPs.
-    /// Created lazily when memory is registered for a specific
-    /// device. `Arc<IbvDomain>` so every `IbvMemoryRegionView`
-    /// registered against the domain can hold a clone and keep the
-    /// PD alive until the last MR is dereg'd. The loopback QP is
+    /// Map of RDMA device names to their opened [`IbvDevice<I>`]
+    /// (which owns the per-device `Arc<IbvContext>` and the
+    /// `DEFAULT_DOMAIN` `Arc<IbvDomain>`) and an optional loopback
+    /// QP used by the CUDA segment scanner. The loopback QP is
     /// owned by this map and destroyed via [`IbvQueuePair`]'s `Drop`
     /// when the entry is removed.
-    device_domains: HashMap<String, (Arc<IbvDomain>, Option<Arc<IbvQueuePair>>)>,
+    devices: HashMap<String, (IbvDevice<I>, Option<IbvQueuePair>)>,
 
     config: IbvConfig,
 
@@ -246,10 +256,12 @@ pub struct IbvManagerActor {
     /// resources are released by the `Arc`s' `Drop`s once no other
     /// holder of those views remains.
     buffer_registrations: HashMap<usize, (IbvBuffer, IbvMemoryRegionView)>,
+
+    _marker: PhantomData<I>,
 }
 
 #[async_trait]
-impl Actor for IbvManagerActor {
+impl<I: IbvDeviceImpl> Actor for IbvManagerActor<I> {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         let owner = if let Some(owner) = this.parent_handle() {
             owner
@@ -263,7 +275,7 @@ impl Actor for IbvManagerActor {
     }
 }
 
-impl Drop for IbvManagerActor {
+impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
     fn drop(&mut self) {
         // Drain active-side QP actors. Each child owns its
         // `IbvQueuePair`; `drain_and_stop` schedules the actor to
@@ -274,20 +286,23 @@ impl Drop for IbvManagerActor {
         }
 
         // The remaining fields (`peer_created_qps`,
-        // `buffer_registrations`, `segments_mr`, `device_domains`)
+        // `buffer_registrations`, `segments_mr`, `devices`)
         // free their FFI resources through their elements' `Drop`s
         // when this struct is dropped.
     }
 }
 
-impl IbvManagerActor {
+// `local_handle` ties to `RdmaManagerActor::get_ibv_actor_ref`'s
+// concrete `ActorRef<IbvManagerActor<MlxDevice>>` return type, so it
+// only exists on the `MlxDevice` monomorphization for now.
+impl IbvManagerActor<MlxDevice> {
     /// Construct an [`ActorHandle`] for the [`IbvManagerActor`] co-located
     /// with the caller by querying the local [`RdmaManagerActor`].
     pub async fn local_handle(
         client: &(impl hyperactor::context::Actor + Send + Sync),
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
         let rdma_handle = RdmaManagerActor::local_handle(client);
-        let ibv_ref: ActorRef<IbvManagerActor> = rdma_handle
+        let ibv_ref: ActorRef<IbvManagerActor<MlxDevice>> = rdma_handle
             .get_ibv_actor_ref(client)
             .await?
             .ok_or_else(|| anyhow::anyhow!("local RdmaManagerActor has no ibverbs backend"))?;
@@ -295,7 +310,9 @@ impl IbvManagerActor {
             .downcast_handle(client)
             .ok_or_else(|| anyhow::anyhow!("IbvManagerActor is not in the local process"))
     }
+}
 
+impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     /// Create a new IbvManagerActor with the given configuration.
     pub async fn new(params: Option<IbvConfig>) -> Result<Self, anyhow::Error> {
         if !ibverbs_supported() {
@@ -304,8 +321,16 @@ impl IbvManagerActor {
             ));
         }
 
-        // Use provided config or default if none provided
-        let mut config = params.unwrap_or_default();
+        // Use the caller's config; when none is given, start from the
+        // defaults and let the backend seed its own.
+        let mut config = match params {
+            Some(config) => config,
+            None => {
+                let mut config = IbvConfig::default();
+                I::apply_config_defaults(&mut config);
+                config
+            }
+        };
         tracing::debug!("rdma is enabled, config device hint: {}", config.device);
 
         let mlx5dv_enabled = resolve_qp_type(config.qp_type) == rdmaxcel_sys::RDMA_QP_TYPE_MLX5DV;
@@ -330,34 +355,36 @@ impl IbvManagerActor {
             owner: OnceLock::new(),
             qp_handles: HashMap::new(),
             peer_created_qps: HashMap::new(),
-            device_domains: HashMap::new(),
+            devices: HashMap::new(),
             config,
             mlx5dv_enabled,
             segments_mr: None,
             mrv_id: 0,
             buffer_registrations: HashMap::new(),
+            _marker: PhantomData,
         };
 
         Ok(actor)
     }
 
-    /// Get or create a domain (and its loopback QP, if mlx5dv is
-    /// supported) for the specified RDMA device. The loopback QP is
-    /// kept in [`Self::device_domains`] solely so the CUDA segment
-    /// scanner can hand its raw pointer to `register_segments`.
+    /// Get or create the default domain (and a loopback QP, if
+    /// mlx5dv is supported) for the named RDMA device. The
+    /// loopback QP is kept in [`Self::devices`] solely so
+    /// the CUDA segment scanner can hand its raw pointer to
+    /// `register_segments`.
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
-        rdma_device: &IbvDeviceInfo,
     ) -> Result<Arc<IbvDomain>, anyhow::Error> {
-        if let Some((domain, _)) = self.device_domains.get(device_name) {
-            return Ok(Arc::clone(domain));
+        if let Some((device, _)) = self.devices.get_mut(device_name) {
+            return device.get_or_create_domain(DEFAULT_DOMAIN);
         }
 
-        // Create new domain for this device
-        let domain = Arc::new(IbvDomain::new(rdma_device.clone()).map_err(|e| {
-            anyhow::anyhow!("could not create domain for device {}: {}", device_name, e)
-        })?);
+        let mut device =
+            IbvDevice::<I>::open(device_name, self.config.clone()).ok_or_else(|| {
+                anyhow::anyhow!("{} does not advertise {}", I::backend_name(), device_name,)
+            })?;
+        let domain = device.get_or_create_domain(DEFAULT_DOMAIN)?;
 
         // Print device info if MONARCH_DEBUG_RDMA=1 is set (before initial QP creation)
         crate::print_device_info_if_debug_enabled(domain.context);
@@ -386,13 +413,12 @@ impl IbvManagerActor {
                 )
             })?;
 
-            Some(Arc::new(qp))
+            Some(qp)
         } else {
             None
         };
 
-        self.device_domains
-            .insert(device_name.to_string(), (Arc::clone(&domain), qp));
+        self.devices.insert(device_name.to_string(), (device, qp));
         Ok(domain)
     }
 
@@ -408,15 +434,19 @@ impl IbvManagerActor {
         let mut pds = Vec::with_capacity(cuda_map.len());
         let mut qps = Vec::with_capacity(cuda_map.len());
         for maybe_device in cuda_map {
-            if let Some(device) = maybe_device {
-                if let Some((domain, qp)) = self.device_domains.get(device.name()) {
-                    pds.push(domain.pd);
+            if let Some(info) = maybe_device {
+                if let Some((device, qp)) = self.devices.get(info.name()) {
+                    let pd = device
+                        .domain(DEFAULT_DOMAIN)
+                        .map(|d| d.pd)
+                        .unwrap_or(std::ptr::null_mut());
+                    pds.push(pd);
                     qps.push(
                         qp.as_ref()
                             // SAFETY: the returned pointer is read by
                             // the segment-scan FFI under a separate
                             // call on this same `&self`; the QP lives
-                            // in `device_domains` for the lifetime of
+                            // in `devices` for the lifetime of
                             // this `IbvManagerActor`, so its `Drop`
                             // cannot run while these pointers are in
                             // use.
@@ -485,15 +515,13 @@ impl IbvManagerActor {
                 }
             }
 
-            // Determine the RDMA device to use
-            let rdma_device = if let Some(device) = selected_rdma_device {
-                device
+            // Determine the RDMA device name to use: CUDA-co-located
+            // NIC if available, otherwise the config fallback.
+            let device_name = if let Some(info) = selected_rdma_device {
+                info.name().clone()
             } else {
-                // Fallback to default device from config
-                self.config.device.clone()
+                self.config.device.name().clone()
             };
-
-            let device_name = rdma_device.name().clone();
             tracing::debug!(
                 "Using RDMA device: {} for memory at 0x{:x}",
                 device_name,
@@ -501,7 +529,7 @@ impl IbvManagerActor {
             );
 
             // Get or create domain and loopback QP for this device
-            let domain = self.get_or_create_device_domain(&device_name, &rdma_device)?;
+            let domain = self.get_or_create_device_domain(&device_name)?;
 
             let access = if crate::efa::is_efa_device() {
                 crate::efa::mr_access_flags()
@@ -655,11 +683,7 @@ impl IbvManagerActor {
             anyhow::bail!("peer queue pair already exists for {qp_key:?}");
         }
         let self_device = &qp_key.self_device;
-        let rdma_device = super::primitives::get_all_devices()
-            .into_iter()
-            .find(|d| d.name() == self_device)
-            .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
-        let domain = self.get_or_create_device_domain(self_device, &rdma_device)?;
+        let domain = self.get_or_create_device_domain(self_device)?;
         let mut qp = IbvQueuePair::new(domain, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create peer IbvQueuePair: {}", e))?;
         let local_info = qp
@@ -685,11 +709,7 @@ impl IbvManagerActor {
             return Ok(h.clone());
         }
         let self_device = &qp_key.self_device;
-        let rdma_device = super::primitives::get_all_devices()
-            .into_iter()
-            .find(|d| d.name() == self_device)
-            .ok_or_else(|| anyhow::anyhow!("RDMA device '{}' not found", self_device))?;
-        let domain = self.get_or_create_device_domain(self_device, &rdma_device)?;
+        let domain = self.get_or_create_device_domain(self_device)?;
         let qp = IbvQueuePair::new(domain, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair for {qp_key:?}: {}", e))?;
         let local_manager: ActorRef<Self> = cx.bind();
@@ -710,8 +730,7 @@ impl IbvManagerActor {
 }
 
 #[async_trait]
-#[hyperactor::handle(IbvManagerMessage)]
-impl IbvManagerMessageHandler for IbvManagerActor {
+impl<I: IbvDeviceImpl> IbvManagerMessageHandler for IbvManagerActor<I> {
     async fn release_buffer(
         &mut self,
         _cx: &Context<Self>,
@@ -725,9 +744,23 @@ impl IbvManagerMessageHandler for IbvManagerActor {
     }
 }
 
+// `#[hyperactor::handle(IbvManagerMessage)]` would generate a
+// non-generic `impl Handler<...> for IbvManagerActor<I>` that
+// can't see `I`; we write the generic delegation by hand.
 #[async_trait]
-impl Handler<SubmitOps> for IbvManagerActor {
-    async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps) -> Result<(), anyhow::Error> {
+impl<I: IbvDeviceImpl> Handler<IbvManagerMessage> for IbvManagerActor<I> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: IbvManagerMessage,
+    ) -> Result<(), anyhow::Error> {
+        <Self as IbvManagerMessageHandler>::handle(self, cx, message).await
+    }
+}
+
+#[async_trait]
+impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
+    async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps<I>) -> Result<(), anyhow::Error> {
         let SubmitOps { ops, reply } = msg;
 
         // Interleave MR resolution with QP dispatch: as soon as op `i`'s
@@ -779,7 +812,7 @@ impl Handler<SubmitOps> for IbvManagerActor {
     }
 }
 
-impl IbvManagerActor {
+impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     /// Synchronous portion of [`RawQueuePair`] handling: create the
     /// local QP, post `CreatePeerQueuePair` to `peer`, and return the
     /// in-flight reply receiver. The follow-up work (awaiting the
@@ -789,15 +822,11 @@ impl IbvManagerActor {
     fn raw_queue_pair_setup(
         &mut self,
         cx: &Context<'_, Self>,
-        peer: &ActorRef<IbvManagerActor>,
+        peer: &ActorRef<IbvManagerActor<I>>,
         self_device: String,
         peer_device: String,
     ) -> Result<(IbvQueuePair, OncePortReceiver<Result<IbvQpInfo, String>>), anyhow::Error> {
-        let rdma_device = super::primitives::get_all_devices()
-            .into_iter()
-            .find(|d| d.name() == &self_device)
-            .ok_or_else(|| anyhow::anyhow!("RDMA device '{self_device}' not found"))?;
-        let domain = self.get_or_create_device_domain(&self_device, &rdma_device)?;
+        let domain = self.get_or_create_device_domain(&self_device)?;
         let mut qp = IbvQueuePair::new(domain, self.config.clone())
             .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {e}"))?;
         let sender_info = qp
@@ -806,7 +835,7 @@ impl IbvManagerActor {
         let (reply, rx) = Mailbox::mailbox(cx).open_once_port::<Result<IbvQpInfo, String>>();
         peer.post(
             cx,
-            CreatePeerQueuePair::<IbvManagerActor> {
+            CreatePeerQueuePair::<IbvManagerActor<I>> {
                 sender: cx.bind(),
                 sender_device: self_device,
                 receiver_device: peer_device,
@@ -819,8 +848,12 @@ impl IbvManagerActor {
 }
 
 #[async_trait]
-impl Handler<RawQueuePair> for IbvManagerActor {
-    async fn handle(&mut self, cx: &Context<Self>, msg: RawQueuePair) -> Result<(), anyhow::Error> {
+impl<I: IbvDeviceImpl> Handler<RawQueuePair<I>> for IbvManagerActor<I> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        msg: RawQueuePair<I>,
+    ) -> Result<(), anyhow::Error> {
         let RawQueuePair {
             peer,
             self_device,
@@ -868,11 +901,11 @@ impl Handler<RawQueuePair> for IbvManagerActor {
 }
 
 #[async_trait]
-impl Handler<CreatePeerQueuePair<IbvManagerActor>> for IbvManagerActor {
+impl<I: IbvDeviceImpl> Handler<CreatePeerQueuePair<IbvManagerActor<I>>> for IbvManagerActor<I> {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
-        msg: CreatePeerQueuePair<IbvManagerActor>,
+        msg: CreatePeerQueuePair<IbvManagerActor<I>>,
     ) -> Result<(), anyhow::Error> {
         let CreatePeerQueuePair {
             sender,
@@ -895,8 +928,7 @@ impl Handler<CreatePeerQueuePair<IbvManagerActor>> for IbvManagerActor {
 }
 
 #[async_trait]
-#[hyperactor::handle(IbvManagerLocalMessage)]
-impl IbvManagerLocalMessageHandler for IbvManagerActor {
+impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
     async fn register_remote_buffer(
         &mut self,
         _cx: &Context<Self>,
@@ -928,22 +960,45 @@ impl IbvManagerLocalMessageHandler for IbvManagerActor {
     }
 }
 
-/// Wrapper around [`ActorHandle<IbvManagerActor>`] that moves the RDMA
+// `#[hyperactor::handle(IbvManagerLocalMessage)]` analogue, written
+// generically; see the `IbvManagerMessage` block above.
+#[async_trait]
+impl<I: IbvDeviceImpl> Handler<IbvManagerLocalMessage> for IbvManagerActor<I> {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: IbvManagerLocalMessage,
+    ) -> Result<(), anyhow::Error> {
+        <Self as IbvManagerLocalMessageHandler>::handle(self, cx, message).await
+    }
+}
+
+/// Wrapper around [`ActorHandle<IbvManagerActor<I>>`] that moves the RDMA
 /// data-plane (post send/recv, poll CQ) off the actor loop while keeping
 /// state-mutating operations (MR registration/deregistration, QP management)
 /// serialized through actor messages.
-#[derive(Debug, Clone)]
-pub struct IbvBackend(pub ActorHandle<IbvManagerActor>);
+#[derive(Debug)]
+pub struct IbvBackend<I: IbvDeviceImpl>(pub ActorHandle<IbvManagerActor<I>>);
 
-impl std::ops::Deref for IbvBackend {
-    type Target = ActorHandle<IbvManagerActor>;
+impl<I: IbvDeviceImpl> Clone for IbvBackend<I> {
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<I: IbvDeviceImpl> std::ops::Deref for IbvBackend<I> {
+    type Target = ActorHandle<IbvManagerActor<I>>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
+// `submit` builds a `SubmitOps<MlxDevice>` (because `resolve_ibv`
+// returns an `ActorRef<IbvManagerActor<MlxDevice>>`), so the
+// `RdmaBackend` impl is locked to the `MlxDevice` monomorphization
+// for now.
 #[async_trait]
-impl RdmaBackend for IbvBackend {
+impl RdmaBackend for IbvBackend<MlxDevice> {
     type TransportInfo = ();
 
     /// Submit a batch of RDMA operations.
@@ -1085,6 +1140,7 @@ mod tests {
     use serde::Serialize;
     use typeuri::Named;
 
+    use super::super::mlx_device::MlxDevice;
     use super::IbvBackend;
     use super::IbvManagerActor;
     use super::IbvManagerLocalMessageClient;
@@ -1286,7 +1342,7 @@ mod tests {
                     remote: op.remote_buf,
                 });
             }
-            let ibv_handle = IbvManagerActor::local_handle(cx).await?;
+            let ibv_handle = IbvManagerActor::<MlxDevice>::local_handle(cx).await?;
             let mut backend = IbvBackend(ibv_handle);
             let result = backend
                 .submit(cx, rdma_ops, Duration::from_secs(timeout_secs))
@@ -1587,7 +1643,7 @@ mod tests {
     async fn test_register_remote_buffer_fills_mr_slot() -> Result<(), anyhow::Error> {
         require_rdma();
         let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
-        let ibv_handle = IbvManagerActor::local_handle(&env.client).await?;
+        let ibv_handle = IbvManagerActor::<MlxDevice>::local_handle(&env.client).await?;
         let buf: Box<[u8]> = vec![0u8; 1024].into_boxed_slice();
         let local = KeepaliveLocalMemory::new(Arc::new(buf));
         assert!(

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -130,8 +130,10 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
 /// Extract the ibverbs `(lkey, rkey)` from a remote buffer.
 fn ibv_keys_of(remote: &crate::RdmaRemoteBuffer) -> Result<(u32, u32), anyhow::Error> {
     let (_mgr, buf) = remote
-        .resolve_ibv()
-        .ok_or_else(|| anyhow::anyhow!("remote buffer has no ibverbs backend context"))?;
+        .resolve_nic()
+        .expect("remote buffer has a NIC backend")
+        .into_mlx()
+        .expect("remote buffer is Mellanox");
     Ok((buf.lkey, buf.rkey))
 }
 

--- a/monarch_rdma/src/backend/ibverbs/mlx_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_device.rs
@@ -21,8 +21,8 @@ use crate::register_ibv_device_impl;
 const MELLANOX_VENDOR_ID: u32 = 0x02c9;
 
 /// Mellanox backend.
-#[derive(Named)]
-pub(crate) struct MlxDevice;
+#[derive(Debug, Named)]
+pub struct MlxDevice;
 
 impl IbvDeviceImpl for MlxDevice {
     fn backend_name() -> &'static str {

--- a/monarch_rdma/src/backend/ibverbs/mlx_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_device.rs
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Mellanox backend for [`IbvDevice`].
+
+use std::sync::Arc;
+
+use typeuri::Named;
+
+use super::device::IbvContext;
+use super::device::IbvDeviceImpl;
+use super::primitives::IbvConfig;
+use crate::register_ibv_device_impl;
+
+/// PCI vendor ID for Mellanox Technologies.
+const MELLANOX_VENDOR_ID: u32 = 0x02c9;
+
+/// Mellanox backend.
+#[derive(Named)]
+pub(crate) struct MlxDevice;
+
+impl IbvDeviceImpl for MlxDevice {
+    fn backend_name() -> &'static str {
+        "mellanox"
+    }
+
+    fn is_instance(ctx: Arc<IbvContext>) -> bool {
+        let mut attr = rdmaxcel_sys::ibv_device_attr::default();
+        // SAFETY: `ctx.as_ptr()` is a non-null context owned by
+        // the `Arc<IbvContext>` for the duration of this call;
+        // `&mut attr` is a writable, properly aligned
+        // `ibv_device_attr`.
+        let queried = unsafe { rdmaxcel_sys::ibv_query_device(ctx.as_ptr(), &mut attr) } == 0;
+        queried && attr.vendor_id == MELLANOX_VENDOR_ID
+    }
+
+    fn apply_config_defaults(_config: &mut IbvConfig) {}
+}
+
+register_ibv_device_impl!(MlxDevice);

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -17,7 +17,7 @@
 //! - `IbvConfig`: Represents ibverbs specific configurations, holding parameters required to establish and
 //!   manage an RDMA connection, including settings for the RDMA device, queue pair attributes, and other
 //!   connection-specific parameters.
-//! - `IbvDevice`: Represents an RDMA device, i.e. 'mlx5_0'. Contains information about the device, such as:
+//! - `IbvDeviceInfo`: Represents an RDMA device, i.e. 'mlx5_0'. Contains information about the device, such as:
 //!   its name, vendor ID, vendor part ID, hardware version, firmware version, node GUID, and capabilities.
 //! - `IbvPort`: Represents information about the port of an RDMA device, including state, physical state,
 //!   LID (Local Identifier), and GID (Global Identifier) information.
@@ -36,6 +36,8 @@ use serde::Serialize;
 use typeuri::Named;
 
 use super::domain::IbvDomain;
+use crate::backend::ibverbs::device::IbvDeviceImpl;
+use crate::backend::ibverbs::efa_device::EfaDevice;
 
 #[derive(
     Default,
@@ -132,7 +134,7 @@ pub fn resolve_qp_type(qp_type: IbvQpType) -> u32 {
 #[derive(Debug, Named, Clone, Serialize, Deserialize)]
 pub struct IbvConfig {
     /// `device` - The RDMA device to use for the connection.
-    pub device: IbvDevice,
+    pub device: IbvDeviceInfo,
     /// `cq_entries` - The number of completion queue entries.
     pub cq_entries: i32,
     /// `port_num` - The physical port number on the device.
@@ -185,7 +187,7 @@ wirevalue::register_type!(IbvConfig);
 impl Default for IbvConfig {
     fn default() -> Self {
         let mut config = Self {
-            device: IbvDevice::default(),
+            device: IbvDeviceInfo::default(),
             cq_entries: 1024,
             port_num: 1,
             gid_index: 3,
@@ -208,7 +210,7 @@ impl Default for IbvConfig {
             max_sge_override: 0,
         };
         if crate::efa::is_efa_device() {
-            crate::efa::apply_efa_defaults(&mut config);
+            EfaDevice::apply_config_defaults(&mut config);
         }
         config
     }
@@ -295,7 +297,7 @@ impl std::fmt::Display for IbvConfig {
 /// }
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct IbvDevice {
+pub struct IbvDeviceInfo {
     /// `name` - The name of the RDMA device (e.g., "mlx5_0").
     pub name: String,
     /// `vendor_id` - The vendor ID of the device.
@@ -324,14 +326,14 @@ pub struct IbvDevice {
     max_sge: i32,
 }
 
-impl IbvDevice {
+impl IbvDeviceInfo {
     /// Returns the name of the RDMA device.
     pub fn name(&self) -> &String {
         &self.name
     }
 
     /// Returns the first available RDMA device, if any.
-    pub fn first_available() -> Option<IbvDevice> {
+    pub fn first_available() -> Option<IbvDeviceInfo> {
         let devices = get_all_devices();
         if devices.is_empty() {
             None
@@ -401,7 +403,7 @@ impl IbvDevice {
     }
 }
 
-impl Default for IbvDevice {
+impl Default for IbvDeviceInfo {
     fn default() -> Self {
         // Try to get a smart default using device selection logic (defaults to cpu:0)
         if let Some(device) = super::device_selection::select_optimal_ibv_device(Some("cpu:0")) {
@@ -440,7 +442,7 @@ pub struct IbvPort {
     gid_tbl_len: i32,
 }
 
-impl fmt::Display for IbvDevice {
+impl fmt::Display for IbvDeviceInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "{}", self.name)?;
         writeln!(f, "\tNumber of ports: {}", self.ports.len())?;
@@ -578,107 +580,134 @@ pub fn format_gid(gid: &[u8; 16]) -> String {
 ///
 /// # Returns
 ///
-/// A vector of `IbvDevice` structures, each representing an RDMA device in the system.
+/// A vector of `IbvDeviceInfo` structures, each representing an RDMA device in the system.
 /// Returns an empty vector if no devices are found or if there was an error querying
 /// the devices.
-pub fn get_all_devices() -> Vec<IbvDevice> {
+pub fn get_all_devices() -> Vec<IbvDeviceInfo> {
     let mut devices = Vec::new();
-
-    // SAFETY: We are calling several C functions from libibverbs.
-    unsafe {
-        let mut num_devices = 0;
-        let device_list = rdmaxcel_sys::ibv_get_device_list(&mut num_devices);
-        if device_list.is_null() || num_devices == 0 {
-            return devices;
-        }
-
-        for i in 0..num_devices {
-            let device = *device_list.add(i as usize);
-            if device.is_null() {
-                continue;
-            }
-
-            let context = rdmaxcel_sys::ibv_open_device(device);
-            if context.is_null() {
-                continue;
-            }
-
-            let device_name = CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device))
-                .to_string_lossy()
-                .into_owned();
-
-            let mut device_attr = rdmaxcel_sys::ibv_device_attr::default();
-            if rdmaxcel_sys::ibv_query_device(context, &mut device_attr) != 0 {
-                rdmaxcel_sys::ibv_close_device(context);
-                continue;
-            }
-
-            let fw_ver = CStr::from_ptr(device_attr.fw_ver.as_ptr())
-                .to_string_lossy()
-                .into_owned();
-
-            let mut rdma_device = IbvDevice {
-                name: device_name,
-                vendor_id: device_attr.vendor_id,
-                vendor_part_id: device_attr.vendor_part_id,
-                hw_ver: device_attr.hw_ver,
-                fw_ver,
-                node_guid: device_attr.node_guid,
-                ports: Vec::new(),
-                max_qp: device_attr.max_qp,
-                max_cq: device_attr.max_cq,
-                max_mr: device_attr.max_mr,
-                max_pd: device_attr.max_pd,
-                max_qp_wr: device_attr.max_qp_wr,
-                max_sge: device_attr.max_sge,
-            };
-
-            for port_num in 1..=device_attr.phys_port_cnt {
-                let mut port_attr = rdmaxcel_sys::ibv_port_attr::default();
-                if rdmaxcel_sys::ibv_query_port(
-                    context,
-                    port_num,
-                    &mut port_attr as *mut rdmaxcel_sys::ibv_port_attr as *mut _,
-                ) != 0
-                {
-                    continue;
-                }
-                let state = get_port_state_str(port_attr.state);
-                let physical_state = get_port_phy_state_str(port_attr.phys_state);
-
-                let link_layer = get_link_layer_str(port_attr.link_layer);
-
-                let mut gid = rdmaxcel_sys::ibv_gid::default();
-                let gid_str = if rdmaxcel_sys::ibv_query_gid(context, port_num, 0, &mut gid) == 0 {
-                    format_gid(&gid.raw)
-                } else {
-                    "N/A".to_string()
-                };
-
-                let rdma_port = IbvPort {
-                    port_num,
-                    state,
-                    physical_state,
-                    base_lid: port_attr.lid,
-                    lmc: port_attr.lmc,
-                    sm_lid: port_attr.sm_lid,
-                    capability_mask: port_attr.port_cap_flags,
-                    link_layer,
-                    gid: gid_str,
-                    gid_tbl_len: port_attr.gid_tbl_len,
-                };
-
-                rdma_device.ports.push(rdma_port);
-            }
-
-            devices.push(rdma_device);
-            rdmaxcel_sys::ibv_close_device(context);
-        }
-
-        rdmaxcel_sys::ibv_free_device_list(device_list);
+    let mut num_devices = 0;
+    // SAFETY: `ibv_get_device_list` populates `num_devices` and
+    // returns either null or a pointer to `num_devices` entries;
+    // we free it before returning.
+    let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
+    if device_list.is_null() {
+        return devices;
     }
-
+    for i in 0..num_devices {
+        // SAFETY: `device_list` is non-null with `num_devices`
+        // valid entries (checked above).
+        let device = unsafe { *device_list.add(i as usize) };
+        if device.is_null() {
+            continue;
+        }
+        // SAFETY: `device` is non-null per the check above.
+        let context = unsafe { rdmaxcel_sys::ibv_open_device(device) };
+        if context.is_null() {
+            continue;
+        }
+        // SAFETY: `device` and `context` are non-null and
+        // `context` was returned by `ibv_open_device(device)`.
+        if let Some(info) = unsafe { query_device_info(device, context) } {
+            devices.push(info);
+        }
+        // SAFETY: `context` was returned by `ibv_open_device`
+        // above and has not been closed elsewhere.
+        unsafe { rdmaxcel_sys::ibv_close_device(context) };
+    }
+    // SAFETY: `device_list` was returned by
+    // `ibv_get_device_list` above and has not been freed.
+    unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
     devices
+}
+
+/// Builds an [`IbvDeviceInfo`] from an already-open
+/// `ibv_context`. Returns `None` if `ibv_query_device` fails.
+///
+/// # Safety
+///
+/// `device` and `context` must both be non-null and valid for
+/// the duration of the call; `context` must be the result of
+/// `ibv_open_device(device)`.
+pub(super) unsafe fn query_device_info(
+    device: *mut rdmaxcel_sys::ibv_device,
+    context: *mut rdmaxcel_sys::ibv_context,
+) -> Option<IbvDeviceInfo> {
+    // SAFETY: `device` is non-null per the caller's contract;
+    // `ibv_get_device_name` returns a null-terminated C string
+    // owned by the device list.
+    let device_name = unsafe { CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(device)) }
+        .to_string_lossy()
+        .into_owned();
+    let mut device_attr = rdmaxcel_sys::ibv_device_attr::default();
+    // SAFETY: `context` is a non-null context per the caller's
+    // contract; `&mut device_attr` is a writable, properly
+    // aligned `ibv_device_attr`.
+    if unsafe { rdmaxcel_sys::ibv_query_device(context, &mut device_attr) } != 0 {
+        return None;
+    }
+    // SAFETY: `device_attr.fw_ver` is a null-terminated C buffer
+    // populated by `ibv_query_device`.
+    let fw_ver = unsafe { CStr::from_ptr(device_attr.fw_ver.as_ptr()) }
+        .to_string_lossy()
+        .into_owned();
+    let mut info = IbvDeviceInfo {
+        name: device_name,
+        vendor_id: device_attr.vendor_id,
+        vendor_part_id: device_attr.vendor_part_id,
+        hw_ver: device_attr.hw_ver,
+        fw_ver,
+        node_guid: device_attr.node_guid,
+        ports: Vec::new(),
+        max_qp: device_attr.max_qp,
+        max_cq: device_attr.max_cq,
+        max_mr: device_attr.max_mr,
+        max_pd: device_attr.max_pd,
+        max_qp_wr: device_attr.max_qp_wr,
+        max_sge: device_attr.max_sge,
+    };
+    for port_num in 1..=device_attr.phys_port_cnt {
+        let mut port_attr = rdmaxcel_sys::ibv_port_attr::default();
+        // SAFETY: `context` is a valid context; `port_attr` is
+        // a writable, properly aligned `ibv_port_attr`.
+        if unsafe {
+            rdmaxcel_sys::ibv_query_port(
+                context,
+                port_num,
+                &mut port_attr as *mut rdmaxcel_sys::ibv_port_attr as *mut _,
+            )
+        } != 0
+        {
+            continue;
+        }
+        let state = get_port_state_str(port_attr.state);
+        let physical_state = get_port_phy_state_str(port_attr.phys_state);
+        let link_layer = get_link_layer_str(port_attr.link_layer);
+        let mut gid = rdmaxcel_sys::ibv_gid::default();
+        // SAFETY: `context` is a valid context; `&mut gid` is a
+        // writable, properly aligned `ibv_gid`.
+        let gid_str = if unsafe { rdmaxcel_sys::ibv_query_gid(context, port_num, 0, &mut gid) } == 0
+        {
+            // SAFETY: `gid.raw` is a union field that is
+            // always initialized; `ibv_query_gid` filled it.
+            let raw = unsafe { gid.raw };
+            format_gid(&raw)
+        } else {
+            "N/A".to_string()
+        };
+        info.ports.push(IbvPort {
+            port_num,
+            state,
+            physical_state,
+            base_lid: port_attr.lid,
+            lmc: port_attr.lmc,
+            sm_lid: port_attr.sm_lid,
+            capability_mask: port_attr.port_cap_flags,
+            link_layer,
+            gid: gid_str,
+            gid_tbl_len: port_attr.gid_tbl_len,
+        });
+    }
+    Some(info)
 }
 
 /// Cached result of mlx5dv support check.
@@ -1109,7 +1138,7 @@ mod tests {
 
     #[test]
     fn test_device_display() {
-        if let Some(device) = IbvDevice::first_available() {
+        if let Some(device) = IbvDeviceInfo::first_available() {
             let display_output = format!("{}", device);
             assert!(
                 display_output.contains(&device.name),
@@ -1124,7 +1153,7 @@ mod tests {
 
     #[test]
     fn test_port_display() {
-        if let Some(device) = IbvDevice::first_available()
+        if let Some(device) = IbvDeviceInfo::first_available()
             && !device.ports().is_empty()
         {
             let port = &device.ports()[0];

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -25,7 +25,6 @@ use bytes::BytesMut;
 use dashmap::DashMap;
 use hyperactor::Actor;
 use hyperactor::ActorHandle;
-use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::HandleClient;
@@ -359,7 +358,7 @@ impl TcpManagerActor {
         client: &(impl context::Actor + Send + Sync),
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
         let rdma_handle = RdmaManagerActor::local_handle(client);
-        let tcp_ref: ActorRef<TcpManagerActor> = rdma_handle.get_tcp_actor_ref(client).await?;
+        let tcp_ref = rdma_handle.get_tcp_actor_ref(client).await?;
         tcp_ref
             .downcast_handle(client)
             .ok_or_else(|| anyhow::anyhow!("TcpManagerActor is not in the local process"))
@@ -1551,23 +1550,6 @@ mod tests {
 
         let mut envs = setup_same_proc_tcp_env(4096).await?;
         do_round_trip_test(&mut envs, 4096, Duration::from_secs(10)).await
-    }
-
-    /// When TCP fallback is disabled and ibverbs is unavailable,
-    /// RdmaManagerActor::new returns an error.
-    #[timed_test::async_timed_test(timeout_secs = 30)]
-    async fn test_tcp_fallback_disabled_fails() -> anyhow::Result<()> {
-        let config = hyperactor_config::global::lock();
-        let _guard = config.override_key(crate::config::RDMA_ALLOW_TCP_FALLBACK, false);
-
-        let result = RdmaManagerActor::new(None, Flattrs::default()).await;
-        if crate::ibverbs_supported() {
-            assert!(result.is_ok());
-        } else {
-            assert!(result.is_err());
-        }
-
-        Ok(())
     }
 
     // --- Multi-GPU TCP fallback tests ---

--- a/monarch_rdma/src/efa.rs
+++ b/monarch_rdma/src/efa.rs
@@ -13,8 +13,6 @@
 
 use std::sync::OnceLock;
 
-use crate::backend::ibverbs::primitives::IbvConfig;
-
 /// Cached result of EFA device check.
 static EFA_DEVICE_CACHE: OnceLock<bool> = OnceLock::new();
 
@@ -54,20 +52,6 @@ fn is_efa_device_impl() -> bool {
         rdmaxcel_sys::ibv_free_device_list(device_list);
         found
     }
-}
-
-/// Applies EFA-specific defaults to an `IbvConfig`.
-///
-/// EFA devices have different capabilities than standard InfiniBand/RoCE devices:
-/// - GID index 0 (instead of 3)
-/// - Max 1 SGE per work request
-/// - No RDMA atomics support
-pub fn apply_efa_defaults(config: &mut IbvConfig) {
-    config.gid_index = 0;
-    config.max_send_sge = 1;
-    config.max_recv_sge = 1;
-    config.max_dest_rd_atomic = 0;
-    config.max_rd_atomic = 0;
 }
 
 /// Returns the MR access flags appropriate for EFA devices.

--- a/monarch_rdma/src/lib.rs
+++ b/monarch_rdma/src/lib.rs
@@ -22,6 +22,7 @@ pub mod config;
 pub mod device_selection;
 pub mod efa;
 pub mod local_memory;
+pub mod nic;
 mod rdma_components;
 mod rdma_manager_actor;
 

--- a/monarch_rdma/src/nic.rs
+++ b/monarch_rdma/src/nic.rs
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! NIC transport backends for RDMA.
+
+use std::time::Duration;
+
+use anyhow::Result;
+use enum_as_inner::EnumAsInner;
+use hyperactor::Actor;
+use hyperactor::ActorRef;
+use hyperactor::Instance;
+use serde::Deserialize;
+use serde::Serialize;
+use typeuri::Named;
+
+use crate::RdmaOp;
+use crate::backend::RdmaBackend;
+use crate::backend::ibverbs::IbvBuffer;
+use crate::backend::ibverbs::device::IbvDevice;
+use crate::backend::ibverbs::efa_device::EfaDevice;
+use crate::backend::ibverbs::manager_actor::IbvBackend;
+use crate::backend::ibverbs::manager_actor::IbvManagerActor;
+use crate::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
+use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
+use crate::backend::ibverbs::mlx_device::MlxDevice;
+use crate::backend::ibverbs::primitives::IbvConfig;
+use crate::local_memory::KeepaliveLocalMemory;
+
+/// Backend context carried by [`crate::RdmaRemoteBuffer`] for a
+/// buffer reachable over a NIC.
+#[derive(Debug, Clone, Serialize, Deserialize, Named, EnumAsInner)]
+pub enum NicRemoteBackendContext {
+    Mlx(ActorRef<IbvManagerActor<MlxDevice>>, IbvBuffer),
+    Efa(ActorRef<IbvManagerActor<EfaDevice>>, IbvBuffer),
+}
+wirevalue::register_type!(NicRemoteBackendContext);
+
+impl NicRemoteBackendContext {
+    /// Whether `handle` drives the same backend as this context.
+    pub(crate) fn is_compatible_with(&self, handle: &NicBackendHandle) -> bool {
+        matches!(
+            (self, handle),
+            (NicRemoteBackendContext::Mlx(..), NicBackendHandle::Mlx(_))
+                | (NicRemoteBackendContext::Efa(..), NicBackendHandle::Efa(_))
+        )
+    }
+}
+
+/// In-process handle to a NIC backend.
+#[derive(Debug, Clone)]
+pub enum NicBackendHandle {
+    Mlx(IbvBackend<MlxDevice>),
+    Efa(IbvBackend<EfaDevice>),
+}
+
+impl NicBackendHandle {
+    /// Spawn this proc's NIC backend, if one is available. Returns
+    /// `None`, after logging the reason, when no NIC backend can be
+    /// spawned; returns `Err` only when an available backend fails to
+    /// initialize.
+    pub(crate) async fn spawn(
+        this: &Instance<impl Actor>,
+        params: Option<IbvConfig>,
+    ) -> Result<Option<NicBackendHandle>> {
+        if hyperactor_config::global::get(crate::config::RDMA_DISABLE_IBVERBS) {
+            tracing::warn!("ibverbs disabled by configuration");
+            return Ok(None);
+        }
+        if IbvDevice::<MlxDevice>::available() {
+            let actor = IbvManagerActor::<MlxDevice>::new(params).await?;
+            return Ok(Some(NicBackendHandle::Mlx(IbvBackend(this.spawn(actor)))));
+        }
+        if IbvDevice::<EfaDevice>::available() {
+            let actor = IbvManagerActor::<EfaDevice>::new(params).await?;
+            return Ok(Some(NicBackendHandle::Efa(IbvBackend(this.spawn(actor)))));
+        }
+        tracing::warn!("no RDMA NIC devices found");
+        Ok(None)
+    }
+
+    /// Register `local` for remote access and return its backend context.
+    pub(crate) async fn register_remote_buffer(
+        &self,
+        cx: &(impl hyperactor::context::Actor + Send + Sync),
+        remote_buf_id: usize,
+        local: KeepaliveLocalMemory,
+    ) -> Result<NicRemoteBackendContext> {
+        match self {
+            NicBackendHandle::Mlx(backend) => {
+                let buf = backend
+                    .register_remote_buffer(cx, remote_buf_id, local)
+                    .await?
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                Ok(NicRemoteBackendContext::Mlx(backend.bind(), buf))
+            }
+            NicBackendHandle::Efa(backend) => {
+                let buf = backend
+                    .register_remote_buffer(cx, remote_buf_id, local)
+                    .await?
+                    .map_err(|e| anyhow::anyhow!(e))?;
+                Ok(NicRemoteBackendContext::Efa(backend.bind(), buf))
+            }
+        }
+    }
+
+    /// Release a buffer registration by id.
+    pub(crate) async fn release_buffer(
+        &self,
+        cx: &(impl hyperactor::context::Actor + Send + Sync),
+        remote_buf_id: usize,
+    ) -> Result<()> {
+        match self {
+            NicBackendHandle::Mlx(backend) => backend.release_buffer(cx, remote_buf_id).await,
+            NicBackendHandle::Efa(backend) => backend.release_buffer(cx, remote_buf_id).await,
+        }
+    }
+
+    /// Submit a batch of RDMA ops to this backend.
+    pub(crate) async fn submit(
+        &self,
+        cx: &(impl hyperactor::context::Actor + Send + Sync),
+        ops: Vec<RdmaOp>,
+        timeout: Duration,
+    ) -> Result<()> {
+        match self {
+            NicBackendHandle::Mlx(backend) => backend.clone().submit(cx, ops, timeout).await,
+            NicBackendHandle::Efa(backend) => backend.clone().submit(cx, ops, timeout).await,
+        }
+    }
+}

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -55,11 +55,9 @@ use crate::RdmaAction;
 use crate::RdmaManagerActor;
 use crate::ReleaseBufferClient;
 use crate::backend::RdmaRemoteBackendContext;
-use crate::backend::ibverbs::IbvBuffer;
-use crate::backend::ibverbs::manager_actor::IbvManagerActor;
-use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
+use crate::nic::NicRemoteBackendContext;
 
 /// Lightweight handle representing a registered RDMA buffer.
 ///
@@ -109,20 +107,10 @@ impl RdmaRemoteBuffer {
         Ok(())
     }
 
-    /// Whether this buffer has an ibverbs backend context.
-    pub(crate) fn has_ibverbs_backend(&self) -> bool {
-        self.backends
-            .iter()
-            .any(|b| matches!(b, RdmaRemoteBackendContext::Ibverbs(..)))
-    }
-
-    /// Extract the ibverbs backend context for this buffer.
-    ///
-    /// Returns `None` if the buffer has no ibverbs backend context
-    /// (i.e., the remote side was created without ibverbs).
-    pub fn resolve_ibv(&self) -> Option<(ActorRef<IbvManagerActor<MlxDevice>>, IbvBuffer)> {
+    /// NIC backend context for this buffer, if any.
+    pub fn resolve_nic(&self) -> Option<NicRemoteBackendContext> {
         self.backends.iter().find_map(|b| match b {
-            RdmaRemoteBackendContext::Ibverbs(mgr, buf) => Some((mgr.clone(), buf.clone())),
+            RdmaRemoteBackendContext::Nic(ctx) => Some(ctx.clone()),
             _ => None,
         })
     }

--- a/monarch_rdma/src/rdma_components.rs
+++ b/monarch_rdma/src/rdma_components.rs
@@ -57,6 +57,7 @@ use crate::ReleaseBufferClient;
 use crate::backend::RdmaRemoteBackendContext;
 use crate::backend::ibverbs::IbvBuffer;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
+use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
 
@@ -119,7 +120,7 @@ impl RdmaRemoteBuffer {
     ///
     /// Returns `None` if the buffer has no ibverbs backend context
     /// (i.e., the remote side was created without ibverbs).
-    pub fn resolve_ibv(&self) -> Option<(ActorRef<IbvManagerActor>, IbvBuffer)> {
+    pub fn resolve_ibv(&self) -> Option<(ActorRef<IbvManagerActor<MlxDevice>>, IbvBuffer)> {
         self.backends.iter().find_map(|b| match b {
             RdmaRemoteBackendContext::Ibverbs(mgr, buf) => Some((mgr.clone(), buf.clone())),
             _ => None,

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -48,6 +48,7 @@ use crate::backend::RdmaRemoteBackendContext;
 use crate::backend::ibverbs::manager_actor::IbvManagerActor;
 use crate::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
 use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
+use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::ibverbs::primitives::IbvConfig;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
@@ -100,7 +101,7 @@ wirevalue::register_type!(ReleaseBuffer);
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
 pub struct GetIbvActorRef {
     #[reply]
-    pub reply: OncePortRef<Option<ActorRef<IbvManagerActor>>>,
+    pub reply: OncePortRef<Option<ActorRef<IbvManagerActor<MlxDevice>>>>,
 }
 wirevalue::register_type!(GetIbvActorRef);
 
@@ -154,7 +155,7 @@ impl<A: Actor> RdmaBackendActor<A> {
 pub struct RdmaManagerActor {
     next_remote_buf_id: usize,
     buffers: HashMap<usize, KeepaliveLocalMemory>,
-    ibverbs: Option<RdmaBackendActor<IbvManagerActor>>,
+    ibverbs: Option<RdmaBackendActor<IbvManagerActor<MlxDevice>>>,
     tcp: RdmaBackendActor<TcpManagerActor>,
 }
 
@@ -191,7 +192,7 @@ impl RemoteSpawn for RdmaManagerActor {
                 );
             }
         } else {
-            match IbvManagerActor::new(params).await {
+            match IbvManagerActor::<MlxDevice>::new(params).await {
                 Ok(actor) => Some(RdmaBackendActor::Created(actor)),
                 Err(e) => {
                     if hyperactor_config::global::get(crate::config::RDMA_ALLOW_TCP_FALLBACK) {
@@ -249,7 +250,7 @@ impl GetIbvActorRefHandler for RdmaManagerActor {
     async fn get_ibv_actor_ref(
         &mut self,
         _cx: &Context<Self>,
-    ) -> Result<Option<ActorRef<IbvManagerActor>>, anyhow::Error> {
+    ) -> Result<Option<ActorRef<IbvManagerActor<MlxDevice>>>, anyhow::Error> {
         Ok(self.ibverbs.as_ref().map(|ibv| ibv.handle().bind()))
     }
 }

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -9,8 +9,7 @@
 //! # RDMA Manager Actor
 //!
 //! Per-process actor that owns RDMA buffer registrations and delegates
-//! transport-specific work to backend actors ([`IbvManagerActor`] and
-//! [`TcpManagerActor`]).
+//! transport-specific work to a NIC backend and [`TcpManagerActor`].
 //!
 //! ## Responsibilities
 //!
@@ -18,12 +17,13 @@
 //!   and stores the [`KeepaliveLocalMemory`] for later retrieval.
 //! - Produces [`RdmaRemoteBuffer`] tokens that can be sent to remote peers so
 //!   they can address this buffer over RDMA.
-//! - Delegates MR registration, QP management, and data movement to the
-//!   ibverbs backend ([`IbvManagerActor`]) when available, or falls back to
-//!   the TCP backend ([`TcpManagerActor`]).
+//! - Delegates MR registration, QP management, and data movement to a NIC
+//!   backend when available, or falls back to the TCP backend
+//!   ([`TcpManagerActor`]).
 //! - Handles remote [`ReleaseBuffer`] requests to clean up registrations.
 
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
@@ -38,20 +38,16 @@ use hyperactor::OncePortRef;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::context;
-use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
 use crate::backend::RdmaRemoteBackendContext;
-use crate::backend::ibverbs::manager_actor::IbvManagerActor;
-use crate::backend::ibverbs::manager_actor::IbvManagerLocalMessageClient;
-use crate::backend::ibverbs::manager_actor::IbvManagerMessageClient;
-use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::backend::ibverbs::primitives::IbvConfig;
 use crate::backend::tcp::manager_actor::TcpManagerActor;
 use crate::local_memory::KeepaliveLocalMemory;
+use crate::nic::NicBackendHandle;
 use crate::rdma_components::RdmaRemoteBuffer;
 
 /// Helper function to get detailed error messages from RDMAXCEL error codes
@@ -84,6 +80,11 @@ pub enum RdmaManagerMessage {
         #[reply]
         reply: OncePortHandle<Option<KeepaliveLocalMemory>>,
     },
+    /// Return an in-process handle to the local NIC backend, if any.
+    GetNicBackendHandle {
+        #[reply]
+        reply: OncePortHandle<Option<NicBackendHandle>>,
+    },
 }
 
 /// Serializable release message for wire transport.
@@ -96,15 +97,6 @@ pub struct ReleaseBuffer {
 }
 wirevalue::register_type!(ReleaseBuffer);
 
-/// Serializable query for resolving the [`IbvManagerActor`] ref
-/// from a remote [`RdmaManagerActor`]. Only used in testing.
-#[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
-pub struct GetIbvActorRef {
-    #[reply]
-    pub reply: OncePortRef<Option<ActorRef<IbvManagerActor<MlxDevice>>>>,
-}
-wirevalue::register_type!(GetIbvActorRef);
-
 /// Serializable query for resolving the [`TcpManagerActor`] ref
 /// from a remote [`RdmaManagerActor`].
 #[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
@@ -115,38 +107,8 @@ pub struct GetTcpActorRef {
 wirevalue::register_type!(GetTcpActorRef);
 
 #[derive(Debug)]
-enum RdmaBackendActor<A: Actor> {
-    Uninit,
-    Created(A),
-    Spawned(ActorHandle<A>),
-}
-
-impl<A: Actor> RdmaBackendActor<A> {
-    fn spawn(&mut self, rdma_manager: &Instance<RdmaManagerActor>) -> anyhow::Result<()> {
-        let created = std::mem::replace(self, RdmaBackendActor::Uninit);
-        let actor = if let RdmaBackendActor::Created(actor) = created {
-            actor
-        } else {
-            panic!("rdma backend actor already spawned");
-        };
-        let handle = rdma_manager.spawn(actor);
-        *self = RdmaBackendActor::Spawned(handle);
-        Ok(())
-    }
-
-    fn handle(&self) -> &ActorHandle<A> {
-        if let RdmaBackendActor::Spawned(handle) = self {
-            handle
-        } else {
-            panic!("cannot get handle")
-        }
-    }
-}
-
-#[derive(Debug)]
 #[hyperactor::export(
     handlers = [
-        GetIbvActorRef,
         GetTcpActorRef,
         ReleaseBuffer,
     ],
@@ -155,8 +117,9 @@ impl<A: Actor> RdmaBackendActor<A> {
 pub struct RdmaManagerActor {
     next_remote_buf_id: usize,
     buffers: HashMap<usize, KeepaliveLocalMemory>,
-    ibverbs: Option<RdmaBackendActor<IbvManagerActor<MlxDevice>>>,
-    tcp: RdmaBackendActor<TcpManagerActor>,
+    params: Option<IbvConfig>,
+    nic: OnceLock<NicBackendHandle>,
+    tcp: OnceLock<ActorHandle<TcpManagerActor>>,
 }
 
 impl RdmaManagerActor {
@@ -181,40 +144,12 @@ impl RemoteSpawn for RdmaManagerActor {
     type Params = Option<IbvConfig>;
 
     async fn new(params: Self::Params, _environment: Flattrs) -> Result<Self, anyhow::Error> {
-        let ibv = if hyperactor_config::global::get(crate::config::RDMA_DISABLE_IBVERBS) {
-            if hyperactor_config::global::get(crate::config::RDMA_ALLOW_TCP_FALLBACK) {
-                tracing::info!("ibverbs disabled by configuration, using TCP transport");
-                None
-            } else {
-                anyhow::bail!(
-                    "ibverbs is disabled (rdma_disable_ibverbs=true) \
-                     but TCP fallback is also disabled"
-                );
-            }
-        } else {
-            match IbvManagerActor::<MlxDevice>::new(params).await {
-                Ok(actor) => Some(RdmaBackendActor::Created(actor)),
-                Err(e) => {
-                    if hyperactor_config::global::get(crate::config::RDMA_ALLOW_TCP_FALLBACK) {
-                        tracing::warn!(
-                            "ibverbs initialization failed, TCP fallback enabled: {}",
-                            e
-                        );
-                        None
-                    } else {
-                        return Err(e);
-                    }
-                }
-            }
-        };
-
-        let tcp = RdmaBackendActor::Created(TcpManagerActor::new());
-
         Ok(Self {
             next_remote_buf_id: 0,
             buffers: HashMap::new(),
-            ibverbs: ibv,
-            tcp,
+            params,
+            nic: OnceLock::new(),
+            tcp: OnceLock::new(),
         })
     }
 }
@@ -222,36 +157,35 @@ impl RemoteSpawn for RdmaManagerActor {
 #[async_trait]
 impl Actor for RdmaManagerActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
-        if let Some(ibv) = &mut self.ibverbs {
-            ibv.spawn(this)?;
+        // A detected NIC that fails to initialize is fatal unless TCP
+        // fallback is enabled, in which case we warn and fall back to TCP.
+        let mut nic_init_failure = None;
+        let nic = match NicBackendHandle::spawn(this, self.params.clone()).await {
+            Ok(nic) => nic,
+            Err(e) => {
+                nic_init_failure = Some(e);
+                None
+            }
+        };
+        if let Some(nic) = nic {
+            self.nic.set(nic).expect("nic set once");
+        } else if !hyperactor_config::global::get(crate::config::RDMA_ALLOW_TCP_FALLBACK) {
+            if let Some(e) = nic_init_failure {
+                anyhow::bail!(
+                    "RDMA NIC backend initialization failed and TCP fallback is disabled: {e}"
+                );
+            } else {
+                anyhow::bail!("no RDMA NIC backend available and TCP fallback is disabled")
+            }
+        } else if let Some(e) = nic_init_failure {
+            tracing::warn!(
+                "RDMA NIC backend initialization failed, but TCP fallback is enabled: {e}"
+            );
         }
-        self.tcp.spawn(this)?;
-        tracing::debug!("RdmaManagerActor initialized with lazy domain/QP creation");
+        self.tcp
+            .set(this.spawn(TcpManagerActor::new()))
+            .expect("tcp set once");
         Ok(())
-    }
-
-    async fn handle_supervision_event(
-        &mut self,
-        _cx: &Instance<Self>,
-        event: &ActorSupervisionEvent,
-    ) -> Result<bool, anyhow::Error> {
-        if !event.is_error() {
-            return Ok(true);
-        }
-        tracing::error!("rdmaManagerActor supervision event: {:?}", event);
-        tracing::error!("rdmaManagerActor error occurred, stop the worker process, exit code: 1");
-        std::process::exit(1);
-    }
-}
-
-#[async_trait]
-#[hyperactor::handle(GetIbvActorRef)]
-impl GetIbvActorRefHandler for RdmaManagerActor {
-    async fn get_ibv_actor_ref(
-        &mut self,
-        _cx: &Context<Self>,
-    ) -> Result<Option<ActorRef<IbvManagerActor<MlxDevice>>>, anyhow::Error> {
-        Ok(self.ibverbs.as_ref().map(|ibv| ibv.handle().bind()))
     }
 }
 
@@ -262,7 +196,7 @@ impl GetTcpActorRefHandler for RdmaManagerActor {
         &mut self,
         _cx: &Context<Self>,
     ) -> Result<ActorRef<TcpManagerActor>, anyhow::Error> {
-        Ok(self.tcp.handle().bind())
+        Ok(self.tcp.get().expect("tcp set in init").bind())
     }
 }
 
@@ -271,8 +205,8 @@ impl GetTcpActorRefHandler for RdmaManagerActor {
 impl ReleaseBufferHandler for RdmaManagerActor {
     async fn release_buffer(&mut self, cx: &Context<Self>, id: usize) -> Result<(), anyhow::Error> {
         self.buffers.remove(&id);
-        if let Some(ibv) = &self.ibverbs {
-            ibv.handle().release_buffer(cx, id).await?;
+        if let Some(nic) = self.nic.get() {
+            nic.release_buffer(cx, id).await?;
         }
         Ok(())
     }
@@ -291,22 +225,16 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         let size = local.size();
 
         let mut backends = Vec::new();
-
-        if let Some(ibv) = &self.ibverbs {
-            let ibv_buffer = ibv
-                .handle()
+        if let Some(nic) = self.nic.get() {
+            let ctx = nic
                 .register_remote_buffer(cx, remote_buf_id, local.clone())
-                .await?
-                .map_err(|e| anyhow::anyhow!(e))?;
-            backends.push(RdmaRemoteBackendContext::Ibverbs(
-                ibv.handle().bind(),
-                ibv_buffer,
-            ));
+                .await?;
+            backends.push(RdmaRemoteBackendContext::Nic(ctx));
         }
-
         self.buffers.insert(remote_buf_id, local);
-
-        backends.push(RdmaRemoteBackendContext::Tcp(self.tcp.handle().bind()));
+        backends.push(RdmaRemoteBackendContext::Tcp(
+            self.tcp.get().expect("tcp set in init").bind(),
+        ));
 
         Ok(RdmaRemoteBuffer {
             id: remote_buf_id,
@@ -322,5 +250,12 @@ impl RdmaManagerMessageHandler for RdmaManagerActor {
         remote_buf_id: usize,
     ) -> Result<Option<KeepaliveLocalMemory>, anyhow::Error> {
         Ok(self.buffers.get(&remote_buf_id).cloned())
+    }
+
+    async fn get_nic_backend_handle(
+        &mut self,
+        _cx: &Context<Self>,
+    ) -> Result<Option<NicBackendHandle>, anyhow::Error> {
+        Ok(self.nic.get().cloned())
     }
 }

--- a/python/tests/test_rdma_unsupported.py
+++ b/python/tests/test_rdma_unsupported.py
@@ -20,6 +20,7 @@ import pytest
 if sys.platform != "linux":
     pytest.skip("linux-only", allow_module_level=True)
 
+from isolate_in_subprocess import isolate_in_subprocess
 from monarch.config import configured
 from monarch.rdma import is_ibverbs_available
 
@@ -31,35 +32,58 @@ needs_no_rdma = pytest.mark.skipif(
 
 
 @needs_no_rdma
-@pytest.mark.asyncio
-async def test_rdma_manager_creation_fails_when_unsupported():
-    """Test that RdmaManagerActor creation fails with correct error when RDMA is not supported.
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_rdma_manager_creation_fails_when_unsupported() -> None:
+    """RdmaManagerActor creation surfaces a supervision fault when RDMA is unsupported.
 
-    This test only runs on systems where RDMA is not available.
-    If RDMA is available, the test is skipped since we cannot test the unsupported path.
+    This test only runs on systems where RDMA is not available. If RDMA is
+    available, the test is skipped, since we cannot exercise the unsupported
+    path.
 
-    Note: We don't use mock here because the error originates from a cross-language call
-    chain (Python → Rust → C ibverbs library). Python mocks cannot intercept the native
-    ibverbs_supported() function that calls ibv_get_device_list() in the C library.
+    With TCP fallback disabled and no NIC backend present, the actor spawns
+    successfully but its init fails. The failure is delivered to
+    ``unhandled_fault_hook`` as a supervision fault, not raised as an exception
+    from the creation call.
+
+    We don't mock here because the failure originates from a cross-language call
+    chain (Python -> Rust -> C ibverbs library); a Python mock cannot intercept
+    the native device probe.
     """
+    import asyncio
+
+    import monarch.actor
     from monarch._rust_bindings.rdma import _RdmaManager
     from monarch._src.actor.actor_mesh import context
     from monarch._src.actor.future import Future
     from monarch.actor import this_host
 
+    faults = []
+    faulted = asyncio.Event()
+
+    def fault_hook(failure):
+        faults.append(failure)
+        faulted.set()
+
+    monarch.actor.unhandled_fault_hook = fault_hook
+
     with configured(rdma_allow_tcp_fallback=False):
         proc_mesh = this_host().spawn_procs(per_host={"cpus": 1})
 
-        with pytest.raises(Exception) as exc_info:
-            await Future(
-                coro=_RdmaManager.create_rdma_manager_nonblocking(
-                    await Future(coro=proc_mesh._proc_mesh.task()),
-                    context().actor_instance,
-                )
+        # Spawning succeeds; the RdmaManagerActor's init then fails because no
+        # NIC backend is available and TCP fallback is disabled.
+        await Future(
+            coro=_RdmaManager.create_rdma_manager_nonblocking(
+                await Future(coro=proc_mesh._proc_mesh.task()),
+                context().actor_instance,
             )
+        )
 
-        error_message = str(exc_info.value)
-        assert (
-            "Cannot create IbvManagerActor because RDMA is not supported on this machine"
-            in error_message
-        ), f"Expected specific error message not found. Actual error: {error_message}"
+        # The init failure arrives asynchronously as a supervision fault.
+        await asyncio.wait_for(faulted.wait(), timeout=15.0)
+
+    assert len(faults) >= 1, "Expected a supervision fault, got none"
+    failure_message = str(faults[0])
+    assert (
+        "no RDMA NIC backend available and TCP fallback is disabled" in failure_message
+    ), f"Expected specific failure message not found. Actual fault: {failure_message}"


### PR DESCRIPTION
Summary:

Propagate the generic `IbvManagerActor<I>` through the rest of the RDMA subsystem so a proc selects a Mellanox or EFA NIC backend at runtime, with TCP as the fallback.

A new `nic` module owns the abstraction: `NicRemoteBackendContext` is the backend context carried by an `RdmaRemoteBuffer`, and `NicBackendHandle` is the in-process handle that selects, spawns, and dispatches to whichever backend is available. `RdmaManagerActor` holds the NIC and TCP handles in `OnceLock`s and performs all setup in `Actor::init`, so a missing backend surfaces through normal supervision. `RdmaAction::submit` routes each op to the NIC when the remote context is compatible and to TCP otherwise.

Reviewed By: zdevito

Differential Revision: D107298527
