### PR TITLE
concurrent_endpoint: fail the actor on an escaped exception

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -845,9 +845,10 @@ Pass endpoint options directly to `@concurrent_endpoint(...)`, such as
 
 There is nothing special about `@concurrent_endpoint`: it packages the
 `explicit_response_port=True` pattern with `asyncio.create_task`, result
-forwarding for non-explicit endpoints, warning logs for escaped explicit-port
-exceptions, and cleanup-time cancellation of the tasks it starts. You can write
-the simple version yourself when you want full control:
+forwarding for non-explicit endpoints, failing the actor when an explicit-port
+endpoint lets an exception escape the function, and cleanup-time cancellation of
+the tasks it starts. You can write the simple version yourself when you want full
+control:
 
 ```python
 import asyncio
@@ -872,9 +873,11 @@ class ManualGate(Actor):
 ```
 
 This manual form intentionally has no extra task tracking; the task lifetime is
-part of the endpoint protocol you are writing. If an explicit-port endpoint lets
-an exception escape before sending a response, the caller will keep waiting until
-it times out or is cancelled.
+part of the endpoint protocol you are writing. Because the body runs in a
+detached task that you own, an exception escaping it before a response is sent
+leaves the caller waiting until it times out or is cancelled, while the actor
+survives. By contrast, `@concurrent_endpoint` fails the actor with a supervision
+error in that case, following the principle of no silent errors.
 
 `@concurrent_endpoint` works on individual endpoints, including inherited
 endpoints, so an actor can mix concurrent and sequential endpoints. For protocols

--- a/python/monarch/actor/concurrent.py
+++ b/python/monarch/actor/concurrent.py
@@ -9,9 +9,9 @@
 import asyncio
 import functools
 import inspect
-import logging
 import weakref
 from dataclasses import dataclass, field
+from traceback import TracebackException
 from typing import Any, Awaitable, Callable, cast
 
 from monarch._rust_bindings.monarch_hyperactor.logging import log_endpoint_exception
@@ -21,7 +21,6 @@ from monarch._src.actor.telemetry import span
 
 _WRAPPER_ATTR = "_monarch_concurrent_endpoint_wrapper"
 _CLEANUP_WRAPPER_ATTR = "_monarch_concurrent_endpoint_cleanup_wrapper"
-logger: logging.Logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -52,15 +51,20 @@ def _send_exception(port: Any, actor_error: ActorError) -> None:
         pass
 
 
