### PR TITLE
run the RDMA actors on their own data-plane runtime (#4302)

### DIFF
--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -83,6 +83,7 @@ pub mod port;
 pub mod proc;
 pub mod ref_;
 pub mod remote;
+pub mod runtime_identity;
 pub(crate) mod sequenced;
 mod signal_handler;
 mod stdio_redirect;

--- a/hyperactor/src/runtime_identity.rs
+++ b/hyperactor/src/runtime_identity.rs
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Runtime-identity tagging: which Tokio runtime a thread belongs to.
+//!
+//! Monarch runs Python on more than one Tokio runtime: the shared control-plane
+//! runtime that drives `PythonActor` dispatch, and separate data-plane runtimes
+//! where GIL work runs safely, off the control plane (the tensor engine; the
+//! RDMA managers, during buffer registration). The
+//! hazard is contention on the shared runtime, where a thread holding the GIL
+//! while blocked stalls every actor loop, supervisor, and network task on it.
+//! So data-plane work runs on its own runtime, and control-plane GIL use is
+//! kept to brief, sanctioned sites. This module records a thread's
+//! [`RuntimeKind`] (stamped at thread start via `on_thread_start`, read via
+//! [`current_runtime_kind`]) so GIL-entry sites can tell the two apart.
+//!
+//! # Invariants (RI-*)
+//!
+//! - **RI-1 (unstamped-is-foreign):** [`current_runtime_kind`] returns `Foreign`
+//!   on any thread no runtime builder has tagged. Enforced by the
+//!   `const { Cell::new(Foreign) }` thread-local init.
+//! - **RI-2 (tagging-is-thread-local):** [`tag_current_thread`] sets only the
+//!   current OS thread's marker.
+//! - **RI-3 (data-plane-workers-tagged):** [`build_data_plane_runtime`] stamps
+//!   every worker thread of the runtime it returns `DataPlane(label)`, via the
+//!   builder's `on_thread_start`.
+//! - **RI-4 (tagging-does-not-leak):** spawning work onto a tagged runtime does
+//!   not change the spawning thread's observed kind.
+//! - **RI-5 (process-lifetime-runtime):** the handle from
+//!   [`build_data_plane_runtime`] is kept alive by the `DATA_PLANE_RUNTIMES`
+//!   registry and stays valid until the runtime is torn down by
+//!   [`shutdown_data_plane_runtimes`] at process teardown; callers must not spawn
+//!   onto it afterward.
+//! - **RI-7 (teardown-registered):** every runtime from
+//!   [`build_data_plane_runtime`] is registered in `DATA_PLANE_RUNTIMES` and shut
+//!   down by [`shutdown_data_plane_runtimes`]. The pyo3 layer calls that at
+//!   Python teardown before `Py_Finalize`; this crate stays Python-free.
+
+use std::cell::Cell;
+use std::sync::Mutex;
+use std::time::Duration;
+
+/// Which kind of Tokio runtime a thread belongs to.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum RuntimeKind {
+    /// The shared control-plane runtime that drives actor dispatch.
+    /// Control-plane GIL use is kept to brief, sanctioned sites.
+    ControlPlane,
+    /// A runtime off the control plane. GIL work here is safe because it does
+    /// not drive actor dispatch (the tensor engine; the RDMA managers during
+    /// buffer registration).
+    DataPlane(&'static str),
+    /// A thread not stamped by any monarch runtime (e.g. a Python-owned thread).
+    Foreign,
+}
+
+thread_local! {
+    // Default `Foreign`: a thread is unstamped until a runtime builder's
+    // `on_thread_start` tags it, so non-runtime threads (e.g. Python-owned
+    // asyncio threads) read as `Foreign`.
+    static KIND: Cell<RuntimeKind> = const { Cell::new(RuntimeKind::Foreign) };
+}
+
+/// Stamp the current thread with `kind`. Call from a runtime builder's
+/// `on_thread_start` so every worker of that runtime carries the marker.
+pub fn tag_current_thread(kind: RuntimeKind) {
+    KIND.with(|k| k.set(kind));
+}
+
+/// The [`RuntimeKind`] of the current thread (`Foreign` if unstamped).
+pub fn current_runtime_kind() -> RuntimeKind {
+    KIND.with(|k| k.get())
+}
+
+/// Data-plane runtimes built by [`build_data_plane_runtime`], retained so they
+/// stay alive and can be torn down at process teardown via
+/// [`shutdown_data_plane_runtimes`].
+static DATA_PLANE_RUNTIMES: Mutex<Vec<tokio::runtime::Runtime>> = Mutex::new(Vec::new());
+
+/// Build a dedicated data-plane runtime on its own OS thread, tagged
+/// `DataPlane(label)`, and return a handle for spawning onto it.
+///
+/// The runtime runs on a standalone `std::thread` rather than a Tokio
+/// `spawn_blocking` thread: a runtime-managed blocking thread is awaited at
+/// teardown, so uninterruptible FFI (CUDA, NCCL, ibverbs) running on it would
+/// hang shutdown forever. A standalone thread is not awaited. Its worker threads
+/// are stamped `DataPlane(label)` via `on_thread_start`. The returned
+/// [`Handle`](tokio::runtime::Handle) stays valid until the runtime (retained in
+/// `DATA_PLANE_RUNTIMES`) is torn down by [`shutdown_data_plane_runtimes`] at
+/// process teardown.
+pub fn build_data_plane_runtime(
+    label: &'static str,
+    worker_threads: usize,
+) -> tokio::runtime::Handle {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::Builder::new()
+        .name(label.to_string())
+        .spawn(move || {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(worker_threads)
+                .on_thread_start(move || tag_current_thread(RuntimeKind::DataPlane(label)))
+                .enable_all()
+                .build()
+                .expect("failed to build data-plane runtime");
+            let handle = rt.handle().clone();
+            // Stash the owned runtime so it stays alive (its worker threads keep
+            // running) and can be torn down at process teardown via
+            // shutdown_data_plane_runtimes; the builder thread then exits.
+            DATA_PLANE_RUNTIMES
+                .lock()
+                .expect("DATA_PLANE_RUNTIMES poisoned")
+                .push(rt);
+            tx.send(handle)
+                .expect("failed to hand back data-plane runtime handle");
+        })
+        .expect("failed to spawn data-plane runtime thread");
+    rx.recv()
+        .expect("failed to receive data-plane runtime handle")
+}
+
+/// Shut down every data-plane runtime built by [`build_data_plane_runtime`],
+/// waiting up to `timeout` for each. Idempotent: a second call finds an empty
+/// registry and does nothing. Pure Rust (no Python); the pyo3 layer must call
+/// this at Python teardown, before `Py_Finalize`, so data-plane workers stop
+/// before the interpreter is finalized.
+pub fn shutdown_data_plane_runtimes(timeout: Duration) {
+    // Drain under the lock, then shut down outside it (shutdown_timeout blocks).
+    let runtimes: Vec<tokio::runtime::Runtime> = DATA_PLANE_RUNTIMES
+        .lock()
+        .expect("DATA_PLANE_RUNTIMES poisoned")
+        .drain(..)
+        .collect();
+    shutdown_runtimes(runtimes, timeout);
+}
+
+fn shutdown_runtimes(runtimes: Vec<tokio::runtime::Runtime>, timeout: Duration) {
+    for rt in runtimes {
+        rt.shutdown_timeout(timeout);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // RI invariant coverage:
+    // RI-1 (unstamped-is-foreign): tag_and_read_round_trip; build_data_plane_runtime_tags_workers.
+    // RI-2 (tagging-is-thread-local): tag_and_read_round_trip.
+    // RI-3 (data-plane-workers-tagged): build_data_plane_runtime_tags_workers.
+    // RI-4 (tagging-does-not-leak): build_data_plane_runtime_tags_workers.
+    // RI-5 (process-lifetime-runtime): structural (the registry keeps it alive;
+    //   the tests rely on the runtime staying alive).
+    // RI-7 (teardown-registered): shutdown_aborts_in_flight_task;
+    //   shutdown_runtimes_empty_is_noop. (the global registry drain is a thin
+    //   Vec::drain wrapper, exercised structurally.)
+
+    // RI-1/RI-2: a fresh thread is Foreign; tagging then reads back on that thread.
+    #[test]
+    fn tag_and_read_round_trip() {
+        // A fresh thread is unstamped.
+        assert_eq!(current_runtime_kind(), RuntimeKind::Foreign);
+        tag_current_thread(RuntimeKind::ControlPlane);
+        assert_eq!(current_runtime_kind(), RuntimeKind::ControlPlane);
+    }
+
+    // RI-3/RI-4: workers are stamped DataPlane(label) while the caller stays Foreign.
+    #[test]
+    fn build_data_plane_runtime_tags_workers() {
+        // The calling (test) thread is unstamped.
+        assert_eq!(current_runtime_kind(), RuntimeKind::Foreign);
+
+        let handle = build_data_plane_runtime("test-dp", 1);
+        let (tx, rx) = std::sync::mpsc::channel();
+        handle.spawn(async move {
+            let _ = tx.send(current_runtime_kind());
+        });
+
+        // A task on the data-plane runtime observes its DataPlane stamp,
+        assert_eq!(rx.recv().unwrap(), RuntimeKind::DataPlane("test-dp"));
+        // while the stamp stays confined to that runtime's worker threads.
+        assert_eq!(current_runtime_kind(), RuntimeKind::Foreign);
+    }
+
+    // RI-7: shut down a runtime with an in-flight task, and confirm the task is
+    // aborted. Built locally (not via the shared registry) so the test is
+    // isolated. Race-safe: wait for the task to signal it is live and pending
+    // before shutting down.
+    #[test]
+    fn shutdown_aborts_in_flight_task() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        use std::sync::atomic::Ordering;
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+        let (live_tx, live_rx) = std::sync::mpsc::channel();
+        let reached_end = Arc::new(AtomicBool::new(false));
+        let reached_end_task = reached_end.clone();
+        rt.spawn(async move {
+            let _ = live_tx.send(()); // signal live before the long await
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            reached_end_task.store(true, Ordering::SeqCst); // only if not aborted
+        });
+        live_rx.recv().unwrap(); // task is live and pending at the await
+
+        shutdown_runtimes(vec![rt], Duration::from_millis(200));
+
+        assert!(!reached_end.load(Ordering::SeqCst));
+    }
+
+    // RI-7: shutting down an empty set is a no-op (the idempotent second call).
+    #[test]
+    fn shutdown_runtimes_empty_is_noop() {
+        shutdown_runtimes(vec![], Duration::from_secs(1));
+    }
+}

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -17,6 +17,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Result;
+use hyperactor::runtime_identity::shutdown_data_plane_runtimes;
 use pyo3::PyResult;
 use pyo3::Python;
 use pyo3::exceptions::PyRuntimeError;
@@ -65,7 +66,7 @@ pub fn get_tokio_runtime() -> Handle {
     global_runtime().handle.clone()
 }
 
-/// atexit handler that tears down the global Tokio runtime.
+/// atexit handler that tears down the data-plane runtimes and the global Tokio runtime.
 ///
 /// Callers obtain a cloned `Handle` from `get_tokio_runtime()` rather
 /// than a guard, so the `runtime` mutex is uncontended at shutdown. We
@@ -80,6 +81,10 @@ pub fn shutdown_tokio_runtime(py: Python<'_>) {
     // Called from Python's atexit, which holds the GIL. Release it so tokio
     // worker threads can acquire it to complete their Python work.
     py.detach(|| {
+        // Tear down the data-plane runtimes (e.g. rdma) first, while the
+        // control-plane runtime is still intact, so their GIL-taking workers
+        // stop before Py_Finalize.
+        shutdown_data_plane_runtimes(Duration::from_secs(1));
         let Some(global) = INSTANCE.get() else {
             return;
         };

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -211,6 +211,17 @@ impl<I: IbvDeviceImpl> Actor for IbvManagerActor<I> {
             .expect("owner should only be set once during init");
         Ok(())
     }
+
+    // This actor is implemented in Rust, but the RDMA registration path may enter
+    // Python and take the GIL. Run its loop on the dedicated rdma runtime rather
+    // than the shared control-plane runtime; see `crate::rdma_runtime`.
+    fn spawn_server_task<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        crate::rdma_runtime::spawn_on_rdma_runtime(future)
+    }
 }
 
 impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1675,6 +1675,17 @@ impl<M: Manager, Qp: QueuePair> Actor for QueuePairActor<M, Qp> {
         })?;
         Ok(())
     }
