### PR TITLE
Register stop_all_proc_meshes as a pytest_asyncio fixture

### DIFF
--- a/python/tests/proc_mesh_test_utils.py
+++ b/python/tests/proc_mesh_test_utils.py
@@ -13,12 +13,12 @@ auto-discovers the fixture in the importing module and runs it around every
 test in that module.
 """
 
-import pytest
+import pytest_asyncio
 from monarch.actor import context, ProcMesh
 from monarch.config import configured
 
 
-@pytest.fixture(autouse=True)
+@pytest_asyncio.fixture(autouse=True)
 async def stop_all_proc_meshes():
     """Tear down ProcMeshes that the test left attached to the root client.
 


### PR DESCRIPTION
Summary:
The shared autouse `stop_all_proc_meshes` fixture is async but declared with a plain `pytest.fixture`. Newer `pytest-asyncio` (1.x, resolved by the OSS/uv build) no longer auto-claims such a fixture, so the RDMA Python tests raise `PytestRemovedIn9Warning` ("async fixture ... no plugin or hook that handled it"), which is escalated to an error.

Decorate it with `pytest_asyncio.fixture` so it is handled explicitly under every asyncio mode and version, and update the `proc_mesh_test_utils` Buck dep to `pytest-asyncio` accordingly.

Reviewed By: dulinriley

Differential Revision: D108370239


