### PR TITLE
add proc-wide status control port (#4266)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -1091,7 +1091,7 @@ impl Debug for AnyActorGuard {
 }
 
 /// IntoFuture allows users to await the handle to join it. The future
-/// resolves when the actor itself has stopped processing messages.
+/// resolves when the actor runtime has fully stopped.
 /// The future resolves to the actor's final status.
 impl IntoFuture for AnyActorHandle {
     type Output = ActorStatus;
@@ -1128,7 +1128,7 @@ impl Clone for AnyActorHandle {
 }
 
 /// IntoFuture allows users to await the handle to join it. The future
-/// resolves when the actor itself has stopped processing messages.
+/// resolves when the actor runtime has fully stopped.
 /// The future resolves to the actor's final status.
 impl<A: Actor> IntoFuture for ActorHandle<A> {
     type Output = ActorStatus;
@@ -3224,8 +3224,8 @@ mod tests {
 
     /// Exercises CI-2 (see `proc` module doc).
     ///
-    /// Dropping the instance transitions status to terminal,
-    /// causing `serve_introspect` to store a terminated snapshot.
+    /// Dropping the instance shuts down and joins `serve_introspect`
+    /// before terminal status is published.
     #[tokio::test]
     async fn test_introspectable_instance_snapshot_on_drop() {
         let proc = Proc::isolated();
@@ -3237,21 +3237,8 @@ mod tests {
             "should appear in all_actor_ids while live"
         );
 
-        // Dropping `instance` transitions status to Stopped, waking
-        // the serve_introspect task which stores the snapshot.
         drop(instance);
-
-        let deadline = std::time::Instant::now() + Duration::from_secs(5);
-        loop {
-            if proc.terminated_snapshot(&actor_id).is_some() {
-                break;
-            }
-            assert!(
-                std::time::Instant::now() < deadline,
-                "timed out waiting for terminated snapshot"
-            );
-            tokio::task::yield_now().await;
-        }
+        handle.await;
 
         let snapshot = proc.terminated_snapshot(&actor_id).unwrap();
         let actor_status = attrs_get(&snapshot.attrs, "status")

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -914,8 +914,15 @@ fn build_actor_attrs(cell: &crate::InstanceCell, snap: &ActorSnapshot) -> String
 /// the cell. Used by the introspect task (which runs outside
 /// the actor's message loop) and by `Instance::introspect_payload`.
 pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
-    let actor_id = cell.actor_addr();
     let status = cell.status().borrow().clone();
+    live_actor_payload_with_status(cell, &status)
+}
+
+fn live_actor_payload_with_status(
+    cell: &InstanceCell,
+    status: &crate::actor::ActorStatus,
+) -> IntrospectResult {
+    let actor_id = cell.actor_addr();
     let last_handler = cell.last_message_handler();
 
     let children: Vec<IntrospectRef> = cell
@@ -983,11 +990,27 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
     }
 }
 
-/// Introspect task: runs on a dedicated tokio task per actor,
-/// handling [`IntrospectMessage`] by reading [`InstanceCell`]
-/// directly and replying through the owning [`Proc`](crate::Proc).
+/// Serve introspection for one actor.
 ///
-/// The actor's message loop never sees these messages.
+/// This runs on a dedicated Tokio task owned by the actor runtime. It
+/// handles [`IntrospectMessage`] by reading [`InstanceCell`] directly
+/// and replying through the owning [`Proc`](crate::Proc). The actor's
+/// message loop never sees these messages, so a stuck actor can still
+/// be introspected.
+///
+/// The task's lifetime is controlled by `shutdown`, not by terminal
+/// [`ActorStatus`](crate::actor::ActorStatus). Runtime teardown sends
+/// the final status through `shutdown`; this task then builds and
+/// stores the terminated snapshot with that status and exits. The
+/// actor's serving loop, or the proc-managed lifecycle for detached
+/// instances, joins this task before publishing terminal status, so
+/// terminal status remains the single authoritative signal that the
+/// actor's full runtime, including introspection, has shut down.
+///
+/// If the introspect receiver closes before shutdown, the task stops
+/// accepting queries but remains alive until runtime shutdown. This
+/// preserves the shutdown path that stores the post-mortem snapshot and
+/// breaks the `InstanceCell` reference cycle.
 ///
 /// # Invariants exercised
 ///
@@ -995,45 +1018,30 @@ pub fn live_actor_payload(cell: &InstanceCell) -> IntrospectResult {
 pub(crate) async fn serve_introspect(
     cell: InstanceCell,
     mut receiver: crate::mailbox::PortReceiver<IntrospectMessage>,
+    mut shutdown: tokio::sync::oneshot::Receiver<crate::actor::ActorStatus>,
 ) {
-    use crate::actor::ActorStatus;
     use crate::mailbox::PortSender as _;
 
-    // Watch for terminal status so we can break the reference cycle:
-    // InstanceCellState → Ports → introspect sender → keeps receiver
-    // open → this task holds InstanceCell → InstanceCellState.
-    // Without this, a stopped actor's InstanceCellState is never
-    // dropped and the actor lingers in the proc's instances map.
-    let mut status = cell.status().clone();
+    // Runtime shutdown, not terminal status, owns this task's lifetime.
+    // Terminal status is published only after this task snapshots and exits.
+    let mut receiver_open = true;
 
     loop {
         let msg = tokio::select! {
-            msg = receiver.recv() => {
+            msg = receiver.recv(), if receiver_open => {
                 match msg {
                     Ok(msg) => msg,
                     Err(_) => {
-                        // Channel closed. If the actor reached a
-                        // terminal state, snapshot it before exiting
-                        // so it remains queryable post-mortem.
-                        if cell.status().borrow().is_terminal() {
-                            let snapshot = live_actor_payload(&cell);
-                            cell.store_terminated_snapshot(snapshot);
-                        }
-                        break;
+                        receiver_open = false;
+                        continue;
                     }
                 }
             }
-            status_ref = status.wait_for(ActorStatus::is_terminal) => {
-                // Explicitly drop the Ref before calling live_actor_payload.
-                // wait_for returns a Ref that holds a read lock on the watch
-                // channel's RwLock<ActorStatus>. tokio select! uses a match
-                // internally, so the scrutinee (and its read lock) stays alive
-                // through the arm body. live_actor_payload also calls borrow(),
-                // and parking_lot's write-preferring RwLock blocks new readers
-                // once a writer is queued — causing a deadlock if InstanceState
-                // ::drop tries to write between wait_for and live_actor_payload.
-                drop(status_ref);
-                let snapshot = live_actor_payload(&cell);
+            terminal_status = &mut shutdown => {
+                let Ok(terminal_status) = terminal_status else {
+                    break;
+                };
+                let snapshot = live_actor_payload_with_status(&cell, &terminal_status);
                 cell.store_terminated_snapshot(snapshot);
                 break;
             }

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -184,6 +184,7 @@ pub use proc::Context;
 pub use proc::Instance;
 pub use proc::InstanceCell;
 pub use proc::Proc;
+pub use proc::StatusMessage;
 pub use proc::WeakProc;
 pub use ref_::ActorRef;
 pub use ref_::OncePortRef;

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -112,6 +112,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::sync::RwLock;
 use std::sync::Weak;
 use std::sync::atomic::AtomicU64;
@@ -3353,6 +3354,7 @@ impl fmt::Debug for State {
 #[derive(Clone)]
 pub struct MailboxMuxer {
     mailboxes: Arc<DashMap<ActorId, Box<dyn MailboxSender + Send + Sync>>>,
+    status_sender: Arc<OnceLock<Box<dyn MailboxSender + Send + Sync>>>,
 }
 
 impl Default for MailboxMuxer {
@@ -3366,6 +3368,7 @@ impl MailboxMuxer {
     pub fn new() -> Self {
         Self {
             mailboxes: Arc::new(DashMap::new()),
+            status_sender: Arc::new(OnceLock::new()),
         }
     }
 
@@ -3388,6 +3391,12 @@ impl MailboxMuxer {
         self.bind(mailbox.actor_addr().id().clone(), mailbox)
     }
 
+    /// Route status messages to the provided sender, regardless of the
+    /// destination actor's liveness.
+    pub fn bind_status(&self, sender: impl MailboxSender + 'static) -> bool {
+        self.status_sender.set(Box::new(sender)).is_ok()
+    }
+
     /// Unbind the sender associated with the provided actor ID. After
     /// unbinding, the muxer will no longer be able to send messages to
     /// that actor.
@@ -3404,6 +3413,13 @@ impl MailboxSender for MailboxMuxer {
         envelope: MessageEnvelope,
         return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
     ) {
+        if envelope.dest().is_control_port_kind(ControlPort::Status)
+            && let Some(sender) = self.status_sender.get()
+        {
+            sender.post(envelope, return_handle);
+            return;
+        }
+
         let dest_actor_ref = envelope.dest().actor_addr();
         match self.mailboxes.get(dest_actor_ref.id()) {
             None => {

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -33,6 +33,7 @@ use crate::PortAddr;
 /// (i.e. one that must not be wired through `Ports::get`).
 pub(crate) fn is_bypass_workq_type_id(id: TypeId) -> bool {
     id == TypeId::of::<crate::introspect::IntrospectMessage>()
+        || id == TypeId::of::<crate::proc::StatusMessage>()
 }
 
 /// Per-session receiver-local ordering snapshot. This does not lock the
@@ -274,6 +275,7 @@ mod tests {
     use crate::mailbox::headers::stamp_sender_actor_id;
     use crate::port::ControlPort;
     use crate::port::Port;
+    use crate::proc::StatusMessage;
     use crate::testing::ids::test_actor_id;
 
     /// Test message type 1 for handler port sequencing tests.
@@ -401,6 +403,11 @@ mod tests {
     #[test]
     fn bypass_registry_introspect_message() {
         assert!(is_bypass_workq_type_id(TypeId::of::<IntrospectMessage>()));
+    }
+
+    #[test]
+    fn bypass_registry_status_message() {
+        assert!(is_bypass_workq_type_id(TypeId::of::<StatusMessage>()));
     }
 
     #[test]

--- a/hyperactor/src/port.rs
+++ b/hyperactor/src/port.rs
@@ -59,6 +59,8 @@ pub enum ControlPort {
     Introspect,
     /// Actor lifecycle signals.
     Signal,
+    /// Actor lifecycle status.
+    Status,
 }
 
 /// Errors that can occur when parsing a [`ControlPort`].
@@ -118,6 +120,7 @@ impl Port {
             }),
             Self::Control(ControlPort::Introspect) => 0,
             Self::Control(ControlPort::Signal) => 1,
+            Self::Control(ControlPort::Status) => 2,
         }
     }
 }
@@ -170,6 +173,7 @@ impl fmt::Display for ControlPort {
         match self {
             Self::Introspect => f.write_str("introspect"),
             Self::Signal => f.write_str("signal"),
+            Self::Status => f.write_str("status"),
         }
     }
 }
@@ -181,6 +185,7 @@ impl FromStr for ControlPort {
         match s {
             "introspect" => Ok(Self::Introspect),
             "signal" => Ok(Self::Signal),
+            "status" => Ok(Self::Status),
             _ => Err(ControlPortParseError::Unknown(s.to_string())),
         }
     }
@@ -234,6 +239,16 @@ mod tests {
         let s = port.to_string();
         let parsed: Port = s.parse().expect("parse port");
         assert_eq!(port, parsed);
+    }
+
+    #[test]
+    fn test_control_port_status() {
+        assert_eq!(ControlPort::Status.to_string(), "status");
+        assert_eq!(
+            "status".parse::<ControlPort>().expect("parse status"),
+            ControlPort::Status
+        );
+        assert_eq!(Port::control(ControlPort::Status).as_u64(), 2);
     }
 
     #[test]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -131,6 +131,8 @@ use hyperactor_telemetry::notify_actor_status_changed;
 use hyperactor_telemetry::notify_message;
 use hyperactor_telemetry::notify_message_status;
 use hyperactor_telemetry::recorder::Recording;
+use serde::Deserialize;
+use serde::Serialize;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
@@ -192,8 +194,10 @@ use crate::mailbox::MailboxSender;
 use crate::mailbox::MessageEnvelope;
 use crate::mailbox::OncePortHandle;
 use crate::mailbox::OncePortReceiver;
+use crate::mailbox::PortGone;
 use crate::mailbox::PortHandle;
 use crate::mailbox::PortReceiver;
+use crate::mailbox::PortSender as _;
 use crate::mailbox::TransportFailure;
 use crate::mailbox::TransportFailureReason;
 use crate::mailbox::Undeliverable;
@@ -433,6 +437,12 @@ struct ProcState {
     /// [`config::TERMINATED_SNAPSHOT_RETENTION`].
     terminated_snapshots: DashMap<ActorId, TerminatedSnapshot>,
 
+    /// Terminal statuses for actors that existed on this proc.
+    /// Note: this map is retained for the lifetime of the process; thus
+    /// tombstones will grow with the number of actors that have ever existed
+    /// in the proc.
+    actor_tombstones: DashMap<ActorId, ActorStatus>,
+
     /// Used by root actors to send events to the actor coordinating
     /// supervision of root actors in this proc.
     supervision_coordinator_port: OnceLock<PortHandle<ActorSupervisionEvent>>,
@@ -460,6 +470,69 @@ struct ProcState {
 struct TerminatedSnapshot {
     actor_addr: ActorAddr,
     payload: crate::introspect::IntrospectResult,
+}
+
+/// Actor status control-plane message.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Named)]
+pub enum StatusMessage {
+    /// Return the destination actor's current or tombstoned status.
+    GetStatus {
+        /// Reply port receiving `None` for an unknown actor and
+        /// `Some(status)` for a known actor.
+        reply: crate::OncePortRef<Option<ActorStatus>>,
+    },
+}
+wirevalue::register_type!(StatusMessage);
+
+struct StatusSender(WeakProc);
+
+impl StatusSender {
+    fn new(weak_proc: WeakProc) -> Self {
+        Self(weak_proc)
+    }
+}
+
+#[async_trait]
+impl MailboxSender for StatusSender {
+    fn post_unchecked(
+        &self,
+        envelope: MessageEnvelope,
+        return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+    ) {
+        let reply = match envelope.deserialized() {
+            Ok(StatusMessage::GetStatus { reply }) => reply,
+            Err(err) => {
+                let target = envelope.dest().clone();
+                let failure =
+                    DeliveryFailure::new(UndeliverableReason::Transport(TransportFailure::new(
+                        target,
+                        TransportFailureReason::LinkUnavailable(format!(
+                            "status message deserialization failed: {err}"
+                        )),
+                    )));
+                envelope.undeliverable(failure, return_handle);
+                return;
+            }
+        };
+
+        let Some(proc) = self.0.upgrade() else {
+            let failure = DeliveryFailure::new(UndeliverableReason::PortGone(PortGone::new(
+                envelope.dest().clone(),
+                envelope.data().typename().map(str::to_string),
+            )));
+            envelope.undeliverable(failure, return_handle);
+            return;
+        };
+
+        let actor_id = envelope.dest().actor_id().clone();
+        let status = proc.status_for_actor(&actor_id);
+
+        if let Err(err) =
+            proc.serialize_and_send_once(reply, status, crate::mailbox::monitored_return_handle())
+        {
+            tracing::error!("status reply failed: {err}");
+        }
+    }
 }
 
 impl Drop for ProcState {
@@ -661,12 +734,21 @@ impl Proc {
                 root_actors: DashSet::new(),
                 queue_stats: Arc::new(ProcQueueStats::new()),
                 terminated_snapshots: DashMap::new(),
+                actor_tombstones: DashMap::new(),
                 supervision_coordinator_port: OnceLock::new(),
                 supervision_coordinator_actor_id: OnceLock::new(),
                 mailbox_server_handle: std::sync::Mutex::new(None),
                 _attached_proc_guard: OnceLock::new(),
             }),
         };
+        let bound = proc
+            .inner
+            .proc_muxer
+            .bind_status(StatusSender::new(proc.downgrade()));
+        assert!(
+            bound,
+            "fresh proc muxer must not have a status control port"
+        );
         // Attach to the gateway now that the `Arc<ProcState>` exists;
         // the returned guard's drop will remove the entry when the last
         // `Proc` referencing this state is dropped.
@@ -676,6 +758,21 @@ impl Proc {
             .set(guard)
             .expect("fresh ProcState's attached-proc guard slot is empty");
         proc
+    }
+
+    fn status_for_actor(&self, actor_id: &ActorId) -> Option<ActorStatus> {
+        let live_status = self
+            .inner
+            .instances
+            .get(actor_id)
+            .and_then(|entry| entry.value().upgrade())
+            .map(|cell| cell.status().borrow().clone());
+        live_status.or_else(|| {
+            self.inner
+                .actor_tombstones
+                .get(actor_id)
+                .map(|entry| entry.value().clone())
+        })
     }
 
     fn from_parts(proc_id: ProcId, gateway: Gateway) -> Self {
@@ -2119,14 +2216,19 @@ impl<A: Actor> InstanceState<A> {
 }
 
 fn publish_dropped_instance_status(
+    proc: Proc,
     status_tx: watch::Sender<ActorStatus>,
     actor_addr: ActorAddr,
     terminal_status: ActorStatus,
 ) {
+    let actor_id = actor_addr.id().clone();
     status_tx.send_if_modified(|status| {
         if status.is_terminal() {
             false
         } else {
+            proc.inner
+                .actor_tombstones
+                .insert(actor_id.clone(), terminal_status.clone());
             tracing::info!(
                 name = "ActorStatus",
                 actor_id = %actor_addr,
@@ -2155,6 +2257,7 @@ impl<A: Actor> Drop for InstanceState<A> {
         let _ = self.introspect_task_handle.lock().unwrap().take();
 
         publish_dropped_instance_status(
+            self.proc.clone(),
             self.status_tx.clone(),
             self.self_addr().clone(),
             terminal_status,
@@ -2307,6 +2410,7 @@ impl<A: Actor> Instance<A> {
             introspect_shutdown_rx,
         ));
 
+        let proc = self.inner.proc.clone();
         let status_tx = self.inner.status_tx.clone();
         let actor_addr = self.self_addr().clone();
         tokio::spawn(async move {
@@ -2317,7 +2421,7 @@ impl<A: Actor> Instance<A> {
             if let Err(err) = introspect_handle.await {
                 tracing::debug!("introspect task join failed: {:?}", err);
             }
-            publish_dropped_instance_status(status_tx, actor_addr, terminal_status);
+            publish_dropped_instance_status(proc, status_tx, actor_addr, terminal_status);
         });
 
         let mut shutdown = self.inner.detached_introspect_shutdown_tx.lock().unwrap();
@@ -2347,6 +2451,13 @@ impl<A: Actor> Instance<A> {
     /// the last status was active for.
     #[track_caller]
     pub fn change_status(&self, new: ActorStatus) {
+        if new.is_terminal() {
+            self.inner
+                .proc
+                .inner
+                .actor_tombstones
+                .insert(self.self_addr().id().clone(), new.clone());
+        }
         let old = self.inner.status_tx.send_replace(new.clone());
         // 2 cases are allowed:
         // * non-terminal -> non-terminal
@@ -3887,6 +3998,8 @@ impl InstanceCell {
             }),
         };
         cell.maybe_link_parent();
+        // TODO: disallow reuse; maybe only for instance ids.
+        proc.inner.actor_tombstones.remove(actor_id.id());
         proc.inner
             .instances
             .insert(actor_id.id().clone(), cell.downgrade());
@@ -4566,10 +4679,68 @@ mod tests {
 
     impl Actor for TestActor {}
 
+    async fn get_status(client: &Client, actor_addr: &ActorAddr) -> Option<ActorStatus> {
+        let (reply_port, reply_rx) = client.open_once_port::<Option<ActorStatus>>();
+        PortRef::<StatusMessage>::attest_control_port(actor_addr, crate::ControlPort::Status).post(
+            client,
+            StatusMessage::GetStatus {
+                reply: reply_port.bind(),
+            },
+        );
+        tokio::time::timeout(Duration::from_secs(5), reply_rx.recv())
+            .await
+            .expect("status reply should arrive")
+            .expect("status reply port should remain open")
+    }
+
     #[derive(Debug)]
     struct ChildLabelActor;
 
     impl Actor for ChildLabelActor {}
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_status_control_port_reports_live_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let handle = proc.spawn(TestActor);
+
+        let mut status_rx = handle.status();
+        status_rx
+            .wait_for(|status| matches!(status, ActorStatus::Idle))
+            .await
+            .expect("actor should become idle");
+
+        let status = get_status(&client, handle.actor_addr()).await;
+        assert_eq!(status, Some(ActorStatus::Idle));
+
+        handle.drain_and_stop("test").unwrap();
+        handle.await;
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_status_control_port_reports_tombstoned_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let handle = proc.spawn(TestActor);
+        let actor_addr = handle.actor_addr().clone();
+
+        handle.drain_and_stop("test").unwrap();
+        let terminal_status = handle.await;
+
+        assert_eq!(
+            get_status(&client, &actor_addr).await,
+            Some(terminal_status)
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn test_status_control_port_reports_unknown_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let missing = proc.root_addr(Uid::instance(Label::strip("missing")));
+
+        assert_eq!(get_status(&client, &missing).await, None);
+    }
 
     #[derive(Debug)]
     struct DelayedSelfActor {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -133,6 +133,7 @@ use hyperactor_telemetry::notify_message_status;
 use hyperactor_telemetry::recorder::Recording;
 use tokio::sync::Notify;
 use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tracing::Instrument;
@@ -1031,10 +1032,7 @@ impl Proc {
         let (instance, receivers) = Instance::new(self.clone(), actor_id, false, None);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
-        tokio::spawn(crate::introspect::serve_introspect(
-            instance.inner.cell.clone(),
-            receivers.introspect,
-        ));
+        instance.spawn_detached_introspect(receivers.introspect);
         Ok((instance, handle))
     }
 
@@ -1054,10 +1052,7 @@ impl Proc {
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
 
-        tokio::spawn(crate::introspect::serve_introspect(
-            instance.inner.cell.clone(),
-            receivers.introspect,
-        ));
+        instance.spawn_detached_introspect(receivers.introspect);
 
         let (signal_rx, supervision_rx) = receivers.actor_loop.unwrap();
         Ok(ActorInstance {
@@ -1422,14 +1417,11 @@ impl Proc {
     /// - the actor's `InstanceCell` has been dropped, or
     /// - the actor's status is terminal (stopped or failed).
     ///
-    /// The terminal-status check guards a race window: the introspect
-    /// task (`serve_introspect`) holds a strong `InstanceCell` Arc
-    /// and drops it only after observing terminal status. Between the
-    /// actor reaching terminal and the introspect task reacting,
-    /// `upgrade()` on the weak ref succeeds even though the actor is
-    /// dead. The `is_terminal()` check closes that window. Once the
-    /// introspect task exits, the Arc is dropped and `upgrade()`
-    /// returns `None` on its own.
+    /// The terminal-status check makes the live/dead boundary explicit:
+    /// terminal status is published only after runtime epilogue tasks
+    /// such as introspection have completed, so a terminal actor must
+    /// not be returned even if another local handle still keeps its cell
+    /// alive.
     ///
     /// Bounds:
     /// - `R: Actor` — must be a real actor that can live in this
@@ -1799,6 +1791,17 @@ struct InstanceState<A: Actor> {
     /// Runtime-owned delayed-post scheduler.
     delayed_posts: DelayedPosts<A>,
 
+    /// Shutdown signal for the runtime-owned introspection task.
+    introspect_shutdown_tx: Mutex<Option<oneshot::Sender<ActorStatus>>>,
+
+    /// Join handle for the runtime-owned introspection task.
+    introspect_task_handle: Mutex<Option<JoinHandle<()>>>,
+
+    /// Shutdown signal for proc-managed detached introspection
+    /// lifecycle. Used by client/inverted instances that have no actor
+    /// serving loop to join introspection.
+    detached_introspect_shutdown_tx: Mutex<Option<oneshot::Sender<ActorStatus>>>,
+
     /// A watch for communicating the actor's state.
     status_tx: watch::Sender<ActorStatus>,
 
@@ -2115,24 +2118,47 @@ impl<A: Actor> InstanceState<A> {
     }
 }
 
+fn publish_dropped_instance_status(
+    status_tx: watch::Sender<ActorStatus>,
+    actor_addr: ActorAddr,
+    terminal_status: ActorStatus,
+) {
+    status_tx.send_if_modified(|status| {
+        if status.is_terminal() {
+            false
+        } else {
+            tracing::info!(
+                name = "ActorStatus",
+                actor_id = %actor_addr,
+                actor_name = actor_addr.log_name(),
+                status = "Stopped",
+                prev_status = status.arm().unwrap_or("unknown"),
+                "instance is dropped",
+            );
+            *status = terminal_status.clone();
+            true
+        }
+    });
+}
+
 impl<A: Actor> Drop for InstanceState<A> {
     fn drop(&mut self) {
-        self.status_tx.send_if_modified(|status| {
-            if status.is_terminal() {
-                false
-            } else {
-                tracing::info!(
-                    name = "ActorStatus",
-                    actor_id = %self.self_addr(),
-                    actor_name = self.self_addr().log_name(),
-                    status = "Stopped",
-                    prev_status = status.arm().unwrap_or("unknown"),
-                    "instance is dropped",
-                );
-                *status = ActorStatus::Stopped("instance is dropped".into());
-                true
-            }
-        });
+        let terminal_status = ActorStatus::Stopped("instance is dropped".into());
+        if let Some(shutdown_tx) = self.detached_introspect_shutdown_tx.lock().unwrap().take() {
+            let _ = shutdown_tx.send(terminal_status.clone());
+            return;
+        }
+
+        if let Some(shutdown_tx) = self.introspect_shutdown_tx.lock().unwrap().take() {
+            let _ = shutdown_tx.send(terminal_status.clone());
+        }
+        let _ = self.introspect_task_handle.lock().unwrap().take();
+
+        publish_dropped_instance_status(
+            self.status_tx.clone(),
+            self.self_addr().clone(),
+            terminal_status,
+        );
     }
 }
 
@@ -2235,6 +2261,9 @@ impl<A: Actor> Instance<A> {
             mailbox,
             ports,
             delayed_posts: DelayedPosts::new(),
+            introspect_shutdown_tx: Mutex::new(None),
+            introspect_task_handle: Mutex::new(None),
+            detached_introspect_shutdown_tx: Mutex::new(None),
             status_tx,
             sequencer: Sequencer::new(instance_id),
             id: instance_id,
@@ -2248,6 +2277,70 @@ impl<A: Actor> Instance<A> {
                 introspect: introspect_receiver,
             },
         )
+    }
+
+    fn spawn_introspect(&self, receiver: PortReceiver<IntrospectMessage>) {
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
+        let handle = tokio::spawn(crate::introspect::serve_introspect(
+            self.inner.cell.clone(),
+            receiver,
+            shutdown_rx,
+        ));
+
+        let mut shutdown = self.inner.introspect_shutdown_tx.lock().unwrap();
+        assert!(
+            shutdown.is_none(),
+            "introspection shutdown handle already set"
+        );
+        let mut task = self.inner.introspect_task_handle.lock().unwrap();
+        assert!(task.is_none(), "introspection task already set");
+        *shutdown = Some(shutdown_tx);
+        *task = Some(handle);
+    }
+
+    fn spawn_detached_introspect(&self, receiver: PortReceiver<IntrospectMessage>) {
+        let (detached_shutdown_tx, detached_shutdown_rx) = oneshot::channel::<ActorStatus>();
+        let (introspect_shutdown_tx, introspect_shutdown_rx) = oneshot::channel();
+        let introspect_handle = tokio::spawn(crate::introspect::serve_introspect(
+            self.inner.cell.clone(),
+            receiver,
+            introspect_shutdown_rx,
+        ));
+
+        let status_tx = self.inner.status_tx.clone();
+        let actor_addr = self.self_addr().clone();
+        tokio::spawn(async move {
+            let Ok(terminal_status) = detached_shutdown_rx.await else {
+                return;
+            };
+            let _ = introspect_shutdown_tx.send(terminal_status.clone());
+            if let Err(err) = introspect_handle.await {
+                tracing::debug!("introspect task join failed: {:?}", err);
+            }
+            publish_dropped_instance_status(status_tx, actor_addr, terminal_status);
+        });
+
+        let mut shutdown = self.inner.detached_introspect_shutdown_tx.lock().unwrap();
+        assert!(
+            shutdown.is_none(),
+            "detached introspection shutdown handle already set"
+        );
+        *shutdown = Some(detached_shutdown_tx);
+    }
+
+    fn signal_introspect_stop(&self, terminal_status: ActorStatus) -> Option<JoinHandle<()>> {
+        if let Some(shutdown_tx) = self.inner.introspect_shutdown_tx.lock().unwrap().take() {
+            let _ = shutdown_tx.send(terminal_status);
+        }
+        self.inner.introspect_task_handle.lock().unwrap().take()
+    }
+
+    async fn stop_introspect(&self, terminal_status: ActorStatus) {
+        if let Some(handle) = self.signal_introspect_stop(terminal_status)
+            && let Err(err) = handle.await
+        {
+            tracing::debug!("introspect task join failed: {:?}", err);
+        }
     }
 
     /// Notify subscribers of a change in the actors status and bump counters with the duration which
@@ -2714,10 +2807,7 @@ impl<A: Actor> Instance<A> {
         // Spawn the introspect task — a separate tokio task that
         // reads InstanceCell directly and replies through the owning Proc. The
         // actor loop never sees IntrospectMessage.
-        tokio::spawn(crate::introspect::serve_introspect(
-            self.inner.cell.clone(),
-            receivers.introspect,
-        ));
+        self.spawn_introspect(receivers.introspect);
 
         let actor_loop_receivers = receivers
             .actor_loop
@@ -2829,6 +2919,7 @@ impl<A: Actor> Instance<A> {
             }
         }
 
+        self.stop_introspect(terminal_status.clone()).await;
         self.change_status(terminal_status);
     }
 


### PR DESCRIPTION
Summary:


Add `ControlPort::Status` and `StatusMessage::GetStatus`, served directly by the proc-wide mailbox muxer rather than per-actor mailboxes. The status reply is `Option<ActorStatus>`, where `None` means the actor is unknown and terminal `ActorStatus` values distinguish known dead actors via proc tombstones. Status messages bypass actor work queues, malformed status requests are returned as undeliverable, and reply failures are logged at error level.
ghstack-source-id: 393492735
exported-using-ghexport

Reviewed By: dulinriley

Differential Revision: D108629141


