### PR TITLE
add an out-of-band mesh-reference table to PythonMessage (#4330)

### DIFF
--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -419,9 +419,10 @@ impl Invocation {
                                         overlay
                                             .push_run(
                                                 rank..rank + 1,
-                                                PythonResponseMessage::Exception(
-                                                    exception.as_ref().message.clone(),
-                                                ),
+                                                PythonResponseMessage::Exception {
+                                                    part: exception.as_ref().message.clone(),
+                                                    refs: exception.as_ref().refs.clone(),
+                                                },
                                             )
                                             .expect("exception runs should not overlap");
                                     }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -40,9 +40,12 @@ use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::UndeliverableReason;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
+use hyperactor_mesh::ProcMeshRef;
+use hyperactor_mesh::actor_mesh::ActorMeshRef;
 use hyperactor_mesh::casting::update_undeliverable_envelope_for_casting;
 use hyperactor_mesh::comm::multicast::CAST_POINT;
 use hyperactor_mesh::comm::multicast::CastInfo;
+use hyperactor_mesh::host_mesh::HostMeshRef;
 use hyperactor_mesh::introspect::ActiveHandler;
 use hyperactor_mesh::introspect::EXECUTION;
 use hyperactor_mesh::introspect::Execution;
@@ -148,8 +151,14 @@ impl MethodSpecifier {
 /// a single run.
 #[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
 pub enum PythonResponseMessage {
-    Result(serde_multipart::Part),
-    Exception(serde_multipart::Part),
+    Result {
+        part: serde_multipart::Part,
+        refs: Vec<MeshRef>,
+    },
+    Exception {
+        part: serde_multipart::Part,
+        refs: Vec<MeshRef>,
+    },
 }
 
 wirevalue::register_type!(PythonResponseMessage);
@@ -200,11 +209,21 @@ fn mailbox<'py, T: Actor>(py: Python<'py>, cx: &Context<'_, T>) -> Bound<'py, Py
     mailbox.into_bound_py_any(py).unwrap()
 }
 
+/// A serializable reference to a mesh (actor, proc, or host).
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+pub enum MeshRef {
+    Actor(Box<ActorMeshRef<PythonActor>>),
+    Proc(Box<ProcMeshRef>),
+    Host(Box<HostMeshRef>),
+}
+
 #[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
 #[derive(Clone, Serialize, Deserialize, Named, Default, PartialEq)]
 pub struct PythonMessage {
     pub kind: PythonMessageKind,
     pub message: Part,
+    /// Mesh references carried out-of-band from the pickled `message`.
+    pub refs: Vec<MeshRef>,
 }
 
 /// Extract the endpoint method name from a [`PythonMessage`].
@@ -241,6 +260,7 @@ impl From<ValueOverlay<PythonResponseMessage>> for PythonMessage {
         PythonMessage {
             kind: PythonMessageKind::AccumulatedResponses(AccumulatedResponses(overlay)),
             message: Default::default(),
+            refs: Vec::new(),
         }
     }
 }
@@ -256,7 +276,13 @@ impl PythonMessage {
             PythonMessageKind::Result { rank, .. } => {
                 let rank = rank.expect("accumulated response should have a rank");
                 let mut overlay = ValueOverlay::new();
-                overlay.push_run(rank..rank + 1, PythonResponseMessage::Result(self.message))?;
+                overlay.push_run(
+                    rank..rank + 1,
+                    PythonResponseMessage::Result {
+                        part: self.message,
+                        refs: self.refs,
+                    },
+                )?;
                 Ok(overlay)
             }
             PythonMessageKind::Exception { rank, .. } => {
@@ -264,7 +290,10 @@ impl PythonMessage {
                 let mut overlay = ValueOverlay::new();
                 overlay.push_run(
                     rank..rank + 1,
-                    PythonResponseMessage::Exception(self.message),
+                    PythonResponseMessage::Exception {
+                        part: self.message,
+                        refs: self.refs,
+                    },
                 )?;
                 Ok(overlay)
             }
@@ -324,6 +353,7 @@ impl PythonMessage {
         Self {
             kind,
             message: message.into(),
+            refs: Vec::new(),
         }
     }
 
@@ -333,10 +363,12 @@ impl PythonMessage {
             PythonMessageKind::Result { .. } => PythonMessage {
                 kind: PythonMessageKind::Result { rank },
                 message: self.message,
+                refs: self.refs,
             },
             PythonMessageKind::Exception { .. } => PythonMessage {
                 kind: PythonMessageKind::Exception { rank },
                 message: self.message,
+                refs: self.refs,
             },
             _ => panic!("PythonMessage is not a response but {:?}", self),
         }
@@ -446,6 +478,7 @@ impl std::fmt::Debug for PythonMessage {
                 "message",
                 &wirevalue::HexFmt(&(*self.message.to_bytes())[..]).to_string(),
             )
+            .field("refs", &self.refs.len())
             .finish()
     }
 }
@@ -2100,6 +2133,7 @@ mod tests {
                 response_port: Some(EitherPortRef::Unbounded(port_ref.clone().into())),
             },
             message: Part::from(vec![1, 2, 3]),
