### PR TITLE
Fix for flaky sccache access to S3, fallback to rustc (#4326)

### DIFF
--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -111,14 +111,57 @@ setup_sccache() {
     fi
 
     echo "Setting up sccache..."
-    pip install sccache
+    if ! pip install sccache; then
+        echo "Warning: failed to install sccache; continuing without Rust compiler cache"
+        unset RUSTC_WRAPPER
+        return
+    fi
 
-    export RUSTC_WRAPPER=sccache
     export SCCACHE_BUCKET=ossci-compiler-cache
     export SCCACHE_REGION=us-east-1
     export SCCACHE_S3_KEY_PREFIX=monarch
+    export SCCACHE_FALLBACK_DISABLE_FILE="${RUNNER_TEMP:-/tmp}/monarch-sccache-disabled"
+    rm -f "${SCCACHE_FALLBACK_DISABLE_FILE}" 2>/dev/null || true
 
-    echo "sccache configured: bucket=${SCCACHE_BUCKET}, prefix=${SCCACHE_S3_KEY_PREFIX}"
+    # Validate sccache before handing it to cargo. sccache starts its server on
+    # first use and verifies the remote S3 cache by reading .sccache_check; if
+    # S3 returns a transient 5xx here, cargo would otherwise fail before the
+    # build begins (for example while probing `rustc -vV`).
+    local rustc_path
+    rustc_path=$(rustup which rustc 2>/dev/null || command -v rustc || true)
+    if [ -z "${rustc_path}" ]; then
+        echo "Warning: could not locate rustc; continuing without Rust compiler cache"
+        unset RUSTC_WRAPPER
+        unset SCCACHE_BUCKET
+        unset SCCACHE_REGION
+        unset SCCACHE_S3_KEY_PREFIX
+        unset SCCACHE_FALLBACK_DISABLE_FILE
+        return
+    fi
+    local sccache_check_log
+    sccache_check_log=$(mktemp -t monarch-sccache-check.XXXXXX)
+    if ! sccache "${rustc_path}" -vV >"${sccache_check_log}" 2>&1; then
+        echo "Warning: sccache failed its startup/cache check; continuing without Rust compiler cache"
+        cat "${sccache_check_log}"
+        rm -f "${sccache_check_log}"
+        unset RUSTC_WRAPPER
+        unset SCCACHE_BUCKET
+        unset SCCACHE_REGION
+        unset SCCACHE_S3_KEY_PREFIX
+        unset SCCACHE_FALLBACK_DISABLE_FILE
+        return
+    fi
+    rm -f "${sccache_check_log}"
+
+    local common_setup_dir
+    common_setup_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+    local sccache_wrapper="${common_setup_dir}/sccache-rustc-wrapper.sh"
+    # The wrapper is committed executable (0755); ensure the bit survives odd
+    # checkouts without aborting setup on a read-only mount.
+    chmod +x "${sccache_wrapper}" 2>/dev/null || true
+    export RUSTC_WRAPPER="${sccache_wrapper}"
+
+    echo "sccache configured: bucket=${SCCACHE_BUCKET}, prefix=${SCCACHE_S3_KEY_PREFIX}, wrapper=${RUSTC_WRAPPER}"
 }
 
 # Install Python test dependencies

--- a/scripts/sccache-rustc-wrapper.sh
+++ b/scripts/sccache-rustc-wrapper.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# RUSTC_WRAPPER shim used by CI. It prefers sccache, but falls back to invoking
+# rustc directly if sccache itself is unavailable (for example when the remote
+# S3 cache returns a transient 5xx while the sccache server is starting). Rust
+# compiler errors are still returned unchanged.
+
+set -u
+
+if [ "$#" -lt 1 ]; then
+    echo "sccache-rustc-wrapper: expected rustc path as first argument" >&2
+    exit 2
+fi
+
+# Once one invocation observes an sccache infrastructure failure, bypass
+# sccache for the rest of the job. Cargo can invoke the wrapper many times in
+# parallel; using a sentinel avoids paying the sccache startup failure cost for
+# every rustc process.
+disable_file="${SCCACHE_FALLBACK_DISABLE_FILE:-/tmp/monarch-sccache-disabled}"
+if [ -f "$disable_file" ]; then
+    exec "$@"
+fi
+
+if ! command -v sccache >/dev/null 2>&1; then
+    echo "sccache-rustc-wrapper: sccache not found; falling back to rustc" >&2
+    mkdir -p "$(dirname "$disable_file")" 2>/dev/null || true
+    touch "$disable_file" 2>/dev/null || true
+    exec "$@"
+fi
+
+stderr_file="$(mktemp -t monarch-sccache-stderr.XXXXXX)"
+
+set +e
+sccache "$@" 2>"$stderr_file"
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+    rm -f "$stderr_file"
+    exit 0
+fi
+
+# sccache failed. Rather than parse its error text to guess whether the fault
+# was the cache or the compiler, just retry with plain rustc. A genuine
+# compiler error reproduces (rustc fails the same way and we propagate it); an
+# sccache infrastructure failure (S3 5xx, cache or connection error) does not,
+# so rustc succeeds and the build proceeds without the cache.
+set +e
+"$@"
+rustc_status=$?
+set -e
+
+if [ "$rustc_status" -eq 0 ]; then
+    # rustc succeeded where sccache did not, so sccache itself is at fault.
+    # Surface its error once and disable it for the rest of the job to avoid
+    # repeating the failing startup on every subsequent invocation.
+    echo "sccache-rustc-wrapper: sccache failed (exit ${status}) but rustc succeeded; disabling sccache for the rest of this job" >&2
+    sed 's/^/sccache-rustc-wrapper: /' "$stderr_file" >&2
+    mkdir -p "$(dirname "$disable_file")" 2>/dev/null || true
+    touch "$disable_file" 2>/dev/null || true
+fi
+
+rm -f "$stderr_file"
+exit "$rustc_status"


### PR DESCRIPTION
Summary:
One example job: https://github.com/meta-pytorch/monarch/actions/runs/28407343417/job/84172712395 failed with an error:
```
error: process didn't exit successfully: `sccache /root/.rustup/toolchains/nightly-2026-04-11-x86_64-unknown-linux-gnu/bin/rustc -vV` (exit status: 2)
--- stderr
sccache: error: Server startup failed: cache storage failed to read: Unexpected (temporary) at read

Context:
   uri: https://s3.us-east-1.amazonaws.com/ossci-compiler-cache/monarch/.sccache_check
   response: Parts { status: 503, version: HTTP/1.1, headers: {"date": "Mon, 29 Jun 26 22:49:46 GMT", "connection": "close", "x-amz-id-2": "1JFZL3S/45Pdz8ydOcKScABlYQW+Qsx3AcWSFzstAhApV7PHsgI9r2so7SuNBZRwNAnpVuTN4618pLVI+RXLZshVsNMFwedQzZ5Bn/YFZzRtIisHuQAUHA==", "x-amz-request-id": "97F8AEE30D827057", "content-type": "application/xml", "server": "AmazonS3", "content-length": "0"} }
   service: s3
   path: .sccache_check
   range: 0-

Backtrace:
   0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: <unknown>
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: __libc_start_main
  15: <unknown>


Run with SCCACHE_LOG=debug SCCACHE_NO_DAEMON=1 to get more information
```

This appears to be a transient S3 issue. When this occurs we should just fall back to normal rustc instead of sccache.


Test Plan:
Exercised the RUSTC_WRAPPER shim locally with stubbed `sccache` and `rustc` binaries on `PATH`, covering every branch:

1. `sccache` succeeds: wrapper exits 0 and writes no sentinel.
2. `sccache` infrastructure failure at startup (stub emits an S3 503 `cache storage failed to read` and exits 2 without compiling): wrapper retries plain `rustc`, which succeeds, so the wrapper exits 0, surfaces `sccache`s error once, and writes the disable sentinel.
3. Genuine compiler error (stub forwards `error[E0425]` and exits 1): wrapper retries plain `rustc`, which reproduces the same error, so the wrapper exits 1, prints the diagnostic exactly once, and writes no sentinel.
4. `sccache` not on `PATH`: wrapper falls back to `rustc` and writes the sentinel.
5. Sentinel already present: wrapper execs `rustc` directly without invoking `sccache`.

No leaked temp files remained after any path. `arc lint` reports no new warnings on either script (the pre-existing `SC2046`/`SC2155` in `setup_cuda_environment` are untouched), and the `SC2317` unreachable-command warning on the wrapper is resolved.

Reviewed By: shayne-fletcher

Differential Revision: D110200190

Pulled By: dulinriley


