### PR TITLE
Fix test_config.py for bumped MESH_ATTACH_CONFIG_TIMEOUT default

### DIFF
--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -240,7 +240,7 @@ def test_duration_config_multiple() -> None:
         ("proc_stop_max_idle", "45s", "45s", "30s"),
         ("get_proc_state_max_idle", "90s", "1m 30s", "1m"),
         # Mesh attach
-        ("mesh_attach_config_timeout", "20s", "20s", "10s"),
+        ("mesh_attach_config_timeout", "20s", "20s", "1m"),
     ],
 )
 def test_duration_params(param_name, test_value, expected_value, default_value):
@@ -472,7 +472,7 @@ def test_all_params_together():
     assert config["proc_stop_max_idle"] == "30s"
     assert config["get_proc_state_max_idle"] == "1m"
     assert config["actor_queue_dispatch"] is True
-    assert config["mesh_attach_config_timeout"] == "10s"
+    assert config["mesh_attach_config_timeout"] == "1m"
     assert config["mesh_admin_addr"] == "[::]:1729"
 
 


### PR DESCRIPTION
Summary:
D109752153 bumped the default of `MESH_ATTACH_CONFIG_TIMEOUT` in `fbcode/monarch/hyperactor_mesh/src/config.rs` from `Duration::from_secs(10)` to `Duration::from_secs(60)`, but did not update the Python test that asserts on this default. Since the config value is rendered via humantime, 60 seconds renders as `"1m"` (not `"60s"`), which broke two tests.

This updates the expected default for `mesh_attach_config_timeout` in `test_config.py`:
- `test_duration_params` parametrize tuple: default `"10s"` → `"1m"`
- `test_all_params_together` restored-to-defaults assertion: `"10s"` → `"1m"`

The explicitly-set test value `"20s"` is unchanged since it is unaffected by the default change.

Differential Revision: D109986416


