### PR TITLE
Support `Local` transport for duplex channels (#4291)

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -29,6 +29,7 @@ use serde::Serialize;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 use tokio::sync::watch;
+use tokio::time::Instant;
 
 use crate as hyperactor;
 use crate::RemoteMessage;
@@ -250,97 +251,6 @@ pub trait Rx<M: RemoteMessage> {
         Self: Sized;
 }
 
-#[allow(dead_code)] // Not used outside tests.
-struct MpscTx<M: RemoteMessage> {
-    tx: mpsc::UnboundedSender<M>,
-    addr: ChannelAddr,
-    status: watch::Receiver<TxStatus>,
-}
-
-impl<M: RemoteMessage> MpscTx<M> {
-    #[allow(dead_code)] // Not used outside tests.
-    pub fn new(tx: mpsc::UnboundedSender<M>, addr: ChannelAddr) -> (Self, watch::Sender<TxStatus>) {
-        let (sender, receiver) = watch::channel(TxStatus::Active);
-        (
-            Self {
-                tx,
-                addr,
-                status: receiver,
-            },
-            sender,
-        )
-    }
-}
-
-#[async_trait]
-impl<M: RemoteMessage> Tx<M> for MpscTx<M> {
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        if let Err(mpsc::error::SendError(message)) = self.tx.send(message)
-            && let Some(return_channel) = return_channel
-        {
-            return_channel
-                .send(SendError {
-                    error: ChannelError::Closed,
-                    message,
-                    reason: None,
-                })
-                .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
-        }
-    }
-
-    fn addr(&self) -> ChannelAddr {
-        self.addr.clone()
-    }
-
-    fn status(&self) -> &watch::Receiver<TxStatus> {
-        &self.status
-    }
-}
-
-#[allow(dead_code)] // Not used outside tests.
-struct MpscRx<M: RemoteMessage> {
-    rx: mpsc::UnboundedReceiver<M>,
-    addr: ChannelAddr,
-    // Used to report the status to the Tx side.
-    status_sender: watch::Sender<TxStatus>,
-}
-
-impl<M: RemoteMessage> MpscRx<M> {
-    #[allow(dead_code)] // Not used outside tests.
-    pub fn new(
-        rx: mpsc::UnboundedReceiver<M>,
-        addr: ChannelAddr,
-        status_sender: watch::Sender<TxStatus>,
-    ) -> Self {
-        Self {
-            rx,
-            addr,
-            status_sender,
-        }
-    }
-}
-
-impl<M: RemoteMessage> Drop for MpscRx<M> {
-    fn drop(&mut self) {
-        let _ = self.status_sender.send(TxStatus::Closed(CloseReason::Other(
-            "receiver dropped".into(),
-        )));
-    }
-}
-
-#[async_trait]
-impl<M: RemoteMessage> Rx<M> for MpscRx<M> {
-    async fn recv(&mut self) -> Result<M, ChannelError> {
-        self.rx.recv().await.ok_or(ChannelError::Closed)
-    }
-
-    fn addr(&self) -> ChannelAddr {
-        self.addr.clone()
-    }
-
-    async fn join(self) {}
-}
-
 /// The hostname to use for TLS connections.
 #[derive(
     Clone,
@@ -468,7 +378,8 @@ pub enum ChannelTransport {
     /// Transport over a QUIC connection with TLS support within Meta.
     MetaQuic(TlsMode),
 
-    /// Local transports uses an in-process registry and mpsc channels.
+    /// Local transports use a process-local registry and private Unix socket
+    /// pairs.
     Local,
 
     /// Transport over unix domain socket.
@@ -553,9 +464,7 @@ impl ChannelTransport {
     }
 
     /// Returns true if this transport can carry the duplex byte-stream
-    /// protocol (see [`crate::channel::net::duplex`]). In-process
-    /// transports cannot carry a duplex wire protocol and must fall
-    /// back to a simplex channel.
+    /// protocol (see [`crate::channel::net::duplex`]).
     pub fn supports_duplex(&self) -> bool {
         match self {
             ChannelTransport::Tcp(_) => true,
@@ -565,7 +474,7 @@ impl ChannelTransport {
             ChannelTransport::Quic => false,
             ChannelTransport::MetaQuic(_) => false,
             ChannelTransport::Unix => true,
-            ChannelTransport::Local => false,
+            ChannelTransport::Local => true,
         }
     }
 }
@@ -1157,9 +1066,12 @@ impl ChannelAddr {
     }
 }
 
-/// Universal channel transmitter.
+/// Universal channel transmitter. Manages the link state, reconnections,
+/// etc. on top of a [`net::Link`].
 pub struct ChannelTx<M: RemoteMessage> {
-    inner: ChannelTxKind<M>,
+    sender: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
+    dest: ChannelAddr,
+    status: watch::Receiver<TxStatus>,
 }
 
 impl<M: RemoteMessage> fmt::Debug for ChannelTx<M> {
@@ -1170,39 +1082,46 @@ impl<M: RemoteMessage> fmt::Debug for ChannelTx<M> {
     }
 }
 
-/// Universal channel transmitter.
-enum ChannelTxKind<M: RemoteMessage> {
-    Local(local::LocalTx<M>),
-    Net(net::NetTx<M>),
-}
-
 #[async_trait]
 impl<M: RemoteMessage> Tx<M> for ChannelTx<M> {
     fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        match &self.inner {
-            ChannelTxKind::Local(tx) => tx.do_post(message, return_channel),
-            ChannelTxKind::Net(tx) => tx.do_post(message, return_channel),
+        tracing::trace!(
+            name = "post",
+            dest = %self.dest,
+            "sending message"
+        );
+
+        let return_channel = return_channel.unwrap_or_else(|| oneshot::channel().0);
+        if let Err(mpsc::error::SendError((message, return_channel, _))) =
+            self.sender.send((message, return_channel, Instant::now()))
+        {
+            let reason = self
+                .status
+                .borrow()
+                .as_closed()
+                .map(|r| SendErrorReason::Other(r.to_string()));
+            let _ = return_channel.send(SendError {
+                error: ChannelError::Closed,
+                message,
+                reason,
+            });
         }
     }
 
     fn addr(&self) -> ChannelAddr {
-        match &self.inner {
-            ChannelTxKind::Local(tx) => tx.addr(),
-            ChannelTxKind::Net(tx) => Tx::<M>::addr(tx),
-        }
+        self.dest.clone()
     }
 
     fn status(&self) -> &watch::Receiver<TxStatus> {
-        match &self.inner {
-            ChannelTxKind::Local(tx) => tx.status(),
-            ChannelTxKind::Net(tx) => tx.status(),
-        }
+        &self.status
     }
 }
 
 /// Universal channel receiver.
 pub struct ChannelRx<M: RemoteMessage> {
-    inner: ChannelRxKind<M>,
+    receiver: mpsc::Receiver<M>,
+    dest: ChannelAddr,
+    server: net::ServerHandle,
 }
 
 impl<M: RemoteMessage> fmt::Debug for ChannelRx<M> {
@@ -1213,34 +1132,44 @@ impl<M: RemoteMessage> fmt::Debug for ChannelRx<M> {
     }
 }
 
