### PR TITLE
Cast proc_states via GetHostProcStates through the host tree (#4238)

### DIFF
--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -38,6 +38,7 @@ hyperactor_cast = { version = "0.0.0", path = "../hyperactor_cast" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
+inventory = "0.3.24"
 libc = "0.2.186"
 ndslice = { version = "0.0.0", path = "../ndslice" }
 opentelemetry = "0.31"
@@ -70,7 +71,6 @@ zbus = { version = "5.14.0", features = ["async-executor", "async-fs", "async-io
 buck-resources = "1"
 clap = { version = "4.6.0", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["async_tokio", "csv_output"] }
-inventory = "0.3.24"
 jsonschema = "0.17.0"
 maplit = "1.0"
 timed_test = { version = "0.0.0", path = "../timed_test" }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1520,6 +1520,14 @@ impl HostMeshRef {
         &self.id
     }
 
+    /// The `ActorMesh<HostAgent>` backing this host mesh. Casting to it routes
+    /// through the host mesh's cast tree (root = its cast actor 0), so replies
+    /// to a bound port reduce up the tree instead of every host dialing the
+    /// caller directly.
+    pub(crate) fn agent_mesh(&self) -> &ActorMeshRef<HostAgent> {
+        &self.host_agent_mesh
+    }
+
     /// The host channel addresses in rank order.
     pub fn host_addrs(&self) -> Vec<ChannelAddr> {
         self.host_agent_mesh

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -45,8 +45,10 @@ use hyperactor::actor::ActorStatus;
 use hyperactor::context;
 use hyperactor::gateway::GatewayServeHandle;
 use hyperactor::id::Label;
+use hyperactor::value_mesh::ValueOverlay;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
+use ndslice::view::Region;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::time::Duration;
@@ -343,6 +345,7 @@ impl fmt::Debug for DrainWorker {
         resource::Stop,
         resource::GetState<ProcState>,
         resource::KeepaliveGetState<ProcState>,
+        GetHostProcStates,
         resource::StreamState<ProcState>,
         resource::GetRankStatus,
         resource::WaitRankStatus,
@@ -1443,19 +1446,36 @@ pub struct ProcState {
 }
 wirevalue::register_type!(ProcState);
 
-#[async_trait]
-impl Handler<resource::GetState<ProcState>> for HostAgent {
-    async fn handle(
-        &mut self,
-        cx: &Context<Self>,
-        get_state: resource::GetState<ProcState>,
-    ) -> anyhow::Result<()> {
-        let state = match self.created.get(&get_state.id) {
-            Some(ProcCreationState {
+impl HostAgent {
+    /// Build the `State<ProcState>` for a single proc `id` from `created`.
+    /// Shared by the `GetState` and `GetHostProcStates` handlers.
+    async fn proc_state(&self, id: &ResourceId) -> resource::State<ProcState> {
+        match self.created.get(id) {
+            Some(state) => self.proc_state_from(id, state).await,
+            None => resource::State {
+                id: id.clone(),
+                status: resource::Status::NotExist,
+                state: None,
+                generation: 0,
+                timestamp: std::time::SystemTime::now(),
+            },
+        }
+    }
+
+    /// Like [`Self::proc_state`], but for an already-borrowed `ProcCreationState`
+    /// so callers iterating `self.created` avoid a second lookup for the same
+    /// entry.
+    async fn proc_state_from(
+        &self,
+        id: &ResourceId,
+        state: &ProcCreationState,
+    ) -> resource::State<ProcState> {
+        match state {
+            ProcCreationState {
                 rank,
                 created: Ok((proc_id, mesh_agent)),
                 ..
-            }) => {
+            } => {
                 let (raw_status, proc_status, bootstrap_command) = match self.host() {
                     Some(host) => {
                         let (status, proc_status) = host.proc_status(proc_id).await;
@@ -1465,7 +1485,7 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
                 };
                 let status = raw_status.clamp_min(self.min_proc_status());
                 resource::State {
-                    id: get_state.id.clone(),
+                    id: id.clone(),
                     status,
                     state: Some(ProcState {
                         proc_id: proc_id.clone(),
@@ -1478,25 +1498,110 @@ impl Handler<resource::GetState<ProcState>> for HostAgent {
                     timestamp: std::time::SystemTime::now(),
                 }
             }
-            Some(ProcCreationState {
+            ProcCreationState {
                 created: Err(e), ..
-            }) => resource::State {
-                id: get_state.id.clone(),
+            } => resource::State {
+                id: id.clone(),
                 status: resource::Status::Failed(e.to_string()),
                 state: None,
                 generation: 0,
                 timestamp: std::time::SystemTime::now(),
             },
-            None => resource::State {
-                id: get_state.id.clone(),
-                status: resource::Status::NotExist,
-                state: None,
-                generation: 0,
-                timestamp: std::time::SystemTime::now(),
-            },
+        }
+    }
+}
+
+#[async_trait]
+impl Handler<resource::GetState<ProcState>> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        get_state: resource::GetState<ProcState>,
+    ) -> anyhow::Result<()> {
+        let state = self.proc_state(&get_state.id).await;
+        get_state.reply.post(cx, state);
+        Ok(())
+    }
+}
+
+/// Query the state of a proc mesh's procs, cast to the host agents backing that
+/// mesh. The caller casts ONE of these carrying the queried `region` (the mesh
+/// may be sliced, so the region need not be a dense `0..n`). The cast reaches
+/// every routing host, but each rank's proc lives on exactly one host, so each
+/// `HostAgent` that owns at least one selected proc reports those procs in a
+/// single batch. Hosts that own no selected procs do not reply.
+///
+/// The bound `reply` port is split by the cast tree, so replies reduce up the
+/// tree (to cast actor 0) instead of every host dialing the caller directly.
+/// One batched reply per owning host means the caller sees `O(hosts)` reply
+/// messages instead of `O(procs)`.
+///
+/// `GetState<ProcState>` cannot be cast this way because it carries a
+/// fully-resolved id; this message resolves ids host-side instead.
+///
+/// If `keepalive` is `Some`, each proc's expiry is extended (same
+/// orphan-protection semantics as `KeepaliveGetState`).
+#[derive(Debug, Clone, Serialize, Deserialize, Named)]
+pub struct GetHostProcStates {
+    pub proc_mesh_id: ProcMeshId,
+    /// The (possibly sliced) region being queried. Each host keeps the procs it
+    /// owns for this mesh whose global rank lies in the region, tested with
+    /// `Slice::contains` (offset/stride-aware) — so a sliced or host-offset
+    /// region resolves correctly without relying on the recipient's stamped rank.
+    pub region: Region,
+    pub keepalive: Option<std::time::SystemTime>,
+    /// Sparse overlay of the ranks this host owns for the mesh. The caller opens
+    /// an accumulator port seeded with a full-region template, so per-host
+    /// overlays reduce up the cast tree into the complete proc-state mesh (see
+    /// `ProcMeshRef::states`).
+    pub reply: hyperactor::PortRef<ValueOverlay<resource::State<ProcState>>>,
+}
+wirevalue::register_type!(GetHostProcStates);
+
+#[async_trait]
+impl Handler<GetHostProcStates> for HostAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: GetHostProcStates,
+    ) -> anyhow::Result<()> {
+        let selects = |state: &ProcCreationState| {
+            state.proc_mesh_id.as_ref() == Some(&message.proc_mesh_id)
+                && message.region.slice().contains(state.rank)
         };
 
-        get_state.reply.post(cx, state);
+        // Bump keepalive (if requested) in a separate mutable pass, so the read
+        // loop can borrow `&self` via `proc_state` (mirrors `KeepaliveGetState`).
+        if let Some(expires_after) = message.keepalive {
+            for state in self.created.values_mut() {
+                if selects(state) {
+                    state.expiry_time = Some(expires_after);
+                }
+            }
+        }
+
+        // Build a sparse overlay of just the ranks this host owns for the mesh,
+        // keyed by each proc's *base index within the queried region* — not its
+        // absolute rank. The caller's `ValueMesh` addresses cells by base rank,
+        // so on a sliced region (e.g. gpus 2..4 → ranks {2,3,6,7}) the absolute
+        // rank would land in the wrong cell or out of bounds. The caller's
+        // accumulator merges these per-host overlays into the full proc-state
+        // mesh; a host owning no selected procs simply posts nothing.
+        let mut runs = Vec::new();
+        for (id, state) in self.created.iter() {
+            if selects(state) {
+                let base = message.region.slice().index(state.rank)?;
+                runs.push((base..(base + 1), self.proc_state_from(id, state).await));
+            }
+        }
+
+        if !runs.is_empty() {
+            // Runs are single-rank at distinct ranks; sort so the overlay's
+            // sorted/non-overlapping normalization invariant holds.
+            runs.sort_by_key(|(range, _)| range.start);
+            message.reply.post(cx, ValueOverlay::try_from_runs(runs)?);
+        }
+
         Ok(())
     }
 }

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -9,7 +9,6 @@
 //! This crate provides hyperactor's mesh abstractions.
 
 #![feature(associated_type_defaults)]
-#![feature(exit_status_error)]
 #![feature(impl_trait_in_bindings)]
 #![feature(get_disjoint_mut_helpers)]
 #![feature(exact_size_is_empty)]
@@ -117,10 +116,19 @@ pub type StatusMesh = ValueMesh<Status>;
 /// Construct via `ValueOverlay::try_from_runs` after normalizing.
 pub type StatusOverlay = value_mesh::ValueOverlay<Status>;
 
-hyperactor::internal_macro_support::inventory::submit! {
+inventory::submit! {
     hyperactor::accum::ReducerFactory {
         typehash_f: <hyperactor::value_mesh::ValueOverlayReducer<crate::resource::Status> as typeuri::Named>::typehash,
         builder_f: |_| Ok(Box::new(hyperactor::value_mesh::ValueOverlayReducer::<crate::resource::Status>::new())),
+    }
+}
+
+// Reducer for per-proc `State<ProcState>` overlays, so `ProcMeshRef::states`
+// can reduce partial per-host meshes up the cast tree (see `GetHostProcStates`).
+inventory::submit! {
+    hyperactor::accum::ReducerFactory {
+        typehash_f: <hyperactor::value_mesh::ValueOverlayReducer<crate::resource::State<crate::host_mesh::host_agent::ProcState>> as typeuri::Named>::typehash,
+        builder_f: |_| Ok(Box::new(hyperactor::value_mesh::ValueOverlayReducer::<crate::resource::State<crate::host_mesh::host_agent::ProcState>>::new())),
     }
 }
 

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -47,8 +47,8 @@ use crate::Error;
 use crate::HostMeshRef;
 use crate::ValueMesh;
 use crate::host_mesh::GET_PROC_STATE_MAX_IDLE;
+use crate::host_mesh::host_agent::GetHostProcStates;
 use crate::host_mesh::host_agent::ProcState;
-use crate::host_mesh::host_agent_ref;
 use crate::host_mesh::mesh_to_rankedvalues_with_default;
 use crate::mesh_controller::ActorMeshControlPlane;
 use crate::mesh_controller::ActorMeshController;
@@ -571,14 +571,18 @@ impl ProcMeshRef {
         Ok(vm)
     }
 
-    /// Get the state of all procs in this proc mesh.
+    /// Get the state of every proc in this proc mesh.
     ///
-    /// Sends one `GetState` per proc (or `KeepaliveGetState` when `keepalive`
-    /// is `Some`, so the host agent extends each proc's expiry) directly to the
-    /// proc's host agent, and collects the replies into a rank-ordered
-    /// `ValueMesh`. Returns `None` when this proc mesh is not backed by a host
-    /// mesh (local/in-process meshes). On timeout, missing ranks are padded
-    /// with a `Timeout` state.
+    /// Casts a single `GetHostProcStates` to the routing host-agent mesh
+    /// carrying this mesh's selected global ranks (the mesh may be sliced, so
+    /// they need not be a dense `0..n`). The cast may reach hosts that own no
+    /// selected procs, but each HostAgent filters locally and only hosts with
+    /// matching ranks reply. Replies reduce up the cast tree (fanning in at cast
+    /// actor 0) instead of every host dialing this caller. When `keepalive` is
+    /// `Some`, each proc's expiry is extended (orphan protection, as with
+    /// `KeepaliveGetState`). Returns `None` when this proc mesh is not backed by
+    /// a host mesh (local/in-process meshes). On timeout, ranks whose host did
+    /// not reply are padded with a `Timeout` state.
     #[allow(clippy::result_large_err)]
     pub async fn states(
         &self,
@@ -586,111 +590,68 @@ impl ProcMeshRef {
         keepalive: Option<std::time::SystemTime>,
     ) -> crate::Result<Option<ValueMesh<resource::State<ProcState>>>> {
         // Only meaningful when this proc mesh is backed by a host mesh.
-        if self.host_mesh.is_none() {
+        let Some(host_mesh) = self.host_mesh.as_ref() else {
             return Ok(None);
-        }
+        };
         let region = self.region.clone();
-
-        let (tx, mut rx) = cx.mailbox().open_port();
-
-        let mut num_ranks = 0;
-        let mut proc_names = Vec::new();
-        for proc_id in self.proc_ids() {
-            num_ranks += 1;
-            let addr = proc_id.addr().clone();
-
-            // Note that we don't send 1 message per host agent, we send 1 message
-            // per proc.
-            let host_agent = host_agent_ref(addr);
-            let proc_resource_id = ResourceId::new(proc_id.uid().clone(), proc_id.label().cloned());
-            proc_names.push(proc_resource_id.clone());
-            let mut reply = tx.bind();
-            // If this proc dies or some other issue renders the reply undeliverable,
-            // the reply does not need to be returned to the sender.
-            reply.return_undeliverable(false);
-            let mut send_port = host_agent.port();
-            // If the message is undeliverable, the timeout below will catch the issue, and the caller
-            // can handle the error as it pleases. Set this so an undeliverable message doesn't cause
-            // a supervision crash.
-            send_port.return_undeliverable(false);
-            let get_state = resource::GetState {
-                id: proc_resource_id,
-                reply,
-            };
-            if let Some(expires_after) = keepalive {
-                let mut keepalive_port = host_agent.port();
-                keepalive_port.return_undeliverable(false);
-                keepalive_port.post(
-                    cx,
-                    resource::KeepaliveGetState {
-                        expires_after,
-                        get_state,
-                    },
-                );
-            } else {
-                send_port.post(cx, get_state);
-            }
-        }
-
-        let mut states = Vec::with_capacity(num_ranks);
         let timeout = hyperactor_config::global::get(GET_PROC_STATE_MAX_IDLE);
-        for _ in 0..num_ranks {
-            // The agent runs on the same process as the running actor, so if some
-            // fatal event caused the process to crash (e.g. OOM, signal, process exit),
-            // the agent will be unresponsive.
-            // We handle this by setting a timeout on the recv, and if we don't get a
-            // message we assume the agent is dead and return a failed state.
-            let state = tokio::time::timeout(timeout, rx.recv()).await;
-            if let Ok(state) = state {
-                // Handle non-timeout receiver error.
-                let state = state?;
-                match state.state {
-                    Some(ref inner) => {
-                        states.push((inner.create_rank, state));
-                    }
-                    None => {
-                        return Err(crate::Error::NotExist(state.id));
-                    }
-                }
-            } else {
-                // Timeout error, stop reading from the receiver and send back what we have so far,
-                // padding with failed states.
-                tracing::warn!(
-                    "Timeout waiting for response from host mesh agent for proc states after {:?}",
-                    timeout
-                );
-                let all_ranks = (0..num_ranks).collect::<HashSet<_>>();
-                let completed_ranks = states.iter().map(|(rank, _)| *rank).collect::<HashSet<_>>();
-                let mut leftover_ranks = all_ranks.difference(&completed_ranks).collect::<Vec<_>>();
-                assert_eq!(leftover_ranks.len(), num_ranks - states.len());
-                while states.len() < num_ranks {
-                    let rank = *leftover_ranks
-                        .pop()
-                        .expect("leftover ranks should not be empty");
-                    states.push((
-                        // We populate with any ranks leftover at the time of the timeout.
-                        rank,
-                        resource::State {
-                            id: proc_names[rank].clone(),
-                            status: resource::Status::Timeout(timeout),
-                            state: None,
-                            generation: 0,
-                            timestamp: std::time::SystemTime::now(),
-                        },
-                    ));
-                }
-                break;
-            }
-        }
-        // Ensure that all ranks have replied. Note that if the mesh is sliced,
-        // not all create_ranks may be in the mesh.
-        // Sort by rank, so that the resulting mesh is ordered.
-        states.sort_by_key(|(rank, _)| *rank);
-        let vm = states
-            .into_iter()
-            .map(|(_, state)| state)
-            .collect_mesh::<ValueMesh<_>>(region)?;
-        Ok(Some(vm))
+
+        // Per-rank template seeded with `Timeout` placeholders. Hosts overlay
+        // the ranks they own, so any rank never reported keeps its placeholder
+        // and the result is a complete mesh with no post-hoc padding.
+        let template: ValueMesh<resource::State<ProcState>> = self
+            .ranks
+            .iter()
+            .map(|proc_ref| resource::State {
+                id: ResourceId::new(
+                    proc_ref.proc_id.uid().clone(),
+                    proc_ref.proc_id.label().cloned(),
+                ),
+                status: resource::Status::Timeout(timeout),
+                state: None,
+                generation: 0,
+                timestamp: std::time::SystemTime::now(),
+            })
+            .collect_mesh::<ValueMesh<_>>(region.clone())?;
+        // Snapshot returned if no host replies before the idle timeout.
+        let fallback = template.clone();
+
+        // Accumulator port: receives sparse per-host overlays and emits the
+        // merged full mesh (right-wins). The host mesh is a routing
+        // over-approximation for sliced proc meshes; HostAgents that own
+        // selected ranks post an overlay, others stay silent.
+        let (port, rx) = cx.mailbox().open_accum_port_opts(
+            template,
+            StreamingReducerOpts {
+                max_update_interval: Some(Duration::from_millis(50)),
+                initial_update_interval: None,
+            },
+        );
+
+        host_mesh.agent_mesh().cast(
+            cx,
+            GetHostProcStates {
+                proc_mesh_id: self.id.clone(),
+                region: region.clone(),
+                keepalive,
+                reply: port.bind(),
+            },
+        )?;
+
+        // Wait until every rank has reported (moved off its `Timeout`
+        // placeholder) or we idle out. Either way the mesh is complete: ranks
+        // whose host never replied stay `Timeout`, and a failed proc surfaces as
+        // its `Failed` state rather than an error.
+        let mesh =
+            match resource::wait_mesh(rx, timeout, fallback, |s: &resource::State<ProcState>| {
+                !matches!(s.status, resource::Status::Timeout(_))
+            })
+            .await
+            {
+                Ok(mesh) | Err(mesh) => mesh,
+            };
+
+        Ok(Some(mesh))
     }
 
     /// Returns an iterator over the proc ids in this mesh.
@@ -1556,6 +1517,81 @@ mod tests {
             crate::Error::NotExist(name) if name == expected_name => {}
             other => panic!("expected NotExist for {expected_name}, got {other:?}"),
         }
+
+        let _ = hm.shutdown(instance).await;
+    }
+
+    /// `proc_states` must resolve exactly the procs of the (possibly sliced)
+    /// mesh it is called on — gpu-dim slices, host-dim slices, and
+    /// slice-of-slice — rather than re-deriving a dense `0..n` from per-host
+    /// counts or from the recipient's stamped (sliced-ordinal) rank.
+    #[cfg(fbcode_build)]
+    async fn assert_proc_states_match_slice<C: hyperactor::context::Actor>(
+        mesh: &super::ProcMeshRef,
+        cx: &C,
+    ) {
+        // The slice's own procs, by their original global rank.
+        let mut expected: Vec<usize> = mesh.ranks.iter().map(|r| r.create_rank).collect();
+        expected.sort();
+
+        let states = mesh
+            .states(cx, None)
+            .await
+            .unwrap()
+            .expect("host-backed mesh yields Some");
+
+        assert_eq!(states.extent(), mesh.extent());
+
+        let mut got: Vec<usize> = states
+            .values()
+            .map(|s| {
+                assert!(
+                    !matches!(
+                        s.status,
+                        Status::NotExist | Status::Failed(_) | Status::Timeout(_)
+                    ),
+                    "rank should resolve to a live proc, got status {:?}",
+                    s.status
+                );
+                s.state.expect("live proc carries ProcState").create_rank
+            })
+            .collect();
+
+        got.sort();
+
+        assert_eq!(
+            got, expected,
+            "proc_states must return exactly this (sub)mesh's procs"
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 60)]
+    #[cfg(fbcode_build)]
+    async fn test_proc_states_on_sliced_mesh() {
+        let instance = testing::instance();
+        let mut hm = testing::host_mesh(2).await;
+        // 2 hosts x 4 gpus, host-major: global rank = host * 4 + gpu.
+        let proc_mesh = hm
+            .spawn(&instance, "test", extent!(gpus = 4), None, None)
+            .await
+            .unwrap();
+
+        // Full mesh: ranks 0..8.
+        assert_proc_states_match_slice(&proc_mesh, instance).await;
+        // gpu-dim slice (gpus 2..4): ranks {2,3,6,7} — the original mis-derivation.
+        assert_proc_states_match_slice(&proc_mesh.range("gpus", 2..4).unwrap(), instance).await;
+        // host-dim slice (host 1): ranks {4,5,6,7} — the stamped-ordinal trap.
+        assert_proc_states_match_slice(&proc_mesh.range("hosts", 1..2).unwrap(), instance).await;
+        // slice-of-slice (host 1, gpus 2..4): ranks {6,7} — pins base-rank composition.
+        assert_proc_states_match_slice(
+            &proc_mesh
+                .range("gpus", 2..4)
+                .unwrap()
+                .range("hosts", 1..2)
+                .unwrap(),
+            instance,
+        )
+        .await;
 
         let _ = hm.shutdown(instance).await;
     }

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -38,6 +38,7 @@ use serde::Serialize;
 use typeuri::Named;
 
 use crate::StatusOverlay;
+use crate::ValueMesh;
 use crate::bootstrap;
 use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::ProcBind;
@@ -242,48 +243,64 @@ pub struct WaitRankStatus {
     pub reply: PortRef<StatusOverlay>,
 }
 
+/// Collect an accumulated [`ValueMesh<T>`] from `rx` until every rank has been
+/// reported or `max_idle_time` elapses with no update.
+///
+/// `reported` decides whether a rank's current value counts as "reported" (e.g.
+/// moved off a `NotExist`/`Timeout` placeholder). The accumulator emits the full
+/// mesh over the target region, so completion is "every cell reported". Returns
+/// `Ok(mesh)` once all ranks are reported, or `Err(mesh)` carrying the latest
+/// snapshot (or `fallback` if nothing arrived) on idle timeout / channel close.
+pub async fn wait_mesh<T>(
+    mut rx: PortReceiver<ValueMesh<T>>,
+    max_idle_time: Duration,
+    fallback: ValueMesh<T>,
+    reported: impl Fn(&T) -> bool,
+) -> Result<ValueMesh<T>, ValueMesh<T>>
+where
+    T: Send + Sync + Clone + 'static,
+{
+    let mut alarm = hyperactor::time::Alarm::new();
+    alarm.arm(max_idle_time);
+
+    // Latest-wins snapshot; `fallback` stands in until the first update arrives.
+    let mut snapshot = fallback;
+
+    loop {
+        let mut sleeper = alarm.sleeper();
+        tokio::select! {
+            _ = sleeper.sleep() => return Err(snapshot),
+            next = rx.recv() => {
+                match next {
+                    Ok(mesh) => { snapshot = mesh; }   // latest-wins snapshot
+                    Err(_)   => return Err(snapshot),
+                }
+            }
+        }
+
+        alarm.arm(max_idle_time);
+
+        // Short-circuit: done as soon as no rank is still unreported.
+        if snapshot.values().all(|v| reported(&v)) {
+            break Ok(snapshot);
+        }
+    }
+}
+
 impl GetRankStatus {
     pub async fn wait(
-        mut rx: PortReceiver<crate::StatusMesh>,
+        rx: PortReceiver<crate::StatusMesh>,
         num_ranks: usize,
         max_idle_time: Duration,
         region: Region, // used only for fallback
     ) -> Result<crate::StatusMesh, crate::StatusMesh> {
         debug_assert_eq!(region.num_ranks(), num_ranks, "region/num_ranks mismatch");
 
-        let mut alarm = hyperactor::time::Alarm::new();
-        alarm.arm(max_idle_time);
-
-        // Fallback snapshot if we time out before receiving anything.
-        let mut snapshot =
-            crate::StatusMesh::from_single(region, crate::resource::Status::NotExist);
-
-        loop {
-            let mut sleeper = alarm.sleeper();
-            tokio::select! {
-                _ = sleeper.sleep() => return Err(snapshot),
-                next = rx.recv() => {
-                    match next {
-                        Ok(mesh) => { snapshot = mesh; }   // latest-wins snapshot
-                        Err(_)   => return Err(snapshot),
-                    }
-                }
-            }
-
-            alarm.arm(max_idle_time);
-
-            // Completion: once every expected rank has reported at least
-            // something (i.e. moved off NotExist). Sliced meshes may report at
-            // non-zero base ranks, so do not assume the relevant ranks occupy
-            // the first `num_ranks` dense slots.
-            let reported = snapshot
-                .values()
-                .filter(|s| !matches!(s, crate::resource::Status::NotExist))
-                .count();
-            if reported >= num_ranks {
-                break Ok(snapshot);
-            }
-        }
+        let fallback = crate::StatusMesh::from_single(region, crate::resource::Status::NotExist);
+        wait_mesh(rx, max_idle_time, fallback, |s| {
+            !matches!(s, crate::resource::Status::NotExist)
+        })
+        .await
     }
 }
 


### PR DESCRIPTION
Summary:

Convert `ProcMeshRef::proc_states` (the supervision poll's per-proc state query) from per-proc direct `GetState`/`KeepaliveGetState` posts -- O(procs) direct dials from the client -- into a single cast over the host-agent mesh, so the read fans in through the cast tree instead.

Add `GetHostProcStates`: the caller casts ONE of these; each `HostAgent` combines its cast-stamped `rank` with `num_per_host` to re-derive the proc resource ids for its slots (via `proc_name`) and replies with a batch of their states. The client thus sees O(hosts) batched replies reduced up the tree (to cast actor 0) instead of O(procs) individual ones dialed directly. The per-proc `State` builder is factored into `HostAgent::proc_state`, shared by the `GetState` and `GetHostProcStates` handlers. `GetState<ProcState>` cannot be cast this way because it carries a fully-resolved id; this message re-derives the ids host-side. If `keepalive` is `Some`, each proc's expiry is extended (same orphan-protection semantics as `KeepaliveGetState`). Builds on the prep commit that relocated `proc_states` to `ProcMeshRef`.

Reviewed By: mariusae

Differential Revision: D108359901


