### PR TITLE
[hyperactor] add proc-wide status control port

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -189,6 +189,7 @@ pub use proc::Context;
 pub use proc::Instance;
 pub use proc::InstanceCell;
 pub use proc::Proc;
+pub use proc::StatusMessage;
 pub use proc::WeakProc;
 pub use ref_::ActorRef;
 pub use ref_::OncePortRef;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -112,6 +112,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::sync::Weak;
 use std::sync::atomic::AtomicU64;
@@ -3354,6 +3355,7 @@ impl fmt::Debug for State {
 #[derive(Clone)]
 pub struct MailboxMuxer {
     mailboxes: Arc<DashMap<ActorId, Box<dyn MailboxSender + Send + Sync>>>,
+    status_sender: Arc<OnceLock<Box<dyn MailboxSender + Send + Sync>>>,
 }
 
 impl Default for MailboxMuxer {
@@ -3367,6 +3369,7 @@ impl MailboxMuxer {
     pub fn new() -> Self {
         Self {
             mailboxes: Arc::new(DashMap::new()),
+            status_sender: Arc::new(OnceLock::new()),
         }
     }
 
@@ -3389,6 +3392,12 @@ impl MailboxMuxer {
         self.bind(mailbox.actor_addr().id().clone(), mailbox)
     }
 
+    /// Route status messages to the provided sender, regardless of the
+    /// destination actor's liveness.
+    pub fn bind_status(&self, sender: impl MailboxSender + 'static) -> bool {
+        self.status_sender.set(Box::new(sender)).is_ok()
+    }
+
     /// Unbind the sender associated with the provided actor ID. After
     /// unbinding, the muxer will no longer be able to send messages to
     /// that actor.
@@ -3405,6 +3414,13 @@ impl MailboxSender for MailboxMuxer {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
+        if envelope.dest().is_control_port_kind(ControlPort::Status)
+            && let Some(sender) = self.status_sender.get()
+        {
+            sender.post(envelope, return_handle);
+            return;
+        }
+
         let dest_actor_ref = envelope.dest().actor_addr();
         match self.mailboxes.get(dest_actor_ref.id()) {
             None => {

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -33,6 +33,7 @@ use crate::PortAddr;
 /// (i.e. one that must not be wired through `Ports::get`).
 pub(crate) fn is_bypass_workq_type_id(id: TypeId) -> bool {
     id == TypeId::of::<crate::introspect::IntrospectMessage>()
+        || id == TypeId::of::<crate::proc::StatusMessage>()
 }
 
 /// Per-session receiver-local ordering snapshot. This does not lock the
@@ -274,6 +275,7 @@ mod tests {
     use crate::mailbox::headers::stamp_sender_actor_id;
     use crate::port::ControlPort;
     use crate::port::Port;
+    use crate::proc::StatusMessage;
     use crate::testing::ids::test_actor_id;
 
     /// Test message type 1 for handler port sequencing tests.
@@ -401,6 +403,11 @@ mod tests {
     #[test]
     fn bypass_registry_introspect_message() {
         assert!(is_bypass_workq_type_id(TypeId::of::<IntrospectMessage>()));
+    }
+
+    #[test]
+    fn bypass_registry_status_message() {
+        assert!(is_bypass_workq_type_id(TypeId::of::<StatusMessage>()));
     }
 
     #[test]

--- a/hyperactor/src/port.rs
+++ b/hyperactor/src/port.rs
@@ -59,6 +59,8 @@ pub enum ControlPort {
     Introspect,
     /// Actor lifecycle signals.
     Signal,
+    /// Actor lifecycle status.
+    Status,
 }
 
 /// Errors that can occur when parsing a [`ControlPort`].
@@ -118,6 +120,7 @@ impl Port {
             }),
             Self::Control(ControlPort::Introspect) => 0,
             Self::Control(ControlPort::Signal) => 1,
+            Self::Control(ControlPort::Status) => 2,
         }
     }
 }
@@ -170,6 +173,7 @@ impl fmt::Display for ControlPort {
         match self {
             Self::Introspect => f.write_str("introspect"),
             Self::Signal => f.write_str("signal"),
+            Self::Status => f.write_str("status"),
         }
     }
 }
@@ -181,6 +185,7 @@ impl FromStr for ControlPort {
         match s {
             "introspect" => Ok(Self::Introspect),
             "signal" => Ok(Self::Signal),
+            "status" => Ok(Self::Status),
             _ => Err(ControlPortParseError::Unknown(s.to_string())),
         }
     }
@@ -234,6 +239,16 @@ mod tests {
         let s = port.to_string();
         let parsed: Port = s.parse().expect("parse port");
         assert_eq!(port, parsed);
+    }
+
+    #[test]
+    fn test_control_port_status() {
+        assert_eq!(ControlPort::Status.to_string(), "status");
+        assert_eq!(
+            "status".parse::<ControlPort>().expect("parse status"),
+            ControlPort::Status
+        );
+        assert_eq!(Port::control(ControlPort::Status).as_u64(), 2);
     }
 
     #[test]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -131,6 +131,8 @@ use hyperactor_telemetry::notify_actor_status_changed;
 use hyperactor_telemetry::notify_message;
 use hyperactor_telemetry::notify_message_status;
 use hyperactor_telemetry::recorder::Recording;
+use serde::Deserialize;
+use serde::Serialize;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -192,8 +194,10 @@ use crate::mailbox::MailboxSender;
 use crate::mailbox::MessageEnvelope;
 use crate::mailbox::OncePortHandle;
 use crate::mailbox::OncePortReceiver;
+use crate::mailbox::PortGone;
 use crate::mailbox::PortHandle;
 use crate::mailbox::PortReceiver;
+use crate::mailbox::PortSender as _;
 use crate::mailbox::TransportFailure;
 use crate::mailbox::TransportFailureReason;
 use crate::mailbox::Undeliverable;
@@ -433,6 +437,9 @@ struct ProcState {
     /// [`config::TERMINATED_SNAPSHOT_RETENTION`].
     terminated_snapshots: DashMap<ActorId, TerminatedSnapshot>,
 
+    /// Terminal statuses for actors that existed on this proc.
+    actor_tombstones: DashMap<ActorId, ActorStatus>,
+
     /// Used by root actors to send events to the actor coordinating
     /// supervision of root actors in this proc.
     supervision_coordinator_port: OnceLock<PortHandle<ActorSupervisionEvent>>,
@@ -460,6 +467,71 @@ struct ProcState {
 struct TerminatedSnapshot {
     actor_addr: ActorAddr,
     payload: crate::introspect::IntrospectResult,
+}
+
+/// Actor status control-plane message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
+pub enum StatusMessage {
+    /// Return the destination actor's current or tombstoned status.
+    GetStatus {
+        /// Reply port receiving `None` for an unknown actor and
+        /// `Some(status)` for a known actor.
+        reply: crate::OncePortRef<Option<ActorStatus>>,
+    },
+}
+wirevalue::register_type!(StatusMessage);
+
+struct StatusSender {
+    weak_proc: WeakProc,
+}
+
+impl StatusSender {
+    fn new(weak_proc: WeakProc) -> Self {
+        Self { weak_proc }
+    }
+}
+
+#[async_trait]
+impl MailboxSender for StatusSender {
+    fn post_unchecked(
+        &self,
+        envelope: MessageEnvelope,
+        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+    ) {
+        let reply = match envelope.deserialized() {
+            Ok(StatusMessage::GetStatus { reply }) => reply,
+            Err(err) => {
+                let target = envelope.dest().clone();
+                let failure =
+                    DeliveryFailure::new(UndeliverableReason::Transport(TransportFailure::new(
+                        target,
+                        TransportFailureReason::LinkUnavailable(format!(
+                            "status message deserialization failed: {err}"
+                        )),
+                    )));
+                envelope.undeliverable(failure, return_handle);
+                return;
+            }
+        };
+
+        let Some(proc) = self.weak_proc.upgrade() else {
+            let failure = DeliveryFailure::new(UndeliverableReason::PortGone(PortGone::new(
+                envelope.dest().clone(),
+                envelope.data().typename().map(str::to_string),
+            )));
+            envelope.undeliverable(failure, return_handle);
+            return;
+        };
+
+        let actor_id = envelope.dest().actor_id().clone();
+        let status = proc.status_for_actor(&actor_id);
+
+        if let Err(err) =
+            proc.serialize_and_send_once(reply, status, crate::mailbox::monitored_return_handle())
+        {
+            tracing::error!("status reply failed: {err}");
+        }
+    }
 }
 
 impl Drop for ProcState {
@@ -661,12 +733,21 @@ impl Proc {
                 root_actors: DashSet::new(),
                 queue_stats: Arc::new(ProcQueueStats::new()),
                 terminated_snapshots: DashMap::new(),
+                actor_tombstones: DashMap::new(),
                 supervision_coordinator_port: OnceLock::new(),
                 supervision_coordinator_actor_id: OnceLock::new(),
                 mailbox_server_handle: std::sync::Mutex::new(None),
                 _attached_proc_guard: OnceLock::new(),
             }),
         };
+        let bound = proc
+            .inner
+            .proc_muxer
+            .bind_status(StatusSender::new(proc.downgrade()));
+        assert!(
+            bound,
+            "fresh proc muxer must not have a status control port"
+        );
         // Attach to the gateway now that the `Arc<ProcState>` exists;
         // the returned guard's drop will remove the entry when the last
         // `Proc` referencing this state is dropped.
@@ -676,6 +757,21 @@ impl Proc {
             .set(guard)
             .expect("fresh ProcState's attached-proc guard slot is empty");
         proc
+    }
+
+    fn status_for_actor(&self, actor_id: &ActorId) -> Option<ActorStatus> {
+        let live_status = self
+            .inner
+            .instances
+            .get(actor_id)
+            .and_then(|entry| entry.value().upgrade())
+            .map(|cell| cell.status().borrow().clone());
+        live_status.or_else(|| {
+            self.inner
+                .actor_tombstones
+                .get(actor_id)
+                .map(|entry| entry.value().clone())
+        })
     }
 
     fn from_parts(proc_id: ProcId, gateway: Gateway) -> Self {
@@ -2123,11 +2219,16 @@ impl<A: Actor> Drop for InstanceState<A> {
 
         let status_tx = self.status_tx.clone();
         let actor_addr = self.self_addr().clone();
+        let actor_id = actor_addr.id().clone();
+        let proc = self.proc.clone();
         let publish_terminal = move || {
             status_tx.send_if_modified(|status| {
                 if status.is_terminal() {
                     false
                 } else {
+                    proc.inner
+                        .actor_tombstones
+                        .insert(actor_id.clone(), terminal_status.clone());
                     tracing::info!(
                         name = "ActorStatus",
                         actor_id = %actor_addr,
@@ -2136,7 +2237,7 @@ impl<A: Actor> Drop for InstanceState<A> {
                         prev_status = status.arm().unwrap_or("unknown"),
                         "instance is dropped",
                     );
-                    *status = terminal_status;
+                    *status = terminal_status.clone();
                     true
                 }
             });
@@ -2315,6 +2416,13 @@ impl<A: Actor> Instance<A> {
     /// the last status was active for.
     #[track_caller]
     pub fn change_status(&self, new: ActorStatus) {
+        if new.is_terminal() {
+            self.inner
+                .proc
+                .inner
+                .actor_tombstones
+                .insert(self.self_addr().id().clone(), new.clone());
+        }
         let old = self.inner.status_tx.send_replace(new.clone());
         // 2 cases are allowed:
         // * non-terminal -> non-terminal
@@ -3855,6 +3963,8 @@ impl InstanceCell {
             }),
         };
         cell.maybe_link_parent();
+        // TODO: disallow reuse; maybe only for instance ids.
+        proc.inner.actor_tombstones.remove(actor_id.id());
         proc.inner
             .instances
             .insert(actor_id.id().clone(), cell.downgrade());
@@ -4534,10 +4644,68 @@ mod tests {
 
     impl Actor for TestActor {}
 
+    async fn get_status(client: &Client, actor_addr: &ActorAddr) -> Option<ActorStatus> {
+        let (reply_port, reply_rx) = client.open_once_port::<Option<ActorStatus>>();
+        PortRef::<StatusMessage>::attest_control_port(actor_addr, crate::ControlPort::Status).post(
+            client,
+            StatusMessage::GetStatus {
+                reply: reply_port.bind(),
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(5), reply_rx.recv())
+            .await
+            .expect("status reply should arrive")
+            .expect("status reply port should remain open")
+    }
+
     #[derive(Debug)]
     struct ChildLabelActor;
 
     impl Actor for ChildLabelActor {}
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_status_control_port_reports_live_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let handle = proc.spawn(TestActor);
+
+        let mut status_rx = handle.status();
+        status_rx
+            .wait_for(|status| matches!(status, ActorStatus::Idle))
+            .await
+            .expect("actor should become idle");
+
+        let status = get_status(&client, handle.actor_addr()).await;
+        assert_eq!(status, Some(ActorStatus::Idle));
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_status_control_port_reports_tombstoned_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let handle = proc.spawn(TestActor);
+        let actor_addr = handle.actor_addr().clone();
+
+        handle.drain_and_stop("test").unwrap();
+        let terminal_status = handle.await;
+
+        assert_eq!(
+            get_status(&client, &actor_addr).await,
+            Some(terminal_status)
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_status_control_port_reports_unknown_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let missing = proc.root_addr(Uid::instance(Label::strip("missing")));
+
+        assert_eq!(get_status(&client, &missing).await, None);
+    }
 
     #[derive(Debug)]
     struct DelayedSelfActor {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4255
* #4254

Add `ControlPort::Status` and `StatusMessage::GetStatus`, served directly by the proc-wide mailbox muxer rather than per-actor mailboxes. The status reply is `Option<ActorStatus>`, where `None` means the actor is unknown and terminal `ActorStatus` values distinguish known dead actors via proc tombstones. Status messages bypass actor work queues, malformed status requests are returned as undeliverable, and reply failures are logged at error level.

Differential Revision: [D108629141](https://our.internmc.facebook.com/intern/diff/D108629141/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108629141/)!