### PR TITLE
route mesh references through the refs table, gated off (#4331)

### DIFF
--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -619,7 +619,7 @@ impl History {
                     let exe = remote_exception
                         .call1((exception.backtrace, traceback, rank))
                         .unwrap();
-                    let mut state = pickle(py, exe.unbind(), false, false).unwrap();
+                    let mut state = pickle(py, exe.unbind(), false, false, false).unwrap();
                     let inner = state.take_inner().unwrap();
                     PythonMessage::new_from_buf(
                         PythonMessageKind::Exception { rank: Some(rank) },

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -419,9 +419,10 @@ impl Invocation {
                                         overlay
                                             .push_run(
                                                 rank..rank + 1,
-                                                PythonResponseMessage::Exception(
-                                                    exception.as_ref().message.clone(),
-                                                ),
+                                                PythonResponseMessage::Exception {
+                                                    part: exception.as_ref().message.clone(),
+                                                    refs: exception.as_ref().refs.clone(),
+                                                },
                                             )
                                             .expect("exception runs should not overlap");
                                     }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -217,6 +217,65 @@ pub enum MeshRef {
     Host(Box<HostMeshRef>),
 }
 
+impl MeshRef {
+    /// Reconstruct the Python mesh wrapper this reference points at.
+    ///
+    /// Mirrors the `py_*_from_bytes` reconstructors, but takes an
+    /// already-deserialized [`MeshRef`] from the message's `refs` table.
+    pub(crate) fn reconstruct(self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        match self {
+            MeshRef::Proc(r) => {
+                Ok(Py::new(py, crate::proc_mesh::PyProcMesh::new_ref(*r))?.into_any())
+            }
+            MeshRef::Host(r) => {
+                Ok(Py::new(py, crate::host_mesh::PyHostMesh::new_ref(*r))?.into_any())
+            }
+            MeshRef::Actor(r) => {
+                let inner = crate::actor_mesh::PythonActorMeshImpl::new_ref(*r);
+                let async_mesh = crate::actor_mesh::AsyncActorMesh::from_impl(Arc::new(inner));
+                let mesh = crate::actor_mesh::PythonActorMesh::from_impl(Arc::from(async_mesh));
+                Ok(Py::new(py, mesh)?.into_any())
+            }
+        }
+    }
+}
+
+/// An opaque carrier so a `MeshRef` can ride in `PythonMessage.refs` across
+/// the Python boundary (the message getter out, the `PicklingState` ctor in).
+#[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
+pub struct PyMeshRef {
+    pub(crate) inner: MeshRef,
+}
+
+impl<'py> IntoPyObject<'py> for MeshRef {
+    type Target = PyMeshRef;
+    type Output = Bound<'py, PyMeshRef>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Bound::new(py, PyMeshRef { inner: self })
+    }
+}
+
+/// Extract the serializable [`MeshRef`] from a resolved mesh wrapper (the
+/// inverse of [`MeshRef::reconstruct`]), for the sender-side pending fill.
+pub(crate) fn mesh_ref_from_pyobject(value: &Bound<'_, PyAny>) -> PyResult<MeshRef> {
+    if let Ok(m) = value.downcast::<crate::proc_mesh::PyProcMesh>() {
+        return Ok(MeshRef::Proc(Box::new(m.borrow().mesh_ref()?)));
+    }
+    if let Ok(m) = value.downcast::<crate::host_mesh::PyHostMesh>() {
+        return Ok(MeshRef::Host(Box::new(m.borrow().mesh_ref().map_err(
+            |e| pyo3::exceptions::PyValueError::new_err(e.to_string()),
+        )?)));
+    }
+    if let Ok(m) = value.downcast::<crate::actor_mesh::PythonActorMesh>() {
+        return Ok(MeshRef::Actor(Box::new(m.borrow().get_inner().mesh_ref()?)));
+    }
+    Err(pyo3::exceptions::PyRuntimeError::new_err(
+        "pending pickle did not resolve to a mesh reference",
+    ))
+}
+
 #[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
 #[derive(Clone, Serialize, Deserialize, Named, Default, PartialEq)]
 pub struct PythonMessage {
@@ -311,6 +370,7 @@ struct ResolvedCallMethod {
     method: MethodSpecifier,
     bytes: FrozenBuffer,
     local_state: Option<Py<PyAny>>,
+    mesh_references: Vec<MeshRef>,
     /// Implements PortProtocol
     /// Concretely either a Port, DroppingPort, or LocalPort
     response_port: ResponsePort,
@@ -345,15 +405,25 @@ pub struct QueuedMessage {
     #[pyo3(get)]
     pub local_state: Py<PyAny>,
     #[pyo3(get)]
+    pub refs: Py<PyAny>,
+    #[pyo3(get)]
     pub response_port: Py<PyAny>,
 }
 
 impl PythonMessage {
     pub fn new_from_buf(kind: PythonMessageKind, message: impl Into<Part>) -> Self {
+        Self::new_from_buf_with_refs(kind, message, Vec::new())
+    }
+
+    pub fn new_from_buf_with_refs(
+        kind: PythonMessageKind,
+        message: impl Into<Part>,
+        refs: Vec<MeshRef>,
+    ) -> Self {
         Self {
             kind,
             message: message.into(),
-            refs: Vec::new(),
+            refs,
         }
     }
 
@@ -416,6 +486,7 @@ impl PythonMessage {
                             inner: self.message.into_bytes(),
                         },
                         local_state,
+                        mesh_references: self.refs,
                         response_port,
                     })
                 })
@@ -460,6 +531,7 @@ impl PythonMessage {
                         inner: self.message.into_bytes(),
                     },
                     local_state: None,
+                    mesh_references: self.refs,
                     response_port,
                 })
             }
@@ -501,6 +573,11 @@ impl PythonMessage {
         FrozenBuffer {
             inner: self.message.to_bytes(),
         }
+    }
+
+    #[getter]
+    fn refs(&self) -> Vec<MeshRef> {
+        self.refs.clone()
     }
 }
 
