### PR TITLE
Surface all test-suite results in Monarch's GitHub CI UI

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -46,6 +46,25 @@ jobs:
     with:
       runner: macos-latest
 
+  # Publish the macOS suites' JUnit XML as its own check + annotations. Distinct
+  # check_name from the Linux CI workflow avoids collisions on the same commit;
+  # comment-mode off keeps the canonical PR comment owned by Linux CI (macOS is
+  # opt-in via ciflow/macos and runs rarely). Omitted from status-check.needs so
+  # reporting never gates merging.
+  publish-test-results-macos:
+    name: Publish Test Results (macOS)
+    needs: [test-cpu-python-macos, test-cpu-rust-macos]
+    if: always()
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      issues: read
+    uses: ./.github/workflows/publish-test-results.yml
+    with:
+      check-name: Test Results (macOS)
+      comment-mode: 'off'
+
   status-check:
     name: Status Check
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,23 @@ jobs:
     needs: build-gpu
     uses: ./.github/workflows/test-gpu-rust.yml
 
+  # Aggregate every suite's JUnit XML into a single "Test Results" check + PR
+  # comment + annotations. if: always() so results report even when tests fail.
+  # Job-level permissions override the restrictive workflow-level block above
+  # (id-token/contents only) to grant the publisher check + comment write.
+  # Intentionally omitted from status-check.needs: reporting is informational
+  # and must never gate merging (mirrors type-check-python).
+  publish-test-results:
+    name: Publish Test Results
+    needs: [test-cpu-python, test-gpu-python, test-cpu-rust, test-gpu-rust]
+    if: always()
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+      issues: read
+    uses: ./.github/workflows/publish-test-results.yml
+
   build-docker:
     name: Build Docker image
     needs: build-gpu

--- a/.github/workflows/publish-test-results.yml
+++ b/.github/workflows/publish-test-results.yml
@@ -1,0 +1,67 @@
+name: Publish Test Results
+
+# Aggregates the JUnit XML that every test workflow already uploads as a
+# `test-results-*` artifact and renders it in the GitHub UI as a check run,
+# PR comment, and inline failure annotations.
+#
+# Why a separate job (rather than a step inside each test job): the Linux test
+# jobs delegate to pytorch/test-infra's reusable `linux_job_v2.yml` and only
+# pass a `script:`, so there is nowhere to add a post-test reporting step.
+# Collecting artifacts in one downstream job covers Python and Rust, Linux and
+# macOS, CPU and GPU uniformly.
+#
+# Why EnricoMi (not pytest-results-action): test-infra's built-in
+# pytest-results-action cannot parse cargo-nextest's JUnit dialect, which is
+# why Rust results were never surfaced. EnricoMi parses both pytest and nextest
+# JUnit XML.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-pattern:
+        description: 'Glob of test-results artifacts to download and publish'
+        type: string
+        default: 'test-results-*'
+      check-name:
+        description: 'Name of the published check run'
+        type: string
+        default: 'Test Results'
+      comment-mode:
+        description: 'EnricoMi PR comment mode (always, changes, failures, errors, off)'
+        type: string
+        default: 'always'
+
+# Least-privilege token for the result publisher: just enough to create the
+# check and post/update the PR comment. On fork PRs the token is read-only and
+# EnricoMi degrades to a no-op (it logs that it cannot post, but does not fail
+# the job); same-repo `gh/**` export PRs and `main` pushes get the full report.
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+  issues: read
+
+jobs:
+  publish-test-results:
+    name: Publish Test Results
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download test result artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ${{ inputs.artifact-pattern }}
+          path: test-artifacts
+          # Do NOT merge-multiple: several artifacts share inner filenames
+          # (nextest-junit.xml, test-results.xml across matrix legs) that would
+          # clobber each other in a single directory. Keeping one subdirectory
+          # per artifact preserves them all.
+
+      - name: Publish test results
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040  # v2
+        with:
+          check_name: ${{ inputs.check-name }}
+          comment_mode: ${{ inputs.comment-mode }}
+          # Recurse the per-artifact subdirectories. Matches both pytest
+          # (test-results.xml) and cargo-nextest (nextest-junit.xml) output.
+          files: |
+            test-artifacts/**/*.xml

--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,9 @@ docs/**/generated/**
 disabled_tests.txt
 .config/nextest-filter.txt
 
+# Local JUnit output from run_test_groups (CI uploads it as an artifact;
+# cargo-nextest's junit.xml lands under the already-ignored target/).
+test-results/
+
 # whittle
 .whittle.json


### PR DESCRIPTION
Summary:
Monarch's GitHub Actions CI runs six test suites (CPU/GPU Python and Rust on Linux, plus Python and Rust on macOS) and every job already uploads its JUnit XML as a `test-results-*` artifact, but only Linux Python results were rendered in the GitHub UI. That reporting comes from `pytorch/test-infra`'s `linux_job_v2.yml`, which feeds `$RUNNER_TEST_RESULTS_DIR` to `pytest-results-action` — and `pytest-results-action` cannot parse cargo-nextest's JUnit dialect, so all Rust results (and both macOS suites) were produced but never surfaced as a check, PR comment, or annotations.

This adds a single reusable workflow, `publish-test-results.yml`, that downloads the existing `test-results-*` artifacts and runs `EnricoMi/publish-unit-test-result-action` (SHA-pinned) over them. EnricoMi parses both pytest and cargo-nextest JUnit, so one aggregated "Test Results" check now covers Python and Rust uniformly. The Linux test jobs delegate to `linux_job_v2.yml` and only pass a `script:`, so there is nowhere to add an in-job reporting step; an aggregating downstream job is the clean fit.

Wiring:
- `ci.yml`: new `publish-test-results` job, `needs` all four Linux test jobs, `if: always()`. Job-level `permissions` (checks/pull-requests write) override the restrictive workflow-level block so EnricoMi can post; the job is intentionally omitted from `status-check.needs` so reporting never gates merging (mirrors `type-check-python`).
- `ci-macos.yml`: `publish-test-results-macos` job with a distinct `check_name` and `comment_mode: off` (the macOS suite is opt-in via `ciflow/macos`; the Linux job owns the canonical PR comment).
- `.gitignore`: ignore local `test-results/` output from `run_test_groups` (cargo-nextest's `junit.xml` lands under the already-ignored `target/`).

Known follow-ups: on external fork PRs the `GITHUB_TOKEN` is read-only and EnricoMi degrades to a no-op (full `workflow_run` fork support deferred); Linux GPU Python now appears in both test-infra's check and the aggregated one.

Differential Revision: D108145498


