### PR TITLE
Constant for cast_actor (#4222)

### DIFF
--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -376,7 +376,7 @@ fn next_tiles(
 ///
 /// One `CastActor` is expected to run on every proc under this name. Internal
 /// setup uses this known address to route setup commands to child tile roots.
-const CAST_ACTOR_NAME: &str = "cast";
+pub const CAST_ACTOR_NAME: &str = "cast";
 
 /// System actor that establishes casting domains.
 ///

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -43,6 +43,7 @@ use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableReason;
 use hyperactor::proc::Proc;
 use hyperactor::supervision::ActorSupervisionEvent;
+use hyperactor_cast::cast_actor::CAST_ACTOR_NAME;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
@@ -331,7 +332,7 @@ impl ProcAgent {
         shutdown_tx: Option<tokio::sync::oneshot::Sender<i32>>,
     ) -> Result<ActorHandle<Self>, anyhow::Error> {
         let cast_handle = proc.spawn_with_uid(
-            Uid::singleton(Label::strip("cast")),
+            Uid::singleton(Label::strip(CAST_ACTOR_NAME)),
             hyperactor_cast::cast_actor::CastActor::default(),
         )?;
         cast_handle.bind::<hyperactor_cast::cast_actor::CastActor>();


### PR DESCRIPTION
Summary:

This ends up appearing in a bunch more places so its cleaner to just make it a constant now just like we do with `"host_agent"` and `"proc_agent"`

Reviewed By: shayne-fletcher

Differential Revision: D108306613


