### PR TITLE
gather_mount: keep a dead or stuck source from wedging the mount (EIO, not D-state) (#4267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,16 @@ jobs:
     with:
       artifact-name: monarch-cpu-${{ github.sha }}-py3.10
 
+  # FUSE mount tests run on a hosted ubuntu VM (which has /dev/fuse), not the
+  # test-infra container lanes (which don't). Uses the CPU wheel.
+  test-fuse-python:
+    name: Test FUSE Python
+    if: ${{ !startsWith(github.ref, 'refs/tags/ciflow/rocm/') }}
+    needs: build-cpu
+    uses: ./.github/workflows/test-fuse-python.yml
+    with:
+      artifact-name: monarch-cpu-${{ github.sha }}-py3.10
+
   # Runs pyright as its own check so type errors surface as a separate
   # signal. This job is intentionally omitted from status-check.needs so type
   # failures never gate test results or merging.
@@ -79,7 +89,7 @@ jobs:
   status-check:
     name: Status Check
     runs-on: ubuntu-latest
-    needs: [test-cpu-python, test-gpu-python, test-cpu-rust, test-gpu-rust]
+    needs: [test-cpu-python, test-fuse-python, test-gpu-python, test-cpu-rust, test-gpu-rust]
     if: always()
     steps:
       # Fail if any job failed or was cancelled; skipped jobs are OK

--- a/.github/workflows/test-fuse-python.yml
+++ b/.github/workflows/test-fuse-python.yml
@@ -1,0 +1,100 @@
+name: Test FUSE Python
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: 'Wheel artifact name from build workflow'
+        required: true
+        type: string
+      python-version:
+        description: 'Python version to test with'
+        type: string
+        default: '3.10'
+
+concurrency:
+  group: test-fuse-python-${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.run_number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-fuse-python:
+    name: Test FUSE Python - gather_mount
+    # GitHub-hosted ubuntu runners are full VMs with /dev/fuse and allow
+    # unprivileged FUSE mounts via the setuid fusermount3 helper. The
+    # pytorch/test-infra linux_job_v2 container used by the other Linux lanes
+    # does NOT expose /dev/fuse (its docker run only adds --cap-add=SYS_PTRACE),
+    # so the real-FUSE mount tests run here instead.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.python-version }}
+
+      - name: Install FUSE
+        shell: bash
+        run: |
+          set -eux
+          sudo apt-get update
+          sudo apt-get install -y fuse3
+          sudo modprobe fuse || true
+          # gather_mount mounts may use allow_other; internal devservers set
+          # this in /etc/fuse.conf, so mirror it here.
+          echo 'user_allow_other' | sudo tee -a /etc/fuse.conf
+          # Fail early (surfacing a runner regression) if FUSE isn't really here.
+          command -v fusermount3
+          ls -l /dev/fuse
+
+      - name: Install PyTorch (CPU) and test dependencies
+        shell: bash
+        run: |
+          set -eux
+          python -m pip install --upgrade pip
+          pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
+          pip install -r python/tests/requirements.txt
+
+      - name: Fetch disabled tests
+        shell: bash
+        run: |
+          set -eux
+          python3 scripts/fetch_disabled_tests.py
+
+      - name: Download wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: ${{ runner.temp }}/wheel-artifact
+
+      - name: Install wheel
+        shell: bash
+        run: |
+          set -eux
+          python -m pip install "${{ runner.temp }}/wheel-artifact"/*.whl
+
+      - name: Verify import
+        shell: bash
+        run: |
+          set -eux
+          python -c "import monarch; import monarch.gather_mount; print('Monarch + gather_mount imported successfully')"
+
+      - name: Run gather_mount FUSE tests
+        shell: bash
+        run: |
+          set -eux
+          mkdir -p test-results
+          LC_ALL=C pytest python/tests/test_gather_mount.py -s -v \
+            --junit-xml=test-results/test-results.xml
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results-fuse-python-${{ github.sha }}
+          path: test-results/*.xml
+          if-no-files-found: ignore

--- a/python/monarch/_src/gather_mount/gather_mount.py
+++ b/python/monarch/_src/gather_mount/gather_mount.py
@@ -50,14 +50,16 @@ import os
 import stat as _stat
 import struct
 import time
-from collections.abc import Mapping
+from collections.abc import Awaitable, Mapping
 from dataclasses import dataclass
 from itertools import product
+from typing import TypeVar
 
 from monarch._rust_bindings.monarch_extension.readonly_fuse import (  # pyre-ignore[21]
     mount_read_only_filesystem,
 )
-from monarch.actor import Actor, context, endpoint, HostMesh, this_proc
+from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
+from monarch.actor import Actor, context, endpoint, HostMesh, MeshFailure, this_proc
 from monarch.remotemount.remotemount import prepare_mount_point
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -78,6 +80,12 @@ _IN_CLOEXEC: int = 0o02000000
 _WATCH_MASK: int = _IN_MODIFY | _IN_CLOSE_WRITE | _IN_ATTRIB
 _INOTIFY_EVENT_FMT: str = "iIII"
 _INOTIFY_EVENT_SIZE: int = struct.calcsize(_INOTIFY_EVENT_FMT)
+
+# Per-FUSE-op timeout on remote source calls. This is load-bearing -- see
+# ``_bounded`` for exactly why a timeout (not just supervision) is required.
+_SOURCE_TIMEOUT_S: float = float(os.environ.get("MONARCH_GATHER_MOUNT_TIMEOUT_S", "10"))
+
+_T = TypeVar("_T")
 
 
 # ── inotify wrapper ───────────────────────────────────────────────────────────
@@ -286,6 +294,34 @@ class _CacheEntry:
         return self.offset + len(self.data)
 
 
+async def _bounded(awaitable: Awaitable[_T]) -> _T:
+    """Bound a remote ``GatherSourceActor`` call so a stuck source can't wedge
+    the mount. This per-op timeout is load-bearing -- here is exactly why.
+
+    Every FUSE op calls a source actor on the worker mesh, synchronously from the
+    kernel FUSE thread. Two layers you'd hope would bound it do not:
+
+    * The Rust read-only FUSE layer (``readonly_fuse``) has **no timeout** -- it
+      awaits the Python endpoint indefinitely. (It does map a raised exception to
+      ``errno.EIO``, so we don't need to catch one for cleanliness -- but it never
+      gives up on a call that simply never returns.)
+    * Monarch **supervision** only fires when a source *process* dies (then the
+      call raises ``SupervisionError`` on its own, ~9-60s later, which is fine).
+      It does **not** fire when the source process is *alive and healthy* but one
+      call hangs -- e.g. a hung source-side ``stat``/``read`` on a wedged disk or
+      NFS, or a deadlocked endpoint. To supervision the source looks fine, so no
+      error is ever raised.
+
+    In that alive-but-stuck case the call never resolves and no signal arrives, so
+    without this timeout the kernel FUSE thread parks in uninterruptible D-state
+    **forever**, wedging every process that touches the mount until the FUSE
+    connection is force-aborted (``/sys/fs/fuse/connections/<minor>/abort``) -- an
+    unrecoverable state. ``asyncio.wait_for`` turns that into a bounded
+    ``TimeoutError``, which the FUSE endpoints return as ``errno.EIO``.
+    """
+    return await asyncio.wait_for(awaitable, _SOURCE_TIMEOUT_S)
+
+
 class GatherClientActor(Actor):
     """Local actor: owns the stat/file caches and handles all client-side logic.
 
@@ -295,7 +331,36 @@ class GatherClientActor(Actor):
     synchronous ``.call_one(...).get()`` calls from the FUSE threads.
     """
 
-    def __init__(self, actors: object) -> None:
+    def __init__(self, host_mesh: HostMesh, remote_mount_point: str) -> None:
+        # The client SPAWNS + OWNS the source mesh (in ``setup``) so a source
+        # death's supervision fault routes to *this* actor's ``__supervise__`` and
+        # is contained there. If the sources were spawned by the caller and merely
+        # passed in by reference, their fault would route to the caller (the mount
+        # sidecar = the FUSE-serving proc) and an uncaught one would ``sys.exit``
+        # it -- killing the FUSE daemon and wedging the mount in D-state until the
+        # connection is aborted.
+        self._host_mesh: HostMesh = host_mesh
+        self._remote_mount_point: str = remote_mount_point
+        self._actors: object = None
+        self._key_to_point: dict[str, dict[str, int]] = {}
+        # (shard_key, rel_path) → _CacheEntry; evicted by invalidate()
+        self._cache: dict[tuple[str, str], _CacheEntry] = {}
+
+    @endpoint
+    async def setup(self, self_ref: object) -> None:
+        """Spawn + own the source mesh, derive shard points, and wire inotify.
+
+        Spawning the sources here (in the client's own context) makes the client
+        their supervision owner, so ``__supervise__`` receives their failures.
+        ``self_ref`` is this actor's own mesh handle, handed to the sources for
+        the ``invalidate`` callback. ``init_watch`` is bounded and catches a
+        source that dies during setup, so the mount degrades to stale/EIO rather
+        than failing (or crashing) the whole mount.
+        """
+        procs = self._host_mesh.spawn_procs(name="gather_mount")
+        actors = procs.spawn(
+            "GatherSourceActor", GatherSourceActor, self._remote_mount_point
+        )
         self._actors = actors
         extent: dict[str, int] = dict(actors.extent)  # pyre-ignore[16]
         if not extent:
@@ -306,11 +371,25 @@ class GatherClientActor(Actor):
                 dict(zip([n for n, _ in dims], indices))
                 for indices in product(*(range(s) for _, s in dims))
             ]
-        self._key_to_point: dict[str, dict[str, int]] = {
-            _point_to_key(p): p for p in shard_points
-        }
-        # (shard_key, rel_path) → _CacheEntry; evicted by invalidate()
-        self._cache: dict[tuple[str, str], _CacheEntry] = {}
+        self._key_to_point = {_point_to_key(p): p for p in shard_points}
+        try:
+            # pyre-ignore[16]
+            await _bounded(actors.init_watch.call(self_ref))
+        except (asyncio.TimeoutError, SupervisionError):
+            logger.warning(
+                "gather_mount: init_watch did not complete (source slow/dead); "
+                "serving with degraded cache invalidation"
+            )
+
+    def __supervise__(self, failure: MeshFailure) -> bool:
+        # Contain source-mesh supervision faults. This actor owns ONLY the source
+        # mesh, so every fault it receives is a dead/preempted source -- which the
+        # FUSE endpoints already degrade to EIO via the per-call timeout. Returning True
+        # stops propagation to the root client (whose unhandled_fault_hook would
+        # ``sys.exit`` this FUSE-serving proc and wedge the mount). The result is
+        # a *dead* mount (EIO), never a *stuck* one.
+        logger.warning("gather_mount: contained source supervision fault: %s", failure)
+        return True
 
     @endpoint
     async def invalidate(self, shard_key: str, paths: list[str]) -> None:
@@ -340,7 +419,10 @@ class GatherClientActor(Actor):
         assert rel_path is not None
         cache_key = (_point_to_key(point), rel_path)
         cached = cache_key in self._cache
-        entry = await self._ensure_cached(point, rel_path)
+        try:
+            entry = await self._ensure_cached(point, rel_path)
+        except (asyncio.TimeoutError, SupervisionError):
+            return errno.EIO
         if entry is None:
             return errno.ENOENT
         logger.debug(
@@ -362,8 +444,11 @@ class GatherClientActor(Actor):
         if point is None:
             return list(self._key_to_point.keys())
         logger.debug("LISTDIR path=%r", path)
-        # pyre-ignore[16]
-        return await self._actor_for(point).listdir.call_one(rel_path)
+        try:
+            # pyre-ignore[16]
+            return await _bounded(self._actor_for(point).listdir.call_one(rel_path))
+        except (asyncio.TimeoutError, SupervisionError):
+            return errno.EIO
 
     @endpoint
     async def read_path(self, path: str, size: int, offset: int) -> bytes | int:
@@ -378,35 +463,38 @@ class GatherClientActor(Actor):
 
         cache_key = (_point_to_key(point), rel_path)
         stat_cached = cache_key in self._cache
-        entry = await self._ensure_cached(point, rel_path)
-        if entry is None:
-            return errno.ENOENT
-        if _stat.S_ISDIR(entry.mode):
-            return errno.EISDIR
+        try:
+            entry = await self._ensure_cached(point, rel_path)
+            if entry is None:
+                return errno.ENOENT
+            if _stat.S_ISDIR(entry.mode):
+                return errno.EISDIR
 
-        # Fetch prefix if the read starts before the cached window.
-        if offset < entry.offset:
-            fetch_len = entry.offset - offset
-            logger.debug(
-                "READ path=%r offset=%d size=%d → fetch [%d, %d) (stat=%s)",
-                path,
-                offset,
-                size,
-                offset,
-                entry.offset,
-                "MISS→rpc" if not stat_cached else "HIT",
-            )
-            prefix = await self._fetch_range(point, rel_path, offset, fetch_len)
-            entry.data = bytearray(prefix) + entry.data
-            entry.offset = offset
-        else:
-            logger.debug(
-                "READ path=%r offset=%d size=%d → cache HIT (stat=%s)",
-                path,
-                offset,
-                size,
-                "MISS→rpc" if not stat_cached else "HIT",
-            )
+            # Fetch prefix if the read starts before the cached window.
+            if offset < entry.offset:
+                fetch_len = entry.offset - offset
+                logger.debug(
+                    "READ path=%r offset=%d size=%d → fetch [%d, %d) (stat=%s)",
+                    path,
+                    offset,
+                    size,
+                    offset,
+                    entry.offset,
+                    "MISS→rpc" if not stat_cached else "HIT",
+                )
+                prefix = await self._fetch_range(point, rel_path, offset, fetch_len)
+                entry.data = bytearray(prefix) + entry.data
+                entry.offset = offset
+            else:
+                logger.debug(
+                    "READ path=%r offset=%d size=%d → cache HIT (stat=%s)",
+                    path,
+                    offset,
+                    size,
+                    "MISS→rpc" if not stat_cached else "HIT",
+                )
+        except (asyncio.TimeoutError, SupervisionError):
+            return errno.EIO
 
         data_start = offset - entry.offset
         return bytes(entry.data[data_start : data_start + size])
@@ -453,10 +541,9 @@ class GatherClientActor(Actor):
         entry = self._cache.get(cache_key)
         if entry is not None:
             return entry
-        # pyre-ignore[16]
-        raw: tuple[int, int, int] | None = await self._actor_for(
-            point
-        ).stat_and_watch.call_one(rel_path)
+        raw: tuple[int, int, int] | None = await _bounded(
+            self._actor_for(point).stat_and_watch.call_one(rel_path)  # pyre-ignore[16]
+        )
         if raw is None:
             return None
         mtime_ns, size, mode = raw
@@ -472,11 +559,10 @@ class GatherClientActor(Actor):
         actor = self._actor_for(point)
         if length < _RDMA_THRESHOLD:
             # pyre-ignore[16]
-            return await actor.read_bytes.call_one(rel_path, offset, length)
+            return await _bounded(actor.read_bytes.call_one(rel_path, offset, length))
         # RDMA path
-        # pyre-ignore[16]
-        token, rdma_buf, actual_len = await actor.prepare_rdma.call_one(
-            rel_path, offset, length
+        token, rdma_buf, actual_len = await _bounded(
+            actor.prepare_rdma.call_one(rel_path, offset, length)  # pyre-ignore[16]
         )
         if actual_len == 0 or rdma_buf is None:
             return b""
@@ -484,7 +570,8 @@ class GatherClientActor(Actor):
         try:
             # pyrefly: ignore [bad-assignment]
             mv: memoryview[bytes] = memoryview(mm)[:actual_len]
-            await rdma_buf.read_into(mv)
+            # pyre-ignore[16]
+            await _bounded(rdma_buf.read_into(mv))
             data = bytes(mv)
             mv.release()
         finally:
@@ -553,16 +640,20 @@ class GatherMount:
         self._local_mount_point = local_mount_point
         self._mounted: bool = False
 
-        procs = host_mesh.spawn_procs(name="gather_mount")
-
-        actors = procs.spawn("GatherSourceActor", GatherSourceActor, remote_mount_point)
-        client_actor = this_proc().spawn("GatherClientActor", GatherClientActor, actors)
+        # The client spawns + OWNS the source mesh (in setup) so a source death's
+        # supervision fault is contained by GatherClientActor.__supervise__ and
+        # cannot sys.exit this FUSE-serving proc (which would wedge the mount in
+        # D-state until the connection is aborted). See GatherClientActor.
+        client_actor = this_proc().spawn(
+            "GatherClientActor", GatherClientActor, host_mesh, remote_mount_point
+        )
 
         prepare_mount_point(local_mount_point)
 
-        # Call init_watch on all source actors and wait for completion before
-        # mounting — ensures inotify is ready before the first FUSE operation.
-        actors.init_watch.call(client_actor).get()
+        # setup() spawns the (client-owned) sources, derives shard points, and
+        # wires inotify before the first FUSE op; we pass the client its own ref
+        # so the sources can call back ``invalidate``.
+        client_actor.setup.call(client_actor).get()
 
         # The Rust FUSE session runs on the shared Tokio runtime; it calls
         # back into client_actor for every filesystem operation.

--- a/python/tests/test_gather_mount.py
+++ b/python/tests/test_gather_mount.py
@@ -16,22 +16,40 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 import tempfile
 import time
 import unittest
 
 
-def _skip_if_no_fuse() -> None:
-    """Skip the test if FUSE is unavailable in the current environment."""
-    if shutil.which("fusermount3") is None and shutil.which("fusermount") is None:
-        raise unittest.SkipTest("fusermount / fusermount3 not found on PATH")
+def _require_fuse() -> None:
+    """Fail loudly if FUSE is unavailable on a platform that supports it.
+
+    FUSE is Linux-only, so on non-Linux (e.g. the macOS CI runner) these tests
+    are skipped. On Linux FUSE is expected to be available (internal CI runs on
+    a Sandcastle host, and the OSS Linux lanes install fuse3 and provide
+    /dev/fuse), so a missing FUSE is an environment regression we surface as a
+    failure rather than a silent skip; it doubles as a canary for devservers.
+    """
+    if sys.platform != "linux":
+        raise unittest.SkipTest(f"FUSE is Linux-only; skipping on {sys.platform}")
+    fuse_ok = (
+        shutil.which("fusermount3") is not None
+        or shutil.which("fusermount") is not None
+    ) and os.path.exists("/dev/fuse")
+    if not fuse_ok:
+        raise AssertionError(
+            "FUSE expected on Linux but unavailable (missing fusermount/"
+            "fusermount3 or /dev/fuse). This is an environment regression, "
+            "not a test bug."
+        )
 
 
 class GatherMountBasicTest(unittest.TestCase):
     """Basic correctness tests for gather_mount running entirely on localhost."""
 
     def setUp(self) -> None:
-        _skip_if_no_fuse()
+        _require_fuse()
         self._cleanup: list[str] = []
 
     def tearDown(self) -> None:
@@ -293,7 +311,7 @@ class GatherMountProcessJobTest(unittest.TestCase):
     """Multi-host gather_mount tests using ProcessJob for fake local hosts."""
 
     def setUp(self) -> None:
-        _skip_if_no_fuse()
+        _require_fuse()
         self._cleanup: list[str] = []
 
     def tearDown(self) -> None:

--- a/scripts/common-setup-macos.sh
+++ b/scripts/common-setup-macos.sh
@@ -42,8 +42,11 @@ run_test_groups() {
         pkill -9 python || true
         pkill -9 pytest || true
         sleep 2
+        # test_gather_mount.py needs a real FUSE mount (/dev/fuse); those tests
+        # run in the dedicated ubuntu-latest test-fuse-python lane, not on macOS.
         LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
             --ignore-glob="**/meta/**" \
+            --ignore=python/tests/test_gather_mount.py \
             --dist=no \
             --group="$GROUP" \
             --junit-xml="$test_results_dir/test-results-$GROUP.xml" \

--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -292,8 +292,12 @@ run_test_groups() {
   export LD_PRELOAD="${CONDA_LIBSTDCPP}${LD_PRELOAD:+:$LD_PRELOAD}"
   export RUST_BACKTRACE=1
   mkdir -p "$test_results_dir"
+  # test_gather_mount.py needs a real FUSE mount (/dev/fuse), which this
+  # linux_job_v2 container does not provide; those tests run in the dedicated
+  # test-fuse-python (ubuntu-latest) lane instead.
   LC_ALL=C pytest python/tests/ -s -v -m "not oss_skip" \
       --ignore-glob="**/meta/**" \
+      --ignore=python/tests/test_gather_mount.py \
       --crash-recovery \
       --max-crashes=10 \
       --max-leaked-procs=16 \


### PR DESCRIPTION
Summary:

A gather mount's FUSE handlers call `GatherSourceActor` on the worker mesh for every filesystem op, synchronously from the kernel FUSE thread. When a source went away or hung, the mount could wedge in uninterruptible D-state — every process touching it (and bystanders like `df` and shell tab-completion) blocked until the FUSE connection was force-aborted or the box rebooted.

This is not hypothetical. While developing the remotemount on-demand-pull stack we hit it repeatedly: a preempted worker, or a training `monarch exec` that got killed, left an `ls` / `tail` / `cat` of a `hosts_N/` log path hung unkillably in D-state — wedging every process that touched the mount — until we aborted the FUSE connection (`/sys/fs/fuse/connections/<minor>/abort`); in the moment we just rebooted.

There are two distinct ways a source wedges the mount, and they need different fixes:

1. Crash -> dead daemon. A source process death raises a supervision fault. `GatherClientActor` lives in the mount sidecar = the FUSE daemon, and the source mesh used to be owned by the *caller*, so the fault routed to the sidecar's root client and, uncaught, `sys.exit`'d it. A dead FUSE daemon doesn't unmount — the kernel wedges every op in D-state until the connection is aborted. Fix: `GatherClientActor` now spawns and owns the source mesh and overrides `__supervise__` to contain source faults (returns `True`), so a dead/preempted source can never take down the FUSE daemon.

2. Alive-but-stuck -> permanent hang. A source process that is alive and healthy but whose specific call never returns (a hung source-side `stat`/`read` on a wedged disk or NFS, a deadlocked endpoint) is invisible to supervision (the process looks fine), and the Rust read-only FUSE layer (`readonly_fuse`) awaits the Python endpoint with no timeout of its own — so the kernel FUSE thread parks in D-state forever. Fix: every source call is wrapped in a per-op `asyncio.wait_for` (`_bounded`, `MONARCH_GATHER_MOUNT_TIMEOUT_S`, default 10s); on timeout — or a dead mesh's `SupervisionError` — the FUSE endpoint returns `errno.EIO`.

Net: a dead or stuck source yields a *dead* mount (EIO), never a *stuck* one.

An earlier version of this diff used a `_SourceBreaker` (per-shard `asyncio.wait_for` + a dead-shard cooldown). It is removed: the breaker only wraps the in-flight call, so it could not prevent the out-of-band crash -> dead-daemon path (fix 1), and its `SupervisionError` catch was redundant — the Rust FUSE layer already maps any raised exception to `errno.EIO`. The load-bearing piece, the per-op timeout, remains as `_bounded`.

This diff also makes the gather_mount FUSE integration tests fail loud in CI instead of silently skipping, and adds a dedicated `ubuntu-latest` lane that actually has `/dev/fuse` to run them (the test-infra `linux_job_v2` container the other Linux lanes use can't expose it).

- `python/monarch/_src/gather_mount/gather_mount.py`: `GatherClientActor` spawns + owns the source mesh (`setup`) and contains source faults (`__supervise__`); `_bounded` per-op timeout at every source call; endpoints return `EIO` on timeout / `SupervisionError`.
- `python/tests/test_gather_mount.py`: `_require_fuse()` fails loud on Linux (skips only on non-Linux); remove `SourceBreakerTest` (the breaker is gone).
- `.github/workflows/test-fuse-python.yml` (new), `.github/workflows/ci.yml`: a `ubuntu-latest` FUSE lane that installs `fuse3` and runs `test_gather_mount.py`.
- `scripts/common-setup.sh`, `scripts/common-setup-macos.sh`: `--ignore` `test_gather_mount.py` in the container / macOS lanes (no `/dev/fuse`).

Differential Revision: D108680842


