### PR TITLE
[hyperactor] make introspection shutdown structured

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -1111,7 +1111,7 @@ impl Debug for AnyActorGuard {
 }
 
 /// IntoFuture allows users to await the handle to join it. The future
-/// resolves when the actor itself has stopped processing messages.
+/// resolves when the actor runtime has fully stopped.
 /// The future resolves to the actor's final status.
 impl IntoFuture for AnyActorHandle {
     type Output = ActorStatus;
@@ -1148,7 +1148,7 @@ impl Clone for AnyActorHandle {
 }
 
 /// IntoFuture allows users to await the handle to join it. The future
-/// resolves when the actor itself has stopped processing messages.
+/// resolves when the actor runtime has fully stopped.
 /// The future resolves to the actor's final status.
 impl<A: Actor> IntoFuture for ActorHandle<A> {
     type Output = ActorStatus;
@@ -3244,8 +3244,8 @@ mod tests {
 
     /// Exercises CI-2 (see `proc` module doc).
     ///
-    /// Dropping the instance transitions status to terminal,
-    /// causing `serve_introspect` to store a terminated snapshot.
+    /// Dropping the instance shuts down and joins `serve_introspect`
+    /// before terminal status is published.
     #[tokio::test]
     async fn test_introspectable_instance_snapshot_on_drop() {
         let proc = Proc::isolated();
@@ -3257,21 +3257,8 @@ mod tests {
             "should appear in all_actor_ids while live"
         );
 
-        // Dropping `instance` transitions status to Stopped, waking
-        // the serve_introspect task which stores the snapshot.
         drop(instance);
-
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            if proc.terminated_snapshot(&actor_id).is_some() {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "timed out waiting for terminated snapshot"
-            );
-            tokio::task::yield_now().await;
-        }
+        handle.await;
 
         let snapshot = proc.terminated_snapshot(&actor_id).unwrap();
         let actor_status = attrs_get(&snapshot.attrs, "status")

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -914,8 +914,15 @@ fn build_actor_attrs(cell: &crate::InstanceCell, snap: &ActorSnapshot) -> String
 /// the cell. Used by the introspect task (which runs outside
 /// the actor's message loop) and by `Instance::introspect_payload`.
 pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
-    let actor_id = cell.actor_addr();
     let status = cell.status().borrow().clone();
+    live_actor_payload_with_status(cell, &status)
+}
+
+fn live_actor_payload_with_status(
+    cell: &InstanceCell,
+    status: &crate::actor::ActorStatus,
+) -> IntrospectResult {
+    let actor_id = cell.actor_addr();
     let last_handler = cell.last_message_handler();
 
     let children: Vec<IntrospectRef> = cell
@@ -983,11 +990,26 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     }
 }
 
-/// Introspect task: runs on a dedicated tokio task per actor,
-/// handling [`IntrospectMessage`] by reading [`InstanceCell`]
-/// directly and replying through the owning [`Proc`](crate::Proc).
+/// Serve introspection for one actor.
 ///
-/// The actor's message loop never sees these messages.
+/// This runs on a dedicated Tokio task owned by the actor runtime. It
+/// handles [`IntrospectMessage`] by reading [`InstanceCell`] directly
+/// and replying through the owning [`Proc`](crate::Proc). The actor's
+/// message loop never sees these messages, so a stuck actor can still
+/// be introspected.
+///
+/// The task's lifetime is controlled by `shutdown`, not by terminal
+/// [`ActorStatus`](crate::actor::ActorStatus). Runtime teardown sends
+/// the final status through `shutdown`; this task then builds and
+/// stores the terminated snapshot with that status and exits. The actor
+/// runtime joins this task before publishing terminal status, so
+/// terminal status remains the single authoritative signal that the
+/// actor's full runtime, including introspection, has shut down.
+///
+/// If the introspect receiver closes before shutdown, the task stops
+/// accepting queries but remains alive until runtime shutdown. This
+/// preserves the shutdown path that stores the post-mortem snapshot and
+/// breaks the `InstanceCell` reference cycle.
 ///
 /// # Invariants exercised
 ///
@@ -995,45 +1017,30 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
 pub(crate) async fn serve_introspect(
     cell: InstanceCell,
     mut receiver: crate::mailbox::PortReceiver<IntrospectMessage>,
+    mut shutdown: tokio::sync::oneshot::Receiver<crate::actor::ActorStatus>,
 ) {
-    use crate::actor::ActorStatus;
     use crate::mailbox::PortSender as _;
 
-    // Watch for terminal status so we can break the reference cycle:
-    // InstanceCellState → Ports → introspect sender → keeps receiver
-    // open → this task holds InstanceCell → InstanceCellState.
-    // Without this, a stopped actor's InstanceCellState is never
-    // dropped and the actor lingers in the proc's instances map.
-    let mut status = cell.status().clone();
+    // Runtime shutdown, not terminal status, owns this task's lifetime.
+    // Terminal status is published only after this task snapshots and exits.
+    let mut receiver_open = true;
 
     loop {
         let msg = tokio::select! {
-            msg = receiver.recv() => {
+            msg = receiver.recv(), if receiver_open => {
                 match msg {
                     Ok(msg) => msg,
                     Err(_) => {
-                        // Channel closed. If the actor reached a
-                        // terminal state, snapshot it before exiting
-                        // so it remains queryable post-mortem.
-                        if cell.status().borrow().is_terminal() {
-                            let snapshot = live_actor_payload(&cell);
-                            cell.store_terminated_snapshot(snapshot);
-                        }
-                        break;
+                        receiver_open = false;
+                        continue;
                     }
                 }
             }
-            status_ref = status.wait_for(ActorStatus::is_terminal) => {
-                // Explicitly drop the Ref before calling live_actor_payload.
-                // wait_for returns a Ref that holds a read lock on the watch
-                // channel's RwLock<ActorStatus>. tokio select! uses a match
-                // internally, so the scrutinee (and its read lock) stays alive
-                // through the arm body. live_actor_payload also calls borrow(),
-                // and parking_lot's write-preferring RwLock blocks new readers
-                // once a writer is queued — causing a deadlock if InstanceState
-                // ::drop tries to write between wait_for and live_actor_payload.
-                drop(status_ref);
-                let snapshot = live_actor_payload(&cell);
+            terminal_status = &mut shutdown => {
+                let Ok(terminal_status) = terminal_status else {
+                    break;
+                };
+                let snapshot = live_actor_payload_with_status(&cell, &terminal_status);
                 cell.store_terminated_snapshot(snapshot);
                 break;
             }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -133,6 +133,7 @@ use hyperactor_telemetry::notify_message_status;
 use hyperactor_telemetry::recorder::Recording;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
@@ -1031,10 +1032,7 @@ impl Proc {
         let (instance, receivers) = Instance::new(self.clone(), actor_id, false, None);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
-        tokio::spawn(crate::introspect::serve_introspect(
-            instance.inner.cell.clone(),
-            receivers.introspect,
-        ));
+        instance.spawn_introspect(receivers.introspect);
         Ok((instance, handle))
     }
 
@@ -1054,10 +1052,7 @@ impl Proc {
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
 
-        tokio::spawn(crate::introspect::serve_introspect(
-            instance.inner.cell.clone(),
-            receivers.introspect,
-        ));
+        instance.spawn_introspect(receivers.introspect);
 
         let (signal_rx, supervision_rx) = receivers.actor_loop.unwrap();
         Ok(ActorInstance {
@@ -1422,14 +1417,11 @@ impl Proc {
     /// - the actor's `InstanceCell` has been dropped, or
     /// - the actor's status is terminal (stopped or failed).
     ///
-    /// The terminal-status check guards a race window: the introspect
-    /// task (`serve_introspect`) holds a strong `InstanceCell` Arc
-    /// and drops it only after observing terminal status. Between the
-    /// actor reaching terminal and the introspect task reacting,
-    /// `upgrade()` on the weak ref succeeds even though the actor is
-    /// dead. The `is_terminal()` check closes that window. Once the
-    /// introspect task exits, the Arc is dropped and `upgrade()`
-    /// returns `None` on its own.
+    /// The terminal-status check makes the live/dead boundary explicit:
+    /// terminal status is published only after runtime epilogue tasks
+    /// such as introspection have completed, so a terminal actor must
+    /// not be returned even if another local handle still keeps its cell
+    /// alive.
     ///
     /// Bounds:
     /// - `R: Actor` — must be a real actor that can live in this
@@ -1799,6 +1791,12 @@ struct InstanceState<A: Actor> {
     /// Runtime-owned delayed-post scheduler.
     delayed_posts: DelayedPosts<A>,
 
+    /// Shutdown signal for the runtime-owned introspection task.
+    introspect_shutdown_tx: Mutex<Option<oneshot::Sender<ActorStatus>>>,
+
+    /// Join handle for the runtime-owned introspection task.
+    introspect_task_handle: Mutex<Option<JoinHandle<()>>>,
+
     /// A watch for communicating the actor's state.
     status_tx: watch::Sender<ActorStatus>,
 
@@ -2117,22 +2115,46 @@ impl<A: Actor> InstanceState<A> {
 
 impl<A: Actor> Drop for InstanceState<A> {
     fn drop(&mut self) {
-        self.status_tx.send_if_modified(|status| {
-            if status.is_terminal() {
-                false
-            } else {
-                tracing::info!(
-                    name = "ActorStatus",
-                    actor_id = %self.self_addr(),
-                    actor_name = self.self_addr().log_name(),
-                    status = "Stopped",
-                    prev_status = status.arm().unwrap_or("unknown"),
-                    "instance is dropped",
-                );
-                *status = ActorStatus::Stopped("instance is dropped".into());
-                true
-            }
-        });
+        let terminal_status = ActorStatus::Stopped("instance is dropped".into());
+        if let Some(shutdown_tx) = self.introspect_shutdown_tx.lock().unwrap().take() {
+            let _ = shutdown_tx.send(terminal_status.clone());
+        }
+        let introspect_task = self.introspect_task_handle.lock().unwrap().take();
+
+        let status_tx = self.status_tx.clone();
+        let actor_addr = self.self_addr().clone();
+        let publish_terminal = move || {
+            status_tx.send_if_modified(|status| {
+                if status.is_terminal() {
+                    false
+                } else {
+                    tracing::info!(
+                        name = "ActorStatus",
+                        actor_id = %actor_addr,
+                        actor_name = actor_addr.log_name(),
+                        status = "Stopped",
+                        prev_status = status.arm().unwrap_or("unknown"),
+                        "instance is dropped",
+                    );
+                    *status = terminal_status;
+                    true
+                }
+            });
+        };
+
+        if let Some(handle) = introspect_task
+            && let Ok(runtime) = tokio::runtime::Handle::try_current()
+        {
+            runtime.spawn(async move {
+                if let Err(err) = handle.await {
+                    tracing::debug!("introspect task join failed: {:?}", err);
+                }
+                publish_terminal();
+            });
+            return;
+        }
+
+        publish_terminal();
     }
 }
 
@@ -2235,6 +2257,8 @@ impl<A: Actor> Instance<A> {
             mailbox,
             ports,
             delayed_posts: DelayedPosts::new(),
+            introspect_shutdown_tx: Mutex::new(None),
+            introspect_task_handle: Mutex::new(None),
             status_tx,
             sequencer: Sequencer::new(instance_id),
             id: instance_id,
@@ -2248,6 +2272,43 @@ impl<A: Actor> Instance<A> {
                 introspect: introspect_receiver,
             },
         )
+    }
+
+    fn spawn_introspect(&self, receiver: PortReceiver<IntrospectMessage>) {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let handle = tokio::spawn(crate::introspect::serve_introspect(
+            self.inner.cell.clone(),
+            receiver,
+            shutdown_rx,
+        ));
+
+        let _ = self
+            .inner
+            .introspect_shutdown_tx
+            .lock()
+            .unwrap()
+            .replace(shutdown_tx);
+        let _ = self
+            .inner
+            .introspect_task_handle
+            .lock()
+            .unwrap()
+            .replace(handle);
+    }
+
+    fn signal_introspect_stop(&self, terminal_status: ActorStatus) -> Option<JoinHandle<()>> {
+        if let Some(shutdown_tx) = self.inner.introspect_shutdown_tx.lock().unwrap().take() {
+            let _ = shutdown_tx.send(terminal_status);
+        }
+        self.inner.introspect_task_handle.lock().unwrap().take()
+    }
+
+    async fn stop_introspect(&self, terminal_status: ActorStatus) {
+        if let Some(handle) = self.signal_introspect_stop(terminal_status)
+            && let Err(err) = handle.await
+        {
+            tracing::debug!("introspect task join failed: {:?}", err);
+        }
     }
 
     /// Notify subscribers of a change in the actors status and bump counters with the duration which
@@ -2714,10 +2775,7 @@ impl<A: Actor> Instance<A> {
         // Spawn the introspect task — a separate tokio task that
         // reads InstanceCell directly and replies through the owning Proc. The
         // actor loop never sees IntrospectMessage.
-        tokio::spawn(crate::introspect::serve_introspect(
-            self.inner.cell.clone(),
-            receivers.introspect,
-        ));
+        self.spawn_introspect(receivers.introspect);
 
         let actor_loop_receivers = receivers
             .actor_loop
@@ -2829,6 +2887,7 @@ impl<A: Actor> Instance<A> {
             }
         }
 
+        self.stop_introspect(terminal_status.clone()).await;
         self.change_status(terminal_status);
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4255
* __->__ #4254

Store actor introspection task ownership in `Instance`, stop it with a one-shot final `ActorStatus`, and join it before publishing terminal status so `ActorHandle::await` observes full runtime shutdown. Document the `serve_introspect` shutdown lifecycle and update the snapshot-on-drop test to await the handle instead of polling.

Differential Revision: [D108629140](https://our.internmc.facebook.com/intern/diff/D108629140/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108629140/)!