### PR TITLE
[hyperactor] represent different port kinds explicitly

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -2378,7 +2378,11 @@ mod tests {
         let handle = proc.spawn(actor);
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2551,7 +2555,11 @@ mod tests {
 
         let child_ref = crate::Addr::Actor(test_proc_id("nonexistent").actor_addr("child"));
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::QueryChild {
                 child_ref,
@@ -2597,7 +2605,11 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2634,7 +2646,11 @@ mod tests {
 
         // Query the child — supervisor should be the parent.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&child_handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            child_handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2661,14 +2677,17 @@ mod tests {
 
         // Query the parent — children should include the child.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&parent_handle.actor_addr().clone())
-            .post(
-                &client,
-                IntrospectMessage::Query {
-                    view: IntrospectView::Actor,
-                    reply: reply_port.bind(),
-                },
-            );
+        PortRef::<IntrospectMessage>::attest_control_port(
+            parent_handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
+            &client,
+            IntrospectMessage::Query {
+                view: IntrospectView::Actor,
+                reply: reply_port.bind(),
+            },
+        );
         let parent_payload = reply_rx.recv().await.unwrap();
 
         assert!(parent_payload.parent.is_none());
@@ -2706,7 +2725,11 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2739,7 +2762,11 @@ mod tests {
         let _ = rx.recv().await.unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2776,7 +2803,11 @@ mod tests {
 
         // First introspect query.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2787,7 +2818,11 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2956,7 +2991,11 @@ mod tests {
 
         // Send introspect query via the dedicated introspect port.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2999,7 +3038,11 @@ mod tests {
 
         // First introspect query.
         let (reply_port1, reply_rx1) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&handle.actor_addr().clone()).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -3010,7 +3053,11 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        crate::PortRef::<IntrospectMessage>::attest_handler_port(handle.actor_addr()).post(
+        crate::PortRef::<IntrospectMessage>::attest_control_port(
+            handle.actor_addr(),
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -3045,7 +3092,11 @@ mod tests {
         let actor_id: crate::ActorAddr = handle.actor_addr().clone();
 
         let (reply_port, reply_rx) = bridge.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&actor_id).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            &actor_id,
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &bridge,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -3085,7 +3136,11 @@ mod tests {
         let mailbox_id: crate::ActorAddr = mailbox.self_addr().clone();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_handler_port(&mailbox_id).post(
+        PortRef::<IntrospectMessage>::attest_control_port(
+            &mailbox_id,
+            crate::ControlPort::Introspect,
+        )
+        .post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,

--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -28,6 +28,8 @@
 //! controller<2MuAHeDjLCEd>@tcp://[::1]:2345
 //! controller<2MuAHeDjLCEd>.local@inproc://0
 //! <2MuAHeDjLCEd>.<NRjEZGYjYibf>:42@tcp://[::1]:2345
+//! <2MuAHeDjLCEd>.<NRjEZGYjYibf>:handler<NRjEZGYjYibf>@tcp://[::1]:2345
+//! <2MuAHeDjLCEd>.<NRjEZGYjYibf>!introspect@tcp://[::1]:2345
 //! ```
 
 use std::fmt;
@@ -47,6 +49,7 @@ use crate::id::PortId;
 use crate::id::ProcId;
 use crate::id::Uid;
 use crate::parse;
+use crate::port::ControlPort;
 use crate::port::Port;
 
 /// A network location.
@@ -486,9 +489,24 @@ impl PortAddr {
         self.id.port().is_handler()
     }
 
+    /// Whether this is the provided control port.
+    pub(crate) fn is_control_port_kind(&self, port: ControlPort) -> bool {
+        self.id.port() == Port::control(port)
+    }
+
+    /// The port.
+    pub fn port(&self) -> Port {
+        self.id.port()
+    }
+
     /// The port index.
     pub fn index(&self) -> u64 {
         self.id.port().as_u64()
+    }
+
+    /// The ephemeral port index.
+    pub fn ephemeral_index(&self) -> Option<u64> {
+        self.id.port().ephemeral_index()
     }
 
     /// Reconstruct the parent ActorAddr (with location preserved).

--- a/hyperactor/src/id.rs
+++ b/hyperactor/src/id.rs
@@ -19,6 +19,8 @@
 //! actor-id     := actor-part "." proc-id
 //! actor-part   := label | "<" uid58 ">" | label "<" uid58 ">"
 //! port-id      := actor-id ":" decimal-port
+//!              | actor-id ":" uid
+//!              | actor-id "!" control-port
 //! ```
 //!
 //! Singletons are self-documenting and therefore display as bare labels.
@@ -254,6 +256,14 @@ impl Uid {
         match self {
             Uid::Singleton(_) => None,
             Uid::Instance(uid, _) => Some(encode_base58_uid(*uid)),
+        }
+    }
+
+    /// Returns the raw instance uid.
+    pub fn instance_value(&self) -> Option<u64> {
+        match self {
+            Uid::Singleton(_) => None,
+            Uid::Instance(uid, _) => Some(*uid),
         }
     }
 
@@ -743,7 +753,7 @@ impl PortId {
 
     /// Returns the port.
     pub fn port(&self) -> Port {
-        self.port
+        self.port.clone()
     }
 
     /// Returns the proc id (delegates to actor_id).
@@ -783,7 +793,10 @@ impl Ord for PortId {
 
 impl fmt::Display for PortId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.actor_id, self.port)
+        match &self.port {
+            Port::Control(port) => write!(f, "{}!{}", self.actor_id, port),
+            _ => write!(f, "{}:{}", self.actor_id, self.port),
+        }
     }
 }
 
@@ -791,20 +804,16 @@ impl fmt::Debug for PortId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (self.actor_id.label(), self.actor_id.proc_id().label()) {
             (Some(actor_label), Some(proc_label)) => {
-                write!(
-                    f,
-                    "<'{}.{}' {}:{}>",
-                    actor_label, proc_label, self.actor_id, self.port
-                )
+                write!(f, "<'{}.{}' {}>", actor_label, proc_label, self)
             }
             (Some(actor_label), None) => {
-                write!(f, "<'{}' {}:{}>", actor_label, self.actor_id, self.port)
+                write!(f, "<'{}' {}>", actor_label, self)
             }
             (None, Some(proc_label)) => {
-                write!(f, "<'.{}' {}:{}>", proc_label, self.actor_id, self.port)
+                write!(f, "<'.{}' {}>", proc_label, self)
             }
             (None, None) => {
-                write!(f, "<{}:{}>", self.actor_id, self.port)
+                write!(f, "<{}>", self)
             }
         }
     }
@@ -1700,7 +1709,7 @@ mod tests {
             Some(Label::new("my-actor").unwrap()),
         );
         let port = Port::from(42);
-        let pid = PortId::new(actor_id.clone(), port);
+        let pid = PortId::new(actor_id.clone(), port.clone());
         assert_eq!(pid.actor_id(), &actor_id);
         assert_eq!(pid.port(), port);
         assert_eq!(pid.proc_id(), &proc_id);

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -36,9 +36,9 @@
 //!   `InstanceCell` never sets `last_message_handler` to
 //!   `IntrospectMessage`.
 //! - **S3.** Sender routing is unchanged -- senders target the same
-//!   `PortId` (`IntrospectMessage::port()`) across processes.
+//!   control `PortId` across processes.
 //! - **S4.** `IntrospectMessage` never produces a `WorkCell` --
-//!   pre-registration via `bind_handler_port` gives the introspect
+//!   pre-registration via `bind_control_port` gives the introspect
 //!   port its own channel, independent of the actor's work queue.
 //! - **S5.** Replies never use `PanickingMailboxSender` -- the
 //!   introspect task replies via `Mailbox::serialize_and_send_once`.

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -182,6 +182,8 @@ pub use mailbox::Message;
 pub use mailbox::OncePortHandle;
 pub use mailbox::PortHandle;
 pub use mailbox::RemoteMessage;
+pub use port::ControlPort;
+pub use port::Port;
 pub use proc::Context;
 pub use proc::Instance;
 pub use proc::InstanceCell;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -151,8 +151,6 @@ use crate::accum::Accumulator;
 use crate::accum::ReducerSpec;
 use crate::accum::StreamingReducerOpts;
 use crate::actor::ActorStatus;
-use crate::actor::Signal;
-use crate::actor::remote::USER_PORT_OFFSET;
 use crate::channel;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
@@ -166,6 +164,7 @@ use crate::id::ActorId;
 use crate::metrics;
 use crate::ordering::SEQ_INFO;
 use crate::ordering::SeqInfo;
+use crate::port::ControlPort;
 use crate::port::Port;
 
 mod undeliverable;
@@ -622,7 +621,8 @@ impl MessageEnvelope {
 
     /// Tells whether this is a signal message.
     pub fn is_signal(&self) -> bool {
-        self.dest.index() == Signal::port()
+        self.dest
+            .is_control_port_kind(crate::port::ControlPort::Signal)
     }
 
     /// Push a structured delivery failure onto this message's failure history.
@@ -1845,7 +1845,6 @@ impl Mailbox {
         (
             OncePortHandle {
                 mailbox: self.clone(),
-                port_index,
                 port_id: port_id.clone(),
                 sender,
                 reducer_spec: None,
@@ -1891,7 +1890,6 @@ impl Mailbox {
         (
             OncePortHandle {
                 mailbox: self.clone(),
-                port_index,
                 port_id: port_id.clone(),
                 sender,
                 reducer_spec,
@@ -1910,15 +1908,15 @@ impl Mailbox {
     }
 
     fn lookup_sender<M: RemoteMessage>(&self) -> Option<UnboundedPortSender<M>> {
-        let port_index = M::port();
-        self.inner.ports.get(&port_index).and_then(|boxed| {
+        let port = Port::handler::<M>();
+        self.inner.ports.get(&port).and_then(|boxed| {
             boxed
                 .as_any()
                 .downcast_ref::<UnboundedSender<M>>()
                 .map(|s| {
                     assert_eq!(
                         s.port_id,
-                        self.actor_addr().port_addr(Port::from(port_index)),
+                        self.actor_addr().port_addr(port.clone()),
                         "port_id mismatch in downcasted UnboundedSender"
                     );
                     s.sender.clone()
@@ -1948,7 +1946,7 @@ impl Mailbox {
         let port_ref = self
             .actor_addr()
             .port_addr(Port::from(handle.inner.port_index));
-        match self.inner.ports.entry(handle.inner.port_index) {
+        match self.inner.ports.entry(port_ref.port()) {
             Entry::Vacant(entry) => {
                 entry.insert(Arc::new(UnboundedSender::new(
                     handle.inner.sender.clone(),
@@ -1962,19 +1960,26 @@ impl Mailbox {
     }
 
     fn bind_to_handler_port<M: RemoteMessage>(&self, handle: &PortHandle<M>) {
+        self.bind_to_port(handle, Port::handler::<M>());
+    }
+
+    fn bind_to_control_port<M: RemoteMessage>(&self, handle: &PortHandle<M>, port: ControlPort) {
+        self.bind_to_port(handle, Port::control(port));
+    }
+
+    fn bind_to_port<M: RemoteMessage>(&self, handle: &PortHandle<M>, port: Port) {
         assert_eq!(
             handle.inner.mailbox.actor_addr(),
             self.actor_addr(),
             "port does not belong to mailbox"
         );
 
-        let port_index = M::port();
-        let port_ref = self.actor_addr().port_addr(Port::from(port_index));
-        match self.inner.ports.entry(port_index) {
+        let port_ref = self.actor_addr().port_addr(port.clone());
+        match self.inner.ports.entry(port) {
             Entry::Vacant(entry) => {
                 entry.insert(Arc::new(UnboundedSender::new(
                     handle.inner.sender.clone(),
-                    port_ref,
+                    port_ref.clone(),
                 )));
             }
             Entry::Occupied(_entry) => panic!("port {} already bound", port_ref),
@@ -1983,7 +1988,7 @@ impl Mailbox {
 
     fn bind_once<M: RemoteMessage>(&self, handle: OncePortHandle<M>) {
         let port_id = handle.port_addr().clone();
-        match self.inner.ports.entry(handle.port_index) {
+        match self.inner.ports.entry(port_id.port()) {
             Entry::Vacant(entry) => {
                 entry.insert(Arc::new(OnceSender::new(handle.sender, port_id.clone())));
             }
@@ -1998,7 +2003,7 @@ impl Mailbox {
             "port does not belong to mailbox"
         );
 
-        match self.inner.ports.entry(port_id.index()) {
+        match self.inner.ports.entry(port_id.port()) {
             Entry::Vacant(entry) => {
                 entry.insert(Arc::new(sender));
             }
@@ -2090,7 +2095,7 @@ impl MailboxSender for Mailbox {
             return envelope.undeliverable(failure, return_handle);
         }
 
-        let port_index = envelope.dest().index();
+        let port = envelope.dest().port();
 
         // Clone the Arc<dyn SerializedSender> out of the DashMap while holding
         // only a short-lived read lock, then release the lock before calling
@@ -2101,12 +2106,12 @@ impl MailboxSender for Mailbox {
         // (RwLock is not reentrant). DashMap uses a random per-process hasher,
         // so whether two port indices collide in the same shard varies across
         // test runs, explaining the longstanding flaky timeout failures.
-        let port_sender = match self.inner.ports.get(&port_index) {
+        let port_sender = match self.inner.ports.get(&port) {
             None => {
                 let failure = unbound_port_delivery_failure(
                     envelope.dest(),
                     envelope.data(),
-                    self.inner.next_port.load(Ordering::SeqCst),
+                    self.inner.next_ephemeral_port.load(Ordering::SeqCst),
                 );
                 return envelope.undeliverable(failure, return_handle);
             }
@@ -2194,11 +2199,11 @@ impl MailboxSender for Mailbox {
                 );
 
                 if disposition == SerializedSendDisposition::DeliveredAndExhausted {
-                    self.inner.ports.remove(&port_index);
+                    self.inner.ports.remove(&port);
                 }
             }
             Err(SerializedSendFailure::Dead { data, headers }) => {
-                self.inner.ports.remove(&port_index);
+                self.inner.ports.remove(&port);
                 let failure = port_gone_delivery_failure(&dest, &data);
 
                 MessageEnvelope::seal(
@@ -2241,20 +2246,21 @@ impl MailboxSender for Mailbox {
 fn unbound_port_delivery_failure(
     port: &PortAddr,
     data: &wirevalue::Any,
-    next_port: u64,
+    next_ephemeral_port: u64,
 ) -> DeliveryFailure {
     if port.is_handler_port() {
         DeliveryFailure::new(InvalidReference::new(
             port.clone(),
             InvalidReferenceReason::HandlerNotBound,
         ))
-    } else if port.index() < next_port {
-        port_gone_delivery_failure(port, data)
     } else {
-        DeliveryFailure::new(InvalidReference::new(
-            port.clone(),
-            InvalidReferenceReason::PortNeverAllocated,
-        ))
+        match port.ephemeral_index() {
+            Some(index) if index < next_ephemeral_port => port_gone_delivery_failure(port, data),
+            _ => DeliveryFailure::new(InvalidReference::new(
+                port.clone(),
+                InvalidReferenceReason::PortNeverAllocated,
+            )),
+        }
     }
 }
 
@@ -2515,11 +2521,19 @@ impl<M: RemoteMessage> PortHandle<M> {
     /// This is used by [`actor::Binder`] implementations to bind actor refs.
     /// This is not intended for general use.
     pub(crate) fn bind_handler_port(&self) {
-        let port_id = self
-            .inner
-            .mailbox
-            .actor_addr()
-            .port_addr(Port::from(M::port()));
+        self.bind_to_port(Port::handler::<M>());
+        self.inner.mailbox.bind_to_handler_port(self);
+    }
+
+    /// Bind this handle to a control port. This method will panic if the handle
+    /// is already bound.
+    pub(crate) fn bind_control_port(&self, port: ControlPort) {
+        self.bind_to_port(Port::control(port));
+        self.inner.mailbox.bind_to_control_port(self, port);
+    }
+
+    fn bind_to_port(&self, port: Port) {
+        let port_id = self.inner.mailbox.actor_addr().port_addr(port);
         {
             let mut guard = self.inner.bound.write().unwrap();
             if guard.is_some() {
@@ -2530,7 +2544,6 @@ impl<M: RemoteMessage> PortHandle<M> {
             }
             *guard = Some(port_id);
         }
-        self.inner.mailbox.bind_to_handler_port(self);
     }
 }
 
@@ -2552,7 +2565,6 @@ impl<M: Message> fmt::Display for PortHandle<M> {
 #[derive(Debug)]
 pub struct OncePortHandle<M: Message> {
     mailbox: Mailbox,
-    port_index: u64,
     port_id: PortAddr,
     sender: oneshot::Sender<M>,
     reducer_spec: Option<ReducerSpec>,
@@ -2717,8 +2729,8 @@ impl<M> PortReceiver<M> {
         drained
     }
 
-    fn port(&self) -> u64 {
-        self.port_id.index()
+    fn port(&self) -> Port {
+        self.port_id.port()
     }
 
     fn actor_addr(&self) -> ActorAddr {
@@ -2769,8 +2781,8 @@ impl<M> OncePortReceiver<M> {
             })
     }
 
-    fn port(&self) -> u64 {
-        self.port_id.index()
+    fn port(&self) -> Port {
+        self.port_id.port()
     }
 
     fn actor_addr(&self) -> ActorAddr {
@@ -3197,10 +3209,10 @@ struct State {
     // insert if it's serializable; otherwise don't.
     /// The set of active ports in the mailbox. All currently
     /// allocated ports are
-    ports: DashMap<u64, Arc<dyn SerializedSender>>,
+    ports: DashMap<Port, Arc<dyn SerializedSender>>,
 
-    /// The next port ID to allocate.
-    next_port: AtomicU64,
+    /// The next ephemeral port ID to allocate.
+    next_ephemeral_port: AtomicU64,
 
     /// If a value is present, the mailbox has been closed with the provided
     /// status, and any subsequent `Mailbox::post_unchecked` calls will fail.
@@ -3216,9 +3228,7 @@ impl State {
         Self {
             actor_id,
             ports: DashMap::new(),
-            // The first 1024 ports are allocated to actor handlers.
-            // Other port IDs are ephemeral.
-            next_port: AtomicU64::new(USER_PORT_OFFSET),
+            next_ephemeral_port: AtomicU64::new(0),
             closed: RwLock::new(None),
             handler_ingress: Arc::new(HandlerIngressGate::new()),
         }
@@ -3226,7 +3236,7 @@ impl State {
 
     /// Allocate a fresh port.
     fn allocate_port(&self) -> u64 {
-        self.next_port.fetch_add(1, Ordering::SeqCst)
+        self.next_ephemeral_port.fetch_add(1, Ordering::SeqCst)
     }
 }
 
@@ -3236,9 +3246,13 @@ impl fmt::Debug for State {
             .field("actor_id", &self.actor_id)
             .field(
                 "open_ports",
-                &self.ports.iter().map(|e| *e.key()).collect::<Vec<_>>(),
+                &self
+                    .ports
+                    .iter()
+                    .map(|e| e.key().clone())
+                    .collect::<Vec<_>>(),
             )
-            .field("next_port", &self.next_port)
+            .field("next_ephemeral_port", &self.next_ephemeral_port)
             .finish()
     }
 }
@@ -4096,7 +4110,7 @@ mod tests {
     #[tokio::test]
     async fn test_missing_never_allocated_port_records_invalid_reference() {
         let mbox = Mailbox::new(test_actor_id("0", "test"));
-        let dest = mbox.actor_addr().port_addr(Port::from(USER_PORT_OFFSET));
+        let dest = mbox.actor_addr().port_addr(Port::from(0));
         let envelope =
             MessageEnvelope::serialize(mbox.actor_addr().clone(), dest, &42u64, Flattrs::new())
                 .expect("serialize");
@@ -4256,7 +4270,7 @@ mod tests {
             InvalidReferenceReason::ProtocolMismatch
         );
         assert!(
-            mbox.inner.ports.contains_key(&port_index),
+            mbox.inner.ports.contains_key(&Port::from(port_index)),
             "deserialization mismatch should not evict reusable port",
         );
 
@@ -4284,7 +4298,7 @@ mod tests {
         drop(receiver);
 
         mbox.inner.ports.insert(
-            port_index,
+            Port::from(port_index),
             Arc::new(UnboundedSender::new(
                 UnboundedPortSender::Mpsc(sender),
                 port_id,
@@ -4306,7 +4320,7 @@ mod tests {
             "expected port-gone error in {envelope}",
         );
         assert!(
-            !mbox.inner.ports.contains_key(&port_index),
+            !mbox.inner.ports.contains_key(&Port::from(port_index)),
             "dead reusable port should be removed after send failure",
         );
 
@@ -4360,7 +4374,7 @@ mod tests {
             InvalidReferenceReason::ProtocolMismatch
         );
         assert!(
-            mbox.inner.ports.contains_key(&port_index),
+            mbox.inner.ports.contains_key(&Port::from(port_index)),
             "once port should survive deserialization mismatch before delivery",
         );
 
@@ -4374,7 +4388,7 @@ mod tests {
             123u64
         );
         assert!(
-            !mbox.inner.ports.contains_key(&port_index),
+            !mbox.inner.ports.contains_key(&Port::from(port_index)),
             "successful once send should remove the sender entry",
         );
     }
@@ -5821,7 +5835,7 @@ mod tests {
     #[test]
     fn test_bind_port_handle_to_handler_port() {
         let mbox = Mailbox::new(test_actor_id("0", "test"));
-        let default_port = mbox.actor_addr().port_addr(Port::from(String::port()));
+        let default_port = mbox.actor_addr().port_addr(Port::handler::<String>());
         let (handle, _rx) = mbox.open_port::<String>();
         // Handle's port index is allocated by mailbox, not the handler port.
         assert_ne!(default_port.index(), handle.inner.port_index);

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -23,7 +23,6 @@ use crate::ActorAddr;
 use crate::PortAddr;
 use crate::metrics::MESSAGE_LATENCY_MICROS;
 use crate::ordering::SeqInfo;
-use crate::ordering::is_bypass_workq_actor_port;
 
 declare_attrs! {
     /// Send timestamp for message latency tracking
@@ -118,10 +117,7 @@ pub fn stamp_sender_actor_id(
     if let SeqInfo::Session { seq, .. } = seq_info {
         let early_session = *seq <= 4;
         let caller_set_stale = headers.contains_key(SENDER_ACTOR_ID);
-        if (early_session || caller_set_stale)
-            && dest.is_handler_port()
-            && !is_bypass_workq_actor_port(dest.index())
-        {
+        if (early_session || caller_set_stale) && dest.is_handler_port() {
             headers.set(SENDER_ACTOR_ID, owner.clone());
         }
     }
@@ -136,7 +132,7 @@ pub(crate) fn stamp_sender_actor_id_fresh(
     dest: &PortAddr,
     owner: &ActorAddr,
 ) {
-    if seq <= 4 && dest.is_handler_port() && !is_bypass_workq_actor_port(dest.index()) {
+    if seq <= 4 && dest.is_handler_port() {
         headers.set(SENDER_ACTOR_ID, owner.clone());
     }
 }
@@ -170,11 +166,10 @@ pub fn log_message_latency_if_sampling(headers: &Flattrs, actor_id: String) {
 
 #[cfg(test)]
 mod tests {
-    use typeuri::Named;
     use uuid::Uuid;
 
     use super::*;
-    use crate::introspect::IntrospectMessage;
+    use crate::port::ControlPort;
     use crate::port::Port;
     use crate::testing::ids::test_actor_id;
 
@@ -187,17 +182,7 @@ mod tests {
 
     fn handler_port(actor_name: &str) -> (ActorAddr, PortAddr) {
         let addr: ActorAddr = test_actor_id(actor_name, "worker");
-        // Use a fabricated handler-port index (high bit set) by going through
-        // the existing IntrospectMessage::port() — it's a bypass port though,
-        // so for a NON-bypass handler port we'll use an explicit message
-        // type. Easier: spin up via Port::from of any u64 with the handler
-        // bit set. Since the test util test_actor_id already returns an
-        // ActorAddr, and the only requirement is that .is_handler_port() is
-        // true, we construct a PortAddr that points to a known handler port
-        // — for headers tests we can use IntrospectMessage::port() (a bypass
-        // handler port — gate should skip it) or a fabricated non-bypass
-        // handler. Use TestHandlerMsg below.
-        let port = addr.port_addr(Port::from(TestHandlerMsg::port()));
+        let port = addr.port_addr(Port::handler::<TestHandlerMsg>());
         (addr, port)
     }
 
@@ -210,9 +195,9 @@ mod tests {
         (addr, port)
     }
 
-    fn bypass_port(actor_name: &str) -> (ActorAddr, PortAddr) {
+    fn control_port(actor_name: &str) -> (ActorAddr, PortAddr) {
         let addr: ActorAddr = test_actor_id(actor_name, "worker");
-        let port = addr.port_addr(Port::from(IntrospectMessage::port()));
+        let port = addr.port_addr(Port::control(ControlPort::Introspect));
         (addr, port)
     }
 
@@ -264,8 +249,8 @@ mod tests {
     }
 
     #[test]
-    fn test_stamp_helper_skips_bypass_port() {
-        let (owner, dest) = bypass_port("test_0");
+    fn test_stamp_helper_skips_control_port() {
+        let (owner, dest) = control_port("test_0");
         let mut headers = Flattrs::new();
         stamp_sender_actor_id(&mut headers, &session(1), &dest, &owner);
         assert_eq!(headers.get(SENDER_ACTOR_ID), None);

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -28,31 +28,15 @@ use uuid::Uuid;
 
 use crate::ActorAddr;
 use crate::PortAddr;
-use crate::introspect::IntrospectMessage;
 
-// Bypass-actor-workq: message types whose receivers are delivered via
-// dedicated channels rather than the actor's work queue.
-//
-// The bypass-workq message type shares two invariants that the framework
-// must honor:
-//   1. Its actor port is pre-registered via `Ports::open_message_port` in
-//      `Instance::new`; `Ports::get` rejects it via `is_bypass_workq_type_id`
-//      so it can't accidentally be wired to the work queue.
-//   2. Its sender-side sequence numbers must NOT share the per-actor seq
-//      counter (`SeqKey::Actor`), because the work queue never observes them
-//      and would otherwise see seq gaps that buffer subsequent workq messages
-//      indefinitely. `Sequencer::assign_seq` uses `SeqKey::Port` for them.
+// Control ports are delivered through runtime-owned channels rather than the
+// actor's work queue, so they must not share the per-actor handler-port
+// sequence counter.
 
 /// Returns true if `id` is the `TypeId` of a bypass-channel message type
 /// (i.e. one that must not be wired through `Ports::get`).
 pub(crate) fn is_bypass_workq_type_id(id: TypeId) -> bool {
-    id == TypeId::of::<IntrospectMessage>()
-}
-
-/// Returns true if `port` is the actor-port index of a bypass-channel
-/// message type (i.e. the sequencer must use `SeqKey::Port` for it).
-pub(crate) fn is_bypass_workq_actor_port(port: u64) -> bool {
-    port == IntrospectMessage::port()
+    id == TypeId::of::<crate::introspect::IntrospectMessage>()
 }
 
 /// A client's re-ordering buffer state.
@@ -442,11 +426,11 @@ impl Sequencer {
     ///
     /// - Handler ports: share the same sequence scheme per actor (keyed by ActorAddr)
     /// - Non-handler ports: get individual sequence schemes (keyed by PortAddr)
-    /// - Bypass-workq actor ports: messages sent to these ports are delivered
+    /// - Bypass-workq control ports: messages sent to these ports are delivered
     ///   to their dedicated channels rather than the actor's work queue. As a
     ///   result, they use the per-port counter instead.
     pub fn assign_seq(&self, port_id: &PortAddr) -> SeqInfo {
-        let key = if port_id.is_handler_port() && !is_bypass_workq_actor_port(port_id.index()) {
+        let key = if port_id.is_handler_port() {
             SeqKey::Actor(port_id.actor_addr().clone())
         } else {
             SeqKey::Port(port_id.clone())
@@ -493,8 +477,10 @@ mod tests {
     use crate::Handler;
     use crate::Proc;
     use crate::config;
+    use crate::introspect::IntrospectMessage;
     use crate::mailbox::headers::SENDER_ACTOR_ID;
     use crate::mailbox::headers::stamp_sender_actor_id;
+    use crate::port::ControlPort;
     use crate::port::Port;
     use crate::testing::ids::test_actor_id;
 
@@ -711,9 +697,9 @@ mod tests {
         };
 
         let actor_ref: ActorAddr = test_actor_id("worker_0", "worker");
-        // Two different handler ports for the same actor (using Named::port())
-        let handler_port_1 = actor_ref.port_addr(Port::from(TestMsg1::port()));
-        let handler_port_2 = actor_ref.port_addr(Port::from(TestMsg2::port()));
+        // Two different handler ports for the same actor.
+        let handler_port_1 = actor_ref.port_addr(Port::handler::<TestMsg1>());
+        let handler_port_2 = actor_ref.port_addr(Port::handler::<TestMsg2>());
 
         // Handler ports should share a sequence (keyed by ActorAddr)
         assert_eq!(get_seq(sequencer.assign_seq(&handler_port_1)), 1);
@@ -722,7 +708,7 @@ mod tests {
 
         // Handler ports from a different actor get their own shared sequence
         let actor_ref_2: ActorAddr = test_actor_id("worker_1", "worker");
-        let handler_port_3 = actor_ref_2.port_addr(Port::from(TestMsg1::port()));
+        let handler_port_3 = actor_ref_2.port_addr(Port::handler::<TestMsg1>());
         assert_eq!(get_seq(sequencer.assign_seq(&handler_port_3)), 1); // independent from actor_ref
     }
 
@@ -736,7 +722,7 @@ mod tests {
         let actor_ref_0: ActorAddr = test_actor_id("worker_0", "worker");
         let actor_ref_1: ActorAddr = test_actor_id("worker_1", "worker");
 
-        // Non-handler ports from the same actor (without ACTOR_PORT_BIT)
+        // Ephemeral ports from the same actor.
         let port_1 = actor_ref_0.port_addr(Port::from(1));
         let port_2 = actor_ref_0.port_addr(Port::from(2));
 
@@ -763,8 +749,8 @@ mod tests {
         let actor_ref: ActorAddr = test_actor_id("worker_0", "worker");
 
         // Handler ports (share sequence per actor)
-        let handler_port_1 = actor_ref.port_addr(Port::from(TestMsg1::port()));
-        let handler_port_2 = actor_ref.port_addr(Port::from(TestMsg2::port()));
+        let handler_port_1 = actor_ref.port_addr(Port::handler::<TestMsg1>());
+        let handler_port_2 = actor_ref.port_addr(Port::handler::<TestMsg2>());
 
         // Non-handler ports (independent sequences per port)
         let non_handler_port_1 = actor_ref.port_addr(Port::from(1));
@@ -783,20 +769,19 @@ mod tests {
     #[test]
     fn bypass_registry_introspect_message() {
         assert!(is_bypass_workq_type_id(TypeId::of::<IntrospectMessage>()));
-        assert!(is_bypass_workq_actor_port(IntrospectMessage::port()));
     }
 
     #[test]
-    fn bypass_actor_port_uses_per_port_seq_counter() {
+    fn control_port_uses_per_port_seq_counter() {
         // Regression test for the seq-gap bug that caused pyspy 504s when
-        // ENABLE_DEST_ACTOR_REORDERING_BUFFER=true. A bypass-channel actor port
+        // ENABLE_DEST_ACTOR_REORDERING_BUFFER=true. A bypass-channel control port
         // (IntrospectMessage) must use SeqKey::Port so it doesn't share a counter
         // with workq-bound messages to the same actor.
         let sequencer = Sequencer::new(Uuid::now_v7());
         let actor_ref: ActorAddr = test_actor_id("agent_0", "proc_agent");
 
-        let introspect_port = actor_ref.port_addr(Port::from(IntrospectMessage::port()));
-        let regular_actor_port = actor_ref.port_addr(Port::from(TestMsg1::port()));
+        let introspect_port = actor_ref.port_addr(Port::control(ControlPort::Introspect));
+        let regular_actor_port = actor_ref.port_addr(Port::handler::<TestMsg1>());
 
         // Both should start at seq=1 because their counters are independent.
         assert_eq!(get_seq(sequencer.assign_seq(&introspect_port)), 1);
@@ -895,7 +880,7 @@ mod tests {
     fn test_sequencer_skip_advances_counter() {
         let sequencer = Sequencer::new(Uuid::now_v7());
         let actor_ref: ActorAddr = test_actor_id("test_0", "test");
-        let dest = actor_ref.port_addr(Port::from(TestMsg1::port()));
+        let dest = actor_ref.port_addr(Port::handler::<TestMsg1>());
 
         // Assign once: seq 1.
         assert_eq!(get_seq(sequencer.assign_seq(&dest)), 1);

--- a/hyperactor/src/parse/id.rs
+++ b/hyperactor/src/parse/id.rs
@@ -23,6 +23,7 @@ use crate::parse::lex::Lexer;
 use crate::parse::lex::Span;
 use crate::parse::lex::Token;
 use crate::parse::lex::TokenKind;
+use crate::port::ControlPort;
 use crate::port::Port;
 
 /// Flickr base58 alphabet.
@@ -74,12 +75,18 @@ pub(crate) fn parse_id_with_parser(parser: &mut Parser<'_>) -> Result<Id, ParseE
             parser.bump();
             let proc_id = parse_proc_id_with_parser(parser)?;
             let actor_id = ActorId::new(first, proc_id, None);
-            if parser.peek().kind == TokenKind::Colon {
-                parser.bump();
-                let port = parse_port(parser)?;
-                Ok(Id::Port(PortId::new(actor_id, port)))
-            } else {
-                Ok(Id::Actor(actor_id))
+            match parser.peek().kind {
+                TokenKind::Colon => {
+                    parser.bump();
+                    let port = parse_port(parser)?;
+                    Ok(Id::Port(PortId::new(actor_id, port)))
+                }
+                TokenKind::Bang => {
+                    parser.bump();
+                    let port = parse_control_port(parser)?;
+                    Ok(Id::Port(PortId::new(actor_id, port)))
+                }
+                _ => Ok(Id::Actor(actor_id)),
             }
         }
         _ => Ok(Id::Proc(ProcId::new(first, None))),
@@ -99,37 +106,63 @@ pub(crate) fn parse_actor_id_with_parser(parser: &mut Parser<'_>) -> Result<Acto
 
 pub(crate) fn parse_port_id_with_parser(parser: &mut Parser<'_>) -> Result<PortId, ParseError> {
     let actor_id = parse_actor_id_with_parser(parser)?;
-    parser.expect_kind(TokenKind::Colon)?;
-    let port = parse_port(parser)?;
+    let port = match parser.peek().kind {
+        TokenKind::Colon => {
+            parser.bump();
+            parse_port(parser)?
+        }
+        TokenKind::Bang => {
+            parser.bump();
+            parse_control_port(parser)?
+        }
+        _ => return Err(ParseError::expected(parser.peek(), "\":\" or \"!\"")),
+    };
     Ok(PortId::new(actor_id, port))
 }
 
 fn parse_port(parser: &mut Parser<'_>) -> Result<Port, ParseError> {
-    let port = parser.expect_text("decimal port")?;
-    if !port.text.bytes().all(|ch| ch.is_ascii_digit()) {
-        return Err(ParseError::invalid_port(port));
+    match parser.peek().kind {
+        TokenKind::Text => {
+            let port = parser.bump();
+            if port.text.bytes().all(|ch| ch.is_ascii_digit()) {
+                let port: u64 = port
+                    .text
+                    .parse()
+                    .map_err(|_| ParseError::invalid_port(port))?;
+                return Ok(Port::ephemeral(port));
+            }
+
+            let uid = parse_id_component_from_first_text(port, parser)?;
+            parse_handler_port(uid, port)
+        }
+        TokenKind::LessThan => {
+            let port = parser.peek();
+            parse_handler_port(parse_id_component(parser)?, port)
+        }
+        _ => Err(ParseError::expected(parser.peek(), "port")),
     }
-    let port: u64 = port
-        .text
-        .parse()
-        .map_err(|_| ParseError::invalid_port(port))?;
-    Ok(Port::from(port))
+}
+
+fn parse_handler_port(uid: Uid, token: Token<'_>) -> Result<Port, ParseError> {
+    match uid {
+        Uid::Instance(_, _) => Ok(Port::Handler(uid)),
+        Uid::Singleton(_) => Err(ParseError::invalid_port(token)),
+    }
+}
+
+fn parse_control_port(parser: &mut Parser<'_>) -> Result<Port, ParseError> {
+    let port = parser.expect_text("control port")?;
+    port.text
+        .parse::<ControlPort>()
+        .map(Port::control)
+        .map_err(|_| ParseError::invalid_port(port))
 }
 
 pub(crate) fn parse_id_component(parser: &mut Parser<'_>) -> Result<Uid, ParseError> {
     match parser.peek().kind {
         TokenKind::Text => {
             let label = parser.bump();
-            if parser.peek().kind == TokenKind::LessThan {
-                parser.bump();
-                let uid = parser.expect_text("uid text")?;
-                parser.expect_kind(TokenKind::GreaterThan)?;
-                let label = parse_label(label)?;
-                let uid = parse_base58_uid(uid)?;
-                Ok(Uid::Instance(uid, Some(label)))
-            } else {
-                Ok(Uid::Singleton(parse_label(label)?))
-            }
+            parse_id_component_from_first_text(label, parser)
         }
         TokenKind::LessThan => {
             parser.bump();
@@ -138,6 +171,22 @@ pub(crate) fn parse_id_component(parser: &mut Parser<'_>) -> Result<Uid, ParseEr
             Ok(Uid::Instance(parse_base58_uid(uid)?, None))
         }
         _ => Err(ParseError::expected(parser.bump(), "\"label\" or \"<\"")),
+    }
+}
+
+fn parse_id_component_from_first_text(
+    label: Token<'_>,
+    parser: &mut Parser<'_>,
+) -> Result<Uid, ParseError> {
+    if parser.peek().kind == TokenKind::LessThan {
+        parser.bump();
+        let uid = parser.expect_text("uid text")?;
+        parser.expect_kind(TokenKind::GreaterThan)?;
+        let label = parse_label(label)?;
+        let uid = parse_base58_uid(uid)?;
+        Ok(Uid::Instance(uid, Some(label)))
+    } else {
+        Ok(Uid::Singleton(parse_label(label)?))
     }
 }
 
@@ -297,6 +346,18 @@ mod tests {
             parse_port_id("controller.local:7").unwrap().to_string(),
             "controller.local:7"
         );
+        assert_eq!(
+            parse_port_id("controller.local:handler<2>")
+                .unwrap()
+                .to_string(),
+            "controller.local:handler<2>"
+        );
+        assert_eq!(
+            parse_port_id("controller.local!introspect")
+                .unwrap()
+                .to_string(),
+            "controller.local!introspect"
+        );
     }
 
     #[test]
@@ -350,7 +411,7 @@ mod tests {
     #[test]
     fn test_parse_port_id_reports_missing_port_token() {
         let err = parse_port_id("controller.local:@inproc://0").unwrap_err();
-        assert_eq!(err.to_string(), "expected decimal port, found \"@\"");
+        assert_eq!(err.to_string(), "expected port, found \"@\"");
         assert_eq!(err.span, Span::new(17, 18));
     }
 

--- a/hyperactor/src/parse/lex.rs
+++ b/hyperactor/src/parse/lex.rs
@@ -37,6 +37,8 @@ pub(crate) enum TokenKind {
     Colon,
     /// `@`
     At,
+    /// `!`
+    Bang,
     /// `<`
     LessThan,
     /// `>`
@@ -52,6 +54,7 @@ impl TokenKind {
             Self::Dot => ".",
             Self::Colon => ":",
             Self::At => "@",
+            Self::Bang => "!",
             Self::LessThan => "<",
             Self::GreaterThan => ">",
             Self::Eof => "end of input",
@@ -64,6 +67,7 @@ impl TokenKind {
             Self::Dot => "\".\"",
             Self::Colon => "\":\"",
             Self::At => "\"@\"",
+            Self::Bang => "\"!\"",
             Self::LessThan => "\"<\"",
             Self::GreaterThan => "\">\"",
             Self::Eof => "end of input",
@@ -165,6 +169,14 @@ impl<'a> Iterator for Lexer<'a> {
                     span: Span::new(start, self.offset),
                 }
             }
+            b'!' => {
+                self.offset += 1;
+                Token {
+                    kind: TokenKind::Bang,
+                    text: &self.input[start..self.offset],
+                    span: Span::new(start, self.offset),
+                }
+            }
             b'<' => {
                 self.offset += 1;
                 Token {
@@ -182,7 +194,9 @@ impl<'a> Iterator for Lexer<'a> {
                 }
             }
             _ => {
-                let len = rest.find(['.', ':', '@', '<', '>']).unwrap_or(rest.len());
+                let len = rest
+                    .find(['.', ':', '@', '!', '<', '>'])
+                    .unwrap_or(rest.len());
                 self.offset += len;
                 Token {
                     kind: TokenKind::Text,
@@ -201,7 +215,7 @@ mod tests {
 
     #[test]
     fn test_lexer_tokenizes_id_and_ref_syntax() {
-        let tokens = Lexer::new("controller<abc>.local:7@inproc://0").collect::<Vec<_>>();
+        let tokens = Lexer::new("controller<abc>.local!introspect@inproc://0").collect::<Vec<_>>();
         assert_eq!(
             tokens,
             vec![
@@ -236,34 +250,34 @@ mod tests {
                     span: Span::new(16, 21),
                 },
                 Token {
-                    kind: TokenKind::Colon,
-                    text: ":",
+                    kind: TokenKind::Bang,
+                    text: "!",
                     span: Span::new(21, 22),
                 },
                 Token {
                     kind: TokenKind::Text,
-                    text: "7",
-                    span: Span::new(22, 23),
+                    text: "introspect",
+                    span: Span::new(22, 32),
                 },
                 Token {
                     kind: TokenKind::At,
                     text: "@",
-                    span: Span::new(23, 24),
+                    span: Span::new(32, 33),
                 },
                 Token {
                     kind: TokenKind::Text,
                     text: "inproc",
-                    span: Span::new(24, 30),
+                    span: Span::new(33, 39),
                 },
                 Token {
                     kind: TokenKind::Colon,
                     text: ":",
-                    span: Span::new(30, 31),
+                    span: Span::new(39, 40),
                 },
                 Token {
                     kind: TokenKind::Text,
                     text: "//0",
-                    span: Span::new(31, 34),
+                    span: Span::new(40, 43),
                 },
             ]
         );

--- a/hyperactor/src/port.rs
+++ b/hyperactor/src/port.rs
@@ -6,20 +6,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Port identifier newtype.
+//! Port identifiers.
 
 use std::fmt;
+use std::num::ParseIntError;
 use std::str::FromStr;
 
+use enum_as_inner::EnumAsInner;
 use serde::Deserialize;
 use serde::Serialize;
-use typeuri::ACTOR_PORT_BIT;
 use typeuri::Named;
+
+use crate::id::Label;
+use crate::id::Uid;
 
 /// A port identifier within an actor.
 #[derive(
     Clone,
-    Copy,
+    EnumAsInner,
     PartialEq,
     Eq,
     Hash,
@@ -28,50 +32,165 @@ use typeuri::Named;
     Serialize,
     Deserialize
 )]
-pub struct Port(u64);
+pub enum Port {
+    /// Ephemeral ports, indexed starting at 0.
+    Ephemeral(u64),
+    /// Handler ports, indexed by uid. The label usually carries the type name.
+    Handler(Uid),
+    /// Control ports.
+    Control(ControlPort),
+}
+
+/// Runtime-owned control ports.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    Serialize,
+    Deserialize
+)]
+pub enum ControlPort {
+    /// Actor introspection.
+    Introspect,
+    /// Actor lifecycle signals.
+    Signal,
+}
+
+/// Errors that can occur when parsing a [`ControlPort`].
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ControlPortParseError {
+    /// The control port name is not known.
+    #[error("unknown control port {0:?}")]
+    Unknown(String),
+}
+
+/// Errors that can occur when parsing a [`Port`].
+#[derive(Debug, thiserror::Error)]
+pub enum PortParseError {
+    /// The ephemeral port index is invalid.
+    #[error("invalid ephemeral port: {0}")]
+    InvalidEphemeral(#[from] ParseIntError),
+    /// The handler port uid is invalid.
+    #[error("invalid handler port: {0}")]
+    InvalidHandler(#[from] crate::id::UidParseError),
+}
 
 impl Port {
+    /// Create an ephemeral port.
+    pub fn ephemeral(index: u64) -> Self {
+        Self::Ephemeral(index)
+    }
+
     /// Create a port for handler message type `M`.
     pub fn handler<M: Named>() -> Self {
-        Port(M::port())
+        Self::handler_id(M::typehash(), Some(Label::strip(handler_label::<M>())))
     }
 
-    /// Whether this port uses the handler-port discriminator bit.
-    pub fn is_handler(&self) -> bool {
-        self.0 & ACTOR_PORT_BIT != 0
+    /// Create a handler port from a type hash and optional display label.
+    pub fn handler_id(typehash: u64, label: Option<Label>) -> Self {
+        Self::Handler(Uid::Instance(typehash, label))
     }
 
-    /// The raw port index.
+    /// Create a control port.
+    pub fn control(port: ControlPort) -> Self {
+        Self::Control(port)
+    }
+
+    /// The ephemeral port index, if this is an ephemeral port.
+    pub fn ephemeral_index(&self) -> Option<u64> {
+        match self {
+            Self::Ephemeral(index) => Some(*index),
+            _ => None,
+        }
+    }
+
+    /// A numeric representation for telemetry and raw protocol fields.
     pub fn as_u64(&self) -> u64 {
-        self.0
+        match self {
+            Self::Ephemeral(index) => *index,
+            Self::Handler(uid) => uid.instance_value().unwrap_or_else(|| {
+                panic!("handler port should be identified by an instance uid: {uid}")
+            }),
+            Self::Control(ControlPort::Introspect) => 0,
+            Self::Control(ControlPort::Signal) => 1,
+        }
     }
 }
 
 impl From<u64> for Port {
     fn from(v: u64) -> Self {
-        Port(v)
+        Port::Ephemeral(v)
     }
 }
 
 impl fmt::Display for Port {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        match self {
+            Self::Ephemeral(index) => write!(f, "{index}"),
+            Self::Handler(uid) => write!(f, "{uid}"),
+            Self::Control(port) => write!(f, "{port}"),
+        }
     }
 }
 
 impl fmt::Debug for Port {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "Port({})", self.0)
+        match self {
+            Self::Ephemeral(index) => write!(f, "Port::Ephemeral({index})"),
+            Self::Handler(uid) => write!(f, "Port::Handler({uid})"),
+            Self::Control(port) => write!(f, "Port::Control({port:?})"),
+        }
     }
 }
 
 impl FromStr for Port {
-    type Err = std::num::ParseIntError;
+    type Err = PortParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let v: u64 = s.parse()?;
-        Ok(Port(v))
+        if s.bytes().all(|ch| ch.is_ascii_digit()) {
+            return Ok(Self::Ephemeral(s.parse()?));
+        }
+        let uid = s.parse()?;
+        match uid {
+            Uid::Instance(_, _) => Ok(Self::Handler(uid)),
+            Uid::Singleton(_) => Err(PortParseError::InvalidHandler(
+                crate::id::UidParseError::InvalidSyntax(s.to_string()),
+            )),
+        }
     }
+}
+
+impl fmt::Display for ControlPort {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Introspect => f.write_str("introspect"),
+            Self::Signal => f.write_str("signal"),
+        }
+    }
+}
+
+impl FromStr for ControlPort {
+    type Err = ControlPortParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "introspect" => Ok(Self::Introspect),
+            "signal" => Ok(Self::Signal),
+            _ => Err(ControlPortParseError::Unknown(s.to_string())),
+        }
+    }
+}
+
+fn handler_label<M: Named>() -> &'static str {
+    M::typename()
+        .rsplit("::")
+        .next()
+        .unwrap_or_else(M::typename)
 }
 
 #[cfg(test)]
@@ -89,28 +208,23 @@ mod tests {
     #[test]
     fn test_handler_port() {
         let port = Port::handler::<TestMsg>();
-        assert!(
-            port.is_handler(),
-            "handler ports should have ACTOR_PORT_BIT set"
-        );
-        assert_eq!(port.as_u64(), TestMsg::port());
+        assert!(port.is_handler(), "handler ports should be explicit");
+        assert_eq!(port.as_u64(), TestMsg::typehash());
     }
 
     #[test]
-    fn test_non_handler_port() {
+    fn test_ephemeral_port() {
         let port = Port::from(42);
-        assert!(
-            !port.is_handler(),
-            "plain ports should not have ACTOR_PORT_BIT set"
-        );
+        assert!(port.is_ephemeral(), "decimal ports should be ephemeral");
+        assert!(!port.is_handler(), "ephemeral ports should not be handlers");
         assert_eq!(port.as_u64(), 42);
     }
 
     #[test]
-    fn test_display_fromstr_roundtrip() {
+    fn test_display_fromstr_roundtrip_ephemeral() {
         let port = Port::from(12345);
         assert_eq!(port.to_string(), "12345");
-        let parsed: Port = port.to_string().parse().unwrap();
+        let parsed: Port = port.to_string().parse().expect("parse port");
         assert_eq!(port, parsed);
     }
 
@@ -118,13 +232,13 @@ mod tests {
     fn test_display_fromstr_roundtrip_handler() {
         let port = Port::handler::<TestMsg>();
         let s = port.to_string();
-        let parsed: Port = s.parse().unwrap();
+        let parsed: Port = s.parse().expect("parse port");
         assert_eq!(port, parsed);
     }
 
     #[test]
     fn test_debug() {
         let port = Port::from(42);
-        assert_eq!(format!("{:?}", port), "Port(42)");
+        assert_eq!(format!("{:?}", port), "Port::Ephemeral(42)");
     }
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -200,6 +200,7 @@ use crate::mailbox::UndeliverableReason;
 use crate::metrics::ACTOR_MESSAGE_HANDLER_DURATION;
 use crate::metrics::ACTOR_MESSAGE_QUEUE_SIZE;
 use crate::metrics::ACTOR_MESSAGES_RECEIVED;
+use crate::port::Port;
 use crate::subject::AsSubject as _;
 
 tokio::task_local! {
@@ -2171,13 +2172,12 @@ impl<A: Actor> Instance<A> {
         let (actor_loop, actor_loop_receivers) = actor_loop_ports.unzip();
 
         // Introspect port: a separate channel handled by a dedicated
-        // tokio task (not the actor's message loop). bind_handler_port()
-        // registers in the mailbox
-        // dispatch table at IntrospectMessage::port().
+        // tokio task (not the actor's message loop). bind_control_port()
+        // registers it in the mailbox dispatch table.
         //
         // Exercises S3, S4, S9 (see introspect module doc).
         let (introspect_port, introspect_receiver) = mailbox.open_port::<IntrospectMessage>();
-        introspect_port.bind_handler_port();
+        introspect_port.bind_control_port(crate::port::ControlPort::Introspect);
 
         let instance_id = Uuid::now_v7();
 
@@ -3544,7 +3544,7 @@ struct InstanceCellState {
     actor_task_handle: OnceLock<JoinHandle<()>>,
 
     /// The set of named ports that are exported by this actor.
-    exported_named_ports: DashMap<u64, &'static str>,
+    exported_named_ports: DashMap<Port, &'static str>,
 
     /// The number of messages processed by this actor.
     num_processed_messages: AtomicU64,
@@ -4089,7 +4089,7 @@ impl InstanceCell {
         for entry in ports.bound.iter() {
             self.inner
                 .exported_named_ports
-                .insert(*entry.key(), entry.value());
+                .insert(entry.key().clone(), entry.value());
         }
         ActorRef::attest(ActorAddr::new(
             self.actor_addr().id().clone(),
@@ -4182,7 +4182,7 @@ impl WeakInstanceCell {
 /// actor.
 pub struct HandlerPorts<A: Actor> {
     ports: DashMap<TypeId, Box<dyn Any + Send + Sync + 'static>>,
-    bound: DashMap<u64, &'static str>,
+    bound: DashMap<Port, &'static str>,
     mailbox: Mailbox,
     workq: OrderedSender<WorkCell<A>>,
     /// Per-actor queue depth (PD-5). Shared with `InstanceCellState`.
@@ -4322,8 +4322,8 @@ impl<A: Actor> HandlerPorts<A> {
     where
         A: Handler<M>,
     {
-        let port_index = M::port();
-        match self.bound.entry(port_index) {
+        let port = Port::handler::<M>();
+        match self.bound.entry(port.clone()) {
             Entry::Vacant(entry) => {
                 self.get::<M>().bind_handler_port();
                 entry.insert(M::typename());
@@ -4332,9 +4332,9 @@ impl<A: Actor> HandlerPorts<A> {
                 assert_eq!(
                     *entry.get(),
                     M::typename(),
-                    "bind {}: port index {} already bound to type {}",
+                    "bind {}: port {} already bound to type {}",
                     M::typename(),
-                    port_index,
+                    port,
                     entry.get(),
                 );
             }
@@ -4946,8 +4946,6 @@ mod tests {
     /// outbound envelope.
     #[tokio::test]
     async fn test_mailbox_ext_post_stamps_sender_actor_id() {
-        use typeuri::Named;
-
         use crate::mailbox::headers::SENDER_ACTOR_ID;
 
         #[derive(typeuri::Named)]
@@ -4981,7 +4979,7 @@ mod tests {
         // forwarder (CapturingSender), where we can inspect the headers.
         let remote_dest = ProcAddr::instance(ChannelAddr::Local(2), "remote")
             .actor_addr("worker")
-            .port_addr(Port::from(DestHandlerMsg::port()));
+            .port_addr(Port::handler::<DestHandlerMsg>());
 
         // UFCS to select MailboxExt::post over Endpoint::post (also in
         // scope at module level via `use ... as _`). Client implements
@@ -5090,7 +5088,7 @@ mod tests {
         let (port, mut receiver) = instance.bind_handler_port::<u64>();
 
         let PortLocation::Bound(default_dest) = port.location() else {
-            panic!("actor port must be bound");
+            panic!("handler port must be bound");
         };
         let alternate_dest =
             PortAddr::new(default_dest.id().clone(), ChannelAddr::Local(9876).into());
@@ -6897,8 +6895,6 @@ mod tests {
     /// is not timing-sensitive.
     #[async_timed_test(timeout_secs = 30)]
     async fn test_inbound_ordering_snapshot_callback_publishes_session() {
-        use typeuri::Named;
-
         // Pin reorder buffering ON regardless of any global config
         // overrides set by other tests in the same binary. Without this
         // guard the snapshot would observe `enabled = false` and the
@@ -6921,7 +6917,7 @@ mod tests {
         // Reserve seq 1 on the actor's BufferTestMsg handler port so
         // subsequent client posts get seqs 2..=N which then buffer
         // (waiting for seq 1, which will never arrive).
-        let handler_port = actor_id.port_addr(Port::from(BufferTestMsg::port()));
+        let handler_port = actor_id.port_addr(Port::handler::<BufferTestMsg>());
         // Reserve one seq directly on the client's sequencer. Equivalent
         // to `Instance::debug_skip_next_ordering_seq(dest, 1)`, but
         // inlined here so the test does not depend on a Client-side

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -43,6 +43,7 @@ use crate::mailbox::PortSink;
 use crate::message::Bind;
 use crate::message::Bindings;
 use crate::message::Unbind;
+use crate::port::ControlPort;
 use crate::port::Port;
 
 /// ActorRefs are typed references to actors.
@@ -59,7 +60,7 @@ impl<A: Referable> ActorRef<A> {
     where
         A: RemoteHandles<M>,
     {
-        PortRef::attest(self.actor_addr.port_addr(Port::from(<M as Named>::port())))
+        PortRef::attest(self.actor_addr.port_addr(Port::handler::<M>()))
     }
 
     /// The caller guarantees that the provided actor ID is also a valid,
@@ -273,7 +274,13 @@ impl<M: RemoteMessage> PortRef<M> {
     /// The caller attests that the provided actor exposes a reachable handler
     /// port for message type `M`.
     pub fn attest_handler_port(actor: &ActorAddr) -> Self {
-        PortRef::<M>::attest(actor.port_addr(Port::from(<M as Named>::port())))
+        PortRef::<M>::attest(actor.port_addr(Port::handler::<M>()))
+    }
+
+    /// The caller attests that the provided actor exposes a reachable control
+    /// port for message type `M`.
+    pub fn attest_control_port(actor: &ActorAddr, port: ControlPort) -> Self {
+        PortRef::<M>::attest(actor.port_addr(Port::control(port)))
     }
 
     /// The typehash of this port's reducer, if any. Reducers

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -890,6 +890,7 @@ mod tests {
     use ndslice::Slice;
     use ndslice::ViewExt;
     use ndslice::shape;
+    use ndslice::view::Ranked;
     use proptest::prelude::*;
     use timed_test::async_timed_test;
     use typeuri::Named;

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -890,7 +890,6 @@ mod tests {
     use ndslice::Slice;
     use ndslice::ViewExt;
     use ndslice::shape;
-    use ndslice::view::Ranked;
     use proptest::prelude::*;
     use timed_test::async_timed_test;
     use typeuri::Named;

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -46,7 +46,6 @@ use ndslice::Region;
 use ndslice::Shape;
 use ndslice::view::BuildFromRegionIndexed;
 use ndslice::view::MapIntoExt;
-use ndslice::view::Ranked;
 use ndslice::view::View;
 use serde::Deserialize;
 use serde::Serialize;
@@ -323,7 +322,7 @@ impl CastDomainRef {
     ) -> Result<(Uuid, ValueMesh<u64>)> {
         let sequencer = cx.instance().sequencer();
         let seqs = self.members.as_ref().map_into(|member| {
-            let port = member.port_addr(Port::from(dest_port));
+            let port = member.port_addr(Port::handler_id(dest_port, None));
             let SeqInfo::Session { session_id: _, seq } = sequencer.assign_seq(&port) else {
                 unreachable!("assign_seq always returns SeqInfo::Session");
             };
@@ -782,7 +781,9 @@ impl Handler<CastMessage> for CastActor {
             #[cfg(test)]
             headers.set(CAST_LINEAGE, local_lineage.ranks());
 
-            let dest = domain.local_actor.port_addr(Port::from(message.dest_port));
+            let dest = domain
+                .local_actor
+                .port_addr(Port::handler_id(message.dest_port, None));
             hyperactor::mailbox::headers::stamp_sender_actor_id(
                 &mut headers,
                 &seq_info,

--- a/hyperactor_macros/tests/export.rs
+++ b/hyperactor_macros/tests/export.rs
@@ -157,25 +157,21 @@ mod tests {
             // TestMessage type
             let port_id = actor_handle
                 .actor_addr()
-                .port_addr(Port::from(TestMessage::port()));
+                .port_addr(Port::handler::<TestMessage>());
             let port_ref: reference::PortRef<TestMessage> = reference::PortRef::attest(port_id);
             port_ref.post(&client, TestMessage("abc".to_string()));
             assert_eq!(rx.recv().await.unwrap(), "abc");
         }
         {
             // () type
-            let port_id = actor_handle
-                .actor_addr()
-                .port_addr(Port::from(<()>::port()));
+            let port_id = actor_handle.actor_addr().port_addr(Port::handler::<()>());
             let port_ref: reference::PortRef<()> = reference::PortRef::attest(port_id);
             port_ref.post(&client, ());
             assert_eq!(rx.recv().await.unwrap(), "()");
         }
         {
             // u64 type
-            let port_id = actor_handle
-                .actor_addr()
-                .port_addr(Port::from(<u64>::port()));
+            let port_id = actor_handle.actor_addr().port_addr(Port::handler::<u64>());
             let port_ref: reference::PortRef<u64> = reference::PortRef::attest(port_id);
             port_ref.post(&client, 987654321);
             assert_eq!(rx.recv().await.unwrap(), "u64: 987654321");
@@ -184,7 +180,7 @@ mod tests {
             // MyGeneric<()> type
             let port_id = actor_handle
                 .actor_addr()
-                .port_addr(Port::from(MyGeneric::<()>::port()));
+                .port_addr(Port::handler::<MyGeneric<()>>());
             let port_ref: reference::PortRef<MyGeneric<()>> = reference::PortRef::attest(port_id);
             port_ref.post(&client, MyGeneric(()));
             assert_eq!(rx.recv().await.unwrap(), "MyGeneric<()>");
@@ -197,7 +193,7 @@ mod tests {
             let indexed_msg = IndexedErasedUnbound::<TestMessage>::from(erased_msg);
             let port_id = actor_handle
                 .actor_addr()
-                .port_addr(Port::from(<IndexedErasedUnbound<TestMessage>>::port()));
+                .port_addr(Port::handler::<IndexedErasedUnbound<TestMessage>>());
             let port_ref: reference::PortRef<IndexedErasedUnbound<TestMessage>> =
                 reference::PortRef::attest(port_id);
             port_ref.post(&client, indexed_msg);
@@ -210,7 +206,7 @@ mod tests {
             let indexed_msg = IndexedErasedUnbound::<()>::from(erased_msg);
             let port_id = actor_handle
                 .actor_addr()
-                .port_addr(Port::from(<IndexedErasedUnbound<()>>::port()));
+                .port_addr(Port::handler::<IndexedErasedUnbound<()>>());
             let port_ref: reference::PortRef<IndexedErasedUnbound<()>> =
                 reference::PortRef::attest(port_id);
             port_ref.post(&client, indexed_msg);
@@ -223,7 +219,7 @@ mod tests {
             let indexed_msg = IndexedErasedUnbound::<MyGeneric<()>>::from(erased_msg);
             let port_id = actor_handle
                 .actor_addr()
-                .port_addr(Port::from(<IndexedErasedUnbound<MyGeneric<()>>>::port()));
+                .port_addr(Port::handler::<IndexedErasedUnbound<MyGeneric<()>>>());
             let port_ref: reference::PortRef<IndexedErasedUnbound<MyGeneric<()>>> =
                 reference::PortRef::attest(port_id);
             port_ref.post(&client, indexed_msg);
@@ -279,7 +275,7 @@ mod tests {
 
         let port_id = actor_handle
             .actor_addr()
-            .port_addr(Port::from(GenericMessage::<u64>::port()));
+            .port_addr(Port::handler::<GenericMessage<u64>>());
         let port_ref: reference::PortRef<GenericMessage<u64>> = reference::PortRef::attest(port_id);
         port_ref.post(&client, GenericMessage(42));
         assert_eq!(rx.recv().await.unwrap(), "42");

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -733,7 +733,7 @@ impl<A: Referable> ActorMeshRef<A> {
                 let port_id = actor_ids
                     .get(rank)
                     .expect("mismatched actor_ids and dest_region")
-                    .port_addr(Port::from(dest_port));
+                    .port_addr(Port::handler_id(dest_port, None));
 
                 cx.instance().post(
                     port_id,
@@ -749,7 +749,7 @@ impl<A: Referable> ActorMeshRef<A> {
             let sequencer = cx.instance().sequencer();
             let seqs: ValueMesh<u64> = actor_ids.map_into(|actor_id| {
                 let hyperactor::ordering::SeqInfo::Session { seq, .. } = sequencer
-                    .assign_seq(&actor_id.port_addr(Port::from(<M as typeuri::Named>::port())))
+                    .assign_seq(&actor_id.port_addr(Port::handler::<IndexedErasedUnbound<M>>()))
                 else {
                     unreachable!("assign_seq always returns SeqInfo::Session")
                 };

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -380,7 +380,10 @@ impl CommActor {
             .self_addr()
             .proc_addr()
             .actor_addr_uid(message.dest_port().actor_uid().clone())
-            .port_addr(hyperactor::port::Port::from(message.dest_port().port()));
+            .port_addr(hyperactor::Port::handler_id(
+                message.dest_port().port(),
+                None,
+            ));
 
         // Stamp SENDER_ACTOR_ID when headers already carry SEQ_INFO (V1
         // path). V0 path leaves SEQ_INFO absent here; MailboxExt::post will

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1961,7 +1961,10 @@ mod tests {
             .proc_addr()
             .actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
         let agent_id: ActorAddr = agent_ref;
-        let port = PortRef::<IntrospectMessage>::attest_handler_port(&agent_id);
+        let port = PortRef::<IntrospectMessage>::attest_control_port(
+            &agent_id,
+            hyperactor::ControlPort::Introspect,
+        );
 
         // Poll until we see non-zero watermark (evidence of queue
         // traffic since startup).

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -399,7 +399,10 @@ async fn query_introspect(
     timeout: Duration,
     err_ctx: &str,
 ) -> Result<IntrospectResult, anyhow::Error> {
-    let introspect_port = hyperactor::PortRef::<IntrospectMessage>::attest_handler_port(actor_id);
+    let introspect_port = hyperactor::PortRef::<IntrospectMessage>::attest_control_port(
+        actor_id,
+        hyperactor::ControlPort::Introspect,
+    );
     let (reply_handle, reply_rx) = open_once_port::<IntrospectResult>(cx);
     let mut reply_ref = reply_handle.bind();
     reply_ref.return_undeliverable(false);
@@ -424,7 +427,10 @@ async fn query_child_introspect(
     timeout: Duration,
     err_ctx: &str,
 ) -> Result<IntrospectResult, anyhow::Error> {
-    let introspect_port = hyperactor::PortRef::<IntrospectMessage>::attest_handler_port(actor_id);
+    let introspect_port = hyperactor::PortRef::<IntrospectMessage>::attest_control_port(
+        actor_id,
+        hyperactor::ControlPort::Introspect,
+    );
     let (reply_handle, reply_rx) = open_once_port::<IntrospectResult>(cx);
     let mut reply_ref = reply_handle.bind();
     reply_ref.return_undeliverable(false);
@@ -2118,7 +2124,10 @@ async fn probe_actor(
     cx: &Instance<()>,
     agent_id: &hyperactor::ActorAddr,
 ) -> Result<bool, ApiError> {
-    let port = hyperactor::PortRef::<IntrospectMessage>::attest_handler_port(agent_id);
+    let port = hyperactor::PortRef::<IntrospectMessage>::attest_control_port(
+        agent_id,
+        hyperactor::ControlPort::Introspect,
+    );
     let (handle, rx) = open_once_port::<IntrospectResult>(cx);
     port.post(
         cx,

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -1307,7 +1307,10 @@ mod tests {
         let client = client_proc.client("client");
 
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
-        let port = PortRef::<IntrospectMessage>::attest_handler_port(&agent_id);
+        let port = PortRef::<IntrospectMessage>::attest_control_port(
+            &agent_id,
+            hyperactor::ControlPort::Introspect,
+        );
 
         // Helper: send QueryChild(Proc) and return the payload with a
         // timeout so a misrouted reply fails fast rather than hanging.
@@ -1412,7 +1415,10 @@ mod tests {
         let client = client_proc.client("client");
 
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
-        let port = PortRef::<IntrospectMessage>::attest_handler_port(&agent_id);
+        let port = PortRef::<IntrospectMessage>::attest_control_port(
+            &agent_id,
+            hyperactor::ControlPort::Introspect,
+        );
 
         // Concurrent query task: send QueryChild(Proc) every 10ms.
         let query_client_proc =
@@ -1724,7 +1730,10 @@ mod tests {
         // QueryChild(Proc) — same aggregation logic as mesh-admin
         // resolution.
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
-        let port = PortRef::<IntrospectMessage>::attest_handler_port(&agent_id);
+        let port = PortRef::<IntrospectMessage>::attest_control_port(
+            &agent_id,
+            hyperactor::ControlPort::Introspect,
+        );
 
         // Poll until queue stats are non-zero.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -146,10 +146,10 @@ impl PyInstance {
     /// observable without any extra plumbing.
     #[pyo3(name = "_debug_skip_next_ordering_seq")]
     fn debug_skip_next_ordering_seq(&self, receiver: &PyActorAddr, count: u64) {
-        use typeuri::Named;
-
         use crate::actor::PythonMessage;
-        let port_addr = receiver.inner.port_addr(PythonMessage::port().into());
+        let port_addr = receiver
+            .inner
+            .port_addr(hyperactor::Port::handler::<PythonMessage>());
         self.inner.debug_skip_next_ordering_seq(&port_addr, count);
     }
 }

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -117,7 +117,9 @@ impl PyMailbox {
     }
 
     pub(super) fn post(&self, dest: &PyActorAddr, message: &PythonMessage) -> PyResult<()> {
-        let port_id = dest.inner.port_addr(PythonMessage::port().into());
+        let port_id = dest
+            .inner
+            .port_addr(hyperactor::Port::handler::<PythonMessage>());
         let message = wirevalue::Any::serialize(message).map_err(|err| {
             PyRuntimeError::new_err(format!(
                 "failed to serialize message ({:?}) to Any: {}",

--- a/monarch_hyperactor/src/proc.rs
+++ b/monarch_hyperactor/src/proc.rs
@@ -354,7 +354,7 @@ impl<M: RemoteMessage> InstanceWrapper<M> {
         );
         actor_id
             .inner
-            .port_addr(message.port().into())
+            .port_addr(hyperactor::Port::handler_id(message.port(), None))
             .send(&self.instance, message.inner.clone());
         Ok(())
     }

--- a/typeuri/src/lib.rs
+++ b/typeuri/src/lib.rs
@@ -18,9 +18,6 @@ pub use dashmap;
 // Re-export the Named derive macro from typeuri_macros
 pub use typeuri_macros::Named;
 
-/// Actor handler port should have its most significant bit set to 1.
-pub static ACTOR_PORT_BIT: u64 = 1 << 63;
-
 /// A [`Named`] type is a type that has a globally unique name.
 pub trait Named: Sized + 'static {
     /// The globally unique type name for the type.
@@ -41,10 +38,9 @@ pub trait Named: Sized + 'static {
         TypeId::of::<Self>()
     }
 
-    /// The globally unique port for this type. Typed ports are in the range
-    /// of 1<<63..1<<64-1.
+    /// A globally unique numeric identifier for this type.
     fn port() -> u64 {
-        Self::typehash() | ACTOR_PORT_BIT
+        Self::typehash()
     }
 
     /// If the named type is an enum, this returns the name of the arm
@@ -206,7 +202,7 @@ mod tests {
     #[test]
     fn test_ports() {
         assert_eq!(String::typehash(), 3947244799002047352u64);
-        assert_eq!(String::port(), 13170616835856823160u64);
+        assert_eq!(String::port(), String::typehash());
         assert_ne!(
             Vec::<Vec::<Vec::<String>>>::typehash(),
             Vec::<Vec::<Vec::<Vec::<String>>>>::typehash(),

--- a/wirevalue/src/lib.rs
+++ b/wirevalue/src/lib.rs
@@ -697,7 +697,7 @@ mod tests {
     #[test]
     fn test_ports() {
         assert_eq!(String::typehash(), 3947244799002047352u64);
-        assert_eq!(String::port(), 13170616835856823160u64);
+        assert_eq!(String::port(), String::typehash());
         assert_ne!(
             Vec::<Vec::<Vec::<String>>>::typehash(),
             Vec::<Vec::<Vec::<Vec::<String>>>>::typehash(),


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4179
* #4178
* #4177
* #4176
* __->__ #4175

A `Port` is today a u64, but that integer carries more specific meaning, by reserving different ranges for handler and ephemeral ports. There is also a third category of port -- the control port, which is used to talk to the actor's *runtime* which is not explicitly represented today.

This change makes it all explicit:

Convert `Port` from a numeric encoding to explicit `Ephemeral`, `Handler`, and `Control` variants. Update address parsing/display for decimal ephemeral ports, UID handler ports, and `!`-delimited control ports; bind introspection as a control port; update mailbox, ordering, mesh cast routing, Monarch bindings, docs, and tests. Remove `ACTOR_PORT_BIT` usage and standardize on handler-port terminology.

Differential Revision: [D107330910](https://our.internmc.facebook.com/intern/diff/D107330910/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D107330910/)!