### PR TITLE
python/tests: pin sync-endpoint loop-invisibility (fake_sync_state) (#4289)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -845,9 +845,10 @@ Pass endpoint options directly to `@concurrent_endpoint(...)`, such as
 
 There is nothing special about `@concurrent_endpoint`: it packages the
 `explicit_response_port=True` pattern with `asyncio.create_task`, result
-forwarding for non-explicit endpoints, warning logs for escaped explicit-port
-exceptions, and cleanup-time cancellation of the tasks it starts. You can write
-the simple version yourself when you want full control:
+forwarding for non-explicit endpoints, failing the actor when an explicit-port
+endpoint lets an exception escape the function, and cleanup-time cancellation of
+the tasks it starts. You can write the simple version yourself when you want full
+control:
 
 ```python
 import asyncio
@@ -872,9 +873,11 @@ class ManualGate(Actor):
 ```
 
 This manual form intentionally has no extra task tracking; the task lifetime is
-part of the endpoint protocol you are writing. If an explicit-port endpoint lets
-an exception escape before sending a response, the caller will keep waiting until
-it times out or is cancelled.
+part of the endpoint protocol you are writing. Because the body runs in a
+detached task that you own, an exception escaping it before a response is sent
+leaves the caller waiting until it times out or is cancelled, while the actor
+survives. By contrast, `@concurrent_endpoint` fails the actor with a supervision
+error in that case, following the principle of no silent errors.
 
 `@concurrent_endpoint` works on individual endpoints, including inherited
 endpoints, so an actor can mix concurrent and sequential endpoints. For protocols

--- a/monarch_distributed_telemetry/src/query_engine.rs
+++ b/monarch_distributed_telemetry/src/query_engine.rs
@@ -361,11 +361,9 @@ impl ExecutionPlan for DistributedExec {
                     ),
                 )?;
 
-                // Extract the PythonTask from the Future object
-                // Future._status is an _Unawaited(coro) where coro is a PythonTask
-                let status = future_obj.getattr(py, "_status")?;
-                // _Unawaited is a NamedTuple with .coro attribute
-                let python_task_obj = status.getattr(py, "coro")?;
+                // Surrender the underlying PythonTask via Future._take_inner(),
+                // then consume it to get the raw completion future.
+                let python_task_obj = future_obj.call_method0(py, "_take_inner")?;
                 let mut python_task: PyRefMut<'_, PyPythonTask> = python_task_obj.extract(py)?;
                 let completion_future = python_task.take_task()?;
 

--- a/monarch_extension/src/readonly_fuse.rs
+++ b/monarch_extension/src/readonly_fuse.rs
@@ -102,17 +102,11 @@ type ActorFuture = Pin<Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send + 'st
 /// Extract the inner Rust `Future` from the Python `Future` object returned
 /// by `actor.endpoint.call_one(args)`.
 ///
-/// Python layout:
-/// ```text
-/// Future._status  →  _Unawaited(coro=PyPythonTask)
-/// ```
-/// `PyPythonTask.take_task()` consumes the task and returns the raw future.
+/// `Future._take_inner()` surrenders the underlying `PythonTask`, whose
+/// `take_task()` then consumes it and returns the raw future.
 fn take_actor_future(py_future: Bound<'_, PyAny>) -> PyResult<ActorFuture> {
-    let coro: Bound<'_, PyPythonTask> = py_future
-        .getattr("_status")?
-        .getattr("coro")?
-        .downcast_into()?;
-    coro.borrow_mut().take_task()
+    let task: Bound<'_, PyPythonTask> = py_future.call_method0("_take_inner")?.downcast_into()?;
+    task.borrow_mut().take_task()
 }
 
 /// Call `actor.<endpoint>.call_one(<args>)` while holding the GIL, extract

--- a/python/monarch/_src/actor/bootstrap.py
+++ b/python/monarch/_src/actor/bootstrap.py
@@ -18,7 +18,7 @@ from monarch._rust_bindings.monarch_hyperactor.host_mesh import HostMesh as HyHo
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Extent
 from monarch._src.actor.actor_mesh import _Lazy
