### PR TITLE
classify payloads status-first (DP-5) (#4181)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -2540,6 +2540,91 @@ mod tests {
         handle.await;
     }
 
+    /// AS-1 (snapshot-opacity): an INTROSPECT-tagged actor-supplied attr
+    /// is transported into the Actor view verbatim. `LAST_HANDLER` is
+    /// INTROSPECT-tagged and left unset by the core builder for a
+    /// message-free actor, so it shows additive transport cleanly (and
+    /// satisfies the accessor's INTROSPECT-tagging guard).
+    #[tokio::test]
+    async fn test_actor_attrs_snapshot_appears_verbatim() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (tx, _rx) = client.open_port::<u64>();
+        let handle = proc.spawn(EchoActor(tx.bind()));
+
+        handle.cell().set_attrs_snapshot(|| {
+            let mut attrs = hyperactor_config::Attrs::new();
+            attrs.set(crate::introspect::LAST_HANDLER, "seam-probe".to_string());
+            attrs
+        });
+
+        let payload = crate::introspect::live_actor_payload(handle.cell());
+        assert_valid_attrs(&payload);
+        assert_eq!(
+            attrs_get(&payload.attrs, "last_handler").and_then(|v| v.as_str().map(String::from)),
+            Some("seam-probe".to_string()),
+            "AS-1: actor-supplied attr must appear verbatim"
+        );
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    /// AS-2 (core-precedence): on a key collision, the core/runtime
+    /// value wins over the actor-supplied snapshot.
+    #[tokio::test]
+    async fn test_actor_attrs_snapshot_core_wins_on_collision() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (tx, _rx) = client.open_port::<u64>();
+        let handle = proc.spawn(EchoActor(tx.bind()));
+
+        // The snapshot tries to clobber a core key with a bogus value;
+        // `build_actor_attrs` sets `messages_processed` unconditionally,
+        // so core must win.
+        handle.cell().set_attrs_snapshot(|| {
+            let mut attrs = hyperactor_config::Attrs::new();
+            attrs.set(crate::introspect::MESSAGES_PROCESSED, 999u64);
+            attrs
+        });
+
+        let payload = crate::introspect::live_actor_payload(handle.cell());
+        let messages = attrs_get(&payload.attrs, "messages_processed")
+            .and_then(|v| v.as_u64())
+            .expect("attrs must contain messages_processed");
+        // Fresh actor processed no messages: the exact core value is 0,
+        // and it wins over the snapshot's bogus 999.
+        assert_eq!(messages, 0, "AS-2: core value must win over the snapshot");
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    /// AS-3 (snapshot-non-fatal): a panicking snapshot degrades to the
+    /// core-only Actor view rather than emptying or invalidating attrs.
+    #[tokio::test]
+    async fn test_actor_attrs_snapshot_panic_is_non_fatal() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (tx, _rx) = client.open_port::<u64>();
+        let handle = proc.spawn(EchoActor(tx.bind()));
+
+        handle
+            .cell()
+            .set_attrs_snapshot(|| -> hyperactor_config::Attrs {
+                panic!("snapshot callback boom")
+            });
+
+        let payload = crate::introspect::live_actor_payload(handle.cell());
+        // Core view survives a panicking snapshot intact (IA-1, IA-5, AS-3).
+        assert_valid_attrs(&payload);
+        assert_has_attr(&payload, "status");
+        assert_has_attr(&payload, "actor_type");
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
     // Verifies that QueryChild returns an error for actors without
     // a registered query_child_handler callback. The runtime
     // introspect task responds with the error sentinel payload

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -155,6 +155,32 @@
 //!   arithmetic or ordering relationship between them is part of the
 //!   API contract; the accounting paths are free to change. Consumers
 //!   must not derive one from the other.
