### PR TITLE
Cancel pending tasks on the asyncio loop before exiting the actor

### DIFF
--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -908,6 +908,60 @@ impl PythonActor {
         )?)
     }
 
+    fn cancel_tasks_on_python_loop<'py>(
+        py: Python<'py>,
+        task_locals: &pyo3_async_runtimes::TaskLocals,
+    ) -> PyResult<Option<Bound<'py, PyAny>>> {
+        let asyncio = py.import("asyncio")?;
+        let event_loop = task_locals.event_loop(py);
+        let tasks = asyncio.call_method1("all_tasks", (&event_loop,))?;
+        let mut has_tasks = false;
+        for task in tasks.try_iter()? {
+            let task = task?;
+            let cancel = task.getattr("cancel")?;
+            event_loop.call_method1("call_soon_threadsafe", (cancel,))?;
+            has_tasks = true;
+        }
+        if !has_tasks {
+            return Ok(None);
+        }
+        Ok(Some(asyncio.call_method1("sleep", (0,))?))
+    }
+
+    async fn cancel_pending_python_tasks(&self) -> anyhow::Result<()> {
+        let Some(task_locals) = &self.task_locals else {
+            return Ok(());
+        };
+        let future = monarch_with_gil(|py| {
+            let Some(awaitable) = Self::cancel_tasks_on_python_loop(py, task_locals)? else {
+                return Ok(None);
+            };
+            pyo3_async_runtimes::into_future_with_locals(task_locals, awaitable).map(Some)
+        })
+        .await
+        .map_err(anyhow::Error::from)?;
+        if let Some(future) = future {
+            future.await.map_err(anyhow::Error::from)?;
+        }
+        Ok(())
+    }
+
+    fn stop_task_locals_event_loop(&self) -> anyhow::Result<()> {
+        let Some(task_locals) = &self.task_locals else {
+            return Ok(());
+        };
+        monarch_with_gil_blocking(|py| -> anyhow::Result<()> {
+            let event_loop = task_locals.event_loop(py);
+            let stop = event_loop
+                .getattr("stop")
+                .map_err(|err| anyhow::Error::from(SerializablePyErr::from(py, &err)))?;
+            event_loop
+                .call_method1("call_soon_threadsafe", (stop,))
+                .map_err(|err| anyhow::Error::from(SerializablePyErr::from(py, &err)))?;
+            Ok(())
+        })
+    }
+
     /// Get the TaskLocals to use for this actor.
     /// Returns either the shared TaskLocals or this actor's own TaskLocals based on configuration.
     fn get_task_locals(&self, py: Python) -> &pyo3_async_runtimes::TaskLocals {
@@ -1301,10 +1355,17 @@ impl Actor for PythonActor {
                     .map_err(anyhow::Error::from)
             }
         })
-        .await?;
-        if let Some(future) = future {
-            future.await.map_err(anyhow::Error::from)?;
-        }
+        .await;
+        let cleanup_result = match future {
+            Ok(Some(future)) => future.await.map(|_| ()).map_err(anyhow::Error::from),
+            Ok(None) => Ok(()),
+            Err(err) => Err(err),
+        };
+        let cancel_result = self.cancel_pending_python_tasks().await;
+        let stop_result = self.stop_task_locals_event_loop();
+        cleanup_result?;
+        cancel_result?;
+        stop_result?;
         Ok(())
     }
 

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import abc
+import asyncio
 import collections
 import contextvars
 import functools
@@ -1207,14 +1208,19 @@ async def _dispatch_loop(
         self_instance: The actor's own Instance, used to kill self on
             an unhandled exception.
     """
-    while True:
-        msg = await receiver.recv()
-        try:
-            await _handle_queued_message(actor, msg)
-        except BaseException as e:
-            reason = "".join(TracebackException.from_exception(e).format())
-            self_instance.kill(reason)
-            raise
+    try:
+        while True:
+            msg = await receiver.recv()
+            try:
+                await _handle_queued_message(actor, msg)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as e:
+                reason = "".join(TracebackException.from_exception(e).format())
+                self_instance.kill(reason)
+                raise
+    except asyncio.CancelledError:
+        return
 
 
 async def _handle_queued_message(actor: Any, msg: "QueuedMessage") -> None:


### PR DESCRIPTION
Summary:
Cancel pending tasks directly from `PythonActor::cleanup` before stopping an actor-owned asyncio loop. This ensures any pending tasks are cancelled before destroying access to things like actor ports.

For actors with private `TaskLocals`, cleanup now enumerates `asyncio.all_tasks(loop)` from Rust, schedules each task's `cancel()` with `loop.call_soon_threadsafe`, awaits `asyncio.sleep(0)` on the same `TaskLocals` to give cancellation handlers one loop turn, and then schedules `loop.stop()`. Actors using the shared asyncio runtime are left alone because that loop can contain unrelated actor work.

The main outcome of this change is that background async tasks now have a chance to run their finally blocks (and context manager
exits) to clean stuff up before the actor they were created from exits completely.

Differential Revision: D108458594


