### PR TITLE
[hyperactor] replace channel completion oneshots with receipts

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -11,6 +11,7 @@
 
 use core::net::SocketAddr;
 use std::fmt;
+use std::future::Future;
 use std::net::IpAddr;
 use std::net::Ipv6Addr;
 #[cfg(target_os = "linux")]
@@ -18,18 +19,23 @@ use std::os::linux::net::SocketAddrExt;
 use std::os::unix::io::FromRawFd;
 use std::os::unix::io::RawFd;
 use std::panic::Location;
+use std::pin::Pin;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicU8;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::task::Context;
+use std::task::Poll;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
+use futures::task::AtomicWaker;
 use hyperactor_config::attrs::AttrValue;
 use serde::Deserialize;
 use serde::Serialize;
 use tokio::sync::mpsc;
-use tokio::sync::oneshot;
 use tokio::sync::watch;
 
 use crate as hyperactor;
@@ -133,6 +139,118 @@ pub struct SendError<M: RemoteMessage> {
     pub reason: Option<SendErrorReason>,
 }
 
+#[repr(u8)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CompletionStatus {
+    Pending = 0,
+    Accepted = 1,
+    Rejected = 2,
+}
+
+impl CompletionStatus {
+    fn from_u8(value: u8) -> Self {
+        match value {
+            value if value == Self::Pending as u8 => Self::Pending,
+            value if value == Self::Accepted as u8 => Self::Accepted,
+            value if value == Self::Rejected as u8 => Self::Rejected,
+            _ => panic!("invalid completion state"),
+        }
+    }
+}
+
+struct CompletionState<M: RemoteMessage> {
+    state: AtomicU8,
+    waker: AtomicWaker,
+    rejected: Mutex<Option<Box<SendError<M>>>>,
+}
+
+pub(crate) struct CompletionSender<M: RemoteMessage> {
+    inner: Arc<CompletionState<M>>,
+}
+
+/// Future that resolves when a posted message is accepted or rejected.
+pub struct CompletionReceipt<M: RemoteMessage> {
+    inner: Arc<CompletionState<M>>,
+}
+
+impl<M: RemoteMessage> CompletionSender<M> {
+    fn pair() -> (Self, CompletionReceipt<M>) {
+        let inner = Arc::new(CompletionState {
+            state: AtomicU8::new(CompletionStatus::Pending as u8),
+            waker: AtomicWaker::new(),
+            rejected: Mutex::new(None),
+        });
+
+        (
+            Self {
+                inner: Arc::clone(&inner),
+            },
+            CompletionReceipt { inner },
+        )
+    }
+
+    fn accept(self) {
+        self.inner
+            .state
+            .store(CompletionStatus::Accepted as u8, Ordering::Release);
+        self.inner.waker.wake();
+    }
+
+    fn reject(self, error: SendError<M>) {
+        *self.inner.rejected.lock().unwrap() = Some(Box::new(error));
+        self.inner
+            .state
+            .store(CompletionStatus::Rejected as u8, Ordering::Release);
+        self.inner.waker.wake();
+    }
+}
+
+impl<M: RemoteMessage> Drop for CompletionSender<M> {
+    fn drop(&mut self) {
+        if CompletionStatus::from_u8(self.inner.state.load(Ordering::Acquire))
+            == CompletionStatus::Pending
+        {
+            self.inner
+                .state
+                .store(CompletionStatus::Accepted as u8, Ordering::Release);
+            self.inner.waker.wake();
+        }
+    }
+}
+
+impl<M: RemoteMessage> Future for CompletionReceipt<M> {
+    type Output = Result<(), SendError<M>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        match self.poll_ready() {
+            Poll::Ready(result) => Poll::Ready(result),
+            Poll::Pending => {
+                self.inner.waker.register(cx.waker());
+                self.poll_ready()
+            }
+        }
+    }
+}
+
+impl<M: RemoteMessage> CompletionReceipt<M> {
+    fn poll_ready(&self) -> Poll<Result<(), SendError<M>>> {
+        match CompletionStatus::from_u8(self.inner.state.load(Ordering::Acquire)) {
+            CompletionStatus::Accepted => Poll::Ready(Ok(())),
+            CompletionStatus::Rejected => {
+                let error = self
+                    .inner
+                    .rejected
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .expect("rejected completion should store send error");
+                Poll::Ready(Err(*error))
+            }
+            CompletionStatus::Pending => Poll::Pending,
+        }
+    }
+}
+
 /// Shared completion counter for sinks that need to wake flush waiters.
 pub(crate) struct CompletionTracker {
     completed: Arc<AtomicUsize>,
@@ -158,7 +276,7 @@ impl CompletionTracker {
 
 enum CompletionSinkInner<M: RemoteMessage> {
     Ignore,
-    OneShot(oneshot::Sender<SendError<M>>),
+    Receipt(CompletionSender<M>),
     OnReject(Box<dyn FnOnce(SendError<M>) + Send + Sync>),
     Tracked {
         tracker: CompletionTracker,
@@ -180,9 +298,10 @@ impl<M: RemoteMessage> CompletionSink<M> {
         Self(CompletionSinkInner::OnReject(Box::new(f)))
     }
 
-    /// Adapt a legacy oneshot send-error sender into a completion sink.
-    pub fn oneshot(sender: oneshot::Sender<SendError<M>>) -> Self {
-        Self(CompletionSinkInner::OneShot(sender))
+    /// Return a completion sink and a receipt that observes its terminal outcome.
+    pub fn receipt() -> (Self, CompletionReceipt<M>) {
+        let (sender, receipt) = CompletionSender::pair();
+        (Self(CompletionSinkInner::Receipt(sender)), receipt)
     }
 
     /// Track every completion and invoke `on_reject` only for rejected messages.
@@ -203,9 +322,11 @@ impl<M: RemoteMessage> CompletionSink<M> {
     ) -> CompletionSink<N> {
         match self.0 {
             CompletionSinkInner::Ignore => CompletionSink::ignore(),
-            CompletionSinkInner::OneShot(sender) => CompletionSink::on_reject(move |error| {
+            CompletionSinkInner::Receipt(sender) => CompletionSink::on_reject(move |error| {
                 if let Some(error) = f(error) {
-                    let _ = sender.send(error);
+                    sender.reject(error);
+                } else {
+                    sender.accept();
                 }
             }),
             CompletionSinkInner::OnReject(on_reject) => CompletionSink::on_reject(move |error| {
@@ -227,7 +348,7 @@ impl<M: RemoteMessage> CompletionSink<M> {
     pub fn accept(self) {
         match self.0 {
             CompletionSinkInner::Ignore => {}
-            CompletionSinkInner::OneShot(_) => {}
+            CompletionSinkInner::Receipt(sender) => sender.accept(),
             CompletionSinkInner::OnReject(_) => {}
             CompletionSinkInner::Tracked { tracker, .. } => tracker.complete(),
         }
@@ -237,21 +358,13 @@ impl<M: RemoteMessage> CompletionSink<M> {
     pub fn reject(self, error: SendError<M>) {
         match self.0 {
             CompletionSinkInner::Ignore => {}
-            CompletionSinkInner::OneShot(sender) => {
-                let _ = sender.send(error);
-            }
+            CompletionSinkInner::Receipt(sender) => sender.reject(error),
             CompletionSinkInner::OnReject(on_reject) => on_reject(error),
             CompletionSinkInner::Tracked { tracker, on_reject } => {
                 on_reject(error);
                 tracker.complete();
             }
         }
-    }
-}
-
-impl<M: RemoteMessage> From<oneshot::Sender<SendError<M>>> for CompletionSink<M> {
-    fn from(sender: oneshot::Sender<SendError<M>>) -> Self {
-        Self::oneshot(sender)
     }
 }
 
@@ -317,13 +430,13 @@ pub trait Tx<M: RemoteMessage> {
     /// Users should use the `try_post`, and `post` variants directly.
     fn do_post(&self, message: M, completion: CompletionSink<M>);
 
-    /// Enqueue a `message` on the local end of the channel. The
-    /// message is either delivered, or we eventually discover that
-    /// the channel has failed and it will be sent back on `return_channel`.
-    #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SendError`.
+    /// Enqueue a `message` on the local end of the channel and return a receipt
+    /// that resolves when the message is accepted or rejected.
     #[tracing::instrument(level = "debug", skip_all)]
-    fn try_post(&self, message: M, return_channel: oneshot::Sender<SendError<M>>) {
-        self.do_post(message, CompletionSink::oneshot(return_channel));
+    fn try_post(&self, message: M) -> CompletionReceipt<M> {
+        let (completion, receipt) = CompletionSink::receipt();
+        self.do_post(message, completion);
+        receipt
     }
 
     /// Enqueue a message to be sent on the channel.
@@ -335,16 +448,7 @@ pub trait Tx<M: RemoteMessage> {
     /// Send a message synchronously, returning when the message has
     /// been delivered to the remote end of the channel.
     async fn send(&self, message: M) -> Result<(), SendError<M>> {
-        let (tx, rx) = oneshot::channel();
-        self.try_post(message, tx);
-        match rx.await {
-            // Channel was closed; the message was not delivered.
-            Ok(err) => Err(err),
-
-            // Channel was dropped; the message was successfully enqueued
-            // on the remote end of the channel.
-            Err(_) => Ok(()),
-        }
+        self.try_post(message).await
     }
 
     /// The channel address to which this Tx is sending.
@@ -1913,17 +2017,15 @@ mod tests {
             let start = tokio::time::Instant::now();
 
             let result = loop {
-                let (return_tx, return_rx) = oneshot::channel();
-                tx.try_post(123, return_tx);
-                let result = return_rx.await;
+                let result = tx.try_post(123).await;
 
-                if result.is_ok() || start.elapsed() > Duration::from_secs(10) {
+                if result.is_err() || start.elapsed() > Duration::from_secs(10) {
                     break result;
                 }
             };
             assert_matches!(
                 result,
-                Ok(SendError {
+                Err(SendError {
                     error: ChannelError::Closed,
                     message: 123,
                     reason: None

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -238,11 +238,9 @@ mod tests {
 
         drop(rx);
 
-        let (return_tx, return_rx) = oneshot::channel();
-        tx.try_post(123, return_tx);
         assert_matches!(
-            return_rx.await,
-            Ok(SendError {
+            tx.try_post(123).await,
+            Err(SendError {
                 error: ChannelError::Closed,
                 message: 123,
                 ..

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2520,11 +2520,9 @@ mod tests {
             let tx = channel::dial::<u64>(addr).unwrap();
             drop(rx);
 
-            let (return_tx, return_rx) = oneshot::channel();
-            tx.try_post(123, return_tx);
             assert_matches!(
-                return_rx.await,
-                Ok(SendError {
+                tx.try_post(123).await,
+                Err(SendError {
                     error: ChannelError::Closed,
                     message: 123,
                     ..
@@ -2595,11 +2593,9 @@ mod tests {
             let tx = channel::dial::<u64>(addr).unwrap();
             drop(rx);
 
-            let (return_tx, return_rx) = oneshot::channel();
-            tx.try_post(123, return_tx);
             assert_matches!(
-                return_rx.await,
-                Ok(SendError {
+                tx.try_post(123).await,
+                Err(SendError {
                     error: ChannelError::Closed,
                     message: 123,
                     ..
@@ -2666,10 +2662,8 @@ mod tests {
         }
         // Bigger than the default size will fail.
         {
-            let (return_channel, return_receiver) = oneshot::channel();
             let message = "a".repeat(default_size_in_bytes + 1024);
-            tx.try_post(message.clone(), return_channel);
-            let returned = return_receiver.await.unwrap();
+            let returned = tx.try_post(message.clone()).await.unwrap_err();
             assert_eq!(message, returned.message);
         }
     }
@@ -2689,13 +2683,10 @@ mod tests {
         let (addr, mut net_rx) =
             server::serve::<u64>(ChannelAddr::Tcp("[::1]:0".parse().unwrap()), None).unwrap();
         let net_tx = channel::dial::<u64>(addr.clone()).unwrap();
-        let (tx, rx) = oneshot::channel();
-        net_tx.try_post(1, tx);
+        let receipt = net_tx.try_post(1);
         assert_eq!(net_rx.recv().await.unwrap(), 1);
         drop(net_rx);
-        // Using `is_err` to confirm the message is delivered/acked is confusing,
-        // but is correct. See how send is implemented: https://fburl.com/code/ywt8lip2
-        assert!(rx.await.is_err());
+        assert!(receipt.await.is_ok());
     }
 
     #[async_timed_test(timeout_secs = 60)]
@@ -2731,11 +2722,9 @@ mod tests {
             let tx = channel::dial::<u64>(local_addr).unwrap();
             drop(rx);
 
-            let (return_tx, return_rx) = oneshot::channel();
-            tx.try_post(123, return_tx);
             assert_matches!(
-                return_rx.await,
-                Ok(SendError {
+                tx.try_post(123).await,
+                Err(SendError {
                     error: ChannelError::Closed,
                     message: 123,
                     ..
@@ -3348,8 +3337,7 @@ mod tests {
         let config = hyperactor_config::global::lock();
         let _guard = config.override_key(config::MESSAGE_DELIVERY_TIMEOUT, Duration::from_secs(1));
         let mut tx_receiver = tx.status().clone();
-        let (return_channel, _return_receiver) = oneshot::channel();
-        tx.try_post(123, return_channel);
+        let _receipt = tx.try_post(123);
         verify_tx_closed(&mut tx_receiver, "failed to deliver message within timeout").await;
     }
 
@@ -3656,8 +3644,7 @@ mod tests {
 
         // Verify sent-and-ack a message. This is necessary for the test to
         // trigger a connection.
-        let (return_channel_tx, return_channel_rx) = oneshot::channel();
-        net_tx.try_post(100, return_channel_tx);
+        let receipt = net_tx.try_post(100);
         let (mut reader, mut writer) = take_receiver(&receiver_storage).await;
         verify_stream(&mut reader, &[(0u64, 100u64)], None, line!()).await;
         // ack it
@@ -3671,10 +3658,7 @@ mod tests {
         .map_err(|(_, e)| e)
         .unwrap();
         // confirm Tx received ack
-        //
-        // Using `is_err` to confirm the message is delivered/acked is confusing,
-        // but is correct. See how send is implemented: https://fburl.com/code/ywt8lip2
-        assert!(return_channel_rx.await.is_err());
+        assert!(receipt.await.is_ok());
 
         // Now fake an unknown delivery for Tx:
         // Although Tx did not actually send seq=1, we still ack it from Rx to
@@ -3690,17 +3674,14 @@ mod tests {
         .map_err(|(_, e)| e)
         .unwrap();
 
-        let (return_channel_tx, return_channel_rx) = oneshot::channel();
-        net_tx.try_post(101, return_channel_tx);
+        let receipt = net_tx.try_post(101);
         // Verify the message is sent to Rx.
         verify_message(&mut reader, (1u64, 101u64), line!()).await;
         // although we did not ack the message after it is sent, since we already
         // acked it previously, Tx will treat it as acked, and considered the
         // message delivered successfully.
         //
-        // Using `is_err` to confirm the message is delivered/acked is confusing,
-        // but is correct. See how send is implemented: https://fburl.com/code/ywt8lip2
-        assert!(return_channel_rx.await.is_err());
+        assert!(receipt.await.is_ok());
     }
 
     async fn verify_ack_exceeded_limit(disconnect_before_ack: bool) {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4260
* #4259
* #4258
* #4257

Replace the legacy `oneshot::Sender<SendError<M>>` completion adapter with `CompletionSink::receipt()`, backed by a small `CompletionSender` / `CompletionReceipt` pair whose accepted path stores a zero-payload state and wakes a single waiter while the rare rejected path stores the returned `SendError<M>`. Convert `Tx::try_post()` to return the receipt directly, simplify `send()` to await it, and update channel tests to assert `Ok(())` for accepted completions and `Err(SendError)` for rejected completions.

Differential Revision: [D108622924](https://our.internmc.facebook.com/intern/diff/D108622924/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108622924/)!