### PR TITLE
derive the RoCE v2 source GID from device info, not a config knob

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -181,12 +181,13 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
             {
                 // SAFETY: `device` and `ctx.as_ptr()` are non-null and
                 // `ctx.as_ptr()` was returned by `ibv_open_device(device)`.
-                if let Some(info) = unsafe { query_device_info(device, ctx.as_ptr()) } {
-                    by_impl
+                match unsafe { query_device_info(device, ctx.as_ptr()) } {
+                    Ok(info) => by_impl
                         .get_mut((reg.typename)())
                         .expect("registration typename present in map")
                         .devices
-                        .push(info);
+                        .push(info),
+                    Err(err) => tracing::warn!("failed to query RDMA device info: {err:#}"),
                 }
             }
             // `ctx` drops here, closing the transient context.

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -36,7 +36,6 @@ impl IbvDeviceImpl for EfaDevice {
     }
 
     fn apply_config_defaults(config: &mut IbvConfig) {
-        config.gid_index = 0;
         config.max_send_sge = 1;
         config.max_recv_sge = 1;
         config.max_dest_rd_atomic = 0;

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -36,6 +36,8 @@ use super::domain::register_host_or_dmabuf_mr;
 use super::memory_region::IbvMemoryRegionKeepalive;
 use super::memory_region::IbvMemoryRegionView;
 use super::mlx_queue_pair::MlxQueuePair;
+use super::primitives::GidScope;
+use super::primitives::GidType;
 use super::primitives::IbvConfig;
 use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvQp;
@@ -277,15 +279,20 @@ impl MlxDomainOps for ProdMlxDomainOps {
             .context("could not create loopback QP for mkey binding")?;
         let context = domain.context.as_ptr();
         let access_flags = domain.access_flags();
+        let gid = domain.device_info().select_gid(
+            config.port_num,
+            Some(GidScope::Global),
+            Some(GidType::RoCEv2),
+        )?;
 
         // Connect the QP to itself (loopback) so it reaches RTS, the state
         // required to post work requests.
         // SAFETY: `parts.qp` wraps the live QP just created above and `context`
         // is its live device context.
-        let info = unsafe { get_qp_info(parts.qp.as_ptr(), context, config) }
+        let info = unsafe { get_qp_info(parts.qp.as_ptr(), context, config, gid) }
             .context("could not query loopback QP info for mkey binding")?;
         // SAFETY: as above.
-        unsafe { connect(parts.qp.as_ptr(), config, access_flags, &info) }
+        unsafe { connect(parts.qp.as_ptr(), config, access_flags, &info, gid.index()) }
             .context("could not connect loopback QP for mkey binding")?;
 
         Ok(parts)

--- a/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
@@ -15,6 +15,8 @@ use std::sync::Arc;
 use super::IbvBuffer;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
+use super::primitives::GidScope;
+use super::primitives::GidType;
 use super::primitives::IbvConfig;
 use super::primitives::IbvCq;
 use super::primitives::IbvQp;
@@ -120,6 +122,11 @@ impl IbvQueuePair for MlxQueuePair {
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an MlxQueuePair from config {}", config);
+        let gid = domain.device_info().select_gid(
+            config.port_num,
+            Some(GidScope::Global),
+            Some(GidType::RoCEv2),
+        )?;
         let parts = Self::create_raw_parts(&domain, &config)?;
         let context = domain.context.clone();
         let access_flags = domain.access_flags();
@@ -128,7 +135,7 @@ impl IbvQueuePair for MlxQueuePair {
         // context/PD with its completion queues; ownership transfers to the
         // inner `RCQueuePair`.
         let inner =
-            unsafe { RCQueuePair::from_parts(parts, context, config, access_flags, domain) };
+            unsafe { RCQueuePair::from_parts(parts, context, config, gid, access_flags, domain) };
         Ok(MlxQueuePair(inner))
     }
 

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -24,11 +24,14 @@
 //! - `IbvOperation`: Represents the type of RDMA operation to perform (Read or Write).
 //! - `IbvQpInfo`: Contains connection information needed to establish an RDMA connection with a remote endpoint.
 //! - `IbvWc`: Wrapper around ibverbs work completion structure, used to track the status of RDMA operations.
+use std::collections::BTreeMap;
 use std::ffi::CStr;
 use std::fmt;
 use std::io::Error;
+use std::net::Ipv6Addr;
 use std::sync::OnceLock;
 
+use anyhow::Context;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -40,7 +43,6 @@ use crate::backend::ibverbs::device_selection::resolve_target;
 use crate::device_selection::MemoryLocation;
 
 #[derive(
-    Default,
     Copy,
     Clone,
     Debug,
@@ -50,12 +52,48 @@ use crate::device_selection::MemoryLocation;
     serde::Serialize,
     serde::Deserialize
 )]
-#[repr(transparent)]
+// `AsRef`/`AsMut`/`From<Gid>` reinterpret the leading `raw` bytes in place as an
+// `ibv_gid` (which is 8-aligned, holding `__be64`s). `repr(C, align(8))` keeps
+// `raw` first and 8-aligned so that pointer cast is well-defined; without it the
+// derived layout can place `raw` at a misaligned offset, faulting on that read.
+#[repr(C, align(8))]
 pub struct Gid {
     raw: [u8; 16],
+    /// The GID's index in its port's GID table.
+    index: u8,
+    /// Address scope, classified from `raw` at construction.
+    scope: GidScope,
+    /// RoCE type, from the port's `gid_attrs/types` sysfs entry.
+    gid_type: GidType,
 }
 
 impl Gid {
+    /// Builds a GID from its IPv6 address, RoCE type, and GID-table index,
+    /// classifying the address's scope.
+    fn new(addr: Ipv6Addr, gid_type: GidType, index: u8) -> Self {
+        Self {
+            raw: addr.octets(),
+            index,
+            scope: GidScope::of(addr),
+            gid_type,
+        }
+    }
+
+    /// The GID's index in its port's GID table.
+    pub(crate) fn index(&self) -> u8 {
+        self.index
+    }
+
+    /// The GID's address scope.
+    fn scope(&self) -> GidScope {
+        self.scope
+    }
+
+    /// The GID's RoCE type.
+    fn gid_type(&self) -> GidType {
+        self.gid_type
+    }
+
     #[allow(dead_code)]
     fn subnet_prefix(&self) -> u64 {
         u64::from_be_bytes(self.raw[..8].try_into().unwrap())
@@ -64,13 +102,6 @@ impl Gid {
     #[allow(dead_code)]
     fn interface_id(&self) -> u64 {
         u64::from_be_bytes(self.raw[8..].try_into().unwrap())
-    }
-}
-impl From<rdmaxcel_sys::ibv_gid> for Gid {
-    fn from(gid: rdmaxcel_sys::ibv_gid) -> Self {
-        Self {
-            raw: unsafe { gid.raw },
-        }
     }
 }
 
@@ -89,6 +120,98 @@ impl AsRef<rdmaxcel_sys::ibv_gid> for Gid {
 impl AsMut<rdmaxcel_sys::ibv_gid> for Gid {
     fn as_mut(&mut self) -> &mut rdmaxcel_sys::ibv_gid {
         unsafe { &mut *self.raw.as_mut_ptr().cast::<rdmaxcel_sys::ibv_gid>() }
+    }
+}
+
+impl fmt::Display for Gid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&format_gid(&self.raw))
+    }
+}
+
+/// Scope of an IPv6-form GID. RoCE encodes the source GID as an IPv6 address, so
+/// the usual IPv6 scopes apply.
+///
+/// - [`Loopback`](GidScope::Loopback): `::1`, or IPv4-mapped loopback
+///   (`::ffff:127.0.0.0/8`).
+/// - [`LinkLocal`](GidScope::LinkLocal): `fe80::/10` (the default GID prefix), or
+///   IPv4-mapped link-local (`::ffff:169.254.0.0/16`).
+/// - [`SiteLocal`](GidScope::SiteLocal): `fec0::/10`, deprecated by RFC 3879.
+/// - [`Global`](GidScope::Global): everything else, including globally-routable
+///   IPv4-mapped, global, and ULA IPv6.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize
+)]
+pub(crate) enum GidScope {
+    Loopback,
+    LinkLocal,
+    SiteLocal,
+    Global,
+}
+
+impl GidScope {
+    /// Classifies an IPv6 address by scope. IPv4-mapped addresses
+    /// (`::ffff:a.b.c.d`) are classified by their embedded IPv4 address, so an
+    /// IPv4 loopback/link-local GID is not mistaken for a global one.
+    fn of(addr: Ipv6Addr) -> Self {
+        if addr.is_loopback() {
+            return GidScope::Loopback;
+        }
+        if let Some(v4) = addr.to_ipv4_mapped() {
+            return if v4.is_loopback() {
+                GidScope::Loopback
+            } else if v4.is_link_local() {
+                GidScope::LinkLocal
+            } else {
+                GidScope::Global
+            };
+        }
+        let [a, b, ..] = addr.octets();
+        if a == 0xfe && b & 0xc0 == 0x80 {
+            GidScope::LinkLocal
+        } else if a == 0xfe && b & 0xc0 == 0xc0 {
+            GidScope::SiteLocal
+        } else {
+            GidScope::Global
+        }
+    }
+}
+
+/// RoCE type of a GID, from its `gid_attrs/types` sysfs entry.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize
+)]
+pub(crate) enum GidType {
+    /// `IB/RoCE v1`.
+    RoCEv1,
+    /// `RoCE v2`.
+    RoCEv2,
+    /// Any other or unrecognized type.
+    Unknown,
+}
+
+impl GidType {
+    /// Classifies a `gid_attrs/types` sysfs value.
+    fn of(gid_type: &str) -> Self {
+        match gid_type.trim() {
+            "RoCE v2" => GidType::RoCEv2,
+            "IB/RoCE v1" => GidType::RoCEv1,
+            _ => GidType::Unknown,
+        }
     }
 }
 
