### PR TITLE
Replace monarch_rdma get_all_devices with IbvDevice::list()

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -746,7 +746,7 @@ pub async fn run() -> Result<(), anyhow::Error> {
     let expected_data_values = expected_buffer[0..start].to_vec().into_boxed_slice();
 
     // Get all available RDMA devices
-    let devices = monarch_rdma::get_all_devices();
+    let devices = monarch_rdma::backend::ibverbs::device::list_all_devices();
     // Configure RDMA for the two actors
     // For H100 machines, we use different devices for better performance
     let device_1_ibv_config: IbvConfig;

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -463,7 +463,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
         .with_max_level(tracing::Level::INFO)
         .init();
 
-    let devices = monarch_rdma::get_all_devices();
+    let devices = monarch_rdma::backend::ibverbs::device::list_all_devices();
 
     // In this example, the parameter server and workers all live on the same host.
     // Parameter server is assigned to its unique ibverbs device, and all workers

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -430,4 +430,27 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             .get(I::typename())
             .is_some_and(|backend| !backend.devices.is_empty())
     }
+
+    /// All devices claimed by impl `I` on this host. Reads the
+    /// [`DEVICE_NAMES_BY_IMPL`] registry, built on first access by a
+    /// single walk of the ibverbs device list.
+    pub fn list() -> Vec<IbvDeviceInfo> {
+        DEVICE_NAMES_BY_IMPL
+            .get(I::typename())
+            .map(|backend| backend.devices.clone())
+            .unwrap_or_default()
+    }
+}
+
+/// All RDMA devices on this host, across every registered backend
+/// impl. Reads the [`DEVICE_NAMES_BY_IMPL`] registry, built on first
+/// access by a single walk of the ibverbs device list.
+///
+/// A device claimed by no registered [`IbvDeviceImpl`] is omitted; in
+/// practice every RDMA NIC is claimed by some backend.
+pub fn list_all_devices() -> Vec<IbvDeviceInfo> {
+    DEVICE_NAMES_BY_IMPL
+        .values()
+        .flat_map(|backend| backend.devices.iter().cloned())
+        .collect()
 }

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -11,8 +11,8 @@
 
 use std::sync::OnceLock;
 
+use super::device::list_all_devices;
 use super::primitives::IbvDeviceInfo;
-use super::primitives::get_all_devices;
 use crate::device_selection::PCIDevice;
 use crate::device_selection::get_all_rdma_devices;
 use crate::device_selection::get_cuda_pci_address;
