### PR TITLE
Add `ProcSpawner` and `UnixProcSpawner`

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -159,6 +159,7 @@ use crate::Handler;
 use crate::Location;
 use crate::Message;
 use crate::PortAddr;
+use crate::PortRef;
 use crate::ProcAddr;
 use crate::ProcId;
 use crate::RemoteMessage;
@@ -449,8 +450,10 @@ struct ProcState {
     actor_tombstones: DashMap<ActorId, ActorStatus>,
 
     /// Used by root actors to send events to the actor coordinating
-    /// supervision of root actors in this proc.
-    supervision_coordinator_port: OnceLock<PortHandle<ActorSupervisionEvent>>,
+    /// supervision of root actors in this proc. Stored as a [`PortRef`] so
+    /// the coordinator may live in another proc — e.g. a process monitor
+    /// supervising this proc from its parent — reached over the gateway.
+    supervision_coordinator_port: OnceLock<PortRef<ActorSupervisionEvent>>,
 
     /// The actor ID of the supervision coordinator, if it lives on this proc.
     /// Used to ensure the coordinator is shut down last during proc teardown.
@@ -889,9 +892,9 @@ impl Proc {
     /// already set.
     pub fn set_supervision_coordinator(
         &self,
-        port: PortHandle<ActorSupervisionEvent>,
+        port: PortRef<ActorSupervisionEvent>,
     ) -> Result<(), anyhow::Error> {
-        let actor_ref: ActorAddr = port.location().actor_addr();
+        let actor_ref: ActorAddr = port.port_addr().actor_addr();
         self.state()
             .supervision_coordinator_port
             .set(port)

--- a/hyperactor/src/testing/proc_supervison.rs
+++ b/hyperactor/src/testing/proc_supervison.rs
@@ -53,7 +53,7 @@ impl ProcSupervisionCoordinator {
             last: last.clone(),
         };
         let coordinator = proc.spawn(actor);
-        proc.set_supervision_coordinator(coordinator.port())?;
+        proc.set_supervision_coordinator(coordinator.port().bind())?;
         Ok((ReportedEvent { rx, last }, coordinator))
     }
 }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -502,7 +502,7 @@ impl ProcAgent {
 impl Actor for ProcAgent {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
         this.set_system();
-        self.proc.set_supervision_coordinator(this.port())?;
+        self.proc.set_supervision_coordinator(this.port().bind())?;
         let _ = self.publish_introspect_properties(this);
 
         // Resolve terminated actor snapshots via QueryChild so that

--- a/hyperactor_remote/Cargo.toml
+++ b/hyperactor_remote/Cargo.toml
@@ -22,8 +22,11 @@ anyhow = "1.0.102"
 async-trait = "0.1.86"
 base64 = { version = "0.22.1", features = ["alloc"] }
 bincode = { version = "2", features = ["serde"] }
+erased-serde = "0.4.10"
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
+libc = "0.2.186"
+nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 thiserror = "2.0.18"

--- a/hyperactor_remote/example/remote_spawner.rs
+++ b/hyperactor_remote/example/remote_spawner.rs
@@ -6,24 +6,25 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! RemoteSpawner remote-spawn demo.
+//! Remote proc and actor spawn demo.
 //!
-//! Run `proc` in one process and `driver` in another. The proc process starts
-//! a [`RemoteSpawner`], publishes a rendezvous token, and waits. The driver joins
-//! that token to obtain an [`ActorRef<RemoteSpawner>`], spawns a remote
-//! [`Calculator`] actor, issues one calculation, and exits through
-//! [`Instance::exit`]. Exiting the driver tears down its local supervisor tree,
-//! which stops the remote calculator before the driver actor finishes. Run the
+//! Run `spawner` in one process and `driver` in another. The spawner process
+//! starts a [`UnixProcSpawner`], publishes a rendezvous token for its
+//! [`ProcSpawner`] interface, and waits. The driver joins that token, asks the
+//! spawner to spawn a Unix child proc, receives the proc's `SpawnActor`
+//! interface, spawns a remote [`Calculator`] actor through that proc-local spawner, issues one
+//! calculation, and exits through [`Instance::exit`]. The spawned child process
+//! runs the `proc` role and exits when its actor-spawn endpoint exits. Run the
 //! driver as `overflow` to show a remote calculator failure propagating back to
 //! the driver.
 
 use std::path::Path;
 use std::path::PathBuf;
-use std::time::Duration;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorAddr;
+use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Endpoint as _;
@@ -38,21 +39,34 @@ use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
+use hyperactor_remote::ActorSpawnerEndpoint;
 use hyperactor_remote::JoinResult;
-use hyperactor_remote::RemoteSpawner;
-use hyperactor_remote::RemoteSpawnerEndpoint;
+use hyperactor_remote::ProcSpawner;
+use hyperactor_remote::ProcSpawnerEndpoint;
 use hyperactor_remote::Token;
 use hyperactor_remote::TokenOptions;
+use hyperactor_remote::proc_spawner::unix::UnixProc;
+use hyperactor_remote::proc_spawner::unix::UnixProcCommand;
+use hyperactor_remote::proc_spawner::unix::UnixProcSpawner;
 use hyperactor_remote::token;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-type DemoToken = Token<ActorRef<RemoteSpawner>, ActorAddr>;
+type DemoToken = Token<ActorRef<ProcSpawner>, ActorAddr>;
+
+#[derive(Debug)]
+struct SpawnerArgs {
+    token_file: PathBuf,
+    /// If set, passed to each spawned child proc as `--status-file`, so the
+    /// child records its final lifecycle status on a clean exit.
+    proc_status_file: Option<PathBuf>,
+}
 
 #[derive(Debug)]
 struct ProcArgs {
-    token_file: PathBuf,
+    /// If set, the child records its final lifecycle status here on a clean exit.
+    status_file: Option<PathBuf>,
 }
 
 #[derive(Debug)]
@@ -77,21 +91,21 @@ struct CalculationResult {
 }
 wirevalue::register_type!(CalculationResult);
 
+/// Tells the calculator to crash its entire child proc (OS process exit),
+/// exercising proc-death supervision rather than a recoverable actor failure.
+#[derive(Clone, Debug, Serialize, Deserialize, Named)]
+struct Crash;
+wirevalue::register_type!(Crash);
+
 #[derive(Clone, Copy, Debug)]
 enum DriverMode {
     Add,
     Overflow,
+    Crash,
 }
 
 #[derive(Debug)]
-struct SendCalculation {
-    calculator: ActorRef<Calculator>,
-    lhs: i64,
-    rhs: i64,
-}
-
-#[derive(Debug)]
-#[hyperactor::export(Calculate)]
+#[hyperactor::export(Calculate, Crash)]
 struct Calculator;
 
 #[async_trait]
@@ -152,33 +166,71 @@ impl Handler<Calculate> for Calculator {
     }
 }
 
+#[async_trait]
+impl Handler<Crash> for Calculator {
+    async fn handle(&mut self, _cx: &Context<Self>, _message: Crash) -> anyhow::Result<()> {
+        println!("calculator crashing its proc via process::exit(1)");
+        std::process::exit(1);
+    }
+}
+
 hyperactor::register_spawnable!(Calculator);
 
 #[derive(Debug)]
-struct ProcHost {
-    remote_spawner: ActorRef<RemoteSpawner>,
+struct SpawnerBootstrap {
     token_file: PathBuf,
+    proc_program: PathBuf,
+    proc_status_file: Option<PathBuf>,
+    proc_spawner: Option<ActorHandle<UnixProcSpawner>>,
 }
 
 #[async_trait]
-impl Actor for ProcHost {
+impl Actor for SpawnerBootstrap {
     async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+        let mut command = UnixProcCommand::new(self.proc_program.clone())
+            .arg("proc")
+            .env("RUST_BACKTRACE", "1");
+        if let Some(path) = &self.proc_status_file {
+            command = command.arg("--status-file").arg(path.clone());
+        }
+        let proc_spawner = this.spawn(UnixProcSpawner::new_with_command(command));
         let token = token::create(
             this,
-            self.remote_spawner.clone(),
+            proc_spawner.bind::<ProcSpawner>(),
             this.port::<token::Joined<ActorAddr>>().bind(),
             TokenOptions::default(),
         )?;
         // Pass the token out of band. In principle, hyperactor_remote does not care
         // about the specific token-passing mechanism used.
         write_text(&self.token_file, &token.to_string()).await?;
-        println!("remote spawner token {}", token);
+        println!("proc spawner token {}", token);
+        self.proc_spawner = Some(proc_spawner);
+        Ok(())
+    }
+
+    async fn handle_stop(
+        &mut self,
+        this: &Instance<Self>,
+        mode: StopMode,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        if let Some(proc_spawner) = &self.proc_spawner {
+            let _ = match mode {
+                StopMode::Stop => proc_spawner.stop(reason),
+                StopMode::DrainAndStop => proc_spawner.drain_and_stop(reason),
+            };
+        }
+        this.close();
+        match mode {
+            StopMode::Stop => this.exit(reason)?,
+            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
+        }
         Ok(())
     }
 }
 
 #[async_trait]
-impl Handler<token::Joined<ActorAddr>> for ProcHost {
+impl Handler<token::Joined<ActorAddr>> for SpawnerBootstrap {
     async fn handle(
         &mut self,
         _cx: &Context<Self>,
@@ -198,11 +250,11 @@ struct Driver {
 #[async_trait]
 impl Actor for Driver {
     async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
-        println!("driver joining remote spawner token");
+        println!("driver joining proc spawner token");
         self.token.join(
             this,
             this.self_addr().clone(),
-            this.port::<JoinResult<ActorRef<RemoteSpawner>>>().bind(),
+            this.port::<JoinResult<ActorRef<ProcSpawner>>>().bind(),
         )?;
         Ok(())
     }
@@ -218,60 +270,72 @@ impl Actor for Driver {
 }
 
 #[async_trait]
-impl Handler<JoinResult<ActorRef<RemoteSpawner>>> for Driver {
+impl Handler<JoinResult<ActorRef<ProcSpawner>>> for Driver {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
-        message: JoinResult<ActorRef<RemoteSpawner>>,
+        message: JoinResult<ActorRef<ProcSpawner>>,
     ) -> anyhow::Result<()> {
-        let remote_spawner = match message {
+        let proc_spawner = match message {
             JoinResult::Joined { peer } => peer,
             JoinResult::Rejected { reason } => {
                 anyhow::bail!("token join rejected: {}", reason);
             }
         };
-        println!(
-            "driver joined remote spawner {}",
-            remote_spawner.actor_addr()
-        );
-        let calculator = remote_spawner.spawn_uid::<Calculator>(
+        println!("driver joined proc spawner {}", proc_spawner.actor_addr());
+        // Spawn the proc and wait for its actor-spawn endpoint to become
+        // reachable before spawning on it. The readiness port carries no
+        // payload — we already hold the endpoint ref returned synchronously.
+        let (proc_ready, proc_ready_rx) = cx.open_once_port::<()>();
+        let actor_spawner = proc_spawner.spawn_proc_uid_with_ready(
+            cx,
+            Uid::instance(Label::new("calculator-proc").unwrap()),
+            proc_ready,
+        )?;
+        println!("driver requested proc {}", actor_spawner.actor_addr());
+        proc_ready_rx.recv().await?;
+
+        // The proc booted and joined: its actor-spawn endpoint now routes, so
+        // spawn the calculator and wait for its own readiness signal.
+        let (calc_ready, calc_ready_rx) = cx.open_once_port::<()>();
+        let calculator = actor_spawner.spawn_uid_with_ready::<Calculator>(
             cx,
             Uid::instance(Label::new("calculator").unwrap()),
             (),
+            calc_ready,
         )?;
         println!("driver spawned calculator {}", calculator.actor_addr());
-        let (lhs, rhs) = match self.mode {
-            DriverMode::Add => (40, 2),
-            DriverMode::Overflow => (i64::MAX, 1),
-        };
-        cx.post_after(
-            cx,
-            SendCalculation {
-                calculator,
-                lhs,
-                rhs,
-            },
-            Duration::from_millis(250),
-        );
-        Ok(())
-    }
-}
+        calc_ready_rx.recv().await?;
 
-#[async_trait]
-impl Handler<SendCalculation> for Driver {
-    async fn handle(&mut self, cx: &Context<Self>, message: SendCalculation) -> anyhow::Result<()> {
-        println!(
-            "driver issuing calculation request: {} + {}",
-            message.lhs, message.rhs
-        );
-        message.calculator.post(
-            cx,
-            Calculate {
-                lhs: message.lhs,
-                rhs: message.rhs,
-                result: cx.port::<CalculationResult>().bind(),
-            },
-        );
+        // The calculator linked and is now reachable: drive the scenario.
+        match self.mode {
+            DriverMode::Add => {
+                println!("driver issuing calculation request: 40 + 2");
+                calculator.post(
+                    cx,
+                    Calculate {
+                        lhs: 40,
+                        rhs: 2,
+                        result: cx.port::<CalculationResult>().bind(),
+                    },
+                );
+            }
+            DriverMode::Overflow => {
+                println!("driver issuing calculation request: {} + 1", i64::MAX);
+                calculator.post(
+                    cx,
+                    Calculate {
+                        lhs: i64::MAX,
+                        rhs: 1,
+                        result: cx.port::<CalculationResult>().bind(),
+                    },
+                );
+            }
+            DriverMode::Crash => {
+                println!("driver telling calculator to crash its proc");
+                calculator.post(cx, Crash);
+            }
+        }
         Ok(())
     }
 }
@@ -297,20 +361,37 @@ impl Handler<CalculationResult> for Driver {
 async fn main() -> anyhow::Result<()> {
     let role = parse_args()?;
     match role {
-        Role::Proc(args) => run_proc(args).await,
+        Role::Spawner(args) => run_spawner(args).await,
         Role::Driver(args) => run_driver(args).await,
+        Role::Proc(args) => run_proc(args).await,
     }
 }
 
-async fn run_proc(args: ProcArgs) -> anyhow::Result<()> {
+async fn run_spawner(args: SpawnerArgs) -> anyhow::Result<()> {
     let _serve = hyperactor::serve(ChannelAddr::any(ChannelTransport::Unix))?;
-    let remote_spawner = hyperactor::spawn(RemoteSpawner);
-    let host = hyperactor::spawn(ProcHost {
-        remote_spawner: remote_spawner.bind::<RemoteSpawner>(),
+    let spawner = hyperactor::spawn(SpawnerBootstrap {
         token_file: args.token_file,
+        proc_program: std::env::current_exe()?,
+        proc_status_file: args.proc_status_file,
+        proc_spawner: None,
     });
-    host.await;
-    println!("proc host exited");
+    spawner.await;
+    println!("demo proc spawner exited");
+    Ok(())
+}
+
+async fn run_proc(args: ProcArgs) -> anyhow::Result<()> {
+    let status = UnixProc::boot_from_env().await?;
+    println!("demo proc exited after proc-like actor status: {status}");
+    if let Some(path) = args.status_file {
+        // Record whether the proc came down via a clean drain (graceful stop)
+        // vs. some other terminal state, so tests can assert on it.
+        let marker = match &status {
+            ActorStatus::Stopped(_) => format!("STOPPED_CLEANLY: {status}"),
+            other => format!("NOT_CLEAN: {other}"),
+        };
+        tokio::fs::write(&path, marker).await?;
+    }
     Ok(())
 }
 
@@ -328,6 +409,10 @@ async fn run_driver(args: DriverArgs) -> anyhow::Result<()> {
         (DriverMode::Overflow, ActorStatus::Failed(error)) => {
             println!("driver failed after propagated calculator failure: {error}");
             anyhow::bail!("overflow demo failed as expected")
+        }
+        (DriverMode::Crash, ActorStatus::Failed(error)) => {
+            println!("driver failed after observing proc death: {error}");
+            anyhow::bail!("crash demo failed as expected")
         }
         (mode, status) => {
             anyhow::bail!("driver exited unexpectedly in {:?} mode: {}", mode, status)
@@ -347,24 +432,33 @@ async fn write_text(path: &Path, text: &str) -> anyhow::Result<()> {
 
 #[derive(Debug)]
 enum Role {
-    Proc(ProcArgs),
+    Spawner(SpawnerArgs),
     Driver(DriverArgs),
+    Proc(ProcArgs),
 }
 
 fn parse_args() -> anyhow::Result<Role> {
     let mut args = std::env::args().skip(1).collect::<Vec<_>>();
     if args.is_empty() {
-        anyhow::bail!("usage: remote_spawner <proc|driver|overflow> --token-file PATH");
+        anyhow::bail!(
+            "usage: remote_spawner <spawner|driver|overflow|crash|proc> --token-file PATH"
+        );
     }
     let role = args.remove(0);
     let token_file = take_value(&mut args, "--token-file")?
         .map(PathBuf::from)
         .unwrap_or_else(|| PathBuf::from("/tmp/hyperactor_remote_remote_spawner_demo.token"));
+    let proc_status_file = take_value(&mut args, "--proc-status-file")?.map(PathBuf::from);
+    let status_file = take_value(&mut args, "--status-file")?.map(PathBuf::from);
     if !args.is_empty() {
         anyhow::bail!("unknown arguments: {:?}", args);
     }
     match role.as_str() {
-        "proc" => Ok(Role::Proc(ProcArgs { token_file })),
+        "spawner" => Ok(Role::Spawner(SpawnerArgs {
+            token_file,
+            proc_status_file,
+        })),
+        "proc" => Ok(Role::Proc(ProcArgs { status_file })),
         "driver" => Ok(Role::Driver(DriverArgs {
             token_file,
             mode: DriverMode::Add,
@@ -372,6 +466,10 @@ fn parse_args() -> anyhow::Result<Role> {
         "overflow" => Ok(Role::Driver(DriverArgs {
             token_file,
             mode: DriverMode::Overflow,
+        })),
+        "crash" => Ok(Role::Driver(DriverArgs {
+            token_file,
+            mode: DriverMode::Crash,
         })),
         _ => anyhow::bail!("unknown role: {}", role),
     }

--- a/hyperactor_remote/src/actor_spawner.rs
+++ b/hyperactor_remote/src/actor_spawner.rs
@@ -8,16 +8,16 @@
 
 //! Actor interface for remotely spawning actors.
 //!
-//! [`RemoteSpawner`] is a spawn factory actor. A proc that wants to accept
-//! dynamic actor spawns runs a `RemoteSpawner` locally and exposes an
-//! [`ActorRef<RemoteSpawner>`] to callers, for example through a token
+//! [`ActorSpawner`] is a spawn factory actor. A proc that wants to accept
+//! dynamic actor spawns runs an `ActorSpawner` locally and exposes an
+//! [`ActorRef<ActorSpawner>`] to callers, for example through a token
 //! rendezvous. A caller can post [`SpawnActor`] directly, but most callers
-//! should use [`RemoteSpawnerEndpoint`]. The extension trait builds the spawn
+//! should use [`ActorSpawnerEndpoint`]. The extension trait builds the spawn
 //! request, starts the local supervisor that owns the remote actor lifetime,
 //! and returns the [`ActorRef`] for the actor that will be created on the
 //! remote proc.
 //!
-//! Spawning through [`RemoteSpawnerEndpoint`] makes the spawning actor the
+//! Spawning through [`ActorSpawnerEndpoint`] makes the spawning actor the
 //! supervisor of the spawned remote actor. Logically, the remote actor becomes
 //! part of the spawner's supervision tree even though it runs on another proc:
 //!
@@ -25,7 +25,7 @@
 //! caller proc                         remote proc
 //!
 //! caller actor
-//! `- spawned actor A  -------- runs on -------->  RemoteSpawner's proc
+//! `- spawned actor A  -------- runs on -------->  ActorSpawner's proc
 //! ```
 //!
 //! The implementation realizes that logical edge with a caller-side supervisor,
@@ -36,7 +36,7 @@
 //! caller proc                                      remote proc
 //!
 //! caller actor
-//! `- [Supervisor] -- SpawnActor ---------------->  [RemoteSpawner]
+//! `- [Supervisor] -- SpawnActor ---------------->  [ActorSpawner]
 //!                                                `- [Worker]
 //!                                                   `- [spawned actor A]
 //!
@@ -45,7 +45,7 @@
 //!
 //! The caller-side [`Supervisor`] is spawned as a child of the actor that
 //! requested the remote spawn. Its bootstrap posts [`SpawnActor`] to the remote
-//! [`RemoteSpawner`]. The remote [`RemoteSpawner`] spawns a [`Worker`] child and asks it
+//! [`ActorSpawner`]. The remote [`ActorSpawner`] spawns a [`Worker`] child and asks it
 //! to deserialize the [`Gspawn`] specification, spawn the requested actor as its
 //! own child, and attach it to the caller-side supervisor. The caller-side
 //! supervisor also owns the private liveness machinery that lets either proc
@@ -59,7 +59,10 @@
 //! that into a terminal supervision event instead of leaving an orphaned remote
 //! actor.
 //!
-//! A typical caller only needs the extension trait:
+//! A typical caller only needs the extension trait. The returned [`ActorRef`]
+//! names where the actor will run, but the remote proc has to spawn and link it
+//! before it can route — messages sent earlier are dropped. Spawn with a
+//! readiness port and wait for the signal before messaging the actor:
 //!
 //! ```rust,ignore
 //! use hyperactor::ActorRef;
@@ -68,21 +71,26 @@
 //! use hyperactor::Label;
 //! use hyperactor::RemoteSpawn;
 //! use hyperactor::Uid;
-//! use hyperactor_remote::RemoteSpawner;
-//! use hyperactor_remote::RemoteSpawnerEndpoint;
+//! use hyperactor_remote::ActorSpawner;
+//! use hyperactor_remote::ActorSpawnerEndpoint;
 //!
 //! struct Driver {
-//!     remote_spawner: ActorRef<RemoteSpawner>,
+//!     actor_spawner: ActorRef<ActorSpawner>,
 //! }
 //!
 //! impl Handler<Start> for Driver {
 //!     async fn handle(&mut self, cx: &Context<Self>, _start: Start) -> anyhow::Result<()> {
-//!         let calculator: ActorRef<Calculator> = self.remote_spawner.spawn_uid::<Calculator>(
+//!         let (ready, ready_rx) = cx.open_once_port::<()>();
+//!         let calculator = self.actor_spawner.spawn_uid_with_ready::<Calculator>(
 //!             cx,
 //!             Uid::instance(Label::new("calculator").unwrap()),
 //!             CalculatorParams { initial_value: 0 },
+//!             ready,
 //!         )?;
-//!
+//!         // The returned ref names the calculator, but it cannot route until
+//!         // the remote proc spawns and links it. Wait for the readiness signal
+//!         // first, then message the actor we already hold a ref to.
+//!         ready_rx.recv().await?;
 //!         calculator.post(cx, Add { lhs: 40, rhs: 2 });
 //!         Ok(())
 //!     }
@@ -102,52 +110,61 @@
 //! # }
 //! ```
 
-use std::time::Duration;
-
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Endpoint;
 use hyperactor::Handler;
+use hyperactor::OncePortHandle;
 use hyperactor::RemoteSpawn;
 use hyperactor::Uid;
 use hyperactor::context;
 
 use crate::Gspawn;
 use crate::KeepaliveLink;
-use crate::SpawnActor;
+use crate::SpawnActor as SpawnActorMessage;
 use crate::SupervisionOptions;
 use crate::Supervisor;
 use crate::Worker;
 use crate::supervision::GspawnAndSupervise;
 
+// Actor-spawn interface exposed by an actor spawner.
+hyperactor::behavior!(SpawnActor, SpawnActorMessage);
+
 /// Remote actor that accepts dynamic remote spawn requests.
 #[derive(Debug, Default)]
-#[hyperactor::export(SpawnActor)]
-pub struct RemoteSpawner;
+#[hyperactor::export(SpawnActorMessage)]
+#[hyperactor::spawnable]
+pub struct ActorSpawner;
 
 #[async_trait]
-impl Actor for RemoteSpawner {}
+impl Actor for ActorSpawner {}
 
 #[async_trait]
-impl Handler<SpawnActor> for RemoteSpawner {
-    async fn handle(&mut self, cx: &Context<Self>, message: SpawnActor) -> anyhow::Result<()> {
-        let SpawnActor { gspawn, supervise } = message;
+impl Handler<SpawnActorMessage> for ActorSpawner {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: SpawnActorMessage,
+    ) -> anyhow::Result<()> {
+        let SpawnActorMessage { gspawn, supervise } = message;
         let worker = context::Actor::instance(cx).spawn(Worker::new());
         worker.post(cx, GspawnAndSupervise::new(gspawn, supervise));
         Ok(())
     }
 }
 
+hyperactor::assert_behaves!(ActorSpawner as SpawnActor);
+
 /// Convenience methods for endpoints that accept [`SpawnActor`] requests.
-pub trait RemoteSpawnerEndpoint {
+pub trait ActorSpawnerEndpoint {
     /// Spawn a registered actor with a fresh actor uid.
     fn spawn<A>(&self, cx: &impl context::Actor, params: A::Params) -> anyhow::Result<ActorRef<A>>
     where
         A: RemoteSpawn,
         Self: Clone + Send + 'static,
-        for<'a> &'a Self: Endpoint<SpawnActor>,
+        for<'a> &'a Self: Endpoint<SpawnActorMessage>,
     {
         self.spawn_uid::<A>(cx, Uid::anonymous(), params)
     }
@@ -162,13 +179,37 @@ pub trait RemoteSpawnerEndpoint {
     where
         A: RemoteSpawn,
         Self: Clone + Send + 'static,
-        for<'a> &'a Self: Endpoint<SpawnActor>,
+        for<'a> &'a Self: Endpoint<SpawnActorMessage>,
     {
-        self.spawn_uid_with_link::<A>(
+        self.spawn_uid_with_link::<A>(cx, uid, params, KeepaliveLink::default())
+    }
+
+    /// Spawn a registered actor and report when it becomes reachable.
+    ///
+    /// The returned [`ActorRef`] names where the actor will run, but the remote
+    /// proc has to spawn and link it before it can route — messages sent earlier
+    /// are dropped. A bare readiness signal is posted to `ready` once the actor
+    /// has linked, so callers that need to message it can wait for that signal
+    /// instead of guessing with a delay. The address is already known from the
+    /// synchronously returned [`ActorRef`], so `ready` carries no payload.
+    fn spawn_uid_with_ready<A>(
+        &self,
+        cx: &impl context::Actor,
+        uid: Uid,
+        params: A::Params,
+        ready: OncePortHandle<()>,
+    ) -> anyhow::Result<ActorRef<A>>
+    where
+        A: RemoteSpawn,
+        Self: Clone + Send + 'static,
+        for<'a> &'a Self: Endpoint<SpawnActorMessage>,
+    {
+        self.spawn_uid_with_link_and_ready::<A>(
             cx,
             uid,
             params,
-            KeepaliveLink::new(Duration::from_secs(60), Duration::from_secs(60)),
+            KeepaliveLink::default(),
+            Some(ready),
         )
     }
 
@@ -183,14 +224,34 @@ pub trait RemoteSpawnerEndpoint {
     where
         A: RemoteSpawn,
         Self: Clone + Send + 'static,
-        for<'a> &'a Self: Endpoint<SpawnActor>,
+        for<'a> &'a Self: Endpoint<SpawnActorMessage>,
+    {
+        self.spawn_uid_with_link_and_ready::<A>(cx, uid, params, liveness, None)
+    }
+
+    /// Spawn a registered actor with an explicit actor uid, liveness link, and
+    /// optional readiness port. This is the general form behind the other
+    /// `spawn*` methods; see [`spawn_uid_with_ready`](Self::spawn_uid_with_ready)
+    /// for the readiness semantics.
+    fn spawn_uid_with_link_and_ready<A>(
+        &self,
+        cx: &impl context::Actor,
+        uid: Uid,
+        params: A::Params,
+        liveness: KeepaliveLink,
+        ready: Option<OncePortHandle<()>>,
+    ) -> anyhow::Result<ActorRef<A>>
+    where
+        A: RemoteSpawn,
+        Self: Clone + Send + 'static,
+        for<'a> &'a Self: Endpoint<SpawnActorMessage>,
     {
         // We can safely compute the resulting actor ref: by definition it
-        // will be on the same proc as the remote spawner itself, and we use a
+        // will be on the same proc as the actor spawner itself, and we use a
         // Uid to identify it.
         anyhow::ensure!(
             uid.is_instance(),
-            "RemoteSpawner-spawned actors cannot be singletons"
+            "ActorSpawner-spawned actors cannot be singletons"
         );
         let actor_ref = ActorRef::attest(
             self.endpoint_location()
@@ -198,15 +259,16 @@ pub trait RemoteSpawnerEndpoint {
                 .proc_addr()
                 .actor_addr_uid(uid.clone()),
         );
-        let remote_spawner = self.clone();
+        let actor_spawner = self.clone();
         let gspawn = Gspawn::for_actor_uid::<A>(uid, params)?;
         cx.instance().spawn(Supervisor::bootstrap_uid(
             liveness,
             SupervisionOptions::default(),
             Uid::anonymous(),
             actor_ref.actor_addr().clone(),
+            ready,
             move |cx, supervise| {
-                remote_spawner.post(cx, SpawnActor { gspawn, supervise });
+                actor_spawner.post(cx, SpawnActorMessage { gspawn, supervise });
                 Ok(())
             },
         ));
@@ -214,7 +276,7 @@ pub trait RemoteSpawnerEndpoint {
     }
 }
 
-impl<T> RemoteSpawnerEndpoint for T where for<'a> &'a T: Endpoint<SpawnActor> {}
+impl<T> ActorSpawnerEndpoint for T where for<'a> &'a T: Endpoint<SpawnActorMessage> {}
 
 #[cfg(test)]
 mod tests {
@@ -229,6 +291,7 @@ mod tests {
     use hyperactor::Handler;
     use hyperactor::Instance;
     use hyperactor::Label;
+    use hyperactor::OncePortHandle;
     use hyperactor::PortRef;
     use hyperactor::Proc;
     use hyperactor::RemoteSpawn;
@@ -300,7 +363,7 @@ mod tests {
 
     #[derive(Debug)]
     struct PlainSpawner {
-        remote_spawner: ActorHandle<RemoteSpawner>,
+        actor_spawner: ActorHandle<ActorSpawner>,
         spawned: PortRef<ActorAddr>,
         events: PortRef<ActorSupervisionEvent>,
     }
@@ -308,7 +371,7 @@ mod tests {
     #[async_trait]
     impl Actor for PlainSpawner {
         async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
-            let actor_ref = self.remote_spawner.spawn_uid::<FailingChild>(
+            let actor_ref = self.actor_spawner.spawn_uid::<FailingChild>(
                 this,
                 Uid::instance(Label::new("failing_child").unwrap()),
                 (),
@@ -328,12 +391,43 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct ReadySpawner {
+        actor_spawner: ActorHandle<ActorSpawner>,
+        spawned: PortRef<ActorAddr>,
+        ready: Option<OncePortHandle<()>>,
+    }
+
+    #[async_trait]
+    impl Actor for ReadySpawner {
+        async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+            let ready = self.ready.take().expect("ready spawner initialized once");
+            let actor_ref = self.actor_spawner.spawn_uid_with_ready::<TestChild>(
+                this,
+                Uid::instance(Label::new("ready_child").unwrap()),
+                (),
+                ready,
+            )?;
+            self.spawned.post(this, actor_ref.actor_addr().clone());
+            Ok(())
+        }
+
+        async fn handle_supervision_event(
+            &mut self,
+            _this: &Instance<Self>,
+            event: &ActorSupervisionEvent,
+        ) -> anyhow::Result<bool> {
+            // Absorb teardown events so cleanup doesn't surface as a root failure.
+            Ok(!event.is_error())
+        }
+    }
+
     fn encoded_unit() -> Vec<u8> {
         bincode::serde::encode_to_vec((), bincode::config::legacy()).unwrap()
     }
 
     async fn spawn_test_child(
-        remote_spawner: &ActorHandle<RemoteSpawner>,
+        actor_spawner: &ActorHandle<ActorSpawner>,
         client: &hyperactor::Client,
         supervisor: PortRef<SupervisorEvent>,
         session_id: Uid,
@@ -342,9 +436,9 @@ mod tests {
             KeepaliveLink::new(Duration::from_secs(60), Duration::from_secs(60))
                 .spawn_supervisor(client)
                 .unwrap();
-        remote_spawner.post(
+        actor_spawner.post(
             client,
-            SpawnActor {
+            SpawnActorMessage {
                 gspawn: Gspawn::for_actor_uid::<TestChild>(
                     Uid::instance(Label::new("test_child").unwrap()),
                     (),
@@ -365,11 +459,11 @@ mod tests {
     async fn test_spawn_actor_endpoint_works_from_plain_actor() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let remote_spawner = proc.spawn(RemoteSpawner);
+        let actor_spawner = proc.spawn(ActorSpawner);
         let (spawned, mut spawned_rx) = client.open_port::<ActorAddr>();
         let (events, mut events_rx) = client.open_port::<ActorSupervisionEvent>();
         let spawner = proc.spawn(PlainSpawner {
-            remote_spawner: remote_spawner.clone(),
+            actor_spawner: actor_spawner.clone(),
             spawned: spawned.bind(),
             events: events.bind(),
         });
@@ -385,25 +479,60 @@ mod tests {
         assert!(event.is_error());
         assert_eq!(event.actor_id, spawned_actor);
 
-        remote_spawner.stop("test").unwrap();
+        actor_spawner.stop("test").unwrap();
         tokio::time::timeout(Duration::from_secs(5), spawner)
             .await
             .unwrap();
-        tokio::time::timeout(Duration::from_secs(5), remote_spawner)
+        tokio::time::timeout(Duration::from_secs(5), actor_spawner)
             .await
             .unwrap();
     }
 
     #[tokio::test]
-    async fn test_remote_spawner_worker_reports_child_failure() {
+    async fn test_spawn_uid_with_ready_signals_when_child_links() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let remote_spawner = proc.spawn(RemoteSpawner);
+        let actor_spawner = proc.spawn(ActorSpawner);
+        let (spawned, mut spawned_rx) = client.open_port::<ActorAddr>();
+        let (ready, ready_rx) = client.open_once_port::<()>();
+        let spawner = proc.spawn(ReadySpawner {
+            actor_spawner: actor_spawner.clone(),
+            spawned: spawned.bind(),
+            ready: Some(ready),
+        });
+
+        let _attested = tokio::time::timeout(Duration::from_secs(5), spawned_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        // The readiness port fires once the child links and becomes reachable.
+        // It carries no payload — the caller already holds the address from the
+        // synchronously returned ref — so receiving it is the reachability signal.
+        tokio::time::timeout(Duration::from_secs(5), ready_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+
+        spawner.stop("test").unwrap();
+        tokio::time::timeout(Duration::from_secs(5), spawner)
+            .await
+            .unwrap();
+        actor_spawner.stop("test").unwrap();
+        tokio::time::timeout(Duration::from_secs(5), actor_spawner)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_actor_spawner_worker_reports_child_failure() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let actor_spawner = proc.spawn(ActorSpawner);
         let (supervisor, mut supervisor_rx) = client.open_port::<SupervisorEvent>();
         let session_id = Uid::instance(Label::new("session").unwrap());
 
         spawn_test_child(
-            &remote_spawner,
+            &actor_spawner,
             &client,
             supervisor.bind(),
             session_id.clone(),
@@ -434,17 +563,17 @@ mod tests {
             message => panic!("expected terminal supervision event, got {:?}", message),
         }
 
-        remote_spawner.stop("test").unwrap();
-        tokio::time::timeout(Duration::from_secs(5), remote_spawner)
+        actor_spawner.stop("test").unwrap();
+        tokio::time::timeout(Duration::from_secs(5), actor_spawner)
             .await
             .unwrap();
     }
 
     #[tokio::test]
-    async fn test_remote_spawner_rejects_unknown_actor_type() {
+    async fn test_actor_spawner_rejects_unknown_actor_type() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let remote_spawner = proc.spawn(RemoteSpawner);
+        let actor_spawner = proc.spawn(ActorSpawner);
         let (supervisor, mut supervisor_rx) = client.open_port::<SupervisorEvent>();
         let (_link_handle, liveness) =
             KeepaliveLink::new(Duration::from_secs(60), Duration::from_secs(60))
@@ -452,9 +581,9 @@ mod tests {
                 .unwrap();
         let session_id = Uid::instance(Label::new("session").unwrap());
 
-        remote_spawner.post(
+        actor_spawner.post(
             &client,
-            SpawnActor {
+            SpawnActorMessage {
                 gspawn: Gspawn::with_uid("unknown::Actor", Uid::anonymous(), encoded_unit()),
                 supervise: Supervise {
                     session_id: session_id.clone(),
@@ -479,8 +608,8 @@ mod tests {
             message => panic!("expected supervise rejection, got {:?}", message),
         }
 
-        remote_spawner.stop("test").unwrap();
-        tokio::time::timeout(Duration::from_secs(5), remote_spawner)
+        actor_spawner.stop("test").unwrap();
+        tokio::time::timeout(Duration::from_secs(5), actor_spawner)
             .await
             .unwrap();
     }

--- a/hyperactor_remote/src/config.rs
+++ b/hyperactor_remote/src/config.rs
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Configuration keys for `hyperactor_remote`.
+
+use std::time::Duration;
+
+use hyperactor_config::CONFIG;
+use hyperactor_config::ConfigAttr;
+use hyperactor_config::attrs::declare_attrs;
+
+declare_attrs! {
+    /// Grace period a child proc gets to drain and exit after a graceful stop
+    /// request before the spawner force-kills the OS process.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_REMOTE_STOP_GRACE_PERIOD".to_string()),
+        Some("stop_grace_period".to_string()),
+    ))
+    pub attr STOP_GRACE_PERIOD: Duration = Duration::from_secs(10);
+}

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -86,6 +86,13 @@ impl KeepaliveParams {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct KeepaliveLink(KeepaliveParams);
 
+impl Default for KeepaliveLink {
+    /// A 60-second keepalive interval and 60-second timeout.
+    fn default() -> Self {
+        Self::new(Duration::from_secs(60), Duration::from_secs(60))
+    }
+}
+
 impl KeepaliveLink {
     /// Create a keepalive link configuration.
     ///

--- a/hyperactor_remote/src/lib.rs
+++ b/hyperactor_remote/src/lib.rs
@@ -10,13 +10,17 @@
 
 #![deny(missing_docs)]
 
+pub mod actor_spawner;
+pub mod config;
 pub mod keepalive;
 pub mod link;
+pub mod proc_spawner;
 pub mod proto;
-pub mod spawner;
 pub mod supervision;
 pub mod token;
 
+pub use actor_spawner::ActorSpawner;
+pub use actor_spawner::ActorSpawnerEndpoint;
 pub use keepalive::Keepalive;
 pub use keepalive::KeepaliveAck;
 pub use keepalive::KeepaliveLink;
@@ -26,17 +30,18 @@ pub use keepalive::KeepaliveSupervisorParams;
 pub use keepalive::KeepaliveWorker;
 pub use keepalive::KeepaliveWorkerParams;
 pub use link::LinkSpec;
+pub use proc_spawner::ProcSpawner;
+pub use proc_spawner::ProcSpawnerEndpoint;
 pub use proto::Gspawn;
 pub use proto::OrphanPolicy;
 pub use proto::RemoteActorDisposition;
 pub use proto::SpawnActor;
+pub use proto::SpawnProc;
 pub use proto::Supervise;
 pub use proto::SupervisionOptions;
 pub use proto::SupervisorEvent;
 pub use proto::WorkerCommand;
 pub use proto::WorkerLike;
-pub use spawner::RemoteSpawner;
-pub use spawner::RemoteSpawnerEndpoint;
 pub use supervision::Spawn;
 pub use supervision::Supervisor;
 pub use supervision::Worker;

--- a/hyperactor_remote/src/proc_spawner.rs
+++ b/hyperactor_remote/src/proc_spawner.rs
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Remote proc spawning protocol.
+//!
+//! [`ProcSpawnerEndpoint`] is the proc-level counterpart to
+//! [`crate::ActorSpawnerEndpoint`]. A proc-spawner endpoint accepts [`SpawnProc`],
+//! starts a new proc, creates a proc-local [`SpawnActor`] endpoint, and links that
+//! actor-spawn endpoint back to the caller through the same remote supervision
+//! machinery used for remote actor spawns.
+
+use hyperactor::ActorRef;
+use hyperactor::Endpoint;
+use hyperactor::Label;
+use hyperactor::Location;
+use hyperactor::OncePortHandle;
+use hyperactor::ProcAddr;
+use hyperactor::ProcId;
+use hyperactor::Uid;
+use hyperactor::context;
+
+use crate::KeepaliveLink;
+use crate::SpawnProc;
+use crate::SupervisionOptions;
+use crate::Supervisor;
+use crate::actor_spawner::SpawnActor;
+
+pub mod unix;
+
+// Behavior implemented by actors that expose proc spawning.
+hyperactor::behavior!(ProcSpawner, SpawnProc);
+
+/// Convenience methods for endpoints that accept [`SpawnProc`] requests.
+pub trait ProcSpawnerEndpoint {
+    /// Spawn a proc with a fresh proc uid.
+    fn spawn_proc(&self, cx: &impl context::Actor) -> anyhow::Result<ActorRef<SpawnActor>>
+    where
+        Self: Clone + Send + 'static,
+        for<'a> &'a Self: Endpoint<SpawnProc>,
+    {
+        self.spawn_proc_uid(cx, Uid::anonymous())
+    }
+
+    /// Spawn a proc with an explicit proc uid.
+    fn spawn_proc_uid(
+        &self,
+        cx: &impl context::Actor,
+        uid: Uid,
+    ) -> anyhow::Result<ActorRef<SpawnActor>>
+    where
+        Self: Clone + Send + 'static,
+        for<'a> &'a Self: Endpoint<SpawnProc>,
+    {
+        self.spawn_proc_uid_with_link(cx, uid, KeepaliveLink::default())
+    }
+
+    /// Spawn a proc and report when it becomes reachable.
+    ///
+    /// The returned [`ActorRef`] names the proc's actor-spawn endpoint, but the
+    /// proc has to launch and join before that endpoint can route — messages
+    /// sent earlier are dropped. A bare readiness signal is posted to `ready`
+    /// once the proc has joined, so callers that need to use the endpoint can
+    /// wait for that signal instead of guessing with a delay. The endpoint
+    /// address is already known from the synchronously returned [`ActorRef`], so
+    /// `ready` carries no payload.
+    fn spawn_proc_uid_with_ready(
+        &self,
+        cx: &impl context::Actor,
+        uid: Uid,
+        ready: OncePortHandle<()>,
+    ) -> anyhow::Result<ActorRef<SpawnActor>>
+    where
+        Self: Clone + Send + 'static,
+        for<'a> &'a Self: Endpoint<SpawnProc>,
+    {
+        self.spawn_proc_uid_with_link_and_ready(cx, uid, KeepaliveLink::default(), Some(ready))
+    }
+
+    /// Spawn a proc with an explicit proc uid and liveness link.
+    fn spawn_proc_uid_with_link(
+        &self,
+        cx: &impl context::Actor,
+        uid: Uid,
+        liveness: KeepaliveLink,
+    ) -> anyhow::Result<ActorRef<SpawnActor>>
+    where
+        Self: Clone + Send + 'static,
+        for<'a> &'a Self: Endpoint<SpawnProc>,
+    {
+        self.spawn_proc_uid_with_link_and_ready(cx, uid, liveness, None)
+    }
+
+    /// Spawn a proc with an explicit proc uid, liveness link, and optional
+    /// readiness port. This is the general form behind the other `spawn_proc*`
+    /// methods; see [`spawn_proc_uid_with_ready`](Self::spawn_proc_uid_with_ready)
+    /// for the readiness semantics.
+    fn spawn_proc_uid_with_link_and_ready(
+        &self,
+        cx: &impl context::Actor,
+        uid: Uid,
+        liveness: KeepaliveLink,
+        ready: Option<OncePortHandle<()>>,
+    ) -> anyhow::Result<ActorRef<SpawnActor>>
+    where
+        Self: Clone + Send + 'static,
+        for<'a> &'a Self: Endpoint<SpawnProc>,
+    {
+        anyhow::ensure!(uid.is_instance(), "spawned procs cannot be singletons");
+
+        let actor_spawner = spawned_actor_spawner(self, &uid);
+        let proc_spawner = self.clone();
+        cx.instance().spawn(Supervisor::bootstrap_uid(
+            liveness,
+            SupervisionOptions::default(),
+            Uid::anonymous(),
+            actor_spawner.actor_addr().clone(),
+            ready,
+            move |cx, supervise| {
+                proc_spawner.post(cx, SpawnProc { uid, supervise });
+                Ok(())
+            },
+        ));
+        Ok(actor_spawner)
+    }
+}
+
+impl<T> ProcSpawnerEndpoint for T where for<'a> &'a T: Endpoint<SpawnProc> {}
+
+/// Well-known singleton name of a proc's actor-spawn endpoint.
+pub(crate) const ACTOR_SPAWNER_NAME: &str = "spawner";
+
+/// The singleton uid of a proc's actor-spawn endpoint. The spawner
+/// attests the endpoint ref at this uid, and the child proc spawns its
+/// `ActorSpawner` under it, so the two agree without a round trip.
+pub(crate) fn actor_spawner_uid() -> Uid {
+    Uid::singleton(Label::strip(ACTOR_SPAWNER_NAME))
+}
+
+pub(crate) fn actor_spawner_ref(proc_addr: &ProcAddr) -> ActorRef<SpawnActor> {
+    ActorRef::attest(proc_addr.actor_addr_uid(actor_spawner_uid()))
+}
+
+fn spawned_proc_addr(spawner: impl Endpoint<SpawnProc>, uid: &Uid) -> ProcAddr {
+    let spawner_addr = spawner.endpoint_location().actor_addr().proc_addr();
+    spawned_proc_addr_for_spawner_addr(&spawner_addr, uid)
+}
+
+pub(crate) fn spawned_proc_addr_for_spawner_addr(spawner: &ProcAddr, uid: &Uid) -> ProcAddr {
+    let location = append_inner_via(spawner.location().clone(), uid.clone());
+    ProcAddr::new(ProcId::new(uid.clone(), None), location)
+}
+
+fn spawned_actor_spawner(spawner: impl Endpoint<SpawnProc>, uid: &Uid) -> ActorRef<SpawnActor> {
+    actor_spawner_ref(&spawned_proc_addr(spawner, uid))
+}
+
+fn append_inner_via(location: Location, uid: Uid) -> Location {
+    match location {
+        Location::Addr(addr) => Location::Addr(addr).with_via(uid),
+        Location::Via(via, inner) => Location::Via(via, Box::new(append_inner_via(*inner, uid))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::Label;
+    use hyperactor::channel::ChannelAddr;
+
+    use super::*;
+
+    #[test]
+    fn spawned_proc_addr_preserves_spawner_via_route() {
+        let spawner_uid = Uid::instance(Label::new("spawner").unwrap());
+        let outer = Uid::instance(Label::new("outer").unwrap());
+        let inner = Uid::instance(Label::new("inner").unwrap());
+        let child = Uid::instance(Label::new("child").unwrap());
+        let terminal = ChannelAddr::Local(123);
+        let spawner = ProcAddr::new(
+            ProcId::new(spawner_uid, None),
+            Location::from(terminal.clone())
+                .with_via(inner.clone())
+                .with_via(outer.clone()),
+        );
+
+        let spawned = spawned_proc_addr_for_spawner_addr(&spawner, &child);
+
+        let (outer_uid, location) = spawned
+            .location()
+            .as_via()
+            .expect("outer via must be preserved");
+        assert_eq!(outer_uid, &outer);
+        let (inner_uid, location) = location
+            .as_via()
+            .expect("inner via must be preserved before child");
+        assert_eq!(inner_uid, &inner);
+        let (child_uid, location) = location
+            .as_via()
+            .expect("child via must be appended inside spawner route");
+        assert_eq!(child_uid, &child);
+        assert_eq!(location.as_addr(), Some(&terminal));
+    }
+}

--- a/hyperactor_remote/src/proc_spawner/unix.rs
+++ b/hyperactor_remote/src/proc_spawner/unix.rs
@@ -1,0 +1,1151 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Unix process backed proc spawning.
+//!
+//! [`UnixProcSpawner`] launches one OS child process per spawned proc and
+//! supervises it through a per-proc `UnixProcWorker`. Inside the child, a
+//! proc-local [`SpawnActor`] endpoint hosts the spawned actors. The child joins
+//! its spawner over a one-shot token; the worker then links the proc and relays
+//! its supervision to the caller.
+//!
+//! The actors (boxes) and the messages they exchange, grouped by the proc each
+//! runs on. `UnixProcSpawner` and its per-proc `UnixProcWorker`s share the
+//! spawner proc; the caller's `Supervisor` lives on the caller proc (possibly
+//! remote); each spawned `ActorSpawner` runs in its own OS process, a child
+//! proc of the spawner proc. Once linked, the caller spawns actors directly on
+//! the child through its `ActorSpawner` endpoint (the `SpawnActor` arrow) — the
+//! spawner's job is only to create and supervise the proc.
+//!
+//! ```text
+//!   ┌─────────────┐   SpawnProc        ┌─────────────────┐
+//!   │             │ ─────────────────▶ │ UnixProcSpawner │ ┐
+//!   │             │                    └─────────────────┘ │
+//!   │             │   WorkerCommand             │ spawns    │ spawner proc
+//!   │  Supervisor │ ─────────────────▶ ┌────────▼────────┐ │
+//!   │             │ ◀───────────────── │  UnixProcWorker │ ┘ ◀─ UnixProcExited (reaper)
+//!   │             │   SupervisorEvent  └─────────────────┘   ◀─ KillProc (self)
+//!   │             │                       │          ▲
+//!   │             │              StopProc │          │ token::Joined<UnixProcJoin>
+//!   │             │                       ▼          │ ActorSupervisionEvent
+//!   │             │   SpawnActor       ┌─────────────────┐ ┐ child proc
+//!   │             │ ─────────────────▶ │   ActorSpawner  │ ┘ (child of the
+//!   └─────────────┘   (future)         └─────────────────┘   spawner proc)
+//!     caller proc
+//! ```
+//!
+//! - `SpawnProc`: the caller asks the spawner to create a proc.
+//! - `WorkerCommand`: the caller drives a linked proc (stop, unlink).
+//! - `SupervisorEvent`: the worker reports lifecycle to the caller's supervisor.
+//! - `token::Joined<UnixProcJoin>`: the child joins, handing back its gateway
+//!   address, [`SpawnActor`] endpoint, and control port.
+//! - `StopProc`: the worker asks the child to drain and stop gracefully.
+//! - `ActorSupervisionEvent`: the child forwards a top-level failure to the worker.
+//! - `UnixProcExited`: the OS-process reaper task reports the child's exit status.
+//! - `KillProc`: a worker self-message that hard-kills the child when a graceful
+//!   stop misses the grace period.
+//! - `SpawnActor`: after linking, the caller spawns actors directly on the child
+//!   proc through its `ActorSpawner` endpoint.
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fmt;
+use std::path::PathBuf;
+use std::process::ExitStatus;
+use std::str::FromStr;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use hyperactor::Actor;
+use hyperactor::ActorHandle;
+use hyperactor::ActorRef;
+use hyperactor::AnyActorHandle;
+use hyperactor::Context;
+use hyperactor::Endpoint;
+use hyperactor::Gateway;
+use hyperactor::Handler;
+use hyperactor::Instance;
+use hyperactor::Location;
+use hyperactor::PortRef;
+use hyperactor::Proc;
+use hyperactor::ProcAddr;
+use hyperactor::Uid;
+use hyperactor::actor::ActorStatus;
+use hyperactor::actor::StopMode;
+use hyperactor::channel::ChannelAddr;
+use hyperactor::channel::ChannelTransport;
+use hyperactor::context;
+use hyperactor::context::Actor as _;
+use hyperactor::gateway::GatewayServeHandle;
+use hyperactor::gateway::PeerAttachGuard;
+use hyperactor::mailbox::IntoBoxedMailboxSender as _;
+use hyperactor::mailbox::MailboxClient;
+use hyperactor::supervision::ActorSupervisionEvent;
+use nix::errno::Errno;
+use nix::sys::signal;
+use nix::sys::signal::Signal;
+use nix::unistd::Pid;
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::process::Child;
+use tokio::process::Command;
+use tokio::sync::oneshot;
+use typeuri::Named;
+
+use super::ProcSpawner;
+use super::actor_spawner_ref;
+use super::actor_spawner_uid;
+use super::spawned_proc_addr_for_spawner_addr;
+use crate::ActorSpawner;
+use crate::OrphanPolicy;
+use crate::RemoteActorDisposition;
+use crate::SpawnProc;
+use crate::Supervise;
+use crate::SupervisionOptions;
+use crate::SupervisorEvent;
+use crate::TokenOptions;
+use crate::TokenPolicy;
+use crate::WorkerCommand;
+use crate::actor_spawner::SpawnActor;
+use crate::token;
+
+/// Environment variable containing the one-shot token a child proc uses to boot and join its spawner.
+pub const UNIX_PROC_TOKEN_ENV: &str = "HYPERACTOR_REMOTE_PROC_TOKEN";
+
+/// Token used by a Unix child proc to boot and report readiness to its spawner.
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+pub struct UnixProcToken {
+    proc_addr: ProcAddr,
+    /// Port on the spawner-side worker that coordinates this proc's
+    /// top-level supervision events. The child installs it as the proc's
+    /// supervision coordinator so failures surface to the worker at once.
+    supervisor_events: PortRef<ActorSupervisionEvent>,
+    rendezvous: token::Token<(), UnixProcJoin>,
+}
+
+impl UnixProcToken {
+    /// Create a Unix proc boot token.
+    pub fn new(
+        proc_addr: ProcAddr,
+        supervisor_events: PortRef<ActorSupervisionEvent>,
+        rendezvous: token::Token<(), UnixProcJoin>,
+    ) -> Self {
+        Self {
+            proc_addr,
+            supervisor_events,
+            rendezvous,
+        }
+    }
+
+    /// The proc address that the child should use.
+    pub fn proc_addr(&self) -> &ProcAddr {
+        &self.proc_addr
+    }
+
+    /// The worker port that coordinates this proc's supervision events.
+    pub fn supervisor_events(&self) -> &PortRef<ActorSupervisionEvent> {
+        &self.supervisor_events
+    }
+
+    fn join(
+        &self,
+        cx: &impl context::Actor,
+        joiner: UnixProcJoin,
+        result: PortRef<token::JoinResult<()>>,
+    ) -> anyhow::Result<()> {
+        self.rendezvous.join(cx, joiner, result)
+    }
+}
+
+impl fmt::Display for UnixProcToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let token = serde_json::to_string(self).map_err(|_| fmt::Error)?;
+        f.write_str(&token)
+    }
+}
+
+impl FromStr for UnixProcToken {
+    type Err = anyhow::Error;
+
+    fn from_str(token: &str) -> Result<Self, Self::Err> {
+        Ok(serde_json::from_str(token)?)
+    }
+}
+
+/// Graceful stop request sent by the spawner to a child proc's control
+/// endpoint. The child drains and stops its actor-spawn endpoint, which
+/// tears the proc down cleanly so the OS process exits with a normal status.
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+pub struct StopProc {
+    mode: StopMode,
+    reason: String,
+}
+wirevalue::register_type!(StopProc);
+
+/// Information exchanged with a Unix child proc when it joins its spawner.
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+pub struct UnixProcJoin {
+    /// Address where the child proc accepts gateway traffic.
+    pub gateway_addr: Location,
+    /// The child proc's [`SpawnActor`] endpoint.
+    pub actor_spawner: ActorRef<SpawnActor>,
+    /// Endpoint the spawner posts a graceful [`StopProc`] to.
+    pub control: PortRef<StopProc>,
+}
+wirevalue::register_type!(UnixProcJoin);
+
+/// Command used by [`UnixProcSpawner`] to launch child procs.
+#[derive(Clone, Debug)]
+pub struct UnixProcCommand {
+    program: PathBuf,
+    args: Vec<OsString>,
+    env: Vec<(OsString, OsString)>,
+}
+
+impl UnixProcCommand {
+    /// Create a command from an executable path.
+    pub fn new(program: impl Into<PathBuf>) -> Self {
+        Self {
+            program: program.into(),
+            args: Vec::new(),
+            env: Vec::new(),
+        }
+    }
+
+    /// Add one command-line argument.
+    pub fn arg(mut self, arg: impl Into<OsString>) -> Self {
+        self.args.push(arg.into());
+        self
+    }
+
+    /// Add command-line arguments.
+    pub fn args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<OsString>,
+    {
+        self.args.extend(args.into_iter().map(Into::into));
+        self
+    }
+
+    /// Add one environment variable.
+    pub fn env(mut self, key: impl Into<OsString>, value: impl Into<OsString>) -> Self {
+        self.env.push((key.into(), value.into()));
+        self
+    }
+
+    /// Spawn the child OS process, passing `token` to it through the
+    /// environment. The child runs in its own process group so a later stop can
+    /// signal the whole proc tree (see [`signal_proc_group`]), and is killed if
+    /// the returned handle is dropped.
+    fn spawn(&self, token: &UnixProcToken) -> std::io::Result<Child> {
+        let mut command = Command::new(&self.program);
+        command.args(&self.args);
+        for (key, value) in &self.env {
+            command.env(key, value);
+        }
+        command.env(UNIX_PROC_TOKEN_ENV, token.to_string());
+        command.kill_on_drop(true);
+        // Put the child in its own process group so a stop signals the whole
+        // proc tree via the negative pid, mirroring the host bootstrap launcher.
+        // SAFETY: runs in the forked child before exec; only calls the
+        // async-signal-safe `setpgid` with constant arguments.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setpgid(0, 0) != 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        command.spawn()
+    }
+}
+
+/// Unix process backed implementation of [`ProcSpawner`].
+///
+/// `UnixProcSpawner` starts one OS child process per spawned proc. The child
+/// process calls [`UnixProc::boot_from_env`], starts a proc-local [`SpawnActor`]
+/// endpoint, serves its gateway on a Unix domain socket, and joins the one-shot
+/// token supplied by the spawner. The spawner links the proc only after that
+/// join, and the child process exits when the actor-spawn endpoint exits.
+#[derive(Debug)]
+#[hyperactor::export(SpawnProc)]
+pub struct UnixProcSpawner {
+    command: UnixProcCommand,
+    procs: HashMap<Uid, ActorHandle<UnixProcWorker>>,
+}
+
+impl UnixProcSpawner {
+    /// Create a Unix proc spawner that launches `program` for every child proc.
+    pub fn new(program: impl Into<PathBuf>) -> Self {
+        Self::new_with_command(UnixProcCommand::new(program))
+    }
+
+    /// Create a Unix proc spawner with a pre-built child command.
+    pub fn new_with_command(command: UnixProcCommand) -> Self {
+        Self {
+            command,
+            procs: HashMap::new(),
+        }
+    }
+}
+
+#[async_trait]
+impl Actor for UnixProcSpawner {
+    async fn handle_supervision_event(
+        &mut self,
+        _this: &Instance<Self>,
+        event: &ActorSupervisionEvent,
+    ) -> anyhow::Result<bool> {
+        let exited_uid = self.procs.iter().find_map(|(uid, worker)| {
+            (worker.actor_addr() == &event.actor_id).then(|| uid.clone())
+        });
+        if let Some(uid) = exited_uid {
+            self.procs.remove(&uid);
+        }
+        Ok(!event.is_error())
+    }
+
+    async fn handle_stop(
+        &mut self,
+        this: &Instance<Self>,
+        mode: StopMode,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        // The caller-side supervision tree owns each spawned actor-spawn endpoint.
+        // `UnixProcSpawner` also owns the OS child processes, so spawner shutdown must
+        // stop every worker even if no individual caller has requested it.
+        for worker in self.procs.values() {
+            let _ = match mode {
+                StopMode::Stop => worker.stop(reason),
+                StopMode::DrainAndStop => worker.drain_and_stop(reason),
+            };
+        }
+        this.close();
+        match mode {
+            StopMode::Stop => this.exit(reason)?,
+            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<SpawnProc> for UnixProcSpawner {
+    async fn handle(&mut self, cx: &Context<Self>, message: SpawnProc) -> anyhow::Result<()> {
+        if !message.uid.is_instance() {
+            reject_supervise(cx, &message.supervise, "spawned procs cannot be singletons");
+            return Ok(());
+        }
+        let existing_is_active = self.procs.get(&message.uid).is_some_and(|worker| {
+            let status = worker.status();
+            !status.borrow().is_terminal()
+        });
+        if existing_is_active {
+            reject_supervise(
+                cx,
+                &message.supervise,
+                format!("proc {} already exists", message.uid),
+            );
+            return Ok(());
+        }
+        self.procs.remove(&message.uid);
+
+        let spawner_addr = cx.self_addr().proc_addr();
+        let proc_addr = spawned_proc_addr_for_spawner_addr(&spawner_addr, &message.uid);
+        let actor_spawner = actor_spawner_ref(&proc_addr);
+        let worker = cx.spawn(UnixProcWorker::new(
+            message.uid.clone(),
+            proc_addr,
+            actor_spawner,
+            self.command.clone(),
+            message.supervise,
+        ));
+        self.procs.insert(message.uid, worker);
+        Ok(())
+    }
+}
+
+hyperactor::assert_behaves!(UnixProcSpawner as ProcSpawner);
+
+/// Helper for Unix child processes launched by [`UnixProcSpawner`].
+pub struct UnixProc;
+
+impl UnixProc {
+    /// Boot a Unix child proc from the environment set by [`UnixProcSpawner`].
+    pub async fn boot_from_env() -> anyhow::Result<ActorStatus> {
+        let token = parse_env::<UnixProcToken>(UNIX_PROC_TOKEN_ENV)?;
+        Self::boot(token).await
+    }
+
+    /// Boot a Unix child proc and join its spawner.
+    pub async fn boot(token: UnixProcToken) -> anyhow::Result<ActorStatus> {
+        // If the spawner dies, the kernel should take this proc down with it.
+        let _ = install_pdeathsig_kill();
+        let proc_addr = token.proc_addr().clone();
+        let advertised_location = proc_addr.location().clone();
+        Gateway::global().set_default_location(advertised_location.clone());
+        let proc = Proc::builder().proc_id(proc_addr.id().clone()).build()?;
+        // Route this proc's top-level supervision events to the spawner-side
+        // worker so a failure here surfaces immediately with full detail,
+        // rather than only as a process exit observed by `waitpid`.
+        proc.set_supervision_coordinator(token.supervisor_events().clone())?;
+        let actor_spawner_handle = proc.spawn_with_uid(actor_spawner_uid(), ActorSpawner)?;
+        let actor_spawner = actor_spawner_handle.bind::<SpawnActor>();
+
+        let (mut serve, gateway_addr) = Self::serve_own_socket(&proc)?;
+        let client = proc.client("unix-proc-bootstrap");
+        let (result, mut result_rx) = client.open_port::<token::JoinResult<()>>();
+        let (control, mut control_rx) = client.open_port::<StopProc>();
+        // `serve_own_socket` left the gateway's default location at the
+        // bound socket; restore the advertised location.
+        proc.set_default_location(advertised_location);
+        token.join(
+            &client,
+            UnixProcJoin {
+                gateway_addr,
+                actor_spawner,
+                control: control.bind(),
+            },
+            result.bind(),
+        )?;
+        match result_rx.recv().await? {
+            token::JoinResult::Joined { peer: _ } => {}
+            token::JoinResult::Rejected { reason } => {
+                anyhow::bail!("unix proc token join rejected: {}", reason);
+            }
+        }
+
+        // Run until the actor-spawn endpoint stops on its own, or the spawner
+        // asks us to drain and stop it. A graceful stop drains the endpoint,
+        // tearing the proc down cleanly so the process exits with a normal
+        // status the spawner observes via `waitpid`.
+        let mut status = actor_spawner_handle.status();
+        let mut control_open = true;
+        let final_status = loop {
+            let current = status.borrow().clone();
+            if current.is_terminal() {
+                break current;
+            }
+            tokio::select! {
+                changed = status.changed() => {
+                    if changed.is_err() {
+                        break status.borrow().clone();
+                    }
+                }
+                stop = control_rx.recv(), if control_open => {
+                    match stop {
+                        Ok(StopProc { mode, reason }) => {
+                            let _ = match mode {
+                                StopMode::Stop => actor_spawner_handle.stop(&reason),
+                                StopMode::DrainAndStop => actor_spawner_handle.drain_and_stop(&reason),
+                            };
+                        }
+                        Err(_) => control_open = false,
+                    }
+                }
+            }
+        };
+
+        let mut proc = proc;
+        let _ = proc
+            .destroy_and_wait(Duration::from_secs(5), "actor-spawn endpoint exited")
+            .await;
+        serve.stop("actor-spawn endpoint exited");
+        let _ = serve.join().await;
+        Ok(final_status)
+    }
+
+    /// Serve `proc`'s gateway on a fresh Unix socket of its own, returning
+    /// the serve handle and the bound location to advertise back to the
+    /// spawner. The child serves on its own socket — not the
+    /// spawner-derived proc address — so the spawner can dial it and
+    /// install a via-peer route, mirroring how `Host` dials a spawned
+    /// proc's own socket. Serving sets the gateway's default location to
+    /// the bound socket; the caller restores the advertised location.
+    fn serve_own_socket(proc: &Proc) -> anyhow::Result<(GatewayServeHandle, Location)> {
+        let serve = proc
+            .gateway()
+            .serve(ChannelAddr::any(ChannelTransport::Unix))?;
+        // `serve` sets the gateway's default location to the freshly bound
+        // socket; read it back rather than threading the address out of serve.
+        let gateway_addr = proc.gateway().default_location();
+        Ok((serve, gateway_addr))
+    }
+}
+
+#[derive(Debug)]
+struct UnixProcSession {
+    session_id: Uid,
+    supervisor: PortRef<SupervisorEvent>,
+    options: SupervisionOptions,
+    liveness_handle: AnyActorHandle,
+}
+
+/// Outcome of reaping the child OS process. A process either exits with a
+/// status code or is terminated by a signal, never both, so these are
+/// distinct variants rather than a pair of `Option`s.
+#[derive(Clone, Debug, Serialize, Deserialize, Named)]
+enum UnixProcExited {
+    Exited { code: i32 },
+    Signalled { signal: i32 },
+    WaitFailed { error: String },
+}
+wirevalue::register_type!(UnixProcExited);
+
+impl UnixProcExited {
+    fn from_wait_result(result: std::io::Result<ExitStatus>) -> Self {
+        let status = match result {
+            Ok(status) => status,
+            Err(error) => {
+                return Self::WaitFailed {
+                    error: error.to_string(),
+                };
+            }
+        };
+        match (status.code(), exit_signal(&status)) {
+            (Some(code), None) => Self::Exited { code },
+            (None, Some(signal)) => Self::Signalled { signal },
+            (code, signal) => panic!(
+                "unix proc wait returned an impossible status (code={code:?}, signal={signal:?})"
+            ),
+        }
+    }
+
+    fn actor_status(&self, stop_reason: Option<&str>) -> ActorStatus {
+        match (self, stop_reason) {
+            (Self::WaitFailed { error }, _) => {
+                ActorStatus::generic_failure(format!("unix proc wait failed: {error}"))
+            }
+            // A requested stop makes any process exit a clean actor stop.
+            (Self::Exited { .. } | Self::Signalled { .. }, Some(reason)) => {
+                ActorStatus::Stopped(reason.to_string())
+            }
+            (Self::Exited { code: 0 }, None) => {
+                ActorStatus::Stopped("unix proc exited".to_string())
+            }
+            (Self::Exited { .. } | Self::Signalled { .. }, None) => {
+                ActorStatus::generic_failure(self.describe())
+            }
+        }
+    }
+
+    fn describe(&self) -> String {
+        match self {
+            Self::WaitFailed { error } => format!("wait failed: {error}"),
+            Self::Exited { code } => format!("exited with code {code}"),
+            Self::Signalled { signal } => match Signal::try_from(*signal) {
+                Ok(sig) => format!("terminated by signal {signal} ({})", sig.as_str()),
+                Err(_) => format!("terminated by signal {signal}"),
+            },
+        }
+    }
+}
+
+#[derive(Debug)]
+#[hyperactor::export(WorkerCommand, UnixProcExited, ActorSupervisionEvent)]
+struct UnixProcWorker {
+    uid: Uid,
+    proc_addr: ProcAddr,
+    actor_spawner: ActorRef<SpawnActor>,
+    command: UnixProcCommand,
+    supervise: Option<Supervise>,
+    session: Option<UnixProcSession>,
+    peer_guard: Option<PeerAttachGuard>,
+    control: Option<PortRef<StopProc>>,
+    pid: Option<u32>,
+    stop_reason: Option<String>,
+    /// Resolves when the OS-process reaper observes the child exit. Lets
+    /// `handle_stop` wait for a graceful drain before force-signaling.
+    child_exit: Option<oneshot::Receiver<()>>,
+}
+
+impl UnixProcWorker {
+    fn new(
+        uid: Uid,
+        proc_addr: ProcAddr,
+        actor_spawner: ActorRef<SpawnActor>,
+        command: UnixProcCommand,
+        supervise: Supervise,
+    ) -> Self {
+        Self {
+            uid,
+            proc_addr,
+            actor_spawner,
+            command,
+            supervise: Some(supervise),
+            session: None,
+            peer_guard: None,
+            control: None,
+            pid: None,
+            stop_reason: None,
+            child_exit: None,
+        }
+    }
+
+    fn launch(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+        let rendezvous = token::create(
+            this,
+            (),
+            this.port::<token::Joined<UnixProcJoin>>().bind(),
+            TokenOptions {
+                policy: TokenPolicy::Once,
+            },
+        )?;
+        let token = UnixProcToken::new(
+            self.proc_addr.clone(),
+            this.port::<ActorSupervisionEvent>().bind(),
+            rendezvous,
+        );
+
+        let mut child = self.command.spawn(&token)?;
+        self.pid = child.id();
+        let notify = this.port::<UnixProcExited>();
+        let client = Instance::<()>::self_client();
+        let (exit_tx, exit_rx) = oneshot::channel();
+        self.child_exit = Some(exit_rx);
+        tokio::spawn(async move {
+            let exited = UnixProcExited::from_wait_result(child.wait().await);
+            // Unblock a graceful `handle_stop` waiting on the exit, then report
+            // the terminal status to the worker's own port.
+            let _ = exit_tx.send(());
+            let _ = notify.post(client, exited);
+        });
+        Ok(())
+    }
+
+    /// Wait up to `grace` for the OS-process reaper to observe the child exit.
+    /// Returns `true` if the child exited in time (a clean drain); `false` if
+    /// the wait timed out or the reaper vanished without reporting, in which
+    /// case the caller should force the process down.
+    async fn await_child_exit(&mut self, grace: Duration) -> bool {
+        let Some(exit) = self.child_exit.take() else {
+            return true;
+        };
+        matches!(tokio::time::timeout(grace, exit).await, Ok(Ok(())))
+    }
+
+    fn reject_and_stop(
+        &mut self,
+        cx: &Context<Self>,
+        supervise: &Supervise,
+        reason: impl Into<String>,
+    ) {
+        reject_supervise(cx, supervise, reason);
+        self.signal_child(Signal::SIGKILL, "rejected proc supervision");
+    }
+
+    fn signal_child(&mut self, sig: Signal, reason: &str) {
+        let Some(pid) = self.pid else {
+            return;
+        };
+        if let Err(error) = signal_proc_group(pid, sig) {
+            let _ = (error, reason);
+        }
+    }
+
+    fn ensure_session(&self, session_id: Uid) -> anyhow::Result<Uid> {
+        let Some(session) = &self.session else {
+            anyhow::bail!("unix proc worker is not supervised");
+        };
+        if session.session_id != session_id {
+            anyhow::bail!("remote supervision session id mismatch");
+        }
+        Ok(session_id)
+    }
+
+    async fn link_proc(
+        &mut self,
+        cx: &Context<'_, Self>,
+        joined: UnixProcJoin,
+    ) -> anyhow::Result<()> {
+        let Some(supervise) = self.supervise.take() else {
+            self.signal_child(Signal::SIGKILL, "duplicate unix proc join");
+            return Ok(());
+        };
+        if joined.actor_spawner != self.actor_spawner {
+            self.reject_and_stop(
+                cx,
+                &supervise,
+                format!(
+                    "proc joined with unexpected actor-spawn endpoint {}; expected {}",
+                    joined.actor_spawner.actor_addr(),
+                    self.actor_spawner.actor_addr()
+                ),
+            );
+            return Ok(());
+        }
+
+        let gateway_addr = joined.gateway_addr.addr().clone();
+        let child_sender = match MailboxClient::dial(gateway_addr.clone()) {
+            Ok(sender) => sender,
+            Err(error) => {
+                self.reject_and_stop(
+                    cx,
+                    &supervise,
+                    format!("failed to dial spawned proc at {}: {}", gateway_addr, error),
+                );
+                return Ok(());
+            }
+        };
+        let peer_guard = match cx
+            .instance()
+            .proc()
+            .gateway()
+            .attach_peer(self.uid.clone(), child_sender.into_boxed())
+        {
+            Ok(guard) => guard,
+            Err(error) => {
+                self.reject_and_stop(
+                    cx,
+                    &supervise,
+                    format!("failed to attach spawned proc route: {error}"),
+                );
+                return Ok(());
+            }
+        };
+
+        let liveness_handle = match supervise.liveness.clone().spawn_worker(cx).await {
+            Ok(liveness_handle) => liveness_handle,
+            Err(error) => {
+                self.reject_and_stop(
+                    cx,
+                    &supervise,
+                    format!("failed to spawn proc liveness actor: {error}"),
+                );
+                return Ok(());
+            }
+        };
+        let supervisor = supervise.supervisor.clone();
+        self.peer_guard = Some(peer_guard);
+        self.control = Some(joined.control);
+        self.session = Some(UnixProcSession {
+            session_id: supervise.session_id.clone(),
+            supervisor: supervise.supervisor,
+            options: supervise.options,
+            liveness_handle,
+        });
+        supervisor.post(
+            cx,
+            SupervisorEvent::Linked {
+                session_id: supervise.session_id,
+                worker: cx.port::<WorkerCommand>().bind(),
+                child: self.actor_spawner.actor_addr().clone(),
+                display_name: Some(self.uid.to_string()),
+            },
+        );
+        Ok(())
+    }
+
+    fn handle_liveness_event(
+        &mut self,
+        cx: &impl context::Actor,
+        event: &ActorSupervisionEvent,
+    ) -> anyhow::Result<bool> {
+        let Some(session) = &self.session else {
+            return Ok(true);
+        };
+        if session.liveness_handle.actor_id() != &event.actor_id {
+            return Ok(!event.is_error());
+        }
+
+        let session = self
+            .session
+            .take()
+            .expect("liveness event must have an active session");
+        let _ = session
+            .liveness_handle
+            .stop("proc supervision liveness failed");
+        session.supervisor.post(
+            cx,
+            SupervisorEvent::SupervisionEvent {
+                session_id: session.session_id.clone(),
+                event: ActorSupervisionEvent::new(
+                    self.actor_spawner.actor_addr().clone(),
+                    Some(self.uid.to_string()),
+                    ActorStatus::generic_failure("proc supervision liveness failed"),
+                    None,
+                ),
+                disposition: RemoteActorDisposition::Unreachable,
+            },
+        );
+        if session.options.orphan_policy == OrphanPolicy::Stop {
+            self.signal_child(Signal::SIGTERM, "proc supervision liveness failed");
+        }
+        Ok(true)
+    }
+
+    fn unlink_session(&mut self, reason: &str) -> Option<UnixProcSession> {
+        let session = self.session.take()?;
+        let _ = session.liveness_handle.stop(reason);
+        Some(session)
+    }
+
+    /// Begin stopping the child proc. When linked, posts a graceful
+    /// [`StopProc`] to the child's control endpoint and schedules a hard
+    /// kill after the configured grace period ([`crate::config::STOP_GRACE_PERIOD`])
+    /// in case the drain stalls; otherwise signals the OS process directly. Does
+    /// not exit the worker — it exits once the process is reaped (see
+    /// [`Handler<UnixProcExited>`]).
+    fn request_child_stop(&mut self, cx: &Context<Self>, mode: StopMode, reason: &str) {
+        self.stop_reason = Some(reason.to_string());
+        let Some(control) = &self.control else {
+            self.signal_child(Signal::SIGTERM, reason);
+            return;
+        };
+        control.post(
+            cx,
+            StopProc {
+                mode,
+                reason: reason.to_string(),
+            },
+        );
+        // After the grace period, hard-kill the proc with a `KillProc`
+        // self-message — a no-op if it already drained and exited, and
+        // discarded outright if this worker has stopped by then.
+        cx.post_after(
+            cx,
+            KillProc {
+                reason: reason.to_string(),
+            },
+            hyperactor_config::global::get(crate::config::STOP_GRACE_PERIOD),
+        );
+    }
+}
+
+/// Self-message: hard-kill the child OS process. The worker posts this to
+/// itself when a graceful stop misses the grace period
+/// ([`crate::config::STOP_GRACE_PERIOD`]).
+#[derive(Debug)]
+struct KillProc {
+    reason: String,
+}
+
+#[async_trait]
+impl Actor for UnixProcWorker {
+    async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+        if let Err(error) = self.launch(this)
+            && let Some(supervise) = self.supervise.take()
+        {
+            reject_supervise(
+                this,
+                &supervise,
+                format!("failed to launch unix proc: {error}"),
+            );
+            this.exit("failed to launch unix proc")?;
+        }
+        Ok(())
+    }
+
+    async fn handle_supervision_event(
+        &mut self,
+        this: &Instance<Self>,
+        event: &ActorSupervisionEvent,
+    ) -> anyhow::Result<bool> {
+        self.handle_liveness_event(this, event)
+    }
+
+    async fn handle_stop(
+        &mut self,
+        this: &Instance<Self>,
+        mode: StopMode,
+        reason: &str,
+    ) -> anyhow::Result<()> {
+        self.stop_reason = Some(reason.to_string());
+        let _ = self.unlink_session(reason);
+        // Ask the proc to drain gracefully over the control channel and wait for
+        // the OS process to exit on its own; signal it down only if the drain
+        // overruns the grace period. Unlike `request_child_stop`, this path must
+        // exit the worker itself, so it waits inline rather than escalating
+        // through a `KillProc` self-message.
+        if let Some(control) = self.control.take() {
+            control.post(
+                this,
+                StopProc {
+                    mode,
+                    reason: reason.to_string(),
+                },
+            );
+            let grace = hyperactor_config::global::get(crate::config::STOP_GRACE_PERIOD);
+            if !self.await_child_exit(grace).await {
+                self.signal_child(Signal::SIGTERM, reason);
+            }
+        } else {
+            // Not linked, so there is no control channel to drain over; signal
+            // the OS process directly.
+            self.signal_child(Signal::SIGTERM, reason);
+        }
+        this.close();
+        match mode {
+            StopMode::Stop => this.exit(reason)?,
+            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<token::Joined<UnixProcJoin>> for UnixProcWorker {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: token::Joined<UnixProcJoin>,
+    ) -> anyhow::Result<()> {
+        self.link_proc(cx, message.peer).await
+    }
+}
+
+#[async_trait]
+impl Handler<WorkerCommand> for UnixProcWorker {
+    async fn handle(&mut self, cx: &Context<Self>, message: WorkerCommand) -> anyhow::Result<()> {
+        match message {
+            WorkerCommand::Stop {
+                session_id,
+                mode,
+                reason,
+            } => {
+                self.ensure_session(session_id)?;
+                // Drain the proc gracefully over the actor channel, hard-
+                // killing the OS process only if the drain misses the grace
+                // period. The worker exits once the process is reaped (see
+                // `Handler<UnixProcExited>`).
+                self.request_child_stop(cx, mode, &reason);
+            }
+            WorkerCommand::Unlink { session_id, reason } => {
+                self.ensure_session(session_id.clone())?;
+                if let Some(session) = self.unlink_session(&reason) {
+                    if session.options.orphan_policy == OrphanPolicy::Stop {
+                        self.stop_reason = Some(reason.clone());
+                        self.signal_child(Signal::SIGTERM, &reason);
+                    }
+                    let _ = session
+                        .supervisor
+                        .post(cx, SupervisorEvent::Unlinked { session_id, reason });
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<UnixProcExited> for UnixProcWorker {
+    async fn handle(&mut self, cx: &Context<Self>, message: UnixProcExited) -> anyhow::Result<()> {
+        self.pid = None;
+        self.peer_guard.take();
+        self.control = None;
+        let actor_status = message.actor_status(self.stop_reason.as_deref());
+        if let Some(session) = self.unlink_session("unix proc exited") {
+            session.supervisor.post(
+                cx,
+                SupervisorEvent::SupervisionEvent {
+                    session_id: session.session_id,
+                    event: ActorSupervisionEvent::new(
+                        self.actor_spawner.actor_addr().clone(),
+                        Some(self.uid.to_string()),
+                        actor_status,
+                        None,
+                    ),
+                    disposition: RemoteActorDisposition::Terminal,
+                },
+            );
+        } else if let Some(supervise) = self.supervise.take() {
+            reject_supervise(
+                cx,
+                &supervise,
+                format!("unix proc exited before joining: {}", message.describe()),
+            );
+        }
+        cx.exit("unix proc exited")?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<ActorSupervisionEvent> for UnixProcWorker {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        event: ActorSupervisionEvent,
+    ) -> anyhow::Result<()> {
+        // A top-level supervision event forwarded by the child proc's
+        // coordinator. Clean lifecycle events need no action — the proc-exit
+        // path reports a clean stop. A failure is surfaced to the caller at
+        // once, with full detail, then the proc is drained and stopped.
+        if !event.is_error() {
+            return Ok(());
+        }
+        if let Some(session) = self.unlink_session("child proc reported a failure") {
+            session.supervisor.post(
+                cx,
+                SupervisorEvent::SupervisionEvent {
+                    session_id: session.session_id,
+                    event,
+                    disposition: RemoteActorDisposition::Terminal,
+                },
+            );
+        }
+        self.request_child_stop(cx, StopMode::DrainAndStop, "child proc reported a failure");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<KillProc> for UnixProcWorker {
+    async fn handle(&mut self, _cx: &Context<Self>, message: KillProc) -> anyhow::Result<()> {
+        // Hard kill: a graceful drain missed the grace period. A no-op if the
+        // process already exited.
+        self.signal_child(Signal::SIGKILL, &message.reason);
+        Ok(())
+    }
+}
+
+fn reject_supervise(cx: &impl context::Actor, supervise: &Supervise, reason: impl Into<String>) {
+    let _ = supervise.supervisor.post(
+        cx,
+        SupervisorEvent::SuperviseRejected {
+            session_id: supervise.session_id.clone(),
+            reason: reason.into(),
+        },
+    );
+}
+
+fn parse_env<T>(key: &str) -> anyhow::Result<T>
+where
+    T: std::str::FromStr,
+    T::Err: Into<anyhow::Error>,
+{
+    std::env::var(key)?
+        .parse()
+        .map_err(|error: T::Err| error.into())
+}
+
+/// Send `sig` to the child's process group, mirroring how the host bootstrap
+/// launcher signals procs. The child is its own group leader (see `launch`), so
+/// the negative pid targets the whole proc tree rather than just the leader. A
+/// vanished group (`ESRCH`) is treated as success, since the goal — that group
+/// being gone — is already met.
+fn signal_proc_group(pid: u32, sig: Signal) -> nix::Result<()> {
+    let pgid = Pid::from_raw(-(pid as i32));
+    match signal::kill(pgid, sig) {
+        Ok(()) | Err(Errno::ESRCH) => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// Ask the kernel to SIGKILL this process if its parent (the spawner) dies,
+/// mirroring the host bootstrap safety net. A normal stop arrives over the
+/// control channel; this only guards against the spawner vanishing without one.
+/// Best-effort, but if the parent already died before `prctl` ran no signal
+/// will arrive, so the reparent is detected and this process exits at once.
+fn install_pdeathsig_kill() -> std::io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: `getppid` takes no arguments and only reads the parent pid.
+        let ppid_before = unsafe { libc::getppid() };
+        // SAFETY: `prctl(PR_SET_PDEATHSIG, ...)` reads only scalar arguments.
+        let rc = unsafe { libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGKILL as libc::c_int) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        // SAFETY: as above; re-read the parent pid to detect a reparent.
+        if unsafe { libc::getppid() } != ppid_before {
+            std::process::exit(0);
+        }
+    }
+    Ok(())
+}
+
+fn exit_signal(status: &ExitStatus) -> Option<i32> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::ExitStatusExt as _;
+        status.signal()
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = status;
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor::Label;
+    use hyperactor::ProcId;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn serves_on_its_own_socket_not_the_spawner_address() {
+        // A child proc address derived from a spawner: it is advertised
+        // through the spawner's terminal address, which the child must not
+        // serve on.
+        let spawner = ProcAddr::new(
+            ProcId::new(Uid::instance(Label::strip("spawner")), None),
+            Location::from(ChannelAddr::any(ChannelTransport::Unix)),
+        );
+        let proc_addr =
+            spawned_proc_addr_for_spawner_addr(&spawner, &Uid::instance(Label::strip("child")));
+
+        let proc = Proc::isolated();
+        let (mut serve, gateway_addr) = UnixProc::serve_own_socket(&proc).unwrap();
+
+        let served = gateway_addr
+            .as_addr()
+            .expect("child reports a terminal address, not a via route");
+        assert!(
+            matches!(served, ChannelAddr::Unix(_)),
+            "child serves on its own unix socket, got {served}"
+        );
+        assert_ne!(
+            served,
+            proc_addr.addr(),
+            "child must serve on its own socket, not the spawner-derived address"
+        );
+
+        serve.stop("test complete");
+        let _ = serve.join().await;
+    }
+
+    #[test]
+    fn requested_stop_reports_stopped_even_when_process_exits_by_signal() {
+        let status = UnixProcExited::Signalled {
+            signal: libc::SIGTERM,
+        }
+        .actor_status(Some("caller stopped proc"));
+
+        assert_eq!(
+            status,
+            ActorStatus::Stopped("caller stopped proc".to_string())
+        );
+    }
+
+    #[test]
+    fn unexpected_signal_exit_reports_failure() {
+        let status = UnixProcExited::Signalled {
+            signal: libc::SIGTERM,
+        }
+        .actor_status(None);
+
+        assert!(status.is_failed());
+    }
+
+    #[test]
+    fn describe_names_the_terminating_signal() {
+        let exited = UnixProcExited::Signalled {
+            signal: libc::SIGTERM,
+        };
+        // SIGTERM is 15; `describe` looks the name up from the number.
+        assert_eq!(
+            exited.describe(),
+            format!("terminated by signal {} (SIGTERM)", libc::SIGTERM)
+        );
+    }
+}

--- a/hyperactor_remote/src/proto.rs
+++ b/hyperactor_remote/src/proto.rs
@@ -99,7 +99,7 @@ impl Gspawn {
     }
 }
 
-/// Request sent to a remote spawner to spawn and supervise one registered actor.
+/// Request sent to an actor spawner to spawn and supervise one registered actor.
 #[derive(
     Clone,
     Debug,
@@ -119,6 +119,27 @@ pub struct SpawnActor {
     pub supervise: Supervise,
 }
 wirevalue::register_type!(SpawnActor);
+
+/// Request sent to a proc-spawner endpoint to spawn and supervise one proc.
+#[derive(
+    Clone,
+    Debug,
+    Serialize,
+    Deserialize,
+    Named,
+    PartialEq,
+    Eq,
+    Handler,
+    HandleClient,
+    RefClient
+)]
+pub struct SpawnProc {
+    /// Proc uid to spawn.
+    pub uid: Uid,
+    /// Supervise request to send back.
+    pub supervise: Supervise,
+}
+wirevalue::register_type!(SpawnProc);
 
 /// Request sent by a supervisor proxy to a worker actor.
 #[derive(

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -28,6 +28,7 @@ use hyperactor::Context;
 use hyperactor::Endpoint;
 use hyperactor::Handler;
 use hyperactor::Instance;
+use hyperactor::OncePortHandle;
 use hyperactor::PortRef;
 use hyperactor::Uid;
 use hyperactor::actor::ActorErrorKind;
@@ -143,6 +144,13 @@ pub struct Supervisor {
     liveness_handle: Option<ActorHandle<KeepaliveSupervisor>>,
     session: Option<SupervisorSession>,
     pending_stop: Option<PendingStop>,
+    /// If set, a bare readiness signal is posted here once the worker reports
+    /// [`SupervisorEvent::Linked`] — i.e., once the remote child has become
+    /// reachable. The child's address is returned synchronously by the spawn
+    /// call, so this carries no payload. Fires at most once, hence a
+    /// [`OncePortHandle`]; the supervisor and the caller that opened the port
+    /// are always on the same proc.
+    ready: Option<OncePortHandle<()>>,
 }
 
 impl Supervisor {
@@ -167,6 +175,7 @@ impl Supervisor {
             liveness,
             options,
             session_id,
+            None,
         )
     }
 
@@ -184,11 +193,16 @@ impl Supervisor {
     /// supervisor has no worker control endpoint; stop requests are therefore
     /// held pending. `fallback_actor` is used only to synthesize a supervision
     /// event if liveness fails before the worker reports the supervised child.
+    /// When `ready` is set, a bare readiness signal is posted to it once the
+    /// worker reports `Linked` — the earliest point at which messages to the
+    /// child are guaranteed to route — so callers can wait for reachability
+    /// instead of guessing with a delay.
     pub(crate) fn bootstrap_uid<F>(
         liveness: KeepaliveLink,
         options: SupervisionOptions,
         session_id: Uid,
         fallback_actor: ActorAddr,
+        ready: Option<OncePortHandle<()>>,
         bootstrap: F,
     ) -> Self
     where
@@ -202,6 +216,7 @@ impl Supervisor {
             liveness,
             options,
             session_id,
+            ready,
         )
     }
 
@@ -210,6 +225,7 @@ impl Supervisor {
         liveness: KeepaliveLink,
         options: SupervisionOptions,
         session_id: Uid,
+        ready: Option<OncePortHandle<()>>,
     ) -> Self {
         Self {
             bootstrap,
@@ -219,6 +235,7 @@ impl Supervisor {
             liveness_handle: None,
             session: None,
             pending_stop: None,
+            ready,
         }
     }
 }
@@ -286,6 +303,9 @@ impl Handler<SupervisorEvent> for Supervisor {
                 display_name,
             } => {
                 self.ensure_session(&session_id)?;
+                if let Some(ready) = self.ready.take() {
+                    ready.post(cx, ());
+                }
                 self.session = Some(SupervisorSession {
                     worker,
                     child,

--- a/hyperactor_remote/tests/remote_spawner.rs
+++ b/hyperactor_remote/tests/remote_spawner.rs
@@ -18,7 +18,7 @@ use std::time::SystemTime;
 
 struct DemoRun {
     driver: Output,
-    proc: Output,
+    spawner: Output,
 }
 
 #[test]
@@ -27,15 +27,21 @@ fn test_remote_spawner_demo_add() {
 
     assert!(
         run.driver.status.success(),
-        "driver failed:\n{}\nproc:\n{}",
+        "driver failed:\n{}\nspawner:\n{}",
         output_text(&run.driver),
-        output_text(&run.proc)
+        output_text(&run.spawner)
+    );
+    assert!(
+        output_text(&run.driver).contains("driver requested proc"),
+        "driver output did not include proc spawn request:\n{}\nspawner:\n{}",
+        output_text(&run.driver),
+        output_text(&run.spawner)
     );
     assert!(
         output_text(&run.driver).contains("driver received result: 40 + 2 = 42"),
-        "driver output did not include calculation result:\n{}\nproc:\n{}",
+        "driver output did not include calculation result:\n{}\nspawner:\n{}",
         output_text(&run.driver),
-        output_text(&run.proc)
+        output_text(&run.spawner)
     );
 }
 
@@ -45,46 +51,145 @@ fn test_remote_spawner_demo_overflow() {
 
     assert!(
         !run.driver.status.success(),
-        "overflow driver unexpectedly succeeded:\n{}\nproc:\n{}",
+        "overflow driver unexpectedly succeeded:\n{}\nspawner:\n{}",
         output_text(&run.driver),
-        output_text(&run.proc)
+        output_text(&run.spawner)
     );
     let driver_output = output_text(&run.driver);
     assert!(
         driver_output.contains("driver observed supervision event and will propagate it"),
-        "driver output did not include propagated supervision event:\n{}\nproc:\n{}",
+        "driver output did not include propagated supervision event:\n{}\nspawner:\n{}",
         driver_output,
-        output_text(&run.proc)
+        output_text(&run.spawner)
     );
     assert!(
         driver_output.contains("integer overflow while adding"),
-        "driver output did not include expected overflow failure:\n{}\nproc:\n{}",
+        "driver output did not include expected overflow failure:\n{}\nspawner:\n{}",
         driver_output,
-        output_text(&run.proc)
+        output_text(&run.spawner)
+    );
+}
+
+#[test]
+fn test_remote_spawner_demo_proc_death() {
+    // The spawned actor exits its whole OS process (process::exit(1)). The
+    // spawner-side worker observes the process exit and reports a terminal
+    // supervision event, which propagates back to the driver.
+    let run = run_demo("crash");
+
+    assert!(
+        !run.driver.status.success(),
+        "crash driver unexpectedly succeeded:\n{}\nspawner:\n{}",
+        output_text(&run.driver),
+        output_text(&run.spawner)
+    );
+    let driver_output = output_text(&run.driver);
+    assert!(
+        driver_output.contains("driver observed supervision event and will propagate it"),
+        "driver did not observe a supervision event for the dead proc:\n{}\nspawner:\n{}",
+        driver_output,
+        output_text(&run.spawner)
+    );
+    assert!(
+        driver_output.contains("exited with code 1"),
+        "driver supervision event did not reflect the proc's OS-process exit:\n{}\nspawner:\n{}",
+        driver_output,
+        output_text(&run.spawner)
+    );
+}
+
+#[test]
+fn test_remote_spawner_demo_graceful_stop() {
+    // The driver computes once and exits cleanly; that clean exit triggers a
+    // graceful stop of the spawned proc, which drains and exits on its own
+    // rather than being hard-killed. The child records "STOPPED_CLEANLY" only
+    // when it came down via a clean drain.
+    let tmp = temp_dir();
+    std::fs::create_dir_all(&tmp).unwrap();
+    let token_file = tmp.join("spawner-token");
+    let status_file = tmp.join("proc-status");
+    let binary = remote_spawner_binary();
+
+    let spawner = Command::new(&binary)
+        .arg("spawner")
+        .arg("--token-file")
+        .arg(&token_file)
+        .arg("--proc-status-file")
+        .arg(&status_file)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap_or_else(|error| {
+            panic!("failed to spawn proc spawner {}: {error}", binary.display())
+        });
+
+    if let Err(error) = wait_for_file(&token_file) {
+        let spawner_output = stop_child(spawner);
+        let _ = std::fs::remove_dir_all(&tmp);
+        panic!("{error}\nspawner output:\n{}", output_text(&spawner_output));
+    }
+
+    let driver = Command::new(&binary)
+        .arg("driver")
+        .arg("--token-file")
+        .arg(&token_file)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run driver {}: {error}", binary.display()));
+
+    // The child writes its status only after draining; wait for it before
+    // tearing down the spawner (which would otherwise hard-kill the child).
+    let status_wait = wait_for_file(&status_file);
+    let status_contents = std::fs::read_to_string(&status_file).unwrap_or_default();
+    let spawner = stop_child(spawner);
+    let _ = std::fs::remove_dir_all(&tmp);
+
+    assert!(
+        driver.status.success(),
+        "driver failed:\n{}\nspawner:\n{}",
+        output_text(&driver),
+        output_text(&spawner)
+    );
+    assert!(
+        status_wait.is_ok(),
+        "spawned proc never recorded a clean exit:\n{}\nspawner:\n{}",
+        output_text(&driver),
+        output_text(&spawner)
+    );
+    assert!(
+        status_contents.contains("STOPPED_CLEANLY"),
+        "spawned proc did not stop cleanly (status file: {status_contents:?}):\n{}\nspawner:\n{}",
+        output_text(&driver),
+        output_text(&spawner)
     );
 }
 
 fn run_demo(mode: &str) -> DemoRun {
     let tmp = temp_dir();
     std::fs::create_dir_all(&tmp).unwrap();
-    let token_file = tmp.join("proc-token");
+    let token_file = tmp.join("spawner-token");
     let binary = remote_spawner_binary();
 
-    let proc = Command::new(&binary)
-        .arg("proc")
+    let spawner = Command::new(&binary)
+        .arg("spawner")
         .arg("--token-file")
         .arg(&token_file)
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .unwrap_or_else(|error| panic!("failed to spawn proc {}: {error}", binary.display()));
+        .unwrap_or_else(|error| {
+            panic!("failed to spawn proc spawner {}: {error}", binary.display())
+        });
 
     if let Err(error) = wait_for_file(&token_file) {
-        let proc_output = stop_child(proc);
+        let spawner_output = stop_child(spawner);
         let _ = std::fs::remove_dir_all(&tmp);
         panic!(
-            "{error}\nproc output:\n{}",
-            output_text_from_parts(proc_output.status, &proc_output.stdout, &proc_output.stderr)
+            "{error}\nspawner output:\n{}",
+            output_text_from_parts(
+                spawner_output.status,
+                &spawner_output.stdout,
+                &spawner_output.stderr
+            )
         );
     }
 
@@ -95,10 +200,10 @@ fn run_demo(mode: &str) -> DemoRun {
         .output()
         .unwrap_or_else(|error| panic!("failed to run driver {}: {error}", binary.display()));
 
-    let proc = stop_child(proc);
+    let spawner = stop_child(spawner);
     let _ = std::fs::remove_dir_all(&tmp);
 
-    DemoRun { driver, proc }
+    DemoRun { driver, spawner }
 }
 
 #[cfg(not(fbcode_build))]

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -1975,7 +1975,7 @@ mod tests {
                 proc.attach_actor::<ControllerActor, ControllerMessage>("controller")?;
             let client = proc.client("client");
             let (supervision_tx, supervision_rx) = client.open_port();
-            proc.set_supervision_coordinator(supervision_tx)?;
+            proc.set_supervision_coordinator(supervision_tx.bind())?;
             let stream_actor = proc.spawn(StreamActor::new(StreamParams {
                 world_size,
                 rank: 0,


### PR DESCRIPTION
Summary:
Add a `ProcSpawner` protocol (the `SpawnProc` message) to `hyperactor_remote`, plus a `UnixProcSpawner` implementation that spawns OS-process-backed procs. A caller uses `ProcSpawnerEndpoint::spawn_proc_uid` to ask a `UnixProcSpawner` for a new proc: the spawner launches a child process, which boots via `UnixProc::boot`, starts a proc-local `ActorSpawner` (the actor-spawn factory, formerly `RemoteSpawner`) under a well-known singleton uid reached via `SpawnActor`, serves its gateway on its own Unix socket, and joins back through the token/join rendezvous. The spawner-side `UnixProcWorker` attaches the child's route (`attach_peer`) only after the join, reports `SupervisorEvent::Linked` for the `ActorSpawner`, and forwards liveness and OS-process-exit events so the proc's lifetime is tied to its actor-spawn endpoint. A spawned proc's top-level supervision events route back to the `UnixProcWorker` over the gateway (the proc's supervision coordinator is now a `PortRef`, so it can live in another proc), and a stop drains the proc gracefully, escalating to a hard kill (`KillProc`) only if the drain misses its grace period. The OS-process lifecycle parallels the host bootstrap launcher: the child runs in its own process group (`setpgid`) and is signalled as a group through `nix` (treating an already-gone group as success), and it installs `PR_SET_PDEATHSIG` so the kernel reaps it if the spawner dies.

Because a freshly spawned proc or actor isn't routable until it joins and links — messages sent before then are dropped, not buffered — the spawn endpoints now take an optional readiness port (`spawn_proc_uid_with_ready` / `spawn_uid_with_ready`). The caller-side `Supervisor` posts the child's address to that port once it observes `SupervisorEvent::Linked`, the earliest point at which messages route, so callers wait for reachability instead of guessing with a fixed delay. (Match the reported address by its location-free identity, since it is the spawner's view of the endpoint.)

The `remote_spawner` example publishes a `ProcSpawner` token from a `SpawnerBootstrap` actor, spawns a Unix child proc through `UnixProcSpawner`, then spawns the `Calculator` through the child's `ActorSpawner` — each step driven by its readiness signal rather than a sleep.

Reviewed By: mariusae

Differential Revision: D108065661
