### PR TITLE
Introduce IbvDomainImpl with Mlx/Efa domain strategies (#4270)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -18,8 +18,11 @@ pub mod device;
 pub mod device_selection;
 pub(crate) mod domain;
 pub mod efa_device;
+pub mod efa_domain;
 pub mod manager_actor;
+pub mod memory_region;
 pub mod mlx_device;
+pub mod mlx_domain;
 pub mod primitives;
 pub mod queue_pair;
 

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -34,6 +34,7 @@ use std::sync::LazyLock;
 use typeuri::Named;
 
 use super::domain::IbvDomain;
+use super::domain::IbvDomainImpl;
 use super::primitives::IbvConfig;
 use super::primitives::IbvDeviceInfo;
 use super::primitives::query_device_info;
@@ -41,6 +42,11 @@ use super::primitives::query_device_info;
 /// Per-backend driver for [`IbvDevice`]. Concrete impls register
 /// themselves via [`register_ibv_device_impl!`].
 pub trait IbvDeviceImpl: Named + std::fmt::Debug + Send + Sync + 'static {
+    /// The per-domain strategy used by this backend (how memory regions
+    /// are registered and queue pairs built against a PD). A follow-up
+    /// commit makes [`IbvDomain`] generic over this.
+    type IbvDomainImpl: IbvDomainImpl;
+
     /// Human-readable display name for the backend this impl
     /// drives (e.g., `"mellanox"`, `"efa"`). Surfaced in
     /// diagnostics; not used as a registry key.
@@ -50,31 +56,6 @@ pub trait IbvDeviceImpl: Named + std::fmt::Debug + Send + Sync + 'static {
     /// transiently, once per ibverbs device, while
     /// [`DEVICE_NAMES_BY_IMPL`] is built.
     fn is_instance(ctx: Arc<IbvContext>) -> bool;
-
-    /// Allocates a protection domain against `ctx` and wraps it in
-    /// an [`IbvDomain`]. The returned `Arc<IbvDomain>` is the sole
-    /// owner of the PD; the last drop runs `ibv_dealloc_pd`.
-    ///
-    /// The default implementation calls `ibv_alloc_pd` on
-    /// `ctx.as_ptr()` and constructs a plain [`IbvDomain`].
-    /// In a followup, we'll add an `IbvDomainImpl` trait to allow for
-    /// backend-specific domain implementations.
-    fn create_domain(ctx: Arc<IbvContext>) -> anyhow::Result<Arc<IbvDomain>> {
-        // SAFETY: `ctx.as_ptr()` is the non-null context owned by
-        // the `Arc<IbvContext>` for the duration of this call.
-        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(ctx.as_ptr()) };
-        if pd.is_null() {
-            anyhow::bail!("ibv_alloc_pd failed: {}", std::io::Error::last_os_error());
-        }
-        // TODO: `IbvDomain` should hold the `Arc<IbvContext>`
-        // itself so the context outlives the PD by construction;
-        // for now we copy the raw pointer and rely on the
-        // surrounding [`IbvDevice`] to keep the context alive.
-        Ok(Arc::new(IbvDomain {
-            context: ctx.as_ptr(),
-            pd,
-        }))
-    }
 
     /// Seeds an [`IbvConfig`] with backend-appropriate defaults
     /// (e.g., EFA caps `max_send_sge` at 1).
@@ -190,7 +171,9 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
             if raw_ctx.is_null() {
                 continue;
             }
-            let ctx = Arc::new(IbvContext(raw_ctx));
+            // SAFETY: `raw_ctx` was just returned by `ibv_open_device` and is
+            // non-null (checked above); this `Arc<IbvContext>` is its sole owner.
+            let ctx = Arc::new(unsafe { IbvContext::new(raw_ctx) });
             // Assign the device to the first impl that claims it.
             if let Some(reg) = registrations
                 .iter()
@@ -221,7 +204,9 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
 /// the raw pointer can be passed around with a lifetime safeguard
 /// where borrow-checked references aren't practical.
 #[derive(Debug)]
-pub struct IbvContext(*mut rdmaxcel_sys::ibv_context);
+pub struct IbvContext {
+    context: *mut rdmaxcel_sys::ibv_context,
+}
 
 // SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
 // operations we perform (allocation, polling, and the final close).
@@ -229,27 +214,40 @@ unsafe impl Send for IbvContext {}
 unsafe impl Sync for IbvContext {}
 
 impl IbvContext {
+    /// Wraps a raw `ibv_context*`. A null pointer yields a no-op context
+    /// (its `Drop` does nothing).
+    ///
+    /// # Safety
+    ///
+    /// `context` must be either null or a pointer returned by
+    /// `ibv_open_device` that has not been (and will not be) closed elsewhere:
+    /// the resulting `IbvContext` takes sole ownership and its `Drop` calls
+    /// `ibv_close_device` exactly once.
+    pub(super) unsafe fn new(context: *mut rdmaxcel_sys::ibv_context) -> Self {
+        Self { context }
+    }
+
     /// Returns the raw `ibv_context*`. The pointer is valid for
     /// the lifetime of `&self`.
     pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
-        self.0
+        self.context
     }
 }
 
 impl Drop for IbvContext {
     fn drop(&mut self) {
-        if self.0.is_null() {
+        if self.context.is_null() {
             return;
         }
-        // SAFETY: `self.0` was returned by `ibv_open_device` in
+        // SAFETY: `self.context` was returned by `ibv_open_device` in
         // `IbvDevice::open` and has not been closed elsewhere. The
         // intended ownership is a single `Arc<IbvContext>`, whose
         // final `Drop` calls `ibv_close_device` exactly once.
-        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.0) };
+        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.context) };
         if result != 0 {
             tracing::error!(
                 "ibv_close_device failed for context {:p}: error code {}",
-                self.0,
+                self.context,
                 result
             );
         }
@@ -382,7 +380,10 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             domains: HashMap::new(),
             device_info,
             config,
-            context: Arc::new(IbvContext(context)),
+            // SAFETY: `context` was returned by `ibv_open_device` above and is
+            // non-null (a null open set `failure`, which panics before here);
+            // this `Arc<IbvContext>` is its sole owner.
+            context: Arc::new(unsafe { IbvContext::new(context) }),
             _marker: PhantomData,
         })
     }
@@ -410,14 +411,17 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
         self.domains.get(name)
     }
 
-    /// Returns the `Arc<IbvDomain>` registered under `name`,
-    /// creating (and caching) a new one via
-    /// [`IbvDeviceImpl::create_domain`] on first access.
+    /// Returns the `Arc<IbvDomain>` registered under `name`, creating (and
+    /// caching) a new one via [`IbvDomain::new`] on first access.
     pub fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
         if let Some(domain) = self.domains.get(name) {
             return Ok(Arc::clone(domain));
         }
-        let domain = I::create_domain(Arc::clone(&self.context))?;
+        // SAFETY: `self.context` wraps the live `ibv_context` opened by
+        // `IbvDevice::open`, valid for this device's lifetime.
+        let domain = Arc::new(unsafe {
+            IbvDomain::new(Arc::clone(&self.context), self.device_info.clone())
+        }?);
         self.domains.insert(name.to_string(), Arc::clone(&domain));
         Ok(domain)
     }

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -12,34 +12,50 @@
 //! required for RDMA operations. It provides the foundation for creating
 //! queue pairs and establishing connections between RDMA devices.
 
