### PR TITLE
monarch_extension: split rdma cargo feature out of tensor_engine_gpu so monarch.rdma is available without the tensor-engine build

### DIFF
--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -51,8 +51,9 @@ monarch_cpp_static_libs = { path = "../monarch_cpp_static_libs", optional = true
 default = ["tensor_engine"]
 distributed_sql_telemetry = ["dep:monarch_distributed_telemetry", "dep:monarch_introspection_snapshot"]
 extension-module = ["pyo3/extension-module"]
+rdma = ["dep:monarch_cpp_static_libs", "dep:monarch_rdma_extension"]
 tensor_engine = ["dep:monarch_messages", "dep:monarch_tensor_worker", "dep:torch-sys-cuda"]
-tensor_engine_gpu = ["dep:monarch_cpp_static_libs", "dep:monarch_rdma_extension", "dep:nccl-sys", "dep:rdmaxcel-sys", "monarch_messages/cuda", "monarch_tensor_worker/cuda", "tensor_engine", "torch-sys-cuda/cuda"]
+tensor_engine_gpu = ["dep:nccl-sys", "dep:rdmaxcel-sys", "monarch_messages/cuda", "monarch_tensor_worker/cuda", "rdma", "tensor_engine", "torch-sys-cuda/cuda"]
 
 [lints]
 workspace = true

--- a/monarch_extension/build.rs
+++ b/monarch_extension/build.rs
@@ -7,8 +7,12 @@
  */
 
 fn main() {
-    // Only set up static linking if tensor_engine_gpu feature is enabled
-    if std::env::var("CARGO_FEATURE_TENSOR_ENGINE_GPU").is_ok() {
+    // RDMA bindings need the rdma-core static link setup. The slim OSS build
+    // enables it via the `rdma` feature; internal buck builds get it through
+    // `tensor_engine_gpu` (which folds in `rdma`).
+    if std::env::var("CARGO_FEATURE_RDMA").is_ok()
+        || std::env::var("CARGO_FEATURE_TENSOR_ENGINE_GPU").is_ok()
+    {
         // Set up static linking for rdma-core
         // This emits link directives for libmlx5.a, libibverbs.a, librdma_util.a
         let _config = build_utils::setup_cpp_static_libs();

--- a/monarch_extension/src/lib.rs
+++ b/monarch_extension/src/lib.rs
@@ -130,7 +130,9 @@ pub fn mod_init(module: &Bound<'_, PyModule>) -> PyResult<()> {
             "monarch_extension.mesh_controller",
         )?)?;
     }
-    #[cfg(feature = "tensor_engine_gpu")]
+    // rdma registers under the OSS slim wheel's `rdma` feature or, for internal
+    // (buck) builds, transitively via `tensor_engine_gpu`.
+    #[cfg(any(feature = "rdma", feature = "tensor_engine_gpu"))]
     {
         monarch_rdma_extension::register_python_bindings(&get_or_add_new_module(module, "rdma")?)?;
     }

--- a/setup.py
+++ b/setup.py
@@ -163,13 +163,28 @@ if not gpu_platform and build_tensor_engine and cuda_home and rocm_home:
         "Both CUDA and ROCm detected. Set MONARCH_GPU_PLATFORM=cuda, =rocm, or =none."
     )
 
-build_cuda = build_tensor_engine and (
-    gpu_platform == "cuda" or (not gpu_platform and cuda_home)
-)
-build_rocm = build_tensor_engine and (
-    gpu_platform == "rocm" or (not gpu_platform and rocm_home)
-)
+# Two independent axes drive the cargo features below:
+#   * torch present?            -> build_tensor_engine ("tensor_engine")
+#   * CUDA/ROCm toolchain?      -> has_cuda / has_rocm
+# MONARCH_GPU_PLATFORM forces the platform ("cuda"/"rocm"/"none"); empty means
+# auto-detect. Invalid / forced-but-missing / both-installed cases already
+# errored out above, so here we just read the result.
+auto_detect = gpu_platform == ""
+has_cuda = gpu_platform == "cuda" or (auto_detect and cuda_home is not None)
+has_rocm = gpu_platform == "rocm" or (auto_detect and rocm_home is not None)
+
+# GPU tensor-engine build needs torch AND a toolchain -> "tensor_engine_gpu"
+# feature (which itself folds in "rdma", see monarch_extension/Cargo.toml).
+build_cuda = build_tensor_engine and has_cuda
+build_rocm = build_tensor_engine and has_rocm
 build_gpu = build_cuda or build_rocm
+
+# rdma needs only the toolchain, not torch, so it can ship in the no-torch
+# (USE_TENSOR_ENGINE=0) build too.
+# TODO: this coupling makes no sense and should be removed in a follow-up —
+# rdma (ibverbs) is a network transport with nothing to do with GPU compute;
+# it can't build today only because rdmaxcel-sys compiles device code.
+build_rdma = has_cuda or has_rocm
 
 print("=" * 80)
 if build_tensor_engine:
@@ -181,11 +196,15 @@ if build_tensor_engine:
         elif build_rocm:
             print(f"  - ROCm: {rocm_home}")
     else:
-        print("✓ Building WITH tensor_engine (CPU-only, no GPU/NCCL/RDMA)")
+        print("✓ Building WITH tensor_engine (CPU-only, no GPU/NCCL)")
         print(f"  - PyTorch: {torch_config['lib_path']}")
     print(f"  - C++11 ABI: {'enabled' if torch_config['cxx11_abi'] else 'disabled'}")
 else:
-    print("Building WITHOUT tensor_engine (actors only, no torch)")
+    print("Building WITHOUT tensor_engine (no torch)")
+if build_rdma:
+    print("  - RDMA: included")
+else:
+    print("  - RDMA: not included (no CUDA/ROCm toolchain found; see TODO in setup.py)")
 print("=" * 80)
 
 # Set PYO3_PYTHON for Rust binaries
@@ -363,10 +382,12 @@ rust_extensions = []
 
 # Main Python extension
 rust_features = ["extension-module", "distributed_sql_telemetry"]
+if build_rdma:
+    rust_features.append("rdma")
 if build_tensor_engine:
     rust_features.append("tensor_engine")
 if build_gpu:
-    rust_features.append("tensor_engine_gpu")
+    rust_features.append("tensor_engine_gpu")  # folds in "rdma" too
 
 rust_extensions.append(
     RustExtension(


### PR DESCRIPTION
Summary:
`monarch._rust_bindings.rdma` (the RDMA Python bindings) was only compiled into the wheel when the `tensor_engine_gpu` cargo feature was enabled, a build with torch and cuda — even though the rdma code itself does not depend on torch.

This splits `rdma` into its own cargo feature (`monarch_cpp_static_libs` + `monarch_rdma_extension`) so `monarch.rdma` is compiled independent of the tensor-engine/GPU build. `tensor_engine_gpu` folds in `rdma`, so torch builds are unchanged.

`setup.py` adds `rdma` to the feature set only when a CUDA/ROCm toolchain (nvcc/hipcc) is present (`build_rdma = has_cuda or has_rocm`). rdma pulls in `rdmaxcel-sys`, whose `build.rs` requires that toolchain, so a slim (no-torch, no-CUDA) build drops rdma from the feature set and still succeeds, plainly reporting that `monarch.rdma` is not included (the same as before this change — CPU/no-torch builds never carried `monarch.rdma`). A `TODO` above `build_rdma` records that this coupling makes no sense — rdma (ibverbs) is a network transport with nothing to do with GPU compute — and should be removed in a follow-up so `monarch.rdma` is also included on CPU (`USE_TENSOR_ENGINE=0`) builds.

`src/lib.rs` registers the module under `#[cfg(any(feature = "rdma", feature = "tensor_engine_gpu"))]`. `build.rs` runs the rdma-core static-link setup under `CARGO_FEATURE_RDMA || CARGO_FEATURE_TENSOR_ENGINE_GPU`. The buck `monarch_extension` target's `features`/`deps` are unchanged — only the autocargo `cargo_toml_config` map gains the `rdma` feature (used to generate `Cargo.toml`). `pyproject.toml` keeps `torch` in build-requires.

Cost: a no-torch (`USE_TENSOR_ENGINE=0`) build with a CUDA/ROCm toolchain present compiles the rdma code and the statically-linked rdma-core libraries, growing `_rust_bindings.so` by ~13.8 MiB unstripped (224.6 -> 238.4 MiB, +5.8%; +8.9 MiB `.text`). A build with no toolchain pays nothing — rdma is not compiled.

Reviewed By: dulinriley

Differential Revision: D106564678


