### PR TITLE
[ROCm] - skip device-pointer probe until a HIP primary context exists

### DIFF
--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -24,14 +24,8 @@ use crate::backend::ibverbs::primitives::IbvMemoryRegionView;
 /// Probes the CUDA driver via `cuPointerGetAttribute`; returns `false`
 /// when CUDA is unavailable or the pointer is not device memory.
 pub fn is_device_ptr(addr: usize) -> bool {
-    // rdmaxcel must not be the first component to create a GPU context. On
-    // ROCm, creating a HIP primary context before PyTorch initializes its own
-    // runtime leaves torch unable to allocate device memory. When no primary
-    // context is active, no device pointer can exist, so `addr` is necessarily
-    // host memory and we skip the probe, which would otherwise force context
-    // creation. `rdmaxcel_cuPrimaryCtxActive` returns 1 on CUDA, so this is a
-    // no-op there. The runtime, once initialized, stays initialized, so we
-    // latch a ready result and avoid the FFI call on the steady-state path.
+    // On ROCm, a primary HIP context is created even if the pointer is in host memory.
+    // We only want to init primary HIP context if the pointer is actually on the device
     static RUNTIME_READY: std::sync::atomic::AtomicBool =
         std::sync::atomic::AtomicBool::new(false);
     if !RUNTIME_READY.load(std::sync::atomic::Ordering::Relaxed) {

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -24,6 +24,24 @@ use crate::backend::ibverbs::primitives::IbvMemoryRegionView;
 /// Probes the CUDA driver via `cuPointerGetAttribute`; returns `false`
 /// when CUDA is unavailable or the pointer is not device memory.
 pub fn is_device_ptr(addr: usize) -> bool {
+    // rdmaxcel must not be the first component to create a GPU context. On
+    // ROCm, creating a HIP primary context before PyTorch initializes its own
+    // runtime leaves torch unable to allocate device memory. When no primary
+    // context is active, no device pointer can exist, so `addr` is necessarily
+    // host memory and we skip the probe, which would otherwise force context
+    // creation. `rdmaxcel_cuPrimaryCtxActive` returns 1 on CUDA, so this is a
+    // no-op there. The runtime, once initialized, stays initialized, so we
+    // latch a ready result and avoid the FFI call on the steady-state path.
+    static RUNTIME_READY: std::sync::atomic::AtomicBool =
+        std::sync::atomic::AtomicBool::new(false);
+    if !RUNTIME_READY.load(std::sync::atomic::Ordering::Relaxed) {
+        // SAFETY: queries runtime/context state only; creates no context and
+        // does not access `addr`.
+        if unsafe { rdmaxcel_sys::rdmaxcel_cuPrimaryCtxActive() } == 0 {
+            return false;
+        }
+        RUNTIME_READY.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
     // SAFETY: FFI call that queries pointer metadata without accessing
     // the pointed-to memory.
     unsafe {

--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -273,6 +273,56 @@ CUresult rdmaxcel_cuPointerGetAttribute(
   return rdmaxcel::DriverAPI::get()->pointerGetAttribute_(data, attribute, ptr);
 }
 
+int rdmaxcel_cuPrimaryCtxActive(void) {
+#ifdef USE_ROCM
+  // Deliberately bypasses DriverAPI::get(), whose cudaFree(0) creates a
+  // context. RTLD_NOLOAD: if the HIP runtime is not even loaded, nothing has
+  // initialized HIP and no device pointer can exist.
+  void* handle = dlopen("libamdhip64.so", RTLD_LAZY | RTLD_NOLOAD);
+  if (!handle) {
+    return 0;
+  }
+  auto hip_init =
+      reinterpret_cast<hipError_t (*)(unsigned int)>(dlsym(handle, "hipInit"));
+  auto get_device_count = reinterpret_cast<hipError_t (*)(int*)>(
+      dlsym(handle, "hipGetDeviceCount"));
+  auto device_get = reinterpret_cast<hipError_t (*)(hipDevice_t*, int)>(
+      dlsym(handle, "hipDeviceGet"));
+  auto primary_ctx_get_state =
+      reinterpret_cast<hipError_t (*)(hipDevice_t, unsigned int*, int*)>(
+          dlsym(handle, "hipDevicePrimaryCtxGetState"));
+  if (!hip_init || !get_device_count || !device_get ||
+      !primary_ctx_get_state) {
+    return 0;
+  }
+  // hipInit initializes the driver but never creates a context, so it does
+  // not perturb torch's lazy runtime initialization.
+  if (hip_init(0) != hipSuccess) {
+    return 0;
+  }
+  int count = 0;
+  if (get_device_count(&count) != hipSuccess) {
+    return 0;
+  }
+  for (int i = 0; i < count; ++i) {
+    hipDevice_t dev = 0;
+    if (device_get(&dev, i) != hipSuccess) {
+      continue;
+    }
+    unsigned int flags = 0;
+    int active = 0;
+    if (primary_ctx_get_state(dev, &flags, &active) == hipSuccess && active) {
+      return 1;
+    }
+  }
+  return 0;
+#else
+  // CUDA: rdmaxcel attaching to the driver does not corrupt torch's runtime
+  // init, so always allow the pointer probe (behavior unchanged).
+  return 1;
+#endif
+}
+
 // Device management
 CUresult rdmaxcel_cuInit(unsigned int Flags) {
   return rdmaxcel::DriverAPI::get()->init_(Flags);

--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -295,8 +295,6 @@ int rdmaxcel_cuPrimaryCtxActive(void) {
       !primary_ctx_get_state) {
     return 0;
   }
-  // hipInit initializes the driver but never creates a context, so it does
-  // not perturb torch's lazy runtime initialization.
   if (hip_init(0) != hipSuccess) {
     return 0;
   }
@@ -317,8 +315,7 @@ int rdmaxcel_cuPrimaryCtxActive(void) {
   }
   return 0;
 #else
-  // CUDA: rdmaxcel attaching to the driver does not corrupt torch's runtime
-  // init, so always allow the pointer probe (behavior unchanged).
+  // CUDA: behavior unchanged
   return 1;
 #endif
 }

--- a/rdmaxcel-sys/src/driver_api.h
+++ b/rdmaxcel-sys/src/driver_api.h
@@ -88,6 +88,13 @@ CUresult rdmaxcel_cuPointerGetAttribute(
     CUpointer_attribute attribute,
     CUdeviceptr ptr);
 
+// Returns nonzero if the GPU runtime is initialized such that a device
+// pointer could exist. On ROCm, returns nonzero only when some device's
+// primary context is active; on CUDA it always returns nonzero. Used to
+// avoid rdmaxcel creating a HIP context before PyTorch initializes its own
+// runtime, which corrupts torch's lazy device initialization.
+int rdmaxcel_cuPrimaryCtxActive(void);
+
 // Device management
 CUresult rdmaxcel_cuInit(unsigned int Flags);
 

--- a/rdmaxcel-sys/src/driver_api.h
+++ b/rdmaxcel-sys/src/driver_api.h
@@ -90,9 +90,7 @@ CUresult rdmaxcel_cuPointerGetAttribute(
 
 // Returns nonzero if the GPU runtime is initialized such that a device
 // pointer could exist. On ROCm, returns nonzero only when some device's
-// primary context is active; on CUDA it always returns nonzero. Used to
-// avoid rdmaxcel creating a HIP context before PyTorch initializes its own
-// runtime, which corrupts torch's lazy device initialization.
+// primary context is active; on CUDA it always returns nonzero.
 int rdmaxcel_cuPrimaryCtxActive(void);
 
 // Device management


### PR DESCRIPTION
# Fix: prevent rdmaxcel from initializing the HIP runtime before PyTorch (ROCm)

## Summary

On ROCm, creating a local RDMA memory handle for **host** memory could leave
PyTorch unable to allocate **device** memory, failing with
`torch.AcceleratorError: CUDA error: invalid argument`. The root cause is an
initialization-ordering bug: `is_device_ptr` unconditionally probes the GPU
driver, and on ROCm that probe forces creation of a HIP primary context. If
rdmaxcel wins this race and brings up HIP before PyTorch initializes its own
runtime, torch's later lazy device initialization is corrupted.

This change gates the eager driver probe behind a new check,
`rdmaxcel_cuPrimaryCtxActive`, that reports whether a GPU context already
exists. When none exists, no device pointer can exist either, so the address is
treated as host memory and the probe is skipped — meaning rdmaxcel never
initializes HIP before torch. The new function returns a constant on CUDA, so
the CUDA path is behaviorally unchanged.

## Background / root cause

`monarch_rdma::local_memory::is_device_ptr` is called for **every** local memory
handle, including host memory, from `LocalMemoryInner::new`. It calls
`rdmaxcel_cuPointerGetAttribute`, which routes through
`rdmaxcel::DriverAPI::get()`. That accessor runs `cudaFree(0)` (hipified to
`hipFree(0)` on ROCm) to "ensure a valid context," which **creates the HIP
primary context**.

In the failing scenario:

1. A host tensor handle is created. `is_device_ptr` runs and, via
   `DriverAPI::get()`, creates the HIP primary context. This is the process's
   first interaction with the GPU runtime — torch has not initialized HIP yet.
2. Code then allocates a device tensor (`torch.tensor(..., device="cuda")`).
   Torch's lazy HIP initialization now runs against a context it did not
   establish, and the device allocation fails with HIP `invalid argument`.

This was reproduced and isolated to the ordering (not the device test itself):

- `hipInit(0)` alone does **not** poison torch — the poison is context
  *creation* (`hipFree(0)`), not driver init.
- If torch initializes HIP first, the identical rdmaxcel probe is harmless.
- `expandable_segments` is **not** required to trigger the failure; it
  reproduces with the default caching allocator too.

### Why it only manifested when running the whole test suite

pytest runs all tests in a single process, and GPU/HIP runtime state is
process-global, so it leaks across tests. In `python/tests/test_rdma.py`,
`test_host_memory_handle_read_write` (host tensor) is defined before
`test_device_memory_handle_read_write`. The host test never touches the GPU
through torch, but it does build a local memory handle, which triggered the
rdmaxcel HIP first-touch and poisoned state for the device test that followed.

Run in isolation, the device test's `torch.tensor(..., device="cuda")` is the
first GPU touch; torch initializes HIP cleanly and rdmaxcel's later probe simply
attaches to the existing context. Hence the test passed alone but failed
in-suite.

## The fix

A new GPU-runtime readiness check determines whether it is safe to probe a
pointer, *without itself creating a context*:

- **ROCm:** initialize only the HIP driver (`hipInit`, which never creates a
  context) and query each device's primary-context state via
  `hipDevicePrimaryCtxGetState`. Return nonzero if any device's primary context
  is active. If `libamdhip64` is not even loaded (`dlopen` with `RTLD_NOLOAD`
  returns null), HIP cannot have been initialized, so return zero. This path
  deliberately bypasses `DriverAPI::get()` so it never runs the
  context-creating `hipFree(0)`.
- **CUDA:** return `1` unconditionally — rdmaxcel attaching to the driver does
  not corrupt torch's runtime init, so the probe should always run, exactly as
  before.

`is_device_ptr` calls this first. If it reports "not ready," no device pointer
can exist, so the address is host and we return `false` without probing — and
therefore without creating a context. Once the runtime is ready it stays ready,
so the result is latched in an `AtomicBool` and the steady-state cost is a
single relaxed load.

### Why this fixes the bug

In the suite, when the host test builds its handle, no GPU context is active
yet, so `rdmaxcel_cuPrimaryCtxActive` returns 0 and `is_device_ptr` returns
`false` *without* probing. The context-creating `hipFree(0)` is never reached.
PyTorch is therefore free to initialize HIP cleanly in the device test, and
rdmaxcel's later probe (now that a primary context exists) simply attaches to
torch's context. The classification of host vs. device memory is unchanged once
the runtime is up — the probe is only suppressed *before* any context exists,
when the answer is unambiguously "host."

### Why it does not affect the CUDA path

- On CUDA, `rdmaxcel_cuPrimaryCtxActive` compiles to `return 1;`, so
  `is_device_ptr` always proceeds to the existing probe. Pointer classification
  is identical to before this change.
- The only added cost on CUDA is one FFI call returning a constant on the first
  invocation (after which the `AtomicBool` latches), plus a relaxed atomic load
  per call. No behavioral change.
- The ROCm-specific logic is entirely under `#ifdef USE_ROCM` in C, which is
  defined only for ROCm builds, so it is not compiled into CUDA binaries.
- No bindgen/`build.rs` change is required: the new symbol matches the existing
  `allowlist_function("rdmaxcel_cu.*")` rule.

## Files changed

- **`rdmaxcel-sys/src/driver_api.h`** — declare `int rdmaxcel_cuPrimaryCtxActive(void);`.
- **`rdmaxcel-sys/src/driver_api.cpp`** — define it. ROCm path self-loads the
  HIP runtime (`dlopen`/`dlsym`) and calls only `hipInit` +
  `hipGetDeviceCount` + `hipDeviceGet` + `hipDevicePrimaryCtxGetState`,
  deliberately bypassing `DriverAPI::get()` (whose `hipFree(0)` creates the
  context). CUDA path is `#else return 1;`.
- **`monarch_rdma/src/local_memory.rs`** — `is_device_ptr` calls
  `rdmaxcel_cuPrimaryCtxActive` first; returns `false` (host) when it reports 0,
  otherwise runs the existing `rdmaxcel_cuPointerGetAttribute` probe. A
  process-wide `AtomicBool` latches the ready state.

## Testing

- `python -m pytest python/tests/test_rdma.py` now reports **5 passed,
  19 skipped** (previously **1 failed, 4 passed, 19 skipped**).
- The minimal repro (host test then device test in one process) passes both.
- The device test asserts exact `read_at`/`write_at` round-trip values on a CUDA
  tensor, which exercise the GPU copy path — confirming device memory is still
  correctly classified as device once the runtime is initialized, i.e. the fix
  does not silently route device pointers through the host path.


## Caveats / assumptions

- **CUDA was not exercised here** (this was reproduced and verified on a
  ROCm-only host where `torch.version.cuda is None`). The CUDA path is
  behavior-preserving by construction (`#else return 1;`), but it was not run
  on CUDA hardware in this change.
- The readiness signal assumes device memory lives under a **primary** context,
  which holds for PyTorch's caching allocator (including `expandable_segments`).
  A device pointer allocated under a user-created *non-primary* context with no
  active primary context would be misclassified as host. This is exotic and was
  not handled by the previous code either.
- `rdmaxcel_cuPrimaryCtxActive` scans **all** devices, not just device 0, so
  the readiness check is correct when PyTorch initializes a non-zero device.
