### PR TITLE
[hyperactor] relax mailbox flush counters

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -151,7 +151,7 @@ impl CompletionTracker {
     }
 
     fn complete(&self) {
-        self.completed.fetch_add(1, Ordering::SeqCst);
+        self.completed.fetch_add(1, Ordering::Relaxed);
         self.completed_notify.notify_waiters();
     }
 }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1643,17 +1643,20 @@ impl MailboxSender for MailboxClient {
             // Failed to enqueue.
             envelope.undeliverable(failure, return_handle);
         } else {
-            self.submitted.fetch_add(1, Ordering::SeqCst);
+            self.submitted.fetch_add(1, Ordering::Relaxed);
         }
     }
 
     async fn flush(&self) -> Result<(), anyhow::Error> {
-        let target = self.submitted.load(Ordering::SeqCst);
+        let target = self.submitted.load(Ordering::Relaxed);
         loop {
-            if self.completed.load(Ordering::SeqCst) >= target {
+            // Register before checking so a completion cannot notify between
+            // the check and the wait.
+            let notified = self.completed_notify.notified();
+            if self.completed.load(Ordering::Relaxed) >= target {
                 return Ok(());
             }
-            self.completed_notify.notified().await;
+            notified.await;
         }
     }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4260
* __->__ #4259
* #4258
* #4257

Use relaxed ordering for the mailbox submitted and completed counters because they are monotonic progress markers, not data publication fences. Register the flush waiter before checking the completed counter so `notify_waiters()` cannot race between the check and the wait.

Differential Revision: [D108622921](https://our.internmc.facebook.com/intern/diff/D108622921/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108622921/)!