### PR TITLE
[SlurmJob][Fix]: re-apply transport config on unpickle for batch mode

### DIFF
--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -104,6 +104,15 @@ class SlurmJob(JobTrait):
         self._all_hostnames: List[str] = []
         super().__init__()
 
+    def __setstate__(self, state: Dict[str, Any]) -> None:
+        # In batch mode the in-allocation client rehydrates this object via
+        # pickle.load (job_load), which bypasses __init__. Re-apply the
+        # transport config here so the client's host_agent serves on a TCP
+        # address remote workers can dial back, instead of an abstract unix
+        # socket whose namespace is local to the original (head) node.
+        self.__dict__.update(state)
+        configure(default_transport=ChannelTransport.TcpWithHostname)
+
     def add_mesh(self, name: str, num_nodes: int) -> None:
         self._meshes[name] = num_nodes
 


### PR DESCRIPTION
## Bug Description

Submitter process (login node):

```python
  job = SlurmJob(meshes={"a": 1, "b": 1}, ...)
  # __init__ runs -> configure(default_transport=TcpWithHostname). OK.
  job.apply(client_script="my_client.py")  # sbatch + dump SlurmJob to disk, exit
```

 In-allocation client process:
```python
  job = job_load()           # pickle.load -> __init__ is NOT called
  # default_transport silently remains its baked-in default: Unix
  state = job.state()        # host_agent binds to abstract unix socket: unix:@<random>
  proc_a = state.a.spawn_procs(...)
  proc_b = state.b.spawn_procs(...)
  await setup_torch_elastic_env_async(proc_a)   # OK if host(a) == controller host
  await setup_torch_elastic_env_async(proc_b)   # remote host -> hangs forever
  # Worker on host(b) tries to dial unix:@<random>, gets ECONNREFUSED indefinitely
  # because that abstract socket namespace only exists in the head node's kernel.
  # Controller gives up at MESH_ATTACH_CONFIG_TIMEOUT.
```

## Root Cause Analysis
`SlurmJob.__init__` calls `configure(default_transport=ChannelTransport.TcpWithHostname)` (slurm.py:87), but in
batch mode the in-allocation client rehydrates the job via `job_load()` → `pickle.load`, which bypasses `__init__`. 
Consequently, the runtime falls back to `Unix`, the client's host_agent  serves on an abstract unix socket whose namespace is local to the head node, and remote workers `ECONNREFUSED`-loop until `MESH_ATTACH_CONFIG_TIMEOUT`. 

## Fix 
Add `__setstate__` to re-apply the same config after unpickling.

Submitter process: unchanged.
In-allocation client process:
```
  job = job_load()           # pickle.load -> __setstate__ runs
  # __setstate__ replays configure(default_transport=TcpWithHostname)
  state = job.state()        # host_agent binds to tcp://<hostname>:<port>
  proc_a = state.a.spawn_procs(...)
  proc_b = state.b.spawn_procs(...)
  await setup_torch_elastic_env_async(proc_a)   # OK
  await setup_torch_elastic_env_async(proc_b)   # OK -- workers dial the hostname, succeed
```

## Test Plan

Build the wheel from source, then test both interactive mode and batch mode on the Slurm cluster using the above minimal repo snippets.