@@ -1614,6 +1691,7 @@ impl PythonActor {
                         resolved
                             .local_state
                             .unwrap_or_else(|| PyList::empty(py).unbind().into()),
+                        resolved.mesh_references.into_py_any(py)?,
                         resolved.response_port.into_py_any(py)?,
                     ),
                     None,
@@ -1664,6 +1742,7 @@ impl PythonActor {
                     local_state: resolved
                         .local_state
                         .unwrap_or_else(|| PyList::empty(py).unbind().into()),
+                    refs: resolved.mesh_references.into_py_any(py)?,
                     response_port: resolved.response_port.into_py_any(py)?,
                 })
             },
@@ -2087,6 +2166,7 @@ impl Port {
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PythonActorHandle>()?;
     hyperactor_mod.add_class::<PythonMessage>()?;
+    hyperactor_mod.add_class::<PyMeshRef>()?;
     hyperactor_mod.add_class::<PythonMessageKind>()?;
     hyperactor_mod.add_class::<MethodSpecifier>()?;
     hyperactor_mod.add_class::<UnflattenArg>()?;

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -40,9 +40,12 @@ use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::UndeliverableReason;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
+use hyperactor_mesh::ProcMeshRef;
+use hyperactor_mesh::actor_mesh::ActorMeshRef;
 use hyperactor_mesh::casting::update_undeliverable_envelope_for_casting;
 use hyperactor_mesh::comm::multicast::CAST_POINT;
 use hyperactor_mesh::comm::multicast::CastInfo;
+use hyperactor_mesh::host_mesh::HostMeshRef;
 use hyperactor_mesh::introspect::ActiveHandler;
 use hyperactor_mesh::introspect::EXECUTION;
 use hyperactor_mesh::introspect::Execution;
@@ -148,8 +151,14 @@ impl MethodSpecifier {
 /// a single run.
 #[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
 pub enum PythonResponseMessage {
-    Result(serde_multipart::Part),
-    Exception(serde_multipart::Part),
+    Result {
+        part: serde_multipart::Part,
+        refs: Vec<MeshRef>,
+    },
+    Exception {
+        part: serde_multipart::Part,
+        refs: Vec<MeshRef>,
+    },
 }
 
 wirevalue::register_type!(PythonResponseMessage);
@@ -200,11 +209,21 @@ fn mailbox<'py, T: Actor>(py: Python<'py>, cx: &Context<'_, T>) -> Bound<'py, Py
     mailbox.into_bound_py_any(py).unwrap()
 }
 
+/// A serializable reference to a mesh (actor, proc, or host).
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+pub enum MeshRef {
+    Actor(Box<ActorMeshRef<PythonActor>>),
+    Proc(Box<ProcMeshRef>),
+    Host(Box<HostMeshRef>),
+}
+
 #[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
 #[derive(Clone, Serialize, Deserialize, Named, Default, PartialEq)]
 pub struct PythonMessage {
     pub kind: PythonMessageKind,
     pub message: Part,
+    /// Mesh references carried out-of-band from the pickled `message`.
+    pub refs: Vec<MeshRef>,
 }
 
 /// Extract the endpoint method name from a [`PythonMessage`].
@@ -241,6 +260,7 @@ impl From<ValueOverlay<PythonResponseMessage>> for PythonMessage {
         PythonMessage {
             kind: PythonMessageKind::AccumulatedResponses(AccumulatedResponses(overlay)),
             message: Default::default(),
+            refs: Vec::new(),
         }
     }
 }
@@ -256,7 +276,13 @@ impl PythonMessage {
             PythonMessageKind::Result { rank, .. } => {
                 let rank = rank.expect("accumulated response should have a rank");
                 let mut overlay = ValueOverlay::new();
-                overlay.push_run(rank..rank + 1, PythonResponseMessage::Result(self.message))?;
+                overlay.push_run(
+                    rank..rank + 1,
+                    PythonResponseMessage::Result {
+                        part: self.message,
+                        refs: self.refs,
+                    },
+                )?;
                 Ok(overlay)
             }
             PythonMessageKind::Exception { rank, .. } => {
@@ -264,7 +290,10 @@ impl PythonMessage {
                 let mut overlay = ValueOverlay::new();
                 overlay.push_run(
                     rank..rank + 1,
-                    PythonResponseMessage::Exception(self.message),
+                    PythonResponseMessage::Exception {
+                        part: self.message,
+                        refs: self.refs,
+                    },
                 )?;
                 Ok(overlay)
             }
@@ -324,6 +353,7 @@ impl PythonMessage {
         Self {
             kind,
             message: message.into(),
+            refs: Vec::new(),
         }
     }
 
@@ -333,10 +363,12 @@ impl PythonMessage {
             PythonMessageKind::Result { .. } => PythonMessage {
                 kind: PythonMessageKind::Result { rank },
                 message: self.message,
+                refs: self.refs,
             },
             PythonMessageKind::Exception { .. } => PythonMessage {
                 kind: PythonMessageKind::Exception { rank },
                 message: self.message,
+                refs: self.refs,
             },
             _ => panic!("PythonMessage is not a response but {:?}", self),
         }
@@ -446,6 +478,7 @@ impl std::fmt::Debug for PythonMessage {
                 "message",
                 &wirevalue::HexFmt(&(*self.message.to_bytes())[..]).to_string(),
             )
+            .field("refs", &self.refs.len())
             .finish()
     }
 }
@@ -2100,6 +2133,7 @@ mod tests {
                 response_port: Some(EitherPortRef::Unbounded(port_ref.clone().into())),
             },
             message: Part::from(vec![1, 2, 3]),