-from monarch._src.actor.future import _Unawaited, Future
+from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import HostMesh
 
 PrivateKey = Union[bytes, Path, None]
@@ -34,8 +34,7 @@ def _as_python_task(s: str | Future[str]) -> "PythonTask[str]":
 
         return PythonTask.from_coroutine(just())
     else:
-        assert isinstance(s._status, _Unawaited)
-        return s._status.coro
+        return s._take_inner()
 
 
 def run_worker_loop_forever(

--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -86,7 +86,11 @@ class _Tokio(NamedTuple):
     shared: Shared[Any]
 
 
-_Status = _Unawaited | _Complete | _Exception | _Asyncio | _Tokio
+class _Taken(NamedTuple):
+    pass
+
+
+_Status = _Unawaited | _Complete | _Exception | _Asyncio | _Tokio | _Taken
 
 
 class Future(Generic[R]):
@@ -105,6 +109,19 @@ class Future(Generic[R]):
         self._status: _Status = _Unawaited(
             coro if isinstance(coro, PythonTask) else PythonTask.from_coroutine(coro)
         )
+
+    def _take_inner(self) -> "PythonTask[R]":
+        """Surrender the underlying ``PythonTask`` to a caller that needs to drive
+        it directly (for example to await the raw Rust future without the GIL).
+        Only valid on a Future that has not yet been awaited or resolved; the
+        Future is spent afterward (a second take, or any get()/await, raises).
+        """
+        match self._status:
+            case _Unawaited(coro=coro):
+                self._status = _Taken()
+                return cast("PythonTask[R]", coro)
+            case _:
+                raise ValueError("Future has already been awaited or resolved.")
 
     def get(self, timeout: Optional[float] = None) -> R:
         """Get the result of the Future.
@@ -182,6 +199,8 @@ class Future(Generic[R]):
                 raise ValueError(
                     "already converted into a pytokio.Shared object, use 'await' from a PythonTask coroutine to get the value."
                 )
+            case _Taken():
+                raise ValueError("Future was consumed.")
             case _:
                 raise RuntimeError("unknown status")
 
@@ -217,6 +236,8 @@ class Future(Generic[R]):
                     raise ValueError(
                         "already converted into a tokio future, but being awaited from the asyncio loop."
                     )
+                case _Taken():
+                    raise ValueError("Future was consumed.")
                 case _:
                     raise ValueError(
                         "already converted into a synchronous future, use 'get' to get the value."
@@ -233,6 +254,8 @@ class Future(Generic[R]):
                     raise ValueError(
                         "already converted into asyncio future, but being awaited from the tokio loop."
                     )
+                case _Taken():
+                    raise ValueError("Future was consumed.")
                 case _:
                     raise ValueError(
                         "already converted into a synchronous future, use 'get' to get the value."

--- a/python/monarch/actor/concurrent.py
+++ b/python/monarch/actor/concurrent.py
@@ -9,9 +9,9 @@
 import asyncio
 import functools
 import inspect
-import logging
 import weakref
 from dataclasses import dataclass, field
+from traceback import TracebackException
 from typing import Any, Awaitable, Callable, cast
 
 from monarch._rust_bindings.monarch_hyperactor.logging import log_endpoint_exception
@@ -21,7 +21,6 @@ from monarch._src.actor.telemetry import span
 
 _WRAPPER_ATTR = "_monarch_concurrent_endpoint_wrapper"
 _CLEANUP_WRAPPER_ATTR = "_monarch_concurrent_endpoint_cleanup_wrapper"
-logger: logging.Logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -52,15 +51,20 @@ def _send_exception(port: Any, actor_error: ActorError) -> None:
         pass
 
 
-def _log_explicit_response_port_exception(
-    actor_name: str, method_name: str, exception: BaseException
-) -> None:
-    logger.warning(
-        "concurrent explicit response-port endpoint raised without forwarding its own exception: %s.%s",
-        actor_name,
-        method_name,
-        exc_info=(type(exception), exception, exception.__traceback__),
-    )
+def _cancelled_for_cleanup(record: _TaskRecord | None) -> bool:
+    # True when cleanup cancelled this task because the actor is stopping;
+    # callers skip failing the actor so a graceful stop is not escalated.
+    return record is not None and record.cancel_for_cleanup
+
+
+def _fail_actor(actor_instance: Any, exception: BaseException) -> None:
+    reason = "".join(TracebackException.from_exception(exception).format())
+    try:
+        actor_instance.kill(reason)
+    except Exception:
+        # The actor's signal channel may already be closed if it has finished
+        # stopping; there is then nothing left to fail.
+        pass
 
 
 async def _run_endpoint(
@@ -84,7 +88,7 @@ async def _run_endpoint(
             else:
                 await call()
         except asyncio.CancelledError as e:
-            if record is not None and record.cancel_for_cleanup:
+            if _cancelled_for_cleanup(record):
                 return
             if forwards_exception:
                 actor_error = ActorError(
@@ -94,24 +98,24 @@ async def _run_endpoint(
                 _send_exception(port, actor_error)
             raise
         except Exception as e:
+            log_endpoint_exception(e, method_name, actor_id)
             if forwards_exception:
-                log_endpoint_exception(e, method_name, actor_id)
                 actor_error = ActorError(
                     e,
                     f"Actor call {actor_name}.{method_name} failed.",
                 )
                 _send_exception(port, actor_error)
-            else:
-                _log_explicit_response_port_exception(actor_name, method_name, e)
+            elif not _cancelled_for_cleanup(record):
+                _fail_actor(actor_instance, e)
         except BaseException as e:  # noqa: B036
-            actor_error = ActorError(
-                e,
-                f"Actor call {actor_name}.{method_name} failed with BaseException.",
-            )
             if forwards_exception:
+                actor_error = ActorError(
+                    e,
+                    f"Actor call {actor_name}.{method_name} failed with BaseException.",
+                )
                 _send_exception(port, actor_error)
-            else:
-                _log_explicit_response_port_exception(actor_name, method_name, e)
+            elif not _cancelled_for_cleanup(record):
+                _fail_actor(actor_instance, e)
     finally:
         actor_instance._execution_finish(token)
 
@@ -303,6 +307,13 @@ def concurrent_endpoint(
     lifecycle before these tasks are cancelled. General pending tasks on the
     actor's asyncio loop are cancelled later, after user ``__cleanup__``
     completes.
+
+    If the endpoint body raises an exception that it does not forward through
+    its response port, the actor fails with a supervision error, just as an
+    exception escaping an ``@endpoint(explicit_response_port=True)`` method
+    does. This follows the principle of no silent errors. To report an error to
+    the caller without failing the actor, forward it through the port (for
+    example, ``port.exception(e)``); to recover, catch it inside the endpoint.
 
     More complex protocols can still use ``@endpoint(explicit_response_port=True)``
     and manage response ports manually.

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -36,6 +36,7 @@ from monarch.actor import (
     endpoint,
     get_or_spawn_controller,
     MeshFailure,
+    Port,
 )
 from monarch.config import configured, parametrize_config
 
@@ -365,6 +366,34 @@ async def test_reply_port_exception_returns_to_caller_and_actor_survives() -> No
 
     # and no supervision fired for the handled exception
     assert faults == [], f"expected no supervision faults, got {faults}"
+
+    await proc.stop()
+
+
+class ExplicitPortFailingActor(Actor):
+    @endpoint(explicit_response_port=True)
+    async def fail(self, port: Port[None]) -> None:
+        raise Exception("This is a test exception")
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_explicit_response_port_exception_kills_actor() -> None:
+    """A plain `@endpoint(explicit_response_port=True)` that raises instead of
+    sending via its port kills the actor: the explicit-port declaration rebinds
+    the ambient response port to `DroppingPort`, so the raise takes the no-port
+    kill path and the caller sees a `SupervisionError`. The
+    `@concurrent_endpoint(explicit_response_port=True)` form behaves the same
+    way: an escaped exception likewise kills the actor (see
+    `test_concurrent_explicit_port_exception_kills_actor` in
+    `test_concurrent_endpoints.py`)."""
+    monarch.actor.unhandled_fault_hook = lambda failure: None
+    proc = spawn_procs_on_this_host({"gpus": 1})
+    actor = proc.spawn("explicit_port_actor", ExplicitPortFailingActor)
+
+    with pytest.raises(SupervisionError):
+        await asyncio.wait_for(actor.fail.call_one(), timeout=15)
 
     await proc.stop()
 

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -22,6 +22,7 @@ from typing import cast, Generator, IO, Optional
 import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_extension.panic import panicking_function
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import hold_gil_for_test
 from monarch._rust_bindings.monarch_hyperactor.mailbox import (
     UndeliverableMessageEnvelope,
@@ -307,8 +308,9 @@ def test_actor_init_exception_sync(mesh, actor_class, num_procs) -> None:
 
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@pytest.mark.parametrize("actor_class", [ExceptionActor, ExceptionActorSync])
 @isolate_in_subprocess
-async def test_broadcast_exception_with_no_reply_port_kills_actor() -> None:
+async def test_broadcast_exception_with_no_reply_port_kills_actor(actor_class) -> None:
     """A plain `Exception` from an endpoint invoked with *no reply port*
     (fire-and-forget `broadcast()`) fails the actor: the return is dropped, the
     exception escapes through `DroppingPort.exception`, and the actor is killed,
@@ -326,7 +328,7 @@ async def test_broadcast_exception_with_no_reply_port_kills_actor() -> None:
 
     monarch.actor.unhandled_fault_hook = fault_hook
     proc = spawn_procs_on_this_host({"gpus": 1})
-    actor = proc.spawn("exception_actor", ExceptionActor)
+    actor = proc.spawn("exception_actor", actor_class)
 
     actor.raise_exception.broadcast()  # no reply port => the actor dies
     await asyncio.wait_for(faulted.wait(), timeout=15.0)
@@ -341,8 +343,11 @@ async def test_broadcast_exception_with_no_reply_port_kills_actor() -> None:
 
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@pytest.mark.parametrize("actor_class", [ExceptionActor, ExceptionActorSync])
 @isolate_in_subprocess
-async def test_reply_port_exception_returns_to_caller_and_actor_survives() -> None:
+async def test_reply_port_exception_returns_to_caller_and_actor_survives(
+    actor_class,
+) -> None:
     """The reply-port half of the contract, and the only cell where the actor
     lives: an endpoint `Exception` called *with* a reply port comes back to the
     caller as `ActorError`, the actor stays alive (a follow-up call succeeds),
@@ -352,7 +357,7 @@ async def test_reply_port_exception_returns_to_caller_and_actor_survives() -> No
     faults = []
     monarch.actor.unhandled_fault_hook = lambda failure: faults.append(failure)
     proc = spawn_procs_on_this_host({"gpus": 1})
-    actor = proc.spawn("exception_actor", ExceptionActor)
+    actor = proc.spawn("exception_actor", actor_class)
 
     with pytest.raises(ActorError, match="This is a test exception"):
         await actor.raise_exception.call_one()
@@ -376,10 +381,19 @@ class ExplicitPortFailingActor(Actor):
         raise Exception("This is a test exception")
 
 
+class ExplicitPortFailingActorSync(Actor):
+    @endpoint(explicit_response_port=True)
+    def fail(self, port: Port[None]) -> None:
+        raise Exception("This is a test exception")
+
+
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
+@pytest.mark.parametrize(
+    "actor_class", [ExplicitPortFailingActor, ExplicitPortFailingActorSync]
+)
 @isolate_in_subprocess
-async def test_explicit_response_port_exception_kills_actor() -> None:
+async def test_explicit_response_port_exception_kills_actor(actor_class) -> None:
     """A plain `@endpoint(explicit_response_port=True)` that raises instead of
     sending via its port kills the actor: the explicit-port declaration rebinds
     the ambient response port to `DroppingPort`, so the raise takes the no-port
@@ -390,12 +404,114 @@ async def test_explicit_response_port_exception_kills_actor() -> None:
     `test_concurrent_endpoints.py`)."""
     monarch.actor.unhandled_fault_hook = lambda failure: None
     proc = spawn_procs_on_this_host({"gpus": 1})
-    actor = proc.spawn("explicit_port_actor", ExplicitPortFailingActor)
+    actor = proc.spawn("explicit_port_actor", actor_class)
 
     with pytest.raises(SupervisionError):
         await asyncio.wait_for(actor.fail.call_one(), timeout=15)
 
     await proc.stop()
+
+
+class PanicActor(Actor):
+    @endpoint
+    async def cause_panic(self) -> None:
+        """Raise a Rust panic, which pyo3 re-raises into Python as a
+        `PanicException` (a `BaseException`, not an `Exception`)."""
+        panicking_function()
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_endpoint_panic_kills_actor() -> None:
+    """A Rust panic in an endpoint surfaces in Python as a pyo3 `PanicException`
+    (a `BaseException`, not an `Exception`), which kills the actor and arrives as
+    a supervision fault. This is a different path from a plain `Exception`:
+    `_Actor.handle`'s `except BaseException` routes it through
+    `panic_flag.signal_panic` (direct dispatch) or `_QueuePanicFlag` +
+    `_dispatch_loop` (queue dispatch), never the response port. The fault
+    reason's exact text is racy (a known signal_panic-vs-Aborted format race),
+    so this pins death and delivery, not the message string."""
+    faults = []
+    faulted = asyncio.Event()
+
+    def fault_hook(failure):
+        faults.append(failure)
+        faulted.set()
+
+    monarch.actor.unhandled_fault_hook = fault_hook
+    proc = spawn_procs_on_this_host({"gpus": 1})
+    actor = proc.spawn("panic_actor", PanicActor)
+
+    actor.cause_panic.broadcast()  # no reply port => the actor dies
+    await asyncio.wait_for(faulted.wait(), timeout=15.0)
+
+    assert len(faults) >= 1
+    assert "panic_actor" in str(faults[0])
+
+    await proc.stop()
+
+
+class SuperviseExceptionParent(Actor):
+    """Owner actor that records `__supervise__` faults from a child it spawns.
+
+    Pins that a plain-`Exception` no-reply-port kill in the child is delivered
+    to the owner's supervisor callback, not only the root fault hook. Existing
+    `__supervise__` coverage drives the child with supervision-specific failures
+    rather than a plain `Exception`.
+    """
+
+    def __init__(self, proc_mesh: ProcMesh) -> None:
+        self.child = proc_mesh.spawn("exception_actor", ExceptionActor)
+        self.failures: list[MeshFailure] = []
+        self.faulted = asyncio.Event()
+
+    @endpoint
+    async def child_broadcast_fail(self) -> None:
+        await self.child.noop.call()  # ensure the child is alive first
+        # no reply port => the child dies; the failure must still reach
+        # __supervise__ on the owner.
+        self.child.raise_exception.broadcast()
+        await asyncio.wait_for(self.faulted.wait(), timeout=30)
+
+    @endpoint
+    async def get_failures(self) -> list[str]:
+        # MeshFailure is not picklable, so return strings.
+        return [str(f) for f in self.failures]
+
+    def __supervise__(self, failure: MeshFailure) -> bool:
+        self.failures.append(failure)
+        self.faulted.set()
+        return True  # suppress so the fault does not propagate further
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_no_reply_port_exception_delivered_to_supervisor() -> None:
+    """End-to-end supervision: a plain `Exception` from a child endpoint invoked
+    with no reply port (`broadcast()`) is delivered to the owner's
+    `__supervise__` as a `MeshFailure`. Companion to
+    `test_broadcast_exception_with_no_reply_port_kills_actor`, which pins the
+    kill at the root fault hook; this pins the parent-delivery half."""
+    pm = spawn_procs_on_this_host({"gpus": 1})
+    # A separate mesh for the child avoids an intermittent same-mesh spawn race
+    # (see the other supervise tests).
+    second_mesh = spawn_procs_on_this_host({"gpus": 1})
+    supervisor = pm.spawn("supervisor", SuperviseExceptionParent, second_mesh)
+
+    await supervisor.child_broadcast_fail.call()
+    result = await supervisor.get_failures.call()
+    result = [f for _, f in result]
+    assert len(result) == 1
+    r = result[0]
+    assert len(r) >= 1, f"expected at least one supervision event, got {len(r)}"
+    for msg in r:
+        assert "MeshFailure" in msg
+        assert "exception_actor" in msg
+
+    await pm.stop()
+    await second_mesh.stop()
 
 
 @parametrize_config(actor_queue_dispatch={True, False})

--- a/python/tests/test_concurrent_endpoints.py
+++ b/python/tests/test_concurrent_endpoints.py
@@ -11,8 +11,10 @@ import os
 from tempfile import TemporaryDirectory
 from typing import Any, cast
 
+import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
 from monarch.actor import Actor, concurrent_endpoint, endpoint, Port, this_host
 from monarch.config import parametrize_config
 
@@ -232,16 +234,21 @@ async def test_concurrent_endpoint_exception_uses_actor_error_context() -> None:
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 @isolate_in_subprocess
-async def test_concurrent_explicit_port_exception_is_not_auto_forwarded() -> None:
+async def test_concurrent_explicit_port_exception_kills_actor() -> None:
+    """An ``@concurrent_endpoint(explicit_response_port=True)`` body that raises
+    instead of sending through its port kills the actor with a supervision
+    error, just as a plain ``@endpoint(explicit_response_port=True)`` does (see
+    ``test_explicit_response_port_exception_kills_actor`` in
+    ``test_actor_error.py``). The escaped exception is not silently swallowed."""
+    monarch.actor.unhandled_fault_hook = lambda failure: None
     proc = this_host().spawn_procs(per_host={"gpus": 1})
     actor = proc.spawn(
         "concurrent_explicit_port_failing_actor", ConcurrentExplicitPortFailingActor
     )
 
     try:
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(actor.fail.call_one(), timeout=0.2)
-        assert await asyncio.wait_for(actor.ping.call_one(), timeout=10) == "pong"
+        with pytest.raises(SupervisionError):
+            await asyncio.wait_for(actor.fail.call_one(), timeout=15)
     finally:
         await proc.stop()
 

--- a/python/tests/test_future_characterization.py
+++ b/python/tests/test_future_characterization.py
@@ -8,14 +8,11 @@
 
 """Characterization oracle for the public ``monarch`` ``Future`` state machine.
 
