### PR TITLE
Fix test_local_supervision_propagation topology race

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -6289,13 +6289,24 @@ mod tests {
         }
     }
 
-    // Supervision propagation is deterministic (uses Notify + channel
-    // recv for ordering), but the chain of message passes is sensitive
-    // to tokio runtime scheduling. Under suite-wide CPU contention this
-    // can take well above the natural sub-second runtime; 120s gives
-    // headroom without masking genuine hangs.
-    #[cfg_attr(not(target_os = "linux"), ignore = "linux-only")]
-    #[async_timed_test(timeout_secs = 120)]
+    // Two independent supervision trees on one proc exercise both
+    // propagation outcomes concurrently:
+    //   - tree 1 (`root` -> `root_1` -> `root_1_1` -> `root_1_1_1`): a leaf
+    //     failure bubbles up and is *contained* at `root_1`, the one actor
+    //     that handles supervision events.
+    //   - tree 2 (`root_2` -> `root_2_1`): a leaf failure has no handler and
+    //     bubbles all the way to the `ProcSupervisionCoordinator`.
+    //
+    // The trees must not share an ancestor. If tree 2 hung off `root`, then
+    // failing `root_2_1` would fail `root` (which does not handle events),
+    // and a failed parent tears down its whole subtree — including `root_1`
+    // — before `root_1` could handle its own subtree's failure. Whichever
+    // chain reached `root` first won that race; when tree 2 won, `root_1`
+    // was stopped without ever handling, its subtree's failure was rerouted
+    // to the coordinator, and the test blocked forever on `root_1`'s Notify.
+    // Independent trees make both outcomes deterministic regardless of
+    // scheduling.
+    #[async_timed_test(timeout_secs = 30)]
     async fn test_local_supervision_propagation() {
         hyperactor_telemetry::initialize_logging_for_test();
 
@@ -6374,8 +6385,9 @@ mod tests {
             root_1_1.cell().clone(),
             make_actor(&root_1_1_1_state, false),
         );
-        let root_2 =
-            proc.spawn_child::<TestActor>(root.cell().clone(), make_actor(&root_2_state, false));
+        // `root_2` is a second, independent root — deliberately not a child
+        // of `root` — so failing its subtree cannot tear down tree 1.
+        let root_2 = proc.spawn_with_label::<TestActor>("root_2", make_actor(&root_2_state, false));
         let root_2_1 = proc
             .spawn_child::<TestActor>(root_2.cell().clone(), make_actor(&root_2_1_state, false));
 


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/3182
Fixes: https://github.com/meta-pytorch/monarch/issues/3667

There was a pre-existing race in `test_local_supervision_propagation` that hung ~40% of runs under >=2x CPU oversubscription (192 concurrent copies of the test binary on a 96-CPU host). It looked like a lost-wakeup or a lock cycle, but it is neither: the in-proc supervision runtime behaves correctly, and the test topology is at fault.

The test built a single tree with a shared `root`:

```
root (no handler)
├── root_1 (handles supervision events)
│   └── root_1_1
│       └── root_1_1_1   <- failure injected
└── root_2
    └── root_2_1         <- failure injected
```

It fails `root_1_1_1` (expecting the failure to bubble up and be contained at `root_1`, which returns `true` from `handle_supervision_event`) and `root_2_1` (expecting it to reach the `ProcSupervisionCoordinator`) concurrently, then blocks unconditionally on `root_1`'s `Notify`. But `root_2_1`'s failure bubbles unhandled through `root_2` up to `root`, so `root` fails — and a failed parent tears down its entire subtree, including `root_1`, via `Stop` then `ExitRequested`. Whichever chain reached `root` first won the race; when the `root_2` chain won, `root_1` was stopped before it ever handled its own subtree's failure (which, finding its parent already gone, was rerouted to the coordinator), so it never called `notify_one()` and `notified().await` blocked forever.

This change makes `root_2` an independent root (`spawn_with_label` instead of `spawn_child(root.cell())`) so the two chains can no longer tear each other down; both outcomes are now deterministic regardless of scheduling. It also drops the misleading 120s timeout to 30s and rewrites the comments that blamed tokio runtime scheduling and CPU contention.

Diagnosed by running ~192 copies concurrently, catching a hang, and dumping threads with `eu-stack` (all tokio workers parked and no Rust `Mutex`/`RwLock` held, so not a lock cycle), then tracing the propagation with `eprintln!` markers under `--nocapture`: every hang was stuck on `root_1`'s `Notify` await with no actor ever handling a supervision event.

Differential Revision: D110337398


