### PR TITLE
python/tests: add endpoint-panic, sync, and supervisor-delivery characterization tests (#4286)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -845,9 +845,10 @@ Pass endpoint options directly to `@concurrent_endpoint(...)`, such as
 
 There is nothing special about `@concurrent_endpoint`: it packages the
 `explicit_response_port=True` pattern with `asyncio.create_task`, result
-forwarding for non-explicit endpoints, warning logs for escaped explicit-port
-exceptions, and cleanup-time cancellation of the tasks it starts. You can write
-the simple version yourself when you want full control:
+forwarding for non-explicit endpoints, failing the actor when an explicit-port
+endpoint lets an exception escape the function, and cleanup-time cancellation of
+the tasks it starts. You can write the simple version yourself when you want full
+control:
 
 ```python
 import asyncio
@@ -872,9 +873,11 @@ class ManualGate(Actor):
 ```
 
 This manual form intentionally has no extra task tracking; the task lifetime is
-part of the endpoint protocol you are writing. If an explicit-port endpoint lets
-an exception escape before sending a response, the caller will keep waiting until
-it times out or is cancelled.
+part of the endpoint protocol you are writing. Because the body runs in a
+detached task that you own, an exception escaping it before a response is sent
+leaves the caller waiting until it times out or is cancelled, while the actor
+survives. By contrast, `@concurrent_endpoint` fails the actor with a supervision
+error in that case, following the principle of no silent errors.
 
 `@concurrent_endpoint` works on individual endpoints, including inherited
 endpoints, so an actor can mix concurrent and sequential endpoints. For protocols

--- a/python/monarch/actor/concurrent.py
+++ b/python/monarch/actor/concurrent.py
@@ -9,9 +9,9 @@
 import asyncio
 import functools
 import inspect
-import logging
 import weakref
 from dataclasses import dataclass, field
+from traceback import TracebackException
 from typing import Any, Awaitable, Callable, cast
 
 from monarch._rust_bindings.monarch_hyperactor.logging import log_endpoint_exception
@@ -21,7 +21,6 @@ from monarch._src.actor.telemetry import span
 
 _WRAPPER_ATTR = "_monarch_concurrent_endpoint_wrapper"
 _CLEANUP_WRAPPER_ATTR = "_monarch_concurrent_endpoint_cleanup_wrapper"
-logger: logging.Logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -52,15 +51,20 @@ def _send_exception(port: Any, actor_error: ActorError) -> None:
         pass
 
 
-def _log_explicit_response_port_exception(
-    actor_name: str, method_name: str, exception: BaseException
-) -> None:
-    logger.warning(
-        "concurrent explicit response-port endpoint raised without forwarding its own exception: %s.%s",
-        actor_name,
-        method_name,
-        exc_info=(type(exception), exception, exception.__traceback__),
-    )
+def _cancelled_for_cleanup(record: _TaskRecord | None) -> bool:
+    # True when cleanup cancelled this task because the actor is stopping;
+    # callers skip failing the actor so a graceful stop is not escalated.
+    return record is not None and record.cancel_for_cleanup
+
+
+def _fail_actor(actor_instance: Any, exception: BaseException) -> None:
+    reason = "".join(TracebackException.from_exception(exception).format())
+    try:
+        actor_instance.kill(reason)
+    except Exception:
+        # The actor's signal channel may already be closed if it has finished
+        # stopping; there is then nothing left to fail.
+        pass
 
 
 async def _run_endpoint(
@@ -84,7 +88,7 @@ async def _run_endpoint(
             else:
                 await call()
         except asyncio.CancelledError as e:
-            if record is not None and record.cancel_for_cleanup:
+            if _cancelled_for_cleanup(record):
                 return
             if forwards_exception:
                 actor_error = ActorError(
@@ -94,24 +98,24 @@ async def _run_endpoint(
                 _send_exception(port, actor_error)
             raise
         except Exception as e:
+            log_endpoint_exception(e, method_name, actor_id)
             if forwards_exception:
-                log_endpoint_exception(e, method_name, actor_id)
                 actor_error = ActorError(
                     e,
                     f"Actor call {actor_name}.{method_name} failed.",
                 )
                 _send_exception(port, actor_error)
-            else:
-                _log_explicit_response_port_exception(actor_name, method_name, e)
+            elif not _cancelled_for_cleanup(record):
+                _fail_actor(actor_instance, e)
         except BaseException as e:  # noqa: B036
-            actor_error = ActorError(
-                e,
-                f"Actor call {actor_name}.{method_name} failed with BaseException.",
-            )
             if forwards_exception:
+                actor_error = ActorError(
+                    e,
+                    f"Actor call {actor_name}.{method_name} failed with BaseException.",
+                )
                 _send_exception(port, actor_error)
-            else:
-                _log_explicit_response_port_exception(actor_name, method_name, e)
+            elif not _cancelled_for_cleanup(record):
+                _fail_actor(actor_instance, e)
     finally:
         actor_instance._execution_finish(token)
 
@@ -303,6 +307,13 @@ def concurrent_endpoint(
     lifecycle before these tasks are cancelled. General pending tasks on the
     actor's asyncio loop are cancelled later, after user ``__cleanup__``
     completes.
+
+    If the endpoint body raises an exception that it does not forward through
+    its response port, the actor fails with a supervision error, just as an
+    exception escaping an ``@endpoint(explicit_response_port=True)`` method
+    does. This follows the principle of no silent errors. To report an error to
+    the caller without failing the actor, forward it through the port (for
+    example, ``port.exception(e)``); to recover, catch it inside the endpoint.
 
     More complex protocols can still use ``@endpoint(explicit_response_port=True)``
     and manage response ports manually.

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -36,6 +36,7 @@ from monarch.actor import (
     endpoint,
     get_or_spawn_controller,
     MeshFailure,
+    Port,
 )
 from monarch.config import configured, parametrize_config
 
@@ -365,6 +366,34 @@ async def test_reply_port_exception_returns_to_caller_and_actor_survives() -> No
 
     # and no supervision fired for the handled exception
     assert faults == [], f"expected no supervision faults, got {faults}"
+
+    await proc.stop()
+
+
+class ExplicitPortFailingActor(Actor):
+    @endpoint(explicit_response_port=True)
+    async def fail(self, port: Port[None]) -> None:
+        raise Exception("This is a test exception")
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_explicit_response_port_exception_kills_actor() -> None:
+    """A plain `@endpoint(explicit_response_port=True)` that raises instead of
+    sending via its port kills the actor: the explicit-port declaration rebinds
+    the ambient response port to `DroppingPort`, so the raise takes the no-port
+    kill path and the caller sees a `SupervisionError`. The
+    `@concurrent_endpoint(explicit_response_port=True)` form behaves the same
+    way: an escaped exception likewise kills the actor (see
+    `test_concurrent_explicit_port_exception_kills_actor` in
+    `test_concurrent_endpoints.py`)."""
+    monarch.actor.unhandled_fault_hook = lambda failure: None
+    proc = spawn_procs_on_this_host({"gpus": 1})
+    actor = proc.spawn("explicit_port_actor", ExplicitPortFailingActor)
+
+    with pytest.raises(SupervisionError):
+        await asyncio.wait_for(actor.fail.call_one(), timeout=15)
 
     await proc.stop()
 

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -22,6 +22,7 @@ from typing import cast, Generator, IO, Optional
 import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_extension.panic import panicking_function
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import hold_gil_for_test
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     UndeliverableMessageEnvelope,
@@ -307,8 +308,9 @@ def test_actor_init_exception_sync(mesh, actor_class, num_procs) -> None:
 
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@pytest.mark.parametrize("actor_class", [ExceptionActor, ExceptionActorSync])
 @isolate_in_subprocess
-async def test_broadcast_exception_with_no_reply_port_kills_actor() -> None:
+async def test_broadcast_exception_with_no_reply_port_kills_actor(actor_class) -> None:
     """A plain `Exception` from an endpoint invoked with *no reply port*
     (fire-and-forget `broadcast()`) fails the actor: the return is dropped, the
     exception escapes through `DroppingPort.exception`, and the actor is killed,
@@ -326,7 +328,7 @@ async def test_broadcast_exception_with_no_reply_port_kills_actor() -> None:
 
     monarch.actor.unhandled_fault_hook = fault_hook
     proc = spawn_procs_on_this_host({"gpus": 1})
-    actor = proc.spawn("exception_actor", ExceptionActor)
+    actor = proc.spawn("exception_actor", actor_class)
 
     actor.raise_exception.broadcast()  # no reply port => the actor dies
     await asyncio.wait_for(faulted.wait(), timeout=15.0)
@@ -341,8 +343,11 @@ async def test_broadcast_exception_with_no_reply_port_kills_actor() -> None:
 
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@pytest.mark.parametrize("actor_class", [ExceptionActor, ExceptionActorSync])
 @isolate_in_subprocess
-async def test_reply_port_exception_returns_to_caller_and_actor_survives() -> None:
+async def test_reply_port_exception_returns_to_caller_and_actor_survives(
+    actor_class,
+) -> None:
     """The reply-port half of the contract, and the only cell where the actor
     lives: an endpoint `Exception` called *with* a reply port comes back to the
     caller as `ActorError`, the actor stays alive (a follow-up call succeeds),
@@ -352,7 +357,7 @@ async def test_reply_port_exception_returns_to_caller_and_actor_survives() -> No
     faults = []
     monarch.actor.unhandled_fault_hook = lambda failure: faults.append(failure)
     proc = spawn_procs_on_this_host({"gpus": 1})
-    actor = proc.spawn("exception_actor", ExceptionActor)
+    actor = proc.spawn("exception_actor", actor_class)
 
     with pytest.raises(ActorError, match="This is a test exception"):
         await actor.raise_exception.call_one()
@@ -376,10 +381,19 @@ class ExplicitPortFailingActor(Actor):
         raise Exception("This is a test exception")
 
 
+class ExplicitPortFailingActorSync(Actor):
+    @endpoint(explicit_response_port=True)
+    def fail(self, port: Port[None]) -> None:
+        raise Exception("This is a test exception")
+
+
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@pytest.mark.parametrize(
+    "actor_class", [ExplicitPortFailingActor, ExplicitPortFailingActorSync]
+)
 @isolate_in_subprocess
-async def test_explicit_response_port_exception_kills_actor() -> None:
+async def test_explicit_response_port_exception_kills_actor(actor_class) -> None:
     """A plain `@endpoint(explicit_response_port=True)` that raises instead of
     sending via its port kills the actor: the explicit-port declaration rebinds
     the ambient response port to `DroppingPort`, so the raise takes the no-port
@@ -390,12 +404,114 @@ async def test_explicit_response_port_exception_kills_actor() -> None:
     `test_concurrent_endpoints.py`)."""
     monarch.actor.unhandled_fault_hook = lambda failure: None
     proc = spawn_procs_on_this_host({"gpus": 1})
-    actor = proc.spawn("explicit_port_actor", ExplicitPortFailingActor)
+    actor = proc.spawn("explicit_port_actor", actor_class)
 
     with pytest.raises(SupervisionError):
         await asyncio.wait_for(actor.fail.call_one(), timeout=15)
 
     await proc.stop()
+
+
+class PanicActor(Actor):
+    @endpoint
+    async def cause_panic(self) -> None:
+        """Raise a Rust panic, which pyo3 re-raises into Python as a
+        `PanicException` (a `BaseException`, not an `Exception`)."""
+        panicking_function()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_endpoint_panic_kills_actor() -> None:
+    """A Rust panic in an endpoint surfaces in Python as a pyo3 `PanicException`
+    (a `BaseException`, not an `Exception`), which kills the actor and arrives as
+    a supervision fault. This is a different path from a plain `Exception`:
+    `_Actor.handle`'s `except BaseException` routes it through
+    `panic_flag.signal_panic` (direct dispatch) or `_QueuePanicFlag` +
+    `_dispatch_loop` (queue dispatch), never the response port. The fault
+    reason's exact text is racy (a known signal_panic-vs-Aborted format race),
+    so this pins death and delivery, not the message string."""
+    faults = []
+    faulted = asyncio.Event()
+
+    def fault_hook(failure):
+        faults.append(failure)
+        faulted.set()
+
+    monarch.actor.unhandled_fault_hook = fault_hook
+    proc = spawn_procs_on_this_host({"gpus": 1})
+    actor = proc.spawn("panic_actor", PanicActor)
+
+    actor.cause_panic.broadcast()  # no reply port => the actor dies
+    await asyncio.wait_for(faulted.wait(), timeout=15.0)
+
+    assert len(faults) >= 1
+    assert "panic_actor" in str(faults[0])
+
+    await proc.stop()
+
+
+class SuperviseExceptionParent(Actor):
+    """Owner actor that records `__supervise__` faults from a child it spawns.
+
+    Pins that a plain-`Exception` no-reply-port kill in the child is delivered
+    to the owner's supervisor callback, not only the root fault hook. Existing
+    `__supervise__` coverage drives the child with supervision-specific failures
+    rather than a plain `Exception`.
+    """
+
+    def __init__(self, proc_mesh: ProcMesh) -> None:
+        self.child = proc_mesh.spawn("exception_actor", ExceptionActor)
+        self.failures: list[MeshFailure] = []
+        self.faulted = asyncio.Event()
+
+    @endpoint
+    async def child_broadcast_fail(self) -> None:
+        await self.child.noop.call()  # ensure the child is alive first
+        # no reply port => the child dies; the failure must still reach
+        # __supervise__ on the owner.
+        self.child.raise_exception.broadcast()
+        await asyncio.wait_for(self.faulted.wait(), timeout=30)
+
+    @endpoint
+    async def get_failures(self) -> list[str]:
+        # MeshFailure is not picklable, so return strings.
+        return [str(f) for f in self.failures]
+
+    def __supervise__(self, failure: MeshFailure) -> bool:
+        self.failures.append(failure)
+        self.faulted.set()
+        return True  # suppress so the fault does not propagate further
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_no_reply_port_exception_delivered_to_supervisor() -> None:
+    """End-to-end supervision: a plain `Exception` from a child endpoint invoked
+    with no reply port (`broadcast()`) is delivered to the owner's
+    `__supervise__` as a `MeshFailure`. Companion to
+    `test_broadcast_exception_with_no_reply_port_kills_actor`, which pins the
+    kill at the root fault hook; this pins the parent-delivery half."""
+    pm = spawn_procs_on_this_host({"gpus": 1})
+    # A separate mesh for the child avoids an intermittent same-mesh spawn race
+    # (see the other supervise tests).
+    second_mesh = spawn_procs_on_this_host({"gpus": 1})
+    supervisor = pm.spawn("supervisor", SuperviseExceptionParent, second_mesh)
+
+    await supervisor.child_broadcast_fail.call()
+    result = await supervisor.get_failures.call()
+    result = [f for _, f in result]
+    assert len(result) == 1
+    r = result[0]
+    assert len(r) >= 1, f"expected at least one supervision event, got {len(r)}"
+    for msg in r:
+        assert "MeshFailure" in msg
+        assert "exception_actor" in msg
+
+    await pm.stop()
+    await second_mesh.stop()
 
 
 @parametrize_config(actor_queue_dispatch={True, False})

--- a/python/tests/test_concurrent_endpoints.py
+++ b/python/tests/test_concurrent_endpoints.py
@@ -11,8 +11,10 @@ import os
 from tempfile import TemporaryDirectory
 from typing import Any, cast
 
+import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
 from monarch.actor import Actor, concurrent_endpoint, endpoint, Port, this_host
 from monarch.config import parametrize_config
 
@@ -232,16 +234,21 @@ async def test_concurrent_endpoint_exception_uses_actor_error_context() -> None:
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 @isolate_in_subprocess
-async def test_concurrent_explicit_port_exception_is_not_auto_forwarded() -> None:
+async def test_concurrent_explicit_port_exception_kills_actor() -> None:
+    """An ``@concurrent_endpoint(explicit_response_port=True)`` body that raises
+    instead of sending through its port kills the actor with a supervision
+    error, just as a plain ``@endpoint(explicit_response_port=True)`` does (see
+    ``test_explicit_response_port_exception_kills_actor`` in
+    ``test_actor_error.py``). The escaped exception is not silently swallowed."""
+    monarch.actor.unhandled_fault_hook = lambda failure: None
     proc = this_host().spawn_procs(per_host={"gpus": 1})
     actor = proc.spawn(
         "concurrent_explicit_port_failing_actor", ConcurrentExplicitPortFailingActor
     )
 
     try:
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(actor.fail.call_one(), timeout=0.2)
-        assert await asyncio.wait_for(actor.ping.call_one(), timeout=10) == "pong"
+        with pytest.raises(SupervisionError):
+            await asyncio.wait_for(actor.fail.call_one(), timeout=15)
     finally:
         await proc.stop()
 


### PR DESCRIPTION
Summary:

stage 0 of retiring pytokio: close the remaining supervision-oracle gaps before the refactor, against an oracle. RFC: https://docs.google.com/document/d/1jNRPQLrAJawTDvVq1Ddxsl7kgZqg89mN/edit#bookmark=id.127riaf3vylf

three additions to `test_actor_error.py`:

- endpoint panic: a Rust panic in an endpoint (pyo3 `PanicException`, a `BaseException`) kills the actor and arrives as a supervision fault, via the `signal_panic` side-channel (direct dispatch) or `_QueuePanicFlag` + `_dispatch_loop` (queue dispatch) rather than the response port. this is the path stage 5 deletes when it removes the panic side-channel, so it needs an oracle; the fault reason text is racy, so the test pins death and delivery, not the string.
- sync coverage: the reply-port and explicit-port exception cells added earlier in the stack only ran async actors; parametrized them over `actor_class` (`ExceptionActor`/`ExceptionActorSync`, plus a sync explicit-port actor) so sync endpoints are pinned too, since stage 5 changes sync execution.
- supervisor delivery: a plain `Exception` from a child endpoint invoked with no reply port (`broadcast()`) is delivered to the owner's `__supervise__` as a `MeshFailure`, not only observed at the root fault hook. existing `__supervise__` coverage drives the child with supervision-specific failures, not a plain `Exception`.

pure test additions, no product code. all parametrized over both dispatch modes.

Reviewed By: pzhan9

Differential Revision: D109504589