+            refs: Vec::new(),
         };
         {
             let mut multipart_message =

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -417,11 +417,11 @@ async fn collect_valuemesh(
                     overlay.runs().try_fold(
                         Vec::with_capacity(expected_count),
                         |mut parts, (range, payload)| match payload {
-                            PythonResponseMessage::Result(part) => {
+                            PythonResponseMessage::Result { part, .. } => {
                                 parts.extend(range.clone().map(|_| part.clone()));
                                 Ok(parts)
                             }
-                            PythonResponseMessage::Exception(part) => {
+                            PythonResponseMessage::Exception { part, .. } => {
                                 record_guard.mark_error();
                                 monarch_with_gil_blocking(GilSite::Traceback, |py| {
                                     Err(PyErr::from_value(unpickle_from_part(py, part.clone())?))

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -708,6 +708,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
             },
             message: pickled_args.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);
@@ -791,6 +792,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: None,
             },
             message: pickled.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);
@@ -832,6 +834,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: None,
             },
             message: pickled.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);

--- a/python/tests/test_deferred_pickle_characterization.py
+++ b/python/tests/test_deferred_pickle_characterization.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Characterization oracle for deferred pickling.
+
+Pins today's observable behavior: a mesh reference that is still *pending*
+(spawned and sent in the same breath, before its background init finishes)
+arrives at the other side as a usable reference, on both send paths: as an
+endpoint argument (request path) and as an endpoint return value (reply path).
+Today this rides the deferred-pickle subsystem (resolve-before-send plus a
+re-pickle); a change to how pending references serialize must preserve these
+outcomes. This is the safety net such a change checks against.
+
+There is no hook to force the pending path; it relies on the
+spawn-then-immediately-send race, which the synchronous pickle wins in practice
+(the async mesh init cannot complete in the gap). The tests assert the
+end-to-end outcome, which is what must be preserved either way.
+"""
+
+from __future__ import annotations
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._src.actor.actor_mesh import Actor
+from monarch._src.actor.endpoint import endpoint
+from monarch._src.actor.host_mesh import this_host
+from monarch._src.job.process import ProcessJob
+from scoped_state import scoped_state
+
+
+class _Target(Actor):
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+
+class _Receiver(Actor):
+    @endpoint
+    async def use_mesh(self, target: _Target) -> list[str]:
+        # Use the mesh we were handed (it was pending when it was sent).
+        results = await target.ping.call()
+        return [value for _, value in results]
+
+
+class _Spawner(Actor):
+    @endpoint
+    async def spawn_and_return_pending(self) -> _Target:
+        # Spawn a fresh mesh and return it without awaiting init, so it is
+        # pending when this reply is pickled.
+        return this_host().spawn_procs(name="inner_proc").spawn("inner", _Target)
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_mesh_sent_as_endpoint_argument_resolves_on_receiver() -> None:
+    """Request path: a just-spawned (pending) mesh passed as an endpoint argument
+    reaches the receiver as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        receiver = host.spawn_procs(name="recv_proc").spawn("receiver", _Receiver)
+        # Spawned and sent in the same breath: pending at pickle time.
+        target = host.spawn_procs(name="target_proc").spawn("target", _Target)
+        result = receiver.use_mesh.call_one(target).get()
+        assert result == ["pong"]
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_mesh_returned_from_endpoint_resolves_on_caller() -> None:
+    """Reply path: a just-spawned (pending) mesh returned from an endpoint reaches
+    the caller as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _Spawner)
+        returned = spawner.spawn_and_return_pending.call_one().get()
+        result = returned.ping.call_one().get()
+        assert result == "pong"
+
+
+class _ProcReceiver(Actor):
+    @endpoint
+    async def use_proc_mesh(self, proc_mesh) -> list[str]:
+        # Use the proc mesh we were handed (it was pending when it was sent).
+        actors = proc_mesh.spawn("inner", _Target)
+        results = await actors.ping.call()
+        return [value for _, value in results]
+
+
+class _ProcSpawner(Actor):
+    @endpoint
+    async def spawn_and_return_pending_proc(self):
+        # Return a fresh proc mesh without awaiting init, so it is pending when
+        # this reply is pickled.
+        return this_host().spawn_procs(name="inner_proc")
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_proc_mesh_sent_as_endpoint_argument_resolves_on_receiver() -> None:
+    """Request path: a just-spawned (pending) proc mesh passed as an endpoint
+    argument reaches the receiver as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        receiver = host.spawn_procs(name="recv_proc").spawn("receiver", _ProcReceiver)
+        # Spawned and sent in the same breath: pending at pickle time.
+        proc_mesh = host.spawn_procs(name="target_proc")
+        result = receiver.use_proc_mesh.call_one(proc_mesh).get()
+        assert result == ["pong"]
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_proc_mesh_returned_from_endpoint_resolves_on_caller() -> None:
+    """Reply path: a just-spawned (pending) proc mesh returned from an endpoint
+    reaches the caller as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _ProcSpawner)
+        returned = spawner.spawn_and_return_pending_proc.call_one().get()
+        actors = returned.spawn("t", _Target)
+        result = actors.ping.call_one().get()
+        assert result == "pong"


### PR DESCRIPTION
Summary:

adds a `refs: Vec<MeshRef>` field to `PythonMessage`, where `MeshRef` is a serializable reference to a mesh (actor, proc, or host). this is the out-of-band channel for mesh references that today ride the deferred-pickle path (resolve-before-send plus a second serialization pass); later diffs fill it sender-side and read it on unpickle with no re-pickle, then delete the deferral subsystem.

this diff only lands the field, empty: nothing populates or reads it yet, so it is behavior-preserving. `Vec` keeps `PythonMessage` deriving `Default` even though the ref types are not `Default`, so no derive changed, and `into_rank` carries `self.refs` so rank-stamped replies will preserve the table. `hyperactor_mesh` was already a dependency, so there is no BUCK change.

Differential Revision: D110216335


