### PR TITLE
Fix size handling for mismatched read_into/write_from buffers (#4273)

### DIFF
--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -676,7 +676,12 @@ impl PyRdmaBuffer {
             buffer
                 .read_into_local(client.deref(), dst.inner, timeout)
                 .await
-                .map_err(|e| PyException::new_err(format!("failed to read into buffer: {}", e)))?;
+                .map_err(|e| {
+                    PyException::new_err(format!(
+                        "failed to read from remote buffer into local buffer: {}",
+                        e
+                    ))
+                })?;
 
             Ok(())
         })
@@ -701,7 +706,12 @@ impl PyRdmaBuffer {
             buffer
                 .write_from_local(client.deref(), src.inner, timeout)
                 .await
-                .map_err(|e| PyException::new_err(format!("failed to write from buffer: {}", e)))?;
+                .map_err(|e| {
+                    PyException::new_err(format!(
+                        "failed to write from local buffer into remote buffer: {}",
+                        e
+                    ))
+                })?;
 
             Ok(())
         })

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -619,7 +619,7 @@ impl IbvQueuePair {
         let total_size = lhandle.size;
         if rhandle.size < total_size {
             return Err(anyhow::anyhow!(
-                "Remote buffer size ({}) is smaller than local buffer size ({})",
+                "remote buffer size ({}) is smaller than local buffer size ({})",
                 rhandle.size,
                 total_size
             ));
@@ -769,12 +769,12 @@ impl IbvQueuePair {
         lhandle: IbvBuffer,
         rhandle: IbvBuffer,
     ) -> Result<Vec<u64>, anyhow::Error> {
-        let total_size = lhandle.size;
-        if rhandle.size < total_size {
+        let total_size = rhandle.size;
+        if rhandle.size > lhandle.size {
             return Err(anyhow::anyhow!(
-                "Remote buffer size ({}) is smaller than local buffer size ({})",
+                "remote buffer size ({}) is larger than local buffer size ({})",
                 rhandle.size,
-                total_size
+                lhandle.size
             ));
         }
 

--- a/monarch_rdma/src/backend/tcp.rs
+++ b/monarch_rdma/src/backend/tcp.rs
@@ -27,4 +27,5 @@ pub struct TcpOp {
     pub local_memory: KeepaliveLocalMemory,
     pub remote_tcp_manager: ActorRef<TcpManagerActor>,
     pub remote_buf_id: usize,
+    pub remote_size: usize,
 }

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -669,6 +669,15 @@ impl TcpBackend {
         chunk_size: usize,
         deadline: Instant,
     ) -> Result<()> {
+        // A write transfers the whole local buffer into the remote prefix; the
+        // remote buffer may be larger, so its tail is left untouched.
+        if op.local_memory.size() > op.remote_size {
+            anyhow::bail!(
+                "remote buffer size ({}) is smaller than local buffer size ({})",
+                op.remote_size,
+                op.local_memory.size(),
+            );
+        }
         let size = op.local_memory.size();
         let total_chunks = size.div_ceil(chunk_size);
 
@@ -724,7 +733,16 @@ impl TcpBackend {
         chunk_size: usize,
         deadline: Instant,
     ) -> Result<()> {
-        let size = op.local_memory.size();
+        // A read transfers the whole remote buffer into the local prefix; the
+        // local buffer may be larger, so its tail is left untouched.
+        if op.remote_size > op.local_memory.size() {
+            anyhow::bail!(
+                "remote buffer size ({}) is larger than local buffer size ({})",
+                op.remote_size,
+                op.local_memory.size(),
+            );
+        }
+        let size = op.remote_size;
         let total_chunks = size.div_ceil(chunk_size);
 
         let (done_handle, done_rx) = hyperactor::mailbox::open_once_port::<Result<(), String>>(cx);
@@ -785,6 +803,15 @@ impl TcpBackend {
         chunk_size: usize,
         deadline: Instant,
     ) -> Result<()> {
+        // A write transfers the whole local buffer into the remote prefix; the
+        // remote buffer may be larger, so its tail is left untouched.
+        if op.local_memory.size() > op.remote_size {
+            anyhow::bail!(
+                "remote buffer size ({}) is smaller than local buffer size ({})",
+                op.remote_size,
+                op.local_memory.size(),
+            );
+        }
         let size = op.local_memory.size();
         let mut offset = 0;
 
@@ -827,7 +854,16 @@ impl TcpBackend {
         chunk_size: usize,
         deadline: Instant,
     ) -> Result<()> {
-        let size = op.local_memory.size();
+        // A read transfers the whole remote buffer into the local prefix; the
+        // local buffer may be larger, so its tail is left untouched.
+        if op.remote_size > op.local_memory.size() {
+            anyhow::bail!(
+                "remote buffer size ({}) is larger than local buffer size ({})",
+                op.remote_size,
+                op.local_memory.size(),
+            );
+        }
+        let size = op.remote_size;
         let mut offset = 0;
 
         while offset < size {
@@ -900,6 +936,7 @@ impl RdmaBackend for TcpBackend {
                 local_memory: op.local,
                 remote_tcp_manager: remote_tcp_mgr,
                 remote_buf_id,
+                remote_size: op.remote.size,
             };
 
             if parallelism > 1 {

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -314,6 +314,98 @@ async def test_rdma_buffer_drop():
     print(f"✓ Buffer operations failed after drop as expected: {error_result}")
 
 
+@rdma_backends
+async def test_read_into_remote_smaller_than_local():
+    """read_into when the remote buffer is smaller than the local tensor.
+
+    The transfer copies the whole remote buffer into the leading bytes of the
+    local tensor and leaves the trailing bytes untouched.
+    """
+    remote_proc = this_host().spawn_procs(per_host={"processes": 1})
+    local_proc = this_host().spawn_procs(per_host={"processes": 1})
+
+    class RemoteActor(Actor):
+        def __init__(self):
+            # Four floats; smaller than the local tensor below.
+            self.data = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float32)
+
+        @endpoint
+        async def buffer(self) -> RDMABuffer:
+            byte_tensor = self.data.view(torch.uint8).flatten()
+            return RDMABuffer(byte_tensor)
+
+    class LocalActor(Actor):
+        def __init__(self):
+            # Eight floats; the -1.0 sentinel marks bytes that must stay
+            # untouched by the read.
+            self.local = torch.full((8,), -1.0, dtype=torch.float32)
+
+        @endpoint
+        async def read(self, buffer: RDMABuffer) -> torch.Tensor:
+            byte_tensor = self.local.view(torch.uint8).flatten()
+            await buffer.read_into(byte_tensor)
+            return self.local
+
+    remote = remote_proc.spawn("remote", RemoteActor)
+    local = local_proc.spawn("local", LocalActor)
+
+    buffer = await remote.buffer.call_one()
+    result = await local.read.call_one(buffer)
+
+    # The leading floats hold the remote buffer's contents ...
+    assert torch.equal(result[:4], torch.tensor([1.0, 2.0, 3.0, 4.0]))
+    # ... and the trailing floats keep their sentinel value.
+    assert torch.equal(result[4:], torch.full((4,), -1.0))
+
+
+@rdma_backends
+async def test_write_from_local_smaller_than_remote():
+    """write_from when the local tensor is smaller than the remote buffer.
+
+    The transfer copies the whole local tensor into the leading bytes of the
+    remote buffer and leaves the trailing bytes untouched.
+    """
+    remote_proc = this_host().spawn_procs(per_host={"processes": 1})
+    local_proc = this_host().spawn_procs(per_host={"processes": 1})
+
+    class RemoteActor(Actor):
+        def __init__(self):
+            # Eight floats; the -1.0 sentinel marks bytes that must stay
+            # untouched by the write.
+            self.data = torch.full((8,), -1.0, dtype=torch.float32)
+
+        @endpoint
+        async def buffer(self) -> RDMABuffer:
+            byte_tensor = self.data.view(torch.uint8).flatten()
+            return RDMABuffer(byte_tensor)
+
+        @endpoint
+        async def get_data(self) -> torch.Tensor:
+            return self.data
+
+    class LocalActor(Actor):
+        def __init__(self):
+            # Four floats; smaller than the remote buffer above.
+            self.local = torch.tensor([5.0, 6.0, 7.0, 8.0], dtype=torch.float32)
+
+        @endpoint
+        async def write(self, buffer: RDMABuffer) -> None:
+            byte_tensor = self.local.view(torch.uint8).flatten()
+            await buffer.write_from(byte_tensor)
+
+    remote = remote_proc.spawn("remote", RemoteActor)
+    local = local_proc.spawn("local", LocalActor)
+
+    buffer = await remote.buffer.call_one()
+    await local.write.call_one(buffer)
+    result = await remote.get_data.call_one()
+
+    # The leading floats hold the local tensor's contents ...
+    assert torch.equal(result[:4], torch.tensor([5.0, 6.0, 7.0, 8.0]))
+    # ... and the trailing floats keep their sentinel value.
+    assert torch.equal(result[4:], torch.full((4,), -1.0))
+
+
 class TrainerActor(Actor):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
Summary:

A `read_into` whose remote buffer was smaller than the local destination was incorrectly rejected, and the ibverbs and TCP backends sized and bounds-checked transfers inconsistently. Make both backends agree: a read transfers the remote buffer's bytes into the local prefix and fails only when the remote is larger than the local; a write transfers the local buffer's bytes into the remote prefix and fails only when the remote is smaller than the local. The trailing bytes of the larger buffer are left untouched.

Reviewed By: cpuhrsch

Differential Revision: D109081560