+
+    // This actor is implemented in Rust, but the RDMA registration path may enter
+    // Python and take the GIL. Run its loop on the dedicated rdma runtime rather
+    // than the shared control-plane runtime; see `crate::rdma_runtime`.
+    fn spawn_server_task<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        crate::rdma_runtime::spawn_on_rdma_runtime(future)
+    }
 }
 
 #[async_trait]

--- a/monarch_rdma/src/lib.rs
+++ b/monarch_rdma/src/lib.rs
@@ -24,6 +24,7 @@ pub mod efa;
 pub mod local_memory;
 mod rdma_components;
 mod rdma_manager_actor;
+mod rdma_runtime;
 
 pub use backend::ibverbs::primitives::*;
 

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -168,6 +168,17 @@ impl Actor for RdmaManagerActor {
         self.backends.set(backends).expect("backends set once");
         Ok(())
     }
+
+    // This actor is implemented in Rust, but the RDMA registration path may enter
+    // Python and take the GIL. Run its loop on the dedicated rdma runtime rather
+    // than the shared control-plane runtime; see `crate::rdma_runtime`.
+    fn spawn_server_task<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+    where
+        F: std::future::Future + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        crate::rdma_runtime::spawn_on_rdma_runtime(future)
+    }
 }
 
 #[async_trait]