-use std::ffi::CStr;
+use std::ffi::c_void;
 use std::io::Error;
+use std::os::fd::AsRawFd;
+use std::os::fd::FromRawFd;
+use std::os::fd::OwnedFd;
 use std::result::Result;
+use std::sync::Arc;
 
+use super::device::IbvContext;
+use super::memory_region::IbvMemoryRegion;
+use super::memory_region::IbvMemoryRegionView;
+use super::primitives::IbvConfig;
 use super::primitives::IbvDeviceInfo;
+use super::queue_pair::IbvQueuePair;
+use crate::local_memory::KeepaliveLocalMemory;
+use crate::local_memory::is_device_ptr;
 
 /// Manages RDMA resources including context and protection domain.
 ///
 /// # Fields
 ///
-/// * `context`: A pointer to the RDMA device context.
-/// * `pd`: A pointer to the protection domain, which provides isolation between
-///   different connections.
+/// * `context`: The owning [`Arc<IbvContext>`]; held (rather than a raw
+///   pointer) so the device context outlives the PD by construction. The
+///   PD is freed in `Drop` before this `Arc` is released.
+/// * `pd`: The protection domain pointer (private; read via [`Self::as_ptr`]),
+///   which provides isolation between connections.
+/// * `device_info`: Metadata for the device this PD is allocated on.
 ///
 /// `IbvDomain` is not `Clone`: the `Drop` impl runs
 /// `ibv_dealloc_pd` and copying the pointer would lead to a
 /// double-free. Share the domain across owners via
 /// `Arc<IbvDomain>` instead.
 pub struct IbvDomain {
-    pub context: *mut rdmaxcel_sys::ibv_context,
-    pub pd: *mut rdmaxcel_sys::ibv_pd,
+    pub context: Arc<IbvContext>,
+    pd: *mut rdmaxcel_sys::ibv_pd,
+    pub device_info: IbvDeviceInfo,
 }
 
 impl std::fmt::Debug for IbvDomain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IbvDomain")
-            .field("context", &format!("{:p}", self.context))
+            .field("context", &format!("{:p}", self.context.as_ptr()))
             .field("pd", &format!("{:p}", self.pd))
+            .field("device_info", &self.device_info)
             .finish()
     }
 }
