### PR TITLE
add a generic actor-attrs snapshot seam (#4180)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -2540,6 +2540,91 @@ mod tests {
         handle.await;
     }
 
+    /// AS-1 (snapshot-opacity): an INTROSPECT-tagged actor-supplied attr
+    /// is transported into the Actor view verbatim. `LAST_HANDLER` is
+    /// INTROSPECT-tagged and left unset by the core builder for a
+    /// message-free actor, so it shows additive transport cleanly (and
+    /// satisfies the accessor's INTROSPECT-tagging guard).
+    #[tokio::test]
+    async fn test_actor_attrs_snapshot_appears_verbatim() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (tx, _rx) = client.open_port::<u64>();
+        let handle = proc.spawn(EchoActor(tx.bind()));
+
+        handle.cell().set_attrs_snapshot(|| {
+            let mut attrs = hyperactor_config::Attrs::new();
+            attrs.set(crate::introspect::LAST_HANDLER, "seam-probe".to_string());
+            attrs
+        });
+
+        let payload = crate::introspect::live_actor_payload(handle.cell());
+        assert_valid_attrs(&payload);
+        assert_eq!(
+            attrs_get(&payload.attrs, "last_handler").and_then(|v| v.as_str().map(String::from)),
+            Some("seam-probe".to_string()),
+            "AS-1: actor-supplied attr must appear verbatim"
+        );
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    /// AS-2 (core-precedence): on a key collision, the core/runtime
+    /// value wins over the actor-supplied snapshot.
+    #[tokio::test]
+    async fn test_actor_attrs_snapshot_core_wins_on_collision() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (tx, _rx) = client.open_port::<u64>();
+        let handle = proc.spawn(EchoActor(tx.bind()));
+
+        // The snapshot tries to clobber a core key with a bogus value;
+        // `build_actor_attrs` sets `messages_processed` unconditionally,
+        // so core must win.
+        handle.cell().set_attrs_snapshot(|| {
+            let mut attrs = hyperactor_config::Attrs::new();
+            attrs.set(crate::introspect::MESSAGES_PROCESSED, 999u64);
+            attrs
+        });
+
+        let payload = crate::introspect::live_actor_payload(handle.cell());
+        let messages = attrs_get(&payload.attrs, "messages_processed")
+            .and_then(|v| v.as_u64())
+            .expect("attrs must contain messages_processed");
+        // Fresh actor processed no messages: the exact core value is 0,
+        // and it wins over the snapshot's bogus 999.
+        assert_eq!(messages, 0, "AS-2: core value must win over the snapshot");
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    /// AS-3 (snapshot-non-fatal): a panicking snapshot degrades to the
+    /// core-only Actor view rather than emptying or invalidating attrs.
+    #[tokio::test]
+    async fn test_actor_attrs_snapshot_panic_is_non_fatal() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (tx, _rx) = client.open_port::<u64>();
+        let handle = proc.spawn(EchoActor(tx.bind()));
+
+        handle
+            .cell()
+            .set_attrs_snapshot(|| -> hyperactor_config::Attrs {
+                panic!("snapshot callback boom")
+            });
+
+        let payload = crate::introspect::live_actor_payload(handle.cell());
+        // Core view survives a panicking snapshot intact (IA-1, IA-5, AS-3).
+        assert_valid_attrs(&payload);
+        assert_has_attr(&payload, "status");
+        assert_has_attr(&payload, "actor_type");
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
     // Verifies that QueryChild returns an error for actors without
     // a registered query_child_handler callback. The runtime
     // introspect task responds with the error sentinel payload

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -155,6 +155,32 @@
 //!   arithmetic or ordering relationship between them is part of the
 //!   API contract; the accounting paths are free to change. Consumers
 //!   must not derive one from the other.
