### PR TITLE
Rename mount worker to job sidecar (#4191)

### DIFF
--- a/python/monarch/_src/job/_job_sidecar_worker.py
+++ b/python/monarch/_src/job/_job_sidecar_worker.py
@@ -6,16 +6,16 @@
 
 # pyre-unsafe
 
-"""Entry point for the background mount process.
+"""Entry point for the background job sidecar process.
 
-Launched by :func:`~monarch._src.job.mount_config.Mounts.ensure_open`.
+Launched by :func:`~monarch._src.job.job_sidecar.create_job_sidecar`.
 Receives the socket path and lock fd as arguments. Binds the socket
-immediately to signal readiness, then serves refresh/shutdown requests.
-The first ``refresh`` initialises the mounts; subsequent ones refresh them.
+immediately to signal readiness, then serves job-scoped refresh/shutdown
+requests.
 
 Usage::
 
-    python -m monarch._src.job._mount_worker <socket_path> <lock_fd>
+    python -m monarch._src.job._job_sidecar_worker <socket_path> <lock_fd>
 """
 
 import sys
@@ -25,9 +25,9 @@ def main() -> None:
     socket_path = sys.argv[1]
     int(sys.argv[2])  # keep fd open to hold the flock for the process lifetime
 
-    from monarch._src.job.mount_config import _run_mount_process
+    from monarch._src.job.job_sidecar import _run_job_sidecar
 
-    _run_mount_process(socket_path)
+    _run_job_sidecar(socket_path)
 
 
 if __name__ == "__main__":

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -26,6 +26,7 @@ from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.host_mesh import _spawn_admin
 from monarch._src.actor.sync_state import fake_sync_state
+from monarch._src.job.job_sidecar import stop_job_sidecar
 from monarch._src.job.mount_config import Mounts
 
 # note: the jobs api is intended as a library so it should
@@ -670,7 +671,7 @@ class JobTrait(ABC):
         apply_id = self.apply_id
         running = self._running
         if apply_id is not None and running is not None:
-            self._mounts.ensure_open(running)
+            self._mounts.ensure_open(apply_id, raw._hosts)
         hosts = {}
         for mesh_name, mesh in raw._hosts.items():
             exe = self._python_executables.get(mesh_name, self._default_python_exe)
@@ -743,8 +744,9 @@ class JobTrait(ABC):
         return pickle.dumps(self)
 
     def kill(self):
-        if self._apply_id is not None:
-            self._mounts.ensure_stopped(self._apply_id)
+        apply_id = self.apply_id
+        if apply_id is not None:
+            stop_job_sidecar(apply_id)
         running = self._running
         if running is not None:
             running._kill()

--- a/python/monarch/_src/job/job_sidecar.py
+++ b/python/monarch/_src/job/job_sidecar.py
@@ -1,0 +1,185 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Per-job sidecar command server.
+
+The sidecar process is keyed by a job ``apply_id`` and kept alive by ``ProcessGuard``.
+"""
+
+import os
+import pickle
+import socket
+import sys
+import threading
+import time
+import traceback
+from dataclasses import dataclass
+from typing import Any
+
+from monarch.actor import HostMesh
+
+
+def job_sidecar_lock_path(apply_id: str) -> str:
+    """Return the lock path for the per-job sidecar process."""
+    return f"/tmp/monarch_job_sidecar_{apply_id}.lock"
+
+
+def create_job_sidecar(apply_id: str) -> Any:
+    """Ensure the per-job sidecar process is running and return its guard."""
+    from monarch._src.job.process_guard import ProcessGuard
+
+    return ProcessGuard.create(
+        job_sidecar_lock_path(apply_id),
+        apply_id,
+        [sys.executable, "-m", "monarch._src.job._job_sidecar_worker"],
+    )
+
+
+def find_job_sidecar(apply_id: str) -> Any | None:
+    """Return the per-job sidecar process guard if it exists."""
+    from monarch._src.job.process_guard import find_process
+
+    return find_process(job_sidecar_lock_path(apply_id))
+
+
+def stop_job_sidecar(apply_id: str) -> None:
+    """Shut down the per-job sidecar process for an apply id if it exists."""
+    guard = find_job_sidecar(apply_id)
+    if guard is not None:
+        guard.shutdown()
+
+
+@dataclass
+class ClearMountsRequest:
+    """Clear the job sidecar's mount state."""
+
+
+@dataclass
+class MountsRequest:
+    """Refresh the job sidecar's mount state."""
+
+    mounts: Any
+    host_meshes: dict[str, HostMesh]
+
+
+class _JobSidecarState:
+    """State owned by the background job sidecar process."""
+
+    def __init__(self) -> None:
+        self._mounts_handle: Any | None = None
+        self._mounts_key: bytes | None = None
+
+    def handle_mounts(self, request: MountsRequest) -> str:
+        # The request carries declarative mount config. Compare that serialized
+        # config so edited mounts replace the live handles, while unchanged
+        # config refreshes existing remote mounts in-place.
+        # @lint-ignore PYTHONPICKLEISBAD
+        mounts_key = pickle.dumps(request.mounts)
+        t0 = time.time()
+        if self._mounts_handle is None:
+            _dbg("initialising mounts")
+            self._mounts_handle = request.mounts.open(request.host_meshes)
+            self._mounts_key = mounts_key
+            _dbg(f"mounts opened in {time.time() - t0:.2f}s")
+            return "ok"
+
+        if mounts_key != self._mounts_key:
+            _dbg("replacing mounts")
+            self._mounts_handle.close()
+            self._mounts_handle = request.mounts.open(request.host_meshes)
+            self._mounts_key = mounts_key
+            _dbg(f"mounts replaced in {time.time() - t0:.2f}s")
+            return "ok"
+
+        _dbg("refreshing mounts")
+        self._mounts_handle.refresh()
+        _dbg(f"refresh complete in {time.time() - t0:.2f}s")
+        return "ok"
+
+    def clear_mounts(self) -> str:
+        """Close any live mounts and reset mount state."""
+        if self._mounts_handle is not None:
+            self._mounts_handle.close()
+            self._mounts_handle = None
+            self._mounts_key = None
+        return "ok"
+
+    def shutdown(self) -> None:
+        self.clear_mounts()
+
+
+def _dbg(msg: str) -> None:
+    print(f"[job_sidecar pid={os.getpid()}] {msg}", file=sys.stderr, flush=True)
+
+
+def _run_job_sidecar(socket_path: str) -> None:
+    """Run in the child process: bind socket then serve refresh/shutdown requests."""
+    import signal as _signal
+
+    # Signal handlers are process-global and only legal from the main thread.
+    if threading.current_thread() is threading.main_thread():
+        _signal.signal(_signal.SIGINT, _signal.SIG_DFL)
+        _signal.signal(_signal.SIGTERM, _signal.SIG_DFL)
+
+    from monarch._src.job.process_guard import _Shutdown
+
+    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server.bind(socket_path)
+    server.listen(5)
+    _dbg(f"listening on {socket_path}")
+
+    state = _JobSidecarState()
+
+    while True:
+        try:
+            conn, _ = server.accept()
+        except OSError:
+            break
+        try:
+            f = conn.makefile("rb")
+            while True:
+                try:
+                    # @lint-ignore PYTHONPICKLEISBAD
+                    msg = pickle.load(f)
+                except EOFError:
+                    break  # client disconnected (e.g. readiness probe)
+                if isinstance(msg, _Shutdown):
+                    _dbg("received shutdown")
+                    state.shutdown()
+                    conn.close()
+                    server.close()
+                    try:
+                        os.unlink(socket_path)
+                    except OSError:
+                        pass
+                    _dbg("exiting")
+                    return
+                try:
+                    if isinstance(msg, MountsRequest):
+                        response = state.handle_mounts(msg)
+                    elif isinstance(msg, ClearMountsRequest):
+                        response = state.clear_mounts()
+                    else:
+                        raise RuntimeError(f"unexpected job sidecar request: {msg!r}")
+                except Exception:
+                    _dbg(
+                        "ERROR during job sidecar operation:\n" + traceback.format_exc()
+                    )
+                    response = "ok"
+                # @lint-ignore PYTHONPICKLEISBAD
+                conn.sendall(pickle.dumps(response))
+        except Exception:
+            _dbg("ERROR handling connection:\n" + traceback.format_exc())
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    server.close()
+    _dbg("exiting")

--- a/python/monarch/_src/job/mount_config.py
+++ b/python/monarch/_src/job/mount_config.py
@@ -8,15 +8,18 @@
 
 import logging
 import os
-import pickle
-import socket
 import sys
-import time
 import traceback
 from dataclasses import dataclass, field
-from typing import Any, List, Optional
+from typing import Any, List, Mapping, Optional
 
-from monarch._src.job.job_state import JobState
+from monarch._src.job.job_sidecar import (
+    ClearMountsRequest,
+    create_job_sidecar,
+    find_job_sidecar,
+    MountsRequest,
+)
+from monarch.actor import HostMesh
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -30,7 +33,7 @@ class RemoteMountEntry:
     meshes: Optional[List[str]] = None
     kwargs: dict = field(default_factory=dict)
 
-    def apply(self, raw_state: JobState) -> "list[Any]":
+    def apply(self, host_meshes: Mapping[str, HostMesh]) -> "list[Any]":
         """Open the remote mount for each targeted mesh. Returns handles.
 
         If ``mntpoint`` contains ``$SUBDIR`` it is replaced with the mesh name,
@@ -39,7 +42,7 @@ class RemoteMountEntry:
         from monarch.remotemount.remotemount import remotemount as _remotemount
 
         handles = []
-        for mesh_name, raw_mesh in raw_state._hosts.items():
+        for mesh_name, raw_mesh in host_meshes.items():
             if self.meshes is not None and mesh_name not in self.meshes:
                 continue
             handler = _remotemount(
@@ -58,7 +61,7 @@ class GatherMountEntry:
     local_mount_point: str
     meshes: Optional[List[str]] = None
 
-    def apply(self, raw_state: JobState) -> "list[Any]":
+    def apply(self, host_meshes: Mapping[str, HostMesh]) -> "list[Any]":
         """Start the gather mount for each targeted mesh. Returns handles.
 
         Single targeted mesh: mounts directly at ``local_mount_point``.
@@ -68,7 +71,7 @@ class GatherMountEntry:
 
         target_meshes = [
             (mesh_name, raw_mesh)
-            for mesh_name, raw_mesh in raw_state._hosts.items()
+            for mesh_name, raw_mesh in host_meshes.items()
             if self.meshes is None or mesh_name in self.meshes
         ]
         multi = len(target_meshes) > 1
@@ -88,8 +91,8 @@ class Mounts:
     """Declarative mount configuration for a job.
 
     Call :meth:`remote_mount` and :meth:`gather_mount` to register mounts.
-    The live handles are managed by :class:`MountsHandle` in the background
-    mount process.
+    The live handles are managed by :class:`MountsHandle` in the background job
+    sidecar process.
     """
 
     def __init__(self) -> None:
@@ -125,56 +128,37 @@ class Mounts:
             )
         )
 
