### PR TITLE
Drop eager cudaFree(0); handle cuda/hip sticky error discrepancy (#4226)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -324,6 +324,10 @@ impl RemoteSpawn for CudaRdmaActor {
         // For this example, we'll use a regular Rust allocation as a placeholder
         // The actual CUDA allocation would be handled by the monarch_rdma library
         unsafe {
+            // rdmaxcel only adopts an already-loaded driver, so load it first.
+            if rdmaxcel_sys::ensure_cuda_driver_loaded() != 0 {
+                anyhow::bail!("failed to load the CUDA driver");
+            }
             cu_check!(rdmaxcel_sys::rdmaxcel_cuInit(0));
             let mut dptr: rdmaxcel_sys::CUdeviceptr = std::mem::zeroed();
             let mut handle: rdmaxcel_sys::CUmemGenericAllocationHandle = std::mem::zeroed();

--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -256,6 +256,12 @@ impl CudaAllocator {
     pub fn get() -> &'static CudaAllocator {
         CUDA_ALLOCATOR.get_or_init(|| {
             unsafe {
+                // rdmaxcel only adopts an already-loaded driver, so load it first.
+                assert_eq!(
+                    rdmaxcel_sys::ensure_cuda_driver_loaded(),
+                    0,
+                    "failed to load the CUDA driver"
+                );
                 cu_check!(rdmaxcel_sys::rdmaxcel_cuInit(0));
             }
             CudaAllocator {
@@ -411,12 +417,29 @@ impl CudaAllocator {
     }
 }
 
-/// Number of CUDA devices visible to the driver, or 0 on failure.
-/// Delegates to the canonical
-/// [`crate::backend::ibverbs::device_selection::cuda_device_count`].
+/// Number of CUDA devices the driver can use, or 0 on failure. Initializes
+/// CUDA (loading the driver if needed) and queries the driver directly, so it
+/// honors `CUDA_VISIBLE_DEVICES` — unlike
+/// [`crate::backend::ibverbs::device_selection::cuda_device_count`], which
+/// counts the kernel-visible GPUs without initializing CUDA.
 #[cfg(test)]
 pub(crate) fn cuda_device_count() -> i32 {
-    crate::backend::ibverbs::device_selection::cuda_device_count() as i32
+    // SAFETY: FFI to the CUDA driver. rdmaxcel only adopts an already-loaded
+    // driver, so load it first; `cuInit` must precede any other driver call.
+    // A non-success status is treated as "no devices".
+    unsafe {
+        if rdmaxcel_sys::ensure_cuda_driver_loaded() != 0 {
+            return 0;
+        }
+        if rdmaxcel_sys::rdmaxcel_cuInit(0) != rdmaxcel_sys::CUDA_SUCCESS {
+            return 0;
+        }
+        let mut count: i32 = 0;
+        if rdmaxcel_sys::rdmaxcel_cuDeviceGetCount(&mut count) != rdmaxcel_sys::CUDA_SUCCESS {
+            return 0;
+        }
+        count.max(0)
+    }
 }
 
 /// Segment scanner callback compatible with `rdmaxcel_segment_scanner_fn`.

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -141,22 +141,17 @@ fn cap_by_port_speed(path: PciPath, nic: &IbvDeviceInfo) -> PciPath {
     }
 }
 
-/// Number of CUDA devices visible to this process (0 if CUDA is
-/// unavailable or can't be initialized).
-pub(crate) fn cuda_device_count() -> usize {
-    // SAFETY: FFI to the CUDA driver. `cuInit` must precede any other
-    // driver call, and each call writes only through its out-pointer; a
-    // non-success status is treated as "no devices".
-    unsafe {
-        if rdmaxcel_sys::rdmaxcel_cuInit(0) != rdmaxcel_sys::CUDA_SUCCESS {
-            return 0;
-        }
-        let mut count: i32 = 0;
-        if rdmaxcel_sys::rdmaxcel_cuDeviceGetCount(&mut count) != rdmaxcel_sys::CUDA_SUCCESS {
-            return 0;
-        }
-        count.max(0) as usize
-    }
+/// Number of NVIDIA GPUs visible to the kernel driver, counted from the
+/// per-GPU directories under `/proc/driver/nvidia/gpus`. This reads kernel
+/// driver state, so unlike `cuDeviceGetCount` it needs no CUDA
+/// initialization; it returns 0 when the NVIDIA driver is absent (no GPU, or
+/// a non-NVIDIA platform).
+///
+/// TODO(slurye): Generalize this (and `get_cuda_pci_address`) to support AMD.
+pub(crate) fn cuda_device_count() -> i32 {
+    std::fs::read_dir("/proc/driver/nvidia/gpus")
+        .map(|entries| entries.flatten().count() as i32)
+        .unwrap_or(0)
 }
 
 /// Resolves an [`IbvDeviceTarget`] to a single NIC of backend `I`: the

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -95,6 +95,10 @@ impl RemoteSpawn for CudaActor {
 
     async fn new(device_id: i32, _environment: Flattrs) -> Result<Self, anyhow::Error> {
         unsafe {
+            // rdmaxcel only adopts an already-loaded driver, so load it first.
+            if rdmaxcel_sys::ensure_cuda_driver_loaded() != 0 {
+                anyhow::bail!("failed to load the CUDA driver");
+            }
             cu_check!(rdmaxcel_sys::rdmaxcel_cuInit(0));
             let mut device: rdmaxcel_sys::CUdevice = std::mem::zeroed();
             cu_check!(rdmaxcel_sys::rdmaxcel_cuDeviceGet(&mut device, device_id));

--- a/monarch_rdma/src/test_utils.rs
+++ b/monarch_rdma/src/test_utils.rs
@@ -45,6 +45,10 @@ pub fn is_cuda_available() -> bool {
 /// Internal function that performs the actual CUDA availability check
 fn check_cuda_available() -> bool {
     unsafe {
+        // rdmaxcel only adopts an already-loaded driver, so load it first.
+        if rdmaxcel_sys::ensure_cuda_driver_loaded() != 0 {
+            return false;
+        }
         // Try to initialize CUDA
         let result = rdmaxcel_sys::rdmaxcel_cuInit(0);
 

--- a/rdmaxcel-sys/build.rs
+++ b/rdmaxcel-sys/build.rs
@@ -147,6 +147,7 @@ fn main() {
         .allowlist_function("rdma_get_all_registered_segment_info")
         .allowlist_function("register_segments")
         .allowlist_function("deregister_segments")
+        .allowlist_function("ensure_cuda_driver_loaded")
         .allowlist_function("rdmaxcel_cu.*")
         .allowlist_function("get_cuda_pci_address_from_ptr")
         .allowlist_function("rdmaxcel_print_device_info")

--- a/rdmaxcel-sys/src/driver_api.cpp
+++ b/rdmaxcel-sys/src/driver_api.cpp
@@ -7,10 +7,11 @@
  */
 
 #include "driver_api.h"
-#include <cuda_runtime.h>
 #include <dlfcn.h>
+#include <atomic>
+#include <exception>
 #include <iostream>
-#include <stdexcept>
+#include <utility>
 
 // Two-level stringify macro to ensure macro arguments are expanded before
 // stringification
@@ -39,10 +40,12 @@
 #define SYM_CTX_CREATE hipCtxCreate
 #define SYM_DEVICE_PRIMARY_CTX_RETAIN hipDevicePrimaryCtxRetain
 #define SYM_DEVICE_PRIMARY_CTX_RELEASE hipDevicePrimaryCtxRelease
+#define SYM_DEVICE_PRIMARY_CTX_GET_STATE hipDevicePrimaryCtxGetState
 #define SYM_CTX_GET_CURRENT hipCtxGetCurrent
 #define SYM_CTX_SET_CURRENT hipCtxSetCurrent
 #define SYM_CTX_SYNCHRONIZE hipCtxSynchronize
 #define SYM_GET_ERROR_STRING hipDrvGetErrorString
+#define RDMAXCEL_DRIVER_LIB "libamdhip64.so"
 #else
 #define SYM_MEM_GET_HANDLE_FOR_ADDRESS_RANGE cuMemGetHandleForAddressRange
 #define SYM_MEM_GET_ALLOCATION_GRANULARITY cuMemGetAllocationGranularity
@@ -71,10 +74,12 @@ cuCtxCreate_v2(CUcontext* pctx, unsigned int flags, CUdevice dev);
 #define SYM_CTX_CREATE cuCtxCreate_v2
 #define SYM_DEVICE_PRIMARY_CTX_RETAIN cuDevicePrimaryCtxRetain
 #define SYM_DEVICE_PRIMARY_CTX_RELEASE cuDevicePrimaryCtxRelease
+#define SYM_DEVICE_PRIMARY_CTX_GET_STATE cuDevicePrimaryCtxGetState
 #define SYM_CTX_GET_CURRENT cuCtxGetCurrent
 #define SYM_CTX_SET_CURRENT cuCtxSetCurrent
 #define SYM_CTX_SYNCHRONIZE cuCtxSynchronize
 #define SYM_GET_ERROR_STRING cuGetErrorString
+#define RDMAXCEL_DRIVER_LIB "libcuda.so.1"
 #endif
 
 // List of GPU driver functions needed by rdmaxcel
@@ -102,95 +107,252 @@ cuCtxCreate_v2(CUcontext* pctx, unsigned int flags, CUdevice dev);
   _(ctxCreate, SYM_CTX_CREATE)                                         \
   _(devicePrimaryCtxRetain, SYM_DEVICE_PRIMARY_CTX_RETAIN)             \
   _(devicePrimaryCtxRelease, SYM_DEVICE_PRIMARY_CTX_RELEASE)           \
+  _(devicePrimaryCtxGetState, SYM_DEVICE_PRIMARY_CTX_GET_STATE)        \
   _(ctxGetCurrent, SYM_CTX_GET_CURRENT)                                \
   _(ctxSetCurrent, SYM_CTX_SET_CURRENT)                                \
   _(ctxSynchronize, SYM_CTX_SYNCHRONIZE)                               \
   _(getErrorString, SYM_GET_ERROR_STRING)
 
 namespace rdmaxcel {
+namespace {
+
+// On ROCm, a failed HIP driver call leaves a sticky error that subsequent
+// calls return, unlike the CUDA driver. Clearing it with hipGetLastError
+// after each failure makes ROCm match CUDA's behavior. On CUDA this is a
+// no-op pass-through.
+CUresult clear_sticky_error(CUresult rc) {
+#ifdef USE_ROCM
+  if (rc != CUDA_SUCCESS) {
+    hipGetLastError();
+  }
+#endif
+  return rc;
+}
+
+// Wraps a driver function pointer so every call routes its result through
+// clear_sticky_error. Call sites invoke it exactly as they would the raw
+// pointer.
+template <typename Fn>
+struct Wrapped {
+  Fn fn;
+
+  template <typename... Args>
+  CUresult operator()(Args&&... args) const {
+    return clear_sticky_error(fn(std::forward<Args>(args)...));
+  }
+};
 
 struct DriverAPI {
-#define CREATE_MEMBER(name, sym) decltype(&sym) name##_;
+#define CREATE_MEMBER(name, sym) Wrapped<decltype(&sym)> name##_;
   RDMAXCEL_CUDA_DRIVER_API(CREATE_MEMBER)
 #undef CREATE_MEMBER
   static DriverAPI* get();
 };
 
-namespace {
+// dlerror() returns nullptr when there is no pending error -- notably after a
+// RTLD_NOLOAD dlopen that simply finds the library not loaded. Passing that
+// nullptr to std::string concatenation would crash, so always route dlerror()
+// through this fallback when building messages.
+const char* dlerror_or(const char* fallback) {
+  const char* err = dlerror();
+  return err != nullptr ? err : fallback;
+}
 
+// Signals a driver-load failure that has already been logged at the point it
+// occurred. create_driver_api_or_null catches it and returns nullptr without
+// logging again; any other exception is unexpected and logged there.
+struct DriverLoadError : std::exception {};
+
+// dlcloses a handle on scope exit unless dismissed. Used to drop the handle on
+// the error paths while retaining it on success (held for process lifetime).
+struct HandleGuard {
+  void* handle;
+
+  explicit HandleGuard(void* h) : handle(h) {}
+  HandleGuard(const HandleGuard&) = delete;
+  HandleGuard& operator=(const HandleGuard&) = delete;
+  HandleGuard(HandleGuard&&) = delete;
+  HandleGuard& operator=(HandleGuard&&) = delete;
+  ~HandleGuard() {
+    if (handle != nullptr) {
+      dlclose(handle);
+    }
+  }
+
+  void dismiss() {
+    handle = nullptr;
+  }
+};
+
+// Build the driver-API table. The driver library is adopted only if it is
+// already loaded into the process (RTLD_NOLOAD); rdmaxcel never loads CUDA or
+// HIP itself. Each failure logs once at the failure site -- throttled per site,
+// so distinct causes are each reported -- and throws DriverLoadError.
 DriverAPI create_driver_api() {
-#ifdef USE_ROCM
-  // Try to open libamdhip64.so - RTLD_NOLOAD means only succeed if already
-  // loaded
-  void* handle = dlopen("libamdhip64.so", RTLD_LAZY | RTLD_NOLOAD);
+  void* handle = dlopen(RDMAXCEL_DRIVER_LIB, RTLD_LAZY | RTLD_NOLOAD);
   if (!handle) {
-    std::cerr
-        << "[RdmaXcel] Warning: libamdhip64.so not loaded, trying to load it now"
-        << std::endl;
-    handle = dlopen("libamdhip64.so", RTLD_LAZY);
+    static std::atomic<bool> logged{false};
+    if (!logged.exchange(true, std::memory_order_relaxed)) {
+      std::cerr << "[RdmaXcel] Can't open " RDMAXCEL_DRIVER_LIB ": "
+                << dlerror_or("library not loaded") << std::endl;
+    }
+    throw DriverLoadError{};
   }
 
-  if (!handle) {
-    throw std::runtime_error(
-        std::string("[RdmaXcel] Can't open libamdhip64.so: ") + dlerror());
-  }
-#else
-  // Try to open libcuda.so.1 - RTLD_NOLOAD means only succeed if already loaded
-  void* handle = dlopen("libcuda.so.1", RTLD_LAZY | RTLD_NOLOAD);
-  if (!handle) {
-    std::cerr
-        << "[RdmaXcel] Warning: libcuda.so.1 not loaded, trying to load it now"
-        << std::endl;
-    handle = dlopen("libcuda.so.1", RTLD_LAZY);
-  }
-
-  if (!handle) {
-    throw std::runtime_error(
-        std::string("[RdmaXcel] Can't open libcuda.so.1: ") + dlerror());
-  }
-#endif
+  // Close the handle if we bail out before the table is built. On success we
+  // dismiss the guard and intentionally retain this one reference for the
+  // lifetime of the process: the driver must stay resident for the cached
+  // function pointers to remain valid.
+  HandleGuard guard{handle};
 
   DriverAPI r{};
 
-#define LOOKUP_CUDA_ENTRY(name, sym)                                           \
-  r.name##_ = reinterpret_cast<decltype(&sym)>(dlsym(handle, STRINGIFY(sym))); \
-  if (!r.name##_) {                                                            \
-    throw std::runtime_error(                                                  \
-        std::string("[RdmaXcel] Can't find ") + STRINGIFY(sym) + ": " +        \
-        dlerror());                                                            \
+#define LOOKUP_CUDA_ENTRY(name, sym)                                   \
+  r.name##_.fn =                                                       \
+      reinterpret_cast<decltype(&sym)>(dlsym(handle, STRINGIFY(sym))); \
+  if (!r.name##_.fn) {                                                 \
+    static std::atomic<bool> logged{false};                            \
+    if (!logged.exchange(true, std::memory_order_relaxed)) {           \
+      std::cerr << "[RdmaXcel] Can't find " STRINGIFY(sym) ": "        \
+                << dlerror_or("symbol not found") << std::endl;        \
+    }                                                                  \
+    throw DriverLoadError{};                                           \
   }
 
   RDMAXCEL_CUDA_DRIVER_API(LOOKUP_CUDA_ENTRY)
 #undef LOOKUP_CUDA_ENTRY
 
+  guard.dismiss();
   return r;
 }
 
-// Initialize the driver-API table once. create_driver_api() can throw on
-// dlopen/dlsym failure; catch it here so the exception never crosses the
-// extern "C" boundary into Rust (which would be undefined behavior). On
-// failure, log once and return nullptr; callers translate that into a
-// CUresult error.
+// Ensure a CUDA context is current on the calling thread before a
+// context-sensitive driver call. If one is already current, do nothing.
+// Otherwise adopt the primary context of the first device that already has
+// one active -- never creating a context, so we don't initialize one before
+// the owning framework has. The adopted primary context is retained and
+// intentionally never released, mirroring the CUDA runtime's primary-context
+// lifecycle (held for the lifetime of the process). On success, sets
+// `*out_api` to the driver table and returns CUDA_SUCCESS once a context is
+// current; otherwise returns an error to propagate to the caller.
+CUresult ensure_active_context(DriverAPI** out_api) {
+  DriverAPI* api = DriverAPI::get();
+  if (api == nullptr) {
+    return CUDA_ERROR_NOT_INITIALIZED;
+  }
+  *out_api = api;
+
+  CUcontext ctx = nullptr;
+  CUresult rc = api->ctxGetCurrent_(&ctx);
+  if (rc != CUDA_SUCCESS) {
+    std::cerr << "[RdmaXcel] Failed to get current CUDA context." << std::endl;
+    return rc;
+  }
+  if (ctx != nullptr) {
+    return CUDA_SUCCESS;
+  }
+
+  int count = 0;
+  rc = api->deviceGetCount_(&count);
+  if (rc != CUDA_SUCCESS) {
+    std::cerr << "[RdmaXcel] Failed to get device count." << std::endl;
+    return rc;
+  }
+
+  CUresult last_error = CUDA_ERROR_INVALID_CONTEXT;
+  for (int ordinal = 0; ordinal < count; ++ordinal) {
+    CUdevice device = 0;
+    if (api->deviceGet_(&device, ordinal) != CUDA_SUCCESS) {
+      std::cerr << "[RdmaXcel] Failed to get device " << ordinal << std::endl;
+      continue;
+    }
+    // `flags` is required by the API but unused here; only `active` matters.
+    unsigned int flags = 0;
+    int active = 0;
+    if (api->devicePrimaryCtxGetState_(device, &flags, &active) !=
+        CUDA_SUCCESS) {
+      std::cerr << "[RdmaXcel] Failed to get device " << ordinal
+                << " primary context state" << std::endl;
+      continue;
+    }
+    if (!active) {
+      continue;
+    }
+
+    CUcontext primary = nullptr;
+    rc = api->devicePrimaryCtxRetain_(&primary, device);
+    if (rc != CUDA_SUCCESS) {
+      std::cerr << "[RdmaXcel] Failed to retain primary context for device "
+                << ordinal << std::endl;
+      last_error = rc;
+      continue;
+    }
+    rc = api->ctxSetCurrent_(primary);
+    if (rc != CUDA_SUCCESS) {
+      std::cerr << "[RdmaXcel] Failed to set primary context for device "
+                << ordinal << std::endl;
+      CUresult rc_release = api->devicePrimaryCtxRelease_(device);
+      if (rc_release != CUDA_SUCCESS) {
+        std::cerr << "[RdmaXcel] Failed to release primary context for device "
+                  << ordinal << std::endl;
+      }
+      last_error = rc;
+      continue;
+    }
+    return CUDA_SUCCESS;
+  }
+
+  std::cerr
+      << "[RdmaXcel] No CUDA context is active on the calling thread and no "
+         "device primary context could be adopted. Initialize CUDA and ensure "
+         "either that a CUDA context is active on the calling thread or that a "
+         "device primary context exists."
+      << std::endl;
+  return last_error;
+}
+
+// Build the driver-API table, caching it on first success. create_driver_api()
+// throws on dlopen/dlsym failure; catch it here so no exception crosses the
+// extern "C" boundary into Rust (which would be undefined behavior), returning
+// nullptr instead for callers to translate into a CUresult error. A throwing
+// static initializer leaves the static uninitialized and is retried on the
+// next call, so a failed no-load attempt can still succeed later once the
+// driver library is loaded externally. Expected failures (DriverLoadError) are
+// already logged at the site and swallowed silently here; any other exception
+// is unexpected and logged every time.
 DriverAPI* create_driver_api_or_null() noexcept {
   try {
     static DriverAPI instance = create_driver_api();
     return &instance;
+  } catch (const DriverLoadError&) {
+    return nullptr;
   } catch (const std::exception& e) {
     std::cerr << "[RdmaXcel] Failed to load CUDA driver API: " << e.what()
+              << std::endl;
+    return nullptr;
+  } catch (...) {
+    std::cerr << "[RdmaXcel] Failed to load CUDA driver API: unknown error"
               << std::endl;
     return nullptr;
   }
 }
 
-} // namespace
+#define ENSURE_ACTIVE_DRIVER(api)                              \
+  rdmaxcel::DriverAPI* api = nullptr;                          \
+  if (CUresult ctx_rc = rdmaxcel::ensure_active_context(&api); \
+      ctx_rc != CUDA_SUCCESS) {                                \
+    return ctx_rc;                                             \
+  }
 
 DriverAPI* DriverAPI::get() {
-  // Ensure we have a valid CUDA context for this thread
-  cudaFree(0);
-  static DriverAPI* singleton = create_driver_api_or_null();
-  return singleton;
+  // Never cache a failure: the driver library may be loaded externally (e.g.
+  // by PyTorch) between calls, so every call re-attempts adoption and can
+  // start succeeding once the library appears. A successful table is cached
+  // by the function-local static inside create_driver_api_or_null().
+  return create_driver_api_or_null();
 }
 
+} // namespace
 } // namespace rdmaxcel
 
 // C API wrapper implementations
@@ -203,10 +365,7 @@ CUresult rdmaxcel_cuMemGetHandleForAddressRange(
     size_t size,
     CUmemRangeHandleType handleType,
     unsigned long long flags) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memGetHandleForAddressRange_(
       handle, dptr, size, handleType, flags);
 }
@@ -215,10 +374,7 @@ CUresult rdmaxcel_cuMemGetAllocationGranularity(
     size_t* granularity,
     const CUmemAllocationProp* prop,
     CUmemAllocationGranularity_flags option) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memGetAllocationGranularity_(granularity, prop, option);
 }
 
@@ -227,10 +383,7 @@ CUresult rdmaxcel_cuMemCreate(
     size_t size,
     const CUmemAllocationProp* prop,
     unsigned long long flags) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memCreate_(handle, size, prop, flags);
 }
 
@@ -240,10 +393,7 @@ CUresult rdmaxcel_cuMemAddressReserve(
     size_t alignment,
     CUdeviceptr addr,
     unsigned long long flags) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memAddressReserve_(ptr, size, alignment, addr, flags);
 }
 
@@ -253,10 +403,7 @@ CUresult rdmaxcel_cuMemMap(
     size_t offset,
     CUmemGenericAllocationHandle handle,
     unsigned long long flags) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memMap_(ptr, size, offset, handle, flags);
 }
 
@@ -265,34 +412,22 @@ CUresult rdmaxcel_cuMemSetAccess(
     size_t size,
     const CUmemAccessDesc* desc,
     size_t count) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memSetAccess_(ptr, size, desc, count);
 }
 
 CUresult rdmaxcel_cuMemUnmap(CUdeviceptr ptr, size_t size) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memUnmap_(ptr, size);
 }
 
 CUresult rdmaxcel_cuMemAddressFree(CUdeviceptr ptr, size_t size) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memAddressFree_(ptr, size);
 }
 
 CUresult rdmaxcel_cuMemRelease(CUmemGenericAllocationHandle handle) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memRelease_(handle);
 }
 
@@ -300,10 +435,7 @@ CUresult rdmaxcel_cuMemcpyHtoD_v2(
     CUdeviceptr dstDevice,
     const void* srcHost,
     size_t ByteCount) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memcpyHtoD_(dstDevice, srcHost, ByteCount);
 }
 
@@ -311,19 +443,13 @@ CUresult rdmaxcel_cuMemcpyDtoH_v2(
     void* dstHost,
     CUdeviceptr srcDevice,
     size_t ByteCount) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memcpyDtoH_(dstHost, srcDevice, ByteCount);
 }
 
 CUresult
 rdmaxcel_cuMemsetD8_v2(CUdeviceptr dstDevice, unsigned char uc, size_t N) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->memsetD8_(dstDevice, uc, N);
 }
 
@@ -332,15 +458,36 @@ CUresult rdmaxcel_cuPointerGetAttribute(
     void* data,
     CUpointer_attribute attribute,
     CUdeviceptr ptr) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->pointerGetAttribute_(data, attribute, ptr);
+}
+
+// Driver library loading
+int ensure_cuda_driver_loaded(void) {
+  // Load the driver, or adopt it if already resident -- a plain dlopen does
+  // both in one step (it bumps the refcount on an existing mapping rather than
+  // reloading). The handle is cached in a function-local static and held for
+  // the lifetime of the process -- never dlclosed -- so the driver stays
+  // resident for later adoption by the wrappers; exactly one reference is
+  // taken, so nothing accumulates across calls. This is the only entry point
+  // that loads the driver; the wrappers never do. A load failure is logged
+  // once, during the static's initialization.
+  static void* handle = []() -> void* {
+    void* h = dlopen(RDMAXCEL_DRIVER_LIB, RTLD_LAZY);
+    if (h == nullptr) {
+      std::cerr << "[RdmaXcel] Failed to load " RDMAXCEL_DRIVER_LIB ": "
+                << rdmaxcel::dlerror_or("unknown error") << std::endl;
+    }
+    return h;
+  }();
+  return handle != nullptr ? 0 : -1;
 }
 
 // Device management
 CUresult rdmaxcel_cuInit(unsigned int Flags) {
+  // Adopts an already-loaded driver only; it does not load CUDA/HIP itself.
+  // Callers that need the driver loaded must dlopen it before calling this
+  // (e.g. via ensure_cuda_driver_loaded).
   rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
   if (api == nullptr) {
     return CUDA_ERROR_NOT_INITIALIZED;
@@ -418,10 +565,7 @@ CUresult rdmaxcel_cuCtxSetCurrent(CUcontext ctx) {
 }
 
 CUresult rdmaxcel_cuCtxSynchronize(void) {
-  rdmaxcel::DriverAPI* api = rdmaxcel::DriverAPI::get();
-  if (api == nullptr) {
-    return CUDA_ERROR_NOT_INITIALIZED;
-  }
+  ENSURE_ACTIVE_DRIVER(api);
   return api->ctxSynchronize_();
 }
 

--- a/rdmaxcel-sys/src/driver_api.h
+++ b/rdmaxcel-sys/src/driver_api.h
@@ -88,6 +88,17 @@ CUresult rdmaxcel_cuPointerGetAttribute(
     CUpointer_attribute attribute,
     CUdeviceptr ptr);
 
+// Driver library loading
+//
+// Ensure the GPU driver library is loaded into the process. Call this before
+// rdmaxcel_cuInit from tests/tools that must initialize the driver from
+// scratch; the wrapper functions never load the library themselves -- they
+// only adopt one the owning framework loaded. Returns 0 on success and -1
+// if the library could not be loaded. A load failure will be cached behind
+// a function-local static variable, so if this fails once, it will never
+// succeed for the lifetime of the process.
+int ensure_cuda_driver_loaded(void);
+
 // Device management
 CUresult rdmaxcel_cuInit(unsigned int Flags);
 


### PR DESCRIPTION
Summary:

`DriverAPI::get()` called `cudaFree(0)` before every driver call to lazily bind a CUDA context to the calling thread. This PR changes monarch rdma's behavior such that it will never initialize CUDA or create a CUDA context for the user if one does not already exist. Each driver call that requires an active context is now wrapped in the following behavior:

- Try to get the active cuda context.
  - On failure, return early.
  - On success:
    - If ctx is not null, proceed with the driver call.
    - If ctx is null:
      - See if a primary context exists. If so, set it on the thread and proceed with the driver call. If not, fail with `CUDA_ERROR_INVALID_CONTEXT`.

In the same spirit, rdmaxcel never loads the GPU driver library itself. `DriverAPI::get()` opens `libcuda.so.1` / `libamdhip64.so` with `RTLD_NOLOAD`, adopting the library only when its owning framework (e.g. PyTorch) has already loaded it; otherwise driver calls -- including `rdmaxcel_cuInit` -- return `CUDA_ERROR_NOT_INITIALIZED` rather than forcing the library into the process. Load failures are not cached, so a process that loads CUDA later still picks it up on a subsequent call; the "library not loaded" diagnostic is throttled to a single log. Callers that must initialize the driver from scratch (tests, tools) load it first with the dedicated `ensure_cuda_driver_loaded()` entry point.

This PR also adds logic to account for a behavioral discrepancy between cuda and hip. When a cuda driver function returns an error, subsequent driver function calls are unaffected and can continue to succeed. Contrastingly, when a hip driver function returns an error, the error is sticky:  subsequent driver function calls will continue to return the same error until it is consumed via `hipGetLastError`. In order for cuda and hip to behave the same, every driver api function call in rdmaxcel needs to explicitly call `hipGetLastError` after observing a failure before returning to the caller.

Reviewed By: zdevito

Differential Revision: D108370238