@@ -140,8 +263,6 @@ pub struct IbvConfig {
     pub cq_entries: i32,
     /// `port_num` - The physical port number on the device.
     pub port_num: u8,
-    /// `gid_index` - The GID index for the RDMA device.
-    pub gid_index: u8,
     /// `max_send_wr` - The maximum number of outstanding send work requests.
     pub max_send_wr: u32,
     /// `max_recv_wr` - The maximum number of outstanding receive work requests.
@@ -192,7 +313,6 @@ impl Default for IbvConfig {
             target: IbvDeviceTarget::MemoryLocation(MemoryLocation::Cpu(Some(0))),
             cq_entries: 1024,
             port_num: 1,
-            gid_index: 3,
             max_send_wr: 512,
             max_recv_wr: 512,
             max_send_sge: 30,
@@ -229,10 +349,9 @@ impl std::fmt::Display for IbvConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "IbvConfig {{ target: {:?}, port_num: {}, gid_index: {}, max_send_wr: {}, max_recv_wr: {}, max_send_sge: {}, max_recv_sge: {}, path_mtu: {:?}, retry_cnt: {}, rnr_retry: {}, qp_timeout: {}, min_rnr_timer: {}, max_dest_rd_atomic: {}, max_rd_atomic: {}, pkey_index: {}, psn: 0x{:x} }}",
+            "IbvConfig {{ target: {:?}, port_num: {}, max_send_wr: {}, max_recv_wr: {}, max_send_sge: {}, max_recv_sge: {}, path_mtu: {:?}, retry_cnt: {}, rnr_retry: {}, qp_timeout: {}, min_rnr_timer: {}, max_dest_rd_atomic: {}, max_rd_atomic: {}, pkey_index: {}, psn: 0x{:x} }}",
             self.target,
             self.port_num,
-            self.gid_index,
             self.max_send_wr,
             self.max_recv_wr,
             self.max_send_sge,
@@ -339,6 +458,57 @@ impl IbvDeviceInfo {
         &self.ports
     }
 
+    /// Returns the port with the given `port_num`, if present.
+    pub fn port(&self, port_num: u8) -> Option<&IbvPort> {
+        self.ports.iter().find(|port| port.port_num == port_num)
+    }
+
+    /// The lowest-indexed GID on `port_num` matching `scope` (if `Some`) and
+    /// `gid_type` (if `Some`); a `None` filter matches any value. Errors if the
+    /// device has no such port or no GID matches.
+    pub(crate) fn select_gid(
+        &self,
+        port_num: u8,
+        scope: Option<GidScope>,
+        gid_type: Option<GidType>,
+    ) -> Result<Gid, anyhow::Error> {
+        let port = self
+            .port(port_num)
+            .ok_or_else(|| anyhow::anyhow!("device {} has no port {}", self.name, port_num))?;
+        port.gids
+            .values()
+            .find(|gid| {
+                scope.is_none_or(|s| gid.scope() == s)
+                    && gid_type.is_none_or(|t| gid.gid_type() == t)
+            })
+            .copied()
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "device {} port {} has no GID with scope {:?} and type {:?}",
+                    self.name,
+                    port_num,
+                    scope,
+                    gid_type
+                )
+            })
+    }
+
+    /// The GID at `index` on `port_num`. Errors if the device has no such port
+    /// or the port has no GID at that index.
+    pub(crate) fn gid_at(&self, port_num: u8, index: u8) -> Result<Gid, anyhow::Error> {
+        let port = self
+            .port(port_num)
+            .ok_or_else(|| anyhow::anyhow!("device {} has no port {}", self.name, port_num))?;
+        port.gids.get(&index).copied().ok_or_else(|| {
+            anyhow::anyhow!(
+                "device {} port {} has no GID at index {}",
+                self.name,
+                port_num,
+                index
+            )
+        })
+    }
+
     /// Aggregate bandwidth (MB/s) of the device's fastest active port,
     /// derived from its IB `active_speed` / `active_width`. 0 if no port
     /// is active, which ranks the device at the worst case.