+            refs: Vec::new(),
         };
         {
             let mut multipart_message =

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -142,6 +142,14 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>;
 
+    /// The serializable reference for this mesh, for the out-of-band `refs`
+    /// table. Defaults to an error; impls that hold a resolved ref override.
+    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>> {
+        Err(pyo3::exceptions::PyRuntimeError::new_err(
+            "mesh_ref() is not available for this actor mesh",
+        ))
+    }
+
     /// Stop the actor mesh asynchronously.
     /// Default implementation raises NotImplementedError for types that don't support stopping.
     fn stop(&self, _instance: &PyInstance, _reason: String) -> PyResult<PyPythonTask> {
@@ -426,6 +434,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
                             pyerr.into_value(py).into_any(),
                             false,
                             false,
+                            false,
                         )?;
                         let _ = port_ref.post(
                             &instance,
@@ -453,9 +462,16 @@ impl ActorMeshProtocol for AsyncActorMesh {
                 let shared =
                     PyPythonTask::new(async move { Ok(PythonActorMesh::from_impl(fut.await?)) })?
                         .spawn_abortable()?;
+                let shared = Py::new(py, shared)?;
+                if crate::pickle::reserve_mesh_reference_if_active(shared.clone_ref(py)) {
+                    let pop_fn = py
+                        .import("monarch._rust_bindings.monarch_hyperactor.pickle")?
+                        .getattr("pop_mesh_reference")?;
+                    return Ok((pop_fn, PyTuple::empty(py).into_any()));
+                }
                 // Get Shared.block_on as an unbound method
                 let block_on = shared_class(py).getattr("block_on")?;
-                let args = PyTuple::new(py, [shared.into_pyobject(py)?])?;
+                let args = PyTuple::new(py, [shared])?;
                 Ok((block_on, args.into_any()))
             }
         }
@@ -637,6 +653,11 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
         self.mesh_ref().__reduce__(py)
     }
 