-/// Universal channel receiver.
-enum ChannelRxKind<M: RemoteMessage> {
-    Local(local::LocalRx<M>),
-    Net(net::NetRx<M>),
+impl<M: RemoteMessage> ChannelRx<M> {
+    /// Stop the channel server, tagging the log with what triggered shutdown.
+    fn stop(&self, trigger: &str) {
+        self.server.stop(&format!(
+            "ChannelRx {trigger}; channel address: {}",
+            self.dest
+        ));
+    }
 }
 
 #[async_trait]
 impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn recv(&mut self) -> Result<M, ChannelError> {
-        match &mut self.inner {
-            ChannelRxKind::Local(rx) => rx.recv().await,
-            ChannelRxKind::Net(rx) => rx.recv().await,
-        }
+        tracing::trace!(
+            name = "recv",
+            dest = %self.dest,
+            "receiving message"
+        );
+        self.receiver.recv().await.ok_or(ChannelError::Closed)
     }
 
     fn addr(&self) -> ChannelAddr {
-        match &self.inner {
-            ChannelRxKind::Local(rx) => rx.addr(),
-            ChannelRxKind::Net(rx) => rx.addr(),
-        }
+        self.dest.clone()
     }
 
-    async fn join(self) {
-        match self.inner {
-            ChannelRxKind::Local(rx) => rx.join().await,
-            ChannelRxKind::Net(rx) => rx.join().await,
-        }
+    /// Gracefully shut down the channel server, waiting for pending
+    /// acks to be flushed before returning.
+    async fn join(mut self) {
+        self.stop("joined");
+        let _ = (&mut self.server).await;
+        // Drop will call stop() again which is harmless (token already cancelled).
+    }
+}
+
+impl<M: RemoteMessage> Drop for ChannelRx<M> {
+    fn drop(&mut self) {
+        self.stop("dropped");
     }
 }
 
@@ -1252,19 +1181,11 @@ impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
 pub fn dial<M: RemoteMessage>(addr: ChannelAddr) -> Result<ChannelTx<M>, ChannelError> {
     let addr = addr.into_dial_addr();
     tracing::debug!(name = "dial", caller = %Location::caller(), %addr, "dialing channel {}", addr);
-    let inner = match addr {
-        ChannelAddr::Local(port) => ChannelTxKind::Local(local::dial(port)?),
-        ChannelAddr::Tcp(_)
-        | ChannelAddr::Unix(_)
-        | ChannelAddr::Tls(_)
-        | ChannelAddr::MetaTls(_)
-        | ChannelAddr::Quic(_)
-        | ChannelAddr::MetaQuic(_) => {
-            ChannelTxKind::Net(net::spawn(net::link(addr, net::SessionId::random(), 0)?))
-        }
-        ChannelAddr::Alias { .. } => unreachable!("aliases are canonicalized before dialing"),
-    };
-    Ok(ChannelTx { inner })
+    Ok(net::spawn::<M>(net::link(
+        addr,
+        net::SessionId::random(),
+        0,
+    )?))
 }
 
 /// Channels that may deliver messages out of send order.
@@ -1327,8 +1248,7 @@ pub mod unordered {
         let links: Vec<net::NetLink> = (1..=num_streams)
             .map(|i| net::link(addr.clone(), session_id, i as u8))
             .collect::<Result<_, _>>()?;
-        let inner = ChannelTxKind::Net(net::spawn_unordered(links));
-        Ok(ChannelTx { inner })
+        Ok(net::spawn_unordered::<M>(links))
     }
 
     /// Serve a receiver that accepts unordered senders.
@@ -1374,20 +1294,20 @@ pub fn serve_with_listener<M: RemoteMessage>(
     listener: Option<std::net::TcpListener>,
 ) -> Result<(ChannelAddr, ChannelRx<M>), ChannelError> {
     let caller = Location::caller();
-    serve_inner(addr, listener).map(|(addr, inner)| {
+    serve_inner(addr, listener).map(|(addr, rx)| {
         tracing::debug!(
             name = "serve",
             %addr,
             %caller,
         );
-        (addr, ChannelRx { inner })
+        (addr, rx)
     })
 }
 
 fn serve_inner<M: RemoteMessage>(
     addr: ChannelAddr,
     listener: Option<std::net::TcpListener>,
-) -> Result<(ChannelAddr, ChannelRxKind<M>), ChannelError> {
+) -> Result<(ChannelAddr, ChannelRx<M>), ChannelError> {
     match addr {
         ChannelAddr::Unix(_) => {
             assert!(
@@ -1395,9 +1315,10 @@ fn serve_inner<M: RemoteMessage>(
                 "pre-opened listener not supported for Unix transport"
             );
             let (addr, rx) = net::server::serve::<M>(addr, listener)?;
-            Ok((addr, ChannelRxKind::Net(rx)))
+            Ok((addr, rx))
         }
         ChannelAddr::Tcp(_)
+        | ChannelAddr::Local(_)
         | ChannelAddr::Tls(_)
         | ChannelAddr::MetaTls(_)
         | ChannelAddr::Quic(_)
@@ -1407,43 +1328,25 @@ fn serve_inner<M: RemoteMessage>(
         // the same net serve path as the other TCP-based transports.
         | ChannelAddr::Alias { .. } => {
             let (addr, rx) = net::server::serve::<M>(addr, listener)?;
-            Ok((addr, ChannelRxKind::Net(rx)))
+            Ok((addr, rx))
         }
-        ChannelAddr::Local(0) => {
-            assert!(
-                listener.is_none(),
-                "pre-opened listener not supported for Local transport"
-            );
-            let (port, rx) = local::serve::<M>();
-            Ok((ChannelAddr::Local(port), ChannelRxKind::Local(rx)))
-        }
-        ChannelAddr::Local(a) => Ok((
-            ChannelAddr::Local(a),
-            ChannelRxKind::Local(local::bind::<M>(a)?),
-        )),
     }
 }
 
 /// Serve on the local address. The server is turned down
 /// when the returned Rx is dropped.
 pub fn serve_local<M: RemoteMessage>() -> (ChannelAddr, ChannelRx<M>) {
-    let (port, rx) = local::serve::<M>();
-    (
-        ChannelAddr::Local(port),
-        ChannelRx {
-            inner: ChannelRxKind::Local(rx),
-        },
-    )
+    serve::<M>(ChannelAddr::Local(0)).expect("fresh local stream port must bind")
 }
 
 /// Reserve a local channel address that can be served later.
 ///
-/// Local channels are backed by an in-process port registry, so reserving a
-/// concrete address is a synchronous allocation that does not require a Tokio
-/// runtime or an OS listener. Gateways use this to have a stable advertised
-/// local location immediately, including when the process-wide gateway is
-/// initialized from a [`std::sync::OnceLock`]. Serving is a separate step that
-/// binds the reserved port to a receiver.
+/// Local channels are backed by a process-local port registry, so reserving a
+/// concrete address is a synchronous allocation that does not bind an OS
+/// listener. Gateways use this to have a stable advertised local location
+/// immediately, including when the process-wide gateway is initialized from a
+/// [`std::sync::OnceLock`]. Serving is a separate step that binds the reserved
+/// port to a receiver.
 ///
 /// Network transports do not have an equivalent reservation API here: their
 /// concrete addresses come from binding sockets and starting the corresponding
@@ -1665,7 +1568,7 @@ mod tests {
         let tx = dial::<u64>(addr.clone()).unwrap();
         tx.post(123);
         assert_eq!(rx.recv().await.unwrap(), 123);
-        drop(rx);
+        rx.join().await;
 
         let (rebound_addr, _rx) = serve::<u64>(addr.clone()).unwrap();
         assert_eq!(rebound_addr, addr);

--- a/hyperactor/src/channel/local.rs
+++ b/hyperactor/src/channel/local.rs
@@ -8,27 +8,22 @@
 
 //! Local (in-process) channel implementation.
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 
-use serde_multipart::Message;
+use tokio::net::UnixStream;
+use tokio::sync::mpsc;
 
 use super::*;
 
-/// Create a new local channel, returning its two ends.
-#[allow(dead_code)] // Not used outside tests.
-pub fn new<M: RemoteMessage>() -> (impl Tx<M>, impl Rx<M>) {
-    let (tx, rx) = mpsc::unbounded_channel::<M>();
-    let (mpsc_tx, status_sender) = MpscTx::new(tx, ChannelAddr::Local(0));
-    let mpsc_rx = MpscRx::new(rx, ChannelAddr::Local(0), status_sender);
-    (mpsc_tx, mpsc_rx)
-}
-
 // In-process channels, with a shared registry.
 
+struct PortEntry {
+    tx: Option<mpsc::UnboundedSender<UnixStream>>,
+}
+
 struct Ports {
-    ports: HashMap<u64, (mpsc::UnboundedSender<Message>, watch::Receiver<TxStatus>)>,
+    ports: HashMap<u64, PortEntry>,
     next_port: u64,
 }
 
@@ -36,49 +31,54 @@ impl Ports {
     fn reserve(&mut self) -> u64 {
         let port = self.next_port;
         self.next_port += 1;
+        if self.ports.insert(port, PortEntry { tx: None }).is_some() {
+            panic!("port reused")
+        }
         port
     }
 
-    fn alloc(
-        &mut self,
-    ) -> (
-        u64,
-        mpsc::UnboundedReceiver<Message>,
-        watch::Sender<TxStatus>,
-    ) {
+    fn alloc_stream(&mut self) -> (u64, mpsc::UnboundedReceiver<UnixStream>) {
         let port = self.reserve();
-        let (rx, status_tx) = self.bind(port).expect("fresh local port must bind");
-        (port, rx, status_tx)
+        let rx = self
+            .bind_stream(port)
+            .expect("fresh local stream port must bind");
+        (port, rx)
     }
 
-    fn bind(
+    fn bind_stream(
         &mut self,
         port: u64,
-    ) -> Result<(mpsc::UnboundedReceiver<Message>, watch::Sender<TxStatus>), ChannelError> {
-        if self.ports.contains_key(&port) {
+    ) -> Result<mpsc::UnboundedReceiver<UnixStream>, ChannelError> {
+        if self
+            .ports
+            .get(&port)
+            .and_then(|entry| entry.tx.as_ref())
+            .is_some()
+        {
             return Err(ChannelError::InvalidAddress(format!(
                 "local addr already bound: {}",
                 port
             )));
         }
         self.next_port = self.next_port.max(port.saturating_add(1));
-        let (tx, rx) = mpsc::unbounded_channel::<Message>();
-        let (status_tx, status_rx) = watch::channel(TxStatus::Active);
-        if self.ports.insert(port, (tx.clone(), status_rx)).is_some() {
-            panic!("port reused")
-        }
-        Ok((rx, status_tx))
+        let (tx, rx) = mpsc::unbounded_channel::<UnixStream>();
+        self.ports.insert(port, PortEntry { tx: Some(tx) });
+        Ok(rx)
     }
 
     fn free(&mut self, port: u64) {
         self.ports.remove(&port);
     }
 
-    fn get(
-        &self,
-        port: u64,
-    ) -> Option<&(mpsc::UnboundedSender<Message>, watch::Receiver<TxStatus>)> {
-        self.ports.get(&port)
+    fn get_stream(&self, port: u64) -> Option<mpsc::UnboundedSender<UnixStream>> {
+        self.ports.get(&port).and_then(|entry| entry.tx.clone())
+    }
+
+    fn has_stream(&self, port: u64) -> bool {
+        self.ports
+            .get(&port)
+            .and_then(|entry| entry.tx.as_ref())
+            .is_some()
     }
 }
 
@@ -93,129 +93,186 @@ impl Default for Ports {
 
 static PORTS: LazyLock<Mutex<Ports>> = LazyLock::new(|| Mutex::new(Ports::default()));
 
-pub struct LocalTx<M: RemoteMessage> {
-    tx: mpsc::UnboundedSender<Message>,
-    port: u64,
-    status: watch::Receiver<TxStatus>, // Default impl. Always reports `Active`.
-    _phantom: PhantomData<M>,
-}
-
-#[async_trait]
-impl<M: RemoteMessage> Tx<M> for LocalTx<M> {
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        let data = match serde_multipart::serialize_bincode(&message) {
-            Ok(data) => data,
-            Err(err) => {
-                if let Some(return_channel) = return_channel {
-                    return_channel
-                        .send(SendError {
-                            error: ChannelError::Other(anyhow::Error::from(err)),
-                            message,
-                            reason: None,
-                        })
-                        .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
-                }
-                return;
-            }
-        };
-        if self.tx.send(data).is_err()
-            && let Some(return_channel) = return_channel
-        {
-            return_channel
-                .send(SendError {
-                    error: ChannelError::Closed,
-                    message,
-                    reason: None,
-                })
-                .unwrap_or_else(|m| tracing::warn!("failed to deliver SendError: {}", m));
-        }
-    }
-
-    fn addr(&self) -> ChannelAddr {
-        ChannelAddr::Local(self.port)
-    }
-
-    fn status(&self) -> &watch::Receiver<TxStatus> {
-        &self.status
-    }
-}
-
-pub struct LocalRx<M: RemoteMessage> {
-    data_rx: mpsc::UnboundedReceiver<Message>,
-    status_tx: watch::Sender<TxStatus>,
-    port: u64,
-    _phantom: PhantomData<M>,
-}
-
-#[async_trait]
-impl<M: RemoteMessage> Rx<M> for LocalRx<M> {
-    async fn recv(&mut self) -> Result<M, ChannelError> {
-        let message = self.data_rx.recv().await.ok_or(ChannelError::Closed)?;
-        serde_multipart::deserialize_bincode(message)
-            .map_err(|err| ChannelError::Other(anyhow::Error::from(err)))
-    }
-
-    fn addr(&self) -> ChannelAddr {
-        ChannelAddr::Local(self.port)
-    }
-
-    async fn join(self) {}
-}
-
-impl<M: RemoteMessage> Drop for LocalRx<M> {
-    fn drop(&mut self) {
-        let _ = self.status_tx.send(TxStatus::Closed(CloseReason::Other(
-            "receiver dropped".into(),
-        )));
-        PORTS.lock().unwrap().free(self.port);
-    }
-}
-
-/// Dial a local port, returning a Tx for it.
-#[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `ChannelError`.
-pub fn dial<M: RemoteMessage>(port: u64) -> Result<LocalTx<M>, ChannelError> {
-    let ports = PORTS.lock().unwrap();
-    let result = ports.get(port);
-    if let Some((data_tx, status_rx)) = result {
-        Ok(LocalTx {
-            tx: data_tx.clone(),
-            port,
-            status: status_rx.clone(),
-            _phantom: PhantomData,
-        })
-    } else {
-        Err(ChannelError::Closed)
-    }
-}
-
-/// Serve a local port. The server is shut down when the returned Rx is dropped.
-pub fn serve<M: RemoteMessage>() -> (u64, LocalRx<M>) {
-    let (port, data_rx, status_tx) = PORTS.lock().unwrap().alloc();
-    (
-        port,
-        LocalRx {
-            data_rx,
-            status_tx,
-            port,
-            _phantom: PhantomData,
-        },
-    )
-}
-
 /// Reserve a local address that can be served later.
 pub fn reserve() -> u64 {
     PORTS.lock().unwrap().reserve()
 }
 
-/// Bind a specific local port. The server is shut down when the returned Rx is dropped.
-pub fn bind<M: RemoteMessage>(port: u64) -> Result<LocalRx<M>, ChannelError> {
-    let (data_rx, status_tx) = PORTS.lock().unwrap().bind(port)?;
-    Ok(LocalRx {
-        data_rx,
-        status_tx,
-        port,
-        _phantom: PhantomData,
-    })
+pub(crate) mod stream {
+    use std::fmt;
+    use std::os::unix::net::UnixStream as StdUnixStream;
+
+    use async_trait::async_trait;
+    use tokio::net::UnixStream;
+    use tokio::sync::mpsc;
+
+    use super::PORTS;
+    use crate::channel::ChannelAddr;
+    use crate::channel::net::ClientError;
+    use crate::channel::net::Link;
+    use crate::channel::net::Listener;
+    use crate::channel::net::ServerError;
+    use crate::channel::net::SessionId;
+    use crate::channel::net::write_link_init;
+
+    #[derive(Debug)]
+    pub(crate) struct LocalLink {
+        port: u64,
+        session_id: SessionId,
+        stream_id: u8,
+    }
+
+    impl LocalLink {
+        pub(crate) fn new(port: u64, session_id: SessionId, stream_id: u8) -> Self {
+            Self {
+                port,
+                session_id,
+                stream_id,
+            }
+        }
+
+        fn dest(&self) -> ChannelAddr {
+            ChannelAddr::Local(self.port)
+        }
+
+        fn pair(&self) -> Result<(UnixStream, UnixStream), ClientError> {
+            let dest = self.dest();
+            let (client, server) = StdUnixStream::pair().map_err(|err| {
+                ClientError::Connect(dest.clone(), err, "local socket pair failed".into())
+            })?;
+            client.set_nonblocking(true).map_err(|err| {
+                ClientError::Connect(dest.clone(), err, "local client socket setup failed".into())
+            })?;
+            server.set_nonblocking(true).map_err(|err| {
+                ClientError::Connect(dest.clone(), err, "local server socket setup failed".into())
+            })?;
+            let client =
+                UnixStream::from_std(client).map_err(|err| ClientError::Io(dest.clone(), err))?;
+            let server =
+                UnixStream::from_std(server).map_err(|err| ClientError::Io(dest.clone(), err))?;
+            Ok((client, server))
+        }
+
+        fn connect(&self, server: UnixStream) -> Result<(), ClientError> {
+            let dest = self.dest();
+            let accept_tx = PORTS.lock().unwrap().get_stream(self.port).ok_or_else(|| {
+                ClientError::Connect(
+                    dest.clone(),
+                    std::io::Error::new(std::io::ErrorKind::NotConnected, "channel closed"),
+                    "channel closed".into(),
+                )
+            })?;
+            accept_tx.send(server).map_err(|_| {
+                ClientError::Connect(
+                    dest,
+                    std::io::Error::new(std::io::ErrorKind::ConnectionRefused, "channel closed"),
+                    "channel closed".into(),
+                )
+            })
+        }
+    }
+
+    pub(crate) fn check(port: u64) -> Result<(), ClientError> {
+        if PORTS.lock().unwrap().has_stream(port) {
+            Ok(())
+        } else {
+            Err(ClientError::Connect(
+                ChannelAddr::Local(port),
+                std::io::Error::new(std::io::ErrorKind::NotConnected, "channel closed"),
+                "channel closed".into(),
+            ))
+        }
+    }
+
+    #[async_trait]
+    impl Link for LocalLink {
+        type Stream = UnixStream;
+
+        fn dest(&self) -> ChannelAddr {
+            ChannelAddr::Local(self.port)
+        }
+
+        fn link_id(&self) -> SessionId {
+            self.session_id
+        }
+
+        async fn next(&mut self) -> Result<Self::Stream, ClientError> {
+            let (mut client, server) = self.pair()?;
+            self.connect(server)?;
+            write_link_init(&mut client, self.session_id, self.stream_id)
+                .await
+                .map_err(|err| ClientError::Io(self.dest(), err))?;
+            Ok(client)
+        }
+    }
+
+    pub(crate) struct LocalListener {
+        accept_rx: mpsc::UnboundedReceiver<UnixStream>,
+        port: u64,
+    }
+
+    impl fmt::Debug for LocalListener {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("LocalListener")
+                .field("addr", &ChannelAddr::Local(self.port))
+                .finish()
+        }
+    }
+
+    impl Drop for LocalListener {
+        fn drop(&mut self) {
+            PORTS.lock().unwrap().free(self.port);
+        }
+    }
+
+    #[async_trait]
+    impl Listener for LocalListener {
+        type Stream = UnixStream;
+
+        async fn accept(&mut self) -> Result<(Self::Stream, ChannelAddr), ServerError> {
+            let addr = ChannelAddr::Local(self.port);
+            let stream = self.accept_rx.recv().await.ok_or_else(|| {
+                ServerError::Io(addr.clone(), std::io::Error::other("local listener closed"))
+            })?;
+            Ok((stream, addr))
+        }
+    }
+
+    pub(crate) fn listen(
+        addr: ChannelAddr,
+        prebound: Option<std::net::TcpListener>,
+    ) -> Result<(LocalListener, ChannelAddr), ServerError> {
+        if prebound.is_some() {
+            return Err(ServerError::Listen(
+                addr,
+                std::io::Error::other("pre-opened listener not supported for Local transport"),
+            ));
+        }
+
+        let ChannelAddr::Local(port) = addr else {
+            return Err(ServerError::Listen(
+                addr.clone(),
+                std::io::Error::other(format!("unsupported transport: {}", addr)),
+            ));
+        };
+        let (port, accept_rx) = if port == 0 {
+            PORTS.lock().unwrap().alloc_stream()
+        } else {
+            let accept_rx = PORTS.lock().unwrap().bind_stream(port).map_err(|err| {
+                ServerError::Listen(
+                    ChannelAddr::Local(port),
+                    std::io::Error::other(err.to_string()),
+                )
+            })?;
+            (port, accept_rx)
+        };
+        let addr = ChannelAddr::Local(port);
+        Ok((LocalListener { accept_rx, port }, addr))
+    }
+
+    pub(crate) fn link(port: u64, session_id: SessionId, stream_id: u8) -> LocalLink {
+        LocalLink::new(port, session_id, stream_id)
+    }
 }
 
 #[cfg(test)]
@@ -223,22 +280,19 @@ mod tests {
     use std::assert_matches;
 
     use super::*;
+    use crate::channel as public_channel;
+    use crate::channel::duplex as public_duplex;
 
     #[tokio::test]
-    async fn test_local_basic() {
-        let (tx, mut rx) = local::new::<u64>();
-
-        tx.post(123);
-        assert_eq!(rx.recv().await.unwrap(), 123);
-    }
-
-    #[tokio::test]
-    async fn test_local_dial_serve() {
-        let (port, mut rx) = local::serve::<u64>();
+    async fn test_public_local_dial_serve() {
+        let (addr, mut rx) =
+            public_channel::serve::<u64>(ChannelAddr::any(ChannelTransport::Local)).unwrap();
+        let ChannelAddr::Local(port) = addr else {
+            panic!("local server must bind a local address");
+        };
         assert!(port != 0);
 
-        let tx = local::dial::<u64>(port).unwrap();
-
+        let tx = public_channel::dial::<u64>(ChannelAddr::Local(port)).unwrap();
         tx.post(123);
         assert_eq!(rx.recv().await.unwrap(), 123);
 
@@ -257,18 +311,43 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_local_drop() {
-        let (port, mut rx) = local::serve::<u64>();
-        let tx = local::dial::<u64>(port).unwrap();
+    async fn test_public_local_drop() {
+        let (addr, mut rx) =
+            public_channel::serve::<u64>(ChannelAddr::any(ChannelTransport::Local)).unwrap();
+        let ChannelAddr::Local(port) = addr else {
+            panic!("local server must bind a local address");
+        };
+        let tx = public_channel::dial::<u64>(ChannelAddr::Local(port)).unwrap();
 
         tx.post(123);
         assert_eq!(rx.recv().await.unwrap(), 123);
 
-        drop(rx);
+        rx.join().await;
 
-        assert_matches!(
-            local::dial::<u64>(port).err().unwrap(),
-            ChannelError::Closed
-        );
+        assert!(public_channel::dial::<u64>(ChannelAddr::Local(port)).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_public_local_duplex_dial_serve() {
+        assert!(ChannelTransport::Local.supports_duplex());
+
+        let mut server =
+            public_duplex::serve::<u64, String>(ChannelAddr::any(ChannelTransport::Local), None)
+                .unwrap();
+        let ChannelAddr::Local(port) = server.addr().clone() else {
+            panic!("local duplex server must bind a local address");
+        };
+        assert!(port != 0);
+
+        let mut client = public_duplex::dial::<u64, String>(server.addr().clone()).unwrap();
+        let client_tx = client.tx();
+        let mut client_rx = client.take_rx().unwrap();
+        let (mut server_rx, server_tx) = server.accept().await.unwrap();
+
+        client_tx.post(7);
+        assert_eq!(server_rx.recv().await.unwrap(), 7);
+
+        server_tx.post("seven".to_string());
+        assert_eq!(client_rx.recv().await.unwrap(), "seven");
     }
 }

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -64,7 +64,6 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::watch;
-use tokio::time::Instant;
 
 use super::*;
 use crate::RemoteMessage;
@@ -126,7 +125,7 @@ pub(crate) struct LinkInit {
 }
 
 /// Write a LinkInit header to the stream.
-async fn write_link_init<S: AsyncWrite + Unpin>(
+pub(crate) async fn write_link_init<S: AsyncWrite + Unpin>(
     stream: &mut S,
     session_id: SessionId,
     stream_id: u8,
@@ -330,14 +329,16 @@ fn classify_send_loop_error(error: &session::SendLoopError, log_id: &str) -> Clo
 }
 
 /// Establish a simplex (send-only) session over the given link. Returns a send handle.
-pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
-    spawn_inner(link)
+pub(crate) fn spawn<M: RemoteMessage>(link: impl Link) -> super::ChannelTx<M> {
+    spawn_inner::<M>(link)
 }
 
 /// Establish a multi-stream (unordered) simplex session over N
 /// links sharing the same `SessionId`. Returns a single send handle
 /// that distributes frames across streams.
-pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>) -> NetTx<M> {
+pub(crate) fn spawn_unordered<M: RemoteMessage>(
+    links: Vec<impl Link + 'static>,
+) -> super::ChannelTx<M> {
     assert!(!links.is_empty());
     if links.len() == 1 {
         return spawn(links.into_iter().next().unwrap());
@@ -347,7 +348,7 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
     let dest = links[0].dest();
     let session_id = links[0].link_id();
     let (notify, status) = watch::channel(TxStatus::Active);
-    let tx = NetTx {
+    let tx = super::ChannelTx {
         sender,
         dest: dest.clone(),
         status,
@@ -560,12 +561,12 @@ pub(crate) fn spawn_unordered<M: RemoteMessage>(links: Vec<impl Link + 'static>)
     tx
 }
 
-fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
+fn spawn_inner<M: RemoteMessage>(link: impl Link) -> super::ChannelTx<M> {
     let (sender, receiver) = tokio::sync::mpsc::unbounded_channel();
     let dest = link.dest();
     let session_id = link.link_id();
     let (notify, status) = watch::channel(TxStatus::Active);
-    let tx = NetTx {
+    let tx = super::ChannelTx {
         sender,
         dest: dest.clone(),
         status,
@@ -712,7 +713,7 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> NetTx<M> {
         };
 
         tracing::info!(
-            dest = %dest, session_id = session_id.0, "NetTx closing: {reason}"
+            dest = %dest, session_id = session_id.0, "ChannelTx closing: {reason}"
         );
 
         let send_error_reason = match &reason {
@@ -750,6 +751,7 @@ pub(crate) enum NetLink {
     Unix(unix::UnixLink),
     Tls(tls::TlsLink),
     Quic(quic::QuicLink),
+    Local(local::stream::LocalLink),
 }
 
 /// Create a link for the given channel address with the given
@@ -766,6 +768,12 @@ pub(crate) fn link(
         }
         ChannelAddr::Unix(unix_addr) => {
             Ok(NetLink::Unix(unix::link(unix_addr, session_id, stream_id)))
+        }
+        ChannelAddr::Local(port) => {
+            local::stream::check(port)?;
+            Ok(NetLink::Local(local::stream::link(
+                port, session_id, stream_id,
+            )))
         }
         ChannelAddr::Tls(tls_addr) => Ok(NetLink::Tls(tls::link(tls_addr, session_id, stream_id)?)),
         ChannelAddr::MetaTls(meta_addr) => {
@@ -801,6 +809,7 @@ impl Link for NetLink {
             Self::Unix(l) => l.dest(),
             Self::Tls(l) => l.dest(),
             Self::Quic(l) => l.dest(),
+            Self::Local(l) => l.dest(),
         }
     }
 
@@ -810,6 +819,7 @@ impl Link for NetLink {
             Self::Unix(l) => l.link_id(),
             Self::Tls(l) => l.link_id(),
             Self::Quic(l) => l.link_id(),
+            Self::Local(l) => l.link_id(),
         }
     }
 
@@ -819,6 +829,7 @@ impl Link for NetLink {
             Self::Unix(l) => Ok(Box::new(l.next().await?)),
             Self::Tls(l) => Ok(Box::new(l.next().await?)),
             Self::Quic(l) => Ok(Box::new(l.next().await?)),
+            Self::Local(l) => Ok(Box::new(l.next().await?)),
         }
     }
 }
@@ -845,6 +856,7 @@ pub(crate) enum NetListener {
     Tcp(tcp::TcpSocketListener),
     Unix(unix::UnixSocketListener),
     Quic(quic::QuicSocketListener),
+    Local(local::stream::LocalListener),
 }
 
 #[async_trait]
@@ -862,6 +874,10 @@ impl Listener for NetListener {
                 Ok((Box::new(stream), addr))
             }
             Self::Quic(l) => {
+                let (stream, addr) = l.accept().await?;
+                Ok((Box::new(stream), addr))
+            }
+            Self::Local(l) => {
                 let (stream, addr) = l.accept().await?;
                 Ok((Box::new(stream), addr))
             }
@@ -924,6 +940,10 @@ pub(crate) fn listen_with_prebound(
                 addr: bound_addr.clone(),
             };
             Ok((NetListener::Unix(listener), ChannelAddr::Unix(bound_addr)))
+        }
+        ChannelAddr::Local(_) => {
+            let (listener, addr) = local::stream::listen(addr, prebound)?;
+            Ok((NetListener::Local(listener), addr))
         }
         addr @ (ChannelAddr::Tls(_) | ChannelAddr::MetaTls(_)) => {
             let is_meta = matches!(addr, ChannelAddr::MetaTls(_));
@@ -1005,10 +1025,6 @@ pub(crate) fn listen_with_prebound(
             let (listener, _bound_addr) = listen_with_prebound(*bind_to, prebound)?;
             Ok((listener, *dial_to))
         }
-        other => Err(ServerError::Listen(
-            other.clone(),
-            std::io::Error::other(format!("unsupported transport: {}", other)),
-        )),
     }
 }
 
@@ -1022,7 +1038,7 @@ pub(super) enum Frame<M> {
 #[derive(Debug, Serialize, Deserialize, EnumAsInner)]
 pub(super) enum NetRxResponse {
     Ack(u64),
-    /// This session is rejected with the given reason. NetTx should stop reconnecting.
+    /// This session is rejected with the given reason. ChannelTx should stop reconnecting.
     Reject(String),
     /// This channel is closed.
     Closed,
@@ -1038,84 +1054,6 @@ pub(super) fn deserialize_response(
     data: Bytes,
 ) -> Result<NetRxResponse, bincode::error::DecodeError> {
     bincode::serde::decode_from_slice(&data, bincode::config::legacy()).map(|(v, _)| v)
-}
-
-/// A Tx implemented on top of a Link. The Tx manages the link state,
-/// reconnections, etc.
-pub(crate) struct NetTx<M: RemoteMessage> {
-    sender: mpsc::UnboundedSender<(M, oneshot::Sender<SendError<M>>, Instant)>,
-    dest: ChannelAddr,
-    status: watch::Receiver<TxStatus>,
-}
-
-#[async_trait]
-impl<M: RemoteMessage> Tx<M> for NetTx<M> {
-    fn addr(&self) -> ChannelAddr {
-        self.dest.clone()
-    }
-
-    fn status(&self) -> &watch::Receiver<TxStatus> {
-        &self.status
-    }
-
-    fn do_post(&self, message: M, return_channel: Option<oneshot::Sender<SendError<M>>>) {
-        tracing::trace!(
-            name = "post",
-            dest = %self.dest,
-            "sending message"
-        );
-
-        let return_channel = return_channel.unwrap_or_else(|| oneshot::channel().0);
-        if let Err(mpsc::error::SendError((message, return_channel, _))) =
-            self.sender
-                .send((message, return_channel, tokio::time::Instant::now()))
-        {
-            let reason = self
-                .status
-                .borrow()
-                .as_closed()
-                .map(|r| SendErrorReason::Other(r.to_string()));
-            let _ = return_channel.send(SendError {
-                error: ChannelError::Closed,
-                message,
-                reason,
-            });
-        }
-    }
-}
-
-pub struct NetRx<M: RemoteMessage>(mpsc::Receiver<M>, ChannelAddr, ServerHandle);
-
-#[async_trait]
-impl<M: RemoteMessage> Rx<M> for NetRx<M> {
-    async fn recv(&mut self) -> Result<M, ChannelError> {
-        tracing::trace!(
-            name = "recv",
-            dest = %self.1,
-            "receiving message"
-        );
-        self.0.recv().await.ok_or(ChannelError::Closed)
-    }
-
-    fn addr(&self) -> ChannelAddr {
-        self.1.clone()
-    }
-
-    /// Gracefully shut down the channel server, waiting for pending
-    /// acks to be flushed before returning.
-    async fn join(mut self) {
-        self.2
-            .stop(&format!("NetRx joined; channel address: {}", self.1));
-        let _ = (&mut self.2).await;
-        // Drop will call stop() again which is harmless (token already cancelled).
-    }
-}
-
-impl<M: RemoteMessage> Drop for NetRx<M> {
-    fn drop(&mut self) {
-        self.2
-            .stop(&format!("NetRx dropped; channel address: {}", self.1));
-    }
 }
 
 /// Error returned during server operations.
@@ -1155,15 +1093,16 @@ pub enum ClientError {
 /// from local transports.
 #[cfg(test)]
 pub(super) fn is_net_addr(addr: &ChannelAddr) -> bool {
-    match addr.transport() {
-        ChannelTransport::Tcp(_) => true,
-        ChannelTransport::MetaTls(_) => true,
-        ChannelTransport::Tls => true,
-        ChannelTransport::Quic => true,
-        ChannelTransport::MetaQuic(_) => true,
-        ChannelTransport::Unix => true,
-        _ => false,
-    }
+    matches!(
+        addr.transport(),
+        ChannelTransport::Tcp(_)
+            | ChannelTransport::MetaTls(_)
+            | ChannelTransport::Tls
+            | ChannelTransport::Quic
+            | ChannelTransport::MetaQuic(_)
+            | ChannelTransport::Unix
+            | ChannelTransport::Local
+    )
 }
 
 pub(crate) mod unix {
@@ -2012,6 +1951,7 @@ pub(crate) mod tls {
         use timed_test::async_timed_test;
 
         use super::*;
+        use crate::channel::ChannelTx;
         use crate::channel::Rx;
         use crate::channel::Tx;
         use crate::channel::dial;
@@ -2121,7 +2061,7 @@ u19txmtkiMEH+aNmekk=
                 server::serve::<u64>(ChannelAddr::Tls(addr), None).expect("failed to serve");
 
             // Dial the server
-            let tx: super::NetTx<u64> = super::spawn(
+            let tx: ChannelTx<u64> = super::spawn(
                 link(
                     match &local_addr {
                         ChannelAddr::Tls(addr) => addr.clone(),
@@ -2208,7 +2148,7 @@ u19txmtkiMEH+aNmekk=
 
             let (local_addr, mut rx) =
                 server::serve::<String>(ChannelAddr::Tls(addr), None).expect("failed to serve");
-            let tx: super::NetTx<String> = super::spawn(
+            let tx: ChannelTx<String> = super::spawn(
                 link(
                     match &local_addr {
                         ChannelAddr::Tls(addr) => addr.clone(),
@@ -2439,11 +2379,14 @@ mod tests {
     use tokio::io::ReadHalf;
     use tokio::io::WriteHalf;
     use tokio::task::JoinHandle;
+    use tokio::time::Instant;
     use tokio_util::sync::CancellationToken;
 
     use super::server;
     use super::*;
     use crate::channel;
+    use crate::channel::ChannelRx;
+    use crate::channel::ChannelTx;
     use crate::channel::net::framed::FrameReader;
     use crate::channel::net::framed::FrameWrite;
     use crate::channel::net::server::AcceptorLink;
@@ -2483,8 +2426,8 @@ mod tests {
         // It is important to keep Tx alive until all expected messages are
         // received. Otherwise, the channel would be closed when Tx is dropped.
         // Although the messages are sent to the server's buffer before the
-        // channel was closed, NetRx could still error out before taking them
-        // out of the buffer because NetRx could not ack through the closed
+        // channel was closed, ChannelRx could still error out before taking them
+        // out of the buffer because ChannelRx could not ack through the closed
         // channel.
         {
             let tx: ChannelTx<u64> = channel::dial::<u64>(addr.clone()).unwrap();
@@ -3378,7 +3321,7 @@ mod tests {
         }
     }
 
-    async fn net_tx_send(tx: &NetTx<u64>, msgs: &[u64]) {
+    async fn net_tx_send(tx: &ChannelTx<u64>, msgs: &[u64]) {
         for msg in msgs {
             tx.post(*msg);
         }
@@ -3420,7 +3363,7 @@ mod tests {
                 .map_err(|(_, e)| e)
                 .unwrap();
             }
-            // Wait for the acks to be processed by NetTx.
+            // Wait for the acks to be processed by ChannelTx.
             tokio::time::sleep(Duration::from_secs(3)).await;
             // Drop both halves to break the in-memory connection (parity with old drop of DuplexStream).
             drop(reader);
@@ -3483,7 +3426,7 @@ mod tests {
                     .await
                     .map_err(|(_, e)| e)
                     .unwrap();
-                    // Wait for the acks to be processed by NetTx.
+                    // Wait for the acks to be processed by ChannelTx.
                     tokio::time::sleep(Duration::from_secs(3)).await;
                 }
                 // client DuplexStream is dropped here. This breaks the connection.
@@ -3565,7 +3508,7 @@ mod tests {
                     .await
                     .map_err(|(_, e)| e)
                     .unwrap();
-                    // Wait for the acks to be processed by NetTx.
+                    // Wait for the acks to be processed by ChannelTx.
                     tokio::time::sleep(Duration::from_secs(3)).await;
                 }
                 // client DuplexStream is dropped here. This breaks the connection.
@@ -3605,7 +3548,7 @@ mod tests {
                     .await
                     .map_err(|(_, e)| e)
                     .unwrap();
-                    // Wait for the acks to be processed by NetTx.
+                    // Wait for the acks to be processed by ChannelTx.
                     tokio::time::sleep(Duration::from_secs(3)).await;
                 }
                 // client DuplexStream is dropped here. This breaks the connection.
@@ -3776,7 +3719,7 @@ mod tests {
         let receiver_storage = link.receiver_storage();
         let listener = MockLinkListener::new(receiver_storage.clone(), link.dest());
         let local_addr = listener.channel_addr.clone();
-        let (_, mut nx): (ChannelAddr, NetRx<u64>) =
+        let (_, mut nx): (ChannelAddr, ChannelRx<u64>) =
             super::server::serve_with_listener(listener, local_addr).unwrap();
         let tx = spawn::<u64>(link);
         let messages: Vec<_> = (0..10001).collect();
@@ -3785,13 +3728,13 @@ mod tests {
         // side concurrently.
         let send_task_handle = tokio::spawn(async move {
             for message in messages_clone {
-                // Add a small delay between messages to give NetRx time to ack.
+                // Add a small delay between messages to give ChannelRx time to ack.
                 // Technically, this test still can pass without this delay. But
                 // the test will need a might larger timeout. The reason is
                 // fairly convoluted:
                 //
                 // MockLink uses the number of delivery to calculate the disconnection
-                // probability. If NetRx sends messages much faster than NetTx
+                // probability. If ChannelRx sends messages much faster than ChannelTx
                 // can ack them, there is a higher chance that the messages are
                 // not acked before reconnect. Then those message would be redelivered.
                 // The repeated redelivery increases the total time of sending
@@ -3799,7 +3742,7 @@ mod tests {
                 tokio::time::sleep(Duration::from_micros(rand::random::<u64>() % 100)).await;
                 tx.post(message);
             }
-            tracing::debug!("NetTx sent all messages");
+            tracing::debug!("ChannelTx sent all messages");
             // It is important to return tx instead of dropping it here, because
             // Rx might not receive all messages yet.
             tx
@@ -3807,11 +3750,11 @@ mod tests {
 
         for message in &messages {
             if message % sampling_rate == 0 {
-                tracing::debug!("NetRx received a message: {message}");
+                tracing::debug!("ChannelRx received a message: {message}");
             }
             assert_eq!(nx.recv().await.unwrap(), *message);
         }
-        tracing::debug!("NetRx received all messages");
+        tracing::debug!("ChannelRx received all messages");
 
         let send_result = send_task_handle.await;
         assert!(send_result.is_ok());
@@ -3820,7 +3763,7 @@ mod tests {
             "MockLink disconnected {} times.",
             disconnected_count.load(Ordering::SeqCst)
         );
-        // TODO(pzhang) after the return_handle work in NetTx is done, add a
+        // TODO(pzhang) after the return_handle work in ChannelTx is done, add a
         // check here to verify the messages are acked correctly.
     }
 
@@ -3853,7 +3796,7 @@ mod tests {
         let receiver_storage = link.receiver_storage();
         let listener = MockLinkListener::new(receiver_storage.clone(), link.dest());
         let local_addr = listener.channel_addr.clone();
-        let (_, mut nx): (ChannelAddr, NetRx<u64>) =
+        let (_, mut nx): (ChannelAddr, ChannelRx<u64>) =
             super::server::serve_with_listener(listener, local_addr).unwrap();
         let tx = spawn::<u64>(link);
         let messages: Vec<_> = (0..20001).collect();
@@ -3866,14 +3809,14 @@ mod tests {
                 tx.post(message);
             }
             tokio::time::sleep(Duration::from_secs(5)).await;
-            tracing::debug!("NetTx sent all messages");
+            tracing::debug!("ChannelTx sent all messages");
             tx
         });
 
         for message in &messages {
             assert_eq!(nx.recv().await.unwrap(), *message);
         }
-        tracing::debug!("NetRx received all messages");
+        tracing::debug!("ChannelRx received all messages");
 
         let send_result = send_task_handle.await;
         assert!(send_result.is_ok());
@@ -3980,7 +3923,7 @@ mod tests {
             .await
             .map_err(|(_, e)| e);
 
-            // Wait for response to be processed by NetTx before dropping reader/writer. Otherwise
+            // Wait for response to be processed by ChannelTx before dropping reader/writer. Otherwise
             // the channel will be closed and we will get the wrong error.
             tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
         }
@@ -4030,22 +3973,22 @@ mod tests {
             ChannelAddr::Tcp(a) => a,
             _ => panic!("unexpected channel type"),
         };
-        let tx: NetTx<u64> = spawn(tcp::link(socket_addr, SessionId::random(), 0));
-        // NetTx will not establish a connection until it sends the 1st message.
-        // Without a live connection, NetTx cannot received the Closed message
-        // from NetRx. Therefore, we need to send a message to establish the
+        let tx: ChannelTx<u64> = spawn(tcp::link(socket_addr, SessionId::random(), 0));
+        // ChannelTx will not establish a connection until it sends the 1st message.
+        // Without a live connection, ChannelTx cannot received the Closed message
+        // from ChannelRx. Therefore, we need to send a message to establish the
         //connection.
         tx.send(100).await.unwrap();
         assert_eq!(rx.recv().await.unwrap(), 100);
-        // Drop rx will close the NetRx server.
-        rx.2.stop("testing");
+        // Drop rx will close the ChannelRx server.
+        rx.server.stop("testing");
         assert!(rx.recv().await.is_err());
 
-        // NetTx will only read from the stream when it needs to send a message
+        // ChannelTx will only read from the stream when it needs to send a message
         // or wait for an ack. Therefore we need to send a message to trigger that.
         tx.post(101);
         let mut watcher = tx.status().clone();
-        // When NetRx exits, it should notify NetTx to exit as well.
+        // When ChannelRx exits, it should notify ChannelTx to exit as well.
         let _ = watcher.wait_for(|val| val.is_closed()).await;
         // wait_for could return Err due to race between when watch's sender was
         // dropped and when wait_for was called. So we still need to do an
@@ -4289,7 +4232,7 @@ mod tests {
     /// send three messages with disjoint seqs filling the contiguous
     /// range 0..=8. Each stream's cleanup reads `highest_uncommitted`
     /// and emits `Ack(8)` on its own wire so the peer's per-wire
-    /// NetTx sees an ack for messages it sent there; the receiver
+    /// ChannelTx sees an ack for messages it sent there; the receiver
     /// discards duplicates. Every stream also emits its own `Closed`.
     #[async_timed_test(timeout_secs = 30)]
     async fn rx_join_flushes_pending_ack_shared_multi_stream_session() {

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -97,6 +97,15 @@ impl<In: RemoteMessage, Out: RemoteMessage> DuplexServer<In, Out> {
     }
 }
 
+impl<In: RemoteMessage, Out: RemoteMessage> Drop for DuplexServer<In, Out> {
+    fn drop(&mut self) {
+        self.handle.stop(&format!(
+            "DuplexServer dropped; channel address: {}",
+            self.addr
+        ));
+    }
+}
+
 /// Receiver half of a duplex channel.
 pub struct DuplexRx<M: RemoteMessage>(mpsc::Receiver<M>, ChannelAddr);
 
@@ -841,6 +850,7 @@ pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
 pub fn dial<Out: RemoteMessage, In: RemoteMessage>(
     addr: ChannelAddr,
 ) -> Result<DuplexClient<Out, In>, ClientError> {
+    let addr = addr.into_dial_addr();
     Ok(spawn(super::link(addr, super::SessionId::random(), 0)?))
 }
 

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -32,8 +32,8 @@ use super::session::Next;
 use super::session::Session;
 use crate::RemoteMessage;
 use crate::channel::ChannelAddr;
+use crate::channel::ChannelRx;
 use crate::channel::ChannelTransport;
-use crate::channel::net::NetRx;
 use crate::channel::net::ServerError;
 use crate::channel::net::Stream;
 use crate::channel::net::meta;
@@ -390,7 +390,7 @@ async fn dispatch_multi_stream<M: RemoteMessage, S: Stream>(
         };
 
         // Each stream emits the cumulative watermark on its own wire
-        // so the peer's per-wire NetTx sees an ack for messages it
+        // so the peer's per-wire ChannelTx sees an ack for messages it
         // sent on this connection.
         let pending_ack = shared_state
             .ack_watermark
@@ -636,7 +636,7 @@ impl Future for ServerHandle {
 pub(in crate::channel) fn serve<M: RemoteMessage>(
     addr: ChannelAddr,
     prebound_listener: Option<std::net::TcpListener>,
-) -> Result<(ChannelAddr, NetRx<M>), ServerError> {
+) -> Result<(ChannelAddr, ChannelRx<M>), ServerError> {
     let (mut listener, channel_addr) = super::listen_with_prebound(addr, prebound_listener)?;
 
     metrics::CHANNEL_CONNECTIONS.add(
@@ -725,7 +725,11 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
 
     Ok((
         server_handle.channel_addr.clone(),
-        NetRx(rx, channel_addr, server_handle),
+        ChannelRx {
+            receiver: rx,
+            dest: channel_addr,
+            server: server_handle,
+        },
     ))
 }
 
@@ -735,7 +739,7 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
 pub(super) fn serve_with_listener<M, L>(
     mut listener: L,
     channel_addr: ChannelAddr,
-) -> Result<(ChannelAddr, NetRx<M>), ServerError>
+) -> Result<(ChannelAddr, ChannelRx<M>), ServerError>
 where
     M: RemoteMessage,
     L: super::Listener + 'static,
@@ -797,6 +801,10 @@ where
 
     Ok((
         server_handle.channel_addr.clone(),
-        NetRx(rx, channel_addr, server_handle),
+        ChannelRx {
+            receiver: rx,
+            dest: channel_addr,
+            server: server_handle,
+        },
     ))
 }

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -3940,6 +3940,7 @@ mod tests {
     use std::sync::atomic::AtomicUsize;
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use timed_test::async_timed_test;
 
     use super::*;
@@ -3987,6 +3988,45 @@ mod tests {
             panic!("expected invalid reference, got {root_failure}");
         };
         invalid_reference
+    }
+
+    struct ClosedChannelTx {
+        addr: ChannelAddr,
+        status: watch::Receiver<TxStatus>,
+    }
+
+    impl ClosedChannelTx {
+        fn new(addr: ChannelAddr) -> Self {
+            let (_sender, status) = watch::channel(TxStatus::Closed(CloseReason::Other(
+                "test channel closed".into(),
+            )));
+            Self { addr, status }
+        }
+    }
+
+    #[async_trait]
+    impl channel::Tx<MessageEnvelope> for ClosedChannelTx {
+        fn do_post(
+            &self,
+            message: MessageEnvelope,
+            return_channel: Option<oneshot::Sender<SendError<MessageEnvelope>>>,
+        ) {
+            if let Some(return_channel) = return_channel {
+                let _ = return_channel.send(SendError {
+                    error: ChannelError::Closed,
+                    message,
+                    reason: None,
+                });
+            }
+        }
+
+        fn addr(&self) -> ChannelAddr {
+            self.addr.clone()
+        }
+
+        fn status(&self) -> &watch::Receiver<TxStatus> {
+            &self.status
+        }
     }
 
     #[test]
@@ -4600,7 +4640,9 @@ mod tests {
     #[tokio::test]
     async fn test_local_client_server() {
         let mbox = Mailbox::new(test_actor_id("0", "actor0"));
-        let (tx, rx) = channel::local::new();
+        let (addr, rx) =
+            channel::serve(ChannelAddr::any(ChannelTransport::Local)).expect("serve local");
+        let tx = channel::dial(addr).expect("dial local");
         let serve_handle = mbox.clone().serve(rx);
         let client = MailboxClient::new(tx);
 
@@ -4618,9 +4660,7 @@ mod tests {
     #[tokio::test]
     async fn test_mailbox_client_records_channel_closed_failure() {
         let mbox = Mailbox::new(test_actor_id("0", "actor0"));
-        let (tx, rx) = channel::local::new();
-        drop(rx);
-        let client = MailboxClient::new(tx);
+        let client = MailboxClient::new(ClosedChannelTx::new(ChannelAddr::Local(0)));
         let addr = client.addr.clone();
 
         let (port, _receiver) = mbox.open_once_port::<u64>();
@@ -4990,9 +5030,8 @@ mod tests {
         let client1 = router.dial(&addr, mbox.actor_addr()).unwrap();
         let mut status = client1.tx_status().clone();
 
-        // LocalRx::drop closes the watcher with a non-stale reason — the
-        // string never contains "out-of-sequence message", so it must not
-        // trigger eviction.
+        // Tearing down the local server closes the watcher with a non-stale
+        // reason, so it must not trigger eviction.
         h.stop("test teardown");
         let _ = h.await;
         while !status.borrow_and_update().is_closed() {


### PR DESCRIPTION
Summary:

Implement the `Local` backing transport with a UnixStream so that the local transport
supports net-based functionality like duplex. `ChannelTransport::Local` now reports duplex support, so callers can use the same duplex API for local and network endpoints.

The main user of the duplex protocol right now is the Gateway, which uses it for
attaching other gateways. By extending support to local duplex servers, it makes it easier
to port unit tests that use LocalProcManager. There is no production code using Local
transports.

Reviewed By: mariusae

Differential Revision: D108900363


