### PR TITLE
add typed control port accessors (#4276)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -2358,11 +2358,7 @@ mod tests {
         let handle = proc.spawn(actor);
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2620,11 +2616,7 @@ mod tests {
 
         let child_ref = crate::Addr::Actor(test_proc_id("nonexistent").actor_addr("child"));
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::QueryChild {
                 child_ref,
@@ -2670,11 +2662,7 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2711,11 +2699,7 @@ mod tests {
 
         // Query the child — supervisor should be the parent.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            child_handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        child_handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2742,11 +2726,7 @@ mod tests {
 
         // Query the parent — children should include the child.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            parent_handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        parent_handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2790,11 +2770,7 @@ mod tests {
             .unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2827,11 +2803,7 @@ mod tests {
         let _ = rx.recv().await.unwrap();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2868,11 +2840,7 @@ mod tests {
 
         // First introspect query.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -2883,11 +2851,7 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -3056,11 +3020,7 @@ mod tests {
 
         // Send introspect query via the dedicated introspect port.
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -3103,11 +3063,7 @@ mod tests {
 
         // First introspect query.
         let (reply_port1, reply_rx1) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -3118,11 +3074,7 @@ mod tests {
 
         // Second introspect query.
         let (reply_port2, reply_rx2) = client.open_once_port::<IntrospectResult>();
-        crate::PortRef::<IntrospectMessage>::attest_control_port(
-            handle.actor_addr(),
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        handle.actor_addr().introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -3157,11 +3109,7 @@ mod tests {
         let actor_id: crate::ActorAddr = handle.actor_addr().clone();
 
         let (reply_port, reply_rx) = bridge.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            &actor_id,
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        actor_id.introspect_port().post(
             &bridge,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,
@@ -3201,11 +3149,7 @@ mod tests {
         let mailbox_id: crate::ActorAddr = mailbox.self_addr().clone();
 
         let (reply_port, reply_rx) = client.open_once_port::<IntrospectResult>();
-        PortRef::<IntrospectMessage>::attest_control_port(
-            &mailbox_id,
-            crate::ControlPort::Introspect,
-        )
-        .post(
+        mailbox_id.introspect_port().post(
             &client,
             IntrospectMessage::Query {
                 view: IntrospectView::Actor,

--- a/hyperactor/src/addr.rs
+++ b/hyperactor/src/addr.rs
@@ -48,9 +48,12 @@ use crate::id::Label;
 use crate::id::PortId;
 use crate::id::ProcId;
 use crate::id::Uid;
+use crate::introspect::IntrospectMessage;
 use crate::parse;
 use crate::port::ControlPort;
 use crate::port::Port;
+use crate::proc::StatusMessage;
+use crate::ref_::PortRef;
 
 /// A network location.
 ///
@@ -359,6 +362,16 @@ impl ActorAddr {
             id::PortId::new(self.id.clone(), port),
             self.location.clone(),
         )
+    }
+
+    /// The actor's introspection control port.
+    pub fn introspect_port(&self) -> PortRef<IntrospectMessage> {
+        PortRef::attest(self.port_addr(Port::control(ControlPort::Introspect)))
+    }
+
+    /// The actor's lifecycle status control port.
+    pub fn status_port(&self) -> PortRef<StatusMessage> {
+        PortRef::attest(self.port_addr(Port::control(ControlPort::Status)))
     }
 
     /// Create an ActorAddr for a root actor on a proc.

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -4681,7 +4681,7 @@ mod tests {
 
     async fn get_status(client: &Client, actor_addr: &ActorAddr) -> Option<ActorStatus> {
         let (reply_port, reply_rx) = client.open_once_port::<Option<ActorStatus>>();
-        PortRef::<StatusMessage>::attest_control_port(actor_addr, crate::ControlPort::Status).post(
+        actor_addr.status_port().post(
             client,
             StatusMessage::GetStatus {
                 reply: reply_port.bind(),

--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -40,7 +40,6 @@ use crate::mailbox::DeliveryFailureReport;
 use crate::mailbox::MailboxSenderError;
 use crate::mailbox::MailboxSenderErrorKind;
 use crate::mailbox::PortSink;
-use crate::port::ControlPort;
 use crate::port::Port;
 
 /// ActorRefs are typed references to actors.
@@ -350,12 +349,6 @@ impl<M: RemoteMessage> PortRef<M> {
     /// port for message type `M`.
     pub fn attest_handler_port(actor: &ActorAddr) -> Self {
         PortRef::<M>::attest(actor.port_addr(Port::handler::<M>()))
-    }
-
-    /// The caller attests that the provided actor exposes a reachable control
-    /// port for message type `M`.
-    pub fn attest_control_port(actor: &ActorAddr, port: ControlPort) -> Self {
-        PortRef::<M>::attest(actor.port_addr(Port::control(port)))
     }
 
     /// The typehash of this port's reducer, if any. Reducers

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -2032,10 +2032,7 @@ mod tests {
             .proc_addr()
             .actor_addr(HOST_MESH_AGENT_ACTOR_NAME);
         let agent_id: ActorAddr = agent_ref;
-        let port = PortRef::<IntrospectMessage>::attest_control_port(
-            &agent_id,
-            hyperactor::ControlPort::Introspect,
-        );
+        let port = agent_id.introspect_port();
 
         // Poll until we see non-zero watermark (evidence of queue
         // traffic since startup).

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -399,10 +399,7 @@ async fn query_introspect(
     timeout: Duration,
     err_ctx: &str,
 ) -> Result<IntrospectResult, anyhow::Error> {
-    let introspect_port = hyperactor::PortRef::<IntrospectMessage>::attest_control_port(
-        actor_id,
-        hyperactor::ControlPort::Introspect,
-    );
+    let introspect_port = actor_id.introspect_port();
     let (reply_handle, reply_rx) = open_once_port::<IntrospectResult>(cx);
     let mut reply_ref = reply_handle.bind();
     reply_ref.return_undeliverable(false);
@@ -427,10 +424,7 @@ async fn query_child_introspect(
     timeout: Duration,
     err_ctx: &str,
 ) -> Result<IntrospectResult, anyhow::Error> {
-    let introspect_port = hyperactor::PortRef::<IntrospectMessage>::attest_control_port(
-        actor_id,
-        hyperactor::ControlPort::Introspect,
-    );
+    let introspect_port = actor_id.introspect_port();
     let (reply_handle, reply_rx) = open_once_port::<IntrospectResult>(cx);
     let mut reply_ref = reply_handle.bind();
     reply_ref.return_undeliverable(false);
@@ -2124,10 +2118,7 @@ async fn probe_actor(
     cx: &Instance<()>,
     agent_id: &hyperactor::ActorAddr,
 ) -> Result<bool, ApiError> {
-    let port = hyperactor::PortRef::<IntrospectMessage>::attest_control_port(
-        agent_id,
-        hyperactor::ControlPort::Introspect,
-    );
+    let port = agent_id.introspect_port();
     let (handle, rx) = open_once_port::<IntrospectResult>(cx);
     port.post(
         cx,

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -1302,10 +1302,7 @@ mod tests {
         let client = client_proc.client("client");
 
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
-        let port = PortRef::<IntrospectMessage>::attest_control_port(
-            &agent_id,
-            hyperactor::ControlPort::Introspect,
-        );
+        let port = agent_id.introspect_port();
 
         // Helper: send QueryChild(Proc) and return the payload with a
         // timeout so a misrouted reply fails fast rather than hanging.
@@ -1410,10 +1407,7 @@ mod tests {
         let client = client_proc.client("client");
 
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
-        let port = PortRef::<IntrospectMessage>::attest_control_port(
-            &agent_id,
-            hyperactor::ControlPort::Introspect,
-        );
+        let port = agent_id.introspect_port();
 
         // Concurrent query task: send QueryChild(Proc) every 10ms.
         let query_client_proc =
@@ -1725,10 +1719,7 @@ mod tests {
         // QueryChild(Proc) — same aggregation logic as mesh-admin
         // resolution.
         let agent_id: ActorAddr = proc.proc_addr().actor_addr(PROC_AGENT_ACTOR_NAME);
-        let port = PortRef::<IntrospectMessage>::attest_control_port(
-            &agent_id,
-            hyperactor::ControlPort::Introspect,
-        );
+        let port = agent_id.introspect_port();
 
         // Poll until queue stats are non-zero.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);


### PR DESCRIPTION
Summary:

Add `ActorAddr::status_port` and `ActorAddr::introspect_port` for canonical control ports, and remove `PortRef::attest_control_port` so callers do not pair arbitrary `ControlPort` values with message types.

Differential Revision: D109220078