-Stage 0 of the pytokio removal (RFC1): this pins the *current* behavior of
-``monarch._src.actor.future.Future`` -- its five internal states, every
-transition between them, its seven conversion-error strings, and the
-``get()``-inside-a-loop warning -- so the later stages, which make ``Future``
-two-state and non-awaitable, have an oracle to diff against.
-
-This is a *transitional* oracle: stage 6 deletes the state machine it pins, so
-this file is expected to be rewritten or removed at that point.
+Pins the *current* behavior of ``monarch._src.actor.future.Future`` -- its
+internal states and every transition between them, its conversion-error
+strings, the ``get()``-inside-a-loop warning, and the ``_take_inner()``
+accessor with its ``_Taken`` terminal state -- so that any change to that
+behavior is caught here and made explicit.
 """
 
 import asyncio
@@ -266,3 +263,90 @@ def test_get_in_tokio_thread_warns_then_cannot_block(monkeypatch):
         _run_in_tokio(attempt())
     assert len(calls) == 1
     assert calls[0]["extra"]["context"] == "tokio"
+
+
+# ---------------------------------------------------------------------------
+# _take_inner() and the _Taken terminal state
+#
+# _take_inner() requires an unawaited Future -- it fails if the Future was
+# already resolved or converted by get()/await. On success it surrenders the
+# underlying PythonTask to a caller that drives it directly and transitions the
+# Future to the terminal _Taken state, so the Future is spent: a second take,
+# or any later get()/await, fails rather than silently re-driving the one-shot
+# task.
+# ---------------------------------------------------------------------------
+
+
+def test_take_inner_returns_task_and_marks_future_taken():
+    """_take_inner() on an unawaited Future returns the underlying (still
+    drivable) PythonTask and transitions the Future to the terminal _Taken
+    state."""
+    fut: Future[int] = Future(coro=_value(1))
+    task = fut._take_inner()
+    assert isinstance(task, PythonTask)
+    assert isinstance(fut._status, future_mod._Taken)
+    assert task.block_on() == 1
+
+
+def test_take_inner_twice_raises():
+    """The Future is spent after the first _take_inner(); a second raises."""
+    fut: Future[int] = Future(coro=_value(1))
+    fut._take_inner()
+    with pytest.raises(ValueError, match="already been awaited"):
+        fut._take_inner()
+
+
+def test_get_after_take_inner_raises():
+    """get() after _take_inner() fails at the Future instead of re-driving the
+    surrendered task."""
+    fut: Future[int] = Future(coro=_value(1))
+    fut._take_inner()
+    with pytest.raises(ValueError, match="consumed"):
+        fut.get()
+
+
+async def test_await_asyncio_after_take_inner_raises():
+    """await under asyncio after _take_inner() fails instead of re-driving."""
+    fut: Future[int] = Future(coro=_value(1))
+    fut._take_inner()
+    with pytest.raises(ValueError, match="consumed"):
+        await fut
+
+
+def test_await_tokio_after_take_inner_raises():
+    """await on a tokio thread after _take_inner() fails instead of re-driving."""
+    fut: Future[int] = Future(coro=_value(1))
+    fut._take_inner()
+
+    async def attempt():
+        await fut
+
+    with pytest.raises(ValueError, match="consumed"):
+        _run_in_tokio(attempt())
+
+
+def test_take_inner_after_get_raises():
+    """_take_inner() requires an unawaited Future: once get() has resolved it
+    (_Complete), taking the inner task is refused."""
+    fut: Future[int] = Future(coro=_value(1))
+    assert fut.get() == 1  # -> _Complete
+    with pytest.raises(ValueError, match="already been awaited"):
+        fut._take_inner()
+
+
+def test_take_inner_after_asyncio_await_raises():
+    """Once an asyncio await has converted the Future (_Asyncio), _take_inner()
+    is refused."""
+    fut: Future[int] = Future(coro=_value(1))
+    asyncio.run(_await_once(fut))  # -> _Asyncio
+    with pytest.raises(ValueError, match="already been awaited"):
+        fut._take_inner()
+
+
+def test_take_inner_after_tokio_await_raises():
+    """Once a tokio await has converted the Future (_Tokio), _take_inner() is
+    refused."""
+    fut: Future[int] = Future(coro=_value(1))
+    _run_in_tokio(_await_once(fut))  # -> _Tokio
+    with pytest.raises(ValueError, match="already been awaited"):
+        fut._take_inner()

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -209,6 +209,58 @@ def test_alias_bootstrap() -> None:
 
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
+def test_attach_to_workers_accepts_future_addresses() -> None:
+    """`attach_to_workers` accepts ``Future[str]`` worker addresses, exercising
+    the ``_as_python_task`` -> ``Future._take_inner()`` path: the Future's
+    underlying task is surrendered to Rust, driven there to yield the address,
+    and the attach proceeds exactly as for plain ``str`` workers."""
+    from monarch._src.actor.future import Future
+
+    async def _resolve(addr: str) -> str:
+        return addr
+
+    procs = []
+    workers = []
+    for _i in range(2):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.bind(("127.0.0.1", 0))
+        port = sock.getsockname()[1]
+        sock.close()
+
+        env = {**os.environ}
+        if "FB_XAR_INVOKED_NAME" in os.environ:
+            env["PYTHONPATH"] = ":".join(sys.path)
+
+        addr = f"tcp://127.0.0.1:{port}"
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import sys; from monarch.actor import run_worker_loop_forever; "
+                f'run_worker_loop_forever(address={addr!r}, ca="trust_all_connections")',
+            ],
+            env=env,
+        )
+        procs.append(proc)
+        # Wrap the address in a Future[str] so attach goes through _take_inner.
+        fut: Future[str] = Future(coro=_resolve(addr))
+        workers.append(fut)
+
+    try:
+        # pyrefly: ignore [bad-argument-type]
+        hosts = attach_to_workers(ca="trust_all_connections", workers=workers)
+        am = hosts.spawn_procs(per_host={"gpus": 1}).spawn("rank", RankActor)
+        ranks = sorted(v for _, v in am.get_rank.call().get().items())
+        assert ranks == [0, 1]
+        hosts.shutdown().get()
+    finally:
+        for proc in procs:
+            proc.kill()
+            proc.wait()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
 async def test_host_mesh_context_manager() -> None:
     """Tests that the HostMesh can be used as a context manager and that it runs
     shutdown on exit"""

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -22,6 +22,7 @@ import threading
 import time
 import unittest
 import unittest.mock
+import warnings
 from tempfile import TemporaryDirectory
 from types import ModuleType
 from typing import Any, cast, Dict, Iterator, NamedTuple, Tuple
@@ -267,6 +268,40 @@ def test_sync_actor_sync_client() -> None:
     r = a.sync_endpoint.choose(c).get()
     assert r == 5
     proc.stop().get()
+
+
+class SyncContextActor(Actor):
+    @endpoint
+    def observe_sync_context(self, a_counter: Counter) -> Tuple[bool, bool, int]:
+        # A sync endpoint runs with no asyncio loop visible on its thread, so
+        # get_running_loop() raises and Future.get() blocks without the
+        # active-event-loop warning.
+        try:
+            asyncio.get_running_loop()
+            loop_visible = True
+        except RuntimeError:
+            loop_visible = False
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            value = a_counter.value.choose().get()
+        warned = any("active event loop" in str(w.message) for w in caught)
+        return loop_visible, warned, value
+
+
+@pytest.mark.timeout(60)
+@parametrize_config(actor_queue_dispatch={True, False})
+async def test_sync_endpoint_has_no_visible_loop_and_get_does_not_warn() -> None:
+    """A sync (`def`) endpoint runs without a visible asyncio loop:
+    `asyncio.get_running_loop()` raises inside it, and `Future.get()` therefore
+    takes the legal blocking path without the "active event loop" warning."""
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    a = proc.spawn("actor", SyncContextActor)
+    c = proc.spawn("counter", Counter, 5)
+    loop_visible, warned, value = await a.observe_sync_context.choose(c)
+    assert loop_visible is False, "a sync endpoint should see no running loop"
+    assert warned is False, "Future.get() in a sync endpoint should not warn"
+    assert value == 5
+    await proc.stop()
 
 
 @pytest.mark.timeout(60)


### PR DESCRIPTION
Summary:

while retiring pytokio, pin the execution-context invariant `fake_sync_state` gives sync endpoints, before stage 5 reworks how it's provided. RFC: https://docs.google.com/document/d/1jNRPQLrAJawTDvVq1Ddxsl7kgZqg89mN/edit#bookmark=id.127riaf3vylf

a sync (`def`) endpoint runs with no visible asyncio loop: `asyncio.get_running_loop()` raises inside it, and `Future.get()` therefore takes the legal blocking path without the "active event loop" warning. `test_python_actors.py` already exercises sync endpoints (`test_sync_actor`) but asserts only the return value; this adds `SyncContextActor.observe_sync_context` plus a test pinning the loop-invisibility and the no-warn `get()`, parametrized over both dispatch modes.

durable oracle: stage 5 deletes `fake_sync_state` and runs sync endpoints on a per-actor executor thread, which preserves the same invariant (a real loop-less thread), so this stays green through that change. pure test addition, no product code.

Reviewed By: pzhan9

Differential Revision: D109590921
