### PR TITLE
tag the control-plane and stream runtimes (RuntimeKind) (#4303)

### DIFF
--- a/hyperactor/src/runtime_identity.rs
+++ b/hyperactor/src/runtime_identity.rs
@@ -10,7 +10,7 @@
 //!
 //! Monarch runs Python on more than one Tokio runtime: the shared control-plane
 //! runtime that drives `PythonActor` dispatch, and separate data-plane runtimes
-//! where GIL work runs safely, off the control plane (the tensor engine; the
+//! where GIL work runs safely, off the control plane (the tensor streams; the
 //! RDMA managers, during buffer registration). The
 //! hazard is contention on the shared runtime, where a thread holding the GIL
 //! while blocked stalls every actor loop, supervisor, and network task on it.
@@ -36,6 +36,10 @@
 //!   registry and stays valid until the runtime is torn down by
 //!   [`shutdown_data_plane_runtimes`] at process teardown; callers must not spawn
 //!   onto it afterward.
+//! - **RI-6 (block-on-host-tagged):** a data-plane runtime hosted on a manually
+//!   spawned thread that drives its work via `rt.block_on` must tag that hosting
+//!   thread explicitly; `on_thread_start` stamps only the runtime's own worker
+//!   threads, not the `block_on` caller.
 //! - **RI-7 (teardown-registered):** every runtime from
 //!   [`build_data_plane_runtime`] is registered in `DATA_PLANE_RUNTIMES` and shut
 //!   down by [`shutdown_data_plane_runtimes`]. The pyo3 layer calls that at
@@ -52,7 +56,7 @@ pub enum RuntimeKind {
     /// Control-plane GIL use is kept to brief, sanctioned sites.
     ControlPlane,
     /// A runtime off the control plane. GIL work here is safe because it does
-    /// not drive actor dispatch (the tensor engine; the RDMA managers during
+    /// not drive actor dispatch (the tensor streams; the RDMA managers during
     /// buffer registration).
     DataPlane(&'static str),
     /// A thread not stamped by any monarch runtime (e.g. a Python-owned thread).
@@ -155,6 +159,7 @@ mod tests {
     // RI-4 (tagging-does-not-leak): build_data_plane_runtime_tags_workers.
     // RI-5 (process-lifetime-runtime): structural (the registry keeps it alive;
     //   the tests rely on the runtime staying alive).
+    // RI-6 (block-on-host-tagged): on_thread_start_does_not_tag_the_block_on_thread.
     // RI-7 (teardown-registered): shutdown_aborts_in_flight_task;
     //   shutdown_runtimes_empty_is_noop. (the global registry drain is a thin
     //   Vec::drain wrapper, exercised structurally.)
@@ -184,6 +189,36 @@ mod tests {
         assert_eq!(rx.recv().unwrap(), RuntimeKind::DataPlane("test-dp"));
         // while the stamp stays confined to that runtime's worker threads.
         assert_eq!(current_runtime_kind(), RuntimeKind::Foreign);
+    }
+
+    // RI-6 (block-on-host-tagged): `rt.block_on` drives its future on the CALLING
+    // thread, which is not a runtime worker, so `on_thread_start` does not cover
+    // it. A thread that runs work via `block_on` (the StreamActor pattern) must
+    // tag itself explicitly; the `on_thread_start` tag alone leaves it `Foreign`.
+    #[test]
+    fn on_thread_start_does_not_tag_the_block_on_thread() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .on_thread_start(|| tag_current_thread(RuntimeKind::DataPlane("x")))
+                .enable_all()
+                .build()
+                .unwrap();
+            // block_on runs on this (the calling) thread, which on_thread_start
+            // does not tag -> still Foreign.
+            let on_caller = rt.block_on(async { current_runtime_kind() });
+            // a spawned task runs on a worker -> DataPlane.
+            let on_worker = rt.block_on(async {
+                tokio::spawn(async { current_runtime_kind() })
+                    .await
+                    .unwrap()
+            });
+            let _ = tx.send((on_caller, on_worker));
+        });
+        let (on_caller, on_worker) = rx.recv().unwrap();
+        assert_eq!(on_caller, RuntimeKind::Foreign);
+        assert_eq!(on_worker, RuntimeKind::DataPlane("x"));
     }
 
     // RI-7: shut down a runtime with an in-flight task, and confirm the task is

--- a/monarch_extension/src/snapshot_integration.rs
+++ b/monarch_extension/src/snapshot_integration.rs
@@ -30,6 +30,13 @@ use pyo3::prelude::*;
 #[pyo3(name = "_pre_register_snapshot_schemas")]
 fn pre_register_snapshot_schemas_py(py: Python<'_>, scanner: &DatabaseScanner) -> PyResult<()> {
     let table_store = scanner.table_store();
+    // This is the pyo3-async-runtimes library's own tokio runtime, not monarch's
+    // control-plane runtime (`get_tokio_runtime()`); monarch does not tag it with
+    // a `RuntimeKind` (see `hyperactor::runtime_identity`), so GIL work here would
+    // not be classified by the runtime-identity net. Safe today only because this
+    // work is GIL-free: the GIL is released (`py.detach`) before `block_on` and
+    // `register_snapshot_schemas` is pure Arrow. If GIL work is ever needed here,
+    // route it through `get_tokio_runtime()` (or another tagged runtime).
     py.detach(|| {
         pyo3_async_runtimes::tokio::get_runtime()
             .block_on(async { register_snapshot_schemas(&table_store).await })
@@ -61,6 +68,9 @@ fn start_periodic_snapshots_py(
     }
     let interval = Duration::from_secs_f64(interval_secs);
 
+    // See the runtime-identity caveat in `pre_register_snapshot_schemas_py`:
+    // this enters that same library runtime, which monarch does not tag. The work
+    // here only spawns a Rust actor and takes no GIL; keep it that way.
     let _guard = pyo3_async_runtimes::tokio::get_runtime().enter();
     start_periodic_snapshots(&**instance, table_store, admin_ref, interval)
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -17,7 +17,9 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Result;
+use hyperactor::runtime_identity::RuntimeKind;
 use hyperactor::runtime_identity::shutdown_data_plane_runtimes;
+use hyperactor::runtime_identity::tag_current_thread;
 use pyo3::PyResult;
 use pyo3::Python;
 use pyo3::exceptions::PyRuntimeError;
@@ -51,6 +53,10 @@ fn global_runtime() -> &'static GlobalRuntime {
                 let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
                 format!("monarch-pytokio-worker-{}", id)
             })
+            // The shared control-plane runtime: stamp its workers (and
+            // blocking-pool threads) so GIL-entry sites can tell they are on the
+            // control plane. See `hyperactor::runtime_identity`.
+            .on_thread_start(|| tag_current_thread(RuntimeKind::ControlPlane))
             .enable_all()
             .build()
             .unwrap();
@@ -416,4 +422,35 @@ where
 {
     let _depth_guard = increment_gil_depth();
     Python::attach(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::runtime_identity::RuntimeKind;
+    use hyperactor::runtime_identity::current_runtime_kind;
+
+    use super::*;
+
+    // The shared control-plane runtime stamps its worker threads ControlPlane.
+    #[test]
+    fn global_runtime_workers_are_control_plane() {
+        let kind = get_tokio_runtime().block_on(async {
+            tokio::spawn(async { current_runtime_kind() })
+                .await
+                .unwrap()
+        });
+        assert_eq!(kind, RuntimeKind::ControlPlane);
+    }
+
+    // on_thread_start also reaches the blocking pool, so GIL work on a
+    // spawn_blocking thread is still seen as control-plane.
+    #[test]
+    fn global_runtime_blocking_pool_is_control_plane() {
+        let kind = get_tokio_runtime().block_on(async {
+            tokio::task::spawn_blocking(current_runtime_kind)
+                .await
+                .unwrap()
+        });
+        assert_eq!(kind, RuntimeKind::ControlPlane);
+    }
 }

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -35,6 +35,8 @@ use hyperactor::id::Label;
 use hyperactor::mailbox::OncePortHandle;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::Proc;
+use hyperactor::runtime_identity::RuntimeKind;
+use hyperactor::runtime_identity::tag_current_thread;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
 use monarch_hyperactor::local_state_broker::BrokerId;
@@ -538,11 +540,20 @@ impl Actor for StreamActor {
         // hang forever.
         let builder = std::thread::Builder::new().name("worker-stream".to_string());
         let _thread_handle = builder.spawn(move || {
+            // Data-plane worker. The stream actor loop runs on THIS thread (via
+            // `rt.block_on` below, which drives its future on the calling thread,
+            // not a runtime worker), so tag this thread directly. The
+            // `on_thread_start` below additionally tags the runtime's own
+            // worker/blocking threads. Either way the Torch/CUDA GIL use here
+            // reads `DataPlane("stream")`, not the control plane. See
+            // `hyperactor::runtime_identity` (RI-6).
+            tag_current_thread(RuntimeKind::DataPlane("stream"));
             // Spawn a new thread with a single-threaded tokio runtime to run the
             // actor loop.  We avoid the current-threaded runtime, so that we can
             // use `block_in_place` for nested async-to-sync-to-async flows.
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(1)
+                .on_thread_start(|| tag_current_thread(RuntimeKind::DataPlane("stream")))
                 .enable_all()
                 .build()
                 .unwrap();


### PR DESCRIPTION
Summary:

stamps the two remaining production runtimes with their `RuntimeKind` (the primitive landed in the previous diff). the shared control-plane runtime (`global_runtime()`, which drives `PythonActor` dispatch) tags its workers and blocking-pool threads `ControlPlane`. StreamActor's per-stream runtime tags `DataPlane("stream")` on both the actor-loop thread (which runs via `rt.block_on`, so `on_thread_start` alone would miss it) and the runtime's own workers; invariant RI-6 and the `on_thread_start_does_not_tag_the_block_on_thread` test pin that the `block_on` thread needs its own tag. an exhaustive sweep confirmed these two plus the rdma runtime are every runtime that runs actor/Python work; the rest (cleanup, CLI, bench, test, telemetry threads) carry no GIL and stay `Foreign`. one exception is flagged at source: `snapshot_integration.rs` uses pyo3-async-runtimes' own untagged runtime (GIL-free today), with a comment to keep it that way until a follow-up routes or allowlists it.

Differential Revision: D109865991