@@ -66,11 +82,10 @@ impl Drop for IbvDomain {
 }
 
 impl IbvDomain {
-    /// Creates a new IbvDomain for the given device.
+    /// Creates an `IbvDomain` over an already-opened device `context`,
+    /// allocating its protection domain.
     ///
-    /// Initializes the RDMA device context and creates a protection domain.
-    ///
-    /// SAFETY:
+    /// Note:
     /// Our memory region (MR) registration uses implicit ODP for RDMA access, which maps large virtual
     /// address ranges without explicit pinning. This is convenient, but it broadens the memory footprint
     /// exposed to the NIC and introduces a security liability.
@@ -79,62 +94,261 @@ impl IbvDomain {
     /// at this layer. We plan to investigate mitigations - such as memory windows or tighter registration
     /// boundaries in future follow-ups.
     ///
+    /// # Safety
+    ///
+    /// `context` must wrap a valid, live `ibv_context`: the `Arc<IbvContext>`
+    /// keeps it open for this call and for the returned domain's lifetime (the
+    /// PD allocated here is freed against that context on `Drop`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `context` is null.
+    ///
     /// # Errors
     ///
-    /// Returns errors if no RDMA devices are found, the specified device cannot be found,
-    /// device context creation fails, or protection domain allocation fails.
-    pub fn new(device: IbvDeviceInfo) -> Result<Self, anyhow::Error> {
-        tracing::debug!("creating IbvDomain for device {}", device.name());
-        unsafe {
-            let device_name = device.name();
-            let mut num_devices = 0i32;
-            let devices = rdmaxcel_sys::ibv_get_device_list(&mut num_devices as *mut _);
+    /// Returns an error if protection-domain allocation fails.
+    pub unsafe fn new(
+        context: Arc<IbvContext>,
+        device_info: IbvDeviceInfo,
+    ) -> Result<Self, anyhow::Error> {
+        assert!(
+            !context.as_ptr().is_null(),
+            "IbvDomain::new requires a non-null ibv_context"
+        );
+        // SAFETY: `context.as_ptr()` is non-null (asserted above) and, per this
+        // function's contract, a valid live `ibv_context` owned by the
+        // `Arc<IbvContext>` for the duration of this call.
+        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(context.as_ptr()) };
+        if pd.is_null() {
+            anyhow::bail!("ibv_alloc_pd failed: {}", Error::last_os_error());
+        }
+        Ok(Self {
+            context,
+            pd,
+            device_info,
+        })
+    }
 
-            if devices.is_null() || num_devices == 0 {
-                return Err(anyhow::anyhow!("no RDMA devices found"));
-            }
-
-            let mut device_ptr = std::ptr::null_mut();
-            for i in 0..num_devices {
-                let dev = *devices.offset(i as isize);
-                let dev_name =
-                    CStr::from_ptr(rdmaxcel_sys::ibv_get_device_name(dev)).to_string_lossy();
-
-                if dev_name == *device_name {
-                    device_ptr = dev;
-                    break;
-                }
-            }
-
-            if device_ptr.is_null() {
-                rdmaxcel_sys::ibv_free_device_list(devices);
-                return Err(anyhow::anyhow!("device '{}' not found", device_name));
-            }
-            tracing::info!("using RDMA device: {}", device_name);
-
-            let context = rdmaxcel_sys::ibv_open_device(device_ptr);
-            if context.is_null() {
-                rdmaxcel_sys::ibv_free_device_list(devices);
-                let os_error = Error::last_os_error();
-                return Err(anyhow::anyhow!("failed to create context: {}", os_error));
-            }
-
-            let pd = rdmaxcel_sys::ibv_alloc_pd(context);
-            if pd.is_null() {
-                rdmaxcel_sys::ibv_close_device(context);
-                rdmaxcel_sys::ibv_free_device_list(devices);
-                let os_error = Error::last_os_error();
-                return Err(anyhow::anyhow!(
-                    "failed to create protection domain (PD): {}",
-                    os_error
-                ));
-            }
-
-            rdmaxcel_sys::ibv_free_device_list(devices);
-
-            let domain = IbvDomain { context, pd };
-
-            Ok(domain)
+    /// Test-only constructor assembling a domain from raw parts (typically with
+    /// a null `pd`/`context` whose `Drop` is a no-op) for use as a keepalive.
+    ///
+    /// # Safety
+    ///
+    /// If `pd` is non-null it must be a protection domain allocated against
+    /// `context` and owned solely by the returned domain (its `Drop` calls
+    /// `ibv_dealloc_pd` once); `context` must satisfy [`IbvContext`]'s validity
+    /// contract.
+    #[cfg(test)]
+    pub(super) unsafe fn from_parts(
+        context: Arc<IbvContext>,
+        pd: *mut rdmaxcel_sys::ibv_pd,
+        device_info: IbvDeviceInfo,
+    ) -> Self {
+        Self {
+            context,
+            pd,
+            device_info,
         }
     }
+
+    /// The protection domain pointer. Valid for the lifetime of `&self`.
+    /// Prefer this over touching the field directly (which is private).
+    pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_pd {
+        self.pd
+    }
+
+    /// Metadata for the device this domain's PD is allocated on.
+    pub fn device_info(&self) -> &IbvDeviceInfo {
+        &self.device_info
+    }
+}
+
+/// Per-backend strategy for a protection domain: how memory regions are
+/// registered and how queue pairs are built against the PD.
+///
+/// One strategy is constructed per opened device via [`Self::new`], which
+/// inspects the device behind the context to decide backend-specific
+/// behavior up front. The per-op methods take the owning `Arc<IbvDomain>`
+/// so the returned resources can anchor the PD's lifetime as a keepalive; a
+/// follow-up commit makes this the backend-generic `Arc<IbvDomain<Self>>`.
+pub trait IbvDomainImpl: Send + Sync + 'static + Sized {
+    /// Build the strategy for the device behind `context` (whose queried
+    /// metadata is `device_info`), using `config` for any setup it performs.
+    ///
+    /// # Safety
+    ///
+    /// If `context` is non-null it must wrap a valid, live `ibv_context`;
+    /// implementations may query the device behind it.
+    unsafe fn new(context: &IbvContext, device_info: &IbvDeviceInfo, config: &IbvConfig) -> Self;
+
+    /// Access flags used when registering memory regions on this domain.
+    fn mr_access_flags(&self) -> i32;
+
+    /// Register `mem` against `domain`'s PD and return a view of the
+    /// resulting memory region.
+    ///
+    /// The default implementation covers host memory (`ibv_reg_mr`) and
+    /// the device-memory dmabuf path (`ibv_reg_dmabuf_mr`); backends
+    /// override to add hardware-specific registration, falling back to
+    /// this default for the cases they do not special-case.
+    ///
+    /// # Safety
+    ///
+    /// `domain`'s PD (`domain.as_ptr()`) must be null or a live protection
+    /// domain; `mem`'s backing memory must stay valid for the returned MR's
+    /// lifetime.
+    unsafe fn register_mr(
+        &self,
+        domain: Arc<IbvDomain>,
+        mem: &KeepaliveLocalMemory,
+    ) -> anyhow::Result<IbvMemoryRegionView> {
+        // SAFETY: `domain.as_ptr()` is null or a live PD (per this method's
+        // contract; `register_host_or_dmabuf_mr` errors on null), and the caller
+        // keeps `mem`'s backing memory valid for the MR's lifetime.
+        unsafe { register_host_or_dmabuf_mr(domain, self.mr_access_flags(), mem) }
+    }
+
+    /// Create a queue pair against `domain`.
+    fn create_queue_pair(
+        &self,
+        domain: Arc<IbvDomain>,
+        config: &IbvConfig,
+    ) -> anyhow::Result<IbvQueuePair> {
+        IbvQueuePair::new(domain, config.clone())
+    }
+}
+
+/// Register host memory as a standard MR via `ibv_reg_mr`. Returns the raw
+/// `ibv_mr`; the caller wraps it in an [`IbvMemoryRegion`] guard.
+///
+/// # Safety
+///
+/// If `pd` is non-null it must be a live protection domain whose context
+/// outlives this call. `[addr, addr + size)` must name a host mapping that
+/// stays valid for the lifetime of the returned MR.
+pub(super) unsafe fn register_host_mr(
+    pd: *mut rdmaxcel_sys::ibv_pd,
+    addr: usize,
+    size: usize,
+    access_flags: i32,
+) -> anyhow::Result<*mut rdmaxcel_sys::ibv_mr> {
+    if pd.is_null() {
+        anyhow::bail!("register_host_mr called with a null protection domain");
+    }
+    // SAFETY: `pd` is non-null (checked above) and, per this function's
+    // contract, a live protection domain; `[addr, addr + size)` is a
+    // caller-guaranteed valid mapping. `ibv_reg_mr` returns null on failure,
+    // which we check before returning the pointer.
+    let mr = unsafe { rdmaxcel_sys::ibv_reg_mr(pd, addr as *mut c_void, size, access_flags) };
+    if mr.is_null() {
+        anyhow::bail!("failed to register standard MR");
+    }
+    Ok(mr)
+}
+
+/// Register device memory as a dmabuf MR via `ibv_reg_dmabuf_mr`. Returns
+/// the raw `ibv_mr`.
+///
+/// # Safety
+///
+/// If `pd` is non-null it must be a live protection domain whose context
+/// outlives this call. `[addr, addr + size)` must name a CUDA device allocation
+/// that stays valid for the lifetime of the returned MR.
+pub(super) unsafe fn register_dmabuf_mr(
+    pd: *mut rdmaxcel_sys::ibv_pd,
+    addr: usize,
+    size: usize,
+    access_flags: i32,
+) -> anyhow::Result<*mut rdmaxcel_sys::ibv_mr> {
+    if pd.is_null() {
+        anyhow::bail!("register_dmabuf_mr called with a null protection domain");
+    }
+    let mut fd: i32 = -1;
+    // SAFETY: `rdmaxcel_cuMemGetHandleForAddressRange` writes the dmabuf fd for
+    // `[addr, addr + size)` into `fd` and touches no Rust memory beyond the
+    // `&mut fd` out-param; it reports failure via its return code, checked next.
+    let cu_err = unsafe {
+        rdmaxcel_sys::rdmaxcel_cuMemGetHandleForAddressRange(
+            &mut fd,
+            addr as rdmaxcel_sys::CUdeviceptr,
+            size,
+            rdmaxcel_sys::CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+            0,
+        )
+    };
+    if cu_err != rdmaxcel_sys::CUDA_SUCCESS || fd < 0 {
+        anyhow::bail!(
+            "failed to get dmabuf handle for CUDA memory (addr: 0x{:x}, size: {}, cu_err: {}, fd: {})",
+            addr,
+            size,
+            cu_err,
+            fd
+        );
+    }
+    // SAFETY: `fd >= 0` (checked above) is a fresh dmabuf descriptor we
+    // exclusively own; wrapping it in `OwnedFd` closes it on drop and keeps it
+    // open across the registration below.
+    let fd = unsafe { OwnedFd::from_raw_fd(fd) };
+    // SAFETY: `pd` is a non-null protection domain (checked above) belonging to
+    // a live context; `fd` is a valid dmabuf descriptor kept open by the
+    // `OwnedFd` across this call; `size` matches the range queried above.
+    // `ibv_reg_dmabuf_mr` returns null on failure, which we check.
+    let mr =
+        unsafe { rdmaxcel_sys::ibv_reg_dmabuf_mr(pd, 0, size, 0, fd.as_raw_fd(), access_flags) };
+    if mr.is_null() {
+        anyhow::bail!("failed to register dmabuf MR");
+    }
+    Ok(mr)
+}
+
+/// Default MR registration: host memory via [`register_host_mr`], device
+/// memory via [`register_dmabuf_mr`]. Shared by the [`IbvDomainImpl`]
+/// default `register_mr` and by backends as the fallback for memory they
+/// do not special-case.
+///
+/// # Safety
+///
+/// `domain.as_ptr()` must be null or a live protection domain whose context
+/// outlives this call (a null PD yields an error). `mem`'s
+/// `[addr, addr + size)` must stay valid for the lifetime of the returned
+/// view's MR — the MR keepalive maintains the `ibv_mr` but does not keep the
+/// backing memory mapped.
+pub(super) unsafe fn register_host_or_dmabuf_mr(
+    domain: Arc<IbvDomain>,
+    access_flags: i32,
+    mem: &KeepaliveLocalMemory,
+) -> anyhow::Result<IbvMemoryRegionView> {
+    let addr = mem.addr();
+    let size = mem.size();
+    // SAFETY: per this function's contract `domain.as_ptr()` is null or a live
+    // PD (the helpers error on null), and `[addr, addr + size)` stays valid for
+    // the returned MR's lifetime.
+    let mr = unsafe {
+        if is_device_ptr(addr) {
+            register_dmabuf_mr(domain.as_ptr(), addr, size, access_flags)?
+        } else {
+            register_host_mr(domain.as_ptr(), addr, size, access_flags)?
+        }
+    };
+
+    // SAFETY: `mr` is non-null — `register_dmabuf_mr`/`register_host_mr` only
+    // return `Ok` with a non-null, freshly-registered `ibv_mr` — so reading its
+    // `addr`/`lkey`/`rkey` here is sound.
+    let (rdma_addr, lkey, rkey) = unsafe { ((*mr).addr as usize, (*mr).lkey, (*mr).rkey) };
+    let device_name = domain.device_info().name().to_string();
+    // The `IbvMemoryRegion` guard owns the MR (deregistered on its `Drop`) and anchors
+    // the PD past that deregistration; it coerces to `Arc<dyn IbvMemoryRegionKeepalive>`.
+    let guard = Arc::new(IbvMemoryRegion {
+        mr,
+        _domain: domain,
+    });
+    Ok(IbvMemoryRegionView::new(
+        addr,
+        rdma_addr,
+        size,
+        lkey,
+        rkey,
+        device_name,
+        guard,
+    ))
 }

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -14,6 +14,7 @@ use typeuri::Named;
 
 use super::device::IbvContext;
 use super::device::IbvDeviceImpl;
+use super::efa_domain::EfaDomain;
 use super::primitives::IbvConfig;
 use crate::register_ibv_device_impl;
 
@@ -22,6 +23,8 @@ use crate::register_ibv_device_impl;
 pub struct EfaDevice;
 
 impl IbvDeviceImpl for EfaDevice {
+    type IbvDomainImpl = EfaDomain;
+
     fn backend_name() -> &'static str {
         "efa"
     }

--- a/monarch_rdma/src/backend/ibverbs/efa_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_domain.rs
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! EFA domain strategy for [`IbvDomainImpl`].
+
+use super::device::IbvContext;
+use super::domain::IbvDomainImpl;
+use super::primitives::IbvConfig;
+use super::primitives::IbvDeviceInfo;
+
+/// EFA [`IbvDomainImpl`]. Uses the default host/dmabuf MR registration;
+/// EFA has no device-specific memory-key binding to add.
+#[derive(Debug)]
+pub struct EfaDomain;
+
+impl IbvDomainImpl for EfaDomain {
+    unsafe fn new(
+        _context: &IbvContext,
+        _device_info: &IbvDeviceInfo,
+        _config: &IbvConfig,
+    ) -> Self {
+        EfaDomain
+    }
+
+    fn mr_access_flags(&self) -> i32 {
+        // EFA does not support `IBV_ACCESS_REMOTE_ATOMIC`.
+        (rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE
+            | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE
+            | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_READ)
+            .0 as i32
+    }
+
+    // TODO: add a custom `create_queue_pair` implementation for EFA's
+    // queue pairs.
+}

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -371,7 +371,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         let domain = device.get_or_create_domain(DEFAULT_DOMAIN)?;
 
         // Print device info if MONARCH_DEBUG_RDMA=1 is set (before initial QP creation)
-        crate::print_device_info_if_debug_enabled(domain.context);
+        crate::print_device_info_if_debug_enabled(domain.context.as_ptr());
 
         // Create loopback QP for this domain if mlx5dv is supported (needed for segment registration)
         // For EFA, we don't need a loopback QP for segment scanning
@@ -422,7 +422,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                 if let Some((device, qp)) = self.devices.get(info.name()) {
                     let pd = device
                         .domain(DEFAULT_DOMAIN)
-                        .map(|d| d.pd)
+                        .map(|d| d.as_ptr())
                         .unwrap_or(std::ptr::null_mut());
                     pds.push(pd);
                     qps.push(
@@ -534,7 +534,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                 let mut segment_info = None;
                 if self.mlx5dv_enabled {
                     // Try to find in already registered segments
-                    segment_info = self.find_cuda_segment_for_address(addr, size, domain.pd);
+                    segment_info = self.find_cuda_segment_for_address(addr, size, domain.as_ptr());
 
                     // If not found, trigger a re-sync with the allocator and retry
                     if segment_info.is_none() {
@@ -559,7 +559,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                             self.segments_mr
                                 .get_or_insert_with(|| Arc::new(IbvMemoryRegion::Segments));
                             segment_info =
-                                self.find_cuda_segment_for_address(addr, size, domain.pd);
+                                self.find_cuda_segment_for_address(addr, size, domain.as_ptr());
                         }
                     }
                 }
@@ -601,8 +601,14 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                             fd
                         ));
                     }
