### PR TITLE
monarch: move torchx-nightly to an optional [torchx] extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "pyre-extensions",
     "typing-extensions>=4.12",
     "cloudpickle",
-    "torchx-nightly",
+    # torchx-nightly is an optional dependency; see the `torchx` extra below.
     "lark",
     "tabulate",
     "opentelemetry-api",
@@ -114,6 +114,10 @@ examples = [
     "ipython",
     "psutil",
 ]
+torchx = [
+    # Optional dependency — only needed for TorchX-backed scheduling / job launching.
+    "torchx-nightly",
+]
 test = [
     "kubernetes",
     "pytest",
@@ -121,6 +125,7 @@ test = [
     "pytest-asyncio",
     "pytest-xdist",
     "pyright",
+    "torchx-nightly",
 ]
 kubernetes = [
     "kubernetes",
@@ -136,6 +141,7 @@ dev = [
     "pytest-split",
     "pyright>=1.1",
     "torch>=2.9.1",
+    "torchx-nightly",
     "setuptools-rust",
 ]
 

--- a/python/monarch/_src/tools/commands.py
+++ b/python/monarch/_src/tools/commands.py
@@ -6,6 +6,16 @@
 
 # pyre-strict
 
+# ``from __future__ import annotations`` turns every annotation in this file
+# into a string that's only evaluated by tools that ask for it (type checkers,
+# ``typing.get_type_hints``). That lets us reference ``Runner``,
+# ``AppDef``, ``ServerSpec``, etc. in signatures without paying the cost of
+# importing ``torchx`` or ``monarch.tools.mesh_spec`` at module-load time.
+# All runtime uses of those names are pushed inside the functions that need
+# them so ``from monarch._src.tools.commands import load_current_job`` (and
+# any other no-scheduler entry point) works without ``torchx`` installed.
+from __future__ import annotations
+
 import asyncio
 import getpass
 import logging
@@ -16,18 +26,16 @@ import tempfile
 import time
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Mapping, Optional, Union
+from typing import Any, Mapping, Optional, TYPE_CHECKING, Union
 
 from monarch.tools.colors import CYAN, ENDC
-from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
-    Config,
-    defaults,
-)
-from monarch.tools.mesh_spec import mesh_spec_from_metadata, ServerSpec
 from monarch.tools.utils import MONARCH_HOME
-from torchx.runner import Runner  # @manual=//torchx/runner:lib_core
-from torchx.specs import AppDef, AppDryRunInfo, AppState, CfgVal, parse_app_handle
-from torchx.specs.api import is_terminal
+
+if TYPE_CHECKING:
+    from monarch.tools.config import Config
+    from monarch.tools.mesh_spec import ServerSpec
+    from torchx.runner import Runner
+    from torchx.specs import AppDryRunInfo
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -40,6 +48,11 @@ TIMEOUT_AFTER_KILL = 300  # 5 minutes
 
 
 def torchx_runner() -> Runner:
+    from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
+        defaults,
+    )
+    from torchx.runner import Runner  # @manual=//torchx/runner:lib_core
+
     # namespace is currently unused so make it empty str
     # so that server handle is short (e.g. slurm:///job-id)
     _EMPTY_NS = ""
