### PR TITLE
torchtitan_mast example: run torchtitan on MAST via remote_mount (#4279)

### DIFF
--- a/examples/torchtitan_mast/.gitignore
+++ b/examples/torchtitan_mast/.gitignore
@@ -1,0 +1,4 @@
+torchtitan_mast.egg-info/
+*.egg-info/
+.monarch/
+__pycache__/

--- a/examples/torchtitan_mast/BENCHMARK.md
+++ b/examples/torchtitan_mast/BENCHMARK.md
@@ -1,0 +1,244 @@
+# torchtitan on MAST, with the workspace served from your devvm
+
+This example runs `torchtitan`'s `qwen3_1_7b` config on a 4-host MAST h100 allocation. No fbpkg packaging of torch or torchtitan; everything that isn't already in the worker fbpkg (torch, torchtitan, the FineWeb-Edu shards, an editable `monarch` checkout when you want it) is `remote_mount`-ed from your devvm at runtime.
+
+It's a smoke test for an opinion: that you can run real training off of a local source tree without the half-hour packaging cycle in the middle. The qwen3_1_7b run at the end of this writeup is the end-to-end check — a 1.72 B-parameter dense model trains to a real loss on 32 H100s mounted off a devvm checkout, with no packaging step.
+
+Measured on `fbcode/warm` c64cd5acf157 (monarch @ fbcode c2ef6f3431a3 / D108446513; monarch @ github ed01b60f4db3fb6dc570c233edd6bb731b007976, PR meta-pytorch/monarch#4243). Github users: `git checkout ed01b60` to reproduce the baseline. The apply and cold-import numbers below are from a fresh run today against a 4-host PCI1 allocation. Both `import torch` numbers are `monarch exec --one` (single-worker) cold imports.
+
+## What you actually mount
+
+`setup_env.sh` (step 4) builds `~/dev/titan_workspace/` with `uv`:
+
+```text
+~/dev/titan_workspace/
+├── .venv/                              7.5 GiB
+│   ├── bin/python3.12                  symlink to platform010 python
+│   └── lib/python3.12/site-packages/
+│       ├── monarch/ + _rust_bindings   uv-built wheel (same as client+worker)
+│       ├── torch/ + nvidia/            uv-installed wheel (cu128 channel)
+│       ├── __editable__.torchtitan-*.pth + finder
+│       └── ...
+├── torchtitan -> ~/dev/torchtitan      symlink to your local checkout
+└── (FineWeb-Edu lives elsewhere; mounted separately)
+```
+
+Workers use this venv's python end-to-end — `spawn_procs` resolves to `<workspace>/.venv/bin/python3.12` (via `python_exe=` on the workspace `remote_mount` call) and `monarch exec -- python ...` finds the same binary via the prepended `PATH`. Three pythons in play (client venv, worker fbpkg, workspace venv) all install the same monarch wheel produced by `setup_env.sh`, so no version skew.
+
+Three things worth pulling out:
+
+1. **`.venv` is opaque to fbcode.** torch and torchtitan come from `uv pip install`, not `buck build`. The loop is "edit a Python file, re-run". No packaging step.
+
+2. **monarch is built from source via `uv build`.** `setup_env.sh` produces a wheel out of `<fbsource>/fbcode/monarch` (no Buck) and installs it into the client venv, the worker venv, *and* the workspace `.venv` — so workers run the workspace venv's python end-to-end without bridging via PYTHONPATH. Pass `MONARCH_CLIENT_EDITABLE=1` to install monarch into the client venv editable from the source tree (the workspace and worker stay on the wheel — the worker ships inside an fbpkg, the workspace mounts via FUSE).
+
+3. **The torchtitan checkout is editable + symlinked.** The workspace `torchtitan/` is a symlink to wherever you cloned it; setup_env.sh does `uv pip install -e $WORKSPACE/torchtitan` so site-packages only has the PEP-660 finder, not a copy. Edit local torchtitan, re-run `monarch exec` — the next import sees the change.
+
+`job.py` does up to four `remote_mount` calls — workspace, the torchtitan symlink target so the editable finder's path resolves on workers, the example dir itself (so `train.py` resolves at its absolute path on workers), and the FineWeb directory (if present). Each opens at the same absolute path on the worker as on the devvm, so paths resolve without rewriting.
+
+## The file-size distribution that drives everything
+
+Run this on the workspace (devvm):
+
+```bash
+find ~/dev/titan_workspace/.venv -type f -printf '%s\n' \
+  | awk 'BEGIN{n_small=0;n_big=0;b_small=0;b_big=0}
+         {if ($1>=100*1024*1024){n_big++;b_big+=$1} else {n_small++;b_small+=$1}}
+         END {printf "Small (<100MiB):  %d files, %.1f GiB\n",
+                       n_small, b_small/1024/1024/1024;
+              printf "Big   (>=100MiB): %d files, %.1f GiB\n",
+                       n_big, b_big/1024/1024/1024}'
+```
+
+Output on the venv used for this writeup:
+
+```
+Small (<100MiB):  23881 files, 1.4 GiB
+Big   (>=100MiB): 20 files, 6.0 GiB
+```
+
+99.92% of files (by count) are small; 81% of bytes (by size) are in just 20 big files. The big-file list:
+
+```text
+ 870 MiB  torch/lib/libtorch_cuda.so
+ 717 MiB  nvidia/cublas/lib/libcublasLt.so.12
+ 492 MiB  nvidia/cudnn/lib/libcudnn_engines_precompiled.so.9
+ 431 MiB  nvidia/cusparselt/lib/libcusparseLt.so.0
+ 430 MiB  torch/lib/libtorch_cpu.so
+ 396 MiB  triton/_C/libtriton.so
+ 382 MiB  nvidia/nccl/lib/libnccl.so.2
+ 370 MiB  nvidia/cusparse/lib/libcusparse.so.12
+ 266 MiB  nvidia/cufft/lib/libcufft.so.11
+ 260 MiB  nvidia/cudnn/lib/libcudnn_adv.so.9
+ 239 MiB  hf_xet/hf_xet.abi3.so
+ 232 MiB  nvidia/cusolver/lib/libcusolver.so.11
+ 229 MiB  monarch/_rust_bindings.cpython-312-x86_64-linux-gnu.so
+ 154 MiB  nvidia/cusolver/lib/libcusolverMg.so.11
+ 153 MiB  nvidia/nvshmem/lib/libnvshmem_host.so.3
+ 130 MiB  nvidia/curand/lib/libcurand.so.10
+ 114 MiB  torch/lib/libtorch_cuda_linalg.so
+ 111 MiB  nvidia/cublas/lib/libcublas.so.12
+ 102 MiB  nvidia/cudnn/lib/libcudnn_ops.so.9
+ 100 MiB  nvidia/cuda_nvrtc/lib/libnvrtc.alt.so.12
+```
+
+## The data plane: eager apply, fast first import
+
+This baseline ships the whole workspace tree **eagerly at apply**. When you `monarch apply`, the mount-open phase walks every mount and transfers all of it — the 1.4 GiB of small files *and* the 6.0 GiB of big libraries — to the workers before the mount goes live. By the time `apply` returns, every byte the trainer will read is already resident on each worker.
+
+The upside is that the first read is free. There is no on-demand fault path: when the dynamic linker `dlopen`-walks `libtorch_cuda.so`, `libcublasLt.so.12`, `libtriton.so` and the rest during the first `import torch`, every block is already on the worker's local disk, so the import runs at warm speed from the page cache. The first `import torch` on a fresh allocation costs the same as the second.
+
+The cost lives entirely in apply. Shipping ~7.5 GiB of workspace plus the FineWeb shards synchronously at mount-open is the dominant cost of this design:
+
+- **Apply is expensive.** Mount-open has to move the full tree before it can return. On the 4-host allocation used here that's **128.57 s** of mount-open — minutes, not seconds, dominated by pushing the big `.so`s and the parquet shards across the region.
+- **It is paid per cold apply, not per re-apply.** A *fresh* `monarch apply` (new job, or after a preempt) ships the full tree before it returns. A no-change re-apply to a *running* job does **not** re-ship — it reconnects (measured ~12–23 s; see the Apply numbers). So the tax recurs whenever you spin up a fresh job/allocation, not on every iteration against a live one.
+- **The split is wrong for the workload.** Most of those bytes are a handful of giant libraries that the linker reads exactly once, sequentially, at native bandwidth. Paying minutes up front to pre-stage them buys nothing the first read wouldn't have paid anyway — and it blocks `apply` from returning while it does.
+
+That is the problem this baseline leaves on the table: apply is a multi-minute cost on every fresh job, dominated by eagerly shipping bytes that a demand-driven path could have streamed in the background of the first read. A later change makes apply cheap by prefilling only what actually benefits from prefetching and deferring the big libraries to a demand path; this writeup is the eager baseline it improves on.
+
+## Numbers
+
+The apply and cold-import numbers below are from a fresh run today against a 4-host PCI1 allocation. (The training run further down is data-plane-independent — the mount layer adds nothing to the steady-state loop, as the MFU section explains.)
+
+### Apply
+
+The apply ships every mount eagerly and returns only once the whole tree is resident on the workers.
+
+```text
+# four mounts: workspace (7.5 GiB / ~23.5k files), torchtitan
+# (205 MiB / 804 files), the example dir, FineWeb (27 GiB / 30 parquet)
+[mount_process] mounts opened in 128.57s
+Job is ready (1s)
+```
+
+- **Mounts opened (all four):** 128.57 s. This is the eager ship — the full 7.5 GiB workspace, the torchtitan checkout, and the FineWeb parquet are transferred to every worker before mount-open returns.
+- **No-change re-apply reconnects (no re-ship).** A `monarch apply` against the unchanged tree while the job is still running just reconnects to it — measured **~12–23 s** (`Found cached job` → `Job is ready`, no `mounts opened` line; the workers' mounts are already up). The expensive 128.57 s mount-open is a per-*cold*-apply (fresh-job) cost, not a per-re-apply one.
+
+The mount-open is the *useful* number; the `monarch apply` CLI wall-clock also includes MAST queue wait for PCI capacity, which varies.
+
+### Cold and warm import
+
+Because apply shipped everything eagerly, the first `import torch` on a fresh allocation reads only from the worker's local disk — there is no transfer on the import path. Run on a single worker (`monarch exec --one`):
+
+| Operation                                       | Result   |
+|-------------------------------------------------|----------|
+| cold `import torch` (resident, eager apply)     | 3.26 s   |
+| warm `import torch` (second invocation)         | ~3.3 s   |
+| `import torchtitan`                             | 0.08 s   |
+
+The cold import is fast precisely because the eager apply already moved the ~3.9 GiB of `.so`s onto the worker. The linker faults each library out of the local page cache, so the cold number tracks the warm number — the transfer cost was paid up front, at apply, not here. `import torchtitan` never touches a big file (torchtitan is all small `.py`), so it is cheap regardless.
+
+torch is `2.11.0+cu128`.
+
+### Training: qwen3_1_7b, 300 steps, 4×8 H100
+
+The point of putting torchtitan on this mount is to actually train. Same `monarch exec` invocation, same workspace, no fbpkg of torch:
+
+```bash
+monarch exec --all --per-host gpu=8 \
+    -e MASTER_ADDR=$(monarch exec --one -- hostname) \
+    -e MASTER_PORT=29500 \
+    -e TITAN_TORCHTITAN=$HOME/dev/torchtitan \
+    -e TITAN_MODEL_MODULE=qwen3 \
+    -e TITAN_MODEL_CONFIG=qwen3_1_7b \
+    -e TITAN_TRAINING_STEPS=300 \
+    -e TITAN_DATASET=fineweb_edu_10BT \
+    -e TITAN_LOSS=ce \
+    -- python train.py
+```
+
+`dp_shard=-1` lets torchtitan FSDP-shard the 1.72 B parameters across all 32 GPUs. FineWeb-Edu-10BT shards stream through the third mount. `TITAN_LOSS=ce` forces plain CrossEntropyLoss as a workaround for an unrelated qwen3 backward-pass crash. Step lines from rank 0, abbreviated:
+
+```text
+step:   1   loss: 12.441   tflops:  26.24   mfu:  2.65%   memory: 48.31 GiB  (smoke, single H100)
+step:  10   loss:  8.889   tflops: 334.03   mfu: 33.77%   memory: 48.34 GiB
+step: 100   loss:  6.341   tflops: 331.37   mfu: 33.51%
+step: 200   loss:  5.682   tflops: 328.77   mfu: 33.24%
+step: 300   loss:  5.244   tflops: 325.44   mfu: 32.91%   (final, 32-H100 run)
+```
+
+- **Initial → final loss:** 12.4 → 5.24 in 300 steps. (Initial loss is `ln(151936) ≈ 11.93` for the qwen3 vocab; the smoke-test step 1 was 12.44 from identical model init. 300 steps doesn't fully converge but the trajectory is healthy.)
+- **Sustained throughput:** ~330 TFLOPS/GPU, MFU ~34%, ~25.6K tokens/s/GPU, ~0.64 s/step.
+- **GPU memory:** 48.34 GiB / H100 (61% of an 80 GiB H100).
+- **Wall-clock:** ~3 min for 300 steps end-to-end.
+
+What this proves about the mount layer: after the apply finishes, every byte the trainer reads — the big libraries during the first `import torch` on each worker, plus the FineWeb-Edu shards as the dataloader scans them — is already resident on the worker, and the inner training loop sees no FUSE traffic at all. The 33% MFU number is the same MFU you'd get from a fbpkg-baked torch — the mount adds nothing to the steady-state loop.
+
+## Reproduction commands
+
+Everything below was run on a Meta devvm. Adjust paths to taste.
+
+### One-time: bootstrap everything
+
+```bash
+cd <fbsource>/fbcode/monarch/examples/torchtitan_mast
+bash setup_env.sh
+export PATH="$HOME/monarch_bench_envs/client/bin:$PATH"
+```
+
+`setup_env.sh` builds the monarch wheel (from source, no Buck), client + worker venvs, the torchtitan workspace `.venv` (torch from the cu128 channel + editable torchtitan), and pip-installs this dir into the client venv. See `./setup_env.sh --help` for tunables.
+
+### File-size distribution
+
+```bash
+find $HOME/dev/titan_workspace/.venv -type f -printf '%s\n' \
+  | awk 'BEGIN{n_small=0;n_big=0;b_small=0;b_big=0}
+         {if ($1>=100*1024*1024){n_big++;b_big+=$1} else {n_small++;b_small+=$1}}
+         END {printf "Small (<100MiB):  %d files, %.1f GiB\n",
+                       n_small, b_small/1024/1024/1024;
+              printf "Big   (>=100MiB): %d files, %.1f GiB\n",
+                       n_big, b_big/1024/1024/1024}'
+```
+
+### `monarch apply`
+
+```bash
+cd <fbsource>/fbcode/monarch/examples/torchtitan_mast
+rm -rf .monarch              # discard any prior job state
+monarch apply job.job
+```
+
+The apply CLI itself only prints high-level progress (`Job is ready (Ns)`). The mount_process daemon's detailed timings (mount-open, refresh durations) are written to `/tmp/monarch_mounts_<apply_id>.log`. The apply CLI prints the log path on exit; grep it for the breakdown:
+
+```bash
+LOG=$(ls -t /tmp/monarch_mounts_*.log | head -1)
+grep -E "mounts opened|refresh complete" $LOG
+```
+
+### Run training
+
+```bash
+# Single command — same `monarch exec` you'd use for any worker job.
+# TITAN_TORCHTITAN bypasses the workspace symlink (FUSE doesn't follow
+# the bare symlink on workers), pointing the launcher straight at the
+# realpath that job.py mounts separately.
+monarch exec --all --per-host gpu=8 \
+    -e MASTER_ADDR=$(monarch exec --one -- hostname) \
+    -e MASTER_PORT=29500 \
+    -e TITAN_TORCHTITAN=$HOME/dev/torchtitan \
+    -e TITAN_MODEL_MODULE=qwen3 \
+    -e TITAN_MODEL_CONFIG=qwen3_1_7b \
+    -e TITAN_TRAINING_STEPS=300 \
+    -e TITAN_DATASET=fineweb_edu_10BT \
+    -e TITAN_LOSS=ce \
+    -- python train.py 2>&1 | tee /tmp/qwen3_mast.log
+```
+
+Bump `TITAN_TRAINING_STEPS` higher for a longer run. 300 steps is the smoke-test value used for this writeup (~3 min, loss → ~5.24).
+
+Tail rank 0's per-worker stdout for live step lines:
+
+```bash
+tail -f /home/cpuhrsch/torchtitan_logs/hosts_0/exec_outputs/*/stdout.txt | grep step:
+```
+
+### Tear down
+
+```bash
+monarch kill
+```
+
+## Caveats
+
+- **MAST queue wait dominates wall-clock for `apply`.** The mount-open phase is on the order of tens of seconds; total `apply` wall-clock is dominated by however long MAST takes to allocate the requested hardware, which varies by cluster load. Mount-open is the number that's reproducible — the queue wait isn't.
+- **Daemon-side detail messages write to a log file**, not the apply CLI's stdout. The mount_process daemon is detached (`start_new_session=True`) and its stdout/stderr go to `/tmp/monarch_mounts_<apply_id>.log`; the apply CLI prints the log path on exit. Grep that file for `mounts opened` to see per-mount timings.
+- **Preemption is *not* handled transparently anymore.** Hostnames are resolved once at apply time and cached in `.monarch/job_state.pkl`. The previous design re-resolved on every `monarch exec` via `mast get-status` (~600 ms per call); after profiling showed the live-resolution overhead dominated steady-state exec, we moved to apply-time caching. If MAST preempts and re-places task instances under the same job ID, the cached hostnames go silently stale and the next `monarch exec` will surface a TLS handshake / connect timeout rather than a clean "job preempted" error. Workaround for now: `monarch kill && monarch apply job.job` to force a fresh apply. An upcoming Monarch feature surfaces host-liveness through the existing supervision channel (no extra subprocess); once it lands we get clean preempt-detection back without paying per-call subprocess cost.

--- a/examples/torchtitan_mast/README.md
+++ b/examples/torchtitan_mast/README.md
@@ -1,0 +1,208 @@
+# torchtitan on MAST via monarch (H100 x86)
+
+Run torchtitan `llama3_debugmodel` across 4 h100 nodes (32 GPUs total) using
+the `monarch apply` / `monarch exec` workflow. The trainer code (`torchtitan` +
+`torch`) ships to workers via `remote_mount` of a uv-managed `.venv`, not via
+the worker fbpkg.
+
+H100 x86 only. monarch is built from source via `uv build` (no Buck). Jobs run
+on MAST via the vendored `SimpleMastJob` in the `simple_mast_job/` package.
+
+## What each file does
+
+| File                      | Role                                                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `job.py`                  | Defines `job` (a `SimpleMastJob` configured for 4 h100s with the workspace + example dir mounted via `remote_mount`).|
+| `train.py`                | torchtitan launcher. Runs as plain `python train.py` locally (single GPU) or via `monarch exec` remotely (32 GPU distributed). No monarch imports. |
+| `train_with_actors.py`    | **Alternative** client-side driver using the monarch actor framework — spawns a `TrainerActor` per GPU and uses the actor mailbox as the torch rdzv. See appendix. |
+| `simple_mast_job/`        | Vendored `SimpleMastJob` (MAST-backed JobTrait) + `build_bootstrap.py`. `build_bootstrap` builds a slim monarch venv (reusing the wheel `setup_env.sh` cached in `/tmp/monarch_bootstrap_$USER/wheel`), fbpkgs it as `monarch_additional_packages`, and `launch_mast` schedules the h100 jobspec. |
+| `setup_env.sh`            | One-shot bootstrap: builds the monarch wheel from source, creates the client venv, builds the torchtitan workspace `.venv`, caches the wheel for `build_bootstrap`, and pip-installs this dir editable. |
+| `pyproject.toml`          | Declares this dir an installable project (`pip install -e .` puts `job`/`train`/`train_with_actors`/`simple_mast_job` on `sys.path`) and holds the default `workspace` path under `[tool.torchtitan_mast.paths]`. |
+
+## Layout
+
+```
+~/dev/titan_workspace/         <-- this whole directory gets remote_mounted
+├── .venv/                     <-- uv venv with torch installed
+└── torchtitan -> ~/dev/torchtitan   <-- symlink (editable install)
+```
+
+Workers see the workspace at the same absolute path it has locally, and the
+FUSE-served `.venv/bin/python3.12` is what `monarch exec` and the spawned
+actor procs use. Torch lives in `.venv/lib/python3.12/site-packages/torch/` and
+gets BFS-prefetched at mount time (via `python_exe=<path>` to
+`MountHandler.open`).
+
+## One-time setup
+
+```bash
+cd <fbsource>/fbcode/monarch/examples/torchtitan_mast
+bash setup_env.sh
+```
+
+`setup_env.sh` builds, in one pass:
+
+1. A monarch wheel from `<fbsource>/fbcode/monarch` (`uv build --wheel`, no
+   Buck) at `/tmp/torchtitan_mast_monarch_wheel.<pid>/`, also copied into
+   `/tmp/monarch_bootstrap_$USER/wheel/` where `build_bootstrap` reuses it.
+2. A client venv at `~/monarch_bench_envs/client` with the monarch wheel +
+   `fire` + a staged `libomp.so`.
+3. A torchtitan workspace `.venv` at `~/dev/titan_workspace/.venv` with torch
+   (`cu128` channel) + (non-editable) torchtitan + extras, plus a symlink to
+   your local torchtitan checkout.
+4. `pip install -e .` of this example dir into the client venv so `job` /
+   `train` / `train_with_actors` / `simple_mast_job` are importable from any
+   cwd.
+
+The slim worker (bootstrap) fbpkg is not built here — `monarch apply` builds
+it on demand via `simple_mast_job.build_bootstrap`, reusing the cached wheel.
+
+Required prereqs (the script checks these):
+- Python at `/usr/local/fbcode/platform010/bin/python3.12`
+- `uv` on `$PATH`
+- A torchtitan checkout at `~/dev/torchtitan` (override via `TITAN_TORCHTITAN=`)
+
+After it finishes, add the client venv to your `PATH`:
+
+```bash
+export PATH="$HOME/monarch_bench_envs/client/bin:$PATH"
+```
+
+Or invoke `monarch` by full path: `~/monarch_bench_envs/client/bin/monarch`.
+
+Re-run with `--force` to wipe the venvs and rebuild. Pass `MONARCH_CLIENT_EDITABLE=1`
+to install monarch into the client venv editable from the source tree (the
+bootstrap fbpkg always ships the wheel to MAST). Set `MONARCH_REBUILD=1` to make
+`monarch apply` re-upload the bootstrap fbpkg even if cached (the wheel itself
+is rebuilt by `setup_env.sh --force`).
+
+## Run
+
+The idea: write a vanilla training script (`train.py`) that runs locally with
+`python train.py` against your activated torchtitan venv, then run the **same
+script** remotely via `monarch exec`. monarch is only on the launch path; your
+venv and your script don't import it.
+
+```bash
+# (Optional) local single-GPU smoke test with your torchtitan venv active.
+source ~/dev/titan_workspace/.venv/bin/activate
+python train.py     # rank 0 of world 1
+deactivate
+
+cd <fbsource>/fbcode/monarch/examples/torchtitan_mast
+
+# 1. Allocate 4 h100s on MAST and mount the workspace + this example dir.
+monarch apply job.job
+
+# 2. Run 32-way distributed training. Two ``monarch exec`` calls:
+#    first resolve rank 0's hostname for the torch.distributed TCPStore
+#    rendezvous, then dispatch ``python train.py`` to every (host, gpu)
+#    coordinate. The realpath of train.py matches the worker's mount
+#    point regardless of whether you cd'd in via a symlink. job.py injects
+#    TITAN_TORCHTITAN and TITAN_LOSS=ce into the worker env and MASTER_PORT
+#    defaults to 29500, so MASTER_ADDR is the only -e you need here.
+HOST0=$(monarch exec --one -- hostname | tail -1)
+monarch exec --all --per-host gpu=8 -e MASTER_ADDR="$HOST0" -- python "$(realpath train.py)"
+
+# 3. Tear down (or just `rm -rf .monarch` to forget the cached job).
+monarch kill
+```
+
+### Why the bootstrap venv should stay slim
+
+The bootstrap wheel is built with `USE_TENSOR_ENGINE=0` (no torch, no
+`nvidia/`), so the worker fbpkg stays small (~530 MB vs the ~5 GB a fat one
+would be). That matters: a fat worker bloats the upload, wastes host memory,
+and creates a second torch installation that's easy to import by accident and
+silently divergent from the workspace `.venv`'s torch — which is what the
+workers actually run. To point MAST at a prebuilt fbpkg instead of building
+one, set `MONARCH_MAST_WORKER_FBPKG_ID=<your-fbpkg-id>`.
+
+The worker-side `python` resolves to the workspace `.venv/bin/python3.12`
+(FUSE-mounted) because `job.py` prepends `<workspace>/.venv/bin` to the worker
+`PATH` and passes that same binary as `python_exe` to `remote_mount` (so
+`spawn_procs` uses it too). The workspace venv has monarch + torch +
+torchtitan in its own site-packages, so `import monarch` / `import torch` /
+`import torchtitan` Just Work — no PYTHONPATH bridging needed.
+
+## Benchmark
+
+[`benchmark_table.csv`](benchmark_table.csv) is the measured comparison: one
+runnable command per row, the metric it produces, and the result on each data
+plane — `baseline` (the eager warm build) vs `v3` (this example's on-demand
+build). The commands are identical across planes; only the installed build
+differs, so any row is paste-and-run. GitHub renders the file as a table.
+
+- `mount_open` is the reproducible apply cost; `wall_incl_mast_alloc` also
+  includes MAST queue/allocation, which varies run to run.
+- v3's on-demand cost shows up in `perworker_import_cold` (it pulls the `.so`s
+  on first import), not at the command wall — its faster `monarch exec` floor
+  (`echo`/`hostname`) more than hides it.
+- File-size and qwen3-training rows are data-plane-independent.
+
+The command rows are one 4×h100 run (2026-06-19); `BENCHMARK.md` cites a
+separate pinned run, so headline numbers differ by allocation noise.
+`BENCHMARK.md` is the full writeup (data-plane mechanism, dedup table,
+big-file list, exec-floor breakdown).
+
+## Tunables
+
+The workspace path default lives in `pyproject.toml` under
+`[tool.torchtitan_mast.paths]`; the env vars below override per-run. The
+`TITAN_*` knobs control job shape and are env-only.
+
+| Variable                  | Default                                         | Description                                                                  |
+| ------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------- |
+| `TITAN_WORKSPACE`         | `paths.workspace` (`~/dev/titan_workspace`)     | Local dir holding `.venv/` and the torchtitan symlink. |
+| `TITAN_TORCHTITAN`        | `~/dev/torchtitan`       | Your torchtitan checkout (used by `setup_env.sh`).                          |
+| `TITAN_NUM_HOSTS`         | `4`                      | Number of MAST hosts to allocate.                                            |
+| `TITAN_GPUS_PER_HOST`     | `8`                      | Procs/actors spawned per host.                                               |
+| `TITAN_MODEL_CONFIG`      | `llama3_debugmodel`      | Any config registered in `torchtitan/models/.../config_registry.py`.         |
+| `TITAN_TRAINING_STEPS`    | `20`                     | Training steps to run before stopping.                                       |
+| `TITAN_FINEWEB_DIR`       | `~/dev/llm_data/fineweb_edu_10BT` | If present, mounted as an extra `remote_mount` and used when `TITAN_DATASET=fineweb_edu_10BT`. |
+| `TITAN_LOG_DIR`           | `~/torchtitan_logs`      | Client-side gather mount target (per-worker `/tmp/torchtitan_logs` surfaced as `hosts_N/` subdirs). |
+
+## Iteration loop
+
+Because the workspace is `remote_mount`-ed, an edit in
+`$TITAN_TORCHTITAN/torchtitan/...` is picked up on the next `monarch exec`
+invocation — `_mounts.ensure_open` triggers a daemon-side `refresh()` that
+re-syncs only the changed files. No need to kill MAST and re-`apply`. Same for
+edits to `train.py` (the example dir is also remote-mounted).
+
+## Appendix: actor-driven launch (alternative to step 3)
+
+`train.py` is the "use monarch as a remote runner" approach — the script knows
+nothing about monarch, just reads env vars. The other way to launch the same
+training is to drive it through monarch's actor framework, where each rank is
+a `TrainerActor` and the actor mailbox plays the role of torch's rendezvous
+backend. That's what `train_with_actors.py` does:
+
+```bash
+monarch apply job.job
+python train_with_actors.py    # client-side driver; runs as long as training runs
+monarch kill
+```
+
+`train_with_actors.py` connects to the running MAST allocation, calls
+`spawn_procs(per_host={"gpus": 8})` to lay out 32 procs, runs
+`monarch.spmd.setup_torch_elastic_env_async(proc_mesh)` to populate
+`MASTER_ADDR`/`MASTER_PORT`/`RANK`/`WORLD_SIZE`/`LOCAL_RANK` on each proc via
+the actor mailbox, then spawns `TrainerActor` instances and calls
+`.start_training.call()` on the whole mesh.
+
+### When to pick which
+
+| Aspect                          | Option (a) `train.py` via `monarch exec`           | Option (b) `train_with_actors.py` (actor framework)         |
+| ------------------------------- | -------------------------------------------------- | ----------------------------------------------------------- |
+| Mental model                    | "Run my existing script remotely."                 | "Build a distributed program on top of monarch primitives." |
+| Coupling to monarch             | None inside the training script.                   | Trainer logic is wrapped in `@endpoint` methods.            |
+| Multi-host rendezvous           | TCP via `MASTER_ADDR` (rank 0's hostname).         | Actor mailbox; no external port needed.                     |
+| Surfacing per-rank Python errors| Whatever `torchrun`-style stderr you'd see.        | Each actor's exception comes back as `ActorError` with traceback. |
+| Live introspection of a rank    | Not really; you only see stdout/stderr.            | `bench.slice(hosts=2).foo.call_one()` on a live actor.      |
+| RDMA buffers / actor messaging  | Not available — plain process.                     | Available (`RDMABuffer`, `mesh_admin`, py-spy plumbing).    |
+| Code in this dir                | `train.py` (~180 lines, no monarch).               | `train_with_actors.py` (~230 lines, monarch + torchtitan).  |
+| Recommended first encounter     | Easiest path if you already have a torch script.   | Pick this once you want monarch features beyond remote-exec.|
+
+Both depend on the same `job.py` apply step. You can keep both files checked
+in and pick at run time; nothing forces a choice.

--- a/examples/torchtitan_mast/benchmark_table.csv
+++ b/examples/torchtitan_mast/benchmark_table.csv
@@ -1,0 +1,22 @@
+command,metric,baseline,v3,unit
+rm -rf .monarch && monarch apply job.job,mount_open,116.7,,s
+rm -rf .monarch && monarch apply job.job,wall_incl_mast_alloc,305,,s
+monarch exec --all -- echo hello,wall,18,,s
+monarch exec --one -- hostname,wall,38,,s
+monarch exec --all -- python -c 'import time; t=time.perf_counter(); import torch; print(time.perf_counter()-t)',wall_cold,20,,s
+monarch exec --all -- python -c 'import time; t=time.perf_counter(); import torch; print(time.perf_counter()-t)',perworker_import_cold,3.21,,s
+monarch exec --all -- python -c 'import time; t=time.perf_counter(); import torch; print(time.perf_counter()-t)',wall_warm,18,,s
+monarch exec --all -- python -c 'import time; t=time.perf_counter(); import torch; print(time.perf_counter()-t)',perworker_import_warm,3.32,,s
+monarch apply job.job,reapply_nochange_wall,13,,s
+monarch apply job.job,reapply_nochange_mount_open,n/a,,s
+monarch exec --all --per-host gpu=8 -e MASTER_ADDR=$(monarch exec --one -- hostname | tail -1) -- python train.py,wall_20step,45,,s
+monarch exec --all --per-host gpu=8 -e MASTER_ADDR=$(monarch exec --one -- hostname | tail -1) -- python train.py,loss_step1,8.15,,loss
+monarch exec --all --per-host gpu=8 -e MASTER_ADDR=$(monarch exec --one -- hostname | tail -1) -- python train.py,loss_step20,3.28,,loss
+monarch kill,wall,5,,s
+find $HOME/dev/titan_workspace/.venv -type f -size -100M | wc -l,files_lt100MiB,23881,,count
+find $HOME/dev/titan_workspace/.venv -type f -size +100M | wc -l,files_ge100MiB,20,,count
+find $HOME/dev/titan_workspace/.venv -type f -size -100M -printf '%s\n' | awk '{s+=$1}END{print s/2^30}',GiB_lt100MiB,1.4,,GiB
+find $HOME/dev/titan_workspace/.venv -type f -size +100M -printf '%s\n' | awk '{s+=$1}END{print s/2^30}',GiB_ge100MiB,6.0,,GiB
+monarch exec --all --per-host gpu=8 -e MASTER_ADDR=$(monarch exec --one -- hostname | tail -1) -e TITAN_MODEL_MODULE=qwen3 -e TITAN_MODEL_CONFIG=qwen3_1_7b -e TITAN_TRAINING_STEPS=300 -e TITAN_DATASET=fineweb_edu_10BT -- python train.py,loss_step1,12.44,,loss
+monarch exec --all --per-host gpu=8 -e MASTER_ADDR=$(monarch exec --one -- hostname | tail -1) -e TITAN_MODEL_MODULE=qwen3 -e TITAN_MODEL_CONFIG=qwen3_1_7b -e TITAN_TRAINING_STEPS=300 -e TITAN_DATASET=fineweb_edu_10BT -- python train.py,loss_step300,5.244,,loss
+monarch exec --all --per-host gpu=8 -e MASTER_ADDR=$(monarch exec --one -- hostname | tail -1) -e TITAN_MODEL_MODULE=qwen3 -e TITAN_MODEL_CONFIG=qwen3_1_7b -e TITAN_TRAINING_STEPS=300 -e TITAN_DATASET=fineweb_edu_10BT -- python train.py,mfu,34,,pct

--- a/examples/torchtitan_mast/job.py
+++ b/examples/torchtitan_mast/job.py
@@ -1,0 +1,251 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MAST job spec for torchtitan ``llama3_debugmodel`` on 4 h100 nodes.
+
+Mounts a local "titan workspace" (a directory containing a uv-managed
+``.venv/`` with torch + torchtitan) onto every worker via ``remote_mount``.
+Workers boot using the slim monarch bootstrap fbpkg python (which carries
+monarch only); ``PYTHONPATH`` is set to the mounted venv's site-packages so
+``import torch`` and ``import torchtitan`` resolve from the mount without
+anything being baked into the bootstrap fbpkg.
+
+Setup (one-time per clone):
+1. ``setup_env.sh`` builds the client monarch venv at
+   ``~/monarch_bench_envs/client``, the torchtitan workspace at
+   ``~/dev/titan_workspace``, and pip-installs this example dir into the
+   client venv. The slim bootstrap fbpkg the workers boot from is built on
+   demand by ``simple_mast_job.build_bootstrap`` (reusing the wheel
+   setup_env.sh cached in ``/tmp/monarch_bootstrap_$USER/wheel``).
+
+The workspace path is the default in ``pyproject.toml`` under
+``[tool.torchtitan_mast.paths]``; set ``TITAN_WORKSPACE`` to override for a
+single run.
+
+Run:
+```bash
+~/monarch_bench_envs/client/bin/monarch apply job.job
+~/monarch_bench_envs/client/bin/python3.12 train.py
+~/monarch_bench_envs/client/bin/monarch kill
+```
+"""
+
+from __future__ import annotations
+
+import os
+import tomllib
+from pathlib import Path
+
+from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+from monarch.actor import enable_transport
+from monarch.config import configure
+from simple_mast_job import SimpleMastJob
+
+# The workspace default comes from pyproject.toml's
+# [tool.torchtitan_mast.paths] section; it is produced by setup_env.sh at a
+# well-known location (~/dev/titan_workspace) so the default works for any
+# user. The TITAN_WORKSPACE env var overrides per-call.
+_PYPROJECT_PATH = Path(__file__).resolve().parent / "pyproject.toml"
+
+
+def _resolve_paths() -> str:
+    with _PYPROJECT_PATH.open("rb") as f:
+        defaults = (
+            tomllib.load(f).get("tool", {}).get("torchtitan_mast", {}).get("paths", {})
+        )
+
+    workspace = os.environ.get("TITAN_WORKSPACE") or defaults.get("workspace")
+    if not workspace:
+        raise RuntimeError(
+            "pyproject.toml is missing [tool.torchtitan_mast.paths].workspace"
+        )
+
+    workspace = os.path.abspath(os.path.expanduser(workspace))
+    venv_site_packages = os.path.join(
+        workspace, ".venv", "lib", "python3.12", "site-packages"
+    )
+    if not os.path.isdir(venv_site_packages):
+        raise RuntimeError(
+            f"expected a uv venv at {workspace}/.venv; run setup_env.sh "
+            f"to create it, or override with TITAN_WORKSPACE=<path>"
+        )
+    return workspace
+
+
+def _make_job() -> SimpleMastJob:
+    workspace = _resolve_paths()
+
+    configure(
+        default_transport=ChannelTransport.MetaTlsWithHostname,
+        message_ack_time_interval="10ms",
+        stop_actor_timeout="100ms",
+        process_exit_timeout="30s",
+        host_spawn_ready_timeout="300s",
+        mesh_proc_spawn_max_idle="300s",
+        actor_spawn_max_idle="300s",
+        message_delivery_timeout="600s",
+        # Capture child stdio so worker proc startup errors show up in
+        # ``mesh_tail_log_lines`` (we surface this in the ValueError when
+        # a proc fails to configure).
+        enable_log_forwarding=True,
+        enable_file_capture=True,
+        tail_log_lines=100,
+    )
+    enable_transport("metatls-hostname")
+
+    # Workers boot on the bootstrap-fbpkg python (carries monarch only). We
+    # prepend the workspace ``.venv/bin`` to PATH so bare ``python`` /
+    # ``python3.12`` on workers resolve to the FUSE-mounted venv binary for
+    # ``monarch exec -- python ...``; ``PYTHONPATH`` (below) makes torch +
+    # torchtitan importable from the mounted venv's site-packages without
+    # baking them into the bootstrap fbpkg.
+    workspace_venv_bin = f"{workspace}/.venv/bin"
+    workspace_site_packages = f"{workspace}/.venv/lib/python3.12/site-packages"
+    # $WORKSPACE/torchtitan is a symlink to your local torchtitan checkout;
+    # resolve the realpath so we can mount the target (which lives outside
+    # the workspace) at the same absolute path on workers, so the editable
+    # install's finder can reach it.
+    torchtitan_link = os.path.join(workspace, "torchtitan")
+    torchtitan_source = (
+        os.path.realpath(torchtitan_link)
+        if os.path.islink(torchtitan_link)
+        else torchtitan_link
+    )
+    # Number of parallel TCP streams used by both the warm-cache pre-fetch
+    # remote_mount call and the bulk-TCP fallback transport. Same value
+    # exported to worker procs so submit() picks up the right parallelism.
+    streams = int(os.environ.get("TITAN_STREAMS", "8"))
+    job = SimpleMastJob(
+        hosts=int(os.environ.get("TITAN_NUM_HOSTS", "4")),
+        env={
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "PATH": f"{workspace_venv_bin}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            # The bootstrap-fbpkg python carries monarch only; PYTHONPATH bridges
+            # torch + torchtitan in from the mounted venv's site-packages.
+            "PYTHONPATH": workspace_site_packages,
+            # Workers run as root so ``~`` expands to ``/root``; export the
+            # workspace path so ``train.py`` (and any other consumer) doesn't
+            # fall back to its ``~/dev/titan_workspace`` default.
+            "TITAN_WORKSPACE": workspace,
+            # Export the resolved torchtitan realpath so train.py finds it
+            # without a per-run -e TITAN_TORCHTITAN: workers can't follow the
+            # workspace's torchtitan symlink (FUSE drops symlinks), but the
+            # realpath is mounted at the same absolute path below.
+            "TITAN_TORCHTITAN": torchtitan_source,
+            # llama3_debugmodel and qwen3_1_7b on torch 2.11 both hit a
+            # ChunkedCELoss autograd bug; plain CE is the workaround. Bake it in
+            # so the train command needs no -e TITAN_LOSS=ce (override with
+            # -e TITAN_LOSS=<other> for a config that doesn't need it).
+            "TITAN_LOSS": "ce",
+            # Re-enabling MAST prechecks (vs the old skip-everything bench
+            # defaults) lets MAST detect and avoid hosts with broken NVIDIA
+            # driver state.
+            "HOOKS_DISABLED": "1",
+            "RUST_LOG": "info",
+            # Worker-side parallelism for the bulk-TCP fallback. Without
+            # this the worker's TcpBackend defaults to 1 regardless of
+            # what the client passed via Python ``configured()`` -- that
+            # context is thread-local on the client and doesn't propagate
+            # over actor RPC. Set explicitly so submit() picks it up.
+            "MONARCH_RDMA_TCP_FALLBACK_PARALLELISM": str(streams),
+            # Worker-side hyperactor config. The client-side
+            # ``configure(message_ack_time_interval="10ms")`` above is
+            # thread-local on the client and does NOT propagate to the
+            # worker procs. Workers default to 500 ms ack batching, which
+            # adds ~1-2 s of dead time to small RPCs like the
+            # ``mark_blocks_available`` broadcast the mount issues after
+            # each on-demand push.
+            "HYPERACTOR_MESSAGE_ACK_TIME_INTERVAL": "10ms",
+        },
+    )
+
+    # Mount the local workspace (``.venv/`` with monarch + torch + torchtitan)
+    # at the SAME path on every worker. The v2 mechanism ships the full tree
+    # immediately, prefills small "code" files, and streams big .so's on demand.
+    #
+    # ``python_exe`` is forwarded to the mount layer, but it ALSO sets
+    # ``_default_python_exe`` -- which we immediately reset to None. The
+    # mount-serving FUSEActor mesh is spawned BEFORE the mount exists, so its
+    # interpreter must be the bootstrap-fbpkg python (baked into the worker,
+    # carries monarch). If proc meshes booted from the mounted ``.venv`` python
+    # instead, the FUSEActor spawn would ENOENT (the venv isn't mounted yet) and
+    # mount-open would time out. Workers boot on the bootstrap python; PYTHONPATH
+    # (above) makes torch + torchtitan importable from the mount.
+    chunk_size = int(os.environ.get("TITAN_CHUNK_SIZE_MB", "256")) * 1024 * 1024
+    job.remote_mount(
+        workspace,
+        mntpoint=workspace,
+        python_exe=".venv/bin/python3.12",
+        backend="mast",
+        chunk_size=chunk_size,
+        num_parallel_streams=streams,
+    )
+    # Pass python_exe (above) for the mount layer, but do NOT let it become the
+    # proc-bootstrap interpreter -- see the comment above. Workers boot on the
+    # bootstrap-fbpkg python; torch/torchtitan come from the mount via PYTHONPATH.
+    job._default_python_exe = None
+
+    # The workspace's ``torchtitan/`` is a symlink to your local checkout
+    # (resolved above into ``torchtitan_source``). The FUSE mount serves the
+    # symlink as-is, but its target lives outside the workspace -- mount the
+    # target separately at the same path so the symlink resolves on workers,
+    # and so ``torchtitan_source`` on PYTHONPATH is reachable.
+    if torchtitan_source != torchtitan_link:
+        job.remote_mount(
+            torchtitan_source,
+            mntpoint=torchtitan_source,
+            python_exe=None,
+            backend="mast",
+            chunk_size=chunk_size,
+            num_parallel_streams=streams,
+        )
+
+    # Mount the example dir itself so ``train.py`` is reachable on workers
+    # at the same absolute path it has on the client. Without this,
+    # ``monarch exec -- python /path/to/train.py`` would fail with
+    # ``No such file`` on the worker.
+    example_dir = os.path.dirname(os.path.abspath(__file__))
+    job.remote_mount(
+        example_dir,
+        mntpoint=example_dir,
+        python_exe=None,
+        backend="mast",
+        chunk_size=chunk_size,
+        num_parallel_streams=streams,
+    )
+
+    # Optional FineWeb-Edu sample-10BT shards (~25 GB) as a separate mount.
+    # torchtitan reads this via the ``fineweb_edu_10BT`` entry in
+    # ``torchtitan/hf_datasets/text_datasets.py:DATASETS``. The shards are big
+    # (>= 1 block), so the v2 mechanism leaves them out of the code prefill and
+    # streams each in on demand the first time a worker reads it.
+    fineweb_dir = os.path.expanduser(
+        os.environ.get("TITAN_FINEWEB_DIR", "~/dev/llm_data/fineweb_edu_10BT")
+    )
+    fineweb_dir = os.path.abspath(fineweb_dir)
+    if os.path.isdir(fineweb_dir):
+        job.remote_mount(
+            fineweb_dir,
+            mntpoint=fineweb_dir,
+            python_exe=None,
+            backend="mast",
+            chunk_size=chunk_size,
+            num_parallel_streams=streams,
+        )
+
+    # Gather mount: per-worker writable log directory exposed back on the
+    # client as ``hosts_N/`` subdirs. Workers write to /tmp/torchtitan_logs;
+    # client sees the gathered view under ~/torchtitan_logs/. Kept outside
+    # any remote_mount source path to avoid FUSE-in-FUSE nesting.
+    log_local = os.path.expanduser(os.environ.get("TITAN_LOG_DIR", "~/torchtitan_logs"))
+    job.gather_mount(
+        remote_mount_point="/tmp/torchtitan_logs",
+        local_mount_point=os.path.abspath(log_local),
+    )
+    return job
+
+
+job = _make_job()

--- a/examples/torchtitan_mast/pyproject.toml
+++ b/examples/torchtitan_mast/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "torchtitan-mast"
+version = "0.0.1"
+description = "MAST + monarch torchtitan example (H100 x86, SimpleMAST, OSS-built monarch)."
+requires-python = ">=3.12"
+
+[tool.setuptools]
+py-modules = ["job", "train", "train_with_actors"]
+packages = ["simple_mast_job"]
+
+# Default workspace path used by job.py. Produced by setup_env.sh at this
+# location, so the default works without per-user editing. The TITAN_WORKSPACE
+# env var overrides per-call.
+[tool.torchtitan_mast.paths]
+workspace = "~/dev/titan_workspace"

--- a/examples/torchtitan_mast/setup_env.sh
+++ b/examples/torchtitan_mast/setup_env.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# Build the monarch client venv, the torchtitan workspace .venv, and the
+# monarch wheel, then pip-install this example dir editable into the client
+# venv. The slim worker (bootstrap) fbpkg is built on demand by
+# simple_mast_job.build_bootstrap, which reuses the wheel this script caches
+# in /tmp/monarch_bootstrap_$USER/wheel.
+# H100 x86, OSS tools only (uv + pip + maturin/setuptools-rust; no buck).
+# --force wipes and rebuilds.
+
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MONARCH_SRC="$(cd "$HERE/../.." && pwd)"
+PLATFORM="${PLATFORM:-/usr/local/fbcode/platform010}"
+PYTHON="$PLATFORM/bin/python3.12"
+
+ROOT="${ROOT:-$HOME/monarch_bench_envs}"
+CLIENT="$ROOT/client"
+WHEEL_DIR="${WHEEL_DIR:-/tmp/torchtitan_mast_monarch_wheel.$$}"
+# build_bootstrap reuses a wheel from this cache dir (skips its own build).
+BOOTSTRAP_WHEEL_DIR="/tmp/monarch_bootstrap_${USER}/wheel"
+WORKSPACE="${TITAN_WORKSPACE:-$HOME/dev/titan_workspace}"
+TORCHTITAN="${TITAN_TORCHTITAN:-$HOME/dev/torchtitan}"
+TORCH_SPEC="${TITAN_TORCH_SPEC:-torch}"
+TORCH_INDEX="${TITAN_TORCH_INDEX:-https://download.pytorch.org/whl/cu128}"
+HF_ASSETS="${TITAN_HF_ASSETS:-Qwen/Qwen3-1.7B}"
+
+[[ "${1:-}" =~ ^(-f|--force)$ ]] && { rm -rf "$CLIENT" "$WORKSPACE/.venv" "$WHEEL_DIR"; }
+[ -x "$PYTHON" ]                 || { echo "ERROR: $PYTHON not found" >&2; exit 1; }
+command -v uv >/dev/null         || { echo "ERROR: uv not on PATH" >&2; exit 1; }
+[ -f "$MONARCH_SRC/setup.py" ]   || { echo "ERROR: no setup.py at $MONARCH_SRC" >&2; exit 1; }
+[ -d "$TORCHTITAN" ]             || { echo "ERROR: TITAN_TORCHTITAN=$TORCHTITAN missing" >&2; exit 1; }
+mkdir -p "$CLIENT" "$WHEEL_DIR" "$WORKSPACE" "$BOOTSTRAP_WHEEL_DIR"
+
+# [1] Build the monarch wheel from $MONARCH_SRC (USE_TENSOR_ENGINE=0 -> slim,
+# no torch/nccl; the `rdma` cargo feature is on by default in setup.py so
+# monarch.rdma is still registered).
+"$PYTHON" -m venv --clear "$CLIENT"
+"$CLIENT/bin/python3.12" -m pip install --upgrade --disable-pip-version-check \
+    libclang numpy "setuptools>=64" setuptools-rust wheel
+( cd "$MONARCH_SRC" && \
+    USE_TENSOR_ENGINE=0 \
+    LIBCLANG_PATH="$CLIENT/lib/python3.12/site-packages/clang/native" \
+    BINDGEN_EXTRA_CLANG_ARGS="-I/usr/lib/gcc/x86_64-redhat-linux/11/include" \
+    uv build --wheel --no-build-isolation \
+        --python "$CLIENT/bin/python3.12" --out-dir "$WHEEL_DIR" )
+# Cache the freshly-built wheel where simple_mast_job.build_bootstrap looks
+# first, so `monarch apply` reuses it instead of rebuilding the slim wheel.
+rm -f "$BOOTSTRAP_WHEEL_DIR"/*.whl
+cp -f "$WHEEL_DIR"/*.whl "$BOOTSTRAP_WHEEL_DIR/"
+
+# [2] Client venv
+"$CLIENT/bin/python3.12" -m pip install "$WHEEL_DIR"/*.whl fire
+cp -f "$PLATFORM/lib/libomp.so" "$CLIENT/lib/"
+
+# [3] Workspace: uv .venv with monarch + torch + (editable) torchtitan +
+# extras, plus a symlink to your local torchtitan checkout. monarch is
+# installed here too (from the same wheel as the client venv and the
+# bootstrap fbpkg) so workers use this venv's python end-to-end -- no
+# PYTHONPATH bridging between a slim worker python and the mounted workspace
+# site-packages.
+[ -e "$WORKSPACE/torchtitan" ] || ln -s "$TORCHTITAN" "$WORKSPACE/torchtitan"
+[ -d "$WORKSPACE/.venv" ] || uv venv --python "$PYTHON" "$WORKSPACE/.venv"
+VENV_PY="$WORKSPACE/.venv/bin/python3.12"
+VIRTUAL_ENV="$WORKSPACE/.venv" uv pip install --upgrade --python "$VENV_PY" \
+    --index "$TORCH_INDEX" "$TORCH_SPEC"
+VIRTUAL_ENV="$WORKSPACE/.venv" uv pip install --python "$VENV_PY" \
+    "$WHEEL_DIR"/*.whl -e "$WORKSPACE/torchtitan" psutil tqdm tomli
+# HF tokenizer/config download (Xet CAS endpoint isn't reachable from Meta devvms).
+IFS=',' read -r -a _hf <<< "$HF_ASSETS"
+for _r in "${_hf[@]}"; do
+    [ -f "$TORCHTITAN/assets/hf/${_r##*/}/tokenizer.json" ] && continue
+    HF_HUB_DISABLE_XET="${HF_HUB_DISABLE_XET:-1}" VIRTUAL_ENV="$WORKSPACE/.venv" \
+        "$VENV_PY" "$TORCHTITAN/scripts/download_hf_assets.py" \
+        --repo_id "$_r" --assets tokenizer config --local_dir "$TORCHTITAN/assets/hf/"
+done
+
+# [4] Editable install of this dir into the client venv.
+"$CLIENT/bin/python3.12" -m pip install --disable-pip-version-check -e "$HERE"
+
+# [5] Sidecar transport shim (client venv only). The per-job mount sidecar is
+# spawned as a bare `python -m monarch._src.job._job_sidecar_worker`, so it never
+# calls enable_transport() and defaults to the Unix transport -- which a remote
+# MAST worker host cannot dial back, so the sidecar's FUSEActor proc-spawn times
+# out (GetRankStatus) and the mounts never open. A sitecustomize.py in the client
+# venv makes every client-venv interpreter (the sidecar included) enable
+# metatls-hostname at startup; enable_transport() with the same transport is a
+# no-op, so the apply/exec processes that also set it are unaffected. (The proper
+# fix belongs in monarch core; this keeps the example runnable on an unfixed monarch.)
+cat > "$CLIENT/lib/python3.12/site-packages/sitecustomize.py" <<'PYEOF'
+# Generated by torchtitan_mast/setup_env.sh -- enable metatls so the mount
+# sidecar (a bare `python -m ...`) does not fall back to the un-dialable Unix
+# transport. enable_transport() with the same transport is a no-op.
+try:
+    from monarch.actor import enable_transport
+
+    enable_transport("metatls-hostname")
+except Exception:
+    pass
+PYEOF
+
+echo
+echo "=== Done ==="
+PATHW=0
+for p in "$WHEEL_DIR" "$CLIENT" "$WORKSPACE" "$BOOTSTRAP_WHEEL_DIR"; do (( ${#p} > PATHW )) && PATHW=${#p}; done
+for entry in "Monarch wheel:|$WHEEL_DIR" "Client venv:|$CLIENT" "Workspace:|$WORKSPACE" "Bootstrap wheel:|$BOOTSTRAP_WHEEL_DIR"; do
+    printf '  %-16s %-*s  (%s)\n' "${entry%%|*}" "$PATHW" "${entry#*|}" \
+        "$(du -sh "${entry#*|}" 2>/dev/null | cut -f1)"
+done
+command -v monarch >/dev/null && [[ "$(command -v monarch)" == "$CLIENT/bin/monarch" ]] || \
+    echo "  PATH: export PATH=\"$CLIENT/bin:\$PATH\""

--- a/examples/torchtitan_mast/simple_mast_job/__init__.py
+++ b/examples/torchtitan_mast/simple_mast_job/__init__.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""SimpleMastJob: a minimal MAST-backed JobTrait built around the ``mast`` CLI.
+
+Vendored here so the torchtitan_mast example is self-contained. ``job.py``
+imports ``SimpleMastJob`` from this package. It builds (or reuses) a slim
+monarch bootstrap fbpkg via ``build_bootstrap``, schedules ``hosts`` h100
+workers via ``launch_mast``, caches the resolved hostnames at apply time
+(reused on later ``state()`` calls -- goes stale on MAST preemption, see the
+note in ``_state``), and connects via ``attach_to_workers`` over MetaTLS.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import tempfile
+import time
+from typing import Optional
+
+import monarch.actor
+from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
+from monarch._src.actor.bootstrap import attach_to_workers
+from monarch._src.job.job import JobState, JobTrait
+from monarch.config import configure
+from simple_mast_job.build_bootstrap import build_bootstrap, launch_mast
+
+_WORKER_PORT = 26600
+_PENDING_STATES = {"PENDING", "STARTING", "ALLOCATED", "QUEUED"}
+_RUNNING_STATE = "RUNNING"
+_POLL_INTERVAL_SECS = 5
+
+# The per-job mount sidecar is spawned as a bare ``python -m ...`` and never
+# calls enable_transport(), so it would default to the un-dialable Unix
+# transport. Enable metatls-hostname at import so every interpreter that
+# imports this module agrees on the transport. (enable_transport with the
+# same transport is a no-op.)
+monarch.actor.enable_transport("metatls-hostname")
+
+
+def _task_sort_key(task_id: str) -> tuple[int, str]:
+    match = re.search(r"(\d+)$", task_id)
+    if match is None:
+        return (0, task_id)
+    return (int(match.group(1)), task_id)
+
+
+class SimpleMastJob(JobTrait):
+    """A small example-local MAST backend built around ``mast`` CLI calls."""
+
+    def __init__(
+        self,
+        *,
+        hosts: int = 1,
+        env: Optional[dict[str, str]] = None,
+    ) -> None:
+        super().__init__()
+        self._num_hosts = hosts
+        self._env = dict(env or {})
+        self._mast_job_name: Optional[str] = None
+        self._package_version: Optional[str] = None
+        # Resolved once at apply time and reused (pickled into
+        # ``.monarch/job_state.pkl``) so later ``monarch exec`` invocations skip
+        # the ~520ms ``mast get-status`` roundtrip. Goes stale on MAST
+        # preemption -- see the note in ``_state``.
+        self._hostnames: Optional[list[str]] = None
+
+    @property
+    def mast_job_name(self) -> Optional[str]:
+        return self._mast_job_name
+
+    @staticmethod
+    def from_job_name(mast_job_name: str) -> SimpleMastJob:
+        raise NotImplementedError("attach-to-running-job is not supported")
+
+    def _get_status(self) -> dict:
+        assert self._mast_job_name is not None, "Job has not been created yet"
+        cmd = ["mast", "get-status", "--output", "json", self._mast_job_name]
+        last_exc: Exception | None = None
+        for _ in range(5):
+            try:
+                output = subprocess.check_output(cmd, text=True)
+                return json.loads(output)["data"]
+            except (
+                subprocess.CalledProcessError,
+                json.JSONDecodeError,
+                KeyError,
+            ) as exc:
+                # ``mast get-status`` occasionally exits non-zero or returns a
+                # payload missing the ``data`` envelope mid-poll; retry rather
+                # than abort -- the next poll almost always returns clean.
+                last_exc = exc
+                time.sleep(2)
+        raise RuntimeError(f"mast get-status failed 5x: {last_exc!r}")
+
+    def _ready_hostnames_from_status(self, status: dict) -> list[str] | None:
+        hostnames = []
+        latest = status.get("latestAttempt", {})
+        tg_attempts = latest.get("taskGroupExecutionAttempts", {})
+        if not tg_attempts:
+            return None
+        for tg_list in tg_attempts.values():
+            for tg in tg_list:
+                expected = tg.get("numTasks", 0)
+                task_map = tg.get("taskExecutionAttempts", {})
+                if len(task_map) < expected:
+                    return None
+                for task_id in sorted(task_map, key=_task_sort_key):
+                    task_attempts = task_map[task_id]
+                    if not task_attempts:
+                        return None
+                    attempt = task_attempts[-1]
+                    if attempt.get("state") != _RUNNING_STATE:
+                        return None
+                    hostname = attempt.get("hostname")
+                    if not hostname:
+                        return None
+                    hostnames.append(hostname)
+        return hostnames if hostnames else None
+
+    def _fetch_failure_logs(self, status: dict) -> str:
+        log_dir = tempfile.mkdtemp(prefix=f"monarch_failure_{self._mast_job_name}_")
+        latest = status.get("latestAttempt", {})
+        tg_attempts = latest.get("taskGroupExecutionAttempts", {})
+        for tg_list in tg_attempts.values():
+            for tg in tg_list:
+                tw_handle = tg.get("twJobHandle", "")
+                if not tw_handle:
+                    continue
+                num_tasks = tg.get("numTasks", 1)
+                for task_id in range(num_tasks):
+                    task_handle = f"{tw_handle}/{task_id}"
+                    log_path = f"{log_dir}/task_{task_id}_dedicated_log_monarch.log"
+                    try:
+                        with open(log_path, "w") as log_file:
+                            subprocess.run(
+                                [
+                                    "tw",
+                                    "log",
+                                    task_handle,
+                                    "--file",
+                                    "dedicated_log_monarch.log",
+                                ],
+                                stdout=log_file,
+                                stderr=subprocess.STDOUT,
+                                timeout=60,
+                            )
+                    except Exception as exc:
+                        with open(log_path, "w") as log_file:
+                            log_file.write(f"Failed to fetch logs: {exc}\n")
+        return log_dir
+
+    def _create(self, client_script: Optional[str]) -> None:
+        if client_script is not None:
+            raise RuntimeError("SimpleMastJob cannot run batch-mode scripts")
+        if self._mast_job_name is not None:
+            return
+        identifier = build_bootstrap()
+        package_name, self._package_version = identifier.split(":", 1)
+        self._mast_job_name = launch_mast(
+            package_name=package_name,
+            package_version=self._package_version,
+            hosts=self._num_hosts,
+            env=self._env,
+        )
+        # Block until every task is RUNNING and capture hostnames once.
+        self._hostnames = self._wait_for_hostnames()
+
+    def can_run(self, spec: JobTrait) -> bool:
+        if not isinstance(spec, SimpleMastJob):
+            return False
+        return spec._num_hosts == self._num_hosts and spec._env == self._env
+
+    def _state(self) -> JobState:
+        configure(default_transport=ChannelTransport.MetaTlsWithHostname)
+
+        # Hostnames are cached at apply time and pickled into
+        # ``.monarch/job_state.pkl``; later ``monarch exec`` invocations reuse
+        # them and skip the ~520ms ``mast get-status`` subprocess.
+        #
+        # TRADEOFF: if MAST preempts and re-places the job's tasks, the cached
+        # hostnames go stale and the next endpoint call surfaces a connect / TLS
+        # timeout rather than a clean "preempted" error. We accept this because
+        # per-call ``mast get-status`` cost ~1s of every exec; an upcoming
+        # supervision-channel liveness signal restores clean preempt-detection
+        # for free. ``getattr`` lets old pickles re-resolve on first call.
+        hostnames = getattr(self, "_hostnames", None)
+        if hostnames is None:
+            hostnames = self._wait_for_hostnames()
+            self._hostnames = hostnames
+
+        workers = [
+            f"metatls://{hostname}.facebook.com:{_WORKER_PORT}"
+            for hostname in hostnames
+        ]
+        print(f"Connecting to workers: {workers}")
+        return JobState(
+            {
+                "workers": attach_to_workers(
+                    name="workers",
+                    ca="trust_all_connections",
+                    workers=workers,
+                )
+            }
+        )
+
+    def _wait_for_hostnames(self) -> list[str]:
+        """Poll ``mast get-status`` until all tasks are RUNNING, then return
+        their current hostnames."""
+        while True:
+            status = self._get_status()
+            state = status.get("state", "UNKNOWN")
+            if state not in _PENDING_STATES and state != _RUNNING_STATE:
+                log_dir = self._fetch_failure_logs(status)
+                print(f"Failure logs saved to: {log_dir}")
+                raise RuntimeError(
+                    f"MAST job {self._mast_job_name} entered terminal state: {state}. "
+                    f"Logs saved to: {log_dir}"
+                )
+            hostnames = self._ready_hostnames_from_status(status)
+            if hostnames is not None:
+                return hostnames
+            print(
+                f"Job {self._mast_job_name} is {state}, "
+                "waiting for all tasks to be RUNNING..."
+            )
+            time.sleep(_POLL_INTERVAL_SECS)
+
+    def _kill(self) -> None:
+        if self._mast_job_name is not None:
+            subprocess.check_call(
+                [
+                    "mast",
+                    "kill",
+                    "--comment",
+                    "killed by SimpleMastJob",
+                    self._mast_job_name,
+                ]
+            )

--- a/examples/torchtitan_mast/simple_mast_job/build_bootstrap.py
+++ b/examples/torchtitan_mast/simple_mast_job/build_bootstrap.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Build a slim monarch bootstrap fbpkg and launch the h100 MAST job.
+
+H100 x86 only. ``build_bootstrap`` packages the slim wheel that
+``setup_env.sh`` cached in ``/tmp/monarch_bootstrap_$USER/wheel`` into a
+monarch-only venv and uploads it as an ephemeral fbpkg (cached, keyed by the
+wheel). ``launch_mast`` schedules the torchtitan h100 jobspec; the worker boots
+as ``run_worker_loop_forever`` from that fbpkg.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+from subprocess import check_output
+from typing import Optional
+
+_WORKER_PORT = 26600
+_DEFAULT_CACHE_DIR = Path(f"/tmp/monarch_bootstrap_{os.environ['USER']}")
+# Python used to create the worker venv on the devvm (platform010 is present on
+# every host we target; the wheel installed into it is python3.12).
+_PYTHON = "/usr/local/fbcode/platform010/bin/python3.12"
+
+DEFAULT_WORKER_FBPKG_NAME = "monarch_additional_packages"
+
+_DEFAULT_NETWORK_AFFINITY = {"preferredScope": 3, "fallbackScope": 3}
+_DEFAULT_X86_LOCALITY_CONSTRAINTS = ("region", "pci")
+
+# h100 x86 host shape (whole 8-GPU host) for resourceLimit/machineConstraints.
+_H100_RAM_MB = (2048 - 145) * 1024
+_H100_CPU = 112
+_H100_GPU = 8
+_H100_SERVER_SUBTYPE = 200007
+
+# Boot the worker loop. Kept in the ``-X faulthandler -c <code>`` form so a
+# hung worker dumps tracebacks on SIGABRT.
+_BOOTSTRAP_CODE = (
+    "import socket; "
+    "from monarch.actor import run_worker_loop_forever; "
+    f'run_worker_loop_forever(address=f"metatls://{{socket.getfqdn()}}:{_WORKER_PORT}", '
+    'ca="trust_all_connections")'
+)
+
+
+def run(cmd: list[str], **kwargs: object) -> subprocess.CompletedProcess[bytes]:
+    print(f"+ {' '.join(str(c) for c in cmd)}")
+    return subprocess.run(cmd, check=True, **kwargs)  # pyre-ignore[6]
+
+
+def find_wheel(wheel_dir: Path) -> Path | None:
+    wheels = list(wheel_dir.glob("*.whl"))
+    return wheels[0] if wheels else None
+
+
+def _cache_path(wheel: Path, package_name: str, cache_dir: Path) -> Path:
+    """Identifier cache keyed by the wheel's identity so a fresh wheel rebuilds."""
+    stat = wheel.stat()
+    cache_key = hashlib.sha256(
+        json.dumps(
+            {
+                "wheel": wheel.name,
+                "wheel_mtime_ns": stat.st_mtime_ns,
+                "package_name": package_name,
+            },
+            sort_keys=True,
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    return cache_dir / f"{package_name}_{cache_key}.txt"
+
+
+def create_fbpkg(name: str, directory: str, expire: str) -> str:
+    """Upload directory contents as an ephemeral fbpkg. Returns 'name:version'."""
+    config_dir = tempfile.mkdtemp()
+    try:
+        materialized_dir = os.path.join(config_dir, "materialized_configs")
+        os.makedirs(materialized_dir)
+        json_path = os.path.join(materialized_dir, f"{name}.fbpkg.materialized_JSON")
+
+        package_json = {
+            "paths": sorted(os.listdir(directory)),
+            "build_command": "",
+        }
+        with open(json_path, "w") as f:
+            json.dump(package_json, f)
+
+        output = check_output(
+            [
+                "fbpkg",
+                "build",
+                "--yes",
+                "--ephemeral",
+                "--configerator-path",
+                config_dir,
+                name,
+                "--expire",
+                expire,
+            ],
+            cwd=directory,
+        ).decode("utf-8")
+    finally:
+        subprocess.run(["rm", "-rf", config_dir], check=False)
+
+    print(output)
+    lines = [line for line in output.splitlines() if line.strip()]
+    return lines[-1].strip()
+
+
+def build_bootstrap(
+    package_name: str = DEFAULT_WORKER_FBPKG_NAME,
+    cache_dir: Path = _DEFAULT_CACHE_DIR,
+    expire: str = "4w",
+    rebuild: bool = False,
+) -> str:
+    """Package the slim wheel ``setup_env.sh`` cached into an ephemeral fbpkg.
+
+    Returns the fbpkg identifier, cached (keyed by the wheel) so repeat applies
+    skip the venv build + upload. Set ``MONARCH_MAST_WORKER_FBPKG_ID`` to reuse
+    a prebuilt fbpkg, or ``MONARCH_REBUILD=1`` to force a re-upload.
+    """
+    override_identifier = os.environ.get("MONARCH_MAST_WORKER_FBPKG_ID")
+    if override_identifier:
+        return override_identifier
+
+    if not rebuild:
+        rebuild = os.environ.get("MONARCH_REBUILD", "0") == "1"
+
+    wheel_dir = cache_dir / "wheel"
+    venv_dir = cache_dir / "venv"
+    wheel_dir.mkdir(parents=True, exist_ok=True)
+
+    if rebuild:
+        print("=== MONARCH_REBUILD set -- clearing cached fbpkg identifier ===")
+        for f in cache_dir.glob(f"{package_name}_*.txt"):
+            f.unlink()
+
+    # The wheel is built + cached by setup_env.sh; we only package it.
+    wheel = find_wheel(wheel_dir)
+    if wheel is None:
+        raise RuntimeError(
+            f"no monarch wheel in {wheel_dir}; run setup_env.sh first (it builds "
+            "the slim wheel and caches it here)"
+        )
+    print(f"=== Using wheel: {wheel} ===")
+
+    package_file = _cache_path(wheel, package_name, cache_dir)
+    if package_file.exists():
+        identifier = package_file.read_text().strip()
+        if identifier:
+            print(f"=== Using cached fbpkg identifier: {identifier} ===")
+            return identifier
+
+    print("\n=== Creating venv ===")
+    if venv_dir.exists():
+        shutil.rmtree(venv_dir)
+    venv_python = venv_dir / "bin" / "python3.12"
+    run([_PYTHON, "-m", "venv", str(venv_dir)])
+
+    print("\n=== Installing wheel into venv ===")
+    run([str(venv_python), "-m", "pip", "install", str(wheel)])
+
+    print("\n=== Uploading venv as fbpkg ===")
+    identifier = create_fbpkg(package_name, str(venv_dir), expire)
+    package_file.write_text(identifier + "\n")
+    print(f"Done. fbpkg identifier: {identifier}")
+    return identifier
+
+
+def _package_spec(name: str, version: str) -> dict[str, object]:
+    package: dict[str, object] = {
+        "name": name,
+        "fbpkgIdentifier": f"{name}:{version}",
+    }
+    if re.fullmatch(r"[0-9a-fA-F]+", version):
+        package["version"] = {"ephemeralId": version}
+    return package
+
+
+def _parse_locality_constraints(parts: tuple[str, ...]) -> Optional[dict[str, object]]:
+    if not parts:
+        return None
+    kind, *options = parts
+    if kind != "region":
+        raise ValueError(
+            f"Only region locality is supported in this example. Got {kind!r}"
+        )
+    if not options:
+        raise ValueError("Region locality requires at least one option")
+    return {"locality": 1, "options": list(options)}
+
+
+def launch_mast(
+    *,
+    package_name: str,
+    package_version: str,
+    hosts: int,
+    hpc_identity: str = "hyper_monarch",
+    hpc_job_oncall: str = "monarch",
+    rm_attribution: str = "msl_infra_pytorch_dev",
+    hpc_cluster_uuid: str = "MastGenAICluster",
+    env: Optional[dict[str, str]] = None,
+    locality_constraints: tuple[str, ...] = (),
+    job_name_prefix: str = "monarch_remotemount",
+    run: bool = True,
+) -> str:
+    """Launch the torchtitan h100 MAST job using the bootstrap fbpkg (x86 only)."""
+    if not locality_constraints:
+        locality_constraints = _DEFAULT_X86_LOCALITY_CONSTRAINTS
+
+    name = f"{job_name_prefix}_{time.time_ns()}"
+    package = _package_spec(package_name, package_version)
+    package_root = f"/packages/{package_name}"
+
+    jobspec = {
+        "name": name,
+        "hpcClusterUuid": hpc_cluster_uuid,
+        "hpcTaskGroups": [
+            {
+                "name": "workers",
+                "taskCount": hosts,
+                "taskCountPerHost": 1,
+                "hardwareSpecificTaskGroupOverride": {},
+                "spec": {
+                    "command": f"{package_root}/bin/python3.12",
+                    "arguments": [
+                        "-X",
+                        "faulthandler",
+                        "-c",
+                        _BOOTSTRAP_CODE,
+                    ],
+                    "applicationPackages": [package],
+                    "packages": [],
+                    "env": {
+                        "CONDA_DIR": package_root,
+                        # No LD_LIBRARY_PATH: the slim worker has nothing under
+                        # /packages/<pkg>/lib that needs it, and setting it is
+                        # what historically let fat-worker fbpkgs clobber the
+                        # workspace .venv's CUDA.
+                        "PATH": (
+                            f"{package_root}/bin:"
+                            "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+                        ),
+                        "PYTHONDONTWRITEBYTECODE": "1",
+                        "PYTHONNOUSERSITE": "1",
+                        **(env or {}),
+                    },
+                    "resourceLimit": {
+                        "ramMB": _H100_RAM_MB,
+                        "compute": {"cpu": _H100_CPU, "gpu": _H100_GPU},
+                        "enableSwapAndSenpai": False,
+                        "limitType": 1,
+                        "wholeHost": True,
+                        "enableZSwap": True,
+                        "migType": 0,
+                    },
+                    "machineConstraints": {
+                        "types": {"serverSubTypes": [_H100_SERVER_SUBTYPE]}
+                    },
+                    "networkAffinity": dict(_DEFAULT_NETWORK_AFFINITY),
+                    "oncallShortname": hpc_job_oncall,
+                    "ports": {"mesh": _WORKER_PORT},
+                    "bindMounts": [],
+                    "runningTimeoutSec": 2592000,
+                    "unixUser": "root",
+                    "restartPolicy": {
+                        "scope": 0,
+                        "maxTotalFailures": 0,
+                        "failoverOnHostFailures": False,
+                        "failJobOnFinalFailure": True,
+                    },
+                    "ttlsConfig": {"enable": False},
+                    "opecTag": 0,
+                },
+            }
+        ],
+        "networkAffinity": dict(_DEFAULT_NETWORK_AFFINITY),
+        "applicationMetadata": {
+            "model_type_name": "gen_ai_default",
+            "rm_attribution": rm_attribution,
+        },
+        "identity": {"name": hpc_identity},
+        "owner": {
+            "oncallShortname": hpc_job_oncall,
+            "unixname": os.environ["USER"],
+        },
+        "enableGracefulPreemption": False,
+        "maxJobFailures": 0,
+        "jobType": 0,
+        "aiTrainingMetadata": {
+            "jobType": 0,
+            "modelTypeName": "gen_ai_default",
+            "entitlement": rm_attribution,
+            "productGroup": "gen_ai",
+            "mastJobID": name,
+            "model_lifecycle_status": {},
+        },
+    }
+
+    locality = _parse_locality_constraints(locality_constraints)
+    if locality is not None:
+        jobspec["localityConstraints"] = locality
+
+    with tempfile.NamedTemporaryFile(
+        delete=False, mode="w", suffix=".json"
+    ) as spec_file:
+        json.dump(jobspec, spec_file)
+        spec_path = spec_file.name
+        print(f"Job spec written to: {spec_path}")
+
+    try:
+        if run:
+            subprocess.check_call(["mast", "schedule", spec_path])
+    finally:
+        subprocess.run(["rm", "-f", spec_path], check=False)
+
+    # Honor MONARCH_MAST_JOB_PRIORITY (e.g. ``high``, ``very_high``) by raising
+    # the freshly-scheduled job's priority -- the on-demand mount is sensitive
+    # to mid-apply preemption, and a higher priority avoids the reschedule.
+    priority = os.environ.get("MONARCH_MAST_JOB_PRIORITY")
+    if run and priority:
+        subprocess.check_call(
+            ["mast", "update-job-priority", name, "--priority", priority.lower()]
+        )
+
+    return name
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--expire", default="4w", help="fbpkg expiry (default: 4w)")
+    parser.add_argument(
+        "--rebuild",
+        action="store_true",
+        default=os.environ.get("MONARCH_REBUILD", "0") == "1",
+        help="Re-upload the fbpkg even if cached (also set by MONARCH_REBUILD=1)",
+    )
+    parser.add_argument(
+        "--launch", action="store_true", help="Launch a MAST job after building"
+    )
+    parser.add_argument(
+        "--hosts", type=int, default=1, help="Number of hosts (default: 1)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print job spec without submitting"
+    )
+    args = parser.parse_args()
+
+    identifier = build_bootstrap(expire=args.expire, rebuild=args.rebuild)
+    print(f"Done. fbpkg identifier: {identifier}")
+
+    if args.launch or args.dry_run:
+        package_name, package_version = identifier.split(":", 1)
+        job_name = launch_mast(
+            package_name=package_name,
+            package_version=package_version,
+            hosts=args.hosts,
+            run=not args.dry_run,
+        )
+        if args.dry_run:
+            print(f"\nDry run -- job name would be: {job_name}")
+        else:
+            print(f"\nScheduled MAST job: {job_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/torchtitan_mast/train.py
+++ b/examples/torchtitan_mast/train.py
@@ -1,0 +1,189 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""torchtitan launcher (defaults to llama3_debugmodel; override via env).
+
+Designed to be invoked the *same way* locally and remotely:
+
+    # Local (single GPU smoke test, requires CUDA + the torchtitan venv active)
+    python train.py
+
+    # Remote on a live MAST job (4 hosts x 8 GPUs)
+    monarch exec --all --per-host gpu=8 \\
+        -e MASTER_ADDR=$(monarch exec --one -- hostname) \\
+        -e MASTER_PORT=29500 \\
+        -- python train.py
+
+Rank / world-size are derived from monarch's ``MONARCH_RANK_<dim>`` /
+``MONARCH_SIZE_<dim>`` env vars when present; otherwise we run as
+rank 0 of a world of 1. MASTER_ADDR / MASTER_PORT are read from env
+unchanged (defaults: ``127.0.0.1`` / ``29500``) -- the remote launcher
+above injects rank 0's hostname for cross-host rdzv.
+
+Env knobs:
+  TITAN_MODEL_MODULE   torchtitan module name (default: ``llama3``).
+  TITAN_MODEL_CONFIG   config function in that module's config_registry
+                       (default: ``llama3_debugmodel``).
+  TITAN_TRAINING_STEPS overrides cfg.training.steps (default: 20).
+  TITAN_DATASET        overrides cfg.dataloader.dataset; set to
+                       ``fineweb_edu_10BT`` to read from locally mounted
+                       parquet shards instead of HF ``c4``.
+  TITAN_LOSS           ``ce`` forces plain CrossEntropyLoss (workaround
+                       for the autograd bug in torch 2.10/2.11 +
+                       llama3_debugmodel + ChunkedCELoss).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def _populate_torch_env() -> tuple[int, int, int]:
+    """Map monarch's per-rank env vars to the ones torch.distributed wants.
+
+    Returns ``(rank, world_size, local_rank)``. When no MONARCH_RANK_*
+    variables are set, behaves as a single-rank standalone run.
+    """
+    h_rank = os.environ.get("MONARCH_RANK_hosts")
+    g_rank = os.environ.get("MONARCH_RANK_gpu")
+    h_size = os.environ.get("MONARCH_SIZE_hosts")
+    g_size = os.environ.get("MONARCH_SIZE_gpu")
+    if any(v is None for v in (h_rank, g_rank, h_size, g_size)):
+        rank, world_size, local_rank = 0, 1, 0
+    else:
+        h_rank, g_rank, h_size, g_size = (
+            int(h_rank),
+            int(g_rank),
+            int(h_size),
+            int(g_size),
+        )
+        rank = h_rank * g_size + g_rank
+        world_size = h_size * g_size
+        local_rank = g_rank
+
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29500")
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world_size)
+    os.environ["LOCAL_RANK"] = str(local_rank)
+    return rank, world_size, local_rank
+
+
+def main() -> None:
+    rank, world_size, local_rank = _populate_torch_env()
+    print(
+        f"train: rank={rank} world_size={world_size} "
+        f"local_rank={local_rank} master={os.environ['MASTER_ADDR']}:"
+        f"{os.environ['MASTER_PORT']}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+    # torchtitan's llama3_debugmodel loads ``./tests/assets/tokenizer`` as a
+    # relative path, so we cd into the torchtitan source tree before building
+    # the Trainer. ``TITAN_TORCHTITAN`` takes precedence -- when the workspace
+    # is delivered via a FUSE mount that drops symlinks (workers don't see
+    # ``<workspace>/torchtitan``), the launcher passes the realpath here
+    # directly.
+    explicit = os.environ.get("TITAN_TORCHTITAN")
+    if explicit:
+        torchtitan_dir = os.path.abspath(os.path.expanduser(explicit))
+    else:
+        workspace = os.path.abspath(
+            os.path.expanduser(
+                os.environ.get("TITAN_WORKSPACE", "~/dev/titan_workspace")
+            )
+        )
+        torchtitan_link = os.path.join(workspace, "torchtitan")
+        torchtitan_dir = (
+            os.path.realpath(torchtitan_link)
+            if os.path.islink(torchtitan_link)
+            else torchtitan_link
+        )
+    os.chdir(torchtitan_dir)
+
+    from torchtitan.config import ConfigManager
+    from torchtitan.tools.logging import init_logger
+    from torchtitan.trainer import Trainer
+
+    init_logger()
+
+    model_module = os.environ.get("TITAN_MODEL_MODULE", "llama3")
+    model_config = os.environ.get("TITAN_MODEL_CONFIG", "llama3_debugmodel")
+    cfg = ConfigManager().parse_args(
+        ["--module", model_module, "--config", model_config]
+    )
+    cfg.training.steps = int(os.environ.get("TITAN_TRAINING_STEPS", "20"))
+    dataset_override = os.environ.get("TITAN_DATASET")
+    if dataset_override:
+        cfg.dataloader.dataset = dataset_override
+    if os.environ.get("TITAN_LOSS") == "ce":
+        # Workaround: ChunkedCELoss trips an autograd bug on torch 2.10/2.11
+        # + llama3_debugmodel. Opt into plain CE only when the caller asks.
+        from torchtitan.components.loss import CrossEntropyLoss
+
+        cfg.loss = CrossEntropyLoss.Config()
+
+    trainer = Trainer(cfg)
+    trainer.train()
+
+    # Optional: greedy-decode a short sample from the just-trained model so we
+    # can see what generations the model produces. Uses the live in-memory
+    # model (no checkpoint round-trip). Enable via TITAN_GENERATE=1.
+    #
+    # Because the model is FSDP-sharded, every ``model(...)`` call triggers an
+    # all-gather collective -- ALL ranks must participate or the gather hangs.
+    # Every rank runs the same greedy loop in lockstep; only rank 0 prints.
+    if os.environ.get("TITAN_GENERATE"):
+        import torch
+
+        prompts = os.environ.get(
+            "TITAN_GEN_PROMPTS", "The quick brown fox|In the beginning"
+        ).split("|")
+        max_new = int(os.environ.get("TITAN_GEN_MAX_NEW", "30"))
+        model = trainer.model_parts[0]
+        tokenizer = trainer.tokenizer
+        device = next(model.parameters()).device
+        model.eval()
+        if rank == 0:
+            sys.stderr.write("\n==== GENERATE ====\n")
+        with torch.no_grad():
+            for prompt in prompts:
+                ids = tokenizer.encode(prompt)
+                input_ids = torch.tensor([ids], dtype=torch.long, device=device)
+                for _ in range(max_new):
+                    logits = model(input_ids)
+                    next_id = int(logits[0, -1].argmax().item())
+                    input_ids = torch.cat(
+                        [
+                            input_ids,
+                            torch.tensor([[next_id]], dtype=torch.long, device=device),
+                        ],
+                        dim=1,
+                    )
+                if rank == 0:
+                    generated = tokenizer.decode(input_ids[0].tolist())
+                    sys.stderr.write(f"prompt:    {prompt!r}\n")
+                    sys.stderr.write(f"generated: {generated!r}\n\n")
+                    sys.stderr.flush()
+        model.train()
+
+    trainer.close()
+
+
+if __name__ == "__main__":
+    main()
+    # Training has completed and ``trainer.close()`` has run, but a plain
+    # interpreter exit can hang here: the FineWeb/HF-datasets streaming
+    # dataloader leaves a non-daemon prefetch thread alive and NCCL keeps its
+    # InfiniBand event threads running, so the process never exits -- it sits
+    # holding the GPUs and the MASTER_PORT, which makes ``monarch exec`` appear
+    # hung and makes the next launch fail with EADDRINUSE. Flush and force-exit
+    # so the process (and all of its threads) is reclaimed by the OS now.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)

--- a/examples/torchtitan_mast/train_with_actors.py
+++ b/examples/torchtitan_mast/train_with_actors.py
@@ -1,0 +1,210 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Client-side driver that runs torchtitan llama3_debugmodel on a live MAST job.
+
+Run AFTER ``monarch apply job.job``.
+
+This script runs on the local machine. It:
+1. Connects to the running MAST allocation via ``load_current_job()``.
+2. Spawns a process mesh with 8 procs per host (one per GPU).
+3. Sets up torch-elastic env vars on each proc so torch.distributed
+   can rendezvous via hyperactor mailbox.
+4. Spawns ``TrainerActor`` across the mesh and calls ``start_training()``.
+
+The actor code itself runs on the workers using the python interpreter from
+the mounted ``.venv``, which has torch + torchtitan installed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from monarch._src.tools.commands import load_current_job
+from monarch.actor import Actor, current_rank, endpoint
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+
+class TrainerActor(Actor):
+    """Wraps a torchtitan ``Trainer`` instance and runs it on a single rank.
+
+    All imports of torch / torchtitan live inside method bodies so that
+    *constructing* this actor on the client side (where torch is not
+    installed) doesn't fail; only ``start_training()`` on the worker
+    needs the heavy deps, and at that point the worker's python_exe is
+    pointed at the mounted venv that has them.
+    """
+
+    def __init__(
+        self,
+        model_config: str,
+        training_steps: int,
+        workspace: str,
+        torchtitan_dir: str,
+    ) -> None:
+        self._model_config = model_config
+        self._training_steps = training_steps
+        self._workspace = workspace
+        self._torchtitan_dir = torchtitan_dir
+        self._trainer: object | None = None
+        rank = current_rank().rank
+        self._uid = f"trainer_{rank}"
+        self._rank = rank
+
+    @endpoint
+    async def start_training(self) -> None:
+        import os
+
+        # ``llama3_debugmodel.hf_assets_path`` is the relative path
+        # ``./tests/assets/tokenizer``, so we cd into the torchtitan
+        # checkout before the trainer runs. torch + torchtitan are
+        # importable here because the mount daemon's job spec puts
+        # the workspace .venv on ``PYTHONPATH``.
+        os.chdir(self._torchtitan_dir)
+
+        from torchtitan.components.loss import CrossEntropyLoss
+        from torchtitan.config import ConfigManager
+        from torchtitan.tools.logging import init_logger, logger as titan_logger
+        from torchtitan.trainer import Trainer
+
+        init_logger()
+
+        cfg_mgr = ConfigManager()
+        job_config = cfg_mgr.parse_args(
+            ["--module", "llama3", "--config", self._model_config]
+        )
+        job_config.training.steps = self._training_steps
+        # ChunkedCELoss for debug-model hits an autograd "tensor data not
+        # allocated" bug on torch 2.10-2.11 + this torchtitan version. Plain
+        # CrossEntropyLoss is sufficient for the smoke-test.
+        job_config.loss = CrossEntropyLoss.Config()
+
+        self._trainer = Trainer(job_config)
+        titan_logger.info(f"{self._uid}: initialized, starting training")
+        self._trainer.train()
+        titan_logger.info(f"{self._uid}: training complete")
+
+    @endpoint
+    async def generate(self, prompt: str, max_new_tokens: int = 32) -> str:
+        """Autoregressive greedy decoding from the trained model.
+
+        All ranks participate in the forward pass (TP/FSDP collectives), but
+        only rank 0 returns the decoded string -- everyone else returns "".
+        For llama3_debugmodel (random init + few training steps + tiny dataset)
+        the output is gibberish by design: the goal is to verify the
+        train -> infer pipeline plumbing, not language quality.
+        """
+        import torch
+        from torchtitan.tools.logging import logger as titan_logger
+
+        if self._trainer is None:
+            return "" if self._rank != 0 else "<no trainer>"
+
+        model = self._trainer.model_parts[0]
+        tokenizer = self._trainer.tokenizer
+
+        model.eval()
+        with torch.no_grad():
+            ids = tokenizer.encode(prompt, add_special_tokens=False)
+            input_ids = torch.tensor([ids], device="cuda")
+            for _ in range(max_new_tokens):
+                logits = model(input_ids)
+                if isinstance(logits, (tuple, list)):
+                    logits = logits[0]
+                next_tok = int(logits[0, -1].argmax().item())
+                input_ids = torch.cat(
+                    [input_ids, torch.tensor([[next_tok]], device="cuda")],
+                    dim=-1,
+                )
+            out_ids = input_ids[0].tolist()
+
+        if self._rank != 0:
+            return ""
+        text = tokenizer.decode(out_ids)
+        titan_logger.info(f"{self._uid}: generated text = {text!r}")
+        return text
+
+    @endpoint
+    async def close(self) -> None:
+        import torch
+
+        if self._trainer is not None:
+            self._trainer.close()
+            self._trainer = None
+        if torch.distributed.is_initialized():
+            torch.distributed.destroy_process_group()
+
+
+async def main() -> None:
+    num_hosts = int(os.environ.get("TITAN_NUM_HOSTS", "4"))
+    gpus_per_host = int(os.environ.get("TITAN_GPUS_PER_HOST", "8"))
+    training_steps = int(os.environ.get("TITAN_TRAINING_STEPS", "20"))
+    model_config = os.environ.get("TITAN_MODEL_CONFIG", "llama3_debugmodel")
+
+    job = load_current_job()
+    state = job.state()
+
+    # SimpleMastJob exposes its mesh as "workers"; confirm and grab it.
+    if "workers" not in state._hosts:
+        raise RuntimeError(f"expected a 'workers' host mesh, got: {list(state._hosts)}")
+    host_mesh = state._hosts["workers"]
+
+    logger.info(
+        "spawning %d procs/host across %d hosts",
+        gpus_per_host,
+        num_hosts,
+    )
+    proc_mesh = host_mesh.spawn_procs(per_host={"gpus": gpus_per_host})
+    await proc_mesh.logging_option(stream_to_client=True)
+
+    from monarch.spmd import setup_torch_elastic_env_async
+
+    await setup_torch_elastic_env_async(proc_mesh)
+
+    workspace = os.path.expanduser(
+        os.environ.get("TITAN_WORKSPACE", "~/dev/titan_workspace")
+    )
+    workspace = os.path.abspath(workspace)
+    torchtitan_link = os.path.join(workspace, "torchtitan")
+    torchtitan_dir = (
+        os.path.realpath(torchtitan_link)
+        if os.path.islink(torchtitan_link)
+        else torchtitan_link
+    )
+    trainer = proc_mesh.spawn(
+        "trainer",
+        TrainerActor,
+        model_config,
+        training_steps,
+        workspace,
+        torchtitan_dir,
+    )
+    await trainer.start_training.call()
+    logger.info("training run complete")
+
+    prompt = os.environ.get("TITAN_GEN_PROMPT", "Once upon a time")
+    max_new = int(os.environ.get("TITAN_GEN_TOKENS", "32"))
+    logger.info("generating: prompt=%r max_new_tokens=%d", prompt, max_new)
+    results = await trainer.generate.call(prompt, max_new)
+    for _rank_key, text in results:
+        if text:
+            print(f"\n=== Generated text ===\n{text}\n======================\n")
+            break
+
+    await trainer.close.call()
+    logger.info("done")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    asyncio.run(main())


### PR DESCRIPTION
Summary:

Adds the `torchtitan_mast` example: run torchtitan on MAST with monarch's `remote_mount` (the trainer's `.venv` + torchtitan checkout mount onto the workers at apply) and `monarch apply` / `monarch exec` -- no fbpkg of torch. `setup_env.sh` builds the venvs from a source `uv build` (no Buck); `SimpleMastJob` (in `simple_mast_job/`) schedules the h100 job from a slim monarch-only bootstrap fbpkg; `train.py` runs the same way locally and via `monarch exec`. `benchmark_table.csv` / `BENCHMARK.md` capture the measured apply / import / train timings.

Sits directly on `remote/fbcode/warm` and lands independently.

Reviewed By: zdevito

Differential Revision: D109068858


