### PR TITLE
Make IbvDomain generic over IbvDomainImpl (#4275)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -43,8 +43,8 @@ use super::primitives::query_device_info;
 /// themselves via [`register_ibv_device_impl!`].
 pub trait IbvDeviceImpl: Named + std::fmt::Debug + Send + Sync + 'static {
     /// The per-domain strategy used by this backend (how memory regions
-    /// are registered and queue pairs built against a PD). A follow-up
-    /// commit makes [`IbvDomain`] generic over this.
+    /// are registered and queue pairs built against a PD). [`IbvDomain`] is
+    /// generic over this.
     type IbvDomainImpl: IbvDomainImpl;
 
     /// Human-readable display name for the backend this impl
@@ -270,7 +270,7 @@ impl Drop for IbvContext {
 /// reference closes the context.
 #[derive(Debug)]
 pub(crate) struct IbvDevice<I: IbvDeviceImpl> {
-    domains: HashMap<String, Arc<IbvDomain>>,
+    domains: HashMap<String, Arc<IbvDomain<I::IbvDomainImpl>>>,
     device_info: IbvDeviceInfo,
     config: IbvConfig,
     context: Arc<IbvContext>,
@@ -407,20 +407,27 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
     /// Returns the `Arc<IbvDomain>` registered under `name`, if
     /// one has already been created. Read-only lookup; use
     /// [`Self::get_or_create_domain`] to create on demand.
-    pub fn domain(&self, name: &str) -> Option<&Arc<IbvDomain>> {
+    pub fn domain(&self, name: &str) -> Option<&Arc<IbvDomain<I::IbvDomainImpl>>> {
         self.domains.get(name)
     }
 
     /// Returns the `Arc<IbvDomain>` registered under `name`, creating (and
     /// caching) a new one via [`IbvDomain::new`] on first access.
-    pub fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
+    pub fn get_or_create_domain(
+        &mut self,
+        name: &str,
+    ) -> anyhow::Result<Arc<IbvDomain<I::IbvDomainImpl>>> {
         if let Some(domain) = self.domains.get(name) {
             return Ok(Arc::clone(domain));
         }
         // SAFETY: `self.context` wraps the live `ibv_context` opened by
         // `IbvDevice::open`, valid for this device's lifetime.
         let domain = Arc::new(unsafe {
-            IbvDomain::new(Arc::clone(&self.context), self.device_info.clone())
+            IbvDomain::<I::IbvDomainImpl>::new(
+                Arc::clone(&self.context),
+                self.device_info.clone(),
+                &self.config,
+            )
         }?);
         self.domains.insert(name.to_string(), Arc::clone(&domain));
         Ok(domain)

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -14,6 +14,7 @@
 
 use std::ffi::c_void;
 use std::io::Error;
+use std::mem::ManuallyDrop;
 use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
@@ -34,28 +35,36 @@ use crate::local_memory::is_device_ptr;
 /// # Fields
 ///
 /// * `context`: The owning [`Arc<IbvContext>`]; held (rather than a raw
-///   pointer) so the device context outlives the PD by construction. The
-///   PD is freed in `Drop` before this `Arc` is released.
+///   pointer) so the device context outlives the PD by construction. The PD is
+///   deallocated in `Drop` before this `Arc` is released.
 /// * `pd`: The protection domain pointer (private; read via [`Self::as_ptr`]),
 ///   which provides isolation between connections.
 /// * `device_info`: Metadata for the device this PD is allocated on.
+/// * `domain_impl`: The backend [`IbvDomainImpl`] strategy for this PD. It may
+///   own FFI resources allocated against the PD, so `Drop` releases it before
+///   deallocating the PD. Held in a [`ManuallyDrop`] so that ordering can be
+///   enforced by hand.
 ///
-/// `IbvDomain` is not `Clone`: the `Drop` impl runs
-/// `ibv_dealloc_pd` and copying the pointer would lead to a
-/// double-free. Share the domain across owners via
+/// `I` is the backend [`IbvDomainImpl`] strategy parameterizing per-PD
+/// behavior.
+///
+/// `IbvDomain` is not `Clone`: its `Drop` runs `ibv_dealloc_pd` and copying the
+/// pointer would lead to a double-free. Share the domain across owners via
 /// `Arc<IbvDomain>` instead.
-pub struct IbvDomain {
+pub struct IbvDomain<I: IbvDomainImpl> {
     pub context: Arc<IbvContext>,
     pd: *mut rdmaxcel_sys::ibv_pd,
     pub device_info: IbvDeviceInfo,
+    domain_impl: ManuallyDrop<I>,
 }
 
-impl std::fmt::Debug for IbvDomain {
+impl<I: IbvDomainImpl> std::fmt::Debug for IbvDomain<I> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IbvDomain")
             .field("context", &format!("{:p}", self.context.as_ptr()))
             .field("pd", &format!("{:p}", self.pd))
             .field("device_info", &self.device_info)
+            .field("domain_impl", &self.domain_impl)
             .finish()
     }
 }
@@ -64,26 +73,53 @@ impl std::fmt::Debug for IbvDomain {
 // IbvDomain is `Send` because the raw pointers to ibverbs structs can be
 // accessed from any thread, and it is safe to drop `IbvDomain` (and run the
 // ibverbs destructors) from any thread.
-unsafe impl Send for IbvDomain {}
+unsafe impl<I: IbvDomainImpl> Send for IbvDomain<I> {}
 
 // SAFETY:
 // IbvDomain is `Sync` because the underlying ibverbs APIs are thread-safe.
-unsafe impl Sync for IbvDomain {}
+unsafe impl<I: IbvDomainImpl> Sync for IbvDomain<I> {}
 
-impl Drop for IbvDomain {
+/// Type-erased keepalive for an [`IbvDomain`] of any backend. Lets holders that
+/// only need to keep a domain's PD (and context) alive — standalone MR guards,
+/// queue pairs — hold an `Arc<dyn IbvDomainKeepalive>` without being generic
+/// over the backend [`IbvDomainImpl`].
+pub(super) trait IbvDomainKeepalive: std::fmt::Debug + Send + Sync {}
+
+impl<I: IbvDomainImpl> IbvDomainKeepalive for IbvDomain<I> {}
+
+impl<I: IbvDomainImpl> Drop for IbvDomain<I> {
     fn drop(&mut self) {
+        // Drop the backend strategy first: it may own FFI resources allocated
+        // against `pd`, which must be released before the PD is deallocated.
+        // SAFETY: `domain_impl` is dropped exactly once — here — and never
+        // accessed afterward (this is `IbvDomain`'s own `Drop`).
+        unsafe {
+            ManuallyDrop::drop(&mut self.domain_impl);
+        }
         if self.pd.is_null() {
             return;
         }
-        unsafe {
-            rdmaxcel_sys::ibv_dealloc_pd(self.pd);
+        // SAFETY: `pd` was returned by `ibv_alloc_pd` and is deallocated exactly
+        // once (`IbvDomain` is not `Clone`). `context` is a separate field,
+        // dropped only after this returns, so the device is still open here.
+        let result = unsafe { rdmaxcel_sys::ibv_dealloc_pd(self.pd) };
+        if result != 0 {
+            tracing::error!(
+                "failed to deallocate protection domain {:p}: error code {}",
+                self.pd,
+                result
+            );
         }
     }
 }
 
-impl IbvDomain {
-    /// Creates an `IbvDomain` over an already-opened device `context`,
-    /// allocating its protection domain.
+impl<I: IbvDomainImpl> IbvDomain<I> {
+    /// Creates an `IbvDomain` over an already-opened device `context`.
+    ///
+    /// Builds the backend [`IbvDomainImpl`] strategy `I` from `config`, then
+    /// allocates the protection domain against `context`. The PD is allocated
+    /// only *after* the strategy is built, so a panicking
+    /// [`IbvDomainImpl::new`] never leaks a PD.
     ///
     /// Note:
     /// Our memory region (MR) registration uses implicit ODP for RDMA access, which maps large virtual
@@ -110,11 +146,17 @@ impl IbvDomain {
     pub unsafe fn new(
         context: Arc<IbvContext>,
         device_info: IbvDeviceInfo,
+        config: &IbvConfig,
     ) -> Result<Self, anyhow::Error> {
         assert!(
             !context.as_ptr().is_null(),
             "IbvDomain::new requires a non-null ibv_context"
         );
+        // Build the strategy first; the PD below is allocated only if this
+        // returns, so a panicking `IbvDomainImpl::new` never leaks a PD.
+        // SAFETY: per this function's contract `context` wraps a valid, live
+        // `ibv_context`, which is what `I::new` requires to query the device.
+        let domain_impl = unsafe { I::new(&context, &device_info, config) };
         // SAFETY: `context.as_ptr()` is non-null (asserted above) and, per this
         // function's contract, a valid live `ibv_context` owned by the
         // `Arc<IbvContext>` for the duration of this call.
@@ -126,11 +168,13 @@ impl IbvDomain {
             context,
             pd,
             device_info,
+            domain_impl: ManuallyDrop::new(domain_impl),
         })
     }
 
-    /// Test-only constructor assembling a domain from raw parts (typically with
-    /// a null `pd`/`context` whose `Drop` is a no-op) for use as a keepalive.
+    /// Test-only constructor assembling a domain from raw parts without
+    /// allocating a PD, so unit tests can fabricate a domain (typically with a
+    /// null `pd`/`context` whose `Drop` is a no-op).
     ///
     /// # Safety
     ///
@@ -139,15 +183,17 @@ impl IbvDomain {
     /// `ibv_dealloc_pd` once); `context` must satisfy [`IbvContext`]'s validity
     /// contract.
     #[cfg(test)]
-    pub(super) unsafe fn from_parts(
+    pub(super) unsafe fn for_test(
         context: Arc<IbvContext>,
         pd: *mut rdmaxcel_sys::ibv_pd,
         device_info: IbvDeviceInfo,
+        domain_impl: I,
     ) -> Self {
         Self {
             context,
             pd,
             device_info,
+            domain_impl: ManuallyDrop::new(domain_impl),
         }
     }
 
@@ -155,6 +201,11 @@ impl IbvDomain {
     /// Prefer this over touching the field directly (which is private).
     pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_pd {
         self.pd
+    }
+
+    /// The backend [`IbvDomainImpl`] strategy for this domain.
+    pub(super) fn domain_impl(&self) -> &I {
+        &self.domain_impl
     }
 
     /// Metadata for the device this domain's PD is allocated on.
@@ -166,12 +217,12 @@ impl IbvDomain {
 /// Per-backend strategy for a protection domain: how memory regions are
 /// registered and how queue pairs are built against the PD.
 ///
-/// One strategy is constructed per opened device via [`Self::new`], which
-/// inspects the device behind the context to decide backend-specific
-/// behavior up front. The per-op methods take the owning `Arc<IbvDomain>`
-/// so the returned resources can anchor the PD's lifetime as a keepalive; a
-/// follow-up commit makes this the backend-generic `Arc<IbvDomain<Self>>`.
-pub trait IbvDomainImpl: Send + Sync + 'static + Sized {
+/// One strategy is constructed per domain via [`Self::new`], which
+/// inspects the device behind the context to decide backend-specific behavior
+/// up front, and is then stored in the [`IbvDomain`] it drives. The per-op
+/// methods are associated functions taking the owning `Arc<IbvDomain<Self>>`
+/// and reach the strategy itself through [`IbvDomain::domain_impl`].
+pub trait IbvDomainImpl: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// Build the strategy for the device behind `context` (whose queried
     /// metadata is `device_info`), using `config` for any setup it performs.
     ///
@@ -198,20 +249,19 @@ pub trait IbvDomainImpl: Send + Sync + 'static + Sized {
     /// domain; `mem`'s backing memory must stay valid for the returned MR's
     /// lifetime.
     unsafe fn register_mr(
-        &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<Self>>,
         mem: &KeepaliveLocalMemory,
     ) -> anyhow::Result<IbvMemoryRegionView> {
+        let access = domain.domain_impl().mr_access_flags();
         // SAFETY: `domain.as_ptr()` is null or a live PD (per this method's
         // contract; `register_host_or_dmabuf_mr` errors on null), and the caller
         // keeps `mem`'s backing memory valid for the MR's lifetime.
-        unsafe { register_host_or_dmabuf_mr(domain, self.mr_access_flags(), mem) }
+        unsafe { register_host_or_dmabuf_mr(domain, access, mem) }
     }
 
     /// Create a queue pair against `domain`.
     fn create_queue_pair(
-        &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<Self>>,
         config: &IbvConfig,
     ) -> anyhow::Result<IbvQueuePair> {
         IbvQueuePair::new(domain, config.clone())
@@ -313,8 +363,8 @@ pub(super) unsafe fn register_dmabuf_mr(
 /// `[addr, addr + size)` must stay valid for the lifetime of the returned
 /// view's MR — the MR keepalive maintains the `ibv_mr` but does not keep the
 /// backing memory mapped.
-pub(super) unsafe fn register_host_or_dmabuf_mr(
-    domain: Arc<IbvDomain>,
+pub(super) unsafe fn register_host_or_dmabuf_mr<I: IbvDomainImpl>(
+    domain: Arc<IbvDomain<I>>,
     access_flags: i32,
     mem: &KeepaliveLocalMemory,
 ) -> anyhow::Result<IbvMemoryRegionView> {

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -359,7 +359,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
-    ) -> Result<Arc<IbvDomain>, anyhow::Error> {
+    ) -> Result<Arc<IbvDomain<I::IbvDomainImpl>>, anyhow::Error> {
         if let Some((device, _)) = self.devices.get_mut(device_name) {
             return device.get_or_create_domain(DEFAULT_DOMAIN);
         }
@@ -614,6 +614,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                     }
                     let id = self.mrv_id;
                     self.mrv_id += 1;
+                    let keepalive = Arc::clone(&domain);
                     mrv = IbvMemoryRegionView::new(
                         id,
                         addr,
@@ -624,7 +625,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                         device_name.clone(),
                         Arc::new(IbvMemoryRegion::Direct {
                             mr,
-                            _domain: Arc::clone(&domain),
+                            _domain: keepalive,
                         }),
                     );
                 }
@@ -643,6 +644,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
 
                 let id = self.mrv_id;
                 self.mrv_id += 1;
+                let keepalive = Arc::clone(&domain);
                 mrv = IbvMemoryRegionView::new(
                     id,
                     addr,
@@ -653,7 +655,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                     device_name.clone(),
                     Arc::new(IbvMemoryRegion::Direct {
                         mr,
-                        _domain: Arc::clone(&domain),
+                        _domain: keepalive,
                     }),
                 );
             }

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use super::domain::IbvDomain;
+use super::domain::IbvDomainKeepalive;
 
 /// Guards the resources behind a registered MR, releasing them when the last
 /// [`IbvMemoryRegionView`] over it drops. Each implementor frees whatever it
@@ -35,7 +35,7 @@ pub(super) struct IbvMemoryRegion {
     /// Keepalive for the PD `mr` was registered against; dropped only after
     /// this struct's `Drop` returns, so the PD is alive during `ibv_dereg_mr`.
     /// Never read directly.
-    pub(super) _domain: Arc<IbvDomain>,
+    pub(super) _domain: Arc<dyn IbvDomainKeepalive>,
 }
 
 // SAFETY: `mr` is only handed to `ibv_dereg_mr` (which libibverbs treats as

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -138,7 +138,7 @@ pub(super) trait MlxDomainOps: Send + Sync + 'static {
     /// we only ever use it for indirect mkey binding.
     fn create_loopback_qp(
         &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<MlxDomain>>,
         config: &IbvConfig,
     ) -> anyhow::Result<*mut rdmaxcel_sys::rdmaxcel_qp>;
 
@@ -262,7 +262,7 @@ impl MlxDomainOps for ProdMlxDomainOps {
 
     fn create_loopback_qp(
         &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<MlxDomain>>,
         config: &IbvConfig,
     ) -> anyhow::Result<*mut rdmaxcel_sys::rdmaxcel_qp> {
         // Build a full queue pair (QP + mlx5dv structures) and connect it to
@@ -345,22 +345,23 @@ impl MlxDomainOps for ProdMlxDomainOps {
 // RegisteredSegment: a CUDA segment bound to an indirect key
 // ===========================================================================
 
-/// [`IbvMemoryRegionKeepalive`] for a segment-bound mlx5dv MR: a no-op (no `Drop`). It pins the
-/// owning [`RegisteredSegment`] — which deregisters its MRs and destroys its
-/// keys on its own `Drop` — and the domain (PD keepalive).
+/// [`IbvMemoryRegionKeepalive`] for a segment-bound mlx5dv MR: a no-op (no
+/// `Drop`). It pins the owning [`RegisteredSegment`] — which deregisters its MRs
+/// and destroys its keys on its own `Drop` — and the domain (PD keepalive).
 ///
 /// `_segment` is declared before `_domain` so it drops first (struct fields
-/// drop in declaration order). A follow-up commit stores an [`IbvDomainImpl`]
-/// in each [`IbvDomain`], so `IbvDomain<MlxDomain>` will itself hold a strong
-/// reference to every `Arc<RegisteredSegment>`. Were `_domain` dropped before
-/// `_segment`, the PD could be deallocated before a segment registered against
-/// it — wrong. Dropping `_segment` first won't actually free the segment (the
-/// domain still references it), but it ensures that once the last `_domain`
-/// reference drops, the segment is freed before the PD is deallocated.
+/// drop in declaration order). Each [`IbvDomain`] stores its [`IbvDomainImpl`]
+/// (here, [`MlxDomain`]), so an `IbvDomain<MlxDomain>` itself holds a strong
+/// reference to every `Arc<RegisteredSegment>` it has bound. Were `_domain`
+/// dropped before `_segment`, the PD could be deallocated before a segment
+/// registered against it — wrong. Dropping `_segment` first won't actually free
+/// the segment (the domain still references it), but it ensures that once the
+/// last `_domain` reference drops, the segment is freed before the PD is
+/// deallocated.
 #[derive(Debug)]
 struct Mlx5dvMemoryRegion {
     _segment: Arc<RegisteredSegment>,
-    _domain: Arc<IbvDomain>,
+    _domain: Arc<IbvDomain<MlxDomain>>,
 }
 
 impl IbvMemoryRegionKeepalive for Mlx5dvMemoryRegion {}
@@ -537,7 +538,7 @@ impl RegisteredSegment {
         seg: &Arc<Self>,
         addr: usize,
         size: usize,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<MlxDomain>>,
     ) -> IbvMemoryRegionView {
         let mkey = seg.state.lock().expect("segment state lock poisoned").mkey;
         // SAFETY: `view` is only called on a segment that covers the request,
@@ -654,6 +655,15 @@ pub struct MlxDomain {
     segments: Mutex<HashMap<(usize, i32), Arc<RegisteredSegment>>>,
 }
 
+impl std::fmt::Debug for MlxDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MlxDomain")
+            .field("mlx5dv_enabled", &self.mlx5dv_enabled)
+            .field("cuda_ordinals", &self.cuda_ordinals)
+            .finish_non_exhaustive()
+    }
+}
+
 impl Drop for MlxDomain {
     fn drop(&mut self) {
         if let Some(&qp) = self.loopback_qp.get() {
@@ -687,7 +697,7 @@ impl MlxDomain {
     /// pointer.
     fn loopback_qp_ptr(
         &self,
-        domain: &Arc<IbvDomain>,
+        domain: &Arc<IbvDomain<MlxDomain>>,
     ) -> anyhow::Result<*mut rdmaxcel_sys::rdmaxcel_qp> {
         // `OnceLock::get_or_try_init` would fit here but is still unstable
         // (`once_cell_try`); calls are serialized under the `segments` lock,
@@ -716,7 +726,7 @@ impl MlxDomain {
     /// outlives this call.
     unsafe fn register_cuda_mlx5dv_mr(
         &self,
-        domain: &Arc<IbvDomain>,
+        domain: &Arc<IbvDomain<MlxDomain>>,
         addr: usize,
         size: usize,
     ) -> anyhow::Result<IbvMemoryRegionView> {
@@ -805,24 +815,25 @@ impl IbvDomainImpl for MlxDomain {
     }
 
     unsafe fn register_mr(
-        &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<MlxDomain>>,
         mem: &KeepaliveLocalMemory,
     ) -> anyhow::Result<IbvMemoryRegionView> {
-        if self.mlx5dv_enabled && is_device_ptr(mem.addr()) {
+        let this = domain.domain_impl();
+        if this.mlx5dv_enabled && is_device_ptr(mem.addr()) {
             // SAFETY: `domain.as_ptr()` is null or a live PD, per this method's
             // contract.
-            match unsafe { self.register_cuda_mlx5dv_mr(&domain, mem.addr(), mem.size()) } {
+            match unsafe { this.register_cuda_mlx5dv_mr(&domain, mem.addr(), mem.size()) } {
                 Ok(view) => return Ok(view),
                 Err(e) => {
                     tracing::warn!("mlx5dv CUDA registration failed, falling back to dmabuf: {e}")
                 }
             }
         }
+        let access = this.mr_access_flags();
         // SAFETY: `domain.as_ptr()` is null or a live PD (per this method's
         // contract; `register_host_or_dmabuf_mr` errors on null), and the caller
         // keeps `mem`'s backing memory valid for the MR's lifetime.
-        unsafe { register_host_or_dmabuf_mr(domain, self.mr_access_flags(), mem) }
+        unsafe { register_host_or_dmabuf_mr(domain, access, mem) }
     }
 }
 
@@ -837,21 +848,6 @@ mod tests {
 
     const MIB2: usize = 2 * 1024 * 1024;
     const SERVED_NIC: &str = "mlx5_0";
-
-    /// A test domain whose `pd`/`context` are null, so its `Drop` is a
-    /// no-op. The `MockOps` ignore the `pd`, and the resulting views only
-    /// hold this as a (never-read) keepalive.
-    fn fake_domain() -> Arc<IbvDomain> {
-        // SAFETY: null `ibv_context*`/`pd` are explicitly allowed — both
-        // `IbvContext` and `IbvDomain` skip their FFI destructors for null.
-        unsafe {
-            Arc::new(IbvDomain::from_parts(
-                Arc::new(IbvContext::new(std::ptr::null_mut())),
-                std::ptr::null_mut(),
-                IbvDeviceInfo::for_test_named("test"),
-            ))
-        }
-    }
 
     fn seg(address: usize, size: usize, cuda_ordinal: i32) -> ScannedSegment {
         ScannedSegment {
@@ -911,7 +907,7 @@ mod tests {
         /// When set, `dereg_mr` records whether this (weakly-held) domain is
         /// still alive at each MR deregistration. Lets a test assert a
         /// segment's MRs are freed while its domain's PD is still alive.
-        domain_probe: Option<std::sync::Weak<IbvDomain>>,
+        domain_probe: Option<std::sync::Weak<IbvDomain<MlxDomain>>>,
         /// One entry per `dereg_mr` while `domain_probe` is set: whether the
         /// probed domain was still alive.
         domain_alive_at_dereg: Vec<bool>,
@@ -999,7 +995,7 @@ mod tests {
 
         fn create_loopback_qp(
             &self,
-            _domain: Arc<IbvDomain>,
+            _domain: Arc<IbvDomain<MlxDomain>>,
             _config: &IbvConfig,
         ) -> anyhow::Result<*mut rdmaxcel_sys::rdmaxcel_qp> {
             let mut s = self.lock();
@@ -1054,19 +1050,36 @@ mod tests {
         }
     }
 
-    fn domain(mock: Arc<MockOps>) -> MlxDomain {
-        MlxDomain::new_with_ops(mock, IbvConfig::default())
+    /// A domain wrapping the mock-driven [`MlxDomain`] under test. Its
+    /// `pd`/`context` are null (no-op `Drop`); the segment views built against
+    /// it hold it only as a keepalive. Drive the strategy via
+    /// [`IbvDomain::domain_impl`].
+    fn domain(mock: Arc<MockOps>) -> Arc<IbvDomain<MlxDomain>> {
+        let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default());
+        // SAFETY: null `ibv_context*`/`pd` are explicitly allowed — both
+        // `IbvContext` and `IbvDomain` skip their FFI destructors for null.
+        unsafe {
+            Arc::new(IbvDomain::for_test(
+                Arc::new(IbvContext::new(std::ptr::null_mut())),
+                std::ptr::null_mut(),
+                IbvDeviceInfo::for_test_named("test"),
+                mlx,
+            ))
+        }
     }
 
-    /// Drive [`MlxDomain::register_cuda_mlx5dv_mr`] against a [`fake_domain`].
+    /// Drive `domain`'s own [`MlxDomain`] strategy to register CUDA memory.
     fn register_cuda(
-        domain: &MlxDomain,
+        domain: &Arc<IbvDomain<MlxDomain>>,
         addr: usize,
         size: usize,
     ) -> anyhow::Result<IbvMemoryRegionView> {
-        // SAFETY: `fake_domain`'s pd is null and the `MockOps` never dereference
-        // it, so passing it through is sound.
-        unsafe { domain.register_cuda_mlx5dv_mr(&fake_domain(), addr, size) }
+        // SAFETY: `domain`'s pd is null and the `MockOps` never dereference it.
+        unsafe {
+            domain
+                .domain_impl()
+                .register_cuda_mlx5dv_mr(domain, addr, size)
+        }
     }
 
     fn null_pd() -> *mut rdmaxcel_sys::ibv_pd {
@@ -1305,7 +1318,7 @@ mod tests {
         let rs = bind_fresh(&ops, base, MIB2);
 
         assert!(rs.covers(base + 0x400, 4096));
-        let view = RegisteredSegment::view(&rs, base + 0x400, 4096, fake_domain());
+        let view = RegisteredSegment::view(&rs, base + 0x400, 4096, domain(ops.clone()));
         assert_eq!(
             view.rdma_addr, 0x400,
             "rdma_addr is the offset from the segment base"
@@ -1407,7 +1420,7 @@ mod tests {
         let ops = MockOps::new(SERVED_NIC, true, &[0]);
         let base = 0x10_0000_0000;
         let rs = bind_fresh(&ops, base, MIB2);
-        let domain = fake_domain();
+        let domain = domain(ops.clone());
         ops.lock().domain_probe = Some(Arc::downgrade(&domain));
 
         let view = RegisteredSegment::view(&rs, base, 4096, Arc::clone(&domain));
@@ -1436,8 +1449,8 @@ mod tests {
     fn test_cuda_ordinals_and_mlx5dv_enabled_derived_from_ops() {
         let mock = MockOps::new(SERVED_NIC, true, &[0, 2]);
         let domain = domain(mock);
-        assert_eq!(domain.cuda_ordinals, vec![0, 2]);
-        assert!(domain.mlx5dv_enabled);
+        assert_eq!(domain.domain_impl().cuda_ordinals, vec![0, 2]);
+        assert!(domain.domain_impl().mlx5dv_enabled);
     }
 
     #[test]
@@ -1619,7 +1632,7 @@ mod tests {
         let domain = domain(mock.clone());
         // The registration path registers MRs with the domain's own access
         // flags; capture them to assert the dmabuf registration arguments.
-        let access = domain.mr_access_flags();
+        let access = domain.domain_impl().mr_access_flags();
 
         // Validate every field of a returned view: its address fields, its
         // size, the serving NIC's name, and the keys. The mock's `mkey_keys`

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -35,7 +35,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-use super::domain::IbvDomain;
+use super::domain::IbvDomainKeepalive;
 use crate::backend::ibverbs::device::IbvDeviceImpl;
 use crate::backend::ibverbs::device::list_all_devices;
 use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
@@ -768,12 +768,12 @@ fn ibverbs_supported_impl() -> bool {
 /// [`IbvMemoryRegionView`] backed by the region; the FFI resource
 /// is released by [`Drop`] when the last clone goes away.
 ///
-/// `Direct` carries an `Arc<IbvDomain>` so the PD the MR was
+/// `Direct` carries an `Arc<dyn IbvDomainKeepalive>` so the PD the MR was
 /// registered against outlives the `ibv_dereg_mr` call. The struct
 /// field order is significant: the `mr` pointer is dereg'd in
 /// `Drop` before the `_domain` field is released, so the PD is
 /// still alive when libibverbs walks back to it. The eventual
-/// `ibv_dealloc_pd` only fires when every other `Arc<IbvDomain>`
+/// `ibv_dealloc_pd` only fires when every other `Arc<dyn IbvDomainKeepalive>`
 /// (e.g. the manager's `device_domains` entry) is also gone.
 #[derive(Debug)]
 pub(super) enum IbvMemoryRegion {
@@ -783,7 +783,7 @@ pub(super) enum IbvMemoryRegion {
         mr: *mut rdmaxcel_sys::ibv_mr,
         /// PD the MR was registered against, kept alive past
         /// `ibv_dereg_mr` via this clone. Never read directly.
-        _domain: Arc<IbvDomain>,
+        _domain: Arc<dyn IbvDomainKeepalive>,
     },
     /// Singleton owner shared by every segment-backed view from the
     /// mlx5dv segment scanner. `Drop` calls
@@ -812,7 +812,7 @@ impl Drop for IbvMemoryRegion {
                 // once when the last clone goes away, meaning
                 // `ibv_dereg_mr` is called exactly once on this
                 // pointer. The PD the MR was registered against is
-                // kept alive by the sibling `_domain` `Arc<IbvDomain>`
+                // kept alive by the sibling `_domain` `Arc<dyn IbvDomainKeepalive>`
                 // until after this dereg returns.
                 let result = unsafe { rdmaxcel_sys::ibv_dereg_mr(*mr) };
                 if result != 0 {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -46,6 +46,8 @@ use typeuri::Named;
 use super::IbvBuffer;
 use super::IbvOp;
 use super::domain::IbvDomain;
+use super::domain::IbvDomainImpl;
+use super::domain::IbvDomainKeepalive;
 use super::manager_actor::CreatePeerQueuePair;
 use super::primitives::Gid;
 use super::primitives::IbvConfig;
@@ -173,7 +175,7 @@ pub struct IbvQueuePair {
     // Keepalive for the domain whose `context`/`pd` this QP was built
     // against, so it outlives the QP regardless of other owners (the
     // manager, registered MRs, etc.). Never read directly.
-    _domain: Arc<IbvDomain>,
+    _domain: Arc<dyn IbvDomainKeepalive>,
 }
 
 impl Drop for IbvQueuePair {
@@ -260,7 +262,10 @@ impl IbvQueuePair {
     /// # Errors
     ///
     /// Returns errors if CQ or QP creation fails.
-    pub fn new(domain: Arc<IbvDomain>, config: IbvConfig) -> Result<Self, anyhow::Error> {
+    pub fn new<I: IbvDomainImpl>(
+        domain: Arc<IbvDomain<I>>,
+        config: IbvConfig,
+    ) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an IbvQueuePair from config {}", config);
         let context = domain.context.as_ptr();
         let pd = domain.as_ptr();
@@ -1728,6 +1733,7 @@ mod tests {
     use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::device_selection::resolve_target;
     use crate::backend::ibverbs::domain::IbvDomain;
+    use crate::backend::ibverbs::efa_domain::EfaDomain;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
 
@@ -2362,17 +2368,18 @@ mod tests {
     /// A throwaway [`IbvDomain`] with null `context`/`pd`, used as the
     /// `_domain` keepalive of [`fake_mrv`]'s region; its `Drop` deallocs
     /// nothing (null `pd`).
-    fn null_domain() -> Arc<IbvDomain> {
+    fn null_domain() -> Arc<IbvDomain<EfaDomain>> {
         // SAFETY: a null `ibv_context*` is explicitly allowed — `IbvContext`'s
         // `Drop` is a no-op for null, so nothing is ever closed.
         let context = Arc::new(unsafe { IbvContext::new(std::ptr::null_mut()) });
         // SAFETY: a null `pd` is allowed — `IbvDomain`'s `Drop` skips
         // `ibv_dealloc_pd` for null, so nothing is ever freed.
         Arc::new(unsafe {
-            IbvDomain::from_parts(
+            IbvDomain::for_test(
                 context,
                 std::ptr::null_mut(),
                 IbvDeviceInfo::for_test_named("null_domain"),
+                EfaDomain,
             )
         })
     }


### PR DESCRIPTION
Summary:

Make `IbvDomain` generic over its backend strategy: `IbvDomain<I: IbvDomainImpl>` stores the strategy in a private `ManuallyDrop<I>` field, so the domain owns the backend's PD-scoped FFI resources and `Drop` releases the strategy before deallocating the PD.

`IbvDomainImpl::register_mr` and `create_queue_pair` now take the owning `Arc<IbvDomain<Self>>` and reach the strategy via `domain_impl()`. Holders that only need to keep a PD alive — `IbvQueuePair` and the standalone MR guard — hold a type-erased `Arc<dyn IbvDomainKeepalive>` so they stay non-generic.

Reviewed By: zdevito

Differential Revision: D109168543


