### PR TITLE
add actor_executions and active_handlers rows to the snapshot DB (#4190)

### DIFF
--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -9,6 +9,7 @@
 use std::time::SystemTime;
 
 use hyperactor::introspect::RecordedEvent;
+use hyperactor_mesh::introspect::Execution;
 use hyperactor_mesh::introspect::FailureInfo;
 use hyperactor_mesh::introspect::InboundOrdering;
 use hyperactor_mesh::introspect::NodePayload;
@@ -322,6 +323,7 @@ pub(crate) fn render_node_detail(
             total_processing_time_us,
             flight_recorder,
             inbound_ordering,
+            execution,
             failure_info,
             ..
         } => {
@@ -339,6 +341,7 @@ pub(crate) fn render_node_detail(
                 *total_processing_time_us,
                 flight_recorder.as_deref(),
                 inbound_ordering.as_deref(),
+                execution.as_deref(),
                 failure_info.as_ref(),
                 scheme,
                 labels,
@@ -608,6 +611,7 @@ fn render_actor_detail(
     total_processing_time_us: u64,
     flight_recorder_json: Option<&str>,
     inbound_ordering: Option<&InboundOrdering>,
+    execution: Option<&Execution>,
     failure_info: Option<&FailureInfo>,
     scheme: &ColorScheme,
     l: &Labels,
@@ -616,11 +620,17 @@ fn render_actor_detail(
     // lines (Instance, Queue depth) in the info block.
     let info_height: u16 = if failure_info.is_some() { 17 } else { 13 };
     let ordering_height = compute_ordering_height(area.height, info_height, inbound_ordering);
+    // Execution section is hidden (height 0) when the actor reports no
+    // execution (None = unsupported) or nothing is in flight; its budget
+    // comes after info + ordering, preserving the flight recorder's minimum.
+    let execution_height =
+        compute_execution_height(area.height, info_height, ordering_height, execution);
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([
             Constraint::Length(info_height),
             Constraint::Length(ordering_height),
+            Constraint::Length(execution_height),
             Constraint::Min(MIN_FLIGHT_RECORDER_HEIGHT),
         ])
         .split(area);
@@ -702,6 +712,9 @@ fn render_actor_detail(
     // Inbound ordering
     render_inbound_ordering(frame, chunks[1], inbound_ordering, scheme, l);
 
+    // Execution (hidden via a zero-height chunk when None / active_count 0).
+    render_execution(frame, chunks[2], execution, scheme, l);
+
     // Flight recorder
     let recorder_block = Block::default()
         .title(l.pane_flight_recorder)
@@ -744,7 +757,7 @@ fn render_actor_detail(
     let recorder = Paragraph::new(events)
         .block(recorder_block)
         .wrap(Wrap { trim: true });
-    frame.render_widget(recorder, chunks[2]);
+    frame.render_widget(recorder, chunks[3]);
 }
 
 /// Compute the desired height for the inbound-ordering section, capped
@@ -775,6 +788,120 @@ fn compute_ordering_height(
         }
     };
     want.min(budget)
+}
+
+/// Compute the desired height for the Execution section.
+///
+/// Returns 0 when the actor reports no execution (`None` = unsupported) or
+/// nothing is in flight (`active_count == 0`), hiding the section entirely.
+/// Otherwise sizes to the rendered line count, capped against the remaining
+/// budget so the flight recorder keeps its minimum height. Must match the
+/// line count produced by `build_execution_lines`.
+fn compute_execution_height(
+    area_height: u16,
+    info_height: u16,
+    ordering_height: u16,
+    execution: Option<&Execution>,
+) -> u16 {
+    let Some(e) = execution else {
+        return 0;
+    };
+    if e.active_count == 0 {
+        return 0;
+    }
+    let budget = area_height
+        .saturating_sub(info_height)
+        .saturating_sub(ordering_height)
+        .saturating_sub(MIN_FLIGHT_RECORDER_HEIGHT);
+    // border(2) + count line(1) + oldest line(1 iff a row exists)
+    // + per-name rows + truncation marker(1 iff truncated).
+    let oldest_line = u16::from(!e.active_handlers.is_empty());
+    let rows = e.active_handlers.len() as u16;
+    let more_row = u16::from(e.truncated);
+    let want = 2 + 1 + oldest_line + rows + more_row;
+    want.min(budget)
+}
+
+/// Render the Execution section: the second plane to lifecycle status,
+/// answering "what is this actor handling right now?".
+///
+/// Drawn only when the actor reports execution (`Some`) with
+/// `active_count > 0` (the caller gives this a zero-height chunk
+/// otherwise). The top-level count comes straight from `active_count` --
+/// never summed from the (possibly truncated) per-name rows (EX-3).
+fn render_execution(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    execution: Option<&Execution>,
+    scheme: &ColorScheme,
+    l: &Labels,
+) {
+    let Some(e) = execution else {
+        return;
+    };
+    if e.active_count == 0 {
+        return;
+    }
+    let block = Block::default()
+        .title(l.pane_execution)
+        .borders(Borders::ALL)
+        .border_style(scheme.border);
+    let p = Paragraph::new(build_execution_lines(e, scheme, l))
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(p, area);
+}
+
+fn build_execution_lines<'a>(
+    e: &'a Execution,
+    scheme: &ColorScheme,
+    l: &'a Labels,
+) -> Vec<Line<'a>> {
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Top-level count: read directly from active_count (EX-3).
+    lines.push(detail_line(
+        l.execution_active_handlers,
+        e.active_count.to_string(),
+        scheme,
+    ));
+
+    // Oldest live invocation: the first row (aggregated by name and sorted
+    // oldest-first upstream, EX-4). Absent when per-handler detail was
+    // momentarily unavailable on this poll (EX-2: complete == false leaves
+    // active_handlers empty while the count above stays authoritative).
+    if let Some(first) = e.active_handlers.first() {
+        lines.push(detail_line(
+            l.execution_oldest,
+            format!(
+                "{} ({})",
+                first.name,
+                format_system_time_relative(&first.oldest_since)
+            ),
+            scheme,
+        ));
+    }
+
+    // Per-name rows: "name ×active_count  age".
+    for h in &e.active_handlers {
+        lines.push(Line::from(Span::raw(format!(
+            "{} \u{00d7}{}  {}",
+            h.name,
+            h.active_count,
+            format_system_time_relative(&h.oldest_since),
+        ))));
+    }
+
+    // Truncation marker (EX-4): some of the oldest names were dropped. We
+    // don't carry a precise hidden-name count, so the marker is unqualified.
+    if e.truncated {
+        lines.push(Line::from(Span::styled(
+            l.execution_more_names,
+            scheme.detail_label,
+        )));
+    }
+
+    lines
 }
 
 /// Column widths for the per-session table. Owner column truncates
@@ -1393,6 +1520,96 @@ mod tests {
             parent: None,
             as_of: SystemTime::now(),
         }
+    }
+
+    fn actor_payload_with_execution(execution: Execution) -> NodePayload {
+        let mut payload = actor_payload(None);
+        if let NodeProperties::Actor { execution: e, .. } = &mut payload.properties {
+            *e = Some(Box::new(execution));
+        }
+        payload
+    }
+
+    // EX-1: a supported-but-idle actor (Some, active_count 0) hides the
+    // Execution section -- no border title, no count line.
+    #[test]
+    fn render_actor_detail_execution_hidden_when_idle() {
+        let idle = Execution {
+            active_count: 0,
+            active_handlers: vec![],
+            complete: true,
+            truncated: false,
+        };
+        let text = render_detail_to_string_with_size(&actor_payload_with_execution(idle), 120, 45);
+        assert!(
+            !text.contains("Active handlers"),
+            "Execution section must be hidden at active_count 0: {text}"
+        );
+    }
+
+    // Populated: the count line reads active_count directly (2), the oldest
+    // line names the oldest endpoint, and the aggregated per-name row shows
+    // "hold ×2".
+    #[test]
+    fn render_actor_detail_execution_populated() {
+        let execution = Execution {
+            active_count: 2,
+            active_handlers: vec![ActiveHandler {
+                name: "hold".to_string(),
+                active_count: 2,
+                oldest_since: SystemTime::now(),
+            }],
+            complete: true,
+            truncated: false,
+        };
+        let text =
+            render_detail_to_string_with_size(&actor_payload_with_execution(execution), 120, 45);
+        assert!(
+            text.contains("Active handlers: 2"),
+            "expected count line from active_count: {text}"
+        );
+        assert!(
+            text.contains("Oldest: hold"),
+            "expected oldest endpoint name: {text}"
+        );
+        assert!(
+            text.contains("hold \u{00d7}2"),
+            "expected aggregated row 'hold ×2': {text}"
+        );
+        assert!(
+            !text.contains("more endpoint names"),
+            "no truncation marker when not truncated: {text}"
+        );
+    }
+
+    // Truncation: the count line still reads the FULL total (200); the marker
+    // appears (we carry no precise hidden-name count, so it is unqualified).
+    #[test]
+    fn render_actor_detail_execution_truncated_marker() {
+        let mut active_handlers = Vec::new();
+        for i in 0..16u64 {
+            active_handlers.push(ActiveHandler {
+                name: format!("ep_{i:02}"),
+                active_count: 1,
+                oldest_since: SystemTime::now(),
+            });
+        }
+        let execution = Execution {
+            active_count: 200,
+            active_handlers,
+            complete: true,
+            truncated: true,
+        };
+        let text =
+            render_detail_to_string_with_size(&actor_payload_with_execution(execution), 120, 60);
+        assert!(
+            text.contains("Active handlers: 200"),
+            "count line is the full total, not the row count: {text}"
+        );
+        assert!(
+            text.contains("more endpoint names"),
+            "truncation marker present when truncated: {text}"
+        );
     }
 
     fn session(

--- a/hyperactor_mesh_admin_tui/src/theme.rs
+++ b/hyperactor_mesh_admin_tui/src/theme.rs
@@ -123,6 +123,12 @@ pub(crate) struct Labels {
     pub(crate) ordering_sender_fallback: &'static str,
     pub(crate) ordering_footer: &'static str,
 
+    // Execution pane labels.
+    pub(crate) pane_execution: &'static str,
+    pub(crate) execution_active_handlers: &'static str,
+    pub(crate) execution_oldest: &'static str,
+    pub(crate) execution_more_names: &'static str,
+
     // Failure detail labels
     pub(crate) error_message: &'static str,
     pub(crate) root_cause: &'static str,
@@ -233,6 +239,10 @@ impl Labels {
             ordering_more_row: "… and {n} more",
             ordering_sender_fallback: "(no owner; session {id})",
             ordering_footer: "Owner = SEQ_INFO session owner (V1 = sender; V0 = forwarding CommActor).",
+            pane_execution: "Execution",
+            execution_active_handlers: "Active handlers: ",
+            execution_oldest: "Oldest: ",
+            execution_more_names: "… more endpoint names",
             error_message: "Error: ",
             root_cause: "Root cause: ",
             failed_at: "Failed at: ",
@@ -334,6 +344,10 @@ impl Labels {
             ordering_more_row: "… 还有 {n} 个",
             ordering_sender_fallback: "（无所有者；会话 {id}）",
             ordering_footer: "所有者 = SEQ_INFO 会话所有者（V1 = 发送者；V0 = 转发 CommActor）。",
+            pane_execution: "执行",
+            execution_active_handlers: "活跃处理器: ",
+            execution_oldest: "最早: ",
+            execution_more_names: "… 还有更多端点名称",
             error_message: "错误: ",
             root_cause: "根因: ",
             failed_at: "失败时间: ",

--- a/monarch_extension/src/snapshot_integration.rs
+++ b/monarch_extension/src/snapshot_integration.rs
@@ -21,7 +21,7 @@ use monarch_introspection_snapshot::integration::register_snapshot_schemas;
 use monarch_introspection_snapshot::integration::start_periodic_snapshots;
 use pyo3::prelude::*;
 
-/// Pre-register the 11 snapshot table schemas in a `DatabaseScanner`.
+/// Pre-register the 13 snapshot table schemas in a `DatabaseScanner`.
 ///
 /// Must be called after `DatabaseScanner` creation and before
 /// `QueryEngine` construction, because table discovery is static.

--- a/monarch_introspection_snapshot/src/bundle.rs
+++ b/monarch_introspection_snapshot/src/bundle.rs
@@ -8,7 +8,7 @@
 
 //! Durable snapshot bundle export and import.
 //!
-//! A snapshot bundle is a directory containing 11 Arrow IPC files (one
+//! A snapshot bundle is a directory containing 13 Arrow IPC files (one
 //! per table) and a JSON manifest. It represents exactly one snapshot
 //! and is the persistence mechanism for historical TUI debugging.
 //!
@@ -122,6 +122,8 @@ fn counts_from_batches(batches: &[NamedBatch]) -> NodeCounts {
         actor_failures: row_count("actor_failures"),
         actor_inbound_orderings: row_count("actor_inbound_orderings"),
         ordering_sessions: row_count("ordering_sessions"),
+        actor_executions: row_count("actor_executions"),
+        active_handlers: row_count("active_handlers"),
         resolution_errors: row_count("resolution_errors"),
     }
 }
@@ -146,6 +148,8 @@ fn counts_from_loaded(loaded: &[(&str, usize)]) -> NodeCounts {
         actor_failures: row_count("actor_failures"),
         actor_inbound_orderings: row_count("actor_inbound_orderings"),
         ordering_sessions: row_count("ordering_sessions"),
+        actor_executions: row_count("actor_executions"),
+        active_handlers: row_count("active_handlers"),
         resolution_errors: row_count("resolution_errors"),
     }
 }
@@ -365,6 +369,8 @@ mod tests {
             actor_failures: vec![],
             actor_inbound_orderings: vec![],
             ordering_sessions: vec![],
+            actor_executions: vec![],
+            active_handlers: vec![],
             resolution_errors: vec![],
         }
     }
@@ -469,6 +475,8 @@ mod tests {
             actor_failures: vec![],
             actor_inbound_orderings: vec![],
             ordering_sessions: vec![],
+            actor_executions: vec![],
+            active_handlers: vec![],
             resolution_errors: vec![],
         }
     }

--- a/monarch_introspection_snapshot/src/capture.rs
+++ b/monarch_introspection_snapshot/src/capture.rs
@@ -31,7 +31,9 @@
 //!   [`NodeRow`], exactly one subtype-table row matching `kind_row`,
 //!   optionally one [`ActorFailureRow`], optionally one
 //!   [`ActorInboundOrderingRow`] (CV-8), all of its
-//!   [`OrderingSessionRow`]s (CV-9), and all of its [`ChildRow`]s.
+//!   [`OrderingSessionRow`]s (CV-9), optionally one
+//!   [`ActorExecutionRow`] (CV-10), all of its [`ActiveHandlerRow`]s
+//!   (CV-11), and all of its [`ChildRow`]s.
 //! - **CS-6 (resolution-error-boundary):** Resolver transport/query
 //!   failure aborts capture with `Err`. Only successfully resolved
 //!   payloads with `NodeProperties::Error` populate
@@ -55,6 +57,8 @@ use crate::convert::ConvertedNode;
 use crate::convert::NodeKindRow;
 use crate::convert::convert_node;
 use crate::convert::to_micros;
+use crate::schema::ActiveHandlerRow;
+use crate::schema::ActorExecutionRow;
 use crate::schema::ActorFailureRow;
 use crate::schema::ActorInboundOrderingRow;
 use crate::schema::ActorNodeRow;
@@ -95,6 +99,12 @@ pub struct SnapshotData {
     /// snapshot (CV-9). Skipped sessions are NOT enumerated; they
     /// appear only in the parent rollup's `skipped_session_count`.
     pub ordering_sessions: Vec<OrderingSessionRow>,
+    /// One row per actor with `execution: Some(…)` (CV-10).
+    pub actor_executions: Vec<ActorExecutionRow>,
+    /// One row per in-flight handler in any actor's execution snapshot
+    /// (CV-11). A prefix of the N oldest when truncated; empty when the
+    /// rollup's `complete == false`.
+    pub active_handlers: Vec<ActiveHandlerRow>,
     /// One row per successfully resolved `NodeProperties::Error`
     /// (CS-6: distinct from resolver transport failures).
     pub resolution_errors: Vec<ResolutionErrorRow>,
@@ -115,6 +125,10 @@ impl SnapshotData {
             self.actor_inbound_orderings.push(io);
         }
         self.ordering_sessions.extend(converted.ordering_sessions);
+        if let Some(e) = converted.actor_execution {
+            self.actor_executions.push(e);
+        }
+        self.active_handlers.extend(converted.active_handlers);
         match converted.kind_row {
             NodeKindRow::Root(r) => self.root_nodes.push(r),
             NodeKindRow::Host(h) => self.host_nodes.push(h),
@@ -154,6 +168,8 @@ where
         actor_failures: Vec::new(),
         actor_inbound_orderings: Vec::new(),
         ordering_sessions: Vec::new(),
+        actor_executions: Vec::new(),
+        active_handlers: Vec::new(),
         resolution_errors: Vec::new(),
     };
 
@@ -717,6 +733,8 @@ mod tests {
                     actor_failure: None,
                     actor_inbound_ordering: None,
                     ordering_sessions: vec![],
+                    actor_execution: None,
+                    active_handlers: vec![],
                     children: vec![ChildRow {
                         snapshot_id: "s".to_owned(),
                         parent_id: "root".to_owned(),
@@ -740,6 +758,8 @@ mod tests {
                     actor_failure: None,
                     actor_inbound_ordering: None,
                     ordering_sessions: vec![],
+                    actor_execution: None,
+                    active_handlers: vec![],
                     children: vec![],
                 },
                 "Host",
@@ -759,6 +779,8 @@ mod tests {
                     actor_failure: None,
                     actor_inbound_ordering: None,
                     ordering_sessions: vec![],
+                    actor_execution: None,
+                    active_handlers: vec![],
                     children: vec![],
                 },
                 "Proc",
@@ -790,6 +812,8 @@ mod tests {
                     }),
                     actor_inbound_ordering: None,
                     ordering_sessions: vec![],
+                    actor_execution: None,
+                    active_handlers: vec![],
                     children: vec![],
                 },
                 "Actor",
@@ -806,6 +830,8 @@ mod tests {
                     actor_failure: None,
                     actor_inbound_ordering: None,
                     ordering_sessions: vec![],
+                    actor_execution: None,
+                    active_handlers: vec![],
                     children: vec![],
                 },
                 "ResolutionError",
@@ -826,6 +852,8 @@ mod tests {
             actor_failures: Vec::new(),
             actor_inbound_orderings: Vec::new(),
             ordering_sessions: Vec::new(),
+            actor_executions: Vec::new(),
+            active_handlers: Vec::new(),
             resolution_errors: Vec::new(),
         };
 

--- a/monarch_introspection_snapshot/src/convert.rs
+++ b/monarch_introspection_snapshot/src/convert.rs
@@ -47,18 +47,30 @@
 //!   Skipped sessions are reflected only via
 //!   `ActorInboundOrderingRow.skipped_session_count`; they are NOT
 //!   enumerated as `OrderingSessionRow`s.
+//! - **CV-10 (execution-conditional-row):**
+//!   `ConvertedNode::actor_execution` is `Some` iff
+//!   `NodeProperties::Actor { execution: Some(_) }`. Other
+//!   `NodeProperties` variants always emit `None`. Mirrors CV-8.
+//! - **CV-11 (active-handlers detail):**
+//!   `ConvertedNode::active_handlers` contains exactly the per-handler
+//!   rows in `Execution.active_handlers` — a prefix of the N oldest when
+//!   the rollup is `truncated`, empty when `complete == false`. The
+//!   rollup's `active_count` stays the authoritative total. Mirrors CV-9.
 
 use std::collections::HashSet;
 use std::time::SystemTime;
 use std::time::UNIX_EPOCH;
 
 use anyhow::Context;
+use hyperactor_mesh::introspect::Execution;
 use hyperactor_mesh::introspect::FailureInfo;
 use hyperactor_mesh::introspect::InboundOrdering;
 use hyperactor_mesh::introspect::NodePayload;
 use hyperactor_mesh::introspect::NodeProperties;
 use hyperactor_mesh::introspect::NodeRef;
 
+use crate::schema::ActiveHandlerRow;
+use crate::schema::ActorExecutionRow;
 use crate::schema::ActorFailureRow;
 use crate::schema::ActorInboundOrderingRow;
 use crate::schema::ActorNodeRow;
@@ -91,6 +103,12 @@ pub struct ConvertedNode {
     /// Per-returned-session detail rows (CV-9). Empty for non-actor
     /// nodes and for actors with `inbound_ordering: None`.
     pub ordering_sessions: Vec<OrderingSessionRow>,
+    /// Execution rollup, present only for actor nodes with
+    /// `execution: Some(…)` (CV-10).
+    pub actor_execution: Option<ActorExecutionRow>,
+    /// Per-handler detail rows (CV-11). A prefix of the N oldest when the
+    /// rollup is `truncated`; empty when `complete == false`.
+    pub active_handlers: Vec<ActiveHandlerRow>,
     /// One [`ChildRow`] per entry in `payload.children`, in
     /// enumeration order (CV-4).
     pub children: Vec<ChildRow>,
@@ -235,114 +253,160 @@ pub fn convert_node(snapshot_id: &str, payload: &NodePayload) -> anyhow::Result<
     // Subtype row + optional failure + optional inbound-ordering rollup
     // + per-session detail. Done first because NodeRow.node_kind is
     // derived from the same match via kind_row.kind_str().
-    let (kind_row, actor_failure, actor_inbound_ordering, ordering_sessions) =
-        match &payload.properties {
-            NodeProperties::Root {
-                num_hosts,
-                started_at,
-                started_by,
-                ..
-            } => {
-                let row = RootNodeRow {
-                    snapshot_id: snapshot_id.to_owned(),
-                    node_id: node_id.clone(),
-                    num_hosts: i64::try_from(*num_hosts).context("num_hosts overflow i64")?,
-                    started_at: to_micros(*started_at)?,
-                    started_by: started_by.clone(),
-                };
-                (NodeKindRow::Root(row), None, None, Vec::new())
-            }
-            NodeProperties::Host {
-                addr, num_procs, ..
-            } => {
-                let row = HostNodeRow {
-                    snapshot_id: snapshot_id.to_owned(),
-                    node_id: node_id.clone(),
-                    addr: addr.clone(),
-                    host_num_procs: i64::try_from(*num_procs).context("num_procs overflow i64")?,
-                };
-                (NodeKindRow::Host(row), None, None, Vec::new())
-            }
-            NodeProperties::Proc {
-                proc_name,
-                num_actors,
-                stopped_retention_cap,
-                is_poisoned,
-                failed_actor_count,
-                ..
-            } => {
-                let row = ProcNodeRow {
-                    snapshot_id: snapshot_id.to_owned(),
-                    node_id: node_id.clone(),
-                    proc_name: proc_name.clone(),
-                    num_actors: i64::try_from(*num_actors).context("num_actors overflow i64")?,
-                    stopped_retention_cap: i64::try_from(*stopped_retention_cap)
-                        .context("stopped_retention_cap overflow i64")?,
-                    is_poisoned: *is_poisoned,
-                    failed_actor_count: i64::try_from(*failed_actor_count)
-                        .context("failed_actor_count overflow i64")?,
-                };
-                (NodeKindRow::Proc(row), None, None, Vec::new())
-            }
-            NodeProperties::Actor {
-                actor_status,
-                actor_type,
-                instance_id,
-                messages_processed,
-                created_at,
-                last_message_handler,
-                total_processing_time_us,
-                queue_depth,
-                is_system,
-                inbound_ordering,
-                failure_info,
-                ..
-            } => {
-                let actor_row = ActorNodeRow {
-                    snapshot_id: snapshot_id.to_owned(),
-                    node_id: node_id.clone(),
-                    actor_status: actor_status.clone(),
-                    actor_type: actor_type.clone(),
-                    instance_id: instance_id.clone(),
-                    messages_processed: i64::try_from(*messages_processed)
-                        .context("messages_processed overflow i64")?,
-                    created_at: to_opt_micros(*created_at)?,
-                    last_message_handler: last_message_handler.clone(),
-                    total_processing_time_us: i64::try_from(*total_processing_time_us)
-                        .context("total_processing_time_us overflow i64")?,
-                    queue_depth: to_i64("queue_depth", *queue_depth)?,
-                    is_system: *is_system,
-                };
-                let failure = failure_info
-                    .as_ref()
-                    .map(|fi| convert_failure(snapshot_id, &node_id, fi))
-                    .transpose()?;
-                let actor_inbound_ordering = inbound_ordering
-                    .as_deref()
-                    .map(|io| convert_inbound_ordering(snapshot_id, &node_id, io))
-                    .transpose()?;
-                let ordering_sessions = inbound_ordering
-                    .as_deref()
-                    .map(|io| convert_ordering_sessions(snapshot_id, &node_id, io))
-                    .transpose()?
-                    .unwrap_or_default();
-                (
-                    NodeKindRow::Actor(actor_row),
-                    failure,
-                    actor_inbound_ordering,
-                    ordering_sessions,
-                )
-            }
-            NodeProperties::Error { code, message } => {
-                let row = ResolutionErrorRow {
-                    snapshot_id: snapshot_id.to_owned(),
-                    node_id: node_id.clone(),
-                    error_code: code.clone(),
-                    error_message: message.clone(),
-                };
-                (NodeKindRow::ResolutionError(row), None, None, Vec::new())
-            }
-        };
+    let (
+        kind_row,
+        actor_failure,
+        actor_inbound_ordering,
+        ordering_sessions,
+        actor_execution,
+        active_handlers,
+    ) = match &payload.properties {
+        NodeProperties::Root {
+            num_hosts,
+            started_at,
+            started_by,
+            ..
+        } => {
+            let row = RootNodeRow {
+                snapshot_id: snapshot_id.to_owned(),
+                node_id: node_id.clone(),
+                num_hosts: i64::try_from(*num_hosts).context("num_hosts overflow i64")?,
+                started_at: to_micros(*started_at)?,
+                started_by: started_by.clone(),
+            };
+            (
+                NodeKindRow::Root(row),
+                None,
+                None,
+                Vec::new(),
+                None,
+                Vec::new(),
+            )
+        }
+        NodeProperties::Host {
+            addr, num_procs, ..
+        } => {
+            let row = HostNodeRow {
+                snapshot_id: snapshot_id.to_owned(),
+                node_id: node_id.clone(),
+                addr: addr.clone(),
+                host_num_procs: i64::try_from(*num_procs).context("num_procs overflow i64")?,
+            };
+            (
+                NodeKindRow::Host(row),
+                None,
+                None,
+                Vec::new(),
+                None,
+                Vec::new(),
+            )
+        }
+        NodeProperties::Proc {
+            proc_name,
+            num_actors,
+            stopped_retention_cap,
+            is_poisoned,
+            failed_actor_count,
+            ..
+        } => {
+            let row = ProcNodeRow {
+                snapshot_id: snapshot_id.to_owned(),
+                node_id: node_id.clone(),
+                proc_name: proc_name.clone(),
+                num_actors: i64::try_from(*num_actors).context("num_actors overflow i64")?,
+                stopped_retention_cap: i64::try_from(*stopped_retention_cap)
+                    .context("stopped_retention_cap overflow i64")?,
+                is_poisoned: *is_poisoned,
+                failed_actor_count: i64::try_from(*failed_actor_count)
+                    .context("failed_actor_count overflow i64")?,
+            };
+            (
+                NodeKindRow::Proc(row),
+                None,
+                None,
+                Vec::new(),
+                None,
+                Vec::new(),
+            )
+        }
+        NodeProperties::Actor {
+            actor_status,
+            actor_type,
+            instance_id,
+            messages_processed,
+            created_at,
+            last_message_handler,
+            total_processing_time_us,
+            queue_depth,
+            is_system,
+            inbound_ordering,
+            failure_info,
+            execution,
+            ..
+        } => {
+            let actor_row = ActorNodeRow {
+                snapshot_id: snapshot_id.to_owned(),
+                node_id: node_id.clone(),
+                actor_status: actor_status.clone(),
+                actor_type: actor_type.clone(),
+                instance_id: instance_id.clone(),
+                messages_processed: i64::try_from(*messages_processed)
+                    .context("messages_processed overflow i64")?,
+                created_at: to_opt_micros(*created_at)?,
+                last_message_handler: last_message_handler.clone(),
+                total_processing_time_us: i64::try_from(*total_processing_time_us)
+                    .context("total_processing_time_us overflow i64")?,
+                queue_depth: to_i64("queue_depth", *queue_depth)?,
+                is_system: *is_system,
+            };
+            let failure = failure_info
+                .as_ref()
+                .map(|fi| convert_failure(snapshot_id, &node_id, fi))
+                .transpose()?;
+            let actor_inbound_ordering = inbound_ordering
+                .as_deref()
+                .map(|io| convert_inbound_ordering(snapshot_id, &node_id, io))
+                .transpose()?;
+            let ordering_sessions = inbound_ordering
+                .as_deref()
+                .map(|io| convert_ordering_sessions(snapshot_id, &node_id, io))
+                .transpose()?
+                .unwrap_or_default();
+            let actor_execution = execution
+                .as_deref()
+                .map(|e| convert_execution(snapshot_id, &node_id, e))
+                .transpose()?;
+            let active_handlers = execution
+                .as_deref()
+                .map(|e| convert_active_handlers(snapshot_id, &node_id, e))
+                .transpose()?
+                .unwrap_or_default();
+            (
+                NodeKindRow::Actor(actor_row),
+                failure,
+                actor_inbound_ordering,
+                ordering_sessions,
+                actor_execution,
+                active_handlers,
+            )
+        }
+        NodeProperties::Error { code, message } => {
+            let row = ResolutionErrorRow {
+                snapshot_id: snapshot_id.to_owned(),
+                node_id: node_id.clone(),
+                error_code: code.clone(),
+                error_message: message.clone(),
+            };
+            (
+                NodeKindRow::ResolutionError(row),
+                None,
+                None,
+                Vec::new(),
+                None,
+                Vec::new(),
+            )
+        }
+    };
 
     let node = NodeRow {
         snapshot_id: snapshot_id.to_owned(),
@@ -361,6 +425,8 @@ pub fn convert_node(snapshot_id: &str, payload: &NodePayload) -> anyhow::Result<
         actor_failure,
         actor_inbound_ordering,
         ordering_sessions,
+        actor_execution,
+        active_handlers,
         children,
     })
 }
@@ -432,6 +498,39 @@ fn convert_ordering_sessions(
                     .newest_buffered_seq
                     .map(|v| to_i64("newest_buffered_seq", v))
                     .transpose()?,
+            })
+        })
+        .collect()
+}
+
+fn convert_execution(
+    snapshot_id: &str,
+    node_id: &str,
+    exec: &Execution,
+) -> anyhow::Result<ActorExecutionRow> {
+    Ok(ActorExecutionRow {
+        snapshot_id: snapshot_id.to_owned(),
+        node_id: node_id.to_owned(),
+        active_count: to_i64("active_count", exec.active_count)?,
+        complete: exec.complete,
+        truncated: exec.truncated,
+    })
+}
+
+fn convert_active_handlers(
+    snapshot_id: &str,
+    node_id: &str,
+    exec: &Execution,
+) -> anyhow::Result<Vec<ActiveHandlerRow>> {
+    exec.active_handlers
+        .iter()
+        .map(|h| {
+            Ok(ActiveHandlerRow {
+                snapshot_id: snapshot_id.to_owned(),
+                node_id: node_id.to_owned(),
+                name: h.name.clone(),
+                active_count: to_i64("active_count", h.active_count)?,
+                oldest_since: to_micros(h.oldest_since)?,
             })
         })
         .collect()
@@ -732,6 +831,118 @@ mod tests {
         };
         assert_eq!(actor.instance_id, "019e5661-7d33-7380-9afe-699ffc567531");
         assert_eq!(actor.queue_depth, 8);
+    }
+
+    // CV-10 (Some case) and CV-11 (per-handler detail): Actor with
+    // `execution: Some(...)` emits one `ActorExecutionRow` and one
+    // `ActiveHandlerRow` per entry in `Execution.active_handlers`.
+    #[test]
+    fn test_convert_actor_with_execution() {
+        let payload = NodePayload {
+            identity: NodeRef::Actor(test_actor_id()),
+            properties: NodeProperties::Actor {
+                actor_status: "running".to_owned(),
+                actor_type: "MyActor".to_owned(),
+                messages_processed: 1,
+                created_at: None,
+                last_message_handler: None,
+                total_processing_time_us: 0,
+                flight_recorder: None,
+                instance_id: "019e5661-7d33-7380-9afe-699ffc567531".to_owned(),
+                queue_depth: 0,
+                is_system: false,
+                inbound_ordering: None,
+                failure_info: None,
+                execution: Some(Box::new(hyperactor_mesh::introspect::Execution {
+                    // EX-3: the rollup total is observational, not the
+                    // sum of the per-handler detail (2 + 1 = 3 here).
+                    active_count: 5,
+                    complete: true,
+                    truncated: false,
+                    active_handlers: vec![
+                        hyperactor_mesh::introspect::ActiveHandler {
+                            name: "endpoint_slow".to_owned(),
+                            active_count: 2,
+                            oldest_since: std::time::UNIX_EPOCH
+                                + std::time::Duration::from_micros(2),
+                        },
+                        hyperactor_mesh::introspect::ActiveHandler {
+                            name: "endpoint_fast".to_owned(),
+                            active_count: 1,
+                            oldest_since: std::time::UNIX_EPOCH
+                                + std::time::Duration::from_micros(6),
+                        },
+                    ],
+                })),
+            },
+            children: vec![],
+            parent: Some(NodeRef::Proc(test_proc_id())),
+            as_of: test_time(),
+        };
+
+        let result = convert_node("snap-1", &payload).unwrap();
+
+        // CV-10: Some-side emits exactly one rollup row carrying the
+        // observational total (EX-3), independent of the detail sum.
+        let exec = result
+            .actor_execution
+            .as_ref()
+            .expect("CV-10: Some-side must emit ActorExecutionRow");
+        assert_eq!(exec.active_count, 5);
+        assert!(exec.complete);
+        assert!(!exec.truncated);
+
+        // CV-11: one detail row per `Execution.active_handlers` entry;
+        // `oldest_since` carried through as micros-since-epoch.
+        assert_eq!(result.active_handlers.len(), 2);
+        let slow = result
+            .active_handlers
+            .iter()
+            .find(|h| h.name == "endpoint_slow")
+            .unwrap();
+        assert_eq!(slow.active_count, 2);
+        assert_eq!(slow.oldest_since, 2);
+        let fast = result
+            .active_handlers
+            .iter()
+            .find(|h| h.name == "endpoint_fast")
+            .unwrap();
+        assert_eq!(fast.active_count, 1);
+        assert_eq!(fast.oldest_since, 6);
+    }
+
+    // CV-10 (None case): Actor with `execution: None` emits no
+    // `ActorExecutionRow` and no `ActiveHandlerRow`s.
+    #[test]
+    fn test_convert_actor_without_execution() {
+        let payload = NodePayload {
+            identity: NodeRef::Actor(test_actor_id()),
+            properties: NodeProperties::Actor {
+                actor_status: "running".to_owned(),
+                actor_type: "MyActor".to_owned(),
+                messages_processed: 0,
+                created_at: None,
+                last_message_handler: None,
+                total_processing_time_us: 0,
+                flight_recorder: None,
+                instance_id: String::new(),
+                queue_depth: 0,
+                is_system: false,
+                inbound_ordering: None,
+                failure_info: None,
+                execution: None,
+            },
+            children: vec![],
+            parent: Some(NodeRef::Proc(test_proc_id())),
+            as_of: test_time(),
+        };
+
+        let result = convert_node("snap-1", &payload).unwrap();
+        assert!(
+            result.actor_execution.is_none(),
+            "CV-10: None-side must not emit ActorExecutionRow"
+        );
+        assert!(result.active_handlers.is_empty());
     }
 
     // CV-1, CV-2, CV-3 (Some case), CV-6: Actor with failure.