+    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>> {
+        // `self.mesh_ref()` resolves to the inherent borrow-returning method.
+        Ok(PythonActorMeshImpl::mesh_ref(self).clone())
+    }
+
     fn name(&self) -> PyResult<PyPythonTask> {
         let name = self.mesh_ref().id().to_string();
         PyPythonTask::new(async move { Ok(name) })
@@ -711,6 +732,14 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        if crate::pickle::push_mesh_reference_if_active(crate::actor::MeshRef::Actor(Box::new(
+            self.clone(),
+        ))) {
+            let pop_fn = py
+                .import("monarch._rust_bindings.monarch_hyperactor.pickle")?
+                .getattr("pop_mesh_reference")?;
+            return Ok((pop_fn, pyo3::types::PyTuple::empty(py).into_any()));
+        }
         let bytes = bincode::serde::encode_to_vec(self, bincode::config::legacy())
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
@@ -719,6 +748,10 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
             .unwrap();
         let from_bytes = module.getattr("py_actor_mesh_from_bytes").unwrap();
         Ok((from_bytes, py_bytes))
+    }
+
+    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>> {
+        Ok(self.clone())
     }
 
     fn name(&self) -> PyResult<PyPythonTask> {

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -417,11 +417,11 @@ async fn collect_valuemesh(
                     overlay.runs().try_fold(
                         Vec::with_capacity(expected_count),
                         |mut parts, (range, payload)| match payload {
-                            PythonResponseMessage::Result(part) => {
+                            PythonResponseMessage::Result { part, .. } => {
                                 parts.extend(range.clone().map(|_| part.clone()));
                                 Ok(parts)
                             }
-                            PythonResponseMessage::Exception(part) => {
+                            PythonResponseMessage::Exception { part, .. } => {
                                 record_guard.mark_error();
                                 monarch_with_gil_blocking(GilSite::Traceback, |py| {
                                     Err(PyErr::from_value(unpickle_from_part(py, part.clone())?))

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -149,7 +149,7 @@ impl PyHostMesh {
         Self::Ref(PyHostMeshRefImpl(inner))
     }
 
-    fn mesh_ref(&self) -> Result<HostMeshRef, anyhow::Error> {
+    pub(crate) fn mesh_ref(&self) -> Result<HostMeshRef, anyhow::Error> {
         match self {
             PyHostMesh::Owned(inner) => Ok(inner.0.borrow()?.clone()),
             PyHostMesh::Ref(inner) => Ok(inner.0.clone()),
@@ -239,7 +239,15 @@ impl PyHostMesh {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
-        let bytes = bincode::serde::encode_to_vec(&self.mesh_ref()?, bincode::config::legacy())
+        let mesh_ref = self.mesh_ref()?;
+        if crate::pickle::push_mesh_reference_if_active(crate::actor::MeshRef::Host(Box::new(
+            mesh_ref.clone(),
+        ))) {
+            let pop_fn = PyModule::import(py, "monarch._rust_bindings.monarch_hyperactor.pickle")?
+                .getattr("pop_mesh_reference")?;
+            return Ok((pop_fn, pyo3::types::PyTuple::empty(py).into_any()));
+        }
+        let bytes = bincode::serde::encode_to_vec(&mesh_ref, bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
         let from_bytes =

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -22,6 +22,8 @@ use pyo3::types::PyList;
 use pyo3::types::PyTuple;
 use serde_multipart::Part;
 
+use crate::actor::MeshRef;
+use crate::actor::PyMeshRef;
 use crate::actor::PythonMessage;
 use crate::actor::PythonMessageKind;
 use crate::buffers::Buffer;
@@ -88,6 +90,14 @@ py_global!(
 // Thread-local storage for the active pickling state.
 // Set by pickle/unpickle operations so free functions used in __reduce__
 // implementations can access it.
+//
+// It is thread-local by design: two threads pickling at once (even the same
+// mesh ref) collect into independent `mesh_references` / `pending_mesh_fills`,
+// so there is nothing shared to race on. `pickle()` then moves the state out of
+// the thread-local into an owned `PicklingState` before the GIL-releasing
+// `PicklingState::resolve`, so the sender-side slot fill mutates a single-owner
+// value across its awaits, never this thread-local. Both properties (thread-
+// local, and moved out before resolve) are what make releasing the GIL safe.
 thread_local! {
     static ACTIVE_PICKLING_STATE: RefCell<Option<ActivePicklingState>> = const { RefCell::new(None) };
 }
@@ -125,20 +135,35 @@ struct ActivePicklingState {
     tensor_engine_references: VecDeque<Py<PyAny>>,
     /// Pending pickles (PyShared values) that must be resolved.
     pending_pickles: VecDeque<Py<PyShared>>,
+    /// Mesh references collected out-of-band into the message's `refs` table.
+    /// A `None` is a slot reserved for a pending mesh, filled sender-side.
+    mesh_references: VecDeque<Option<MeshRef>>,
+    /// Pending mesh slots awaiting a sender-side fill: (index into
+    /// `mesh_references`, the handle whose resolved mesh supplies the ref).
+    pending_mesh_fills: Vec<(usize, Py<PyShared>)>,
     /// Whether pending pickles are allowed in this pickling context.
     allow_pending_pickles: bool,
     /// Whether tensor engine references are allowed in this pickling context.
     allow_tensor_engine_references: bool,
+    /// Whether mesh references are collected out-of-band in this context.
+    allow_mesh_references: bool,
 }
 
 impl ActivePicklingState {
     /// Create a new ActivePicklingState.
-    fn new(allow_pending_pickles: bool, allow_tensor_engine_references: bool) -> Self {
+    fn new(
+        allow_pending_pickles: bool,
+        allow_tensor_engine_references: bool,
+        allow_mesh_references: bool,
+    ) -> Self {
         Self {
             tensor_engine_references: VecDeque::new(),
             pending_pickles: VecDeque::new(),
+            mesh_references: VecDeque::new(),
+            pending_mesh_fills: Vec::new(),
             allow_pending_pickles,
             allow_tensor_engine_references,
+            allow_mesh_references,
         }
     }
 
@@ -148,6 +173,8 @@ impl ActivePicklingState {
             buffer,
             tensor_engine_references: self.tensor_engine_references,
             pending_pickles: self.pending_pickles,
+            mesh_references: self.mesh_references,
+            pending_mesh_fills: self.pending_mesh_fills,
         }
     }
 }
@@ -163,6 +190,11 @@ pub struct PicklingStateInner {
     tensor_engine_references: VecDeque<Py<PyAny>>,
     /// Pending pickles (PyShared values) that must be resolved.
     pending_pickles: VecDeque<Py<PyShared>>,
+    /// Mesh references carried out-of-band into the message's `refs` table.
+    /// A `None` is a slot reserved for a pending mesh, filled sender-side.
+    mesh_references: VecDeque<Option<MeshRef>>,
+    /// Pending mesh slots awaiting a sender-side fill.
+    pending_mesh_fills: Vec<(usize, Py<PyShared>)>,
 }
 
 impl PicklingStateInner {
@@ -207,13 +239,24 @@ impl PicklingState {
     /// This is used for unpickling received messages that may contain tensor engine
     /// references that need to be restored during deserialization.
     #[new]
-    #[pyo3(signature = (buffer, tensor_engine_references=None))]
+    #[pyo3(signature = (buffer, tensor_engine_references=None, mesh_references=None))]
     fn py_new(
+        py: Python<'_>,
         buffer: PyRef<'_, crate::buffers::FrozenBuffer>,
         tensor_engine_references: Option<&Bound<'_, PyList>>,
+        mesh_references: Option<Vec<Py<PyMeshRef>>>,
     ) -> PyResult<Self> {
         let refs: VecDeque<Py<PyAny>> = tensor_engine_references
             .map(|list| list.iter().map(|item| item.unbind()).collect())
+            .unwrap_or_default();
+
+        // pyo3 type-checks each element as a `PyMeshRef` during extraction.
+        let mesh_refs: VecDeque<Option<MeshRef>> = mesh_references
+            .map(|list| {
+                list.into_iter()
+                    .map(|m| Some(m.borrow(py).inner.clone()))
+                    .collect()
+            })
             .unwrap_or_default();
 
         Ok(Self {
@@ -221,6 +264,8 @@ impl PicklingState {
                 buffer: Part::from(buffer.inner.clone()),
                 tensor_engine_references: refs,
                 pending_pickles: VecDeque::new(),
+                mesh_references: mesh_refs,
+                pending_mesh_fills: Vec::new(),
             }),
         })
     }
@@ -267,9 +312,11 @@ impl PicklingState {
 
         // Set up an active state for unpickling (to handle pop calls).
         // The guard restores any previous state on drop (including on panic).
-        let mut active = ActivePicklingState::new(false, false);
+        let mut active = ActivePicklingState::new(false, false, false);
         active.pending_pickles = inner.pending_pickles;
         active.tensor_engine_references = inner.tensor_engine_references;
+        active.mesh_references = inner.mesh_references;
+        active.pending_mesh_fills = inner.pending_mesh_fills;
 
         let _guard = ActivePicklingGuard::enter(active);
 
@@ -298,12 +345,46 @@ impl PicklingState {
     /// 3. Calls unpickle to reconstruct the object
     /// 4. Calls pickle again to get a new PicklingState without pending pickles
     pub async fn resolve(mut self) -> PyResult<PicklingState> {
-        // Short-circuit if there are no pending pickles
+        // Take the pending mesh fills out: a plain move, no GIL and no
+        // `clone_ref`. Each is a slot index plus the handle whose resolved mesh
+        // supplies the ref.
+        let fills = std::mem::take(
+            &mut self
+                .inner
+                .as_mut()
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "PicklingState has already been consumed",
+                    )
+                })?
+                .pending_mesh_fills,
+        );
+
+        for (index, handle) in fills {
+            // Await the mesh's init task (these run concurrently, so the wait
+            // is the slowest init, not the sum).
+            let mut task =
+                monarch_with_gil_blocking(GilSite::AwaitDrive, |py| handle.borrow(py).task())?;
+            task.take_task()?.await?;
+
+            // Extract the `*MeshRef` from the now-resolved mesh and fill the slot.
+            monarch_with_gil_blocking(GilSite::Convert, |py| -> PyResult<()> {
+                let value = handle.borrow(py).poll()?.ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err("pending mesh handle did not resolve")
+                })?;
+                let mesh_ref = crate::actor::mesh_ref_from_pyobject(value.bind(py))?;
+                if let Some(inner) = self.inner.as_mut() {
+                    inner.mesh_references[index] = Some(mesh_ref);
+                }
+                Ok(())
+            })?;
+        }
+
+        // Resolve any deferred (non-mesh) pending pickles by re-pickling. Empty
+        // for mesh-only messages, where the table filled above is the result.
         if self.inner_ref()?.pending_pickles.is_empty() {
             return Ok(self);
         }
-
-        // Await all pending pickles to ensure they're resolved
         let pending: Vec<Py<PyShared>> = monarch_with_gil_blocking(GilSite::Convert, |py| {
             self.inner_ref().map(|inner| {
                 inner
@@ -313,18 +394,15 @@ impl PicklingState {
                     .collect()
             })
         })?;
-
         for pending_pickle in pending {
             let mut task = monarch_with_gil_blocking(GilSite::AwaitDrive, |py| {
                 pending_pickle.borrow(py).task()
             })?;
             task.take_task()?.await?;
         }
-
-        // Unpickle (pending pickles are now resolved) and re-pickle without allowing new ones
         monarch_with_gil_blocking(GilSite::Convert, |py| {
             let obj = self.unpickle(py)?;
-            pickle(py, obj, false, true)
+            pickle(py, obj, false, true, false)
         })
     }
 }
@@ -358,19 +436,34 @@ impl PendingMessage {
         })
     }
 
-    /// Resolve all pending pickles and convert this into a PythonMessage.
+    /// Resolve any reserved mesh slots and convert this into a PythonMessage.
     ///
     /// This is an async method that:
-    /// 1. Awaits all pending pickles in the PicklingState
-    /// 2. Re-pickles the resolved object
-    /// 3. Returns a PythonMessage with the resolved bytes (no GIL needed for final step)
+    /// 1. Fills the reserved mesh slots from their pending handles
+    /// 2. Builds a PythonMessage with the resolved bytes and `refs` table
     pub async fn resolve(self) -> PyResult<PythonMessage> {
-        // Resolve the pickling state (awaits all pending pickles and re-pickles)
+        // Fill any reserved mesh slots, then build the message with the
+        // finalized `refs` table. No GIL needed for the assembly: neither the
+        // Part nor the MeshRef table holds Py<> values.
         let mut resolved_state = self.state.resolve().await?;
 
-        // Take the Part directly - no GIL needed since Part doesn't contain Py<>
         let inner = resolved_state.take_inner()?;
-        Ok(PythonMessage::new_from_buf(self.kind, inner.take_buffer()))
+        let refs: Vec<MeshRef> = inner
+            .mesh_references
+            .into_iter()
+            .map(|r| {
+                r.ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "mesh reference slot was never filled",
+                    )
+                })
+            })
+            .collect::<PyResult<_>>()?;
+        Ok(PythonMessage::new_from_buf_with_refs(
+            self.kind,
+            inner.buffer,
+            refs,
+        ))
     }
 }
 
@@ -476,6 +569,75 @@ fn pop_pending_pickle(py: Python<'_>) -> PyResult<Py<PyShared>> {
     })
 }
 
+/// Pop a mesh reference from the active pickling state and rebuild its
+/// Python mesh wrapper.
+///
+/// Called from the unpickle stream wherever a mesh slot was emitted in
+/// place of inline bytes.
+#[pyfunction]
+fn pop_mesh_reference(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    let mesh_ref = ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) => s.mesh_references.pop_front().ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err("No mesh references remaining")
+            }),
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "No active pickling state",
+            )),
+        }
+    })?;
+    let mesh_ref = mesh_ref.ok_or_else(|| {
+        pyo3::exceptions::PyRuntimeError::new_err("mesh reference slot was never filled")
+    })?;
+    mesh_ref.reconstruct(py)
+}
+
+/// Push a mesh reference to the active pickling state if mesh-reference
+/// collection is active in this context.
+///
+/// Returns true if the reference was collected (the caller emits a slot);
+/// false otherwise (the caller inlines the reference as usual).
+pub fn push_mesh_reference_if_active(mesh_ref: MeshRef) -> bool {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) if s.allow_mesh_references => {
+                s.mesh_references.push_back(Some(mesh_ref));
+                true
+            }
+            _ => false,
+        }
+    })
+}
+
+/// Reserve a slot for a *pending* mesh whose `*MeshRef` is not available yet,
+/// registering `handle` for a sender-side fill once the mesh resolves.
+///
+/// Returns true if a slot was reserved (the caller emits a `pop_mesh_reference`
+/// placeholder); false otherwise (the caller keeps its current behavior).
+pub fn reserve_mesh_reference_if_active(handle: Py<PyShared>) -> bool {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) if s.allow_mesh_references => {
+                let index = s.mesh_references.len();
+                s.mesh_references.push_back(None);
+                s.pending_mesh_fills.push((index, handle));
+                true
+            }
+            _ => false,
+        }
+    })
+}
+
+/// Python-callable wrapper over [`reserve_mesh_reference_if_active`] for the
+/// typed Proc/Host reduces, which reserve their pending slot from Python.
+#[pyfunction]
+fn reserve_mesh_reference(handle: Py<PyShared>) -> bool {
+    reserve_mesh_reference_if_active(handle)
+}
+
 /// Push a pending pickle to the active pickling state (Rust-only).
 ///
 /// This is used by __reduce__ implementations to register a PyShared