+//!
+//! ## Actor-attrs snapshot invariants (AS-*)
+//!
+//! These govern the generic per-actor introspection-attrs snapshot
+//! seam: an actor may install a `Fn() -> Attrs` callback via
+//! `Instance::set_attrs_snapshot`, which the introspect task invokes in
+//! `build_actor_attrs` and merges into the Actor view. The seam is the
+//! runtime-agnostic transport for actor-supplied introspection data
+//! (e.g. a Python actor reporting in-flight handler execution); core
+//! interprets none of it.
+//!
+//! - **AS-1 (snapshot-opacity):** actor-supplied attrs are merged into
+//!   the Actor view verbatim. Core neither interprets nor validates the
+//!   keys -- any key the actor sets is transported as-is. This is what
+//!   keeps the seam runtime-agnostic (no Rust-vs-Python knowledge, no
+//!   "endpoint" concept in core).
+//! - **AS-2 (core-precedence):** on a key collision, the core/runtime
+//!   key wins over the actor-supplied value. This is the Actor-view
+//!   analog of IA-2, which governs the published-attrs path; the two
+//!   sources of actor-supplied keys (published attrs, snapshot seam) are
+//!   distinct, but both yield to core keys.
+//! - **AS-3 (snapshot-non-fatal):** an absent, empty, or panicking
+//!   snapshot degrades to the core-only Actor view. The callback is
+//!   `catch_unwind`-guarded and the merge falls back to the core attrs,
+//!   so a bad snapshot can never empty or invalidate `attrs` (with IA-1,
+//!   IA-5).
 
 use std::fmt;
 use std::str::FromStr;
@@ -864,7 +890,22 @@ fn build_actor_attrs(cell: &crate::InstanceCell, snap: &ActorSnapshot) -> String
     // IA-4: failure attrs absent when not failed — guaranteed by
     // starting from a fresh Attrs bag (no stale keys possible).
 
-    serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string())
+    let core_json = serde_json::to_string(&attrs).unwrap_or_else(|_| "{}".to_string());
+
+    // Merge actor-supplied attrs (the generic seam, AS-1). `Attrs::merge`
+    // overwrites the receiver's keys with the argument's, so merging the
+    // core bag *onto* the actor snapshot makes core keys win on collision
+    // (AS-2, the Actor-view analog of IA-2). No snapshot → the core bag is
+    // returned unchanged; if the merged bag somehow fails to serialize,
+    // fall back to the core-only JSON so a bad snapshot can never empty or
+    // invalidate the actor view (AS-3).
+    match cell.actor_attrs_snapshot() {
+        None => core_json,
+        Some(mut merged) => {
+            merged.merge(attrs);
+            serde_json::to_string(&merged).unwrap_or(core_json)
+        }
+    }
 }
 
 /// Build an [`IntrospectResult`] from live [`InstanceCell`] state.

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2437,6 +2437,22 @@ impl<A: Actor> Instance<A> {
         self.inner.cell.merge_published_attr(key, value);
     }
 
+    /// Install an actor-supplied introspection-attrs snapshot callback.
+    ///
+    /// The callback is invoked by the introspect task (outside the actor
+    /// loop) when building this actor's node payload; its `Attrs` are
+    /// merged into the Actor view, core keys winning on collision (AS-2).
+    /// It must be `Send + Sync`, non-blocking (`try_lock`), and
+    /// infallible. Core does not interpret the keys — the actor owns its
+    /// own introspection vocabulary (AS-1). See the AS-* family in
+    /// `introspect.rs`.
+    pub fn set_attrs_snapshot(
+        &self,
+        callback: impl Fn() -> hyperactor_config::Attrs + Send + Sync + 'static,
+    ) {
+        self.inner.cell.set_attrs_snapshot(callback);
+    }
+
     /// Mark this actor as system/infrastructure. System actors are
     /// hidden by default in the TUI (toggled via `s`).
     pub fn set_system(&self) {
@@ -3649,6 +3665,20 @@ struct InstanceCellState {
     /// `Instance::new`; production live actors always install Some.
     inbound_ordering_snapshot:
         Option<Box<dyn Fn() -> crate::ordering::OrderingSnapshot + Send + Sync>>,
+
+    /// Type-erased snapshot callback for actor-supplied introspection
+    /// attrs. Installed by the actor (e.g. in `Actor::init`) via
+    /// `Instance::set_attrs_snapshot`; invoked by the introspect task
+    /// (outside the actor loop) in `build_actor_attrs`, where the
+    /// returned `Attrs` are merged into the Actor view with core keys
+    /// winning on collision (AS-2).
+    ///
+    /// Generic: core does not interpret the keys (AS-1). The callback
+    /// must be non-blocking (`try_lock` internally); it is
+    /// `catch_unwind`-guarded at the call site so a panic degrades to no
+    /// extra attrs rather than breaking introspection (AS-3). `None`
+    /// means the actor publishes no extra attrs.
+    actor_attrs_snapshot: RwLock<Option<Box<dyn Fn() -> hyperactor_config::Attrs + Send + Sync>>>,
 }
 
 impl InstanceCellState {
@@ -3762,6 +3792,7 @@ impl InstanceCell {
                 is_system: AtomicBool::new(false),
                 ports,
                 inbound_ordering_snapshot,
+                actor_attrs_snapshot: RwLock::new(None),
             }),
         };
         cell.maybe_link_parent();
