### PR TITLE
route casts through typed multipart parts

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -482,7 +482,7 @@ where
         cx: &Context<Self>,
         msg: IndexedErasedUnbound<M>,
     ) -> anyhow::Result<()> {
-        let message = msg.downcast()?.bind()?;
+        let message = msg.deserialize()?;
         Handler::handle(self, cx, message).await
     }
 }

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -191,7 +191,11 @@ pub use proc::Proc;
 pub use proc::WeakProc;
 pub use ref_::ActorRef;
 pub use ref_::OncePortRef;
+#[doc(hidden)]
+pub use ref_::OncePortRefRepr;
 pub use ref_::PortRef;
+#[doc(hidden)]
+pub use ref_::PortRefRepr;
 pub use ref_::UnboundPort;
 pub use ref_::UnboundPortKind;
 pub use remote::Accepts;

--- a/hyperactor/src/message.rs
+++ b/hyperactor/src/message.rs
@@ -65,8 +65,8 @@ pub trait Bind: Sized {
 
 /// This trait collects the necessary requirements for messages that are can be
 /// cast.
-pub trait Castable: RemoteMessage + Bind + Unbind {}
-impl<T: RemoteMessage + Bind + Unbind> Castable for T {}
+pub trait Castable: RemoteMessage {}
+impl<T: RemoteMessage> Castable for T {}
 
 /// Information extracted from a message through [Unbind], which can be merged
 /// back to the message through [Bind].
@@ -193,25 +193,34 @@ impl ErasedUnbound {
         &self.message
     }
 
+    /// Convert this wrapper into its inner serialized message.
+    pub fn into_message(self) -> wirevalue::Any {
+        self.message
+    }
+
     /// Create an object from a typed message.
     // Note: cannot implement TryFrom<T> due to conflict with core crate's blanket impl.
     // More can be found in this issue: https://github.com/rust-lang/rust/issues/50133
-    pub fn try_from_message<T: Unbind + Serialize + Named>(msg: T) -> Result<Self, anyhow::Error> {
-        let unbound = Unbound::try_from_message(msg)?;
-        let serialized = wirevalue::Any::serialize(&unbound.message)?;
+    pub fn try_from_message<T: Serialize + Named>(msg: T) -> Result<Self, anyhow::Error> {
+        let serialized =
+            wirevalue::Any::serialize_with_encoding(wirevalue::Encoding::Multipart, &msg)?;
         Ok(Self {
             message: serialized,
-            bindings: unbound.bindings,
+            bindings: Bindings::default(),
         })
     }
 
-    /// Use the provided function to update values inside bindings in the same
-    /// order as they were pushed into bindings.
+    /// Use the provided function to update matching typed multipart parts.
     pub fn visit_mut<T: Serialize + DeserializeOwned + Named>(
         &mut self,
         f: impl FnMut(&mut T) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
-        self.bindings.visit_mut(f)
+        Ok(self.message.visit_multipart_parts_mut(f)?)
+    }
+
+    /// Deserialize the contained message.
+    pub fn deserialize<M: DeserializeOwned>(self) -> anyhow::Result<M> {
+        Ok(self.message.deserialized_unchecked()?)
     }
 
     fn downcast<M: DeserializeOwned + Named>(self) -> anyhow::Result<Unbound<M>> {
@@ -232,6 +241,10 @@ pub struct IndexedErasedUnbound<M>(ErasedUnbound, PhantomData<M>);
 impl<M: DeserializeOwned + Named> IndexedErasedUnbound<M> {
     pub(crate) fn downcast(self) -> anyhow::Result<Unbound<M>> {
         self.0.downcast()
+    }
+
+    pub(crate) fn deserialize(self) -> anyhow::Result<M> {
+        self.0.deserialize()
     }
 
     /// Access the inner serialized message.
@@ -335,8 +348,8 @@ mod tests {
     use crate as hyperactor; // for macros
     use crate::Bind;
     use crate::PortRef;
+    use crate::PortRefRepr;
     use crate::Unbind;
-    use crate::UnboundPort;
     use crate::accum::ReducerSpec;
     use crate::accum::StreamingReducerOpts;
     use crate::testing::ids::test_port_id;
@@ -383,28 +396,17 @@ mod tests {
             reply1: original_port1.clone(),
         };
 
-        let serialized_my_message = wirevalue::Any::serialize(&my_message).unwrap();
+        let serialized_multipart_my_message =
+            wirevalue::Any::serialize_with_encoding(wirevalue::Encoding::Multipart, &my_message)
+                .unwrap();
 
         // convert to ErasedUnbound
         let mut erased = ErasedUnbound::try_from_message(my_message.clone()).unwrap();
         assert_eq!(
             erased,
             ErasedUnbound {
-                message: serialized_my_message.clone(),
-                bindings: Bindings(
-                    [
-                        (
-                            UnboundPort::typehash(),
-                            wirevalue::Any::serialize(&UnboundPort::from(&original_port0)).unwrap(),
-                        ),
-                        (
-                            UnboundPort::typehash(),
-                            wirevalue::Any::serialize(&UnboundPort::from(&original_port1)).unwrap(),
-                        ),
-                    ]
-                    .into_iter()
-                    .collect()
-                ),
+                message: serialized_multipart_my_message,
+                bindings: Bindings::default(),
             }
         );
 
@@ -416,9 +418,9 @@ mod tests {
 
         let mut new_ports = vec![&new_port_id0, &new_port_id1].into_iter();
         erased
-            .visit_mut::<UnboundPort>(|b| {
+            .visit_mut::<PortRefRepr>(|b| {
                 let port = new_ports.next().unwrap();
-                b.update(port.clone());
+                b.update_port_addr(port.clone());
                 Ok(())
             })
             .unwrap();
@@ -432,38 +434,8 @@ mod tests {
             }),
             StreamingReducerOpts::default(),
         );
-        let new_bindings = Bindings(
-            [
-                (
-                    UnboundPort::typehash(),
-                    wirevalue::Any::serialize(&UnboundPort::from(&new_port0)).unwrap(),
-                ),
-                (
-                    UnboundPort::typehash(),
-                    wirevalue::Any::serialize(&UnboundPort::from(&new_port1)).unwrap(),
-                ),
-            ]
-            .into_iter()
-            .collect(),
-        );
-        assert_eq!(
-            erased,
-            ErasedUnbound {
-                message: serialized_my_message.clone(),
-                bindings: new_bindings.clone(),
-            }
-        );
-
         // convert back to MyMessage
-        let unbound = erased.downcast::<MyMessage>().unwrap();
-        assert_eq!(
-            unbound,
-            Unbound {
-                message: my_message,
-                bindings: new_bindings,
-            }
-        );
-        let new_my_message = unbound.bind().unwrap();
+        let new_my_message = erased.deserialize::<MyMessage>().unwrap();
         assert_eq!(
             new_my_message,
             MyMessage {

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -235,13 +235,45 @@ pub struct PortRef<M> {
 }
 
 #[doc(hidden)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct PortRefRepr {
     port_addr: PortAddr,
     reducer_spec: Option<ReducerSpec>,
     streaming_opts: StreamingReducerOpts,
     return_undeliverable: bool,
     unsplit: bool,
+}
+
+impl PortRefRepr {
+    /// This port's address.
+    pub fn port_addr(&self) -> &PortAddr {
+        &self.port_addr
+    }
+
+    /// The typehash of this port's reducer, if any.
+    pub fn reducer_spec(&self) -> &Option<ReducerSpec> {
+        &self.reducer_spec
+    }
+
+    /// This port's streaming reducer options.
+    pub fn streaming_opts(&self) -> &StreamingReducerOpts {
+        &self.streaming_opts
+    }
+
+    /// Get whether undeliverable messages should be returned to the sender.
+    pub fn get_return_undeliverable(&self) -> bool {
+        self.return_undeliverable
+    }
+
+    /// Whether the port must not be split.
+    pub fn unsplit(&self) -> bool {
+        self.unsplit
+    }
+
+    /// Update this port's address.
+    pub fn update_port_addr(&mut self, port_addr: PortAddr) {
+        self.port_addr = port_addr;
+    }
 }
 
 impl<M> TryFrom<&PortRef<M>> for PortRefRepr {
@@ -533,12 +565,39 @@ pub struct OncePortRef<M> {
 }
 
 #[doc(hidden)]
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
 pub struct OncePortRefRepr {
     port_addr: PortAddr,
     reducer_spec: Option<ReducerSpec>,
     return_undeliverable: bool,
     unsplit: bool,
+}
+
+impl OncePortRefRepr {
+    /// This port's address.
+    pub fn port_addr(&self) -> &PortAddr {
+        &self.port_addr
+    }
+
+    /// The typehash of this port's reducer, if any.
+    pub fn reducer_spec(&self) -> &Option<ReducerSpec> {
+        &self.reducer_spec
+    }
+
+    /// Get whether undeliverable messages should be returned to the sender.
+    pub fn get_return_undeliverable(&self) -> bool {
+        self.return_undeliverable
+    }
+
+    /// Whether the port must not be split.
+    pub fn unsplit(&self) -> bool {
+        self.unsplit
+    }
+
+    /// Update this port's address.
+    pub fn update_port_addr(&mut self, port_addr: PortAddr) {
+        self.port_addr = port_addr;
+    }
 }
 
 impl<M> TryFrom<&OncePortRef<M>> for OncePortRefRepr {
@@ -818,14 +877,9 @@ mod tests {
 
         let message = serde_multipart::serialize_bincode(&value).unwrap();
         assert_eq!(message.num_parts(), 1);
-        assert_eq!(
-            message.parts()[0].typehash(),
-            Some(PortRef::<String>::typehash())
-        );
+        assert_eq!(message.parts()[0].typehash(), Some(PortRefRepr::typehash()));
 
-        let repr = message.parts()[0]
-            .deserialized_as::<PortRef<String>, PortRefRepr>()
-            .unwrap();
+        let repr = message.parts()[0].deserialized::<PortRefRepr>().unwrap();
         assert_eq!(repr.port_addr, value.port.port_addr().clone());
         assert!(!repr.return_undeliverable);
         assert!(repr.unsplit);
@@ -846,11 +900,11 @@ mod tests {
         assert_eq!(message.num_parts(), 1);
         assert_eq!(
             message.parts()[0].typehash(),
-            Some(OncePortRef::<String>::typehash())
+            Some(OncePortRefRepr::typehash())
         );
 
         let repr = message.parts()[0]
-            .deserialized_as::<OncePortRef<String>, OncePortRefRepr>()
+            .deserialized::<OncePortRefRepr>()
             .unwrap();
         assert_eq!(repr.port_addr, value.port.port_addr().clone());
         assert!(!repr.return_undeliverable);

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -21,11 +21,11 @@ use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
 use hyperactor::Label;
+use hyperactor::OncePortRefRepr;
 use hyperactor::PortRef;
+use hyperactor::PortRefRepr;
 use hyperactor::RemoteEndpoint as _;
 use hyperactor::Uid;
-use hyperactor::UnboundPort;
-use hyperactor::UnboundPortKind;
 use hyperactor::accum::ReducerMode;
 use hyperactor::context;
 use hyperactor::mailbox::MailboxSender;
@@ -35,7 +35,6 @@ use hyperactor::mailbox::UndeliverableMailboxSender;
 use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::monitored_return_handle;
 use hyperactor::message::ErasedUnbound;
-use hyperactor::message::IndexedErasedUnbound;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
 use hyperactor::port::Port;
@@ -269,7 +268,7 @@ impl CastDomainRef {
     /// `headers` are the destination envelope headers supplied by the caller.
     /// The cast layer stamps cast-owned fields on top before sending the
     /// [`CastMessage`] through the domain entry point.
-    pub fn cast<M: hyperactor::message::Unbind + Serialize + Named>(
+    pub fn cast<M: Serialize + Named>(
         &self,
         cx: &impl context::Actor,
         headers: Flattrs,
@@ -277,7 +276,7 @@ impl CastDomainRef {
     ) -> anyhow::Result<()> {
         let data = ErasedUnbound::try_from_message(message)?;
         let sender = cx.mailbox().actor_addr().clone();
-        let dest_port = <IndexedErasedUnbound<M>>::port();
+        let dest_port = M::port();
         let (session_id, seqs) = self.seqs_for_cast(cx, dest_port)?;
 
         let cast_headers = headers.clone();
@@ -619,7 +618,7 @@ impl Handler<CreateCastDomain> for CastActor {
     }
 }
 
-/// Rewrite reply ports in the message bindings so that downstream
+/// Rewrite reply port parts in the serialized message so that downstream
 /// actors reply through local proxy ports on this CastActor instead
 /// of directly to the original sender. Each proxy port reduces
 /// replies from downstream next hops plus the optional local delivery,
@@ -632,44 +631,52 @@ fn split_ports(
     num_next_hops: usize,
     deliver_here: bool,
 ) -> Result<()> {
-    data.visit_mut::<UnboundPort>(
-        |UnboundPort(port_id, reducer_spec, return_undeliverable, kind, unsplit)| {
-            if *unsplit {
-                return Ok(());
-            }
+    data.visit_mut::<PortRefRepr>(|port| {
+        if port.unsplit() {
+            return Ok(());
+        }
 
-            let reducer_mode = match kind {
-                UnboundPortKind::Streaming(opts) => {
-                    ReducerMode::Streaming(opts.clone().unwrap_or_default())
-                }
-                UnboundPortKind::Once if reducer_spec.is_none() => {
-                    // OncePorts without reducers cannot be split —
-                    // pass through as-is.  Using the port more than
-                    // once will cause a delivery error downstream.
-                    return Ok(());
-                }
-                UnboundPortKind::Once => {
-                    let peer_count = num_next_hops + if deliver_here { 1 } else { 0 };
-                    ReducerMode::Once(peer_count)
-                }
-            };
+        let split = port.port_addr().split(
+            cx,
+            port.reducer_spec().clone(),
+            ReducerMode::Streaming(port.streaming_opts().clone()),
+            port.get_return_undeliverable(),
+        )?;
 
-            let split = port_id.split(
-                cx,
-                reducer_spec.clone(),
-                reducer_mode,
-                *return_undeliverable,
-            )?;
+        #[cfg(test)]
+        {
+            tests::collect_split_port(port.port_addr(), &split, deliver_here);
+        }
 
-            #[cfg(test)]
-            {
-                tests::collect_split_port(port_id, &split, deliver_here);
-            }
+        port.update_port_addr(split);
+        Ok(())
+    })?;
 
-            *port_id = split;
-            Ok(())
-        },
-    )
+    data.visit_mut::<OncePortRefRepr>(|port| {
+        if port.unsplit() || port.reducer_spec().is_none() {
+            // OncePorts without reducers cannot be split. Pass through as-is.
+            // Using the port more than once will cause a delivery error downstream.
+            return Ok(());
+        }
+
+        let peer_count = num_next_hops + if deliver_here { 1 } else { 0 };
+        let split = port.port_addr().split(
+            cx,
+            port.reducer_spec().clone(),
+            ReducerMode::Once(peer_count),
+            true,
+        )?;
+
+        #[cfg(test)]
+        {
+            tests::collect_split_port(port.port_addr(), &split, deliver_here);
+        }
+
+        port.update_port_addr(split);
+        Ok(())
+    })?;
+
+    Ok(())
 }
 /// Test-only forwarding path metadata.
 ///
@@ -803,7 +810,7 @@ impl Handler<CastMessage> for CastActor {
                 &dest,
                 &message.sender,
             );
-            cx.post_with_external_seq_info(dest, headers, wirevalue::Any::serialize(&data)?);
+            cx.post_with_external_seq_info(dest, headers, data.clone().into_message());
         }
 
         for next_hop in &domain.next_hops {
@@ -892,11 +899,9 @@ mod tests {
     use std::sync::OnceLock;
     use std::time::Duration;
 
-    use hyperactor::Bind;
     use hyperactor::Client;
     use hyperactor::PortAddr;
     use hyperactor::ProcAddr;
-    use hyperactor::Unbind;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::proc::Proc;
     use ndslice::Shape;
@@ -1074,7 +1079,7 @@ mod tests {
     // -- Integration test infrastructure --
 
     /// A simple castable message type for testing delivery.
-    #[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named, Bind, Unbind)]
+    #[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
     struct TestDelivery {
         payload: String,
     }
@@ -1097,9 +1102,7 @@ mod tests {
         Eq,
         Serialize,
         Deserialize,
-        typeuri::Named,
-        Bind,
-        Unbind
+        typeuri::Named
     )]
     struct TestDeliveryHistories {
         by_proc: BTreeMap<String, Vec<TestDeliveryRecord>>,
@@ -1124,9 +1127,8 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Serialize, Deserialize, typeuri::Named, Bind, Unbind)]
+    #[derive(Debug, Serialize, Deserialize, typeuri::Named)]
     struct GetHistory {
-        #[binding(include)]
         reply_to: hyperactor::OncePortRef<TestDeliveryHistories>,
     }
     wirevalue::register_type!(GetHistory);
@@ -1730,7 +1732,7 @@ mod tests {
                 seqs: ValueMesh::new(Region::from(Shape::unity()), vec![1]).unwrap(),
                 lineage: Vec::new(),
                 headers: Flattrs::new(),
-                dest_port: <IndexedErasedUnbound<TestDelivery>>::port(),
+                dest_port: TestDelivery::port(),
                 data: ErasedUnbound::try_from_message(TestDelivery {
                     payload: "hello".to_string(),
                 })
@@ -2033,9 +2035,7 @@ mod tests {
         Eq,
         Serialize,
         Deserialize,
-        typeuri::Named,
-        Bind,
-        Unbind
+        typeuri::Named
     )]
     struct TestReplyCounts {
         counts_by_proc: BTreeMap<String, u64>,
@@ -2099,10 +2099,9 @@ mod tests {
     }
 
     /// A castable message with a reply port for testing port splitting.
-    #[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named, Bind, Unbind)]
+    #[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
     struct TestRequestWithReply {
         payload: String,
-        #[binding(include)]
         reply_to: hyperactor::OncePortRef<TestReplyCounts>,
     }
     wirevalue::register_type!(TestRequestWithReply);

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -50,6 +50,7 @@ schemars = { version = "1.2.1", features = ["indexmap2"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
+serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 strum = { version = "0.28.0", features = ["derive"] }
 tempfile = "3.27.0"
 thiserror = "2.0.18"

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -23,12 +23,12 @@ use std::time::Duration;
 use hyperactor::ActorLocal;
 use hyperactor::ActorRef;
 use hyperactor::Endpoint as _;
+use hyperactor::OncePortRefRepr;
 use hyperactor::PortRef;
+use hyperactor::PortRefRepr;
 use hyperactor::RemoteEndpoint as _;
 use hyperactor::RemoteHandles;
 use hyperactor::RemoteMessage;
-use hyperactor::UnboundPort;
-use hyperactor::UnboundPortKind;
 use hyperactor::accum::ReducerMode;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Referable;
@@ -36,8 +36,6 @@ use hyperactor::context;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::message::Castable;
 use hyperactor::message::ErasedUnbound;
-use hyperactor::message::IndexedErasedUnbound;
-use hyperactor::message::Unbound;
 use hyperactor::port::Port;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
@@ -467,7 +465,7 @@ impl<A: Referable> ActorMeshRef<A> {
     #[allow(clippy::result_large_err)]
     pub fn cast<M>(&self, cx: &impl context::Actor, message: M) -> crate::Result<()>
     where
-        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        A: RemoteHandles<M>,
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
         self.cast_with_headers(cx, &Flattrs::new(), message)
@@ -487,7 +485,7 @@ impl<A: Referable> ActorMeshRef<A> {
         message: M,
     ) -> crate::Result<()>
     where
-        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        A: RemoteHandles<M>,
         M: Castable + RemoteMessage + Clone,
     {
         self.check_cached_failure(cx)?;
@@ -524,7 +522,7 @@ impl<A: Referable> ActorMeshRef<A> {
         message: M,
     ) -> crate::Result<()>
     where
-        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        A: RemoteHandles<M>,
         M: Castable + RemoteMessage + Clone,
     {
         self.check_cached_failure(cx)?;
@@ -564,7 +562,7 @@ impl<A: Referable> ActorMeshRef<A> {
         message: M,
     ) -> crate::Result<()>
     where
-        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        A: RemoteHandles<M>,
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
         self.check_cached_failure(cx)?;
@@ -661,18 +659,17 @@ impl<A: Referable> ActorMeshRef<A> {
         let mut headers = caller_headers.clone();
         multicast::set_cast_info_on_headers(&mut headers, point, cx.instance().self_addr().clone());
 
-        // Make sure that we re-bind ranks, as these may be used for
+        // Make sure that we rewrite ranks, as these may be used for
         // bootstrapping comm actors.
-        let mut unbound = Unbound::try_from_message(message)
+        let mut data = ErasedUnbound::try_from_message(message)
             .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-        unbound
-            .visit_mut::<resource::Rank>(|resource::Rank(rank)| {
-                *rank = Some(create_rank);
-                Ok(())
-            })
-            .map_err(|e| Error::CastingError(self.id.clone(), e))?;
-        let rebound_message = unbound
-            .bind()
+        data.visit_mut::<resource::RankRepr>(|resource::RankRepr(rank)| {
+            *rank = Some(create_rank);
+            Ok(())
+        })
+        .map_err(|e| Error::CastingError(self.id.clone(), e))?;
+        let rebound_message = data
+            .deserialize()
             .map_err(|e| Error::CastingError(self.id.clone(), e))?;
         actor.post_with_headers(cx, headers, rebound_message);
         Ok(())
@@ -688,7 +685,7 @@ impl<A: Referable> ActorMeshRef<A> {
         caller_headers: &Flattrs,
     ) -> crate::Result<()>
     where
-        A: RemoteHandles<IndexedErasedUnbound<M>>,
+        A: RemoteHandles<M>,
         M: Castable + RemoteMessage + Clone, // Clone is required until we are fully onto comm actor
     {
         let cast_mesh_shape = view::Ranked::region(self).into();
@@ -729,7 +726,7 @@ impl<A: Referable> ActorMeshRef<A> {
         root_comm_actor: &ActorRef<CommActor>,
         caller_headers: &Flattrs,
     ) where
-        A: RemoteHandles<M> + RemoteHandles<IndexedErasedUnbound<M>>,
+        A: RemoteHandles<M>,
         M: Castable + RemoteMessage,
     {
         let _ = metrics::ACTOR_MESH_CAST_DURATION.start(hyperactor::kv_pairs!(
@@ -758,40 +755,44 @@ impl<A: Referable> ActorMeshRef<A> {
             // bypassing the comm actor tree for lower latency when fanout
             // is small.
             let sender = cx.instance().self_addr().clone();
-            let dest_port = <IndexedErasedUnbound<M> as typeuri::Named>::port();
+            let dest_port = M::port();
 
             let mut data = ErasedUnbound::try_from_message(message)
                 .expect("cast message serialization should not fail");
 
             // Split ports for N destinations, matching the comm tree's
             // split_ports behavior.
-            data.visit_mut::<UnboundPort>(
-                |UnboundPort(port_id, reducer_spec, return_undeliverable, kind, unsplit)| {
-                    if *unsplit {
-                        return Ok(());
-                    }
-                    let reducer_mode = match kind {
-                        UnboundPortKind::Streaming(opts) => {
-                            ReducerMode::Streaming(opts.clone().unwrap_or_default())
-                        }
-                        UnboundPortKind::Once if reducer_spec.is_none() => {
-                            // Once ports without reducers pass through — same as
-                            // the comm tree's split_ports.
-                            return Ok(());
-                        }
-                        UnboundPortKind::Once => ReducerMode::Once(num_ranks),
-                    };
-                    let split = port_id.split(
-                        cx,
-                        reducer_spec.clone(),
-                        reducer_mode,
-                        *return_undeliverable,
-                    )?;
-                    *port_id = split;
-                    Ok(())
-                },
-            )
+            data.visit_mut::<PortRefRepr>(|port| {
+                if port.unsplit() {
+                    return Ok(());
+                }
+                let split = port.port_addr().split(
+                    cx,
+                    port.reducer_spec().clone(),
+                    ReducerMode::Streaming(port.streaming_opts().clone()),
+                    port.get_return_undeliverable(),
+                )?;
+                port.update_port_addr(split);
+                Ok(())
+            })
             .expect("port splitting should not fail");
+
+            data.visit_mut::<OncePortRefRepr>(|port| {
+                if port.unsplit() || port.reducer_spec().is_none() {
+                    // Once ports without reducers pass through, same as the comm
+                    // tree's split_ports.
+                    return Ok(());
+                }
+                let split = port.port_addr().split(
+                    cx,
+                    port.reducer_spec().clone(),
+                    ReducerMode::Once(num_ranks),
+                    true,
+                )?;
+                port.update_port_addr(split);
+                Ok(())
+            })
+            .expect("once port splitting should not fail");
 
             for rank in 0..num_ranks {
                 let mut rank_data = data.clone();
@@ -801,7 +802,7 @@ impl<A: Referable> ActorMeshRef<A> {
                     .expect("rank should be valid in region");
 
                 rank_data
-                    .visit_mut::<resource::Rank>(|resource::Rank(r)| {
+                    .visit_mut::<resource::RankRepr>(|resource::RankRepr(r)| {
                         *r = Some(cast_point.rank());
                         Ok(())
                     })
@@ -815,12 +816,8 @@ impl<A: Referable> ActorMeshRef<A> {
                     .expect("mismatched actor_ids and dest_region")
                     .port_addr(Port::handler_id(dest_port, None));
 
-                cx.instance().post(
-                    port_id,
-                    rank_headers,
-                    wirevalue::Any::serialize(&rank_data)
-                        .expect("cast message serialization should not fail"),
-                );
+                cx.instance()
+                    .post(port_id, rank_headers, rank_data.into_message());
             }
         } else {
             // Tree path: route through the comm actor tree.
@@ -828,8 +825,8 @@ impl<A: Referable> ActorMeshRef<A> {
             // rollback is not a concern.
             let sequencer = cx.instance().sequencer();
             let seqs: ValueMesh<u64> = actor_ids.map_into(|actor_id| {
-                let hyperactor::ordering::SeqInfo::Session { seq, .. } = sequencer
-                    .assign_seq(&actor_id.port_addr(Port::handler::<IndexedErasedUnbound<M>>()))
+                let hyperactor::ordering::SeqInfo::Session { seq, .. } =
+                    sequencer.assign_seq(&actor_id.port_addr(Port::handler::<M>()))
                 else {
                     unreachable!("assign_seq always returns SeqInfo::Session")
                 };

--- a/hyperactor_mesh/src/casting.rs
+++ b/hyperactor_mesh/src/casting.rs
@@ -22,7 +22,6 @@ use hyperactor::mailbox::MailboxSenderError;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::message::Castable;
-use hyperactor::message::IndexedErasedUnbound;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::Selection;
@@ -108,7 +107,7 @@ pub(crate) fn actor_mesh_cast<A, M>(
     caller_headers: &Flattrs,
 ) -> Result<(), CastError>
 where
-    A: Referable + RemoteHandles<IndexedErasedUnbound<M>>,
+    A: Referable + RemoteHandles<M>,
     M: Castable + RemoteMessage,
 {
     let _ = metrics::ACTOR_MESH_CAST_DURATION.start(hyperactor::kv_pairs!(
@@ -190,7 +189,7 @@ pub(crate) fn cast_to_sliced_mesh<A, M>(
     caller_headers: &Flattrs,
 ) -> Result<(), CastError>
 where
-    A: Referable + RemoteHandles<IndexedErasedUnbound<M>>,
+    A: Referable + RemoteHandles<M>,
     M: Castable + RemoteMessage,
 {
     let root_slice = root_mesh_shape.slice();

--- a/hyperactor_mesh/src/comm.rs
+++ b/hyperactor_mesh/src/comm.rs
@@ -28,12 +28,12 @@ use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::OncePortRefRepr;
 use hyperactor::PortAddr;
 use hyperactor::PortRef;
+use hyperactor::PortRefRepr;
 use hyperactor::RemoteEndpoint as _;
 use hyperactor::RemoteMessage;
-use hyperactor::UnboundPort;
-use hyperactor::UnboundPortKind;
 use hyperactor::accum::ReducerMode;
 use hyperactor::mailbox::MailboxSender;
 use hyperactor::mailbox::Undeliverable;
@@ -400,7 +400,7 @@ impl CommActor {
             );
         }
 
-        cx.post_with_external_seq_info(dest, headers, wirevalue::Any::serialize(message.data())?);
+        cx.post_with_external_seq_info(dest, headers, message.data().message().clone());
 
         Ok(())
     }
@@ -418,51 +418,53 @@ fn split_ports(
     // Split ports, if any, and update message with new ports. In this
     // way, children actors will reply to this comm actor's ports, instead
     // of to the original ports provided by parent.
-    data.visit_mut::<UnboundPort>(
-        |UnboundPort(port_id, reducer_spec, return_undeliverable, kind, unsplit)| {
-            if *unsplit {
-                return Ok(());
-            }
-            let reducer_mode = match kind {
-                UnboundPortKind::Streaming(opts) => {
-                    ReducerMode::Streaming(opts.clone().unwrap_or_default())
-                }
-                UnboundPortKind::Once if reducer_spec.is_none() => {
-                    // We can only split OncePorts that have reducers.
-                    // Pass this through -- if it is used multiple times,
-                    // it will cause a delivery error downstream.
-                    // However we should reconsider this behavior
-                    // as it its semantics will now differ between
-                    // unicast and broadcast messages.
-                    return Ok(());
-                }
-                UnboundPortKind::Once => {
-                    // Compute peer count for OncePort splitting. This is the number of
-                    // destinations the message will be delivered to, so that the split
-                    // port can correctly accumulate responses.
-                    let peer_count = next_steps.len() + if deliver_here { 1 } else { 0 };
-                    ReducerMode::Once(peer_count)
-                }
-            };
+    data.visit_mut::<PortRefRepr>(|port| {
+        if port.unsplit() {
+            return Ok(());
+        }
 
-            let split = port_id.clone().split(
-                cx,
-                reducer_spec.clone(),
-                reducer_mode,
-                *return_undeliverable,
-            )?;
+        let split = port.port_addr().split(
+            cx,
+            port.reducer_spec().clone(),
+            ReducerMode::Streaming(port.streaming_opts().clone()),
+            port.get_return_undeliverable(),
+        )?;
 
-            #[cfg(test)]
-            tests::collect_split_port(&port_id.clone(), &split, deliver_here);
+        #[cfg(test)]
+        tests::collect_split_port(port.port_addr(), &split, deliver_here);
 
-            *port_id = split;
-            Ok(())
-        },
-    )
+        port.update_port_addr(split);
+        Ok(())
+    })?;
+
+    data.visit_mut::<OncePortRefRepr>(|port| {
+        if port.unsplit() || port.reducer_spec().is_none() {
+            // We can only split OncePorts that have reducers. Pass this
+            // through; if it is used multiple times, it will cause a delivery
+            // error downstream.
+            return Ok(());
+        }
+
+        let peer_count = next_steps.len() + if deliver_here { 1 } else { 0 };
+        let split = port.port_addr().split(
+            cx,
+            port.reducer_spec().clone(),
+            ReducerMode::Once(peer_count),
+            true,
+        )?;
+
+        #[cfg(test)]
+        tests::collect_split_port(port.port_addr(), &split, deliver_here);
+
+        port.update_port_addr(split);
+        Ok(())
+    })?;
+
+    Ok(())
 }
 
 fn replace_with_self_ranks(cast_point: &Point, data: &mut ErasedUnbound) -> anyhow::Result<()> {
-    data.visit_mut::<resource::Rank>(|resource::Rank(rank)| {
+    data.visit_mut::<resource::RankRepr>(|resource::RankRepr(rank)| {
         *rank = Some(cast_point.rank());
         Ok(())
     })
@@ -701,11 +703,9 @@ pub mod test_utils {
     use async_trait::async_trait;
     use hyperactor::Actor;
     use hyperactor::ActorAddr;
-    use hyperactor::Bind;
     use hyperactor::Context;
     use hyperactor::Handler;
     use hyperactor::PortRef;
-    use hyperactor::Unbind;
     use serde::Deserialize;
     use serde::Serialize;
     use typeuri::Named;
@@ -718,31 +718,25 @@ pub mod test_utils {
         pub value: u64,
     }
 
-    #[derive(Debug, Named, Serialize, Deserialize, PartialEq, Clone, Bind, Unbind)]
+    #[derive(Debug, Named, Serialize, Deserialize, PartialEq, Clone)]
     #[expect(
         clippy::large_enum_variant,
-        reason = "test fixture; CastAndReply carries #[binding(include)] PortRefs whose Bind/Unbind derive interaction with Box<T> needs verification — separate diff"
+        reason = "test fixture; CastAndReply carries PortRefs and boxing fields ripples into handler assertions"
     )]
     pub enum TestMessage {
         Forward(String),
         CastAndReply {
             arg: String,
-            // Intentionally not including 0. As a result, this port will not be
-            // split.
-            // #[binding(include)]
+            // Intentionally unsplit so this port should pass through unchanged.
             reply_to0: PortRef<String>,
-            #[binding(include)]
             reply_to1: PortRef<u64>,
-            #[binding(include)]
             reply_to2: PortRef<MyReply>,
         },
         CastAndReplyOnce {
             arg: String,
-            #[binding(include)]
             reply_to: hyperactor::OncePortRef<u64>,
         },
         CastWithUnsplitPort {
-            #[binding(include)]
             reply_to: PortRef<u64>,
         },
     }
@@ -793,7 +787,7 @@ pub mod test_utils {
     // #[doc(hidden)] because this is a test fixture, not API.
 
     #[doc(hidden)]
-    #[derive(Debug, Clone, Serialize, Deserialize, Named, Bind, Unbind)]
+    #[derive(Debug, Clone, Serialize, Deserialize, Named)]
     pub struct SenderCaptureMsg();
 
     #[doc(hidden)]
@@ -1593,7 +1587,7 @@ mod tests {
         let reply_port_ref2 = reply_port_handle2.bind();
         let message = TestMessage::CastAndReply {
             arg: "abc".to_string(),
-            reply_to0: reply_port_ref0.clone(),
+            reply_to0: reply_port_ref0.clone().unsplit(),
             reply_to1: reply_port_ref1.clone(),
             reply_to2: reply_port_ref2.clone(),
         };
@@ -1612,9 +1606,8 @@ mod tests {
                     reply_to2,
                 } => {
                     assert_eq!(arg, "abc");
-                    // port 0 is still the same as the original one because it
-                    // is not included in MutVisitor.
-                    assert_eq!(reply_to0, reply_port_ref0);
+                    // port 0 is still the same as the original one because it is unsplit.
+                    assert_eq!(reply_to0, reply_port_ref0.clone().unsplit());
                     // ports have been replaced by split ports.
                     assert_ne!(reply_to1, reply_port_ref1);
                     assert_ne!(reply_to2, reply_port_ref2);

--- a/hyperactor_mesh/src/comm/multicast.rs
+++ b/hyperactor_mesh/src/comm/multicast.rs
@@ -17,7 +17,6 @@ use hyperactor::actor::Referable;
 use hyperactor::id::Uid;
 use hyperactor::message::Castable;
 use hyperactor::message::ErasedUnbound;
-use hyperactor::message::IndexedErasedUnbound;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::Extent;
@@ -121,7 +120,7 @@ impl CastMessageEnvelope {
         message: M,
     ) -> Result<Self, anyhow::Error>
     where
-        A: Referable + RemoteHandles<IndexedErasedUnbound<M>>,
+        A: Referable + RemoteHandles<M>,
         M: Castable + RemoteMessage,
     {
         let actor_uid = actor_mesh_id.uid().clone();
@@ -221,12 +220,12 @@ impl DestinationPort {
     /// Create a new DestinationPort for an actor uid and message type.
     pub fn new<A, M>(actor_uid: Uid) -> Self
     where
-        A: Referable + RemoteHandles<IndexedErasedUnbound<M>>,
+        A: Referable + RemoteHandles<M>,
         M: Castable + RemoteMessage,
     {
         Self {
             actor_uid,
-            port: IndexedErasedUnbound::<M>::port(),
+            port: M::port(),
         }
     }
 
@@ -329,7 +328,7 @@ impl CastMessageV1 {
         seqs: ValueMesh<u64>,
     ) -> Result<Self, anyhow::Error>
     where
-        A: Referable + RemoteHandles<IndexedErasedUnbound<M>>,
+        A: Referable + RemoteHandles<M>,
         M: Castable + RemoteMessage,
     {
         let data = ErasedUnbound::try_from_message(message)?;

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -157,11 +157,38 @@ impl From<crate::host::LocalProcStatus> for Status {
 }
 
 /// Data type used to communicate ranks.
-/// Implements [`Bind`] and [`Unbind`]; the comm actor replaces
-/// instances with the delivered rank.
-#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq, Default)]
+/// Serialized as a typed multipart part so comm actors can replace instances
+/// with the delivered rank while the message is in transit.
+#[derive(Clone, Debug, Named, PartialEq, Eq, Default)]
 pub struct Rank(pub Option<usize>);
 wirevalue::register_type!(Rank);
+
+/// Serialized representation for [`Rank`] multipart parts.
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+pub struct RankRepr(pub Option<usize>);
+
+impl TryFrom<&Rank> for RankRepr {
+    type Error = serde_multipart::Error;
+
+    fn try_from(rank: &Rank) -> serde_multipart::Result<Self> {
+        Ok(Self(rank.0))
+    }
+}
+
+impl TryFrom<RankRepr> for Rank {
+    type Error = serde_multipart::Error;
+
+    fn try_from(repr: RankRepr) -> serde_multipart::Result<Self> {
+        Ok(Self(repr.0))
+    }
+}
+
+serde_multipart::part_codec! {
+    impl Rank
+    {
+        type Repr = RankRepr;
+    }
+}
 
 impl Rank {
     /// Create a new rank with the provided value.

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -2105,7 +2105,6 @@ mod tests {
     use hyperactor::accum::StreamingReducerOpts;
     use hyperactor::id::Label;
     use hyperactor::message::ErasedUnbound;
-    use hyperactor::message::Unbound;
     use hyperactor::testing::ids::test_port_id;
     use hyperactor_mesh::Error as MeshError;
     use hyperactor_mesh::host_mesh::host_agent::ProcState;
@@ -2118,7 +2117,7 @@ mod tests {
     use crate::actor::to_py_error;
 
     #[test]
-    fn test_python_message_bind_unbind() {
+    fn test_python_message_part_codec() {
         let reducer_spec = ReducerSpec {
             typehash: 123,
             builder_params: Some(wirevalue::Any::serialize(&"abcdefg12345".to_string()).unwrap()),
@@ -2139,16 +2138,22 @@ mod tests {
         };
         {
             let mut erased = ErasedUnbound::try_from_message(message.clone()).unwrap();
-            let mut bindings = vec![];
+            let mut ports = vec![];
             erased
-                .visit_mut::<reference::UnboundPort>(|b| {
-                    bindings.push(b.clone());
+                .visit_mut::<reference::PortRefRepr>(|b| {
+                    ports.push(b.clone());
                     Ok(())
                 })
                 .unwrap();
-            assert_eq!(bindings, vec![reference::UnboundPort::from(&port_ref)]);
-            let unbound = Unbound::try_from_message(message.clone()).unwrap();
-            assert_eq!(message, unbound.bind().unwrap());
+            assert_eq!(ports.len(), 1);
+            assert_eq!(ports[0].port_addr(), port_ref.port_addr());
+            assert_eq!(ports[0].reducer_spec(), port_ref.reducer_spec());
+            assert_eq!(
+                ports[0].get_return_undeliverable(),
+                port_ref.get_return_undeliverable()
+            );
+            assert!(!ports[0].unsplit());
+            assert_eq!(message, erased.deserialize::<PythonMessage>().unwrap());
         }
 
         let no_port_message = PythonMessage {
@@ -2162,16 +2167,18 @@ mod tests {
         };
         {
             let mut erased = ErasedUnbound::try_from_message(no_port_message.clone()).unwrap();
-            let mut bindings = vec![];
+            let mut ports = vec![];
             erased
-                .visit_mut::<reference::UnboundPort>(|b| {
-                    bindings.push(b.clone());
+                .visit_mut::<reference::PortRefRepr>(|b| {
+                    ports.push(b.clone());
                     Ok(())
                 })
                 .unwrap();
-            assert_eq!(bindings.len(), 0);
-            let unbound = Unbound::try_from_message(no_port_message.clone()).unwrap();
-            assert_eq!(no_port_message, unbound.bind().unwrap());
+            assert_eq!(ports.len(), 0);
+            assert_eq!(
+                no_port_message,
+                erased.deserialize::<PythonMessage>().unwrap()
+            );
         }
     }
 

--- a/serde_multipart/src/codec.rs
+++ b/serde_multipart/src/codec.rs
@@ -16,13 +16,14 @@ use crate::part::BincodeDeserializer;
 use crate::part::BincodeSerializer;
 
 /// Converts a framework type to and from a typed multipart part.
-pub trait PartCodec: Sized + Named
+pub trait PartCodec: Sized
 where
+    Self::Repr: Serialize + DeserializeOwned + Named,
     for<'a> Self::Repr: std::convert::TryFrom<&'a Self, Error = crate::Error>,
     Self: std::convert::TryFrom<Self::Repr, Error = crate::Error>,
 {
     /// The bincode representation stored in typed parts.
-    type Repr: Serialize + DeserializeOwned;
+    type Repr;
 
     /// Convert this value to its typed part representation.
     fn to_repr(&self) -> crate::Result<Self::Repr> {
@@ -36,12 +37,12 @@ where
 
     /// Convert this value to a typed part.
     fn to_part(&self) -> crate::Result<Part> {
-        Part::serialize_as::<Self, _>(&self.to_repr()?)
+        Part::serialize(&self.to_repr()?)
     }
 
     /// Rebuild this value from a typed part.
     fn from_part(part: Part) -> crate::Result<Self> {
-        let repr = part.deserialized_as::<Self, Self::Repr>()?;
+        let repr = part.deserialized::<Self::Repr>()?;
         Self::from_repr(repr)
     }
 }
@@ -160,7 +161,7 @@ macro_rules! part_codec {
     ) => {
         impl $($impl_generics)* $crate::PartCodec for $ty
         where
-            $ty: typeuri::Named,
+            $repr: serde::Serialize + serde::de::DeserializeOwned + typeuri::Named,
             for<'a> $repr: std::convert::TryFrom<&'a $ty, Error = $crate::Error>,
             $ty: std::convert::TryFrom<$repr, Error = $crate::Error>,
         {

--- a/serde_multipart/src/lib.rs
+++ b/serde_multipart/src/lib.rs
@@ -51,6 +51,8 @@ pub use codec::serialize_part_codec;
 pub use part::Part;
 use serde::Deserialize;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
+use typeuri::Named;
 
 /// The type of error returned by typed part operations.
 #[derive(Debug, thiserror::Error)]
@@ -121,6 +123,25 @@ impl Message {
     /// Convert this message into its constituent components.
     pub fn into_inner(self) -> (Part, Vec<Part>) {
         (self.body, self.parts)
+    }
+
+    /// Visit every typed part containing a `T`-typed value.
+    pub fn visit_parts_mut<T, E>(
+        &mut self,
+        mut f: impl FnMut(&mut T) -> std::result::Result<(), E>,
+    ) -> std::result::Result<(), E>
+    where
+        T: Serialize + DeserializeOwned + Named,
+        E: From<Error>,
+    {
+        for part in &mut self.parts {
+            if part.is::<T>() {
+                let mut value = part.deserialized::<T>().map_err(E::from)?;
+                f(&mut value)?;
+                *part = Part::serialize(&value).map_err(E::from)?;
+            }
+        }
+        Ok(())
     }
 
     /// Returns the total size (in bytes) of the message when it is framed.
@@ -768,6 +789,96 @@ mod tests {
 
         let deserialized: Envelope = deserialize_bincode(message).unwrap();
         assert_eq!(deserialized, value);
+    }
+
+    #[test]
+    fn test_visit_parts_mut() {
+        #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
+        struct Envelope {
+            first: CodecPayload,
+            raw_typed: Part,
+            raw_untyped: Part,
+            many: Vec<CodecPayload>,
+        }
+
+        let typed_payload = TypedPayload {
+            label: "typed".to_string(),
+            value: 7,
+        };
+        let value = Envelope {
+            first: CodecPayload {
+                label: "one".to_string(),
+                value: 1,
+            },
+            raw_typed: Part::serialize(&typed_payload).unwrap(),
+            raw_untyped: Part::from("raw"),
+            many: vec![
+                CodecPayload {
+                    label: "two".to_string(),
+                    value: 2,
+                },
+                CodecPayload {
+                    label: "three".to_string(),
+                    value: 3,
+                },
+            ],
+        };
+
+        let mut message = serialize_bincode(&value).unwrap();
+        assert_eq!(message.num_parts(), 5);
+
+        let mut visited = 0;
+        message
+            .visit_parts_mut::<CodecPayloadRepr, _>(|repr| {
+                visited += 1;
+                repr.label.push_str("-visited");
+                repr.value += 10;
+                Ok::<(), Error>(())
+            })
+            .unwrap();
+
+        assert_eq!(visited, 3);
+        assert_eq!(
+            message
+                .parts()
+                .iter()
+                .filter(|part| part.typehash() == Some(CodecPayloadRepr::typehash()))
+                .count(),
+            3
+        );
+        assert_eq!(
+            message.parts()[1].typehash(),
+            Some(TypedPayload::typehash())
+        );
+        assert_eq!(
+            message.parts()[1].deserialized::<TypedPayload>().unwrap(),
+            typed_payload
+        );
+        assert_eq!(message.parts()[2].typehash(), None);
+        assert_eq!(message.parts()[2].to_bytes(), value.raw_untyped.to_bytes());
+
+        let deserialized: Envelope = deserialize_bincode(message).unwrap();
+        assert_eq!(
+            deserialized,
+            Envelope {
+                first: CodecPayload {
+                    label: "one-visited".to_string(),
+                    value: 11,
+                },
+                raw_typed: value.raw_typed,
+                raw_untyped: value.raw_untyped,
+                many: vec![
+                    CodecPayload {
+                        label: "two-visited".to_string(),
+                        value: 12,
+                    },
+                    CodecPayload {
+                        label: "three-visited".to_string(),
+                        value: 13,
+                    },
+                ],
+            }
+        );
     }
 
     #[test]

--- a/serde_multipart/src/lib.rs
+++ b/serde_multipart/src/lib.rs
@@ -427,7 +427,7 @@ mod tests {
         value: u64,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
     struct TypedPayloadRepr {
         label: String,
         value: u64,
@@ -439,7 +439,7 @@ mod tests {
         value: u64,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
     struct CodecPayloadRepr {
         label: String,
         value: u64,
@@ -495,7 +495,7 @@ mod tests {
         value: u64,
     }
 
-    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Named)]
     struct MacroCodecPayloadRepr {
         label: String,
         value: u64,
@@ -708,11 +708,11 @@ mod tests {
         assert_eq!(message.num_parts(), 1);
         assert_eq!(
             message.parts()[0].typehash(),
-            Some(CodecPayload::typehash())
+            Some(CodecPayloadRepr::typehash())
         );
         assert_eq!(
             message.parts()[0]
-                .deserialized_as::<CodecPayload, CodecPayloadRepr>()
+                .deserialized::<CodecPayloadRepr>()
                 .unwrap(),
             repr
         );
@@ -756,14 +756,14 @@ mod tests {
         assert_eq!(message.num_parts(), 4);
         assert_eq!(
             message.parts()[0].typehash(),
-            Some(CodecPayload::typehash())
+            Some(CodecPayloadRepr::typehash())
         );
         assert_eq!(message.parts()[1].typehash(), None);
         assert_eq!(message.parts()[1].to_bytes(), value.raw.to_bytes());
         assert!(
             message.parts()[2..]
                 .iter()
-                .all(|part| part.typehash() == Some(CodecPayload::typehash()))
+                .all(|part| part.typehash() == Some(CodecPayloadRepr::typehash()))
         );
 
         let deserialized: Envelope = deserialize_bincode(message).unwrap();
@@ -813,7 +813,7 @@ mod tests {
         assert_eq!(message.num_parts(), 1);
         assert_eq!(
             message.parts()[0].typehash(),
-            Some(MacroCodecPayload::typehash())
+            Some(MacroCodecPayloadRepr::typehash())
         );
 
         let deserialized: MacroCodecPayload = deserialize_bincode(message).unwrap();

--- a/wirevalue/src/lib.rs
+++ b/wirevalue/src/lib.rs
@@ -474,6 +474,21 @@ impl Any {
         }
     }
 
+    /// Visit every typed multipart part containing a `T`-typed value.
+    pub fn visit_multipart_parts_mut<T, E>(
+        &mut self,
+        f: impl FnMut(&mut T) -> std::result::Result<(), E>,
+    ) -> std::result::Result<(), E>
+    where
+        T: Serialize + DeserializeOwned + Named,
+        E: From<serde_multipart::Error>,
+    {
+        if let Encoded::Multipart(message) = &mut self.encoded {
+            message.visit_parts_mut(f)?;
+        }
+        Ok(())
+    }
+
     /// Transcode the serialized value to JSON. This operation will succeed if the type hash
     /// is embedded in the value, and the corresponding type is available in this binary.
     pub fn transcode_to_json(self) -> std::result::Result<Self, Self> {


### PR DESCRIPTION
Summary:
Switch multicast/cast routing to mutate typed multipart repr parts instead of `Bindings`. `ErasedUnbound` now carries multipart data, visitors update `PortRefRepr`, `OncePortRefRepr`, and `RankRepr`, and cast delivery targets the ordinary typed handler port. The old bind/unbind and indexed wrapper definitions remain for the cleanup commit.
ghstack-source-id: 392905408
exported-using-ghexport

Reviewed By: shayne-fletcher

Differential Revision: D108442500


