### PR TITLE
Flip `actor_queue_dispatch` default to True (#4211)

### DIFF
--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -436,7 +436,7 @@ Actor Configuration
     Enable queue-based dispatch for actor message handling.
 
     - **Type**: ``bool``
-    - **Default**: ``False``
+    - **Default**: ``True``
     - **Environment**: ``HYPERACTOR_ACTOR_QUEUE_DISPATCH``
 
     When ``True``, actor messages are dispatched through a queue rather than

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -13,6 +13,7 @@ use std::future::pending;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::Once;
 use std::sync::OnceLock;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering as AtomicOrdering;
@@ -820,6 +821,14 @@ impl PythonActor {
         mesh_base_name: Option<String>,
     ) -> Result<Self, anyhow::Error> {
         let use_queue_dispatch = hyperactor_config::global::get(ACTOR_QUEUE_DISPATCH);
+        if !use_queue_dispatch {
+            static WARNED: Once = Once::new();
+            WARNED.call_once(|| {
+                tracing::warn!(
+                    "actor_queue_dispatch=false is deprecated and direct dispatch will be removed in a future release"
+                );
+            });
+        }
 
         Ok(monarch_with_gil_blocking(
             |py| -> Result<Self, SerializablePyErr> {

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -859,6 +859,7 @@ mod tests {
     use super::*;
     use crate::actor::PythonActor;
     use crate::actor::PythonActorParams;
+    use crate::config::ACTOR_QUEUE_DISPATCH;
 
     /// Minimal root-client actor for test infrastructure.
     /// Handles MeshFailure by panicking (test failure).
@@ -964,14 +965,15 @@ mod tests {
             .unwrap()
         });
 
+        let actor_params = PythonActorParams::new(pickled_type, None, None);
+        let config_lock = hyperactor_config::global::lock();
+        let _queue_dispatch_guard = config_lock.override_key(ACTOR_QUEUE_DISPATCH, false);
         let actor_mesh = proc_mesh
-            .spawn::<PythonActor, _>(
-                instance,
-                "test_actors",
-                &PythonActorParams::new(pickled_type, None, None),
-            )
+            .spawn::<PythonActor, _>(instance, "test_actors", &actor_params)
             .await
             .unwrap();
+        drop(_queue_dispatch_guard);
+        drop(config_lock);
 
         let controller = actor_mesh.controller().as_ref().unwrap().clone();
 

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -210,7 +210,7 @@ declare_attrs! {
         Some("MONARCH_ACTOR_QUEUE_DISPATCH".to_string()),
         Some("actor_queue_dispatch".to_string()),
     ))
-    pub attr ACTOR_QUEUE_DISPATCH: bool = false;
+    pub attr ACTOR_QUEUE_DISPATCH: bool = true;
 }
 
 /// Python API for configuration management

--- a/python/examples/execution_workload.py
+++ b/python/examples/execution_workload.py
@@ -27,10 +27,13 @@ Actors:
     (that would deadlock the dispatch loop); the test asserts
     ``count == 1`` then tears the proc down.
 
-Queue dispatch is forced for the queue proc by a ``bootstrap`` callable
-that sets ``MONARCH_ACTOR_QUEUE_DISPATCH=1`` before any actor spawns on
-it; ``ACTOR_QUEUE_DISPATCH`` is read from the process-global config at
-actor-spawn time.
+Each proc pins its dispatch mode explicitly via a ``bootstrap`` callable
+that sets ``MONARCH_ACTOR_QUEUE_DISPATCH`` and calls
+``reload_config_from_env()`` before any actor spawns on it (``0`` for the
+direct-dispatch ``busy``/``idle`` procs, ``1`` for the ``queue`` proc), so
+the choice is independent of the process-global default. The reload is
+required: the Env config layer is materialized once at proc start, so
+setting the variable in the bootstrap only takes effect after the reload.
 
 Stdin command protocol, one command per line::
 
@@ -54,6 +57,9 @@ import logging
 import os
 import sys
 
+from monarch._rust_bindings.monarch_hyperactor.config import (  # @manual=//monarch/monarch_extension:monarch_extension
+    reload_config_from_env,
+)
 from monarch._src.actor.actor_mesh import Channel, Port, PortReceiver
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, context, endpoint
@@ -67,11 +73,26 @@ logger.setLevel(logging.INFO)
 def _enable_queue_dispatch() -> None:
     """Proc bootstrap: force queue dispatch for actors spawned here.
 
-    ``ACTOR_QUEUE_DISPATCH`` is read at actor-spawn time from the
-    process-global config, which is backed by ``MONARCH_ACTOR_QUEUE_DISPATCH``.
-    Setting it here affects only this proc, not the direct-dispatch procs.
+    The reload is required, not cosmetic: the Env config layer is
+    materialized once at proc start (before this bootstrap runs), so setting
+    the variable only takes effect after ``reload_config_from_env()`` rebuilds
+    that layer. Affects only this proc.
     """
     os.environ["MONARCH_ACTOR_QUEUE_DISPATCH"] = "1"
+    reload_config_from_env()
+
+
+def _disable_queue_dispatch() -> None:
+    """Proc bootstrap: force direct (concurrent) dispatch for actors here.
+
+    ``BusyActor`` depends on concurrent dispatch -- it holds one ``hold``
+    while a second ``hold``/``control`` overlaps -- so this proc is pinned to
+    direct dispatch rather than inheriting the process-global
+    ``ACTOR_QUEUE_DISPATCH`` default (now queue dispatch). See
+    ``_enable_queue_dispatch`` for why the reload is required.
+    """
+    os.environ["MONARCH_ACTOR_QUEUE_DISPATCH"] = "0"
+    reload_config_from_env()
 
 
 class BusyActor(Actor):
@@ -171,8 +192,12 @@ async def async_main() -> None:
     state = job.state(cached_path=None)
     host = state.hosts
 
-    busy_proc = host.spawn_procs(name="execution_busy")
-    idle_proc = host.spawn_procs(name="execution_idle")
+    busy_proc = host.spawn_procs(
+        name="execution_busy", bootstrap=_disable_queue_dispatch
+    )
+    idle_proc = host.spawn_procs(
+        name="execution_idle", bootstrap=_disable_queue_dispatch
+    )
     queue_proc = host.spawn_procs(
         name="execution_queue", bootstrap=_enable_queue_dispatch
     )

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1860,6 +1860,7 @@ async def test_actor_abort(reason) -> None:
 
 
 @pytest.mark.timeout(500)
+@parametrize_config(actor_queue_dispatch={False})
 @isolate_in_subprocess
 async def test_gil_stall():
     """Test that many concurrent actor calls don't cause GIL stall issues.

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -301,7 +301,7 @@ def test_integer_params(param_name, test_value, default_value):
         ("force_file_log", False),
         ("prefix_with_rank", True),
         # Actor queue dispatch
-        ("actor_queue_dispatch", False),
+        ("actor_queue_dispatch", True),
     ],
 )
 def test_boolean_params(param_name, default_value):
@@ -408,7 +408,7 @@ def test_all_params_together():
         proc_stop_max_idle="45s",
         get_proc_state_max_idle="90s",
         # Actor queue dispatch
-        actor_queue_dispatch=True,
+        actor_queue_dispatch=False,
         # Mesh attach
         mesh_attach_config_timeout="20s",
         # Mesh admin
@@ -440,7 +440,7 @@ def test_all_params_together():
         assert config["supervision_watchdog_timeout"] == "1m 30s"
         assert config["proc_stop_max_idle"] == "45s"
         assert config["get_proc_state_max_idle"] == "1m 30s"
-        assert config["actor_queue_dispatch"] is True
+        assert config["actor_queue_dispatch"] is False
         assert config["mesh_attach_config_timeout"] == "20s"
         assert config["mesh_admin_addr"] == "[::]:8080"
 
@@ -471,7 +471,7 @@ def test_all_params_together():
     assert config["supervision_watchdog_timeout"] == "2m"
     assert config["proc_stop_max_idle"] == "30s"
     assert config["get_proc_state_max_idle"] == "1m"
-    assert config["actor_queue_dispatch"] is False
+    assert config["actor_queue_dispatch"] is True
     assert config["mesh_attach_config_timeout"] == "10s"
     assert config["mesh_admin_addr"] == "[::]:1729"
 

--- a/python/tests/test_inter_mesh_ping_pong.py
+++ b/python/tests/test_inter_mesh_ping_pong.py
@@ -29,6 +29,7 @@ import pytest
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch._src.actor.host_mesh import this_host
 from monarch.actor import Actor, endpoint
+from monarch.config import parametrize_config
 
 
 @dataclass
@@ -91,6 +92,7 @@ class PingPongActor(Actor):
 
 
 @pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={False})
 async def test_inter_mesh_ping_pong() -> None:
     """
     Test that two separate ProcMeshes can communicate by passing

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1361,8 +1361,10 @@ class UndeliverableMessageSenderWithOverride(UndeliverableMessageSender):
 
 
 @pytest.mark.timeout(10)
+# Pinned to direct dispatch; this test assumes concurrent dispatch and isn't
+# compatible with the queue-based path.
+@parametrize_config(actor_queue_dispatch={False})
 @isolate_in_subprocess
-# Not compatible with queue dispatch, as it assumes concurrent dispatch
 async def test_undeliverable_message_with_override() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 1})
     receiver = pm.spawn("undeliverable_receiver", UndeliverableMessageReceiver)


### PR DESCRIPTION
Summary:

Queue-based dispatch is now the default for Python actors. Direct dispatch is still available by setting `actor_queue_dispatch=False` (or the equivalent `MONARCH_ACTOR_QUEUE_DISPATCH=0`); the option itself stays in place so that we can run an explicit deprecation cycle before removing it.

Direct dispatch now also emits a `tracing::warn!` once per process, the first time a `PythonActor` is constructed with `actor_queue_dispatch=false`. This gives users a chance to migrate before the option is removed.

Reviewed By: shayne-fletcher

Differential Revision: D105859633


