### PR TITLE
Bump MESH_ATTACH_CONFIG_TIMEOUT to 60s

### DIFF
--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -166,7 +166,7 @@ declare_attrs! {
         Some("HYPERACTOR_MESH_ATTACH_CONFIG_TIMEOUT".to_string()),
         Some("mesh_attach_config_timeout".to_string()),
     ))
-    pub attr MESH_ATTACH_CONFIG_TIMEOUT: Duration = Duration::from_secs(10);
+    pub attr MESH_ATTACH_CONFIG_TIMEOUT: Duration = Duration::from_secs(60);
 
     /// Timeout for targeted introspection queries that hit a single,
     /// specific host. Kept short so a slow or dying actor cannot block


### PR DESCRIPTION
Summary:
When controller and workers are all bootstrapped on MAST, their bootstraps start roughly around the same time. When contoller's bootstrap is slower than workers, e.g. tw happens to start that host later, than it is easier to hit this timeout.

Bump it to 60s to avoid this problem.

More discussion in: https://chat.google.com/room/AAQA8ub_cFI/_h_0k2JAwdk/XiNIoNx1vY0?cls=10

Reviewed By: shayne-fletcher

Differential Revision: D109752153