@@ -437,8 +607,9 @@ pub struct IbvPort {
     capability_mask: u32,
     /// `link_layer` - The link layer type (e.g., InfiniBand, Ethernet).
     link_layer: String,
-    /// `gid` - Global Identifier for the port.
-    gid: String,
+    /// `gids` - The port's populated GID-table entries, keyed by table index
+    /// (empty slots omitted).
+    gids: BTreeMap<u8, Gid>,
     /// `gid_tbl_len` - Length of the GID table.
     gid_tbl_len: i32,
     /// `active_speed` - IB active speed bitmask (one bit set).
@@ -471,6 +642,13 @@ impl fmt::Display for IbvDeviceInfo {
     }
 }
 
+impl IbvPort {
+    /// The port's populated GID-table entries, keyed by table index.
+    pub fn gids(&self) -> &BTreeMap<u8, Gid> {
+        &self.gids
+    }
+}
+
 impl fmt::Display for IbvPort {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "\tPort {}:", self.port_num)?;
@@ -481,8 +659,17 @@ impl fmt::Display for IbvPort {
         writeln!(f, "\t\tSM lid: {}", self.sm_lid)?;
         writeln!(f, "\t\tCapability mask: 0x{:08x}", self.capability_mask)?;
         writeln!(f, "\t\tLink layer: {}", self.link_layer)?;
-        writeln!(f, "\t\tGID: {}", self.gid)?;
         writeln!(f, "\t\tGID table length: {}", self.gid_tbl_len)?;
+        for (index, gid) in &self.gids {
+            writeln!(
+                f,
+                "\t\tGID[{}]: {} ({:?}, {:?})",
+                index,
+                gid,
+                gid.scope(),
+                gid.gid_type()
+            )?;
+        }
         Ok(())
     }
 }
