### PR TITLE
Ensure entire RPC path covered by debug spans

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -200,7 +200,6 @@ pub trait Tx<M: RemoteMessage> {
     /// message is either delivered, or we eventually discover that
     /// the channel has failed and it will be sent back on `return_channel`.
     #[allow(clippy::result_large_err)] // TODO: Consider reducing the size of `SendError`.
-    #[tracing::instrument(level = "debug", skip_all)]
     fn try_post(&self, message: M, return_channel: oneshot::Sender<SendError<M>>) {
         self.do_post(message, Some(return_channel));
     }
@@ -1144,7 +1143,6 @@ impl<M: RemoteMessage> ChannelRx<M> {
 
 #[async_trait]
 impl<M: RemoteMessage> Rx<M> for ChannelRx<M> {
-    #[tracing::instrument(level = "debug", skip_all)]
     async fn recv(&mut self) -> Result<M, ChannelError> {
         tracing::trace!(
             name = "recv",

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -64,6 +64,7 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 use tokio::sync::watch;
+use tracing::Instrument;
 
 use super::*;
 use crate::RemoteMessage;
@@ -739,7 +740,7 @@ fn spawn_inner<M: RemoteMessage>(link: impl Link) -> super::ChannelTx<M> {
         }
 
         let _ = notify.send(TxStatus::Closed(reason));
-    });
+    }.instrument(tracing::debug_span!("net tx loop")));
     tx
 }
 

