### PR TITLE
[hyperactor] use receiver-local sequencing for handler work

### DIFF
--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -133,23 +133,23 @@
 //!     while the cell exists -- inherit that Some.
 //!   * `Some({enabled: false, ...})` -- ordered path exists but reorder
 //!     buffering is disabled; `sessions` is empty regardless of traffic.
-//!     Messages flow via `OrderedSender::direct_send`.
+//!     Messages bypass receiver-local sequencing.
 //!   * `Some({enabled: true, ...})` -- buffering active; `sessions`
 //!     is meaningful.
 //!
 //!   `None` is NOT equivalent to `Some({enabled: false, ...})`.
 //! - **IO-2 (inbound-ordering reflects publish-time state):** When
 //!   present, the snapshot is computed at `build_actor_attrs`
-//!   invocation time via `OrderedSender::snapshot`. `last_released_seq`
-//!   etc. are point-in-time. Sessions held by a concurrent `send` show
-//!   up in `skipped_session_count` (never silently omitted);
+//!   invocation time via the sequenced receiver's snapshot handle.
+//!   `last_released_seq` etc. are point-in-time. Sessions held by a
+//!   concurrent receive show up in `skipped_session_count` (never silently omitted);
 //!   `is_complete()` reports the all-clear.
 //! - **IO-3 (queue-depth and inbound-ordering are independent
 //!   diagnostics, no arithmetic contract):**
 //!   * `ACTOR_QUEUE_DEPTH` (per PD-5a/PD-5b in `proc.rs`): accepted
 //!     handler work not yet dequeued by the actor loop.
 //!   * `INBOUND_ORDERING.sessions[*].buffered_count`: messages held by
-//!     `OrderedSender` waiting for a seq gap to fill.
+//!     receiver-local sequencing waiting for a seq gap to fill.
 //!
 //!   These are two independent point-in-time diagnostics. No
 //!   arithmetic or ordering relationship between them is part of the
@@ -420,9 +420,9 @@ declare_attrs! {
     })
     pub attr ACTOR_QUEUE_DEPTH: u64 = 0;
 
-    /// Per-session reorder state from `OrderedSender::snapshot`.
+    /// Per-session reorder state from the sequenced receiver snapshot.
     /// `sessions[*].buffered_count` reports messages held by
-    /// `OrderedSender` waiting for a seq gap to fill. Independent
+    /// receiver-local sequencing waiting for a seq gap to fill. Independent
     /// diagnostic from `queue_depth`; no arithmetic contract -- see
     /// IO-3.
     ///
@@ -431,7 +431,7 @@ declare_attrs! {
     /// means the path exists but buffering is disabled. See IO-1.
     @meta(INTROSPECT = IntrospectAttr {
         name: "inbound_ordering".into(),
-        desc: "Per-session reorder-buffer state from OrderedSender. Independent diagnostic from queue_depth; no arithmetic contract -- see IO-3. Absence vs Some({enabled: false}) is meaningful -- see IO-1.".into(),
+        desc: "Per-session reorder-buffer state from receiver-local sequencing. Independent diagnostic from queue_depth; no arithmetic contract -- see IO-3. Absence vs Some({enabled: false}) is meaningful -- see IO-1.".into(),
     })
     pub attr INBOUND_ORDERING: crate::ordering::OrderingSnapshot;
 }

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -12,17 +12,13 @@
 use std::any::TypeId;
 use std::collections::HashMap;
 use std::fmt;
-use std::ops::DerefMut;
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use dashmap::DashMap;
 use hyperactor_config::AttrValue;
 use hyperactor_config::attrs::declare_attrs;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::sync::mpsc;
-use tokio::sync::mpsc::error::SendError;
 use typeuri::Named;
 use uuid::Uuid;
 
@@ -39,226 +35,16 @@ pub(crate) fn is_bypass_workq_type_id(id: TypeId) -> bool {
     id == TypeId::of::<crate::introspect::IntrospectMessage>()
 }
 
