### PR TITLE
python/tests: add endpoint-exception supervision characterization tests (#4283)

### DIFF
--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -278,6 +278,71 @@ def test_actor_init_exception_sync(mesh, actor_class, num_procs) -> None:
     proc.stop().get()
 
 
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_broadcast_exception_with_no_reply_port_kills_actor() -> None:
+    """A plain `Exception` from an endpoint invoked with *no reply port*
+    (fire-and-forget `broadcast()`) fails the actor: the return is dropped, the
+    exception escapes through `DroppingPort.exception`, and the actor is killed,
+    surfacing as a supervision fault at the client. Parametrized over both
+    dispatch modes because the kill reaches `Signal::Kill` by different paths
+    (direct: the endpoint task resolves `Err`; queue: `_dispatch_loop` calls
+    `self_instance.kill`). The existing broadcast-failure coverage uses a
+    `BaseException`; this pins the plain-`Exception` path."""
+    faults = []
+    faulted = asyncio.Event()
+
+    def fault_hook(failure):
+        faults.append(failure)
+        faulted.set()
+
+    monarch.actor.unhandled_fault_hook = fault_hook
+    proc = spawn_procs_on_this_host({"gpus": 1})
+    actor = proc.spawn("exception_actor", ExceptionActor)
+
+    actor.raise_exception.broadcast()  # no reply port => the actor dies
+    await asyncio.wait_for(faulted.wait(), timeout=15.0)
+
+    assert len(faults) >= 1
+    fault_str = str(faults[0])
+    assert "exception_actor" in fault_str
+    assert "This is a test exception" in fault_str
+
+    await proc.stop()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_reply_port_exception_returns_to_caller_and_actor_survives() -> None:
+    """The reply-port half of the contract, and the only cell where the actor
+    lives: an endpoint `Exception` called *with* a reply port comes back to the
+    caller as `ActorError`, the actor stays alive (a follow-up call succeeds),
+    and no supervision fires (a surviving actor is not a failure). The suite
+    already asserts the `ActorError`; the survival and the supervision-silence
+    are what this adds."""
+    faults = []
+    monarch.actor.unhandled_fault_hook = lambda failure: faults.append(failure)
+    proc = spawn_procs_on_this_host({"gpus": 1})
+    actor = proc.spawn("exception_actor", ExceptionActor)
+
+    with pytest.raises(ActorError, match="This is a test exception"):
+        await actor.raise_exception.call_one()
+
+    # the actor survived: a subsequent call still works
+    await actor.noop.call_one()
+
+    # supervision faults reach the hook asynchronously; drain so a late delivery
+    # can't slip past the empty-check below.
+    await asyncio.sleep(0.5)
+
+    # and no supervision fired for the handled exception
+    assert faults == [], f"expected no supervision faults, got {faults}"
+
+    await proc.stop()
+
+
 @parametrize_config(actor_queue_dispatch={True, False})
 @pytest.mark.parametrize(
     "mesh",

--- a/python/tests/test_future_characterization.py
+++ b/python/tests/test_future_characterization.py
@@ -1,0 +1,268 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Characterization oracle for the public ``monarch`` ``Future`` state machine.
+
+Stage 0 of the pytokio removal (RFC1): this pins the *current* behavior of
+``monarch._src.actor.future.Future`` -- its five internal states, every
+transition between them, its seven conversion-error strings, and the
+``get()``-inside-a-loop warning -- so the later stages, which make ``Future``
+two-state and non-awaitable, have an oracle to diff against.
+
+This is a *transitional* oracle: stage 6 deletes the state machine it pins, so
+this file is expected to be rewritten or removed at that point.
+"""
+
+import asyncio
+
+import pytest
+from monarch._rust_bindings.monarch_hyperactor.pytokio import (
+    is_tokio_thread,
+    PythonTask,
+)
+from monarch._src.actor import future as future_mod
+from monarch._src.actor.future import Future
+
+
+async def _value(v):
+    return v
+
+
+async def _raise(exc: BaseException):
+    raise exc
+
+
+async def _await_once(fut: Future):
+    return await fut
+
+
+def _run_in_tokio(coro):
+    # Drive ``coro`` to completion on the Tokio runtime. Code inside ``coro``
+    # runs on a Tokio worker thread, where ``is_tokio_thread()`` is True and a
+    # ``Future`` takes its ``__await__`` tokio branch. ``block_on`` itself runs
+    # on the (non-worker) calling thread, so it is allowed to block.
+    return PythonTask.from_coroutine(coro).block_on()
+
+
+# ---------------------------------------------------------------------------
+# States and transitions
+#
+# A fresh Future is _Unawaited; the first access drives the underlying task
+# exactly once and moves it to a terminal/converted state (_Complete,
+# _Exception, _Asyncio, or _Tokio). These pin that lifecycle and its
+# idempotency. The two-state redesign must preserve resolve-and-cache for
+# results and errors; the two *awaitable* branches (_Asyncio/_Tokio) are the
+# dual-world machinery it removes -- after D1 a Future is not awaitable and
+# callers use as_asyncio().
+# ---------------------------------------------------------------------------
+
+
+def test_get_success_transitions_to_complete_and_is_idempotent():
+    """First sync get() drives the task, transitions _Unawaited -> _Complete,
+    and returns the value; a second get() returns the cached value without
+    re-running the coroutine. The coroutine must run exactly once, so
+    resolve-and-cache is the contract being pinned."""
+    fut: Future[int] = Future(coro=_value(42))
+    assert fut.get() == 42
+    assert fut.get() == 42
+
+
+def test_get_exception_transitions_to_exception_and_reraises_stored():
+    """Failure mirror of the success terminal: the first get() catches the
+    raised exception, transitions _Unawaited -> _Exception (caching the
+    object), and re-raises; a second get() re-raises the *same stored* object
+    without re-running. Identity is asserted between the two gets (not against
+    the constructed ValueError) because the exception crosses the Rust/pyo3
+    boundary -- the contract is that _Exception caches one object and re-raises
+    it."""
+    fut: Future[int] = Future(coro=_raise(ValueError("boom")))
+    with pytest.raises(ValueError, match="boom") as first:
+        fut.get()
+    with pytest.raises(ValueError, match="boom") as second:
+        fut.get()
+    assert second.value is first.value
+
+
+def test_get_timeout_raises_timeout_error():
+    """get(timeout=...) wraps the task in with_timeout, so an unfinished task
+    surfaces a TimeoutError (caught, stored as _Exception, raised) rather than
+    hanging."""
+    fut: Future[None] = Future(coro=PythonTask.sleep(3600))
+    with pytest.raises(TimeoutError):
+        fut.get(timeout=0.1)
+
+
+async def test_await_asyncio_transitions_to_asyncio_and_is_idempotent():
+    """Awaiting under an asyncio loop transitions _Unawaited -> _Asyncio
+    (bridging the task to an asyncio.Future) and yields the value; re-awaiting
+    reuses the _Asyncio future. This is one of the two awaitable branches the
+    redesign removes."""
+    fut: Future[int] = Future(coro=_value(7))
+    assert await fut == 7  # _Unawaited -> _Asyncio
+    assert await fut == 7  # idempotent re-await of the _Asyncio state
+
+
+def test_await_tokio_transitions_to_tokio_and_is_idempotent():
+    """Awaiting on a tokio thread (inside from_coroutine, where
+    is_tokio_thread() is True) transitions _Unawaited -> _Tokio (spawning a
+    Shared) and yields the value; re-awaiting reuses it. The _Asyncio-vs-_Tokio
+    split is exactly the "which async world am I in" duality P1/D1 collapse."""
+    fut: Future[int] = Future(coro=_value(9))
+
+    async def driver():
+        assert is_tokio_thread()
+        first = await fut  # _Unawaited -> _Tokio
+        second = await fut  # idempotent re-await of the _Tokio state
+        return first, second
+
+    assert _run_in_tokio(driver()) == (9, 9)
+
+
+# ---------------------------------------------------------------------------
+# Conversion errors -- the seven state-tied raises, pinned verbatim. (The
+# numbers follow the source's raises; #3, the unreachable RuntimeError
+# "unknown status" fallthrough, is intentionally not pinned.)
+#
+# These are the five-state machine's "which async world / already-converted"
+# mixing guards -- the errors the RFC's Motivation quotes ("already converted
+# into an asyncio.Future, ..."). Each is keyed off the *state*, not the data: a
+# Future can hold a fully-resolved value and still refuse the wrong accessor.
+# The two-state, non-awaitable redesign deletes all of them (no _Asyncio/_Tokio
+# states and no await => none of these errors); this oracle is what flags any
+# change to them before stage 6 intends it.
+# ---------------------------------------------------------------------------
+
+
+def test_error1_get_after_asyncio_conversion():
+    """get() after an asyncio await (_Asyncio). The value is fully available in
+    the bridged asyncio.Future, yet get() refuses it and says to use 'await' --
+    the guard is on state, not data."""
+    fut: Future[int] = Future(coro=_value(1))
+    asyncio.run(_await_once(fut))  # -> _Asyncio
+    with pytest.raises(ValueError, match=r"already converted into an asyncio\.Future"):
+        fut.get()
+
+
+def test_error2_get_after_tokio_conversion():
+    """get() after a tokio await (_Tokio): symmetric to error1 -- once converted
+    to a pytokio Shared, get() refuses and points at awaiting inside a
+    from_coroutine coroutine."""
+    fut: Future[int] = Future(coro=_value(1))
+    _run_in_tokio(_await_once(fut))  # -> _Tokio
+    with pytest.raises(
+        ValueError, match=r"already converted into a pytokio\.Shared object"
+    ):
+        fut.get()
+
+
+def test_error4_await_asyncio_on_tokio_converted():
+    """Cross-runtime: convert on tokio (_Tokio), then await under asyncio -- the
+    asyncio branch refuses a tokio-converted Future."""
+    fut: Future[int] = Future(coro=_value(1))
+    _run_in_tokio(_await_once(fut))  # -> _Tokio
+
+    async def attempt():
+        with pytest.raises(ValueError, match="already converted into a tokio future"):
+            await fut
+
+    asyncio.run(attempt())
+
+
+def test_error5_await_asyncio_after_resolved():
+    """await under asyncio after a sync get() resolved it (_Complete): the
+    synchronous world was already chosen, so the asyncio await is refused."""
+    fut: Future[int] = Future(coro=_value(1))
+    assert fut.get() == 1  # -> _Complete
+
+    async def attempt():
+        with pytest.raises(
+            ValueError, match="already converted into a synchronous future"
+        ):
+            await fut
+
+    asyncio.run(attempt())
+
+
+def test_error6_await_tokio_on_asyncio_converted():
+    """Cross-runtime mirror of error4: convert on asyncio (_Asyncio), then await
+    on a tokio thread -- the tokio branch refuses an asyncio-converted Future."""
+    fut: Future[int] = Future(coro=_value(1))
+    asyncio.run(_await_once(fut))  # -> _Asyncio
+
+    async def attempt():
+        await fut
+
+    with pytest.raises(ValueError, match="already converted into asyncio future"):
+        _run_in_tokio(attempt())
+
+
+def test_error7_await_tokio_after_resolved():
+    """await on a tokio thread after a sync get() resolved it (_Complete): the
+    same refusal as error5 (same message), reached from the tokio branch."""
+    fut: Future[int] = Future(coro=_value(1))
+    assert fut.get() == 1  # -> _Complete
+
+    async def attempt():
+        await fut
+
+    with pytest.raises(ValueError, match="already converted into a synchronous future"):
+        _run_in_tokio(attempt())
+
+
+def test_error8_await_with_no_event_loop():
+    """await with neither an asyncio loop nor a tokio runtime active: there is no
+    driver, so __await__ refuses outright."""
+    fut: Future[int] = Future(coro=_value(1))
+    with pytest.raises(ValueError, match="no active event loop"):
+        fut.__await__()
+
+
+# ---------------------------------------------------------------------------
+# get()-inside-a-loop warning -- both branches
+#
+# The warning fires for asyncio OR tokio callers and forwards a tracing event
+# with extra["context"] = "asyncio"/"tokio". We assert the observable seam by
+# monkeypatching the module-level log_with_tracing rather than reading Rust
+# tracing output.
+# ---------------------------------------------------------------------------
+
+
+def test_get_in_asyncio_loop_warns_and_still_returns(monkeypatch):
+    """get() inside an asyncio loop (main thread) warns and forwards a tracing
+    event with context='asyncio', but -- because the block is legal on the main
+    thread -- still returns the value (backward-compatible)."""
+    calls = []
+    monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
+
+    async def runner():
+        fut: Future[int] = Future(coro=_value(5))
+        with pytest.warns(UserWarning, match="active event loop"):
+            return fut.get()
+
+    assert asyncio.run(runner()) == 5
+    assert len(calls) == 1
+    assert calls[0]["extra"]["context"] == "asyncio"
+
+
+def test_get_in_tokio_thread_warns_then_cannot_block(monkeypatch):
+    """On a real tokio thread get() warns (context='tokio') but then cannot
+    block within the runtime, so it raises rather than returning -- the
+    asymmetry with the asyncio branch, and precisely the case WouldBlockRuntime
+    is meant to replace."""
+    calls = []
+    monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
+    fut: Future[int] = Future(coro=_value(5))
+
+    async def attempt():
+        assert is_tokio_thread()
+        return fut.get()
+
+    with pytest.raises(BaseException, match="from within a runtime"):
+        _run_in_tokio(attempt())
+    assert len(calls) == 1
+    assert calls[0]["extra"]["context"] == "tokio"

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1853,24 +1853,6 @@ def test_context_propagated_through_python_task_spawn_blocking():
     p.stop().get()
 
 
-@pytest.mark.timeout(15)
-def test_future_get_inside_async_loop_warns():
-    """Calling Future.get() from inside an active asyncio loop blocks the
-    surrounding loop. Verify a UserWarning fires while the call still
-    completes for backward compatibility.
-    """
-
-    async def runner() -> int:
-        async def inner() -> int:
-            return 1
-
-        f: Future[int] = Future(coro=inner())
-        with pytest.warns(UserWarning, match="event loop"):
-            return f.get()
-
-    assert asyncio.run(runner()) == 1
-
-
 class ActorWithCleanup(Actor):
     def __init__(self, counter: Counter) -> None:
         self.counter = counter


### PR DESCRIPTION
Summary:

stage 0 of retiring pytokio: pin the current supervision behavior for endpoint exceptions before the refactor, so changes are caught against an oracle. RFC: https://docs.google.com/document/d/1jNRPQLrAJawTDvVq1Ddxsl7kgZqg89mN/edit#bookmark=id.127riaf3vylf

extends `test_actor_error.py` with the reply-port `Exception` contract: a plain `Exception` from an endpoint invoked with no reply port (`broadcast()`) kills the actor (observed via the supervision fault hook); the same exception with a reply port returns to the caller as `ActorError`, leaves the actor alive, and fires no supervision. both are parametrized over `actor_queue_dispatch={True, False}` so the no-port case exercises both kill paths.

these are durable: supervision is meant to behave the same after the refactor, so they should stay green throughout. pure test additions, no product code.

Reviewed By: dulinriley

Differential Revision: D109473260