--- a/monarch_rdma/src/rdma_runtime.rs
+++ b/monarch_rdma/src/rdma_runtime.rs
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! A shared, dedicated Tokio runtime for the RDMA manager actors.
+//!
+//! RDMA buffer registration scans `torch.cuda` segments under the GIL
+//! (`backend::ibverbs::mlx_domain` -> `pytorch_cuda_segments`), so the RDMA actor
+//! loops run here rather than on the shared control-plane runtime.
+//!
+//! # Invariants (RR-*)
+//!
+//! - **RR-1 (process-singleton):** one shared rdma runtime exists per process
+//!   (built once, lazily), serving all RDMA actors rather than one per actor.
+//!   Sharing is safe because RDMA keeps no per-thread state that would pin an
+//!   actor to a worker, and the `QueuePairActor`s are cooperative (each re-arms a
+//!   `Tick` and yields rather than busy-polling), so a small worker pool serves
+//!   many without starving.
+//! - **RR-2 (shared-runtime-routing):** the RDMA actors (`RdmaManagerActor`,
+//!   `IbvManagerActor`, `QueuePairActor`) route `spawn_server_task` through
+//!   [`spawn_on_rdma_runtime`], not ad hoc `tokio::spawn`.
+//! - **RR-3 (rdma-is-data-plane):** [`spawn_on_rdma_runtime`] runs its future on
+//!   a `DataPlane("rdma")` thread.
+//! - **RR-4 (registration-off-control-plane):** consequently, the GIL taken
+//!   during buffer registration lands on a `DataPlane("rdma")` thread, never the
+//!   shared control-plane runtime (where a blocked GIL-holder would stall actor
+//!   dispatch, supervision, and networking).
+//! - **RR-5 (cross-runtime-joinhandle):** the `JoinHandle` from
+//!   [`spawn_on_rdma_runtime`] is awaitable from the caller's runtime, so it is
+//!   returned directly rather than bridged through a relay task.
+
+use std::sync::OnceLock;
+
+use hyperactor::runtime_identity::build_data_plane_runtime;
+
+/// Worker-thread count for the shared rdma runtime. >1 so concurrent
+/// `QueuePairActor` ticks make progress in parallel.
+const RDMA_RUNTIME_WORKER_THREADS: usize = 4;
+
+/// The process-wide rdma data-plane runtime, built on first use and tagged
+/// `DataPlane("rdma")`.
+fn rdma_runtime() -> &'static tokio::runtime::Handle {
+    static RT: OnceLock<tokio::runtime::Handle> = OnceLock::new();
+    RT.get_or_init(|| build_data_plane_runtime("rdma", RDMA_RUNTIME_WORKER_THREADS))
+}
+
+/// Spawn an actor server loop onto the shared rdma runtime and return its
+/// `JoinHandle`. Used as `Actor::spawn_server_task` by the RDMA actors. The
+/// rdma-runtime handle is returned directly: a tokio `JoinHandle` can be awaited
+/// from any runtime, including the caller's.
+///
+/// Must not be called after `shutdown_data_plane_runtimes` has torn the rdma
+/// runtime down: the cached handle would then point at a dropped runtime and
+/// `spawn` would panic. Safe in practice because the RDMA actors are drained
+/// before that atexit teardown runs.
+pub(crate) fn spawn_on_rdma_runtime<F>(future: F) -> tokio::task::JoinHandle<F::Output>
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: Send + 'static,
+{
+    rdma_runtime().spawn(future)
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::Actor;
+    use hyperactor::runtime_identity::RuntimeKind;
+    use hyperactor::runtime_identity::current_runtime_kind;
+
+    use super::*;
+    use crate::RdmaManagerActor;
+
+    // RR invariant coverage:
+    // RR-1 (process-singleton): structural (built once via OnceLock).
+    // RR-2 (shared-runtime-routing): rdma_manager_routes_spawn_server_task_to_rdma_runtime;
+    //   the generic actors share the identical override (structural).
+    // RR-3 (rdma-is-data-plane): spawn_on_rdma_runtime_runs_on_data_plane.
+    // RR-4 (registration-off-control-plane): structural (RR-2 + RR-3); the full
+    //   end-to-end assertion is the Diff-4 fitness test (GPU/IB-gated).
+    // RR-5 (cross-runtime-joinhandle): handle_awaitable_from_caller_runtime.
+
+    // RR-3: a future routed through spawn_on_rdma_runtime runs on a DataPlane("rdma") thread.
+    #[test]
+    fn spawn_on_rdma_runtime_runs_on_data_plane() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let _join = spawn_on_rdma_runtime(async move {
+            let _ = tx.send(current_runtime_kind());
+        });
+        assert_eq!(rx.recv().unwrap(), RuntimeKind::DataPlane("rdma"));
+    }
+
+    // RR-2: RdmaManagerActor's spawn_server_task override routes onto the rdma
+    // runtime (the default tokio::spawn would have no runtime here and panic).
+    #[test]
+    fn rdma_manager_routes_spawn_server_task_to_rdma_runtime() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let _join = <RdmaManagerActor as Actor>::spawn_server_task(async move {
+            let _ = tx.send(current_runtime_kind());
+        });
+        assert_eq!(rx.recv().unwrap(), RuntimeKind::DataPlane("rdma"));
+    }
+
+    // RR-5: the rdma-runtime JoinHandle is awaitable from a different runtime.
+    #[tokio::test]
+    async fn handle_awaitable_from_caller_runtime() {
+        let out = spawn_on_rdma_runtime(async { 7 }).await.unwrap();
+        assert_eq!(out, 7);
+    }
+}


