### PR TITLE
Route MR registration and QP creation through IbvDomainImpl; delete legacy MR types (#4278)

### DIFF
--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -21,13 +21,14 @@ use monarch_rdma::RdmaAction;
 use monarch_rdma::RdmaManagerActor;
 use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
+use monarch_rdma::ScannedSegment;
 use monarch_rdma::ibverbs_supported;
 use monarch_rdma::local_memory::Keepalive;
 use monarch_rdma::local_memory::KeepaliveLocalMemory;
 use monarch_rdma::local_memory::WeakKeepalive;
 use monarch_rdma::local_memory::WeakLocalMemory;
 use monarch_rdma::rdma_supported;
-use monarch_rdma::register_segment_scanner;
+use monarch_rdma::register_cuda_segment_scanner;
 use monarch_types::py_global;
 use monarch_types::py_module_add_function;
 use pyo3::IntoPyObjectExt;
@@ -42,88 +43,58 @@ use pyo3::types::PyTuple;
 use pyo3::types::PyType;
 use typeuri::Named;
 
-/// Segment scanner callback that uses PyTorch's memory snapshot API.
+/// CUDA segment scanner backed by PyTorch's memory snapshot API.
 ///
-/// This function calls torch.cuda.memory._snapshot() to get CUDA memory segments
-/// and fills the provided buffer with segment information.
-///
-/// # Safety
-/// This function is called from C code as a callback.
-unsafe extern "C" fn pytorch_segment_scanner(
-    segments_out: *mut monarch_rdma::rdmaxcel_sys::rdmaxcel_scanned_segment_t,
-    max_segments: usize,
-) -> usize {
-    // Acquire the GIL to call Python code
-    // Note: We use Python::attach here instead of monarch_with_gil_blocking because
-    // the raw pointer segments_out is not Sync and monarch_with_gil_blocking requires Send.
-    let result = Python::attach(|py| -> PyResult<usize> {
-        // Check if torch is already imported - don't import it ourselves
+/// Enumerates the live CUDA caching-allocator segments via
+/// `torch.cuda.memory._snapshot()`. Returns an empty list when torch is not
+/// imported, CUDA is unavailable, or the snapshot fails — so the mlx5dv
+/// segment binder simply falls back to per-buffer dmabuf MRs rather than
+/// erroring.
+fn pytorch_cuda_segments() -> Vec<ScannedSegment> {
+    // Acquire the GIL to call Python code.
+    let result = monarch_with_gil_blocking(|py| -> PyResult<Vec<ScannedSegment>> {
+        // Check if torch is already imported - don't import it ourselves.
         let sys = py.import("sys")?;
         let modules = sys.getattr("modules")?;
-
-        // Try to get torch from sys.modules
         let torch = match modules.get_item("torch") {
             Ok(torch_module) => torch_module,
-            Err(_) => {
-                // torch not imported yet, return 0 segments
-                return Ok(0);
-            }
+            Err(_) => return Ok(Vec::new()),
         };
 
-        // Check if CUDA is available
         let cuda_available: bool = torch
             .getattr("cuda")?
             .getattr("is_available")?
             .call0()?
             .extract()?;
-
         if !cuda_available {
-            return Ok(0);
+            return Ok(Vec::new());
         }
 
-        // Call torch.cuda.memory._snapshot()
         let snapshot = torch
             .getattr("cuda")?
             .getattr("memory")?
             .getattr("_snapshot")?
             .call0()?;
-
-        // Get the segments list from the snapshot dict
         let segments = snapshot.get_item("segments")?;
         let segments_list: Vec<Bound<'_, PyAny>> = segments.extract()?;
 
-        let num_segments = segments_list.len();
-
-        // Fill the output buffer with as many segments as will fit
-        let segments_to_write = num_segments.min(max_segments);
-
-        for (i, segment) in segments_list.iter().take(segments_to_write).enumerate() {
-            // Extract fields from the segment dict
-            let address: u64 = segment.get_item("address")?.extract()?;
-            let total_size: usize = segment.get_item("total_size")?.extract()?;
-            let device: i32 = segment.get_item("device")?.extract()?;
-            let is_expandable: bool = segment.get_item("is_expandable")?.extract()?;
-
-            // Write to the output buffer - only the fields the scanner needs to provide
-            let seg_info = &mut *segments_out.add(i);
-            seg_info.address = address as usize;
-            seg_info.size = total_size;
-            seg_info.device = device;
-            seg_info.is_expandable = if is_expandable { 1 } else { 0 };
-        }
-
-        // Return total number of segments found (may be > max_segments)
-        Ok(num_segments)
+        segments_list
+            .iter()
+            .map(|segment| {
+                Ok(ScannedSegment {
+                    address: segment.get_item("address")?.extract::<u64>()? as usize,
+                    size: segment.get_item("total_size")?.extract()?,
+                    cuda_ordinal: segment.get_item("device")?.extract()?,
+                    is_expandable: segment.get_item("is_expandable")?.extract()?,
+                })
+            })
+            .collect()
     });
 
-    match result {
-        Ok(count) => count,
-        Err(e) => {
-            // Log the specific error for debugging
-            eprintln!("[monarch_rdma] pytorch_segment_scanner failed: {}", e);
-            0
-        }
-    }
+    result.unwrap_or_else(|e| {
+        tracing::error!("pytorch_cuda_segments failed: {}", e);
+        Vec::new()
+    })
 }
 
 /// Resolve a Python `weakref.ref` to a strong [`Py<PyAny>`], or
@@ -627,9 +598,9 @@ async fn create_rdma_buffer(
 #[pymethods]
 impl PyRdmaBuffer {
     #[classmethod]
-    fn create_rdma_buffer_nonblocking<'py>(
+    fn create_rdma_buffer_nonblocking(
         _cls: &Bound<'_, PyType>,
-        _py: Python<'py>,
+        _py: Python<'_>,
         local: PyLocalMemoryHandle,
         client: PyInstance,
     ) -> PyResult<PyPythonTask> {
@@ -640,9 +611,9 @@ impl PyRdmaBuffer {
     }
 
     #[classmethod]
-    fn create_rdma_buffer_blocking<'py>(
+    fn create_rdma_buffer_blocking(
         _cls: &Bound<'_, PyType>,
-        py: Python<'py>,
+        py: Python<'_>,
         local: PyLocalMemoryHandle,
         client: PyInstance,
     ) -> PyResult<PyRdmaBuffer> {
@@ -663,9 +634,9 @@ impl PyRdmaBuffer {
     /// * `dst` - Local memory region to read into
     /// * `client` - The actor performing the read
     /// * `timeout` - Maximum time in seconds to wait for the operation
-    fn read_into<'py>(
+    fn read_into(
         &self,
-        _py: Python<'py>,
+        _py: Python<'_>,
         dst: PyLocalMemoryHandle,
         client: PyInstance,
         timeout: u64,
@@ -693,9 +664,9 @@ impl PyRdmaBuffer {
     /// * `src` - Local memory region to write from
     /// * `client` - The actor performing the write
     /// * `timeout` - Maximum time in seconds to wait for the operation
-    fn write_from<'py>(
+    fn write_from(
         &self,
-        _py: Python<'py>,
+        _py: Python<'_>,
         src: PyLocalMemoryHandle,
         client: PyInstance,
         timeout: u64,
@@ -740,7 +711,7 @@ impl PyRdmaBuffer {
         Ok(PyRdmaBuffer { buffer })
     }
 
-    fn drop<'py>(&self, _py: Python<'py>, client: PyInstance) -> PyResult<PyPythonTask> {
+    fn drop(&self, _py: Python<'_>, client: PyInstance) -> PyResult<PyPythonTask> {
         let buffer = self.buffer.clone();
         PyPythonTask::new(async move {
             buffer
@@ -816,9 +787,10 @@ fn rdma_supported_py() -> bool {
 }
 
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
-    // Register the PyTorch segment scanner callback.
-    // This calls torch.cuda.memory._snapshot() to get CUDA memory segments.
-    register_segment_scanner(Some(pytorch_segment_scanner));
+    // Install the process-wide CUDA segment scanner, backed by
+    // torch.cuda.memory._snapshot(). The mlx5dv segment binder consults it to
+    // map whole allocator segments to a single indirect mkey.
+    register_cuda_segment_scanner(Arc::new(pytorch_cuda_segments));
 
     module.add_class::<PyLocalMemoryHandle>()?;
     module.add_class::<PyWeakLocalMemoryHandle>()?;

--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -28,9 +28,10 @@ use hyperactor_config::Flattrs;
 use crate::RdmaManagerActor;
 use crate::RdmaManagerMessageClient;
 use crate::RdmaRemoteBuffer;
+use crate::ScannedSegment;
 use crate::local_memory::Keepalive;
 use crate::local_memory::KeepaliveLocalMemory;
-use crate::register_segment_scanner;
+use crate::register_cuda_segment_scanner;
 
 /// One physical chunk mapped into an expandable segment's VA
 /// reservation. Owns a single `cuMemCreate` handle.
@@ -442,38 +443,27 @@ pub(crate) fn cuda_device_count() -> i32 {
     }
 }
 
-/// Segment scanner callback compatible with `rdmaxcel_segment_scanner_fn`.
-/// Reports all allocations tracked by `CudaAllocator`.
-pub unsafe extern "C" fn cuda_allocator_scanner(
-    out: *mut rdmaxcel_sys::rdmaxcel_scanned_segment_t,
-    max: usize,
-) -> usize {
+/// CUDA segment scanner reporting all allocations tracked by `CudaAllocator`.
+fn cuda_allocator_segments() -> Vec<ScannedSegment> {
     let Some(allocator) = CUDA_ALLOCATOR.get() else {
-        return 0;
+        return Vec::new();
     };
     let allocs = allocator.allocations.lock().unwrap();
-    let mut written = 0;
-    for weak in allocs.values() {
-        let Some(inner) = weak.upgrade() else {
-            continue;
-        };
-        // Report the *currently mapped* extent, not the reserved
-        // VA. Expandable segments grow this on each `expand` call.
-        let mapped_size = inner.state.lock().unwrap().mapped_size;
-        if !out.is_null() && written < max {
-            // SAFETY: caller guarantees `out` points to a buffer of at least `max` entries.
-            unsafe {
-                *out.add(written) = rdmaxcel_sys::rdmaxcel_scanned_segment_t {
-                    address: inner.ptr,
-                    size: mapped_size,
-                    device: inner.device,
-                    is_expandable: 1,
-                };
+    allocs
+        .values()
+        .filter_map(|weak| weak.upgrade())
+        .map(|inner| {
+            // Report the *currently mapped* extent, not the reserved VA.
+            // Expandable segments grow this on each `expand` call.
+            let mapped_size = inner.state.lock().unwrap().mapped_size;
+            ScannedSegment {
+                address: inner.ptr,
+                size: mapped_size,
+                cuda_ordinal: inner.device,
+                is_expandable: true,
             }
-        }
-        written += 1;
-    }
-    written
+        })
+        .collect()
 }
 
 /// Runs in the sender's child process. Allocates GPU memory via CudaAllocator,
@@ -496,7 +486,7 @@ impl RemoteSpawn for SenderActor {
     type Params = i32;
 
     async fn new(device_id: i32, _env: Flattrs) -> Result<Self, anyhow::Error> {
-        register_segment_scanner(Some(cuda_allocator_scanner));
+        register_cuda_segment_scanner(Arc::new(cuda_allocator_segments));
         Ok(Self {
             device: device_id,
             allocations: Vec::new(),

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -46,7 +46,6 @@ use crate::local_memory::KeepaliveLocalMemory;
 /// [`IbvManagerMessage::RequestBuffer`].
 #[derive(Debug, Clone, Serialize, Deserialize, Named)]
 pub struct IbvBuffer {
-    pub mr_id: usize,
     pub lkey: u32,
     pub rkey: u32,
     /// RDMA address (may differ from virtual address for CUDA memory).
@@ -54,6 +53,20 @@ pub struct IbvBuffer {
     pub size: usize,
     /// Name of the RDMA device this buffer is associated with (e.g., "mlx5_0").
     pub device_name: String,
+}
+
+impl From<&memory_region::IbvMemoryRegionView> for IbvBuffer {
+    /// The wire transport details are fully derived from the registered MR
+    /// view: the keys, the RDMA address, the size, and the device name.
+    fn from(view: &memory_region::IbvMemoryRegionView) -> Self {
+        Self {
+            lkey: view.lkey,
+            rkey: view.rkey,
+            addr: view.rdma_addr,
+            size: view.size,
+            device_name: view.device_name.clone(),
+        }
+    }
 }
 
 /// A single RDMA op for the [`IbvBackend`](manager_actor::IbvBackend).

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -43,8 +43,8 @@ use super::primitives::query_device_info;
 /// themselves via [`register_ibv_device_impl!`].
 pub trait IbvDeviceImpl: Named + std::fmt::Debug + Send + Sync + 'static {
     /// The per-domain strategy used by this backend (how memory regions
-    /// are registered and queue pairs built against a PD). A follow-up
-    /// commit makes [`IbvDomain`] generic over this.
+    /// are registered and queue pairs built against a PD). [`IbvDomain`] is
+    /// generic over this.
     type IbvDomainImpl: IbvDomainImpl;
 
     /// Human-readable display name for the backend this impl
@@ -270,7 +270,7 @@ impl Drop for IbvContext {
 /// reference closes the context.
 #[derive(Debug)]
 pub(crate) struct IbvDevice<I: IbvDeviceImpl> {
-    domains: HashMap<String, Arc<IbvDomain>>,
+    domains: HashMap<String, Arc<IbvDomain<I::IbvDomainImpl>>>,
     device_info: IbvDeviceInfo,
     config: IbvConfig,
     context: Arc<IbvContext>,
@@ -407,20 +407,27 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
     /// Returns the `Arc<IbvDomain>` registered under `name`, if
     /// one has already been created. Read-only lookup; use
     /// [`Self::get_or_create_domain`] to create on demand.
-    pub fn domain(&self, name: &str) -> Option<&Arc<IbvDomain>> {
+    pub fn domain(&self, name: &str) -> Option<&Arc<IbvDomain<I::IbvDomainImpl>>> {
         self.domains.get(name)
     }
 
     /// Returns the `Arc<IbvDomain>` registered under `name`, creating (and
     /// caching) a new one via [`IbvDomain::new`] on first access.
-    pub fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<Arc<IbvDomain>> {
+    pub fn get_or_create_domain(
+        &mut self,
+        name: &str,
+    ) -> anyhow::Result<Arc<IbvDomain<I::IbvDomainImpl>>> {
         if let Some(domain) = self.domains.get(name) {
             return Ok(Arc::clone(domain));
         }
         // SAFETY: `self.context` wraps the live `ibv_context` opened by
         // `IbvDevice::open`, valid for this device's lifetime.
         let domain = Arc::new(unsafe {
-            IbvDomain::new(Arc::clone(&self.context), self.device_info.clone())
+            IbvDomain::<I::IbvDomainImpl>::new(
+                Arc::clone(&self.context),
+                self.device_info.clone(),
+                &self.config,
+            )
         }?);
         self.domains.insert(name.to_string(), Arc::clone(&domain));
         Ok(domain)

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -10,7 +10,6 @@
 //! RDMA NIC(s) that have the best PCIe path to it.
 
 use std::sync::LazyLock;
-use std::sync::OnceLock;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -18,7 +17,6 @@ use dashmap::DashMap;
 
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
-use super::mlx_device::MlxDevice;
 use super::primitives::IbvDeviceInfo;
 use crate::device_selection::MemoryLocation;
 use crate::device_selection::PCIAddress;
@@ -169,17 +167,23 @@ pub fn resolve_target<I: IbvDeviceImpl>(target: &IbvDeviceTarget) -> Option<IbvD
     }
 }
 
-/// Process-wide CUDA ordinal → optimal Mellanox NIC map, computed once on
-/// first use. CPU-only workloads pay no initialization cost.
-pub fn get_cuda_device_to_ibv_device() -> &'static Vec<Option<IbvDeviceInfo>> {
-    static CUDA_DEVICE_TO_IBV: OnceLock<Vec<Option<IbvDeviceInfo>>> = OnceLock::new();
-    CUDA_DEVICE_TO_IBV.get_or_init(|| {
-        (0..cuda_device_count())
+/// Process-wide CUDA ordinal → optimal NIC map, computed once per backend and
+/// cached. CPU-only workloads pay no initialization cost.
+pub fn get_cuda_device_to_ibv_device<I: IbvDeviceImpl>() -> &'static Vec<Option<IbvDeviceInfo>> {
+    // A function-local `static` in a generic fn is one cell shared across every
+    // `I`, so the cache must be keyed per backend; `I::typename()` selects it.
+    // Each backend's map is `Box::leak`ed once so the cache stores (and returns) a
+    // `&'static`.
+    static CACHE: LazyLock<DashMap<&'static str, &'static Vec<Option<IbvDeviceInfo>>>> =
+        LazyLock::new(DashMap::new);
+    *CACHE.entry(I::typename()).or_insert_with(|| {
+        let result: Vec<Option<IbvDeviceInfo>> = (0..cuda_device_count())
             .map(|ordinal| {
-                select_optimal_ibv_devices::<MlxDevice>(MemoryLocation::Gpu(Some(ordinal as u32)))
+                select_optimal_ibv_devices::<I>(MemoryLocation::Gpu(Some(ordinal as u32)))
                     .into_iter()
                     .next()
             })
-            .collect()
+            .collect();
+        Box::leak(Box::new(result))
     })
 }

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -14,6 +14,7 @@
 
 use std::ffi::c_void;
 use std::io::Error;
+use std::mem::ManuallyDrop;
 use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
@@ -34,28 +35,36 @@ use crate::local_memory::is_device_ptr;
 /// # Fields
 ///
 /// * `context`: The owning [`Arc<IbvContext>`]; held (rather than a raw
-///   pointer) so the device context outlives the PD by construction. The
-///   PD is freed in `Drop` before this `Arc` is released.
+///   pointer) so the device context outlives the PD by construction. The PD is
+///   deallocated in `Drop` before this `Arc` is released.
 /// * `pd`: The protection domain pointer (private; read via [`Self::as_ptr`]),
 ///   which provides isolation between connections.
 /// * `device_info`: Metadata for the device this PD is allocated on.
+/// * `domain_impl`: The backend [`IbvDomainImpl`] strategy for this PD. It may
+///   own FFI resources allocated against the PD, so `Drop` releases it before
+///   deallocating the PD. Held in a [`ManuallyDrop`] so that ordering can be
+///   enforced by hand.
 ///
-/// `IbvDomain` is not `Clone`: the `Drop` impl runs
-/// `ibv_dealloc_pd` and copying the pointer would lead to a
-/// double-free. Share the domain across owners via
+/// `I` is the backend [`IbvDomainImpl`] strategy parameterizing per-PD
+/// behavior.
+///
+/// `IbvDomain` is not `Clone`: its `Drop` runs `ibv_dealloc_pd` and copying the
+/// pointer would lead to a double-free. Share the domain across owners via
 /// `Arc<IbvDomain>` instead.
-pub struct IbvDomain {
+pub struct IbvDomain<I: IbvDomainImpl> {
     pub context: Arc<IbvContext>,
     pd: *mut rdmaxcel_sys::ibv_pd,
     pub device_info: IbvDeviceInfo,
+    domain_impl: ManuallyDrop<I>,
 }
 
-impl std::fmt::Debug for IbvDomain {
+impl<I: IbvDomainImpl> std::fmt::Debug for IbvDomain<I> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IbvDomain")
             .field("context", &format!("{:p}", self.context.as_ptr()))
             .field("pd", &format!("{:p}", self.pd))
             .field("device_info", &self.device_info)
+            .field("domain_impl", &self.domain_impl)
             .finish()
     }
 }
@@ -64,26 +73,53 @@ impl std::fmt::Debug for IbvDomain {
 // IbvDomain is `Send` because the raw pointers to ibverbs structs can be
 // accessed from any thread, and it is safe to drop `IbvDomain` (and run the
 // ibverbs destructors) from any thread.
-unsafe impl Send for IbvDomain {}
+unsafe impl<I: IbvDomainImpl> Send for IbvDomain<I> {}
 
 // SAFETY:
 // IbvDomain is `Sync` because the underlying ibverbs APIs are thread-safe.
-unsafe impl Sync for IbvDomain {}
+unsafe impl<I: IbvDomainImpl> Sync for IbvDomain<I> {}
 
-impl Drop for IbvDomain {
+/// Type-erased keepalive for an [`IbvDomain`] of any backend. Lets holders that
+/// only need to keep a domain's PD (and context) alive — standalone MR guards,
+/// queue pairs — hold an `Arc<dyn IbvDomainKeepalive>` without being generic
+/// over the backend [`IbvDomainImpl`].
+pub(super) trait IbvDomainKeepalive: std::fmt::Debug + Send + Sync {}
+
+impl<I: IbvDomainImpl> IbvDomainKeepalive for IbvDomain<I> {}
+
+impl<I: IbvDomainImpl> Drop for IbvDomain<I> {
     fn drop(&mut self) {
+        // Drop the backend strategy first: it may own FFI resources allocated
+        // against `pd`, which must be released before the PD is deallocated.
+        // SAFETY: `domain_impl` is dropped exactly once — here — and never
+        // accessed afterward (this is `IbvDomain`'s own `Drop`).
+        unsafe {
+            ManuallyDrop::drop(&mut self.domain_impl);
+        }
         if self.pd.is_null() {
             return;
         }
-        unsafe {
-            rdmaxcel_sys::ibv_dealloc_pd(self.pd);
+        // SAFETY: `pd` was returned by `ibv_alloc_pd` and is deallocated exactly
+        // once (`IbvDomain` is not `Clone`). `context` is a separate field,
+        // dropped only after this returns, so the device is still open here.
+        let result = unsafe { rdmaxcel_sys::ibv_dealloc_pd(self.pd) };
+        if result != 0 {
+            tracing::error!(
+                "failed to deallocate protection domain {:p}: error code {}",
+                self.pd,
+                result
+            );
         }
     }
 }
 
-impl IbvDomain {
-    /// Creates an `IbvDomain` over an already-opened device `context`,
-    /// allocating its protection domain.
+impl<I: IbvDomainImpl> IbvDomain<I> {
+    /// Creates an `IbvDomain` over an already-opened device `context`.
+    ///
+    /// Builds the backend [`IbvDomainImpl`] strategy `I` from `config`, then
+    /// allocates the protection domain against `context`. The PD is allocated
+    /// only *after* the strategy is built, so a panicking
+    /// [`IbvDomainImpl::new`] never leaks a PD.
     ///
     /// Note:
     /// Our memory region (MR) registration uses implicit ODP for RDMA access, which maps large virtual
@@ -110,11 +146,17 @@ impl IbvDomain {
     pub unsafe fn new(
         context: Arc<IbvContext>,
         device_info: IbvDeviceInfo,
+        config: &IbvConfig,
     ) -> Result<Self, anyhow::Error> {
         assert!(
             !context.as_ptr().is_null(),
             "IbvDomain::new requires a non-null ibv_context"
         );
+        // Build the strategy first; the PD below is allocated only if this
+        // returns, so a panicking `IbvDomainImpl::new` never leaks a PD.
+        // SAFETY: per this function's contract `context` wraps a valid, live
+        // `ibv_context`, which is what `I::new` requires to query the device.
+        let domain_impl = unsafe { I::new(&context, &device_info, config) };
         // SAFETY: `context.as_ptr()` is non-null (asserted above) and, per this
         // function's contract, a valid live `ibv_context` owned by the
         // `Arc<IbvContext>` for the duration of this call.
@@ -126,11 +168,13 @@ impl IbvDomain {
             context,
             pd,
             device_info,
+            domain_impl: ManuallyDrop::new(domain_impl),
         })
     }
 
-    /// Test-only constructor assembling a domain from raw parts (typically with
-    /// a null `pd`/`context` whose `Drop` is a no-op) for use as a keepalive.
+    /// Test-only constructor assembling a domain from raw parts without
+    /// allocating a PD, so unit tests can fabricate a domain (typically with a
+    /// null `pd`/`context` whose `Drop` is a no-op).
     ///
     /// # Safety
     ///
@@ -139,15 +183,17 @@ impl IbvDomain {
     /// `ibv_dealloc_pd` once); `context` must satisfy [`IbvContext`]'s validity
     /// contract.
     #[cfg(test)]
-    pub(super) unsafe fn from_parts(
+    pub(super) unsafe fn for_test(
         context: Arc<IbvContext>,
         pd: *mut rdmaxcel_sys::ibv_pd,
         device_info: IbvDeviceInfo,
+        domain_impl: I,
     ) -> Self {
         Self {
             context,
             pd,
             device_info,
+            domain_impl: ManuallyDrop::new(domain_impl),
         }
     }
 
@@ -155,6 +201,11 @@ impl IbvDomain {
     /// Prefer this over touching the field directly (which is private).
     pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_pd {
         self.pd
+    }
+
+    /// The backend [`IbvDomainImpl`] strategy for this domain.
+    pub(super) fn domain_impl(&self) -> &I {
+        &self.domain_impl
     }
 
     /// Metadata for the device this domain's PD is allocated on.
@@ -166,12 +217,12 @@ impl IbvDomain {
 /// Per-backend strategy for a protection domain: how memory regions are
 /// registered and how queue pairs are built against the PD.
 ///
-/// One strategy is constructed per opened device via [`Self::new`], which
-/// inspects the device behind the context to decide backend-specific
-/// behavior up front. The per-op methods take the owning `Arc<IbvDomain>`
-/// so the returned resources can anchor the PD's lifetime as a keepalive; a
-/// follow-up commit makes this the backend-generic `Arc<IbvDomain<Self>>`.
-pub trait IbvDomainImpl: Send + Sync + 'static + Sized {
+/// One strategy is constructed per domain via [`Self::new`], which
+/// inspects the device behind the context to decide backend-specific behavior
+/// up front, and is then stored in the [`IbvDomain`] it drives. The per-op
+/// methods are associated functions taking the owning `Arc<IbvDomain<Self>>`
+/// and reach the strategy itself through [`IbvDomain::domain_impl`].
+pub trait IbvDomainImpl: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// Build the strategy for the device behind `context` (whose queried
     /// metadata is `device_info`), using `config` for any setup it performs.
     ///
@@ -198,20 +249,19 @@ pub trait IbvDomainImpl: Send + Sync + 'static + Sized {
     /// domain; `mem`'s backing memory must stay valid for the returned MR's
     /// lifetime.
     unsafe fn register_mr(
-        &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<Self>>,
         mem: &KeepaliveLocalMemory,
     ) -> anyhow::Result<IbvMemoryRegionView> {
+        let access = domain.domain_impl().mr_access_flags();
         // SAFETY: `domain.as_ptr()` is null or a live PD (per this method's
         // contract; `register_host_or_dmabuf_mr` errors on null), and the caller
         // keeps `mem`'s backing memory valid for the MR's lifetime.
-        unsafe { register_host_or_dmabuf_mr(domain, self.mr_access_flags(), mem) }
+        unsafe { register_host_or_dmabuf_mr(domain, access, mem) }
     }
 
     /// Create a queue pair against `domain`.
     fn create_queue_pair(
-        &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<Self>>,
         config: &IbvConfig,
     ) -> anyhow::Result<IbvQueuePair> {
         IbvQueuePair::new(domain, config.clone())
@@ -313,8 +363,8 @@ pub(super) unsafe fn register_dmabuf_mr(
 /// `[addr, addr + size)` must stay valid for the lifetime of the returned
 /// view's MR — the MR keepalive maintains the `ibv_mr` but does not keep the
 /// backing memory mapped.
-pub(super) unsafe fn register_host_or_dmabuf_mr(
-    domain: Arc<IbvDomain>,
+pub(super) unsafe fn register_host_or_dmabuf_mr<I: IbvDomainImpl>(
+    domain: Arc<IbvDomain<I>>,
     access_flags: i32,
     mem: &KeepaliveLocalMemory,
 ) -> anyhow::Result<IbvMemoryRegionView> {

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -212,6 +212,24 @@ impl<I: IbvDomainImpl> IbvDomain<I> {
     pub fn device_info(&self) -> &IbvDeviceInfo {
         &self.device_info
     }
+
+    /// Register `mem` against this domain's PD, dispatching to the backend
+    /// [`IbvDomainImpl`] strategy.
+    pub fn register_mr(
+        self: Arc<Self>,
+        mem: &KeepaliveLocalMemory,
+    ) -> anyhow::Result<IbvMemoryRegionView> {
+        // SAFETY: a fully-constructed `IbvDomain` holds a null-or-live PD per its
+        // construction contract, and `KeepaliveLocalMemory` keeps `mem`'s backing
+        // memory alive for the registration.
+        unsafe { I::register_mr(self, mem) }
+    }
+
+    /// Create a queue pair against this domain, dispatching to the backend
+    /// [`IbvDomainImpl`] strategy.
+    pub fn create_queue_pair(self: Arc<Self>, config: &IbvConfig) -> anyhow::Result<IbvQueuePair> {
+        I::create_queue_pair(self, config)
+    }
 }
 
 /// Per-backend strategy for a protection domain: how memory regions are

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -771,11 +771,11 @@ impl DoorbellTestEnv {
 
     pub async fn cleanup(self) -> Result<(), anyhow::Error> {
         self.ibv_actor_1
-            .release_buffer(&self.client_1, self.ibv_buffer_1.mr_id)
+            .release_buffer(&self.client_1, self.rdma_handle_1.id)
             .await?;
 
         self.ibv_actor_2
-            .release_buffer(&self.client_2, self.ibv_buffer_2.mr_id)
+            .release_buffer(&self.client_2, self.rdma_handle_2.id)
             .await?;
         Ok(())
     }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -18,7 +18,6 @@
 
 use std::collections::HashMap;
 use std::fmt::Write as _;
-use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -52,15 +51,12 @@ use super::device::IbvDeviceImpl;
 use super::device_selection::resolve_target;
 use super::domain::IbvDomain;
 use super::efa_device::EfaDevice;
+use super::memory_region::IbvMemoryRegionView;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
 use super::primitives::IbvDeviceInfo;
-use super::primitives::IbvMemoryRegion;
-use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
-use super::primitives::mlx5dv_supported;
-use super::primitives::resolve_qp_type;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::OpResult;
 use super::queue_pair::ProcessOps;
@@ -70,8 +66,8 @@ use crate::RdmaOp;
 use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
 use crate::local_memory::KeepaliveLocalMemory;
+use crate::local_memory::is_device_ptr;
 use crate::nic::NicRemoteBackendContext;
-use crate::rdma_components::get_registered_cuda_segments;
 use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::validate_execution_context;
 
@@ -150,53 +146,6 @@ pub enum IbvManagerLocalMessage {
     },
 }
 
-/// Look up `(addr, size)` in a slice of registered CUDA segments
-/// and return a view into the matching mkey.
-///
-/// Bounded by `mr_size` (what the mkey actually covers), NOT by
-/// `phys_size` (the scanner-reported extent). They diverge when
-/// `register_segments` hits `max_sge` and stops growing the binding.
-/// Returning a view based on `phys_size` would hand out an
-/// `(lkey, offset)` past the bound and the WR would fail with
-/// `IBV_WC_LOC_PROT_ERR`; bounding by `mr_size` makes the gap a
-/// miss so the caller falls back to per-buffer dmabuf.
-///
-/// Free function so the boundary can be unit-tested without an actor.
-pub(super) fn lookup_segment_for_address(
-    segments: &[rdmaxcel_sys::rdma_segment_info_t],
-    addr: usize,
-    size: usize,
-) -> Option<SegmentInfo> {
-    for segment in segments {
-        let start_addr = segment.phys_address;
-        let end_addr = start_addr + segment.mr_size;
-        if start_addr <= addr && addr + size <= end_addr {
-            let offset = addr - start_addr;
-            let rdma_addr = segment.mr_addr + offset;
-            return Some(SegmentInfo {
-                rdma_addr,
-                size,
-                lkey: segment.lkey,
-                rkey: segment.rkey,
-            });
-        }
-    }
-    None
-}
-
-/// Result of a successful [`lookup_segment_for_address`] hit. Just
-/// the device-derived facts about the matched mkey; the caller
-/// composes these with whatever provenance it needs (mrv id,
-/// device name, refcounted owners) when materializing an
-/// [`IbvMemoryRegionView`].
-#[derive(Debug)]
-pub(super) struct SegmentInfo {
-    pub(super) rdma_addr: usize,
-    pub(super) size: usize,
-    pub(super) lkey: u32,
-    pub(super) rkey: u32,
-}
-
 /// Default key used for the per-device protection domain inside
 /// each [`IbvDevice<I>`] entry of [`IbvManagerActor::devices`].
 const DEFAULT_DOMAIN: &str = "default";
@@ -232,36 +181,19 @@ pub struct IbvManagerActor<I: IbvDeviceImpl> {
     /// each QP via [`IbvQueuePair`]'s own `Drop`.
     peer_created_qps: HashMap<QpKey, IbvQueuePair>,
 
-    /// Map of RDMA device names to their opened [`IbvDevice<I>`]
-    /// (which owns the per-device `Arc<IbvContext>` and the
-    /// `DEFAULT_DOMAIN` `Arc<IbvDomain>`) and an optional loopback
-    /// QP used by the CUDA segment scanner. The loopback QP is
-    /// owned by this map and destroyed via [`IbvQueuePair`]'s `Drop`
-    /// when the entry is removed.
-    devices: HashMap<String, (IbvDevice<I>, Option<IbvQueuePair>)>,
+    /// Map of RDMA device names to their opened [`IbvDevice<I>`], each of
+    /// which owns the per-device `Arc<IbvContext>` and the `DEFAULT_DOMAIN`
+    /// `Arc<IbvDomain>`.
+    devices: HashMap<String, IbvDevice<I>>,
 
     config: IbvConfig,
 
-    mlx5dv_enabled: bool,
-
-    /// Singleton Arc owning the CUDA segment scanner state. `Some`
-    /// once `register_segments` succeeds; cloned into every
-    /// segment-backed view. `deregister_segments` runs from the
-    /// `IbvMemoryRegion::Segments` Drop when the last reference goes
-    /// away.
-    segments_mr: Option<Arc<IbvMemoryRegion>>,
-
-    /// Id for next mrv created.
-    mrv_id: usize,
-
-    /// Map from buffer_id to the buffer's `(IbvBuffer, view)`. The
-    /// view keeps the MR (and its PD) alive for the lifetime of the
-    /// registration; `ReleaseBuffer` drops the entry, and the FFI
-    /// resources are released by the `Arc`s' `Drop`s once no other
-    /// holder of those views remains.
-    buffer_registrations: HashMap<usize, (IbvBuffer, IbvMemoryRegionView)>,
-
-    _marker: PhantomData<I>,
+    /// Map from buffer_id to the registered MR view. The view keeps the MR (and
+    /// its PD) alive for the lifetime of the registration; `ReleaseBuffer` drops
+    /// the entry, and the FFI resources are released by the `Arc`s' `Drop`s once
+    /// no other holder of the view remains. The wire-facing [`IbvBuffer`] is
+    /// derived from the view on demand.
+    buffer_registrations: HashMap<usize, IbvMemoryRegionView>,
 }
 
 #[async_trait]
@@ -290,9 +222,8 @@ impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
         }
 
         // The remaining fields (`peer_created_qps`,
-        // `buffer_registrations`, `segments_mr`, `devices`)
-        // free their FFI resources through their elements' `Drop`s
-        // when this struct is dropped.
+        // `buffer_registrations`, `devices`) free their FFI resources
+        // through their elements' `Drop`s when this struct is dropped.
     }
 }
 
@@ -317,8 +248,6 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         };
         tracing::debug!("rdma is enabled, config target: {:?}", config.target);
 
-        let mlx5dv_enabled = resolve_qp_type(config.qp_type) == rdmaxcel_sys::RDMA_QP_TYPE_MLX5DV;
-
         // check config and hardware support align
         if config.use_gpu_direct {
             match validate_execution_context().await {
@@ -341,26 +270,19 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             peer_created_qps: HashMap::new(),
             devices: HashMap::new(),
             config,
-            mlx5dv_enabled,
-            segments_mr: None,
-            mrv_id: 0,
             buffer_registrations: HashMap::new(),
-            _marker: PhantomData,
         };
 
         Ok(actor)
     }
 
-    /// Get or create the default domain (and a loopback QP, if
-    /// mlx5dv is supported) for the named RDMA device. The
-    /// loopback QP is kept in [`Self::devices`] solely so
-    /// the CUDA segment scanner can hand its raw pointer to
-    /// `register_segments`.
+    /// Get or create the `DEFAULT_DOMAIN` for the named RDMA device, opening
+    /// the device on first use.
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
     ) -> Result<Arc<IbvDomain<I::IbvDomainImpl>>, anyhow::Error> {
-        if let Some((device, _)) = self.devices.get_mut(device_name) {
+        if let Some(device) = self.devices.get_mut(device_name) {
             return device.get_or_create_domain(DEFAULT_DOMAIN);
         }
 
@@ -370,99 +292,18 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             })?;
         let domain = device.get_or_create_domain(DEFAULT_DOMAIN)?;
 
-        // Print device info if MONARCH_DEBUG_RDMA=1 is set (before initial QP creation)
+        // Print device info if MONARCH_DEBUG_RDMA=1 is set.
         crate::print_device_info_if_debug_enabled(domain.context.as_ptr());
 
-        // Create loopback QP for this domain if mlx5dv is supported (needed for segment registration)
-        // For EFA, we don't need a loopback QP for segment scanning
-        let qp = if mlx5dv_supported() && !crate::efa::is_efa_device() {
-            let mut qp =
-                IbvQueuePair::new(Arc::clone(&domain), self.config.clone()).map_err(|e| {
-                    anyhow::anyhow!(
-                        "could not create loopback QP for device {}: {}",
-                        device_name,
-                        e
-                    )
-                })?;
-
-            let endpoint = qp.get_qp_info().map_err(|e| {
-                anyhow::anyhow!("could not get QP info for device {}: {}", device_name, e)
-            })?;
-
-            qp.connect(&endpoint).map_err(|e| {
-                anyhow::anyhow!(
-                    "could not connect loopback QP for device {}: {}",
-                    device_name,
-                    e
-                )
-            })?;
-
-            Some(qp)
-        } else {
-            None
-        };
-
-        self.devices.insert(device_name.to_string(), (device, qp));
+        self.devices.insert(device_name.to_string(), device);
         Ok(domain)
     }
 
-    /// Build parallel PD/QP arrays indexed by CUDA device ordinal
-    /// for the C++ register_segments call.
-    fn build_per_device_pd_qp_arrays(
-        &self,
-    ) -> (
-        Vec<*mut rdmaxcel_sys::ibv_pd>,
-        Vec<*mut rdmaxcel_sys::rdmaxcel_qp_t>,
-    ) {
-        let cuda_map = super::device_selection::get_cuda_device_to_ibv_device();
-        let mut pds = Vec::with_capacity(cuda_map.len());
-        let mut qps = Vec::with_capacity(cuda_map.len());
-        for maybe_device in cuda_map {
-            if let Some(info) = maybe_device {
-                if let Some((device, qp)) = self.devices.get(info.name()) {
-                    let pd = device
-                        .domain(DEFAULT_DOMAIN)
-                        .map(|d| d.as_ptr())
-                        .unwrap_or(std::ptr::null_mut());
-                    pds.push(pd);
-                    qps.push(
-                        qp.as_ref()
-                            // SAFETY: the returned pointer is read by
-                            // the segment-scan FFI under a separate
-                            // call on this same `&self`; the QP lives
-                            // in `devices` for the lifetime of
-                            // this `IbvManagerActor`, so its `Drop`
-                            // cannot run while these pointers are in
-                            // use.
-                            .map(|q| unsafe { q.as_ptr() } as *mut rdmaxcel_sys::rdmaxcel_qp_t)
-                            .unwrap_or(std::ptr::null_mut()),
-                    );
-                } else {
-                    pds.push(std::ptr::null_mut());
-                    qps.push(std::ptr::null_mut());
-                }
-            } else {
-                pds.push(std::ptr::null_mut());
-                qps.push(std::ptr::null_mut());
-            }
-        }
-        (pds, qps)
-    }
-
-    fn find_cuda_segment_for_address(
-        &self,
-        addr: usize,
-        size: usize,
-        pd: *mut rdmaxcel_sys::ibv_pd,
-    ) -> Option<SegmentInfo> {
-        lookup_segment_for_address(&get_registered_cuda_segments(pd), addr, size)
-    }
-
-    /// Resolve `mem` to an [`IbvMemoryRegionView`] using the slot
-    /// shared by every clone of `mem`. On a cold slot, registers the
-    /// region (CPU via `ibv_reg_mr`, CUDA via segment scanning or a
-    /// dmabuf MR) and installs the result; on a warm slot, returns the
-    /// previously-installed view.
+    /// Resolve `mem` to an [`IbvMemoryRegionView`] using the slot shared by
+    /// every clone of `mem`. On a cold slot, picks the RDMA device (the
+    /// CUDA-co-located NIC for device memory, else the config fallback) and
+    /// registers the region through that device's [`IbvDomainImpl`] strategy,
+    /// installing the result; on a warm slot, returns the cached view.
     fn resolve_local_mr(
         &mut self,
         mem: &KeepaliveLocalMemory,
@@ -471,196 +312,46 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             return Ok(mrv.clone());
         }
         let addr = mem.addr();
-        let size = mem.size();
-        let mrv = unsafe {
-            let mut mem_type: i32 = 0;
-            let ptr = addr as rdmaxcel_sys::CUdeviceptr;
-            let err = rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
-                &mut mem_type as *mut _ as *mut std::ffi::c_void,
-                rdmaxcel_sys::CU_POINTER_ATTRIBUTE_MEMORY_TYPE,
-                ptr,
-            );
-            let is_cuda = err == rdmaxcel_sys::CUDA_SUCCESS;
 
-            let mut selected_rdma_device = None;
-
-            if is_cuda {
-                // Get device ordinal from the CUDA pointer
-                let mut device_ordinal: i32 = -1;
-                let err = rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
+        // Pick the RDMA device: for device memory, the CUDA-co-located NIC;
+        // otherwise the configured fallback.
+        let cuda_nic = if is_device_ptr(addr) {
+            let mut device_ordinal: i32 = -1;
+            // SAFETY: `addr` is a CUDA device pointer (per `is_device_ptr`); the
+            // FFI call writes the owning device ordinal through the out-pointer.
+            let err = unsafe {
+                rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
                     &mut device_ordinal as *mut _ as *mut std::ffi::c_void,
                     rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
-                    ptr,
-                );
-                if err == rdmaxcel_sys::CUDA_SUCCESS && device_ordinal >= 0 {
-                    selected_rdma_device = super::device_selection::get_cuda_device_to_ibv_device()
-                        .get(device_ordinal as usize)
-                        .and_then(|d| d.clone());
-                }
-            }
-
-            // Determine the RDMA device name to use: CUDA-co-located
-            // NIC if available, otherwise the config fallback.
-            let device_name = if let Some(info) = selected_rdma_device {
-                info.name().clone()
-            } else {
-                resolve_target::<I>(&self.config.target)
-                    .unwrap_or_else(|| IbvDeviceInfo::default::<I>())
-                    .name()
-                    .clone()
+                    addr as rdmaxcel_sys::CUdeviceptr,
+                )
             };
-            tracing::debug!(
-                "Using RDMA device: {} for memory at 0x{:x}",
-                device_name,
-                addr
-            );
-
-            // Get or create domain and loopback QP for this device
-            let domain = self.get_or_create_device_domain(&device_name)?;
-
-            let access = if crate::efa::is_efa_device() {
-                crate::efa::mr_access_flags()
-            } else {
-                rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_LOCAL_WRITE
-                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_WRITE
-                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_READ
-                    | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_ATOMIC
-            };
-
-            let mrv;
-
-            if is_cuda {
-                // First, try to use segment scanning if mlx5dv is enabled
-                let mut segment_info = None;
-                if self.mlx5dv_enabled {
-                    // Try to find in already registered segments
-                    segment_info = self.find_cuda_segment_for_address(addr, size, domain.as_ptr());
-
-                    // If not found, trigger a re-sync with the allocator and retry
-                    if segment_info.is_none() {
-                        let (mut pds, mut qps) = self.build_per_device_pd_qp_arrays();
-                        let err = rdmaxcel_sys::register_segments(
-                            pds.as_mut_ptr(),
-                            qps.as_mut_ptr(),
-                            pds.len() as i32,
-                            self.config.max_sge_override,
-                        );
-                        // Only retry if register_segments succeeded
-                        // If it fails (e.g., scanner returns 0 segments), we'll fall back to dmabuf
-                        if err == 0 {
-                            // The scanner just registered (or
-                            // re-synced) global segment state. Lazily
-                            // install the singleton `segments_mr` now,
-                            // independent of whether *this* address
-                            // matches a segment. Without this, a
-                            // subsequent retry that doesn't find a
-                            // segment would leak the newly-registered
-                            // global state on manager teardown.
-                            self.segments_mr
-                                .get_or_insert_with(|| Arc::new(IbvMemoryRegion::Segments));
-                            segment_info =
-                                self.find_cuda_segment_for_address(addr, size, domain.as_ptr());
-                        }
-                    }
-                }
-
-                // Use segment if found, otherwise fall back to direct dmabuf registration
-                if let Some(info) = segment_info {
-                    let segments_mr = Arc::clone(
-                        self.segments_mr
-                            .get_or_insert_with(|| Arc::new(IbvMemoryRegion::Segments)),
-                    );
-                    let id = self.mrv_id;
-                    self.mrv_id += 1;
-                    mrv = IbvMemoryRegionView::new(
-                        id,
-                        addr,
-                        info.rdma_addr,
-                        info.size,
-                        info.lkey,
-                        info.rkey,
-                        device_name.clone(),
-                        segments_mr,
-                    );
-                } else {
-                    // Dmabuf path: used when mlx5dv is disabled OR scanner returns no segments
-                    let mut fd: i32 = -1;
-                    let cu_err = rdmaxcel_sys::rdmaxcel_cuMemGetHandleForAddressRange(
-                        &mut fd,
-                        addr as rdmaxcel_sys::CUdeviceptr,
-                        size,
-                        rdmaxcel_sys::CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
-                        0,
-                    );
-                    if cu_err != rdmaxcel_sys::CUDA_SUCCESS || fd < 0 {
-                        return Err(anyhow::anyhow!(
-                            "failed to get dmabuf handle for CUDA memory (addr: 0x{:x}, size: {}, cu_err: {}, fd: {})",
-                            addr,
-                            size,
-                            cu_err,
-                            fd
-                        ));
-                    }
-                    let mr = rdmaxcel_sys::ibv_reg_dmabuf_mr(
-                        domain.as_ptr(),
-                        0,
-                        size,
-                        0,
-                        fd,
-                        access.0 as i32,
-                    );
-                    if mr.is_null() {
-                        return Err(anyhow::anyhow!("Failed to register dmabuf MR"));
-                    }
-                    let id = self.mrv_id;
-                    self.mrv_id += 1;
-                    let keepalive = Arc::clone(&domain);
-                    mrv = IbvMemoryRegionView::new(
-                        id,
-                        addr,
-                        (*mr).addr as usize,
-                        size,
-                        (*mr).lkey,
-                        (*mr).rkey,
-                        device_name.clone(),
-                        Arc::new(IbvMemoryRegion::Direct {
-                            mr,
-                            _domain: keepalive,
-                        }),
-                    );
-                }
-            } else {
-                // CPU memory path
-                let mr = rdmaxcel_sys::ibv_reg_mr(
-                    domain.as_ptr(),
-                    addr as *mut std::ffi::c_void,
-                    size,
-                    access.0 as i32,
-                );
-
-                if mr.is_null() {
-                    return Err(anyhow::anyhow!("failed to register standard MR"));
-                }
-
-                let id = self.mrv_id;
-                self.mrv_id += 1;
-                let keepalive = Arc::clone(&domain);
-                mrv = IbvMemoryRegionView::new(
-                    id,
-                    addr,
-                    (*mr).addr as usize,
-                    size,
-                    (*mr).lkey,
-                    (*mr).rkey,
-                    device_name.clone(),
-                    Arc::new(IbvMemoryRegion::Direct {
-                        mr,
-                        _domain: keepalive,
-                    }),
-                );
-            }
-            mrv
+            // A non-success code yields no NIC.
+            let ordinal = (err == rdmaxcel_sys::CUDA_SUCCESS).then_some(device_ordinal);
+            ordinal.filter(|o| *o >= 0).and_then(|o| {
+                super::device_selection::get_cuda_device_to_ibv_device::<I>()
+                    .get(o as usize)
+                    .and_then(|d| d.clone())
+            })
+        } else {
+            None
         };
+        let device_name = cuda_nic.map(|info| info.name().clone()).unwrap_or_else(|| {
+            resolve_target::<I>(&self.config.target)
+                .unwrap_or_else(|| IbvDeviceInfo::default::<I>())
+                .name()
+                .clone()
+        });
+        tracing::debug!(
+            "Using RDMA device: {} for memory at 0x{:x}",
+            device_name,
+            addr
+        );
+
+        let domain = self.get_or_create_device_domain(&device_name)?;
+        // The backend strategy handles host vs. device memory (standard MR,
+        // dmabuf MR, or a device-specific segment binding).
+        let mrv = domain.register_mr(mem)?;
         Ok(mem.mr_slot().get_or_init(|| mrv).clone())
     }
 
@@ -679,7 +370,8 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         }
         let self_device = &qp_key.self_device;
         let domain = self.get_or_create_device_domain(self_device)?;
-        let mut qp = IbvQueuePair::new(domain, self.config.clone())
+        let mut qp = domain
+            .create_queue_pair(&self.config)
             .map_err(|e| anyhow::anyhow!("could not create peer IbvQueuePair: {}", e))?;
         let local_info = qp
             .get_qp_info()
@@ -705,7 +397,8 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         }
         let self_device = &qp_key.self_device;
         let domain = self.get_or_create_device_domain(self_device)?;
-        let qp = IbvQueuePair::new(domain, self.config.clone())
+        let qp = domain
+            .create_queue_pair(&self.config)
             .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair for {qp_key:?}: {}", e))?;
         let local_manager: ActorRef<Self> = cx.bind();
         let is_loopback = local_manager.actor_addr() == peer_manager.actor_addr()
@@ -822,7 +515,8 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         peer_device: String,
     ) -> Result<(IbvQueuePair, OncePortReceiver<Result<IbvQpInfo, String>>), anyhow::Error> {
         let domain = self.get_or_create_device_domain(&self_device)?;
-        let mut qp = IbvQueuePair::new(domain, self.config.clone())
+        let mut qp = domain
+            .create_queue_pair(&self.config)
             .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair: {e}"))?;
         let sender_info = qp
             .get_qp_info()
@@ -930,8 +624,8 @@ impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
         remote_buf_id: usize,
         local: KeepaliveLocalMemory,
     ) -> Result<Result<IbvBuffer, String>, anyhow::Error> {
-        if let Some((buf, _)) = self.buffer_registrations.get(&remote_buf_id) {
-            return Ok(Ok(buf.clone()));
+        if let Some(mrv) = self.buffer_registrations.get(&remote_buf_id) {
+            return Ok(Ok(IbvBuffer::from(mrv)));
         }
         // `resolve_local_mr` installs the view in `local`'s shared MR
         // slot, so every clone of this handle — including the one the
@@ -941,16 +635,8 @@ impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
             Ok(v) => v,
             Err(e) => return Ok(Err(e.to_string())),
         };
-        let buf = IbvBuffer {
-            mr_id: mrv.id,
-            lkey: mrv.lkey,
-            rkey: mrv.rkey,
-            addr: mrv.rdma_addr,
-            size: mrv.size,
-            device_name: mrv.device_name.clone(),
-        };
-        self.buffer_registrations
-            .insert(remote_buf_id, (buf.clone(), mrv));
+        let buf = IbvBuffer::from(&mrv);
+        self.buffer_registrations.insert(remote_buf_id, mrv);
         Ok(Ok(buf))
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -359,7 +359,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
-    ) -> Result<Arc<IbvDomain>, anyhow::Error> {
+    ) -> Result<Arc<IbvDomain<I::IbvDomainImpl>>, anyhow::Error> {
         if let Some((device, _)) = self.devices.get_mut(device_name) {
             return device.get_or_create_domain(DEFAULT_DOMAIN);
         }
@@ -614,6 +614,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                     }
                     let id = self.mrv_id;
                     self.mrv_id += 1;
+                    let keepalive = Arc::clone(&domain);
                     mrv = IbvMemoryRegionView::new(
                         id,
                         addr,
@@ -624,7 +625,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                         device_name.clone(),
                         Arc::new(IbvMemoryRegion::Direct {
                             mr,
-                            _domain: Arc::clone(&domain),
+                            _domain: keepalive,
                         }),
                     );
                 }
@@ -643,6 +644,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
 
                 let id = self.mrv_id;
                 self.mrv_id += 1;
+                let keepalive = Arc::clone(&domain);
                 mrv = IbvMemoryRegionView::new(
                     id,
                     addr,
@@ -653,7 +655,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                     device_name.clone(),
                     Arc::new(IbvMemoryRegion::Direct {
                         mr,
-                        _domain: Arc::clone(&domain),
+                        _domain: keepalive,
                     }),
                 );
             }

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use super::domain::IbvDomain;
+use super::domain::IbvDomainKeepalive;
 
 /// Guards the resources behind a registered MR, releasing them when the last
 /// [`IbvMemoryRegionView`] over it drops. Each implementor frees whatever it
@@ -35,7 +35,7 @@ pub(super) struct IbvMemoryRegion {
     /// Keepalive for the PD `mr` was registered against; dropped only after
     /// this struct's `Drop` returns, so the PD is alive during `ibv_dereg_mr`.
     /// Never read directly.
-    pub(super) _domain: Arc<IbvDomain>,
+    pub(super) _domain: Arc<dyn IbvDomainKeepalive>,
 }
 
 // SAFETY: `mr` is only handed to `ibv_dereg_mr` (which libibverbs treats as

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -137,13 +137,14 @@ fn ibv_keys_of(remote: &crate::RdmaRemoteBuffer) -> Result<(u32, u32), anyhow::E
     Ok((buf.lkey, buf.rkey))
 }
 
-/// Integration test for the successful indirect-mkey rebind path.
+/// Integration test for the indirect-mkey segment-growth path.
 ///
-/// Allocates two segments S1 and S2 and registers a buffer in each
-/// (distinct mkeys). Then expands S1 and registers another buffer
-/// in S1's new chunk: the rebind must grow S1's existing mkey, so
-/// the new buffer shares S1's `(lkey, rkey)` and differs from S2's.
-/// Round-trips each buffer to confirm wire payload.
+/// Allocates two segments S1 and S2 and registers a buffer in each (distinct
+/// mkeys). Then expands S1 and registers another buffer in S1's new chunk:
+/// growth rotates S1 onto a fresh mkey (parking the prior one rather than
+/// mutating an in-flight key), so the new buffer carries a key distinct from
+/// both S1's pre-grow buffer and S2's. Round-trips every buffer — including the
+/// pre-grow one — to confirm the parked key stays valid and payloads land.
 ///
 /// Hardware-gated: needs CUDA + mlx5dv.
 #[timed_test::async_timed_test(timeout_secs = 60)]
@@ -245,11 +246,19 @@ async fn test_indirect_mkey_rebind_grows_existing_segment() -> Result<(), anyhow
         .expect("buf C");
 
     let (lkey_c, rkey_c) = ibv_keys_of(&buf_c)?;
-    assert_eq!(
+    // Growth rotates the segment onto a fresh indirect mkey (parking the prior
+    // one), so buf C — carved after the grow — carries a new key, distinct from
+    // buf A's pre-grow key; the round-trips below confirm A's parked key stays
+    // valid. It is also distinct from buf B's separate segment.
+    assert_ne!(
         (lkey_c, rkey_c),
         (lkey_a, rkey_a),
-        "buffer carved from a rebound expandable segment must share \
-         the segment's (lkey, rkey)",
+        "growth rotates the expandable segment onto a new (lkey, rkey)",
+    );
+    assert_ne!(
+        (lkey_c, rkey_c),
+        (lkey_b, rkey_b),
+        "buffers in distinct segments must have distinct (lkey, rkey)",
     );
 
     // Each buffer was filled with its own pattern at registration;
@@ -470,71 +479,4 @@ async fn test_indirect_mkey_rebind_falls_back_to_dmabuf_at_max_sge() -> Result<(
     sender.free_allocations(instance).await?;
     let _ = host_mesh.shutdown(instance).await;
     Ok(())
-}
-
-/// Unit test for the `phys_size` vs `mr_size` boundary in
-/// `lookup_segment_for_address`. Drives the pure helper with a
-/// synthetic `rdma_segment_info_t` shaped like the post-`max_sge`
-/// state (`phys_size > mr_size`) and asserts addresses in the
-/// `[mr_size, phys_size)` gap miss while addresses inside `mr_size`
-/// hit.
-#[test]
-fn test_lookup_segment_respects_mr_size_when_scanner_reports_larger_phys_size() {
-    use rdmaxcel_sys::rdma_segment_info_t;
-
-    use crate::backend::ibverbs::manager_actor::lookup_segment_for_address;
-
-    // Scanner reports 64 MiB but only the first 16 MiB is bound
-    // (max_sge cap). `mr_addr` is the post-registration RDMA
-    // address and need not equal `phys_address`.
-    const PHYS_ADDR: usize = 0x1000_0000;
-    const PHYS_SIZE: usize = 64 * 1024 * 1024;
-    const MR_SIZE: usize = 16 * 1024 * 1024;
-    const MR_ADDR: usize = 0xdead_0000;
-    const LKEY: u32 = 0xabcd;
-    const RKEY: u32 = 0x1234;
-
-    let segment = rdma_segment_info_t {
-        phys_address: PHYS_ADDR,
-        phys_size: PHYS_SIZE,
-        device: 0,
-        is_expandable: 1,
-        lkey: LKEY,
-        rkey: RKEY,
-        mr_size: MR_SIZE,
-        mr_addr: MR_ADDR,
-    };
-    let segments = [segment];
-
-    // Inside the bound region: hit; rdma_addr is offset from the
-    // registered `mr_addr`, not the physical address.
-    let in_bound_addr = PHYS_ADDR + 4 * 1024 * 1024;
-    let in_bound = lookup_segment_for_address(&segments, in_bound_addr, 1024)
-        .expect("in-bound address should hit the segment cache");
-    assert_eq!(in_bound.rdma_addr, MR_ADDR + 4 * 1024 * 1024);
-    assert_eq!(in_bound.lkey, LKEY);
-    assert_eq!(in_bound.rkey, RKEY);
-
-    // Inside the `[mr_size, phys_size)` gap: must miss so the
-    // caller falls through to dmabuf.
-    let in_gap_addr = PHYS_ADDR + MR_SIZE + 1024;
-    assert!(
-        lookup_segment_for_address(&segments, in_gap_addr, 1024).is_none(),
-        "address in the [mr_size, phys_size) gap must not be reported \
-         as covered by the indirect mkey",
-    );
-
-    // Request straddling the mr_size boundary must miss.
-    let straddling_addr = PHYS_ADDR + MR_SIZE - 512;
-    assert!(
-        lookup_segment_for_address(&segments, straddling_addr, 4096).is_none(),
-        "request straddling the mr_size boundary must miss",
-    );
-
-    // Past `phys_size`: out of range.
-    let past_end_addr = PHYS_ADDR + PHYS_SIZE + 1;
-    assert!(
-        lookup_segment_for_address(&segments, past_end_addr, 1).is_none(),
-        "address past phys_size must miss",
-    );
 }

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -138,7 +138,7 @@ pub(super) trait MlxDomainOps: Send + Sync + 'static {
     /// we only ever use it for indirect mkey binding.
     fn create_loopback_qp(
         &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<MlxDomain>>,
         config: &IbvConfig,
     ) -> anyhow::Result<*mut rdmaxcel_sys::rdmaxcel_qp>;
 
@@ -262,7 +262,7 @@ impl MlxDomainOps for ProdMlxDomainOps {
 
     fn create_loopback_qp(
         &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<MlxDomain>>,
         config: &IbvConfig,
     ) -> anyhow::Result<*mut rdmaxcel_sys::rdmaxcel_qp> {
         // Build a full queue pair (QP + mlx5dv structures) and connect it to
@@ -345,22 +345,23 @@ impl MlxDomainOps for ProdMlxDomainOps {
 // RegisteredSegment: a CUDA segment bound to an indirect key
 // ===========================================================================
 
-/// [`IbvMemoryRegionKeepalive`] for a segment-bound mlx5dv MR: a no-op (no `Drop`). It pins the
-/// owning [`RegisteredSegment`] — which deregisters its MRs and destroys its
-/// keys on its own `Drop` — and the domain (PD keepalive).
+/// [`IbvMemoryRegionKeepalive`] for a segment-bound mlx5dv MR: a no-op (no
+/// `Drop`). It pins the owning [`RegisteredSegment`] — which deregisters its MRs
+/// and destroys its keys on its own `Drop` — and the domain (PD keepalive).
 ///
 /// `_segment` is declared before `_domain` so it drops first (struct fields
-/// drop in declaration order). A follow-up commit stores an [`IbvDomainImpl`]
-/// in each [`IbvDomain`], so `IbvDomain<MlxDomain>` will itself hold a strong
-/// reference to every `Arc<RegisteredSegment>`. Were `_domain` dropped before
-/// `_segment`, the PD could be deallocated before a segment registered against
-/// it — wrong. Dropping `_segment` first won't actually free the segment (the
-/// domain still references it), but it ensures that once the last `_domain`
-/// reference drops, the segment is freed before the PD is deallocated.
+/// drop in declaration order). Each [`IbvDomain`] stores its [`IbvDomainImpl`]
+/// (here, [`MlxDomain`]), so an `IbvDomain<MlxDomain>` itself holds a strong
+/// reference to every `Arc<RegisteredSegment>` it has bound. Were `_domain`
+/// dropped before `_segment`, the PD could be deallocated before a segment
+/// registered against it — wrong. Dropping `_segment` first won't actually free
+/// the segment (the domain still references it), but it ensures that once the
+/// last `_domain` reference drops, the segment is freed before the PD is
+/// deallocated.
 #[derive(Debug)]
 struct Mlx5dvMemoryRegion {
     _segment: Arc<RegisteredSegment>,
-    _domain: Arc<IbvDomain>,
+    _domain: Arc<IbvDomain<MlxDomain>>,
 }
 
 impl IbvMemoryRegionKeepalive for Mlx5dvMemoryRegion {}
@@ -537,7 +538,7 @@ impl RegisteredSegment {
         seg: &Arc<Self>,
         addr: usize,
         size: usize,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<MlxDomain>>,
     ) -> IbvMemoryRegionView {
         let mkey = seg.state.lock().expect("segment state lock poisoned").mkey;
         // SAFETY: `view` is only called on a segment that covers the request,
@@ -654,6 +655,15 @@ pub struct MlxDomain {
     segments: Mutex<HashMap<(usize, i32), Arc<RegisteredSegment>>>,
 }
 
+impl std::fmt::Debug for MlxDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MlxDomain")
+            .field("mlx5dv_enabled", &self.mlx5dv_enabled)
+            .field("cuda_ordinals", &self.cuda_ordinals)
+            .finish_non_exhaustive()
+    }
+}
+
 impl Drop for MlxDomain {
     fn drop(&mut self) {
         if let Some(&qp) = self.loopback_qp.get() {
@@ -687,7 +697,7 @@ impl MlxDomain {
     /// pointer.
     fn loopback_qp_ptr(
         &self,
-        domain: &Arc<IbvDomain>,
+        domain: &Arc<IbvDomain<MlxDomain>>,
     ) -> anyhow::Result<*mut rdmaxcel_sys::rdmaxcel_qp> {
         // `OnceLock::get_or_try_init` would fit here but is still unstable
         // (`once_cell_try`); calls are serialized under the `segments` lock,
@@ -716,7 +726,7 @@ impl MlxDomain {
     /// outlives this call.
     unsafe fn register_cuda_mlx5dv_mr(
         &self,
-        domain: &Arc<IbvDomain>,
+        domain: &Arc<IbvDomain<MlxDomain>>,
         addr: usize,
         size: usize,
     ) -> anyhow::Result<IbvMemoryRegionView> {
@@ -805,24 +815,25 @@ impl IbvDomainImpl for MlxDomain {
     }
 
     unsafe fn register_mr(
-        &self,
-        domain: Arc<IbvDomain>,
+        domain: Arc<IbvDomain<MlxDomain>>,
         mem: &KeepaliveLocalMemory,
     ) -> anyhow::Result<IbvMemoryRegionView> {
-        if self.mlx5dv_enabled && is_device_ptr(mem.addr()) {
+        let this = domain.domain_impl();
+        if this.mlx5dv_enabled && is_device_ptr(mem.addr()) {
             // SAFETY: `domain.as_ptr()` is null or a live PD, per this method's
             // contract.
-            match unsafe { self.register_cuda_mlx5dv_mr(&domain, mem.addr(), mem.size()) } {
+            match unsafe { this.register_cuda_mlx5dv_mr(&domain, mem.addr(), mem.size()) } {
                 Ok(view) => return Ok(view),
                 Err(e) => {
                     tracing::warn!("mlx5dv CUDA registration failed, falling back to dmabuf: {e}")
                 }
             }
         }
+        let access = this.mr_access_flags();
         // SAFETY: `domain.as_ptr()` is null or a live PD (per this method's
         // contract; `register_host_or_dmabuf_mr` errors on null), and the caller
         // keeps `mem`'s backing memory valid for the MR's lifetime.
-        unsafe { register_host_or_dmabuf_mr(domain, self.mr_access_flags(), mem) }
+        unsafe { register_host_or_dmabuf_mr(domain, access, mem) }
     }
 }
 
@@ -837,21 +848,6 @@ mod tests {
 
     const MIB2: usize = 2 * 1024 * 1024;
     const SERVED_NIC: &str = "mlx5_0";
-
-    /// A test domain whose `pd`/`context` are null, so its `Drop` is a
-    /// no-op. The `MockOps` ignore the `pd`, and the resulting views only
-    /// hold this as a (never-read) keepalive.
-    fn fake_domain() -> Arc<IbvDomain> {
-        // SAFETY: null `ibv_context*`/`pd` are explicitly allowed — both
-        // `IbvContext` and `IbvDomain` skip their FFI destructors for null.
-        unsafe {
-            Arc::new(IbvDomain::from_parts(
-                Arc::new(IbvContext::new(std::ptr::null_mut())),
-                std::ptr::null_mut(),
-                IbvDeviceInfo::for_test_named("test"),
-            ))
-        }
-    }
 
     fn seg(address: usize, size: usize, cuda_ordinal: i32) -> ScannedSegment {
         ScannedSegment {
@@ -911,7 +907,7 @@ mod tests {
         /// When set, `dereg_mr` records whether this (weakly-held) domain is
         /// still alive at each MR deregistration. Lets a test assert a
         /// segment's MRs are freed while its domain's PD is still alive.
-        domain_probe: Option<std::sync::Weak<IbvDomain>>,
+        domain_probe: Option<std::sync::Weak<IbvDomain<MlxDomain>>>,
         /// One entry per `dereg_mr` while `domain_probe` is set: whether the
         /// probed domain was still alive.
         domain_alive_at_dereg: Vec<bool>,
@@ -999,7 +995,7 @@ mod tests {
 
         fn create_loopback_qp(
             &self,
-            _domain: Arc<IbvDomain>,
+            _domain: Arc<IbvDomain<MlxDomain>>,
             _config: &IbvConfig,
         ) -> anyhow::Result<*mut rdmaxcel_sys::rdmaxcel_qp> {
             let mut s = self.lock();
@@ -1054,19 +1050,36 @@ mod tests {
         }
     }
 
-    fn domain(mock: Arc<MockOps>) -> MlxDomain {
-        MlxDomain::new_with_ops(mock, IbvConfig::default())
+    /// A domain wrapping the mock-driven [`MlxDomain`] under test. Its
+    /// `pd`/`context` are null (no-op `Drop`); the segment views built against
+    /// it hold it only as a keepalive. Drive the strategy via
+    /// [`IbvDomain::domain_impl`].
+    fn domain(mock: Arc<MockOps>) -> Arc<IbvDomain<MlxDomain>> {
+        let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default());
+        // SAFETY: null `ibv_context*`/`pd` are explicitly allowed — both
+        // `IbvContext` and `IbvDomain` skip their FFI destructors for null.
+        unsafe {
+            Arc::new(IbvDomain::for_test(
+                Arc::new(IbvContext::new(std::ptr::null_mut())),
+                std::ptr::null_mut(),
+                IbvDeviceInfo::for_test_named("test"),
+                mlx,
+            ))
+        }
     }
 
-    /// Drive [`MlxDomain::register_cuda_mlx5dv_mr`] against a [`fake_domain`].
+    /// Drive `domain`'s own [`MlxDomain`] strategy to register CUDA memory.
     fn register_cuda(
-        domain: &MlxDomain,
+        domain: &Arc<IbvDomain<MlxDomain>>,
         addr: usize,
         size: usize,
     ) -> anyhow::Result<IbvMemoryRegionView> {
-        // SAFETY: `fake_domain`'s pd is null and the `MockOps` never dereference
-        // it, so passing it through is sound.
-        unsafe { domain.register_cuda_mlx5dv_mr(&fake_domain(), addr, size) }
+        // SAFETY: `domain`'s pd is null and the `MockOps` never dereference it.
+        unsafe {
+            domain
+                .domain_impl()
+                .register_cuda_mlx5dv_mr(domain, addr, size)
+        }
     }
 
     fn null_pd() -> *mut rdmaxcel_sys::ibv_pd {
@@ -1305,7 +1318,7 @@ mod tests {
         let rs = bind_fresh(&ops, base, MIB2);
 
         assert!(rs.covers(base + 0x400, 4096));
-        let view = RegisteredSegment::view(&rs, base + 0x400, 4096, fake_domain());
+        let view = RegisteredSegment::view(&rs, base + 0x400, 4096, domain(ops.clone()));
         assert_eq!(
             view.rdma_addr, 0x400,
             "rdma_addr is the offset from the segment base"
@@ -1407,7 +1420,7 @@ mod tests {
         let ops = MockOps::new(SERVED_NIC, true, &[0]);
         let base = 0x10_0000_0000;
         let rs = bind_fresh(&ops, base, MIB2);
-        let domain = fake_domain();
+        let domain = domain(ops.clone());
         ops.lock().domain_probe = Some(Arc::downgrade(&domain));
 
         let view = RegisteredSegment::view(&rs, base, 4096, Arc::clone(&domain));
@@ -1436,8 +1449,8 @@ mod tests {
     fn test_cuda_ordinals_and_mlx5dv_enabled_derived_from_ops() {
         let mock = MockOps::new(SERVED_NIC, true, &[0, 2]);
         let domain = domain(mock);
-        assert_eq!(domain.cuda_ordinals, vec![0, 2]);
-        assert!(domain.mlx5dv_enabled);
+        assert_eq!(domain.domain_impl().cuda_ordinals, vec![0, 2]);
+        assert!(domain.domain_impl().mlx5dv_enabled);
     }
 
     #[test]
@@ -1619,7 +1632,7 @@ mod tests {
         let domain = domain(mock.clone());
         // The registration path registers MRs with the domain's own access
         // flags; capture them to assert the dmabuf registration arguments.
-        let access = domain.mr_access_flags();
+        let access = domain.domain_impl().mr_access_flags();
 
         // Validate every field of a returned view: its address fields, its
         // size, the serving NIC's name, and the keys. The mock's `mkey_keys`

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -38,6 +38,7 @@ use super::memory_region::IbvMemoryRegionView;
 use super::primitives::IbvConfig;
 use super::primitives::IbvDeviceInfo;
 use super::queue_pair::IbvQueuePair;
+use crate::backend::ibverbs::mlx_device::MlxDevice;
 use crate::local_memory::KeepaliveLocalMemory;
 use crate::local_memory::is_device_ptr;
 
@@ -63,8 +64,10 @@ pub struct ScannedSegment {
     pub is_expandable: bool,
 }
 
-/// Enumerates the currently-live CUDA segments.
-pub type CudaSegmentScanner = Box<dyn Fn() -> Vec<ScannedSegment> + Send + Sync>;
+/// Enumerates the currently-live CUDA segments. An `Arc` (not `Box`) so
+/// [`scan_cuda_segments`] can clone it out and drop the registry lock before
+/// invoking it — see that function.
+pub type CudaSegmentScanner = Arc<dyn Fn() -> Vec<ScannedSegment> + Send + Sync>;
 
 static CUDA_SEGMENT_SCANNER: Mutex<Option<CudaSegmentScanner>> = Mutex::new(None);
 
@@ -79,12 +82,15 @@ pub fn register_cuda_segment_scanner(scanner: CudaSegmentScanner) {
 /// Invoke the registered CUDA segment scanner, returning an empty list when
 /// none is registered.
 fn scan_cuda_segments() -> Vec<ScannedSegment> {
-    CUDA_SEGMENT_SCANNER
+    // Clone the `Arc` and release the registry lock before invoking: the
+    // pytorch scanner takes the Python GIL, and even though scan_cuda_segments
+    // is never called concurrently from multiple threads (in the current design),
+    // this protects against the possibility of deadlock.
+    let scanner = CUDA_SEGMENT_SCANNER
         .lock()
         .expect("CUDA segment scanner lock poisoned")
-        .as_ref()
-        .map(|scan| scan())
-        .unwrap_or_default()
+        .clone();
+    scanner.as_deref().map(|scan| scan()).unwrap_or_default()
 }
 
 // ===========================================================================
@@ -222,7 +228,7 @@ impl MlxDomainOps for ProdMlxDomainOps {
     }
 
     fn assigned_cuda_devices(&self) -> Vec<i32> {
-        get_cuda_device_to_ibv_device()
+        get_cuda_device_to_ibv_device::<MlxDevice>()
             .iter()
             .enumerate()
             .filter_map(|(ordinal, nic)| {
@@ -1108,7 +1114,7 @@ mod tests {
 
     #[test]
     fn test_scanner_registration_round_trips() {
-        register_cuda_segment_scanner(Box::new(|| vec![seg(0x1000, MIB2, 3)]));
+        register_cuda_segment_scanner(Arc::new(|| vec![seg(0x1000, MIB2, 3)]));
         assert_eq!(
             scan_cuda_segments(),
             vec![seg(0x1000, MIB2, 3)],

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -21,21 +21,17 @@
 //!   its name, vendor ID, vendor part ID, hardware version, firmware version, node GUID, and capabilities.
 //! - `IbvPort`: Represents information about the port of an RDMA device, including state, physical state,
 //!   LID (Local Identifier), and GID (Global Identifier) information.
-//! - `IbvMemoryRegionView`: Represents a memory region that can be registered with an RDMA device for direct
-//!   memory access operations.
 //! - `IbvOperation`: Represents the type of RDMA operation to perform (Read or Write).
 //! - `IbvQpInfo`: Contains connection information needed to establish an RDMA connection with a remote endpoint.
 //! - `IbvWc`: Wrapper around ibverbs work completion structure, used to track the status of RDMA operations.
 use std::ffi::CStr;
 use std::fmt;
-use std::sync::Arc;
 use std::sync::OnceLock;
 
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-use super::domain::IbvDomainKeepalive;
 use crate::backend::ibverbs::device::IbvDeviceImpl;
 use crate::backend::ibverbs::device::list_all_devices;
 use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
@@ -760,158 +756,6 @@ fn ibverbs_supported_impl() -> bool {
             rdmaxcel_sys::ibv_free_device_list(device_list);
         }
         num_devices > 0
-    }
-}
-
-/// Refcounted owner of an ibverbs memory region. The intended
-/// sharing pattern is `Arc<IbvMemoryRegion>` cloned into every
-/// [`IbvMemoryRegionView`] backed by the region; the FFI resource
-/// is released by [`Drop`] when the last clone goes away.
-///
-/// `Direct` carries an `Arc<dyn IbvDomainKeepalive>` so the PD the MR was
-/// registered against outlives the `ibv_dereg_mr` call. The struct
-/// field order is significant: the `mr` pointer is dereg'd in
-/// `Drop` before the `_domain` field is released, so the PD is
-/// still alive when libibverbs walks back to it. The eventual
-/// `ibv_dealloc_pd` only fires when every other `Arc<dyn IbvDomainKeepalive>`
-/// (e.g. the manager's `device_domains` entry) is also gone.
-#[derive(Debug)]
-pub(super) enum IbvMemoryRegion {
-    /// A standalone `ibv_mr*` registered via `ibv_reg_mr` /
-    /// `ibv_reg_dmabuf_mr`.
-    Direct {
-        mr: *mut rdmaxcel_sys::ibv_mr,
-        /// PD the MR was registered against, kept alive past
-        /// `ibv_dereg_mr` via this clone. Never read directly.
-        _domain: Arc<dyn IbvDomainKeepalive>,
-    },
-    /// Singleton owner shared by every segment-backed view from the
-    /// mlx5dv segment scanner. `Drop` calls
-    /// `rdmaxcel_sys::deregister_segments`.
-    Segments,
-}
-
-// SAFETY: `IbvMemoryRegion::Direct`'s `*mut ibv_mr` is treated as
-// thread-safe by libibverbs for deregistration; `Segments` holds no
-// data. The intended sharing pattern is `Arc<IbvMemoryRegion>`.
-unsafe impl Send for IbvMemoryRegion {}
-unsafe impl Sync for IbvMemoryRegion {}
-
-impl Drop for IbvMemoryRegion {
-    fn drop(&mut self) {
-        match self {
-            IbvMemoryRegion::Direct { mr, .. } => {
-                if mr.is_null() {
-                    return;
-                }
-                // SAFETY: `*mr` was returned by `ibv_reg_mr` /
-                // `ibv_reg_dmabuf_mr` at construction (see
-                // `resolve_local_mr`) and is non-null per the
-                // null-check above. The intended sharing pattern
-                // is `Arc<IbvMemoryRegion>`, so `Drop` runs exactly
-                // once when the last clone goes away, meaning
-                // `ibv_dereg_mr` is called exactly once on this
-                // pointer. The PD the MR was registered against is
-                // kept alive by the sibling `_domain` `Arc<dyn IbvDomainKeepalive>`
-                // until after this dereg returns.
-                let result = unsafe { rdmaxcel_sys::ibv_dereg_mr(*mr) };
-                if result != 0 {
-                    tracing::error!(
-                        "failed to deregister MR at {:p}: error code {}",
-                        *mr,
-                        result
-                    );
-                }
-            }
-            IbvMemoryRegion::Segments => {
-                // SAFETY: `IbvMemoryRegion::Segments` is the
-                // singleton owner of the mlx5dv scanner's globally
-                // registered segments. `resolve_local_mr` lazily
-                // wraps it in `Arc::new(...)` at most once per
-                // manager (stored in `IbvManagerActor::segments_mr`)
-                // and clones it into every segment-backed view, so
-                // `deregister_segments` runs exactly once when the
-                // last reference is dropped.
-                let result = unsafe { rdmaxcel_sys::deregister_segments() };
-                if result != 0 {
-                    tracing::error!("failed to deregister CUDA segments: error code {}", result);
-                }
-            }
-        }
-    }
-}
-
-/// Represents a view of a memory region that can be registered with an RDMA device.
-///
-/// This is a 'view' of a registered Memory Region, allowing multiple views into a single
-/// large MR registration. This is commonly used with PyTorch's caching allocator, which
-/// reserves large memory blocks and provides different data pointers into that space.
-///
-/// # Example
-/// PyTorch Caching Allocator creates a 16GB segment at virtual address `0x01000000`.
-/// The underlying Memory Region registers 16GB but at RDMA address `0x0`.
-/// To access virtual address `0x01100000`, we return a view at RDMA address `0x100000`.
-///
-/// # Safety
-/// The caller must ensure the memory remains valid and is not freed, moved, or
-/// overwritten while RDMA operations are in progress.
-#[derive(Debug, Clone)]
-pub struct IbvMemoryRegionView {
-    // id should be unique with a given rdmam manager
-    pub id: usize,
-    /// Virtual address in the process address space.
-    /// This is the pointer/address as seen by the local process.
-    pub virtual_addr: usize,
-    /// Memory address assigned after Memory Region (MR) registration.
-    /// This is the address may be offset a base MR addr.
-    pub rdma_addr: usize,
-    pub size: usize,
-    pub lkey: u32,
-    pub rkey: u32,
-    /// Name of the RDMA device the view's protection domain is on.
-    pub device_name: String,
-    /// Keeps the underlying FFI MR (and, transitively, the PD it
-    /// was registered against) alive for the lifetime of any clone
-    /// of this view; the last drop triggers deregistration. Never
-    /// read directly.
-    pub(super) _mr: Arc<IbvMemoryRegion>,
-}
-
-impl IbvMemoryRegionView {
-    pub(super) fn new(
-        id: usize,
-        virtual_addr: usize,
-        rdma_addr: usize,
-        size: usize,
-        lkey: u32,
-        rkey: u32,
-        device_name: String,
-        mr: Arc<IbvMemoryRegion>,
-    ) -> Self {
-        Self {
-            id,
-            virtual_addr,
-            rdma_addr,
-            size,
-            lkey,
-            rkey,
-            device_name,
-            _mr: mr,
-        }
-    }
-}
-
-/// Compact identifier for log messages and per-op errors. Carries
-/// the MR-identifying fields all in one place so callers that
-/// embed an `IbvMemoryRegionView` in their error format get a
-/// consistent shape.
-impl fmt::Display for IbvMemoryRegionView {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "lkey={}, rkey={}, virtual_addr=0x{:x}, rdma_addr=0x{:x}, size={}",
-            self.lkey, self.rkey, self.virtual_addr, self.rdma_addr, self.size,
-        )
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -35,7 +35,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-use super::domain::IbvDomain;
+use super::domain::IbvDomainKeepalive;
 use crate::backend::ibverbs::device::IbvDeviceImpl;
 use crate::backend::ibverbs::device::list_all_devices;
 use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
@@ -768,12 +768,12 @@ fn ibverbs_supported_impl() -> bool {
 /// [`IbvMemoryRegionView`] backed by the region; the FFI resource
 /// is released by [`Drop`] when the last clone goes away.
 ///
-/// `Direct` carries an `Arc<IbvDomain>` so the PD the MR was
+/// `Direct` carries an `Arc<dyn IbvDomainKeepalive>` so the PD the MR was
 /// registered against outlives the `ibv_dereg_mr` call. The struct
 /// field order is significant: the `mr` pointer is dereg'd in
 /// `Drop` before the `_domain` field is released, so the PD is
 /// still alive when libibverbs walks back to it. The eventual
-/// `ibv_dealloc_pd` only fires when every other `Arc<IbvDomain>`
+/// `ibv_dealloc_pd` only fires when every other `Arc<dyn IbvDomainKeepalive>`
 /// (e.g. the manager's `device_domains` entry) is also gone.
 #[derive(Debug)]
 pub(super) enum IbvMemoryRegion {
@@ -783,7 +783,7 @@ pub(super) enum IbvMemoryRegion {
         mr: *mut rdmaxcel_sys::ibv_mr,
         /// PD the MR was registered against, kept alive past
         /// `ibv_dereg_mr` via this clone. Never read directly.
-        _domain: Arc<IbvDomain>,
+        _domain: Arc<dyn IbvDomainKeepalive>,
     },
     /// Singleton owner shared by every segment-backed view from the
     /// mlx5dv segment scanner. `Drop` calls
@@ -812,7 +812,7 @@ impl Drop for IbvMemoryRegion {
                 // once when the last clone goes away, meaning
                 // `ibv_dereg_mr` is called exactly once on this
                 // pointer. The PD the MR was registered against is
-                // kept alive by the sibling `_domain` `Arc<IbvDomain>`
+                // kept alive by the sibling `_domain` `Arc<dyn IbvDomainKeepalive>`
                 // until after this dereg returns.
                 let result = unsafe { rdmaxcel_sys::ibv_dereg_mr(*mr) };
                 if result != 0 {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -46,6 +46,8 @@ use typeuri::Named;
 use super::IbvBuffer;
 use super::IbvOp;
 use super::domain::IbvDomain;
+use super::domain::IbvDomainImpl;
+use super::domain::IbvDomainKeepalive;
 use super::manager_actor::CreatePeerQueuePair;
 use super::primitives::Gid;
 use super::primitives::IbvConfig;
@@ -173,7 +175,7 @@ pub struct IbvQueuePair {
     // Keepalive for the domain whose `context`/`pd` this QP was built
     // against, so it outlives the QP regardless of other owners (the
     // manager, registered MRs, etc.). Never read directly.
-    _domain: Arc<IbvDomain>,
+    _domain: Arc<dyn IbvDomainKeepalive>,
 }
 
 impl Drop for IbvQueuePair {
@@ -260,7 +262,10 @@ impl IbvQueuePair {
     /// # Errors
     ///
     /// Returns errors if CQ or QP creation fails.
-    pub fn new(domain: Arc<IbvDomain>, config: IbvConfig) -> Result<Self, anyhow::Error> {
+    pub fn new<I: IbvDomainImpl>(
+        domain: Arc<IbvDomain<I>>,
+        config: IbvConfig,
+    ) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an IbvQueuePair from config {}", config);
         let context = domain.context.as_ptr();
         let pd = domain.as_ptr();
@@ -1728,6 +1733,7 @@ mod tests {
     use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::device_selection::resolve_target;
     use crate::backend::ibverbs::domain::IbvDomain;
+    use crate::backend::ibverbs::efa_domain::EfaDomain;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
 
@@ -2362,17 +2368,18 @@ mod tests {
     /// A throwaway [`IbvDomain`] with null `context`/`pd`, used as the
     /// `_domain` keepalive of [`fake_mrv`]'s region; its `Drop` deallocs
     /// nothing (null `pd`).
-    fn null_domain() -> Arc<IbvDomain> {
+    fn null_domain() -> Arc<IbvDomain<EfaDomain>> {
         // SAFETY: a null `ibv_context*` is explicitly allowed — `IbvContext`'s
         // `Drop` is a no-op for null, so nothing is ever closed.
         let context = Arc::new(unsafe { IbvContext::new(std::ptr::null_mut()) });
         // SAFETY: a null `pd` is allowed — `IbvDomain`'s `Drop` skips
         // `ibv_dealloc_pd` for null, so nothing is ever freed.
         Arc::new(unsafe {
-            IbvDomain::from_parts(
+            IbvDomain::for_test(
                 context,
                 std::ptr::null_mut(),
                 IbvDeviceInfo::for_test_named("null_domain"),
+                EfaDomain,
             )
         })
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -49,9 +49,9 @@ use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::domain::IbvDomainKeepalive;
 use super::manager_actor::CreatePeerQueuePair;
+use super::memory_region::IbvMemoryRegionView;
 use super::primitives::Gid;
 use super::primitives::IbvConfig;
-use super::primitives::IbvMemoryRegionView;
 use super::primitives::IbvOperation;
 use super::primitives::IbvQpInfo;
 use super::primitives::IbvWc;
@@ -1418,7 +1418,6 @@ impl<M: Manager, Qp: QueuePair> QueuePairActor<M, Qp> {
         } = pending;
 
         let local_buf = IbvBuffer {
-            mr_id: mrv.id,
             lkey: mrv.lkey,
             rkey: mrv.rkey,
             addr: mrv.rdma_addr,
@@ -2360,8 +2359,8 @@ mod tests {
     // =================================================================
 
     use crate::backend::ibverbs::device::IbvContext;
+    use crate::backend::ibverbs::memory_region::IbvMemoryRegion;
     use crate::backend::ibverbs::primitives::IbvDeviceInfo;
-    use crate::backend::ibverbs::primitives::IbvMemoryRegion;
     use crate::local_memory::Keepalive;
     use crate::local_memory::KeepaliveLocalMemory;
 
@@ -2403,16 +2402,15 @@ mod tests {
         KeepaliveLocalMemory::new(Arc::new(FakeKeepalive { addr, size }))
     }
 
-    fn fake_mrv(id: usize, addr: usize, size: usize) -> IbvMemoryRegionView {
+    fn fake_mrv(addr: usize, size: usize) -> IbvMemoryRegionView {
         IbvMemoryRegionView::new(
-            id,
             addr,
             addr,
             size,
             0x1234,
             0x5678,
             "dev0".to_string(),
-            Arc::new(IbvMemoryRegion::Direct {
+            Arc::new(IbvMemoryRegion {
                 mr: std::ptr::null_mut(),
                 _domain: null_domain(),
             }),
@@ -2438,7 +2436,6 @@ mod tests {
             op_type,
             local_memory: fake_local_memory(addr, size),
             remote_buffer: IbvBuffer {
-                mr_id: 1,
                 lkey: 0,
                 rkey: 0,
                 addr: 0x4000_0000,
@@ -2579,7 +2576,7 @@ mod tests {
         let items = vec![(
             7usize,
             make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(1, 0x1000, 4096),
+            fake_mrv(0x1000, 4096),
         )];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2612,7 +2609,7 @@ mod tests {
         let items = vec![(
             11usize,
             make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-            fake_mrv(1, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+            fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
         )];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2648,7 +2645,7 @@ mod tests {
         let items = vec![(
             42usize,
             make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-            fake_mrv(1, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+            fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
         )];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2696,12 +2693,12 @@ mod tests {
             (
                 0usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(1, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+                fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
             ),
             (
                 1usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(2, 0x2000, 4096),
+                fake_mrv(0x2000, 4096),
             ),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
@@ -2746,7 +2743,7 @@ mod tests {
                 (
                     i,
                     make_op(RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096),
-                    fake_mrv(i + 1, 0x1000 + i * 0x1000, 4096),
+                    fake_mrv(0x1000 + i * 0x1000, 4096),
                 )
             })
             .collect();
@@ -2784,7 +2781,7 @@ mod tests {
                 (
                     i,
                     make_op(RdmaOpType::WriteFromLocal, 0x1000 + i * 0x1000, 4096),
-                    fake_mrv(i + 1, 0x1000 + i * 0x1000, 4096),
+                    fake_mrv(0x1000 + i * 0x1000, 4096),
                 )
             })
             .collect();
@@ -2831,27 +2828,27 @@ mod tests {
             (
                 0usize,
                 make_op(RdmaOpType::ReadIntoLocal, 0x1000, 4096),
-                fake_mrv(1, 0x1000, 4096),
+                fake_mrv(0x1000, 4096),
             ),
             (
                 1usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(2, 0x2000, 4096),
+                fake_mrv(0x2000, 4096),
             ),
             (
                 2usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x3000, 4096),
-                fake_mrv(3, 0x3000, 4096),
+                fake_mrv(0x3000, 4096),
             ),
             (
                 3usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x4000, 4096),
-                fake_mrv(4, 0x4000, 4096),
+                fake_mrv(0x4000, 4096),
             ),
             (
                 4usize,
                 make_op(RdmaOpType::ReadIntoLocal, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(5, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
+                fake_mrv(0x5000, 2 * MAX_RDMA_MSG_SIZE),
             ),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
@@ -2904,12 +2901,12 @@ mod tests {
             (
                 10usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-                fake_mrv(1, 0x1000, 4096),
+                fake_mrv(0x1000, 4096),
             ),
             (
                 11usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(2, 0x2000, 4096),
+                fake_mrv(0x2000, 4096),
             ),
         ];
         let mut rx_a = submit_ops(&harness, &actor, batch_a)?;
@@ -2920,12 +2917,12 @@ mod tests {
             (
                 20usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x3000, 4096),
-                fake_mrv(3, 0x3000, 4096),
+                fake_mrv(0x3000, 4096),
             ),
             (
                 21usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x4000, 4096),
-                fake_mrv(4, 0x4000, 4096),
+                fake_mrv(0x4000, 4096),
             ),
         ];
         let mut rx_b = submit_ops(&harness, &actor, batch_b)?;
@@ -2958,12 +2955,12 @@ mod tests {
             (
                 0usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(1, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
+                fake_mrv(0x1000, 2 * MAX_RDMA_MSG_SIZE),
             ),
             (
                 1usize,
                 make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(2, 0x2000, 4096),
+                fake_mrv(0x2000, 4096),
             ),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
@@ -2996,7 +2993,7 @@ mod tests {
         let items = vec![(
             0usize,
             make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(1, 0x1000, 4096),
+            fake_mrv(0x1000, 4096),
         )];
         let _rx = submit_ops(&harness, &actor, items)?;
         let _ = recv_posted(&mut posted_rx).await;
@@ -3026,7 +3023,7 @@ mod tests {
         let items = vec![(
             0usize,
             make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(1, 0x1000, 4096),
+            fake_mrv(0x1000, 4096),
         )];
         let _rx = submit_ops(&harness, &actor, items)?;
 

--- a/monarch_rdma/src/lib.rs
+++ b/monarch_rdma/src/lib.rs
@@ -36,10 +36,12 @@ pub fn rdma_supported() -> bool {
     ibverbs_supported() || hyperactor_config::global::get(config::RDMA_ALLOW_TCP_FALLBACK)
 }
 pub use action::RdmaAction;
+// Re-export the CUDA segment scanner API for the extension/test crates to
+// install a process-wide scanner (see `backend::ibverbs::mlx_domain`).
+pub use backend::ibverbs::mlx_domain::CudaSegmentScanner;
+pub use backend::ibverbs::mlx_domain::ScannedSegment;
+pub use backend::ibverbs::mlx_domain::register_cuda_segment_scanner;
 pub use rdma_components::RdmaRemoteBuffer;
-pub use rdma_components::SegmentScannerFn;
-// Re-export segment scanner types for extension crate
-pub use rdma_components::register_segment_scanner;
 pub use rdma_components::*;
 pub use rdma_manager_actor::*;
 // Re-export rdmaxcel_sys for extension crate to access types

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -17,7 +17,7 @@ use std::sync::Condvar;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 
-use crate::backend::ibverbs::primitives::IbvMemoryRegionView;
+use crate::backend::ibverbs::memory_region::IbvMemoryRegionView;
 
 /// Returns `true` when `addr` is a CUDA device pointer.
 ///

--- a/monarch_rdma/tests/multi_pd_test.rs
+++ b/monarch_rdma/tests/multi_pd_test.rs
@@ -21,12 +21,13 @@ use monarch_rdma::backend::cuda_test_utils::SenderActor;
 use monarch_rdma::backend::cuda_test_utils::SenderMessageClient;
 use monarch_rdma::backend::ibverbs::device_selection::IbvDeviceTarget;
 use monarch_rdma::backend::ibverbs::device_selection::get_cuda_device_to_ibv_device;
+use monarch_rdma::backend::ibverbs::mlx_device::MlxDevice;
 use ndslice::ViewExt;
 
 /// Finds two CUDA devices that map to different RDMA NICs via PCI topology.
 /// Returns `Some((device_a, device_b))` or `None` if all devices share one NIC.
 fn find_devices_on_different_nics() -> Option<(i32, i32)> {
-    let gpu_to_nic: Vec<(i32, String)> = get_cuda_device_to_ibv_device()
+    let gpu_to_nic: Vec<(i32, String)> = get_cuda_device_to_ibv_device::<MlxDevice>()
         .iter()
         .enumerate()
         .filter_map(|(idx, nic)| nic.as_ref().map(|d| (idx as i32, d.name().to_string())))


### PR DESCRIPTION
Summary:

Route the RDMA manager's memory-region registration and queue-pair creation through the `IbvDomainImpl` strategy, and delete the legacy parallel MR path.

`IbvManagerActor::resolve_local_mr` now only selects the device (the CUDA-co-located NIC, else the configured fallback) and delegates registration to its `IbvDomainImpl`; queue-pair creation likewise goes through `IbvDomain::create_queue_pair` instead of calling `IbvQueuePair::new` directly. The inline `ibv_reg_mr`/`ibv_reg_dmabuf_mr`/`register_segments` logic and the legacy `primitives::IbvMemoryRegion`/`IbvMemoryRegionView` types are removed; `MlxDomain` owns its own loopback QP and segment bindings. The CUDA segment scanner is now installed via `register_cuda_segment_scanner` (built from `torch.cuda.memory._snapshot()` in the extension, a fake in tests).

Behavior change: growing an expandable segment rotates onto a fresh indirect mkey (parking the prior one) instead of rebinding the in-flight key in place; previously-issued views keep their parked, still-valid key.

Reviewed By: zdevito

Differential Revision: D109168542


