### PR TITLE
Wire pci_path into monarch_rdma device selection (#4219)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -83,6 +83,7 @@ use monarch_rdma::IbvConfig;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
+use monarch_rdma::backend::ibverbs::device_selection::IbvDeviceTarget;
 use monarch_rdma::backend::ibverbs::manager_actor::RawQueuePair;
 use monarch_rdma::cu_check;
 use monarch_rdma::local_memory::Keepalive;
@@ -754,13 +755,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
     if devices.len() > 4 {
         // Use separate backend devices for H100 configuration
         device_1_ibv_config = IbvConfig {
-            device: devices.clone().into_iter().next().unwrap(),
+            target: IbvDeviceTarget::nic(devices[0].name().clone()),
             ..Default::default()
         };
         // The second device used is the 3rd. Main reason is because 0 and 3 are both backend
         // devices on gtn H100 devices.
         device_2_ibv_config = IbvConfig {
-            device: devices.clone().into_iter().nth(3).unwrap(),
+            target: IbvDeviceTarget::nic(devices[3].name().clone()),
             ..Default::default()
         };
     } else {

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -81,6 +81,7 @@ use monarch_rdma::IbvConfig;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
+use monarch_rdma::backend::ibverbs::device_selection::IbvDeviceTarget;
 use monarch_rdma::local_memory::Keepalive;
 use monarch_rdma::local_memory::KeepaliveLocalMemory;
 use ndslice::extent;
@@ -475,13 +476,13 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     // Quick check for H100
     if devices.len() > 4 {
         ps_ibv_config = IbvConfig {
-            device: devices.clone().into_iter().next().unwrap(),
+            target: IbvDeviceTarget::nic(devices[0].name().clone()),
             ..Default::default()
         };
         // The second device used is the 3rd. Main reason is because 0 and 3 are both backend
         // devices on gtn H100 devices.
         worker_ibv_config = IbvConfig {
-            device: devices.clone().into_iter().nth(3).unwrap(),
+            target: IbvDeviceTarget::nic(devices[3].name().clone()),
             ..Default::default()
         };
     } else {

--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -412,18 +412,11 @@ impl CudaAllocator {
 }
 
 /// Number of CUDA devices visible to the driver, or 0 on failure.
+/// Delegates to the canonical
+/// [`crate::backend::ibverbs::device_selection::cuda_device_count`].
 #[cfg(test)]
 pub(crate) fn cuda_device_count() -> i32 {
-    unsafe {
-        if rdmaxcel_sys::rdmaxcel_cuInit(0) != rdmaxcel_sys::CUDA_SUCCESS {
-            return 0;
-        }
-        let mut count: i32 = 0;
-        if rdmaxcel_sys::rdmaxcel_cuDeviceGetCount(&mut count) != rdmaxcel_sys::CUDA_SUCCESS {
-            return 0;
-        }
-        count
-    }
+    crate::backend::ibverbs::device_selection::cuda_device_count() as i32
 }
 
 /// Segment scanner callback compatible with `rdmaxcel_segment_scanner_fn`.

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -38,7 +38,7 @@ pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDeviceI
         }
         "cuda" | "cpu" => {
             let source_pci_addr = match prefix.as_str() {
-                "cuda" => get_cuda_pci_address(&postfix)?,
+                "cuda" => get_cuda_pci_address(postfix.parse().ok()?)?.to_string(),
                 "cpu" => get_numa_pci_address(&postfix)?,
                 _ => unreachable!(),
             };
@@ -140,8 +140,8 @@ mod tests {
         ];
 
         // Check if we have at least 8 GPUs (GT20 characteristic)
-        let gpu_count = (0..8)
-            .filter(|&i| get_cuda_pci_address(&i.to_string()).is_some())
+        let gpu_count = (0..8u32)
+            .filter(|&i| get_cuda_pci_address(i).is_some())
             .count();
 
         // Must have expected RDMA devices AND 8 GPUs
@@ -199,9 +199,8 @@ mod tests {
 
         // Step 4: Test CUDA PCI address resolution
         println!("\n4. CUDA PCI ADDRESS RESOLUTION");
-        for gpu_idx in 0..8 {
-            let gpu_idx_str = gpu_idx.to_string();
-            match get_cuda_pci_address(&gpu_idx_str) {
+        for gpu_idx in 0..8u32 {
+            match get_cuda_pci_address(gpu_idx) {
                 Some(pci_addr) => {
                     println!("  GPU {} -> PCI: {}", gpu_idx, pci_addr);
                 }
@@ -227,8 +226,8 @@ mod tests {
 
         // Step 6: Test distance calculation for GPU 0
         println!("\n6. DISTANCE CALCULATION TEST (GPU 0)");
-        if let Some(gpu0_pci_addr) = get_cuda_pci_address("0")
-            && let Some(gpu0_device) = pci_devices.get(&gpu0_pci_addr)
+        if let Some(gpu0_pci_addr) = get_cuda_pci_address(0)
+            && let Some(gpu0_device) = pci_devices.get(&gpu0_pci_addr.to_string())
         {
             println!("GPU 0 PCI: {}", gpu0_pci_addr);
             println!("GPU 0 path to root: {:?}", gpu0_device.get_path_to_root());

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -6,390 +6,185 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! ibverbs-specific device selection logic that pairs compute devices
-//! with the best available RDMA NICs based on PCI topology distance.
+//! ibverbs-specific device selection: pairs a [`MemoryLocation`] with the
+//! RDMA NIC(s) that have the best PCIe path to it.
 
+use std::sync::LazyLock;
 use std::sync::OnceLock;
 
-use super::device::list_all_devices;
+use anyhow::Context;
+use anyhow::Result;
+use dashmap::DashMap;
+
+use super::device::IbvDevice;
+use super::device::IbvDeviceImpl;
+use super::mlx_device::MlxDevice;
 use super::primitives::IbvDeviceInfo;
-use crate::device_selection::PCIDevice;
-use crate::device_selection::get_all_rdma_devices;
+use crate::device_selection::MemoryLocation;
+use crate::device_selection::PCIAddress;
+use crate::device_selection::PciPath;
+use crate::device_selection::cpu_path;
 use crate::device_selection::get_cuda_pci_address;
-use crate::device_selection::get_numa_pci_address;
-use crate::device_selection::parse_device_string;
-use crate::device_selection::parse_pci_topology;
+use crate::device_selection::pci_path;
 
-/// Step 1: Parse device string into prefix and postfix
-/// Step 2: Get PCI address from compute device
-/// Step 3: Get PCI address for all RDMA NIC devices
-/// Step 4: Calculate PCI distances and return closest RDMA NIC device
-pub fn select_optimal_ibv_device(device_hint: Option<&str>) -> Option<IbvDeviceInfo> {
-    let device_hint = device_hint?;
+/// What an [`IbvConfig`](super::primitives::IbvConfig) targets: a memory
+/// location (whose best NIC is auto-selected) or an explicit NIC by name.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub enum IbvDeviceTarget {
+    /// Auto-select the best NIC for a CPU/GPU memory location.
+    MemoryLocation(MemoryLocation),
+    /// Use the NIC with this exact device name (e.g. `"mlx5_0"`).
+    Nic(String),
+}
 
-    let (prefix, postfix) = parse_device_string(device_hint)?;
+impl IbvDeviceTarget {
+    /// Target the best NIC for CPU memory on NUMA node `numa`.
+    pub fn cpu(numa: u32) -> Self {
+        Self::MemoryLocation(MemoryLocation::Cpu(Some(numa)))
+    }
 
-    match prefix.as_str() {
-        "nic" => {
-            let all_rdma_devices = list_all_devices();
-            all_rdma_devices
-                .into_iter()
-                .find(|dev| dev.name() == &postfix)
-        }
-        "cuda" | "cpu" => {
-            let source_pci_addr = match prefix.as_str() {
-                "cuda" => get_cuda_pci_address(postfix.parse().ok()?)?.to_string(),
-                "cpu" => get_numa_pci_address(&postfix)?,
-                _ => unreachable!(),
-            };
-            let rdma_devices = get_all_rdma_devices();
-            if rdma_devices.is_empty() {
-                return IbvDeviceInfo::first_available();
-            }
-            let pci_devices = parse_pci_topology().ok()?;
-            let source_device = pci_devices.get(&source_pci_addr)?;
+    /// Target the best NIC for GPU memory on CUDA ordinal `ordinal`.
+    pub fn gpu(ordinal: u32) -> Self {
+        Self::MemoryLocation(MemoryLocation::Gpu(Some(ordinal)))
+    }
 
-            let rdma_names: Vec<String> =
-                rdma_devices.iter().map(|(name, _)| name.clone()).collect();
-            let rdma_pci_devices: Vec<PCIDevice> = rdma_devices
-                .iter()
-                .filter_map(|(_, addr)| pci_devices.get(addr).cloned())
-                .collect();
-
-            if let Some(closest_idx) = source_device.find_closest(&rdma_pci_devices)
-                && let Some(optimal_name) = rdma_names.get(closest_idx)
-            {
-                let all_rdma_devices = list_all_devices();
-                for device in all_rdma_devices {
-                    if *device.name() == *optimal_name {
-                        return Some(device);
-                    }
-                }
-            }
-
-            // Fallback
-            IbvDeviceInfo::first_available()
-        }
-        _ => {
-            // Direct device name lookup for backward compatibility
-            let rdma_devices = list_all_devices();
-            rdma_devices
-                .into_iter()
-                .find(|dev| dev.name() == device_hint)
-        }
+    /// Target the NIC with the given device name.
+    pub fn nic(name: impl Into<String>) -> Self {
+        Self::Nic(name.into())
     }
 }
 
-/// Returns a reference to the process-wide lazily-initialized Vec mapping
-/// CUDA device ordinal → optimal RDMA NIC (`None` if no NIC is mapped).
+/// The PCI address of an RDMA NIC, resolved from its sysfs device link
+/// (`/sys/class/infiniband/<name>/device`).
+pub fn get_pci_address(device: &IbvDeviceInfo) -> Result<PCIAddress> {
+    let link = format!("/sys/class/infiniband/{}/device", device.name());
+    let resolved =
+        std::fs::canonicalize(&link).with_context(|| format!("resolving sysfs link {link}"))?;
+    resolved
+        .file_name()
+        .and_then(|name| name.to_str())
+        .and_then(PCIAddress::parse)
+        .with_context(|| format!("no PCI address in resolved path {resolved:?}"))
+}
+
+/// The NIC(s) of backend `I` with the best path to `location`, ranked by
+/// [`PciPath::is_better_than`] (most local, then highest port-capped
+/// bandwidth) and returning all that tie for best.
 ///
-/// Computed at most once per process on the first RDMA operation involving
-/// CUDA memory. CPU-only workloads pay no initialization cost.
+/// A NIC's path bandwidth is the lesser of its PCIe-chain bottleneck and
+/// its RDMA port speed. Results are cached per `(backend, location)` since
+/// the PCI/NUMA topology is fixed for the process lifetime.
+pub fn select_optimal_ibv_devices<I: IbvDeviceImpl>(
+    location: MemoryLocation,
+) -> Vec<IbvDeviceInfo> {
+    static CACHE: LazyLock<DashMap<(&'static str, MemoryLocation), Vec<IbvDeviceInfo>>> =
+        LazyLock::new(DashMap::new);
+    let key = (I::typename(), location);
+    if let Some(cached) = CACHE.get(&key) {
+        return cached.value().clone();
+    }
+    let result = compute_optimal_ibv_devices::<I>(location);
+    CACHE.insert(key, result.clone());
+    result
+}
+
+/// Uncached core of [`select_optimal_ibv_devices`].
+fn compute_optimal_ibv_devices<I: IbvDeviceImpl>(location: MemoryLocation) -> Vec<IbvDeviceInfo> {
+    let mut best: Option<PciPath> = None;
+    let mut devices: Vec<IbvDeviceInfo> = Vec::new();
+    for nic in IbvDevice::<I>::list() {
+        let Some(path) = nic_path(&nic, location) else {
+            continue;
+        };
+        match best {
+            Some(current) if current.is_better_than(&path) => continue,
+            Some(current) if path.is_better_than(&current) => devices.clear(),
+            _ => {}
+        }
+        best = Some(path);
+        devices.push(nic);
+    }
+    devices
+}
+
+/// The best [`PciPath`] from `location` to `nic`, capped by the NIC's RDMA
+/// port speed. `None` when the path can't be computed — e.g. the NIC's PCI
+/// address or a required GPU address can't be resolved.
+fn nic_path(nic: &IbvDeviceInfo, location: MemoryLocation) -> Option<PciPath> {
+    let nic_addr = get_pci_address(nic).ok()?;
+    let base = match location {
+        MemoryLocation::Cpu(numa) => cpu_path(&nic_addr, numa),
+        MemoryLocation::Gpu(Some(ordinal)) => pci_path(&get_cuda_pci_address(ordinal)?, &nic_addr),
+        MemoryLocation::Gpu(None) => best_gpu_path(&nic_addr)?,
+    };
+    Some(cap_by_port_speed(base, nic))
+}
+
+/// The best path from any visible CUDA device to `nic_addr`, or `None` if
+/// no GPU's PCI address resolves.
+fn best_gpu_path(nic_addr: &PCIAddress) -> Option<PciPath> {
+    (0..cuda_device_count())
+        .filter_map(|ordinal| get_cuda_pci_address(ordinal as u32))
+        .map(|gpu_addr| pci_path(&gpu_addr, nic_addr))
+        .reduce(|a, b| if b.is_better_than(&a) { b } else { a })
+}
+
+/// Caps `path`'s bottleneck at the NIC's RDMA port speed. A NIC with no
+/// ACTIVE port reports a port speed of 0 and is dragged to the worst
+/// case, like an unreadable PCIe link.
+fn cap_by_port_speed(path: PciPath, nic: &IbvDeviceInfo) -> PciPath {
+    PciPath {
+        bottleneck_mbytes_per_sec: path
+            .bottleneck_mbytes_per_sec
+            .min(nic.port_speed_mbytes_per_sec()),
+        ..path
+    }
+}
+
+/// Number of CUDA devices visible to this process (0 if CUDA is
+/// unavailable or can't be initialized).
+pub(crate) fn cuda_device_count() -> usize {
+    // SAFETY: FFI to the CUDA driver. `cuInit` must precede any other
+    // driver call, and each call writes only through its out-pointer; a
+    // non-success status is treated as "no devices".
+    unsafe {
+        if rdmaxcel_sys::rdmaxcel_cuInit(0) != rdmaxcel_sys::CUDA_SUCCESS {
+            return 0;
+        }
+        let mut count: i32 = 0;
+        if rdmaxcel_sys::rdmaxcel_cuDeviceGetCount(&mut count) != rdmaxcel_sys::CUDA_SUCCESS {
+            return 0;
+        }
+        count.max(0) as usize
+    }
+}
+
+/// Resolves an [`IbvDeviceTarget`] to a single NIC of backend `I`: the
+/// named device for [`IbvDeviceTarget::Nic`], or the best NIC for a memory
+/// location. Both arms are scoped to backend `I`, so a name belonging to a
+/// different backend resolves to `None`.
+pub fn resolve_target<I: IbvDeviceImpl>(target: &IbvDeviceTarget) -> Option<IbvDeviceInfo> {
+    match target {
+        IbvDeviceTarget::Nic(name) => IbvDevice::<I>::list()
+            .into_iter()
+            .find(|device| device.name() == name),
+        IbvDeviceTarget::MemoryLocation(location) => select_optimal_ibv_devices::<I>(*location)
+            .into_iter()
+            .next(),
+    }
+}
+
+/// Process-wide CUDA ordinal → optimal Mellanox NIC map, computed once on
+/// first use. CPU-only workloads pay no initialization cost.
 pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDeviceInfo>> {
     static CUDA_DEVICE_TO_IBV: OnceLock<Vec<Option<IbvDeviceInfo>>> = OnceLock::new();
     CUDA_DEVICE_TO_IBV.get_or_init(|| {
-        let count = unsafe {
-            let mut c: i32 = 0;
-            rdmaxcel_sys::rdmaxcel_cuDeviceGetCount(&mut c);
-            c.max(0) as usize
-        };
-        (0..count)
-            .map(|ordinal| select_optimal_ibv_device(Some(&format!("cuda:{}", ordinal))))
+        (0..cuda_device_count())
+            .map(|ordinal| {
+                select_optimal_ibv_devices::<MlxDevice>(MemoryLocation::Gpu(Some(ordinal as u32)))
+                    .into_iter()
+                    .next()
+            })
             .collect()
     })
-}
-
-/// Resolves RDMA device using auto-detection logic when needed.
-///
-/// Applies auto-detection for default devices, but otherwise
-/// returns the device as-is.
-pub fn resolve_ibv_device(device: &IbvDeviceInfo) -> Option<IbvDeviceInfo> {
-    let device_name = device.name();
-
-    if device_name.starts_with("mlx") {
-        return Some(device.clone());
-    }
-
-    let all_devices = list_all_devices();
-    let is_likely_default = if let Some(first_device) = all_devices.first() {
-        device_name == first_device.name()
-    } else {
-        false
-    };
-
-    if is_likely_default {
-        select_optimal_ibv_device(Some("cpu:0"))
-    } else {
-        Some(device.clone())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    /// Detect if we're running on GT20 hardware by checking for expected RDMA device configuration
-    fn is_gt20_hardware() -> bool {
-        let rdma_devices = get_all_rdma_devices();
-        let device_names: std::collections::HashSet<String> =
-            rdma_devices.iter().map(|(name, _)| name.clone()).collect();
-
-        // GT20 hardware should have these specific RDMA devices
-        let expected_gt20_devices = [
-            "mlx5_0", "mlx5_3", "mlx5_4", "mlx5_5", "mlx5_6", "mlx5_9", "mlx5_10", "mlx5_11",
-        ];
-
-        // Check if we have at least 8 GPUs (GT20 characteristic)
-        let gpu_count = (0..8u32)
-            .filter(|&i| get_cuda_pci_address(i).is_some())
-            .count();
-
-        // Must have expected RDMA devices AND 8 GPUs
-        let has_expected_rdma = expected_gt20_devices
-            .iter()
-            .all(|&device| device_names.contains(device));
-
-        has_expected_rdma && gpu_count == 8
-    }
-
-    /// Test each function step by step using the new simplified API - GT20 hardware only
-    #[test]
-    fn test_gt20_hardware() {
-        // Early exit if not on GT20 hardware
-        if !is_gt20_hardware() {
-            println!("⚠️  Skipping test_gt20_hardware: Not running on GT20 hardware");
-            return;
-        }
-
-        println!("✓ Detected GT20 hardware - running full validation test");
-        // Step 1: Test PCI topology parsing
-        println!("\n1. PCI TOPOLOGY PARSING");
-        let pci_devices = match parse_pci_topology() {
-            Ok(devices) => {
-                println!("✓ Found {} PCI devices", devices.len());
-                devices
-            }
-            Err(e) => {
-                println!("✗ Error: {}", e);
-                return;
-            }
-        };
-
-        // Step 2: Test unified RDMA device discovery
-        println!("\n2. RDMA DEVICE DISCOVERY");
-        let rdma_devices = get_all_rdma_devices();
-        println!("✓ Found {} RDMA devices", rdma_devices.len());
-        for (name, pci_addr) in &rdma_devices {
-            println!("  RDMA {}: {}", name, pci_addr);
-        }
-
-        // Step 3: Test device string parsing
-        println!("\n3. DEVICE STRING PARSING");
-        let test_strings = ["cuda:0", "cuda:1", "cpu:0", "cpu:1"];
-        for device_str in &test_strings {
-            if let Some((prefix, postfix)) = parse_device_string(device_str) {
-                println!(
-                    "  '{}' -> prefix: '{}', postfix: '{}'",
-                    device_str, prefix, postfix
-                );
-            } else {
-                println!("  '{}' -> PARSE FAILED", device_str);
-            }
-        }
-
-        // Step 4: Test CUDA PCI address resolution
-        println!("\n4. CUDA PCI ADDRESS RESOLUTION");
-        for gpu_idx in 0..8u32 {
-            match get_cuda_pci_address(gpu_idx) {
-                Some(pci_addr) => {
-                    println!("  GPU {} -> PCI: {}", gpu_idx, pci_addr);
-                }
-                None => {
-                    println!("  GPU {} -> PCI: NOT FOUND", gpu_idx);
-                }
-            }
-        }
-
-        // Step 5: Test CPU/NUMA PCI address resolution
-        println!("\n5. CPU/NUMA PCI ADDRESS RESOLUTION");
-        for numa_node in 0..4 {
-            let numa_str = numa_node.to_string();
-            match get_numa_pci_address(&numa_str) {
-                Some(pci_addr) => {
-                    println!("  NUMA {} -> PCI: {}", numa_node, pci_addr);
-                }
-                None => {
-                    println!("  NUMA {} -> PCI: NOT FOUND", numa_node);
-                }
-            }
-        }
-
-        // Step 6: Test distance calculation for GPU 0
-        println!("\n6. DISTANCE CALCULATION TEST (GPU 0)");
-        if let Some(gpu0_pci_addr) = get_cuda_pci_address(0)
-            && let Some(gpu0_device) = pci_devices.get(&gpu0_pci_addr.to_string())
-        {
-            println!("GPU 0 PCI: {}", gpu0_pci_addr);
-            println!("GPU 0 path to root: {:?}", gpu0_device.get_path_to_root());
-
-            let mut all_distances = Vec::new();
-            for (nic_name, nic_pci_addr) in &rdma_devices {
-                if let Some(nic_device) = pci_devices.get(nic_pci_addr) {
-                    let distance = gpu0_device.distance_to(nic_device);
-                    all_distances.push((distance, nic_name.clone(), nic_pci_addr.clone()));
-                    println!("  {} ({}): distance = {}", nic_name, nic_pci_addr, distance);
-                    println!("    NIC path to root: {:?}", nic_device.get_path_to_root());
-                }
-            }
-
-            // Find the minimum distance
-            all_distances.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-            if let Some((min_dist, min_nic, min_addr)) = all_distances.first() {
-                println!(
-                    "  → CLOSEST: {} ({}) with distance {}",
-                    min_nic, min_addr, min_dist
-                );
-            }
-        }
-
-        // Step 7: Test unified device selection interface
-        println!("\n7. UNIFIED DEVICE SELECTION TEST");
-        let test_cases = [
-            ("cuda:0", "CUDA device 0"),
-            ("cuda:1", "CUDA device 1"),
-            ("cpu:0", "CPU/NUMA node 0"),
-            ("cpu:1", "CPU/NUMA node 1"),
-        ];
-
-        for (device_hint, description) in &test_cases {
-            let selected_device = select_optimal_ibv_device(Some(device_hint));
-            match selected_device {
-                Some(device) => {
-                    println!("  {} ({}) -> {}", device_hint, description, device.name());
-                }
-                None => {
-                    println!("  {} ({}) -> NOT FOUND", device_hint, description);
-                }
-            }
-        }
-
-        // Step 8: Test all 8 GPU mappings against expected GT20 hardware results
-        println!("\n8. GPU-TO-RDMA MAPPING VALIDATION (ALL 8 GPUs)");
-
-        // Expected results from original Python implementation on GT20 hardware
-        let python_expected = [
-            (0, "mlx5_0"),
-            (1, "mlx5_3"),
-            (2, "mlx5_4"),
-            (3, "mlx5_5"),
-            (4, "mlx5_6"),
-            (5, "mlx5_9"),
-            (6, "mlx5_10"),
-            (7, "mlx5_11"),
-        ];
-
-        let mut rust_results = std::collections::HashMap::new();
-        let mut all_match = true;
-
-        // Test all 8 GPU mappings using new unified API
-        for gpu_idx in 0..8 {
-            let cuda_hint = format!("cuda:{}", gpu_idx);
-            let selected_device = select_optimal_ibv_device(Some(&cuda_hint));
-
-            match selected_device {
-                Some(device) => {
-                    let device_name = device.name().to_string();
-                    rust_results.insert(gpu_idx, device_name.clone());
-                    println!("  GPU {} -> {}", gpu_idx, device_name);
-                }
-                None => {
-                    println!("  GPU {} -> NOT FOUND", gpu_idx);
-                    rust_results.insert(gpu_idx, "NOT_FOUND".to_string());
-                }
-            }
-        }
-
-        // Compare against expected results
-        println!("\n=== VALIDATION AGAINST EXPECTED RESULTS ===");
-        for (gpu_idx, expected_nic) in python_expected {
-            if let Some(actual_nic) = rust_results.get(&gpu_idx) {
-                let matches = actual_nic == expected_nic;
-                println!(
-                    "  GPU {} -> {} {} (expected {})",
-                    gpu_idx,
-                    actual_nic,
-                    if matches { "✓" } else { "✗" },
-                    expected_nic
-                );
-                all_match = all_match && matches;
-            } else {
-                println!(
-                    "  GPU {} -> NOT FOUND ✗ (expected {})",
-                    gpu_idx, expected_nic
-                );
-                all_match = false;
-            }
-        }
-
-        if all_match {
-            println!("\n🎉 SUCCESS: All GPU-NIC pairings match expected GT20 hardware results!");
-            println!("✓ New unified API produces identical results to proven algorithm");
-        } else {
-            println!("\n⚠️  WARNING: Some GPU-NIC pairings differ from expected results");
-            println!("   This could indicate:");
-            println!("   - Hardware configuration differences");
-            println!("   - Algorithm implementation differences");
-            println!("   - Environment setup differences");
-        }
-
-        // Step 9: Detailed CPU device selection analysis
-        println!("\n9. DETAILED CPU DEVICE SELECTION ANALYSIS");
-
-        // Check what representative PCI addresses we found for each NUMA node
-        if let Some(numa0_addr) = get_numa_pci_address("0") {
-            println!("  NUMA 0 representative PCI: {}", numa0_addr);
-        } else {
-            println!("  NUMA 0 representative PCI: NOT FOUND");
-        }
-
-        if let Some(numa1_addr) = get_numa_pci_address("1") {
-            println!("  NUMA 1 representative PCI: {}", numa1_addr);
-        } else {
-            println!("  NUMA 1 representative PCI: NOT FOUND");
-        }
-
-        // Now test the actual selections
-        let cpu0_device = select_optimal_ibv_device(Some("cpu:0"));
-        let cpu1_device = select_optimal_ibv_device(Some("cpu:1"));
-
-        match (
-            cpu0_device.as_ref().map(|d| d.name()),
-            cpu1_device.as_ref().map(|d| d.name()),
-        ) {
-            (Some(cpu0_name), Some(cpu1_name)) => {
-                println!("\n  FINAL SELECTIONS:");
-                println!("    CPU:0 -> {}", cpu0_name);
-                println!("    CPU:1 -> {}", cpu1_name);
-                if cpu0_name != cpu1_name {
-                    println!("    ✓ Different NUMA nodes select different RDMA devices");
-                } else {
-                    println!("    ⚠️  Same RDMA device selected for both NUMA nodes");
-                    println!("       This could indicate:");
-                    println!(
-                        "       - {} is genuinely closest to both NUMA nodes",
-                        cpu0_name
-                    );
-                    println!("       - NUMA topology detection issue");
-                    println!("       - Cross-NUMA penalty algorithm working correctly");
-                }
-            }
-            _ => {
-                println!("    ○ CPU device selection not available");
-            }
-        }
-
-        println!("\n✓ GT20 hardware test completed");
-
-        // we can't gaurantee that the test will always match given test infra but is good for diagnostic purposes / tracking.
-    }
 }

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -29,6 +29,7 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor_config::Flattrs;
 
 use super::IbvBuffer;
+use super::device_selection::IbvDeviceTarget;
 use super::manager_actor::IbvManagerActor;
 use super::manager_actor::IbvManagerMessageClient;
 use super::mlx_device::MlxDevice;
@@ -532,6 +533,17 @@ pub struct Buffer {
     cpu_ref: Option<Box<[u8]>>,
 }
 
+/// Maps a test accelerator string (`"cpu:0"`, `"cuda:1"`, `"nic:mlx5_0"`)
+/// to an [`IbvDeviceTarget`].
+fn accel_target(accel: &str) -> IbvDeviceTarget {
+    let (backend, idx) = accel.split_once(':').unwrap();
+    match backend {
+        "cuda" => IbvDeviceTarget::gpu(idx.parse().unwrap()),
+        "nic" => IbvDeviceTarget::nic(idx),
+        _ => IbvDeviceTarget::cpu(idx.parse().unwrap()),
+    }
+}
+
 /// Helper function to parse accelerator strings
 async fn parse_accel(accel: &str, config: &mut IbvConfig) -> (String, usize) {
     let (backend, idx) = accel.split_once(':').unwrap();
@@ -564,8 +576,8 @@ impl DoorbellTestEnv {
         accel2: &str,
         qp_type: super::primitives::IbvQpType,
     ) -> Result<Self, anyhow::Error> {
-        let mut config1 = IbvConfig::targeting(accel1);
-        let mut config2 = IbvConfig::targeting(accel2);
+        let mut config1 = IbvConfig::targeting(accel_target(accel1));
+        let mut config2 = IbvConfig::targeting(accel_target(accel2));
 
         config1.qp_type = qp_type;
         config2.qp_type = qp_type;

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -49,10 +49,12 @@ use super::IbvBuffer;
 use super::IbvOp;
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
+use super::device_selection::resolve_target;
 use super::domain::IbvDomain;
 use super::efa_device::EfaDevice;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
+use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMemoryRegion;
 use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvQpInfo;
@@ -313,7 +315,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                 config
             }
         };
-        tracing::debug!("rdma is enabled, config device hint: {}", config.device);
+        tracing::debug!("rdma is enabled, config target: {:?}", config.target);
 
         let mlx5dv_enabled = resolve_qp_type(config.qp_type) == rdmaxcel_sys::RDMA_QP_TYPE_MLX5DV;
 
@@ -502,7 +504,10 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             let device_name = if let Some(info) = selected_rdma_device {
                 info.name().clone()
             } else {
-                self.config.device.name().clone()
+                resolve_target::<I>(&self.config.target)
+                    .unwrap_or_else(|| IbvDeviceInfo::default::<I>())
+                    .name()
+                    .clone()
             };
             tracing::debug!(
                 "Using RDMA device: {} for memory at 0x{:x}",
@@ -1160,6 +1165,7 @@ mod tests {
     use crate::backend::cuda_test_utils::CudaAllocation;
     use crate::backend::cuda_test_utils::CudaAllocator;
     use crate::backend::ibverbs::device::list_all_devices;
+    use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
     use crate::backend::ibverbs::primitives::IbvQpType;
     use crate::local_memory::KeepaliveLocalMemory;
 
@@ -1650,7 +1656,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_register_remote_buffer_fills_mr_slot() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         let nic = RdmaManagerActor::local_handle(&env.client)
             .get_nic_backend_handle(&env.client)
             .await?
@@ -1677,7 +1683,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_cross_actor_same_device_write() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         run_cross_actor_write(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, 0xa5, 5).await?;
         env.shutdown().await
     }
@@ -1686,7 +1692,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_cross_actor_same_device_read() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         run_cross_actor_read(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, 0x3c, 5).await?;
         env.shutdown().await
     }
@@ -1698,7 +1704,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_loopback_write() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         run_true_loopback(&env, BufferDevice::Cpu, 32).await?;
         env.shutdown().await
     }
@@ -1707,8 +1713,11 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_cross_device_write() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env =
-            TestEnv::new(IbvConfig::targeting("cpu:0"), IbvConfig::targeting("cpu:1")).await?;
+        let env = TestEnv::new(
+            IbvConfig::targeting(IbvDeviceTarget::cpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::cpu(1)),
+        )
+        .await?;
         run_cross_actor_write(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, 0x77, 5).await?;
         env.shutdown().await
     }
@@ -1717,8 +1726,11 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_cross_device_read() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env =
-            TestEnv::new(IbvConfig::targeting("cpu:0"), IbvConfig::targeting("cpu:1")).await?;
+        let env = TestEnv::new(
+            IbvConfig::targeting(IbvDeviceTarget::cpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::cpu(1)),
+        )
+        .await?;
         run_cross_actor_read(&env, BufferDevice::Cpu, BufferDevice::Cpu, 32, 0x88, 5).await?;
         env.shutdown().await
     }
@@ -1729,7 +1741,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_multi_op_same_qp_cpu() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         run_multi_op_same_qp(&env, BufferDevice::Cpu, BufferDevice::Cpu, 64, 5).await?;
         env.shutdown().await
     }
@@ -1743,8 +1755,8 @@ mod tests {
         require_cuda();
         const SIZE: usize = 2 * 1024 * 1024;
         let env = TestEnv::new(
-            IbvConfig::targeting("cuda:0"),
-            IbvConfig::targeting("cuda:1"),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(1)),
         )
         .await?;
         run_multi_op_same_qp(&env, BufferDevice::Cuda(0), BufferDevice::Cuda(1), SIZE, 10).await?;
@@ -1758,8 +1770,8 @@ mod tests {
         require_cuda();
         const SIZE: usize = 2 * 1024 * 1024;
         let env = TestEnv::new(
-            IbvConfig::targeting("cuda:0"),
-            IbvConfig::targeting("cpu:1"),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::cpu(1)),
         )
         .await?;
         run_cross_actor_write(
@@ -1781,8 +1793,8 @@ mod tests {
         require_cuda();
         const SIZE: usize = 2 * 1024 * 1024;
         let env = TestEnv::new(
-            IbvConfig::targeting("cpu:0"),
-            IbvConfig::targeting("cuda:1"),
+            IbvConfig::targeting(IbvDeviceTarget::cpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(1)),
         )
         .await?;
         run_cross_actor_read(
@@ -1804,8 +1816,8 @@ mod tests {
         require_cuda();
         const SIZE: usize = 2 * 1024 * 1024;
         let env = TestEnv::new(
-            IbvConfig::targeting("cpu:0"),
-            IbvConfig::targeting("cuda:1"),
+            IbvConfig::targeting(IbvDeviceTarget::cpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(1)),
         )
         .await?;
         run_cross_actor_write(
@@ -1827,8 +1839,8 @@ mod tests {
         require_cuda();
         const SIZE: usize = 2 * 1024 * 1024;
         let env = TestEnv::new(
-            IbvConfig::targeting("cuda:0"),
-            IbvConfig::targeting("cpu:1"),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::cpu(1)),
         )
         .await?;
         run_cross_actor_read(
@@ -1850,8 +1862,8 @@ mod tests {
         require_cuda();
         const SIZE: usize = 2 * 1024 * 1024;
         let env = TestEnv::new(
-            IbvConfig::targeting("cuda:0"),
-            IbvConfig::targeting("cuda:1"),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(1)),
         )
         .await?;
         run_cross_actor_write(
@@ -1873,8 +1885,8 @@ mod tests {
         require_cuda();
         const SIZE: usize = 2 * 1024 * 1024;
         let env = TestEnv::new(
-            IbvConfig::targeting("cuda:0"),
-            IbvConfig::targeting("cuda:1"),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(0)),
+            IbvConfig::targeting(IbvDeviceTarget::gpu(1)),
         )
         .await?;
         run_cross_actor_read(
@@ -1899,9 +1911,9 @@ mod tests {
         require_rdma();
         require_cuda();
         const SIZE: usize = 16 * 1024 * 1024;
-        let mut config_a = IbvConfig::targeting("cuda:0");
+        let mut config_a = IbvConfig::targeting(IbvDeviceTarget::gpu(0));
         config_a.qp_type = IbvQpType::Standard;
-        let mut config_b = IbvConfig::targeting("cuda:1");
+        let mut config_b = IbvConfig::targeting(IbvDeviceTarget::gpu(1));
         config_b.qp_type = IbvQpType::Standard;
         let env = TestEnv::new(config_a, config_b).await?;
         run_cross_actor_write(
@@ -1923,7 +1935,7 @@ mod tests {
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_multi_batch_same_qp() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         let src1 = env
             .helper_a
             .allocate(&env.client, 32, BufferDevice::Cpu, 0xa1)
@@ -2083,7 +2095,7 @@ mod tests {
     async fn test_submit_timeout() -> Result<(), anyhow::Error> {
         require_rdma();
         const SIZE: usize = 1024 * 1024;
-        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         let src = env
             .helper_a
             .allocate(&env.client, SIZE, BufferDevice::Cpu, 0x77)
@@ -2128,7 +2140,7 @@ mod tests {
 
         require_rdma();
         const SIZE: usize = 32;
-        let env = TestEnv::same_config(IbvConfig::targeting("cpu:0")).await?;
+        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
 
         const GOOD_PAT: u8 = 0xc3;
         const POST_FLUSH_PAT: u8 = 0xde;

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -38,7 +38,9 @@ use typeuri::Named;
 use super::domain::IbvDomain;
 use crate::backend::ibverbs::device::IbvDeviceImpl;
 use crate::backend::ibverbs::device::list_all_devices;
-use crate::backend::ibverbs::efa_device::EfaDevice;
+use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
+use crate::backend::ibverbs::device_selection::resolve_target;
+use crate::device_selection::MemoryLocation;
 
 #[derive(
     Default,
@@ -134,8 +136,9 @@ pub fn resolve_qp_type(qp_type: IbvQpType) -> u32 {
 /// parameters.
 #[derive(Debug, Named, Clone, Serialize, Deserialize)]
 pub struct IbvConfig {
-    /// `device` - The RDMA device to use for the connection.
-    pub device: IbvDeviceInfo,
+    /// `target` - Which RDMA device to use. A consumer resolves this to a
+    /// concrete device for its backend via [`resolve_target`].
+    pub target: IbvDeviceTarget,
     /// `cq_entries` - The number of completion queue entries.
     pub cq_entries: i32,
     /// `port_num` - The physical port number on the device.
@@ -182,13 +185,14 @@ pub struct IbvConfig {
 }
 wirevalue::register_type!(IbvConfig);
 
-/// Default RDMA parameters below are based on common values from rdma-core examples
-/// For high-performance or production use, consider tuning
-/// based on ibv_query_device() results and workload characteristics
+/// rdma-core defaults below come from common rdma-core examples; tune for
+/// production based on `ibv_query_device()` results and workload
+/// characteristics. The default target is CPU NUMA node 0; a consumer
+/// resolves it to a concrete device for its backend via [`resolve_target`].
 impl Default for IbvConfig {
     fn default() -> Self {
-        let mut config = Self {
-            device: IbvDeviceInfo::default(),
+        Self {
+            target: IbvDeviceTarget::MemoryLocation(MemoryLocation::Cpu(Some(0))),
             cq_entries: 1024,
             port_num: 1,
             gid_index: 3,
@@ -209,46 +213,16 @@ impl Default for IbvConfig {
             hw_init_delay_ms: 2,
             qp_type: IbvQpType::Auto,
             max_sge_override: 0,
-        };
-        if crate::efa::is_efa_device() {
-            EfaDevice::apply_config_defaults(&mut config);
         }
-        config
     }
 }
 
 impl IbvConfig {
-    /// Create a new IbvConfig targeting a specific device
-    ///
-    /// Device targets use a unified "type:id" format:
-    /// - "cpu:N" -> finds RDMA device closest to NUMA node N
-    /// - "cuda:N" -> finds RDMA device closest to CUDA device N
-    /// - "nic:mlx5_N" -> returns the specified NIC directly
-    ///
-    /// Shortcuts:
-    /// - "cpu" -> defaults to "cpu:0"
-    /// - "cuda" -> defaults to "cuda:0"
-    ///
-    /// # Arguments
-    ///
-    /// * `target` - Target device specification
-    ///
-    /// # Returns
-    ///
-    /// * `IbvConfig` with resolved device, or default device if resolution fails
-    pub fn targeting(target: &str) -> Self {
-        // Normalize shortcuts
-        let normalized_target = match target {
-            "cpu" => "cpu:0",
-            "cuda" => "cuda:0",
-            _ => target,
-        };
-
-        let device = super::device_selection::select_optimal_ibv_device(Some(normalized_target))
-            .unwrap_or_default();
-
+    /// An [`IbvConfig`] with default parameters whose device
+    /// [`target`](Self::target) is `target` (see [`IbvDeviceTarget`]).
+    pub fn targeting(target: IbvDeviceTarget) -> Self {
         Self {
-            device,
+            target,
             ..Default::default()
         }
     }
@@ -258,8 +232,8 @@ impl std::fmt::Display for IbvConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "IbvConfig {{ device: {}, port_num: {}, gid_index: {}, max_send_wr: {}, max_recv_wr: {}, max_send_sge: {}, max_recv_sge: {}, path_mtu: {:?}, retry_cnt: {}, rnr_retry: {}, qp_timeout: {}, min_rnr_timer: {}, max_dest_rd_atomic: {}, max_rd_atomic: {}, pkey_index: {}, psn: 0x{:x} }}",
-            self.device.name(),
+            "IbvConfig {{ target: {:?}, port_num: {}, gid_index: {}, max_send_wr: {}, max_recv_wr: {}, max_send_sge: {}, max_recv_sge: {}, path_mtu: {:?}, retry_cnt: {}, rnr_retry: {}, qp_timeout: {}, min_rnr_timer: {}, max_dest_rd_atomic: {}, max_rd_atomic: {}, pkey_index: {}, psn: 0x{:x} }}",
+            self.target,
             self.port_num,
             self.gid_index,
             self.max_send_wr,
@@ -370,7 +344,7 @@ impl IbvDeviceInfo {
 
     /// Aggregate bandwidth (MB/s) of the device's fastest active port,
     /// derived from its IB `active_speed` / `active_width`. 0 if no port
-    /// is active (callers treat 0 as "unknown", applying no cap).
+    /// is active, which ranks the device at the worst case.
     pub fn port_speed_mbytes_per_sec(&self) -> u32 {
         self.ports
             .iter()
@@ -413,18 +387,16 @@ impl IbvDeviceInfo {
     }
 }
 
-impl Default for IbvDeviceInfo {
-    fn default() -> Self {
-        // Try to get a smart default using device selection logic (defaults to cpu:0)
-        if let Some(device) = super::device_selection::select_optimal_ibv_device(Some("cpu:0")) {
-            device
-        } else {
-            // Fallback to first available device
-            list_all_devices()
-                .into_iter()
-                .next()
-                .unwrap_or_else(|| panic!("No RDMA devices found"))
-        }
+impl IbvDeviceInfo {
+    /// The optimal default device of backend `I`: the best NIC for CPU
+    /// memory on any NUMA node. Panics if `I` has no devices.
+    #[expect(
+        clippy::should_implement_trait,
+        reason = "generic over the backend impl, so it cannot be the parameterless Default::default"
+    )]
+    pub fn default<I: IbvDeviceImpl>() -> Self {
+        resolve_target::<I>(&IbvDeviceTarget::MemoryLocation(MemoryLocation::Cpu(None)))
+            .unwrap_or_else(|| panic!("no RDMA device for backend {}", I::backend_name()))
     }
 }
 
@@ -496,11 +468,11 @@ impl fmt::Display for IbvPort {
     }
 }
 
-/// Per-lane IB bandwidth (Mbit/s) for an `active_speed` bitmask, indexed by
-/// its lowest set bit (SDR, DDR, QDR, QDR, FDR, EDR, HDR, NDR). Values match
-/// NCCL's `ibvSpeeds` (`transport/net_ib/init.cc`). The `active_speed` field
-/// is a `u8`, so NCCL's 9th rate (XDR, bit 8) is not representable here; an
-/// unset value yields 0.
+/// Per-lane IB bandwidth (Mbit/s) for an `active_speed` bitmask,
+/// indexed by its lowest set bit (SDR, DDR, QDR, QDR, FDR, EDR, HDR, NDR).
+/// Values match NCCL's `ibvSpeeds` (`transport/net_ib/init.cc`). The
+/// `active_speed` field is a `u8`, so NCCL's 9th rate (XDR, bit 8) is not
+/// representable here; an unset value yields 0.
 fn ib_speed_mbits_per_lane(active_speed: u8) -> u32 {
     const RATES: [u32; 8] = [2500, 5000, 10000, 10000, 14000, 25000, 50000, 100000];
     first_set_bit(active_speed)

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -368,6 +368,20 @@ impl IbvDeviceInfo {
         &self.ports
     }
 
+    /// Aggregate bandwidth (MB/s) of the device's fastest active port,
+    /// derived from its IB `active_speed` / `active_width`. 0 if no port
+    /// is active (callers treat 0 as "unknown", applying no cap).
+    pub fn port_speed_mbytes_per_sec(&self) -> u32 {
+        self.ports
+            .iter()
+            .filter(|port| port.state == rdmaxcel_sys::ibv_port_state::IBV_PORT_ACTIVE)
+            .map(|port| {
+                ib_width_lanes(port.active_width) * ib_speed_mbits_per_lane(port.active_speed) / 8
+            })
+            .max()
+            .unwrap_or(0)
+    }
+
     /// Returns the maximum number of queue pairs supported by the RDMA device.
     pub fn max_qp(&self) -> i32 {
         self.max_qp
@@ -418,8 +432,8 @@ impl Default for IbvDeviceInfo {
 pub struct IbvPort {
     /// `port_num` - The physical port number on the device.
     port_num: u8,
-    /// `state` - The current state of the port.
-    state: String,
+    /// `state` - The raw `ibv_port_state` of the port.
+    state: rdmaxcel_sys::ibv_port_state::Type,
     /// `physical_state` - The physical state of the port.
     physical_state: String,
     /// `base_lid` - Base Local Identifier for the port.
@@ -436,6 +450,10 @@ pub struct IbvPort {
     gid: String,
     /// `gid_tbl_len` - Length of the GID table.
     gid_tbl_len: i32,
+    /// `active_speed` - IB active speed bitmask (one bit set).
+    active_speed: u8,
+    /// `active_width` - IB active width bitmask (one bit set).
+    active_width: u8,
 }
 
 impl fmt::Display for IbvDeviceInfo {
@@ -465,7 +483,7 @@ impl fmt::Display for IbvDeviceInfo {
 impl fmt::Display for IbvPort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "\tPort {}:", self.port_num)?;
-        writeln!(f, "\t\tState: {}", self.state)?;
+        writeln!(f, "\t\tState: {}", get_port_state_str(self.state))?;
         writeln!(f, "\t\tPhysical state: {}", self.physical_state)?;
         writeln!(f, "\t\tBase lid: {}", self.base_lid)?;
         writeln!(f, "\t\tLMC: {}", self.lmc)?;
@@ -476,6 +494,33 @@ impl fmt::Display for IbvPort {
         writeln!(f, "\t\tGID table length: {}", self.gid_tbl_len)?;
         Ok(())
     }
+}
+
+/// Per-lane IB bandwidth (Mbit/s) for an `active_speed` bitmask, indexed by
+/// its lowest set bit (SDR, DDR, QDR, QDR, FDR, EDR, HDR, NDR). Values match
+/// NCCL's `ibvSpeeds` (`transport/net_ib/init.cc`). The `active_speed` field
+/// is a `u8`, so NCCL's 9th rate (XDR, bit 8) is not representable here; an
+/// unset value yields 0.
+fn ib_speed_mbits_per_lane(active_speed: u8) -> u32 {
+    const RATES: [u32; 8] = [2500, 5000, 10000, 10000, 14000, 25000, 50000, 100000];
+    first_set_bit(active_speed)
+        .and_then(|bit| RATES.get(bit).copied())
+        .unwrap_or(0)
+}
+
+/// IB link width in lanes for an `active_width` bitmask, indexed by its
+/// lowest set bit (1x, 4x, 8x, 12x, 2x); values match NCCL's `ibvWidths`
+/// (`transport/net_ib/init.cc`). An unset value yields 0.
+fn ib_width_lanes(active_width: u8) -> u32 {
+    const WIDTHS: [u32; 5] = [1, 4, 8, 12, 2];
+    first_set_bit(active_width)
+        .and_then(|bit| WIDTHS.get(bit).copied())
+        .unwrap_or(0)
+}
+
+/// Index of the lowest set bit, or `None` if `v` is 0.
+fn first_set_bit(v: u8) -> Option<usize> {
+    (v != 0).then(|| v.trailing_zeros() as usize)
 }
 
 /// Converts the given port state to a human-readable string.
@@ -627,7 +672,6 @@ pub(super) unsafe fn query_device_info(
         {
             continue;
         }
-        let state = get_port_state_str(port_attr.state);
         let physical_state = get_port_phy_state_str(port_attr.phys_state);
         let link_layer = get_link_layer_str(port_attr.link_layer);
         let mut gid = rdmaxcel_sys::ibv_gid::default();
@@ -644,7 +688,7 @@ pub(super) unsafe fn query_device_info(
         };
         info.ports.push(IbvPort {
             port_num,
-            state,
+            state: port_attr.state,
             physical_state,
             base_lid: port_attr.lid,
             lmc: port_attr.lmc,
@@ -653,6 +697,8 @@ pub(super) unsafe fn query_device_info(
             link_layer,
             gid: gid_str,
             gid_tbl_len: port_attr.gid_tbl_len,
+            active_speed: port_attr.active_speed,
+            active_width: port_attr.active_width,
         });
     }
     Some(info)
@@ -1107,7 +1153,7 @@ mod tests {
             let port = &device.ports()[0];
             let display_output = format!("{}", port);
             assert!(
-                display_output.contains(&port.state),
+                display_output.contains(&get_port_state_str(port.state)),
                 "display should include port state"
             );
             assert!(
@@ -1115,6 +1161,95 @@ mod tests {
                 "display should include link layer"
             );
         }
+    }
+
+    #[test]
+    fn test_ib_speed_mbits_per_lane() {
+        // `active_speed` is a one-hot bitmask, indexed by its lowest set
+        // bit. Values mirror NCCL's `ibvSpeeds` (SDR..NDR).
+        assert_eq!(ib_speed_mbits_per_lane(1), 2500); // SDR
+        assert_eq!(ib_speed_mbits_per_lane(2), 5000); // DDR
+        assert_eq!(ib_speed_mbits_per_lane(4), 10000); // QDR
+        assert_eq!(ib_speed_mbits_per_lane(8), 10000); // QDR / FDR10
+        assert_eq!(ib_speed_mbits_per_lane(16), 14000); // FDR
+        assert_eq!(ib_speed_mbits_per_lane(32), 25000); // EDR
+        assert_eq!(ib_speed_mbits_per_lane(64), 50000); // HDR
+        assert_eq!(ib_speed_mbits_per_lane(128), 100000); // NDR
+        assert_eq!(ib_speed_mbits_per_lane(0), 0); // unset → unknown
+    }
+
+    #[test]
+    fn test_ib_width_lanes() {
+        assert_eq!(ib_width_lanes(1), 1); // 1x
+        assert_eq!(ib_width_lanes(2), 4); // 4x
+        assert_eq!(ib_width_lanes(4), 8); // 8x
+        assert_eq!(ib_width_lanes(8), 12); // 12x
+        assert_eq!(ib_width_lanes(16), 2); // 2x
+        assert_eq!(ib_width_lanes(0), 0); // unset → unknown
+    }
+
+    #[test]
+    fn test_port_speed_mbytes_per_sec() {
+        use rdmaxcel_sys::ibv_port_state::IBV_PORT_ACTIVE;
+        use rdmaxcel_sys::ibv_port_state::IBV_PORT_DOWN;
+        fn mk_port(
+            state: rdmaxcel_sys::ibv_port_state::Type,
+            active_speed: u8,
+            active_width: u8,
+        ) -> IbvPort {
+            IbvPort {
+                port_num: 1,
+                state,
+                physical_state: String::new(),
+                base_lid: 0,
+                lmc: 0,
+                sm_lid: 0,
+                capability_mask: 0,
+                link_layer: String::new(),
+                gid: String::new(),
+                gid_tbl_len: 0,
+                active_speed,
+                active_width,
+            }
+        }
+        fn mk_device(ports: Vec<IbvPort>) -> IbvDeviceInfo {
+            IbvDeviceInfo {
+                name: "test".to_string(),
+                vendor_id: 0,
+                vendor_part_id: 0,
+                hw_ver: 0,
+                fw_ver: String::new(),
+                node_guid: 0,
+                ports,
+                max_qp: 0,
+                max_cq: 0,
+                max_mr: 0,
+                max_pd: 0,
+                max_qp_wr: 0,
+                max_sge: 0,
+            }
+        }
+
+        // NDR (128) x4 (width bit 2): 100000 * 4 / 8 = 50000 MB/s.
+        assert_eq!(
+            mk_device(vec![mk_port(IBV_PORT_ACTIVE, 128, 2)]).port_speed_mbytes_per_sec(),
+            50000
+        );
+
+        // The fastest port is DOWN, so it is ignored; the result is the
+        // fastest ACTIVE port, not the (faster) down one.
+        let mixed = mk_device(vec![
+            mk_port(IBV_PORT_ACTIVE, 32, 2), // EDR x4 = 12500
+            mk_port(IBV_PORT_ACTIVE, 64, 2), // HDR x4 = 25000 (fastest ACTIVE)
+            mk_port(IBV_PORT_DOWN, 128, 2),  // NDR x4 = 50000, but DOWN → ignored
+        ]);
+        assert_eq!(mixed.port_speed_mbytes_per_sec(), 25000);
+
+        // No ACTIVE port → 0 (treated as unknown, no cap).
+        assert_eq!(
+            mk_device(vec![mk_port(IBV_PORT_DOWN, 128, 2)]).port_speed_mbytes_per_sec(),
+            0
+        );
     }
 
     #[test]

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1714,7 +1714,9 @@ mod tests {
 
     use super::*;
     use crate::backend::ibverbs::device::list_all_devices;
+    use crate::backend::ibverbs::device_selection::resolve_target;
     use crate::backend::ibverbs::domain::IbvDomain;
+    use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
 
     #[test]
@@ -1728,7 +1730,7 @@ mod tests {
             use_gpu_direct: false,
             ..Default::default()
         };
-        let domain = IbvDomain::new(config.device.clone());
+        let domain = IbvDomain::new(resolve_target::<MlxDevice>(&config.target).unwrap());
         assert!(domain.is_ok());
 
         let domain = Arc::new(domain.unwrap());
@@ -1752,8 +1754,12 @@ mod tests {
             ..Default::default()
         };
 
-        let server_domain = Arc::new(IbvDomain::new(server_config.device.clone()).unwrap());
-        let client_domain = Arc::new(IbvDomain::new(client_config.device.clone()).unwrap());
+        let server_domain = Arc::new(
+            IbvDomain::new(resolve_target::<MlxDevice>(&server_config.target).unwrap()).unwrap(),
+        );
+        let client_domain = Arc::new(
+            IbvDomain::new(resolve_target::<MlxDevice>(&client_config.target).unwrap()).unwrap(),
+        );
 
         let mut server_qp = IbvQueuePair::new(server_domain, server_config.clone()).unwrap();
         let mut client_qp = IbvQueuePair::new(client_domain, client_config.clone()).unwrap();

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -10,268 +10,12 @@
 //!
 //! ibverbs-specific selection logic lives in [`crate::backend::ibverbs::device_selection`].
 
-use std::collections::HashMap;
 use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
 
 use regex::Regex;
-
-// ==== PCI TOPOLOGY DISTANCE CONSTANTS ====
-//
-// These constants define penalty values for cross-NUMA communication in PCI topology:
-//
-// - CROSS_NUMA_BASE_PENALTY (20.0): Base penalty for cross-NUMA communication.
-//   This value is higher than typical intra-NUMA distances (usually 0-8 hops)
-//   to ensure same-NUMA devices are always preferred over cross-NUMA devices.
-//
-// - ADDRESS_PARSE_FAILURE_PENALTY (Inf): Penalty when PCI address parsing fails.
-//   Used as fallback when we can't determine bus relationships between devices.
-//
-// - CROSS_DOMAIN_PENALTY (1000.0): Very high penalty for different PCI domains.
-//   Different domains typically indicate completely separate I/O subsystems.
-//
-// - BUS_DISTANCE_SCALE (0.1): Scaling factor for bus distance in cross-NUMA penalty.
-//   Small factor to provide tie-breaking between devices at different bus numbers.
-
-const CROSS_NUMA_BASE_PENALTY: f64 = 20.0;
-const ADDRESS_PARSE_FAILURE_PENALTY: f64 = f64::INFINITY;
-const CROSS_DOMAIN_PENALTY: f64 = 1000.0;
-const BUS_DISTANCE_SCALE: f64 = 0.1;
-
-#[derive(Debug, Clone)]
-pub struct PCIDevice {
-    pub address: String,
-    pub parent: Option<Box<PCIDevice>>,
-}
-
-impl PCIDevice {
-    pub fn new(address: String) -> Self {
-        Self {
-            address,
-            parent: None,
-        }
-    }
-
-    pub fn get_path_to_root(&self) -> Vec<String> {
-        let mut path = vec![self.address.clone()];
-        let mut current = self;
-
-        while let Some(ref parent) = current.parent {
-            path.push(parent.address.clone());
-            current = parent;
-        }
-
-        path
-    }
-    pub fn get_numa_node(&self) -> Option<i32> {
-        let numa_file = format!("/sys/bus/pci/devices/{}/numa_node", self.address);
-        std::fs::read_to_string(numa_file).ok()?.trim().parse().ok()
-    }
-
-    pub fn distance_to(&self, other: &PCIDevice) -> f64 {
-        if self.address == other.address {
-            return 0.0;
-        }
-
-        // Get paths to root for both devices
-        let path1 = self.get_path_to_root();
-        let path2 = other.get_path_to_root();
-
-        // Find lowest common ancestor (first common element from the end)
-        let mut common_ancestor = None;
-        let min_len = path1.len().min(path2.len());
-
-        // Check from the root down to find the deepest common ancestor
-        for i in 1..=min_len {
-            if path1[path1.len() - i] == path2[path2.len() - i] {
-                common_ancestor = Some(&path1[path1.len() - i]);
-            } else {
-                break;
-            }
-        }
-
-        if let Some(ancestor) = common_ancestor {
-            let hops1 = path1.iter().position(|addr| addr == ancestor).unwrap_or(0);
-            let hops2 = path2.iter().position(|addr| addr == ancestor).unwrap_or(0);
-            (hops1 + hops2) as f64
-        } else {
-            self.calculate_cross_numa_distance(other)
-        }
-    }
-
-    /// Calculate distance between devices on different NUMA domains/root complexes
-    /// This handles cases where devices don't share a common PCI ancestor
-    fn calculate_cross_numa_distance(&self, other: &PCIDevice) -> f64 {
-        let self_parts = self.parse_pci_address();
-        let other_parts = other.parse_pci_address();
-
-        match (self_parts, other_parts) {
-            (Some((self_domain, self_bus, _, _)), Some((other_domain, other_bus, _, _))) => {
-                if self_domain != other_domain {
-                    return CROSS_DOMAIN_PENALTY;
-                }
-
-                let bus_distance = (self_bus as i32 - other_bus as i32).abs() as f64;
-                CROSS_NUMA_BASE_PENALTY + bus_distance * BUS_DISTANCE_SCALE
-            }
-            _ => ADDRESS_PARSE_FAILURE_PENALTY,
-        }
-    }
-
-    /// Parse PCI address into components (domain, bus, device, function)
-    fn parse_pci_address(&self) -> Option<(u16, u8, u8, u8)> {
-        let parts: Vec<&str> = self.address.split(':').collect();
-        if parts.len() != 3 {
-            return None;
-        }
-
-        let domain = u16::from_str_radix(parts[0], 16).ok()?;
-        let bus = u8::from_str_radix(parts[1], 16).ok()?;
-
-        let dev_func: Vec<&str> = parts[2].split('.').collect();
-        if dev_func.len() != 2 {
-            return None;
-        }
-
-        let device = u8::from_str_radix(dev_func[0], 16).ok()?;
-        let function = u8::from_str_radix(dev_func[1], 16).ok()?;
-
-        Some((domain, bus, device, function))
-    }
-
-    /// Find the index of the closest device from a list of candidates
-    pub fn find_closest(&self, candidate_devices: &[PCIDevice]) -> Option<usize> {
-        if candidate_devices.is_empty() {
-            return None;
-        }
-
-        let mut closest_idx = 0;
-        let mut min_distance = self.distance_to(&candidate_devices[0]);
-
-        for (idx, device) in candidate_devices.iter().enumerate().skip(1) {
-            let distance = self.distance_to(device);
-            if distance < min_distance {
-                min_distance = distance;
-                closest_idx = idx;
-            }
-        }
-
-        Some(closest_idx)
-    }
-}
-
-/// Resolve all symlinks in a path (equivalent to Python's os.path.realpath)
-fn realpath(path: &Path) -> Result<std::path::PathBuf, std::io::Error> {
-    let mut current = path.to_path_buf();
-    let mut seen = std::collections::HashSet::new();
-
-    loop {
-        if seen.contains(&current) {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "Circular symlink detected",
-            ));
-        }
-        seen.insert(current.clone());
-
-        match fs::read_link(&current) {
-            Ok(target) => {
-                current = if target.is_absolute() {
-                    target
-                } else {
-                    current.parent().unwrap_or(Path::new("/")).join(target)
-                };
-            }
-            Err(_) => break, // Not a symlink or error reading
-        }
-    }
-
-    Ok(current)
-}
-
-pub fn parse_pci_topology() -> Result<HashMap<String, PCIDevice>, std::io::Error> {
-    let mut devices = HashMap::new();
-    let mut parent_addresses = HashMap::new();
-    let pci_devices_dir = "/sys/bus/pci/devices";
-
-    if !Path::new(pci_devices_dir).exists() {
-        return Ok(devices);
-    }
-
-    let pci_addr_regex = Regex::new(r"([0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9])$").unwrap();
-
-    // First pass: create all devices without parent references
-    for entry in fs::read_dir(pci_devices_dir)? {
-        let entry = entry?;
-        let pci_addr = entry.file_name().to_string_lossy().to_string();
-        let device_path = entry.path();
-
-        // Find parent device by following the device symlink and extracting PCI address from the path
-        let parent_addr = match realpath(&device_path) {
-            Ok(real_path) => {
-                if let Some(parent_path) = real_path.parent() {
-                    let parent_path_str = parent_path.to_string_lossy();
-                    pci_addr_regex
-                        .captures(&parent_path_str)
-                        .map(|captures| captures.get(1).unwrap().as_str().to_string())
-                } else {
-                    None
-                }
-            }
-            Err(_) => None,
-        };
-
-        devices.insert(pci_addr.clone(), PCIDevice::new(pci_addr.clone()));
-        if let Some(ref parent) = parent_addr
-            && !devices.contains_key(parent)
-        {
-            devices.insert(parent.clone(), PCIDevice::new(parent.clone()));
-        }
-        parent_addresses.insert(pci_addr, parent_addr);
-    }
-
-    // Second pass: set up parent references recursively
-    fn build_parent_chain(
-        devices: &mut HashMap<String, PCIDevice>,
-        parent_addresses: &HashMap<String, Option<String>>,
-        pci_addr: &str,
-        visited: &mut std::collections::HashSet<String>,
-    ) {
-        if visited.contains(pci_addr) {
-            return;
-        }
-        visited.insert(pci_addr.to_string());
-
-        if let Some(Some(parent_addr)) = parent_addresses.get(pci_addr) {
-            build_parent_chain(devices, parent_addresses, parent_addr, visited);
-
-            if let Some(parent_device) = devices.get(parent_addr).cloned()
-                && let Some(device) = devices.get_mut(pci_addr)
-            {
-                device.parent = Some(Box::new(parent_device));
-            }
-        }
-    }
-
-    let mut visited = std::collections::HashSet::new();
-    for pci_addr in devices.keys().cloned().collect::<Vec<_>>() {
-        visited.clear();
-        build_parent_chain(&mut devices, &parent_addresses, &pci_addr, &mut visited);
-    }
-
-    Ok(devices)
-}
-
-pub fn parse_device_string(device_str: &str) -> Option<(String, String)> {
-    let parts: Vec<&str> = device_str.split(':').collect();
-    if parts.len() == 2 {
-        Some((parts[0].to_string(), parts[1].to_string()))
-    } else {
-        None
-    }
-}
 
 /// PCI address of the CUDA device with ordinal `idx`, read from
 /// `/proc/driver/nvidia/gpus/*/information` (the NVIDIA driver keys each
@@ -298,86 +42,6 @@ pub fn get_cuda_pci_address(idx: u32) -> Option<PCIAddress> {
             && device_minor == idx
         {
             return PCIAddress::parse(&entry.file_name().to_string_lossy().to_lowercase());
-        }
-    }
-    None
-}
-
-pub fn get_numa_pci_address(numa_node: &str) -> Option<String> {
-    let node: i32 = numa_node.parse().ok()?;
-    let pci_devices = parse_pci_topology().ok()?;
-
-    let mut candidates = Vec::new();
-    for (pci_addr, device) in &pci_devices {
-        if let Some(device_numa) = device.get_numa_node()
-            && device_numa == node
-        {
-            candidates.push(pci_addr.clone());
-        }
-    }
-
-    if candidates.is_empty() {
-        return None;
-    }
-
-    let mut best_candidate = candidates[0].clone();
-    let mut shortest_path = usize::MAX;
-
-    for pci_addr in &candidates {
-        if let Some(device) = pci_devices.get(pci_addr) {
-            let path_length = device.get_path_to_root().len();
-            if path_length < shortest_path
-                || (path_length == shortest_path && pci_addr < &best_candidate)
-            {
-                shortest_path = path_length;
-                best_candidate = pci_addr.clone();
-            }
-        }
-    }
-
-    Some(best_candidate)
-}
-
-pub fn get_all_rdma_devices() -> Vec<(String, String)> {
-    let mut rdma_devices = Vec::new();
-    let ib_class_dir = "/sys/class/infiniband";
-
-    if !Path::new(ib_class_dir).exists() {
-        return rdma_devices;
-    }
-
-    let pci_regex = Regex::new(r"([0-9a-f]{4}:[0-9a-f]{2}:[0-9a-f]{2}\.[0-9])").unwrap();
-
-    if let Ok(entries) = fs::read_dir(ib_class_dir) {
-        let mut sorted_entries: Vec<_> = entries.collect::<Result<Vec<_>, _>>().unwrap_or_default();
-        sorted_entries.sort_by_key(|entry| entry.file_name());
-
-        for entry in sorted_entries {
-            let ib_dev = entry.file_name().to_string_lossy().to_string();
-            let device_path = entry.path().join("device");
-
-            if let Ok(real_path) = fs::read_link(&device_path) {
-                let real_path_str = real_path.to_string_lossy();
-                let pci_matches: Vec<&str> = pci_regex
-                    .find_iter(&real_path_str)
-                    .map(|m| m.as_str())
-                    .collect();
-
-                if let Some(&last_pci_addr) = pci_matches.last() {
-                    rdma_devices.push((ib_dev, last_pci_addr.to_string()));
-                }
-            }
-        }
-    }
-
-    rdma_devices
-}
-
-pub fn get_nic_pci_address(nic_name: &str) -> Option<String> {
-    let rdma_devices = get_all_rdma_devices();
-    for (name, pci_addr) in rdma_devices {
-        if name == nic_name {
-            return Some(pci_addr);
         }
     }
     None
@@ -426,7 +90,16 @@ impl fmt::Display for PCIAddress {
 /// A source of memory for a transfer. A `None` index means "any device of
 /// this kind": the location is then ranked against the best of all CPU
 /// nodes or all GPUs.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize
+)]
 pub enum MemoryLocation {
     /// CPU memory on the given NUMA node, or any CPU node if `None`.
     Cpu(Option<u32>),
@@ -660,23 +333,6 @@ fn pcie_speed_mbits_per_lane(speed: &str) -> u32 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_parse_device_string() {
-        assert_eq!(
-            parse_device_string("cuda:0"),
-            Some(("cuda".to_string(), "0".to_string()))
-        );
-        assert_eq!(
-            parse_device_string("cpu:1"),
-            Some(("cpu".to_string(), "1".to_string()))
-        );
-        assert_eq!(parse_device_string("invalid"), None);
-        assert_eq!(
-            parse_device_string("cuda:"),
-            Some(("cuda".to_string(), "".to_string()))
-        );
-    }
 
     #[test]
     fn test_pci_address_parse_and_display() {

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -11,8 +11,10 @@
 //! ibverbs-specific selection logic lives in [`crate::backend::ibverbs::device_selection`].
 
 use std::collections::HashMap;
+use std::fmt;
 use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 
 use regex::Regex;
 
@@ -222,10 +224,10 @@ pub fn parse_pci_topology() -> Result<HashMap<String, PCIDevice>, std::io::Error
         };
 
         devices.insert(pci_addr.clone(), PCIDevice::new(pci_addr.clone()));
-        if let Some(ref parent) = parent_addr {
-            if !devices.contains_key(parent) {
-                devices.insert(parent.clone(), PCIDevice::new(parent.clone()));
-            }
+        if let Some(ref parent) = parent_addr
+            && !devices.contains_key(parent)
+        {
+            devices.insert(parent.clone(), PCIDevice::new(parent.clone()));
         }
         parent_addresses.insert(pci_addr, parent_addr);
     }
@@ -245,10 +247,10 @@ pub fn parse_pci_topology() -> Result<HashMap<String, PCIDevice>, std::io::Error
         if let Some(Some(parent_addr)) = parent_addresses.get(pci_addr) {
             build_parent_chain(devices, parent_addresses, parent_addr, visited);
 
-            if let Some(parent_device) = devices.get(parent_addr).cloned() {
-                if let Some(device) = devices.get_mut(pci_addr) {
-                    device.parent = Some(Box::new(parent_device));
-                }
+            if let Some(parent_device) = devices.get(parent_addr).cloned()
+                && let Some(device) = devices.get_mut(pci_addr)
+            {
+                device.parent = Some(Box::new(parent_device));
             }
         }
     }
@@ -271,28 +273,31 @@ pub fn parse_device_string(device_str: &str) -> Option<(String, String)> {
     }
 }
 
-pub fn get_cuda_pci_address(device_idx: &str) -> Option<String> {
-    let idx: i32 = device_idx.parse().ok()?;
+/// PCI address of the CUDA device with ordinal `idx`, read from
+/// `/proc/driver/nvidia/gpus/*/information` (the NVIDIA driver keys each
+/// GPU's bus id there by its device minor, which equals the CUDA ordinal).
+pub fn get_cuda_pci_address(idx: u32) -> Option<PCIAddress> {
     let gpu_proc_dir = "/proc/driver/nvidia/gpus";
-
     if !Path::new(gpu_proc_dir).exists() {
         return None;
     }
 
+    let minor_regex =
+        Regex::new(r"Device Minor:\s*(\d+)").expect("should compile: regex literal is valid");
     for entry in fs::read_dir(gpu_proc_dir).ok()? {
         let entry = entry.ok()?;
-        let pci_addr = entry.file_name().to_string_lossy().to_lowercase();
         let info_file = entry.path().join("information");
 
-        if let Ok(content) = fs::read_to_string(&info_file) {
-            let minor_regex = Regex::new(r"Device Minor:\s*(\d+)").unwrap();
-            if let Some(captures) = minor_regex.captures(&content) {
-                if let Ok(device_minor) = captures.get(1).unwrap().as_str().parse::<i32>() {
-                    if device_minor == idx {
-                        return Some(pci_addr);
-                    }
-                }
-            }
+        if let Ok(content) = fs::read_to_string(&info_file)
+            && let Some(captures) = minor_regex.captures(&content)
+            && let Ok(device_minor) = captures
+                .get(1)
+                .expect("should be present: capture group 1 matched")
+                .as_str()
+                .parse::<u32>()
+            && device_minor == idx
+        {
+            return PCIAddress::parse(&entry.file_name().to_string_lossy().to_lowercase());
         }
     }
     None
@@ -304,10 +309,10 @@ pub fn get_numa_pci_address(numa_node: &str) -> Option<String> {
 
     let mut candidates = Vec::new();
     for (pci_addr, device) in &pci_devices {
-        if let Some(device_numa) = device.get_numa_node() {
-            if device_numa == node {
-                candidates.push(pci_addr.clone());
-            }
+        if let Some(device_numa) = device.get_numa_node()
+            && device_numa == node
+        {
+            candidates.push(pci_addr.clone());
         }
     }
 
@@ -378,6 +383,280 @@ pub fn get_nic_pci_address(nic_name: &str) -> Option<String> {
     None
 }
 
+/// A PCI address, e.g. `0000:07:00.0`, as found under
+/// `/sys/bus/pci/devices`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct PCIAddress {
+    pub domain: u16,
+    pub bus: u8,
+    pub device: u8,
+    pub function: u8,
+}
+
+impl PCIAddress {
+    /// Parse a `dddd:bb:dd.f` lowercase-hex PCI address.
+    pub fn parse(s: &str) -> Option<Self> {
+        let (domain, rest) = s.split_once(':')?;
+        let (bus, rest) = rest.split_once(':')?;
+        let (device, function) = rest.split_once('.')?;
+        Some(Self {
+            domain: u16::from_str_radix(domain, 16).ok()?,
+            bus: u8::from_str_radix(bus, 16).ok()?,
+            device: u8::from_str_radix(device, 16).ok()?,
+            function: u8::from_str_radix(function, 16).ok()?,
+        })
+    }
+
+    /// This device's sysfs directory, `/sys/bus/pci/devices/<bdf>`.
+    pub fn sysfs_path(&self) -> PathBuf {
+        Path::new("/sys/bus/pci/devices").join(self.to_string())
+    }
+}
+
+impl fmt::Display for PCIAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{:04x}:{:02x}:{:02x}.{:x}",
+            self.domain, self.bus, self.device, self.function
+        )
+    }
+}
+
+/// A source of memory for a transfer. A `None` index means "any device of
+/// this kind": the location is then ranked against the best of all CPU
+/// nodes or all GPUs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MemoryLocation {
+    /// CPU memory on the given NUMA node, or any CPU node if `None`.
+    Cpu(Option<u32>),
+    /// GPU memory on the given CUDA device ordinal, or any GPU if `None`.
+    Gpu(Option<u32>),
+}
+
+/// Locality of a path between two PCI endpoints, ordered best to worst.
+/// A path's type is its worst (least local) segment.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PathType {
+    /// Within a single PCIe switch.
+    Pix,
+    /// Across multiple PCIe switches under one host bridge.
+    Pxb,
+    /// Up through the CPU host bridge, within one NUMA node.
+    Phb,
+    /// Across the inter-socket / cross-NUMA interconnect.
+    Sys,
+    /// No path between the endpoints.
+    Dis,
+}
+
+/// A classified path between two PCI endpoints: its [`PathType`] and the
+/// bottleneck (minimum) PCIe link bandwidth along it, in MB/s.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PciPath {
+    pub path_type: PathType,
+    pub bottleneck_mbytes_per_sec: u32,
+}
+
+impl PciPath {
+    /// Whether this path is preferable to `other`: more local (lower
+    /// [`PathType`]) wins, and among equally-local paths the higher
+    /// bottleneck bandwidth wins.
+    pub fn is_better_than(&self, other: &PciPath) -> bool {
+        (self.path_type, other.bottleneck_mbytes_per_sec)
+            < (other.path_type, self.bottleneck_mbytes_per_sec)
+    }
+}
+
+/// The [`PathType`] and bottleneck bandwidth of the PCIe path between two
+/// PCI endpoints.
+///
+/// Walks each endpoint's sysfs ancestor chain toward the root complex,
+/// finds their lowest common ancestor, and takes the minimum link
+/// bandwidth along the way. When the endpoints share no PCIe ancestor the
+/// path runs through the CPU: same NUMA node → [`PathType::Phb`],
+/// different nodes → [`PathType::Sys`], unknown → [`PathType::Dis`].
+pub fn pci_path(a: &PCIAddress, b: &PCIAddress) -> PciPath {
+    classify(
+        &ancestor_chain(a),
+        numa_node(a),
+        &ancestor_chain(b),
+        numa_node(b),
+    )
+}
+
+/// Path from CPU memory to the device at `addr`. With a specific NUMA
+/// node, the device is [`PathType::Phb`] when it sits on that node and
+/// [`PathType::Sys`] otherwise; with `None` (any CPU) it is judged against
+/// its own node and so is always [`PathType::Phb`]. Bandwidth is the
+/// device's PCIe chain bottleneck.
+pub fn cpu_path(addr: &PCIAddress, numa: Option<u32>) -> PciPath {
+    let bottleneck_mbytes_per_sec = min_link_mbytes_per_sec(&ancestor_chain(addr));
+    let path_type = match numa {
+        Some(node) if numa_node(addr) != Some(node) => PathType::Sys,
+        _ => PathType::Phb,
+    };
+    PciPath {
+        path_type,
+        bottleneck_mbytes_per_sec,
+    }
+}
+
+/// One node in a device's PCIe ancestor chain: its resolved sysfs path
+/// and the bandwidth (MB/s) of the PCIe link immediately upstream of it.
+struct PciHop {
+    sysfs: PathBuf,
+    link_mbytes_per_sec: u32,
+}
+
+/// Classify the path between two ancestor chains (device → root complex).
+/// Pure over its inputs, so it is unit-tested without touching sysfs.
+fn classify(a: &[PciHop], numa_a: Option<u32>, b: &[PciHop], numa_b: Option<u32>) -> PciPath {
+    if let Some((ia, ib)) = common_ancestor(a, b) {
+        // The path traverses the links upstream of each hop below the common
+        // ancestor (`a[..ia]` then `b[..ib]`). The ancestor's own upstream
+        // link runs further up the tree and is not part of the path, so it is
+        // excluded.
+        let bottleneck_mbytes_per_sec = a[..ia]
+            .iter()
+            .chain(&b[..ib])
+            .map(|h| h.link_mbytes_per_sec)
+            .min()
+            .unwrap_or(0);
+        // A PCIe switch spans two sysfs hops (its downstream and upstream
+        // ports), so meeting within two hops of the common ancestor means
+        // both devices sit under one switch; farther means multiple.
+        let single_switch = ia <= 2 && ib <= 2;
+        let path_type = if single_switch {
+            PathType::Pix
+        } else {
+            PathType::Pxb
+        };
+        return PciPath {
+            path_type,
+            bottleneck_mbytes_per_sec,
+        };
+    }
+    // No shared PCIe ancestor: the path runs through the CPU.
+    let bottleneck_mbytes_per_sec = min_link_mbytes_per_sec(a).min(min_link_mbytes_per_sec(b));
+    let path_type = match (numa_a, numa_b) {
+        (Some(x), Some(y)) if x == y => PathType::Phb,
+        (Some(_), Some(_)) => PathType::Sys,
+        _ => PathType::Dis,
+    };
+    PciPath {
+        path_type,
+        bottleneck_mbytes_per_sec,
+    }
+}
+
+/// Indices of the deepest sysfs path common to both chains, scanning each
+/// from its device end.
+fn common_ancestor(a: &[PciHop], b: &[PciHop]) -> Option<(usize, usize)> {
+    a.iter().enumerate().find_map(|(ia, na)| {
+        b.iter()
+            .position(|nb| nb.sysfs == na.sysfs)
+            .map(|ib| (ia, ib))
+    })
+}
+
+/// Minimum upstream link bandwidth (MB/s) across `hops`. A hop whose
+/// bandwidth couldn't be read is 0 and drags the whole range to 0, so a
+/// path with an unmeasurable link is treated as the worst case. 0 when
+/// `hops` is empty.
+fn min_link_mbytes_per_sec(hops: &[PciHop]) -> u32 {
+    hops.iter()
+        .map(|h| h.link_mbytes_per_sec)
+        .min()
+        .unwrap_or(0)
+}
+
+/// Walk `addr`'s PCIe ancestor chain from the device up toward the root
+/// complex, resolving sysfs symlinks. Empty if the device's sysfs entry
+/// can't be resolved.
+fn ancestor_chain(addr: &PCIAddress) -> Vec<PciHop> {
+    let mut chain = Vec::new();
+    let mut current = match fs::canonicalize(addr.sysfs_path()) {
+        Ok(p) => p,
+        Err(_) => return chain,
+    };
+    loop {
+        let link_mbytes_per_sec = link_bandwidth_mbytes_per_sec(&current);
+        let parent = current.parent().map(Path::to_path_buf);
+        chain.push(PciHop {
+            sysfs: current,
+            link_mbytes_per_sec,
+        });
+        match parent {
+            Some(parent) if is_pci_bdf(&parent) => current = parent,
+            _ => break,
+        }
+    }
+    chain
+}
+
+/// Whether `path`'s final component parses as a PCI address
+/// (`dddd:bb:dd.f`), e.g. `0000:00:01.0`. The root complex (`pci0000:00`)
+/// does not, which stops the ancestor walk there.
+fn is_pci_bdf(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|n| PCIAddress::parse(n).is_some())
+}
+
+/// NUMA node of the device at `addr`, from `<sysfs>/numa_node`. A `-1`
+/// ("unknown") maps to `None`.
+fn numa_node(addr: &PCIAddress) -> Option<u32> {
+    let raw = fs::read_to_string(addr.sysfs_path().join("numa_node")).ok()?;
+    u32::try_from(raw.trim().parse::<i32>().ok()?).ok()
+}
+
+/// Bandwidth (MB/s) of the PCIe link immediately upstream of the device at
+/// `sysfs`, from its own `max_link_speed` / `max_link_width`. An unreadable
+/// value is 0, so the link is treated as the worst case.
+fn link_bandwidth_mbytes_per_sec(sysfs: &Path) -> u32 {
+    let speed = read_speed_mbits_per_lane(sysfs);
+    let width = read_link_width(sysfs);
+    // `speed` is effective megabits/s per lane (PCIe line-encoding overhead
+    // is already folded into the table), so `speed * width` is the link's
+    // total megabits/s; dividing by 8 converts bits to bytes → MB/s.
+    speed.saturating_mul(width) / 8
+}
+
+/// PCIe lane count from `<dir>/max_link_width`, or 0 if unreadable.
+fn read_link_width(dir: &Path) -> u32 {
+    fs::read_to_string(dir.join("max_link_width"))
+        .ok()
+        .and_then(|s| s.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+/// Per-lane PCIe rate (Mbit/s) from `<dir>/max_link_speed`, or 0 if unreadable.
+fn read_speed_mbits_per_lane(dir: &Path) -> u32 {
+    fs::read_to_string(dir.join("max_link_speed"))
+        .ok()
+        .map(|s| pcie_speed_mbits_per_lane(&s))
+        .unwrap_or(0)
+}
+
+/// Per-lane PCIe bandwidth (Mbit/s) for a `max_link_speed` string such as
+/// `"16 GT/s PCIe"`, with line-encoding overhead folded in. `rate * lanes
+/// / 8` gives the link's MB/s. The values and the Gen3 fallback mirror
+/// NCCL's `kvDictPciGen` (graph/topo.cc).
+fn pcie_speed_mbits_per_lane(speed: &str) -> u32 {
+    // Match the leading "<rate> GT/s" token; the kernel may append a
+    // trailing "PCIe" and prints either "8" or "8.0" style rates.
+    match speed.split_whitespace().next().unwrap_or("") {
+        "2.5" => 1500,          // Gen1
+        "5" | "5.0" => 3000,    // Gen2
+        "8" | "8.0" => 6000,    // Gen3
+        "16" | "16.0" => 12000, // Gen4
+        "32" | "32.0" => 24000, // Gen5
+        "64" | "64.0" => 48000, // Gen6
+        _ => 6000,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -397,5 +676,144 @@ mod tests {
             parse_device_string("cuda:"),
             Some(("cuda".to_string(), "".to_string()))
         );
+    }
+
+    #[test]
+    fn test_pci_address_parse_and_display() {
+        let addr = PCIAddress::parse("0000:07:00.0").unwrap();
+        assert_eq!(
+            addr,
+            PCIAddress {
+                domain: 0,
+                bus: 7,
+                device: 0,
+                function: 0,
+            }
+        );
+        assert_eq!(addr.to_string(), "0000:07:00.0");
+        // Hex components round-trip through Display.
+        assert_eq!(
+            PCIAddress::parse("00ff:1a:1f.7").unwrap().to_string(),
+            "00ff:1a:1f.7"
+        );
+        assert_eq!(PCIAddress::parse("not-an-address"), None);
+        assert_eq!(PCIAddress::parse("0000:07:00"), None);
+    }
+
+    #[test]
+    fn test_path_type_orders_best_to_worst() {
+        assert!(PathType::Pix < PathType::Pxb);
+        assert!(PathType::Pxb < PathType::Phb);
+        assert!(PathType::Phb < PathType::Sys);
+        assert!(PathType::Sys < PathType::Dis);
+    }
+
+    #[test]
+    fn test_pci_path_is_better_than() {
+        let pix_slow = PciPath {
+            path_type: PathType::Pix,
+            bottleneck_mbytes_per_sec: 1000,
+        };
+        let pix_fast = PciPath {
+            path_type: PathType::Pix,
+            bottleneck_mbytes_per_sec: 2000,
+        };
+        let phb_fast = PciPath {
+            path_type: PathType::Phb,
+            bottleneck_mbytes_per_sec: 9000,
+        };
+        // A more local path wins regardless of bandwidth.
+        assert!(pix_slow.is_better_than(&phb_fast));
+        assert!(!phb_fast.is_better_than(&pix_slow));
+        // Equal locality: higher bandwidth wins.
+        assert!(pix_fast.is_better_than(&pix_slow));
+        assert!(!pix_slow.is_better_than(&pix_fast));
+        // A path is not strictly better than itself.
+        assert!(!pix_fast.is_better_than(&pix_fast));
+    }
+
+    #[test]
+    fn test_pcie_speed_mbits_per_lane() {
+        assert_eq!(pcie_speed_mbits_per_lane("2.5 GT/s PCIe"), 1500);
+        assert_eq!(pcie_speed_mbits_per_lane("5 GT/s"), 3000);
+        assert_eq!(pcie_speed_mbits_per_lane("8.0 GT/s"), 6000);
+        assert_eq!(pcie_speed_mbits_per_lane("16 GT/s PCIe"), 12000);
+        assert_eq!(pcie_speed_mbits_per_lane("32 GT/s"), 24000);
+        assert_eq!(pcie_speed_mbits_per_lane("64 GT/s"), 48000);
+        // Unrecognized / empty defaults to Gen3.
+        assert_eq!(pcie_speed_mbits_per_lane("garbage"), 6000);
+        assert_eq!(pcie_speed_mbits_per_lane(""), 6000);
+    }
+
+    fn hop(sysfs: &str, link_mbytes_per_sec: u32) -> PciHop {
+        PciHop {
+            sysfs: PathBuf::from(sysfs),
+            link_mbytes_per_sec,
+        }
+    }
+
+    #[test]
+    fn test_classify_pix_single_switch() {
+        // Both devices meet at a shared switch within two hops: PIX, with
+        // the bottleneck being the slowest link to that switch.
+        let a = vec![
+            hop("/d/a", 12000),
+            hop("/d/sw_a", 12000),
+            hop("/d/sw", 8000),
+        ];
+        let b = vec![hop("/d/b", 12000), hop("/d/sw_b", 6000), hop("/d/sw", 8000)];
+        let path = classify(&a, Some(0), &b, Some(0));
+        assert_eq!(path.path_type, PathType::Pix);
+        assert_eq!(path.bottleneck_mbytes_per_sec, 6000);
+    }
+
+    #[test]
+    fn test_classify_excludes_common_ancestor_upstream() {
+        // The common ancestor's own upstream link runs further up the tree and
+        // is not part of the path between `a` and `b`, so a slow link there
+        // must not lower the bottleneck.
+        let a = vec![hop("/d/a", 12000), hop("/d/sw", 2000)];
+        let b = vec![hop("/d/b", 12000), hop("/d/sw", 2000)];
+        let path = classify(&a, Some(0), &b, Some(0));
+        assert_eq!(path.path_type, PathType::Pix);
+        assert_eq!(
+            path.bottleneck_mbytes_per_sec, 12000,
+            "the common ancestor's 2000 MB/s upstream link is above the path and must be excluded"
+        );
+    }
+
+    #[test]
+    fn test_classify_pxb_multiple_switches() {
+        // The chains meet only at the root, several hops up one side: PXB.
+        let a = vec![
+            hop("/d/a", 12000),
+            hop("/d/sw_a1", 12000),
+            hop("/d/sw_a2", 12000),
+            hop("/d/sw_a3", 12000),
+            hop("/d/root", 16000),
+        ];
+        let b = vec![
+            hop("/d/b", 10000),
+            hop("/d/sw_b", 10000),
+            hop("/d/root", 16000),
+        ];
+        let path = classify(&a, Some(0), &b, Some(0));
+        assert_eq!(path.path_type, PathType::Pxb);
+        assert_eq!(path.bottleneck_mbytes_per_sec, 10000);
+    }
+
+    #[test]
+    fn test_classify_through_cpu() {
+        // No shared PCIe ancestor — the path goes through the CPU.
+        let a = vec![hop("/d/a", 4000), hop("/d/root_a", 16000)];
+        let b = vec![hop("/d/b", 8000), hop("/d/root_b", 16000)];
+        // Same NUMA node → PHB; bottleneck is the slowest link overall.
+        let phb = classify(&a, Some(0), &b, Some(0));
+        assert_eq!(phb.path_type, PathType::Phb);
+        assert_eq!(phb.bottleneck_mbytes_per_sec, 4000);
+        // Different NUMA nodes → SYS.
+        assert_eq!(classify(&a, Some(0), &b, Some(1)).path_type, PathType::Sys);
+        // Unknown NUMA node → DIS.
+        assert_eq!(classify(&a, None, &b, Some(0)).path_type, PathType::Dis);
     }
 }

--- a/monarch_rdma/tests/multi_pd_test.rs
+++ b/monarch_rdma/tests/multi_pd_test.rs
@@ -19,19 +19,18 @@ use monarch_rdma::backend::cuda_test_utils::ReceiverActor;
 use monarch_rdma::backend::cuda_test_utils::ReceiverMessageClient;
 use monarch_rdma::backend::cuda_test_utils::SenderActor;
 use monarch_rdma::backend::cuda_test_utils::SenderMessageClient;
-use monarch_rdma::backend::ibverbs::device_selection::select_optimal_ibv_device;
+use monarch_rdma::backend::ibverbs::device_selection::IbvDeviceTarget;
+use monarch_rdma::backend::ibverbs::device_selection::get_cuda_device_to_ibv_device;
 use ndslice::ViewExt;
 
 /// Finds two CUDA devices that map to different RDMA NICs via PCI topology.
 /// Returns `Some((device_a, device_b))` or `None` if all devices share one NIC.
 fn find_devices_on_different_nics() -> Option<(i32, i32)> {
-    let mut gpu_to_nic: Vec<(i32, String)> = Vec::new();
-    for gpu_idx in 0..8 {
-        let hint = format!("cuda:{gpu_idx}");
-        if let Some(device) = select_optimal_ibv_device(Some(&hint)) {
-            gpu_to_nic.push((gpu_idx, device.name().to_string()));
-        }
-    }
+    let gpu_to_nic: Vec<(i32, String)> = get_cuda_device_to_ibv_device()
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, nic)| nic.as_ref().map(|d| (idx as i32, d.name().to_string())))
+        .collect();
 
     for i in 0..gpu_to_nic.len() {
         for j in (i + 1)..gpu_to_nic.len() {
@@ -103,14 +102,14 @@ async fn test_multi_pd_segment_registration() -> Result<(), anyhow::Error> {
         .spawn_service(
             instance,
             "rdma_manager",
-            &Some(IbvConfig::targeting(&format!("cuda:{device_a}"))),
+            &Some(IbvConfig::targeting(IbvDeviceTarget::gpu(device_a as u32))),
         )
         .await?;
     let _rdma_recv_b: ActorMesh<RdmaManagerActor> = receiver_b_proc
         .spawn_service(
             instance,
             "rdma_manager",
-            &Some(IbvConfig::targeting(&format!("cuda:{device_b}"))),
+            &Some(IbvConfig::targeting(IbvDeviceTarget::gpu(device_b as u32))),
         )
         .await?;
 


### PR DESCRIPTION
Summary:

Replace the ad-hoc device selection with the new PCIe-topology primitives, and rework `IbvConfig` to carry device intent rather than a pre-resolved device.

Selection: `select_optimal_ibv_devices::<I>(MemoryLocation)` ranks a backend's NICs by `pci_path` — most-local `PathType`, then highest bandwidth capped by RDMA port speed — cached per `(backend, location)`. `resolve_target::<I>(&IbvDeviceTarget)` maps a target (a `MemoryLocation`, or an explicit `Nic(name)`) to a concrete device. The old `PCIDevice` / `parse_pci_topology` penalty-distance machinery and `parse_device_string` are deleted.

Config: `IbvConfig` stores `target: IbvDeviceTarget` (default: CPU NUMA node 0) instead of a resolved `device`, so `Default` and `targeting` are non-generic; a consumer resolves the target to a device for its backend at point of use (`IbvManagerActor` does this and applies `apply_config_defaults` itself). `IbvDeviceTarget` and `MemoryLocation` gain `Serialize`/`Deserialize` so `IbvConfig` still crosses the wire.

Reviewed By: zdevito

Differential Revision: D108189339


