### PR TITLE
[hyperactor] sequence ephemeral port receivers

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -166,6 +166,9 @@ use crate::ordering::SEQ_INFO;
 use crate::ordering::SeqInfo;
 use crate::port::ControlPort;
 use crate::port::Port;
+use crate::sequenced::SequencedEnvelope;
+use crate::sequenced::SequencedReceiver;
+use crate::sequenced::sequenced_unbounded;
 
 mod undeliverable;
 /// For [`Undeliverable`], a message type for delivery failures.
@@ -1721,7 +1724,7 @@ impl Mailbox {
     /// for processing the delivered messages.
     pub fn open_port<M: Message>(&self) -> (PortHandle<M>, PortReceiver<M>) {
         let port_index = self.inner.allocate_port();
-        let (sender, receiver) = mpsc::unbounded_channel::<M>();
+        let (sender, receiver) = sequenced_unbounded::<SequencedEnvelope<M>>();
         let port_id = self.inner.actor_id.port_addr(Port::from(port_index));
         tracing::trace!(
             name = "open_port",
@@ -1730,7 +1733,11 @@ impl Mailbox {
             port_id
         );
         (
-            PortHandle::new(self.clone(), port_index, UnboundedPortSender::Mpsc(sender)),
+            PortHandle::new(
+                self.clone(),
+                port_index,
+                UnboundedPortSender::Sequenced(sender),
+            ),
             PortReceiver::new(receiver, port_id, /*coalesce=*/ false, self.clone()),
         )
     }
@@ -1776,14 +1783,14 @@ impl Mailbox {
         A::State: Message + Default + Clone,
     {
         let port_index = self.inner.allocate_port();
-        let (sender, receiver) = mpsc::unbounded_channel::<A::State>();
+        let (sender, receiver) = sequenced_unbounded::<SequencedEnvelope<A::State>>();
         let port_id = self.inner.actor_id.port_addr(Port::from(port_index));
         let state = Mutex::new(A::State::default());
         let reducer_spec = accum.reducer_spec();
         let enqueue = move |_, update: A::Update| {
             let mut state = state.lock().unwrap();
             accum.accumulate(&mut state, update)?;
-            let _ = sender.send(state.clone());
+            let _ = sender.send(SequencedEnvelope::new(SeqInfo::Direct, None, state.clone()));
             Ok(())
         };
         (
@@ -2409,14 +2416,14 @@ impl<M: Message> PortHandle<M> {
 
         crate::mailbox::headers::set_send_timestamp(&mut headers);
         crate::mailbox::headers::set_rust_message_type::<M>(&mut headers);
-        // Hold read lock while checking and sending to prevent race with bind().
-        // Message sent from handle is delivered immediately. It could race with
-        // messages from refs. So we need to assign seq if the handle is bound.
+        // Holding this read lock makes `bind()` a fence: unbound local sends
+        // are enqueued as direct messages before the port is published, while
+        // bound local sends share the same sequence domain as ref/mailbox
+        // sends.
         let bound_guard = self.inner.bound.read().unwrap();
-        if let Some(bound_port) = bound_guard.as_ref() {
+        if let Some(dest) = bound_guard.as_ref() {
             let sequencer = cx.instance().sequencer();
-            let bound_ref: PortAddr = bound_port.clone();
-            let seq_info = sequencer.assign_seq(&bound_ref);
+            let seq_info = sequencer.assign_seq(dest);
             // Pair SENDER_ACTOR_ID stamp with SEQ_INFO. PortHandle::try_post
             // starts with Flattrs::new(), so there's no caller-supplied stale
             // header to defend against — use the simpler "fresh" helper.
@@ -2424,16 +2431,12 @@ impl<M: Message> PortHandle<M> {
                 crate::mailbox::headers::stamp_sender_actor_id_fresh(
                     &mut headers,
                     *seq,
-                    &bound_ref,
+                    dest,
                     cx.mailbox().actor_addr(),
                 );
             }
             headers.set(SEQ_INFO, seq_info);
         } else {
-            // Because the port is not bound, messages can only be sent through
-            // this port handle's underlying tokio channel directly. As a result,
-            // we do not need to assign seq to the message. We do not need to
-            // worry about race condition due to bound_guard.
             headers.set(SEQ_INFO, SeqInfo::Direct);
         }
         // Encountering error means the port is closed. So we do not need to
@@ -2652,7 +2655,7 @@ impl<M: Message> fmt::Display for OncePortHandle<M> {
 /// on open ports.
 #[derive(Debug)]
 pub struct PortReceiver<M> {
-    receiver: mpsc::UnboundedReceiver<M>,
+    receiver: SequencedReceiver<SequencedEnvelope<M>>,
     port_id: PortAddr,
     /// When multiple messages are put in channel, only receive the latest one
     /// if coalesce is true. Other messages will be discarded.
@@ -2664,7 +2667,7 @@ pub struct PortReceiver<M> {
 
 impl<M> PortReceiver<M> {
     fn new(
-        receiver: mpsc::UnboundedReceiver<M>,
+        receiver: SequencedReceiver<SequencedEnvelope<M>>,
         port_id: PortAddr,
         coalesce: bool,
         mailbox: Mailbox,
@@ -2746,6 +2749,8 @@ impl<M> Drop for PortReceiver<M> {
         self.mailbox.inner.ports.remove(&self.port());
     }
 }
+
+impl<M> Unpin for PortReceiver<M> {}
 
 impl<M> Stream for PortReceiver<M> {
     type Item = Result<M, MailboxError>;
@@ -2862,8 +2867,8 @@ fn classify_sender_error(err: anyhow::Error) -> MailboxSenderErrorKind {
 
 /// A sender to an M-typed unbounded port.
 enum UnboundedPortSender<M: Message> {
-    /// Send directly to the mpsc queue.
-    Mpsc(mpsc::UnboundedSender<M>),
+    /// Send through a receiver-local sequencing domain.
+    Sequenced(mpsc::UnboundedSender<SequencedEnvelope<M>>),
     /// Use the provided function to enqueue the item.
     Func(Arc<dyn Fn(Flattrs, M) -> Result<(), anyhow::Error> + Send + Sync>),
     /// A runtime-dispatched handler port that observes mailbox drain state.
@@ -2873,7 +2878,16 @@ enum UnboundedPortSender<M: Message> {
 impl<M: Message> UnboundedPortSender<M> {
     fn send(&self, headers: Flattrs, message: M) -> Result<(), anyhow::Error> {
         match self {
-            Self::Mpsc(sender) => sender.send(message).map_err(anyhow::Error::from),
+            Self::Sequenced(sender) => {
+                let seq_info = headers.get(SEQ_INFO).unwrap_or(SeqInfo::Direct);
+                if !seq_info.is_valid() {
+                    return Err(anyhow::anyhow!("sequenced port send has invalid SEQ_INFO"));
+                }
+                let sender_addr = headers.get(crate::mailbox::headers::SENDER_ACTOR_ID);
+                sender
+                    .send(SequencedEnvelope::new(seq_info, sender_addr, message))
+                    .map_err(anyhow::Error::from)
+            }
             Self::Func(func) => func(headers, message),
             Self::Handler(sender) => sender.send(headers, message),
         }
@@ -2885,7 +2899,7 @@ impl<M: Message> UnboundedPortSender<M> {
 impl<M: Message> Clone for UnboundedPortSender<M> {
     fn clone(&self) -> Self {
         match self {
-            Self::Mpsc(sender) => Self::Mpsc(sender.clone()),
+            Self::Sequenced(sender) => Self::Sequenced(sender.clone()),
             Self::Func(func) => Self::Func(func.clone()),
             Self::Handler(sender) => Self::Handler(sender.clone()),
         }
@@ -2895,7 +2909,10 @@ impl<M: Message> Clone for UnboundedPortSender<M> {
 impl<M: Message> Debug for UnboundedPortSender<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
         match self {
-            Self::Mpsc(q) => f.debug_tuple("UnboundedPortSender::Mpsc").field(q).finish(),
+            Self::Sequenced(q) => f
+                .debug_tuple("UnboundedPortSender::Sequenced")
+                .field(q)
+                .finish(),
             Self::Func(_) => f
                 .debug_tuple("UnboundedPortSender::Func")
                 .field(&"..")
@@ -3068,7 +3085,7 @@ impl<M: RemoteMessage> SerializedSender for UnboundedSender<M> {
         match serialized.deserialized_unchecked() {
             Ok(message) => match self.sender.send(headers.clone(), message) {
                 Ok(()) => Ok(SerializedSendDisposition::Delivered),
-                Err(_) if matches!(&self.sender, UnboundedPortSender::Mpsc(_)) => {
+                Err(_) if matches!(&self.sender, UnboundedPortSender::Sequenced(_)) => {
                     Err(SerializedSendFailure::Dead {
                         data: serialized,
                         headers,
@@ -3816,6 +3833,7 @@ mod tests {
     use crate::accum;
     use crate::accum::ReducerMode;
     use crate::channel::ChannelTransport;
+    use crate::context::Actor as _;
     use crate::context::Mailbox as MailboxContext;
     use crate::context::MailboxExt as _;
     use crate::endpoint::Endpoint as _;
@@ -3972,6 +3990,30 @@ mod tests {
             invalid_reference.reason,
             InvalidReferenceReason::WrongMailboxOwner
         );
+    }
+
+    #[tokio::test]
+    async fn test_ephemeral_port_orders_raw_and_serialized_sends() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (port_handle, mut receiver) = client.open_port::<u64>();
+        let port = port_handle.bind();
+        let session_id = client.instance().sequencer().session_id();
+
+        let mut headers = Flattrs::new();
+        headers.set(SEQ_INFO, SeqInfo::Session { session_id, seq: 2 });
+        let envelope = MessageEnvelope::new(
+            client.mailbox().actor_addr().clone(),
+            port.port_addr().clone(),
+            wirevalue::Any::serialize(&2u64).unwrap(),
+            headers,
+        );
+        client.mailbox().post(envelope, monitored_return_handle());
+
+        port_handle.try_post(&client, 1u64).unwrap();
+
+        assert_eq!(receiver.recv().await.unwrap(), 1);
+        assert_eq!(receiver.recv().await.unwrap(), 2);
     }
 
     #[tokio::test]
@@ -4293,14 +4335,14 @@ mod tests {
         let port = crate::PortRef::attest(port_id.clone());
         let (return_handle, mut return_receiver) =
             crate::mailbox::undeliverable::new_undeliverable_port();
-        let (sender, receiver) = mpsc::unbounded_channel::<u64>();
+        let (sender, receiver) = sequenced_unbounded::<SequencedEnvelope<u64>>();
 
         drop(receiver);
 
         mbox.inner.ports.insert(
             Port::from(port_index),
             Arc::new(UnboundedSender::new(
-                UnboundedPortSender::Mpsc(sender),
+                UnboundedPortSender::Sequenced(sender),
                 port_id,
             )),
         );
@@ -5032,13 +5074,15 @@ mod tests {
     }
 
     async fn verify_receiver(coalesce: bool, drop_sender: bool) {
-        fn create_receiver<M>(coalesce: bool) -> (mpsc::UnboundedSender<M>, PortReceiver<M>) {
+        fn create_receiver<M>(
+            coalesce: bool,
+        ) -> (mpsc::UnboundedSender<SequencedEnvelope<M>>, PortReceiver<M>) {
             // Create dummy state and port_id to create PortReceiver. They are
             // not used in the test.
             let dummy_actor_ref: ActorAddr = test_actor_id("world_0", "actor");
             let dummy_state = State::new(dummy_actor_ref.clone());
             let dummy_port_id = dummy_actor_ref.port_addr(Port::from(0));
-            let (sender, receiver) = mpsc::unbounded_channel::<M>();
+            let (sender, receiver) = sequenced_unbounded::<SequencedEnvelope<M>>();
             let receiver = PortReceiver {
                 receiver,
                 port_id: dummy_port_id,
@@ -5050,19 +5094,25 @@ mod tests {
             (sender, receiver)
         }
 
+        fn send_direct<M>(sender: &mpsc::UnboundedSender<SequencedEnvelope<M>>, message: M) {
+            sender
+                .send(SequencedEnvelope::new(SeqInfo::Direct, None, message))
+                .unwrap();
+        }
+
         // verify fn drain
         {
             let (sender, mut receiver) = create_receiver::<u64>(coalesce);
             assert!(receiver.drain().is_empty());
 
-            sender.send(0).unwrap();
-            sender.send(1).unwrap();
-            sender.send(2).unwrap();
-            sender.send(3).unwrap();
-            sender.send(4).unwrap();
-            sender.send(5).unwrap();
-            sender.send(6).unwrap();
-            sender.send(7).unwrap();
+            send_direct(&sender, 0);
+            send_direct(&sender, 1);
+            send_direct(&sender, 2);
+            send_direct(&sender, 3);
+            send_direct(&sender, 4);
+            send_direct(&sender, 5);
+            send_direct(&sender, 6);
+            send_direct(&sender, 7);
 
             if drop_sender {
                 drop(sender);
@@ -5083,10 +5133,10 @@ mod tests {
             let (sender, mut receiver) = create_receiver::<u64>(coalesce);
             assert!(receiver.try_recv().unwrap().is_none());
 
-            sender.send(0).unwrap();
-            sender.send(1).unwrap();
-            sender.send(2).unwrap();
-            sender.send(3).unwrap();
+            send_direct(&sender, 0);
+            send_direct(&sender, 1);
+            send_direct(&sender, 2);
+            send_direct(&sender, 3);
 
             if drop_sender {
                 drop(sender);
@@ -5123,10 +5173,10 @@ mod tests {
                     .is_err()
             );
 
-            sender.send(4).unwrap();
-            sender.send(5).unwrap();
-            sender.send(6).unwrap();
-            sender.send(7).unwrap();
+            send_direct(&sender, 4);
+            send_direct(&sender, 5);
+            send_direct(&sender, 6);
+            send_direct(&sender, 7);
 
             if drop_sender {
                 drop(sender);


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4179
* #4178
* #4177
* #4176
* #4175

Back ordinary `Mailbox::open_port` receivers with `SequencedReceiver` so raw local handle sends and serialized/ref sends converge on the same per-port sequencing domain. Raw sends to ordinary ephemeral ports now carry `SeqInfo::Session` from port creation, while handler ports keep their existing unbound-direct behavior because binding moves them to the actor-level handler sequencing domain.

Differential Revision: [D107599901](https://our.internmc.facebook.com/intern/diff/D107599901/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D107599901/)!