@@ -507,7 +669,7 @@ pub fn push_pending_pickle(py_shared: Py<PyShared>) -> PyResult<()> {
 ///
 /// This function implements the pickle protocol for PyShared:
 /// 1. If the shared is already finished, return (Shared.from_value, (value,))
-/// 2. If pending pickles are allowed, push it as a pending pickle and return (pop_pending_pickle, ())
+/// 2. If pending pickles are allowed, defer it and return (pop_pending_pickle, ())
 /// 3. Otherwise, block on the shared and return (Shared.from_value, (value,))
 pub fn reduce_shared<'py>(
     py: Python<'py>,
@@ -520,12 +682,13 @@ pub fn reduce_shared<'py>(
         return Ok((from_value, args));
     }
 
-    // Try to push as a pending pickle (will fail if not allowed or no active state)
+    // Pending: defer it (resolved sender-side in `PicklingState::resolve`).
+    // Meshes ride the out-of-band table via their own type-specific reducers;
+    // this generic path is the fallback for any other pending `PyShared`.
     let py_shared_py: Py<PyShared> = py_shared.clone().unbind();
     if push_pending_pickle(py_shared_py).is_ok() {
         let pop_fn = pop_pending_pickle_fn(py);
-        let args = PyTuple::empty(py);
-        return Ok((pop_fn, args));
+        return Ok((pop_fn, PyTuple::empty(py)));
     }
 
     // Fall back to blocking on the shared
