### PR TITLE
flag unsanctioned GIL acquisition on the control-plane runtime (#4305)

### DIFF
--- a/hyperactor/src/runtime_identity.rs
+++ b/hyperactor/src/runtime_identity.rs
@@ -10,7 +10,7 @@
 //!
 //! Monarch runs Python on more than one Tokio runtime: the shared control-plane
 //! runtime that drives `PythonActor` dispatch, and separate data-plane runtimes
-//! where GIL work runs safely, off the control plane (the tensor engine; the
+//! where GIL work runs safely, off the control plane (the tensor streams; the
 //! RDMA managers, during buffer registration). The
 //! hazard is contention on the shared runtime, where a thread holding the GIL
 //! while blocked stalls every actor loop, supervisor, and network task on it.
@@ -36,6 +36,10 @@
 //!   registry and stays valid until the runtime is torn down by
 //!   [`shutdown_data_plane_runtimes`] at process teardown; callers must not spawn
 //!   onto it afterward.
+//! - **RI-6 (block-on-host-tagged):** a data-plane runtime hosted on a manually
+//!   spawned thread that drives its work via `rt.block_on` must tag that hosting
+//!   thread explicitly; `on_thread_start` stamps only the runtime's own worker
+//!   threads, not the `block_on` caller.
 //! - **RI-7 (teardown-registered):** every runtime from
 //!   [`build_data_plane_runtime`] is registered in `DATA_PLANE_RUNTIMES` and shut
 //!   down by [`shutdown_data_plane_runtimes`]. The pyo3 layer calls that at
@@ -52,7 +56,7 @@ pub enum RuntimeKind {
     /// Control-plane GIL use is kept to brief, sanctioned sites.
     ControlPlane,
     /// A runtime off the control plane. GIL work here is safe because it does
-    /// not drive actor dispatch (the tensor engine; the RDMA managers during
+    /// not drive actor dispatch (the tensor streams; the RDMA managers during
     /// buffer registration).
     DataPlane(&'static str),
     /// A thread not stamped by any monarch runtime (e.g. a Python-owned thread).
@@ -155,6 +159,7 @@ mod tests {
     // RI-4 (tagging-does-not-leak): build_data_plane_runtime_tags_workers.
     // RI-5 (process-lifetime-runtime): structural (the registry keeps it alive;
     //   the tests rely on the runtime staying alive).
+    // RI-6 (block-on-host-tagged): on_thread_start_does_not_tag_the_block_on_thread.
     // RI-7 (teardown-registered): shutdown_aborts_in_flight_task;
     //   shutdown_runtimes_empty_is_noop. (the global registry drain is a thin
     //   Vec::drain wrapper, exercised structurally.)
@@ -184,6 +189,36 @@ mod tests {
         assert_eq!(rx.recv().unwrap(), RuntimeKind::DataPlane("test-dp"));
         // while the stamp stays confined to that runtime's worker threads.
         assert_eq!(current_runtime_kind(), RuntimeKind::Foreign);
+    }
+
+    // RI-6 (block-on-host-tagged): `rt.block_on` drives its future on the CALLING
+    // thread, which is not a runtime worker, so `on_thread_start` does not cover
+    // it. A thread that runs work via `block_on` (the StreamActor pattern) must
+    // tag itself explicitly; the `on_thread_start` tag alone leaves it `Foreign`.
+    #[test]
+    fn on_thread_start_does_not_tag_the_block_on_thread() {
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_multi_thread()
+                .worker_threads(1)
+                .on_thread_start(|| tag_current_thread(RuntimeKind::DataPlane("x")))
+                .enable_all()
+                .build()
+                .unwrap();
+            // block_on runs on this (the calling) thread, which on_thread_start
+            // does not tag -> still Foreign.
+            let on_caller = rt.block_on(async { current_runtime_kind() });
+            // a spawned task runs on a worker -> DataPlane.
+            let on_worker = rt.block_on(async {
+                tokio::spawn(async { current_runtime_kind() })
+                    .await
+                    .unwrap()
+            });
+            let _ = tx.send((on_caller, on_worker));
+        });
+        let (on_caller, on_worker) = rx.recv().unwrap();
+        assert_eq!(on_caller, RuntimeKind::Foreign);
+        assert_eq!(on_worker, RuntimeKind::DataPlane("x"));
     }
 
     // RI-7: shut down a runtime with an in-flight task, and confirm the task is

--- a/monarch_extension/src/client.rs
+++ b/monarch_extension/src/client.rs
@@ -14,6 +14,7 @@ use monarch_hyperactor::proc::InstanceWrapper;
 use monarch_hyperactor::proc::PyActorAddr;
 use monarch_hyperactor::proc::PyProc;
 use monarch_hyperactor::proc::PySerialized;
+use monarch_hyperactor::runtime::GilSite;
 use monarch_hyperactor::runtime::monarch_with_gil_blocking;
 use monarch_hyperactor::runtime::signal_safe_block_on;
 use monarch_messages::client::ClientMessage;
@@ -444,7 +445,7 @@ impl ClientActor {
             instance.lock().await.next_message(timeout_msec).await
         })?;
 
-        monarch_with_gil_blocking(|py| match result {
+        monarch_with_gil_blocking(GilSite::ReplyConvert, |py| match result {
             Ok(Some(ClientMessage::Result { seq, result })) => {
                 WorkerResponse { seq, result }.into_py_any(py)
             }

--- a/monarch_extension/src/debugger.rs
+++ b/monarch_extension/src/debugger.rs
@@ -149,6 +149,7 @@ mod tests {
     use hyperactor::Mailbox;
     use hyperactor::mailbox::PortReceiver;
     use hyperactor::proc::Proc;
+    use monarch_hyperactor::runtime::GilSite;
     use monarch_hyperactor::runtime::monarch_with_gil_blocking;
     use monarch_messages::controller::ControllerMessage;
     use typeuri::Named;
@@ -169,7 +170,7 @@ mod tests {
     }
 
     fn receive_on_debugger(actor: &mut PdbActor) -> DebuggerAction {
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Test, |py| {
             let msg = actor.receive(py).unwrap();
             let action: DebuggerAction = msg.extract(py).unwrap();
             action
@@ -179,7 +180,7 @@ mod tests {
     fn receive_on_controller(
         rx: Arc<Mutex<PortReceiver<ControllerMessage>>>,
     ) -> (reference::ActorId, DebuggerAction) {
-        let msg = monarch_with_gil_blocking(|py| {
+        let msg = monarch_with_gil_blocking(GilSite::Test, |py| {
             signal_safe_block_on(py, async move { rx.lock().await.recv().await.unwrap() }).unwrap()
         });
         match msg {
@@ -219,7 +220,9 @@ mod tests {
         let mut actor = PdbActor::new().unwrap();
         let debugger_actor_id = actor.instance.blocking_lock().actor_addr().clone();
 
-        monarch_with_gil_blocking(|py| actor.send(py, DebuggerAction::Paused()).unwrap());
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            actor.send(py, DebuggerAction::Paused()).unwrap()
+        });
 
         let (received_actor_id, action) = receive_on_controller(controller_rx.clone());
         assert_eq!(received_actor_id, debugger_actor_id);
@@ -231,7 +234,7 @@ mod tests {
         let action = receive_on_debugger(&mut actor);
         assert_eq!(action, DebuggerAction::Attach());
 
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Test, |py| {
             actor
                 .send(py, DebuggerAction::Read { requested_size: 4 })
                 .unwrap()
@@ -257,7 +260,7 @@ mod tests {
             }
         );
 
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Test, |py| {
             actor
                 .send(
                     py,
@@ -282,6 +285,6 @@ mod tests {
         let action = receive_on_debugger(&mut actor);
         assert_eq!(action, DebuggerAction::Detach());
 
-        monarch_with_gil_blocking(|py| actor.drain_and_stop(py).unwrap());
+        monarch_with_gil_blocking(GilSite::Test, |py| actor.drain_and_stop(py).unwrap());
     }
 }

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -600,29 +600,32 @@ impl History {
         let invocation = self.inflight_invocations.get(&seq).unwrap().clone();
 
         let python_message = Arc::new(
-            monarch_hyperactor::runtime::monarch_with_gil(|py| {
-                let traceback = invocation
-                    .lock()
-                    .unwrap()
-                    .tracebacks
-                    .bind(py)
-                    .get_item(0)
-                    .unwrap();
-                let remote_exception = py
-                    .import("monarch.mesh_controller")
-                    .unwrap()
-                    .getattr("RemoteException")
-                    .unwrap();
-                let exe = remote_exception
-                    .call1((exception.backtrace, traceback, rank))
-                    .unwrap();
-                let mut state = pickle(py, exe.unbind(), false, false).unwrap();
-                let inner = state.take_inner().unwrap();
-                PythonMessage::new_from_buf(
-                    PythonMessageKind::Exception { rank: Some(rank) },
-                    inner.take_buffer(),
-                )
-            })
+            monarch_hyperactor::runtime::monarch_with_gil(
+                monarch_hyperactor::runtime::GilSite::Traceback,
+                |py| {
+                    let traceback = invocation
+                        .lock()
+                        .unwrap()
+                        .tracebacks
+                        .bind(py)
+                        .get_item(0)
+                        .unwrap();
+                    let remote_exception = py
+                        .import("monarch.mesh_controller")
+                        .unwrap()
+                        .getattr("RemoteException")
+                        .unwrap();
+                    let exe = remote_exception
+                        .call1((exception.backtrace, traceback, rank))
+                        .unwrap();
+                    let mut state = pickle(py, exe.unbind(), false, false).unwrap();
+                    let inner = state.take_inner().unwrap();
+                    PythonMessage::new_from_buf(
+                        PythonMessageKind::Exception { rank: Some(rank) },
+                        inner.take_buffer(),
+                    )
+                },
+            )
             .await,
         );
 
@@ -858,26 +861,30 @@ impl MeshControllerActor {
                     self.debugger_active = None;
                 }
                 DebuggerAction::Read { requested_size } => {
-                    monarch_hyperactor::runtime::monarch_with_gil(|py| {
-                        let read = py
-                            .import("monarch.controller.debugger")
-                            .unwrap()
-                            .getattr("read")
-                            .unwrap();
-                        let bytes: Vec<u8> =
-                            read.call1((requested_size,)).unwrap().extract().unwrap();
+                    monarch_hyperactor::runtime::monarch_with_gil(
+                        monarch_hyperactor::runtime::GilSite::Debugger,
+                        |py| {
+                            let read = py
+                                .import("monarch.controller.debugger")
+                                .unwrap()
+                                .getattr("read")
+                                .unwrap();
+                            let bytes: Vec<u8> =
+                                read.call1((requested_size,)).unwrap().extract().unwrap();
 
-                        debugger_actor.post(
-                            this,
-                            DebuggerMessage::Action {
-                                action: DebuggerAction::Write { bytes },
-                            },
-                        );
-                    })
+                            debugger_actor.post(
+                                this,
+                                DebuggerMessage::Action {
+                                    action: DebuggerAction::Write { bytes },
+                                },
+                            );
+                        },
+                    )
                     .await;
                 }
                 DebuggerAction::Write { bytes } => {
                     monarch_hyperactor::runtime::monarch_with_gil(
+                        monarch_hyperactor::runtime::GilSite::Debugger,
                         |py| -> Result<(), anyhow::Error> {
                             let write = py
                                 .import("monarch.controller.debugger")

--- a/monarch_extension/src/snapshot_integration.rs
+++ b/monarch_extension/src/snapshot_integration.rs
@@ -30,6 +30,13 @@ use pyo3::prelude::*;
 #[pyo3(name = "_pre_register_snapshot_schemas")]
 fn pre_register_snapshot_schemas_py(py: Python<'_>, scanner: &DatabaseScanner) -> PyResult<()> {
     let table_store = scanner.table_store();
+    // This is the pyo3-async-runtimes library's own tokio runtime, not monarch's
+    // control-plane runtime (`get_tokio_runtime()`); monarch does not tag it with
+    // a `RuntimeKind` (see `hyperactor::runtime_identity`), so GIL work here would
+    // not be classified by the runtime-identity net. Safe today only because this
+    // work is GIL-free: the GIL is released (`py.detach`) before `block_on` and
+    // `register_snapshot_schemas` is pure Arrow. If GIL work is ever needed here,
+    // route it through `get_tokio_runtime()` (or another tagged runtime).
     py.detach(|| {
         pyo3_async_runtimes::tokio::get_runtime()
             .block_on(async { register_snapshot_schemas(&table_store).await })
@@ -61,6 +68,9 @@ fn start_periodic_snapshots_py(
     }
     let interval = Duration::from_secs_f64(interval_secs);
 
+    // See the runtime-identity caveat in `pre_register_snapshot_schemas_py`:
+    // this enters that same library runtime, which monarch does not tag. The work
+    // here only spawns a Rust actor and takes no GIL; keep it that way.
     let _guard = pyo3_async_runtimes::tokio::get_runtime().enter();
     start_periodic_snapshots(&**instance, table_store, admin_ref, interval)
         .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("{:#}", e)))

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -86,6 +86,7 @@ use crate::proc::PyActorAddr;
 use crate::pympsc;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PythonTask;
+use crate::runtime::GilSite;
 use crate::runtime::get_tokio_runtime;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
@@ -356,7 +357,7 @@ impl PythonMessage {
                 broker.post(cx, LocalStateBrokerMessage::Get(id, send));
                 let state = recv.recv().await?;
                 let mut state_it = state.state.into_iter();
-                monarch_with_gil(|py| {
+                monarch_with_gil(GilSite::EndpointDispatch, |py| {
                     let mailbox = mailbox(py, cx);
                     let local_state = Some(
                         PyList::new(
@@ -831,6 +832,7 @@ impl PythonActor {
         }
 
         Ok(monarch_with_gil_blocking(
+            GilSite::ActorConstruct,
             |py| -> Result<Self, SerializablePyErr> {
                 let unpickled = actor_type.unpickle(py)?;
                 let class_type: &Bound<'_, PyType> = unpickled.downcast()?;
@@ -894,7 +896,7 @@ impl PythonActor {
 
     fn cancel_pending_python_tasks_and_stop_loop(&self) -> anyhow::Result<()> {
         let task_locals = &self.task_locals;
-        monarch_with_gil_blocking(|py| -> anyhow::Result<()> {
+        monarch_with_gil_blocking(GilSite::Stop, |py| -> anyhow::Result<()> {
             Self::cancel_tasks_and_stop_python_loop(py, task_locals)
                 .map_err(|err| anyhow::Error::from(SerializablePyErr::from(py, &err)))?;
             Ok(())
@@ -1023,7 +1025,7 @@ impl PythonActor {
                             // event and the hook raised, don't re-handle it via
                             // handle_supervision_event — that would call
                             // __supervise__ a second time.
-                            let is_hook_exception = monarch_with_gil(|py| {
+                            let is_hook_exception = monarch_with_gil(GilSite::Supervise, |py| {
                                 err.downcast_ref::<pyo3::PyErr>()
                                     .is_some_and(|pyerr| {
                                         pyerr.is_instance(
@@ -1122,7 +1124,7 @@ impl PythonActor {
                 // There is no way to propagate the exception message, but it
                 // will at least run proper shutdown code as long as BaseException
                 // isn't caught.
-                monarch_with_gil_blocking(|py| {
+                monarch_with_gil_blocking(GilSite::Stop, |py| {
                     // Use _thread.interrupt_main to force the client to exit if it has an
                     // unhandled supervision event.
                     let thread_mod = py.import("_thread").expect("import _thread");
@@ -1175,7 +1177,7 @@ pub(crate) fn root_client_actor(py: Python<'_>) -> &'static Instance<PythonActor
     // a deadlock.
     py.detach(|| {
         ROOT_CLIENT_ACTOR.get_or_init(|| {
-            monarch_with_gil_blocking(|py| {
+            monarch_with_gil_blocking(GilSite::Bootstrap, |py| {
                 let (client, _handle) = PythonActor::bootstrap_client(py);
                 client
             })
@@ -1200,7 +1202,7 @@ impl Actor for PythonActor {
         if let PythonActorDispatchMode::Queue { receiver, .. } = &mut self.dispatch_mode {
             let receiver = receiver.take().unwrap();
 
-            monarch_with_gil(|py| {
+            monarch_with_gil(GilSite::DispatchInit, |py| {
                 let self_instance = self.ensure_py_instance(py, this);
                 let actor_mesh_mod = py.import("monarch._src.actor.actor_mesh")?;
 
@@ -1245,7 +1247,7 @@ impl Actor for PythonActor {
         // have an original exception object or traceback, so we just pass in
         // the message.
         let err_as_str = err.map(|e| e.to_string());
-        let future = monarch_with_gil(|py| {
+        let future = monarch_with_gil(GilSite::EndpointCleanup, |py| {
             let py_cx = match &self.instance {
                 Some(instance) => crate::context::PyContext::new(&cx, instance.clone_ref(py)),
                 None => {
@@ -1297,7 +1299,9 @@ impl Actor for PythonActor {
 
     fn display_name(&self) -> Option<String> {
         self.instance.as_ref().and_then(|instance| {
-            monarch_with_gil_blocking(|py| instance.bind(py).str().ok().map(|s| s.to_string()))
+            monarch_with_gil_blocking(GilSite::DisplayName, |py| {
+                instance.bind(py).str().ok().map(|s| s.to_string())
+            })
         })
     }
 
@@ -1334,7 +1338,7 @@ impl Actor for PythonActor {
 
         let cx = Context::new(ins, envelope.headers().clone());
 
-        let (envelope, handled) = monarch_with_gil(|py| {
+        let (envelope, handled) = monarch_with_gil(GilSite::EndpointDispatch, |py| {
             let py_cx = match &self.instance {
                 Some(instance) => crate::context::PyContext::new(&cx, instance.clone_ref(py)),
                 None => {
@@ -1458,7 +1462,7 @@ impl RemoteSpawn for PythonActor {
 
 /// Create a new TaskLocals with its own asyncio event loop in a dedicated thread.
 fn create_task_locals() -> pyo3_async_runtimes::TaskLocals {
-    monarch_with_gil_blocking(|py| {
+    monarch_with_gil_blocking(GilSite::TaskLocals, |py| {
         let asyncio = Python::import(py, "asyncio").unwrap();
         let event_loop = asyncio.call_method0("new_event_loop").unwrap();
         let task_locals = pyo3_async_runtimes::TaskLocals::new(event_loop.clone())
@@ -1559,33 +1563,36 @@ impl PythonActor {
         // See [Panics in async endpoints].
         let (sender, receiver) = oneshot::channel();
 
-        let future = monarch_with_gil(|py| -> Result<_, SerializablePyErr> {
-            let inst = self.ensure_py_instance(py, cx);
+        let future = monarch_with_gil(
+            GilSite::EndpointDispatch,
+            |py| -> Result<_, SerializablePyErr> {
+                let inst = self.ensure_py_instance(py, cx);
 
-            let awaitable = self.actor.call_method(
-                py,
-                "handle",
-                (
-                    crate::context::PyContext::new(cx, inst.clone_ref(py)),
-                    resolved.method,
-                    resolved.bytes,
-                    PanicFlag {
-                        sender: Some(sender),
-                    },
-                    resolved
-                        .local_state
-                        .unwrap_or_else(|| PyList::empty(py).unbind().into()),
-                    resolved.response_port.into_py_any(py)?,
-                ),
-                None,
-            )?;
+                let awaitable = self.actor.call_method(
+                    py,
+                    "handle",
+                    (
+                        crate::context::PyContext::new(cx, inst.clone_ref(py)),
+                        resolved.method,
+                        resolved.bytes,
+                        PanicFlag {
+                            sender: Some(sender),
+                        },
+                        resolved
+                            .local_state
+                            .unwrap_or_else(|| PyList::empty(py).unbind().into()),
+                        resolved.response_port.into_py_any(py)?,
+                    ),
+                    None,
+                )?;
 
-            pyo3_async_runtimes::into_future_with_locals(
-                &self.task_locals,
-                awaitable.into_bound(py),
-            )
-            .map_err(|err| err.into())
-        })
+                pyo3_async_runtimes::into_future_with_locals(
+                    &self.task_locals,
+                    awaitable.into_bound(py),
+                )
+                .map_err(|err| err.into())
+            },
+        )
         .await?;
 
         // Spawn a child actor to await the Python handler method.
@@ -1609,22 +1616,25 @@ impl PythonActor {
     ) -> anyhow::Result<()> {
         let resolved = message.resolve_indirect_call(cx).await?;
 
-        let queued_msg = monarch_with_gil(|py| -> anyhow::Result<QueuedMessage> {
-            let inst = self.ensure_py_instance(py, cx);
+        let queued_msg = monarch_with_gil(
+            GilSite::QueueDispatch,
+            |py| -> anyhow::Result<QueuedMessage> {
+                let inst = self.ensure_py_instance(py, cx);
 
-            let py_context = crate::context::PyContext::new(cx, inst.clone_ref(py));
-            let py_context_obj = Py::new(py, py_context)?;
+                let py_context = crate::context::PyContext::new(cx, inst.clone_ref(py));
+                let py_context_obj = Py::new(py, py_context)?;
 
-            Ok(QueuedMessage {
-                context: py_context_obj,
-                method: resolved.method,
-                bytes: resolved.bytes,
-                local_state: resolved
-                    .local_state
-                    .unwrap_or_else(|| PyList::empty(py).unbind().into()),
-                response_port: resolved.response_port.into_py_any(py)?,
-            })
-        })
+                Ok(QueuedMessage {
+                    context: py_context_obj,
+                    method: resolved.method,
+                    bytes: resolved.bytes,
+                    local_state: resolved
+                        .local_state
+                        .unwrap_or_else(|| PyList::empty(py).unbind().into()),
+                    response_port: resolved.response_port.into_py_any(py)?,
+                })
+            },
+        )
         .await?;
 
         sender
@@ -1656,7 +1666,7 @@ impl Handler<MeshFailure> for PythonActor {
         // the same loop that runs endpoint coroutines. A sync user
         // `__supervise__` is dispatched under `fake_sync_state` inside
         // `_Actor.__supervise__`, mirroring `__cleanup__`.
-        let (display_name, fut) = monarch_with_gil(|py| {
+        let (display_name, fut) = monarch_with_gil(GilSite::Supervise, |py| {
             let inst = self.ensure_py_instance(py, cx);
             // Compute display_name here since we can't call self.display_name() due to borrow.
             let display_name: Option<String> = inst.bind(py).str().ok().map(|s| s.to_string());
@@ -1684,7 +1694,7 @@ impl Handler<MeshFailure> for PythonActor {
 
         let awaited = fut.await;
 
-        monarch_with_gil(|py| match awaited {
+        monarch_with_gil(GilSite::Supervise, |py| match awaited {
             Ok(s) => {
                 if s.bind(py).is_truthy()? {
                     // If the return value is truthy, then the exception was handled
@@ -1815,7 +1825,7 @@ async fn handle_async_endpoint_panic(
         // processing of the async endpoint, see [Panics in async endpoints].
         match side_channel.await {
             Ok(value) => {
-                monarch_with_gil(|py| -> Option<SerializablePyErr> {
+                monarch_with_gil(GilSite::AwaitDrive, |py| -> Option<SerializablePyErr> {
                     let err: PyErr = value
                         .downcast_bound::<PyBaseException>(py)
                         .unwrap()
@@ -2173,7 +2183,7 @@ mod tests {
         let pyerr = to_py_error(err);
 
         pyo3::Python::initialize();
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Test, |py| {
             assert!(pyerr.get_type(py).is(PyValueError::type_object(py)));
             let py_msg = pyerr.value(py).to_string();
 

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -42,6 +42,7 @@ use crate::context::PyInstance;
 use crate::pickle::PendingMessage;
 use crate::proc::PyActorAddr;
 use crate::pytokio::PyPythonTask;
+use crate::runtime::GilSite;
 use crate::runtime::get_tokio_runtime;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
@@ -272,7 +273,7 @@ impl From<PyErr> for ClonePyErr {
 
 impl Clone for ClonePyErr {
     fn clone(&self) -> Self {
-        monarch_with_gil_blocking(|py| self.inner.clone_ref(py).into())
+        monarch_with_gil_blocking(GilSite::Convert, |py| self.inner.clone_ref(py).into())
     }
 }
 
@@ -389,7 +390,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
             }
             .await;
             if let (Some(mut port_ref), Err(pyerr)) = (port, result) {
-                let _ = monarch_with_gil(|py: Python<'_>| {
+                let _ = monarch_with_gil(GilSite::Traceback, |py: Python<'_>| {
                     let exception_str = crate::logging::format_traceback(py, &pyerr);
                     tracing::error!(
                         actor_id = instance.self_addr().to_string(),
@@ -454,7 +455,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
 
     fn stop(&self, instance: &PyInstance, reason: String) -> PyResult<PyPythonTask> {
         let mesh = self.mesh.clone();
-        let instance = monarch_with_gil_blocking(|_py| instance.clone());
+        let instance = monarch_with_gil_blocking(GilSite::Stop, |_py| instance.clone());
         let (tx, rx) = tokio::sync::oneshot::channel();
         self.push(async move {
             let result =
@@ -609,7 +610,8 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
     }
 
     fn stop(&self, instance: &PyInstance, reason: String) -> PyResult<PyPythonTask> {
-        let (slf, instance) = monarch_with_gil_blocking(|_py| (self.clone(), instance.clone()));
+        let (slf, instance) =
+            monarch_with_gil_blocking(GilSite::Stop, |_py| (self.clone(), instance.clone()));
         match slf {
             PythonActorMeshImpl::Owned(mut mesh) => PyPythonTask::new(async move {
                 mesh.mesh

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -30,6 +30,7 @@ use pyo3::wrap_pyfunction;
 
 use crate::host_mesh::PyHostMesh;
 use crate::pytokio::PyPythonTask;
+use crate::runtime::GilSite;
 use crate::runtime::monarch_with_gil;
 
 #[pyfunction]
@@ -133,16 +134,17 @@ pub fn attach_to_workers(
     PyPythonTask::new(async move {
         let results = try_join_all(tasks).await?;
 
-        let addresses: Result<Vec<ChannelAddr>, anyhow::Error> = monarch_with_gil(|py| {
-            results
-                .into_iter()
-                .map(|result| {
-                    let url_str: String = result.bind(py).extract()?;
-                    Ok(ChannelAddr::from_zmq_url(&url_str)?.into_dial_addr())
-                })
-                .collect()
-        })
-        .await;
+        let addresses: Result<Vec<ChannelAddr>, anyhow::Error> =
+            monarch_with_gil(GilSite::Bootstrap, |py| {
+                results
+                    .into_iter()
+                    .map(|result| {
+                        let url_str: String = result.bind(py).extract()?;
+                        Ok(ChannelAddr::from_zmq_url(&url_str)?.into_dial_addr())
+                    })
+                    .collect()
+            })
+            .await;
         let addresses = addresses?;
 
         let host_mesh = HostMesh::attach(&*instance, name, addresses)

--- a/monarch_hyperactor/src/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/src/code_sync/auto_reload.rs
@@ -23,6 +23,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
+use crate::runtime::GilSite;
 use crate::runtime::monarch_with_gil_blocking;
 
 /// Message to trigger module reloading
@@ -60,7 +61,7 @@ impl AutoReloadActor {
     pub(crate) async fn new() -> Result<Self, anyhow::Error> {
         Ok(Self {
             state: tokio::task::spawn_blocking(move || {
-                monarch_with_gil_blocking(|py| {
+                monarch_with_gil_blocking(GilSite::CodeSync, |py| {
                     Self::create_state(py).map_err(SerializablePyErr::from_fn(py))
                 })
             })
@@ -104,7 +105,7 @@ impl Handler<AutoReloadMessage> for AutoReloadActor {
         let res = async {
             let py_reloader: Arc<_> = self.state.as_ref().map_err(Clone::clone)?.0.clone();
             tokio::task::spawn_blocking(move || {
-                monarch_with_gil_blocking(|py| {
+                monarch_with_gil_blocking(GilSite::CodeSync, |py| {
                     Self::reload(py, py_reloader.as_ref()).map_err(SerializablePyErr::from_fn(py))
                 })
             })

--- a/monarch_hyperactor/src/gil.rs
+++ b/monarch_hyperactor/src/gil.rs
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Control-plane GIL accounting.
+//!
+//! The GIL wrappers (`monarch_with_gil` / `monarch_with_gil_blocking`) route every
+//! Python acquisition through `check_gil_site`, which flags any acquisition on the
+//! shared control-plane runtime whose `GilSite` is not sanctioned
+//! (`is_control_plane_allowed`). This makes "no unsanctioned Python on the
+//! control-plane runtime" a counted, debug-assertable invariant. Builds on the
+//! `RuntimeKind` tagging in `hyperactor::runtime_identity`.
+//!
+//! # Invariants (GIL-*)
+//!
+//! - **GIL-1 (outermost-entry-accountable):** `check_gil_site` acts only at the
+//!   outermost logical GIL entry (when `is_reentrant()` is false); a re-entrant
+//!   acquisition under a sanctioned entry is attributed to that entry, not checked
+//!   on its own.
+//! - **GIL-2 (off-control-plane-exempt):** `check_gil_site` is a no-op on
+//!   `DataPlane`/`Foreign` threads; only `RuntimeKind::ControlPlane` is policed.
+//! - **GIL-3 (allowlist-exhaustive):** `is_control_plane_allowed` is a wildcard-free
+//!   `match` over `GilSite`, so a new variant cannot compile until it is classified,
+//!   and `GilSite` has no catch-all variant.
+//! - **GIL-4 (unsanctioned-accounted):** an unsanctioned control-plane acquisition
+//!   increments `GIL_ON_CONTROL_PLANE`, logs the caller location, and trips a
+//!   `debug_assert` in debug builds.
+
+use std::sync::LazyLock;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+
+use hyperactor::runtime_identity::RuntimeKind;
+use hyperactor::runtime_identity::current_runtime_kind;
+use pyo3::Python;
+use pyo3::prelude::*;
+
+/// Global lock to serialize GIL acquisition from Rust threads in async contexts.
+///
+/// Under high concurrency, many async tasks can simultaneously try to acquire the GIL.
+/// Each call blocks the current tokio worker thread, which can cause runtime starvation
+/// and apparent deadlocks (nothing else gets polled).
+///
+/// This wrapper serializes GIL acquisition among callers that opt in, so at most one
+/// tokio task is blocked in `Python::attach` at a time, improving fairness under
+/// contention.
+///
+/// Note: this does not globally prevent other sync code from calling `Python::attach`
+/// directly. Use `monarch_with_gil` or `monarch_with_gil_blocking` for Python interaction
+/// that occurs on async hot paths.
+static GIL_LOCK: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+// Thread-local depth counter for re-entrant GIL acquisition.
+//
+// This tracks when we're already inside a `monarch_with_gil` or `monarch_with_gil_blocking`
+// call. On re-entry (e.g., when Python calls back into Rust while we're already executing
+// under `Python::attach`), we bypass the `GIL_LOCK` to avoid deadlocks.
+//
+// Without this, the following scenario would deadlock:
+// 1. Rust async code calls `monarch_with_gil`, acquires `GIL_LOCK`
+// 2. Inside the closure, Python code is executed
+// 3. Python code calls back into Rust (e.g., via a PyO3 callback)
+// 4. The callback tries to call `monarch_with_gil` again
+// 5. DEADLOCK: waiting for `GIL_LOCK` which is held by the same logical call chain
+thread_local! {
+    static GIL_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
+/// RAII guard that decrements the GIL depth counter when dropped.
+struct GilDepthGuard {
+    prev_depth: u32,
+}
+
+impl Drop for GilDepthGuard {
+    fn drop(&mut self) {
+        GIL_DEPTH.with(|d| d.set(self.prev_depth));
+    }
+}
+
+/// Increments the GIL depth counter and returns a guard that restores it on drop.
+fn increment_gil_depth() -> GilDepthGuard {
+    let prev_depth = GIL_DEPTH.with(|d| {
+        let current = d.get();
+        d.set(current + 1);
+        current
+    });
+    GilDepthGuard { prev_depth }
+}
+
+/// Returns true if we're already inside a `monarch_with_gil` call (re-entrant).
+fn is_reentrant() -> bool {
+    GIL_DEPTH.with(|d| d.get() > 0)
+}
+
+/// A sanctioned GIL acquisition operation, identifying *why* a
+/// `monarch_with_gil`/`monarch_with_gil_blocking` site takes the GIL. Each
+/// variant names one distinct operation so `is_control_plane_allowed` can
+/// classify it. There is deliberately no catch-all: a new GIL site must add a
+/// variant and classify it, or the code will not compile.
+///
+/// This sanctioned set is transitional and meant to shrink: the goal is to move
+/// Python off the control-plane runtime entirely, retiring these operations over
+/// time, so the allow-list (and this enum) trends toward empty. New variants
+/// should be rare and short-lived.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum GilSite {
+    /// Dispatch a message to a Python endpoint (direct dispatch).
+    EndpointDispatch,
+    /// Build a queued message for queue-dispatch mode.
+    QueueDispatch,
+    /// Start the Python dispatch loop during actor init.
+    DispatchInit,
+    /// Run an actor's `__cleanup__`.
+    EndpointCleanup,
+    /// Run `__supervise__`, or inspect a supervision result.
+    Supervise,
+    /// Render an actor's display name.
+    DisplayName,
+    /// Construct a `PythonActor` (unpickle the actor type).
+    ActorConstruct,
+    /// Bootstrap a client actor, or convert bootstrap addresses.
+    Bootstrap,
+    /// Create or clone a `TaskLocals` (asyncio event loop).
+    TaskLocals,
+    /// Convert a port reply into a Python value.
+    ReplyConvert,
+    /// Run a comm reducer.
+    Reducer,
+    /// Run an accumulator.
+    Accumulate,
+    /// Convert a Rust value into a Python value (or clone a Python value).
+    Convert,
+    /// Capture, format, or clone a Python traceback or exception.
+    Traceback,
+    /// Drive a Python coroutine or blocking task on the bridge.
+    AwaitDrive,
+    /// Cancel pending tasks, stop an event loop, or interrupt the client.
+    Stop,
+    /// Interactive debugger read/write.
+    Debugger,
+    /// Get or set a Python logger.
+    Logging,
+    /// Run the code-sync auto-reloader.
+    CodeSync,
+    /// Register or operate RDMA buffers (runs on the data plane).
+    Rdma,
+    /// Test-only GIL use.
+    Test,
+}
+
+/// Counts GIL acquisitions for unsanctioned operations on the control-plane
+/// runtime. Exposed to Python via `get_gil_on_control_plane` for tests.
+static GIL_ON_CONTROL_PLANE: AtomicU64 = AtomicU64::new(0);
+
+/// Whether `site` is allowed to take the GIL on the control-plane runtime.
+///
+/// This `match` has no wildcard arm on purpose: adding a `GilSite` variant must
+/// fail to compile until it is classified here. `true` is the transitional
+/// sanctioned set of operations that run on the control plane today; `false`
+/// marks operations that must run elsewhere (the data plane).
+fn is_control_plane_allowed(site: GilSite) -> bool {
+    match site {
+        // Dispatch and reply.
+        GilSite::EndpointDispatch
+        | GilSite::QueueDispatch
+        | GilSite::DispatchInit
+        | GilSite::EndpointCleanup
+        | GilSite::ReplyConvert => true,
+        // Supervision and lifecycle.
+        GilSite::Supervise
+        | GilSite::DisplayName
+        | GilSite::ActorConstruct
+        | GilSite::Bootstrap
+        | GilSite::Stop => true,
+        // Accumulation and reduction.
+        GilSite::Reducer | GilSite::Accumulate => true,
+        // Coroutine driving and value conversion.
+        GilSite::TaskLocals | GilSite::Convert | GilSite::Traceback | GilSite::AwaitDrive => true,
+        // Auxiliary control-plane services.
+        GilSite::Debugger | GilSite::Logging | GilSite::CodeSync => true,
+        // Tests run their GIL work on control-plane-tagged threads.
+        GilSite::Test => true,
+        // RDMA buffer registration runs on its own data-plane runtime; a
+        // control-plane Rdma grab is the regression this net catches.
+        GilSite::Rdma => false,
+    }
+}
+
+/// Account for a GIL acquisition at `site`. On the control-plane runtime, an
+/// unsanctioned `site` (per `is_control_plane_allowed`) bumps
+/// `GIL_ON_CONTROL_PLANE`, logs a warning, and trips a `debug_assert`. Only the
+/// outermost logical entry is checked; re-entrant acquisitions are skipped.
+#[track_caller]
+fn check_gil_site(site: GilSite) {
+    if is_reentrant() {
+        return;
+    }
+    if current_runtime_kind() != RuntimeKind::ControlPlane {
+        return;
+    }
+    if is_control_plane_allowed(site) {
+        return;
+    }
+    GIL_ON_CONTROL_PLANE.fetch_add(1, Ordering::Relaxed);
+    tracing::warn!(
+        site = ?site,
+        caller = %std::panic::Location::caller(),
+        "unsanctioned GIL on control-plane runtime"
+    );
+    debug_assert!(
+        false,
+        "unsanctioned GIL on control-plane: {:?} at {}",
+        site,
+        std::panic::Location::caller()
+    );
+}
+
+/// Async wrapper around `Python::attach` intended for async call sites.
+///
+/// Why: under high concurrency, many async tasks can simultaneously
+/// try to acquire the GIL. Each call blocks the current tokio worker
+/// thread, which can cause runtime starvation / apparent deadlocks
+/// (nothing else gets polled).
+///
+/// This wrapper serializes GIL acquisition among async callers so at most one tokio
+/// task is blocked in `Python::attach` at a time, preventing runtime starvation
+/// under GIL contention.
+///
+/// Note: this does not globally prevent other sync code from calling
+/// `Python::attach` directly, so the control-plane GIL accounting
+/// (`check_gil_site`) covers only acquisitions that route through these
+/// wrappers; a raw `Python::attach` elsewhere bypasses it. Use this wrapper
+/// for Python interaction that occurs on async hot paths.
+///
+/// # Re-entrancy Safety
+///
+/// This function is re-entrant safe. If called while already inside a `monarch_with_gil`
+/// or `monarch_with_gil_blocking` call (e.g., from a Python→Rust callback), it bypasses
+/// the `GIL_LOCK` to avoid deadlocks.
+///
+/// # Example
+/// ```ignore
+/// let result = monarch_with_gil(GilSite::Convert, |py| {
+///     // Do work with Python GIL
+///     Ok(42)
+/// })
+/// .await?;
+/// ```
+// No `#[track_caller]` (unlike the blocking wrapper): it does not propagate through
+// `async fn`, so the logged `GilSite` is the diagnostic for async sites.
+pub async fn monarch_with_gil<F, R>(site: GilSite, f: F) -> R
+where
+    F: for<'py> FnOnce(Python<'py>) -> R + Send,
+{
+    check_gil_site(site);
+
+    // If we're already inside a monarch_with_gil call (re-entrant), skip the lock
+    // to avoid deadlock from Python→Rust callbacks
+    if is_reentrant() {
+        let _depth_guard = increment_gil_depth();
+        return Python::attach(f);
+    }
+
+    // Not re-entrant: acquire the serialization lock
+    let _lock_guard = GIL_LOCK.lock().await;
+    let _depth_guard = increment_gil_depth();
+    Python::attach(f)
+}
+
+/// Blocking wrapper around `Python::with_gil` for use in synchronous contexts.
+///
+/// Unlike `monarch_with_gil`, this function does NOT use the `GIL_LOCK` async mutex.
+/// Since it is blocking call, it simply acquires the GIL and releases it when the
+/// closure returns.
+///
+/// Note: like `monarch_with_gil`, the control-plane GIL accounting
+/// (`check_gil_site`) covers only acquisitions that route through these wrappers;
+/// a raw `Python::attach` elsewhere bypasses it.
+///
+/// # Example
+/// ```ignore
+/// let result = monarch_with_gil_blocking(GilSite::Convert, |py| {
+///     // Do work with Python GIL
+///     Ok(42)
+/// })?;
+/// ```
+#[track_caller]
+pub fn monarch_with_gil_blocking<F, R>(site: GilSite, f: F) -> R
+where
+    F: for<'py> FnOnce(Python<'py>) -> R + Send,
+{
+    check_gil_site(site);
+
+    let _depth_guard = increment_gil_depth();
+    Python::attach(f)
+}
+
+/// Number of unsanctioned GIL acquisitions seen on the control-plane runtime.
+/// For tests; see `GIL_ON_CONTROL_PLANE`.
+#[pyfunction]
+#[pyo3(name = "_get_gil_on_control_plane")]
+pub fn get_gil_on_control_plane() -> u64 {
+    GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed)
+}
+
+/// Reset the unsanctioned control-plane GIL counter to zero. For tests.
+#[pyfunction]
+#[pyo3(name = "_reset_gil_on_control_plane")]
+pub fn reset_gil_on_control_plane() {
+    GIL_ON_CONTROL_PLANE.store(0, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::runtime_identity::RuntimeKind;
+    use hyperactor::runtime_identity::tag_current_thread;
+
+    use super::*;
+
+    // GIL invariant coverage:
+    // GIL-1 (outermost-entry-accountable): reentrant_unsanctioned_is_skipped.
+    // GIL-2 (off-control-plane-exempt): unsanctioned_site_off_control_plane_is_silent.
+    // GIL-3 (allowlist-exhaustive): allowed_classification; structural (wildcard-free match, no catch-all).
+    // GIL-4 (unsanctioned-accounted): unsanctioned_site_on_control_plane_panics; allowed_site_on_control_plane_is_silent.
+
+    // The classification is the source of truth for the net: dispatch is
+    // sanctioned; Rdma is not (it must run on the data plane).
+    // GIL-3:
+    #[test]
+    fn allowed_classification() {
+        assert!(is_control_plane_allowed(GilSite::EndpointDispatch));
+        assert!(is_control_plane_allowed(GilSite::Test));
+        assert!(!is_control_plane_allowed(GilSite::Rdma));
+    }
+
+    // An allowlisted site on a control-plane thread is a no-op: the counter does
+    // not move and `check_gil_site` does not trip the debug_assert. Run on a
+    // freshly tagged thread (the test thread itself is Foreign) and assert a
+    // delta so concurrent tests on the global counter do not interfere.
+    // GIL-4:
+    #[test]
+    fn allowed_site_on_control_plane_is_silent() {
+        let before = GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed);
+        std::thread::spawn(|| {
+            tag_current_thread(RuntimeKind::ControlPlane);
+            check_gil_site(GilSite::EndpointDispatch);
+        })
+        .join()
+        .unwrap();
+        let after = GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed);
+        assert_eq!(after, before, "allowed site must not bump the counter");
+    }
+
+    // An unsanctioned site (Rdma) on a control-plane thread trips the
+    // debug_assert (which fires in test builds).
+    // GIL-4:
+    #[test]
+    fn unsanctioned_site_on_control_plane_panics() {
+        // Run on a throwaway thread so the ControlPlane tag never leaks into a
+        // sibling test; the debug_assert fires inside it, so join() returns Err.
+        let res = std::thread::spawn(|| {
+            tag_current_thread(RuntimeKind::ControlPlane);
+            check_gil_site(GilSite::Rdma);
+        })
+        .join();
+        assert!(
+            res.is_err(),
+            "unsanctioned control-plane GIL must trip the debug_assert"
+        );
+    }
+
+    // Off the control plane the runtime-kind gate returns first, so even an
+    // unsanctioned site neither panics nor moves the counter.
+    // GIL-2:
+    #[test]
+    fn unsanctioned_site_off_control_plane_is_silent() {
+        let before = GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed);
+
+        // The test thread is Foreign.
+        check_gil_site(GilSite::Rdma);
+
+        // A DataPlane-tagged thread is likewise exempt.
+        std::thread::spawn(|| {
+            tag_current_thread(RuntimeKind::DataPlane("test-dp"));
+            check_gil_site(GilSite::Rdma);
+        })
+        .join()
+        .unwrap();
+
+        let after = GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed);
+        assert_eq!(after, before, "off control plane must not bump the counter");
+    }
+
+    // The reentrancy gate fires before the runtime-kind and allowlist checks: a
+    // re-entrant acquisition under a sanctioned entry is attributed to that
+    // entry, so an unsanctioned site under it is skipped, even on the control
+    // plane. Run on a freshly tagged thread so the depth guard is the only
+    // reason the check is skipped.
+    // GIL-1:
+    #[test]
+    fn reentrant_unsanctioned_is_skipped() {
+        std::thread::spawn(|| {
+            tag_current_thread(RuntimeKind::ControlPlane);
+            let _g = increment_gil_depth();
+            let before = GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed);
+            check_gil_site(GilSite::Rdma);
+            let after = GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed);
+            assert_eq!(after, before, "reentrant acquisition must not be checked");
+        })
+        .join()
+        .unwrap();
+    }
+}

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -55,6 +55,7 @@ use crate::actor::to_py_error;
 use crate::context::PyInstance;
 use crate::proc_mesh::PyProcMesh;
 use crate::pytokio::PyPythonTask;
+use crate::runtime::GilSite;
 use crate::runtime::monarch_with_gil;
 use crate::shape::PyExtent;
 use crate::shape::PyPoint;
@@ -483,7 +484,7 @@ fn bootstrap_host(
             .await
             .map_err(|e| PyException::new_err(e.to_string()))?;
 
-        let (instance, _handle) = monarch_with_gil(|py| {
+        let (instance, _handle) = monarch_with_gil(GilSite::Bootstrap, |py| {
             PythonActor::bootstrap_client_inner(py, local_proc, &ROOT_CLIENT_INSTANCE_FOR_HOST)
         })
         .await;

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -8,7 +8,6 @@
 
 #![allow(unsafe_op_in_unsafe_fn)]
 #![feature(exit_status_error)]
-#![feature(mapped_lock_guards)]
 
 pub mod actor;
 pub mod actor_mesh;
@@ -19,6 +18,7 @@ pub mod code_sync;
 pub mod config;
 pub mod context;
 pub mod endpoint;
+mod gil;
 pub mod host_mesh;
 pub mod local_state_broker;
 pub mod logging;

--- a/monarch_hyperactor/src/logging.rs
+++ b/monarch_hyperactor/src/logging.rs
@@ -47,6 +47,7 @@ use crate::context::PyInstance;
 use crate::proc::PyActorAddr;
 use crate::proc_mesh::PyProcMesh;
 use crate::pytokio::PyPythonTask;
+use crate::runtime::GilSite;
 use crate::runtime::monarch_with_gil;
 
 #[derive(
@@ -99,9 +100,10 @@ impl RemoteSpawn for LoggerRuntimeActor {
     type Params = ();
 
     async fn new(_: (), _environment: Flattrs) -> Result<Self, anyhow::Error> {
-        let logger =
-            monarch_with_gil(|py| Self::get_logger(py).map_err(SerializablePyErr::from_fn(py)))
-                .await?;
+        let logger = monarch_with_gil(GilSite::Logging, |py| {
+            Self::get_logger(py).map_err(SerializablePyErr::from_fn(py))
+        })
+        .await?;
         Ok(Self {
             logger: Arc::new(logger),
         })
@@ -113,7 +115,7 @@ impl RemoteSpawn for LoggerRuntimeActor {
 impl LoggerRuntimeMessageHandler for LoggerRuntimeActor {
     async fn set_logging(&mut self, _cx: &Context<Self>, level: u8) -> Result<(), anyhow::Error> {
         let logger: Arc<_> = self.logger.clone();
-        monarch_with_gil(|py| {
+        monarch_with_gil(GilSite::Logging, |py| {
             Self::set_logger_level(py, logger.as_ref(), level)
                 .map_err(SerializablePyErr::from_fn(py))
         })
@@ -661,7 +663,7 @@ mod tests {
                 .await
                 .expect("spawn failed (forwarding disabled)");
 
-            monarch_with_gil(|py| {
+            monarch_with_gil(GilSite::Test, |py| {
                 let client_ref = client_py.borrow(py);
                 assert!(
                     client_ref.forwarder_mesh.is_none(),
@@ -685,7 +687,7 @@ mod tests {
                 .await
                 .expect("spawn failed (forwarding enabled)");
 
-            monarch_with_gil(|py| {
+            monarch_with_gil(GilSite::Test, |py| {
                 let client_ref = client_py.borrow(py);
                 assert!(
                     client_ref.forwarder_mesh.is_some(),
@@ -721,7 +723,7 @@ mod tests {
                 .await
                 .expect("spawn failed (forwarding disabled)");
 
-            monarch_with_gil(|py| {
+            monarch_with_gil(GilSite::Test, |py| {
                 let client_ref = client_py.borrow(py);
 
                 // (a) stream_to_client = false, no aggregate window
@@ -781,7 +783,7 @@ mod tests {
                 .await
                 .expect("spawn failed (forwarding enabled)");
 
-            monarch_with_gil(|py| {
+            monarch_with_gil(GilSite::Test, |py| {
                 let client_ref = client_py.borrow(py);
 
                 // (d) stream_to_client = true, aggregate_window_sec =
@@ -840,7 +842,7 @@ mod tests {
                 .expect("spawn failed (forwarding disabled)");
 
             // Call flush() and bring the PyPythonTask back out.
-            let flush_task = monarch_with_gil(|py| {
+            let flush_task = monarch_with_gil(GilSite::Test, |py| {
                 let client_ref = client_py.borrow(py);
                 client_ref
                     .flush(&py_instance)
@@ -872,7 +874,7 @@ mod tests {
 
             // Call flush() to exercise the barrier path, and pull the
             // PyPythonTask out.
-            let flush_task = monarch_with_gil(|py| {
+            let flush_task = monarch_with_gil(GilSite::Test, |py| {
                 client_py
                     .borrow(py)
                     .flush(&py_instance)

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -47,6 +47,7 @@ use crate::context::PyInstance;
 use crate::proc::PyActorAddr;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PythonTask;
+use crate::runtime::GilSite;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
 
@@ -332,7 +333,7 @@ async fn recv_async(
         .await
         .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
 
-    monarch_with_gil(|py| message.into_py_any(py)).await
+    monarch_with_gil(GilSite::ReplyConvert, |py| message.into_py_any(py)).await
 }
 
 #[pymethods]
@@ -535,7 +536,7 @@ impl PythonOncePortReceiver {
                 .await
                 .map_err(|err| PyErr::new::<PyEOFError, _>(format!("Port closed: {}", err)))?;
 
-            monarch_with_gil(|py| message.into_py_any(py)).await
+            monarch_with_gil(GilSite::ReplyConvert, |py| message.into_py_any(py)).await
         };
         Ok(PythonTask::new(fut)?.into())
     }
@@ -640,6 +641,7 @@ impl PythonReducer {
         let p = params.ok_or_else(|| anyhow::anyhow!("params cannot be None"))?;
         let obj: PickledPyObject = p.deserialized()?;
         Ok(monarch_with_gil_blocking(
+            GilSite::Reducer,
             |py: Python<'_>| -> PyResult<Self> {
                 let unpickled = obj.unpickle(py)?;
                 Ok(Self(unpickled.unbind()))
@@ -652,10 +654,13 @@ impl CommReducer for PythonReducer {
     type Update = PythonMessage;
 
     fn reduce(&self, left: Self::Update, right: Self::Update) -> anyhow::Result<Self::Update> {
-        monarch_with_gil_blocking(|py: Python<'_>| -> PyResult<PythonMessage> {
-            let result = self.0.call(py, (left, right), None)?;
-            result.extract::<PythonMessage>(py)
-        })
+        monarch_with_gil_blocking(
+            GilSite::Reducer,
+            |py: Python<'_>| -> PyResult<PythonMessage> {
+                let result = self.0.call(py, (left, right), None)?;
+                result.extract::<PythonMessage>(py)
+            },
+        )
         .map_err(Into::into)
     }
 }
@@ -690,7 +695,7 @@ impl Accumulator for PythonAccumulator {
     type Update = PythonMessage;
 
     fn accumulate(&self, state: &mut Self::State, update: Self::Update) -> anyhow::Result<()> {
-        monarch_with_gil_blocking(|py: Python<'_>| -> PyResult<()> {
+        monarch_with_gil_blocking(GilSite::Accumulate, |py: Python<'_>| -> PyResult<()> {
             // Initialize state if it is empty.
             if matches!(state.kind, PythonMessageKind::Uninit {}) {
                 *state = self

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -33,6 +33,7 @@ use crate::context::PyInstance;
 use crate::pickle::PendingMessage;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PyShared;
+use crate::runtime::GilSite;
 use crate::runtime::get_tokio_runtime;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
@@ -93,26 +94,27 @@ impl PyProcMesh {
 
             let init_message = init_message.resolve().await?;
 
-            let (proc_mesh, params) = monarch_with_gil(|py| -> PyResult<_> {
-                let slf: Bound<PyProcMesh> = proc_mesh.extract(py)?;
-                let slf = slf.borrow();
-                let pickled_type = PickledPyObject::pickle(actor.bind(py).as_any())?;
-                Ok((
-                    slf.mesh_ref()?.clone(),
-                    // Plumb `mesh_base_name` into the actor so the
-                    // direct actor-handled supervision path can
-                    // populate `MeshFailure.actor_mesh_name` without
-                    // a lookup. Kept separate from
-                    // `supervision_display_name` below (rendered
-                    // supervision display string).
-                    PythonActorParams::new(
-                        pickled_type,
-                        Some(init_message),
-                        Some(mesh_base_name.clone()),
-                    ),
-                ))
-            })
-            .await?;
+            let (proc_mesh, params) =
+                monarch_with_gil(GilSite::ActorConstruct, |py| -> PyResult<_> {
+                    let slf: Bound<PyProcMesh> = proc_mesh.extract(py)?;
+                    let slf = slf.borrow();
+                    let pickled_type = PickledPyObject::pickle(actor.bind(py).as_any())?;
+                    Ok((
+                        slf.mesh_ref()?.clone(),
+                        // Plumb `mesh_base_name` into the actor so the
+                        // direct actor-handled supervision path can
+                        // populate `MeshFailure.actor_mesh_name` without
+                        // a lookup. Kept separate from
+                        // `supervision_display_name` below (rendered
+                        // supervision display string).
+                        PythonActorParams::new(
+                            pickled_type,
+                            Some(init_message),
+                            Some(mesh_base_name.clone()),
+                        ),
+                    ))
+                })
+                .await?;
 
             let mesh_name = ActorMeshId::instance(Label::strip(&mesh_base_name));
             let actor_mesh = proc_mesh
@@ -131,7 +133,7 @@ impl PyProcMesh {
             // we give up on doing mesh spawn async for the emulated old version
             // it is too complicated to make both work.
             let r = get_tokio_runtime().block_on(mesh_impl)?;
-            monarch_with_gil_blocking(|py| r.into_py_any(py))
+            monarch_with_gil_blocking(GilSite::Convert, |py| r.into_py_any(py))
         } else {
             let r = PythonActorMesh::new(
                 async move {
@@ -140,7 +142,7 @@ impl PyProcMesh {
                 },
                 true,
             );
-            monarch_with_gil_blocking(|py| r.into_py_any(py))
+            monarch_with_gil_blocking(GilSite::Convert, |py| r.into_py_any(py))
         }
     }
 
@@ -168,7 +170,7 @@ impl PyProcMesh {
 
     fn stop_nonblocking(&self, instance: &PyInstance, reason: String) -> PyResult<PyPythonTask> {
         // Clone the necessary fields from self to avoid capturing self in the async block
-        let (owned_inner, instance) = monarch_with_gil_blocking(|_py| {
+        let (owned_inner, instance) = monarch_with_gil_blocking(GilSite::Stop, |_py| {
             let owned_inner = match self {
                 PyProcMesh::Owned(inner) => inner.clone(),
                 PyProcMesh::Ref(_) => {

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -120,6 +120,7 @@ use tokio::sync::watch;
 use tokio::task::JoinHandle;
 
 use crate::pickle::reduce_shared;
+use crate::runtime::GilSite;
 use crate::runtime::get_tokio_runtime;
 use crate::runtime::monarch_with_gil;
 use crate::runtime::monarch_with_gil_blocking;
@@ -150,7 +151,7 @@ py_global!(actor_mesh_module, "monarch._src.actor", "actor_mesh");
 /// `traceback.extract_stack()`.
 fn current_traceback() -> PyResult<Option<Py<PyAny>>> {
     if hyperactor_config::global::get(ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK) {
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Traceback, |py| {
             Ok(Some(
                 py.import("traceback")?
                     .call_method0("extract_stack")?
@@ -312,7 +313,7 @@ impl PythonTaskAwaitIterator {
     /// Convert the thrown Python exception value into a `PyErr` and
     /// surface it to Rust.
     fn throw(&mut self, value: Py<PyAny>) -> PyResult<Py<PyAny>> {
-        Err(monarch_with_gil_blocking(|py| {
+        Err(monarch_with_gil_blocking(GilSite::Convert, |py| {
             PyErr::from_value(value.into_bound(py))
         }))
     }
@@ -339,7 +340,7 @@ impl PyPythonTask {
         Ok(PythonTask::new_with_traceback(
             async {
                 let result = fut.await?;
-                monarch_with_gil(|py| result.into_py_any(py)).await
+                monarch_with_gil(GilSite::Convert, |py| result.into_py_any(py)).await
             },
             traceback,
         )
@@ -390,7 +391,7 @@ impl PyPythonTask {
     /// Fails if the task has already been consumed.
     fn traceback(&self) -> PyResult<Option<Py<PyAny>>> {
         if let Some(task) = &self.inner {
-            Ok(monarch_with_gil_blocking(|py| {
+            Ok(monarch_with_gil_blocking(GilSite::Traceback, |py| {
                 task.traceback().as_ref().map(|t| t.clone_ref(py))
             }))
         } else {
@@ -445,7 +446,7 @@ fn send_result(
 ) {
     // a SendErr just means that there are no consumers of the value left.
     if let Err(tokio::sync::watch::error::SendError(Some(Err(pyerr)))) = tx.send(Some(result)) {
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Traceback, |py| {
             let tb = if let Some(tb) = traceback {
                 format_traceback(py, &tb).unwrap()
             } else {
@@ -546,7 +547,7 @@ impl PyPythonTask {
         // maintained inside the tokio runtime.
         let monarch_context = context(py).call0()?.unbind();
         PyPythonTask::new(async move {
-            let (coroutine_iterator, none) = monarch_with_gil(|py| {
+            let (coroutine_iterator, none) = monarch_with_gil(GilSite::AwaitDrive, |py| {
                 coro.into_bound(py)
                     .call_method0("__await__")
                     .map(|x| (x.unbind(), py.None()))
@@ -558,7 +559,7 @@ impl PyPythonTask {
                 Wait(Pin<Box<dyn Future<Output = Result<Py<PyAny>, PyErr>> + Send + 'static>>),
             }
             loop {
-                let action = monarch_with_gil(|py| -> PyResult<Action> {
+                let action = monarch_with_gil(GilSite::AwaitDrive, |py| -> PyResult<Action> {
                     // We may be executing in a new thread at this point, so we need to set the value
                     // of context().
                     let _context = actor_mesh_module(py).getattr("_context")?;
@@ -643,14 +644,14 @@ impl PyPythonTask {
         let traceback = current_traceback()?;
         let traceback1 = traceback.as_ref().map_or_else(
             || None,
-            |t| monarch_with_gil_blocking(|py| Some(t.clone_ref(py))),
+            |t| monarch_with_gil_blocking(GilSite::Traceback, |py| Some(t.clone_ref(py))),
         );
         let monarch_context = context(py).call0()?.unbind();
         // The `_context` contextvar needs to be propagated through to the thread that
         // runs the blocking tokio task. Upon completion, the original value of `_context`
         // is restored.
         let handle = get_tokio_runtime().spawn_blocking(move || {
-            let result = monarch_with_gil_blocking(|py| {
+            let result = monarch_with_gil_blocking(GilSite::AwaitDrive, |py| {
                 let _context = actor_mesh_module(py).getattr("_context")?;
                 let old_context = _context.call_method1("get", (PyNone::get(py),))?;
                 _context
@@ -798,7 +799,7 @@ impl PyShared {
                     rx.changed().await.map_err(to_py_error)?;
                 }
                 // We need to hold the GIL when cloning Python objects (Py<PyAny> and PyErr).
-                monarch_with_gil(|py| {
+                monarch_with_gil(GilSite::Convert, |py| {
                     let borrowed = rx.borrow();
                     match borrowed.as_ref().unwrap() {
                         Ok(v) => Ok(v.bind(py).clone().unbind()),
@@ -809,7 +810,7 @@ impl PyShared {
             },
             self.traceback.as_ref().map_or_else(
                 || None,
-                |t| monarch_with_gil_blocking(|py| Some(t.clone_ref(py))),
+                |t| monarch_with_gil_blocking(GilSite::Traceback, |py| Some(t.clone_ref(py))),
             ),
         )
     }
@@ -980,7 +981,7 @@ impl AwaitPyExt for PyPythonTask {
         let py_any: Py<PyAny> = fut.await?;
 
         // Convert Py<PyAny> -> Py<T>.
-        monarch_with_gil(|py| {
+        monarch_with_gil(GilSite::Test, |py| {
             let bound_any = py_any.bind(py);
 
             // Try extract a Py<T>.

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -9,7 +9,6 @@
 use std::cell::OnceCell as UnsyncOnceCell;
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::sync::atomic::AtomicUsize;
@@ -28,6 +27,12 @@ use pyo3::types::PyAnyMethods;
 use pyo3_async_runtimes::TaskLocals;
 use tokio::runtime::Handle;
 use tokio::task;
+
+pub use crate::gil::GilSite;
+pub use crate::gil::get_gil_on_control_plane;
+pub use crate::gil::monarch_with_gil;
+pub use crate::gil::monarch_with_gil_blocking;
+pub use crate::gil::reset_gil_on_control_plane;
 
 /// Global tokio runtime container.
 ///
@@ -248,6 +253,22 @@ pub fn register_python_bindings(runtime_mod: &Bound<'_, PyModule>) -> PyResult<(
         "monarch._rust_bindings.monarch_hyperactor.runtime",
     )?;
     runtime_mod.add_function(sleep_indefinitely_fn)?;
+
+    let get_gil_on_control_plane_fn = wrap_pyfunction!(get_gil_on_control_plane, runtime_mod.py())?;
+    get_gil_on_control_plane_fn.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.runtime",
+    )?;
+    runtime_mod.add_function(get_gil_on_control_plane_fn)?;
+
+    let reset_gil_on_control_plane_fn =
+        wrap_pyfunction!(reset_gil_on_control_plane, runtime_mod.py())?;
+    reset_gil_on_control_plane_fn.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.runtime",
+    )?;
+    runtime_mod.add_function(reset_gil_on_control_plane_fn)?;
+
     Ok(())
 }
 
@@ -285,8 +306,9 @@ impl pyo3_async_runtimes::generic::ContextExt for SimpleRuntime {
     fn get_task_locals() -> Option<TaskLocals> {
         TASK_LOCALS
             .try_with(|c| {
-                c.get()
-                    .map(|locals| monarch_with_gil_blocking(|py| locals.clone_ref(py)))
+                c.get().map(|locals| {
+                    monarch_with_gil_blocking(GilSite::TaskLocals, |py| locals.clone_ref(py))
+                })
             })
             .unwrap_or_default()
     }
@@ -298,130 +320,6 @@ where
     T: for<'py> IntoPyObject<'py>,
 {
     pyo3_async_runtimes::generic::future_into_py::<SimpleRuntime, F, T>(py, fut)
-}
-
-/// Global lock to serialize GIL acquisition from Rust threads in async contexts.
-///
-/// Under high concurrency, many async tasks can simultaneously try to acquire the GIL.
-/// Each call blocks the current tokio worker thread, which can cause runtime starvation
-/// and apparent deadlocks (nothing else gets polled).
-///
-/// This wrapper serializes GIL acquisition among callers that opt in, so at most one
-/// tokio task is blocked in `Python::attach` at a time, improving fairness under
-/// contention.
-///
-/// Note: this does not globally prevent other sync code from calling `Python::attach`
-/// directly. Use `monarch_with_gil` or `monarch_with_gil_blocking` for Python interaction
-/// that occurs on async hot paths.
-static GIL_LOCK: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
-
-// Thread-local depth counter for re-entrant GIL acquisition.
-//
-// This tracks when we're already inside a `monarch_with_gil` or `monarch_with_gil_blocking`
-// call. On re-entry (e.g., when Python calls back into Rust while we're already executing
-// under `Python::attach`), we bypass the `GIL_LOCK` to avoid deadlocks.
-//
-// Without this, the following scenario would deadlock:
-// 1. Rust async code calls `monarch_with_gil`, acquires `GIL_LOCK`
-// 2. Inside the closure, Python code is executed
-// 3. Python code calls back into Rust (e.g., via a PyO3 callback)
-// 4. The callback tries to call `monarch_with_gil` again
-// 5. DEADLOCK: waiting for `GIL_LOCK` which is held by the same logical call chain
-thread_local! {
-    static GIL_DEPTH: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
-}
-
-/// RAII guard that decrements the GIL depth counter when dropped.
-struct GilDepthGuard {
-    prev_depth: u32,
-}
-
-impl Drop for GilDepthGuard {
-    fn drop(&mut self) {
-        GIL_DEPTH.with(|d| d.set(self.prev_depth));
-    }
-}
-
-/// Increments the GIL depth counter and returns a guard that restores it on drop.
-fn increment_gil_depth() -> GilDepthGuard {
-    let prev_depth = GIL_DEPTH.with(|d| {
-        let current = d.get();
-        d.set(current + 1);
-        current
-    });
-    GilDepthGuard { prev_depth }
-}
-
-/// Returns true if we're already inside a `monarch_with_gil` call (re-entrant).
-fn is_reentrant() -> bool {
-    GIL_DEPTH.with(|d| d.get() > 0)
-}
-
-/// Async wrapper around `Python::attach` intended for async call sites.
-///
-/// Why: under high concurrency, many async tasks can simultaneously
-/// try to acquire the GIL. Each call blocks the current tokio worker
-/// thread, which can cause runtime starvation / apparent deadlocks
-/// (nothing else gets polled).
-///
-/// This wrapper serializes GIL acquisition among async callers so at most one tokio
-/// task is blocked in `Python::attach` at a time, preventing runtime starvation
-/// under GIL contention.
-///
-/// Note: this does not globally prevent other sync code from calling
-/// `Python::attach` directly. Use this wrapper for Python
-/// interaction that occurs on async hot paths.
-///
-/// # Re-entrancy Safety
-///
-/// This function is re-entrant safe. If called while already inside a `monarch_with_gil`
-/// or `monarch_with_gil_blocking` call (e.g., from a Python→Rust callback), it bypasses
-/// the `GIL_LOCK` to avoid deadlocks.
-///
-/// # Example
-/// ```ignore
-/// let result = monarch_with_gil(|py| {
-///     // Do work with Python GIL
-///     Ok(42)
-/// })
-/// .await?;
-/// ```
-pub async fn monarch_with_gil<F, R>(f: F) -> R
-where
-    F: for<'py> FnOnce(Python<'py>) -> R + Send,
-{
-    // If we're already inside a monarch_with_gil call (re-entrant), skip the lock
-    // to avoid deadlock from Python→Rust callbacks
-    if is_reentrant() {
-        let _depth_guard = increment_gil_depth();
-        return Python::attach(f);
-    }
-
-    // Not re-entrant: acquire the serialization lock
-    let _lock_guard = GIL_LOCK.lock().await;
-    let _depth_guard = increment_gil_depth();
-    Python::attach(f)
-}
-
-/// Blocking wrapper around `Python::with_gil` for use in synchronous contexts.
-///
-/// Unlike `monarch_with_gil`, this function does NOT use the `GIL_LOCK` async mutex.
-/// Since it is blocking call, it simply acquires the GIL and releases it when the
-/// closure returns.
-///
-/// # Example
-/// ```ignore
-/// let result = monarch_with_gil_blocking(|py| {
-///     // Do work with Python GIL
-///     Ok(42)
-/// })?;
-/// ```
-pub fn monarch_with_gil_blocking<F, R>(f: F) -> R
-where
-    F: for<'py> FnOnce(Python<'py>) -> R + Send,
-{
-    let _depth_guard = increment_gil_depth();
-    Python::attach(f)
 }
 
 #[cfg(test)]

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -17,7 +17,9 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use anyhow::Result;
+use hyperactor::runtime_identity::RuntimeKind;
 use hyperactor::runtime_identity::shutdown_data_plane_runtimes;
+use hyperactor::runtime_identity::tag_current_thread;
 use pyo3::PyResult;
 use pyo3::Python;
 use pyo3::exceptions::PyRuntimeError;
@@ -51,6 +53,10 @@ fn global_runtime() -> &'static GlobalRuntime {
                 let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
                 format!("monarch-pytokio-worker-{}", id)
             })
+            // The shared control-plane runtime: stamp its workers (and
+            // blocking-pool threads) so GIL-entry sites can tell they are on the
+            // control plane. See `hyperactor::runtime_identity`.
+            .on_thread_start(|| tag_current_thread(RuntimeKind::ControlPlane))
             .enable_all()
             .build()
             .unwrap();
@@ -416,4 +422,35 @@ where
 {
     let _depth_guard = increment_gil_depth();
     Python::attach(f)
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::runtime_identity::RuntimeKind;
+    use hyperactor::runtime_identity::current_runtime_kind;
+
+    use super::*;
+
+    // The shared control-plane runtime stamps its worker threads ControlPlane.
+    #[test]
+    fn global_runtime_workers_are_control_plane() {
+        let kind = get_tokio_runtime().block_on(async {
+            tokio::spawn(async { current_runtime_kind() })
+                .await
+                .unwrap()
+        });
+        assert_eq!(kind, RuntimeKind::ControlPlane);
+    }
+
+    // on_thread_start also reaches the blocking pool, so GIL work on a
+    // spawn_blocking thread is still seen as control-plane.
+    #[test]
+    fn global_runtime_blocking_pool_is_control_plane() {
+        let kind = get_tokio_runtime().block_on(async {
+            tokio::task::spawn_blocking(current_runtime_kind)
+                .await
+                .unwrap()
+        });
+        assert_eq!(kind, RuntimeKind::ControlPlane);
+    }
 }

--- a/monarch_hyperactor/tests/code_sync/auto_reload.rs
+++ b/monarch_hyperactor/tests/code_sync/auto_reload.rs
@@ -16,6 +16,7 @@ use hyperactor_mesh::test_utils;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadActor;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadMessage;
 use monarch_hyperactor::code_sync::auto_reload::AutoReloadParams;
+use monarch_hyperactor::runtime::GilSite;
 use monarch_hyperactor::runtime::monarch_with_gil_blocking;
 use ndslice::View;
 use pyo3::ffi::c_str;
@@ -28,7 +29,9 @@ use tokio::fs;
 #[cfg_attr(not(fbcode_build), ignore)]
 async fn test_auto_reload_actor() -> Result<()> {
     pyo3::Python::initialize();
-    monarch_with_gil_blocking(|py| py.run(c_str!("import monarch._rust_bindings"), None, None))?;
+    monarch_with_gil_blocking(GilSite::Test, |py| {
+        py.run(c_str!("import monarch._rust_bindings"), None, None)
+    })?;
 
     // Create a temporary directory for Python files
     let temp_dir = TempDir::new()?;
@@ -72,7 +75,7 @@ CONSTANT = "initial_constant"
     let temp_path = temp_dir.path().to_path_buf();
     let import_result = tokio::task::spawn_blocking({
         move || {
-            monarch_with_gil_blocking(|py| -> PyResult<String> {
+            monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<String> {
                 // Add the temp directory to Python path
                 let sys = py.import("sys")?;
                 let path = sys.getattr("path")?;
@@ -122,7 +125,7 @@ CONSTANT = "modified_constant"
     // Now import the module again and verify the changes were propagated
     let final_result = tokio::task::spawn_blocking({
         move || {
-            monarch_with_gil_blocking(|py| -> PyResult<String> {
+            monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<String> {
                 // Re-import the test module (it should be reloaded now)
                 let test_module = py.import("test_module")?;
                 let get_value_func = test_module.getattr("get_value")?;

--- a/monarch_hyperactor/tests/telemetry.rs
+++ b/monarch_hyperactor/tests/telemetry.rs
@@ -17,6 +17,7 @@
 
 use anyhow::Result;
 use monarch_hyperactor::context::PyContext;
+use monarch_hyperactor::runtime::GilSite;
 use monarch_hyperactor::runtime::monarch_with_gil_blocking;
 use pyo3::ffi::c_str;
 use pyo3::prelude::*;
@@ -32,12 +33,14 @@ async fn forward_to_tracing_captures_via_extract_recording_span() -> Result<()> 
     pyo3::Python::initialize();
     hyperactor_telemetry::initialize_logging_for_test();
 
-    monarch_with_gil_blocking(|py| py.run(c_str!("import monarch._rust_bindings"), None, None))?;
+    monarch_with_gil_blocking(GilSite::Test, |py| {
+        py.run(c_str!("import monarch._rust_bindings"), None, None)
+    })?;
 
     let recording = hyperactor_telemetry::recorder().record(64);
     let span = recording.span("test");
 
-    monarch_with_gil_blocking(|py| -> PyResult<()> {
+    monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<()> {
         // Build a PyContext carrying our recording span.
         let py_ctx = PyContext::for_test(py, Some(span))?;
         let py_ctx_obj = Py::new(py, py_ctx)?;

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -15,6 +15,7 @@ use hyperactor_mesh::ActorMesh;
 use monarch_hyperactor::context::PyInstance;
 use monarch_hyperactor::proc_mesh::PyProcMesh;
 use monarch_hyperactor::pytokio::PyPythonTask;
+use monarch_hyperactor::runtime::GilSite;
 use monarch_hyperactor::runtime::monarch_with_gil_blocking;
 use monarch_hyperactor::runtime::signal_safe_block_on;
 use monarch_rdma::RdmaAction;
@@ -52,7 +53,7 @@ use typeuri::Named;
 /// erroring.
 fn pytorch_cuda_segments() -> Vec<ScannedSegment> {
     // Acquire the GIL to call Python code.
-    let result = monarch_with_gil_blocking(|py| -> PyResult<Vec<ScannedSegment>> {
+    let result = monarch_with_gil_blocking(GilSite::Rdma, |py| -> PyResult<Vec<ScannedSegment>> {
         // Check if torch is already imported - don't import it ourselves.
         let sys = py.import("sys")?;
         let modules = sys.getattr("modules")?;
@@ -223,7 +224,7 @@ impl Keepalive for PyMemoryViewKeepalive {
     }
 
     fn downgrade(&self) -> Option<Arc<dyn WeakKeepalive>> {
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Rdma, |py| {
             let weak = make_weakref(py, &self.mv)?;
             Some(Arc::new(PyMemoryViewWeakKeepalive { weak }) as Arc<dyn WeakKeepalive>)
         })
@@ -241,7 +242,7 @@ struct PyMemoryViewWeakKeepalive {
 
 impl WeakKeepalive for PyMemoryViewWeakKeepalive {
     fn upgrade(&self) -> Option<Arc<dyn Keepalive>> {
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Rdma, |py| {
             let mv = upgrade_weakref(py, &self.weak)?;
             let (addr, size) = memoryview_addr_size(py, &mv)?;
             Some(Arc::new(PyMemoryViewKeepalive { mv, addr, size }) as Arc<dyn Keepalive>)
@@ -273,7 +274,7 @@ impl Keepalive for PyTorchUntypedStorageKeepalive {
     }
 
     fn downgrade(&self) -> Option<Arc<dyn WeakKeepalive>> {
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Rdma, |py| {
             let weak = make_weakref(py, &self.storage)?;
             Some(Arc::new(PyTorchUntypedStorageWeakKeepalive {
                 weak,
@@ -298,7 +299,7 @@ struct PyTorchUntypedStorageWeakKeepalive {
 
 impl WeakKeepalive for PyTorchUntypedStorageWeakKeepalive {
     fn upgrade(&self) -> Option<Arc<dyn Keepalive>> {
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Rdma, |py| {
             let storage = upgrade_weakref(py, &self.weak)?;
             let base_addr: usize = storage
                 .bind(py)
@@ -693,7 +694,7 @@ impl PyRdmaBuffer {
     }
 
     fn __reduce__(&self) -> PyResult<(Py<PyAny>, Py<PyAny>)> {
-        monarch_with_gil_blocking(|py| {
+        monarch_with_gil_blocking(GilSite::Rdma, |py| {
             let ctor = py.get_type::<PyRdmaBuffer>().into_py_any(py)?;
             let json = serde_json::to_string(&self.buffer).map_err(|e| {
                 PyErr::new::<PyValueError, _>(format!("Serialization failed: {}", e))

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -35,6 +35,8 @@ use hyperactor::id::Label;
 use hyperactor::mailbox::OncePortHandle;
 use hyperactor::mailbox::PortReceiver;
 use hyperactor::proc::Proc;
+use hyperactor::runtime_identity::RuntimeKind;
+use hyperactor::runtime_identity::tag_current_thread;
 use monarch_hyperactor::actor::PythonMessage;
 use monarch_hyperactor::actor::PythonMessageKind;
 use monarch_hyperactor::local_state_broker::BrokerId;
@@ -538,11 +540,20 @@ impl Actor for StreamActor {
         // hang forever.
         let builder = std::thread::Builder::new().name("worker-stream".to_string());
         let _thread_handle = builder.spawn(move || {
+            // Data-plane worker. The stream actor loop runs on THIS thread (via
+            // `rt.block_on` below, which drives its future on the calling thread,
+            // not a runtime worker), so tag this thread directly. The
+            // `on_thread_start` below additionally tags the runtime's own
+            // worker/blocking threads. Either way the Torch/CUDA GIL use here
+            // reads `DataPlane("stream")`, not the control plane. See
+            // `hyperactor::runtime_identity` (RI-6).
+            tag_current_thread(RuntimeKind::DataPlane("stream"));
             // Spawn a new thread with a single-threaded tokio runtime to run the
             // actor loop.  We avoid the current-threaded runtime, so that we can
             // use `block_in_place` for nested async-to-sync-to-async flows.
             let rt = tokio::runtime::Builder::new_multi_thread()
                 .worker_threads(1)
+                .on_thread_start(|| tag_current_thread(RuntimeKind::DataPlane("stream")))
                 .enable_all()
                 .build()
                 .unwrap();

--- a/python/monarch/_rust_bindings/monarch_hyperactor/runtime.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/runtime.pyi
@@ -20,3 +20,16 @@ def sleep_indefinitely_for_unit_tests() -> None:
         KeyboardInterrupt: When interrupted by a signal like SIGINT
     """
     ...
+
+def _get_gil_on_control_plane() -> int:
+    """
+    Number of unsanctioned GIL acquisitions seen on the control-plane runtime.
+    For tests.
+    """
+    ...
+
+def _reset_gil_on_control_plane() -> None:
+    """
+    Reset the unsanctioned control-plane GIL counter to zero. For tests.
+    """
+    ...


### PR DESCRIPTION
Summary:

the GIL wrappers (`monarch_with_gil`, `monarch_with_gil_blocking`) now route every acquisition through `check_gil_site`, which flags a GIL taken on the control-plane runtime whose `GilSite` is not sanctioned by `is_control_plane_allowed`: it increments `GIL_ON_CONTROL_PLANE`, logs the caller, and trips a `debug_assert` in debug builds. it is a no-op on `DataPlane`/`Foreign` threads, and only the outermost logical entry is checked (a re-entrant acquisition is attributed to the entry that took the lock). `GilSite` names each sanctioned operation and `is_control_plane_allowed` is a wildcard-free `match` with no catch-all variant, so a new GIL site cannot compile until it is classified. every current wrapper call site is threaded with its `site`; sites that never run on the control plane pass a `GilSite` but never reach the check. `_get_gil_on_control_plane` / `_reset_gil_on_control_plane` are exposed for tests. this builds on the `RuntimeKind` tagging from the earlier diffs in the stack; the end-to-end fitness test asserting the counter stays zero over a real dispatch and an RDMA registration is the next diff.

Reviewed By: thedavekwon

Differential Revision: D109895441