@@ -604,8 +791,42 @@ pub fn format_gid(gid: &[u8; 16]) -> String {
     )
 }
 
-/// Builds an [`IbvDeviceInfo`] from an already-open
-/// `ibv_context`. Returns `None` if `ibv_query_device` fails.
+/// Reads the populated GID-table entries under
+/// `/sys/class/infiniband/{device}/ports/{port}/gids/`, keyed by table index.
+/// Scans indices `0..gid_tbl_len` (capped at the `u8` GID-index range). Empty
+/// slots read as the all-zero GID and have no readable `gid_attrs/types`
+/// attribute, so they are skipped before that file is touched. Errors if a
+/// populated entry's GID or type sysfs file cannot be read.
+fn read_port_gids(
+    device: &str,
+    port: u8,
+    gid_tbl_len: i32,
+) -> Result<BTreeMap<u8, Gid>, anyhow::Error> {
+    let mut gids = BTreeMap::new();
+    for index in 0..gid_tbl_len.min(u8::MAX as i32 + 1) {
+        let gid_path = format!("/sys/class/infiniband/{device}/ports/{port}/gids/{index}");
+        let gid_str =
+            std::fs::read_to_string(&gid_path).with_context(|| format!("reading {gid_path}"))?;
+        // Skip empty (all-zero) or malformed slots before reading the type
+        // attribute, which the kernel leaves unreadable for empty slots.
+        let Ok(addr) = gid_str.trim().parse::<Ipv6Addr>() else {
+            continue;
+        };
+        if addr.is_unspecified() {
+            continue;
+        }
+        let type_path =
+            format!("/sys/class/infiniband/{device}/ports/{port}/gid_attrs/types/{index}");
+        let type_str =
+            std::fs::read_to_string(&type_path).with_context(|| format!("reading {type_path}"))?;
+        let index = index as u8;
+        gids.insert(index, Gid::new(addr, GidType::of(&type_str), index));
+    }
+    Ok(gids)
+}
+
+/// Builds an [`IbvDeviceInfo`] from an already-open `ibv_context`. Errors if
+/// `ibv_query_device` or any GID sysfs read fails.
 ///
 /// # Safety
 ///