@@ -3991,6 +4022,50 @@ impl InstanceCell {
     /// (`try_lock`, non-blocking) and never perturbs ordering state.
     pub fn inbound_ordering_snapshot(&self) -> Option<crate::ordering::OrderingSnapshot> {
         self.inner.inbound_ordering_snapshot.as_ref().map(|f| f())
+    }
+
+    /// Install the actor-supplied introspection-attrs snapshot callback.
+    /// Called by the actor (e.g. in `Actor::init`). The callback runs on
+    /// the introspect task (outside the actor loop), so it must be
+    /// `Send + Sync`, non-blocking (`try_lock`), and must not access
+    /// actor-mutable state.
+    pub fn set_attrs_snapshot(
+        &self,
+        callback: impl Fn() -> hyperactor_config::Attrs + Send + Sync + 'static,
+    ) {
+        *self.inner.actor_attrs_snapshot.write().unwrap() = Some(Box::new(callback));
+    }
+
+    /// Out-of-band actor-supplied introspection attrs. `None` when no
+    /// callback was installed (the actor publishes no extra attrs).
+    /// `catch_unwind`-guarded: a panicking callback degrades to `None`
+    /// rather than killing the introspect task (AS-3).
+    pub fn actor_attrs_snapshot(&self) -> Option<hyperactor_config::Attrs> {
+        let guard = self.inner.actor_attrs_snapshot.read().unwrap();
+        let callback = guard.as_ref()?;
+        let attrs = std::panic::catch_unwind(std::panic::AssertUnwindSafe(callback))
+            .map_err(|_| {
+                tracing::warn!(
+                    actor_id = %self.actor_addr(),
+                    "actor_attrs_snapshot callback panicked; omitting actor attrs",
+                );
+            })
+            .ok()?;
+        // AS-1 discipline: actor-supplied keys must be INTROSPECT-tagged
+        // (mirrors the `publish_attr` guard), so they carry a stable HTTP
+        // short-name and schema entry rather than forming an ungoverned
+        // second introspection channel.
+        #[cfg(debug_assertions)]
+        for (name, _) in attrs.iter() {
+            debug_assert!(
+                inventory::iter::<hyperactor_config::attrs::AttrKeyInfo>().any(|info| {
+                    info.name == name && info.meta.get(hyperactor_config::INTROSPECT).is_some()
+                }),
+                "actor_attrs_snapshot callback returned non-INTROSPECT key `{name}`; \
+                 actor introspection keys must carry @meta(INTROSPECT)"
+            );
+        }
+        Some(attrs)
     }
 
     /// Get parent instance cell, if it exists.

--- a/hyperactor_mesh/src/introspect.rs
+++ b/hyperactor_mesh/src/introspect.rs
@@ -117,19 +117,26 @@
 //! ## Derive invariants (DP-*)
 //!
 //! - **DP-1 (derive-precedence):** `derive_properties` dispatches
-//!   on `node_type` first, then falls back to `error_code`,
-//!   then `status`, then unknown. This order is the canonical
-//!   detection chain.
+//!   on `status` first (DP-5), then `node_type`, then `error_code`,
+//!   then unknown. This order is the canonical detection chain.
 //! - **DP-2 (derive-totality-on-parse-failure):**
 //!   `derive_properties` is total; malformed or incoherent attrs
 //!   never panic and map to `NodeProperties::Error` with detail.
 //! - **DP-3 (derive-precedence-stability):**
 //!   `derive_properties` detection order is stable and explicit:
-//!   `node_type` > `error_code` > `status` > unknown.
+//!   `status` > `node_type` > `error_code` > unknown.
 //! - **DP-4 (error-on-decode-failure):** Any view decode or
 //!   invariant failure maps to a deterministic
 //!   `NodeProperties::Error` with a `malformed_*` code family,
 //!   without panic.
+//! - **DP-5 (actor-view classification safety):** a payload
+//!   carrying the core `STATUS` key always decodes as `Actor`.
+//!   `STATUS` is set only by the blanket Actor builder
+//!   (`build_actor_attrs`) and is core-owned, so the actor-attrs
+//!   snapshot seam can neither remove nor override it (AS-2), and no
+//!   non-actor payload (root/host/proc/error) carries it. Therefore
+//!   an actor cannot inject `node_type`/`error_code` via the seam to
+//!   spoof a different node kind.
 //!
 //! ## Inbound ordering presentation (IO-*)
 //!
@@ -1195,10 +1202,11 @@ impl IntoNodeProperties for hyperactor::introspect::ActorAttrsView {
 
 /// Derive `NodeProperties` from a JSON-serialized attrs string.
 ///
-/// Detection precedence (DP-1, DP-3):
-/// 1. `node_type` = "root" / "host" / "proc" → corresponding variant
-/// 2. `error_code` present → Error
-/// 3. `STATUS` key present → Actor
+/// Detection precedence (DP-1, DP-3, DP-5):
+/// 1. `STATUS` key present → Actor (DP-5: a STATUS-bearing payload always
+///    decodes as Actor, so the actor-attrs seam cannot spoof node kind)
+/// 2. `node_type` = "root" / "host" / "proc" → corresponding variant
+/// 3. `error_code` present → Error
 /// 4. none of the above → Error("unknown_node_type")
 ///
 /// DP-2 / DP-4: this function is total — malformed attrs never
@@ -1206,6 +1214,9 @@ impl IntoNodeProperties for hyperactor::introspect::ActorAttrsView {
 /// with a `malformed_*` code.
 /// AV-3 / IA-6: view decoders ignore unknown keys.
 pub fn derive_properties(attrs_json: &str) -> NodeProperties {
+    use hyperactor::introspect::ERROR_CODE;
+    use hyperactor::introspect::STATUS;
+
     let attrs: Attrs = match serde_json::from_str(attrs_json) {
         Ok(a) => a,
         Err(_) => {
@@ -1215,6 +1226,23 @@ pub fn derive_properties(attrs_json: &str) -> NodeProperties {
             };
         }
     };
+
+    // DP-5 (actor-view classification safety): the core `STATUS` key is set
+    // only by the blanket Actor builder (`build_actor_attrs`) and is
+    // core-owned, so the actor-attrs snapshot seam can neither remove nor
+    // override it (AS-2), and no non-actor payload carries it. Classifying
+    // STATUS-present as `Actor` *before* `node_type`/`error_code` means a
+    // snapshot-injected `node_type`/`error_code` cannot make a blanket actor
+    // decode as Root/Proc/Error.
+    if attrs.get(STATUS).is_some() {
+        return match hyperactor::introspect::ActorAttrsView::from_attrs(&attrs) {
+            Ok(v) => v.into_node_properties(),
+            Err(e) => NodeProperties::Error {
+                code: "malformed_actor".into(),
+                message: e.to_string(),
+            },
+        };
+    }
 
     let node_type = attrs.get(NODE_TYPE).cloned().unwrap_or_default();
 
@@ -1241,11 +1269,8 @@ pub fn derive_properties(attrs_json: &str) -> NodeProperties {
             },
         },
         _ => {
-            // DP-1: error_code → Error, STATUS present → Actor,
-            // else → Error("unknown_node_type").
-            use hyperactor::introspect::ERROR_CODE;
-            use hyperactor::introspect::STATUS;
-
+            // STATUS-bearing payloads decoded as Actor above (DP-5), so
+            // here STATUS is absent: error_code → Error, else unknown.
             if attrs.get(ERROR_CODE).is_some() {
                 return match ErrorAttrsView::from_attrs(&attrs) {
                     Ok(v) => v.into_node_properties(),
@@ -1256,19 +1281,9 @@ pub fn derive_properties(attrs_json: &str) -> NodeProperties {
                 };
             }
 
-            if attrs.get(STATUS).is_none() {
-                return NodeProperties::Error {
-                    code: "unknown_node_type".into(),
-                    message: format!("unrecognized node_type: {:?}", node_type),
-                };
-            }
-
-            match hyperactor::introspect::ActorAttrsView::from_attrs(&attrs) {
-                Ok(v) => v.into_node_properties(),
-                Err(e) => NodeProperties::Error {
-                    code: "malformed_actor".into(),
-                    message: e.to_string(),
-                },
+            NodeProperties::Error {
+                code: "unknown_node_type".into(),
+                message: format!("unrecognized node_type: {:?}", node_type),
             }
         }
     }
@@ -1685,6 +1700,49 @@ mod tests {
                 messages_processed: 7,
                 ..
             }
+        ));
+    }
+
+    /// DP-5: a snapshot-injected `node_type` cannot make a STATUS-bearing
+    /// (blanket) actor decode as a non-Actor node.
+    #[test]
+    fn test_derive_properties_status_first_ignores_injected_node_type() {
+        use hyperactor::introspect::ACTOR_TYPE;
+        use hyperactor::introspect::INSTANCE_ID;
+        use hyperactor::introspect::STATUS;
+
+        let mut attrs = Attrs::new();
+        attrs.set(STATUS, "running".into());
+        attrs.set(ACTOR_TYPE, "TestActor".into());
+        attrs.set(INSTANCE_ID, "01900000-0000-7000-8000-000000000001".into());
+        // Hostile injection via the actor-attrs seam.
+        attrs.set(NODE_TYPE, "root".into());
+        let json = serde_json::to_string(&attrs).unwrap();
+        assert!(matches!(
+            derive_properties(&json),
+            NodeProperties::Actor { .. }
+        ));
+    }
+
+    /// DP-5: a snapshot-injected `error_code` cannot make a STATUS-bearing
+    /// actor decode as an Error node.
+    #[test]
+    fn test_derive_properties_status_first_ignores_injected_error_code() {
+        use hyperactor::introspect::ACTOR_TYPE;
+        use hyperactor::introspect::ERROR_CODE;
+        use hyperactor::introspect::INSTANCE_ID;
+        use hyperactor::introspect::STATUS;
+
+        let mut attrs = Attrs::new();
+        attrs.set(STATUS, "running".into());
+        attrs.set(ACTOR_TYPE, "TestActor".into());
+        attrs.set(INSTANCE_ID, "01900000-0000-7000-8000-000000000001".into());
+        // Hostile injection via the actor-attrs seam.
+        attrs.set(ERROR_CODE, "not_found".into());
+        let json = serde_json::to_string(&attrs).unwrap();
+        assert!(matches!(
+            derive_properties(&json),
+            NodeProperties::Actor { .. }
         ));
     }
 


### PR DESCRIPTION
Summary:

classify a `NodeProperties` payload by the core `STATUS` key first — before `node_type`/`error_code` — in `derive_properties`.

`STATUS` is set only by the blanket Actor builder (`build_actor_attrs`) and is core-owned, so the actor-attrs snapshot seam can neither remove nor override it (AS-2), and no non-actor payload (root/host/proc/error) carries it. without this, an actor's snapshot callback could inject `node_type` or `error_code` and make its Actor-view payload decode as Root/Proc/Error — mesh-admin resolves actors via `IntrospectView::Actor` and runs the result through `derive_properties`, so the misclassification would be observable over the API and the TUI.

behaviour is unchanged for every legitimate payload (no legitimate actor carries `node_type`; no legitimate non-actor carries `STATUS`); only a seam-injected classification key is now ignored. documented as DP-5; the precedence is now `status > node_type > error_code > unknown` (DP-1/DP-3 updated).

Reviewed By: mariusae

Differential Revision: D107666572


