### PR TITLE
Re-enable ROCm CI (#4290)

### DIFF
--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -36,7 +36,6 @@ jobs:
       IS_PUSH: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/heads') }}
       IS_SCHEDULE: ${{ github.event_name == 'schedule' }}
       IS_ROCM_TAG: ${{ startsWith(github.ref, 'refs/tags/ciflow/rocm/') }}
-      HAS_ROCM_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ciflow/rocm') }}
 
     steps:
       - id: set
@@ -61,21 +60,24 @@ jobs:
           ROCM_72_PY310='{"name": "rocm7.2", "python-version": "3.10", "docker-image": "pytorch/manylinux2_28-builder:rocm7.2", "torch-spec": "--pre torch --extra-index-url https://download.pytorch.org/whl/nightly/rocm7.2/"}'
 
           # Build matrix:
-          # - ROCm tag: ROCm only (manual opt-in; CUDA already built in PR run)
-          # - Otherwise (PR/push/schedule): CUDA only
-          # ROCm is disabled in normal CI while it is broken. Push a
-          # ciflow/rocm tag to build and test ROCm manually. See
-          # https://github.com/meta-pytorch/monarch/issues/4145 for re-enabling.
+          # - ROCm tag: ROCm only (CUDA already built in PR run)
+          # - Push/schedule: CUDA + ROCm
+          # - PR (with or without ciflow/rocm label): CUDA only
+          #   ROCm builds are skipped on PRs so CUDA tests don't wait for them;
+          #   ROCm build failures are caught on push to main.
           if [[ "$IS_ROCM_TAG" == "true" ]]; then
             BUILD_MATRIX="[$ROCM_71_PY310, $ROCM_72_PY310]"
+          elif [[ "$IS_PUSH" == "true" || "$IS_SCHEDULE" == "true" ]]; then
+            BUILD_MATRIX="[$CUDA_PY310, $CUDA_PY312, $ROCM_71_PY310, $ROCM_72_PY310]"
           else
             BUILD_MATRIX="[$CUDA_PY310, $CUDA_PY312]"
           fi
 
-          # Test matrix: ROCm tested only on a manual ciflow/rocm tag; CUDA
-          # otherwise. ROCm is disabled in normal CI while it is broken.
+          # Test matrix: ROCm tested only on push/schedule/tag
           if [[ "$IS_ROCM_TAG" == "true" ]]; then
             TEST_MATRIX="[$ROCM_71, $ROCM_72]"
+          elif [[ "$IS_PUSH" == "true" || "$IS_SCHEDULE" == "true" ]]; then
+            TEST_MATRIX="[$CUDA, $ROCM_71, $ROCM_72]"
           else
             TEST_MATRIX="[$CUDA]"
           fi

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -417,8 +417,10 @@ pub(super) unsafe fn register_dmabuf_mr(
     let _ctx_guard = unsafe { crate::local_memory::set_ctx_for_ptr(addr)? };
 
     // Resolve the base and size of the allocation containing `addr`; the dmabuf
-    // handle and MR cover the whole allocation.
-    let mut base: rdmaxcel_sys::CUdeviceptr = 0;
+    // handle and MR cover the whole allocation. The `as rdmaxcel_sys::CUdeviceptr`
+    // is necessary because on CUDA, `CUdeviceptr` is a usize, while on ROCm, it's
+    // *mut c_void.
+    let mut base: rdmaxcel_sys::CUdeviceptr = 0 as rdmaxcel_sys::CUdeviceptr;
     let mut alloc_size: usize = 0;
     // SAFETY: `rdmaxcel_cuMemGetAddressRange` writes the allocation's base and
     // size into the out-params and touches no other Rust memory; it reports


### PR DESCRIPTION
Summary:

Restores ROCm builds and tests to normal CI: push-to-main and scheduled runs again cover CUDA + ROCm7.1 + ROCm7.2. Reverts D107127116. Also drops the unused `HAS_ROCM_LABEL` env var.

Differential Revision: D109591190