@@ -31,7 +31,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDeviceI
 
     match prefix.as_str() {
         "nic" => {
-            let all_rdma_devices = get_all_devices();
+            let all_rdma_devices = list_all_devices();
             all_rdma_devices
                 .into_iter()
                 .find(|dev| dev.name() == &postfix)
@@ -56,13 +56,13 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDeviceI
                 .filter_map(|(_, addr)| pci_devices.get(addr).cloned())
                 .collect();
 
-            if let Some(closest_idx) = source_device.find_closest(&rdma_pci_devices) {
-                if let Some(optimal_name) = rdma_names.get(closest_idx) {
-                    let all_rdma_devices = get_all_devices();
-                    for device in all_rdma_devices {
-                        if *device.name() == *optimal_name {
-                            return Some(device);
-                        }
+            if let Some(closest_idx) = source_device.find_closest(&rdma_pci_devices)
+                && let Some(optimal_name) = rdma_names.get(closest_idx)
+            {
+                let all_rdma_devices = list_all_devices();
+                for device in all_rdma_devices {
+                    if *device.name() == *optimal_name {
+                        return Some(device);
                     }
                 }
             }
@@ -72,7 +72,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDeviceI
         }
         _ => {
             // Direct device name lookup for backward compatibility
-            let rdma_devices = get_all_devices();
+            let rdma_devices = list_all_devices();
             rdma_devices
                 .into_iter()
                 .find(|dev| dev.name() == device_hint)
@@ -110,7 +110,7 @@ pub fn resolve_ibv_device(device: &IbvDeviceInfo) -> Option<IbvDeviceInfo> {
         return Some(device.clone());
     }
 
-    let all_devices = get_all_devices();
+    let all_devices = list_all_devices();
     let is_likely_default = if let Some(first_device) = all_devices.first() {
         device_name == first_device.name()
     } else {
@@ -227,29 +227,29 @@ mod tests {
 
         // Step 6: Test distance calculation for GPU 0
         println!("\n6. DISTANCE CALCULATION TEST (GPU 0)");
-        if let Some(gpu0_pci_addr) = get_cuda_pci_address("0") {
-            if let Some(gpu0_device) = pci_devices.get(&gpu0_pci_addr) {
-                println!("GPU 0 PCI: {}", gpu0_pci_addr);
-                println!("GPU 0 path to root: {:?}", gpu0_device.get_path_to_root());
+        if let Some(gpu0_pci_addr) = get_cuda_pci_address("0")
+            && let Some(gpu0_device) = pci_devices.get(&gpu0_pci_addr)
+        {
+            println!("GPU 0 PCI: {}", gpu0_pci_addr);
+            println!("GPU 0 path to root: {:?}", gpu0_device.get_path_to_root());
 
-                let mut all_distances = Vec::new();
-                for (nic_name, nic_pci_addr) in &rdma_devices {
-                    if let Some(nic_device) = pci_devices.get(nic_pci_addr) {
-                        let distance = gpu0_device.distance_to(nic_device);
-                        all_distances.push((distance, nic_name.clone(), nic_pci_addr.clone()));
-                        println!("  {} ({}): distance = {}", nic_name, nic_pci_addr, distance);
-                        println!("    NIC path to root: {:?}", nic_device.get_path_to_root());
-                    }
+            let mut all_distances = Vec::new();
+            for (nic_name, nic_pci_addr) in &rdma_devices {
+                if let Some(nic_device) = pci_devices.get(nic_pci_addr) {
+                    let distance = gpu0_device.distance_to(nic_device);
+                    all_distances.push((distance, nic_name.clone(), nic_pci_addr.clone()));
+                    println!("  {} ({}): distance = {}", nic_name, nic_pci_addr, distance);
+                    println!("    NIC path to root: {:?}", nic_device.get_path_to_root());
                 }
+            }
 
-                // Find the minimum distance
-                all_distances.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-                if let Some((min_dist, min_nic, min_addr)) = all_distances.first() {
-                    println!(
-                        "  → CLOSEST: {} ({}) with distance {}",
-                        min_nic, min_addr, min_dist
-                    );
-                }
+            // Find the minimum distance
+            all_distances.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+            if let Some((min_dist, min_nic, min_addr)) = all_distances.first() {
+                println!(
+                    "  → CLOSEST: {} ({}) with distance {}",
+                    min_nic, min_addr, min_dist
+                );
             }
         }
 

--- a/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
@@ -21,12 +21,12 @@ mod tests {
 
     use super::super::IbvQueuePair;
     use super::super::PollTarget;
+    use super::super::device::list_all_devices;
     use super::super::doorbell_test_utils::DoorbellTestEnv;
     use super::super::doorbell_test_utils::*;
     use super::super::manager_actor::IbvManagerActor;
     use super::super::manager_actor::RawQueuePair;
     use super::super::mlx_device::MlxDevice;
-    use super::super::primitives::get_all_devices;
     use crate::rdma_components::validate_execution_context;
 
     /// Opens a one-shot reply port and posts [`RawQueuePair`] to bring up
@@ -68,7 +68,7 @@ mod tests {
             return Ok(());
         }
         const BSIZE: usize = 1024;
-        let devices = get_all_devices();
+        let devices = list_all_devices();
         if devices.len() < 4 {
             println!(
                 "skipping this test as it is only configured on H100 nodes with backend network"
@@ -100,7 +100,7 @@ mod tests {
             return Ok(());
         }
         const BSIZE: usize = 1024;
-        let devices = get_all_devices();
+        let devices = list_all_devices();
         if devices.len() < 4 {
             println!(
                 "skipping this test as it is only configured on H100 nodes with backend network"
@@ -137,7 +137,7 @@ mod tests {
             return Ok(());
         }
         const BSIZE: usize = 2 * 1024 * 1024;
-        let devices = get_all_devices();
+        let devices = list_all_devices();
         if devices.len() < 4 {
             println!(
                 "skipping this test as it is only configured on H100 nodes with backend network"
@@ -177,7 +177,7 @@ mod tests {
             return Ok(());
         }
         const BSIZE: usize = 2 * 1024 * 1024;
-        let devices = get_all_devices();
+        let devices = list_all_devices();
         if devices.len() < 4 {
             println!(
                 "skipping this test as it is only configured on H100 nodes with backend network"
@@ -217,7 +217,7 @@ mod tests {
             return Ok(());
         }
         const BSIZE: usize = 2 * 1024 * 1024;
-        let devices = get_all_devices();
+        let devices = list_all_devices();
         if devices.len() < 5 {
             println!(
                 "skipping this test as it is only configured on H100 nodes with backend network"

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -1159,8 +1159,8 @@ mod tests {
     use crate::RdmaRemoteBuffer;
     use crate::backend::cuda_test_utils::CudaAllocation;
     use crate::backend::cuda_test_utils::CudaAllocator;
+    use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::primitives::IbvQpType;
-    use crate::backend::ibverbs::primitives::get_all_devices;
     use crate::local_memory::KeepaliveLocalMemory;
 
     // ====================================================================
@@ -1628,7 +1628,7 @@ mod tests {
     // ====================================================================
 
     fn require_rdma() {
-        if get_all_devices().is_empty() {
+        if list_all_devices().is_empty() {
             panic!("SKIPPED: no RDMA devices available");
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -37,6 +37,7 @@ use typeuri::Named;
 
 use super::domain::IbvDomain;
 use crate::backend::ibverbs::device::IbvDeviceImpl;
+use crate::backend::ibverbs::device::list_all_devices;
 use crate::backend::ibverbs::efa_device::EfaDevice;
 
 #[derive(
@@ -287,9 +288,9 @@ impl std::fmt::Display for IbvConfig {
 /// # Examples
 ///
 /// ```
-/// use monarch_rdma::get_all_devices;
+/// use monarch_rdma::backend::ibverbs::device::list_all_devices;
 ///
-/// let devices = get_all_devices();
+/// let devices = list_all_devices();
 /// if let Some(device) = devices.first() {
 ///     // Access device name and firmware version
 ///     let device_name = device.name();
@@ -334,12 +335,7 @@ impl IbvDeviceInfo {
 
     /// Returns the first available RDMA device, if any.
     pub fn first_available() -> Option<IbvDeviceInfo> {
-        let devices = get_all_devices();
-        if devices.is_empty() {
-            None
-        } else {
-            Some(devices.into_iter().next().unwrap())
-        }
+        list_all_devices().into_iter().next()
     }
 
     /// Returns the vendor ID of the RDMA device.
@@ -410,7 +406,7 @@ impl Default for IbvDeviceInfo {
             device
         } else {
             // Fallback to first available device
-            get_all_devices()
+            list_all_devices()
                 .into_iter()
                 .next()
                 .unwrap_or_else(|| panic!("No RDMA devices found"))
@@ -570,54 +566,6 @@ pub fn format_gid(gid: &[u8; 16]) -> String {
         gid[14],
         gid[15]
     )
-}
-
-/// Retrieves information about all available RDMA devices in the system.
-///
-/// This function queries the system for all available RDMA devices and returns
-/// detailed information about each device, including its capabilities, ports,
-/// and attributes.
-///
-/// # Returns
-///
-/// A vector of `IbvDeviceInfo` structures, each representing an RDMA device in the system.
-/// Returns an empty vector if no devices are found or if there was an error querying
-/// the devices.
-pub fn get_all_devices() -> Vec<IbvDeviceInfo> {
-    let mut devices = Vec::new();
-    let mut num_devices = 0;
-    // SAFETY: `ibv_get_device_list` populates `num_devices` and
-    // returns either null or a pointer to `num_devices` entries;
-    // we free it before returning.
-    let device_list = unsafe { rdmaxcel_sys::ibv_get_device_list(&mut num_devices) };
-    if device_list.is_null() {
-        return devices;
-    }
-    for i in 0..num_devices {
-        // SAFETY: `device_list` is non-null with `num_devices`
-        // valid entries (checked above).
-        let device = unsafe { *device_list.add(i as usize) };
-        if device.is_null() {
-            continue;
-        }
-        // SAFETY: `device` is non-null per the check above.
-        let context = unsafe { rdmaxcel_sys::ibv_open_device(device) };
-        if context.is_null() {
-            continue;
-        }
-        // SAFETY: `device` and `context` are non-null and
-        // `context` was returned by `ibv_open_device(device)`.
-        if let Some(info) = unsafe { query_device_info(device, context) } {
-            devices.push(info);
-        }
-        // SAFETY: `context` was returned by `ibv_open_device`
-        // above and has not been closed elsewhere.
-        unsafe { rdmaxcel_sys::ibv_close_device(context) };
-    }
-    // SAFETY: `device_list` was returned by
-    // `ibv_get_device_list` above and has not been freed.
-    unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
-    devices
 }
 
 /// Builds an [`IbvDeviceInfo`] from an already-open
@@ -1094,9 +1042,9 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_all_devices() {
+    fn test_list_all_devices() {
         // Skip test if RDMA devices are not available
-        let devices = get_all_devices();
+        let devices = list_all_devices();
         if devices.is_empty() {
             println!("Skipping test: RDMA devices not available");
             return;
@@ -1113,7 +1061,7 @@ mod tests {
     #[test]
     fn test_first_available() {
         // Skip test if RDMA is not available
-        let devices = get_all_devices();
+        let devices = list_all_devices();
         if devices.is_empty() {
             println!("Skipping test: RDMA devices not available");
             return;

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1713,13 +1713,13 @@ mod tests {
     use hyperactor::proc::Proc;
 
     use super::*;
+    use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::domain::IbvDomain;
     use crate::backend::ibverbs::primitives::IbvConfig;
-    use crate::backend::ibverbs::primitives::get_all_devices;
 
     #[test]
     fn test_create_connection() {
-        if get_all_devices().is_empty() {
+        if list_all_devices().is_empty() {
             println!("Skipping test: RDMA devices not available");
             return;
         }
@@ -1738,7 +1738,7 @@ mod tests {
 
     #[test]
     fn test_loopback_connection() {
-        if get_all_devices().is_empty() {
+        if list_all_devices().is_empty() {
             println!("Skipping test: RDMA devices not available");
             return;
         }


### PR DESCRIPTION
Summary:
Route RDMA device enumeration through the `DEVICE_NAMES_BY_IMPL` registry: add `IbvDevice::<I>::list()` (devices claimed by backend `I`) and a vendor-agnostic `list_all_devices()`, and delete the standalone `get_all_devices()` that walked the ibverbs device list directly. All call sites move to the registry-backed accessors.

Behavior-preserving; sets up making device selection generic over the backend impl in later commits.

Differential Revision: D108189336