+//!
+//! ## Actor-attrs snapshot invariants (AS-*)
+//!
+//! These govern the generic per-actor introspection-attrs snapshot
+//! seam: an actor may install a `Fn() -> Attrs` callback via
+//! `Instance::set_attrs_snapshot`, which the introspect task invokes in
+//! `build_actor_attrs` and merges into the Actor view. The seam is the
+//! runtime-agnostic transport for actor-supplied introspection data
+//! (e.g. a Python actor reporting in-flight handler execution); core
+//! interprets none of it.
+//!
+//! - **AS-1 (snapshot-opacity):** actor-supplied attrs are merged into
+//!   the Actor view verbatim. Core neither interprets nor validates the
+//!   keys -- any key the actor sets is transported as-is. This is what
+//!   keeps the seam runtime-agnostic (no Rust-vs-Python knowledge, no
+//!   "endpoint" concept in core).
+//! - **AS-2 (core-precedence):** on a key collision, the core/runtime
+//!   key wins over the actor-supplied value. This is the Actor-view
+//!   analog of IA-2, which governs the published-attrs path; the two
+//!   sources of actor-supplied keys (published attrs, snapshot seam) are
+//!   distinct, but both yield to core keys.
+//! - **AS-3 (snapshot-non-fatal):** an absent, empty, or panicking
+//!   snapshot degrades to the core-only Actor view. The callback is
+//!   `catch_unwind`-guarded and the merge falls back to the core attrs,
+//!   so a bad snapshot can never empty or invalidate `attrs` (with IA-1,
+//!   IA-5).
 
 use std::fmt;
 use std::str::FromStr;
@@ -864,7 +890,22 @@ fn build_actor_attrs(cell: &crate::InstanceCell, snap: &ActorSnapshot) -> String
     // IA-4: failure attrs absent when not failed — guaranteed by
     // starting from a fresh Attrs bag (no stale keys possible).
 
-    serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string())
+    let core_json = serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
+
+    // Merge actor-supplied attrs (the generic seam, AS-1). `Attrs::merge`
+    // overwrites the receiver's keys with the argument's, so merging the
+    // core bag *onto* the actor snapshot makes core keys win on collision
+    // (AS-2, the Actor-view analog of IA-2). No snapshot → the core bag is
+    // returned unchanged; if the merged bag somehow fails to serialize,
+    // fall back to the core-only JSON so a bad snapshot can never empty or
+    // invalidate the actor view (AS-3).
+    match cell.actor_attrs_snapshot() {
+        None => core_json,
+        Some(mut merged) => {
+            merged.merge(attrs);
+            serde_json::to_string(&merged).unwrap_or(core_json)
+        }
+    }
 }
 
 /// Build an [`IntrospectResult`] from live [`InstanceCell`] state.

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2437,6 +2437,22 @@ impl<A: Actor> Instance<A> {
         self.inner.cell.merge_published_attr(key, value);
     }
 
+    /// Install an actor-supplied introspection-attrs snapshot callback.
+    ///
+    /// The callback is invoked by the introspect task (outside the actor
+    /// loop) when building this actor's node payload; its `Attrs` are
+    /// merged into the Actor view, core keys winning on collision (AS-2).
+    /// It must be `Send + Sync`, non-blocking (`try_lock`), and
+    /// infallible. Core does not interpret the keys — the actor owns its
+    /// own introspection vocabulary (AS-1). See the AS-* family in
+    /// `introspect.rs`.
+    pub fn set_attrs_snapshot(
+        &self,
+        callback: impl Fn() -> hyperactor_config::Attrs + Send + Sync + 'static,
+    ) {
+        self.inner.cell.set_attrs_snapshot(callback);
+    }
+
     /// Mark this actor as system/infrastructure. System actors are
     /// hidden by default in the TUI (toggled via `s`).
     pub fn set_system(&self) {
@@ -3649,6 +3665,20 @@ struct InstanceCellState {
     /// `Instance::new`; production live actors always install Some.
     inbound_ordering_snapshot:
         Option<Box<dyn Fn() -> crate::ordering::OrderingSnapshot + Send + Sync>>,
+
+    /// Type-erased snapshot callback for actor-supplied introspection
+    /// attrs. Installed by the actor (e.g. in `Actor::init`) via
+    /// `Instance::set_attrs_snapshot`; invoked by the introspect task
+    /// (outside the actor loop) in `build_actor_attrs`, where the
+    /// returned `Attrs` are merged into the Actor view with core keys
+    /// winning on collision (AS-2).
+    ///
+    /// Generic: core does not interpret the keys (AS-1). The callback
+    /// must be non-blocking (`try_lock` internally); it is
+    /// `catch_unwind`-guarded at the call site so a panic degrades to no
+    /// extra attrs rather than breaking introspection (AS-3). `None`
+    /// means the actor publishes no extra attrs.
+    actor_attrs_snapshot: RwLock<Option<Box<dyn Fn() -> hyperactor_config::Attrs + Send + Sync>>>,
 }
 
 impl InstanceCellState {
@@ -3762,6 +3792,7 @@ impl InstanceCell {
                 is_system: AtomicBool::new(false),
                 ports,
                 inbound_ordering_snapshot,
+                actor_attrs_snapshot: RwLock::new(None),
             }),
         };
         cell.maybe_link_parent();