--- a/hyperactor/src/channel/net/duplex.rs
+++ b/hyperactor/src/channel/net/duplex.rs
@@ -416,6 +416,7 @@ enum Either {
 /// joins every dispatch in its `connections` `JoinSet`, so it
 /// finishes only after every recv/send loop has finished — same
 /// contract as the simplex [`dispatch_stream`](super::server::dispatch_stream).
+#[tracing::instrument(level = "debug", skip_all)]
 async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
     session_id: SessionId,
     stream: Box<dyn Stream>,
@@ -620,6 +621,7 @@ async fn dispatch_duplex_stream<In: RemoteMessage, Out: RemoteMessage>(
 /// spawned recv/send task; the client owns a cancellation token so
 /// callers can deterministically tear the session down via
 /// [`DuplexClient::join`].
+#[tracing::instrument(level = "debug", skip_all)]
 pub(crate) fn spawn<Out: RemoteMessage, In: RemoteMessage>(
     link: impl Link,
 ) -> DuplexClient<Out, In> {

--- a/hyperactor/src/channel/net/server.rs
+++ b/hyperactor/src/channel/net/server.rs
@@ -155,6 +155,7 @@ fn resolve_stream<S: Stream>(
 /// channel and return immediately. [`accept_loop`] joins every
 /// dispatch in its `connections` `JoinSet`, so it finishes only
 /// after every recv-loop has finished.
+#[tracing::instrument(level = "debug", skip_all)]
 pub(super) async fn dispatch_stream<M: RemoteMessage, S: Stream>(
     session_id: SessionId,
     streams: Option<(u8, Arc<StreamState<S>>)>,
@@ -310,6 +311,7 @@ pub(super) async fn dispatch_stream<M: RemoteMessage, S: Stream>(
 /// [`dispatch_stream`]: first dispatch for a given (`session_id`,
 /// `stream_id`) runs the recv-loop inline; reconnects hand off via
 /// the per-stream channel and return.
+#[tracing::instrument(level = "debug", skip_all)]
 async fn dispatch_multi_stream<M: RemoteMessage, S: Stream>(
     session_id: SessionId,
     stream_id: u8,
@@ -633,6 +635,7 @@ impl Future for ServerHandle {
 /// Serve new connections on the given address, optionally using a pre-opened TCP listener.
 /// When `prebound_listener` is `Some`, it is used instead of binding a new socket.
 /// This is only supported for TCP-based transports (Tcp, Tls, MetaTls).
+#[tracing::instrument(level = "debug", skip_all)]
 pub(in crate::channel) fn serve<M: RemoteMessage>(
     addr: ChannelAddr,
     prebound_listener: Option<std::net::TcpListener>,
@@ -736,6 +739,7 @@ pub(in crate::channel) fn serve<M: RemoteMessage>(
 /// Test-only variant that accepts an arbitrary `Listener`. Used by
 /// mock-link tests that cannot go through `net::listen()`.
 #[cfg(test)]
+#[tracing::instrument(level = "debug", skip_all)]
 pub(super) fn serve_with_listener<M, L>(
     mut listener: L,
     channel_addr: ChannelAddr,

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -137,6 +137,7 @@ use tokio::sync::oneshot;
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
+use tracing::Instrument;
 use typeuri::Named;
 
 use crate::ActorAddr;
@@ -1447,7 +1448,7 @@ pub trait MailboxServer: MailboxSender + Clone + Sized + 'static {
             rx.join().await;
 
             result
-        });
+        }.instrument(tracing::debug_span!("MailboxServer")));
 
         MailboxServerHandle {
             join_handle,
@@ -1474,14 +1475,17 @@ impl<T: Message> Buffer<T> {
     {
         let (queue, mut next) = mpsc::unbounded_channel();
         let (last_processed, processed) = watch::channel(0);
-        crate::init::get_runtime().spawn(async move {
-            let mut seq = 0;
-            while let Some((msg, return_handle)) = next.recv().await {
-                process(msg, return_handle).await;
-                seq += 1;
-                let _ = last_processed.send(seq);
+        crate::init::get_runtime().spawn(
+            async move {
+                let mut seq = 0;
+                while let Some((msg, return_handle)) = next.recv().await {
+                    process(msg, return_handle).await;
+                    seq += 1;
+                    let _ = last_processed.send(seq);
+                }
             }
-        });
+            .instrument(tracing::debug_span!("mailbox::Buffer")),
+        );
         Self {
             queue,
             processed,
@@ -1652,7 +1656,6 @@ impl MailboxClient {
 
 #[async_trait]
 impl MailboxSender for MailboxClient {
-    #[tracing::instrument(level = "debug", skip_all)]
     fn post_unchecked(
         &self,
         envelope: MessageEnvelope,

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -2001,6 +2001,7 @@ impl Port {
         self.port_ref.set_return_undeliverable(value);
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn send(&mut self, py: Python<'_>, obj: Py<PyAny>) -> PyResult<()> {
         let message = PythonMessage::new_from_buf(
             PythonMessageKind::Result { rank: self.rank },
@@ -2012,6 +2013,7 @@ impl Port {
             .map_err(|e| PyRuntimeError::new_err(e.to_string()))
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn send_message(&mut self, message: PythonMessage) -> PyResult<()> {
         self.port_ref
             .post_with_headers(&self.instance, self.reply_headers.clone(), message)

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -34,6 +34,7 @@ use pyo3::types::PyBytes;
 use pyo3::types::PyTuple;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::mpsc::unbounded_channel;
+use tracing::Instrument;
 
 use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
@@ -382,58 +383,65 @@ impl ActorMeshProtocol for AsyncActorMesh {
             PythonMessageKind::CallMethod { response_port, .. } => response_port.clone(),
             _ => None,
         };
-        self.push(async move {
-            let result = async {
-                let resolved = message.resolve().await?;
-                mesh.await?
-                    .cast_with_headers(resolved, selection, &instance, caller_headers)
-            }
-            .await;
-            if let (Some(mut port_ref), Err(pyerr)) = (port, result) {
-                let _ = monarch_with_gil(GilSite::Traceback, |py: Python<'_>| {
-                    let exception_str = crate::logging::format_traceback(py, &pyerr);
-                    tracing::error!(
-                        actor_id = instance.self_addr().to_string(),
-                        "error occurred during cast unresolved: {}",
-                        exception_str
-                    );
-
-                    // Endpoint calls create a response port: the
-                    // PortRef is sent to the remote worker (to send
-                    // results back), and collect_valuemesh owns the
-                    // PortReceiver. If mesh.cast() fails here, we try
-                    // to send the exception back to the caller via
-                    // the PortRef ourselves. But a supervision event
-                    // can cause collect_valuemesh to drop the
-                    // PortReceiver (removing the port from the
-                    // mailbox) before we get here. Disable
-                    // return-undeliverable so a delivery failure
-                    // doesn't bounce back and crash the root client.
-                    //
-                    // TODO: Tie the lifetime of this queued work to
-                    // the PortReceiver (e.g. a cancellation token set
-                    // on drop) so we can distinguish
-                    // supervision-caused failures — where the caller
-                    // already knows — from other cast errors where
-                    // the caller actually needs this exception.
-
-                    port_ref.set_return_undeliverable(false);
-
-                    let mut state =
-                        crate::pickle::pickle(py, pyerr.into_value(py).into_any(), false, false)?;
-                    let _ = port_ref.post(
-                        &instance,
-                        PythonMessage::new_from_buf(
-                            PythonMessageKind::Exception { rank: Some(0) },
-                            state.take_inner()?.take_buffer(),
-                        ),
-                    );
-
-                    Ok::<_, PyErr>(())
-                })
+        self.push(
+            async move {
+                let result = async {
+                    let resolved = message.resolve().await?;
+                    mesh.await?
+                        .cast_with_headers(resolved, selection, &instance, caller_headers)
+                }
                 .await;
+                if let (Some(mut port_ref), Err(pyerr)) = (port, result) {
+                    let _ = monarch_with_gil(GilSite::Traceback, |py: Python<'_>| {
+                        let exception_str = crate::logging::format_traceback(py, &pyerr);
+                        tracing::error!(
+                            actor_id = instance.self_addr().to_string(),
+                            "error occurred during cast unresolved: {}",
+                            exception_str
+                        );
+
+                        // Endpoint calls create a response port: the
+                        // PortRef is sent to the remote worker (to send
+                        // results back), and collect_valuemesh owns the
+                        // PortReceiver. If mesh.cast() fails here, we try
+                        // to send the exception back to the caller via
+                        // the PortRef ourselves. But a supervision event
+                        // can cause collect_valuemesh to drop the
+                        // PortReceiver (removing the port from the
+                        // mailbox) before we get here. Disable
+                        // return-undeliverable so a delivery failure
+                        // doesn't bounce back and crash the root client.
+                        //
+                        // TODO: Tie the lifetime of this queued work to
+                        // the PortReceiver (e.g. a cancellation token set
+                        // on drop) so we can distinguish
+                        // supervision-caused failures — where the caller
+                        // already knows — from other cast errors where
+                        // the caller actually needs this exception.
+
+                        port_ref.set_return_undeliverable(false);
+
+                        let mut state = crate::pickle::pickle(
+                            py,
+                            pyerr.into_value(py).into_any(),
+                            false,
+                            false,
+                        )?;
+                        let _ = port_ref.post(
+                            &instance,
+                            PythonMessage::new_from_buf(
+                                PythonMessageKind::Exception { rank: Some(0) },
+                                state.take_inner()?.take_buffer(),
+                            ),
+                        );
+
+                        Ok::<_, PyErr>(())
+                    })
+                    .await;
+                }
             }
-        });
+            .instrument(tracing::debug_span!("AsyncActorMesh::cast")),
+        );
         Ok(())
     }
 

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -351,6 +351,7 @@ async fn collect_value(
     }
 }
 
+#[tracing::instrument(level = "debug", skip_all)]
 async fn collect_valuemesh(
     extent: Extent,
     rx: OncePortReceiver<PythonMessage>,
@@ -664,6 +665,7 @@ pub(crate) trait Endpoint {
     }
 
     /// Call the endpoint on all actors and collect all responses into a ValueMesh.
+    #[tracing::instrument(level = "debug", skip_all)]
     fn call<'py>(
         &self,
         py: Python<'py>,


### PR DESCRIPTION
Summary: When run with debug level logging (`MONARCH_FILE_LOG=debug`) we want to ensure to for the whole e2e path of an rpc we are at least able to see 1 level of where compute is currently being spent

Reviewed By: thedavekwon

Differential Revision: D110210620


