### PR TITLE
Skip redundant local telemetry collectors (#4197)

### DIFF
--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -509,20 +509,16 @@ impl DatabaseScanner {
         }
     }
 
-    /// Start Unix-socket ingest for this scanner if no collector owns the path.
-    pub fn start_socket_ingest(&self, socket_path: &Path) -> anyhow::Result<bool> {
-        match crate::socket_ingest::non_destructive_bind(socket_path)? {
-            crate::socket_ingest::BindOutcome::Bound(listener) => {
-                let handle = crate::socket_ingest::run_ingest_server(listener, self.table_store())?;
-                self.start_periodic_retention()?;
-                self.socket_ingest_handles
-                    .lock()
-                    .map_err(|_| anyhow::anyhow!("lock poisoned"))?
-                    .push(handle);
-                Ok(true)
-            }
-            crate::socket_ingest::BindOutcome::SkippedExistingCollector => Ok(false),
-        }
+    /// Start Unix-socket ingest for this scanner.
+    pub fn start_socket_ingest(&self, socket_path: &Path) -> anyhow::Result<()> {
+        let listener = crate::socket_ingest::bind_ingest_socket(socket_path)?;
+        let handle = crate::socket_ingest::run_ingest_server(listener, self.table_store())?;
+        self.start_periodic_retention()?;
+        self.socket_ingest_handles
+            .lock()
+            .map_err(|_| anyhow::anyhow!("lock poisoned"))?
+            .push(handle);
+        Ok(())
     }
 
     fn start_periodic_retention(&self) -> anyhow::Result<()> {

--- a/monarch_distributed_telemetry/src/lib.rs
+++ b/monarch_distributed_telemetry/src/lib.rs
@@ -128,7 +128,7 @@ fn reset_record_batch_flush_count() {
 
 /// Start Unix-socket ingest for a database scanner.
 #[pyfunction]
-fn _start_socket_ingest(scanner: PyRef<'_, DatabaseScanner>, socket_path: &str) -> PyResult<bool> {
+fn _start_socket_ingest(scanner: PyRef<'_, DatabaseScanner>, socket_path: &str) -> PyResult<()> {
     scanner
         .start_socket_ingest(std::path::Path::new(socket_path))
         .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))

--- a/monarch_distributed_telemetry/src/socket_ingest.rs
+++ b/monarch_distributed_telemetry/src/socket_ingest.rs
@@ -51,14 +51,6 @@ use crate::database_scanner::TableStore;
 /// Buffered read capacity for producer socket connections.
 const READER_BUFFER_CAPACITY: usize = 64 * 1024;
 
-/// Outcome of a non-destructive telemetry socket bind.
-pub enum BindOutcome {
-    /// This process owns the listener and should start ingest.
-    Bound(StdUnixListener),
-    /// A live collector already owns this socket path.
-    SkippedExistingCollector,
-}
-
 /// Handle for the background socket ingest task.
 pub struct IngestServerHandle {
     task: JoinHandle<()>,
@@ -70,28 +62,27 @@ impl Drop for IngestServerHandle {
     }
 }
 
-/// Bind a Unix listener without replacing a live collector socket.
+/// Bind the telemetry ingest socket for the active collector.
 ///
-/// Socket ingest is optional sidecar plumbing: a scanner should own the path
-/// when it is free, but should quietly skip startup when another live collector
-/// already owns it. That makes this path safe for repeated setup calls and for
-/// mixed deployments during rollout. This is especially useful for
-/// `ProcessJob`, where local subprocess jobs and tests may initialize
-/// telemetry more than once against the same local socket path.
-pub fn non_destructive_bind(path: &Path) -> anyhow::Result<BindOutcome> {
+/// A stale socket file from a crashed collector is removed and replaced. A live
+/// collector is an activation error: callers should avoid starting duplicate
+/// collectors for the same host-local socket namespace.
+pub(crate) fn bind_ingest_socket(path: &Path) -> anyhow::Result<StdUnixListener> {
     match bind_listener(path) {
-        Ok(listener) => Ok(BindOutcome::Bound(listener)),
+        Ok(listener) => Ok(listener),
         Err(error) if error.kind() == ErrorKind::AddrInUse => {
             // `AddrInUse` can mean either a live collector or a stale socket
-            // file. Probe by connecting first so we never unlink another
-            // process's listener.
+            // file. Probe by connecting first so we only remove stale files.
             if StdUnixStream::connect(path).is_ok() {
-                return Ok(BindOutcome::SkippedExistingCollector);
+                return Err(anyhow::anyhow!(
+                    "telemetry socket already has a live collector: {}",
+                    path.display()
+                ));
             }
 
             std::fs::remove_file(path)
                 .with_context(|| format!("remove stale socket {}", path.display()))?;
-            Ok(BindOutcome::Bound(bind_listener(path)?))
+            bind_listener(path).with_context(|| format!("bind socket {}", path.display()))
         }
         Err(error) => Err(error).with_context(|| format!("bind socket {}", path.display())),
     }
@@ -102,11 +93,10 @@ pub fn run_ingest_server(
     listener: StdUnixListener,
     store: TableStore,
 ) -> anyhow::Result<IngestServerHandle> {
-    // `non_destructive_bind` returns a std listener because binding is a
+    // `bind_ingest_socket` returns a std listener because binding is a
     // synchronous ownership decision, not part of the async accept loop. Once
-    // ownership is established, convert the fd into Tokio's listener for
-    // serving connections. Tokio requires the fd to be nonblocking before
-    // `from_std`.
+    // ownership is established, convert the fd into Tokio's listener for serving
+    // connections. Tokio requires the fd to be nonblocking before `from_std`.
     listener.set_nonblocking(true)?;
     // Called from a PyO3 thread with no ambient Tokio runtime. Use monarch's
     // shared runtime.
@@ -366,34 +356,30 @@ mod tests {
     }
 
     #[test]
-    fn non_destructive_bind_skips_live_collector() {
+    fn bind_ingest_socket_rejects_live_collector() {
         let path = socket_path("telemetry.sock");
         let _listener = StdUnixListener::bind(&path).unwrap();
 
-        assert!(matches!(
-            non_destructive_bind(&path).unwrap(),
-            BindOutcome::SkippedExistingCollector
-        ));
+        let error = bind_ingest_socket(&path).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("telemetry socket already has a live collector")
+        );
     }
 
     #[test]
-    fn non_destructive_bind_replaces_stale_socket_file() {
+    fn bind_ingest_socket_replaces_stale_socket_file() {
         let path = socket_path("stale.sock");
         std::fs::write(&path, b"stale").unwrap();
 
-        assert!(matches!(
-            non_destructive_bind(&path).unwrap(),
-            BindOutcome::Bound(_)
-        ));
+        let _listener = bind_ingest_socket(&path).unwrap();
     }
 
     #[tokio::test]
     async fn ingest_server_pushes_registered_batch() {
         let path = socket_path("ingest.sock");
-        let listener = match non_destructive_bind(&path).unwrap() {
-            BindOutcome::Bound(listener) => listener,
-            BindOutcome::SkippedExistingCollector => panic!("test socket should be unowned"),
-        };
+        let listener = bind_ingest_socket(&path).unwrap();
         let store = TableStore::new_empty();
         store.register_table("t", make_batch(&[]).schema()).unwrap();
         let _handle = run_ingest_server(listener, store.clone()).unwrap();
@@ -406,10 +392,7 @@ mod tests {
     #[tokio::test]
     async fn ingest_server_receives_unix_socket_sink_frame() {
         let path = socket_path("integration.sock");
-        let listener = match non_destructive_bind(&path).unwrap() {
-            BindOutcome::Bound(listener) => listener,
-            BindOutcome::SkippedExistingCollector => panic!("test socket should be unowned"),
-        };
+        let listener = bind_ingest_socket(&path).unwrap();
         let store = TableStore::new_empty();
         let mut buffer = EventBuffer::default();
         // Register the generated schema without rows; the socket producer must
@@ -435,10 +418,7 @@ mod tests {
     #[tokio::test]
     async fn ingest_server_rejects_schema_mismatch() {
         let path = socket_path("schema.sock");
-        let listener = match non_destructive_bind(&path).unwrap() {
-            BindOutcome::Bound(listener) => listener,
-            BindOutcome::SkippedExistingCollector => panic!("test socket should be unowned"),
-        };
+        let listener = bind_ingest_socket(&path).unwrap();
         let store = TableStore::new_empty();
         store.register_table("t", make_batch(&[]).schema()).unwrap();
         let _handle = run_ingest_server(listener, store.clone()).unwrap();
@@ -451,10 +431,7 @@ mod tests {
     #[tokio::test]
     async fn ingest_server_keeps_accepting_after_malformed_frame() {
         let path = socket_path("survive.sock");
-        let listener = match non_destructive_bind(&path).unwrap() {
-            BindOutcome::Bound(listener) => listener,
-            BindOutcome::SkippedExistingCollector => panic!("test socket should be unowned"),
-        };
+        let listener = bind_ingest_socket(&path).unwrap();
         let store = TableStore::new_empty();
         store.register_table("t", make_batch(&[]).schema()).unwrap();
         let _handle = run_ingest_server(listener, store.clone()).unwrap();

--- a/monarch_introspection_snapshot/Cargo.toml
+++ b/monarch_introspection_snapshot/Cargo.toml
@@ -19,7 +19,7 @@ hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_mesh = { version = "0.0.0", path = "../hyperactor_mesh" }
 monarch_distributed_telemetry = { version = "0.0.0", path = "../monarch_distributed_telemetry" }
 monarch_record_batch = { version = "0.0.0", path = "../monarch_record_batch" }
-reqwest = { version = "0.13.2", features = ["blocking", "brotli", "charset", "cookies", "deflate", "gzip", "http2", "json", "multipart", "native-tls", "rustls", "socks", "stream", "system-proxy", "zstd"], default-features = false }
+reqwest = { version = "0.13.2", features = ["blocking", "charset", "cookies", "gzip", "http2", "json", "multipart", "rustls", "socks", "stream", "system-proxy"], default-features = false }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/python/monarch/_rust_bindings/monarch_distributed_telemetry/__init__.pyi
+++ b/python/monarch/_rust_bindings/monarch_distributed_telemetry/__init__.pyi
@@ -23,7 +23,7 @@ def reset_record_batch_flush_count() -> None:
 
 def _start_socket_ingest(
     scanner: database_scanner.DatabaseScanner, socket_path: str
-) -> bool:
+) -> None:
     """Start Unix-socket ingest for a database scanner."""
     ...
 

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -392,6 +392,15 @@ class JobTrait(ABC):
         self._components: JobComponents = JobComponents()
         self._apply_id: Optional[str] = None
 
+    def _should_spawn_telemetry_worker_collector_actors(self) -> bool:
+        """Whether sidecar telemetry should spawn per-host worker collectors.
+
+        Worker collectors only add value when workers run on separate hosts.
+        Single-host jobs (e.g. LocalJob) override this to avoid a redundant
+        local fan-out.
+        """
+        return True
+
     def _connect_host_meshes(self, running_job: "JobTrait") -> Dict[str, HostMesh]:
         """Run the connect phases and return the final host meshes.
 
@@ -939,6 +948,11 @@ class LocalJob(JobTrait):
         Local jobs are the same regardless of what was saved, so just
         use the spec, which has the correct 'hosts' sequence.
         """
+        return False
+
+    def _should_spawn_telemetry_worker_collector_actors(self) -> bool:
+        # LocalJob runs everything on one host; a worker collector fan-out
+        # would duplicate the client collector, so skip it.
         return False
 
     def _state(self) -> JobState:

--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -218,8 +218,12 @@ class SidecarTelemetryComponent(JobComponent):
     telemetry handle and installs the client-process Unix socket sink *before*
     raw host meshes are materialized so host-mesh creation events are captured.
     ``connect`` asks the sidecar to fan worker collectors out across the
-    materialized host meshes. Telemetry is best-effort: any failure is logged
-    and leaves telemetry disabled for this job rather than failing ``state()``.
+    materialized host meshes. Config drift clears parent-side handles, but
+    the sidecar keeps its in-memory telemetry store for the same ``apply_id``.
+    Switching between sidecar and in-process telemetry replaces the telemetry
+    component slot.
+    Telemetry is best-effort: any failure is logged and leaves telemetry
+    disabled for this job rather than failing ``state()``.
     """
 
     def __init__(self, config: TelemetryConfig) -> None:
@@ -231,11 +235,13 @@ class SidecarTelemetryComponent(JobComponent):
     def reset_runtime(self) -> None:
         self._query_engine_client = None
         self._telemetry_url = None
+        self._dashboard_url = None
 
     def __getstate__(self) -> Dict[str, Any]:
         state = self.__dict__.copy()
         state["_query_engine_client"] = None
         state["_telemetry_url"] = None
+        state["_dashboard_url"] = None
         return state
 
     def before_connect(self, job: "JobTrait") -> None:
@@ -283,7 +289,11 @@ class SidecarTelemetryComponent(JobComponent):
             # `_telemetry_url`/`_dashboard_url` are already set by
             # `before_connect`; this call only triggers worker fan-out, so its
             # response is intentionally ignored.
-            Telemetry(self._config).ensure_open(apply_id, host_meshes=host_meshes)
+            Telemetry(self._config).ensure_open(
+                apply_id,
+                host_meshes=host_meshes,
+                spawn_worker_collectors=job._should_spawn_telemetry_worker_collector_actors(),
+            )
         except Exception:
             logger.warning(
                 "job sidecar telemetry worker fan-out failed",

--- a/python/monarch/_src/job/job_sidecar.py
+++ b/python/monarch/_src/job/job_sidecar.py
@@ -120,6 +120,7 @@ class TelemetryRequest:
     apply_id: str
     config: dict[str, object]
     host_meshes: dict[str, HostMesh]
+    spawn_worker_collectors: bool = True
 
 
 class _JobSidecarState:
@@ -178,6 +179,7 @@ class _JobSidecarState:
         return self._telemetry_handle.open_or_refresh(
             request.host_meshes,
             request.config,
+            spawn_worker_collectors=request.spawn_worker_collectors,
         )
 
     def shutdown(self) -> None:

--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -177,6 +177,9 @@ class ProcessJob(JobTrait):
 
         return JobState(host_meshes)
 
+    def _should_spawn_telemetry_worker_collector_actors(self) -> bool:
+        return False
+
     def can_run(self, spec: "JobTrait") -> bool:
         return (
             isinstance(spec, ProcessJob)

--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -14,18 +14,11 @@ write framed Arrow IPC over `telemetry.sock`, Rust socket ingest validates and
 decodes those frames, and the scanner owns the in-memory DataFusion tables.
 Python coordinates activation and exposes actor endpoints for query fan-out.
 
-More than one `TelemetryActor` may be started for what turns out to be the
-same host-local socket namespace. That can happen in collocated/local jobs
-(i.e. ProcessJob) where the client-side sidecar collector and a worker-host
-collector resolve the same `/tmp/monarch_<apply_id>/telemetry.sock`, or during
-a sidecar refresh while an existing collector is still alive. This is a deliberate
-design choice. The non-destructive socket bind is the serialization point; the actor
-that binds the socket owns the store, and an actor that observes a live socket
-leaves its scanner unset and acts as an inert candidate.
-
-TODO: consider dedup'ing the worker fan-out by hostname (or job type) so
-ProcessJob / collocated jobs skip the redundant per-host candidate spawns
-instead of relying on each one to lose the bind race and be torn down.
+Only one live `TelemetryActor` may own a given host-local socket namespace. The
+socket bind is the ownership point: the actor that binds
+`/tmp/monarch_<apply_id>/telemetry.sock` owns the store, and any activation
+candidate that cannot bind leaves its scanner unset and must not participate in
+query fan-out.
 """
 
 from __future__ import annotations
@@ -73,8 +66,8 @@ class TelemetryActor(Actor):
         # disables retention. Passed to DataFusion's periodic retention task.
         self._retention_secs: int = retention_secs
         # The DataFusion store + socket-ingest pair this actor owns. `None`
-        # means this actor did not win (or has not yet attempted) the
-        # non-destructive bind, so it is not a live collector.
+        # means this actor has not activated as the single live collector for
+        # the host-local socket namespace.
         self._scanner: DatabaseScanner | None = None
         # Worker actor meshes this collector fans queries out to. Empty for
         # leaf collectors; the query-root collector receives its list via
@@ -90,9 +83,8 @@ class TelemetryActor(Actor):
     def _activate_impl(self) -> bool:
         """Lazily bind the local socket and stand up the scanner.
 
-        No-op once active. On a previously skipped or failed actor the next
-        call re-attempts activation: the bind is non-destructive, so a retry
-        is safe and may succeed if the prior owner has gone away.
+        No-op once active. On a previously failed actor the next call
+        re-attempts activation and may succeed if the prior owner has gone away.
         """
         if self._scanner is not None:
             return True
@@ -111,9 +103,9 @@ class TelemetryActor(Actor):
         try:
             _register_trace_entity_schemas(scanner)
             _pre_register_snapshot_schemas(scanner)
-            if _start_socket_ingest(scanner, telemetry_socket_path(self._apply_id)):
-                self._scanner = scanner
-                return True
+            _start_socket_ingest(scanner, telemetry_socket_path(self._apply_id))
+            self._scanner = scanner
+            return True
         except Exception as error:
             logger.warning("telemetry collector activation failed: %s", error)
         return False

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -29,13 +29,15 @@ The parent talks to telemetry via two channels:
   framed Arrow IPC from producers, decoded by Rust socket ingest into the
   collector's scanner.
 
-Lifecycle: `Telemetry.ensure_open(apply_id, host_meshes)` is called twice per
-`JobTrait._connect`. The first call (`host_meshes={}`) opens the job sidecar's
-telemetry handle and activates the client process's `UnixSocketSink` *before*
-raw host meshes are materialized, so host-mesh creation events are captured.
-The second call (with materialised `host_meshes`) triggers worker fan-out: the
-telemetry handle spawns per-host `TelemetryActor` candidates and hands the live
-worker refs to the client collector for query fan-out.
+Lifecycle: `Telemetry.ensure_open(apply_id, host_meshes, spawn_worker_collectors)`
+is called during `JobTrait._connect`. The first call (`host_meshes={}`) opens
+the job sidecar's telemetry handle and activates the client process's
+`UnixSocketSink` before raw host meshes are materialized, so host-mesh creation
+events are captured. Jobs call it again with materialised `host_meshes`; that
+second call creates telemetry host proc meshes for proc discovery. Remote jobs
+also activate one live `TelemetryActor` collector per host-local socket
+namespace and hand only those live worker refs to the client collector for
+query fan-out.
 """
 
 from __future__ import annotations
@@ -176,6 +178,7 @@ class Telemetry:
         self,
         apply_id: str,
         host_meshes: Mapping[str, HostMesh] | None = None,
+        spawn_worker_collectors: bool = True,
     ) -> _TelemetryResponse:
         """Ensure the job sidecar's telemetry handle is open and refreshed."""
         if not isinstance(apply_id, str):
@@ -198,6 +201,7 @@ class Telemetry:
                     "dashboard_port": self._config.dashboard_port,
                 },
                 host_meshes=dict(host_meshes or {}),
+                spawn_worker_collectors=spawn_worker_collectors,
             )
         ).get()
         if not isinstance(response, dict):
@@ -242,6 +246,7 @@ class _TelemetryHandle:
         self,
         host_meshes: Mapping[str, HostMesh],
         config: Mapping[str, object],
+        spawn_worker_collectors: bool = True,
     ) -> _TelemetryResponse:
         parsed = _config_from_wire(config)
         if self._first_config is None:
@@ -253,7 +258,11 @@ class _TelemetryHandle:
             logger.warning("telemetry handle config drift ignored")
 
         if host_meshes and self._worker_proc_meshes is None:
-            self._worker_proc_meshes = self._spawn_telemetry_actors(host_meshes, parsed)
+            self._worker_proc_meshes = self._spawn_telemetry_actors(
+                host_meshes,
+                parsed,
+                spawn_worker_collectors=spawn_worker_collectors,
+            )
 
         dashboard_info = self._dashboard_info
         if dashboard_info is None:
@@ -280,10 +289,10 @@ class _TelemetryHandle:
             self._apply_id,
             config.retention_secs,
         )
-        # `activate` is the actor's bind decision: triggers the
-        # non-destructive Unix-socket bind and stands up the scanner. We
-        # do not branch on the return — failures stay scannerless and the
-        # scan endpoint surfaces them as best-effort empty results.
+        # `activate` is the actor's bind decision: it binds the Unix socket and
+        # stands up the scanner for the sidecar host. The job sidecar is keyed
+        # by apply id, so this should be the only live collector for the local
+        # socket namespace.
         client_actor.activate.call_one().get()
 
         query_engine = QueryEngine(client_actor)
@@ -307,10 +316,12 @@ class _TelemetryHandle:
         self,
         host_meshes: Mapping[str, HostMesh],
         config: TelemetryConfig,
+        *,
+        spawn_worker_collectors: bool = True,
     ) -> list[ProcMesh]:
         client_actor = self._client_actor
         if client_actor is None:
-            raise RuntimeError("telemetry sidecar has no client actor")
+            raise RuntimeError("telemetry handle has no client actor")
 
         worker_proc_meshes: list[ProcMesh] = []
         worker_collector_meshes: list[Any] = []
@@ -320,6 +331,7 @@ class _TelemetryHandle:
                     self._start_worker_telemetry_collector(
                         host_mesh,
                         config,
+                        spawn_worker_collector=spawn_worker_collectors,
                     )
                 )
             except Exception:
@@ -339,8 +351,13 @@ class _TelemetryHandle:
         self,
         host_mesh: HostMesh,
         config: TelemetryConfig,
+        *,
+        spawn_worker_collector: bool = True,
     ) -> tuple[ProcMesh, Any | None]:
         proc_mesh = host_mesh.spawn_procs(name="telemetry_hosts")
+        if not spawn_worker_collector:
+            return proc_mesh, None
+
         try:
             worker_collector_mesh = proc_mesh.spawn(
                 "TelemetryActor",
@@ -362,10 +379,9 @@ class _TelemetryHandle:
         if active:
             return proc_mesh, worker_collector_mesh
 
-        # TODO: avoid spawning the local worker collector when the root
-        # collector already owns the socket. Until then, keep the proc alive so
-        # mesh-admin snapshots can still resolve it, but stop the inactive
-        # collector actor so queries do not fan out to it.
+        # Only one live collector may own a host-local socket namespace. Keep
+        # the proc alive so mesh-admin snapshots can still resolve it, but stop
+        # the inactive actor so queries do not fan out to it.
         self._stop_worker_mesh(
             worker_collector_mesh,
             "telemetry collector inactive",

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -124,7 +124,6 @@ def test_telemetry_actor_starts_local_socket_collector() -> None:
             unittest.mock.patch.object(
                 job_telemetry_actor,
                 "_start_socket_ingest",
-                return_value=True,
             ) as start_ingest,
         ):
             assert actor._activate_impl()
@@ -142,7 +141,7 @@ def test_telemetry_actor_starts_local_socket_collector() -> None:
 
 
 @pytest.mark.timeout(30)
-def test_telemetry_actor_skips_active_existing_collector() -> None:
+def test_telemetry_actor_reports_live_collector_activation_failure() -> None:
     apply_id = _new_apply_id()
     _remove_socket_dir(apply_id)
     try:
@@ -156,7 +155,9 @@ def test_telemetry_actor_skips_active_existing_collector() -> None:
             unittest.mock.patch.object(
                 job_telemetry_actor,
                 "_start_socket_ingest",
-                return_value=False,
+                side_effect=RuntimeError(
+                    "telemetry socket already has a live collector"
+                ),
             ),
         ):
             assert not actor._activate_impl()

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -36,6 +36,7 @@ from monarch._src.job.job import (
 )
 from monarch._src.job.job_components import JobComponent, JobComponents, MountComponent
 from monarch._src.job.mount_config import Mounts
+from monarch._src.job.process import ProcessJob
 from monarch._src.job.process_guard import _Shutdown, _wait_for_socket
 from monarch.actor import HostMesh
 
@@ -1158,7 +1159,54 @@ def test_sidecar_bootstrap_then_fanout_carry_host_meshes():
     bootstrap_kwargs = m.ensure_open.call_args_list[0].kwargs
     fanout_kwargs = m.ensure_open.call_args_list[1].kwargs
     assert bootstrap_kwargs["host_meshes"] == {}
+    assert "spawn_worker_collectors" not in bootstrap_kwargs
     assert set(fanout_kwargs["host_meshes"].keys()) == {"hosts"}
+    assert fanout_kwargs["spawn_worker_collectors"] is True
+
+
+def test_local_job_sidecar_skips_worker_collector_actors():
+    """Local sidecar telemetry keeps fan-out procs without collector actors."""
+    with _patched_sidecar() as m:
+        job = LocalJob(hosts=["hosts"]).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)
+
+    assert m.ensure_open.call_count == 2
+    bootstrap_kwargs = m.ensure_open.call_args_list[0].kwargs
+    fanout_kwargs = m.ensure_open.call_args_list[1].kwargs
+    assert bootstrap_kwargs["host_meshes"] == {}
+    assert "spawn_worker_collectors" not in bootstrap_kwargs
+    assert set(fanout_kwargs["host_meshes"].keys()) == {"hosts"}
+    assert fanout_kwargs["spawn_worker_collectors"] is False
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
+
+
+def test_process_job_sidecar_skips_worker_collector_actors():
+    """ProcessJob sidecar telemetry keeps fan-out procs without collector actors."""
+    mock_host_mesh = cast("HostMesh", MagicMock())
+    with (
+        _patched_sidecar() as m,
+        patch.object(ProcessJob, "_create"),
+        patch.object(
+            ProcessJob,
+            "_state",
+            return_value=JobState({"hosts": mock_host_mesh}),
+        ),
+    ):
+        job = ProcessJob({"hosts": 1}).enable_telemetry(
+            TelemetryConfig(use_sidecar=True)
+        )
+        state = job.state(cached_path=None)
+
+    assert m.ensure_open.call_count == 2
+    bootstrap_kwargs = m.ensure_open.call_args_list[0].kwargs
+    fanout_kwargs = m.ensure_open.call_args_list[1].kwargs
+    assert bootstrap_kwargs["host_meshes"] == {}
+    assert "spawn_worker_collectors" not in bootstrap_kwargs
+    assert set(fanout_kwargs["host_meshes"].keys()) == {"hosts"}
+    assert fanout_kwargs["spawn_worker_collectors"] is False
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
 
 
 def test_sidecar_worker_fanout_uses_configured_host_meshes():

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -100,8 +100,8 @@ class _FakeTelemetryHandle:
         self.calls = []
         self.shutdown_called = False
 
-    def open_or_refresh(self, host_meshes, config):
-        self.calls.append((host_meshes, config))
+    def open_or_refresh(self, host_meshes, config, spawn_worker_collectors=True):
+        self.calls.append((host_meshes, config, spawn_worker_collectors))
         return {
             "telemetry_url": "http://telemetry",
             "dashboard_url": "http://dashboard",
@@ -282,6 +282,34 @@ def test_spawn_telemetry_actors_registers_workers_and_stops_on_shutdown() -> Non
     proc_mesh.stop.assert_called_once_with("telemetry shutdown")
     proc_mesh.stop.return_value.get.assert_called_once_with()
     shutdown_context.return_value.get.assert_called_once_with(timeout=5.0)
+
+
+def test_spawn_telemetry_actors_can_skip_worker_collectors() -> None:
+    proc_mesh = MagicMock()
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
+    handle = tc._TelemetryHandle("fanout_test")
+    handle._client_actor = client_actor
+
+    host_mesh.spawn_procs.return_value = proc_mesh
+
+    worker_proc_meshes = handle._spawn_telemetry_actors(
+        {
+            "hosts": host_mesh,
+        },
+        TelemetryConfig(
+            retention_secs=0,
+            include_dashboard=False,
+            dashboard_port=0,
+        ),
+        spawn_worker_collectors=False,
+    )
+
+    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
+    proc_mesh.spawn.assert_not_called()
+    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
+    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
+    assert worker_proc_meshes == [proc_mesh]
 
 
 def test_spawn_telemetry_actors_drops_inactive_worker_collectors() -> None:


### PR DESCRIPTION
Summary:

Skips sidecar worker collector actors for local topologies (`LocalJob`, `ProcessJob`) where the root collector and workers share the same host-local telemetry socket namespace, while still spawning telemetry host proc meshes for discovery, snapshots, and py-spy. Remote jobs continue to spawn worker collectors and fan only active collector meshes into the root query actor. The job decides whether worker collectors are useful at fan-out time, so `JobComponents.configure_telemetry()` stays focused on telemetry config and does not store topology-specific worker-collector state. Socket ingest now treats a live collector as an activation error and only replaces stale socket files, which keeps duplicate collector actors out of query fan-out.

Reviewed By: zdevito

Differential Revision: D107932127