@@ -3991,6 +4022,50 @@ impl InstanceCell {
     /// (`try_lock`, non-blocking) and never perturbs ordering state.
     pub fn inbound_ordering_snapshot(&self) -> Option<crate::ordering::OrderingSnapshot> {
         self.inner.inbound_ordering_snapshot.as_ref().map(|f| f())
+    }
+
+    /// Install the actor-supplied introspection-attrs snapshot callback.
+    /// Called by the actor (e.g. in `Actor::init`). The callback runs on
+    /// the introspect task (outside the actor loop), so it must be
+    /// `Send + Sync`, non-blocking (`try_lock`), and must not access
+    /// actor-mutable state.
+    pub fn set_attrs_snapshot(
+        &self,
+        callback: impl Fn() -> hyperactor_config::Attrs + Send + Sync + 'static,
+    ) {
+        *self.inner.actor_attrs_snapshot.write().unwrap() = Some(Box::new(callback));
+    }
+
+    /// Out-of-band actor-supplied introspection attrs. `None` when no
+    /// callback was installed (the actor publishes no extra attrs).
+    /// `catch_unwind`-guarded: a panicking callback degrades to `None`
+    /// rather than killing the introspect task (AS-3).
+    pub fn actor_attrs_snapshot(&self) -> Option<hyperactor_config::Attrs> {
+        let guard = self.inner.actor_attrs_snapshot.read().unwrap();
+        let callback = guard.as_ref()?;
+        let attrs = std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback))
+            .map_err(|_| {
+                tracing::warn!(
+                    actor_id = %self.actor_addr(),
+                    "actor_attrs_snapshot callback panicked; omitting actor attrs",
+                );
+            })
+            .ok()?;
+        // AS-1 discipline: actor-supplied keys must be INTROSPECT-tagged
+        // (mirrors the `publish_attr` guard), so they carry a stable HTTP
+        // short-name and schema entry rather than forming an ungoverned
+        // second introspection channel.
+        #[cfg(debug_assertions)]
+        for (name, _) in attrs.iter() {
+            debug_assert!(
+                inventory::iter::<hyperactor_config::attrs::AttrKeyInfo>().any(|info| {
+                    info.name == name && info.meta.get(hyperactor_config::INTROSPECT).is_some()
+                }),
+                "actor_attrs_snapshot callback returned non-INTROSPECT key `{name}`; \
+                 actor introspection keys must carry @meta(INTROSPECT)"
+            );
+        }
+        Some(attrs)
     }
 
     /// Get parent instance cell, if it exists.


### PR DESCRIPTION
Summary:

adds a generic, runtime-agnostic seam for an actor to contribute introspection attrs to its Actor view, with core interpreting none of them.

an actor installs a `Fn() -> Attrs` callback via `Instance::set_attrs_snapshot` (mirroring the `query_child_handler` callback pattern); it is stored on `InstanceCellState` and invoked by the introspect task — outside the actor loop — in `build_actor_attrs`, where the returned `Attrs` are merged into the Actor view via `Attrs::merge` with core keys winning on collision.

three invariants govern the seam, documented as the `AS-*` family in the `introspect` module: `AS-1` the snapshot is transported verbatim (core interprets no keys); `AS-2` core/runtime keys win on collision; `AS-3` an absent, empty, or panicking snapshot degrades to the core-only Actor view (`catch_unwind`-guarded; the merge falls back to the core attrs), so a bad snapshot can never empty or invalidate `attrs`.

no attr keys or consumers are added here — this is generic transport only.

Reviewed By: mariusae

Differential Revision: D107663135