-    def ensure_stopped(self, apply_id: str) -> None:
-        """Shut down the background mount process for *apply_id*, if running.
+    def open(self, host_meshes: Mapping[str, HostMesh]) -> "MountsHandle":
+        """Open all mounts against *host_meshes* and return the live handle."""
+        return MountsHandle(self, host_meshes)
 
-        Does nothing if no mounts are configured or no process is found.
+    def ensure_open(self, apply_id: str, host_meshes: Mapping[str, HostMesh]) -> None:
+        """Ensure a background job sidecar is running for this configuration.
+
+        Keyed on ``apply_id``: reuses an existing process, then sends a refresh
+        so the sidecar picks up any mount config changes. Clears existing mount
+        state when no mounts are configured.
         """
-        from monarch._src.job.process_guard import find_process
-
-        lock_path = f"/tmp/monarch_mounts_{apply_id}.lock"
-        guard = find_process(lock_path)
-        if guard is not None:
-            guard.shutdown()
-
-    def open(self, job: "Any") -> "MountsHandle":
-        """Open all mounts against *job* and return the live handle."""
-        return MountsHandle(self, job._state())
-
-    def ensure_open(self, job: "Any") -> None:
-        """Ensure a background mount process is running for this configuration.
-
-        Keyed on ``(apply_id, mounts)``: reuses an existing process with the
-        same config, otherwise shuts down the old one and launches a new one.
-        Always sends a refresh so the mount process picks up any changes.
-        Does nothing if no mounts are configured.
-        """
-        apply_id = job.apply_id
         if not self._remote_entries and not self._gather_entries:
-            self.ensure_stopped(apply_id)
+            guard = find_job_sidecar(apply_id)
+            if guard is not None:
+                guard.send(ClearMountsRequest()).get()
             return
 
-        from monarch._src.job.process_guard import ProcessGuard
-
-        lock_path = f"/tmp/monarch_mounts_{apply_id}.lock"
-        guard = ProcessGuard.create(
-            lock_path,
-            (apply_id, self),
-            [sys.executable, "-m", "monarch._src.job._mount_worker"],
-        )
-        guard.send((self, job)).get()
+        guard = create_job_sidecar(apply_id)
+        guard.send(MountsRequest(self, dict(host_meshes))).get()
 
 
 class MountsHandle:
-    """Live mount handles for a running background mount process."""
+    """Live mount handles for a running background job sidecar."""
 
-    def __init__(self, mounts: Mounts, raw_state: JobState) -> None:
+    def __init__(self, mounts: Mounts, host_meshes: Mapping[str, HostMesh]) -> None:
         self._active_remote: list[Any] = []
         self._active_gather: list[Any] = []
         for entry in mounts._remote_entries:
-            self._active_remote.extend(entry.apply(raw_state))
+            self._active_remote.extend(entry.apply(host_meshes))
         for entry in mounts._gather_entries:
-            self._active_gather.extend(entry.apply(raw_state))
+            self._active_gather.extend(entry.apply(host_meshes))
 
     def refresh(self) -> None:
         """Refresh remote mounts in-place; gather mounts are unaffected."""
@@ -204,76 +188,5 @@ class MountsHandle:
                 _dbg("close: ERROR closing gather mount:\n" + traceback.format_exc())
 
 
-# ── Background mount process ──────────────────────────────────────────────────
-
-
 def _dbg(msg: str) -> None:
-    print(f"[mount_process pid={os.getpid()}] {msg}", file=sys.stderr, flush=True)
-
-
-def _run_mount_process(socket_path: str) -> None:
-    """Run in the child process: bind socket then serve refresh/shutdown requests."""
-    import signal as _signal
-
-    _signal.signal(_signal.SIGINT, _signal.SIG_DFL)
-    _signal.signal(_signal.SIGTERM, _signal.SIG_DFL)
-
-    from monarch._src.job.process_guard import _Shutdown
-
-    server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-    server.bind(socket_path)
-    server.listen(5)
-    _dbg(f"listening on {socket_path}")
-
-    handle: "MountsHandle | None" = None
-
-    while True:
-        try:
-            conn, _ = server.accept()
-        except OSError:
-            break
-        try:
-            f = conn.makefile("rb")
-            while True:
-                try:
-                    # @lint-ignore PYTHONPICKLEISBAD
-                    msg = pickle.load(f)
-                except EOFError:
-                    break  # client disconnected (e.g. readiness probe)
-                if isinstance(msg, _Shutdown):
-                    _dbg("received shutdown")
-                    if handle is not None:
-                        handle.close()
-                    conn.close()
-                    server.close()
-                    try:
-                        os.unlink(socket_path)
-                    except OSError:
-                        pass
-                    _dbg("exiting")
-                    return
-                mounts, job = msg
-                try:
-                    t0 = time.time()
-                    if handle is None:
-                        _dbg("initialising mounts")
-                        handle = mounts.open(job)
-                        _dbg(f"mounts opened in {time.time() - t0:.2f}s")
-                    else:
-                        _dbg("refreshing mounts")
-                        handle.refresh()
-                        _dbg(f"refresh complete in {time.time() - t0:.2f}s")
-                except Exception:
-                    _dbg("ERROR during mount operation:\n" + traceback.format_exc())
-                # @lint-ignore PYTHONPICKLEISBAD
-                conn.sendall(pickle.dumps("ok"))
-        except Exception:
-            _dbg("ERROR handling connection:\n" + traceback.format_exc())
-        finally:
-            try:
-                conn.close()
-            except Exception:
-                pass
-
-    server.close()
-    _dbg("exiting")
+    print(f"[job_sidecar pid={os.getpid()}] {msg}", file=sys.stderr, flush=True)

--- a/python/monarch/_src/job/process_guard.py
+++ b/python/monarch/_src/job/process_guard.py
@@ -162,7 +162,7 @@ def _wait_for_socket(socket_path: str, pid: int = 0, timeout: float = 60.0) -> N
                 os.kill(pid, 0)
             except ProcessLookupError:
                 raise RuntimeError(
-                    f"Mount process (pid {pid}) exited before the socket "
+                    f"Guarded process (pid {pid}) exited before the socket "
                     f"{socket_path!r} became ready."
                 )
         try:

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -7,12 +7,17 @@
 # pyre-unsafe
 
 import os
+import pickle
+import socket
 import subprocess
 import sys
 import tempfile
+import threading
+from dataclasses import dataclass
 from typing import cast, Dict, Optional, Sequence
 from unittest.mock import MagicMock, patch
 
+import monarch._src.job.job_sidecar as js
 import pytest
 
 # Import directly from _src since job module isn't properly exposed
@@ -25,7 +30,63 @@ from monarch._src.job.job import (
     MeshAdminConfig,
     TelemetryConfig,
 )
+from monarch._src.job.mount_config import Mounts
+from monarch._src.job.process_guard import _Shutdown, _wait_for_socket
 from monarch.actor import HostMesh
+
+
+def _append_line(path: str, line: str) -> None:
+    with open(path, "a") as f:
+        f.write(line + "\n")
+
+
+@dataclass
+class _RecordingJob:
+    name: str
+
+
+@dataclass
+class _RecordingMountHandle:
+    name: str
+    log_path: str
+
+    def refresh(self) -> None:
+        _append_line(self.log_path, f"refresh:{self.name}")
+
+    def close(self) -> None:
+        _append_line(self.log_path, f"close:{self.name}")
+
+
+@dataclass
+class _RecordingMounts:
+    name: str
+    log_path: str
+
+    def open(self, job: _RecordingJob) -> _RecordingMountHandle:
+        _append_line(self.log_path, f"open:{self.name}:{job.name}")
+        return _RecordingMountHandle(self.name, self.log_path)
+
+
+def _send_sidecar_request(socket_path: str, message: object) -> object:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        client.connect(socket_path)
+        # @lint-ignore PYTHONPICKLEISBAD
+        client.sendall(pickle.dumps(message))
+        # @lint-ignore PYTHONPICKLEISBAD
+        return pickle.load(client.makefile("rb"))
+    finally:
+        client.close()
+
+
+def _send_sidecar_shutdown(socket_path: str) -> None:
+    client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        client.connect(socket_path)
+        # @lint-ignore PYTHONPICKLEISBAD
+        client.sendall(pickle.dumps(_Shutdown()))
+    finally:
+        client.close()
 
 
 class MockJobTrait(JobTrait):
@@ -89,6 +150,108 @@ class MockJobTrait(JobTrait):
     def _kill(self):
         """Mock implementation that tracks the kill call."""
         self.kill_called = True
+
+
+def test_create_job_sidecar_uses_job_sidecar_worker():
+    """The sidecar launcher should use the renamed job sidecar worker."""
+    with patch("monarch._src.job.process_guard.ProcessGuard.create") as create:
+        js.create_job_sidecar("apply_id")
+
+    lock_path, config_key, command = create.call_args.args
+    assert lock_path == js.job_sidecar_lock_path("apply_id")
+    assert config_key == "apply_id"
+    assert command == [
+        sys.executable,
+        "-m",
+        "monarch._src.job._job_sidecar_worker",
+    ]
+
+
+def test_mounts_ensure_open_clears_existing_sidecar_when_empty():
+    """Empty mount config should clear stale mount state on an existing sidecar."""
+    guard = MagicMock()
+    with patch(
+        "monarch._src.job.mount_config.find_job_sidecar", return_value=guard
+    ) as find_sidecar:
+        Mounts().ensure_open("apply_id", {})
+
+    find_sidecar.assert_called_once_with("apply_id")
+    request = guard.send.call_args.args[0]
+    assert isinstance(request, js.ClearMountsRequest)
+    guard.send.return_value.get.assert_called_once_with()
+
+
+def test_mounts_ensure_open_does_not_create_sidecar_when_empty():
+    """Empty mount config should not start a sidecar just to clear no state."""
+    with (
+        patch(
+            "monarch._src.job.mount_config.find_job_sidecar", return_value=None
+        ) as find_sidecar,
+        patch("monarch._src.job.mount_config.create_job_sidecar") as create_sidecar,
+    ):
+        Mounts().ensure_open("apply_id", {})
+
+    find_sidecar.assert_called_once_with("apply_id")
+    create_sidecar.assert_not_called()
+
+
+def test_run_job_sidecar_manages_mount_lifecycle():
+    """Mount requests open once, refresh unchanged config, replace drift, and
+    clear stale state."""
+    with tempfile.TemporaryDirectory(prefix="monarch_sidecar_", dir="/tmp") as tempdir:
+        socket_path = os.path.join(tempdir, "cmd.sock")
+        log_path = os.path.join(tempdir, "events.log")
+        thread = threading.Thread(
+            target=js._run_job_sidecar,
+            args=(socket_path,),
+            daemon=True,
+        )
+
+        with patch("signal.signal"):
+            thread.start()
+            _wait_for_socket(socket_path, timeout=10.0)
+
+        try:
+            job = _RecordingJob("job")
+            assert (
+                _send_sidecar_request(
+                    socket_path,
+                    js.MountsRequest(_RecordingMounts("one", log_path), job),
+                )
+                == "ok"
+            )
+            assert (
+                _send_sidecar_request(
+                    socket_path,
+                    js.MountsRequest(_RecordingMounts("one", log_path), job),
+                )
+                == "ok"
+            )
+            assert (
+                _send_sidecar_request(
+                    socket_path,
+                    js.MountsRequest(_RecordingMounts("two", log_path), job),
+                )
+                == "ok"
+            )
+            assert _send_sidecar_request(socket_path, js.ClearMountsRequest()) == "ok"
+            assert _send_sidecar_request(socket_path, js.ClearMountsRequest()) == "ok"
+        finally:
+            try:
+                _send_sidecar_shutdown(socket_path)
+            except OSError:
+                pass
+            thread.join(timeout=10.0)
+
+        assert not thread.is_alive(), "job sidecar did not exit on shutdown"
+        with open(log_path) as f:
+            assert f.read().splitlines() == [
+                "open:one:job",
+                "refresh:one",
+                "close:one",
+                "open:two:job",
+                "close:two",
+            ]
 
 
 def test_apply():
@@ -302,14 +465,17 @@ def test_kill():
     """Test the kill method."""
     job = MockJobTrait()
     job.apply()
+    apply_id = job.apply_id
+    assert apply_id is not None
     # Kill shouldn't have been called yet
     assert not job.kill_called
 
-    # Call kill
-    job.kill()
+    with patch("monarch._src.job.job.stop_job_sidecar") as stop_sidecar:
+        job.kill()
 
     # kill_called should now be True
     assert job.kill_called
+    stop_sidecar.assert_called_once_with(apply_id)
 
 
 def test_state_query_engine_none_without_telemetry():


### PR DESCRIPTION
Summary:

Renames the existing remote-mount worker into a per-job sidecar keyed by `apply_id`, with mount operations expressed as `MountsRequest` messages instead of process-wide config keys. `Mounts.ensure_open()` now only creates or refreshes mount state when mounts are configured, while `JobTrait.kill()` owns the single `stop_job_sidecar(apply_id)` call so shared sidecar shutdown is tied to the job lifecycle rather than to the mounts feature.

Reviewed By: zdevito

Differential Revision: D107706653
