### PR TITLE
Make actor abort test tolerate supervision race

### DIFF
--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -1608,8 +1608,13 @@ async def test_actor_abort(reason) -> None:
     monarch.actor.unhandled_fault_hook = make_fault_hook(fut)
     pm = this_host().spawn_procs({"gpus": 1})
     actor = pm.spawn("abort", AbortActor)
-    # This call will succeed, but the actor will abort.
-    await actor.abort.call(reason)
+    # A self-aborting endpoint can race its successful response with the
+    # supervision event for the same abort.
+    try:
+        await actor.abort.call(reason)
+    except SupervisionError:
+        pass
+
     if reason is None:
         assert "no reason provided" in await fut
     else:


### PR DESCRIPTION
Summary: `actor.abort.call(...)` observes two valid signals for a self-aborting endpoint: the endpoint can send its successful response, while the actor mesh can concurrently publish the supervision failure caused by the same abort. There is no deterministic runtime ordering to enforce without changing the endpoint contract or adding an artificial wait for a supervision event that may never arrive, so the test should accept either call result and assert on the `unhandled_fault_hook` report.

Differential Revision: D108665223


