### PR TITLE
fix test_rdma.py::test_rdma_buffer_drop[rdma_disable_ibverbs=False-rdma_allow_tcp_fallback=False]

### DIFF
--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -259,6 +259,16 @@ async def test_rdma_buffer_drop():
             """Drop an RDMABuffer"""
             # pyrefly: ignore [missing-attribute]
             await self.buffer.drop()
+            # Dropping the buffer means that the RDMA manager no longer
+            # forcibly keeps the allocation alive, but as long as the original
+            # tensor is still alive, the memory registration remains valid.
+            # So operations on the buffer would technically continue to succeed
+            # until the original tensor is deleted.
+            del self.data
+
+            import gc
+
+            gc.collect()
 
     class ConsumerActor(Actor):
         def __init__(self):


### PR DESCRIPTION
Summary: Because of the recent MR caching changes, dropping a buffer doesn't actually deregister the associated memory automatically. So for this test to pass, we need to explicitly delete the underlying tensor.

Differential Revision: D108036947