@@ -79,6 +92,11 @@ def create(
         scheduler_args: scheduler configs
         name: the name of the job. If none, a default job name will be created.
     """
+    from monarch.tools.config import (  # @manual=//monarch/python/monarch/tools/config/meta:defaults
+        defaults,
+    )
+    from torchx.specs import AppDef, AppDryRunInfo, CfgVal
+
     if name is None:
         name = _default_name()
     scheduler: str = config.scheduler
@@ -128,6 +146,9 @@ def info(server_handle: str) -> Optional[ServerSpec]:
     NOTE: This function can return non-empty info for jobs that have
     exited recently.
     """
+    from monarch.tools.mesh_spec import mesh_spec_from_metadata, ServerSpec
+    from torchx.specs import parse_app_handle
+
     with torchx_runner() as runner:
         status = runner.status(server_handle)
         if status is None:
@@ -197,6 +218,9 @@ async def server_ready(
                 print(f"Job in {server_info.state} state. Hostnames are not available")
 
     """
+
+    from torchx.specs import AppState
+    from torchx.specs.api import is_terminal
 
     check_interval_seconds = check_interval.total_seconds()
     start = datetime.now()
@@ -344,6 +368,8 @@ def kill_and_confirm(
     is actually terminated before returning to avoid the job still being around
     after cancel() completes.
     """
+    from torchx.specs import AppState
+
     with torchx_runner() as runner:
         runner.cancel(server_handle)
         start_time = time.time()

--- a/python/tests/_src/tools/test_commands.py
+++ b/python/tests/_src/tools/test_commands.py
@@ -90,18 +90,18 @@ class TestCommands(unittest.TestCase):
         mock_schedule.assert_called_once()
         self.assertEqual(server_handle, "slurm:///test_job_id")
 
-    @mock.patch("monarch._src.tools.commands.Runner.cancel")
+    @mock.patch("torchx.runner.Runner.cancel")
     def test_kill(self, mock_cancel: mock.MagicMock) -> None:
         handle = "slurm:///test_job_id"
         commands.kill(handle)
         mock_cancel.assert_called_once_with(handle)
 
-    @mock.patch("monarch._src.tools.commands.Runner.status", return_value=None)
+    @mock.patch("torchx.runner.Runner.status", return_value=None)
     def test_info_non_existent_server(self, _: mock.MagicMock) -> None:
         self.assertIsNone(commands.info("slurm:///job-does-not-exist"))
 
-    @mock.patch("monarch._src.tools.commands.Runner.describe")
-    @mock.patch("monarch._src.tools.commands.Runner.status")
+    @mock.patch("torchx.runner.Runner.describe")
+    @mock.patch("torchx.runner.Runner.status")
     def test_info(
         self, mock_status: mock.MagicMock, mock_describe: mock.MagicMock
     ) -> None:

--- a/python/tests/requirements.txt
+++ b/python/tests/requirements.txt
@@ -4,3 +4,4 @@ pytest-timeout
 pytest-asyncio
 pytest-xdist
 pyright
+torchx-nightly


### PR DESCRIPTION
Summary:
`torchx-nightly` was an unconditional entry in `torchmonarch`'s `[project].dependencies` (so every install pulled it in), even though Monarch's actor / proc-mesh / remotemount APIs never touch TorchX. Since none of those core paths use it, `torchx-nightly` doesn't need to be a mandatory dependency — only the scheduler / job-launch paths do. This makes it optional (`pip install 'torchmonarch[torchx]'`).

- `pyproject.toml`: `torchx-nightly` moves from base `dependencies` to a new `torchx` optional extra (`pip install 'torchmonarch[torchx]'`), and is added to the `test` extra, the `dev` dependency-group, and `python/tests/requirements.txt` (the OSS CI test deps) since the scheduler-driving code paths still need coverage.
- `python/monarch/_src/tools/commands.py`: add `from __future__ import annotations` (plus a `TYPE_CHECKING` block) so the torchx-typed signatures don't import torchx at module-load time, and move the runtime `torchx` / `monarch.tools.config.defaults` / `monarch.tools.mesh_spec` imports into the functions that use them (`torchx_runner`, `create`, `info`, `server_ready`, `kill_and_confirm`). The torchx-free helpers (`MONARCH_HOME`, `monarch.tools.colors`) stay at module top.

Net: importing `monarch._src.tools.commands` and other non-scheduler entry points works without `torchx` installed; callers of the scheduler-driving functions get a clear `ModuleNotFoundError` at the call site instead of an import-time crash. This is a partial step, not a fully torchx-free `monarch`: `monarch.tools.mesh_spec`, `monarch.tools.config.defaults`, and `monarch._src.job.spmd` still import torchx at their module top (dataclass field defaults / scheduler-factory registration / SPMD AppDef parsing), so importing those modules still requires torchx — deferring them is a follow-up. The non-scheduler core paths no longer load them.

Reviewed By: dulinriley

Differential Revision: D106572371