-/// A client's re-ordering buffer state.
-struct BufferState<T> {
-    /// the last sequence number sent to receiver for this client. seq starts
-    /// with 1 and 0 mean no message has been sent.
-    last_seq: u64,
-    /// Buffer out-of-order messages in order to ensures messages are delivered
-    /// strictly in per-client sequence order.
-    ///
-    /// Map's key is seq_no, value is msg.
-    buffer: HashMap<u64, T>,
-    /// Sender ActorAddr, populated by **first non-None wins**: any
-    /// arrival carrying a sender claims the slot if it's still None.
-    /// Captured before the seq-ordering match, so even messages that are
-    /// buffered (not delivered) or rejected as duplicate still record the
-    /// sender. None when the originating send bypassed the normal
-    /// `MailboxExt::post` / `PortHandle::try_post` / cast-leaf path (rare).
-    sender: Option<ActorAddr>,
-}
-
-impl<T> Default for BufferState<T> {
-    fn default() -> Self {
-        Self {
-            last_seq: 0,
-            buffer: HashMap::new(),
-            sender: None,
-        }
-    }
-}
-
-/// The sending half of an ordered channel; internally tracks one ordering
-/// stream per remote sender session.
-pub(crate) struct OrderedSender<T> {
-    tx: mpsc::UnboundedSender<T>,
-    /// Per-session reorder state keyed by `SeqInfo::Session.session_id`; one
-    /// entry corresponds to one logical sender stream.
-    states: Arc<DashMap<Uuid, Arc<Mutex<BufferState<T>>>>>,
-    pub(crate) enable_buffering: bool,
-    /// The identity of this object, used to distinguish it in debugging.
-    log_id: String,
-}
-
-/// A receiver that receives messages in per-client sequence order.
-pub(crate) fn ordered_channel<T>(
-    log_id: String,
-    enable_buffering: bool,
-) -> (OrderedSender<T>, mpsc::UnboundedReceiver<T>) {
-    let (tx, rx) = mpsc::unbounded_channel();
-    (
-        OrderedSender {
-            tx,
-            states: Arc::new(DashMap::new()),
-            enable_buffering,
-            log_id,
-        },
-        rx,
-    )
-}
-
-#[derive(Debug)]
-pub(crate) enum OrderedSenderError<T> {
-    InvalidZeroSeq(T),
-    SendError(SendError<T>),
-    FlushError(anyhow::Error),
-}
-
-impl<T> Clone for OrderedSender<T> {
-    fn clone(&self) -> Self {
-        Self {
-            tx: self.tx.clone(),
-            states: self.states.clone(),
-            enable_buffering: self.enable_buffering,
-            log_id: self.log_id.clone(),
-        }
-    }
-}
-
-impl<T> OrderedSender<T> {
-    /// Buffer msgs if necessary, and deliver them to receiver based on their
-    /// seqs in monotonically increasing order. Note seq is scoped by `sender`
-    /// so the ordering is also scoped by it.
-    ///
-    /// Locking behavior:
-    ///
-    /// For the same channel,
-    /// * Calls from the same client will be serialized with a lock.
-    /// * calls from different clients will be executed concurrently.
-    pub(crate) fn send(
-        &self,
-        session_id: Uuid,
-        seq_no: u64,
-        sender: Option<ActorAddr>,
-        msg: T,
-    ) -> Result<(), OrderedSenderError<T>> {
-        use std::cmp::Ordering;
-
-        assert!(self.enable_buffering);
-        if seq_no == 0 {
-            return Err(OrderedSenderError::InvalidZeroSeq(msg));
-        }
-
-        // Make sure only this session's state is locked, not all states.
-        let state = self.states.entry(session_id).or_default().value().clone();
-        let mut state_guard = state.lock().unwrap();
-
-        // Capture sender BEFORE the seq match: first non-None wins.
-        // Ensures sender is recorded even when the message is buffered
-        // (not delivered) or rejected as duplicate.
-        if state_guard.sender.is_none()
-            && let Some(addr) = sender
-        {
-            state_guard.sender = Some(addr);
-        }
-
-        let BufferState {
-            last_seq,
-            buffer,
-            sender: _,
-        } = state_guard.deref_mut();
-
-        match seq_no.cmp(&(*last_seq + 1)) {
-            Ordering::Less => {
-                tracing::warn!(
-                    "{} duplicate message from session {} with seq no: {}",
-                    self.log_id,
-                    session_id,
-                    seq_no,
-                );
-            }
-            Ordering::Greater => {
-                // Future message: buffer until the gap is filled.
-                let old = buffer.insert(seq_no, msg);
-                assert!(
-                    old.is_none(),
-                    "{}: same seq is insert to buffer twice: {}",
-                    self.log_id,
-                    seq_no
-                );
-            }
-            Ordering::Equal => {
-                // In-order: deliver, then flush consecutives from buffer until
-                // it reaches a gap.
-                self.tx.send(msg).map_err(OrderedSenderError::SendError)?;
-                *last_seq += 1;
-
-                while let Some(m) = buffer.remove(&(*last_seq + 1)) {
-                    match self.tx.send(m) {
-                        Ok(()) => *last_seq += 1,
-                        Err(err) => {
-                            let flush_err = OrderedSenderError::FlushError(anyhow::anyhow!(
-                                "failed to flush buffered message: {}",
-                                err
-                            ));
-                            buffer.insert(*last_seq + 1, err.0);
-                            return Err(flush_err);
-                        }
-                    }
-                }
-                // We do not remove a client's state even if its buffer becomes
-                // empty. This is because a duplicate message might arrive after
-                // the buffer became empty. Removing the state would cause the
-                // duplicate message to be delivered.
-            }
-        }
-
-        Ok(())
-    }
-
-    pub(crate) fn direct_send(&self, msg: T) -> Result<(), SendError<T>> {
-        self.tx.send(msg)
-    }
-
-    /// Out-of-band snapshot of per-session ordering state. Reads each
-    /// session's state via `try_lock`; sessions held by a concurrent
-    /// `send` are counted in `skipped_session_count`, not silently
-    /// dropped. Returned `sessions` are sorted by `session_id` so output
-    /// is stable across calls and across DashMap iteration order.
-    #[allow(dead_code)]
-    pub(crate) fn snapshot(&self) -> OrderingSnapshot {
-        let mut sessions = Vec::new();
-        let mut skipped = 0usize;
-        for entry in self.states.iter() {
-            let session_id = *entry.key();
-            match entry.value().try_lock() {
-                Ok(state) => {
-                    let oldest = state.buffer.keys().min().copied();
-                    let newest = state.buffer.keys().max().copied();
-                    sessions.push(OrderingSessionSnapshot {
-                        session_id,
-                        sender: state.sender.clone(),
-                        last_released_seq: state.last_seq,
-                        expected_next_seq: state.last_seq.saturating_add(1),
-                        buffered_count: state.buffer.len(),
-                        oldest_buffered_seq: oldest,
-                        newest_buffered_seq: newest,
-                    });
-                }
-                Err(_) => skipped += 1,
-            }
-        }
-        // DashMap iter is nondeterministic; sort by session_id for
-        // stable output.
-        sessions.sort_by_key(|s| s.session_id);
-        OrderingSnapshot {
-            enabled: self.enable_buffering,
-            sessions,
-            skipped_session_count: skipped,
-        }
-    }
-}
-
-/// Per-session ordering snapshot. Read out-of-band from `OrderedSender`;
-/// does not lock the work queue or hold per-session mutexes across awaits.
+/// Per-session receiver-local ordering snapshot. This does not lock the
+/// work queue or hold sequencing state across awaits.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Named, AttrValue)]
 pub struct OrderingSessionSnapshot {
     /// Identifier of the session whose ordering state this snapshot
     /// describes; matches `SeqInfo::Session { session_id, .. }` on the
-    /// wire and the DashMap key in `OrderedSender::states`.
+    /// wire.
     pub session_id: Uuid,
 
-    /// Sender `ActorAddr` captured by `BufferState`'s first-non-None-wins
+    /// Sender `ActorAddr` captured by the first-non-None-wins
     /// rule. `None` when every message in this session bypassed the
     /// normal stamping sites (rare: test fixtures, non-handler routes).
     pub sender: Option<ActorAddr>,
@@ -282,37 +68,33 @@ pub struct OrderingSessionSnapshot {
     pub newest_buffered_seq: Option<u64>,
 }
 
-/// Diagnostic projection of an `OrderedSender`.
+/// Diagnostic projection of receiver-local ordering state.
 ///
-/// `OrderedSender` is the sending half of an ordered channel for one actor
-/// work queue, but it multiplexes many remote sender sessions internally.
-/// Each `OrderingSessionSnapshot` corresponds to one `BufferState` entry,
-/// keyed by `SeqInfo::Session.session_id`. Sequence progress here means
+/// Each `OrderingSessionSnapshot` corresponds to one sender session keyed
+/// by `SeqInfo::Session.session_id`. Sequence progress here means
 /// "released into the actor work queue", not "processed by the actor handler".
 ///
 /// Carries completeness metadata so callers can distinguish "no stalled
 /// sessions" from "snapshot was partial" from "buffering is disabled".
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Named, AttrValue)]
 pub struct OrderingSnapshot {
-    /// Whether reorder buffering is enabled for this sender. When
-    /// `false`, messages flow via `direct_send` and `sessions` is empty
-    /// even under load. Sourced from `OrderedSender::enable_buffering`.
+    /// Whether reorder buffering is enabled. When `false`, messages
+    /// bypass sequencing, and `sessions` is empty even under load.
     pub enabled: bool,
 
     /// Per-session entries, sorted by `session_id` for stable output.
     /// Includes idle (drained) sessions with `buffered_count == 0`.
     pub sessions: Vec<OrderingSessionSnapshot>,
 
-    /// Sessions whose mutex was held by a concurrent send when we tried
-    /// to snapshot. NOT in `sessions`. Zero means the snapshot is
-    /// complete.
+    /// Sessions that could not be observed because sequencing state was
+    /// busy when we tried to snapshot. NOT in `sessions`. Zero means
+    /// the snapshot is complete.
     pub skipped_session_count: usize,
 }
 
 impl OrderingSnapshot {
-    /// True when no session was skipped due to a concurrent send -- i.e.,
-    /// every live session's state was successfully captured in
-    /// `sessions`.
+    /// True when no session was skipped, i.e., every live session's
+    /// state was successfully captured in `sessions`.
     pub fn is_complete(&self) -> bool {
         self.skipped_session_count == 0
     }
@@ -369,6 +151,13 @@ pub enum SeqInfo {
     /// This message does not have a seq number and should be delivered
     /// immediately.
     Direct,
+}
+
+impl SeqInfo {
+    /// Whether this sequencing metadata is valid for receive-side ordering.
+    pub fn is_valid(&self) -> bool {
+        !matches!(self, Self::Session { seq: 0, .. })
+    }
 }
 
 impl fmt::Display for SeqInfo {
@@ -495,14 +284,6 @@ mod tests {
     #[derive(Named)]
     struct TestMsg2;
 
-    fn drain_try_recv<T: std::fmt::Debug + Clone>(rx: &mut mpsc::UnboundedReceiver<T>) -> Vec<T> {
-        let mut out = Vec::new();
-        while let Ok(m) = rx.try_recv() {
-            out.push(m);
-        }
-        out
-    }
-
     /// Helper to extract seq from SeqInfo::Session variant (for tests only)
     fn get_seq(seq_info: SeqInfo) -> u64 {
         match seq_info {
@@ -512,164 +293,12 @@ mod tests {
     }
 
     #[test]
-    fn test_ordered_channel_single_client_send_in_order() {
-        let session_id_a = Uuid::now_v7();
-        let (tx, mut rx) = ordered_channel::<u64>("test".to_string(), true);
-        for s in 1..=10 {
-            tx.send(session_id_a, s, None, s).unwrap();
-            let got = drain_try_recv(&mut rx);
-            assert_eq!(got, vec![s]);
-        }
-    }
+    fn seq_info_validity_rejects_zero_session_seq() {
+        let session_id = Uuid::now_v7();
 
-    #[test]
-    fn test_ordered_channel_single_client_send_out_of_order() {
-        let session_id_a = Uuid::now_v7();
-        let (tx, mut rx) = ordered_channel::<u64>("test".to_string(), true);
-
-        // Send 2 to 4 in descending order: all should buffer until 1 arrives.
-        for s in (2..=4).rev() {
-            tx.send(session_id_a, s, None, s).unwrap();
-        }
-
-        // Send 7 to 9 in descending order: all should buffer until 1 - 6 arrives.
-        for s in (7..=9).rev() {
-            tx.send(session_id_a, s, None, s).unwrap();
-        }
-
-        assert!(
-            drain_try_recv(&mut rx).is_empty(),
-            "nothing should be delivered yet"
-        );
-
-        // Now send 1: should deliver 1 then flush 2 - 4.
-        tx.send(session_id_a, 1, None, 1).unwrap();
-        assert_eq!(drain_try_recv(&mut rx), vec![1, 2, 3, 4]);
-
-        // Now send 5: should deliver immediately but not flush 7 - 9.
-        tx.send(session_id_a, 5, None, 5).unwrap();
-        assert_eq!(drain_try_recv(&mut rx), vec![5]);
-
-        // Now send 6: should deliver 6 then flush 7 - 9.
-        tx.send(session_id_a, 6, None, 6).unwrap();
-        assert_eq!(drain_try_recv(&mut rx), vec![6, 7, 8, 9]);
-
-        // Send 10: should deliver immediately.
-        tx.send(session_id_a, 10, None, 10).unwrap();
-        let got = drain_try_recv(&mut rx);
-        assert_eq!(got, vec![10]);
-    }
-
-    #[test]
-    fn test_ordered_channel_multi_clients() {
-        let session_id_a = Uuid::now_v7();
-        let session_id_b = Uuid::now_v7();
-        let (tx, mut rx) = ordered_channel::<(Uuid, u64)>("test".to_string(), true);
-
-        // A1 -> deliver
-        tx.send(session_id_a, 1, None, (session_id_a, 1)).unwrap();
-        assert_eq!(drain_try_recv(&mut rx), vec![(session_id_a, 1)]);
-        // B1 -> deliver
-        tx.send(session_id_b, 1, None, (session_id_b, 1)).unwrap();
-        assert_eq!(drain_try_recv(&mut rx), vec![(session_id_b, 1)]);
-        for s in (3..=5).rev() {
-            // A3-5 -> buffer (waiting for A2)
-            tx.send(session_id_a, s, None, (session_id_a, s)).unwrap();
-            // B3-5 -> buffer (waiting for B2)
-            tx.send(session_id_b, s, None, (session_id_b, s)).unwrap();
-        }
-        for s in (7..=9).rev() {
-            // A7-9 -> buffer (waiting for A1-6)
-            tx.send(session_id_a, s, None, (session_id_a, s)).unwrap();
-            // B7-9 -> buffer (waiting for B1-6)
-            tx.send(session_id_b, s, None, (session_id_b, s)).unwrap();
-        }
-        assert!(
-            drain_try_recv(&mut rx).is_empty(),
-            "nothing should be delivered yet"
-        );
-
-        // A2 -> deliver A2 then flush A3
-        tx.send(session_id_a, 2, None, (session_id_a, 2)).unwrap();
-        assert_eq!(
-            drain_try_recv(&mut rx),
-            vec![
-                (session_id_a, 2),
-                (session_id_a, 3),
-                (session_id_a, 4),
-                (session_id_a, 5),
-            ]
-        );
-        // B2 -> deliver B2 then flush B3
-        tx.send(session_id_b, 2, None, (session_id_b, 2)).unwrap();
-        assert_eq!(
-            drain_try_recv(&mut rx),
-            vec![
-                (session_id_b, 2),
-                (session_id_b, 3),
-                (session_id_b, 4),
-                (session_id_b, 5),
-            ]
-        );
-
-        // A6 -> should deliver immediately and flush A7-9
-        tx.send(session_id_a, 6, None, (session_id_a, 6)).unwrap();
-        assert_eq!(
-            drain_try_recv(&mut rx),
-            vec![
-                (session_id_a, 6),
-                (session_id_a, 7),
-                (session_id_a, 8),
-                (session_id_a, 9)
-            ]
-        );
-        // B6 -> should deliver immediately and flush B7-9
-        tx.send(session_id_b, 6, None, (session_id_b, 6)).unwrap();
-        assert_eq!(
-            drain_try_recv(&mut rx),
-            vec![
-                (session_id_b, 6),
-                (session_id_b, 7),
-                (session_id_b, 8),
-                (session_id_b, 9)
-            ]
-        );
-    }
-
-    #[test]
-    fn test_ordered_channel_duplicates() {
-        let session_id_a = Uuid::now_v7();
-        fn verify_empty_buffers<T>(states: &DashMap<Uuid, Arc<Mutex<BufferState<T>>>>) {
-            for entry in states.iter() {
-                assert!(entry.value().lock().unwrap().buffer.is_empty());
-            }
-        }
-
-        let (tx, mut rx) = ordered_channel::<(Uuid, u64)>("test".to_string(), true);
-        // A1 -> deliver
-        tx.send(session_id_a, 1, None, (session_id_a, 1)).unwrap();
-        assert_eq!(drain_try_recv(&mut rx), vec![(session_id_a, 1)]);
-        verify_empty_buffers(&tx.states);
-        // duplicate A1 -> drop even if the message is different.
-        tx.send(session_id_a, 1, None, (session_id_a, 1_000))
-            .unwrap();
-        assert!(
-            drain_try_recv(&mut rx).is_empty(),
-            "nothing should be delivered yet"
-        );
-        verify_empty_buffers(&tx.states);
-        // A2 -> deliver
-        tx.send(session_id_a, 2, None, (session_id_a, 2)).unwrap();
-        assert_eq!(drain_try_recv(&mut rx), vec![(session_id_a, 2)]);
-        verify_empty_buffers(&tx.states);
-        // late A1 duplicate -> drop
-        tx.send(session_id_a, 1, None, (session_id_a, 1_001))
-            .unwrap();
-        assert!(
-            drain_try_recv(&mut rx).is_empty(),
-            "nothing should be delivered yet"
-        );
-        verify_empty_buffers(&tx.states);
+        assert!(SeqInfo::Direct.is_valid());
+        assert!(SeqInfo::Session { session_id, seq: 1 }.is_valid());
+        assert!(!SeqInfo::Session { session_id, seq: 0 }.is_valid());
     }
 
     #[test]
@@ -791,86 +420,6 @@ mod tests {
         assert_eq!(get_seq(sequencer.assign_seq(&regular_actor_port)), 2);
     }
 
-    // --- SENDER_ACTOR_ID capture tests ---
-
-    /// First send carrying a sender populates BufferState.sender.
-    #[test]
-    fn test_ordered_send_records_sender_on_first_with_addr() {
-        let session_id = Uuid::now_v7();
-        let addr: ActorAddr = test_actor_id("sender_0", "client");
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-
-        tx.send(session_id, 1, Some(addr.clone()), 1).unwrap();
-
-        let state = tx.states.get(&session_id).unwrap().value().clone();
-        assert_eq!(state.lock().unwrap().sender, Some(addr));
-    }
-
-    /// First-non-None wins: a None arrival doesn't claim the slot; a
-    /// subsequent Some arrival does.
-    #[test]
-    fn test_ordered_send_first_non_none_wins() {
-        let session_id = Uuid::now_v7();
-        let addr: ActorAddr = test_actor_id("sender_0", "client");
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-
-        tx.send(session_id, 1, None, 1).unwrap();
-        tx.send(session_id, 2, Some(addr.clone()), 2).unwrap();
-
-        let state = tx.states.get(&session_id).unwrap().value().clone();
-        assert_eq!(state.lock().unwrap().sender, Some(addr));
-    }
-
-    /// Second non-None arrival does NOT overwrite the first. Pathological
-    /// (shouldn't happen in production); documents the invariant.
-    #[test]
-    fn test_ordered_send_second_addr_does_not_overwrite() {
-        let session_id = Uuid::now_v7();
-        let addr1: ActorAddr = test_actor_id("first_0", "client");
-        let addr2: ActorAddr = test_actor_id("second_0", "client");
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-
-        tx.send(session_id, 1, Some(addr1.clone()), 1).unwrap();
-        tx.send(session_id, 2, Some(addr2), 2).unwrap();
-
-        let state = tx.states.get(&session_id).unwrap().value().clone();
-        assert_eq!(state.lock().unwrap().sender, Some(addr1));
-    }
-
-    /// All sends with None sender produce BufferState.sender = None; no panic.
-    #[test]
-    fn test_ordered_send_sender_absent() {
-        let session_id = Uuid::now_v7();
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-
-        tx.send(session_id, 1, None, 1).unwrap();
-        tx.send(session_id, 2, None, 2).unwrap();
-
-        let state = tx.states.get(&session_id).unwrap().value().clone();
-        assert_eq!(state.lock().unwrap().sender, None);
-    }
-
-    /// Sender is captured even for messages that are buffered (not yet
-    /// delivered) -- capture runs before the seq match.
-    #[test]
-    fn test_ordered_send_sender_capture_runs_before_seq_match() {
-        let session_id = Uuid::now_v7();
-        let addr: ActorAddr = test_actor_id("sender_0", "client");
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-
-        // Send seq 5 first: seq 1 is missing, so this gets buffered.
-        // Sender capture must still happen before the buffer insert.
-        tx.send(session_id, 5, Some(addr.clone()), 5).unwrap();
-
-        let state = tx.states.get(&session_id).unwrap().value().clone();
-        let guard = state.lock().unwrap();
-        assert_eq!(guard.sender, Some(addr));
-        // Confirm the message was buffered (not delivered): last_seq stays 0
-        // and the buffer holds the message.
-        assert_eq!(guard.last_seq, 0);
-        assert!(guard.buffer.contains_key(&5));
-    }
-
     /// Sequencer-level test for the debug-skip helper's underlying behavior:
     /// `assign_seq` called `count` times advances the per-(actor,dest)
     /// counter, so a subsequent `assign_seq` returns `count + 1` not 1.
@@ -892,121 +441,6 @@ mod tests {
 
         // Next assignment is seq 4, not 2.
         assert_eq!(get_seq(sequencer.assign_seq(&dest)), 4);
-    }
-
-    // --------------------------------------------------------------------
-    // OrderedSender::snapshot accessor tests.
-
-    #[test]
-    fn test_snapshot_empty() {
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-        let snap = tx.snapshot();
-        assert!(snap.enabled);
-        assert!(snap.sessions.is_empty());
-        assert_eq!(snap.skipped_session_count, 0);
-        assert!(snap.is_complete());
-    }
-
-    #[test]
-    fn test_snapshot_in_order() {
-        let addr: ActorAddr = test_actor_id("sender_actor", "client");
-        let session_id = Uuid::from_u128(1);
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-        for s in 1..=3u64 {
-            tx.send(session_id, s, Some(addr.clone()), s).unwrap();
-        }
-
-        let snap = tx.snapshot();
-        assert_eq!(snap.sessions.len(), 1);
-        let session = &snap.sessions[0];
-        assert_eq!(session.session_id, session_id);
-        assert_eq!(session.sender, Some(addr));
-        assert_eq!(session.last_released_seq, 3);
-        assert_eq!(session.expected_next_seq, 4);
-        assert_eq!(session.buffered_count, 0);
-        assert_eq!(session.oldest_buffered_seq, None);
-        assert_eq!(session.newest_buffered_seq, None);
-    }
-
-    #[test]
-    fn test_snapshot_out_of_order() {
-        let addr: ActorAddr = test_actor_id("sender_actor", "client");
-        let session_id = Uuid::from_u128(1);
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-
-        tx.send(session_id, 1, Some(addr.clone()), 1).unwrap();
-        tx.send(session_id, 3, None, 3).unwrap();
-        tx.send(session_id, 5, None, 5).unwrap();
-
-        let snap = tx.snapshot();
-        assert_eq!(snap.sessions.len(), 1);
-        let session = &snap.sessions[0];
-        assert_eq!(session.last_released_seq, 1);
-        assert_eq!(session.expected_next_seq, 2);
-        assert_eq!(session.buffered_count, 2);
-        assert_eq!(session.oldest_buffered_seq, Some(3));
-        assert_eq!(session.newest_buffered_seq, Some(5));
-        assert_eq!(session.sender, Some(addr));
-    }
-
-    /// The sender captured in `BufferState` during `OrderedSender::send`
-    /// flows out through the snapshot accessor's `sender` field.
-    #[test]
-    fn test_snapshot_includes_sender() {
-        let addr: ActorAddr = test_actor_id("captured", "client");
-        let session_id = Uuid::from_u128(1);
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-        tx.send(session_id, 1, Some(addr.clone()), 1).unwrap();
-
-        let snap = tx.snapshot();
-        assert_eq!(snap.sessions[0].sender, Some(addr));
-    }
-
-    #[test]
-    fn test_snapshot_completeness_under_concurrent_send() {
-        let session_a = Uuid::from_u128(1);
-        let session_b = Uuid::from_u128(2);
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-        tx.send(session_a, 1, None, 1).unwrap();
-        tx.send(session_b, 1, None, 1).unwrap();
-
-        // Hold session_a's mutex; snapshot's try_lock on this session
-        // should fail and be counted as skipped.
-        let state_a = tx.states.get(&session_a).unwrap().value().clone();
-        let _guard = state_a.lock().unwrap();
-
-        let snap = tx.snapshot();
-        assert_eq!(snap.skipped_session_count, 1);
-        assert!(!snap.is_complete());
-        // session_b's mutex is free; it should still appear in `sessions`.
-        assert_eq!(snap.sessions.len(), 1);
-        assert_eq!(snap.sessions[0].session_id, session_b);
-    }
-
-    #[test]
-    fn test_snapshot_disabled_buffering() {
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), false);
-        let snap = tx.snapshot();
-        assert!(!snap.enabled);
-        assert!(snap.sessions.is_empty());
-    }
-
-    /// Pins the `sort_by_key(|s| s.session_id)` guarantee. Uses fixed
-    /// UUIDs (not `Uuid::now_v7()`) so the test is independent of
-    /// timestamp ordering. Sends `session_hi` first, then `session_lo`,
-    /// then asserts the snapshot orders them low -> high.
-    #[test]
-    fn test_snapshot_sorted_by_session_id() {
-        let session_lo = Uuid::from_u128(1);
-        let session_hi = Uuid::from_u128(2);
-        let (tx, _rx) = ordered_channel::<u64>("test".to_string(), true);
-        tx.send(session_hi, 1, None, 1).unwrap();
-        tx.send(session_lo, 1, None, 1).unwrap();
-
-        let snap = tx.snapshot();
-        assert_eq!(snap.sessions.len(), 2);
-        assert_eq!(snap.sessions[0].session_id, session_lo);
-        assert_eq!(snap.sessions[1].session_id, session_hi);
     }
 
     /// Pins the exact `AttrValue` contract used by `declare_attrs!`
@@ -1037,7 +471,7 @@ mod tests {
     // send normally to a ChaosActor. ChaosActor forwards the same messages
     // to ReceiverActor, but in shuffled batches and with optional duplicate
     // replay. ReceiverActor only records what its handler observes; its
-    // mailbox OrderedSender is responsible for restoring per-session order.
+    // sequenced handler receiver restores per-session order.
 
     #[derive(Clone, Debug, Serialize, Deserialize, Named)]
     struct Frame {
@@ -1050,7 +484,7 @@ mod tests {
         sender_idx: u32,
     }
 
-    // What ReceiverActor observed after its mailbox OrderedSender released a
+    // What ReceiverActor observed after its sequenced handler receiver released a
     // frame: the preserved ordering header, the sender-owner header, and the
     // test payload.
     type ReceivedFrame = (SeqInfo, Option<ActorAddr>, Frame);
@@ -1277,9 +711,9 @@ mod tests {
             }
 
             // Replay selected frames after the original batch. A duplicate
-            // that arrives while its original is still buffered trips
-            // OrderedSender's duplicate-buffer assert; these replays are
-            // intended to hit the late-duplicate drop path instead.
+            // that arrives while its original is still buffered is dropped
+            // as a duplicate; these replays are intended to hit the
+            // late-duplicate drop path instead.
             for (seq_info, headers, frame) in duplicates {
                 let (session_id, seq) = match &seq_info {
                     SeqInfo::Session { session_id, seq } => (*session_id, *seq),
@@ -1488,7 +922,7 @@ mod tests {
             overflow,
             0,
             "stats.receiver_overflow = {overflow}; duplicate leaked past \
-             OrderedSender's drop branch after snapshot; {}",
+             sequenced receiver drop branch after snapshot; {}",
             dump_trace(),
         );
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -52,9 +52,9 @@
 //!   not yet dequeued by the actor loop. Accounting increments in
 //!   `HandlerPorts::get`'s enqueue closure *before* the reorder-buffer
 //!   decision, so this counter includes both in-order messages waiting
-//!   in `work_rx` AND out-of-order messages held in the
-//!   `OrderedSender` reorder buffer. (Reflected at the introspection
-//!   layer in IO-3 of the `introspect` module doc.)
+//!   in `work_rx` AND out-of-order messages held in the receiver-local
+//!   reorder buffer. (Reflected at the introspection layer in IO-3 of
+//!   the `introspect` module doc.)
 //! - **PD-5b:** Queue depth is incremented exactly once per accepted
 //!   message in the enqueue closure of `HandlerPorts::get`, before
 //!   the in-order / out-of-order branch.
@@ -365,13 +365,13 @@ fn account_cancel_enqueue(queue_depth: &AtomicU64, proc_stats: &ProcQueueStats, 
         hyperactor_telemetry::kv_pairs!("actor_id" => actor_id.to_owned()),
     );
 }
-use crate::ordering::OrderedSender;
-use crate::ordering::OrderedSenderError;
 use crate::ordering::SEQ_INFO;
 use crate::ordering::SeqInfo;
 use crate::ordering::Sequencer;
-use crate::ordering::ordered_channel;
 use crate::panic_handler;
+use crate::sequenced::SequencedEnvelope;
+use crate::sequenced::SequencedReceiver;
+use crate::sequenced::sequenced_unbounded_with_buffering;
 use crate::supervision::ActorSupervisionEvent;
 
 /// A proc instance is the runtime managing a single proc in Hyperactor.
@@ -504,7 +504,34 @@ pub struct ActorInstance<A: Actor> {
     /// Control signals for the actor.
     pub signal: mpsc::UnboundedReceiver<Signal>,
     /// Primary work queue for handler dispatch.
-    pub work: mpsc::UnboundedReceiver<WorkCell<A>>,
+    pub work: ActorWorkReceiver<A>,
+}
+
+/// Receiver for actor handler work.
+pub struct ActorWorkReceiver<A: Actor> {
+    inner: SequencedReceiver<SequencedEnvelope<WorkCell<A>>>,
+}
+
+impl<A: Actor> fmt::Debug for ActorWorkReceiver<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ActorWorkReceiver").finish_non_exhaustive()
+    }
+}
+
+impl<A: Actor> ActorWorkReceiver<A> {
+    fn new(inner: SequencedReceiver<SequencedEnvelope<WorkCell<A>>>) -> Self {
+        Self { inner }
+    }
+
+    /// Receive the next deliverable handler work item.
+    pub async fn recv(&mut self) -> Option<WorkCell<A>> {
+        self.inner.recv().await
+    }
+
+    /// Try to receive the next deliverable handler work item without waiting.
+    pub fn try_recv(&mut self) -> Result<WorkCell<A>, mpsc::error::TryRecvError> {
+        self.inner.try_recv()
+    }
 }
 
 /// Builder for constructing a [`Proc`] with explicit identity and connectivity.
@@ -2123,7 +2150,7 @@ pub struct InstanceReceivers<A: Actor> {
         mpsc::UnboundedReceiver<ActorSupervisionEvent>,
     )>,
     /// Work queue for dispatching messages to actor handlers.
-    work: mpsc::UnboundedReceiver<WorkCell<A>>,
+    work: ActorWorkReceiver<A>,
     /// Introspect message receiver for the dedicated introspect task.
     introspect: PortReceiver<IntrospectMessage>,
 }
@@ -2138,15 +2165,16 @@ impl<A: Actor> Instance<A> {
     ) -> (Self, InstanceReceivers<A>) {
         // Set up messaging
         let mailbox = Mailbox::new(actor_id.clone());
-        let (work_tx, work_rx) = ordered_channel(
-            actor_id.to_string(),
-            hyperactor_config::global::get(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER),
-        );
+        let enable_buffering =
+            hyperactor_config::global::get(config::ENABLE_DEST_ACTOR_REORDERING_BUFFER);
+        let (work_tx, work_rx) = sequenced_unbounded_with_buffering(enable_buffering);
+        let inbound_ordering_snapshot_handle = work_rx.snapshot_handle();
         let queue_depth = Arc::new(AtomicU64::new(0));
         let proc_stats = Arc::clone(&proc.state().queue_stats);
         let ports: Arc<HandlerPorts<A>> = Arc::new(HandlerPorts::new(
             mailbox.clone(),
             work_tx,
+            enable_buffering,
             Arc::clone(&queue_depth),
             proc_stats,
         ));
@@ -2181,14 +2209,13 @@ impl<A: Actor> Instance<A> {
 
         let instance_id = Uuid::now_v7();
 
-        // Type-erased snapshot callback: captures `Arc<HandlerPorts<A>>::clone()`
-        // (the typed Arc), which lets `InstanceCellState` invoke
-        // `OrderedSender::snapshot` from non-generic code. Only the typed
-        // ports are captured; nothing cyclic (no Instance, no InstanceCell).
-        let workq_ports = ports.clone();
+        // Type-erased snapshot callback: captures only the receiver-local
+        // sequencing snapshot handle. Nothing cyclic is captured.
         let inbound_ordering_snapshot: Option<
             Box<dyn Fn() -> crate::ordering::OrderingSnapshot + Send + Sync>,
-        > = Some(Box::new(move || workq_ports.workq.snapshot()));
+        > = Some(Box::new(move || {
+            inbound_ordering_snapshot_handle.snapshot()
+        }));
 
         let cell = InstanceCell::new(
             actor_id,
@@ -2217,7 +2244,7 @@ impl<A: Actor> Instance<A> {
             Self { inner },
             InstanceReceivers {
                 actor_loop: actor_loop_receivers,
-                work: work_rx,
+                work: ActorWorkReceiver::new(work_rx),
                 introspect: introspect_receiver,
             },
         )
@@ -2590,7 +2617,7 @@ impl<A: Actor> Instance<A> {
             .inner
             .ports
             .workq
-            .direct_send(work)
+            .send(SequencedEnvelope::new(SeqInfo::Direct, None, work))
             .map_err(anyhow::Error::from);
         if result.is_err() {
             account_cancel_enqueue(
@@ -2704,7 +2731,7 @@ impl<A: Actor> Instance<A> {
             mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
-        mut work_rx: mpsc::UnboundedReceiver<WorkCell<A>>,
+        mut work_rx: ActorWorkReceiver<A>,
     ) {
         let result = self
             .run_actor_tree(&mut actor, actor_loop_receivers, &mut work_rx)
@@ -2799,7 +2826,7 @@ impl<A: Actor> Instance<A> {
             mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
-        work_rx: &mut mpsc::UnboundedReceiver<WorkCell<A>>,
+        work_rx: &mut ActorWorkReceiver<A>,
     ) -> Result<String, ActorError> {
         // It is okay to catch all panics here, because we are in a tokio task,
         // and tokio will catch the panic anyway:
@@ -2935,7 +2962,7 @@ impl<A: Actor> Instance<A> {
             mpsc::UnboundedReceiver<Signal>,
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
-        work_rx: &mut mpsc::UnboundedReceiver<WorkCell<A>>,
+        work_rx: &mut ActorWorkReceiver<A>,
     ) -> Result<String, ActorError> {
         let (signal_receiver, supervision_event_receiver) = actor_loop_receivers;
 
@@ -3960,8 +3987,8 @@ impl InstanceCell {
 
     /// Out-of-band inbound ordering snapshot. Returns `None` when no
     /// snapshot callback was installed (see IO-1 in `introspect` module
-    /// doc). The callback uses `OrderedSender::snapshot` (`try_lock`,
-    /// non-blocking) and never perturbs ordering state.
+    /// doc). The callback uses the sequenced receiver's snapshot handle
+    /// (`try_lock`, non-blocking) and never perturbs ordering state.
     pub fn inbound_ordering_snapshot(&self) -> Option<crate::ordering::OrderingSnapshot> {
         self.inner.inbound_ordering_snapshot.as_ref().map(|f| f())
     }
@@ -4184,7 +4211,8 @@ pub struct HandlerPorts<A: Actor> {
     ports: DashMap<TypeId, Box<dyn Any + Send + Sync + 'static>>,
     bound: DashMap<Port, &'static str>,
     mailbox: Mailbox,
-    workq: OrderedSender<WorkCell<A>>,
+    workq: mpsc::UnboundedSender<SequencedEnvelope<WorkCell<A>>>,
+    enable_buffering: bool,
     /// Per-actor queue depth (PD-5). Shared with `InstanceCellState`.
     queue_depth: Arc<AtomicU64>,
     /// Proc-level queue-pressure stats (PD-6 through PD-9).
@@ -4194,7 +4222,8 @@ pub struct HandlerPorts<A: Actor> {
 impl<A: Actor> HandlerPorts<A> {
     fn new(
         mailbox: Mailbox,
-        workq: OrderedSender<WorkCell<A>>,
+        workq: mpsc::UnboundedSender<SequencedEnvelope<WorkCell<A>>>,
+        enable_buffering: bool,
         queue_depth: Arc<AtomicU64>,
         proc_stats: Arc<ProcQueueStats>,
     ) -> Self {
@@ -4203,6 +4232,7 @@ impl<A: Actor> HandlerPorts<A> {
             bound: DashMap::new(),
             mailbox,
             workq,
+            enable_buffering,
             queue_depth,
             proc_stats,
         }
@@ -4228,6 +4258,7 @@ impl<A: Actor> HandlerPorts<A> {
 
                 let type_info = TypeInfo::get_by_typeid(key);
                 let workq = self.workq.clone();
+                let enable_buffering = self.enable_buffering;
                 let actor_id = self.mailbox.actor_addr().to_string();
                 let enqueue_depth = Arc::clone(&self.queue_depth);
                 let enqueue_proc_stats = Arc::clone(&self.proc_stats);
@@ -4235,18 +4266,41 @@ impl<A: Actor> HandlerPorts<A> {
                 // closure runs. Therefore, the drain guarantee depends on this
                 // closure synchronously finishing all work that it admits into
                 // the actor work queue before it returns. That includes the
-                // ordered path: `OrderedSender::send` delivers the current item
-                // and synchronously flushes any consecutive buffered items that
-                // the current item unblocks. Messages already held in the
-                // reorder buffer but still waiting on a future sequence are not
-                // considered drainable accepted work; after draining begins,
-                // that missing future sequence is rejected.
+                // sequenced path: enqueue synchronously hands accepted work to
+                // the receiver's channel. Messages already held in the
+                // receiver-local reorder buffer but still waiting on a future
+                // sequence are not considered drainable accepted work; after
+                // draining begins, that missing future sequence is rejected.
                 let enqueue = move |headers: Flattrs, msg: M| {
                     // Extract values from headers BEFORE they're moved into
                     // WorkCell — Flattrs::get returns owned typed values, so
                     // these bindings don't borrow from `headers` and `headers`
                     // can be moved into WorkCell freely.
-                    let seq_info = headers.get(SEQ_INFO);
+                    let seq_info = if enable_buffering {
+                        match headers.get(SEQ_INFO) {
+                            Some(seq_info) => seq_info,
+                            None => {
+                                let error_msg = format!(
+                                    "in enqueue func for {}, buffering is enabled, but SEQ_INFO is not set for message type {}",
+                                    actor_id,
+                                    std::any::type_name::<M>(),
+                                );
+                                tracing::error!(error_msg);
+                                return Err(anyhow::anyhow!(error_msg));
+                            }
+                        }
+                    } else {
+                        SeqInfo::Direct
+                    };
+                    if !seq_info.is_valid() {
+                        let error_msg = format!(
+                            "in enqueue func for {}, got seq 0 for message type {}",
+                            actor_id,
+                            std::any::type_name::<M>(),
+                        );
+                        tracing::error!(error_msg);
+                        return Err(anyhow::anyhow!(error_msg));
+                    }
                     let sender = headers.get(crate::mailbox::headers::SENDER_ACTOR_ID);
 
                     let work = WorkCell::new(move |actor: &mut A, instance: &Instance<A>| {
@@ -4266,41 +4320,11 @@ impl<A: Actor> HandlerPorts<A> {
                     // failure, `account_cancel_enqueue` rolls back the
                     // counters so `queue_depth` does not drift.
                     account_enqueue(&enqueue_depth, &enqueue_proc_stats, &actor_id);
-                    let result = if workq.enable_buffering {
-                        match seq_info {
-                            Some(SeqInfo::Session { session_id, seq }) => {
-                                // TODO: return the message contained in the error instead of dropping them when converting
-                                // to anyhow::Error. In that way, the message can be picked up by mailbox and returned to sender.
-                                workq.send(session_id, seq, sender, work).map_err(|e| match e {
-                                    OrderedSenderError::InvalidZeroSeq(_) => {
-                                        let error_msg = format!(
-                                            "in enqueue func for {}, got seq 0 for message type {}",
-                                            actor_id,
-                                            std::any::type_name::<M>(),
-                                        );
-                                        tracing::error!(error_msg);
-                                        anyhow::anyhow!(error_msg)
-                                    }
-                                    OrderedSenderError::SendError(e) => anyhow::Error::from(e),
-                                    OrderedSenderError::FlushError(e) => e,
-                                })
-                            }
-                            Some(SeqInfo::Direct) => {
-                                workq.direct_send(work).map_err(anyhow::Error::from)
-                            }
-                            None => {
-                                let error_msg = format!(
-                                    "in enqueue func for {}, buffering is enabled, but SEQ_INFO is not set for message type {}",
-                                    actor_id,
-                                    std::any::type_name::<M>(),
-                                );
-                                tracing::error!(error_msg);
-                                Err(anyhow::anyhow!(error_msg))
-                            }
-                        }
-                    } else {
-                        workq.direct_send(work).map_err(anyhow::Error::from)
-                    };
+                    // TODO: return the message contained in the error instead of dropping them when converting
+                    // to anyhow::Error. In that way, the message can be picked up by mailbox and returned to sender.
+                    let result = workq
+                        .send(SequencedEnvelope::new(seq_info, sender, work))
+                        .map_err(anyhow::Error::from);
                     if result.is_err() {
                         account_cancel_enqueue(&enqueue_depth, &enqueue_proc_stats, &actor_id);
                     }
@@ -6854,10 +6878,9 @@ mod tests {
     // Test-only Named message + dedicated actor with explicit handler
     // export, so the integration test can bind the BufferTestMsg
     // handler port (`handle.bind()`) and drive ordered traffic through
-    // `OrderedSender`. Without the bind, `PortHandle::try_post` stamps
-    // `SeqInfo::Direct` and the enqueue closure takes the `direct_send`
-    // branch -- which never populates `OrderedSender::states`, leaving
-    // the snapshot empty.
+    // the sequenced receiver. Without the bind, `PortHandle::try_post`
+    // stamps `SeqInfo::Direct`, and the enqueue closure bypasses
+    // sequencing, leaving the snapshot empty.
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, typeuri::Named)]
     struct BufferTestMsg;
 
@@ -6925,20 +6948,33 @@ mod tests {
         let _ = client.sequencer().assign_seq(&handler_port);
 
         // Post three messages. These flow through MailboxExt::post ->
-        // HandlerPorts enqueue closure -> OrderedSender::send, where
-        // they buffer (out of order from seq 1's perspective).
+        // HandlerPorts enqueue closure -> SequencedReceiver, where they
+        // buffer (out of order from seq 1's perspective).
         for _ in 0..3 {
             handle.post(&client, BufferTestMsg);
         }
-        // Let the enqueues propagate to the buffer.
-        tokio::task::yield_now().await;
-
         // Direct accessor: cell.inbound_ordering_snapshot() invokes the
-        // type-erased callback installed at Instance::new.
+        // type-erased callback installed at Instance::new. Sequencing is
+        // receiver-local, so wait until the actor loop has polled the
+        // work receiver and populated the buffered session.
         let cell = proc.get_instance(&actor_id).expect("actor exists");
-        let snapshot = cell
-            .inbound_ordering_snapshot()
-            .expect("snapshot callback should be installed for live actors");
+        let snapshot = tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                let snapshot = cell
+                    .inbound_ordering_snapshot()
+                    .expect("snapshot callback should be installed for live actors");
+                if snapshot
+                    .sessions
+                    .first()
+                    .is_some_and(|session| session.buffered_count == 3)
+                {
+                    break snapshot;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("receiver-local sequencing state should be populated");
 
         assert!(snapshot.enabled, "buffering enabled by override");
         assert_eq!(snapshot.sessions.len(), 1, "one client session expected");

--- a/hyperactor/src/sequenced.rs
+++ b/hyperactor/src/sequenced.rs
@@ -14,12 +14,17 @@ use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::collections::btree_map;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::TryLockError;
 
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::TryRecvError;
 use uuid::Uuid;
 
 use crate::ActorAddr;
+use crate::ordering::OrderingSessionSnapshot;
+use crate::ordering::OrderingSnapshot;
 use crate::ordering::SeqInfo;
 
 const RING_BUFFER_LIMIT: usize = 32;
@@ -106,24 +111,107 @@ impl<M> Sequenced for DirectEnvelope<M> {
 /// messages.
 pub(crate) fn sequenced_unbounded<M: Sequenced>() -> (mpsc::UnboundedSender<M>, SequencedReceiver<M>)
 {
+    sequenced_unbounded_with_buffering(true)
+}
+
+/// Open an unbounded channel with explicitly configured sequencing.
+pub(crate) fn sequenced_unbounded_with_buffering<M: Sequenced>(
+    enable_buffering: bool,
+) -> (mpsc::UnboundedSender<M>, SequencedReceiver<M>) {
     let (tx, rx) = mpsc::unbounded_channel();
-    (tx, SequencedReceiver::new(rx))
+    (tx, SequencedReceiver::new(rx, enable_buffering))
+}
+
+/// Out-of-band snapshot handle for a receiver-local sequencing domain.
+#[derive(Debug)]
+pub(crate) struct SequencedSnapshot<M> {
+    enable_buffering: bool,
+    state: Arc<Mutex<SequencedState<M>>>,
+}
+
+impl<M> Clone for SequencedSnapshot<M> {
+    fn clone(&self) -> Self {
+        Self {
+            enable_buffering: self.enable_buffering,
+            state: self.state.clone(),
+        }
+    }
+}
+
+impl<M> SequencedSnapshot<M> {
+    /// Snapshot the currently buffered sequencing state.
+    pub(crate) fn snapshot(&self) -> OrderingSnapshot {
+        if !self.enable_buffering {
+            return OrderingSnapshot {
+                enabled: false,
+                sessions: Vec::new(),
+                skipped_session_count: 0,
+            };
+        }
+
+        let state = match self.state.try_lock() {
+            Ok(state) => state,
+            Err(TryLockError::WouldBlock) => {
+                return OrderingSnapshot {
+                    enabled: true,
+                    sessions: Vec::new(),
+                    skipped_session_count: 1,
+                };
+            }
+            Err(TryLockError::Poisoned(err)) => err.into_inner(),
+        };
+
+        let mut sessions: Vec<_> = state
+            .senders
+            .iter()
+            .map(|(session_id, sequencer)| {
+                let (buffered_count, oldest_buffered_seq, newest_buffered_seq) =
+                    sequencer.buffer.snapshot(sequencer.seq);
+                OrderingSessionSnapshot {
+                    session_id: *session_id,
+                    sender: sequencer.sender.clone(),
+                    last_released_seq: sequencer.seq.saturating_sub(1),
+                    expected_next_seq: sequencer.seq,
+                    buffered_count,
+                    oldest_buffered_seq,
+                    newest_buffered_seq,
+                }
+            })
+            .collect();
+        sessions.sort_by_key(|session| session.session_id);
+
+        OrderingSnapshot {
+            enabled: true,
+            sessions,
+            skipped_session_count: 0,
+        }
+    }
 }
 
 /// A receiver that owns all reorder state for one sequencing domain.
 #[derive(Debug)]
 pub(crate) struct SequencedReceiver<M: Sequenced> {
     rx: mpsc::UnboundedReceiver<M>,
-    senders: HashMap<Uuid, Sequencer<M::Message>>,
+    enable_buffering: bool,
+    state: Arc<Mutex<SequencedState<M::Message>>>,
     ready: VecDeque<M::Message>,
 }
 
 impl<M: Sequenced> SequencedReceiver<M> {
-    fn new(rx: mpsc::UnboundedReceiver<M>) -> Self {
+    fn new(rx: mpsc::UnboundedReceiver<M>, enable_buffering: bool) -> Self {
         Self {
             rx,
-            senders: HashMap::new(),
+            enable_buffering,
+            state: Arc::new(Mutex::new(SequencedState::default())),
             ready: VecDeque::new(),
+        }
+    }
+
+    /// Return a cloneable diagnostic handle for this receiver.
+    pub(crate) fn snapshot_handle(&self) -> SequencedSnapshot<M::Message> {
+        SequencedSnapshot {
+            enable_buffering: self.enable_buffering,
+            state: self.state.clone(),
         }
     }
 
@@ -156,12 +244,17 @@ impl<M: Sequenced> SequencedReceiver<M> {
     }
 
     fn admit(&mut self, item: M) -> Option<M::Message> {
+        if !self.enable_buffering {
+            return Some(item.into_message());
+        }
+
         match item.seq_info() {
             SeqInfo::Direct => Some(item.into_message()),
             SeqInfo::Session { session_id, seq } => {
                 // TODO: allow sequence numbers to start at 0
                 assert!(seq > 0, "sequence number must be nonzero");
-                let sequencer = self.senders.entry(session_id).or_default();
+                let mut state = self.state.lock().unwrap();
+                let sequencer = state.senders.entry(session_id).or_default();
                 if sequencer.sender.is_none()
                     && let Some(sender) = item.sender()
                 {
@@ -169,6 +262,19 @@ impl<M: Sequenced> SequencedReceiver<M> {
                 }
                 sequencer.admit(seq, item.into_message(), &mut self.ready)
             }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct SequencedState<M> {
+    senders: HashMap<Uuid, Sequencer<M>>,
+}
+
+impl<M> Default for SequencedState<M> {
+    fn default() -> Self {
+        Self {
+            senders: HashMap::new(),
         }
     }
 }
@@ -364,6 +470,34 @@ impl<M> Buffer<M> {
             self.head = 0;
         }
     }
+
+    fn snapshot(&self, next_seq: u64) -> (usize, Option<u64>, Option<u64>) {
+        let mut count = 0;
+        let mut oldest = None;
+        let mut newest = None;
+
+        for offset in 0..self.ring.len() {
+            let index = (self.head + offset) % self.ring.len();
+            if self.ring[index].is_some() {
+                let seq = next_seq + offset as u64;
+                count += 1;
+                oldest = Some(oldest.map_or(seq, |oldest: u64| oldest.min(seq)));
+                newest = Some(newest.map_or(seq, |newest: u64| newest.max(seq)));
+            }
+        }
+
+        if let Some(spillover) = &self.spillover {
+            count += spillover.len();
+            if let Some((&seq, _)) = spillover.first_key_value() {
+                oldest = Some(oldest.map_or(seq, |oldest| oldest.min(seq)));
+            }
+            if let Some((&seq, _)) = spillover.last_key_value() {
+                newest = Some(newest.map_or(seq, |newest| newest.max(seq)));
+            }
+        }
+
+        (count, oldest, newest)
+    }
 }
 
 #[cfg(test)]
@@ -372,6 +506,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::*;
+    use crate::testing::ids::test_actor_id;
 
     fn session(seq: u64) -> SeqInfo {
         SeqInfo::Session {
@@ -391,6 +526,23 @@ mod tests {
         SequencedEnvelope::new(seq_info, None, message)
     }
 
+    fn envelope_from(
+        seq_info: SeqInfo,
+        sender: Option<ActorAddr>,
+        message: u64,
+    ) -> SequencedEnvelope<u64> {
+        SequencedEnvelope::new(seq_info, sender, message)
+    }
+
+    fn with_sequencer<T, R>(
+        rx: &SequencedReceiver<SequencedEnvelope<T>>,
+        session_id: u128,
+        f: impl FnOnce(&Sequencer<T>) -> R,
+    ) -> R {
+        let state = rx.state.lock().unwrap();
+        f(state.senders.get(&Uuid::from_u128(session_id)).unwrap())
+    }
+
     #[tokio::test]
     async fn delivers_in_order_messages() {
         let (tx, mut rx) = sequenced_unbounded();
@@ -401,10 +553,11 @@ mod tests {
         assert_eq!(rx.recv().await, Some(10));
         assert_eq!(rx.recv().await, Some(20));
 
-        let sequencer = rx.senders.get(&Uuid::from_u128(1)).unwrap();
-        assert!(sequencer.buffer.ring.is_empty());
-        assert_eq!(sequencer.buffer.ring.capacity(), 0);
-        assert!(sequencer.buffer.spillover.is_none());
+        with_sequencer(&rx, 1, |sequencer| {
+            assert!(sequencer.buffer.ring.is_empty());
+            assert_eq!(sequencer.buffer.ring.capacity(), 0);
+            assert!(sequencer.buffer.spillover.is_none());
+        });
     }
 
     #[test]
@@ -414,9 +567,10 @@ mod tests {
         tx.send(envelope(session(3), 30)).unwrap();
         assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
 
-        let sequencer = rx.senders.get(&Uuid::from_u128(1)).unwrap();
-        assert_eq!(sequencer.buffer.ring.len(), 3);
-        assert!(sequencer.buffer.spillover.is_none());
+        with_sequencer(&rx, 1, |sequencer| {
+            assert_eq!(sequencer.buffer.ring.len(), 3);
+            assert!(sequencer.buffer.spillover.is_none());
+        });
 
         tx.send(envelope(session(1), 10)).unwrap();
         tx.send(envelope(session(2), 20)).unwrap();
@@ -433,15 +587,16 @@ mod tests {
         tx.send(envelope(session(100), 1000)).unwrap();
         assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
 
-        let sequencer = rx.senders.get(&Uuid::from_u128(1)).unwrap();
-        assert_eq!(sequencer.buffer.ring.len(), RING_BUFFER_LIMIT);
-        assert!(
-            sequencer
-                .buffer
-                .spillover
-                .as_ref()
-                .is_some_and(|spillover| spillover.contains_key(&100))
-        );
+        with_sequencer(&rx, 1, |sequencer| {
+            assert_eq!(sequencer.buffer.ring.len(), RING_BUFFER_LIMIT);
+            assert!(
+                sequencer
+                    .buffer
+                    .spillover
+                    .as_ref()
+                    .is_some_and(|spillover| spillover.contains_key(&100))
+            );
+        });
     }
 
     #[test]
@@ -461,10 +616,11 @@ mod tests {
         }
         assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
 
-        let sequencer = rx.senders.get(&Uuid::from_u128(1)).unwrap();
-        assert!(sequencer.buffer.ring.is_empty());
-        assert_eq!(sequencer.buffer.ring.capacity(), 0);
-        assert!(sequencer.buffer.spillover.is_none());
+        with_sequencer(&rx, 1, |sequencer| {
+            assert!(sequencer.buffer.ring.is_empty());
+            assert_eq!(sequencer.buffer.ring.capacity(), 0);
+            assert!(sequencer.buffer.spillover.is_none());
+        });
     }
 
     #[test]
@@ -552,5 +708,78 @@ mod tests {
 
         assert_eq!(rx.try_recv().unwrap(), 10);
         assert_eq!(rx.try_recv().unwrap(), 20);
+    }
+
+    #[test]
+    fn snapshot_empty() {
+        let (_tx, rx) = sequenced_unbounded::<SequencedEnvelope<u64>>();
+        let snapshot = rx.snapshot_handle().snapshot();
+
+        assert!(snapshot.enabled);
+        assert!(snapshot.sessions.is_empty());
+        assert_eq!(snapshot.skipped_session_count, 0);
+        assert!(snapshot.is_complete());
+    }
+
+    #[test]
+    fn snapshot_out_of_order_includes_sender() {
+        let (tx, mut rx) = sequenced_unbounded();
+        let sender = test_actor_id("sender", "client");
+
+        tx.send(envelope_from(session(3), Some(sender.clone()), 30))
+            .unwrap();
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+
+        let snapshot = rx.snapshot_handle().snapshot();
+        assert_eq!(snapshot.sessions.len(), 1);
+        let session = &snapshot.sessions[0];
+        assert_eq!(session.sender, Some(sender));
+        assert_eq!(session.last_released_seq, 0);
+        assert_eq!(session.expected_next_seq, 1);
+        assert_eq!(session.buffered_count, 1);
+        assert_eq!(session.oldest_buffered_seq, Some(3));
+        assert_eq!(session.newest_buffered_seq, Some(3));
+    }
+
+    #[test]
+    fn snapshot_sorts_sessions() {
+        let (tx, mut rx) = sequenced_unbounded();
+        let session_lo = Uuid::from_u128(1);
+        let session_hi = Uuid::from_u128(2);
+
+        tx.send(envelope(
+            SeqInfo::Session {
+                session_id: session_hi,
+                seq: 2,
+            },
+            20,
+        ))
+        .unwrap();
+        tx.send(envelope(
+            SeqInfo::Session {
+                session_id: session_lo,
+                seq: 2,
+            },
+            10,
+        ))
+        .unwrap();
+        assert!(matches!(rx.try_recv(), Err(TryRecvError::Empty)));
+
+        let snapshot = rx.snapshot_handle().snapshot();
+        assert_eq!(snapshot.sessions.len(), 2);
+        assert_eq!(snapshot.sessions[0].session_id, session_lo);
+        assert_eq!(snapshot.sessions[1].session_id, session_hi);
+    }
+
+    #[test]
+    fn disabled_buffering_delivers_without_snapshot_state() {
+        let (tx, mut rx) = sequenced_unbounded_with_buffering(false);
+
+        tx.send(envelope(session(2), 20)).unwrap();
+        assert_eq!(rx.try_recv().unwrap(), 20);
+
+        let snapshot = rx.snapshot_handle().snapshot();
+        assert!(!snapshot.enabled);
+        assert!(snapshot.sessions.is_empty());
     }
 }

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -73,8 +73,8 @@ use hyperactor::mailbox::TransportFailure;
 use hyperactor::mailbox::TransportFailureReason;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableReason;
+use hyperactor::proc::ActorWorkReceiver;
 use hyperactor::proc::Proc;
-use hyperactor::proc::WorkCell;
 use hyperactor::supervision::ActorSupervisionEvent;
 use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
@@ -187,7 +187,7 @@ pub struct GlobalClientActor {
     /// Any bound handler message (e.g. `MeshFailure`,
     /// `Undeliverable<MessageEnvelope>`, introspection, etc.) is
     /// received here and executed via `WorkCell::handle`.
-    work_rx: mpsc::UnboundedReceiver<WorkCell<Self>>,
+    work_rx: ActorWorkReceiver<Self>,
 }
 
 impl GlobalClientActor {

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -31,7 +31,7 @@ use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Signal;
 use hyperactor::channel::ChannelTransport;
-use hyperactor::proc::WorkCell;
+use hyperactor::proc::ActorWorkReceiver;
 use hyperactor::supervision::ActorSupervisionEvent;
 #[cfg(fbcode_build)]
 use tokio::process::Command;
@@ -187,7 +187,7 @@ fn process_name(pid: u32) -> Option<String> {
 pub struct TestRootClient {
     signal_rx: mpsc::UnboundedReceiver<Signal>,
     supervision_rx: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
-    work_rx: mpsc::UnboundedReceiver<WorkCell<Self>>,
+    work_rx: ActorWorkReceiver<Self>,
 }
 
 impl Actor for TestRootClient {}

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -846,7 +846,7 @@ mod tests {
     use hyperactor::actor::Signal;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::mailbox;
-    use hyperactor::proc::WorkCell;
+    use hyperactor::proc::ActorWorkReceiver;
     use hyperactor::supervision::ActorSupervisionEvent;
     use hyperactor_mesh::host_mesh::HostMesh;
     use hyperactor_mesh::mesh_controller::GetSubscriberCount;
@@ -866,7 +866,7 @@ mod tests {
     struct TestClient {
         signal_rx: mpsc::UnboundedReceiver<Signal>,
         supervision_rx: mpsc::UnboundedReceiver<ActorSupervisionEvent>,
-        work_rx: mpsc::UnboundedReceiver<WorkCell<Self>>,
+        work_rx: ActorWorkReceiver<Self>,
     }
 
     impl Actor for TestClient {}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4179
* __->__ #4178
* #4177
* #4176
* #4175

Replace the handler work queue's `OrderedSender` with the receiver-local `sequenced` channel. Handler enqueue now normalizes and validates `SeqInfo`, sends one `SequencedEnvelope`, and exposes inbound ordering snapshots from the sequenced receiver. Remove the old sender-side ordered channel implementation and move its remaining coverage to `sequenced` tests.

The overall goal here is to simplify the receive path.

Differential Revision: [D107599900](https://our.internmc.facebook.com/intern/diff/D107599900/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D107599900/)!