### PR TITLE
Share Python actor queue dispatch loop

### DIFF
--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -22,7 +22,6 @@ async-trait = "0.1.86"
 bincode = { version = "2", features = ["serde"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 erased-serde = "0.4.10"
-fastrand = "2.4.1"
 fbinit = { version = "0.2.0", git = "https://github.com/facebookexperimental/rust-shed.git", branch = "main" }
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 humantime = "2.1"

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1217,19 +1217,18 @@ impl Actor for PythonActor {
 
             monarch_with_gil(|py| {
                 let self_instance = self.ensure_py_instance(py, this);
+                let actor_mesh_mod = py.import("monarch._src.actor.actor_mesh")?;
 
                 let tl = self
                     .task_locals
                     .as_ref()
                     .unwrap_or_else(|| shared_task_locals(py));
-                let awaitable = self.actor.call_method(
-                    py,
+                let awaitable = actor_mesh_mod.call_method(
                     "_dispatch_loop",
-                    (receiver, self_instance),
+                    (self.actor.clone_ref(py), receiver, self_instance),
                     None,
                 )?;
-                let future =
-                    pyo3_async_runtimes::into_future_with_locals(tl, awaitable.into_bound(py))?;
+                let future = pyo3_async_runtimes::into_future_with_locals(tl, awaitable)?;
                 tokio::spawn(async move {
                     if let Err(e) = future.await {
                         tracing::error!("message loop error: {}", e);

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1179,6 +1179,61 @@ class ActorInitArgs:
     args: Tuple[Any, ...]
 
 
+class _QueuePanicFlag:
+    """Panic flag for queue dispatch mode.
+
+    Unlike the DummyPanicFlag, this one stores the exception so it can
+    be re-raised after handle() returns, ensuring proper cleanup.
+    """
+
+    def __init__(self) -> None:
+        self.panic_exception: BaseException | None = None
+
+    def signal_panic(self, ex: BaseException) -> None:
+        self.panic_exception = ex
+
+
+async def _dispatch_loop(
+    actor: Any,
+    receiver: "Receiver[QueuedMessage]",
+    self_instance: "Instance",
+) -> None:
+    """
+    Message loop for queue-dispatch mode. Called from Rust Actor::init.
+
+    Args:
+        actor: The Python actor object that implements ``handle``.
+        receiver: Channel receiver for queued messages.
+        self_instance: The actor's own Instance, used to kill self on
+            an unhandled exception.
+    """
+    while True:
+        msg = await receiver.recv()
+        try:
+            await _handle_queued_message(actor, msg)
+        except BaseException as e:
+            reason = "".join(TracebackException.from_exception(e).format())
+            self_instance.kill(reason)
+            raise
+
+
+async def _handle_queued_message(actor: Any, msg: "QueuedMessage") -> None:
+    """Handle a single queued message."""
+
+    panic_flag = _QueuePanicFlag()
+    await actor.handle(
+        msg.context,
+        msg.method,
+        msg.bytes,
+        panic_flag,  # pyre-ignore[6]: _QueuePanicFlag implements PanicFlag protocol
+        msg.local_state,
+        msg.response_port,
+    )
+    # If a panic was signaled, re-raise it after handle() has cleaned up.
+    if panic_flag.panic_exception is not None:
+        raise panic_flag.panic_exception
+
+
 class _Actor:
     """
     This is the message handling implementation of a Python actor.
@@ -1193,19 +1248,6 @@ class _Actor:
     routes messages to it, managing argument serialization/deserialization and
     error handling.
     """
-
-    class QueuePanicFlag:
-        """Panic flag for queue dispatch mode.
-
-        Unlike the DummyPanicFlag, this one stores the exception so it can
-        be re-raised after handle() returns, ensuring proper cleanup.
-        """
-
-        def __init__(self) -> None:
-            self.panic_exception: BaseException | None = None
-
-        def signal_panic(self, ex: BaseException) -> None:
-            self.panic_exception = ex
 
     def __init__(self) -> None:
         self.instance: object | None = None
@@ -1472,44 +1514,6 @@ class _Actor:
             with fake_sync_state():
                 # pyrefly: ignore [not-callable]
                 return cleanup(exc)
-
-    async def _dispatch_loop(
-        self,
-        receiver: "Receiver[QueuedMessage]",
-        self_instance: "Instance",
-    ) -> None:
-        """
-        Message loop for queue-dispatch mode. Called from Rust Actor::init.
-
-        Args:
-            receiver: Channel receiver for queued messages
-            self_instance: The actor's own Instance, used to kill self on
-                an unhandled exception.
-        """
-        while True:
-            msg = await receiver.recv()
-            try:
-                await self._handle_queued_message(msg)
-            except BaseException as e:
-                reason = "".join(TracebackException.from_exception(e).format())
-                self_instance.kill(reason)
-                raise
-
-    async def _handle_queued_message(self, msg: "QueuedMessage") -> None:
-        """Handle a single queued message."""
-
-        panic_flag = self.QueuePanicFlag()
-        await self.handle(
-            msg.context,
-            msg.method,
-            msg.bytes,
-            panic_flag,  # pyre-ignore[6]: QueuePanicFlag implements PanicFlag protocol
-            msg.local_state,
-            msg.response_port,
-        )
-        # If a panic was signaled, re-raise it after handle() has cleaned up
-        if panic_flag.panic_exception is not None:
-            raise panic_flag.panic_exception
 
     def __repr__(self) -> str:
         return f"_Actor(instance={self.instance!r})"


### PR DESCRIPTION
Summary:
Move queue-dispatch message handling into module-level helpers that take any Python actor object implementing `handle(...)`. This keeps the existing `_Actor` path behavior-preserving: Rust now calls the same module-level loop and passes the `_Actor` instance explicitly instead of invoking a bound `_Actor._dispatch_loop` method.

The purpose of the extraction is forward-looking. It lets lower-level non-`_Actor` Python actor objects reuse queue dispatch without each defining their own loop, as long as they implement `handle(...)`.

Remove the unused `fastrand` dependency from `monarch_hyperactor` while touching the crate metadata.

Reviewed By: shayne-fletcher

Differential Revision: D108322270


