### PR TITLE
Refactor job lifecycle into components (#4208)

### DIFF
--- a/examples/torchtitan_mast/job.py
+++ b/examples/torchtitan_mast/job.py
@@ -186,7 +186,7 @@ def _make_job() -> SimpleMastJob:
     # Pass python_exe (above) for the mount layer, but do NOT let it become the
     # proc-bootstrap interpreter -- see the comment above. Workers boot on the
     # bootstrap-fbpkg python; torch/torchtitan come from the mount via PYTHONPATH.
-    job._default_python_exe = None
+    job._components.mounts._default_python_exe = None
 
     # The workspace's ``torchtitan/`` is a symlink to your local checkout
     # (resolved above into ``torchtitan_source``). The FUSE mount serves the

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -18,17 +18,13 @@ import tempfile
 import traceback
 import uuid
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 
-from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
 from monarch._src.actor.bootstrap import attach_to_workers
-from monarch._src.actor.host_mesh import _spawn_admin
-from monarch._src.actor.sync_state import fake_sync_state
 from monarch._src.job._batch_env import in_batch_job, MONARCH_BATCH_JOB_ENV
+from monarch._src.job.job_components import JobComponents, MeshAdminConfig
 from monarch._src.job.job_sidecar import stop_job_sidecar
-from monarch._src.job.mount_config import Mounts
 from monarch._src.job.telemetry_config import TelemetryConfig
 
 # note: the jobs api is intended as a library so it should
@@ -43,7 +39,6 @@ from monarch.actor import (
     Port,
     this_host,
 )
-from monarch.distributed_telemetry.actor import start_telemetry
 from monarch.distributed_telemetry.engine import QueryEngine
 from typing_extensions import Self
 
@@ -299,23 +294,6 @@ class BashActor(Actor):
         output_port.send(f"{my_rank}:rc:{proc.returncode}")
 
 
-@dataclass
-class MeshAdminConfig:
-    """Configuration for automatic mesh admin agent startup.
-
-    When passed to a job constructor, a MeshAdminAgent HTTP server is
-    spawned automatically when ``state()`` is called.  The server
-    aggregates topology across all host meshes and exposes it via a
-    REST API that the admin TUI can attach to.
-
-    Args:
-        admin_addr: Bind address for the admin HTTP server.  When
-            ``None`` the server picks an available address automatically.
-    """
-
-    admin_addr: Optional[str] = None
-
-
 class JobState:
     """
     Container for the current state of a job.
@@ -406,96 +384,24 @@ class JobTrait(ABC):
         # Use enable_telemetry() / enable_admin() after construction instead.
         super().__init__()
         self._status: Literal["running", "not_running"] | CachedRunning = "not_running"
-        self._telemetry: Optional[TelemetryConfig] = None
-        self._mesh_admin: Optional[MeshAdminConfig] = None
-        self._query_engine: Optional[QueryEngine] = None
-        self._telemetry_url: Optional[str] = None
-        self._admin_url: Optional[str] = None
-        self._scanner = None  # DatabaseScanner, set by _start_telemetry_if_configured
-        self._snapshot_started: bool = False
+        self._components: JobComponents = JobComponents()
         self._apply_id: Optional[str] = None
-        self._mounts: Mounts = Mounts()
-        # Per-mesh python executable overrides.  None key means "all meshes".
-        self._python_executables: Dict[str, str] = {}
-        self._default_python_exe: Optional[str] = None
 
-    def _start_telemetry_if_configured(self) -> None:
-        """Start telemetry if configured and not already running."""
-        if self._telemetry is None or self._query_engine is not None:
-            return
+    def _connect_host_meshes(self, running_job: "JobTrait") -> Dict[str, HostMesh]:
+        """Run the connect phases and return the final host meshes.
 
-        cfg = self._telemetry
-        self._query_engine, self._telemetry_url, self._scanner = start_telemetry(
-            batch_size=cfg.batch_size,
-            retention_secs=cfg.retention_secs,
-            include_dashboard=cfg.include_dashboard,
-            dashboard_port=cfg.dashboard_port,
-        )
+        ``before_connect`` runs before raw host meshes are materialized;
+        ``connect`` receives those raw meshes and returns the final,
+        user-facing meshes. Service bring-up is deferred to :meth:`state` so
+        it spawns on those configured meshes.
 
-    def _start_admin_if_configured(
-        self, host_meshes: List[HostMesh]
-    ) -> Optional[PyMeshAdminRef]:
-        """Start the mesh admin agent if configured and not already running.
-
-        Returns the opaque admin ref for immediate use by snapshot
-        startup, or None if admin is not configured or already running.
+        ``running_job`` is the job whose scheduler-specific state materializes
+        the raw host meshes (``self``, a cached job, or the wrapped
+        CachedRunning job).
         """
-        if self._mesh_admin is None or self._admin_url is not None:
-            return None
-
-        # state() is a sync API but is commonly called from inside
-        # asyncio.run(...); mask the running loop so the inner .get() does not
-        # trip the Future.get-in-loop check.
-        with fake_sync_state():
-            admin_url, admin_ref = _spawn_admin(
-                host_meshes,
-                admin_addr=self._mesh_admin.admin_addr,
-                telemetry_url=self._telemetry_url,
-            ).get()
-        self._admin_url = admin_url
-        return admin_ref
-
-    def _start_periodic_snapshots_if_configured(
-        self, admin_ref: Optional[PyMeshAdminRef]
-    ) -> None:
-        """Start periodic snapshots if configured and not already running.
-
-        Spawns a SnapshotCaptureActor on the local proc. The actor is
-        stopped by framework lifecycle on proc teardown — no manual
-        stop needed. The admin_ref is consumed here and not persisted.
-        """
-        if self._snapshot_started:
-            return
-        if self._telemetry is None or self._scanner is None:
-            return
-        if admin_ref is None:
-            return
-        telemetry = self._telemetry
-        assert telemetry is not None  # guarded above
-        if telemetry.snapshot_interval_secs <= 0:
-            return
-
-        from monarch._rust_bindings.monarch_extension.snapshot_integration import (
-            _start_periodic_snapshots,
-        )
-        from monarch.actor import context
-
-        _start_periodic_snapshots(
-            scanner=self._scanner,
-            admin_ref=admin_ref,
-            instance=context().actor_instance._as_rust(),
-            interval_secs=telemetry.snapshot_interval_secs,
-        )
-        self._snapshot_started = True
-
-    def _wrap_state(self, job_state: JobState) -> JobState:
-        """Attach telemetry and admin fields to a JobState."""
-        if self._query_engine is not None:
-            job_state.query_engine = self._query_engine
-            job_state.telemetry_url = self._telemetry_url
-        if self._admin_url is not None:
-            job_state.admin_url = self._admin_url
-        return job_state
+        self._components.before_connect(self)
+        host_meshes = dict(running_job._state()._hosts)
+        return self._components.connect(self, host_meshes)
 
     def enable_telemetry(
         self,
@@ -512,7 +418,9 @@ class JobTrait(ABC):
         Returns:
             ``self``, for chaining.
         """
-        self._telemetry = config if config is not None else TelemetryConfig(**kwargs)
+        self._components.configure_telemetry(
+            config if config is not None else TelemetryConfig(**kwargs)
+        )
         return self
 
     def enable_admin(
@@ -530,7 +438,9 @@ class JobTrait(ABC):
         Returns:
             ``self``, for chaining.
         """
-        self._mesh_admin = config if config is not None else MeshAdminConfig(**kwargs)
+        self._components.configure_admin(
+            config if config is not None else MeshAdminConfig(**kwargs)
+        )
         return self
 
     @property
@@ -602,29 +512,17 @@ class JobTrait(ABC):
         running_job = self._running
         if running_job is not None:
             logger.info("Job is running, returning current state")
-            job_state = running_job._state()
-            self._start_telemetry_if_configured()
-            admin_ref = self._start_admin_if_configured(list(job_state._hosts.values()))
-            self._start_periodic_snapshots_if_configured(admin_ref)
-            return self._wrap_state(job_state)
+            return JobState(self._connect_host_meshes(running_job))
 
         cached = self._load_cached(cached_path)
         if cached is not None:
             self._status = CachedRunning(cached)
             logger.info("Connecting to cached job")
-            job_state = cached._state()
-            self._start_telemetry_if_configured()
-            admin_ref = self._start_admin_if_configured(list(job_state._hosts.values()))
-            self._start_periodic_snapshots_if_configured(admin_ref)
-            return self._wrap_state(job_state)
+            return JobState(self._connect_host_meshes(cached))
         logger.info("Applying current job")
         self.apply()
         logger.info("Job has started, connecting to current state")
-        job_state = self._state()
-        self._start_telemetry_if_configured()
-        admin_ref = self._start_admin_if_configured(list(job_state._hosts.values()))
-        self._start_periodic_snapshots_if_configured(admin_ref)
-        result = self._wrap_state(job_state)
+        host_meshes = self._connect_host_meshes(self)
         if cached_path is not None:
             # Create the directory for cached_path if it doesn't exist
             cache_dir = os.path.dirname(cached_path)
@@ -632,29 +530,15 @@ class JobTrait(ABC):
                 os.makedirs(cache_dir, exist_ok=True)
             logger.info("Saving job to cache at %s", cached_path)
             self.dump(cached_path)
-        return result
+        return JobState(host_meshes)
 
     def state(
         self, cached_path: Optional[str] = ".monarch/job_state.pkl"
     ) -> "JobState":
-        """Connect to the job and return its state with all configured mounts applied.
-
-        See :meth:`_connect` for the connection logic. After connecting, all
-        mount configs registered via :meth:`remote_mount` and gather mount
-        configs registered via :meth:`gather_mount` are applied before returning.
-        """
-        raw = self._connect(cached_path)
-        apply_id = self.apply_id
-        running = self._running
-        if apply_id is not None and running is not None:
-            self._mounts.ensure_open(apply_id, raw._hosts)
-        hosts = {}
-        for mesh_name, mesh in raw._hosts.items():
-            exe = self._python_executables.get(mesh_name, self._default_python_exe)
-            if exe is not None:
-                mesh = mesh.with_python_executable(exe)
-            hosts[mesh_name] = mesh
-        return self._wrap_state(JobState(hosts))
+        """Connect and run component state hooks on the final host meshes."""
+        job_state = self._connect(cached_path)
+        self._components.state(self, job_state)
+        return job_state
 
     def _load_cached(self, cached_path: Optional[str]) -> "Optional[JobTrait]":
         if cached_path is None:
@@ -690,18 +574,6 @@ class JobTrait(ABC):
             return None
         return job
 
-    def __getstate__(self):
-        state = self.__dict__.copy()
-        # QueryEngine holds Rust bindings / network connections and is not
-        # picklable.  Drop it so deserialized jobs re-initialize telemetry
-        # on the next state() call.
-        state["_query_engine"] = None
-        state["_telemetry_url"] = None
-        state["_admin_url"] = None
-        state["_scanner"] = None
-        state["_snapshot_started"] = False
-        return state
-
     def dump(self, filename: str) -> None:
         """Save job to a file, following any symlink at *filename*.
 
@@ -721,9 +593,10 @@ class JobTrait(ABC):
 
     def kill(self):
         apply_id = self.apply_id
+        running = self._running
+        self._components.reset_runtime()
         if apply_id is not None:
             stop_job_sidecar(apply_id)
-        running = self._running
         if running is not None:
             running._kill()
         self._status = "not_running"
@@ -752,26 +625,13 @@ class JobTrait(ABC):
                 Set to ``None`` to skip. Defaults to ``".venv/bin/python"``.
             **kwargs: Forwarded to :func:`remotemount`.
         """
-        self._mounts.remote_mount(
-            source=source, mntpoint=mntpoint, meshes=meshes, **kwargs
+        self._components.mounts.remote_mount(
+            source=source,
+            mntpoint=mntpoint,
+            meshes=meshes,
+            python_exe=python_exe,
+            **kwargs,
         )
-        if python_exe is not None:
-            abs_source = os.path.abspath(source)
-            local_exe = os.path.join(abs_source, python_exe)
-            if not os.path.isfile(local_exe):
-                raise ValueError(
-                    f"python_exe '{python_exe}' not found locally at '{local_exe}'. "
-                    f"Ensure the virtual environment exists in '{source}' before calling remote_mount."
-                )
-            abs_mntpoint = (
-                os.path.abspath(mntpoint) if mntpoint is not None else abs_source
-            )
-            exe_path = os.path.join(abs_mntpoint, python_exe)
-            if meshes is None:
-                self._default_python_exe = exe_path
-            else:
-                for mesh_name in meshes:
-                    self._python_executables[mesh_name] = exe_path
 
     def gather_mount(
         self,
@@ -794,7 +654,7 @@ class JobTrait(ABC):
             meshes: Names of meshes to gather from. ``None`` means all meshes
                 returned by :meth:`state`.
         """
-        self._mounts.gather_mount(
+        self._components.mounts.gather_mount(
             remote_mount_point=remote_mount_point,
             local_mount_point=local_mount_point,
             meshes=meshes,
@@ -1149,11 +1009,20 @@ class BatchJob(JobTrait):
 
     def __init__(self, job: JobTrait):
         super().__init__()
-        # Copy telemetry/admin config from the wrapped job so the batch
-        # client benefits from the same observability setup.
-        self._telemetry = job._telemetry
-        self._mesh_admin = job._mesh_admin
         self._job = job
+        # BatchJob is a scheduler-state proxy; component config and runtime stay
+        # owned by the wrapped job so there is only one source of truth.
+        self._components = job._components
+
+    def _connect_host_meshes(self, running_job: "JobTrait") -> Dict[str, HostMesh]:
+        return self._job._connect_host_meshes(running_job)
+
+    def state(
+        self, cached_path: Optional[str] = ".monarch/job_state.pkl"
+    ) -> "JobState":
+        job_state = self._connect(cached_path)
+        self._job._components.state(self._job, job_state)
+        return job_state
 
     def can_run(self, spec: JobTrait):
         if in_batch_job():

--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -1,0 +1,412 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Lifecycle components for ``JobTrait``.
+
+``JobTrait`` owns scheduler state and the current allocation. ``JobComponent``
+owns the configuration and live handles for one job-scoped capability: mounts,
+telemetry, admin, or snapshots.
+
+The hooks mirror the job lifecycle after an allocation is selected:
+
+- ``before_connect(job)``: before ``JobTrait._connect()`` materializes raw host
+  meshes.
+- ``connect(job, host_meshes)``: after raw host meshes exist; return the final
+  user-facing meshes.
+- ``state(job, job_state)``: after final meshes are wrapped in ``JobState``;
+  start services and attach fields to the object returned to the caller.
+- ``reset_runtime()``: drop local live handles.
+
+``JobComponents`` is a stable typed container. It owns optional component
+presence, dependency wiring, and phase ordering; ``JobTrait`` owns allocation
+identity.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+from monarch._rust_bindings.monarch_hyperactor.host_mesh import PyMeshAdminRef
+from monarch._src.actor.host_mesh import _spawn_admin
+from monarch._src.actor.sync_state import fake_sync_state
+from monarch._src.job.mount_config import Mounts
+from monarch._src.job.telemetry_config import TelemetryConfig
+from monarch.actor import HostMesh
+from monarch.distributed_telemetry.actor import start_telemetry
+from monarch.distributed_telemetry.engine import QueryEngine
+
+if TYPE_CHECKING:
+    from monarch._src.job.job import JobState, JobTrait
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MeshAdminConfig:
+    """Configuration for automatic mesh admin agent startup.
+
+    When configured via ``JobTrait.enable_admin``, a MeshAdminAgent HTTP
+    server is spawned when ``state()`` is called. The server aggregates
+    topology across all host meshes and exposes it via a REST API that the
+    admin TUI can attach to.
+
+    Args:
+        admin_addr: Bind address for the admin HTTP server.  When
+            ``None`` the server picks an available address automatically.
+    """
+
+    admin_addr: Optional[str] = None
+
+
+class JobComponent:
+    """A job-scoped component driven by ``JobTrait``."""
+
+    def before_connect(self, job: "JobTrait") -> None:
+        """Run at the start of ``JobTrait._connect``, before raw host meshes exist."""
+
+    def connect(
+        self, job: "JobTrait", host_meshes: Dict[str, HostMesh]
+    ) -> Dict[str, HostMesh]:
+        """Run during ``JobTrait._connect`` to produce final user-facing meshes."""
+        return host_meshes
+
+    def state(self, job: "JobTrait", job_state: "JobState") -> None:
+        """Run during ``JobTrait.state`` to bring services up on final meshes."""
+
+    def reset_runtime(self) -> None:
+        """Drop local live handles owned by this component."""
+
+
+class MountComponent(JobComponent):
+    """Open configured mounts and apply per-mesh python executables.
+
+    Runs in ``connect`` -- after ``JobTrait._connect`` materializes the raw
+    host meshes and before any service comes up -- so it produces the final
+    meshes that both the caller and the downstream ``state`` services see.
+    Config drift is copied in place; the next ``connect`` lets
+    ``Mounts.ensure_open`` refresh, replace, or clear sidecar mount state.
+    """
+
+    def __init__(self) -> None:
+        self._mounts: Mounts = Mounts()
+        self._python_executables: Dict[str, str] = {}
+        self._default_python_exe: Optional[str] = None
+
+    def connect(
+        self, job: "JobTrait", host_meshes: Dict[str, HostMesh]
+    ) -> Dict[str, HostMesh]:
+        apply_id = job.apply_id
+        if apply_id is not None:
+            self._mounts.ensure_open(apply_id, host_meshes)
+        result: Dict[str, HostMesh] = {}
+        for mesh_name, mesh in host_meshes.items():
+            exe = self.python_executable_for_mesh(mesh_name)
+            if exe is not None:
+                mesh = mesh.with_python_executable(exe)
+            result[mesh_name] = mesh
+        return result
+
+    def python_executable_for_mesh(self, mesh_name: str) -> Optional[str]:
+        return self._python_executables.get(mesh_name, self._default_python_exe)
+
+    def remote_mount(
+        self,
+        source: str,
+        mntpoint: Optional[str] = None,
+        meshes: Optional[List[str]] = None,
+        python_exe: Optional[str] = ".venv/bin/python",
+        **kwargs: Any,
+    ) -> None:
+        default_exe_path = None
+        mesh_exe_path = None
+        if python_exe is not None:
+            abs_source = os.path.abspath(source)
+            local_exe = os.path.join(abs_source, python_exe)
+            if not os.path.isfile(local_exe):
+                raise ValueError(
+                    f"python_exe '{python_exe}' not found locally at '{local_exe}'. "
+                    f"Ensure the virtual environment exists in '{source}' before calling remote_mount."
+                )
+            abs_mntpoint = (
+                os.path.abspath(mntpoint) if mntpoint is not None else abs_source
+            )
+            exe_path = os.path.join(abs_mntpoint, python_exe)
+            if meshes is None:
+                default_exe_path = exe_path
+            else:
+                mesh_exe_path = exe_path
+        self._mounts.remote_mount(
+            source=source, mntpoint=mntpoint, meshes=meshes, **kwargs
+        )
+        if default_exe_path is not None:
+            self._default_python_exe = default_exe_path
+        elif mesh_exe_path is not None and meshes is not None:
+            for mesh_name in meshes:
+                self._python_executables[mesh_name] = mesh_exe_path
+
+    def gather_mount(
+        self,
+        remote_mount_point: str,
+        local_mount_point: str,
+        meshes: Optional[List[str]] = None,
+    ) -> None:
+        self._mounts.gather_mount(
+            remote_mount_point=remote_mount_point,
+            local_mount_point=local_mount_point,
+            meshes=meshes,
+        )
+
+
+class TelemetryComponent(JobComponent):
+    """Start the legacy in-process telemetry collector once per allocation.
+
+    Owns the query engine, collector URL, and scanner. Dependent components
+    receive this component explicitly instead of reading telemetry state from
+    ``JobTrait``. ``JobComponents`` resets this runtime when config drifts so
+    the next ``state`` starts a collector with the new config.
+    """
+
+    def __init__(self, config: TelemetryConfig) -> None:
+        self._config = config
+        self._query_engine: Optional[QueryEngine] = None
+        self._telemetry_url: Optional[str] = None
+        self._scanner: Any = None
+
+    def reset_runtime(self) -> None:
+        self._query_engine = None
+        self._telemetry_url = None
+        self._scanner = None
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_query_engine"] = None
+        state["_telemetry_url"] = None
+        state["_scanner"] = None
+        return state
+
+    def state(self, job: "JobTrait", job_state: "JobState") -> None:
+        if self._query_engine is None:
+            cfg = self._config
+            self._query_engine, self._telemetry_url, self._scanner = start_telemetry(
+                batch_size=cfg.batch_size,
+                retention_secs=cfg.retention_secs,
+                include_dashboard=cfg.include_dashboard,
+                dashboard_port=cfg.dashboard_port,
+            )
+        job_state.query_engine = self._query_engine
+        job_state.telemetry_url = self._telemetry_url
+
+
+class AdminComponent(JobComponent):
+    """Start the mesh admin agent once per allocation.
+
+    Owns the admin URL and ref. If telemetry is configured, the admin agent
+    receives the telemetry URL from the active telemetry component.
+    ``JobComponents`` resets this runtime when admin config drifts or telemetry
+    config changes.
+    """
+
+    def __init__(
+        self,
+        config: MeshAdminConfig,
+        telemetry: Optional[TelemetryComponent],
+    ) -> None:
+        self._config = config
+        self._telemetry = telemetry
+        self._admin_url: Optional[str] = None
+        self._admin_ref: Optional[PyMeshAdminRef] = None
+
+    def reset_runtime(self) -> None:
+        self._admin_url = None
+        self._admin_ref = None
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_admin_url"] = None
+        state["_admin_ref"] = None
+        return state
+
+    def state(self, job: "JobTrait", job_state: "JobState") -> None:
+        if self._admin_url is None:
+            telemetry_url = (
+                self._telemetry._telemetry_url if self._telemetry is not None else None
+            )
+            # state() is a sync API but is commonly called from inside
+            # asyncio.run(...); mask the running loop so the inner .get() does not
+            # trip the Future.get-in-loop check.
+            with fake_sync_state():
+                self._admin_url, self._admin_ref = _spawn_admin(
+                    list(job_state._hosts.values()),
+                    admin_addr=self._config.admin_addr,
+                    telemetry_url=telemetry_url,
+                ).get()
+        job_state.admin_url = self._admin_url
+
+
+class SnapshotComponent(JobComponent):
+    """Start periodic mesh-introspection snapshots once per allocation.
+
+    Requires both telemetry and admin to have come up, plus a positive
+    ``snapshot_interval_secs``. The snapshot actor is owned by proc lifecycle,
+    so this component has no fine-grained stop handle once started.
+
+    Because the actor cannot be stopped, ``_started`` stays sticky for the life
+    of the allocation: once running, the snapshot is not restarted even when its
+    telemetry or admin dependencies are reset by config drift. Restarting would
+    spawn a duplicate actor against the new runtime while the original keeps
+    capturing from the old one. ``JobComponents`` warns on such drift; picking up
+    new config requires killing and re-applying the job.
+    """
+
+    def __init__(
+        self,
+        telemetry: TelemetryComponent,
+        admin: AdminComponent,
+    ) -> None:
+        self._telemetry = telemetry
+        self._admin = admin
+        self._started = False
+
+    def reset_runtime(self) -> None:
+        self._started = False
+
+    def __getstate__(self) -> Dict[str, Any]:
+        state = self.__dict__.copy()
+        state["_started"] = False
+        return state
+
+    def state(self, job: "JobTrait", job_state: "JobState") -> None:
+        if self._started:
+            return
+        scanner = self._telemetry._scanner
+        admin_ref = self._admin._admin_ref
+        if scanner is None or admin_ref is None:
+            return
+        snapshot_interval_secs = self._telemetry._config.snapshot_interval_secs
+        if snapshot_interval_secs <= 0:
+            return
+
+        from monarch._rust_bindings.monarch_extension.snapshot_integration import (
+            _start_periodic_snapshots,
+        )
+        from monarch.actor import context
+
+        _start_periodic_snapshots(
+            scanner=scanner,
+            admin_ref=admin_ref,
+            instance=context().actor_instance._as_rust(),
+            interval_secs=snapshot_interval_secs,
+        )
+        self._started = True
+
+
+@dataclass
+class JobComponents:
+    """Stable component set for one job.
+
+    Field order is dependency order. Mounts always run first, telemetry
+    feeds admin, and snapshots require both telemetry and admin.
+    """
+
+    mounts: MountComponent = field(default_factory=MountComponent)
+    telemetry: Optional[TelemetryComponent] = None
+    admin: Optional[AdminComponent] = None
+    snapshot: Optional[SnapshotComponent] = None
+
+    def _ordered(self) -> List[JobComponent]:
+        components: List[JobComponent] = [self.mounts]
+        if self.telemetry is not None:
+            components.append(self.telemetry)
+        if self.admin is not None:
+            components.append(self.admin)
+        if self.snapshot is not None:
+            components.append(self.snapshot)
+        return components
+
+    def before_connect(self, job: "JobTrait") -> None:
+        for component in self._ordered():
+            component.before_connect(job)
+
+    def connect(
+        self, job: "JobTrait", host_meshes: Dict[str, HostMesh]
+    ) -> Dict[str, HostMesh]:
+        for component in self._ordered():
+            host_meshes = component.connect(job, host_meshes)
+        return host_meshes
+
+    def state(self, job: "JobTrait", job_state: "JobState") -> None:
+        for component in self._ordered():
+            component.state(job, job_state)
+
+    def reset_runtime(self) -> None:
+        for component in reversed(self._ordered()):
+            component.reset_runtime()
+
+    def configure_telemetry(self, config: TelemetryConfig) -> None:
+        if self.telemetry is None:
+            self.telemetry = TelemetryComponent(config)
+            telemetry_changed = True
+        else:
+            telemetry_changed = self.telemetry._config != config
+            if telemetry_changed:
+                self.telemetry.reset_runtime()
+                self._warn_if_snapshot_stale()
+            self.telemetry._config = config
+        if self.admin is not None:
+            if telemetry_changed:
+                self.admin.reset_runtime()
+            # Admin config is unchanged here; only rewire its telemetry handle.
+            self.admin._telemetry = self.telemetry
+        self._configure_snapshot()
+
+    def configure_admin(self, config: MeshAdminConfig) -> None:
+        if self.admin is None:
+            self.admin = AdminComponent(config, self.telemetry)
+        else:
+            self._set_admin_inputs(config)
+        self._configure_snapshot()
+
+    def _set_admin_inputs(self, config: MeshAdminConfig) -> None:
+        admin = self.admin
+        if admin is None:
+            return
+        if admin._config != config:
+            admin.reset_runtime()
+            self._warn_if_snapshot_stale()
+        admin._config = config
+        admin._telemetry = self.telemetry
+
+    def _warn_if_snapshot_stale(self) -> None:
+        """Warn when a dependency restarts under an already-running snapshot.
+
+        The snapshot actor is fire-and-forget and cannot be stopped within an
+        allocation, so a restarted telemetry or admin runtime leaves it bound to
+        the old runtime. See :class:`SnapshotComponent`.
+
+        TODO: give ``_start_periodic_snapshots`` an abort handle so
+        ``SnapshotComponent.reset_runtime`` can stop the old actor; then reset
+        the snapshot in this drift cascade alongside telemetry and admin.
+        """
+        if self.snapshot is not None and self.snapshot._started:
+            logger.warning(
+                "telemetry or admin config changed while periodic snapshots are running: "
+                "snapshots stay bound to the original runtime until the job is killed and re-applied"
+            )
+
+    def _configure_snapshot(self) -> None:
+        if self.telemetry is not None and self.admin is not None:
+            if self.snapshot is None:
+                self.snapshot = SnapshotComponent(self.telemetry, self.admin)
+            else:
+                self.snapshot._telemetry = self.telemetry
+                self.snapshot._admin = self.admin
+        elif self.snapshot is not None:
+            self.snapshot = None

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -66,8 +66,8 @@ logger: logging.Logger = logging.getLogger(__name__)
 class TelemetryConfig:
     """Configuration for automatic telemetry startup.
 
-    When passed to a job constructor, telemetry (and optionally a dashboard)
-    is started automatically when ``state()`` is called.
+    When configured via ``JobTrait.enable_telemetry``, telemetry
+    (and optionally a dashboard) is started when ``state()`` is called.
 
     Args:
         batch_size: Number of rows to buffer before flushing to a RecordBatch.

--- a/python/monarch/_src/tools/commands.py
+++ b/python/monarch/_src/tools/commands.py
@@ -589,7 +589,7 @@ def _output_dir_for_job(job: "Any") -> tuple[str, str]:
     import uuid as _uuid
 
     run_id = _uuid.uuid4().hex[:8]
-    entries = job._mounts._gather_entries
+    entries = job._components.mounts._mounts._gather_entries
     if entries:
         entry = entries[0]
         remote = entry.remote_mount_point
@@ -683,7 +683,7 @@ def exec_on_job(
         # If a python_exe was set for this mesh's remote mount, prepend its
         # directory to PATH so commands like "python" resolve to the right one.
         mesh_env = dict(env_dict)
-        exe = job._python_executables.get(name, job._default_python_exe)
+        exe = job._components.mounts.python_executable_for_mesh(name)
         if exe is not None:
             bin_dir = os.path.dirname(exe)
             existing_path = mesh_env.get("PATH", os.environ.get("PATH", ""))

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -22,6 +22,7 @@ import pytest
 
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import (
+    BatchJob,
     job_load,
     job_loads,
     JobState,
@@ -30,6 +31,7 @@ from monarch._src.job.job import (
     MeshAdminConfig,
     TelemetryConfig,
 )
+from monarch._src.job.job_components import JobComponent, JobComponents, MountComponent
 from monarch._src.job.mount_config import Mounts
 from monarch._src.job.process_guard import _Shutdown, _wait_for_socket
 from monarch.actor import HostMesh
@@ -513,7 +515,7 @@ def test_state_query_engine_none_without_telemetry():
     assert state.telemetry_url is None
 
 
-@patch("monarch._src.job.job.start_telemetry")
+@patch("monarch._src.job.job_components.start_telemetry")
 def test_state_query_engine_set_with_telemetry(mock_start):
     """Test that query_engine is set when telemetry is configured."""
     mock_engine = MagicMock()
@@ -528,19 +530,258 @@ def test_state_query_engine_set_with_telemetry(mock_start):
     assert state.telemetry_url == mock_url
 
 
-@patch("monarch._src.job.job.start_telemetry")
-def test_telemetry_started_only_once(mock_start):
-    """Test that telemetry is not restarted on subsequent state() calls."""
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_component_configuration_after_apply_adds_telemetry(mock_start):
+    mock_engine = MagicMock()
+    mock_url = "http://localhost:8265"
+    mock_start.return_value = (mock_engine, mock_url, MagicMock())
+
+    job = MockJobTrait()
+    job.apply()
+    components = job._components
+    assert components is not None
+    assert components.telemetry is None
+
+    job.enable_telemetry(TelemetryConfig())
+    state = job.state(cached_path=None)
+
+    assert job._components is components
+    assert components.telemetry is not None
+    assert state.query_engine is mock_engine
+    assert state.telemetry_url == mock_url
+
+
+def test_mount_configuration_after_apply_reuses_mount_component_on_connect():
+    job = MockJobTrait()
+    job.apply()
+    components = job._components
+    assert components is not None
+    mount_component = components.mounts
+
+    job.remote_mount("/source", python_exe=None)
+    job.gather_mount("/worker/path", "/local/path")
+    with patch("monarch._src.job.mount_config.Mounts.ensure_open") as ensure_open:
+        job.state(cached_path=None)
+
+    assert job._components is components
+    assert components.mounts is mount_component
+    ensure_open.assert_called_once()
+
+
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_telemetry_config_change_restarts_telemetry_runtime(mock_start):
+    mock_start.return_value = (MagicMock(), "http://localhost:8265", MagicMock())
+
+    job = MockJobTrait().enable_telemetry(TelemetryConfig(batch_size=1))
+    job.state(cached_path=None)
+    components = job._components
+    assert components is not None
+    mount_component = components.mounts
+    telemetry_component = components.telemetry
+    assert telemetry_component is not None
+
+    job.enable_telemetry(TelemetryConfig(batch_size=2))
+    job.state(cached_path=None)
+
+    assert job._components is components
+    assert components.mounts is mount_component
+    assert components.telemetry is telemetry_component
+    assert mock_start.call_count == 2
+
+
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_cached_running_job_uses_current_component_configuration(mock_start):
+    mock_engine = MagicMock()
+    mock_url = "http://current-telemetry"
+    mock_start.return_value = (mock_engine, mock_url, MagicMock())
+
+    cached_job = MockJobTrait(host_names=["cached"]).enable_telemetry(
+        TelemetryConfig(batch_size=1)
+    )
+    cached_job.apply()
+
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        cache_path = tmp.name
+
+    try:
+        cached_job.dump(cache_path)
+
+        new_job = MockJobTrait(host_names=["new"]).enable_telemetry(
+            TelemetryConfig(batch_size=2)
+        )
+        state = new_job.state(cached_path=cache_path)
+
+        assert not new_job.create_called
+        assert state.cached.name == "cached"
+        assert state.query_engine is mock_engine
+        assert state.telemetry_url == mock_url
+        mock_start.assert_called_once_with(
+            batch_size=2,
+            retention_secs=600,
+            include_dashboard=False,
+            dashboard_port=8265,
+        )
+    finally:
+        if os.path.exists(cache_path):
+            os.unlink(cache_path)
+
+
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_unpickled_running_job_accepts_component_configuration(mock_start):
+    mock_engine = MagicMock()
+    mock_url = "http://localhost:8265"
+    mock_start.return_value = (mock_engine, mock_url, MagicMock())
+
+    original_job = MockJobTrait()
+    original_job.apply()
+    loaded_job = job_loads(original_job.dumps())
+
+    loaded_job.enable_telemetry(TelemetryConfig())
+    state = loaded_job.state(cached_path=None)
+
+    mock_start.assert_called_once()
+    assert state.query_engine is mock_engine
+    assert state.telemetry_url == mock_url
+
+
+def test_lifecycle_component_hooks_use_job_context():
+    class FinalHost:
+        name = "final"
+
+    class ProbeComponent(JobComponent):
+        def __init__(self):
+            self.jobs = []
+            self.events = []
+
+        def before_connect(self, job: JobTrait) -> None:
+            self.jobs.append(job)
+            self.events.append(
+                (
+                    "before_connect",
+                    job.apply_id is not None,
+                    job._running is job,
+                )
+            )
+
+        def connect(
+            self, job: JobTrait, host_meshes: Dict[str, HostMesh]
+        ) -> Dict[str, HostMesh]:
+            self.jobs.append(job)
+            self.events.append(
+                (
+                    "connect",
+                    job.apply_id is not None,
+                    job._running is job,
+                    tuple(sorted(host_meshes)),
+                )
+            )
+            return {"final": cast(HostMesh, FinalHost())}
+
+        def state(self, job: JobTrait, job_state: JobState) -> None:
+            self.jobs.append(job)
+            self.events.append(
+                (
+                    "state",
+                    job.apply_id is not None,
+                    job._running is job,
+                    tuple(sorted(job_state._hosts)),
+                    job_state.final is job_state._hosts["final"],
+                )
+            )
+
+        def reset_runtime(self) -> None:
+            self.events.append(("reset_runtime",))
+
+    probe = ProbeComponent()
+    job = MockJobTrait(host_names=("raw",))
+    job._components = JobComponents(cast(MountComponent, probe))
+    state = job.state(cached_path=None)
+
+    assert state.final.name == "final"
+    assert all(seen_job is job for seen_job in probe.jobs)
+    assert probe.events == [
+        ("before_connect", True, True),
+        ("connect", True, True, ("raw",)),
+        ("state", True, True, ("final",), True),
+    ]
+
+    state = job.state(cached_path=None)
+
+    assert state.final.name == "final"
+    assert probe.events == [
+        ("before_connect", True, True),
+        ("connect", True, True, ("raw",)),
+        ("state", True, True, ("final",), True),
+        ("before_connect", True, True),
+        ("connect", True, True, ("raw",)),
+        ("state", True, True, ("final",), True),
+    ]
+
+    with patch("monarch._src.job.job.stop_job_sidecar"):
+        job.kill()
+
+    assert probe.events[-1] == ("reset_runtime",)
+
+
+def test_batch_job_runs_component_lifecycle_on_wrapped_job():
+    class ProbeComponent(JobComponent):
+        def __init__(self):
+            self.jobs = []
+            self.events = []
+
+        def before_connect(self, job: JobTrait) -> None:
+            self.jobs.append(job)
+            self.events.append("before_connect")
+
+        def connect(
+            self, job: JobTrait, host_meshes: Dict[str, HostMesh]
+        ) -> Dict[str, HostMesh]:
+            self.jobs.append(job)
+            self.events.append("connect")
+            return host_meshes
+
+        def state(self, job: JobTrait, job_state: JobState) -> None:
+            self.jobs.append(job)
+            self.events.append("state")
+
+    probe = ProbeComponent()
+    job = MockJobTrait(host_names=("raw",))
+    job._components = JobComponents(cast(MountComponent, probe))
+    batch = BatchJob(job)
+
+    state = batch.state(cached_path=None)
+
+    assert state.raw.name == "raw"
+    assert all(seen_job is job for seen_job in probe.jobs)
+    assert probe.events == ["before_connect", "connect", "state"]
+
+
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_lifecycle_component_runtime_reset_on_job_teardown(mock_start):
+    """Job teardown resets component runtime while preserving config."""
     mock_start.return_value = (MagicMock(), "http://localhost:8265", MagicMock())
 
     job = MockJobTrait().enable_telemetry(TelemetryConfig())
     job.state(cached_path=None)
-    job.state(cached_path=None)
+    components = job._components
+    apply_id = job.apply_id
 
+    job.state(cached_path=None)
+    assert job._components is components
     mock_start.assert_called_once()
 
+    with patch("monarch._src.job.job.stop_job_sidecar") as stop_sidecar:
+        job.kill()
 
-@patch("monarch._src.job.job.start_telemetry")
+    stop_sidecar.assert_called_once_with(apply_id)
+    assert job._components is components
+
+    job.state(cached_path=None)
+    assert job._components is components
+    assert mock_start.call_count == 2
+
+
+@patch("monarch._src.job.job_components.start_telemetry")
 def test_telemetry_dropped_on_pickle(mock_start):
     """Test that query_engine is dropped during pickling and restored after."""
     mock_start.return_value = (MagicMock(), "http://localhost:8265", MagicMock())
@@ -549,10 +790,9 @@ def test_telemetry_dropped_on_pickle(mock_start):
     job.state(cached_path=None)
     assert mock_start.call_count == 1
 
-    # Serialize and deserialize — query_engine should be dropped
+    # Serialize and deserialize — live handles should be dropped
     loaded_job = job_loads(job.dumps())
-    assert loaded_job._query_engine is None
-    assert loaded_job._telemetry_url is None
+    assert loaded_job._components.telemetry is not None
 
     # Getting state again should re-initialize telemetry
     state = loaded_job.state(cached_path=None)
@@ -567,7 +807,7 @@ def test_state_admin_url_none_without_mesh_admin():
     assert state.admin_url is None
 
 
-@patch("monarch._src.job.job._spawn_admin")
+@patch("monarch._src.job.job_components._spawn_admin")
 def test_state_admin_url_set_with_mesh_admin(mock_spawn):
     """Test that admin_url is available on the first state() call."""
     mock_future = MagicMock()
@@ -582,7 +822,7 @@ def test_state_admin_url_set_with_mesh_admin(mock_spawn):
     assert state.admin_url == "http://localhost:1729"
 
 
-@patch("monarch._src.job.job._spawn_admin")
+@patch("monarch._src.job.job_components._spawn_admin")
 def test_mesh_admin_started_only_once(mock_spawn):
     """Test that mesh admin is not restarted on subsequent state() calls."""
     mock_future = MagicMock()
@@ -597,7 +837,7 @@ def test_mesh_admin_started_only_once(mock_spawn):
     mock_spawn.assert_called_once()
 
 
-@patch("monarch._src.job.job._spawn_admin")
+@patch("monarch._src.job.job_components._spawn_admin")
 def test_mesh_admin_dropped_on_pickle(mock_spawn):
     """Test that admin_url is dropped during pickling and restored after."""
     mock_future = MagicMock()
@@ -609,9 +849,9 @@ def test_mesh_admin_dropped_on_pickle(mock_spawn):
     job.state(cached_path=None)
     assert mock_spawn.call_count == 1
 
-    # Serialize and deserialize — admin_url should be dropped
+    # Serialize and deserialize — live handles should be dropped
     loaded_job = job_loads(job.dumps())
-    assert loaded_job._admin_url is None
+    assert loaded_job._components.admin is not None
 
     # Getting state again should re-spawn admin
     state = loaded_job.state(cached_path=None)
@@ -619,7 +859,7 @@ def test_mesh_admin_dropped_on_pickle(mock_spawn):
     assert state.admin_url is not None
 
 
-@patch("monarch._src.job.job._spawn_admin")
+@patch("monarch._src.job.job_components._spawn_admin")
 def test_mesh_admin_receives_custom_addr(mock_spawn):
     """Test that MeshAdminConfig.admin_addr is forwarded to _spawn_admin."""
     mock_future = MagicMock()
@@ -632,6 +872,138 @@ def test_mesh_admin_receives_custom_addr(mock_spawn):
 
     _, kwargs = mock_spawn.call_args
     assert kwargs.get("admin_addr") == "myhost:9999"
+
+
+@patch("monarch._src.job.job_components._spawn_admin")
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_mesh_admin_receives_telemetry_url(mock_start, mock_spawn):
+    """Test that admin links to telemetry when both are configured."""
+    mock_engine = MagicMock()
+    mock_scanner = MagicMock()
+    mock_start.return_value = (mock_engine, "http://localhost:8265", mock_scanner)
+
+    mock_future = MagicMock()
+    mock_admin_ref = MagicMock()
+    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
+    mock_spawn.return_value = mock_future
+
+    job = (
+        MockJobTrait()
+        .enable_telemetry(TelemetryConfig())
+        .enable_admin(MeshAdminConfig())
+    )
+    state = job.state(cached_path=None)
+
+    _, kwargs = mock_spawn.call_args
+    assert kwargs.get("telemetry_url") == "http://localhost:8265"
+    assert state.telemetry_url == "http://localhost:8265"
+    assert state.admin_url == "http://localhost:1729"
+
+
+@patch("monarch._src.job.job_components._spawn_admin")
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_mesh_admin_restarts_when_telemetry_config_changes(mock_start, mock_spawn):
+    mock_start.side_effect = [
+        (MagicMock(), "http://telemetry-one", MagicMock()),
+        (MagicMock(), "http://telemetry-two", MagicMock()),
+    ]
+
+    mock_future = MagicMock()
+    mock_admin_ref = MagicMock()
+    mock_future.get.side_effect = [
+        ("http://admin-one", mock_admin_ref),
+        ("http://admin-two", mock_admin_ref),
+    ]
+    mock_spawn.return_value = mock_future
+
+    job = (
+        MockJobTrait()
+        .enable_telemetry(TelemetryConfig(batch_size=1))
+        .enable_admin(MeshAdminConfig())
+    )
+    state = job.state(cached_path=None)
+    assert state.telemetry_url == "http://telemetry-one"
+    assert state.admin_url == "http://admin-one"
+
+    job.enable_telemetry(TelemetryConfig(batch_size=2))
+    state = job.state(cached_path=None)
+
+    assert state.telemetry_url == "http://telemetry-two"
+    assert state.admin_url == "http://admin-two"
+    assert mock_start.call_count == 2
+    assert mock_spawn.call_count == 2
+    assert [call.kwargs["telemetry_url"] for call in mock_spawn.call_args_list] == [
+        "http://telemetry-one",
+        "http://telemetry-two",
+    ]
+
+
+@patch(
+    "monarch._rust_bindings.monarch_extension.snapshot_integration._start_periodic_snapshots"
+)
+@patch("monarch.actor.context")
+@patch("monarch._src.job.job_components._spawn_admin")
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_snapshot_component_starts_once_after_telemetry_and_admin(
+    mock_start,
+    mock_spawn,
+    mock_context,
+    mock_start_snapshots,
+):
+    mock_scanner = MagicMock()
+    mock_admin_ref = MagicMock()
+    mock_instance = MagicMock()
+    mock_start.return_value = (MagicMock(), "http://localhost:8265", mock_scanner)
+    mock_future = MagicMock()
+    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
+    mock_spawn.return_value = mock_future
+    mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
+
+    job = (
+        MockJobTrait()
+        .enable_telemetry(TelemetryConfig(snapshot_interval_secs=5.0))
+        .enable_admin(MeshAdminConfig())
+    )
+    job.state(cached_path=None)
+    job.state(cached_path=None)
+
+    mock_start_snapshots.assert_called_once_with(
+        scanner=mock_scanner,
+        admin_ref=mock_admin_ref,
+        instance=mock_instance,
+        interval_secs=5.0,
+    )
+
+
+@patch("monarch._src.job.job_components._spawn_admin")
+@patch("monarch._src.job.job_components.start_telemetry")
+def test_batch_job_shares_component_runtime_with_wrapped_job(mock_start, mock_spawn):
+    mock_engine = MagicMock()
+    mock_scanner = MagicMock()
+    mock_start.return_value = (mock_engine, "http://localhost:8265", mock_scanner)
+
+    mock_future = MagicMock()
+    mock_admin_ref = MagicMock()
+    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
+    mock_spawn.return_value = mock_future
+
+    job = (
+        MockJobTrait(host_names=["hosts"])
+        .enable_telemetry(TelemetryConfig())
+        .enable_admin(MeshAdminConfig())
+    )
+    batch = BatchJob(job)
+    batch_state = batch.state(cached_path=None)
+    job_state = job.state(cached_path=None)
+
+    assert batch_state.query_engine is mock_engine
+    assert batch_state.telemetry_url == "http://localhost:8265"
+    assert batch_state.admin_url == "http://localhost:1729"
+    assert job_state.query_engine is mock_engine
+    assert job_state.telemetry_url == "http://localhost:8265"
+    assert job_state.admin_url == "http://localhost:1729"
+    mock_start.assert_called_once()
+    mock_spawn.assert_called_once()
 
 
 # Tests for LocalJob implementation


### PR DESCRIPTION
Summary:

Move per-job mounts, telemetry, admin, and snapshot state off `JobTrait` into a typed `JobComponent` layer behind a `JobComponents` container.

Non-obvious:
- `JobTrait` retains only allocation identity and a single `_connect()`; the lifecycle is four ordered hooks (`before_connect`, `connect`, `state`, `reset_runtime`) that components opt into.
- `JobComponents` field order is dependency order — mounts, telemetry, admin, snapshot — and `reset_runtime` walks it in reverse.
- Each component owns its own `__getstate__` (dropping the live query engine, admin ref, and scanner) instead of one `JobTrait.__getstate__`; a deserialized job re-initializes on the next `state()`.
- `configure_telemetry` and `configure_admin` mutate the existing component in place and reset only local runtime on config drift, so a running job reconnects with updated config without re-applying.
- The snapshot actor cannot be stopped mid-allocation, so it stays sticky and only logs a warning when telemetry or admin restart underneath it.

Reviewed By: zdevito

Differential Revision: D108088282


