### PR TITLE
Attach serve_via before minting host refs

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1300,11 +1300,13 @@ pub struct MailboxServerHandle {
 impl MailboxServerHandle {
     /// Signal the server to stop serving the mailbox. The caller should
     /// join the handle by awaiting the [`MailboxServerHandle`] future.
-    ///
-    /// Stop should be called at most once.
     pub fn stop(&self, reason: &str) {
         tracing::info!("stopping mailbox server; reason: {}", reason);
-        self.stopped_tx.send(true).expect("stop called twice");
+        // The server task owns the only `stopped_rx`. A failed send means
+        // the task already exited on its own — e.g. a `serve_via` session
+        // whose remote duplex peer closed, which breaks the serve loop
+        // gracefully — so there is nothing left to stop.
+        let _ = self.stopped_tx.send(true);
     }
 
     /// Construct a handle from an already-spawned server task and a

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -274,6 +274,10 @@ impl HostShutdownHandle {
 /// - `listener`: when `Some`, it is used as the frontend listening socket
 ///   instead of binding a new one.
 /// - `gateway`: the gateway this host will multiplex traffic through.
+/// - `via`: when `Some`, attach `gateway` to this remote duplex address
+///   with `serve_via` during bootstrap — after the local serves but
+///   before any ref is minted — so refs advertise the routable `Via`
+///   location (used by out-of-cluster clients).
 pub async fn host(
     addr: ChannelAddr,
     command: Option<BootstrapCommand>,
@@ -281,6 +285,7 @@ pub async fn host(
     exit_on_shutdown: bool,
     listener: Option<std::net::TcpListener>,
     gateway: Gateway,
+    via: Option<ChannelAddr>,
 ) -> anyhow::Result<(ActorHandle<HostAgent>, HostShutdownHandle)> {
     if let Some(attrs) = config {
         hyperactor_config::global::set(hyperactor_config::global::Source::Runtime, attrs);
@@ -295,7 +300,7 @@ pub async fn host(
     };
     let manager = BootstrapProcManager::new(command)?;
 
-    let host = Host::new_with_gateway(manager, addr, listener, gateway).await?;
+    let host = Host::new_with_gateway(manager, addr, listener, gateway, via).await?;
     let addr = host.addr().clone();
 
     // The ShutdownHost handler will send the gateway serve handle back here
@@ -556,6 +561,7 @@ impl Bootstrap {
                     exit_on_shutdown,
                     None,
                     Gateway::global().clone(),
+                    None,
                 )
                 .await?;
                 shutdown.join().await;
@@ -3167,6 +3173,7 @@ mod tests {
             false,
             None,
             Gateway::global().clone(),
+            None,
         )
         .await
         .unwrap();

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -144,6 +144,10 @@ pub enum HostError {
     /// An input parameter was invalid.
     #[error("parameter '{0}' invalid: {1}")]
     InvalidParameter(String, anyhow::Error),
+
+    /// Attaching the gateway to a remote `serve_via` session failed.
+    #[error("failed to attach gateway via session: {0}")]
+    ViaAttachFailure(#[source] anyhow::Error),
 }
 
 /// Lifecycle manager for the procs on one machine.
@@ -167,6 +171,10 @@ pub struct Host<M> {
     gateway: Gateway,
     frontend_handle: Option<GatewayServeHandle>,
     backend_handle: Option<GatewayServeHandle>,
+    /// Duplex `serve_via` session to a remote gateway, present when this
+    /// host was bootstrapped out-of-cluster. Kept alive for the host's
+    /// lifetime so the cluster route and outbound forwarder persist.
+    via_handle: Option<GatewayServeHandle>,
     manager: M,
     service_proc: Proc,
     local_proc: Proc,
@@ -191,7 +199,7 @@ impl<M: ProcManager> Host<M> {
         // host share one routing table with the rest of the process.
         // Callers that need a different gateway (e.g. via attach) build
         // it externally and pass it to [`new_with_gateway`].
-        Self::new_with_gateway(manager, addr, listener, Gateway::global().clone()).await
+        Self::new_with_gateway(manager, addr, listener, Gateway::global().clone(), None).await
     }
 
     /// Like [`new_with_default`], but uses a caller-provided
@@ -204,17 +212,27 @@ impl<M: ProcManager> Host<M> {
     /// gateway's location. Adopting the bound frontend address makes the
     /// legacy pseudo-singleton proc ids (system, local) carry it so remote
     /// hosts can reach them by name.
+    ///
+    /// When `via` is `Some`, the gateway attaches to that remote duplex
+    /// address with [`Gateway::serve_via`] *after* the local
+    /// frontend/backend serves but *before* minting the built-in procs,
+    /// so the via session is the newest active serve. That ordering
+    /// makes every ref minted on this host advertise the routable
+    /// `Via` location rather than the bare local frontend, which is
+    /// what lets an out-of-cluster client receive return traffic over
+    /// the duplex.
     #[hyperactor::instrument(fields(addr=addr.to_string()))]
     pub async fn new_with_gateway(
         manager: M,
         addr: ChannelAddr,
         listener: Option<std::net::TcpListener>,
         gateway: Gateway,
+        via: Option<ChannelAddr>,
     ) -> Result<Self, HostError> {
         let mut backend_handle = Gateway::serve(&gateway, ChannelAddr::any(manager.transport()))?;
         let backend_addr = gateway.default_location().addr().clone();
 
-        let frontend_handle = match gateway.serve_with_listener(addr, listener) {
+        let mut frontend_handle = match gateway.serve_with_listener(addr, listener) {
             Ok(handle) => handle,
             Err(error) => {
                 backend_handle.stop("host setup failed");
@@ -228,6 +246,36 @@ impl<M: ProcManager> Host<M> {
             }
         };
         let frontend_addr = gateway.default_location().addr().clone();
+
+        // Attach to the remote gateway after the local serves are live
+        // but before any proc or actor ref is minted below. `serve_via`
+        // must be the newest active serve so it supplies the gateway's
+        // `default_location`; otherwise the local frontend serve above
+        // would win, and refs would advertise a bare, cluster-
+        // unreachable address — the out-of-cluster return-path bug.
+        let via_handle = match via {
+            Some(via_addr) => match gateway.serve_via(via_addr).await {
+                Ok(handle) => Some(handle),
+                Err(error) => {
+                    frontend_handle.stop("host setup failed");
+                    if let Err(join_error) = frontend_handle.join().await {
+                        tracing::warn!(
+                            error = %join_error,
+                            "failed to join frontend server after via attach error"
+                        );
+                    }
+                    backend_handle.stop("host setup failed");
+                    if let Err(join_error) = backend_handle.join().await {
+                        tracing::warn!(
+                            error = %join_error,
+                            "failed to join backend server after via attach error"
+                        );
+                    }
+                    return Err(HostError::ViaAttachFailure(error));
+                }
+            },
+            None => None,
+        };
 
         // Set up the system proc and the local client proc after the
         // gateway servers are live. The HostAgent is published only
@@ -253,6 +301,7 @@ impl<M: ProcManager> Host<M> {
             gateway,
             frontend_handle: Some(frontend_handle),
             backend_handle: Some(backend_handle),
+            via_handle,
             manager,
             service_proc,
             local_proc,
@@ -371,6 +420,9 @@ impl<M> Drop for Host<M> {
             handle.stop("host dropped");
         }
         if let Some(mut handle) = self.backend_handle.take() {
+            handle.stop("host dropped");
+        }
+        if let Some(mut handle) = self.via_handle.take() {
             handle.stop("host dropped");
         }
     }
@@ -2141,6 +2193,7 @@ mod tests {
             ChannelAddr::any(ChannelTransport::Unix),
             None,
             gateway,
+            None,
         )
         .await
         .unwrap();
@@ -2167,6 +2220,7 @@ mod tests {
             ChannelAddr::any(ChannelTransport::Unix),
             None,
             Gateway::new(),
+            None,
         )
         .await
         .unwrap();
@@ -2188,5 +2242,57 @@ mod tests {
 
         later_frontend.stop("test cleanup");
         later_frontend.join().await.unwrap();
+    }
+
+    // Regression: an out-of-cluster client (`via` set) must advertise
+    // its refs at the `Via` location so in-cluster hosts route return
+    // traffic back over the duplex. Before the fix, the host's own
+    // frontend serve clobbered the via as `default_location`, so refs
+    // carried a bare, cluster-unreachable address and the attach-time
+    // config-push acks timed out (`MESH_ATTACH_CONFIG_TIMEOUT`).
+    #[tokio::test]
+    async fn test_new_with_gateway_via_advertises_via_location() {
+        // A remote gateway accepting duplex attaches stands in for the
+        // in-cluster host the client attaches to.
+        let remote_gw = Gateway::new();
+        let mut remote_accept = remote_gw
+            .serve_duplex(ChannelAddr::any(ChannelTransport::Unix))
+            .unwrap();
+        let remote_addr = remote_gw.default_location().addr().clone();
+
+        let proc_manager = LocalProcManager::new(|proc: Proc| async move {
+            Ok(proc.spawn_with_label::<()>("host_agent", ()))
+        });
+
+        let host = Host::new_with_gateway(
+            proc_manager,
+            ChannelAddr::any(ChannelTransport::Unix),
+            None,
+            Gateway::new(),
+            Some(remote_addr.clone()),
+        )
+        .await
+        .unwrap();
+
+        // The gateway must advertise the Via (not the bare local
+        // frontend) as its default location for newly bound refs.
+        let default_location = host.gateway().default_location();
+        let (via_uid, inner) = default_location
+            .as_via()
+            .expect("default location must carry the via prefix");
+        assert_eq!(via_uid, host.gateway().uid());
+        assert_eq!(inner.addr(), &remote_addr);
+
+        // The built-in service proc, minted after `serve_via`, must
+        // also carry the Via — it advertised a bare address before the
+        // fix.
+        let svc_proc_addr = host.system_proc().proc_addr();
+        let (_, svc_inner) = svc_proc_addr
+            .location()
+            .as_via()
+            .expect("service proc must carry the via prefix");
+        assert_eq!(svc_inner.addr(), &remote_addr);
+
+        remote_accept.stop("test cleanup");
     }
 }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -399,7 +399,7 @@ impl HostMesh {
         // `global_context`), which owns the global gateway; sharing it
         // would collide on the legacy `service`/`local` pseudo-singleton
         // proc ids.
-        let host = Host::new_with_gateway(manager, addr, None, Gateway::new()).await?;
+        let host = Host::new_with_gateway(manager, addr, None, Gateway::new(), None).await?;
         let addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc
@@ -472,7 +472,7 @@ impl HostMesh {
         // process-wide global one. Several hosts coexist in one process
         // here, and the legacy `service`/`local` pseudo-singleton proc
         // ids would collide if they all attached to the same gateway.
-        let host = Host::new_with_gateway(manager, addr, None, Gateway::new()).await?;
+        let host = Host::new_with_gateway(manager, addr, None, Gateway::new(), None).await?;
         let addr = host.addr().clone();
         let system_proc = host.system_proc().clone();
         let host_mesh_agent = system_proc

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -105,9 +105,10 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
     });
 
     PyPythonTask::new(async move {
-        let (_agent_handle, shutdown) = host(addr, command, None, true, listener, Gateway::new())
-            .await
-            .map_pyerr()?;
+        let (_agent_handle, shutdown) =
+            host(addr, command, None, true, listener, Gateway::new(), None)
+                .await
+                .map_pyerr()?;
         shutdown.join().await;
         halt::<()>().await;
         Ok(())

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -9,7 +9,6 @@
 use std::collections::HashMap;
 use std::ops::Deref;
 use std::path::PathBuf;
-use std::sync::Mutex;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -339,54 +338,6 @@ static HOST_SHUTDOWN_HANDLE: OnceLock<
     tokio::sync::Mutex<Option<hyperactor_mesh::bootstrap::HostShutdownHandle>>,
 > = OnceLock::new();
 
-enum ViaServeState {
-    Idle,
-    Starting,
-    Serving(Box<hyperactor::gateway::GatewayServeHandle>),
-}
-
-/// Handle for the via-mode duplex session opened by
-/// [`Gateway::serve_via`]. Kept until shutdown so the cluster-inbound
-/// serve and outbound duplex stay alive for the host's lifetime.
-static VIA_SERVE_HANDLE: OnceLock<Mutex<ViaServeState>> = OnceLock::new();
-
-async fn serve_global_gateway_via(addr: ChannelAddr) -> PyResult<()> {
-    let state = VIA_SERVE_HANDLE.get_or_init(|| Mutex::new(ViaServeState::Idle));
-    {
-        let mut state = state.lock().unwrap();
-        match &*state {
-            ViaServeState::Idle => {
-                *state = ViaServeState::Starting;
-            }
-            ViaServeState::Starting | ViaServeState::Serving(_) => {
-                return Err(PyException::new_err(
-                    "via serve handle is already initialized; \
-                     bootstrap_host called more than once with a via address",
-                ));
-            }
-        }
-    }
-
-    let result = Gateway::global().clone().serve_via(addr).await;
-    let mut state = state.lock().unwrap();
-    match result {
-        Ok(handle) => {
-            assert!(
-                matches!(&*state, ViaServeState::Starting),
-                "via serve state changed while initializing"
-            );
-            *state = ViaServeState::Serving(Box::new(handle));
-            Ok(())
-        }
-        Err(err) => {
-            if matches!(&*state, ViaServeState::Starting) {
-                *state = ViaServeState::Idle;
-            }
-            Err(PyException::new_err(err.to_string()))
-        }
-    }
-}
-
 /// Bootstrap the client host and root client actor.
 ///
 /// This creates a proper Host with BootstrapProcManager, spawns the root client
@@ -427,15 +378,14 @@ fn bootstrap_host(
         .transpose()?;
 
     PyPythonTask::new(async move {
-        // Take the process-wide global gateway up front so `serve_via`
-        // installs the cluster route before host bootstrap creates any
-        // actors or ports. Host bootstrap will serve its own backend
-        // and frontend endpoints, while the via session remains active
-        // as an outbound route and local delivery location.
+        // Pass the via address into `host` so the gateway's `serve_via`
+        // attach runs *after* the host's own frontend serve but *before*
+        // any proc or actor ref is minted. That ordering makes the via
+        // session the newest active serve, so refs advertise the
+        // routable `Via` location and out-of-cluster return traffic
+        // flows back over the duplex. The host owns the resulting serve
+        // handle and tears it down on drop.
         let gateway = Gateway::global().clone();
-        if let Some(addr) = via_addr {
-            serve_global_gateway_via(addr).await?;
-        }
 
         let (host_mesh_agent, shutdown_handle) = host(
             default_bind_spec().binding_addr(),
@@ -444,6 +394,7 @@ fn bootstrap_host(
             false,
             None,
             gateway,
+            via_addr,
         )
         .await
         .map_err(|e| PyException::new_err(e.to_string()))?;
@@ -632,18 +583,6 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
             && let Some(handle) = lock.lock().await.take()
         {
             handle.join().await;
-        }
-
-        let via_handle = VIA_SERVE_HANDLE.get().and_then(|lock| {
-            let mut state = lock.lock().unwrap();
-            match std::mem::replace(&mut *state, ViaServeState::Idle) {
-                ViaServeState::Serving(handle) => Some(*handle),
-                ViaServeState::Idle | ViaServeState::Starting => None,
-            }
-        });
-        if let Some(mut handle) = via_handle {
-            handle.stop("local host shutdown");
-            let _ = handle.join().await;
         }
 
         Ok(())


### PR DESCRIPTION
Summary:
Part of: https://github.com/meta-pytorch/monarch/issues/2657

When a host bootstraps with a `via` address — an out-of-cluster client attaching its gateway to an in-cluster host via `Gateway::serve_via` — its refs must advertise the routable `Via(client_uid, remote_host)` location so peers route return traffic back over the duplex. Previously they advertised the bare local frontend address, which an in-cluster host cannot reach.

The cause was serve ordering. `bootstrap_host` called `serve_via` on the process-global gateway *before* `host()`, and `Host::new_with_gateway` then served the host's own frontend. `Routing::recompute` advertises `active_serves.last()` as the gateway's `default_location`, so the later frontend serve won, and every ref minted afterward (the legacy system/local procs, and any client port bound later) carried the bare frontend address. The gateway's outbound forwarder still preferred the newest `serve_via` session, so client-to-cluster traffic worked; only the reverse path was broken.

This surfaced as an attach-time config-push timeout. With the cast-based `SetClientConfig` ack barrier, each host installs the config and replies to the client's reply port; with a bare reply address, the in-cluster host dialed the partitioned client directly, got `Network is unreachable`, and the attach failed with `MESH_ATTACH_CONFIG_TIMEOUT`. No timeout value helped, since the ack was undeliverable rather than slow.

Fix: thread `via` through `host()` into `Host::new_with_gateway` and call `serve_via` there — after the frontend/backend serves but before minting the built-in procs. The via session is then the newest active serve, so it supplies `default_location` and every ref the host mints carries the `Via`. The host owns the resulting `GatewayServeHandle` and stops it on drop, which lets us delete the process-global `VIA_SERVE_HANDLE` plumbing in `monarch_hyperactor`.

Storing that handle on `Host` and stopping it in `Drop` exposed a latent panic. A `serve_via` session's mailbox server reads inbound traffic from the remote duplex and exits gracefully when that peer closes, dropping the sole watch receiver; `Host::drop` then called `MailboxServerHandle::stop`, whose `stopped_tx.send(true).expect("stop called twice")` panicked because no receiver remained. The panic aborted the client process during `ShutdownHost` and broke the `test_client_attach_addr*` integration tests — the only ones that take the out-of-cluster path where the via handle is `Some`. A server task exiting on its own is an expected state, not a double-stop, so `stop` now treats a failed send as already-stopped.

Walkthrough:
- `hyperactor_mesh/src/host.rs`: `new_with_gateway` gains a `via` param and performs the `serve_via` attach between the local serves and proc minting; the resulting handle is stored on `Host` and stopped in `Drop` (mirroring the frontend/backend handles). Adds `HostError::ViaAttachFailure`.
- `hyperactor_mesh/src/bootstrap.rs`: `host()` gains a `via` param and forwards it; other callers pass `None`.
- `monarch_hyperactor/src/host_mesh.rs`: `bootstrap_host` passes `via_addr` into `host()` instead of pre-attaching, and the now-dead `ViaServeState` / `VIA_SERVE_HANDLE` / `serve_global_gateway_via` machinery and its shutdown drain are removed.
- `hyperactor/src/mailbox.rs`: `MailboxServerHandle::stop` treats a failed `stopped_tx.send` as already-stopped instead of panicking with "stop called twice". The only watch receiver lives in the server task, so a failed send means that task already exited (e.g. the via session's remote duplex closed) — not a double-stop.

Reviewed By: mariusae

Differential Revision: D109774380