@@ -615,7 +836,7 @@ pub fn format_gid(gid: &[u8; 16]) -> String {
 pub(super) unsafe fn query_device_info(
     device: *mut rdmaxcel_sys::ibv_device,
     context: *mut rdmaxcel_sys::ibv_context,
-) -> Option<IbvDeviceInfo> {
+) -> Result<IbvDeviceInfo, anyhow::Error> {
     // SAFETY: `device` is non-null per the caller's contract;
     // `ibv_get_device_name` returns a null-terminated C string
     // owned by the device list.
@@ -626,8 +847,9 @@ pub(super) unsafe fn query_device_info(
     // SAFETY: `context` is a non-null context per the caller's
     // contract; `&mut device_attr` is a writable, properly
     // aligned `ibv_device_attr`.
-    if unsafe { rdmaxcel_sys::ibv_query_device(context, &mut device_attr) } != 0 {
-        return None;
+    let rc = unsafe { rdmaxcel_sys::ibv_query_device(context, &mut device_attr) };
+    if rc != 0 {
+        anyhow::bail!("ibv_query_device failed for device {device_name}: {rc}");
     }
     // SAFETY: `device_attr.fw_ver` is a null-terminated C buffer
     // populated by `ibv_query_device`.
@@ -665,18 +887,7 @@ pub(super) unsafe fn query_device_info(
         }
         let physical_state = get_port_phy_state_str(port_attr.phys_state);
         let link_layer = get_link_layer_str(port_attr.link_layer);
-        let mut gid = rdmaxcel_sys::ibv_gid::default();
-        // SAFETY: `context` is a valid context; `&mut gid` is a
-        // writable, properly aligned `ibv_gid`.
-        let gid_str = if unsafe { rdmaxcel_sys::ibv_query_gid(context, port_num, 0, &mut gid) } == 0
-        {
-            // SAFETY: `gid.raw` is a union field that is
-            // always initialized; `ibv_query_gid` filled it.
-            let raw = unsafe { gid.raw };
-            format_gid(&raw)
-        } else {
-            "N/A".to_string()
-        };
+        let gids = read_port_gids(&info.name, port_num, port_attr.gid_tbl_len)?;
         info.ports.push(IbvPort {
             port_num,
             state: port_attr.state,
@@ -686,13 +897,13 @@ pub(super) unsafe fn query_device_info(
             sm_lid: port_attr.sm_lid,
             capability_mask: port_attr.port_cap_flags,
             link_layer,
-            gid: gid_str,
+            gids,
             gid_tbl_len: port_attr.gid_tbl_len,
             active_speed: port_attr.active_speed,
             active_width: port_attr.active_width,
         });
     }
-    Some(info)
+    Ok(info)
 }
 
 /// Cached result of mlx5dv support check.
@@ -1182,7 +1393,7 @@ mod tests {
                 sm_lid: 0,
                 capability_mask: 0,
                 link_layer: String::new(),
-                gid: String::new(),
+                gids: BTreeMap::new(),
                 gid_tbl_len: 0,
                 active_speed,
                 active_width,
@@ -1282,6 +1493,46 @@ mod tests {
         let ibv_wc = IbvWc::from(wc);
         assert_eq!(ibv_wc.wr_id(), 42);
         assert!(ibv_wc.is_valid());
+    }
+
+    #[test]
+    fn test_gid_scope_of() {
+        fn scope(addr: &str) -> GidScope {
+            GidScope::of(addr.parse().expect("valid IPv6"))
+        }
+
+        // Loopback: `::1` and IPv4-mapped loopback (`::ffff:127.0.0.0/8`) — the
+        // latter must not be classified as global.
+        assert_eq!(scope("::1"), GidScope::Loopback);
+        assert_eq!(scope("::ffff:127.0.0.1"), GidScope::Loopback);
+
+        // Link-local: `fe80::/10` (the default GID prefix) and IPv4-mapped
+        // link-local (`::ffff:169.254.0.0/16`).
+        assert_eq!(scope("fe80::1"), GidScope::LinkLocal);
+        assert_eq!(scope("::ffff:169.254.1.1"), GidScope::LinkLocal);
+
+        // Site-local `fec0::/10`.
+        assert_eq!(scope("fec0::1"), GidScope::SiteLocal);
+
+        // Global: IPv4-mapped (the common RoCE v2 form, in both sysfs hextet and
+        // dotted-quad forms), ULA, and global IPv6.
+        assert_eq!(
+            scope("0000:0000:0000:0000:0000:ffff:0a1e:0f44"),
+            GidScope::Global
+        );
+        assert_eq!(scope("::ffff:10.30.15.68"), GidScope::Global);
+        assert_eq!(scope("fd00::1"), GidScope::Global);
+        assert_eq!(scope("2001:db8::1"), GidScope::Global);
+    }
+
+    #[test]
+    fn test_gid_type_of() {
+        // Matches the sysfs `gid_attrs/types` strings (trailing newline and all);
+        // anything else is `Unknown`.
+        assert_eq!(GidType::of("RoCE v2\n"), GidType::RoCEv2);
+        assert_eq!(GidType::of("IB/RoCE v1\n"), GidType::RoCEv1);
+        assert_eq!(GidType::of(""), GidType::Unknown);
+        assert_eq!(GidType::of("something else"), GidType::Unknown);
     }
 
     #[test]

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -52,6 +52,8 @@ use super::domain::IbvDomainKeepalive;
 use super::manager_actor::CreatePeerQueuePair;
 use super::memory_region::IbvMemoryRegionView;
 use super::primitives::Gid;
+use super::primitives::GidScope;
+use super::primitives::GidType;
 use super::primitives::IbvConfig;
 use super::primitives::IbvCq;
 use super::primitives::IbvOperation;
@@ -280,7 +282,7 @@ impl IbvQueuePair for legacy::IbvQueuePair {
 }
 
 /// Queries the local endpoint info for `qp`, whose device `context` and the QP
-/// `config` (port, GID index, PSN) describe the connection.
+/// `config` (port, PSN) describe the connection. `gid` is the port's source GID.
 ///
 /// # Safety
 ///
@@ -290,6 +292,7 @@ pub(super) unsafe fn get_qp_info(
     qp: *mut rdmaxcel_sys::ibv_qp,
     context: *mut rdmaxcel_sys::ibv_context,
     config: &IbvConfig,
+    gid: Gid,
 ) -> Result<IbvQpInfo, anyhow::Error> {
     let mut port_attr = rdmaxcel_sys::ibv_port_attr::default();
     // SAFETY: `context` is a live device context (caller contract); the
@@ -306,26 +309,6 @@ pub(super) unsafe fn get_qp_info(
         return Err(anyhow::anyhow!(
             "failed to query port attributes: {}",
             Error::from_raw_os_error(errno)
-        ));
-    }
-
-    let mut gid = Gid::default();
-    // SAFETY: `context` is live (caller contract); `gid.as_mut()` is a writable,
-    // properly aligned `ibv_gid`.
-    let ret = unsafe {
-        rdmaxcel_sys::ibv_query_gid(
-            context,
-            config.port_num,
-            i32::from(config.gid_index),
-            gid.as_mut(),
-        )
-    };
-    if ret != 0 {
-        // `ibv_query_gid` returns -1 (not the errno) and sets `errno`, unlike
-        // the other verbs here, so report `last_os_error`.
-        return Err(anyhow::anyhow!(
-            "failed to query GID: {}",
-            Error::last_os_error()
         ));
     }
 
@@ -363,6 +346,8 @@ unsafe fn state(qp: *mut rdmaxcel_sys::ibv_qp) -> Result<u32, anyhow::Error> {
 
 /// Transitions `qp` through `INIT -> RTR -> RTS`, connected to `info`, granting
 /// remote peers `access_flags` and using the connection parameters in `config`.
+/// `sgid_index` is the local source-GID table index, used as the address
+/// handle's `sgid_index` when `info` carries a (remote) GID.
 ///
 /// # Safety
 ///
@@ -372,6 +357,7 @@ pub(super) unsafe fn connect(
     config: &IbvConfig,
     access_flags: i32,
     info: &IbvQpInfo,
+    sgid_index: u8,
 ) -> Result<(), anyhow::Error> {
     // Transition to INIT.
     let mut qp_attr = rdmaxcel_sys::ibv_qp_attr {
@@ -418,7 +404,7 @@ pub(super) unsafe fn connect(
         qp_attr.ah_attr.is_global = 1;
         qp_attr.ah_attr.grh.dgid = rdmaxcel_sys::ibv_gid::from(gid);
         qp_attr.ah_attr.grh.hop_limit = 0xff;
-        qp_attr.ah_attr.grh.sgid_index = config.gid_index;
+        qp_attr.ah_attr.grh.sgid_index = sgid_index;
     } else {
         qp_attr.ah_attr.is_global = 0;
     }
@@ -495,6 +481,10 @@ pub struct RCQueuePair {
     /// The device context, used for the data-path verbs.
     context: Arc<IbvContext>,
     config: IbvConfig,
+    /// The source GID (carrying its table index), resolved from the owning
+    /// device's `IbvDeviceInfo` at construction: the first global RoCE v2 GID on
+    /// `config.port_num`.
+    gid: Gid,
     /// Remote-access flags granted to peers at connect time, taken from the
     /// owning domain at construction.
     access_flags: i32,
@@ -521,6 +511,7 @@ impl RCQueuePair {
         parts: QpParts,
         context: Arc<IbvContext>,
         config: IbvConfig,
+        gid: Gid,
         access_flags: i32,
         domain: Arc<dyn IbvDomainKeepalive>,
     ) -> Self {
@@ -535,6 +526,7 @@ impl RCQueuePair {
             recv_cq,
             context,
             config,
+            gid,
             access_flags,
             next_wr_id: 0,
             _domain: domain,
@@ -641,6 +633,14 @@ impl IbvQueuePair for RCQueuePair {
             anyhow::bail!("cannot create an RCQueuePair on a null protection domain");
         }
 
+        // Resolve the source GID up front (before allocating any FFI resources),
+        // so a port without a global RoCE v2 GID fails cleanly here.
+        let gid = domain.device_info().select_gid(
+            config.port_num,
+            Some(GidScope::Global),
+            Some(GidType::RoCEv2),
+        )?;
+
         // Separate send/recv completion queues. Each `IbvCq` destroys its queue
         // on drop, so an early return below (or a panic) cleans them up.
         // SAFETY: `context_ptr`, if non-null, is live (kept alive by `context`);
@@ -687,19 +687,27 @@ impl IbvQueuePair for RCQueuePair {
 
         // SAFETY: `parts` wraps a live RC QP just created against `pd`/`context`
         // with its completion queues; ownership transfers to the returned value.
-        Ok(unsafe { Self::from_parts(parts, context, config, access_flags, domain) })
+        Ok(unsafe { Self::from_parts(parts, context, config, gid, access_flags, domain) })
     }
 
     fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
         // SAFETY: `self.qp` is the live QP, kept alive for `self`'s lifetime.
-        unsafe { connect(self.qp.as_ptr(), &self.config, self.access_flags, info) }
+        unsafe {
+            connect(
+                self.qp.as_ptr(),
+                &self.config,
+                self.access_flags,
+                info,
+                self.gid.index(),
+            )
+        }
     }
 
     fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
         let context = self.context.as_ptr();
         // SAFETY: `self.qp` is the live QP and `context` its non-null device
         // context (validated inside `new`), both valid for `self`'s lifetime.
-        unsafe { get_qp_info(self.qp.as_ptr(), context, &self.config) }
+        unsafe { get_qp_info(self.qp.as_ptr(), context, &self.config, self.gid) }
     }
 
     fn state(&mut self) -> Result<u32, anyhow::Error> {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
@@ -38,6 +38,10 @@ pub struct IbvQueuePair {
     pub dv_recv_cq: usize, // *mut rdmaxcel_sys::mlx5dv_cq,
     context: usize,        // *mut rdmaxcel_sys::ibv_context,
     config: IbvConfig,
+    // The source GID (carrying its table index), resolved from the owning
+    // device's `IbvDeviceInfo` at construction: index 0 on the EFA path,
+    // otherwise the first global RoCE v2 GID on `config.port_num`.
+    gid: Gid,
     is_efa: bool,
     // Keepalive for the domain whose `context`/`pd` this QP was built
     // against, so it outlives the QP regardless of other owners (the
@@ -125,10 +129,21 @@ impl IbvQueuePair {
         tracing::debug!("creating an IbvQueuePair from config {}", config);
         let context = domain.context.as_ptr();
         let pd = domain.as_ptr();
+        // Resolve Auto to a concrete QP type based on device capabilities.
+        let resolved_qp_type = resolve_qp_type(config.qp_type);
+        let is_efa = resolved_qp_type == rdmaxcel_sys::RDMA_QP_TYPE_EFA;
+        // EFA is not RoCE, so its `gid_attrs/types` never reports "RoCE v2"; it
+        // always uses GID index 0. RoCE selects the first global RoCE v2 GID.
+        let gid = if is_efa {
+            domain.device_info().gid_at(config.port_num, 0)?
+        } else {
+            domain.device_info().select_gid(
+                config.port_num,
+                Some(GidScope::Global),
+                Some(GidType::RoCEv2),
+            )?
+        };
         unsafe {
-            // Resolve Auto to a concrete QP type based on device capabilities
-            let resolved_qp_type = resolve_qp_type(config.qp_type);
-            let is_efa = resolved_qp_type == rdmaxcel_sys::RDMA_QP_TYPE_EFA;
             let qp = rdmaxcel_sys::rdmaxcel_qp_create(
                 context,
                 pd,
@@ -162,6 +177,7 @@ impl IbvQueuePair {
                     dv_recv_cq: 0,
                     context: context as usize,
                     config,
+                    gid,
                     is_efa: true,
                     _domain: domain,
                 });
@@ -201,6 +217,7 @@ impl IbvQueuePair {
                 dv_recv_cq: dv_recv_cq as usize,
                 context: context as usize,
                 config,
+                gid,
                 is_efa: false,
                 _domain: domain,
             })
@@ -213,7 +230,7 @@ impl IbvQueuePair {
         let qp = self.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
         // SAFETY: `(*qp).ibv_qp` is the live `ibv_qp` owned by this `rdmaxcel_qp`,
         // and `context` is its live device context.
-        unsafe { super::get_qp_info((*qp).ibv_qp, context, &self.config) }
+        unsafe { super::get_qp_info((*qp).ibv_qp, context, &self.config, self.gid) }
     }
 
     /// Returns the current state of the QP.
@@ -241,7 +258,15 @@ impl IbvQueuePair {
             .0 as i32;
         let qp = self.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
         // SAFETY: `(*qp).ibv_qp` is the live `ibv_qp` owned by this `rdmaxcel_qp`.
-        unsafe { super::connect((*qp).ibv_qp, &self.config, access_flags, connection_info) }?;
+        unsafe {
+            super::connect(
+                (*qp).ibv_qp,
+                &self.config,
+                access_flags,
+                connection_info,
+                self.gid.index(),
+            )
+        }?;
 
         tracing::debug!(
             "connection sequence has successfully completed (qp: {:?})",
@@ -275,7 +300,7 @@ impl IbvQueuePair {
                 self.config.pkey_index,
                 0x4242, // qkey
                 self.config.psn,
-                self.config.gid_index,
+                self.gid.index(),
                 gid_ptr,
                 connection_info.qp_num,
             );


### PR DESCRIPTION
Summary:
`IbvConfig.gid_index` hard-coded which GID-table entry RoCE used (default `3`, with EFA overriding to `0`) — a hardware property masquerading as caller configuration, and a default that only happened to match common Mellanox setups rather than being derived from the device.

This diff removes `gid_index` from `IbvConfig` and instead reads each port's full GID table from sysfs when `IbvDeviceInfo` is built, so consumers select the source GID from the device rather than from a config knob.

Walkthrough:

- `primitives.rs`: a `Gid` now carries its raw bytes, table `index`, address `scope`, and RoCE `gid_type`. Two new classifiers back these: `GidScope` (`Loopback` / `LinkLocal` / `SiteLocal` / `Global`), computed from the IPv6-form address (IPv4-mapped addresses are classified by their embedded IPv4, so a mapped loopback/link-local GID is not mistaken for a global one), and `GidType` (`RoCEv1` / `RoCEv2` / `Unknown`), parsed from the port's `gid_attrs/types` sysfs entry. `read_port_gids` scans `/sys/class/infiniband/{device}/ports/{port}/gids/` (bounded by the port GID-table length, capped at the `u8` index range), skips empty/all-zero slots before touching their unreadable `types` attribute, and returns the populated entries as a `BTreeMap<u8, Gid>` ordered by index. `query_device_info` now returns `Result` and stores that map on each `IbvPort`; it errors rather than silently degrading when `ibv_query_device` fails (return code included) or a GID sysfs read fails. Selection is exposed through `IbvDeviceInfo::select_gid(port_num, Option<GidScope>, Option<GidType>)` (the lowest-index GID matching the given filters, where a `None` filter matches anything) and `gid_at(port_num, index)`. `Gid` is `#[repr(C, align(8))]` because the `ibv_gid` conversions reinterpret its leading `raw` bytes in place as an 8-aligned `ibv_gid`, so `raw` must stay first and 8-aligned.
- `queue_pair.rs` / `mlx_queue_pair.rs`: RC and mlx5dv queue pairs resolve their source GID at construction via `select_gid(port, Some(Global), Some(RoCEv2))` and thread the resolved `Gid` (and its index) into the shared `get_qp_info` / `connect` helpers, which now take the source GID and `sgid_index` as parameters instead of re-querying.
- `queue_pair/legacy.rs`: the legacy path resolves the same way, except the EFA path pins to `gid_at(port, 0)` to preserve its existing behavior.
- `device.rs`: because `query_device_info` now returns `Result`, device enumeration logs and skips a device whose info cannot be queried instead of dropping it silently.
- `efa_device.rs`: drop the `gid_index = 0` override now that the index is derived from the device.

Reviewed By: zdevito

Differential Revision: D110256920


