### PR TITLE
[wirevalue] add encoding typestates to `Any`

### DIFF
--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -41,23 +41,23 @@ impl<T: RemoteMessage> Castable for T {}
 /// Multipart-serialized message with its message type erased.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, typeuri::Named)]
 pub struct MultipartMessage {
-    message: wirevalue::Any,
+    message: wirevalue::Any<wirevalue::encoding::Multipart>,
 }
 wirevalue::register_type!(MultipartMessage);
 
 impl MultipartMessage {
-    /// Create an object directly from Any.
-    pub fn new(message: wirevalue::Any) -> Self {
+    /// Create an object directly from a multipart [`wirevalue::Any`].
+    pub fn new(message: wirevalue::Any<wirevalue::encoding::Multipart>) -> Self {
         Self { message }
     }
 
     /// Access the inner serialized message.
-    pub fn message(&self) -> &wirevalue::Any {
+    pub fn message(&self) -> &wirevalue::Any<wirevalue::encoding::Multipart> {
         &self.message
     }
 
     /// Convert this wrapper into its inner serialized message.
-    pub fn into_message(self) -> wirevalue::Any {
+    pub fn into_message(self) -> wirevalue::Any<wirevalue::encoding::Multipart> {
         self.message
     }
 
@@ -65,11 +65,8 @@ impl MultipartMessage {
     // Note: cannot implement TryFrom<T> due to conflict with core crate's blanket impl.
     // More can be found in this issue: https://github.com/rust-lang/rust/issues/50133
     pub fn try_from_message<T: Serialize + Named>(msg: T) -> Result<Self, anyhow::Error> {
-        let serialized =
-            wirevalue::Any::serialize_with_encoding(wirevalue::Encoding::Multipart, &msg)?;
-        Ok(Self {
-            message: serialized,
-        })
+        let message = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&msg)?;
+        Ok(Self { message })
     }
 
     /// Use the provided function to update matching typed multipart parts.
@@ -131,8 +128,7 @@ mod tests {
         };
 
         let serialized_multipart_my_message =
-            wirevalue::Any::serialize_with_encoding(wirevalue::Encoding::Multipart, &my_message)
-                .unwrap();
+            wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&my_message).unwrap();
 
         let mut message = MultipartMessage::try_from_message(my_message.clone()).unwrap();
         assert_eq!(

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -810,7 +810,11 @@ impl Handler<CastMessage> for CastActor {
                 &dest,
                 &message.sender,
             );
-            cx.post_with_external_seq_info(dest, headers, data.clone().into_message());
+            cx.post_with_external_seq_info(
+                dest,
+                headers,
+                data.clone().into_message().erase_encoding(),
+            );
         }
 
         for next_hop in &domain.next_hops {

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -816,8 +816,11 @@ impl<A: Referable> ActorMeshRef<A> {
                     .expect("mismatched actor_ids and dest_region")
                     .port_addr(Port::handler_id(dest_port, None));
 
-                cx.instance()
-                    .post(port_id, rank_headers, rank_data.into_message());
+                cx.instance().post(
+                    port_id,
+                    rank_headers,
+                    rank_data.into_message().erase_encoding(),
+                );
             }
         } else {
             // Tree path: route through the comm actor tree.

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -400,7 +400,11 @@ impl CommActor {
             );
         }
 
-        cx.post_with_external_seq_info(dest, headers, message.data().message().clone());
+        cx.post_with_external_seq_info(
+            dest,
+            headers,
+            message.data().message().clone().erase_encoding(),
+        );
 
         Ok(())
     }

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -144,7 +144,7 @@ impl CastMessageEnvelope {
         dest_port: DestinationPort,
         shape: Shape,
         headers: Flattrs,
-        data: wirevalue::Any,
+        data: wirevalue::Any<wirevalue::encoding::Multipart>,
     ) -> Self {
         Self {
             actor_mesh_id,

--- a/hyperactor_mesh/src/pyspy.rs
+++ b/hyperactor_mesh/src/pyspy.rs
@@ -1070,7 +1070,7 @@ mod tests {
             }],
             warnings: vec![],
         };
-        let any = wirevalue::Any::serialize(&original).expect("serialize");
+        let any: wirevalue::Any = wirevalue::Any::serialize(&original).expect("serialize");
         let restored: PySpyResult = any.deserialized().expect("deserialize");
         assert_eq!(original, restored);
     }

--- a/wirevalue/src/lib.rs
+++ b/wirevalue/src/lib.rs
@@ -17,6 +17,7 @@ use std::any::TypeId;
 use std::collections::HashMap;
 use std::fmt;
 use std::io::Cursor;
+use std::marker::PhantomData;
 use std::sync::LazyLock;
 
 use enum_as_inner::EnumAsInner;
@@ -24,6 +25,7 @@ use hyperactor_config::AttrValue;
 use serde::Deserialize;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
+use serde::ser::SerializeStruct;
 pub use typeuri::Named;
 pub use typeuri::intern_typename;
 
@@ -210,6 +212,65 @@ pub enum Encoding {
     Multipart,
 }
 
+/// Type-state markers for [`Any`] encodings.
+pub mod encoding {
+    /// Statically unconstrained encoding.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct AnyEncoding;
+
+    /// Bincode encoding.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Bincode;
+
+    /// JSON encoding.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Json;
+
+    /// Multipart encoding.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct Multipart;
+}
+
+mod private {
+    pub trait Sealed {}
+}
+
+/// Marker trait for supported [`Any`] encoding type states.
+pub trait EncodingMarker: private::Sealed + Clone + Copy + fmt::Debug + PartialEq + Eq {
+    #[doc(hidden)]
+    const EXPECTED_ENCODING: Option<Encoding>;
+}
+
+/// Marker trait for statically known [`Any`] encodings.
+pub trait StaticEncoding: EncodingMarker {
+    #[doc(hidden)]
+    const ENCODING: Encoding;
+}
+
+impl private::Sealed for encoding::AnyEncoding {}
+
+impl EncodingMarker for encoding::AnyEncoding {
+    const EXPECTED_ENCODING: Option<Encoding> = None;
+}
+
+macro_rules! impl_static_encoding {
+    ($marker:ty, $encoding:expr) => {
+        impl private::Sealed for $marker {}
+
+        impl EncodingMarker for $marker {
+            const EXPECTED_ENCODING: Option<Encoding> = Some($encoding);
+        }
+
+        impl StaticEncoding for $marker {
+            const ENCODING: Encoding = $encoding;
+        }
+    };
+}
+
+impl_static_encoding!(encoding::Bincode, Encoding::Bincode);
+impl_static_encoding!(encoding::Json, Encoding::Json);
+impl_static_encoding!(encoding::Multipart, Encoding::Multipart);
+
 /// The encoding used for a serialized value.
 #[derive(Clone, Serialize, Deserialize, PartialEq, EnumAsInner)]
 enum Encoded {
@@ -350,18 +411,20 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// and deserialization details, while ensuring that we pass correctly-serialized
 /// message throughout the system.
 ///
-/// Currently, Any passes through to bincode, but in the future we may include
-/// content-encoding information to allow for other codecs as well.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
-pub struct Any {
+/// The default [`Any`] spelling is encoding-agnostic. Use [`Any`] with an
+/// [`encoding`] marker, such as `Any<encoding::Multipart>`, when an API
+/// requires a specific encoding.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Any<E: EncodingMarker = encoding::AnyEncoding> {
     /// The encoded data
     encoded: Encoded,
     /// The typehash of the serialized value. This is used to provide
     /// typed introspection of the value.
     typehash: u64,
+    _encoding: PhantomData<E>,
 }
 
-impl std::fmt::Display for Any {
+impl<E: EncodingMarker> std::fmt::Display for Any<E> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.dump() {
             Ok(value) => {
@@ -376,28 +439,62 @@ impl std::fmt::Display for Any {
     }
 }
 
+impl<E: EncodingMarker> Serialize for Any<E> {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut state = serializer.serialize_struct("Any", 2)?;
+        state.serialize_field("encoded", &self.encoded)?;
+        state.serialize_field("typehash", &self.typehash)?;
+        state.end()
+    }
+}
+
+#[derive(Deserialize)]
+struct AnyFields {
+    encoded: Encoded,
+    typehash: u64,
+}
+
+impl<'de, E: EncodingMarker> Deserialize<'de> for Any<E> {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let fields = AnyFields::deserialize(deserializer)?;
+        if let Some(expected) = E::EXPECTED_ENCODING {
+            let actual = fields.encoded.encoding();
+            if actual != expected {
+                return Err(serde::de::Error::custom(format!(
+                    "expected {} encoding, found {}",
+                    expected, actual
+                )));
+            }
+        }
+
+        Ok(Self {
+            encoded: fields.encoded,
+            typehash: fields.typehash,
+            _encoding: PhantomData,
+        })
+    }
+}
+
+fn encode_with_encoding<U: Serialize>(encoding: Encoding, value: &U) -> Result<Encoded> {
+    match encoding {
+        Encoding::Bincode => Ok(Encoded::Bincode(
+            bincode::serde::encode_to_vec(value, bincode::config::legacy())?.into(),
+        )),
+        Encoding::Json => Ok(Encoded::Json(serde_json::to_vec(value)?.into())),
+        Encoding::Multipart => Ok(Encoded::Multipart(
+            serde_multipart::serialize_bincode(value)
+                .map_err(|e| Error::InvalidEncoding(e.to_string()))?,
+        )),
+    }
+}
+
 impl Any {
-    /// Construct a new serialized value by serializing the provided T-typed value.
-    /// Serialize uses the default encoding defined by the configuration key
-    /// [`config::DEFAULT_ENCODING`] in the global configuration; use [`serialize_with_encoding`]
-    /// to serialize values with a specific encoding.
-    pub fn serialize<T: Serialize + Named>(value: &T) -> Result<Self> {
-        Self::serialize_with_encoding(
-            hyperactor_config::global::get(config::DEFAULT_ENCODING),
-            value,
-        )
-    }
-
-    /// Serialize U-typed value as a T-typed value. This should be used with care
-    /// (typically only in testing), as the value's representation may be illegally
-    /// coerced.
-    pub fn serialize_as<T: Named, U: Serialize>(value: &U) -> Result<Self> {
-        Self::serialize_with_encoding_as::<T, U>(
-            hyperactor_config::global::get(config::DEFAULT_ENCODING),
-            value,
-        )
-    }
-
     /// Serialize the value with the using the provided encoding.
     pub fn serialize_with_encoding<T: Serialize + Named>(
         encoding: Encoding,
@@ -414,17 +511,9 @@ impl Any {
         value: &U,
     ) -> Result<Self> {
         Ok(Self {
-            encoded: match encoding {
-                Encoding::Bincode => Encoded::Bincode(
-                    bincode::serde::encode_to_vec(value, bincode::config::legacy())?.into(),
-                ),
-                Encoding::Json => Encoded::Json(serde_json::to_vec(value)?.into()),
-                Encoding::Multipart => Encoded::Multipart(
-                    serde_multipart::serialize_bincode(value)
-                        .map_err(|e| Error::InvalidEncoding(e.to_string()))?,
-                ),
-            },
+            encoded: encode_with_encoding(encoding, value)?,
             typehash: T::typehash(),
+            _encoding: PhantomData,
         })
     }
 
@@ -434,6 +523,66 @@ impl Any {
         Self {
             encoded: Encoded::Bincode(bytes::Bytes::new()),
             typehash: BROKEN_TYPEHASH,
+            _encoding: PhantomData,
+        }
+    }
+
+    /// Statically constrain this value to the requested encoding.
+    pub fn try_into_static_encoding<E: StaticEncoding>(self) -> std::result::Result<Any<E>, Self> {
+        if self.encoding() == E::ENCODING {
+            Ok(Any {
+                encoded: self.encoded,
+                typehash: self.typehash,
+                _encoding: PhantomData,
+            })
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Statically constrain this value to bincode encoding.
+    pub fn try_into_bincode(self) -> std::result::Result<Any<encoding::Bincode>, Self> {
+        self.try_into_static_encoding()
+    }
+
+    /// Statically constrain this value to JSON encoding.
+    pub fn try_into_json(self) -> std::result::Result<Any<encoding::Json>, Self> {
+        self.try_into_static_encoding()
+    }
+
+    /// Statically constrain this value to multipart encoding.
+    pub fn try_into_multipart(self) -> std::result::Result<Any<encoding::Multipart>, Self> {
+        self.try_into_static_encoding()
+    }
+}
+
+impl<E: EncodingMarker> Any<E> {
+    /// Construct a new serialized value.
+    ///
+    /// Encoding-agnostic [`Any`] uses [`config::DEFAULT_ENCODING`]. Statically
+    /// constrained values, such as `Any<encoding::Multipart>`, use their static
+    /// encoding.
+    pub fn serialize<T: Serialize + Named>(value: &T) -> Result<Self> {
+        Self::serialize_as::<T, T>(value)
+    }
+
+    /// Serialize U-typed value as a T-typed value.
+    pub fn serialize_as<T: Named, U: Serialize>(value: &U) -> Result<Self> {
+        let encoding = E::EXPECTED_ENCODING
+            .unwrap_or_else(|| hyperactor_config::global::get(config::DEFAULT_ENCODING));
+        Ok(Self {
+            encoded: encode_with_encoding(encoding, value)?,
+            typehash: T::typehash(),
+            _encoding: PhantomData,
+        })
+    }
+
+    /// Erase this value's static encoding marker.
+    pub fn erase_encoding(self) -> Any {
+        Any {
+            encoded: self.encoded,
+            typehash: self.typehash,
+            _encoding: PhantomData,
         }
     }
 
@@ -476,7 +625,7 @@ impl Any {
 
     /// Transcode the serialized value to JSON. This operation will succeed if the type hash
     /// is embedded in the value, and the corresponding type is available in this binary.
-    pub fn transcode_to_json(self) -> std::result::Result<Self, Self> {
+    pub fn transcode_to_json(self) -> std::result::Result<Any<encoding::Json>, Self> {
         match self.encoded {
             Encoded::Bincode(_) | Encoded::Multipart(_) => {
                 let json_value = match self.dump() {
@@ -487,12 +636,17 @@ impl Any {
                     Ok(json_data) => json_data,
                     Err(_) => return Err(self),
                 };
-                Ok(Self {
+                Ok(Any {
                     encoded: Encoded::Json(json_data.into()),
                     typehash: self.typehash,
+                    _encoding: PhantomData,
                 })
             }
-            Encoded::Json(_) => Ok(self),
+            Encoded::Json(_) => Ok(Any {
+                encoded: self.encoded,
+                typehash: self.typehash,
+                _encoding: PhantomData,
+            }),
         }
     }
 
@@ -504,7 +658,7 @@ impl Any {
                 let Some(typeinfo) = TYPE_INFO.get(&self.typehash) else {
                     return Err(Error::MissingTypeInfo(self.typehash));
                 };
-                typeinfo.dump(self.clone())
+                typeinfo.dump(self.clone().erase_encoding())
             }
             Encoded::Json(data) => Ok(serde_json::from_slice(data)?),
         }
@@ -518,21 +672,6 @@ impl Any {
     /// The typehash of the serialized value.
     pub fn typehash(&self) -> u64 {
         self.typehash
-    }
-
-    /// Visit typed multipart parts in this value, if it uses multipart encoding.
-    pub fn visit_multipart_parts_mut<T, E>(
-        &mut self,
-        f: impl FnMut(&mut T) -> std::result::Result<(), E>,
-    ) -> std::result::Result<(), E>
-    where
-        T: Serialize + DeserializeOwned + Named,
-        E: From<serde_multipart::Error>,
-    {
-        match &mut self.encoded {
-            Encoded::Multipart(message) => message.visit_parts_mut(f),
-            Encoded::Bincode(_) | Encoded::Json(_) => Ok(()),
-        }
     }
 
     /// The typename of the serialized value, if available.
@@ -600,6 +739,26 @@ impl Any {
     /// when type information is unavailable.
     pub fn is<M: Named>(&self) -> bool {
         self.typehash == M::typehash()
+    }
+}
+
+impl Any<encoding::Multipart> {
+    /// Visit typed multipart parts in this value.
+    pub fn visit_multipart_parts_mut<T, E>(
+        &mut self,
+        f: impl FnMut(&mut T) -> std::result::Result<(), E>,
+    ) -> std::result::Result<(), E>
+    where
+        T: Serialize + DeserializeOwned + Named,
+        E: From<serde_multipart::Error>,
+    {
+        let Encoded::Multipart(message) = &mut self.encoded else {
+            panic!(
+                "multipart Any contained {} encoding",
+                self.encoded.encoding()
+            );
+        };
+        message.visit_parts_mut(f)
     }
 }
 
@@ -749,7 +908,7 @@ mod tests {
             c: Some(5678),
             d: None,
         };
-        let serialized = Any::serialize(&data).unwrap();
+        let serialized: Any = Any::serialize(&data).unwrap();
         let serialized_json = serialized.clone().transcode_to_json().unwrap();
 
         assert!(serialized.encoded.is_multipart());
@@ -763,7 +922,7 @@ mod tests {
             "{\"a\":\"hello\",\"b\":1234,\"c\":5678,\"d\":null}"
         );
 
-        for serialized in [serialized, serialized_json] {
+        for serialized in [serialized, serialized_json.erase_encoding()] {
             // Note, at this point, serialized has no knowledge other than its embedded typehash.
 
             assert_eq!(
@@ -800,7 +959,7 @@ mod tests {
             d: None,
         };
 
-        let mut ser = Any::serialize(&data).unwrap();
+        let mut ser: Any = Any::serialize(&data).unwrap();
         assert_eq!(ser.prefix::<String>().unwrap(), "hello".to_string());
 
         ser.emplace_prefix("hello, world, 123!".to_string())
@@ -957,13 +1116,46 @@ mod tests {
     }
 
     #[test]
+    fn test_static_multipart_any() {
+        let value = TestDumpStruct {
+            a: "hello, multipart".to_string(),
+            b: 456,
+            c: Some(654),
+            d: Some(Part::from("part")),
+        };
+
+        let multipart = Any::<encoding::Multipart>::serialize(&value).unwrap();
+        assert_eq!(multipart.encoding(), Encoding::Multipart);
+        assert_eq!(multipart.deserialized::<TestDumpStruct>().unwrap(), value);
+
+        let erased = multipart.erase_encoding();
+        let multipart = erased.try_into_multipart().unwrap();
+        assert_eq!(multipart.encoding(), Encoding::Multipart);
+    }
+
+    #[test]
+    fn test_static_encoding_deserialize_rejects_mismatch() {
+        let value = TestDumpStruct {
+            a: "hello, bincode".to_string(),
+            b: 789,
+            c: None,
+            d: None,
+        };
+        let bincode = Any::<encoding::Bincode>::serialize(&value).unwrap();
+        let serialized = serde_json::to_vec(&bincode.erase_encoding()).unwrap();
+
+        let err = serde_json::from_slice::<Any<encoding::Multipart>>(&serialized).unwrap_err();
+        assert!(err.to_string().contains("expected serde_multipart"));
+    }
+
+    #[test]
     fn test_broken_any() {
         let broken = Any::new_broken();
         assert!(broken.is_broken());
         assert_eq!(broken.typehash(), BROKEN_TYPEHASH);
 
         // Normal values are not broken
-        let normal = Any::serialize(&"hello".to_string()).unwrap();
+        let normal: Any = Any::serialize(&"hello".to_string()).unwrap();
         assert!(!normal.is_broken());
 
         // deserialized() should fail for broken values


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4234
* #4233
* __->__ #4232
* #4231
* #4230
* #4229
* #4228
* #4227

Add encoding type-state markers for `wirevalue::Any`, with the existing `wirevalue::Any` spelling preserved as the encoding-agnostic default. `Any<wirevalue::encoding::Multipart>` now statically expresses multipart-only values, serde deserialization validates that the embedded runtime encoding matches the static marker, and `MultipartMessage` stores a multipart-constrained `Any`. Ordinary mailbox delivery still receives encoding-agnostic `Any`, so cast and comm paths erase the marker at those boundaries.

Differential Revision: [D108442507](https://our.internmc.facebook.com/intern/diff/D108442507/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108442507/)!