### PR TITLE
Add `@concurrent_endpoint` for Python actors (#4243)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -796,7 +796,93 @@ If you own a mesh of N actors, each of which generates a supervision error, it m
 
 ## Advanced Patterns
 
-### 1. Explicit Response Ports
+### 1. Concurrent Endpoints
+
+Use `@concurrent_endpoint` when one async endpoint should continue running while
+the actor accepts later messages. This is a convenience wrapper for common
+request/response endpoints; it preserves the normal `call()`, `call_one()`, and
+`stream()` API while running the endpoint body in an `asyncio` task.
+
+For two messages sent from the same source actor to `@concurrent_endpoint`
+methods on the same target actor, the first endpoint body starts before the
+second. This is only a start-order guarantee: the first endpoint runs until its
+first `await`, not to completion, before the second starts.
+
+Warning: if you mix `@concurrent_endpoint` with normal `@endpoint` methods, a
+normal endpoint that follows a concurrent endpoint may run before the
+concurrent endpoint body has started.
+
+```python
+import asyncio
+from monarch.actor import Actor, concurrent_endpoint, endpoint
+
+class Gate(Actor):
+    def __init__(self):
+        self.ready = asyncio.Event()
+        self.unblock = asyncio.Event()
+
+    @concurrent_endpoint
+    async def wait(self) -> str:
+        self.ready.set()
+        await self.unblock.wait()
+        return "done"
+
+    @endpoint
+    async def release_when_ready(self) -> None:
+        await self.ready.wait()
+        self.unblock.set()
+```
+
+When an actor stops, `@concurrent_endpoint` cancels and awaits the outstanding
+tasks that it created before user `__cleanup__` runs. This is a cleanup-time
+guarantee only: meshes owned by the actor may already have been stopped by the
+core actor lifecycle before this cancellation runs. General pending tasks on the
+actor's asyncio loop are cancelled after user `__cleanup__` completes, when the
+loop is stopped.
+
+Pass endpoint options directly to `@concurrent_endpoint(...)`, such as
+`explicit_response_port=True`; do not stack it with `@endpoint`.
+
+There is nothing special about `@concurrent_endpoint`: it packages the
+`explicit_response_port=True` pattern with `asyncio.create_task`, result
+forwarding for non-explicit endpoints, warning logs for escaped explicit-port
+exceptions, and cleanup-time cancellation of the tasks it starts. You can write
+the simple version yourself when you want full control:
+
+```python
+import asyncio
+from monarch.actor import Actor, Port, endpoint
+
+class ManualGate(Actor):
+    def __init__(self):
+        self.ready = asyncio.Event()
+        self.unblock = asyncio.Event()
+
+    @endpoint(explicit_response_port=True)
+    async def wait(self, port: Port[str]) -> None:
+        async def run() -> None:
+            try:
+                self.ready.set()
+                await self.unblock.wait()
+                port.send("done")
+            except Exception as e:
+                port.exception(e)
+
+        asyncio.create_task(run())
+```
+
+This manual form intentionally has no extra task tracking; the task lifetime is
+part of the endpoint protocol you are writing. If an explicit-port endpoint lets
+an exception escape before sending a response, the caller will keep waiting until
+it times out or is cancelled.
+
+`@concurrent_endpoint` works on individual endpoints, including inherited
+endpoints, so an actor can mix concurrent and sequential endpoints. For protocols
+that need custom response ordering, multiple sends, or more complex lifetime
+control, use `@endpoint(explicit_response_port=True)` directly and manage the
+response port yourself.
+
+### 2. Explicit Response Ports
 
 For out-of-order responses or background processing:
 
@@ -825,7 +911,7 @@ class AsyncProcessor(Actor):
             port.send(result)
 ```
 
-### 2. Actor Supervision
+### 3. Actor Supervision
 
 Custom supervision for fine-grained error handling:
 

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -46,6 +46,7 @@ from monarch._src.actor.host_mesh import (
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, ProcMesh
 from monarch._src.actor.supervision import unhandled_fault_hook
 from monarch._src.actor.telemetry import span, traced
+from monarch.actor.concurrent import concurrent_endpoint
 
 __all__ = [
     "Accumulator",
@@ -55,6 +56,7 @@ __all__ = [
     "as_endpoint",
     "current_rank",
     "current_size",
+    "concurrent_endpoint",
     "endpoint",
     "Future",
     "Point",

--- a/python/monarch/actor/concurrent.py
+++ b/python/monarch/actor/concurrent.py
@@ -1,0 +1,330 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+import functools
+import inspect
+import logging
+import weakref
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, cast
+
+from monarch._rust_bindings.monarch_hyperactor.logging import log_endpoint_exception
+from monarch._src.actor.actor_mesh import ActorError, context
+from monarch._src.actor.endpoint import endpoint, EndpointProperty, Propagator
+from monarch._src.actor.telemetry import span
+
+_WRAPPER_ATTR = "_monarch_concurrent_endpoint_wrapper"
+_CLEANUP_WRAPPER_ATTR = "_monarch_concurrent_endpoint_cleanup_wrapper"
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _TaskRecord:
+    cancel_for_cleanup: bool = False
+
+
+@dataclass
+class _ConcurrentState:
+    records: dict[asyncio.Task[None], _TaskRecord] = field(default_factory=dict)
+
+
+_states: weakref.WeakKeyDictionary[Any, _ConcurrentState] = weakref.WeakKeyDictionary()
+
+
+def _state(instance: Any) -> _ConcurrentState:
+    state = _states.get(instance)
+    if state is None:
+        state = _ConcurrentState()
+        _states[instance] = state
+    return state
+
+
+def _send_exception(port: Any, actor_error: ActorError) -> None:
+    try:
+        port.exception(actor_error)
+    except Exception:
+        pass
+
+
+def _log_explicit_response_port_exception(
+    actor_name: str, method_name: str, exception: BaseException
+) -> None:
+    logger.warning(
+        "concurrent explicit response-port endpoint raised without forwarding its own exception: %s.%s",
+        actor_name,
+        method_name,
+        exc_info=(type(exception), exception, exception.__traceback__),
+    )
+
+
+async def _run_endpoint(
+    actor_instance: Any,
+    port: Any,
+    call: Callable[[], Awaitable[None]],
+    *,
+    method_name: str,
+    should_instrument: bool,
+    forwards_exception: bool,
+    record: _TaskRecord | None = None,
+) -> None:
+    actor_name = actor_instance.name
+    actor_id = actor_instance.actor_id
+    token = actor_instance._execution_start(method_name)
+    try:
+        try:
+            if should_instrument:
+                with span(method_name):
+                    await call()
+            else:
+                await call()
+        except asyncio.CancelledError as e:
+            if record is not None and record.cancel_for_cleanup:
+                return
+            if forwards_exception:
+                actor_error = ActorError(
+                    e,
+                    f"Actor call {actor_name}.{method_name} failed with BaseException.",
+                )
+                _send_exception(port, actor_error)
+            raise
+        except Exception as e:
+            if forwards_exception:
+                log_endpoint_exception(e, method_name, actor_id)
+                actor_error = ActorError(
+                    e,
+                    f"Actor call {actor_name}.{method_name} failed.",
+                )
+                _send_exception(port, actor_error)
+            else:
+                _log_explicit_response_port_exception(actor_name, method_name, e)
+        except BaseException as e:  # noqa: B036
+            actor_error = ActorError(
+                e,
+                f"Actor call {actor_name}.{method_name} failed with BaseException.",
+            )
+            if forwards_exception:
+                _send_exception(port, actor_error)
+            else:
+                _log_explicit_response_port_exception(actor_name, method_name, e)
+    finally:
+        actor_instance._execution_finish(token)
+
+
+def _spawn_task(
+    instance: Any,
+    port: Any,
+    call: Callable[[], Awaitable[None]],
+    *,
+    method_name: str,
+    should_instrument: bool,
+    forwards_exception: bool,
+) -> None:
+    _install_cleanup_wrapper(instance)
+    state = _state(instance)
+    record = _TaskRecord()
+    actor_instance = context().actor_instance
+    task = asyncio.create_task(
+        _run_endpoint(
+            actor_instance,
+            port,
+            call,
+            method_name=method_name,
+            should_instrument=should_instrument,
+            forwards_exception=forwards_exception,
+            record=record,
+        )
+    )
+    state.records[task] = record
+
+    def finish_task(done: asyncio.Task[None]) -> None:
+        state.records.pop(done, None)
+
+    task.add_done_callback(finish_task)
+
+
+async def _cancel_tasks(instance: Any) -> None:
+    state = _states.get(instance)
+    if state is None:
+        return
+    while state.records:
+        tasks = tuple(state.records)
+        for task in tasks:
+            record = state.records.get(task)
+            if record is not None and not task.done():
+                record.cancel_for_cleanup = True
+                task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def _has_attr(method: Any, name: str) -> bool:
+    return bool(getattr(method, name, False))
+
+
+def _install_cleanup_wrapper(instance: Any) -> None:
+    cleanup = getattr(instance, "__cleanup__", None)
+    if _has_attr(cleanup, _CLEANUP_WRAPPER_ATTR):
+        return
+
+    cleanup_fn: Callable[[Exception | None], Awaitable[None]] | None = None
+    if cleanup is not None and inspect.iscoroutinefunction(cleanup):
+        cleanup_fn = cast(Callable[[Exception | None], Awaitable[None]], cleanup)
+
+    async def cleanup_wrapper(exc: Exception | None) -> None:
+        await _cancel_tasks(instance)
+        if cleanup_fn is not None:
+            await cleanup_fn(exc)
+
+    setattr(cleanup_wrapper, _CLEANUP_WRAPPER_ATTR, True)
+    instance.__cleanup__ = cleanup_wrapper
+
+
+def _explicit_response_signature(
+    method: Callable[..., Any], *, already_explicit: bool
+) -> inspect.Signature:
+    signature = inspect.signature(method)
+    if already_explicit:
+        return signature
+
+    parameters = list(signature.parameters.values())
+    if not parameters:
+        return signature
+
+    name = "_monarch_response_port"
+    while name in signature.parameters:
+        name = f"{name}_"
+
+    port_kind = inspect.Parameter.POSITIONAL_OR_KEYWORD
+    if any(
+        parameter.kind is inspect.Parameter.POSITIONAL_ONLY
+        for parameter in parameters[1:]
+    ):
+        port_kind = inspect.Parameter.POSITIONAL_ONLY
+
+    return signature.replace(
+        parameters=[
+            parameters[0],
+            inspect.Parameter(name, port_kind),
+            *parameters[1:],
+        ],
+        return_annotation=None,
+    )
+
+
+class _ConcurrentEndpointProperty(EndpointProperty[Any, Any]):
+    def __init__(
+        self,
+        endpoint_property: EndpointProperty[Any, Any],
+    ) -> None:
+        self._name = endpoint_property._method.__name__
+        method = endpoint_property._method
+        has_explicit_response_port = endpoint_property._explicit_response_port
+
+        @functools.wraps(method)
+        async def wrapper(
+            actor_self: Any,
+            port: Any,
+            *args: Any,
+            **kwargs: Any,
+        ) -> None:
+            async def call() -> None:
+                if has_explicit_response_port:
+                    await method(actor_self, port, *args, **kwargs)
+                else:
+                    port.send(await method(actor_self, *args, **kwargs))
+
+            _spawn_task(
+                actor_self,
+                port,
+                call,
+                method_name=self._name,
+                should_instrument=endpoint_property._instrument,
+                forwards_exception=not has_explicit_response_port,
+            )
+
+        # pyre-ignore[16]: function attributes are dynamic
+        wrapper.__signature__ = _explicit_response_signature(
+            method, already_explicit=has_explicit_response_port
+        )
+        setattr(wrapper, _WRAPPER_ATTR, True)
+        super().__init__(
+            wrapper,
+            propagator=endpoint_property._propagator,
+            explicit_response_port=True,
+            instrument=False,
+        )
+
+    def __set_name__(self, owner: Any, name: str) -> None:
+        self._name = name
+
+
+def _wrap_endpoint(
+    endpoint_property: EndpointProperty[Any, Any],
+) -> EndpointProperty[Any, Any]:
+    method = endpoint_property._method
+    if getattr(method, _WRAPPER_ATTR, False):
+        return endpoint_property
+    if not inspect.iscoroutinefunction(method):
+        raise ValueError("concurrent_endpoint can only wrap async endpoints")
+    return _ConcurrentEndpointProperty(endpoint_property)
+
+
+def concurrent_endpoint(
+    method: Any = None,
+    *,
+    propagate: Propagator = None,
+    explicit_response_port: bool = False,
+    instrument: bool = True,
+) -> Any:
+    """Run one async actor endpoint as an ``asyncio`` background task.
+
+    The decorator accepts the same endpoint options as ``@endpoint``. It
+    rewrites the endpoint to use an explicit response port, schedules the
+    original async body as a task, and returns immediately so that the actor can
+    handle another queued message.
+
+    If two messages from the same source actor call ``@concurrent_endpoint``
+    methods on the same target actor, the first endpoint body starts before the
+    second. This is only a start-order guarantee: the first endpoint runs until
+    its first ``await``, not to completion, before the second starts.
+
+    If you mix ``@concurrent_endpoint`` with normal ``@endpoint`` methods, a
+    normal endpoint that follows a concurrent endpoint may run before the
+    concurrent endpoint body has started.
+
+    Outstanding tasks created by this decorator are cancelled and awaited
+    before user ``__cleanup__`` runs. This is a cleanup-time guarantee only:
+    meshes owned by the actor may already have been stopped by the core actor
+    lifecycle before these tasks are cancelled. General pending tasks on the
+    actor's asyncio loop are cancelled later, after user ``__cleanup__``
+    completes.
+
+    More complex protocols can still use ``@endpoint(explicit_response_port=True)``
+    and manage response ports manually.
+    """
+    if method is None:
+        return functools.partial(
+            concurrent_endpoint,
+            propagate=propagate,
+            explicit_response_port=explicit_response_port,
+            instrument=instrument,
+        )
+    if isinstance(method, EndpointProperty):
+        raise ValueError(
+            "concurrent_endpoint does not wrap @endpoint; pass endpoint options to @concurrent_endpoint"
+        )
+    endpoint_property = cast(
+        EndpointProperty[Any, Any],
+        endpoint(
+            method,
+            propagate=propagate,
+            explicit_response_port=explicit_response_port,
+            instrument=instrument,
+        ),
+    )
+    return _wrap_endpoint(endpoint_property)

--- a/python/tests/test_concurrent_endpoints.py
+++ b/python/tests/test_concurrent_endpoints.py
@@ -1,0 +1,358 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import asyncio
+import logging
+import os
+from tempfile import TemporaryDirectory
+from typing import Any, cast
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch.actor import Actor, concurrent_endpoint, endpoint, Port, this_host
+from monarch.actor.concurrent import _run_endpoint
+from monarch.config import parametrize_config
+
+
+class AsyncGate(Actor):
+    def __init__(self) -> None:
+        self.ready = asyncio.Event()
+        self.unblock = asyncio.Event()
+
+    @concurrent_endpoint
+    async def wait(self) -> str:
+        self.ready.set()
+        await self.unblock.wait()
+        return "done"
+
+    @endpoint
+    async def release_when_ready(self) -> str:
+        await self.ready.wait()
+        self.unblock.set()
+        return "released"
+
+
+class ExplicitPortAsyncGate(Actor):
+    def __init__(self) -> None:
+        self.unblock = asyncio.Event()
+
+    @concurrent_endpoint(explicit_response_port=True)
+    async def wait(self, port: Port[str]) -> None:
+        port.send("started")
+        await self.unblock.wait()
+
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+    @endpoint
+    async def release(self) -> None:
+        self.unblock.set()
+
+
+class SequentialExplicitPortGate(Actor):
+    @endpoint(explicit_response_port=True)
+    async def wait(self, port: Port[str]) -> None:
+        port.send("started")
+        await asyncio.sleep(0.3)
+
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+
+class LoopShutdownCancelsConcurrentEndpoint(Actor):
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.unblock = asyncio.Event()
+
+    @concurrent_endpoint(explicit_response_port=True)
+    async def run(self, port: Port[str]) -> None:
+        port.send("started")
+        try:
+            await self.unblock.wait()
+        except asyncio.CancelledError:
+            with open(self.path, "w") as f:
+                f.write("cancelled")
+            raise
+
+
+class ConcurrentEndpointCleanupOrder(Actor):
+    def __init__(self, path: str) -> None:
+        self.path = path
+        self.file = open(path, "w")
+        self.unblock = asyncio.Event()
+
+    @concurrent_endpoint(explicit_response_port=True)
+    async def run(self, port: Port[str]) -> None:
+        port.send("started")
+        try:
+            await self.unblock.wait()
+        finally:
+            self.file.write("task_cancelled\n")
+            self.file.flush()
+
+    async def __cleanup__(self, exc: Exception | None) -> None:  # type: ignore[override]
+        self.file.write("cleanup\n")
+        self.file.close()
+
+
+class FailingConcurrentEndpointActor(Actor):
+    @concurrent_endpoint
+    async def fail(self) -> None:
+        raise ValueError("boom")
+
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+
+class ConcurrentExplicitPortFailingActor(Actor):
+    @concurrent_endpoint(explicit_response_port=True)
+    async def fail(self, port: Port[None]) -> None:
+        raise ValueError("explicit boom")
+
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+
+class InheritedConcurrentBase(Actor):
+    def __init__(self) -> None:
+        self.ready = asyncio.Event()
+        self.unblock = asyncio.Event()
+
+    @concurrent_endpoint
+    async def base_wait(self) -> str:
+        self.ready.set()
+        await self.unblock.wait()
+        return "base"
+
+
+class InheritedConcurrentChild(InheritedConcurrentBase):
+    @concurrent_endpoint
+    async def child_wait(self) -> str:
+        await self.ready.wait()
+        return "child"
+
+    @endpoint
+    async def release(self) -> None:
+        self.unblock.set()
+
+
+class FakePort:
+    def __init__(self) -> None:
+        self.exception_value: Exception | None = None
+
+    def exception(self, exception: Exception) -> None:
+        self.exception_value = exception
+
+
+class FakeActorInstance:
+    name = "fake_actor"
+    actor_id = "fake_actor_id"
+
+    def __init__(self) -> None:
+        self.finished_tokens: list[int] = []
+
+    def _execution_start(self, method_name: str) -> int:
+        return 7
+
+    def _execution_finish(self, token: int) -> None:
+        self.finished_tokens.append(token)
+
+
+def test_concurrent_endpoint_wraps_endpoints() -> None:
+    assert cast(Any, AsyncGate.wait)._explicit_response_port
+    assert cast(Any, ExplicitPortAsyncGate.wait)._explicit_response_port
+
+
+def test_concurrent_endpoint_rejects_endpoint_chaining() -> None:
+    with pytest.raises(ValueError, match="does not wrap @endpoint"):
+
+        class StackedDecoratorActor(Actor):
+            @concurrent_endpoint
+            @endpoint
+            async def ping(self) -> str:
+                return "pong"
+
+
+def test_concurrent_endpoint_allows_mixed_hierarchy() -> None:
+    assert cast(Any, InheritedConcurrentChild.base_wait)._explicit_response_port
+    assert cast(Any, InheritedConcurrentChild.child_wait)._explicit_response_port
+    assert not cast(Any, InheritedConcurrentChild.release)._explicit_response_port
+
+
+async def test_explicit_port_exception_logs_warning_without_response(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    port = FakePort()
+    actor_instance = FakeActorInstance()
+
+    async def call() -> None:
+        raise ValueError("explicit boom")
+
+    with caplog.at_level(logging.WARNING, logger="monarch.actor.concurrent"):
+        await _run_endpoint(
+            actor_instance,
+            port,
+            call,
+            method_name="fail",
+            should_instrument=False,
+            forwards_exception=False,
+        )
+
+    assert port.exception_value is None
+    assert "concurrent explicit response-port endpoint raised" in caplog.text
+    assert actor_instance.finished_tokens == [7]
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_concurrent_async_endpoint_runs_in_parallel() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    gate = proc.spawn("async_gate", AsyncGate)
+
+    try:
+        wait = gate.wait.call_one()
+        assert (
+            await asyncio.wait_for(gate.release_when_ready.call_one(), timeout=10)
+            == "released"
+        )
+        assert await asyncio.wait_for(wait, timeout=10) == "done"
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_concurrent_explicit_port_runs_in_parallel() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    gate = proc.spawn("explicit_port_async_gate", ExplicitPortAsyncGate)
+
+    try:
+        assert await asyncio.wait_for(gate.wait.call_one(), timeout=10) == "started"
+        assert await asyncio.wait_for(gate.ping.call_one(), timeout=10) == "pong"
+        await gate.release.call_one()
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_inherited_concurrent_endpoints_run_in_parallel() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    gate = proc.spawn("inherited_concurrent_child", InheritedConcurrentChild)
+
+    try:
+        base_wait = gate.base_wait.call_one()
+        assert await asyncio.wait_for(gate.child_wait.call_one(), timeout=10) == "child"
+        await gate.release.call_one()
+        assert await asyncio.wait_for(base_wait, timeout=10) == "base"
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_concurrent_endpoint_exception_uses_actor_error_context() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    actor = proc.spawn("failing_concurrent_endpoint", FailingConcurrentEndpointActor)
+
+    try:
+        with pytest.raises(
+            Exception, match="Actor call failing_concurrent_endpoint.fail failed"
+        ):
+            await asyncio.wait_for(actor.fail.call_one(), timeout=10)
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_concurrent_explicit_port_exception_is_not_auto_forwarded() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    actor = proc.spawn(
+        "concurrent_explicit_port_failing_actor", ConcurrentExplicitPortFailingActor
+    )
+
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(actor.fail.call_one(), timeout=0.2)
+        assert await asyncio.wait_for(actor.ping.call_one(), timeout=10) == "pong"
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True})
+@isolate_in_subprocess
+async def test_queue_dispatch_keeps_async_actor_non_concurrent_by_default() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    gate = proc.spawn("sequential_explicit_port_gate", SequentialExplicitPortGate)
+
+    try:
+        assert await asyncio.wait_for(gate.wait.call_one(), timeout=10) == "started"
+        ping = asyncio.ensure_future(gate.ping.call_one())
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(ping), timeout=0.1)
+        assert await asyncio.wait_for(ping, timeout=10) == "pong"
+    finally:
+        await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False}, shared_asyncio_runtime={False})
+@isolate_in_subprocess
+async def test_actor_loop_shutdown_cancels_concurrent_endpoint_tasks() -> None:
+    with TemporaryDirectory() as tmpdir:
+        done_path = os.path.join(tmpdir, "done")
+        proc = this_host().spawn_procs(per_host={"gpus": 1})
+        gate = proc.spawn(
+            "loop_shutdown_cancels_concurrent_endpoint",
+            LoopShutdownCancelsConcurrentEndpoint,
+            done_path,
+        )
+
+        assert await asyncio.wait_for(gate.run.call_one(), timeout=10) == "started"
+        await asyncio.wait_for(proc.stop(), timeout=10)
+        with open(done_path) as f:
+            assert f.read() == "cancelled"
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False}, shared_asyncio_runtime={False})
+@isolate_in_subprocess
+async def test_actor_loop_shutdown_cancels_concurrent_endpoint_before_cleanup() -> None:
+    with TemporaryDirectory() as tmpdir:
+        done_path = os.path.join(tmpdir, "done")
+        proc = this_host().spawn_procs(per_host={"gpus": 1})
+        gate = proc.spawn(
+            "loop_shutdown_cancels_before_cleanup",
+            ConcurrentEndpointCleanupOrder,
+            done_path,
+        )
+
+        assert await asyncio.wait_for(gate.run.call_one(), timeout=10) == "started"
+        await asyncio.wait_for(proc.stop(), timeout=10)
+        with open(done_path) as f:
+            assert f.read() == "task_cancelled\ncleanup\n"
+
+
+def test_concurrent_endpoint_rejects_sync_endpoint() -> None:
+    with pytest.raises(ValueError, match="can only wrap async endpoints"):
+
+        class ConcurrentSyncEndpoint(Actor):
+            @concurrent_endpoint
+            def ping(self) -> str:
+                return "pong"


### PR DESCRIPTION
Summary:

Add a `concurrent_endpoint` decorator as a small convenience wrapper for endpoints that should return an explicit response port immediately and let the endpoint body continue in a background task. This is useful when a Python actor has a small number of endpoints that can safely overlap with other actor work, without converting the whole actor class to a different execution model.

The decorator takes the same arguments as `endpoint` and applies `endpoint(explicit_response_port=True)` itself; callers should use one decorator or the other. The wrapper passes the explicit response port into the original endpoint, starts the endpoint coroutine with `asyncio.create_task`, and immediately returns to the actor dispatch loop. If the original endpoint returns a value instead of using the port, the helper sends that value on success and sends exceptions back through the port. If the endpoint uses the explicit port directly, an escaped exception is only logged as a warning because the user is responsible for that response protocol.

`concurrent_endpoint` does not track spawned tasks or expose cleanup policy. The default stop behavior is provided by `PythonActor`, which cancels pending tasks on the actor-owned asyncio loop before user `__cleanup__` and stops the loop after cleanup. Endpoints that need to wait for work, send multiple responses, or use a different lifetime policy should implement the explicit response port pattern manually with `asyncio.create_task`.

Reviewed By: shayne-fletcher

Differential Revision: D108446513