@@ -563,7 +726,7 @@ fn pickle_into_buffer(py: Python<'_>, obj: &Py<PyAny>, buffer: &Py<Buffer>) -> P
 /// and tensor engine references, and returns the raw serialized bytes instead
 /// of a [`PicklingState`].
 pub fn pickle_to_part(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<Part> {
-    let active = ActivePicklingState::new(false, false);
+    let active = ActivePicklingState::new(false, false, false);
     let buffer = Py::new(py, Buffer::default())?;
     let _guard = ActivePicklingGuard::enter(active);
 
@@ -586,14 +749,19 @@ pub fn pickle_to_part(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<Part> {
 /// # Returns
 /// A PicklingState containing the pickled buffer and any registered references/pending pickles
 #[pyfunction]
-#[pyo3(signature = (obj, allow_pending_pickles=true, allow_tensor_engine_references=true))]
+#[pyo3(signature = (obj, allow_pending_pickles=true, allow_tensor_engine_references=true, allow_mesh_references=false))]
 pub fn pickle(
     py: Python<'_>,
     obj: Py<PyAny>,
     allow_pending_pickles: bool,
     allow_tensor_engine_references: bool,
+    allow_mesh_references: bool,
 ) -> PyResult<PicklingState> {
-    let active = ActivePicklingState::new(allow_pending_pickles, allow_tensor_engine_references);
+    let active = ActivePicklingState::new(
+        allow_pending_pickles,
+        allow_tensor_engine_references,
+        allow_mesh_references,
+    );
     let buffer = Py::new(py, Buffer::default())?;
     let _guard = ActivePicklingGuard::enter(active);
 
@@ -629,5 +797,7 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     module.add_function(wrap_pyfunction!(pop_tensor_engine_reference, module)?)?;
     module.add_function(wrap_pyfunction!(pop_pending_pickle, module)?)?;
+    module.add_function(wrap_pyfunction!(pop_mesh_reference, module)?)?;
+    module.add_function(wrap_pyfunction!(reserve_mesh_reference, module)?)?;
     Ok(())
 }

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -708,6 +708,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
             },
             message: pickled_args.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);
@@ -791,6 +792,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: None,
             },
             message: pickled.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);
@@ -832,6 +834,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: None,
             },
             message: pickled.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -154,7 +154,15 @@ impl PyProcMesh {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
-        let bytes = bincode::serde::encode_to_vec(&self.mesh_ref()?, bincode::config::legacy())
+        let mesh_ref = self.mesh_ref()?;
+        if crate::pickle::push_mesh_reference_if_active(crate::actor::MeshRef::Proc(Box::new(
+            mesh_ref.clone(),
+        ))) {
+            let pop_fn = PyModule::import(py, "monarch._rust_bindings.monarch_hyperactor.pickle")?
+                .getattr("pop_mesh_reference")?;
+            return Ok((pop_fn, pyo3::types::PyTuple::empty(py).into_any()));
+        }
+        let bytes = bincode::serde::encode_to_vec(&mesh_ref, bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
         let from_bytes =

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -99,7 +99,7 @@ fn pickle_python_result(
     result: Bound<'_, PyAny>,
     worker_rank: usize,
 ) -> Result<PythonMessage, anyhow::Error> {
-    let mut state = pickle(py, result.unbind(), false, false)
+    let mut state = pickle(py, result.unbind(), false, false, false)
         .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?;
     let inner = state
         .take_inner()

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -150,6 +150,10 @@ class PythonMessage:
         ...
     @property
     def kind(self) -> PythonMessageKind: ...
+    @property
+    def refs(self) -> List[Any]:
+        """Out-of-band mesh references carried alongside the message."""
+        ...
 
 @final
 class PythonActorHandle:
@@ -204,6 +208,7 @@ class Actor(Protocol):
         message: FrozenBuffer,
         panic_flag: PanicFlag,
         local_state: List[Any],
+        mesh_references: List[Any],
         response_port: PortProtocol[Any],
     ) -> None: ...
 
@@ -232,6 +237,11 @@ class QueuedMessage:
     @property
     def local_state(self) -> Any:
         """The local state for this message."""
+        ...
+
+    @property
+    def refs(self) -> List[Any]:
+        """Out-of-band mesh references carried alongside the message."""
         ...
 
     @property

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
@@ -24,6 +24,7 @@ class PicklingState:
         self,
         buffer: FrozenBuffer,
         tensor_engine_references: List[Any] | None = None,
+        mesh_references: List[Any] | None = None,
     ) -> None:
         """
         Create a new PicklingState from a buffer and optional tensor engine references.
@@ -35,6 +36,8 @@ class PicklingState:
             buffer: The pickled bytes as a FrozenBuffer.
             tensor_engine_references: Optional list of tensor engine references
                 to restore during unpickling.
+            mesh_references: Optional list of out-of-band mesh references to
+                restore during unpickling.
         """
         ...
 
@@ -90,6 +93,7 @@ def pickle(
     obj: Any,
     allow_pending_pickles: bool = True,
     allow_tensor_engine_references: bool = True,
+    allow_mesh_references: bool = False,
 ) -> PicklingState:
     """
     Pickle an object with support for pending pickles and tensor engine references.
@@ -146,5 +150,24 @@ def pop_pending_pickle() -> Shared[Any]:
 
     Raises:
         RuntimeError: If there is no active pickling state or no pending pickles remaining.
+    """
+    ...
+
+def pop_mesh_reference() -> Any:
+    """
+    Pop a mesh reference from the active pickling state and rebuild its
+    Python mesh wrapper.
+
+    Raises:
+        RuntimeError: If there is no active pickling state or no mesh
+            references remaining.
+    """
+    ...
+
+def reserve_mesh_reference(handle: Shared[Any]) -> bool:
+    """
+    Reserve a slot for a pending mesh, filled sender-side once the handle
+    resolves. Returns True if a slot was reserved (mesh-reference collection
+    is active), False otherwise.
     """
     ...

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1201,7 +1201,9 @@ class PortReceiver(Generic[R]):
 
     def _process(self, msg: PythonMessage) -> R:
         # TODO: Try to do something more structured than a cast here
-        payload = cast(R, PicklingState(msg.message).unpickle())
+        payload = cast(
+            R, PicklingState(msg.message, mesh_references=msg.refs).unpickle()
+        )
         match msg.kind:
             # pyrefly: ignore [invalid-pattern]
             case PythonMessageKind.Result():
@@ -1323,6 +1325,7 @@ async def _handle_queued_message(actor: Any, msg: "QueuedMessage") -> None:
         msg.bytes,
         panic_flag,  # pyre-ignore[6]: _QueuePanicFlag implements PanicFlag protocol
         msg.local_state,
+        msg.refs,
         msg.response_port,
     )
     # If a panic was signaled, re-raise it after handle() has cleaned up.
