### PR TITLE
[hyperactor] add explicit channel completion sinks

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -131,6 +131,83 @@ pub struct SendError<M: RemoteMessage> {
     pub reason: Option<SendErrorReason>,
 }
 
+/// Terminal outcome for a posted message.
+pub enum SendCompletion<M: RemoteMessage> {
+    /// The channel accepted responsibility for the message.
+    Accepted,
+    /// The channel rejected the message and returned ownership to the sender.
+    Rejected(SendError<M>),
+}
+
+enum CompletionSinkInner<M: RemoteMessage> {
+    OneShot(oneshot::Sender<SendError<M>>),
+    Callback(Box<dyn FnOnce(SendCompletion<M>) + Send + Sync>),
+    Ignore,
+}
+
+/// Sink for the terminal outcome of a posted message.
+pub struct CompletionSink<M: RemoteMessage>(CompletionSinkInner<M>);
+
+impl<M: RemoteMessage> CompletionSink<M> {
+    /// Ignore the message completion.
+    pub fn ignore() -> Self {
+        Self(CompletionSinkInner::Ignore)
+    }
+
+    /// Invoke `f` when the message completes.
+    pub fn callback(f: impl FnOnce(SendCompletion<M>) + Send + Sync + 'static) -> Self {
+        Self(CompletionSinkInner::Callback(Box::new(f)))
+    }
+
+    /// Adapt a legacy oneshot send-error sender into a completion sink.
+    pub fn oneshot(sender: oneshot::Sender<SendError<M>>) -> Self {
+        Self(CompletionSinkInner::OneShot(sender))
+    }
+
+    /// Adapt rejected send errors for a wrapped message type.
+    pub fn contramap_rejected<N: RemoteMessage>(
+        self,
+        f: impl FnOnce(SendError<N>) -> Option<SendError<M>> + Send + Sync + 'static,
+    ) -> CompletionSink<N> {
+        CompletionSink::callback(move |completion| match completion {
+            SendCompletion::Accepted => self.accept(),
+            SendCompletion::Rejected(error) => {
+                if let Some(error) = f(error) {
+                    self.reject(error);
+                } else {
+                    self.accept();
+                }
+            }
+        })
+    }
+
+    /// Report that the channel accepted the message.
+    pub fn accept(self) {
+        match self.0 {
+            CompletionSinkInner::OneShot(_) => {}
+            CompletionSinkInner::Callback(f) => f(SendCompletion::Accepted),
+            CompletionSinkInner::Ignore => {}
+        }
+    }
+
+    /// Report that the channel rejected the message.
+    pub fn reject(self, error: SendError<M>) {
+        match self.0 {
+            CompletionSinkInner::OneShot(sender) => {
+                let _ = sender.send(error);
+            }
+            CompletionSinkInner::Callback(f) => f(SendCompletion::Rejected(error)),
+            CompletionSinkInner::Ignore => {}
+        }
+    }
+}
+
+impl<M: RemoteMessage> From<oneshot::Sender<SendError<M>>> for CompletionSink<M> {
+    fn from(sender: oneshot::Sender<SendError<M>>) -> Self {
+        Self::oneshot(sender)
+    }
+}
+
 impl<M: RemoteMessage> From<SendError<M>> for ChannelError {
     fn from(error: SendError<M>) -> Self {
         error.error
@@ -188,12 +265,10 @@ pub enum TxStatus {
 /// The transmit end of an M-typed channel.
 #[async_trait]
 pub trait Tx<M: RemoteMessage> {
-    /// Post a message; returning failed deliveries on the return channel, if provided.
-    /// If provided, the sender is dropped when the message has been
-    /// enqueued at the channel endpoint.
+    /// Post a message and report its terminal outcome to `completion`.
     ///
     /// Users should use the `try_post`, and `post` variants directly.
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>);
+    fn do_post(&self, message: M, completion: CompletionSink<M>);
 
     /// Enqueue a `message` on the local end of the channel. The
     /// message is either delivered, or we eventually discover that
@@ -201,13 +276,13 @@ pub trait Tx<M: RemoteMessage> {
     #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SendError`.
     #[tracing::instrument(level = "debug", skip_all)]
     fn try_post(&self, message: M, return_channel: oneshot::Sender<SendError<M>>) {
-        self.do_post(message, Some(return_channel));
+        self.do_post(message, CompletionSink::oneshot(return_channel));
     }
 
     /// Enqueue a message to be sent on the channel.
     #[hyperactor::instrument_infallible]
     fn post(&self, message: M) {
-        self.do_post(message, None);
+        self.do_post(message, CompletionSink::ignore());
     }
 
     /// Send a message synchronously, returning when the message has
@@ -274,17 +349,14 @@ impl<M: RemoteMessage> MpscTx<M> {
 
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for MpscTx<M> {
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        if let Err(mpsc::error::SendError(message)) = self.tx.send(message)
-            && let Some(return_channel) = return_channel
-        {
-            return_channel
-                .send(SendError {
-                    error: ChannelError::Closed,
-                    message,
-                    reason: None,
-                })
-                .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
+    fn do_post(&self, message: M, completion: CompletionSink<M>) {
+        match self.tx.send(message) {
+            Ok(()) => completion.accept(),
+            Err(mpsc::error::SendError(message)) => completion.reject(SendError {
+                error: ChannelError::Closed,
+                message,
+                reason: None,
+            }),
         }
     }
 
@@ -1178,10 +1250,10 @@ enum ChannelTxKind<M: RemoteMessage> {
 
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for ChannelTx<M> {
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
+    fn do_post(&self, message: M, completion: CompletionSink<M>) {
         match &self.inner {
-            ChannelTxKind::Local(tx) => tx.do_post(message, return_channel),
-            ChannelTxKind::Net(tx) => tx.do_post(message, return_channel),
+            ChannelTxKind::Local(tx) => tx.do_post(message, completion),
+            ChannelTxKind::Net(tx) => tx.do_post(message, completion),
         }
     }
 

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -102,32 +102,26 @@ pub struct LocalTx<M: RemoteMessage> {
 
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for LocalTx<M> {
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
+    fn do_post(&self, message: M, completion: CompletionSink<M>) {
         let data = match serde_multipart::serialize_bincode(&message) {
             Ok(data) => data,
             Err(err) => {
-                if let Some(return_channel) = return_channel {
-                    return_channel
-                        .send(SendError {
-                            error: ChannelError::Other(anyhow::Error::from(err)),
-                            message,
-                            reason: None,
-                        })
-                        .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
-                }
+                completion.reject(SendError {
+                    error: ChannelError::Other(anyhow::Error::from(err)),
+                    message,
+                    reason: None,
+                });
                 return;
             }
         };
-        if self.tx.send(data).is_err()
-            && let Some(return_channel) = return_channel
-        {
-            return_channel
-                .send(SendError {
-                    error: ChannelError::Closed,
-                    message,
-                    reason: None,
-                })
-                .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
+        if self.tx.send(data).is_err() {
+            completion.reject(SendError {
+                error: ChannelError::Closed,
+                message,
+                reason: None,
+            });
+        } else {
+            completion.accept();
         }
     }
 

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -423,7 +423,11 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
                                                     let mut guard = unacked.lock().await;
                                                     // Remove all entries with seq <= ack.
                                                     let retain: std::collections::BTreeMap<u64, session::QueuedMessage<M>> = guard.split_off(&(ack + 1));
-                                                    drop(std::mem::replace(&mut *guard, retain));
+                                                    let accepted = std::mem::replace(&mut *guard, retain);
+                                                    drop(guard);
+                                                    accepted.into_values().for_each(|queued| {
+                                                        queued.completion.accept();
+                                                    });
                                                 }
                                                 NetRxResponse::Reject(reason) => {
                                                     return Err(session::SendLoopError::Rejected(reason));
@@ -448,7 +452,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
                                         seq,
                                         message,
                                         received_at,
-                                        return_channel,
+                                        completion,
                                     } = pending;
                                     let frame = Frame::Message(seq, message);
                                     let serialized = match serde_multipart::serialize_bincode(&frame) {
@@ -457,9 +461,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
                                             tracing::error!(
                                                 "{log_id}: serialization error: {e}"
                                             );
-                                            // Drops return_channel; sender perceives success
-                                            // (preserving prior behavior of the dispatcher-side
-                                            // serialize path).
+                                            completion.accept();
                                             continue;
                                         }
                                     };
@@ -468,7 +470,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
                                         message: serialized,
                                         received_at,
                                         sent_at: None,
-                                        return_channel,
+                                        completion,
                                     };
                                     let framed = queued.message.clone().framed();
                                     stream.write(framed).drive().await.map_err(|e| {
@@ -518,6 +520,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
             }));
         }
 
+        let cleanup_rx = queue_rx.clone();
         // Drop our local receiver clone so the queue closes once the
         // dispatcher's sender (queue_tx) is dropped at shutdown.
         drop(queue_rx);
@@ -532,16 +535,17 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
             "multi-stream dispatcher started"
         );
 
-        while let Some((message, return_channel, received_at)) = receiver.recv().await {
+        while let Some((message, completion, received_at)) = receiver.recv().await {
             let pending = session::PendingMessage {
                 seq: next_seq,
                 message,
                 received_at,
-                return_channel,
+                completion,
             };
             next_seq += 1;
 
-            if queue_tx.send(pending).await.is_err() {
+            if let Err(async_channel::SendError(pending)) = queue_tx.send(pending).await {
+                pending.completion.accept();
                 // All writers are gone.
                 break;
             }
@@ -551,6 +555,16 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
         drop(queue_tx);
         for handle in writer_handles {
             let _ = handle.await;
+        }
+        while let Ok(pending) = cleanup_rx.try_recv() {
+            pending.completion.accept();
+        }
+        for queued in Arc::into_inner(unacked)
+            .expect("writer handles should drop their unacked clones")
+            .into_inner()
+            .into_values()
+        {
+            queued.completion.accept();
         }
 
         let reason = format!("{log_id}: dispatcher closed");
@@ -729,8 +743,8 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
             .drain(..)
             .chain(deliveries.outbox.deque.drain(..))
             .for_each(|queued| queued.try_return(send_error_reason.clone()));
-        while let Ok((msg, return_channel, _)) = receiver.try_recv() {
-            let _ = return_channel.send(SendError {
+        while let Ok((msg, completion, _)) = receiver.try_recv() {
+            completion.reject(SendError {
                 error: ChannelError::Closed,
                 message: msg,
                 reason: send_error_reason.clone(),
@@ -1043,7 +1057,7 @@ pub(super) fn deserialize_response(
 /// A Tx implemented on top of a Link. The Tx manages the link state,
 /// reconnections, etc.
 pub(crate) struct NetTx<M: RemoteMessage> {
-    sender: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    sender: mpsc::UnboundedSender<(M, CompletionSink<M>, Instant)>,
     dest: ChannelAddr,
     status: watch::Receiver<TxStatus>,
 }
@@ -1058,24 +1072,23 @@ impl<M: RemoteMessage> Tx<M> for NetTx<M> {
         &self.status
     }
 
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
+    fn do_post(&self, message: M, completion: CompletionSink<M>) {
         tracing::trace!(
             name = "post",
             dest = %self.dest,
             "sending message"
         );
 
-        let return_channel = return_channel.unwrap_or_else(|| oneshot::channel().0);
-        if let Err(mpsc::error::SendError((message, return_channel, _))) =
+        if let Err(mpsc::error::SendError((message, completion, _))) =
             self.sender
-                .send((message, return_channel, tokio::time::Instant::now()))
+                .send((message, completion, tokio::time::Instant::now()))
         {
             let reason = self
                 .status
                 .borrow()
                 .as_closed()
                 .map(|r| SendErrorReason::Other(r.to_string()));
-            let _ = return_channel.send(SendError {
+            completion.reject(SendError {
                 error: ChannelError::Closed,
                 message,
                 reason,

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -33,7 +33,6 @@ use backoff::ExponentialBackoffBuilder;
 use backoff::backoff::Backoff;
 use dashmap::DashMap;
 use tokio::sync::mpsc;
-use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -55,6 +54,7 @@ use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
 use crate::channel::ChannelTransport;
 use crate::channel::CloseReason;
+use crate::channel::CompletionSink;
 use crate::channel::Rx;
 use crate::channel::SendError;
 use crate::channel::SendErrorReason;
@@ -179,14 +179,14 @@ impl<Out: RemoteMessage, In: RemoteMessage> std::fmt::Debug for DuplexClient<Out
 
 /// Sender half of a duplex channel.
 pub struct DuplexTx<M: RemoteMessage> {
-    tx: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    tx: mpsc::UnboundedSender<(M, CompletionSink<M>, Instant)>,
     addr: ChannelAddr,
     status: watch::Receiver<TxStatus>,
 }
 
 impl<M: RemoteMessage> DuplexTx<M> {
     pub(super) fn new(
-        tx: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
+        tx: mpsc::UnboundedSender<(M, CompletionSink<M>, Instant)>,
         addr: ChannelAddr,
         status: watch::Receiver<TxStatus>,
     ) -> Self {
@@ -196,18 +196,17 @@ impl<M: RemoteMessage> DuplexTx<M> {
 
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for DuplexTx<M> {
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        let return_channel = return_channel.unwrap_or_else(|| oneshot::channel().0);
-        if let Err(mpsc::error::SendError((message, return_channel, _))) =
+    fn do_post(&self, message: M, completion: CompletionSink<M>) {
+        if let Err(mpsc::error::SendError((message, completion, _))) =
             self.tx
-                .send((message, return_channel, tokio::time::Instant::now()))
+                .send((message, completion, tokio::time::Instant::now()))
         {
             let reason = self
                 .status
                 .borrow()
                 .as_closed()
                 .map(|r| SendErrorReason::Other(r.to_string()));
-            let _ = return_channel.send(SendError {
+            completion.reject(SendError {
                 error: ChannelError::Closed,
                 message,
                 reason,
@@ -448,7 +447,7 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
     // application-facing handles and yield them to the server.
     let (inbound_tx, inbound_rx) = mpsc::channel::<In>(1024);
     let (outbound_tx, mut outbound_rx) =
-        mpsc::unbounded_channel::<(Out, oneshot::Sender<SendError<Out>>, Instant)>();
+        mpsc::unbounded_channel::<(Out, CompletionSink<Out>, Instant)>();
     let (notify, status) = watch::channel(TxStatus::Active);
     let net_rx = DuplexRx(inbound_rx, addr.clone());
     let net_tx = DuplexTx {

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -35,7 +35,6 @@ use tokio::io::ReadHalf;
 use tokio::io::WriteHalf;
 use tokio::sync::OwnedMutexGuard;
 use tokio::sync::mpsc;
-use tokio::sync::oneshot;
 use tokio::time::Instant;
 
 use super::Frame;
@@ -49,6 +48,7 @@ use super::serialize_response;
 use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
+use crate::channel::CompletionSink;
 use crate::channel::SendError;
 use crate::channel::SendErrorReason;
 use crate::config;
@@ -332,7 +332,7 @@ pub(super) struct PendingMessage<M: RemoteMessage> {
     pub(super) seq: u64,
     pub(super) message: M,
     pub(super) received_at: Instant,
-    pub(super) return_channel: oneshot::Sender<SendError<M>>,
+    pub(super) completion: CompletionSink<M>,
 }
 
 pub(super) struct QueuedMessage<M: RemoteMessage> {
@@ -340,7 +340,7 @@ pub(super) struct QueuedMessage<M: RemoteMessage> {
     pub(super) message: serde_multipart::Message,
     pub(super) received_at: Instant,
     pub(super) sent_at: Option<tokio::time::Instant>,
-    pub(super) return_channel: oneshot::Sender<SendError<M>>,
+    pub(super) completion: CompletionSink<M>,
 }
 
 impl<M: RemoteMessage> fmt::Display for QueuedMessage<M> {
@@ -371,7 +371,7 @@ impl<M: RemoteMessage> QueuedMessage<M> {
     pub(super) fn try_return(self, reason: Option<SendErrorReason>) {
         match serde_multipart::deserialize_bincode::<Frame<M>>(self.message) {
             Ok(Frame::Message(_, msg)) => {
-                let _ = self.return_channel.send(SendError {
+                self.completion.reject(SendError {
                     error: ChannelError::Closed,
                     message: msg,
                     reason,
@@ -382,6 +382,7 @@ impl<M: RemoteMessage> QueuedMessage<M> {
                     seq = self.seq,
                     "failed to deserialize queued frame for return"
                 );
+                self.completion.accept();
             }
         }
     }
@@ -503,7 +504,7 @@ impl<M: RemoteMessage> Outbox<M> {
 
     pub(super) fn push_back(
         &mut self,
-        (message, return_channel, received_at): (M, oneshot::Sender<SendError<M>>, Instant),
+        (message, completion, received_at): (M, CompletionSink<M>, Instant),
     ) -> Result<(), String> {
         assert!(
             self.deque.back().is_none_or(|msg| msg.seq < self.next_seq),
@@ -516,8 +517,13 @@ impl<M: RemoteMessage> Outbox<M> {
         );
 
         let frame = Frame::Message(self.next_seq, message);
-        let message = serde_multipart::serialize_bincode(&frame)
-            .map_err(|e| format!("serialization error: {e}"))?;
+        let message = match serde_multipart::serialize_bincode(&frame) {
+            Ok(message) => message,
+            Err(e) => {
+                completion.accept();
+                return Err(format!("serialization error: {e}"));
+            }
+        };
         let message_size = message.frame_len();
         metrics::REMOTE_MESSAGE_SEND_SIZE.record(message_size as f64, &[]);
 
@@ -542,7 +548,7 @@ impl<M: RemoteMessage> Outbox<M> {
             message,
             received_at,
             sent_at: None,
-            return_channel,
+            completion,
         });
         self.next_seq += 1;
         Ok(())
@@ -611,6 +617,7 @@ impl<M: RemoteMessage> Unacked<M> {
         if let Some(AckedSeq(largest, _)) = self.largest_acked
             && message.seq <= largest
         {
+            message.completion.accept();
             return;
         }
 
@@ -648,6 +655,7 @@ impl<M: RemoteMessage> Unacked<M> {
                         "session_id" => session_id.to_string(),
                     ),
                 );
+                msg.completion.accept();
             } else {
                 break;
             }
@@ -1317,7 +1325,7 @@ mod ack_watermark_tests {
 pub(super) async fn send_connected<M, R, W>(
     stream: &TaggedStream<R, W>,
     deliveries: &mut Deliveries<M>,
-    receiver: &mut mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    receiver: &mut mpsc::UnboundedReceiver<(M, CompletionSink<M>, Instant)>,
 ) -> Result<(), SendLoopError>
 where
     M: RemoteMessage,

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -33,12 +33,19 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::sync::Weak;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use futures::StreamExt as _;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::sync::watch;
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 
 use crate::Location;
 use crate::PortAddr;
+use crate::ProcAddr;
 use crate::ProcId;
 use crate::channel;
 use crate::channel::ChannelAddr;
@@ -62,6 +69,172 @@ use crate::mailbox::UndeliverableReason;
 use crate::mailbox::UnroutableMailboxSender;
 use crate::proc::Proc;
 use crate::proc::WeakProc;
+
+// ---------------------------------------------------------------------------
+// Gateway attach protocol
+// ---------------------------------------------------------------------------
+//
+// Gateways are the connectivity layer; all on-the-wire attach is
+// gateway-to-gateway. A client gateway dials a peer's accept endpoint
+// and sends [`AttachRequest`] carrying its own uid; the peer replies
+// with [`AttachAck`] carrying the via location through which the client
+// is reachable, then both ends serve regular [`MessageEnvelope`]
+// traffic on the same duplex.
+
+/// Label used for attach-control envelopes.
+const ATTACH_CONTROL_LABEL: &str = "attach";
+
+/// Upper bound on how long [`Gateway::serve_via`] waits for the peer's
+/// [`AttachAck`]. A peer that accepts the connection but never replies
+/// (hung, misconfigured, or running an older protocol) would otherwise
+/// block the caller — typically Python `bootstrap_host` — indefinitely.
+const ATTACH_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// First message a gateway sends when attaching to a peer. The peer
+/// records `uid` in its [`peers`] table; afterwards, any
+/// destination whose outermost location hop is `Via(uid, ...)` is
+/// peeled by the peer and forwarded back over the duplex.
+#[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
+pub(crate) struct AttachRequest {
+    /// The attaching gateway's uid.
+    pub(crate) uid: Uid,
+}
+wirevalue::register_type!(AttachRequest);
+
+/// Acknowledgement returned by a peer gateway during attach. Carries
+/// the via location the client should advertise as its
+/// [`default_location`] — `Via(client_uid, peer_default_location)`.
+#[derive(Debug, Clone, Serialize, Deserialize, typeuri::Named)]
+pub(crate) struct AttachAck {
+    /// The location through which the client is now reachable.
+    pub(crate) location: Location,
+}
+wirevalue::register_type!(AttachAck);
+
+/// Wire protocol for the peer → client direction on a duplex attach
+/// connection.
+#[derive(Debug, Serialize, Deserialize, typeuri::Named)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "wire-protocol enum; boxing Envelope would ripple through channel/networking destructure sites"
+)]
+pub(crate) enum AttachWire {
+    /// First message: the peer acknowledges and assigns a via location.
+    Ack(AttachAck),
+    /// Subsequent messages: routed envelopes.
+    Envelope(MessageEnvelope),
+}
+wirevalue::register_type!(AttachWire);
+
+/// [`Rx<MessageEnvelope>`](channel::Rx) adapter that unwraps
+/// [`AttachWire::Envelope`] from a duplex receiver. Errors if the
+/// peer sends another [`AttachWire::Ack`] after the handshake.
+pub(crate) struct AttachRx(pub(crate) channel::duplex::DuplexRx<AttachWire>);
+
+#[async_trait]
+impl channel::Rx<MessageEnvelope> for AttachRx {
+    async fn recv(&mut self) -> Result<MessageEnvelope, ChannelError> {
+        match self.0.recv().await? {
+            AttachWire::Envelope(envelope) => Ok(envelope),
+            AttachWire::Ack(_) => Err(ChannelError::Other(anyhow::anyhow!(
+                "unexpected attach ack after handshake"
+            ))),
+        }
+    }
+
+    fn addr(&self) -> ChannelAddr {
+        self.0.addr()
+    }
+
+    async fn join(self) {
+        self.0.join().await
+    }
+}
+
+/// [`Tx<MessageEnvelope>`](channel::Tx) adapter that wraps outbound
+/// [`MessageEnvelope`]s in [`AttachWire::Envelope`] before posting to
+/// a peer's [`DuplexTx<AttachWire>`]. Used through [`MailboxClient`]
+/// on the accept side so normal sender flushing semantics apply.
+#[derive(Clone)]
+pub(crate) struct AttachTx(pub(crate) channel::duplex::DuplexTx<AttachWire>);
+
+#[async_trait]
+impl channel::Tx<MessageEnvelope> for AttachTx {
+    fn do_post(
+        &self,
+        envelope: MessageEnvelope,
+        completion: channel::CompletionSink<MessageEnvelope>,
+    ) {
+        let completion = completion.contramap_rejected(
+            |channel::SendError {
+                 error,
+                 message,
+                 reason,
+             }| {
+                let AttachWire::Envelope(envelope) = message else {
+                    return None;
+                };
+                Some(channel::SendError {
+                    error,
+                    message: envelope,
+                    reason,
+                })
+            },
+        );
+        self.0.do_post(AttachWire::Envelope(envelope), completion);
+    }
+
+    fn addr(&self) -> ChannelAddr {
+        self.0.addr()
+    }
+
+    fn status(&self) -> &watch::Receiver<channel::TxStatus> {
+        self.0.status()
+    }
+}
+
+struct PreboundAcceptServer {
+    inner: channel::duplex::DuplexServer<MessageEnvelope, AttachWire>,
+}
+
+impl PreboundAcceptServer {
+    fn duplex(
+        addr: ChannelAddr,
+        listener: Option<std::net::TcpListener>,
+    ) -> Result<Self, channel::ServerError> {
+        let inner = channel::duplex::serve::<MessageEnvelope, AttachWire>(addr, listener)?;
+        Ok(Self { inner })
+    }
+
+    fn addr(&self) -> &ChannelAddr {
+        self.inner.addr()
+    }
+}
+
+/// Serialize a control payload into a placeholder [`MessageEnvelope`]
+/// suitable for posting on a duplex client→peer channel.
+///
+/// Sender/dest ids are placeholders the peer consumes without routing;
+/// `return_undeliverable` is cleared so an envelope that ever escapes
+/// into the forwarder is dropped rather than bounced to the fake
+/// sender.
+fn build_control_envelope<T>(payload: &T) -> anyhow::Result<MessageEnvelope>
+where
+    T: serde::Serialize + typeuri::Named,
+{
+    let signal_actor_id = crate::ActorAddr::root(
+        ProcAddr::singleton(
+            ChannelAddr::any(channel::ChannelTransport::Local),
+            ATTACH_CONTROL_LABEL,
+        ),
+        crate::id::Label::strip(ATTACH_CONTROL_LABEL),
+    );
+    let signal_port = signal_actor_id.port_addr(crate::port::Port::from(0u64));
+    let mut envelope =
+        MessageEnvelope::serialize(signal_actor_id, signal_port, payload, Default::default())?;
+    envelope.set_return_undeliverable(false);
+    Ok(envelope)
+}
 
 /// Connectivity boundary for one or more procs.
 #[derive(Clone)]

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -156,6 +156,8 @@ use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
 use crate::channel::ChannelTransport;
 use crate::channel::CloseReason;
+use crate::channel::CompletionSink;
+use crate::channel::SendCompletion;
 use crate::channel::SendError;
 use crate::channel::SendErrorReason;
 use crate::channel::TxStatus;
@@ -1523,52 +1525,49 @@ impl MailboxClient {
             Buffer::new(move |envelope, return_handle| {
                 let tx = Arc::clone(&tx);
                 let addr = addr.clone();
-                let (return_channel, return_receiver) =
-                    oneshot::channel::<SendError<MessageEnvelope>>();
                 // Set up for delivery failure.
                 let return_handle_0 = return_handle.clone();
                 let completed = completed.clone();
                 let completed_notify = completed_notify.clone();
-                tokio::spawn(async move {
-                    match return_receiver.await {
-                        Ok(SendError {
-                            error,
-                            message,
-                            reason,
-                        }) => {
-                            let target = message.dest().clone();
-                            let reason_text = reason
-                                .as_ref()
-                                .map(ToString::to_string)
-                                .unwrap_or_else(|| "channel closed".to_owned());
-                            let reason = match reason {
-                                Some(SendErrorReason::OversizedFrame { len, max }) => {
-                                    TransportFailureReason::OversizedFrame { len, max }
-                                }
-                                Some(SendErrorReason::Other(_)) | None => {
-                                    TransportFailureReason::ChannelClosed { addr }
-                                }
-                            };
-                            let failure = DeliveryFailure::new(UndeliverableReason::Transport(
-                                TransportFailure::new(target, reason.clone()),
-                            ));
-                            tracing::debug!(
-                                %error,
-                                send_error_reason = %reason_text,
-                                ?reason,
-                                "failed to enqueue in mailbox client while processing buffer",
-                            );
-                            message.undeliverable(failure, return_handle_0);
+                let completion =
+                    CompletionSink::callback(move |completion: SendCompletion<MessageEnvelope>| {
+                        match completion {
+                            SendCompletion::Rejected(SendError {
+                                error,
+                                message,
+                                reason,
+                            }) => {
+                                let target = message.dest().clone();
+                                let reason_text = reason
+                                    .as_ref()
+                                    .map(ToString::to_string)
+                                    .unwrap_or_else(|| "channel closed".to_owned());
+                                let reason = match reason {
+                                    Some(SendErrorReason::OversizedFrame { len, max }) => {
+                                        TransportFailureReason::OversizedFrame { len, max }
+                                    }
+                                    Some(SendErrorReason::Other(_)) | None => {
+                                        TransportFailureReason::ChannelClosed { addr }
+                                    }
+                                };
+                                let failure = DeliveryFailure::new(UndeliverableReason::Transport(
+                                    TransportFailure::new(target, reason.clone()),
+                                ));
+                                tracing::debug!(
+                                    %error,
+                                    send_error_reason = %reason_text,
+                                    ?reason,
+                                    "failed to enqueue in mailbox client while processing buffer",
+                                );
+                                message.undeliverable(failure, return_handle_0);
+                            }
+                            SendCompletion::Accepted => {}
                         }
-                        Err(_) => {
-                            // Oneshot sender was dropped — message was acked.
-                        }
-                    }
-                    completed.fetch_add(1, Ordering::SeqCst);
-                    completed_notify.notify_waiters();
-                });
+                        completed.fetch_add(1, Ordering::SeqCst);
+                        completed_notify.notify_waiters();
+                    });
                 // Send the message for transmission.
-                tx.try_post(envelope, return_channel);
+                tx.do_post(envelope, completion);
                 future::ready(())
             })
         };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4260
* #4259
* #4258
* __->__ #4257

Replace the implicit oneshot-based channel return path with an explicit `SendCompletion` / `CompletionSink` contract. `Tx::do_post` now receives a concrete completion sink, `post()` uses `CompletionSink::ignore()`, and `try_post()` adapts the existing oneshot API through `CompletionSink::oneshot()`. Add explicit `accept()` and `reject()` calls at channel terminal points, and use `contramap_rejected()` for adapters such as `AttachTx` so accepted completions pass through unchanged while rejected wrapped messages are translated back to their outer message type. Convert `MailboxClient` to observe completions directly with `CompletionSink::callback()`, removing the per-message task that waited on a return-channel oneshot while preserving undeliverable handling and flush notification.

Differential Revision: [D108622920](https://our.internmc.facebook.com/intern/diff/D108622920/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108622920/)!