### PR TITLE
Make default_bootstrap_cmd public API

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -1142,8 +1142,7 @@ This is particularly useful for:
 The `BootstrapCommand.with_env()` method makes it easy to create modified copies of a base command with additional environment variables. Use `default_bootstrap_cmd()` to get the default command for the current environment:
 
 ```python
-from monarch.actor import this_host
-from monarch._src.actor.host_mesh import default_bootstrap_cmd
+from monarch.actor import default_bootstrap_cmd, this_host
 
 host = this_host()
 

--- a/docs/source/api/monarch.actor.rst
+++ b/docs/source/api/monarch.actor.rst
@@ -31,6 +31,8 @@ are launched across hosts. HostMesh represents a mesh of hosts. ProcMesh is a me
 
 .. autofunction:: this_proc
 
+.. autofunction:: default_bootstrap_cmd
+
 
 Defining Actors
 ===============

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -39,6 +39,7 @@ from monarch._src.actor.debugger.debug_controller import debug_controller
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import (
+    default_bootstrap_cmd,
     HostMesh,
     hosts_from_config,
     this_host,
@@ -70,6 +71,7 @@ __all__ = [
     "get_or_spawn_controller",
     "this_host",
     "this_proc",
+    "default_bootstrap_cmd",
     "HostMesh",
     "context",
     "hosts_from_config",


### PR DESCRIPTION
Summary:
users need this function in order to use `BootstrapCommand.with_env()`. It is mentioned in Monarch's public doc, but this function is still behind [a private module](https://github.com/meta-pytorch/monarch/blob/main/docs/source/actors.md?fbclid=IwY2xjawSwpk5wZG9mBGV4dG4DYWVtAjExAGJyaWQRMWRnbDJXbXNxcE1PQ1JEZDNzcnRjBmFwcF9pZAEwAAEeCXQ3kpG94UCcFM00_napubs8BqgLbYoxsHFbaomJr91TOIKjCNFBpmnVA3s_aem_P7ZE0RvYHb-YeFNctT9x-w#using-with_env-for-ergonomic-customization).

This diff makes it public.

Reviewed By: zdevito, shayne-fletcher

Differential Revision: D110208848