@@ -1358,6 +1361,7 @@ class _Actor:
         message: FrozenBuffer,
         panic_flag: PanicFlag,
         local_state: List[Any],
+        mesh_references: List[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         MESSAGES_HANDLED.add(1)
@@ -1373,7 +1377,9 @@ class _Actor:
 
             DebugContext.set(DebugContext())
 
-            args, kwargs = PicklingState(message, local_state).unpickle()
+            args, kwargs = PicklingState(
+                message, local_state, mesh_references
+            ).unpickle()
 
             match method:
                 # pyrefly: ignore [invalid-pattern]

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -315,6 +315,23 @@ class HostMesh(MeshTrait):
 
     # pyrefly: ignore [invalid-annotation]
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
+        # A pending host mesh has no HostMeshRef yet. When mesh-reference
+        # collection is active, reserve an out-of-band slot (filled sender-side
+        # once the mesh resolves) and reconstruct from the popped mesh;
+        # otherwise fall through to the ordinary reduce.
+        if self._hy_host_mesh.poll() is None:
+            from monarch._rust_bindings.monarch_hyperactor.pickle import (
+                reserve_mesh_reference,
+            )
+            from monarch._src.actor.pickle import _MeshSlot
+
+            if reserve_mesh_reference(self._hy_host_mesh):
+                return HostMesh._from_initialized_hy_host_mesh, (
+                    _MeshSlot(),
+                    self._region,
+                    self.stream_logs,
+                    self.is_fake_in_process,
+                )
         return HostMesh, (
             self._hy_host_mesh,
             self._region,

--- a/python/monarch/_src/actor/pickle.py
+++ b/python/monarch/_src/actor/pickle.py
@@ -19,6 +19,19 @@ from typing import Any, Callable, Iterable, List, Tuple
 
 import cloudpickle
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer, FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.pickle import pop_mesh_reference
+
+
+class _MeshSlot:
+    """Placeholder whose unpickling pops a reserved mesh-reference slot.
+
+    A pending Proc/Host mesh reserves an out-of-band slot at pickle time and
+    emits this sentinel in its reduce; unpickling pops the resolved mesh that
+    the sender filled into that slot.
+    """
+
+    def __reduce__(self) -> Tuple[Any, Tuple[Any, ...]]:
+        return (pop_mesh_reference, ())
 
 
 def maybe_torch() -> types.ModuleType | None:

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -718,6 +718,23 @@ class ProcMesh(MeshTrait):
 
     # pyrefly: ignore [invalid-annotation]
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
+        # A pending proc mesh has no ProcMeshRef yet. When mesh-reference
+        # collection is active, reserve an out-of-band slot (filled sender-side
+        # once the mesh resolves) and reconstruct from the popped mesh;
+        # otherwise fall through to the ordinary reduce.
+        if self._proc_mesh.poll() is None:
+            from monarch._rust_bindings.monarch_hyperactor.pickle import (
+                reserve_mesh_reference,
+            )
+            from monarch._src.actor.pickle import _MeshSlot
+
+            if reserve_mesh_reference(self._proc_mesh):
+                return ProcMesh._from_initialized_hy_proc_mesh, (
+                    _MeshSlot(),
+                    self._host_mesh,
+                    self._region,
+                    self._root_region,
+                )
         return ProcMesh, (
             self._proc_mesh,
             self._host_mesh,

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -81,6 +81,7 @@ class MyActor:
         message: bytes,
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
+        mesh_references: Iterable[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         match method:

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -43,6 +43,7 @@ class MyActor:
         message: bytes,
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
+        mesh_references: Iterable[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         match method:

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -190,6 +190,7 @@ class MyActor:
         message: bytes,
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
+        mesh_references: Iterable[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         match method:

--- a/python/tests/test_deferred_pickle_characterization.py
+++ b/python/tests/test_deferred_pickle_characterization.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Characterization oracle for deferred pickling.
+
+Pins today's observable behavior: a mesh reference that is still *pending*
+(spawned and sent in the same breath, before its background init finishes)
+arrives at the other side as a usable reference, on both send paths: as an
+endpoint argument (request path) and as an endpoint return value (reply path).
+Today this rides the deferred-pickle subsystem (resolve-before-send plus a
+re-pickle); a change to how pending references serialize must preserve these
+outcomes. This is the safety net such a change checks against.
+
+There is no hook to force the pending path; it relies on the
+spawn-then-immediately-send race, which the synchronous pickle wins in practice
+(the async mesh init cannot complete in the gap). The tests assert the
+end-to-end outcome, which is what must be preserved either way.
+"""
+
+from __future__ import annotations
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._src.actor.actor_mesh import Actor
+from monarch._src.actor.endpoint import endpoint
+from monarch._src.actor.host_mesh import this_host
+from monarch._src.job.process import ProcessJob
+from scoped_state import scoped_state
+
+
+class _Target(Actor):
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+
+class _Receiver(Actor):
+    @endpoint
+    async def use_mesh(self, target: _Target) -> list[str]:
+        # Use the mesh we were handed (it was pending when it was sent).
+        results = await target.ping.call()
+        return [value for _, value in results]
+
+
+class _Spawner(Actor):
+    @endpoint
+    async def spawn_and_return_pending(self) -> _Target:
+        # Spawn a fresh mesh and return it without awaiting init, so it is
+        # pending when this reply is pickled.
+        return this_host().spawn_procs(name="inner_proc").spawn("inner", _Target)
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_mesh_sent_as_endpoint_argument_resolves_on_receiver() -> None:
+    """Request path: a just-spawned (pending) mesh passed as an endpoint argument
+    reaches the receiver as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        receiver = host.spawn_procs(name="recv_proc").spawn("receiver", _Receiver)
+        # Spawned and sent in the same breath: pending at pickle time.
+        target = host.spawn_procs(name="target_proc").spawn("target", _Target)
+        result = receiver.use_mesh.call_one(target).get()
+        assert result == ["pong"]
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_mesh_returned_from_endpoint_resolves_on_caller() -> None:
+    """Reply path: a just-spawned (pending) mesh returned from an endpoint reaches
+    the caller as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _Spawner)
+        returned = spawner.spawn_and_return_pending.call_one().get()
+        result = returned.ping.call_one().get()
+        assert result == "pong"
+
+
+class _ProcReceiver(Actor):
+    @endpoint
+    async def use_proc_mesh(self, proc_mesh) -> list[str]:
+        # Use the proc mesh we were handed (it was pending when it was sent).
+        actors = proc_mesh.spawn("inner", _Target)
+        results = await actors.ping.call()
+        return [value for _, value in results]
+
+
+class _ProcSpawner(Actor):
+    @endpoint
+    async def spawn_and_return_pending_proc(self):
+        # Return a fresh proc mesh without awaiting init, so it is pending when
+        # this reply is pickled.
+        return this_host().spawn_procs(name="inner_proc")
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_proc_mesh_sent_as_endpoint_argument_resolves_on_receiver() -> None:
+    """Request path: a just-spawned (pending) proc mesh passed as an endpoint
+    argument reaches the receiver as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        receiver = host.spawn_procs(name="recv_proc").spawn("receiver", _ProcReceiver)
+        # Spawned and sent in the same breath: pending at pickle time.
+        proc_mesh = host.spawn_procs(name="target_proc")
+        result = receiver.use_proc_mesh.call_one(proc_mesh).get()
+        assert result == ["pong"]
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_proc_mesh_returned_from_endpoint_resolves_on_caller() -> None:
+    """Reply path: a just-spawned (pending) proc mesh returned from an endpoint
+    reaches the caller as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _ProcSpawner)
+        returned = spawner.spawn_and_return_pending_proc.call_one().get()
+        actors = returned.spawn("t", _Target)
+        result = actors.ping.call_one().get()
+        assert result == "pong"


### PR DESCRIPTION
Summary:

builds the machinery that carries mesh references in `PythonMessage.refs` instead of inline pickle bytes, gated off so behavior is unchanged.

why out of band: a mesh reference can be pending at pickle time. spawn-then-immediately-send is the ergonomic default and Python runs ahead of Rust's mesh init, so the mesh a message refers to is often still initializing when Python pickles it, and a pending reference has no value to write inline. today's deferred-pickle subsystem copes by pickling with a placeholder, recording the pending handles on the side, then awaiting them and re-pickling the whole object graph with resolved values before the message sends. two structural costs follow: send latency is coupled to mesh init (resolve-before-send), and the graph is serialized twice. a side table lets us pickle once: a resolved mesh writes its `*MeshRef` at pickle time, a pending one reserves a slot the send fills once its init finishes (inits run concurrently, so the wait is the slowest mesh, not the sum), and the receiver decodes the bytes and the table together, never re-pickling. references are capabilities, so they belong out of band rather than in the value bytes; keeping them there also leaves the later `PyShared`-to-`Handle` swap a clean container replacement instead of one tangled with serialization semantics.

send side: the three mesh reduces (`ProcMesh`/`HostMesh`/`ActorMesh`) push their `*MeshRef` into the pickling state's new `mesh_references` collector and emit a `pop_mesh_reference` slot when mesh-ref collection is active, else inline exactly as today.

receive side: the message's `refs` are handed to `PicklingState` (alongside `local_state` through the `handle` dispatch for calls, and straight off the message for replies), staged, and popped by `pop_mesh_reference`, which rebuilds the mesh wrapper from each `MeshRef`.

the gate is the new `allow_mesh_references` flag, defaulting false; no send site sets it yet, so every reduce inlines and `refs` stays empty everywhere. the pending-mesh reserve and its sender-side fill are built here too, gated off; the next diff only flips the gate at the two send sites.

Reviewed By: zdevito, dulinriley

Differential Revision: D110236925


