### PR TITLE
[serde_multipart] type multipart parts by repr

### DIFF
--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -235,13 +235,45 @@ pub struct PortRef<M> {
 }
 
 #[doc(hidden)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct PortRefRepr {
     port_addr: PortAddr,
     reducer_spec: Option<ReducerSpec>,
     streaming_opts: StreamingReducerOpts,
     return_undeliverable: bool,
     unsplit: bool,
+}
+
+impl PortRefRepr {
+    /// This port's address.
+    pub fn port_addr(&self) -> &PortAddr {
+        &self.port_addr
+    }
+
+    /// The typehash of this port's reducer, if any.
+    pub fn reducer_spec(&self) -> &Option<ReducerSpec> {
+        &self.reducer_spec
+    }
+
+    /// This port's streaming reducer options.
+    pub fn streaming_opts(&self) -> &StreamingReducerOpts {
+        &self.streaming_opts
+    }
+
+    /// Get whether undeliverable messages should be returned to the sender.
+    pub fn get_return_undeliverable(&self) -> bool {
+        self.return_undeliverable
+    }
+
+    /// Whether the port must not be split.
+    pub fn unsplit(&self) -> bool {
+        self.unsplit
+    }
+
+    /// Update this port's address.
+    pub fn update_port_addr(&mut self, port_addr: PortAddr) {
+        self.port_addr = port_addr;
+    }
 }
 
 impl<M> TryFrom<&PortRef<M>> for PortRefRepr {
@@ -533,12 +565,39 @@ pub struct OncePortRef<M> {
 }
 
 #[doc(hidden)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct OncePortRefRepr {
     port_addr: PortAddr,
     reducer_spec: Option<ReducerSpec>,
     return_undeliverable: bool,
     unsplit: bool,
+}
+
+impl OncePortRefRepr {
+    /// This port's address.
+    pub fn port_addr(&self) -> &PortAddr {
+        &self.port_addr
+    }
+
+    /// The typehash of this port's reducer, if any.
+    pub fn reducer_spec(&self) -> &Option<ReducerSpec> {
+        &self.reducer_spec
+    }
+
+    /// Get whether undeliverable messages should be returned to the sender.
+    pub fn get_return_undeliverable(&self) -> bool {
+        self.return_undeliverable
+    }
+
+    /// Whether the port must not be split.
+    pub fn unsplit(&self) -> bool {
+        self.unsplit
+    }
+
+    /// Update this port's address.
+    pub fn update_port_addr(&mut self, port_addr: PortAddr) {
+        self.port_addr = port_addr;
+    }
 }
 
 impl<M> TryFrom<&OncePortRef<M>> for OncePortRefRepr {
@@ -818,14 +877,9 @@ mod tests {
 
         let message = serde_multipart::serialize_bincode(&value).unwrap();
         assert_eq!(message.num_parts(), 1);
-        assert_eq!(
-            message.parts()[0].typehash(),
-            Some(PortRef::<String>::typehash())
-        );
+        assert_eq!(message.parts()[0].typehash(), Some(PortRefRepr::typehash()));
 
-        let repr = message.parts()[0]
-            .deserialized_as::<PortRef<String>, PortRefRepr>()
-            .unwrap();
+        let repr = message.parts()[0].deserialized::<PortRefRepr>().unwrap();
         assert_eq!(repr.port_addr, value.port.port_addr().clone());
         assert!(!repr.return_undeliverable);
         assert!(repr.unsplit);
@@ -846,11 +900,11 @@ mod tests {
         assert_eq!(message.num_parts(), 1);
         assert_eq!(
             message.parts()[0].typehash(),
-            Some(OncePortRef::<String>::typehash())
+            Some(OncePortRefRepr::typehash())
         );
 
         let repr = message.parts()[0]
-            .deserialized_as::<OncePortRef<String>, OncePortRefRepr>()
+            .deserialized::<OncePortRefRepr>()
             .unwrap();
         assert_eq!(repr.port_addr, value.port.port_addr().clone());
         assert!(!repr.return_undeliverable);

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -50,6 +50,7 @@ schemars = { version = "1.2.1", features = ["indexmap2"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 strum = { version = "0.28.0", features = ["derive"] }
 tempfile = "3.27.0"
 thiserror = "2.0.18"

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -157,11 +157,38 @@ impl From<crate::host::LocalProcStatus> for Status {
 }
 
 /// Data type used to communicate ranks.
-/// Implements [`Bind`] and [`Unbind`]; the comm actor replaces
-/// instances with the delivered rank.
-#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq, Default)]
+/// Serialized as a typed multipart part so comm actors can replace instances
+/// with the delivered rank while the message is in transit.
+#[derive(Clone, Debug, Named, PartialEq, Eq, Default)]
 pub struct Rank(pub Option<usize>);
 wirevalue::register_type!(Rank);
+
+/// Serialized representation for [`Rank`] multipart parts.
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+pub struct RankRepr(pub Option<usize>);
+
+impl TryFrom<&Rank> for RankRepr {
+    type Error = serde_multipart::Error;
+
+    fn try_from(rank: &Rank) -> serde_multipart::Result<Self> {
+        Ok(Self(rank.0))
+    }
+}
+
+impl TryFrom<RankRepr> for Rank {
+    type Error = serde_multipart::Error;
+
+    fn try_from(repr: RankRepr) -> serde_multipart::Result<Self> {
+        Ok(Self(repr.0))
+    }
+}
+
+serde_multipart::part_codec! {
+    impl Rank
+    {
+        type Repr = RankRepr;
+    }
+}
 
 impl Rank {
     /// Create a new rank with the provided value.

--- a/serde_multipart/src/codec.rs
+++ b/serde_multipart/src/codec.rs
@@ -16,13 +16,14 @@ use crate::part::BincodeDeserializer;
 use crate::part::BincodeSerializer;
 
 /// Converts a framework type to and from a typed multipart part.
-pub trait PartCodec: Sized + Named
+pub trait PartCodec: Sized
 where
+    Self::Repr: Serialize + DeserializeOwned + Named,
     for<'a> Self::Repr: std::convert::TryFrom<&'a Self, Error = crate::Error>,
     Self: std::convert::TryFrom<Self::Repr, Error = crate::Error>,
 {
     /// The bincode representation stored in typed parts.
-    type Repr: Serialize + DeserializeOwned;
+    type Repr;
 
     /// Convert this value to its typed part representation.
     fn to_repr(&self) -> crate::Result<Self::Repr> {
@@ -36,12 +37,12 @@ where
 
     /// Convert this value to a typed part.
     fn to_part(&self) -> crate::Result<Part> {
-        Part::serialize_as::<Self, _>(&self.to_repr()?)
+        Part::serialize(&self.to_repr()?)
     }
 
     /// Rebuild this value from a typed part.
     fn from_part(part: Part) -> crate::Result<Self> {
-        let repr = part.deserialized_as::<Self, Self::Repr>()?;
+        let repr = part.deserialized::<Self::Repr>()?;
         Self::from_repr(repr)
     }
 }
@@ -160,7 +161,7 @@ macro_rules! part_codec {
     ) => {
         impl $($impl_generics)* $crate::PartCodec for $ty
         where
-            $ty: typeuri::Named,
+            $repr: serde::Serialize + serde::de::DeserializeOwned + typeuri::Named,
             for<'a> $repr: std::convert::TryFrom<&'a $ty, Error = $crate::Error>,
             $ty: std::convert::TryFrom<$repr, Error = $crate::Error>,
         {

--- a/serde_multipart/src/lib.rs
+++ b/serde_multipart/src/lib.rs
@@ -428,7 +428,7 @@ mod tests {
         value: u64,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
     struct TypedPayloadRepr {
         label: String,
         value: u64,
@@ -440,7 +440,7 @@ mod tests {
         value: u64,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
     struct CodecPayloadRepr {
         label: String,
         value: u64,
@@ -496,7 +496,7 @@ mod tests {
         value: u64,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
     struct MacroCodecPayloadRepr {
         label: String,
         value: u64,
@@ -709,11 +709,11 @@ mod tests {
         assert_eq!(message.num_parts(), 1);
         assert_eq!(
             message.parts()[0].typehash(),
-            Some(CodecPayload::typehash())
+            Some(CodecPayloadRepr::typehash())
         );
         assert_eq!(
             message.parts()[0]
-                .deserialized_as::<CodecPayload, CodecPayloadRepr>()
+                .deserialized::<CodecPayloadRepr>()
                 .unwrap(),
             repr
         );
@@ -757,14 +757,14 @@ mod tests {
         assert_eq!(message.num_parts(), 4);
         assert_eq!(
             message.parts()[0].typehash(),
-            Some(CodecPayload::typehash())
+            Some(CodecPayloadRepr::typehash())
         );
         assert_eq!(message.parts()[1].typehash(), None);
         assert_eq!(message.parts()[1].to_bytes(), value.raw.to_bytes());
         assert!(
             message.parts()[2..]
                 .iter()
-                .all(|part| part.typehash() == Some(CodecPayload::typehash()))
+                .all(|part| part.typehash() == Some(CodecPayloadRepr::typehash()))
         );
 
         let deserialized: Envelope = deserialize_bincode(message).unwrap();
@@ -814,7 +814,7 @@ mod tests {
         assert_eq!(message.num_parts(), 1);
         assert_eq!(
             message.parts()[0].typehash(),
-            Some(MacroCodecPayload::typehash())
+            Some(MacroCodecPayloadRepr::typehash())
         );
 
         let deserialized: MacroCodecPayload = deserialize_bincode(message).unwrap();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4234
* #4233
* #4232
* #4231
* #4230
* #4229
* #4228
* __->__ #4227

Store `PartCodec` parts under the representation typehash instead of the framework typehash. This makes `PartCodec::Repr` the typed multipart identity, updates `PortRef`, `OncePortRef`, and `Rank` reprs accordingly, and keeps the old binding path intact for now.

Differential Revision: [D108442501](https://our.internmc.facebook.com/intern/diff/D108442501/)