### PR TITLE
optimize completion sink accepted path (#4262)

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -20,6 +20,8 @@ use std::os::unix::io::RawFd;
 use std::panic::Location;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
 use async_trait::async_trait;
 use enum_as_inner::EnumAsInner;
@@ -133,18 +135,37 @@ pub struct SendError<M: RemoteMessage> {
     pub reason: Option<SendErrorReason>,
 }
 
-/// Terminal outcome for a posted message.
-pub enum SendCompletion<M: RemoteMessage> {
-    /// The channel accepted responsibility for the message.
-    Accepted,
-    /// The channel rejected the message and returned ownership to the sender.
-    Rejected(SendError<M>),
+/// Shared completion counter for sinks that need to wake flush waiters.
+pub(crate) struct CompletionTracker {
+    completed: Arc<AtomicUsize>,
+    completed_notify: Arc<tokio::sync::Notify>,
+}
+
+impl CompletionTracker {
+    pub(crate) fn new(
+        completed: Arc<AtomicUsize>,
+        completed_notify: Arc<tokio::sync::Notify>,
+    ) -> Self {
+        Self {
+            completed,
+            completed_notify,
+        }
+    }
+
+    fn complete(&self) {
+        self.completed.fetch_add(1, Ordering::SeqCst);
+        self.completed_notify.notify_waiters();
+    }
 }
 
 enum CompletionSinkInner<M: RemoteMessage> {
-    OneShot(oneshot::Sender<SendError<M>>),
-    Callback(Box<dyn FnOnce(SendCompletion<M>) + Send + Sync>),
     Ignore,
+    OneShot(oneshot::Sender<SendError<M>>),
+    OnReject(Box<dyn FnOnce(SendError<M>) + Send + Sync>),
+    Tracked {
+        tracker: CompletionTracker,
+        on_reject: Box<dyn FnOnce(SendError<M>) + Send + Sync>,
+    },
 }
 
 /// Sink for the terminal outcome of a posted message.
@@ -156,9 +177,9 @@ impl<M: RemoteMessage> CompletionSink<M> {
         Self(CompletionSinkInner::Ignore)
     }
 
-    /// Invoke `f` when the message completes.
-    pub fn callback(f: impl FnOnce(SendCompletion<M>) + Send + Sync + 'static) -> Self {
-        Self(CompletionSinkInner::Callback(Box::new(f)))
+    /// Invoke `f` only when the channel rejects the message.
+    pub fn on_reject(f: impl FnOnce(SendError<M>) + Send + Sync + 'static) -> Self {
+        Self(CompletionSinkInner::OnReject(Box::new(f)))
     }
 
     /// Adapt a legacy oneshot send-error sender into a completion sink.
@@ -166,40 +187,66 @@ impl<M: RemoteMessage> CompletionSink<M> {
         Self(CompletionSinkInner::OneShot(sender))
     }
 
+    /// Track every completion and invoke `on_reject` only for rejected messages.
+    pub(crate) fn tracked(
+        tracker: CompletionTracker,
+        on_reject: impl FnOnce(SendError<M>) + Send + Sync + 'static,
+    ) -> Self {
+        Self(CompletionSinkInner::Tracked {
+            tracker,
+            on_reject: Box::new(on_reject),
+        })
+    }
+
     /// Adapt rejected send errors for a wrapped message type.
     pub fn contramap_rejected<N: RemoteMessage>(
         self,
         f: impl FnOnce(SendError<N>) -> Option<SendError<M>> + Send + Sync + 'static,
     ) -> CompletionSink<N> {
-        CompletionSink::callback(move |completion| match completion {
-            SendCompletion::Accepted => self.accept(),
-            SendCompletion::Rejected(error) => {
+        match self.0 {
+            CompletionSinkInner::Ignore => CompletionSink::ignore(),
+            CompletionSinkInner::OneShot(sender) => CompletionSink::on_reject(move |error| {
                 if let Some(error) = f(error) {
-                    self.reject(error);
-                } else {
-                    self.accept();
+                    let _ = sender.send(error);
                 }
+            }),
+            CompletionSinkInner::OnReject(on_reject) => CompletionSink::on_reject(move |error| {
+                if let Some(error) = f(error) {
+                    on_reject(error);
+                }
+            }),
+            CompletionSinkInner::Tracked { tracker, on_reject } => {
+                CompletionSink::tracked(tracker, move |error| {
+                    if let Some(error) = f(error) {
+                        on_reject(error);
+                    }
+                })
             }
-        })
+        }
     }
 
     /// Report that the channel accepted the message.
     pub fn accept(self) {
         match self.0 {
-            CompletionSinkInner::OneShot(_) => {}
-            CompletionSinkInner::Callback(f) => f(SendCompletion::Accepted),
             CompletionSinkInner::Ignore => {}
+            CompletionSinkInner::OneShot(_) => {}
+            CompletionSinkInner::OnReject(_) => {}
+            CompletionSinkInner::Tracked { tracker, .. } => tracker.complete(),
         }
     }
 
     /// Report that the channel rejected the message.
     pub fn reject(self, error: SendError<M>) {
         match self.0 {
+            CompletionSinkInner::Ignore => {}
             CompletionSinkInner::OneShot(sender) => {
                 let _ = sender.send(error);
             }
-            CompletionSinkInner::Callback(f) => f(SendCompletion::Rejected(error)),
-            CompletionSinkInner::Ignore => {}
+            CompletionSinkInner::OnReject(on_reject) => on_reject(error),
+            CompletionSinkInner::Tracked { tracker, on_reject } => {
+                on_reject(error);
+                tracker.complete();
+            }
         }
     }
 }

--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -133,6 +133,83 @@ pub struct SendError<M: RemoteMessage> {
     pub reason: Option<SendErrorReason>,
 }
 
+/// Terminal outcome for a posted message.
+pub enum SendCompletion<M: RemoteMessage> {
+    /// The channel accepted responsibility for the message.
+    Accepted,
+    /// The channel rejected the message and returned ownership to the sender.
+    Rejected(SendError<M>),
+}
+
+enum CompletionSinkInner<M: RemoteMessage> {
+    OneShot(oneshot::Sender<SendError<M>>),
+    Callback(Box<dyn FnOnce(SendCompletion<M>) + Send + Sync>),
+    Ignore,
+}
+
+/// Sink for the terminal outcome of a posted message.
+pub struct CompletionSink<M: RemoteMessage>(CompletionSinkInner<M>);
+
+impl<M: RemoteMessage> CompletionSink<M> {
+    /// Ignore the message completion.
+    pub fn ignore() -> Self {
+        Self(CompletionSinkInner::Ignore)
+    }
+
+    /// Invoke `f` when the message completes.
+    pub fn callback(f: impl FnOnce(SendCompletion<M>) + Send + Sync + 'static) -> Self {
+        Self(CompletionSinkInner::Callback(Box::new(f)))
+    }
+
+    /// Adapt a legacy oneshot send-error sender into a completion sink.
+    pub fn oneshot(sender: oneshot::Sender<SendError<M>>) -> Self {
+        Self(CompletionSinkInner::OneShot(sender))
+    }
+
+    /// Adapt rejected send errors for a wrapped message type.
+    pub fn contramap_rejected<N: RemoteMessage>(
+        self,
+        f: impl FnOnce(SendError<N>) -> Option<SendError<M>> + Send + Sync + 'static,
+    ) -> CompletionSink<N> {
+        CompletionSink::callback(move |completion| match completion {
+            SendCompletion::Accepted => self.accept(),
+            SendCompletion::Rejected(error) => {
+                if let Some(error) = f(error) {
+                    self.reject(error);
+                } else {
+                    self.accept();
+                }
+            }
+        })
+    }
+
+    /// Report that the channel accepted the message.
+    pub fn accept(self) {
+        match self.0 {
+            CompletionSinkInner::OneShot(_) => {}
+            CompletionSinkInner::Callback(f) => f(SendCompletion::Accepted),
+            CompletionSinkInner::Ignore => {}
+        }
+    }
+
+    /// Report that the channel rejected the message.
+    pub fn reject(self, error: SendError<M>) {
+        match self.0 {
+            CompletionSinkInner::OneShot(sender) => {
+                let _ = sender.send(error);
+            }
+            CompletionSinkInner::Callback(f) => f(SendCompletion::Rejected(error)),
+            CompletionSinkInner::Ignore => {}
+        }
+    }
+}
+
+impl<M: RemoteMessage> From<oneshot::Sender<SendError<M>>> for CompletionSink<M> {
+    fn from(sender: oneshot::Sender<SendError<M>>) -> Self {
+        Self::oneshot(sender)
+    }
+}
+
 impl<M: RemoteMessage> From<SendError<M>> for ChannelError {
     fn from(error: SendError<M>) -> Self {
         error.error
@@ -190,25 +267,23 @@ pub enum TxStatus {
 /// The transmit end of an M-typed channel.
 #[async_trait]
 pub trait Tx<M: RemoteMessage> {
-    /// Post a message; returning failed deliveries on the return channel, if provided.
-    /// If provided, the sender is dropped when the message has been
-    /// enqueued at the channel endpoint.
+    /// Post a message and report its terminal outcome to `completion`.
     ///
     /// Users should use the `try_post`, and `post` variants directly.
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>);
+    fn do_post(&self, message: M, completion: CompletionSink<M>);
 
     /// Enqueue a `message` on the local end of the channel. The
     /// message is either delivered, or we eventually discover that
     /// the channel has failed and it will be sent back on `return_channel`.
     #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SendError`.
     fn try_post(&self, message: M, return_channel: oneshot::Sender<SendError<M>>) {
-        self.do_post(message, Some(return_channel));
+        self.do_post(message, CompletionSink::oneshot(return_channel));
     }
 
     /// Enqueue a message to be sent on the channel.
     #[hyperactor::instrument_infallible]
     fn post(&self, message: M) {
-        self.do_post(message, None);
+        self.do_post(message, CompletionSink::ignore());
     }
 
     /// Send a message synchronously, returning when the message has
@@ -1094,7 +1169,7 @@ impl ChannelAddr {
 /// Universal channel transmitter. Manages the link state, reconnections,
 /// etc. on top of a [`net::Link`].
 pub struct ChannelTx<M: RemoteMessage> {
-    sender: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    sender: mpsc::UnboundedSender<(M, CompletionSink<M>, Instant)>,
     dest: ChannelAddr,
     status: watch::Receiver<TxStatus>,
 }
@@ -1109,23 +1184,22 @@ impl<M: RemoteMessage> fmt::Debug for ChannelTx<M> {
 
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for ChannelTx<M> {
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
+    fn do_post(&self, message: M, completion: CompletionSink<M>) {
         tracing::trace!(
             name = "post",
             dest = %self.dest,
             "sending message"
         );
 
-        let return_channel = return_channel.unwrap_or_else(|| oneshot::channel().0);
-        if let Err(mpsc::error::SendError((message, return_channel, _))) =
-            self.sender.send((message, return_channel, Instant::now()))
+        if let Err(mpsc::error::SendError((message, completion, _))) =
+            self.sender.send((message, completion, Instant::now()))
         {
             let reason = self
                 .status
                 .borrow()
                 .as_closed()
                 .map(|r| SendErrorReason::Other(r.to_string()));
-            let _ = return_channel.send(SendError {
+            completion.reject(SendError {
                 error: ChannelError::Closed,
                 message,
                 reason,

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -522,7 +522,11 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(
                                                     let mut guard = unacked.lock().await;
                                                     // Remove all entries with seq <= ack.
                                                     let retain: std::collections::BTreeMap<u64, session::QueuedMessage<M>> = guard.split_off(&(ack + 1));
-                                                    drop(std::mem::replace(&mut *guard, retain));
+                                                    let accepted = std::mem::replace(&mut *guard, retain);
+                                                    drop(guard);
+                                                    accepted.into_values().for_each(|queued| {
+                                                        queued.completion.accept();
+                                                    });
                                                 }
                                                 NetRxResponse::Reject(reason) => {
                                                     return Err(session::SendLoopError::Rejected(reason));
@@ -547,7 +551,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(
                                         seq,
                                         message,
                                         received_at,
-                                        return_channel,
+                                        completion,
                                     } = pending;
                                     let frame = Frame::Message(seq, message);
                                     let serialized = match serde_multipart::serialize_bincode(&frame) {
@@ -556,9 +560,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(
                                             tracing::error!(
                                                 "{log_id}: serialization error: {e}"
                                             );
-                                            // Drops return_channel; sender perceives success
-                                            // (preserving prior behavior of the dispatcher-side
-                                            // serialize path).
+                                            completion.accept();
                                             continue;
                                         }
                                     };
@@ -567,7 +569,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(
                                         message: serialized,
                                         received_at,
                                         sent_at: None,
-                                        return_channel,
+                                        completion,
                                     };
                                     let framed = queued.message.clone().framed();
                                     stream.write(framed).drive().await.map_err(|e| {
@@ -617,6 +619,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(
             }));
         }
 
+        let cleanup_rx = queue_rx.clone();
         // Drop our local receiver clone so the queue closes once the
         // dispatcher's sender (queue_tx) is dropped at shutdown.
         drop(queue_rx);
@@ -631,16 +634,17 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(
             "multi-stream dispatcher started"
         );
 
-        while let Some((message, return_channel, received_at)) = receiver.recv().await {
+        while let Some((message, completion, received_at)) = receiver.recv().await {
             let pending = session::PendingMessage {
                 seq: next_seq,
                 message,
                 received_at,
-                return_channel,
+                completion,
             };
             next_seq += 1;
 
-            if queue_tx.send(pending).await.is_err() {
+            if let Err(async_channel::SendError(pending)) = queue_tx.send(pending).await {
+                pending.completion.accept();
                 // All writers are gone.
                 break;
             }
@@ -650,6 +654,16 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(
         drop(queue_tx);
         for handle in writer_handles {
             let _ = handle.await;
+        }
+        while let Ok(pending) = cleanup_rx.try_recv() {
+            pending.completion.accept();
+        }
+        for queued in Arc::into_inner(unacked)
+            .expect("writer handles should drop their unacked clones")
+            .into_inner()
+            .into_values()
+        {
+            queued.completion.accept();
         }
 
         let reason = format!("{log_id}: dispatcher closed");
@@ -828,8 +842,8 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> super::ChannelTx<M> {
             .drain(..)
             .chain(deliveries.outbox.deque.drain(..))
             .for_each(|queued| queued.try_return(send_error_reason.clone()));
-        while let Ok((msg, return_channel, _)) = receiver.try_recv() {
-            let _ = return_channel.send(SendError {
+        while let Ok((msg, completion, _)) = receiver.try_recv() {
+            completion.reject(SendError {
                 error: ChannelError::Closed,
                 message: msg,
                 reason: send_error_reason.clone(),

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -34,7 +34,6 @@ use backoff::ExponentialBackoffBuilder;
 use backoff::backoff::Backoff;
 use dashmap::DashMap;
 use tokio::sync::mpsc;
-use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
@@ -56,6 +55,7 @@ use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
 use crate::channel::CloseReason;
+use crate::channel::CompletionSink;
 use crate::channel::Rx;
 use crate::channel::SendError;
 use crate::channel::SendErrorReason;
@@ -212,14 +212,14 @@ impl<Out: RemoteMessage, In: RemoteMessage> std::fmt::Debug for DuplexClient<Out
 
 /// Sender half of a duplex channel.
 pub struct DuplexTx<M: RemoteMessage> {
-    tx: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    tx: mpsc::UnboundedSender<(M, CompletionSink<M>, Instant)>,
     addr: ChannelAddr,
     status: watch::Receiver<TxStatus>,
 }
 
 impl<M: RemoteMessage> DuplexTx<M> {
     pub(super) fn new(
-        tx: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
+        tx: mpsc::UnboundedSender<(M, CompletionSink<M>, Instant)>,
         addr: ChannelAddr,
         status: watch::Receiver<TxStatus>,
     ) -> Self {
@@ -229,18 +229,17 @@ impl<M: RemoteMessage> DuplexTx<M> {
 
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for DuplexTx<M> {
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        let return_channel = return_channel.unwrap_or_else(|| oneshot::channel().0);
-        if let Err(mpsc::error::SendError((message, return_channel, _))) =
+    fn do_post(&self, message: M, completion: CompletionSink<M>) {
+        if let Err(mpsc::error::SendError((message, completion, _))) =
             self.tx
-                .send((message, return_channel, tokio::time::Instant::now()))
+                .send((message, completion, tokio::time::Instant::now()))
         {
             let reason = self
                 .status
                 .borrow()
                 .as_closed()
                 .map(|r| SendErrorReason::Other(r.to_string()));
-            let _ = return_channel.send(SendError {
+            completion.reject(SendError {
                 error: ChannelError::Closed,
                 message,
                 reason,
@@ -477,7 +476,7 @@ pub(super) async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage
     // application-facing handles and yield them to the server.
     let (inbound_tx, inbound_rx) = mpsc::channel::<In>(1024);
     let (outbound_tx, mut outbound_rx) =
-        mpsc::unbounded_channel::<(Out, oneshot::Sender<SendError<Out>>, Instant)>();
+        mpsc::unbounded_channel::<(Out, CompletionSink<Out>, Instant)>();
     let (notify, status) = watch::channel(TxStatus::Active);
     let net_rx = DuplexRx(inbound_rx, addr.clone());
     let net_tx = DuplexTx {

--- a/hyperactor/src/channel/net/session.rs
+++ b/hyperactor/src/channel/net/session.rs
@@ -35,7 +35,6 @@ use tokio::io::ReadHalf;
 use tokio::io::WriteHalf;
 use tokio::sync::OwnedMutexGuard;
 use tokio::sync::mpsc;
-use tokio::sync::oneshot;
 use tokio::time::Instant;
 
 use super::Frame;
@@ -49,6 +48,7 @@ use super::serialize_response;
 use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
+use crate::channel::CompletionSink;
 use crate::channel::SendError;
 use crate::channel::SendErrorReason;
 use crate::config;
@@ -332,7 +332,7 @@ pub(super) struct PendingMessage<M: RemoteMessage> {
     pub(super) seq: u64,
     pub(super) message: M,
     pub(super) received_at: Instant,
-    pub(super) return_channel: oneshot::Sender<SendError<M>>,
+    pub(super) completion: CompletionSink<M>,
 }
 
 pub(super) struct QueuedMessage<M: RemoteMessage> {
@@ -340,7 +340,7 @@ pub(super) struct QueuedMessage<M: RemoteMessage> {
     pub(super) message: serde_multipart::Message,
     pub(super) received_at: Instant,
     pub(super) sent_at: Option<tokio::time::Instant>,
-    pub(super) return_channel: oneshot::Sender<SendError<M>>,
+    pub(super) completion: CompletionSink<M>,
 }
 
 impl<M: RemoteMessage> fmt::Display for QueuedMessage<M> {
@@ -371,7 +371,7 @@ impl<M: RemoteMessage> QueuedMessage<M> {
     pub(super) fn try_return(self, reason: Option<SendErrorReason>) {
         match serde_multipart::deserialize_bincode::<Frame<M>>(self.message) {
             Ok(Frame::Message(_, msg)) => {
-                let _ = self.return_channel.send(SendError {
+                self.completion.reject(SendError {
                     error: ChannelError::Closed,
                     message: msg,
                     reason,
@@ -382,6 +382,7 @@ impl<M: RemoteMessage> QueuedMessage<M> {
                     seq = self.seq,
                     "failed to deserialize queued frame for return"
                 );
+                self.completion.accept();
             }
         }
     }
@@ -503,7 +504,7 @@ impl<M: RemoteMessage> Outbox<M> {
 
     pub(super) fn push_back(
         &mut self,
-        (message, return_channel, received_at): (M, oneshot::Sender<SendError<M>>, Instant),
+        (message, completion, received_at): (M, CompletionSink<M>, Instant),
     ) -> Result<(), String> {
         assert!(
             self.deque.back().is_none_or(|msg| msg.seq < self.next_seq),
@@ -516,8 +517,13 @@ impl<M: RemoteMessage> Outbox<M> {
         );
 
         let frame = Frame::Message(self.next_seq, message);
-        let message = serde_multipart::serialize_bincode(&frame)
-            .map_err(|e| format!("serialization error: {e}"))?;
+        let message = match serde_multipart::serialize_bincode(&frame) {
+            Ok(message) => message,
+            Err(e) => {
+                completion.accept();
+                return Err(format!("serialization error: {e}"));
+            }
+        };
         let message_size = message.frame_len();
         metrics::REMOTE_MESSAGE_SEND_SIZE.record(message_size as f64, &[]);
 
@@ -542,7 +548,7 @@ impl<M: RemoteMessage> Outbox<M> {
             message,
             received_at,
             sent_at: None,
-            return_channel,
+            completion,
         });
         self.next_seq += 1;
         Ok(())
@@ -611,6 +617,7 @@ impl<M: RemoteMessage> Unacked<M> {
         if let Some(AckedSeq(largest, _)) = self.largest_acked
             && message.seq <= largest
         {
+            message.completion.accept();
             return;
         }
 
@@ -648,6 +655,7 @@ impl<M: RemoteMessage> Unacked<M> {
                         "session_id" => session_id.to_string(),
                     ),
                 );
+                msg.completion.accept();
             } else {
                 break;
             }
@@ -1317,7 +1325,7 @@ mod ack_watermark_tests {
 pub(super) async fn send_connected<M, R, W>(
     stream: &TaggedStream<R, W>,
     deliveries: &mut Deliveries<M>,
-    receiver: &mut mpsc::UnboundedReceiver<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    receiver: &mut mpsc::UnboundedReceiver<(M, CompletionSink<M>, Instant)>,
 ) -> Result<(), SendLoopError>
 where
     M: RemoteMessage,

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -35,7 +35,6 @@ use async_trait::async_trait;
 use futures::StreamExt as _;
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
@@ -171,33 +170,25 @@ impl channel::Tx<MessageEnvelope> for AttachTx {
     fn do_post(
         &self,
         envelope: MessageEnvelope,
-        return_channel: Option<oneshot::Sender<channel::SendError<MessageEnvelope>>>,
+        completion: channel::CompletionSink<MessageEnvelope>,
     ) {
-        let return_channel = return_channel.map(|return_channel| {
-            let (wire_return_tx, wire_return_rx) =
-                oneshot::channel::<channel::SendError<AttachWire>>();
-            tokio::spawn(async move {
-                let Ok(channel::SendError {
-                    error,
-                    message,
-                    reason,
-                }) = wire_return_rx.await
-                else {
-                    return;
-                };
+        let completion = completion.contramap_rejected(
+            |channel::SendError {
+                 error,
+                 message,
+                 reason,
+             }| {
                 let AttachWire::Envelope(envelope) = message else {
-                    return;
+                    return None;
                 };
-                let _ = return_channel.send(channel::SendError {
+                Some(channel::SendError {
                     error,
                     message: envelope,
                     reason,
-                });
-            });
-            wire_return_tx
-        });
-        self.0
-            .do_post(AttachWire::Envelope(envelope), return_channel);
+                })
+            },
+        );
+        self.0.do_post(AttachWire::Envelope(envelope), completion);
     }
 
     fn addr(&self) -> ChannelAddr {

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -158,6 +158,8 @@ use crate::channel::ChannelAddr;
 use crate::channel::ChannelError;
 use crate::channel::ChannelTransport;
 use crate::channel::CloseReason;
+use crate::channel::CompletionSink;
+use crate::channel::SendCompletion;
 use crate::channel::SendError;
 use crate::channel::SendErrorReason;
 use crate::channel::TxStatus;
@@ -1554,52 +1556,49 @@ impl MailboxClient {
             Buffer::new(move |envelope, return_handle| {
                 let tx = Arc::clone(&tx);
                 let addr = addr.clone();
-                let (return_channel, return_receiver) =
-                    oneshot::channel::<SendError<MessageEnvelope>>();
                 // Set up for delivery failure.
                 let return_handle_0 = return_handle.clone();
                 let completed = completed.clone();
                 let completed_notify = completed_notify.clone();
-                tokio::spawn(async move {
-                    match return_receiver.await {
-                        Ok(SendError {
-                            error,
-                            message,
-                            reason,
-                        }) => {
-                            let target = message.dest().clone();
-                            let reason_text = reason
-                                .as_ref()
-                                .map(ToString::to_string)
-                                .unwrap_or_else(|| "channel closed".to_owned());
-                            let reason = match reason {
-                                Some(SendErrorReason::OversizedFrame { len, max }) => {
-                                    TransportFailureReason::OversizedFrame { len, max }
-                                }
-                                Some(SendErrorReason::Other(_)) | None => {
-                                    TransportFailureReason::ChannelClosed { addr }
-                                }
-                            };
-                            let failure = DeliveryFailure::new(UndeliverableReason::Transport(
-                                TransportFailure::new(target, reason.clone()),
-                            ));
-                            tracing::debug!(
-                                %error,
-                                send_error_reason = %reason_text,
-                                ?reason,
-                                "failed to enqueue in mailbox client while processing buffer",
-                            );
-                            message.undeliverable(failure, return_handle_0);
+                let completion =
+                    CompletionSink::callback(move |completion: SendCompletion<MessageEnvelope>| {
+                        match completion {
+                            SendCompletion::Rejected(SendError {
+                                error,
+                                message,
+                                reason,
+                            }) => {
+                                let target = message.dest().clone();
+                                let reason_text = reason
+                                    .as_ref()
+                                    .map(ToString::to_string)
+                                    .unwrap_or_else(|| "channel closed".to_owned());
+                                let reason = match reason {
+                                    Some(SendErrorReason::OversizedFrame { len, max }) => {
+                                        TransportFailureReason::OversizedFrame { len, max }
+                                    }
+                                    Some(SendErrorReason::Other(_)) | None => {
+                                        TransportFailureReason::ChannelClosed { addr }
+                                    }
+                                };
+                                let failure = DeliveryFailure::new(UndeliverableReason::Transport(
+                                    TransportFailure::new(target, reason.clone()),
+                                ));
+                                tracing::debug!(
+                                    %error,
+                                    send_error_reason = %reason_text,
+                                    ?reason,
+                                    "failed to enqueue in mailbox client while processing buffer",
+                                );
+                                message.undeliverable(failure, return_handle_0);
+                            }
+                            SendCompletion::Accepted => {}
                         }
-                        Err(_) => {
-                            // Oneshot sender was dropped — message was acked.
-                        }
-                    }
-                    completed.fetch_add(1, Ordering::SeqCst);
-                    completed_notify.notify_waiters();
-                });
+                        completed.fetch_add(1, Ordering::SeqCst);
+                        completed_notify.notify_waiters();
+                    });
                 // Send the message for transmission.
-                tx.try_post(envelope, return_channel);
+                tx.do_post(envelope, completion);
                 future::ready(())
             })
         };
@@ -4011,18 +4010,12 @@ mod tests {
 
     #[async_trait]
     impl channel::Tx<MessageEnvelope> for ClosedChannelTx {
-        fn do_post(
-            &self,
-            message: MessageEnvelope,
-            return_channel: Option<oneshot::Sender<SendError<MessageEnvelope>>>,
-        ) {
-            if let Some(return_channel) = return_channel {
-                let _ = return_channel.send(SendError {
-                    error: ChannelError::Closed,
-                    message,
-                    reason: None,
-                });
-            }
+        fn do_post(&self, message: MessageEnvelope, completion: CompletionSink<MessageEnvelope>) {
+            completion.reject(SendError {
+                error: ChannelError::Closed,
+                message,
+                reason: None,
+            });
         }
 
         fn addr(&self) -> ChannelAddr {

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -159,7 +159,6 @@ use crate::channel::ChannelError;
 use crate::channel::ChannelTransport;
 use crate::channel::CloseReason;
 use crate::channel::CompletionSink;
-use crate::channel::SendCompletion;
 use crate::channel::SendError;
 use crate::channel::SendErrorReason;
 use crate::channel::TxStatus;
@@ -1558,45 +1557,41 @@ impl MailboxClient {
                 let addr = addr.clone();
                 // Set up for delivery failure.
                 let return_handle_0 = return_handle.clone();
-                let completed = completed.clone();
-                let completed_notify = completed_notify.clone();
-                let completion =
-                    CompletionSink::callback(move |completion: SendCompletion<MessageEnvelope>| {
-                        match completion {
-                            SendCompletion::Rejected(SendError {
-                                error,
-                                message,
-                                reason,
-                            }) => {
-                                let target = message.dest().clone();
-                                let reason_text = reason
-                                    .as_ref()
-                                    .map(ToString::to_string)
-                                    .unwrap_or_else(|| "channel closed".to_owned());
-                                let reason = match reason {
-                                    Some(SendErrorReason::OversizedFrame { len, max }) => {
-                                        TransportFailureReason::OversizedFrame { len, max }
-                                    }
-                                    Some(SendErrorReason::Other(_)) | None => {
-                                        TransportFailureReason::ChannelClosed { addr }
-                                    }
-                                };
-                                let failure = DeliveryFailure::new(UndeliverableReason::Transport(
-                                    TransportFailure::new(target, reason.clone()),
-                                ));
-                                tracing::debug!(
-                                    %error,
-                                    send_error_reason = %reason_text,
-                                    ?reason,
-                                    "failed to enqueue in mailbox client while processing buffer",
-                                );
-                                message.undeliverable(failure, return_handle_0);
+                let tracker =
+                    channel::CompletionTracker::new(completed.clone(), completed_notify.clone());
+                let completion = CompletionSink::tracked(
+                    tracker,
+                    move |send_error: SendError<MessageEnvelope>| {
+                        let SendError {
+                            error,
+                            message,
+                            reason,
+                        } = send_error;
+                        let target = message.dest().clone();
+                        let reason_text = reason
+                            .as_ref()
+                            .map(ToString::to_string)
+                            .unwrap_or_else(|| "channel closed".to_owned());
+                        let reason = match reason {
+                            Some(SendErrorReason::OversizedFrame { len, max }) => {
+                                TransportFailureReason::OversizedFrame { len, max }
                             }
-                            SendCompletion::Accepted => {}
-                        }
-                        completed.fetch_add(1, Ordering::SeqCst);
-                        completed_notify.notify_waiters();
-                    });
+                            Some(SendErrorReason::Other(_)) | None => {
+                                TransportFailureReason::ChannelClosed { addr }
+                            }
+                        };
+                        let failure = DeliveryFailure::new(UndeliverableReason::Transport(
+                            TransportFailure::new(target, reason.clone()),
+                        ));
+                        tracing::debug!(
+                            %error,
+                            send_error_reason = %reason_text,
+                            ?reason,
+                            "failed to enqueue in mailbox client while processing buffer",
+                        );
+                        message.undeliverable(failure, return_handle_0);
+                    },
+                );
                 // Send the message for transmission.
                 tx.do_post(envelope, completion);
                 future::ready(())


### PR DESCRIPTION
Summary:


Make the accepted completion path cheap by replacing the generic `SendCompletion` callback sink with explicit rejection-oriented sink variants. `CompletionSink::ignore()` and accepted oneshot completions now avoid callback dispatch, `contramap_rejected()` preserves `Ignore` without allocation, and `MailboxClient` uses a tracked rejection sink so accepted completions only perform the required flush counter update and notification while rejection still runs the undeliverable conversion.
ghstack-source-id: 393929683
exported-using-ghexport

Reviewed By: andrewjcg

Differential Revision: D108622923


