### PR TITLE
Add `@concurrent_actor` for Python actors

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -197,6 +197,7 @@ class FileWriter(Actor):
 - Each owned actor's `__cleanup__` has already run
 - Owned actor meshes and proc meshes are no longer usable from this method
 - For shutdown work that needs an owned mesh, expose a dedicated endpoint and call it before `stop()`
+- For `@concurrent_actor` actors, in-flight endpoint tasks have completed before shutdown finishes; if `__cleanup__` is defined, they complete before it begins
 
 **What to Clean Up Here:**
 - Open files and network connections
@@ -243,6 +244,35 @@ class Calculator(Actor):
     @endpoint
     def get_history(self) -> list:
         return self.history
+```
+
+By default, one actor processes one endpoint message at a time. To schedule
+each async endpoint body as an `asyncio` task and let later messages start
+while that task is still running, decorate the actor class with
+`@concurrent_actor`:
+
+```python
+from monarch.actor import Actor, Port, concurrent_actor, endpoint
+
+@concurrent_actor
+class Fetcher(Actor):
+    @endpoint
+    async def fetch(self, url: str) -> bytes:
+        return await fetch_bytes(url)
+```
+
+The decorator also composes with `explicit_response_port=True`, which is useful
+for endpoints that send a response and then keep running. In that case, the
+same response port is forwarded to the endpoint body, and the endpoint remains
+responsible for sending its own response:
+
+```python
+@concurrent_actor
+class Watcher(Actor):
+    @endpoint(explicit_response_port=True)
+    async def watch(self, port: Port[str]) -> None:
+        port.send("started")
+        await self.watch_forever()
 ```
 
 ### Messaging Adverbs

--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -443,7 +443,7 @@ Actor Configuration
     Enable queue-based dispatch for actor message handling.
 
     - **Type**: ``bool``
-    - **Default**: ``False``
+    - **Default**: ``True``
     - **Environment**: ``HYPERACTOR_ACTOR_QUEUE_DISPATCH``
 
     When ``True``, actor messages are dispatched through a queue rather than

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -10,6 +10,7 @@ use std::error::Error;
 use std::fmt::Debug;
 use std::future::pending;
 use std::ops::Deref;
+use std::sync::Once;
 use std::sync::OnceLock;
 
 use async_trait::async_trait;
@@ -584,6 +585,14 @@ impl PythonActor {
         mesh_base_name: Option<String>,
     ) -> Result<Self, anyhow::Error> {
         let use_queue_dispatch = hyperactor_config::global::get(ACTOR_QUEUE_DISPATCH);
+        if !use_queue_dispatch {
+            static WARNED: Once = Once::new();
+            WARNED.call_once(|| {
+                tracing::warn!(
+                    "actor_queue_dispatch=false is deprecated and direct dispatch will be removed in a future release"
+                );
+            });
+        }
 
         Ok(monarch_with_gil_blocking(
             |py| -> Result<Self, SerializablePyErr> {

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -217,7 +217,7 @@ declare_attrs! {
         Some("MONARCH_ACTOR_QUEUE_DISPATCH".to_string()),
         Some("actor_queue_dispatch".to_string()),
     ))
-    pub attr ACTOR_QUEUE_DISPATCH: bool = false;
+    pub attr ACTOR_QUEUE_DISPATCH: bool = true;
 }
 
 /// Python API for configuration management

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -46,6 +46,7 @@ from monarch._src.actor.host_mesh import (
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, ProcMesh
 from monarch._src.actor.supervision import unhandled_fault_hook
 from monarch._src.actor.telemetry import span, traced
+from monarch.actor.concurrent import concurrent_actor
 
 __all__ = [
     "Accumulator",
@@ -55,6 +56,7 @@ __all__ = [
     "as_endpoint",
     "current_rank",
     "current_size",
+    "concurrent_actor",
     "endpoint",
     "Future",
     "Point",

--- a/python/monarch/actor/concurrent.py
+++ b/python/monarch/actor/concurrent.py
@@ -1,0 +1,165 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+import functools
+import inspect
+from typing import Any, Awaitable, Callable, cast, Coroutine, Type, TypeVar
+
+from monarch._src.actor.endpoint import EndpointProperty
+
+ActorClass = TypeVar("ActorClass", bound=Type[Any])
+_TASKS_ATTR = "_monarch_concurrent_actor_tasks"
+_WRAPPER_ATTR = "_monarch_concurrent_actor_wrapper"
+
+
+def _is_user_override(method: Any) -> bool:
+    return method is not None and not getattr(method, "_monarch_doc_stub", False)
+
+
+def _tasks(instance: Any) -> set[asyncio.Task[None]]:
+    tasks = instance.__dict__.setdefault(_TASKS_ATTR, set())
+    return cast(set[asyncio.Task[None]], tasks)
+
+
+def _spawn_task(instance: Any, coro: Coroutine[Any, Any, None]) -> None:
+    tasks = _tasks(instance)
+    task = asyncio.create_task(coro)
+    tasks.add(task)
+
+    def discard_task(done: asyncio.Task[None]) -> None:
+        tasks.discard(done)
+
+    task.add_done_callback(discard_task)
+
+
+async def _await_tasks(instance: Any) -> None:
+    tasks = _tasks(instance)
+    while tasks:
+        await asyncio.gather(*tuple(tasks))
+
+
+def _explicit_response_signature(
+    method: Callable[..., Any], *, already_explicit: bool
+) -> inspect.Signature:
+    signature = inspect.signature(method)
+    if already_explicit:
+        return signature
+
+    parameters = list(signature.parameters.values())
+    if not parameters:
+        return signature
+
+    name = "_monarch_response_port"
+    while name in signature.parameters:
+        name = f"{name}_"
+
+    port_kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
+    if any(
+        parameter.kind is inspect.Parameter.POSITIONAL_ONLY
+        for parameter in parameters[1:]
+    ):
+        port_kind = inspect.Parameter.POSITIONAL_ONLY
+
+    return signature.replace(
+        parameters=[
+            parameters[0],
+            inspect.Parameter(name, port_kind),
+            *parameters[1:],
+        ],
+        return_annotation=None,
+    )
+
+
+def _wrap_endpoint(
+    endpoint_property: EndpointProperty[Any, Any],
+) -> EndpointProperty[Any, Any]:
+    method = endpoint_property._method
+    if getattr(method, _WRAPPER_ATTR, False):
+        return endpoint_property
+    if not inspect.iscoroutinefunction(method):
+        raise ValueError("concurrent_actor can only wrap async endpoints")
+
+    wrapper: Callable[..., Awaitable[None]]
+    if endpoint_property._explicit_response_port:
+
+        @functools.wraps(method)
+        async def explicit_port_wrapper(
+            self: Any, port: Any, *args: Any, **kwargs: Any
+        ) -> None:
+            async def run() -> None:
+                try:
+                    await method(self, port, *args, **kwargs)
+                except Exception as e:
+                    port.exception(e)
+
+            _spawn_task(self, run())
+
+        wrapper = explicit_port_wrapper
+    else:
+
+        @functools.wraps(method)
+        async def returns_response_wrapper(
+            self: Any, port: Any, *args: Any, **kwargs: Any
+        ) -> None:
+            async def run() -> None:
+                try:
+                    port.send(await method(self, *args, **kwargs))
+                except Exception as e:
+                    port.exception(e)
+
+            _spawn_task(self, run())
+
+        wrapper = returns_response_wrapper
+
+    # pyre-ignore[16]: function attributes are dynamic
+    wrapper.__signature__ = _explicit_response_signature(
+        method, already_explicit=endpoint_property._explicit_response_port
+    )
+    setattr(wrapper, _WRAPPER_ATTR, True)
+    return EndpointProperty(
+        wrapper,
+        propagator=endpoint_property._propagator,
+        explicit_response_port=True,
+        instrument=endpoint_property._instrument,
+    )
+
+
+def _wrap_cleanup(Class: Type[Any]) -> None:
+    cleanup = getattr(Class, "__cleanup__", None)
+    cleanup_fn: Callable[[Any, Exception | None], Awaitable[None]] | None = None
+    if _is_user_override(cleanup):
+        if not inspect.iscoroutinefunction(cleanup):
+            raise ValueError("concurrent_actor requires async __cleanup__")
+        cleanup_fn = cast(
+            Callable[[Any, Exception | None], Awaitable[None]],
+            cleanup,
+        )
+
+    async def cleanup_wrapper(self: Any, exc: Exception | None) -> None:
+        await _await_tasks(self)
+        if cleanup_fn is not None:
+            await cleanup_fn(self, exc)
+
+    Class.__cleanup__ = cleanup_wrapper
+
+
+def concurrent_actor(Class: ActorClass) -> ActorClass:
+    """Run every async endpoint on ``Class`` as an ``asyncio`` background task.
+
+    The decorator rewrites endpoints to use explicit response ports. Each
+    endpoint wrapper schedules the original async body as a task, forwards the
+    result or exception through the response port, and returns immediately so
+    that the next queued message can start.
+    """
+    for attr_name in dir(Class):
+        attr_value = getattr(Class, attr_name, None)
+        if isinstance(attr_value, EndpointProperty):
+            setattr(Class, attr_name, _wrap_endpoint(attr_value))
+    _wrap_cleanup(Class)
+    return Class

--- a/python/tests/test_concurrent_actors.py
+++ b/python/tests/test_concurrent_actors.py
@@ -1,0 +1,204 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import asyncio
+import os
+from tempfile import TemporaryDirectory
+from typing import Any, cast
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch.actor import Actor, concurrent_actor, endpoint, Port, this_host
+from monarch.config import parametrize_config
+
+
+@concurrent_actor
+class AsyncGate(Actor):
+    def __init__(self) -> None:
+        self.ready = asyncio.Event()
+        self.unblock = asyncio.Event()
+
+    @endpoint
+    async def wait(self) -> str:
+        self.ready.set()
+        await self.unblock.wait()
+        return "done"
+
+    @endpoint
+    async def release_when_ready(self) -> str:
+        await self.ready.wait()
+        self.unblock.set()
+        return "released"
+
+
+@concurrent_actor
+class ExplicitPortAsyncGate(Actor):
+    def __init__(self) -> None:
+        self.unblock = asyncio.Event()
+
+    @endpoint(explicit_response_port=True)
+    async def wait(self, port: Port[str]) -> None:
+        port.send("started")
+        await self.unblock.wait()
+
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+    @endpoint
+    async def release(self) -> None:
+        self.unblock.set()
+
+
+class SequentialExplicitPortGate(Actor):
+    @endpoint(explicit_response_port=True)
+    async def wait(self, port: Port[str]) -> None:
+        port.send("started")
+        await asyncio.sleep(0.3)
+
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+
+@concurrent_actor
+class CleanupWaitsForConcurrentEndpoint(Actor):
+    def __init__(self) -> None:
+        self.done = False
+
+    @endpoint(explicit_response_port=True)
+    async def run(self, port: Port[str]) -> None:
+        port.send("started")
+        await asyncio.sleep(0.2)
+        self.done = True
+
+    async def __cleanup__(self, exc: Exception | None) -> None:  # type: ignore[override]
+        assert self.done
+
+
+@concurrent_actor
+class NoCleanupWaitsForConcurrentEndpoint(Actor):
+    def __init__(self, path: str) -> None:
+        self.path = path
+
+    @endpoint(explicit_response_port=True)
+    async def run(self, port: Port[str]) -> None:
+        port.send("started")
+        await asyncio.sleep(0.2)
+        with open(self.path, "w") as f:
+            f.write("done")
+
+
+def test_concurrent_actor_wraps_endpoints() -> None:
+    assert cast(Any, AsyncGate.wait)._explicit_response_port
+    assert cast(Any, ExplicitPortAsyncGate.wait)._explicit_response_port
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True})
+@isolate_in_subprocess
+async def test_queue_dispatch_runs_concurrent_async_endpoint_in_parallel() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    gate = proc.spawn("async_gate", AsyncGate)
+
+    try:
+        wait = gate.wait.call_one()
+        assert (
+            await asyncio.wait_for(gate.release_when_ready.call_one(), timeout=10)
+            == "released"
+        )
+        assert await asyncio.wait_for(wait, timeout=10) == "done"
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True})
+@isolate_in_subprocess
+async def test_queue_dispatch_runs_concurrent_explicit_port_in_parallel() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    gate = proc.spawn("explicit_port_async_gate", ExplicitPortAsyncGate)
+
+    try:
+        assert await asyncio.wait_for(gate.wait.call_one(), timeout=10) == "started"
+        assert await asyncio.wait_for(gate.ping.call_one(), timeout=10) == "pong"
+        await gate.release.call_one()
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True})
+@isolate_in_subprocess
+async def test_queue_dispatch_keeps_async_actor_non_concurrent_by_default() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    gate = proc.spawn("sequential_explicit_port_gate", SequentialExplicitPortGate)
+
+    try:
+        assert await asyncio.wait_for(gate.wait.call_one(), timeout=10) == "started"
+        ping = asyncio.ensure_future(gate.ping.call_one())
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(ping), timeout=0.1)
+        assert await asyncio.wait_for(ping, timeout=10) == "pong"
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True})
+@isolate_in_subprocess
+async def test_queue_dispatch_waits_for_concurrent_messages_before_cleanup() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    gate = proc.spawn(
+        "cleanup_waits_for_concurrent_endpoint", CleanupWaitsForConcurrentEndpoint
+    )
+
+    assert await asyncio.wait_for(gate.run.call_one(), timeout=10) == "started"
+    await asyncio.wait_for(proc.stop(), timeout=10)
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True})
+@isolate_in_subprocess
+async def test_queue_dispatch_waits_for_concurrent_messages_without_cleanup() -> None:
+    with TemporaryDirectory() as tmpdir:
+        done_path = os.path.join(tmpdir, "done")
+        proc = this_host().spawn_procs(per_host={"gpus": 1})
+        gate = proc.spawn(
+            "no_cleanup_waits_for_concurrent_endpoint",
+            NoCleanupWaitsForConcurrentEndpoint,
+            done_path,
+        )
+
+        assert await asyncio.wait_for(gate.run.call_one(), timeout=10) == "started"
+        await asyncio.wait_for(proc.stop(), timeout=10)
+        with open(done_path) as f:
+            assert f.read() == "done"
+
+
+def test_concurrent_actor_rejects_sync_endpoint() -> None:
+    with pytest.raises(ValueError, match="can only wrap async endpoints"):
+
+        @concurrent_actor
+        class ConcurrentSyncEndpoint(Actor):
+            @endpoint
+            def ping(self) -> str:
+                return "pong"
+
+
+def test_concurrent_actor_rejects_sync_cleanup() -> None:
+    with pytest.raises(ValueError, match="requires async __cleanup__"):
+
+        @concurrent_actor
+        class ConcurrentSyncCleanup(Actor):
+            @endpoint
+            async def ping(self) -> str:
+                return "pong"
+
+            def __cleanup__(self, exc: Exception | None) -> None:
+                pass

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -303,7 +303,7 @@ def test_integer_params(param_name, test_value, default_value):
         ("force_file_log", False),
         ("prefix_with_rank", True),
         # Actor queue dispatch
-        ("actor_queue_dispatch", False),
+        ("actor_queue_dispatch", True),
     ],
 )
 def test_boolean_params(param_name, default_value):
@@ -411,7 +411,7 @@ def test_all_params_together():
         proc_stop_max_idle="45s",
         get_proc_state_max_idle="90s",
         # Actor queue dispatch
-        actor_queue_dispatch=True,
+        actor_queue_dispatch=False,
         # Mesh attach
         mesh_attach_config_timeout="20s",
         # Mesh admin
@@ -444,7 +444,7 @@ def test_all_params_together():
         assert config["supervision_watchdog_timeout"] == "1m 30s"
         assert config["proc_stop_max_idle"] == "45s"
         assert config["get_proc_state_max_idle"] == "1m 30s"
-        assert config["actor_queue_dispatch"] is True
+        assert config["actor_queue_dispatch"] is False
         assert config["mesh_attach_config_timeout"] == "20s"
         assert config["mesh_admin_addr"] == "[::]:8080"
 
@@ -476,7 +476,7 @@ def test_all_params_together():
     assert config["supervision_watchdog_timeout"] == "2m"
     assert config["proc_stop_max_idle"] == "30s"
     assert config["get_proc_state_max_idle"] == "1m"
-    assert config["actor_queue_dispatch"] is False
+    assert config["actor_queue_dispatch"] is True
     assert config["mesh_attach_config_timeout"] == "10s"
     assert config["mesh_admin_addr"] == "[::]:1729"
 

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1326,8 +1326,10 @@ class UndeliverableMessageSenderWithOverride(UndeliverableMessageSender):
 
 
 @pytest.mark.timeout(10)
+# Pinned to direct dispatch; this test assumes concurrent dispatch and isn't
+# compatible with the queue-based path.
+@parametrize_config(actor_queue_dispatch={False})
 @isolate_in_subprocess
-# Not compatible with queue dispatch, as it assumes concurrent dispatch
 async def test_undeliverable_message_with_override() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 1})
     receiver = pm.spawn("undeliverable_receiver", UndeliverableMessageReceiver)


### PR DESCRIPTION
Summary:
Implement actor-class concurrency as a pure Python `concurrent_actor` decorator in the public `monarch.actor` package. The decorator validates that endpoint bodies and `__cleanup__` are async, wraps every class-defined endpoint to schedule work with `asyncio.create_task`, and tracks the created tasks per actor instance. Non-explicit endpoints send the awaited return value back on the outer `Port`; explicit-response-port endpoints forward that same outer `Port` into the user body so custom response behavior composes normally. The decorator also wraps or supplies `__cleanup__` so shutdown waits for all in-flight endpoint tasks before running user cleanup, or just waits when no cleanup is defined.

Document the decorator and move concurrent actor coverage into `python/tests/test_concurrent_actors.py`, including checks for default non-concurrent actor behavior, parallel execution, explicit response ports, cleanup ordering, no-cleanup shutdown, and sync validation failures. This keeps the behavior entirely in user-land without modifying the core actor loop or existing actor classes.

Differential Revision: D107568819