-def _log_explicit_response_port_exception(
-    actor_name: str, method_name: str, exception: BaseException
-) -> None:
-    logger.warning(
-        "concurrent explicit response-port endpoint raised without forwarding its own exception: %s.%s",
-        actor_name,
-        method_name,
-        exc_info=(type(exception), exception, exception.__traceback__),
-    )
+def _cancelled_for_cleanup(record: _TaskRecord | None) -> bool:
+    # True when cleanup cancelled this task because the actor is stopping;
+    # callers skip failing the actor so a graceful stop is not escalated.
+    return record is not None and record.cancel_for_cleanup
+
+
+def _fail_actor(actor_instance: Any, exception: BaseException) -> None:
+    reason = "".join(TracebackException.from_exception(exception).format())
+    try:
+        actor_instance.kill(reason)
+    except Exception:
+        # The actor's signal channel may already be closed if it has finished
+        # stopping; there is then nothing left to fail.
+        pass
 
 
 async def _run_endpoint(
@@ -84,7 +88,7 @@ async def _run_endpoint(
             else:
                 await call()
         except asyncio.CancelledError as e:
-            if record is not None and record.cancel_for_cleanup:
+            if _cancelled_for_cleanup(record):
                 return
             if forwards_exception:
                 actor_error = ActorError(
@@ -94,24 +98,24 @@ async def _run_endpoint(
                 _send_exception(port, actor_error)
             raise
         except Exception as e:
+            log_endpoint_exception(e, method_name, actor_id)
             if forwards_exception:
-                log_endpoint_exception(e, method_name, actor_id)
                 actor_error = ActorError(
                     e,
                     f"Actor call {actor_name}.{method_name} failed.",
                 )
                 _send_exception(port, actor_error)
-            else:
-                _log_explicit_response_port_exception(actor_name, method_name, e)
+            elif not _cancelled_for_cleanup(record):
+                _fail_actor(actor_instance, e)
         except BaseException as e:  # noqa: B036
-            actor_error = ActorError(
-                e,
-                f"Actor call {actor_name}.{method_name} failed with BaseException.",
-            )
             if forwards_exception:
+                actor_error = ActorError(
+                    e,
+                    f"Actor call {actor_name}.{method_name} failed with BaseException.",
+                )
                 _send_exception(port, actor_error)
-            else:
-                _log_explicit_response_port_exception(actor_name, method_name, e)
+            elif not _cancelled_for_cleanup(record):
+                _fail_actor(actor_instance, e)
     finally:
         actor_instance._execution_finish(token)
 
@@ -303,6 +307,13 @@ def concurrent_endpoint(
     lifecycle before these tasks are cancelled. General pending tasks on the
     actor's asyncio loop are cancelled later, after user ``__cleanup__``
     completes.
+
+    If the endpoint body raises an exception that it does not forward through
+    its response port, the actor fails with a supervision error, just as an
+    exception escaping an ``@endpoint(explicit_response_port=True)`` method
+    does. This follows the principle of no silent errors. To report an error to
+    the caller without failing the actor, forward it through the port (for
+    example, ``port.exception(e)``); to recover, catch it inside the endpoint.
 
     More complex protocols can still use ``@endpoint(explicit_response_port=True)``
     and manage response ports manually.

--- a/python/tests/test_concurrent_endpoints.py
+++ b/python/tests/test_concurrent_endpoints.py
@@ -11,8 +11,10 @@ import os
 from tempfile import TemporaryDirectory
 from typing import Any, cast
 
+import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
 from monarch.actor import Actor, concurrent_endpoint, endpoint, Port, this_host
 from monarch.config import parametrize_config
 
@@ -232,16 +234,21 @@ async def test_concurrent_endpoint_exception_uses_actor_error_context() -> None:
 @pytest.mark.timeout(60)
 @parametrize_config(actor_queue_dispatch={True, False})
 @isolate_in_subprocess
-async def test_concurrent_explicit_port_exception_is_not_auto_forwarded() -> None:
+async def test_concurrent_explicit_port_exception_kills_actor() -> None:
+    """An ``@concurrent_endpoint(explicit_response_port=True)`` body that raises
+    instead of sending through its port kills the actor with a supervision
+    error, just as a plain ``@endpoint(explicit_response_port=True)`` does (see
+    ``test_explicit_response_port_exception_kills_actor`` in
+    ``test_actor_error.py``). The escaped exception is not silently swallowed."""
+    monarch.actor.unhandled_fault_hook = lambda failure: None
     proc = this_host().spawn_procs(per_host={"gpus": 1})
     actor = proc.spawn(
         "concurrent_explicit_port_failing_actor", ConcurrentExplicitPortFailingActor
     )
 
     try:
-        with pytest.raises(asyncio.TimeoutError):
-            await asyncio.wait_for(actor.fail.call_one(), timeout=0.2)
-        assert await asyncio.wait_for(actor.ping.call_one(), timeout=10) == "pong"
+        with pytest.raises(SupervisionError):
+            await asyncio.wait_for(actor.fail.call_one(), timeout=15)
     finally:
         await proc.stop()
 


### PR DESCRIPTION
Summary:
A plain `endpoint(explicit_response_port=True)` that raises instead of sending through its port kills the actor: the explicit-port declaration rebinds the ambient response port to `DroppingPort`, so the raise takes the no-port kill path and the caller sees a `SupervisionError`. `concurrent_endpoint(explicit_response_port=True)` runs the body in a detached `asyncio` task and only logged such an escape, so the actor survived and the caller hung — a silent error. This brings the two in sync: an exception that escapes the function now fails the actor via `Instance.kill`, the same `Signal::Kill` path that `_dispatch_loop` and the normal explicit-port endpoint already take. Non-explicit (returns-a-value) endpoints are unchanged — they still forward the `ActorError` to the caller and the actor survives.

Caveats on the error path, since the kill fires from a detached task rather than inline in `_Actor.handle`: (1) we skip the kill when cleanup already cancelled the task (`cancel_for_cleanup`), so a shutdown-induced failure cannot escalate a graceful stop into a supervision failure; (2) `kill` is best-effort (wrapped in try/except) because the actor's signal channel may already be closed once it has finished stopping; (3) `CancelledError` is caught first and never triggers a kill — cleanup cancellations return cleanly, other cancellations re-raise cooperatively.

Differential Revision: D109758060


