### PR TITLE
[hyperactor] rename `ErasedUnbound` to `MultipartMessage`

### DIFF
--- a/docs/source/books/hyperactor-book/src/actors/handler.md
+++ b/docs/source/books/hyperactor-book/src/actors/handler.md
@@ -43,7 +43,7 @@ impl<A: Actor> Handler<Signal> for A {
 ### Multipart routed messages
 
 ```rust
-let mut message = ErasedUnbound::try_from_message(value)?;
+let mut message = MultipartMessage::try_from_message(value)?;
 message.visit_mut::<PortRefRepr>(|port| {
     port.update_port_addr(rewritten_addr);
     Ok(())

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -14,9 +14,9 @@
 //! Briefly, it works by following these steps:
 //!
 //! 1. On the sender side, the typed message is serialized with multipart
-//!    encoding and bundled in an [ErasedUnbound] object.
-//! 2. On intermediate nodes, the [ErasedUnbound] object is relayed and selected
-//!    typed parts are mutated in place.
+//!    encoding and bundled in a [`MultipartMessage`] object.
+//! 2. On intermediate nodes, the [`MultipartMessage`] object is relayed and
+//!    selected typed parts are mutated in place.
 //! 3. On the receiver side, the serialized message is delivered to the ordinary
 //!    typed handler port and deserialized as the final message type.
 //!
@@ -40,12 +40,12 @@ impl<T: RemoteMessage> Castable for T {}
 
 /// Multipart-serialized message with its message type erased.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, typeuri::Named)]
-pub struct ErasedUnbound {
+pub struct MultipartMessage {
     message: wirevalue::Any,
 }
-wirevalue::register_type!(ErasedUnbound);
+wirevalue::register_type!(MultipartMessage);
 
-impl ErasedUnbound {
+impl MultipartMessage {
     /// Create an object directly from Any.
     pub fn new(message: wirevalue::Any) -> Self {
         Self { message }
@@ -134,23 +134,21 @@ mod tests {
             wirevalue::Any::serialize_with_encoding(wirevalue::Encoding::Multipart, &my_message)
                 .unwrap();
 
-        // convert to ErasedUnbound
-        let mut erased = ErasedUnbound::try_from_message(my_message.clone()).unwrap();
+        let mut message = MultipartMessage::try_from_message(my_message.clone()).unwrap();
         assert_eq!(
-            erased,
-            ErasedUnbound {
+            message,
+            MultipartMessage {
                 message: serialized_multipart_my_message,
             }
         );
 
-        // Modify the port in the erased
         let new_port_id0 = test_port_id("world_0", "comm", 680);
         assert_ne!(&new_port_id0, original_port0.port_addr());
         let new_port_id1 = test_port_id("world_1", "comm", 257);
         assert_ne!(&new_port_id1, original_port1.port_addr());
 
         let mut new_ports = vec![&new_port_id0, &new_port_id1].into_iter();
-        erased
+        message
             .visit_mut::<PortRefRepr>(|b| {
                 let port = new_ports.next().unwrap();
                 b.update_port_addr(port.clone());
@@ -167,8 +165,7 @@ mod tests {
             }),
             StreamingReducerOpts::default(),
         );
-        // convert back to MyMessage
-        let new_my_message = erased.downcast::<MyMessage>().unwrap();
+        let new_my_message = message.downcast::<MyMessage>().unwrap();
         assert_eq!(
             new_my_message,
             MyMessage {

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -34,7 +34,7 @@ use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableMailboxSender;
 use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::monitored_return_handle;
-use hyperactor::message::ErasedUnbound;
+use hyperactor::message::MultipartMessage;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
 use hyperactor::port::Port;
@@ -274,7 +274,7 @@ impl CastDomainRef {
         headers: Flattrs,
         message: M,
     ) -> anyhow::Result<()> {
-        let data = ErasedUnbound::try_from_message(message)?;
+        let data = MultipartMessage::try_from_message(message)?;
         let sender = cx.mailbox().actor_addr().clone();
         let dest_port = M::port();
         let (session_id, seqs) = self.seqs_for_cast(cx, dest_port)?;
@@ -627,7 +627,7 @@ impl Handler<CreateCastDomain> for CastActor {
 /// Ported from `hyperactor_mesh::comm::split_ports`.
 fn split_ports(
     cx: &Context<'_, CastActor>,
-    data: &mut ErasedUnbound,
+    data: &mut MultipartMessage,
     num_next_hops: usize,
     deliver_here: bool,
 ) -> Result<()> {
@@ -745,7 +745,7 @@ struct CastMessage {
     /// The target port index on each destination actor.
     dest_port: u64,
     /// The serialized message data.
-    data: ErasedUnbound,
+    data: MultipartMessage,
 }
 
 wirevalue::register_type!(CastMessage);
@@ -1733,7 +1733,7 @@ mod tests {
                 lineage: Vec::new(),
                 headers: Flattrs::new(),
                 dest_port: TestDelivery::port(),
-                data: ErasedUnbound::try_from_message(TestDelivery {
+                data: MultipartMessage::try_from_message(TestDelivery {
                     payload: "hello".to_string(),
                 })
                 .unwrap(),

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -35,7 +35,7 @@ use hyperactor::actor::Referable;
 use hyperactor::context;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Castable;
-use hyperactor::message::ErasedUnbound;
+use hyperactor::message::MultipartMessage;
 use hyperactor::port::Port;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
@@ -661,7 +661,7 @@ impl<A: Referable> ActorMeshRef<A> {
 
         // Make sure that we rewrite ranks, as these may be used for
         // bootstrapping comm actors.
-        let mut data = ErasedUnbound::try_from_message(message)
+        let mut data = MultipartMessage::try_from_message(message)
             .map_err(|e| Error::CastingError(self.id.clone(), e))?;
         data.visit_mut::<resource::RankRepr>(|resource::RankRepr(rank)| {
             *rank = Some(create_rank);
@@ -757,7 +757,7 @@ impl<A: Referable> ActorMeshRef<A> {
             let sender = cx.instance().self_addr().clone();
             let dest_port = M::port();
 
-            let mut data = ErasedUnbound::try_from_message(message)
+            let mut data = MultipartMessage::try_from_message(message)
                 .expect("cast message serialization should not fail");
 
             // Split ports for N destinations, matching the comm tree's

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -40,7 +40,7 @@ use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableMailboxSender;
 use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::monitored_return_handle;
-use hyperactor::message::ErasedUnbound;
+use hyperactor::message::MultipartMessage;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
 use hyperactor_config::CONFIG;
@@ -411,7 +411,7 @@ impl CommActor {
 // of to the original ports provided by parent.
 fn split_ports(
     cx: &Context<CommActor>,
-    data: &mut ErasedUnbound,
+    data: &mut MultipartMessage,
     deliver_here: bool,
     next_steps: &HashMap<usize, Vec<RoutingFrame>>,
 ) -> anyhow::Result<()> {
@@ -463,7 +463,7 @@ fn split_ports(
     Ok(())
 }
 
-fn replace_with_self_ranks(cast_point: &Point, data: &mut ErasedUnbound) -> anyhow::Result<()> {
+fn replace_with_self_ranks(cast_point: &Point, data: &mut MultipartMessage) -> anyhow::Result<()> {
     data.visit_mut::<resource::RankRepr>(|resource::RankRepr(rank)| {
         *rank = Some(cast_point.rank());
         Ok(())

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -16,7 +16,7 @@ use hyperactor::RemoteMessage;
 use hyperactor::actor::Referable;
 use hyperactor::id::Uid;
 use hyperactor::message::Castable;
-use hyperactor::message::ErasedUnbound;
+use hyperactor::message::MultipartMessage;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::Extent;
@@ -42,8 +42,8 @@ pub(crate) trait CastEnvelope {
     fn headers(&self) -> &Flattrs;
     fn sender(&self) -> &ActorAddr;
     fn cast_point(&self, config: &CommMeshConfig) -> anyhow::Result<Point>;
-    fn data(&self) -> &ErasedUnbound;
-    fn data_mut(&mut self) -> &mut ErasedUnbound;
+    fn data(&self) -> &MultipartMessage;
+    fn data_mut(&mut self) -> &mut MultipartMessage;
 }
 
 /// A union of slices that can be used to represent arbitrary subset of
@@ -71,7 +71,7 @@ pub struct CastMessageEnvelope {
     /// rank wildcard.
     dest_port: DestinationPort,
     /// The serialized message.
-    data: ErasedUnbound,
+    data: MultipartMessage,
     /// The shape of the cast.
     shape: Shape,
 }
@@ -90,11 +90,11 @@ impl CastEnvelope for CastMessageEnvelope {
         &self.dest_port
     }
 
-    fn data(&self) -> &ErasedUnbound {
+    fn data(&self) -> &MultipartMessage {
         &self.data
     }
 
-    fn data_mut(&mut self) -> &mut ErasedUnbound {
+    fn data_mut(&mut self) -> &mut MultipartMessage {
         &mut self.data
     }
 
@@ -124,7 +124,7 @@ impl CastMessageEnvelope {
         M: Castable + RemoteMessage,
     {
         let actor_uid = actor_mesh_id.uid().clone();
-        let data = ErasedUnbound::try_from_message(message)?;
+        let data = MultipartMessage::try_from_message(message)?;
         Ok(Self {
             actor_mesh_id,
             headers,
@@ -151,7 +151,7 @@ impl CastMessageEnvelope {
             sender,
             headers,
             dest_port,
-            data: ErasedUnbound::new(data),
+            data: MultipartMessage::new(data),
             shape,
         }
     }
@@ -285,7 +285,7 @@ pub(crate) struct CastMessageV1 {
     /// rank wildcard.
     pub(super) dest_port: DestinationPort,
     /// The serialized message.
-    pub(super) data: ErasedUnbound,
+    pub(super) data: MultipartMessage,
 }
 
 impl CastEnvelope for CastMessageV1 {
@@ -301,11 +301,11 @@ impl CastEnvelope for CastMessageV1 {
         &self.dest_port
     }
 
-    fn data(&self) -> &ErasedUnbound {
+    fn data(&self) -> &MultipartMessage {
         &self.data
     }
 
-    fn data_mut(&mut self) -> &mut ErasedUnbound {
+    fn data_mut(&mut self) -> &mut MultipartMessage {
         &mut self.data
     }
 
@@ -331,7 +331,7 @@ impl CastMessageV1 {
         A: Referable + RemoteHandles<M>,
         M: Castable + RemoteMessage,
     {
-        let data = ErasedUnbound::try_from_message(message)?;
+        let data = MultipartMessage::try_from_message(message)?;
         Ok(Self {
             headers,
             sender,

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -2012,7 +2012,7 @@ mod tests {
     use hyperactor::accum::ReducerSpec;
     use hyperactor::accum::StreamingReducerOpts;
     use hyperactor::id::Label;
-    use hyperactor::message::ErasedUnbound;
+    use hyperactor::message::MultipartMessage;
     use hyperactor::testing::ids::test_port_id;
     use hyperactor_mesh::Error as MeshError;
     use hyperactor_mesh::host_mesh::host_agent::ProcState;
@@ -2045,9 +2045,10 @@ mod tests {
             message: Part::from(vec![1, 2, 3]),
         };
         {
-            let mut erased = ErasedUnbound::try_from_message(message.clone()).unwrap();
+            let mut multipart_message =
+                MultipartMessage::try_from_message(message.clone()).unwrap();
             let mut ports = vec![];
-            erased
+            multipart_message
                 .visit_mut::<reference::PortRefRepr>(|b| {
                     ports.push(b.clone());
                     Ok(())
@@ -2061,7 +2062,10 @@ mod tests {
                 port_ref.get_return_undeliverable()
             );
             assert!(!ports[0].unsplit());
-            assert_eq!(message, erased.deserialize::<PythonMessage>().unwrap());
+            assert_eq!(
+                message,
+                multipart_message.deserialize::<PythonMessage>().unwrap()
+            );
         }
 
         let no_port_message = PythonMessage {
@@ -2074,9 +2078,10 @@ mod tests {
             ..message
         };
         {
-            let mut erased = ErasedUnbound::try_from_message(no_port_message.clone()).unwrap();
+            let mut multipart_message =
+                MultipartMessage::try_from_message(no_port_message.clone()).unwrap();
             let mut ports = vec![];
-            erased
+            multipart_message
                 .visit_mut::<reference::PortRefRepr>(|b| {
                     ports.push(b.clone());
                     Ok(())
@@ -2085,7 +2090,7 @@ mod tests {
             assert_eq!(ports.len(), 0);
             assert_eq!(
                 no_port_message,
-                erased.deserialize::<PythonMessage>().unwrap()
+                multipart_message.deserialize::<PythonMessage>().unwrap()
             );
         }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4234
* #4233
* #4232
* __->__ #4231
* #4230
* #4229
* #4228
* #4227

Rename the typed multipart message wrapper from `ErasedUnbound` to `MultipartMessage`. Behavior is unchanged; the new name describes the serialized multipart envelope rather than the removed bind/unbind implementation.

Differential Revision: [D108442504](https://our.internmc.facebook.com/intern/diff/D108442504/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108442504/)!