--- a/monarch_introspection_snapshot/src/integration.rs
+++ b/monarch_introspection_snapshot/src/integration.rs
@@ -18,7 +18,7 @@
 //! # Snapshot integration invariants (SI-*)
 //!
 //! - **SI-1 (snapshot tables discoverable):** After
-//!   `register_snapshot_schemas`, the 11 snapshot table names appear
+//!   `register_snapshot_schemas`, the 13 snapshot table names appear
 //!   in `DatabaseScanner.table_names()` and are discoverable by
 //!   `QueryEngine.setup_tables()`.
 //! - **SI-2 (snapshot tables queryable):** After periodic capture
@@ -55,6 +55,8 @@ use hyperactor_mesh::mesh_admin::MeshAdminAgent;
 use monarch_distributed_telemetry::database_scanner::TableStore;
 use monarch_record_batch::RecordBatchBuffer;
 
+use crate::schema::ActiveHandlerRowBuffer;
+use crate::schema::ActorExecutionRowBuffer;
 use crate::schema::ActorFailureRowBuffer;
 use crate::schema::ActorInboundOrderingRowBuffer;
 use crate::schema::ActorNodeRowBuffer;
@@ -69,7 +71,7 @@ use crate::schema::SnapshotRowBuffer;
 use crate::service::CaptureSnapshot;
 use crate::service::SnapshotCaptureActor;
 