-                    let mr =
-                        rdmaxcel_sys::ibv_reg_dmabuf_mr(domain.pd, 0, size, 0, fd, access.0 as i32);
+                    let mr = rdmaxcel_sys::ibv_reg_dmabuf_mr(
+                        domain.as_ptr(),
+                        0,
+                        size,
+                        0,
+                        fd,
+                        access.0 as i32,
+                    );
                     if mr.is_null() {
                         return Err(anyhow::anyhow!("Failed to register dmabuf MR"));
                     }
@@ -625,7 +631,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             } else {
                 // CPU memory path
                 let mr = rdmaxcel_sys::ibv_reg_mr(
-                    domain.pd,
+                    domain.as_ptr(),
                     addr as *mut std::ffi::c_void,
                     size,
                     access.0 as i32,

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Registered memory regions returned by [`IbvDomainImpl::register_mr`].
+//!
+//! [`IbvMemoryRegionView`] is the cheap, cloneable handle peers use: the keys
+//! and addresses for a slice of registered memory, plus an `Arc<dyn IbvMemoryRegionKeepalive>`
+//! that keeps the backing registration's resources alive until the last clone
+//! of the view drops.
+//!
+//! [`IbvDomainImpl::register_mr`]: super::domain::IbvDomainImpl::register_mr
+
+use std::sync::Arc;
+
+use super::domain::IbvDomain;
+
+/// Guards the resources behind a registered MR, releasing them when the last
+/// [`IbvMemoryRegionView`] over it drops. Each implementor frees whatever it
+/// owns in its own `Drop`; the trait carries no methods and exists only to
+/// type-erase the guards so a view can hold any of them behind an
+/// `Arc<dyn IbvMemoryRegionKeepalive>`.
+pub(super) trait IbvMemoryRegionKeepalive: std::fmt::Debug + Send + Sync {}
+
+/// Guard for a standalone MR registered via `ibv_reg_mr` / `ibv_reg_dmabuf_mr`;
+/// its `Drop` runs `ibv_dereg_mr`. Owns the domain so the PD outlives that
+/// call.
+#[derive(Debug)]
+pub(super) struct IbvMemoryRegion {
+    pub(super) mr: *mut rdmaxcel_sys::ibv_mr,
+    /// Keepalive for the PD `mr` was registered against; dropped only after
+    /// this struct's `Drop` returns, so the PD is alive during `ibv_dereg_mr`.
+    /// Never read directly.
+    pub(super) _domain: Arc<IbvDomain>,
+}
+
+// SAFETY: `mr` is only handed to `ibv_dereg_mr` (which libibverbs treats as
+// thread-safe) and is owned exclusively by this guard; `domain` is itself
+// `Send + Sync`.
+unsafe impl Send for IbvMemoryRegion {}
+unsafe impl Sync for IbvMemoryRegion {}
+
+impl IbvMemoryRegionKeepalive for IbvMemoryRegion {}
+
+impl Drop for IbvMemoryRegion {
+    fn drop(&mut self) {
+        if self.mr.is_null() {
+            return;
+        }
+        // SAFETY: `mr` is non-null (checked above), was returned by
+        // `ibv_reg_mr` / `ibv_reg_dmabuf_mr`, and is deregistered exactly once
+        // (a value's `Drop` runs once). The PD it was registered against is
+        // still alive: `domain` is dropped only after this returns.
+        let result = unsafe { rdmaxcel_sys::ibv_dereg_mr(self.mr) };
+        if result != 0 {
+            tracing::error!(
+                "failed to deregister MR at {:p}: error code {}",
+                self.mr,
+                result
+            );
+        }
+    }
+}
+
+/// A cloneable handle to a slice of registered memory: the keys and addresses
+/// a peer needs, plus an `Arc<dyn IbvMemoryRegionKeepalive>` keepalive.
+///
+/// Cheap to clone; every clone shares the same guard, so the backing
+/// registration stays alive (and registered) until the last clone drops.
+#[derive(Debug, Clone)]
+pub struct IbvMemoryRegionView {
+    /// Virtual address in the local process address space.
+    pub virtual_addr: usize,
+    /// RDMA address, possibly offset from the region's base MR address.
+    pub rdma_addr: usize,
+    pub size: usize,
+    pub lkey: u32,
+    pub rkey: u32,
+    /// Name of the RDMA device the view's protection domain is on.
+    pub device_name: String,
+    /// Keeps the backing registration alive for every clone of this view; the
+    /// last drop releases its resources. Never read directly.
+    pub(super) _guard: Arc<dyn IbvMemoryRegionKeepalive>,
+}
+
+impl IbvMemoryRegionView {
+    pub(super) fn new(
+        virtual_addr: usize,
+        rdma_addr: usize,
+        size: usize,
+        lkey: u32,
+        rkey: u32,
+        device_name: String,
+        guard: Arc<dyn IbvMemoryRegionKeepalive>,
+    ) -> Self {
+        Self {
+            virtual_addr,
+            rdma_addr,
+            size,
+            lkey,
+            rkey,
+            device_name,
+            _guard: guard,
+        }
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/mlx_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_device.rs
@@ -14,6 +14,7 @@ use typeuri::Named;
 
 use super::device::IbvContext;
 use super::device::IbvDeviceImpl;
+use super::mlx_domain::MlxDomain;
 use super::primitives::IbvConfig;
 use crate::register_ibv_device_impl;
 
@@ -25,6 +26,8 @@ const MELLANOX_VENDOR_ID: u32 = 0x02c9;
 pub struct MlxDevice;
 
 impl IbvDeviceImpl for MlxDevice {
+    type IbvDomainImpl = MlxDomain;
+
     fn backend_name() -> &'static str {
         "mellanox"
     }

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Mellanox (mlx5) domain strategy for [`IbvDomainImpl`].
+//!
+//! Host and non-mlx5dv device memory use the default host/dmabuf
+//! registration. On an mlx5dv-capable device, CUDA device memory is bound
+//! to an indirect mlx5dv memory key so a whole allocator segment is
+//! addressable through a single key. That segment scanning + binding
+//! implementation lands in a follow-up commit; this commit introduces the
+//! strategy with the mlx5dv path stubbed (callers fall back to a dmabuf
+//! MR).
+
+use std::sync::Arc;
+
+use super::device::IbvContext;
+use super::domain::IbvDomain;
+use super::domain::IbvDomainImpl;
+use super::domain::register_host_or_dmabuf_mr;
+use super::memory_region::IbvMemoryRegionView;
+use super::primitives::IbvConfig;
+use super::primitives::IbvDeviceInfo;
+use crate::local_memory::KeepaliveLocalMemory;
+use crate::local_memory::is_device_ptr;
+
+/// Mellanox [`IbvDomainImpl`].
+pub struct MlxDomain {
+    mlx5dv_enabled: bool,
+}
+
+impl IbvDomainImpl for MlxDomain {
+    unsafe fn new(context: &IbvContext, _device_info: &IbvDeviceInfo, _config: &IbvConfig) -> Self {
+        let ctx = context.as_ptr();
+        // A null context (e.g. a test double) has no device to query, so treat
+        // it as mlx5dv-unsupported rather than dereferencing null.
+        let mlx5dv_enabled = if ctx.is_null() {
+            false
+        } else {
+            // SAFETY: `ctx` is a non-null, live `ibv_context`; its `device`
+            // field is the `ibv_device` we query for mlx5dv support.
+            unsafe { rdmaxcel_sys::mlx5dv_is_supported((*ctx).device) }
+        };
+        Self { mlx5dv_enabled }
+    }
+
+    fn mr_access_flags(&self) -> i32 {
+        (rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE
+            | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE
+            | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_READ
+            | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_ATOMIC)
+            .0 as i32
+    }
+
+    unsafe fn register_mr(
+        &self,
+        domain: Arc<IbvDomain>,
+        mem: &KeepaliveLocalMemory,
+    ) -> anyhow::Result<IbvMemoryRegionView> {
+        if self.mlx5dv_enabled && is_device_ptr(mem.addr()) {
+            // SAFETY: `domain.as_ptr()` is null or a live PD, per this method's
+            // contract.
+            match unsafe { self.register_cuda_mlx5dv_mr(domain.as_ptr(), mem) } {
+                Ok(view) => return Ok(view),
+                Err(e) => {
+                    tracing::warn!("mlx5dv CUDA registration failed, falling back to dmabuf: {e}")
+                }
+            }
+        }
+        // SAFETY: `domain.as_ptr()` is null or a live PD (per this method's
+        // contract; `register_host_or_dmabuf_mr` errors on null), and the caller
+        // keeps `mem`'s backing memory valid for the MR's lifetime.
+        unsafe { register_host_or_dmabuf_mr(domain, self.mr_access_flags(), mem) }
+    }
+}
+
+impl MlxDomain {
+    /// Bind CUDA memory via an indirect mlx5dv memory key. Stub: the real
+    /// implementation lands in a follow-up commit; today this always errors
+    /// so [`Self::register_mr`] falls back to a dmabuf MR.
+    ///
+    /// # Safety
+    ///
+    /// If `pd` is non-null it must be a live protection domain whose context
+    /// outlives this call.
+    unsafe fn register_cuda_mlx5dv_mr(
+        &self,
+        _pd: *mut rdmaxcel_sys::ibv_pd,
+        _mem: &KeepaliveLocalMemory,
+    ) -> anyhow::Result<IbvMemoryRegionView> {
+        anyhow::bail!("mlx5dv CUDA registration not yet implemented")
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -398,6 +398,28 @@ impl IbvDeviceInfo {
         resolve_target::<I>(&IbvDeviceTarget::MemoryLocation(MemoryLocation::Cpu(None)))
             .unwrap_or_else(|| panic!("no RDMA device for backend {}", I::backend_name()))
     }
+
+    /// Construct an [`IbvDeviceInfo`] with only `name` set (all other
+    /// fields zeroed/empty), for tests that need a named device without
+    /// touching hardware.
+    #[cfg(test)]
+    pub(crate) fn for_test_named(name: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            vendor_id: 0,
+            vendor_part_id: 0,
+            hw_ver: 0,
+            fw_ver: String::new(),
+            node_guid: 0,
+            ports: Vec::new(),
+            max_qp: 0,
+            max_cq: 0,
+            max_mr: 0,
+            max_pd: 0,
+            max_qp_wr: 0,
+            max_sge: 0,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -170,9 +170,9 @@ pub struct IbvQueuePair {
     context: usize,        // *mut rdmaxcel_sys::ibv_context,
     config: IbvConfig,
     is_efa: bool,
-    // The QP's `context` and `pd` pointers are owned by this domain;
-    // hold an `Arc` so the domain outlives the QP regardless of what
-    // happens to other owners (the manager, registered MRs, etc.).
+    // Keepalive for the domain whose `context`/`pd` this QP was built
+    // against, so it outlives the QP regardless of other owners (the
+    // manager, registered MRs, etc.). Never read directly.
     _domain: Arc<IbvDomain>,
 }
 
@@ -251,8 +251,8 @@ impl IbvQueuePair {
     /// Returns errors if CQ or QP creation fails.
     pub fn new(domain: Arc<IbvDomain>, config: IbvConfig) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an IbvQueuePair from config {}", config);
-        let context = domain.context;
-        let pd = domain.pd;
+        let context = domain.context.as_ptr();
+        let pd = domain.as_ptr();
         unsafe {
             // Resolve Auto to a concrete QP type based on device capabilities
             let resolved_qp_type = resolve_qp_type(config.qp_type);
@@ -1713,6 +1713,7 @@ mod tests {
     use hyperactor::proc::Proc;
 
     use super::*;
+    use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::device_selection::resolve_target;
     use crate::backend::ibverbs::domain::IbvDomain;
@@ -1730,10 +1731,12 @@ mod tests {
             use_gpu_direct: false,
             ..Default::default()
         };
-        let domain = IbvDomain::new(resolve_target::<MlxDevice>(&config.target).unwrap());
-        assert!(domain.is_ok());
-
-        let domain = Arc::new(domain.unwrap());
+        let device_info = resolve_target::<MlxDevice>(&config.target).unwrap();
+        let mut device = IbvDevice::<MlxDevice>::open(device_info.name(), config.clone())
+            .expect("resolved device should open");
+        let domain = device
+            .get_or_create_domain("test")
+            .expect("domain creation should succeed");
         let queue_pair = IbvQueuePair::new(domain, config.clone());
         assert!(queue_pair.is_ok());
     }
@@ -1754,12 +1757,20 @@ mod tests {
             ..Default::default()
         };
 
-        let server_domain = Arc::new(
-            IbvDomain::new(resolve_target::<MlxDevice>(&server_config.target).unwrap()).unwrap(),
-        );
-        let client_domain = Arc::new(
-            IbvDomain::new(resolve_target::<MlxDevice>(&client_config.target).unwrap()).unwrap(),
-        );
+        let server_info = resolve_target::<MlxDevice>(&server_config.target).unwrap();
+        let mut server_device =
+            IbvDevice::<MlxDevice>::open(server_info.name(), server_config.clone())
+                .expect("server device should open");
+        let server_domain = server_device
+            .get_or_create_domain("test")
+            .expect("server domain creation should succeed");
+        let client_info = resolve_target::<MlxDevice>(&client_config.target).unwrap();
+        let mut client_device =
+            IbvDevice::<MlxDevice>::open(client_info.name(), client_config.clone())
+                .expect("client device should open");
+        let client_domain = client_device
+            .get_or_create_domain("test")
+            .expect("client domain creation should succeed");
 
         let mut server_qp = IbvQueuePair::new(server_domain, server_config.clone()).unwrap();
         let mut client_qp = IbvQueuePair::new(client_domain, client_config.clone()).unwrap();
@@ -2331,14 +2342,27 @@ mod tests {
     // QueuePairActor op processing
     // =================================================================
 
+    use crate::backend::ibverbs::device::IbvContext;
+    use crate::backend::ibverbs::primitives::IbvDeviceInfo;
     use crate::backend::ibverbs::primitives::IbvMemoryRegion;
     use crate::local_memory::Keepalive;
     use crate::local_memory::KeepaliveLocalMemory;
 
+    /// A throwaway [`IbvDomain`] with null `context`/`pd`, used as the
+    /// `_domain` keepalive of [`fake_mrv`]'s region; its `Drop` deallocs
+    /// nothing (null `pd`).
     fn null_domain() -> Arc<IbvDomain> {
-        Arc::new(IbvDomain {
-            context: std::ptr::null_mut(),
-            pd: std::ptr::null_mut(),
+        // SAFETY: a null `ibv_context*` is explicitly allowed — `IbvContext`'s
+        // `Drop` is a no-op for null, so nothing is ever closed.
+        let context = Arc::new(unsafe { IbvContext::new(std::ptr::null_mut()) });
+        // SAFETY: a null `pd` is allowed — `IbvDomain`'s `Drop` skips
+        // `ibv_dealloc_pd` for null, so nothing is ever freed.
+        Arc::new(unsafe {
+            IbvDomain::from_parts(
+                context,
+                std::ptr::null_mut(),
+                IbvDeviceInfo::for_test_named("null_domain"),
+            )
         })
     }
 

--- a/rdmaxcel-sys/build.rs
+++ b/rdmaxcel-sys/build.rs
@@ -153,6 +153,8 @@ fn main() {
         .allowlist_function("rdmaxcel_error_string")
         .allowlist_function("rdmaxcel_qp_.*")
         .allowlist_function("rdmaxcel_register_segment_scanner")
+        .allowlist_function("rdmaxcel_bind_mr_list")
+        .allowlist_function("rdmaxcel_destroy_mkey")
         .allowlist_function("poll_cq_with_cache")
         .allowlist_function("completion_cache_.*")
         // EFA functions (ibverbs-based)

--- a/rdmaxcel-sys/src/rdmaxcel.cpp
+++ b/rdmaxcel-sys/src/rdmaxcel.cpp
@@ -9,6 +9,7 @@
 #include "rdmaxcel.h"
 #include <cuda.h>
 #include <unistd.h>
+#include <exception>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -219,6 +220,12 @@ int bind_mrs(
     const std::vector<ibv_mr*>& mrs,
     struct mlx5dv_mkey** mkey) {
   auto mrs_cnt = mrs.size();
+  // Defensive: these are passed across the C ABI from Rust; validate rather
+  // than relying on the caller. `qp` is dereferenced below (and via
+  // `ibv_qp_to_qp_ex`), `*mkey` is read, and `pd` feeds mkey creation.
+  if (!pd || !qp || !mkey) {
+    return RDMAXCEL_NULL_ARG;
+  }
   ibv_qp_ex* qpx = ibv_qp_to_qp_ex(qp);
   if (!qpx) {
     return RDMAXCEL_QP_EX_FAILED;
@@ -228,7 +235,24 @@ int bind_mrs(
     return RDMAXCEL_MLX5DV_QP_EX_FAILED;
   }
 
-  if (!*mkey) {
+  // Build the scatter/gather list first, so a bad MR is rejected before we
+  // allocate an mkey (and thus can't leak one).
+  std::vector<ibv_sge> sgl(mrs_cnt);
+  for (size_t i = 0; i < mrs_cnt; i++) {
+    if (!mrs[i]) {
+      return RDMAXCEL_NULL_ARG;
+    }
+    sgl[i].addr = reinterpret_cast<uintptr_t>(mrs[i]->addr);
+    // `ibv_sge.length` is 32-bit; an individual MR is capped well under 4 GiB
+    // (segments are split into <= MAX_MR_SIZE chunks), so this never truncates.
+    sgl[i].length = static_cast<uint32_t>(mrs[i]->length);
+    sgl[i].lkey = mrs[i]->lkey;
+  }
+
+  // Create the indirect mkey if the caller didn't supply one. Track that we
+  // own it so a failed bind below can destroy it rather than leak it.
+  const bool created_mkey_here = (*mkey == nullptr);
+  if (created_mkey_here) {
     struct mlx5dv_mkey_init_attr mkey_attr = {};
     mkey_attr.pd = pd;
     mkey_attr.create_flags = MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT;
@@ -240,12 +264,15 @@ int bind_mrs(
     *mkey = new_mkey;
   }
 
-  std::vector<ibv_sge> sgl(mrs_cnt);
-  for (size_t i = 0; i < mrs_cnt; i++) {
-    sgl[i].addr = reinterpret_cast<uintptr_t>(mrs[i]->addr);
-    sgl[i].length = mrs[i]->length;
-    sgl[i].lkey = mrs[i]->lkey;
-  }
+  // On failure, destroy the mkey we created (if any) so it doesn't leak, and
+  // clear the out-param; a caller-supplied mkey is left untouched.
+  auto fail = [&](int code) {
+    if (created_mkey_here && *mkey) {
+      mlx5dv_destroy_mkey(*mkey);
+      *mkey = nullptr;
+    }
+    return code;
+  };
 
   qpx->wr_flags = IBV_SEND_INLINE | IBV_SEND_SIGNALED;
   ibv_wr_start(qpx);
@@ -253,7 +280,7 @@ int bind_mrs(
   int ret = ibv_wr_complete(qpx);
 
   if (ret != 0) {
-    return RDMAXCEL_WR_COMPLETE_FAILED;
+    return fail(RDMAXCEL_WR_COMPLETE_FAILED);
   }
 
   struct ibv_wc wc{};
@@ -262,7 +289,7 @@ int bind_mrs(
   }
 
   if (wc.status != IBV_WC_SUCCESS) {
-    return RDMAXCEL_WC_STATUS_FAILED;
+    return fail(RDMAXCEL_WC_STATUS_FAILED);
   }
 
   qpx->wr_id += 1;
@@ -271,18 +298,49 @@ int bind_mrs(
   return 0;
 }
 
-// Clean up newly registered MRs and a newly created mkey on failure.
-static void cleanup_new_resources(
-    std::vector<ibv_mr*>& new_mrs,
-    struct mlx5dv_mkey* new_mkey) {
-  for (auto* mr : new_mrs) {
-    if (mr) {
-      ibv_dereg_mr(mr);
+// C-ABI wrapper over `bind_mrs` so Rust can drive the mlx5dv mkey binding
+// directly (the underlying WR-builder verbs are static-inline and not
+// reachable through bindgen).
+int rdmaxcel_bind_mr_list(
+    struct ibv_pd* pd,
+    struct ibv_qp* qp,
+    int access_flags,
+    struct ibv_mr** mrs,
+    size_t mrs_cnt,
+    struct mlx5dv_mkey** mkey) noexcept {
+  // The vector copy and `bind_mrs` allocate; catch every exception and return
+  // an error code so none unwinds across the C ABI into Rust (UB).
+  try {
+    // `mrs` is iterated below to build the vector; guard against a null array.
+    if (!mrs) {
+      return RDMAXCEL_NULL_ARG;
     }
+    std::vector<ibv_mr*> mr_vec(mrs, mrs + mrs_cnt);
+    // `bind_mrs` validates the remaining pointers and, on failure, cleans up
+    // any mkey it created.
+    return bind_mrs(pd, qp, access_flags, mr_vec, mkey);
+  } catch (const std::exception& e) {
+    fprintf(stderr, "[RdmaXcel] rdmaxcel_bind_mr_list failed: %s\n", e.what());
+    return RDMAXCEL_EXCEPTION;
+  } catch (...) {
+    fprintf(stderr, "[RdmaXcel] rdmaxcel_bind_mr_list failed: unknown\n");
+    return RDMAXCEL_EXCEPTION;
   }
-  if (new_mkey) {
-    mlx5dv_destroy_mkey(new_mkey);
+}
+
+int rdmaxcel_destroy_mkey(struct mlx5dv_mkey* mkey) {
+  if (mkey == nullptr) {
+    return RDMAXCEL_SUCCESS;
   }
+  // `mlx5dv_destroy_mkey` follows errno convention (0 / positive errno), unlike
+  // the rest of this API; map any failure into the negative error space so
+  // callers and `rdmaxcel_error_string` stay consistent.
+  const int err = mlx5dv_destroy_mkey(mkey);
+  if (err != 0) {
+    fprintf(stderr, "[RdmaXcel] mlx5dv_destroy_mkey failed: errno %d\n", err);
+    return RDMAXCEL_DESTROY_MKEY_FAILED;
+  }
+  return RDMAXCEL_SUCCESS;
 }
 
 // Compact multiple MRs into a single MR for a segment if SGE_MAX hit
@@ -391,6 +449,17 @@ int register_segments(
 
     std::vector<ibv_mr*> new_mrs;
 
+    // On failure, deregister the MRs we registered for this segment so they
+    // don't leak; any mkey is owned and cleaned up by `bind_mrs`.
+    auto fail = [&](int code) {
+      for (auto* mr : new_mrs) {
+        if (mr) {
+          ibv_dereg_mr(mr);
+        }
+      }
+      return code;
+    };
+
     auto mr_start = seg.phys_address + current_mr_size;
     auto mr_end = seg.phys_address + seg.phys_size;
     auto remaining_size = mr_end - mr_start;
@@ -407,8 +476,7 @@ int register_segments(
 
       // Validate that chunk_size is a multiple of 2MB
       if (chunk_size % MR_ALIGNMENT != 0) {
-        cleanup_new_resources(new_mrs, nullptr);
-        return RDMAXCEL_MR_REGISTRATION_FAILED;
+        return fail(RDMAXCEL_MR_REGISTRATION_FAILED);
       }
 
       int fd = -1;
@@ -420,8 +488,7 @@ int register_segments(
           0);
 
       if (cu_result != CUDA_SUCCESS || fd < 0) {
-        cleanup_new_resources(new_mrs, nullptr);
-        return RDMAXCEL_DMABUF_HANDLE_FAILED;
+        return fail(RDMAXCEL_DMABUF_HANDLE_FAILED);
       }
 
       // Register the dmabuf with fd, address is always 0.
@@ -429,8 +496,7 @@ int register_segments(
       close(fd);
 
       if (!mr) {
-        cleanup_new_resources(new_mrs, nullptr);
-        return RDMAXCEL_MR_REG_FAILED;
+        return fail(RDMAXCEL_MR_REG_FAILED);
       }
 
       new_mrs.push_back(mr);
@@ -442,8 +508,7 @@ int register_segments(
         // if (err != 0) {
         //   return err;
         // }
-        cleanup_new_resources(new_mrs, nullptr);
-        return RDMAXCEL_MKEY_REG_LIMIT;
+        return fail(RDMAXCEL_MKEY_REG_LIMIT);
       }
     }
 
@@ -454,15 +519,15 @@ int register_segments(
     }
     all_mrs.insert(all_mrs.end(), new_mrs.begin(), new_mrs.end());
 
-    // bind_mrs creates the mkey if null
     struct mlx5dv_mkey* mkey =
         seg.registration ? seg.registration->mkey : nullptr;
-    bool had_mkey = mkey != nullptr;
 
+    // bind_mrs creates the mkey when `mkey` is null and, on failure, destroys
+    // any mkey it created (clearing `mkey`), so we only clean up the MRs we
+    // registered here on failure.
     auto err = bind_mrs(pd, qp->ibv_qp, access_flags, all_mrs, &mkey);
     if (err != 0) {
-      cleanup_new_resources(new_mrs, had_mkey ? nullptr : mkey);
-      return err;
+      return fail(err);
     }
 
     // Everything succeeded: commit to the segment registration
@@ -578,7 +643,7 @@ void rdmaxcel_print_device_info(struct ibv_context* context) {
     return;
   }
 
-  struct ibv_device_attr dev_attr;
+  struct ibv_device_attr dev_attr{};
   if (ibv_query_device(context, &dev_attr) != 0) {
     fprintf(stderr, "[RdmaXcel] Error: Failed to query device attributes\n");
     return;
@@ -679,6 +744,12 @@ const char* rdmaxcel_error_string(int error_code) {
       return "[RdmaXcel] Address handle creation failed (ibv_create_ah)";
     case RDMAXCEL_UNSUPPORTED_OP:
       return "[RdmaXcel] Unsupported operation type";
+    case RDMAXCEL_EXCEPTION:
+      return "[RdmaXcel] C++ exception caught at the C-ABI boundary";
+    case RDMAXCEL_NULL_ARG:
+      return "[RdmaXcel] A required pointer argument was NULL";
+    case RDMAXCEL_DESTROY_MKEY_FAILED:
+      return "[RdmaXcel] mlx5dv_destroy_mkey failed";
     default:
       return "[RdmaXcel] Unknown error code";
   }

--- a/rdmaxcel-sys/src/rdmaxcel.h
+++ b/rdmaxcel-sys/src/rdmaxcel.h
@@ -20,9 +20,13 @@
 #ifdef __cplusplus
 #include <atomic>
 #define _Atomic(T) std::atomic<T>
+// `noexcept` is C++-only; elide it for bindgen's C parse of this header (the
+// real guarantee is enforced where the definition is compiled as C++).
+#define RDMAXCEL_NOEXCEPT noexcept
 extern "C" {
 #else
 #include <stdatomic.h>
+#define RDMAXCEL_NOEXCEPT
 #endif
 
 typedef enum {
@@ -148,7 +152,10 @@ typedef enum {
   RDMAXCEL_COMPLETION_FAILED = -17, // Completion status not successful
   RDMAXCEL_QP_MODIFY_FAILED = -18, // ibv_modify_qp failed during connect
   RDMAXCEL_AH_CREATE_FAILED = -19, // ibv_create_ah failed
-  RDMAXCEL_UNSUPPORTED_OP = -20 // Unsupported EFA operation type
+  RDMAXCEL_UNSUPPORTED_OP = -20, // Unsupported EFA operation type
+  RDMAXCEL_EXCEPTION = -21, // C++ exception caught at the C-ABI boundary
+  RDMAXCEL_NULL_ARG = -22, // A required pointer argument was NULL
+  RDMAXCEL_DESTROY_MKEY_FAILED = -23 // mlx5dv_destroy_mkey failed
 } rdmaxcel_error_code_t;
 
 // Error/Debugging functions
@@ -164,6 +171,27 @@ int rdma_get_all_registered_segment_info(
     rdma_segment_info_t* info_array,
     int max_count);
 int deregister_segments();
+
+// mlx5dv indirect-mkey binding primitive.
+//
+// Binds the given MR list onto an indirect mkey using `qp`'s WR builder (a
+// connected loopback QP), so the bound MRs are addressable as a single flat
+// zero-based region. Creates the mkey when `*mkey` is NULL and writes it
+// back through `mkey`; the caller reads `lkey`/`rkey` off the returned
+// `mlx5dv_mkey`. Returns 0 on success, otherwise a negative
+// `rdmaxcel_error_code_t`; the body catches any C++ exception and reports it
+// as `RDMAXCEL_EXCEPTION`. Declared `noexcept` as a hard backstop so an escape
+// terminates rather than unwinding across the C ABI into Rust.
+int rdmaxcel_bind_mr_list(
+    struct ibv_pd* pd,
+    struct ibv_qp* qp,
+    int access_flags,
+    struct ibv_mr** mrs,
+    size_t mrs_cnt,
+    struct mlx5dv_mkey** mkey) RDMAXCEL_NOEXCEPT;
+
+// Destroy an mkey created by `rdmaxcel_bind_mr_list`. No-op when NULL.
+int rdmaxcel_destroy_mkey(struct mlx5dv_mkey* mkey);
 
 // Scanned segment information - minimal fields needed from external scanner
 // This is what the scanner callback fills in, separate from internal


### PR DESCRIPTION
Summary:

Introduces the `IbvDomainImpl` trait — a per-backend strategy for how memory regions are registered and queue pairs are built against a protection domain — and binds each backend to its strategy via a new `IbvDeviceImpl::IbvDomainImpl` associated type (`MlxDevice` -> `MlxDomain`, `EfaDevice` -> `EfaDomain`).

A strategy is built per opened device via `new(&IbvContext, &IbvDeviceInfo, &IbvConfig)`. The trait defaults cover `register_mr` (host memory via `ibv_reg_mr`, device memory via `ibv_reg_dmabuf_mr`) and `create_queue_pair`, with an `mr_access_flags` hook. `EfaDomain` uses the defaults with EFA access flags (no remote atomic); `MlxDomain` detects mlx5dv support and overrides `register_mr` to bind CUDA memory to an indirect mlx5dv key with a dmabuf fallback — stubbed here, implemented in the follow-ups.

Registered MRs are returned as an `IbvMemoryRegionView` backed by an `Arc<dyn IbvMemoryRegionKeepalive>` (new `memory_region` module); the `IbvMemoryRegion` guard runs `ibv_dereg_mr` on `Drop` and pins the owning `Arc<IbvDomain>` so the PD outlives that call. To support this, `IbvDomain` now owns its `Arc<IbvContext>` (so the context outlives the PD by construction, resolving the prior TODO) and carries the device `IbvDeviceInfo`.

The strategies are not yet reached by any caller; a follow-up makes `IbvDomain` generic over `IbvDomainImpl` and routes the manager through it.

Reviewed By: zdevito

Differential Revision: D108834064


