### PR TITLE
[hyperactor] use multipart `Any` directly

### DIFF
--- a/docs/source/books/hyperactor-book/src/actors/handler.md
+++ b/docs/source/books/hyperactor-book/src/actors/handler.md
@@ -43,8 +43,8 @@ impl<A: Actor> Handler<Signal> for A {
 ### Multipart routed messages
 
 ```rust
-let mut message = MultipartMessage::try_from_message(value)?;
-message.visit_mut::<PortRefRepr>(|port| {
+let mut message = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&value)?;
+message.visit_multipart_parts_mut::<PortRefRepr, anyhow::Error>(|port| {
     port.update_port_addr(rewritten_addr);
     Ok(())
 })?;

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -14,9 +14,9 @@
 //! Briefly, it works by following these steps:
 //!
 //! 1. On the sender side, the typed message is serialized with multipart
-//!    encoding and bundled in a [`MultipartMessage`] object.
-//! 2. On intermediate nodes, the [`MultipartMessage`] object is relayed and
-//!    selected typed parts are mutated in place.
+//!    encoding and bundled in a `wirevalue::Any<wirevalue::encoding::Multipart>`.
+//! 2. On intermediate nodes, the serialized message is relayed and selected
+//!    typed parts are mutated in place.
 //! 3. On the receiver side, the serialized message is delivered to the ordinary
 //!    typed handler port and deserialized as the final message type.
 //!
@@ -26,11 +26,6 @@
 //! trait is defined, which collects requirements for message types using
 //! multicast.
 
-use serde::Deserialize;
-use serde::Serialize;
-use serde::de::DeserializeOwned;
-use typeuri::Named;
-
 use crate::RemoteMessage;
 
 /// This trait collects the necessary requirements for messages that are can be
@@ -38,58 +33,11 @@ use crate::RemoteMessage;
 pub trait Castable: RemoteMessage {}
 impl<T: RemoteMessage> Castable for T {}
 
-/// Multipart-serialized message with its message type erased.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, typeuri::Named)]
-pub struct MultipartMessage {
-    message: wirevalue::Any<wirevalue::encoding::Multipart>,
-}
-wirevalue::register_type!(MultipartMessage);
-
-impl MultipartMessage {
-    /// Create an object directly from a multipart [`wirevalue::Any`].
-    pub fn new(message: wirevalue::Any<wirevalue::encoding::Multipart>) -> Self {
-        Self { message }
-    }
-
-    /// Access the inner serialized message.
-    pub fn message(&self) -> &wirevalue::Any<wirevalue::encoding::Multipart> {
-        &self.message
-    }
-
-    /// Convert this wrapper into its inner serialized message.
-    pub fn into_message(self) -> wirevalue::Any<wirevalue::encoding::Multipart> {
-        self.message
-    }
-
-    /// Create an object from a typed message.
-    // Note: cannot implement TryFrom<T> due to conflict with core crate's blanket impl.
-    // More can be found in this issue: https://github.com/rust-lang/rust/issues/50133
-    pub fn try_from_message<T: Serialize + Named>(msg: T) -> Result<Self, anyhow::Error> {
-        let message = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&msg)?;
-        Ok(Self { message })
-    }
-
-    /// Use the provided function to update matching typed multipart parts.
-    pub fn visit_mut<T: Serialize + DeserializeOwned + Named>(
-        &mut self,
-        f: impl FnMut(&mut T) -> anyhow::Result<()>,
-    ) -> anyhow::Result<()> {
-        Ok(self.message.visit_multipart_parts_mut(f)?)
-    }
-
-    /// Deserialize the contained message.
-    pub fn deserialize<M: DeserializeOwned>(self) -> anyhow::Result<M> {
-        self.downcast()
-    }
-
-    fn downcast<M: DeserializeOwned>(self) -> anyhow::Result<M> {
-        Ok(self.message.deserialized_unchecked()?)
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use serde::Deserialize;
+    use serde::Serialize;
+
     use crate::PortRef;
     use crate::PortRefRepr;
     use crate::accum::ReducerSpec;
@@ -130,13 +78,9 @@ mod tests {
         let serialized_multipart_my_message =
             wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&my_message).unwrap();
 
-        let mut message = MultipartMessage::try_from_message(my_message.clone()).unwrap();
-        assert_eq!(
-            message,
-            MultipartMessage {
-                message: serialized_multipart_my_message,
-            }
-        );
+        let mut message =
+            wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&my_message).unwrap();
+        assert_eq!(message, serialized_multipart_my_message);
 
         let new_port_id0 = test_port_id("world_0", "comm", 680);
         assert_ne!(&new_port_id0, original_port0.port_addr());
@@ -145,7 +89,7 @@ mod tests {
 
         let mut new_ports = vec![&new_port_id0, &new_port_id1].into_iter();
         message
-            .visit_mut::<PortRefRepr>(|b| {
+            .visit_multipart_parts_mut::<PortRefRepr, anyhow::Error>(|b| {
                 let port = new_ports.next().unwrap();
                 b.update_port_addr(port.clone());
                 Ok(())
@@ -161,7 +105,7 @@ mod tests {
             }),
             StreamingReducerOpts::default(),
         );
-        let new_my_message = message.downcast::<MyMessage>().unwrap();
+        let new_my_message = message.deserialized_unchecked::<MyMessage>().unwrap();
         assert_eq!(
             new_my_message,
             MyMessage {

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -34,7 +34,6 @@ use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableMailboxSender;
 use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::monitored_return_handle;
-use hyperactor::message::MultipartMessage;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
 use hyperactor::port::Port;
@@ -274,7 +273,7 @@ impl CastDomainRef {
         headers: Flattrs,
         message: M,
     ) -> anyhow::Result<()> {
-        let data = MultipartMessage::try_from_message(message)?;
+        let data = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message)?;
         let sender = cx.mailbox().actor_addr().clone();
         let dest_port = M::port();
         let (session_id, seqs) = self.seqs_for_cast(cx, dest_port)?;
@@ -627,11 +626,11 @@ impl Handler<CreateCastDomain> for CastActor {
 /// Ported from `hyperactor_mesh::comm::split_ports`.
 fn split_ports(
     cx: &Context<'_, CastActor>,
-    data: &mut MultipartMessage,
+    data: &mut wirevalue::Any<wirevalue::encoding::Multipart>,
     num_next_hops: usize,
     deliver_here: bool,
 ) -> Result<()> {
-    data.visit_mut::<PortRefRepr>(|port| {
+    data.visit_multipart_parts_mut::<PortRefRepr, anyhow::Error>(|port| {
         if port.unsplit() {
             return Ok(());
         }
@@ -652,7 +651,7 @@ fn split_ports(
         Ok(())
     })?;
 
-    data.visit_mut::<OncePortRefRepr>(|port| {
+    data.visit_multipart_parts_mut::<OncePortRefRepr, anyhow::Error>(|port| {
         if port.unsplit() || port.reducer_spec().is_none() {
             // OncePorts without reducers cannot be split. Pass through as-is.
             // Using the port more than once will cause a delivery error downstream.
@@ -745,7 +744,7 @@ struct CastMessage {
     /// The target port index on each destination actor.
     dest_port: u64,
     /// The serialized message data.
-    data: MultipartMessage,
+    data: wirevalue::Any<wirevalue::encoding::Multipart>,
 }
 
 wirevalue::register_type!(CastMessage);
@@ -810,11 +809,7 @@ impl Handler<CastMessage> for CastActor {
                 &dest,
                 &message.sender,
             );
-            cx.post_with_external_seq_info(
-                dest,
-                headers,
-                data.clone().into_message().erase_encoding(),
-            );
+            cx.post_with_external_seq_info(dest, headers, data.clone().erase_encoding());
         }
 
         for next_hop in &domain.next_hops {
@@ -1737,7 +1732,7 @@ mod tests {
                 lineage: Vec::new(),
                 headers: Flattrs::new(),
                 dest_port: TestDelivery::port(),
-                data: MultipartMessage::try_from_message(TestDelivery {
+                data: wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&TestDelivery {
                     payload: "hello".to_string(),
                 })
                 .unwrap(),

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -35,7 +35,6 @@ use hyperactor::actor::Referable;
 use hyperactor::context;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Castable;
-use hyperactor::message::MultipartMessage;
 use hyperactor::port::Port;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
@@ -661,17 +660,20 @@ impl<A: Referable> ActorMeshRef<A> {
 
         // Make sure that we rewrite ranks, as these may be used for
         // bootstrapping comm actors.
-        let mut data = MultipartMessage::try_from_message(message)
-            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-        data.visit_mut::<resource::RankRepr>(|resource::RankRepr(rank)| {
-            *rank = Some(create_rank);
-            Ok(())
-        })
+        let mut data = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message)
+            .map_err(|e| Error::CastingError(self.id.clone(), e.into()))?;
+        data.visit_multipart_parts_mut::<resource::RankRepr, anyhow::Error>(
+            |resource::RankRepr(rank)| {
+                *rank = Some(create_rank);
+                Ok(())
+            },
+        )
         .map_err(|e| Error::CastingError(self.id.clone(), e))?;
         let rebound_message = data
-            .deserialize()
-            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
+            .deserialized_unchecked()
+            .map_err(|e| Error::CastingError(self.id.clone(), e.into()))?;
         actor.post_with_headers(cx, headers, rebound_message);
+
         Ok(())
     }
 
@@ -757,12 +759,12 @@ impl<A: Referable> ActorMeshRef<A> {
             let sender = cx.instance().self_addr().clone();
             let dest_port = M::port();
 
-            let mut data = MultipartMessage::try_from_message(message)
+            let mut data = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message)
                 .expect("cast message serialization should not fail");
 
             // Split ports for N destinations, matching the comm tree's
             // split_ports behavior.
-            data.visit_mut::<PortRefRepr>(|port| {
+            data.visit_multipart_parts_mut::<PortRefRepr, anyhow::Error>(|port| {
                 if port.unsplit() {
                     return Ok(());
                 }
@@ -777,7 +779,7 @@ impl<A: Referable> ActorMeshRef<A> {
             })
             .expect("port splitting should not fail");
 
-            data.visit_mut::<OncePortRefRepr>(|port| {
+            data.visit_multipart_parts_mut::<OncePortRefRepr, anyhow::Error>(|port| {
                 if port.unsplit() || port.reducer_spec().is_none() {
                     // Once ports without reducers pass through, same as the comm
                     // tree's split_ports.
@@ -802,10 +804,12 @@ impl<A: Referable> ActorMeshRef<A> {
                     .expect("rank should be valid in region");
 
                 rank_data
-                    .visit_mut::<resource::RankRepr>(|resource::RankRepr(r)| {
-                        *r = Some(cast_point.rank());
-                        Ok(())
-                    })
+                    .visit_multipart_parts_mut::<resource::RankRepr, anyhow::Error>(
+                        |resource::RankRepr(r)| {
+                            *r = Some(cast_point.rank());
+                            Ok(())
+                        },
+                    )
                     .expect("rank replacement should not fail");
 
                 let mut rank_headers = headers.clone();
@@ -816,11 +820,8 @@ impl<A: Referable> ActorMeshRef<A> {
                     .expect("mismatched actor_ids and dest_region")
                     .port_addr(Port::handler_id(dest_port, None));
 
-                cx.instance().post(
-                    port_id,
-                    rank_headers,
-                    rank_data.into_message().erase_encoding(),
-                );
+                cx.instance()
+                    .post(port_id, rank_headers, rank_data.erase_encoding());
             }
         } else {
             // Tree path: route through the comm actor tree.

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -40,7 +40,6 @@ use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableMailboxSender;
 use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::monitored_return_handle;
-use hyperactor::message::MultipartMessage;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
 use hyperactor_config::CONFIG;
@@ -400,11 +399,7 @@ impl CommActor {
             );
         }
 
-        cx.post_with_external_seq_info(
-            dest,
-            headers,
-            message.data().message().clone().erase_encoding(),
-        );
+        cx.post_with_external_seq_info(dest, headers, message.data().clone().erase_encoding());
 
         Ok(())
     }
@@ -415,14 +410,14 @@ impl CommActor {
 // of to the original ports provided by parent.
 fn split_ports(
     cx: &Context<CommActor>,
-    data: &mut MultipartMessage,
+    data: &mut wirevalue::Any<wirevalue::encoding::Multipart>,
     deliver_here: bool,
     next_steps: &HashMap<usize, Vec<RoutingFrame>>,
 ) -> anyhow::Result<()> {
     // Split ports, if any, and update message with new ports. In this
     // way, children actors will reply to this comm actor's ports, instead
     // of to the original ports provided by parent.
-    data.visit_mut::<PortRefRepr>(|port| {
+    data.visit_multipart_parts_mut::<PortRefRepr, anyhow::Error>(|port| {
         if port.unsplit() {
             return Ok(());
         }
@@ -441,7 +436,7 @@ fn split_ports(
         Ok(())
     })?;
 
-    data.visit_mut::<OncePortRefRepr>(|port| {
+    data.visit_multipart_parts_mut::<OncePortRefRepr, anyhow::Error>(|port| {
         if port.unsplit() || port.reducer_spec().is_none() {
             // We can only split OncePorts that have reducers. Pass this
             // through; if it is used multiple times, it will cause a delivery
@@ -467,11 +462,16 @@ fn split_ports(
     Ok(())
 }
 
-fn replace_with_self_ranks(cast_point: &Point, data: &mut MultipartMessage) -> anyhow::Result<()> {
-    data.visit_mut::<resource::RankRepr>(|resource::RankRepr(rank)| {
-        *rank = Some(cast_point.rank());
-        Ok(())
-    })
+fn replace_with_self_ranks(
+    cast_point: &Point,
+    data: &mut wirevalue::Any<wirevalue::encoding::Multipart>,
+) -> anyhow::Result<()> {
+    data.visit_multipart_parts_mut::<resource::RankRepr, anyhow::Error>(
+        |resource::RankRepr(rank)| {
+            *rank = Some(cast_point.rank());
+            Ok(())
+        },
+    )
 }
 
 #[async_trait]

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -16,7 +16,6 @@ use hyperactor::RemoteMessage;
 use hyperactor::actor::Referable;
 use hyperactor::id::Uid;
 use hyperactor::message::Castable;
-use hyperactor::message::MultipartMessage;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::Extent;
@@ -42,8 +41,8 @@ pub(crate) trait CastEnvelope {
     fn headers(&self) -> &Flattrs;
     fn sender(&self) -> &ActorAddr;
     fn cast_point(&self, config: &CommMeshConfig) -> anyhow::Result<Point>;
-    fn data(&self) -> &MultipartMessage;
-    fn data_mut(&mut self) -> &mut MultipartMessage;
+    fn data(&self) -> &wirevalue::Any<wirevalue::encoding::Multipart>;
+    fn data_mut(&mut self) -> &mut wirevalue::Any<wirevalue::encoding::Multipart>;
 }
 
 /// A union of slices that can be used to represent arbitrary subset of
@@ -71,7 +70,7 @@ pub struct CastMessageEnvelope {
     /// rank wildcard.
     dest_port: DestinationPort,
     /// The serialized message.
-    data: MultipartMessage,
+    data: wirevalue::Any<wirevalue::encoding::Multipart>,
     /// The shape of the cast.
     shape: Shape,
 }
@@ -90,11 +89,11 @@ impl CastEnvelope for CastMessageEnvelope {
         &self.dest_port
     }
 
-    fn data(&self) -> &MultipartMessage {
+    fn data(&self) -> &wirevalue::Any<wirevalue::encoding::Multipart> {
         &self.data
     }
 
-    fn data_mut(&mut self) -> &mut MultipartMessage {
+    fn data_mut(&mut self) -> &mut wirevalue::Any<wirevalue::encoding::Multipart> {
         &mut self.data
     }
 
@@ -124,7 +123,7 @@ impl CastMessageEnvelope {
         M: Castable + RemoteMessage,
     {
         let actor_uid = actor_mesh_id.uid().clone();
-        let data = MultipartMessage::try_from_message(message)?;
+        let data = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message)?;
         Ok(Self {
             actor_mesh_id,
             headers,
@@ -151,7 +150,7 @@ impl CastMessageEnvelope {
             sender,
             headers,
             dest_port,
-            data: MultipartMessage::new(data),
+            data,
             shape,
         }
     }
@@ -285,7 +284,7 @@ pub(crate) struct CastMessageV1 {
     /// rank wildcard.
     pub(super) dest_port: DestinationPort,
     /// The serialized message.
-    pub(super) data: MultipartMessage,
+    pub(super) data: wirevalue::Any<wirevalue::encoding::Multipart>,
 }
 
 impl CastEnvelope for CastMessageV1 {
@@ -301,11 +300,11 @@ impl CastEnvelope for CastMessageV1 {
         &self.dest_port
     }
 
-    fn data(&self) -> &MultipartMessage {
+    fn data(&self) -> &wirevalue::Any<wirevalue::encoding::Multipart> {
         &self.data
     }
 
-    fn data_mut(&mut self) -> &mut MultipartMessage {
+    fn data_mut(&mut self) -> &mut wirevalue::Any<wirevalue::encoding::Multipart> {
         &mut self.data
     }
 
@@ -331,7 +330,7 @@ impl CastMessageV1 {
         A: Referable + RemoteHandles<M>,
         M: Castable + RemoteMessage,
     {
-        let data = MultipartMessage::try_from_message(message)?;
+        let data = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message)?;
         Ok(Self {
             headers,
             sender,

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -2012,7 +2012,6 @@ mod tests {
     use hyperactor::accum::ReducerSpec;
     use hyperactor::accum::StreamingReducerOpts;
     use hyperactor::id::Label;
-    use hyperactor::message::MultipartMessage;
     use hyperactor::testing::ids::test_port_id;
     use hyperactor_mesh::Error as MeshError;
     use hyperactor_mesh::host_mesh::host_agent::ProcState;
@@ -2046,10 +2045,10 @@ mod tests {
         };
         {
             let mut multipart_message =
-                MultipartMessage::try_from_message(message.clone()).unwrap();
+                wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message).unwrap();
             let mut ports = vec![];
             multipart_message
-                .visit_mut::<reference::PortRefRepr>(|b| {
+                .visit_multipart_parts_mut::<reference::PortRefRepr, anyhow::Error>(|b| {
                     ports.push(b.clone());
                     Ok(())
                 })
@@ -2064,7 +2063,9 @@ mod tests {
             assert!(!ports[0].unsplit());
             assert_eq!(
                 message,
-                multipart_message.deserialize::<PythonMessage>().unwrap()
+                multipart_message
+                    .deserialized_unchecked::<PythonMessage>()
+                    .unwrap()
             );
         }
 
@@ -2079,10 +2080,11 @@ mod tests {
         };
         {
             let mut multipart_message =
-                MultipartMessage::try_from_message(no_port_message.clone()).unwrap();
+                wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&no_port_message)
+                    .unwrap();
             let mut ports = vec![];
             multipart_message
-                .visit_mut::<reference::PortRefRepr>(|b| {
+                .visit_multipart_parts_mut::<reference::PortRefRepr, anyhow::Error>(|b| {
                     ports.push(b.clone());
                     Ok(())
                 })
@@ -2090,7 +2092,9 @@ mod tests {
             assert_eq!(ports.len(), 0);
             assert_eq!(
                 no_port_message,
-                multipart_message.deserialize::<PythonMessage>().unwrap()
+                multipart_message
+                    .deserialized_unchecked::<PythonMessage>()
+                    .unwrap()
             );
         }
     }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4234
* __->__ #4233
* #4232
* #4231
* #4230
* #4229
* #4228
* #4227

Remove the `MultipartMessage` wrapper now that `wirevalue::Any<wirevalue::encoding::Multipart>` carries the multipart invariant directly. Cast, comm, and tests now serialize to typed multipart `Any`, visit multipart parts on that value, and erase the encoding marker only when handing off to ordinary untyped mailbox delivery.

Differential Revision: [D108442498](https://our.internmc.facebook.com/intern/diff/D108442498/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108442498/)!