### PR TITLE
Remove shared Python actor asyncio runtime

### DIFF
--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -418,13 +418,6 @@ Mesh Bootstrap
 Runtime and Buffering
 ----------------------
 
-``shared_asyncio_runtime``
-    Share asyncio runtime across actors.
-
-    - **Type**: ``bool``
-    - **Default**: ``False``
-    - **Environment**: ``MONARCH_HYPERACTOR_SHARED_ASYNCIO_RUNTIME``
-
 ``small_write_threshold``
     Threshold below which writes are copied (in bytes).
 

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -70,7 +70,6 @@ use typeuri::Named;
 
 use crate::buffers::FrozenBuffer;
 use crate::config::ACTOR_QUEUE_DISPATCH;
-use crate::config::SHARED_ASYNCIO_RUNTIME;
 use crate::context::PyInstance;
 use crate::local_state_broker::BrokerId;
 use crate::local_state_broker::LocalStateBrokerMessage;
@@ -786,8 +785,7 @@ pub struct PythonActor {
     /// The Python object that we delegate message handling to.
     actor: Py<PyAny>,
     /// Stores a reference to the Python event loop to run Python coroutines on.
-    /// This is None when using single runtime mode, Some when using per-actor mode.
-    task_locals: Option<pyo3_async_runtimes::TaskLocals>,
+    task_locals: pyo3_async_runtimes::TaskLocals,
     /// Instance object that we keep across handle calls so that we can store
     /// information from the Init (spawn rank, controller) and provide it to other calls.
     instance: Option<Py<crate::context::PyInstance>>,
@@ -829,9 +827,7 @@ impl PythonActor {
                 let class_type: &Bound<'_, PyType> = unpickled.downcast()?;
                 let actor: Py<PyAny> = class_type.call0()?.into_py_any(py)?;
 
-                // Only create per-actor TaskLocals if not using shared runtime
-                let task_locals = (!hyperactor_config::global::get(SHARED_ASYNCIO_RUNTIME))
-                    .then(|| Python::detach(py, create_task_locals));
+                let task_locals = Python::detach(py, create_task_locals);
 
                 let dispatch_mode = if use_queue_dispatch {
                     let (sender, receiver) = pympsc::channel().map_err(|e| {
@@ -888,22 +884,12 @@ impl PythonActor {
     }
 
     fn cancel_pending_python_tasks_and_stop_loop(&self) -> anyhow::Result<()> {
-        let Some(task_locals) = &self.task_locals else {
-            return Ok(());
-        };
+        let task_locals = &self.task_locals;
         monarch_with_gil_blocking(|py| -> anyhow::Result<()> {
             Self::cancel_tasks_and_stop_python_loop(py, task_locals)
                 .map_err(|err| anyhow::Error::from(SerializablePyErr::from(py, &err)))?;
             Ok(())
         })
-    }
-
-    /// Get the TaskLocals to use for this actor.
-    /// Returns either the shared TaskLocals or this actor's own TaskLocals based on configuration.
-    fn get_task_locals(&self, py: Python) -> &pyo3_async_runtimes::TaskLocals {
-        self.task_locals
-            .as_ref()
-            .unwrap_or_else(|| shared_task_locals(py))
     }
 
     /// Get-or-create the actor's cached `PyInstance`, injecting a clone of
@@ -1209,10 +1195,7 @@ impl Actor for PythonActor {
                 let self_instance = self.ensure_py_instance(py, this);
                 let actor_mesh_mod = py.import("monarch._src.actor.actor_mesh")?;
 
-                let tl = self
-                    .task_locals
-                    .as_ref()
-                    .unwrap_or_else(|| shared_task_locals(py));
+                let tl = &self.task_locals;
                 let awaitable = actor_mesh_mod.call_method(
                     "_dispatch_loop",
                     (self.actor.clone_ref(py), receiver, self_instance),
@@ -1286,7 +1269,7 @@ impl Actor for PythonActor {
             if awaitable.is_none() {
                 Ok(None)
             } else {
-                pyo3_async_runtimes::into_future_with_locals(self.get_task_locals(py), awaitable)
+                pyo3_async_runtimes::into_future_with_locals(&self.task_locals, awaitable)
                     .map(Some)
                     .map_err(anyhow::Error::from)
             }
@@ -1488,12 +1471,6 @@ fn create_task_locals() -> pyo3_async_runtimes::TaskLocals {
     })
 }
 
-/// Get the shared TaskLocals, creating it if necessary.
-fn shared_task_locals(py: Python) -> &'static pyo3_async_runtimes::TaskLocals {
-    static SHARED_TASK_LOCALS: OnceLock<pyo3_async_runtimes::TaskLocals> = OnceLock::new();
-    Python::detach(py, || SHARED_TASK_LOCALS.get_or_init(create_task_locals))
-}
-
 // [Panics in async endpoints]
 // This class exists to solve a deadlock when an async endpoint calls into some
 // Rust code that panics.
@@ -1594,13 +1571,11 @@ impl PythonActor {
                 None,
             )?;
 
-            let tl = self
-                .task_locals
-                .as_ref()
-                .unwrap_or_else(|| shared_task_locals(py));
-
-            pyo3_async_runtimes::into_future_with_locals(tl, awaitable.into_bound(py))
-                .map_err(|err| err.into())
+            pyo3_async_runtimes::into_future_with_locals(
+                &self.task_locals,
+                awaitable.into_bound(py),
+            )
+            .map_err(|err| err.into())
         })
         .await?;
 
@@ -1693,8 +1668,7 @@ impl Handler<MeshFailure> for PythonActor {
                 ),
                 None,
             )?;
-            let fut =
-                pyo3_async_runtimes::into_future_with_locals(self.get_task_locals(py), awaitable)?;
+            let fut = pyo3_async_runtimes::into_future_with_locals(&self.task_locals, awaitable)?;
             anyhow::Ok((display_name, fut))
         })
         .await?;

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -205,13 +205,6 @@ impl<'py> IntoPyObject<'py> for PyDuration {
 
 // Declare monarch-specific configuration keys
 declare_attrs! {
-    /// Use a single asyncio runtime for all Python actors, rather than one per actor
-    @meta(CONFIG = ConfigAttr::new(
-        Some("HYPERACTOR_SHARED_ASYNCIO_RUNTIME".to_string()),
-        Some("shared_asyncio_runtime".to_string()),
-    ))
-    pub attr SHARED_ASYNCIO_RUNTIME: bool = false;
-
     /// Use queue-based message dispatch for Python actors instead of direct dispatch
     @meta(CONFIG = ConfigAttr::new(
         Some("MONARCH_ACTOR_QUEUE_DISPATCH".to_string()),

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -63,7 +63,6 @@ def configure(
     mesh_bootstrap_enable_pdeathsig: bool = ...,
     mesh_terminate_concurrency: int = ...,
     mesh_terminate_timeout: str = ...,
-    shared_asyncio_runtime: bool = ...,
     small_write_threshold: int = ...,
     max_cast_dimension_size: int = ...,
     remote_alloc_bind_to_inaddr_any: bool = ...,
@@ -97,7 +96,7 @@ def configure(
 
     For complete parameter documentation, see the Python wrapper
     `monarch.config.configure()` which provides the same interface
-    with detailed descriptions of all 37 configuration parameters
+    with detailed descriptions of all 36 configuration parameters
     organized into logical categories (transport, logging, message
     handling, mesh bootstrap, allocation, proc/host mesh timeouts,
     etc.).
@@ -142,7 +141,6 @@ def configure(
             during shutdown
         mesh_terminate_timeout: Timeout per child during graceful
             termination (humantime)
-        shared_asyncio_runtime: Share asyncio runtime across actors
         small_write_threshold: Threshold below which writes are copied
             (bytes)
         max_cast_dimension_size: Maximum dimension size for cast

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -66,7 +66,6 @@ if TYPE_CHECKING:
             mesh_bootstrap_enable_pdeathsig: NotRequired[bool]
             mesh_terminate_concurrency: NotRequired[int]
             mesh_terminate_timeout: NotRequired[str]
-            shared_asyncio_runtime: NotRequired[bool]
             small_write_threshold: NotRequired[int]
             max_cast_dimension_size: NotRequired[int]
             remote_alloc_bind_to_inaddr_any: NotRequired[bool]
@@ -141,7 +140,6 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
             mesh_terminate_timeout: Timeout per child during graceful termination (humantime).
 
         Runtime and buffering:
-            shared_asyncio_runtime: Share asyncio runtime across actors.
             small_write_threshold: Threshold below which writes are copied (bytes).
 
         Mesh configuration:
@@ -298,7 +296,7 @@ def parametrize_config(
         >>>
         >>> @parametrize_config(
         ...     actor_queue_dispatch={True, False},
-        ...     shared_asyncio_runtime={True, False},
+        ...     prefix_with_rank={True, False},
         ... )
         ... async def test_actor_feature():
         ...     # Test runs 4 times: all combinations of the two bool options
@@ -388,12 +386,12 @@ def parametrize_config_pointwise(
         >>>
         >>> @parametrize_config_pointwise(
         ...     actor_queue_dispatch=[True, False],
-        ...     shared_asyncio_runtime=[True, False],
+        ...     prefix_with_rank=[True, False],
         ... )
         ... async def test_actor_feature():
         ...     # Runs 2 times:
-        ...     # (actor_queue_dispatch=True, shared_asyncio_runtime=True)
-        ...     # (actor_queue_dispatch=False, shared_asyncio_runtime=False)
+        ...     # (actor_queue_dispatch=True, prefix_with_rank=True)
+        ...     # (actor_queue_dispatch=False, prefix_with_rank=False)
         ...     pass
     """
     import asyncio

--- a/python/tests/test_concurrent_endpoints.py
+++ b/python/tests/test_concurrent_endpoints.py
@@ -312,7 +312,7 @@ async def test_queue_dispatch_keeps_async_actor_non_concurrent_by_default() -> N
 
 
 @pytest.mark.timeout(60)
-@parametrize_config(actor_queue_dispatch={True, False}, shared_asyncio_runtime={False})
+@parametrize_config(actor_queue_dispatch={True, False})
 @isolate_in_subprocess
 async def test_actor_loop_shutdown_cancels_concurrent_endpoint_tasks() -> None:
     with TemporaryDirectory() as tmpdir:
@@ -331,7 +331,7 @@ async def test_actor_loop_shutdown_cancels_concurrent_endpoint_tasks() -> None:
 
 
 @pytest.mark.timeout(60)
-@parametrize_config(actor_queue_dispatch={True, False}, shared_asyncio_runtime={False})
+@parametrize_config(actor_queue_dispatch={True, False})
 @isolate_in_subprocess
 async def test_actor_loop_shutdown_cancels_concurrent_endpoint_before_cleanup() -> None:
     with TemporaryDirectory() as tmpdir:

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -297,8 +297,6 @@ def test_integer_params(param_name, test_value, default_value):
         ("enable_dest_actor_reordering_buffer", True),
         # Mesh bootstrap config
         ("mesh_bootstrap_enable_pdeathsig", True),
-        # Runtime and buffering
-        ("shared_asyncio_runtime", False),
         # Logging config
         ("force_file_log", False),
         ("prefix_with_rank", True),
@@ -373,7 +371,7 @@ def test_encoding_param_invalid():
 
 
 def test_all_params_together():
-    """Test setting all 29 config parameters simultaneously."""
+    """Test setting all 28 config parameters simultaneously."""
     from monarch._rust_bindings.monarch_hyperactor.config import Encoding
 
     with configured(
@@ -395,7 +393,6 @@ def test_all_params_together():
         mesh_terminate_concurrency=16,
         mesh_terminate_timeout="20s",
         # Runtime and buffering
-        shared_asyncio_runtime=True,
         small_write_threshold=512,
         # Mesh config
         max_cast_dimension_size=2048,
@@ -433,7 +430,6 @@ def test_all_params_together():
         assert config["mesh_bootstrap_enable_pdeathsig"] is False
         assert config["mesh_terminate_concurrency"] == 16
         assert config["mesh_terminate_timeout"] == "20s"
-        assert config["shared_asyncio_runtime"] is True
         assert config["small_write_threshold"] == 512
         assert config["max_cast_dimension_size"] == 2048
         assert config["read_log_buffer"] == 16384
@@ -465,7 +461,6 @@ def test_all_params_together():
     assert config["mesh_bootstrap_enable_pdeathsig"] is True
     assert config["mesh_terminate_concurrency"] == 16
     assert config["mesh_terminate_timeout"] == "10s"
-    assert config["shared_asyncio_runtime"] is False
     assert config["small_write_threshold"] == 256
     assert config["max_cast_dimension_size"] == 16
     assert config["read_log_buffer"] == 100


### PR DESCRIPTION
Summary: The `shared_asyncio_runtime` config has no remaining usage and exists only in Monarch internals, docs, and tests. Remove the config and always give each `PythonActor` its own `TaskLocals`, which makes pending task cancellation during actor cleanup actor-scoped by construction. This also removes the shared loop helper and the optional `task_locals` state, trims the Python config API/docs/stub, and updates tests that previously forced `shared_asyncio_runtime=False` to rely on the private-loop invariant.

Reviewed By: shayne-fletcher

Differential Revision: D108462659