### PR DESCRIPTION
Summary:

gives the RDMA manager actors (`RdmaManagerActor`, `IbvManagerActor`, `QueuePairActor`) their own tokio runtime via a `spawn_server_task` override, so the `torch.cuda` segment scan that runs under the GIL during buffer registration (`mlx_domain` -> `pytorch_cuda_segments`) lands on a dedicated data-plane thread instead of the shared control-plane runtime that drives `PythonActor` dispatch, where a GIL-holding blocked thread would stall dispatch, supervision, and networking. adds the runtime-identity primitive it builds on, `hyperactor::runtime_identity` (`RuntimeKind` + `build_data_plane_runtime`), which tags a data-plane runtime's threads `DataPlane(label)` via `on_thread_start`; the shared rdma runtime is `DataPlane("rdma")`. both new modules document their invariants (RI-* in `runtime_identity`, RR-* in `rdma_runtime`) with tests tagged to them.

also tears the data-plane runtimes down at interpreter exit. `build_data_plane_runtime` stashes each `Runtime` in a process-global registry (`DATA_PLANE_RUNTIMES`) instead of parking its builder thread on a never-completing future, and `shutdown_data_plane_runtimes` drains the registry and `shutdown_timeout`s each runtime. the pyo3 layer calls it from `shutdown_tokio_runtime` (the atexit handler) before the global control-plane runtime is torn down and before `Py_Finalize`, so the rdma runtime's GIL-taking workers stop before the interpreter is finalized. the mechanism is plain Rust in `hyperactor` (which stays Python-free); only the atexit wiring lives in `monarch_hyperactor`. this covers runtimes built by `build_data_plane_runtime` (rdma today); StreamActor's per-stream runtime is a separate follow-up.

Differential Revision: D109858587


