### PR TITLE
Stamp resource rank on cast delivery (#4221)

### DIFF
--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -50,7 +50,7 @@ use uuid::Uuid;
 
 use crate::tile::MaterializedTile;
 use crate::tile::Tile;
-use crate::tile::TilingPolicy;
+pub use crate::tile::TilingPolicy;
 
 hyperactor_config::declare_attrs! {
     /// Header stamped on each locally delivered message with the
@@ -80,6 +80,22 @@ hyperactor_config::declare_attrs! {
     /// recipient.
     pub attr CAST_LINEAGE: Vec<usize>;
 }
+
+/// Wire-compatible mirror of `hyperactor_mesh::resource::RankRepr`.
+///
+/// `hyperactor_cast` cannot depend on `hyperactor_mesh` without creating a
+/// crate cycle, but cast delivery still needs to stamp the rank multipart part
+/// for messages whose handlers read rank from the payload. The part is tagged
+/// with `RankRepr`'s typename, so this mirror must match it exactly.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ResourceRankRepr(Option<usize>);
+
+impl Named for ResourceRankRepr {
+    fn typename() -> &'static str {
+        "hyperactor_mesh::resource::RankRepr"
+    }
+}
+
 /// Pure, data-only identifier for a cast domain.
 ///
 /// This type contains no runtime references (e.g. `ActorRef`) and can
@@ -677,6 +693,7 @@ fn split_ports(
 
     Ok(())
 }
+
 /// Test-only forwarding path metadata.
 ///
 /// In production this is zero-sized and optimized away. In tests, each
@@ -779,6 +796,17 @@ impl Handler<CastMessage> for CastActor {
 
         // Deliver to destination actor.
         {
+            let mut local_data = data.clone();
+
+            let rank = domain.point_in_domain.rank();
+
+            local_data.visit_multipart_parts_mut::<ResourceRankRepr, anyhow::Error>(
+                |ResourceRankRepr(resource_rank)| {
+                    *resource_rank = Some(rank);
+                    Ok(())
+                },
+            )?;
+
             let seq = *message
                 .seqs
                 .get_by_base_rank(domain.base_rank_in_domain)
@@ -809,7 +837,7 @@ impl Handler<CastMessage> for CastActor {
                 &dest,
                 &message.sender,
             );
-            cx.post_with_external_seq_info(dest, headers, data.clone().erase_encoding());
+            cx.post_with_external_seq_info(dest, headers, local_data.erase_encoding());
         }
 
         for next_hop in &domain.next_hops {

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1219,6 +1219,7 @@ impl<A: Referable> view::RankedSliceable for ActorMeshRef<A> {
 #[cfg(all(test, fbcode_build))]
 mod tests {
 
+    use std::collections::HashMap;
     use std::collections::HashSet;
     use std::ops::Deref;
 
@@ -1744,6 +1745,87 @@ mod tests {
         assert_eq!(all_ranks, HashSet::from([0, 1]));
 
         let _ = host_mesh.shutdown(instance).await;
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    async fn test_cast_domain_stamps_resource_rank_binding() {
+        let client_proc = hyperactor::proc::Proc::direct(
+            hyperactor::channel::ChannelTransport::Unix.any(),
+            "client_proc".into(),
+        )
+        .unwrap();
+
+        let client = client_proc.client("client");
+
+        let mut procs = Vec::new();
+
+        let members = (0..2)
+            .map(|rank| {
+                let proc = hyperactor::proc::Proc::direct(
+                    hyperactor::channel::ChannelTransport::Unix.any(),
+                    format!("proc_{rank}"),
+                )
+                .unwrap();
+
+                let cast_handle = proc
+                    .spawn_with_uid(
+                        hyperactor::Uid::singleton(Label::strip("cast")),
+                        hyperactor_cast::cast_actor::CastActor::default(),
+                    )
+                    .unwrap();
+
+                let _: hyperactor::ActorRef<hyperactor_cast::cast_actor::CastActor> =
+                    cast_handle.bind();
+
+                let receiver_handle = proc
+                    .spawn_with_uid(
+                        hyperactor::Uid::singleton(Label::strip("receiver")),
+                        testactor::TestActor,
+                    )
+                    .unwrap();
+
+                let _: hyperactor::ActorRef<testactor::TestActor> = receiver_handle.bind();
+
+                let actor_addr =
+                    hyperactor::ActorAddr::root(proc.proc_addr().clone(), Label::strip("receiver"));
+
+                procs.push(proc);
+
+                (rank, actor_addr)
+            })
+            .collect::<HashMap<_, _>>();
+
+        let cast_domain = hyperactor_cast::cast_actor::CastDomainId::new()
+            .materialize(
+                &client,
+                members,
+                Region::from(ndslice::shape!(rank = 2)),
+                hyperactor_cast::cast_actor::TilingPolicy::BlockPartitioning,
+            )
+            .unwrap();
+
+        let (rank_port, mut rank_rx) = client.mailbox().open_port();
+
+        cast_domain
+            .cast(
+                &client,
+                hyperactor_config::Flattrs::new(),
+                testactor::GetResourceRank {
+                    rank: crate::resource::Rank::default(),
+                    reply: rank_port.bind(),
+                },
+            )
+            .unwrap();
+
+        let mut received_ranks = HashSet::new();
+
+        for _ in 0..2 {
+            let (_point, rank) = rank_rx.recv().await.unwrap();
+
+            received_ranks.insert(rank);
+        }
+
+        assert_eq!(received_ranks, HashSet::from([Some(0), Some(1)]));
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -58,6 +58,7 @@ use crate::testing;
     (),
     GetActorId,
     GetCastInfo,
+    GetResourceRank,
     CauseSupervisionEvent,
     Forward,
     GetConfigAttrs,
@@ -238,6 +239,25 @@ impl Handler<GetCastInfo> for TestActor {
         GetCastInfo { cast_info }: GetCastInfo,
     ) -> Result<(), anyhow::Error> {
         cast_info.post(cx, (cx.cast_point(), cx.bind(), cx.sender().clone()));
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, Named, Serialize, Deserialize)]
+pub struct GetResourceRank {
+    pub rank: crate::resource::Rank,
+    pub reply: hyperactor::PortRef<(Point, Option<usize>)>,
+}
+
+#[async_trait]
+impl Handler<GetResourceRank> for TestActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        GetResourceRank { rank, reply }: GetResourceRank,
+    ) -> Result<(), anyhow::Error> {
+        reply.post(cx, (cx.cast_point(), rank.0));
+
         Ok(())
     }
 }


### PR DESCRIPTION
Summary:

We want `rank` to be part of the messaging interface for messages that require it rather than inferring from message headers so CastActor will need to write the rank

Reviewed By: mariusae

Differential Revision: D108306614