-/// Pre-register the 11 snapshot table schemas into `table_store`.
+/// Pre-register the 13 snapshot table schemas into `table_store`.
 ///
 /// Each table is registered with a zero-row `RecordBatch` carrying
 /// the correct Arrow schema. This must be called before the
@@ -81,6 +83,14 @@ use crate::service::SnapshotCaptureActor;
 pub async fn register_snapshot_schemas(table_store: &TableStore) -> anyhow::Result<()> {
     // Order matches SNAPSHOT_TABLE_NAMES (sorted).
     let batches = [
+        (
+            "active_handlers",
+            ActiveHandlerRowBuffer::default().drain_to_record_batch()?,
+        ),
+        (
+            "actor_executions",
+            ActorExecutionRowBuffer::default().drain_to_record_batch()?,
+        ),
         (
             "actor_failures",
             ActorFailureRowBuffer::default().drain_to_record_batch()?,
@@ -162,7 +172,7 @@ mod tests {
     use super::*;
     use crate::push::SNAPSHOT_TABLE_NAMES;
 
-    // SI-1: register_snapshot_schemas populates a TableStore with 11
+    // SI-1: register_snapshot_schemas populates a TableStore with 13
     // table names matching SNAPSHOT_TABLE_NAMES.
     #[tokio::test]
     async fn test_register_snapshot_schemas() {
@@ -170,7 +180,7 @@ mod tests {
         register_snapshot_schemas(&store).await.unwrap();
 
         let names = store.table_names().unwrap();
-        assert_eq!(names.len(), 11);
+        assert_eq!(names.len(), 13);
 
         let expected: Vec<String> = SNAPSHOT_TABLE_NAMES.iter().map(|s| s.to_string()).collect();
         assert_eq!(names, expected);

--- a/monarch_introspection_snapshot/src/push.rs
+++ b/monarch_introspection_snapshot/src/push.rs
@@ -9,14 +9,14 @@
 //! Drain [`SnapshotData`] into [`TableStore`] tables.
 //!
 //! The shared infrastructure is [`drain_to_batches`], which converts
-//! a [`SnapshotData`] into 11 named `RecordBatch` pairs. The public
+//! a [`SnapshotData`] into 13 named `RecordBatch` pairs. The public
 //! entry point [`push_snapshot`] uses this to ingest all tables into
 //! a [`TableStore`].
 //!
 //! # Push-snapshot invariants (PS-*)
 //!
 //! - **PS-1 (full table coverage):** Every `push_snapshot` call
-//!   ingests all eleven logical tables, including empty ones.
+//!   ingests all thirteen logical tables, including empty ones.
 //! - **PS-2 (canonical routing):** Each row family goes only to its
 //!   canonical table.
 //! - **PS-3 (append-preserving counts):** Each table's row count
@@ -38,6 +38,8 @@ use monarch_distributed_telemetry::database_scanner::TableStore;
 use monarch_record_batch::RecordBatchBuffer;
 
 use crate::capture::SnapshotData;
+use crate::schema::ActiveHandlerRowBuffer;
+use crate::schema::ActorExecutionRowBuffer;
 use crate::schema::ActorFailureRowBuffer;
 use crate::schema::ActorInboundOrderingRowBuffer;
 use crate::schema::ActorNodeRowBuffer;
@@ -52,9 +54,11 @@ use crate::schema::SnapshotRowBuffer;
 
 /// Canonical table names in sorted order.
 ///
-/// Every snapshot contains exactly these 11 tables. Both
+/// Every snapshot contains exactly these 13 tables. Both
 /// [`drain_to_batches`] and [`push_snapshot`] use this ordering.
 pub const SNAPSHOT_TABLE_NAMES: &[&str] = &[
+    "active_handlers",
+    "actor_executions",
     "actor_failures",
     "actor_inbound_orderings",
     "actor_nodes",
@@ -73,7 +77,7 @@ pub type NamedBatch = (&'static str, RecordBatch);
 
 /// Drain all row families in `data` to named `RecordBatch` pairs.
 ///
-/// Returns exactly 11 pairs, one per table, in
+/// Returns exactly 13 pairs, one per table, in
 /// [`SNAPSHOT_TABLE_NAMES`] order. Empty families produce zero-row
 /// batches with correct schemas (PS-4).
 pub fn drain_to_batches(data: SnapshotData) -> anyhow::Result<Vec<NamedBatch>> {
@@ -137,7 +141,19 @@ pub fn drain_to_batches(data: SnapshotData) -> anyhow::Result<Vec<NamedBatch>> {
     let mut snapshot_buf = SnapshotRowBuffer::default();
     snapshot_buf.insert(data.snapshot);
 
+    let mut execution_buf = ActorExecutionRowBuffer::default();
+    for row in data.actor_executions {
+        execution_buf.insert(row);
+    }
+
+    let mut handler_buf = ActiveHandlerRowBuffer::default();
+    for row in data.active_handlers {
+        handler_buf.insert(row);
+    }
+
     Ok(vec![
+        ("active_handlers", handler_buf.drain_to_record_batch()?),
+        ("actor_executions", execution_buf.drain_to_record_batch()?),
         ("actor_failures", failure_buf.drain_to_record_batch()?),
         ("actor_inbound_orderings", io_buf.drain_to_record_batch()?),
         ("actor_nodes", actor_buf.drain_to_record_batch()?),
@@ -248,6 +264,8 @@ mod tests {
             actor_failures: vec![],
             actor_inbound_orderings: vec![],
             ordering_sessions: vec![],
+            actor_executions: vec![],
+            active_handlers: vec![],
             resolution_errors: vec![],
         }
     }
@@ -453,7 +471,7 @@ mod tests {
                 },
                 OrderingSessionRow {
                     snapshot_id: id.to_owned(),
-                    node_id: actor_id,
+                    node_id: actor_id.clone(),
                     session_id: FIXTURE_SESSION_CLEAN.to_owned(),
                     sender: Some("client".to_owned()),
                     last_released_seq: 3,
@@ -461,6 +479,33 @@ mod tests {
                     buffered_count: 0,
                     oldest_buffered_seq: None,
                     newest_buffered_seq: None,
+                },
+            ],
+            // One execution rollup for the running actor (CV-10 Some);
+            // the failed actor exercises CV-10 None (no row here).
+            actor_executions: vec![ActorExecutionRow {
+                snapshot_id: id.to_owned(),
+                node_id: actor_id.clone(),
+                active_count: 2,
+                complete: true,
+                truncated: false,
+            }],
+            // Two in-flight handler rows (CV-11), oldest-first. Drives
+            // PS-11 + the execution JOIN test.
+            active_handlers: vec![
+                ActiveHandlerRow {
+                    snapshot_id: id.to_owned(),
+                    node_id: actor_id.clone(),
+                    name: "endpoint_slow".to_owned(),
+                    active_count: 1,
+                    oldest_since: 2,
+                },
+                ActiveHandlerRow {
+                    snapshot_id: id.to_owned(),
+                    node_id: actor_id,
+                    name: "endpoint_fast".to_owned(),
+                    active_count: 1,
+                    oldest_since: 6,
                 },
             ],
             resolution_errors: vec![ResolutionErrorRow {
@@ -472,7 +517,7 @@ mod tests {
         }
     }
 
-    // PS-1: every push ingests all eleven tables, including empty
+    // PS-1: every push ingests all thirteen tables, including empty
     // ones.
     #[tokio::test]
     async fn test_push_snapshot_registers_all_tables() {
@@ -486,7 +531,7 @@ mod tests {
                 .iter()
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>(),
-            "PS-1: all eleven tables should be registered"
+            "PS-1: all thirteen tables should be registered"
         );
     }
 
@@ -518,6 +563,8 @@ mod tests {
         );
         assert_eq!(query_row_count(&ctx, "ordering_sessions").await.unwrap(), 2);
         assert_eq!(query_row_count(&ctx, "resolution_errors").await.unwrap(), 1);
+        assert_eq!(query_row_count(&ctx, "actor_executions").await.unwrap(), 1);
+        assert_eq!(query_row_count(&ctx, "active_handlers").await.unwrap(), 2);
     }
 
     // PS-3: cumulative counts after two pushes into the same store.
@@ -551,6 +598,8 @@ mod tests {
         );
         assert_eq!(query_row_count(&ctx, "ordering_sessions").await.unwrap(), 4);
         assert_eq!(query_row_count(&ctx, "resolution_errors").await.unwrap(), 2);
+        assert_eq!(query_row_count(&ctx, "actor_executions").await.unwrap(), 2);
+        assert_eq!(query_row_count(&ctx, "active_handlers").await.unwrap(), 4);
     }
 
     // PS-4, PS-6: empty subtype tables are still queryable.
@@ -945,14 +994,129 @@ mod tests {
         assert_eq!(expected.value(0), 1);
     }
 
+    // PS-10: when the populated fixture contains an actor with
+    // `execution: Some(...)`, the snapshot publish path produces an
+    // `actor_executions` row queryable via `SELECT complete FROM
+    // actor_executions`.
+    #[tokio::test]
+    async fn test_push_snapshot_actor_executions_presence() {
+        let store = TableStore::new_empty();
+        push_snapshot(&store, populated_snapshot("s1"))
+            .await
+            .unwrap();
+        let ctx = SessionContext::new();
+        register_all(&store, &ctx).await.unwrap();
+
+        let complete = query_bool_scalar(
+            &ctx,
+            "SELECT complete FROM actor_executions LIMIT 1",
+            "complete",
+        )
+        .await
+        .unwrap();
+        assert!(
+            complete,
+            "PS-10: fixture's rollup must have complete = true"
+        );
+    }
+
+    // PS-11: when the populated fixture contains an actor with
+    // `execution: Some({active_handlers: [non-empty]})`, the snapshot
+    // publish path produces `active_handlers` rows queryable via
+    // `SELECT name FROM active_handlers`. Asserts the oldest in-flight
+    // handler surfaces first (CV-11 oldest-first detail).
+    #[tokio::test]
+    async fn test_push_snapshot_active_handlers_presence() {
+        let store = TableStore::new_empty();
+        push_snapshot(&store, populated_snapshot("s1"))
+            .await
+            .unwrap();
+        let ctx = SessionContext::new();
+        register_all(&store, &ctx).await.unwrap();
+
+        let name = query_string_scalar(
+            &ctx,
+            "SELECT name FROM active_handlers ORDER BY oldest_since LIMIT 1",
+            "name",
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            name, "endpoint_slow",
+            "PS-11: oldest in-flight handler must surface first",
+        );
+    }
+
+    // Diagnostic JOIN test: "which in-flight handler is oldest on
+    // which actor?" is answerable in SQL across the three tables.
+    // Asserts the running actor's two handlers surface alongside the
+    // rollup total, oldest-first; the failed actor (no execution row)
+    // is excluded by the inner join.
+    #[tokio::test]
+    async fn test_push_snapshot_execution_join() {
+        let store = TableStore::new_empty();
+        push_snapshot(&store, populated_snapshot("s1"))
+            .await
+            .unwrap();
+        let ctx = SessionContext::new();
+        register_all(&store, &ctx).await.unwrap();
+
+        let df = ctx
+            .sql(
+                "SELECT a.actor_type, \
+                        ae.active_count AS total, \
+                        h.name, \
+                        h.oldest_since \
+                 FROM actor_nodes a \
+                 JOIN actor_executions ae \
+                   USING (snapshot_id, node_id) \
+                 JOIN active_handlers h \
+                   USING (snapshot_id, node_id) \
+                 ORDER BY h.oldest_since ASC",
+            )
+            .await
+            .unwrap();
+        let batches = df.collect().await.unwrap();
+        let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
+        assert_eq!(
+            total_rows, 2,
+            "JOIN must surface both in-flight handler rows from the fixture",
+        );
+        let batch = &batches[0];
+
+        let actor_type = batch
+            .column_by_name("actor_type")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(actor_type.value(0), ACTOR_NAME);
+
+        let total = batch
+            .column_by_name("total")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(total.value(0), 2);
+
+        let name = batch
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::StringArray>()
+            .unwrap();
+        assert_eq!(name.value(0), "endpoint_slow");
+    }
+
     // --- drain_to_batches tests ---
 
-    // PS-1, PS-2: exactly 11 pairs in canonical order.
+    // PS-1, PS-2: exactly 13 pairs in canonical order.
     #[test]
-    fn test_drain_to_batches_produces_eleven_pairs() {
+    fn test_drain_to_batches_produces_thirteen_pairs() {
         let batches = drain_to_batches(populated_snapshot("d1")).unwrap();
         let names: Vec<&str> = batches.iter().map(|(n, _)| *n).collect();
-        assert_eq!(names.len(), 11);
+        assert_eq!(names.len(), 13);
         assert_eq!(names, SNAPSHOT_TABLE_NAMES.to_vec(),);
     }
 
@@ -961,7 +1125,7 @@ mod tests {
     #[test]
     fn test_drain_to_batches_empty_families() {
         let batches = drain_to_batches(minimal_snapshot("d2")).unwrap();
-        assert_eq!(batches.len(), 11);
+        assert_eq!(batches.len(), 13);
         // All tables except "snapshots" should have 0 rows.
         for (name, batch) in &batches {
             if *name == "snapshots" {

--- a/monarch_introspection_snapshot/src/schema.rs
+++ b/monarch_introspection_snapshot/src/schema.rs
@@ -90,7 +90,7 @@ use monarch_record_batch::RecordBatchRow;
 //       (the Rust field name IS the column name).
 // SR-2: ID and identity-string columns (`snapshot_id`, `node_id`,
 //       `parent_id`, `child_id`, `failure_root_cause_actor`,
-//       `instance_id`, `session_id`, `sender`) are Arrow `Utf8`.
+//       `instance_id`, `session_id`, `sender`, `name`) are Arrow `Utf8`.
 // SR-3: Time and count columns (`snapshot_ts`, `as_of`, `started_at`,
 //       `created_at`, `failure_occurred_at`, `num_hosts`,
 //       `host_num_procs`, `num_actors`, `stopped_retention_cap`,
@@ -101,10 +101,11 @@ use monarch_record_batch::RecordBatchRow;
 //       `returned_buffered_message_count`,
 //       `returned_max_buffered_count`, `last_released_seq`,
 //       `expected_next_seq`, `buffered_count`, `oldest_buffered_seq`,
-//       `newest_buffered_seq`) are Arrow `Int64`.
+//       `newest_buffered_seq`, `active_count`, `oldest_since`) are
+//       Arrow `Int64`.
 // SR-4: Flag columns (`is_system`, `is_stopped`, `is_poisoned`,
-//       `failure_is_propagated`, `enabled`, `snapshot_complete`) are
-//       Arrow `Boolean`.
+//       `failure_is_propagated`, `enabled`, `snapshot_complete`,
+//       `complete`, `truncated`) are Arrow `Boolean`.
 // SR-5: Optional source fields map to nullable Arrow columns; required
 //       fields are non-nullable. The optional fields are:
 //       `ActorNodeRow.created_at`, `ActorNodeRow.last_message_handler`,
@@ -344,6 +345,60 @@ pub struct OrderingSessionRow {
     pub newest_buffered_seq: Option<i64>,
 }
 
+/// Snapshot-time execution rollup for an actor. PK:
+/// `(snapshot_id, node_id)`, FK → `ActorNode(snapshot_id, node_id)`.
+///
+/// Conditional row: one row per actor that reports execution
+/// (EX-1: `execution: Some(...)`). Actors with `execution: None`
+/// (unsupported — no snapshot callback installed) have NO row, matching
+/// [`ActorFailureRow`] / [`ActorInboundOrderingRow`].
+///
+/// `active_count` is the authoritative in-flight total (EX-3), never
+/// summed from [`ActiveHandlerRow`] rows (which may be a truncated
+/// prefix). `complete == false` (EX-2) means the per-handler detail was
+/// momentarily unavailable on that read — [`ActiveHandlerRow`] rows for
+/// this key are then empty while `active_count` stays authoritative.
+/// `truncated == true` (EX-4) means [`ActiveHandlerRow`] holds only the
+/// N oldest handler names.
+#[derive(Debug, Clone, PartialEq, RecordBatchRow)]
+pub struct ActorExecutionRow {
+    /// PK component. FK → `ActorNode(snapshot_id, node_id)`.
+    pub snapshot_id: String,
+    /// PK component. FK → `ActorNode(snapshot_id, node_id)`.
+    pub node_id: String,
+    /// EX-3: authoritative count of in-flight handler invocations.
+    pub active_count: i64,
+    /// EX-2: `true` iff the per-handler detail was captured on this read.
+    pub complete: bool,
+    /// EX-4: `true` iff [`ActiveHandlerRow`] is a prefix of the N oldest.
+    pub truncated: bool,
+}
+
+/// Per-handler detail of an actor's in-flight execution. PK:
+/// `(snapshot_id, node_id, name)`, FK →
+/// `ActorExecution(snapshot_id, node_id)`.
+///
+/// One row per in-flight handler name at snapshot time, aggregated by
+/// name and ordered oldest-first upstream. A prefix of the N oldest when
+/// the parent rollup's `truncated == true`; empty when its
+/// `complete == false` (EX-2). The parent's `active_count` stays the full
+/// total regardless.
+#[derive(Debug, Clone, PartialEq, RecordBatchRow)]
+pub struct ActiveHandlerRow {
+    /// PK component. FK → `ActorExecution(snapshot_id, node_id)`.
+    pub snapshot_id: String,
+    /// PK component. FK → `ActorExecution(snapshot_id, node_id)`.
+    pub node_id: String,
+    /// PK component. Handler name (e.g. a Python endpoint method name) —
+    /// the per-actor aggregation key.
+    pub name: String,
+    /// In-flight invocations of this handler.
+    pub active_count: i64,
+    /// Start time of the oldest in-flight invocation, microseconds since
+    /// epoch. Non-null (`SystemTime` in source, not `Option`).
+    pub oldest_since: i64,
+}
+
 /// Snapshot-time failure projection for a failed actor. PK:
 /// `(snapshot_id, node_id)`, FK → `ActorNode(snapshot_id, node_id)`.
 ///
@@ -566,6 +621,31 @@ mod tests {
         assert_field(&schema, 6, "buffered_count", DataType::Int64, false);
         assert_field(&schema, 7, "oldest_buffered_seq", DataType::Int64, true);
         assert_field(&schema, 8, "newest_buffered_seq", DataType::Int64, true);
+    }
+
+    // Verifies SR-1, SR-2, SR-3, SR-4.
+    #[test]
+    fn test_actor_execution_row_schema() {
+        let schema = ActorExecutionRowBuffer::schema();
+        assert_eq!(schema.fields().len(), 5);
+        assert_field(&schema, 0, "snapshot_id", DataType::Utf8, false);
+        assert_field(&schema, 1, "node_id", DataType::Utf8, false);
+        assert_field(&schema, 2, "active_count", DataType::Int64, false);
+        assert_field(&schema, 3, "complete", DataType::Boolean, false);
+        assert_field(&schema, 4, "truncated", DataType::Boolean, false);
+    }
+
+    // Verifies SR-1, SR-2, SR-3. All columns non-null — `oldest_since` is
+    // `SystemTime` (not `Option`) in the source model.
+    #[test]
+    fn test_active_handler_row_schema() {
+        let schema = ActiveHandlerRowBuffer::schema();
+        assert_eq!(schema.fields().len(), 5);
+        assert_field(&schema, 0, "snapshot_id", DataType::Utf8, false);
+        assert_field(&schema, 1, "node_id", DataType::Utf8, false);
+        assert_field(&schema, 2, "name", DataType::Utf8, false);
+        assert_field(&schema, 3, "active_count", DataType::Int64, false);
+        assert_field(&schema, 4, "oldest_since", DataType::Int64, false);
     }
 
     // Verifies SR-1, SR-2, SR-3, SR-4, SR-5.
@@ -955,6 +1035,51 @@ mod tests {
         assert!(!newest.is_null(0));
         assert_eq!(newest.value(0), 6);
         assert!(newest.is_null(1));
+    }
+
+    // Verifies SR-6 for the execution rollup.
+    #[test]
+    fn test_drain_actor_execution_row() {
+        let mut buf = ActorExecutionRowBuffer::default();
+        buf.insert(ActorExecutionRow {
+            snapshot_id: "s1".into(),
+            node_id: "actor-1".into(),
+            active_count: 3,
+            complete: true,
+            truncated: false,
+        });
+        let batch = buf.drain_to_record_batch().unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        let count = batch
+            .column_by_name("active_count")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .unwrap();
+        assert_eq!(count.value(0), 3);
+    }
+
+    // Verifies SR-6 for the per-handler detail (non-null `oldest_since`).
+    #[test]
+    fn test_drain_active_handler_row() {
+        let mut buf = ActiveHandlerRowBuffer::default();
+        buf.insert(ActiveHandlerRow {
+            snapshot_id: "s1".into(),
+            node_id: "actor-1".into(),
+            name: "hold".into(),
+            active_count: 2,
+            oldest_since: 1_700_000_000_000_000,
+        });
+        let batch = buf.drain_to_record_batch().unwrap();
+        assert_eq!(batch.num_rows(), 1);
+        let oldest = batch
+            .column_by_name("oldest_since")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<datafusion::arrow::array::Int64Array>()
+            .unwrap();
+        assert!(!oldest.is_null(0));
+        assert_eq!(oldest.value(0), 1_700_000_000_000_000);
     }
 
     // Verifies SR-5, SR-6.

--- a/monarch_introspection_snapshot/src/service.rs
+++ b/monarch_introspection_snapshot/src/service.rs
@@ -74,7 +74,7 @@
 //! - **SV-2 (single capture):** Each `capture` call performs exactly
 //!   one BFS traversal and one `drain_to_batches`.
 //! - **SV-3 (table-store publication):** When `table_store` is
-//!   `Some`, all 11 tables are ingested (delegates to PS-1..PS-7).
+//!   `Some`, all 13 tables are ingested (delegates to PS-1..PS-7).
 //!   Publication is not atomic — a failure partway through may leave
 //!   some tables ingested and others not.
 //! - **SV-4 (counts before drain):** [`NodeCounts`] is computed from
@@ -406,6 +406,8 @@ pub struct NodeCounts {
     pub actor_failures: usize,
     pub actor_inbound_orderings: usize,
     pub ordering_sessions: usize,
+    pub actor_executions: usize,
+    pub active_handlers: usize,
     pub resolution_errors: usize,
 }
 
@@ -422,6 +424,8 @@ impl NodeCounts {
             actor_failures: data.actor_failures.len(),
             actor_inbound_orderings: data.actor_inbound_orderings.len(),
             ordering_sessions: data.ordering_sessions.len(),
+            actor_executions: data.actor_executions.len(),
+            active_handlers: data.active_handlers.len(),
             resolution_errors: data.resolution_errors.len(),
         }
     }
@@ -654,6 +658,8 @@ mod tests {
                     newest_buffered_seq: None,
                 },
             ],
+            actor_executions: vec![],
+            active_handlers: vec![],
             resolution_errors: vec![],
         };
 
@@ -670,6 +676,8 @@ mod tests {
                 actor_failures: 0,
                 actor_inbound_orderings: 1,
                 ordering_sessions: 2,
+                actor_executions: 0,
+                active_handlers: 0,
                 resolution_errors: 0,
             }
         );
@@ -692,6 +700,8 @@ mod tests {
             actor_failures: vec![],
             actor_inbound_orderings: vec![],
             ordering_sessions: vec![],
+            actor_executions: vec![],
+            active_handlers: vec![],
             resolution_errors: vec![],
         };
 
@@ -708,6 +718,8 @@ mod tests {
                 actor_failures: 0,
                 actor_inbound_orderings: 0,
                 ordering_sessions: 0,
+                actor_executions: 0,
+                active_handlers: 0,
                 resolution_errors: 0,
             }
         );
@@ -726,6 +738,8 @@ mod tests {
             actor_failures: 0,
             actor_inbound_orderings: 0,
             ordering_sessions: 0,
+            actor_executions: 0,
+            active_handlers: 0,
             resolution_errors: 0,
         };
         let json = serde_json::to_string(&counts).unwrap();
@@ -733,6 +747,7 @@ mod tests {
         assert!(json.contains("\"actor_failures\":0"));
         assert!(json.contains("\"actor_inbound_orderings\":0"));
         assert!(json.contains("\"ordering_sessions\":0"));
+        assert!(json.contains("\"actor_executions\":0"));
     }
 
     // --- CaptureResult tests (SV-5) ---
@@ -753,6 +768,8 @@ mod tests {
                 actor_failures: 0,
                 actor_inbound_orderings: 0,
                 ordering_sessions: 0,
+                actor_executions: 0,
+                active_handlers: 0,
                 resolution_errors: 0,
             },
             capture_duration_ms: 42.5,
@@ -796,9 +813,9 @@ mod tests {
         assert_eq!(result.node_counts.ordering_sessions, 0);
         assert_eq!(result.node_counts.resolution_errors, 0);
 
-        // Verify store is populated — all 11 tables registered.
+        // Verify store is populated — all 13 tables registered.
         let names = store.table_names().unwrap();
-        assert_eq!(names.len(), 11);
+        assert_eq!(names.len(), 13);
 
         // Verify data is queryable — snapshot row exists.
         let ctx = datafusion::prelude::SessionContext::new();
@@ -866,7 +883,7 @@ mod tests {
         let result = service.capture(resolve, Some(dir.path())).await.unwrap();
 
         // Table store populated.
-        assert_eq!(store.table_names().unwrap().len(), 11);
+        assert_eq!(store.table_names().unwrap().len(), 13);
 
         // Bundle written.
         let bundle_path = result.bundle_path.as_ref().unwrap();
@@ -916,7 +933,7 @@ mod tests {
         assert!(attempted, "PT-4: tick should attempt capture");
 
         // Store should be populated.
-        assert_eq!(store.table_names().unwrap().len(), 11);
+        assert_eq!(store.table_names().unwrap().len(), 13);
 
         // in_flight should be reset to false.
         assert!(!service.in_flight.load(Ordering::Acquire));
@@ -949,7 +966,7 @@ mod tests {
         let resolve = stub_resolver(payloads);
         let attempted = run_periodic_tick(&service, resolve).await;
         assert!(attempted, "PT-6: second tick should succeed");
-        assert_eq!(store.table_names().unwrap().len(), 11);
+        assert_eq!(store.table_names().unwrap().len(), 13);
     }
 
     // PT-7: run_periodic_tick always passes export_root = None.
@@ -963,7 +980,7 @@ mod tests {
         run_periodic_tick(&service, resolve).await;
 
         // Verify store was populated (live ingest happened).
-        assert_eq!(store.table_names().unwrap().len(), 11);
+        assert_eq!(store.table_names().unwrap().len(), 13);
 
         // PT-7 is structural: run_periodic_tick calls
         // service.capture(resolve, None). No bundle directory

--- a/monarch_introspection_snapshot/test/snapshot_integration_test.rs
+++ b/monarch_introspection_snapshot/test/snapshot_integration_test.rs
@@ -172,11 +172,11 @@ async fn test_snapshot_sql_queries() -> Result<()> {
     let ctx = SessionContext::new();
     register_all(&table_store, &ctx).await?;
 
-    // PS-1: all eleven tables registered.
+    // PS-1: all thirteen tables registered.
     assert_eq!(
         table_store.table_names()?.len(),
-        11,
-        "PS-1: all eleven tables should be registered"
+        13,
+        "PS-1: all thirteen tables should be registered"
     );
 
     // PS-5: exactly one snapshot row.


### PR DESCRIPTION
Summary:

`convert_node` dropped the actor `execution` field via `..`, so the in-flight handler execution exposed on the mesh-admin API was invisible to SQL. this persists it into the relational snapshot DB that `monarch_distributed_telemetry` drives, mirroring how `inbound_ordering` was added in D106240786.

adds two tables:

- `actor_executions` — per-actor rollup, one row iff the actor reports execution (`execution: Some`): `active_count`, `complete`, `truncated`.
- `active_handlers` — per-handler detail, one row per in-flight handler name: `name`, `active_count`, `oldest_since` (micros).

`convert_node` now emits one `ActorExecutionRow` plus one `ActiveHandlerRow` per `Execution.active_handlers` entry; `SNAPSHOT_TABLE_NAMES` grows 11 → 13 and `register_snapshot_schemas` registers both, so the query engine discovers them. additive — no `monarch_distributed_telemetry` change.

Differential Revision: D107711216
