### PR TITLE
delete the now-unused deferred-pickle subsystem (#4337)

### DIFF
--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -619,7 +619,7 @@ impl History {
                     let exe = remote_exception
                         .call1((exception.backtrace, traceback, rank))
                         .unwrap();
-                    let mut state = pickle(py, exe.unbind(), false, false).unwrap();
+                    let mut state = pickle(py, exe.unbind(), false, false, false).unwrap();
                     let inner = state.take_inner().unwrap();
                     PythonMessage::new_from_buf(
                         PythonMessageKind::Exception { rank: Some(rank) },

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -619,7 +619,7 @@ impl History {
                     let exe = remote_exception
                         .call1((exception.backtrace, traceback, rank))
                         .unwrap();
-                    let mut state = pickle(py, exe.unbind(), false, false, false).unwrap();
+                    let mut state = pickle(py, exe.unbind(), false, false).unwrap();
                     let inner = state.take_inner().unwrap();
                     PythonMessage::new_from_buf(
                         PythonMessageKind::Exception { rank: Some(rank) },

--- a/monarch_extension/src/mesh_controller.rs
+++ b/monarch_extension/src/mesh_controller.rs
@@ -419,9 +419,10 @@ impl Invocation {
                                         overlay
                                             .push_run(
                                                 rank..rank + 1,
-                                                PythonResponseMessage::Exception(
-                                                    exception.as_ref().message.clone(),
-                                                ),
+                                                PythonResponseMessage::Exception {
+                                                    part: exception.as_ref().message.clone(),
+                                                    refs: exception.as_ref().refs.clone(),
+                                                },
                                             )
                                             .expect("exception runs should not overlap");
                                     }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -7,6 +7,7 @@
  */
 
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::error::Error;
 use std::fmt::Debug;
 use std::future::pending;
@@ -84,6 +85,7 @@ use crate::metrics::ENDPOINT_ACTOR_COUNT;
 use crate::metrics::ENDPOINT_ACTOR_ERROR;
 use crate::metrics::ENDPOINT_ACTOR_LATENCY_US_HISTOGRAM;
 use crate::metrics::ENDPOINT_ACTOR_PANIC;
+use crate::pickle::PicklingState;
 use crate::pickle::pickle_to_part;
 use crate::proc::PyActorAddr;
 use crate::pympsc;
@@ -163,6 +165,21 @@ pub enum PythonResponseMessage {
 
 wirevalue::register_type!(PythonResponseMessage);
 wirevalue::register_type!(ValueOverlay<PythonResponseMessage>);
+
+impl PythonResponseMessage {
+    /// Decode this response's payload, reuniting its out-of-band `refs` table
+    /// so mesh references reconstruct. Mirrors [`PythonMessage::decode`] for the
+    /// accumulated (valuemesh / `.call()`) path.
+    pub(crate) fn decode(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        let (part, refs) = match self {
+            PythonResponseMessage::Result { part, refs }
+            | PythonResponseMessage::Exception { part, refs } => (part, refs),
+        };
+        let mesh_references = refs.iter().cloned().map(Some).collect();
+        let mut state = PicklingState::from_parts(part.clone(), VecDeque::new(), mesh_references);
+        state.unpickle(py)
+    }
+}
 
 /// Newtype wrapper around [`ValueOverlay<PythonResponseMessage>`] needed
 /// because `PythonMessageKind` is a `#[pyclass]` enum, requiring all variant
@@ -558,9 +575,21 @@ impl std::fmt::Debug for PythonMessage {
 #[pymethods]
 impl PythonMessage {
     #[new]
-    #[pyo3(signature = (kind, message))]
-    pub fn new(kind: PythonMessageKind, message: PyRef<'_, FrozenBuffer>) -> PyResult<Self> {
-        Ok(PythonMessage::new_from_buf(kind, message.inner.clone()))
+    #[pyo3(signature = (kind, message, refs))]
+    pub fn new(
+        kind: PythonMessageKind,
+        message: PyRef<'_, FrozenBuffer>,
+        refs: &Bound<'_, PyList>,
+    ) -> PyResult<Self> {
+        let mesh_refs: Vec<MeshRef> = refs
+            .iter()
+            .map(|item| Ok(item.downcast::<PyMeshRef>()?.borrow().inner.clone()))
+            .collect::<PyResult<_>>()?;
+        Ok(PythonMessage::new_from_buf_with_refs(
+            kind,
+            message.inner.clone(),
+            mesh_refs,
+        ))
     }
 
     #[getter]
@@ -568,11 +597,27 @@ impl PythonMessage {
         self.kind.clone()
     }
 
-    #[getter]
-    fn message(&self) -> FrozenBuffer {
-        FrozenBuffer {
-            inner: self.message.to_bytes(),
-        }
+    /// Decode this message's payload, reuniting the out-of-band `refs` table so
+    /// the `pop_mesh_reference` sentinels in the pickle stream resolve. The raw
+    /// bytes are deliberately not exposed: a payload can only be read back
+    /// through here, so a decode can never silently drop mesh references.
+    #[pyo3(signature = (local_state=None))]
+    fn decode(
+        &self,
+        py: Python<'_>,
+        local_state: Option<&Bound<'_, PyList>>,
+    ) -> PyResult<Py<PyAny>> {
+        let tensor_engine_references: VecDeque<Py<PyAny>> = local_state
+            .map(|list| list.iter().map(|item| item.unbind()).collect())
+            .unwrap_or_default();
+        let mesh_references: VecDeque<Option<MeshRef>> =
+            self.refs.iter().cloned().map(Some).collect();
+        let mut state = PicklingState::from_parts(
+            self.message.clone(),
+            tensor_engine_references,
+            mesh_references,
+        );
+        state.unpickle(py)
     }
 
     #[getter]

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -217,6 +217,65 @@ pub enum MeshRef {
     Host(Box<HostMeshRef>),
 }
 
+impl MeshRef {
+    /// Reconstruct the Python mesh wrapper this reference points at.
+    ///
+    /// Mirrors the `py_*_from_bytes` reconstructors, but takes an
+    /// already-deserialized [`MeshRef`] from the message's `refs` table.
+    pub(crate) fn reconstruct(self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        match self {
+            MeshRef::Proc(r) => {
+                Ok(Py::new(py, crate::proc_mesh::PyProcMesh::new_ref(*r))?.into_any())
+            }
+            MeshRef::Host(r) => {
+                Ok(Py::new(py, crate::host_mesh::PyHostMesh::new_ref(*r))?.into_any())
+            }
+            MeshRef::Actor(r) => {
+                let inner = crate::actor_mesh::PythonActorMeshImpl::new_ref(*r);
+                let async_mesh = crate::actor_mesh::AsyncActorMesh::from_impl(Arc::new(inner));
+                let mesh = crate::actor_mesh::PythonActorMesh::from_impl(Arc::from(async_mesh));
+                Ok(Py::new(py, mesh)?.into_any())
+            }
+        }
+    }
+}
+
+/// An opaque carrier so a `MeshRef` can ride in `PythonMessage.refs` across
+/// the Python boundary (the message getter out, the `PicklingState` ctor in).
+#[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
+pub struct PyMeshRef {
+    pub(crate) inner: MeshRef,
+}
+
+impl<'py> IntoPyObject<'py> for MeshRef {
+    type Target = PyMeshRef;
+    type Output = Bound<'py, PyMeshRef>;
+    type Error = PyErr;
+
+    fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
+        Bound::new(py, PyMeshRef { inner: self })
+    }
+}
+
+/// Extract the serializable [`MeshRef`] from a resolved mesh wrapper (the
+/// inverse of [`MeshRef::reconstruct`]), for the sender-side pending fill.
+pub(crate) fn mesh_ref_from_pyobject(value: &Bound<'_, PyAny>) -> PyResult<MeshRef> {
+    if let Ok(m) = value.downcast::<crate::proc_mesh::PyProcMesh>() {
+        return Ok(MeshRef::Proc(Box::new(m.borrow().mesh_ref()?)));
+    }
+    if let Ok(m) = value.downcast::<crate::host_mesh::PyHostMesh>() {
+        return Ok(MeshRef::Host(Box::new(m.borrow().mesh_ref().map_err(
+            |e| pyo3::exceptions::PyValueError::new_err(e.to_string()),
+        )?)));
+    }
+    if let Ok(m) = value.downcast::<crate::actor_mesh::PythonActorMesh>() {
+        return Ok(MeshRef::Actor(Box::new(m.borrow().get_inner().mesh_ref()?)));
+    }
+    Err(pyo3::exceptions::PyRuntimeError::new_err(
+        "pending pickle did not resolve to a mesh reference",
+    ))
+}
+
 #[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
 #[derive(Clone, Serialize, Deserialize, Named, Default, PartialEq)]
 pub struct PythonMessage {
@@ -311,6 +370,7 @@ struct ResolvedCallMethod {
     method: MethodSpecifier,
     bytes: FrozenBuffer,
     local_state: Option<Py<PyAny>>,
+    mesh_references: Vec<MeshRef>,
     /// Implements PortProtocol
     /// Concretely either a Port, DroppingPort, or LocalPort
     response_port: ResponsePort,
@@ -345,15 +405,25 @@ pub struct QueuedMessage {
     #[pyo3(get)]
     pub local_state: Py<PyAny>,
     #[pyo3(get)]
+    pub refs: Py<PyAny>,
+    #[pyo3(get)]
     pub response_port: Py<PyAny>,
 }
 
 impl PythonMessage {
     pub fn new_from_buf(kind: PythonMessageKind, message: impl Into<Part>) -> Self {
+        Self::new_from_buf_with_refs(kind, message, Vec::new())
+    }
+
+    pub fn new_from_buf_with_refs(
+        kind: PythonMessageKind,
+        message: impl Into<Part>,
+        refs: Vec<MeshRef>,
+    ) -> Self {
         Self {
             kind,
             message: message.into(),
-            refs: Vec::new(),
+            refs,
         }
     }
 
@@ -416,6 +486,7 @@ impl PythonMessage {
                             inner: self.message.into_bytes(),
                         },
                         local_state,
+                        mesh_references: self.refs,
                         response_port,
                     })
                 })
@@ -460,6 +531,7 @@ impl PythonMessage {
                         inner: self.message.into_bytes(),
                     },
                     local_state: None,
+                    mesh_references: self.refs,
                     response_port,
                 })
             }
@@ -501,6 +573,11 @@ impl PythonMessage {
         FrozenBuffer {
             inner: self.message.to_bytes(),
         }
+    }
+
+    #[getter]
+    fn refs(&self) -> Vec<MeshRef> {
+        self.refs.clone()
     }
 }
 
@@ -1614,6 +1691,7 @@ impl PythonActor {
                         resolved
                             .local_state
                             .unwrap_or_else(|| PyList::empty(py).unbind().into()),
+                        resolved.mesh_references.into_py_any(py)?,
                         resolved.response_port.into_py_any(py)?,
                     ),
                     None,
@@ -1664,6 +1742,7 @@ impl PythonActor {
                     local_state: resolved
                         .local_state
                         .unwrap_or_else(|| PyList::empty(py).unbind().into()),
+                    refs: resolved.mesh_references.into_py_any(py)?,
                     response_port: resolved.response_port.into_py_any(py)?,
                 })
             },
@@ -2087,6 +2166,7 @@ impl Port {
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PythonActorHandle>()?;
     hyperactor_mod.add_class::<PythonMessage>()?;
+    hyperactor_mod.add_class::<PyMeshRef>()?;
     hyperactor_mod.add_class::<PythonMessageKind>()?;
     hyperactor_mod.add_class::<MethodSpecifier>()?;
     hyperactor_mod.add_class::<UnflattenArg>()?;

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -40,9 +40,12 @@ use hyperactor::mailbox::UndeliverableMessageError;
 use hyperactor::mailbox::UndeliverableReason;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
+use hyperactor_mesh::ProcMeshRef;
+use hyperactor_mesh::actor_mesh::ActorMeshRef;
 use hyperactor_mesh::casting::update_undeliverable_envelope_for_casting;
 use hyperactor_mesh::comm::multicast::CAST_POINT;
 use hyperactor_mesh::comm::multicast::CastInfo;
+use hyperactor_mesh::host_mesh::HostMeshRef;
 use hyperactor_mesh::introspect::ActiveHandler;
 use hyperactor_mesh::introspect::EXECUTION;
 use hyperactor_mesh::introspect::Execution;
@@ -148,8 +151,14 @@ impl MethodSpecifier {
 /// a single run.
 #[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
 pub enum PythonResponseMessage {
-    Result(serde_multipart::Part),
-    Exception(serde_multipart::Part),
+    Result {
+        part: serde_multipart::Part,
+        refs: Vec<MeshRef>,
+    },
+    Exception {
+        part: serde_multipart::Part,
+        refs: Vec<MeshRef>,
+    },
 }
 
 wirevalue::register_type!(PythonResponseMessage);
@@ -200,11 +209,21 @@ fn mailbox<'py, T: Actor>(py: Python<'py>, cx: &Context<'_, T>) -> Bound<'py, Py
     mailbox.into_bound_py_any(py).unwrap()
 }
 
+/// A serializable reference to a mesh (actor, proc, or host).
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq)]
+pub enum MeshRef {
+    Actor(Box<ActorMeshRef<PythonActor>>),
+    Proc(Box<ProcMeshRef>),
+    Host(Box<HostMeshRef>),
+}
+
 #[pyclass(frozen, module = "monarch._rust_bindings.monarch_hyperactor.actor")]
 #[derive(Clone, Serialize, Deserialize, Named, Default, PartialEq)]
 pub struct PythonMessage {
     pub kind: PythonMessageKind,
     pub message: Part,
+    /// Mesh references carried out-of-band from the pickled `message`.
+    pub refs: Vec<MeshRef>,
 }
 
 /// Extract the endpoint method name from a [`PythonMessage`].
@@ -241,6 +260,7 @@ impl From<ValueOverlay<PythonResponseMessage>> for PythonMessage {
         PythonMessage {
             kind: PythonMessageKind::AccumulatedResponses(AccumulatedResponses(overlay)),
             message: Default::default(),
+            refs: Vec::new(),
         }
     }
 }
@@ -256,7 +276,13 @@ impl PythonMessage {
             PythonMessageKind::Result { rank, .. } => {
                 let rank = rank.expect("accumulated response should have a rank");
                 let mut overlay = ValueOverlay::new();
-                overlay.push_run(rank..rank + 1, PythonResponseMessage::Result(self.message))?;
+                overlay.push_run(
+                    rank..rank + 1,
+                    PythonResponseMessage::Result {
+                        part: self.message,
+                        refs: self.refs,
+                    },
+                )?;
                 Ok(overlay)
             }
             PythonMessageKind::Exception { rank, .. } => {
@@ -264,7 +290,10 @@ impl PythonMessage {
                 let mut overlay = ValueOverlay::new();
                 overlay.push_run(
                     rank..rank + 1,
-                    PythonResponseMessage::Exception(self.message),
+                    PythonResponseMessage::Exception {
+                        part: self.message,
+                        refs: self.refs,
+                    },
                 )?;
                 Ok(overlay)
             }
@@ -324,6 +353,7 @@ impl PythonMessage {
         Self {
             kind,
             message: message.into(),
+            refs: Vec::new(),
         }
     }
 
@@ -333,10 +363,12 @@ impl PythonMessage {
             PythonMessageKind::Result { .. } => PythonMessage {
                 kind: PythonMessageKind::Result { rank },
                 message: self.message,
+                refs: self.refs,
             },
             PythonMessageKind::Exception { .. } => PythonMessage {
                 kind: PythonMessageKind::Exception { rank },
                 message: self.message,
+                refs: self.refs,
             },
             _ => panic!("PythonMessage is not a response but {:?}", self),
         }
@@ -446,6 +478,7 @@ impl std::fmt::Debug for PythonMessage {
                 "message",
                 &wirevalue::HexFmt(&(*self.message.to_bytes())[..]).to_string(),
             )
+            .field("refs", &self.refs.len())
             .finish()
     }
 }
@@ -2100,6 +2133,7 @@ mod tests {
                 response_port: Some(EitherPortRef::Unbounded(port_ref.clone().into())),
             },
             message: Part::from(vec![1, 2, 3]),
+            refs: Vec::new(),
         };
         {
             let mut multipart_message =

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -51,11 +51,6 @@ use crate::shape::PyRegion;
 use crate::supervision::Supervisable;
 use crate::supervision::SupervisionError;
 
-py_global!(
-    is_pending_pickle_allowed,
-    "monarch._src.actor.pickle",
-    "is_pending_pickle_allowed"
-);
 py_global!(_pickle, "monarch._src.actor.actor_mesh", "_pickle");
 
 py_global!(
@@ -429,7 +424,6 @@ impl ActorMeshProtocol for AsyncActorMesh {
                         let mut state = crate::pickle::pickle(
                             py,
                             pyerr.into_value(py).into_any(),
-                            false,
                             false,
                             false,
                         )?;

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -142,6 +142,14 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>;
 
+    /// The serializable reference for this mesh, for the out-of-band `refs`
+    /// table. Defaults to an error; impls that hold a resolved ref override.
+    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>> {
+        Err(pyo3::exceptions::PyRuntimeError::new_err(
+            "mesh_ref() is not available for this actor mesh",
+        ))
+    }
+
     /// Stop the actor mesh asynchronously.
     /// Default implementation raises NotImplementedError for types that don't support stopping.
     fn stop(&self, _instance: &PyInstance, _reason: String) -> PyResult<PyPythonTask> {
@@ -426,6 +434,7 @@ impl ActorMeshProtocol for AsyncActorMesh {
                             pyerr.into_value(py).into_any(),
                             false,
                             false,
+                            false,
                         )?;
                         let _ = port_ref.post(
                             &instance,
@@ -453,9 +462,16 @@ impl ActorMeshProtocol for AsyncActorMesh {
                 let shared =
                     PyPythonTask::new(async move { Ok(PythonActorMesh::from_impl(fut.await?)) })?
                         .spawn_abortable()?;
+                let shared = Py::new(py, shared)?;
+                if crate::pickle::reserve_mesh_reference_if_active(shared.clone_ref(py)) {
+                    let pop_fn = py
+                        .import("monarch._rust_bindings.monarch_hyperactor.pickle")?
+                        .getattr("pop_mesh_reference")?;
+                    return Ok((pop_fn, PyTuple::empty(py).into_any()));
+                }
                 // Get Shared.block_on as an unbound method
                 let block_on = shared_class(py).getattr("block_on")?;
-                let args = PyTuple::new(py, [shared.into_pyobject(py)?])?;
+                let args = PyTuple::new(py, [shared])?;
                 Ok((block_on, args.into_any()))
             }
         }
@@ -637,6 +653,11 @@ impl ActorMeshProtocol for PythonActorMeshImpl {
         self.mesh_ref().__reduce__(py)
     }
 
+    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>> {
+        // `self.mesh_ref()` resolves to the inherent borrow-returning method.
+        Ok(PythonActorMeshImpl::mesh_ref(self).clone())
+    }
+
     fn name(&self) -> PyResult<PyPythonTask> {
         let name = self.mesh_ref().id().to_string();
         PyPythonTask::new(async move { Ok(name) })
@@ -711,6 +732,14 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
+        if crate::pickle::push_mesh_reference_if_active(crate::actor::MeshRef::Actor(Box::new(
+            self.clone(),
+        ))) {
+            let pop_fn = py
+                .import("monarch._rust_bindings.monarch_hyperactor.pickle")?
+                .getattr("pop_mesh_reference")?;
+            return Ok((pop_fn, pyo3::types::PyTuple::empty(py).into_any()));
+        }
         let bytes = bincode::serde::encode_to_vec(self, bincode::config::legacy())
             .map_err(|e| PyValueError::new_err(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
@@ -719,6 +748,10 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
             .unwrap();
         let from_bytes = module.getattr("py_actor_mesh_from_bytes").unwrap();
         Ok((from_bytes, py_bytes))
+    }
+
+    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>> {
+        Ok(self.clone())
     }
 
     fn name(&self) -> PyResult<PyPythonTask> {

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -143,12 +143,9 @@ pub(crate) trait ActorMeshProtocol: Send + Sync {
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)>;
 
     /// The serializable reference for this mesh, for the out-of-band `refs`
-    /// table. Defaults to an error; impls that hold a resolved ref override.
-    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>> {
-        Err(pyo3::exceptions::PyRuntimeError::new_err(
-            "mesh_ref() is not available for this actor mesh",
-        ))
-    }
+    /// table. Required so every impl chooses: hold a resolved ref and return
+    /// it, or (a pending mesh) have none and error explicitly.
+    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>>;
 
     /// Stop the actor mesh asynchronously.
     /// Default implementation raises NotImplementedError for types that don't support stopping.
@@ -475,6 +472,15 @@ impl ActorMeshProtocol for AsyncActorMesh {
                 Ok((block_on, args.into_any()))
             }
         }
+    }
+
+    fn mesh_ref(&self) -> PyResult<ActorMeshRef<PythonActor>> {
+        // A pending mesh has no serializable ref of its own; the reserve/fill
+        // slot carries it out-of-band. This is a backstop: the happy path never
+        // asks a pending mesh for a ref.
+        Err(pyo3::exceptions::PyRuntimeError::new_err(
+            "pending actor mesh has no serializable ref; it is carried via the reserve/fill slot",
+        ))
     }
 
     fn stop(&self, instance: &PyInstance, reason: String) -> PyResult<PyPythonTask> {

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -417,11 +417,11 @@ async fn collect_valuemesh(
                     overlay.runs().try_fold(
                         Vec::with_capacity(expected_count),
                         |mut parts, (range, payload)| match payload {
-                            PythonResponseMessage::Result(part) => {
+                            PythonResponseMessage::Result { part, .. } => {
                                 parts.extend(range.clone().map(|_| part.clone()));
                                 Ok(parts)
                             }
-                            PythonResponseMessage::Exception(part) => {
+                            PythonResponseMessage::Exception { part, .. } => {
                                 record_guard.mark_error();
                                 monarch_with_gil_blocking(GilSite::Traceback, |py| {
                                     Err(PyErr::from_value(unpickle_from_part(py, part.clone())?))

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -7,6 +7,7 @@
  */
 
 use std::cell::Cell;
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -30,6 +31,7 @@ use pyo3::types::PyTuple;
 use serde_multipart::Part;
 use typeuri::Named;
 
+use crate::actor::MeshRef;
 use crate::actor::MethodSpecifier;
 use crate::actor::PythonActor;
 use crate::actor::PythonMessage;
@@ -39,7 +41,6 @@ use crate::actor_mesh::AllOrChoose;
 use crate::actor_mesh::PythonActorMesh;
 use crate::actor_mesh::SupervisableActorMesh;
 use crate::actor_mesh::to_all_or_choose;
-use crate::buffers::FrozenBuffer;
 use crate::context::PyInstance;
 use crate::mailbox::EitherPortRef;
 use crate::mailbox::PythonOncePortRef;
@@ -59,7 +60,7 @@ use crate::metrics::ENDPOINT_STREAM_ERROR;
 use crate::metrics::ENDPOINT_STREAM_LATENCY_US_HISTOGRAM;
 use crate::metrics::ENDPOINT_STREAM_THROUGHPUT;
 use crate::pickle::PendingMessage;
-use crate::pickle::unpickle;
+use crate::pickle::PicklingState;
 use crate::pytokio::PyPythonTask;
 use crate::pytokio::PythonTask;
 use crate::runtime::GilSite;
@@ -82,15 +83,6 @@ py_global!(
     "_dispatch_actor_rref"
 );
 py_global!(make_future, "monarch._src.actor.future", "Future");
-
-fn unpickle_from_part(py: Python<'_>, part: Part) -> PyResult<Bound<'_, PyAny>> {
-    unpickle(
-        py,
-        FrozenBuffer {
-            inner: part.into_bytes(),
-        },
-    )
-}
 
 /// The type of endpoint operation being performed.
 ///
@@ -289,7 +281,7 @@ async fn collect_value(
     supervision_monitor: &Option<Arc<dyn Supervisable>>,
     instance: &Instance<PythonActor>,
     qualified_endpoint_name: &Option<String>,
-) -> PyResult<(Part, Option<usize>)> {
+) -> PyResult<(Part, Vec<MeshRef>, Option<usize>)> {
     enum RaceResult {
         Message(Box<PythonMessage>),
         SupervisionError(PyErr),
@@ -327,12 +319,20 @@ async fn collect_value(
 
     match race_result {
         RaceResult::Message(boxed) => {
-            let PythonMessage { kind, message, .. } = *boxed;
+            let PythonMessage {
+                kind,
+                message,
+                refs,
+            } = *boxed;
             match kind {
-                PythonMessageKind::Result { rank, .. } => Ok((message, rank)),
+                PythonMessageKind::Result { rank, .. } => Ok((message, refs, rank)),
                 PythonMessageKind::Exception { .. } => {
                     monarch_with_gil_blocking(GilSite::Traceback, |py| {
-                        Err(PyErr::from_value(unpickle_from_part(py, message)?))
+                        let mesh_references: VecDeque<Option<MeshRef>> =
+                            refs.into_iter().map(Some).collect();
+                        let mut state =
+                            PicklingState::from_parts(message, VecDeque::new(), mesh_references);
+                        Err(PyErr::from_value(state.unpickle(py)?.into_bound(py)))
                     })
                 }
                 other => Err(pyo3::exceptions::PyValueError::new_err(format!(
@@ -412,27 +412,64 @@ async fn collect_valuemesh(
                 ))
             })?;
             monarch_with_gil_blocking(GilSite::ReplyConvert, |py| {
-                Ok(PyValueMesh::build_from_parts(
-                    &extent,
-                    overlay.runs().try_fold(
-                        Vec::with_capacity(expected_count),
-                        |mut parts, (range, payload)| match payload {
+                // Out-of-band mesh refs reunite only while the `PicklingState` is
+                // live, i.e. during decode, so a ref-carrying response must be
+                // decoded here (eagerly, at accumulation): a lazy decode on access
+                // would have no state to reunite against, the REFS-1 failure. But
+                // decoding *every* response here would revert D96180139, which made
+                // valuemesh values unpickle lazily on access so a large
+                // OnceBuffer-accumulated `.call()` does not pay one big unpickle
+                // burst at the end of collection.
+                //
+                // Reconcile the two by gating on refs. A `.call()` fans one
+                // endpoint over the mesh, so the batch is uniform: either every
+                // response carries refs (the endpoint returns a mesh, the minority)
+                // or none does (plain values, the common case). With no refs we
+                // keep the raw parts and let them unpickle on access (D96180139,
+                // preserved); only with refs present do we decode eagerly to
+                // reunite them.
+                let has_refs = overlay.runs().any(|(_, payload)| {
+                    let (PythonResponseMessage::Result { refs, .. }
+                    | PythonResponseMessage::Exception { refs, .. }) = payload;
+                    !refs.is_empty()
+                });
+
+                if !has_refs {
+                    let mut parts = Vec::with_capacity(expected_count);
+                    for (range, payload) in overlay.runs() {
+                        match payload {
                             PythonResponseMessage::Result { part, .. } => {
                                 parts.extend(range.clone().map(|_| part.clone()));
-                                Ok(parts)
                             }
-                            PythonResponseMessage::Exception { part, .. } => {
+                            PythonResponseMessage::Exception { .. } => {
                                 record_guard.mark_error();
-                                monarch_with_gil_blocking(GilSite::Traceback, |py| {
-                                    Err(PyErr::from_value(unpickle_from_part(py, part.clone())?))
-                                })
+                                return Err(PyErr::from_value(payload.decode(py)?.into_bound(py)));
                             }
-                        },
-                    )?,
-                )?
-                .into_pyobject(py)?
-                .into_any()
-                .unbind())
+                        }
+                    }
+                    return Ok(PyValueMesh::build_from_parts(&extent, parts)?
+                        .into_pyobject(py)?
+                        .into_any()
+                        .unbind());
+                }
+
+                let mut objects: Vec<Py<PyAny>> = Vec::with_capacity(expected_count);
+                for (range, payload) in overlay.runs() {
+                    match payload {
+                        PythonResponseMessage::Result { .. } => {
+                            let obj = payload.decode(py)?;
+                            objects.extend(range.clone().map(|_| obj.clone_ref(py)));
+                        }
+                        PythonResponseMessage::Exception { .. } => {
+                            record_guard.mark_error();
+                            return Err(PyErr::from_value(payload.decode(py)?.into_bound(py)));
+                        }
+                    }
+                }
+                Ok(PyValueMesh::build_from_objects(&extent, objects)?
+                    .into_pyobject(py)?
+                    .into_any()
+                    .unbind())
             })
         }
         RaceResult::RecvError(e) => {
@@ -472,8 +509,12 @@ fn value_collector(
         )
         .await
         {
-            Ok((message, _)) => monarch_with_gil_blocking(GilSite::ReplyConvert, |py| {
-                unpickle_from_part(py, message).map(|obj| obj.unbind())
+            Ok((message, refs, _)) => monarch_with_gil_blocking(GilSite::ReplyConvert, |py| {
+                let mesh_references: VecDeque<Option<MeshRef>> =
+                    refs.into_iter().map(Some).collect();
+                let mut state =
+                    PicklingState::from_parts(message, VecDeque::new(), mesh_references);
+                state.unpickle(py)
             }),
             Err(e) => {
                 record_guard.mark_error();
@@ -540,8 +581,12 @@ impl PyValueStream {
             )
             .await
             {
-                Ok((message, _)) => monarch_with_gil_blocking(GilSite::ReplyConvert, |py| {
-                    unpickle_from_part(py, message).map(|obj| obj.unbind())
+                Ok((message, refs, _)) => monarch_with_gil_blocking(GilSite::ReplyConvert, |py| {
+                    let mesh_references: VecDeque<Option<MeshRef>> =
+                        refs.into_iter().map(Some).collect();
+                    let mut state =
+                        PicklingState::from_parts(message, VecDeque::new(), mesh_references);
+                    state.unpickle(py)
                 }),
                 Err(e) => {
                     record_guard.mark_error();

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -149,7 +149,7 @@ impl PyHostMesh {
         Self::Ref(PyHostMeshRefImpl(inner))
     }
 
-    fn mesh_ref(&self) -> Result<HostMeshRef, anyhow::Error> {
+    pub(crate) fn mesh_ref(&self) -> Result<HostMeshRef, anyhow::Error> {
         match self {
             PyHostMesh::Owned(inner) => Ok(inner.0.borrow()?.clone()),
             PyHostMesh::Ref(inner) => Ok(inner.0.clone()),
@@ -239,7 +239,15 @@ impl PyHostMesh {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
-        let bytes = bincode::serde::encode_to_vec(&self.mesh_ref()?, bincode::config::legacy())
+        let mesh_ref = self.mesh_ref()?;
+        if crate::pickle::push_mesh_reference_if_active(crate::actor::MeshRef::Host(Box::new(
+            mesh_ref.clone(),
+        ))) {
+            let pop_fn = PyModule::import(py, "monarch._rust_bindings.monarch_hyperactor.pickle")?
+                .getattr("pop_mesh_reference")?;
+            return Ok((pop_fn, pyo3::types::PyTuple::empty(py).into_any()));
+        }
+        let bytes = bincode::serde::encode_to_vec(&mesh_ref, bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
         let from_bytes =

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -22,6 +22,8 @@ use pyo3::types::PyList;
 use pyo3::types::PyTuple;
 use serde_multipart::Part;
 
+use crate::actor::MeshRef;
+use crate::actor::PyMeshRef;
 use crate::actor::PythonMessage;
 use crate::actor::PythonMessageKind;
 use crate::buffers::Buffer;
@@ -88,6 +90,14 @@ py_global!(
 // Thread-local storage for the active pickling state.
 // Set by pickle/unpickle operations so free functions used in __reduce__
 // implementations can access it.
+//
+// It is thread-local by design: two threads pickling at once (even the same
+// mesh ref) collect into independent `mesh_references` / `pending_mesh_fills`,
+// so there is nothing shared to race on. `pickle()` then moves the state out of
+// the thread-local into an owned `PicklingState` before the GIL-releasing
+// `PicklingState::resolve`, so the sender-side slot fill mutates a single-owner
+// value across its awaits, never this thread-local. Both properties (thread-
+// local, and moved out before resolve) are what make releasing the GIL safe.
 thread_local! {
     static ACTIVE_PICKLING_STATE: RefCell<Option<ActivePicklingState>> = const { RefCell::new(None) };
 }
@@ -125,20 +135,35 @@ struct ActivePicklingState {
     tensor_engine_references: VecDeque<Py<PyAny>>,
     /// Pending pickles (PyShared values) that must be resolved.
     pending_pickles: VecDeque<Py<PyShared>>,
+    /// Mesh references collected out-of-band into the message's `refs` table.
+    /// A `None` is a slot reserved for a pending mesh, filled sender-side.
+    mesh_references: VecDeque<Option<MeshRef>>,
+    /// Pending mesh slots awaiting a sender-side fill: (index into
+    /// `mesh_references`, the handle whose resolved mesh supplies the ref).
+    pending_mesh_fills: Vec<(usize, Py<PyShared>)>,
     /// Whether pending pickles are allowed in this pickling context.
     allow_pending_pickles: bool,
     /// Whether tensor engine references are allowed in this pickling context.
     allow_tensor_engine_references: bool,
+    /// Whether mesh references are collected out-of-band in this context.
+    allow_mesh_references: bool,
 }
 
 impl ActivePicklingState {
     /// Create a new ActivePicklingState.
-    fn new(allow_pending_pickles: bool, allow_tensor_engine_references: bool) -> Self {
+    fn new(
+        allow_pending_pickles: bool,
+        allow_tensor_engine_references: bool,
+        allow_mesh_references: bool,
+    ) -> Self {
         Self {
             tensor_engine_references: VecDeque::new(),
             pending_pickles: VecDeque::new(),
+            mesh_references: VecDeque::new(),
+            pending_mesh_fills: Vec::new(),
             allow_pending_pickles,
             allow_tensor_engine_references,
+            allow_mesh_references,
         }
     }
 
@@ -148,6 +173,8 @@ impl ActivePicklingState {
             buffer,
             tensor_engine_references: self.tensor_engine_references,
             pending_pickles: self.pending_pickles,
+            mesh_references: self.mesh_references,
+            pending_mesh_fills: self.pending_mesh_fills,
         }
     }
 }
@@ -163,6 +190,11 @@ pub struct PicklingStateInner {
     tensor_engine_references: VecDeque<Py<PyAny>>,
     /// Pending pickles (PyShared values) that must be resolved.
     pending_pickles: VecDeque<Py<PyShared>>,
+    /// Mesh references carried out-of-band into the message's `refs` table.
+    /// A `None` is a slot reserved for a pending mesh, filled sender-side.
+    mesh_references: VecDeque<Option<MeshRef>>,
+    /// Pending mesh slots awaiting a sender-side fill.
+    pending_mesh_fills: Vec<(usize, Py<PyShared>)>,
 }
 
 impl PicklingStateInner {
@@ -207,13 +239,24 @@ impl PicklingState {
     /// This is used for unpickling received messages that may contain tensor engine
     /// references that need to be restored during deserialization.
     #[new]
-    #[pyo3(signature = (buffer, tensor_engine_references=None))]
+    #[pyo3(signature = (buffer, tensor_engine_references=None, mesh_references=None))]
     fn py_new(
+        py: Python<'_>,
         buffer: PyRef<'_, crate::buffers::FrozenBuffer>,
         tensor_engine_references: Option<&Bound<'_, PyList>>,
+        mesh_references: Option<Vec<Py<PyMeshRef>>>,
     ) -> PyResult<Self> {
         let refs: VecDeque<Py<PyAny>> = tensor_engine_references
             .map(|list| list.iter().map(|item| item.unbind()).collect())
+            .unwrap_or_default();
+
+        // pyo3 type-checks each element as a `PyMeshRef` during extraction.
+        let mesh_refs: VecDeque<Option<MeshRef>> = mesh_references
+            .map(|list| {
+                list.into_iter()
+                    .map(|m| Some(m.borrow(py).inner.clone()))
+                    .collect()
+            })
             .unwrap_or_default();
 
         Ok(Self {
@@ -221,6 +264,8 @@ impl PicklingState {
                 buffer: Part::from(buffer.inner.clone()),
                 tensor_engine_references: refs,
                 pending_pickles: VecDeque::new(),
+                mesh_references: mesh_refs,
+                pending_mesh_fills: Vec::new(),
             }),
         })
     }
@@ -267,9 +312,11 @@ impl PicklingState {
 
         // Set up an active state for unpickling (to handle pop calls).
         // The guard restores any previous state on drop (including on panic).
-        let mut active = ActivePicklingState::new(false, false);
+        let mut active = ActivePicklingState::new(false, false, false);
         active.pending_pickles = inner.pending_pickles;
         active.tensor_engine_references = inner.tensor_engine_references;
+        active.mesh_references = inner.mesh_references;
+        active.pending_mesh_fills = inner.pending_mesh_fills;
 
         let _guard = ActivePicklingGuard::enter(active);
 
@@ -298,12 +345,46 @@ impl PicklingState {
     /// 3. Calls unpickle to reconstruct the object
     /// 4. Calls pickle again to get a new PicklingState without pending pickles
     pub async fn resolve(mut self) -> PyResult<PicklingState> {
-        // Short-circuit if there are no pending pickles
+        // Take the pending mesh fills out: a plain move, no GIL and no
+        // `clone_ref`. Each is a slot index plus the handle whose resolved mesh
+        // supplies the ref.
+        let fills = std::mem::take(
+            &mut self
+                .inner
+                .as_mut()
+                .ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "PicklingState has already been consumed",
+                    )
+                })?
+                .pending_mesh_fills,
+        );
+
+        for (index, handle) in fills {
+            // Await the mesh's init task (these run concurrently, so the wait
+            // is the slowest init, not the sum).
+            let mut task =
+                monarch_with_gil_blocking(GilSite::AwaitDrive, |py| handle.borrow(py).task())?;
+            task.take_task()?.await?;
+
+            // Extract the `*MeshRef` from the now-resolved mesh and fill the slot.
+            monarch_with_gil_blocking(GilSite::Convert, |py| -> PyResult<()> {
+                let value = handle.borrow(py).poll()?.ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err("pending mesh handle did not resolve")
+                })?;
+                let mesh_ref = crate::actor::mesh_ref_from_pyobject(value.bind(py))?;
+                if let Some(inner) = self.inner.as_mut() {
+                    inner.mesh_references[index] = Some(mesh_ref);
+                }
+                Ok(())
+            })?;
+        }
+
+        // Resolve any deferred (non-mesh) pending pickles by re-pickling. Empty
+        // for mesh-only messages, where the table filled above is the result.
         if self.inner_ref()?.pending_pickles.is_empty() {
             return Ok(self);
         }
-
-        // Await all pending pickles to ensure they're resolved
         let pending: Vec<Py<PyShared>> = monarch_with_gil_blocking(GilSite::Convert, |py| {
             self.inner_ref().map(|inner| {
                 inner
@@ -313,18 +394,15 @@ impl PicklingState {
                     .collect()
             })
         })?;
-
         for pending_pickle in pending {
             let mut task = monarch_with_gil_blocking(GilSite::AwaitDrive, |py| {
                 pending_pickle.borrow(py).task()
             })?;
             task.take_task()?.await?;
         }
-
-        // Unpickle (pending pickles are now resolved) and re-pickle without allowing new ones
         monarch_with_gil_blocking(GilSite::Convert, |py| {
             let obj = self.unpickle(py)?;
-            pickle(py, obj, false, true)
+            pickle(py, obj, false, true, false)
         })
     }
 }
@@ -358,19 +436,34 @@ impl PendingMessage {
         })
     }
 
-    /// Resolve all pending pickles and convert this into a PythonMessage.
+    /// Resolve any reserved mesh slots and convert this into a PythonMessage.
     ///
     /// This is an async method that:
-    /// 1. Awaits all pending pickles in the PicklingState
-    /// 2. Re-pickles the resolved object
-    /// 3. Returns a PythonMessage with the resolved bytes (no GIL needed for final step)
+    /// 1. Fills the reserved mesh slots from their pending handles
+    /// 2. Builds a PythonMessage with the resolved bytes and `refs` table
     pub async fn resolve(self) -> PyResult<PythonMessage> {
-        // Resolve the pickling state (awaits all pending pickles and re-pickles)
+        // Fill any reserved mesh slots, then build the message with the
+        // finalized `refs` table. No GIL needed for the assembly: neither the
+        // Part nor the MeshRef table holds Py<> values.
         let mut resolved_state = self.state.resolve().await?;
 
-        // Take the Part directly - no GIL needed since Part doesn't contain Py<>
         let inner = resolved_state.take_inner()?;
-        Ok(PythonMessage::new_from_buf(self.kind, inner.take_buffer()))
+        let refs: Vec<MeshRef> = inner
+            .mesh_references
+            .into_iter()
+            .map(|r| {
+                r.ok_or_else(|| {
+                    pyo3::exceptions::PyRuntimeError::new_err(
+                        "mesh reference slot was never filled",
+                    )
+                })
+            })
+            .collect::<PyResult<_>>()?;
+        Ok(PythonMessage::new_from_buf_with_refs(
+            self.kind,
+            inner.buffer,
+            refs,
+        ))
     }
 }
 
@@ -476,6 +569,75 @@ fn pop_pending_pickle(py: Python<'_>) -> PyResult<Py<PyShared>> {
     })
 }
 
+/// Pop a mesh reference from the active pickling state and rebuild its
+/// Python mesh wrapper.
+///
+/// Called from the unpickle stream wherever a mesh slot was emitted in
+/// place of inline bytes.
+#[pyfunction]
+fn pop_mesh_reference(py: Python<'_>) -> PyResult<Py<PyAny>> {
+    let mesh_ref = ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) => s.mesh_references.pop_front().ok_or_else(|| {
+                pyo3::exceptions::PyRuntimeError::new_err("No mesh references remaining")
+            }),
+            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "No active pickling state",
+            )),
+        }
+    })?;
+    let mesh_ref = mesh_ref.ok_or_else(|| {
+        pyo3::exceptions::PyRuntimeError::new_err("mesh reference slot was never filled")
+    })?;
+    mesh_ref.reconstruct(py)
+}
+
+/// Push a mesh reference to the active pickling state if mesh-reference
+/// collection is active in this context.
+///
+/// Returns true if the reference was collected (the caller emits a slot);
+/// false otherwise (the caller inlines the reference as usual).
+pub fn push_mesh_reference_if_active(mesh_ref: MeshRef) -> bool {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) if s.allow_mesh_references => {
+                s.mesh_references.push_back(Some(mesh_ref));
+                true
+            }
+            _ => false,
+        }
+    })
+}
+
+/// Reserve a slot for a *pending* mesh whose `*MeshRef` is not available yet,
+/// registering `handle` for a sender-side fill once the mesh resolves.
+///
+/// Returns true if a slot was reserved (the caller emits a `pop_mesh_reference`
+/// placeholder); false otherwise (the caller keeps its current behavior).
+pub fn reserve_mesh_reference_if_active(handle: Py<PyShared>) -> bool {
+    ACTIVE_PICKLING_STATE.with(|cell| {
+        let mut state = cell.borrow_mut();
+        match state.as_mut() {
+            Some(s) if s.allow_mesh_references => {
+                let index = s.mesh_references.len();
+                s.mesh_references.push_back(None);
+                s.pending_mesh_fills.push((index, handle));
+                true
+            }
+            _ => false,
+        }
+    })
+}
+
+/// Python-callable wrapper over [`reserve_mesh_reference_if_active`] for the
+/// typed Proc/Host reduces, which reserve their pending slot from Python.
+#[pyfunction]
+fn reserve_mesh_reference(handle: Py<PyShared>) -> bool {
+    reserve_mesh_reference_if_active(handle)
+}
+
 /// Push a pending pickle to the active pickling state (Rust-only).
 ///
 /// This is used by __reduce__ implementations to register a PyShared
@@ -507,7 +669,7 @@ pub fn push_pending_pickle(py_shared: Py<PyShared>) -> PyResult<()> {
 ///
 /// This function implements the pickle protocol for PyShared:
 /// 1. If the shared is already finished, return (Shared.from_value, (value,))
-/// 2. If pending pickles are allowed, push it as a pending pickle and return (pop_pending_pickle, ())
+/// 2. If pending pickles are allowed, defer it and return (pop_pending_pickle, ())
 /// 3. Otherwise, block on the shared and return (Shared.from_value, (value,))
 pub fn reduce_shared<'py>(
     py: Python<'py>,
@@ -520,12 +682,13 @@ pub fn reduce_shared<'py>(
         return Ok((from_value, args));
     }
 
-    // Try to push as a pending pickle (will fail if not allowed or no active state)
+    // Pending: defer it (resolved sender-side in `PicklingState::resolve`).
+    // Meshes ride the out-of-band table via their own type-specific reducers;
+    // this generic path is the fallback for any other pending `PyShared`.
     let py_shared_py: Py<PyShared> = py_shared.clone().unbind();
     if push_pending_pickle(py_shared_py).is_ok() {
         let pop_fn = pop_pending_pickle_fn(py);
-        let args = PyTuple::empty(py);
-        return Ok((pop_fn, args));
+        return Ok((pop_fn, PyTuple::empty(py)));
     }
 
     // Fall back to blocking on the shared
@@ -563,7 +726,7 @@ fn pickle_into_buffer(py: Python<'_>, obj: &Py<PyAny>, buffer: &Py<Buffer>) -> P
 /// and tensor engine references, and returns the raw serialized bytes instead
 /// of a [`PicklingState`].
 pub fn pickle_to_part(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<Part> {
-    let active = ActivePicklingState::new(false, false);
+    let active = ActivePicklingState::new(false, false, false);
     let buffer = Py::new(py, Buffer::default())?;
     let _guard = ActivePicklingGuard::enter(active);
 
@@ -586,14 +749,19 @@ pub fn pickle_to_part(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<Part> {
 /// # Returns
 /// A PicklingState containing the pickled buffer and any registered references/pending pickles
 #[pyfunction]
-#[pyo3(signature = (obj, allow_pending_pickles=true, allow_tensor_engine_references=true))]
+#[pyo3(signature = (obj, allow_pending_pickles=true, allow_tensor_engine_references=true, allow_mesh_references=false))]
 pub fn pickle(
     py: Python<'_>,
     obj: Py<PyAny>,
     allow_pending_pickles: bool,
     allow_tensor_engine_references: bool,
+    allow_mesh_references: bool,
 ) -> PyResult<PicklingState> {
-    let active = ActivePicklingState::new(allow_pending_pickles, allow_tensor_engine_references);
+    let active = ActivePicklingState::new(
+        allow_pending_pickles,
+        allow_tensor_engine_references,
+        allow_mesh_references,
+    );
     let buffer = Py::new(py, Buffer::default())?;
     let _guard = ActivePicklingGuard::enter(active);
 
@@ -629,5 +797,7 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     module.add_function(wrap_pyfunction!(pop_tensor_engine_reference, module)?)?;
     module.add_function(wrap_pyfunction!(pop_pending_pickle, module)?)?;
+    module.add_function(wrap_pyfunction!(pop_mesh_reference, module)?)?;
+    module.add_function(wrap_pyfunction!(reserve_mesh_reference, module)?)?;
     Ok(())
 }

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -6,11 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Deferred pickling support for Monarch.
+//! Pickling support for Monarch.
 //!
-//! This module provides utilities for deferring the pickling of objects
-//! that contain async values (futures/tasks) that must be resolved before
-//! the final pickle can be produced.
+//! This module pickles Python objects for actor messages, collecting tensor
+//! engine references and out-of-band mesh references during serialization so
+//! they are restored together on decode.
 //!
 //! ## Out-of-band mesh-reference invariants
 //!
@@ -68,19 +68,6 @@ use crate::pytokio::PyShared;
 use crate::runtime::GilSite;
 use crate::runtime::monarch_with_gil_blocking;
 
-// Python helper used to reconstruct an object graph from a pickled
-// buffer plus a list of "unflatten values" (including placeholders).
-py_global!(unflatten, "monarch._src.actor.pickle", "unflatten");
-
-// Python helper used to pickle an object graph, optionally using a
-// filter to replace certain values with placeholders (e.g.
-// `PendingPickle`).
-//
-// We use `flatten`/`unflatten` to support "deferred pickling":
-// initially pickle with placeholders, then later resolve futures and
-// re-pickle with concrete values.
-py_global!(flatten, "monarch._src.actor.pickle", "flatten");
-
 // cloudpickle module for serialization
 py_global!(cloudpickle, "cloudpickle", "cloudpickle");
 
@@ -114,13 +101,6 @@ py_global!(
     shared_class,
     "monarch._rust_bindings.monarch_hyperactor.pytokio",
     "Shared"
-);
-
-// pop_pending_pickle function for unpickling deferred PyShared values
-py_global!(
-    pop_pending_pickle_fn,
-    "monarch._rust_bindings.monarch_hyperactor.pickle",
-    "pop_pending_pickle"
 );
 
 // Thread-local storage for the active pickling state.
@@ -178,16 +158,12 @@ impl Drop for ActivePicklingGuard {
 struct ActivePicklingState {
     /// References to tensor engine objects that need special handling.
     tensor_engine_references: VecDeque<Py<PyAny>>,
-    /// Pending pickles (PyShared values) that must be resolved.
-    pending_pickles: VecDeque<Py<PyShared>>,
     /// Mesh references collected out-of-band into the message's `refs` table.
     /// A `None` is a slot reserved for a pending mesh, filled sender-side.
     mesh_references: VecDeque<Option<MeshRef>>,
     /// Pending mesh slots awaiting a sender-side fill: (index into
     /// `mesh_references`, the handle whose resolved mesh supplies the ref).
     pending_mesh_fills: Vec<(usize, Py<PyShared>)>,
-    /// Whether pending pickles are allowed in this pickling context.
-    allow_pending_pickles: bool,
     /// Whether tensor engine references are allowed in this pickling context.
     allow_tensor_engine_references: bool,
     /// Whether mesh references are collected out-of-band in this context.
@@ -196,17 +172,11 @@ struct ActivePicklingState {
 
 impl ActivePicklingState {
     /// Create a new ActivePicklingState.
-    fn new(
-        allow_pending_pickles: bool,
-        allow_tensor_engine_references: bool,
-        allow_mesh_references: bool,
-    ) -> Self {
+    fn new(allow_tensor_engine_references: bool, allow_mesh_references: bool) -> Self {
         Self {
             tensor_engine_references: VecDeque::new(),
-            pending_pickles: VecDeque::new(),
             mesh_references: VecDeque::new(),
             pending_mesh_fills: Vec::new(),
-            allow_pending_pickles,
             allow_tensor_engine_references,
             allow_mesh_references,
         }
@@ -217,7 +187,6 @@ impl ActivePicklingState {
         PicklingStateInner {
             buffer,
             tensor_engine_references: self.tensor_engine_references,
-            pending_pickles: self.pending_pickles,
             mesh_references: self.mesh_references,
             pending_mesh_fills: self.pending_mesh_fills,
         }
@@ -233,8 +202,6 @@ pub struct PicklingStateInner {
     buffer: Part,
     /// References to tensor engine objects that need special handling.
     tensor_engine_references: VecDeque<Py<PyAny>>,
-    /// Pending pickles (PyShared values) that must be resolved.
-    pending_pickles: VecDeque<Py<PyShared>>,
     /// Mesh references carried out-of-band into the message's `refs` table.
     /// A `None` is a slot reserved for a pending mesh, filled sender-side.
     mesh_references: VecDeque<Option<MeshRef>>,
@@ -243,11 +210,6 @@ pub struct PicklingStateInner {
 }
 
 impl PicklingStateInner {
-    /// Get a reference to the pending pickles.
-    pub fn pending_pickles(&self) -> &VecDeque<Py<PyShared>> {
-        &self.pending_pickles
-    }
-
     /// Take the Part (pickled bytes) from this inner state.
     pub fn take_buffer(self) -> Part {
         self.buffer
@@ -289,7 +251,6 @@ impl PicklingState {
             inner: Some(PicklingStateInner {
                 buffer,
                 tensor_engine_references,
-                pending_pickles: VecDeque::new(),
                 mesh_references,
                 pending_mesh_fills: Vec::new(),
             }),
@@ -328,7 +289,6 @@ impl PicklingState {
             inner: Some(PicklingStateInner {
                 buffer: Part::from(buffer.inner.clone()),
                 tensor_engine_references: refs,
-                pending_pickles: VecDeque::new(),
                 mesh_references: mesh_refs,
                 pending_mesh_fills: Vec::new(),
             }),
@@ -366,19 +326,9 @@ impl PicklingState {
     pub(crate) fn unpickle(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let inner = self.take_inner()?;
 
-        // Verify all pending pickles are resolved before unpickling
-        for pending in &inner.pending_pickles {
-            if pending.borrow(py).poll()?.is_none() {
-                return Err(pyo3::exceptions::PyRuntimeError::new_err(
-                    "Cannot unpickle: there are unresolved pending pickles",
-                ));
-            }
-        }
-
         // Set up an active state for unpickling (to handle pop calls).
         // The guard restores any previous state on drop (including on panic).
-        let mut active = ActivePicklingState::new(false, false, false);
-        active.pending_pickles = inner.pending_pickles;
+        let mut active = ActivePicklingState::new(false, false);
         active.tensor_engine_references = inner.tensor_engine_references;
         active.mesh_references = inner.mesh_references;
         active.pending_mesh_fills = inner.pending_mesh_fills;
@@ -402,13 +352,11 @@ impl PicklingState {
 }
 
 impl PicklingState {
-    /// Resolve all pending pickles and return a new PicklingState without pending pickles.
+    /// Fill the reserved mesh slots from their pending handles, producing a
+    /// PicklingState whose out-of-band `refs` table is fully populated.
     ///
-    /// This consumes the PicklingState. It:
-    /// 1. If there are no pending pickles, returns self immediately
-    /// 2. Otherwise, awaits all pending pickles until they're finished
-    /// 3. Calls unpickle to reconstruct the object
-    /// 4. Calls pickle again to get a new PicklingState without pending pickles
+    /// Awaits each pending mesh's init task, extracts its `*MeshRef`, and writes
+    /// it into the reserved slot. The payload bytes are unchanged (no re-pickle).
     pub async fn resolve(mut self) -> PyResult<PicklingState> {
         // Take the pending mesh fills out: a plain move, no GIL and no
         // `clone_ref`. Each is a slot index plus the handle whose resolved mesh
@@ -445,38 +393,15 @@ impl PicklingState {
             })?;
         }
 
-        // Resolve any deferred (non-mesh) pending pickles by re-pickling. Empty
-        // for mesh-only messages, where the table filled above is the result.
-        if self.inner_ref()?.pending_pickles.is_empty() {
-            return Ok(self);
-        }
-        let pending: Vec<Py<PyShared>> = monarch_with_gil_blocking(GilSite::Convert, |py| {
-            self.inner_ref().map(|inner| {
-                inner
-                    .pending_pickles
-                    .iter()
-                    .map(|p| p.clone_ref(py))
-                    .collect()
-            })
-        })?;
-        for pending_pickle in pending {
-            let mut task = monarch_with_gil_blocking(GilSite::AwaitDrive, |py| {
-                pending_pickle.borrow(py).task()
-            })?;
-            task.take_task()?.await?;
-        }
-        monarch_with_gil_blocking(GilSite::Convert, |py| {
-            let obj = self.unpickle(py)?;
-            pickle(py, obj, false, true, false)
-        })
+        Ok(self)
     }
 }
 
-/// A message that is pending resolution of async values before it can be sent.
+/// A message whose reserved mesh slots must be filled before it can be sent.
 ///
-/// Contains a `PythonMessageKind` and a `PicklingState`. The `PicklingState` may contain
-/// pending pickles (unresolved async values) that must be resolved before the message
-/// can be converted into a `PythonMessage`.
+/// Contains a `PythonMessageKind` and a `PicklingState`. The `PicklingState` may
+/// hold mesh slots reserved for pending meshes, filled sender-side once their
+/// handles resolve, before the message can be converted into a `PythonMessage`.
 #[pyclass(module = "monarch._rust_bindings.monarch_hyperactor.pickle")]
 pub struct PendingMessage {
     pub(crate) kind: PythonMessageKind,
@@ -554,7 +479,7 @@ impl PendingMessage {
         self.kind.clone()
     }
 
-    /// Resolve pending pickles and return a fully materialized PythonMessage.
+    /// Fill reserved mesh slots and return a fully materialized PythonMessage.
     #[pyo3(name = "resolve")]
     fn py_resolve(&mut self) -> PyResult<PyPythonTask> {
         let message = self.take()?;
@@ -610,28 +535,6 @@ fn pop_tensor_engine_reference(py: Python<'_>) -> PyResult<Py<PyAny>> {
             }
         })
         .map(|obj| obj.clone_ref(py))
-}
-
-/// Pop a pending pickle from the active pickling state.
-///
-/// This is called from Python during unpickling to retrieve the PyShared
-/// object that was deferred during pickling.
-#[pyfunction]
-fn pop_pending_pickle(py: Python<'_>) -> PyResult<Py<PyShared>> {
-    ACTIVE_PICKLING_STATE.with(|cell| {
-        let mut state = cell.borrow_mut();
-        match state.as_mut() {
-            Some(s) => {
-                let shared = s.pending_pickles.pop_front().ok_or_else(|| {
-                    pyo3::exceptions::PyRuntimeError::new_err("No pending pickles remaining")
-                })?;
-                Ok(shared.clone_ref(py))
-            }
-            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
-                "No active pickling state",
-            )),
-        }
-    })
 }
 
 /// Pop a mesh reference from the active pickling state and rebuild its
@@ -705,39 +608,11 @@ fn reserve_mesh_reference(handle: Py<PyShared>) -> bool {
     reserve_mesh_reference_if_active(handle)
 }
 
-/// Push a pending pickle to the active pickling state (Rust-only).
-///
-/// This is used by __reduce__ implementations to register a PyShared
-/// that must be resolved before the pickle is complete.
-///
-/// Returns an error if there is no active pickling state or if pending
-/// pickles are not allowed in the current pickling context.
-pub fn push_pending_pickle(py_shared: Py<PyShared>) -> PyResult<()> {
-    ACTIVE_PICKLING_STATE.with(|cell| {
-        let mut state = cell.borrow_mut();
-        match state.as_mut() {
-            Some(s) => {
-                if !s.allow_pending_pickles {
-                    return Err(pyo3::exceptions::PyRuntimeError::new_err(
-                        "Pending pickles are not allowed in the current pickling context",
-                    ));
-                }
-                s.pending_pickles.push_back(py_shared);
-                Ok(())
-            }
-            None => Err(pyo3::exceptions::PyRuntimeError::new_err(
-                "No active pickling state",
-            )),
-        }
-    })
-}
-
 /// Reduce a PyShared for pickling.
 ///
 /// This function implements the pickle protocol for PyShared:
 /// 1. If the shared is already finished, return (Shared.from_value, (value,))
-/// 2. If pending pickles are allowed, defer it and return (pop_pending_pickle, ())
-/// 3. Otherwise, block on the shared and return (Shared.from_value, (value,))
+/// 2. Otherwise, block on the shared and return (Shared.from_value, (value,))
 pub fn reduce_shared<'py>(
     py: Python<'py>,
     py_shared: &Bound<'py, PyShared>,
@@ -749,16 +624,9 @@ pub fn reduce_shared<'py>(
         return Ok((from_value, args));
     }
 
-    // Pending: defer it (resolved sender-side in `PicklingState::resolve`).
-    // Meshes ride the out-of-band table via their own type-specific reducers;
-    // this generic path is the fallback for any other pending `PyShared`.
-    let py_shared_py: Py<PyShared> = py_shared.clone().unbind();
-    if push_pending_pickle(py_shared_py).is_ok() {
-        let pop_fn = pop_pending_pickle_fn(py);
-        return Ok((pop_fn, PyTuple::empty(py)));
-    }
-
-    // Fall back to blocking on the shared
+    // Pending: block on the shared. Meshes ride the out-of-band table via their
+    // own type-specific reducers; this generic path is the fallback for any
+    // other pending `PyShared`.
     let value = PyShared::block_on(py_shared.borrow(), py)?;
     let from_value = shared_class(py).getattr("from_value")?;
     let args = PyTuple::new(py, [value])?;
@@ -793,7 +661,7 @@ fn pickle_into_buffer(py: Python<'_>, obj: &Py<PyAny>, buffer: &Py<Buffer>) -> P
 /// and tensor engine references, and returns the raw serialized bytes instead
 /// of a [`PicklingState`].
 pub fn pickle_to_part(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<Part> {
-    let active = ActivePicklingState::new(false, false, false);
+    let active = ActivePicklingState::new(false, false);
     let buffer = Py::new(py, Buffer::default())?;
     let _guard = ActivePicklingGuard::enter(active);
 
@@ -810,25 +678,19 @@ pub fn pickle_to_part(py: Python<'_>, obj: &Py<PyAny>) -> PyResult<Part> {
 ///
 /// # Arguments
 /// * `obj` - The Python object to pickle
-/// * `allow_pending_pickles` - If true, allow PyShared values to be registered as pending
 /// * `allow_tensor_engine_references` - If true, allow tensor engine references to be registered
 ///
 /// # Returns
 /// A PicklingState containing the pickled buffer and any registered references/pending pickles
 #[pyfunction]
-#[pyo3(signature = (obj, allow_pending_pickles=true, allow_tensor_engine_references=true, allow_mesh_references=false))]
+#[pyo3(signature = (obj, allow_tensor_engine_references=true, allow_mesh_references=false))]
 pub fn pickle(
     py: Python<'_>,
     obj: Py<PyAny>,
-    allow_pending_pickles: bool,
     allow_tensor_engine_references: bool,
     allow_mesh_references: bool,
 ) -> PyResult<PicklingState> {
-    let active = ActivePicklingState::new(
-        allow_pending_pickles,
-        allow_tensor_engine_references,
-        allow_mesh_references,
-    );
+    let active = ActivePicklingState::new(allow_tensor_engine_references, allow_mesh_references);
     let buffer = Py::new(py, Buffer::default())?;
     let _guard = ActivePicklingGuard::enter(active);
 
@@ -887,7 +749,6 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
         module
     )?)?;
     module.add_function(wrap_pyfunction!(pop_tensor_engine_reference, module)?)?;
-    module.add_function(wrap_pyfunction!(pop_pending_pickle, module)?)?;
     module.add_function(wrap_pyfunction!(pop_mesh_reference, module)?)?;
     module.add_function(wrap_pyfunction!(reserve_mesh_reference, module)?)?;
     module.add_function(wrap_pyfunction!(_get_pending_reserve_count, module)?)?;

--- a/monarch_hyperactor/src/pickle.rs
+++ b/monarch_hyperactor/src/pickle.rs
@@ -11,9 +11,45 @@
 //! This module provides utilities for deferring the pickling of objects
 //! that contain async values (futures/tasks) that must be resolved before
 //! the final pickle can be produced.
+//!
+//! ## Out-of-band mesh-reference invariants
+//!
+//! Mesh references (proc/host/actor meshes) are not pickled inline. They ride
+//! *out of band* in a `refs` table carried next to the payload bytes, leaving a
+//! `pop_mesh_reference` sentinel in the pickle stream. Two invariants keep the
+//! table and its payload from ever drifting apart:
+//!
+//! **REFS-1 (ref-aware decode).** Any payload that can carry out-of-band refs
+//! must be decoded only through a ref-aware path: `PicklingState::from_parts`
+//! and `PicklingState::unpickle`, as wrapped by `PythonMessage::decode` and
+//! `PythonResponseMessage::decode`. A bare `pickle.loads`/`cloudpickle.loads`
+//! on the payload bytes drops the table, so a sentinel later pops with no active
+//! state and raises "No active pickling state". The raw payload bytes are
+//! deliberately not exposed on `PythonMessage` (there is no `.message` getter),
+//! so a bare decode is not even expressible from Python.
+//!
+//! **REFS-2 (refs preserved through intermediates).** Any intermediate that
+//! relays a payload -- `PythonResponseMessage` and the `ValueOverlay` behind a
+//! `.call()` valuemesh -- must carry its `refs` beside the bytes, all the way to
+//! the decode site. Dropping refs at a relay boundary reintroduces the REFS-1
+//! failure downstream. Refs are therefore part of `PythonResponseMessage`
+//! equality: two runs with identical bytes but different refs must not coalesce.
+//!
+//! These invariants have one sound exception. A table entry and a
+//! `pop_mesh_reference` sentinel are emitted together during pickling (1:1),
+//! so an empty `refs` table means the payload carries no sentinels: a bare
+//! decode of it pops nothing and is sound. The `.call()` valuemesh collector
+//! (`collect_valuemesh` in `endpoint.rs`) relies on this to preserve
+//! D96180139's lazy unpickle: it decodes a ref-empty batch lazily via
+//! `PyValueMesh::build_from_parts` (`value_mesh.rs`), which resolves on access
+//! outside the ref-aware path, and only a ref-carrying batch eagerly via
+//! `build_from_objects`. That lazy build is the sole bare decode of a payload
+//! that *could* carry refs; see `collect_valuemesh` for the gate itself.
 
 use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
 
 use monarch_types::py_global;
 use pyo3::IntoPyObjectExt;
@@ -101,6 +137,15 @@ py_global!(
 thread_local! {
     static ACTIVE_PICKLING_STATE: RefCell<Option<ActivePicklingState>> = const { RefCell::new(None) };
 }
+
+/// Counters for tests. `PENDING_RESERVE_COUNT` bumps when a still-pending mesh
+/// reserves an out-of-band slot on the send side; it is pending-specific (a
+/// resolved mesh fills directly), so it proves the pending path ran.
+/// `MESH_POP_COUNT` bumps when any out-of-band mesh reference is reunited on the
+/// decode side; it is not pending-specific, since a resolved mesh also travels
+/// out-of-band, so it proves receive and reconstruct, not pending-ness.
+static PENDING_RESERVE_COUNT: AtomicUsize = AtomicUsize::new(0);
+static MESH_POP_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 /// RAII guard that sets the thread-local `ACTIVE_PICKLING_STATE` on creation
 /// and restores the previous state (if any) on drop. This supports nesting:
@@ -230,6 +275,26 @@ impl PicklingState {
             pyo3::exceptions::PyRuntimeError::new_err("PicklingState has already been consumed")
         })
     }
+
+    /// Build a PicklingState directly from already-separated parts: the pickled
+    /// `buffer`, the ordered local-state/tensor-engine list, and the resolved
+    /// mesh-reference table. Used by `PythonMessage::decode` so a message's
+    /// payload is always unpickled together with its `refs`.
+    pub(crate) fn from_parts(
+        buffer: Part,
+        tensor_engine_references: VecDeque<Py<PyAny>>,
+        mesh_references: VecDeque<Option<MeshRef>>,
+    ) -> Self {
+        Self {
+            inner: Some(PicklingStateInner {
+                buffer,
+                tensor_engine_references,
+                pending_pickles: VecDeque::new(),
+                mesh_references,
+                pending_mesh_fills: Vec::new(),
+            }),
+        }
+    }
 }
 
 #[pymethods]
@@ -298,7 +363,7 @@ impl PicklingState {
     ///
     /// This consumes the PicklingState. It will fail if there are any pending
     /// pickles that haven't been resolved.
-    fn unpickle(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+    pub(crate) fn unpickle(&mut self, py: Python<'_>) -> PyResult<Py<PyAny>> {
         let inner = self.take_inner()?;
 
         // Verify all pending pickles are resolved before unpickling
@@ -590,6 +655,7 @@ fn pop_mesh_reference(py: Python<'_>) -> PyResult<Py<PyAny>> {
     let mesh_ref = mesh_ref.ok_or_else(|| {
         pyo3::exceptions::PyRuntimeError::new_err("mesh reference slot was never filled")
     })?;
+    MESH_POP_COUNT.fetch_add(1, Ordering::Relaxed);
     mesh_ref.reconstruct(py)
 }
 
@@ -624,6 +690,7 @@ pub fn reserve_mesh_reference_if_active(handle: Py<PyShared>) -> bool {
                 let index = s.mesh_references.len();
                 s.mesh_references.push_back(None);
                 s.pending_mesh_fills.push((index, handle));
+                PENDING_RESERVE_COUNT.fetch_add(1, Ordering::Relaxed);
                 true
             }
             _ => false,
@@ -786,6 +853,30 @@ pub(crate) fn unpickle(
     _unpickle(py).call1((buffer.into_py_any(py)?,))
 }
 
+/// Test helper: read the pending-mesh reserve counter.
+#[pyfunction]
+fn _get_pending_reserve_count() -> usize {
+    PENDING_RESERVE_COUNT.load(Ordering::Relaxed)
+}
+
+/// Test helper: reset the pending-mesh reserve counter to zero.
+#[pyfunction]
+fn _reset_pending_reserve_count() {
+    PENDING_RESERVE_COUNT.store(0, Ordering::Relaxed);
+}
+
+/// Test helper: read the mesh-pop counter.
+#[pyfunction]
+fn _get_mesh_pop_count() -> usize {
+    MESH_POP_COUNT.load(Ordering::Relaxed)
+}
+
+/// Test helper: reset the mesh-pop counter to zero.
+#[pyfunction]
+fn _reset_mesh_pop_count() {
+    MESH_POP_COUNT.store(0, Ordering::Relaxed);
+}
+
 /// Register the pickle Python bindings into the given module.
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_class::<PicklingState>()?;
@@ -799,5 +890,9 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(pop_pending_pickle, module)?)?;
     module.add_function(wrap_pyfunction!(pop_mesh_reference, module)?)?;
     module.add_function(wrap_pyfunction!(reserve_mesh_reference, module)?)?;
+    module.add_function(wrap_pyfunction!(_get_pending_reserve_count, module)?)?;
+    module.add_function(wrap_pyfunction!(_reset_pending_reserve_count, module)?)?;
+    module.add_function(wrap_pyfunction!(_get_mesh_pop_count, module)?)?;
+    module.add_function(wrap_pyfunction!(_reset_mesh_pop_count, module)?)?;
     Ok(())
 }

--- a/monarch_hyperactor/src/proc_launcher.rs
+++ b/monarch_hyperactor/src/proc_launcher.rs
@@ -708,6 +708,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: Some(EitherPortRef::Once(PythonOncePortRef::from(bound_port))),
             },
             message: pickled_args.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);
@@ -791,6 +792,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: None,
             },
             message: pickled.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);
@@ -832,6 +834,7 @@ impl ProcLauncher for ActorProcLauncher {
                 response_port: None,
             },
             message: pickled.into(),
+            refs: Vec::new(),
         };
 
         self.spawner.post(&self.instance, message);

--- a/monarch_hyperactor/src/proc_mesh.rs
+++ b/monarch_hyperactor/src/proc_mesh.rs
@@ -154,7 +154,15 @@ impl PyProcMesh {
     }
 
     fn __reduce__<'py>(&self, py: Python<'py>) -> PyResult<(Bound<'py, PyAny>, Bound<'py, PyAny>)> {
-        let bytes = bincode::serde::encode_to_vec(&self.mesh_ref()?, bincode::config::legacy())
+        let mesh_ref = self.mesh_ref()?;
+        if crate::pickle::push_mesh_reference_if_active(crate::actor::MeshRef::Proc(Box::new(
+            mesh_ref.clone(),
+        ))) {
+            let pop_fn = PyModule::import(py, "monarch._rust_bindings.monarch_hyperactor.pickle")?
+                .getattr("pop_mesh_reference")?;
+            return Ok((pop_fn, pyo3::types::PyTuple::empty(py).into_any()));
+        }
+        let bytes = bincode::serde::encode_to_vec(&mesh_ref, bincode::config::legacy())
             .map_err(|e| PyErr::new::<PyValueError, _>(e.to_string()))?;
         let py_bytes = (PyBytes::new(py, &bytes),).into_bound_py_any(py).unwrap();
         let from_bytes =

--- a/monarch_hyperactor/src/value_mesh.rs
+++ b/monarch_hyperactor/src/value_mesh.rs
@@ -170,12 +170,33 @@ impl PyValueMesh {
 }
 
 impl PyValueMesh {
-    /// Create a lazy ValueMesh from an extent and raw pickled parts.
-    /// Values are unpickled on demand when accessed via `get()` or `values()`.
+    /// Create a lazy ValueMesh from raw pickled parts, unpickled on demand at
+    /// `get()`/`values()`: the no-refs decode path for the `.call()` collector.
+    /// See the out-of-band mesh-reference invariants in [`crate::pickle`] for
+    /// why the collector gates on refs and why this lazy decode is sound.
     pub fn build_from_parts(extent: &Extent, parts: Vec<Part>) -> PyResult<Self> {
         let lazy_values: Vec<LazyCell> = parts
             .into_iter()
             .map(|p| Mutex::new(LazyPyObject::Pickled(p)))
+            .collect();
+        let mut inner = <ValueMesh<LazyCell> as BuildFromRegion<LazyCell>>::build_dense(
+            ndslice::View::region(extent),
+            lazy_values,
+        )
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+        compress(&mut inner);
+
+        Ok(Self { inner })
+    }
+
+    /// Create a ValueMesh from already-unpickled objects: the eager, ref-aware
+    /// decode path for the `.call()` collector when responses carry refs. See
+    /// the out-of-band mesh-reference invariants in [`crate::pickle`]; the
+    /// no-ref case uses `build_from_parts`.
+    pub fn build_from_objects(extent: &Extent, objects: Vec<Py<PyAny>>) -> PyResult<Self> {
+        let lazy_values: Vec<LazyCell> = objects
+            .into_iter()
+            .map(|o| Mutex::new(LazyPyObject::Unpickled(o)))
             .collect();
         let mut inner = <ValueMesh<LazyCell> as BuildFromRegion<LazyCell>>::build_dense(
             ndslice::View::region(extent),

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -99,7 +99,7 @@ fn pickle_python_result(
     result: Bound<'_, PyAny>,
     worker_rank: usize,
 ) -> Result<PythonMessage, anyhow::Error> {
-    let mut state = pickle(py, result.unbind(), false, false)
+    let mut state = pickle(py, result.unbind(), false, false, false)
         .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?;
     let inner = state
         .take_inner()

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -99,7 +99,7 @@ fn pickle_python_result(
     result: Bound<'_, PyAny>,
     worker_rank: usize,
 ) -> Result<PythonMessage, anyhow::Error> {
-    let mut state = pickle(py, result.unbind(), false, false, false)
+    let mut state = pickle(py, result.unbind(), false, false)
         .map_err(|pyerr| anyhow::Error::from(SerializablePyErr::from(py, &pyerr)))?;
     let inner = state
         .take_inner()

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -135,6 +135,7 @@ class PythonMessage:
         self,
         kind: PythonMessageKind,
         message: FrozenBuffer,
+        refs: List[Any],
     ) -> None:
         """
         Create a PythonMessage.
@@ -142,11 +143,16 @@ class PythonMessage:
         Args:
             kind: The message kind specifying the method to call.
             message: The pickled arguments as a FrozenBuffer.
+            refs: Out-of-band mesh references carried alongside the payload
+                (empty if the payload contains none).
         """
         ...
-    @property
-    def message(self) -> FrozenBuffer:
-        """The pickled arguments."""
+    def decode(self, local_state: List[Any] | None = None) -> Any:
+        """
+        Decode the payload, reuniting the out-of-band ``refs`` table so mesh
+        references reconstruct. This is the only way to read the payload; the
+        raw bytes are intentionally not exposed, so a decode cannot drop refs.
+        """
         ...
     @property
     def kind(self) -> PythonMessageKind: ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/actor.pyi
@@ -150,6 +150,10 @@ class PythonMessage:
         ...
     @property
     def kind(self) -> PythonMessageKind: ...
+    @property
+    def refs(self) -> List[Any]:
+        """Out-of-band mesh references carried alongside the message."""
+        ...
 
 @final
 class PythonActorHandle:
@@ -204,6 +208,7 @@ class Actor(Protocol):
         message: FrozenBuffer,
         panic_flag: PanicFlag,
         local_state: List[Any],
+        mesh_references: List[Any],
         response_port: PortProtocol[Any],
     ) -> None: ...
 
@@ -232,6 +237,11 @@ class QueuedMessage:
     @property
     def local_state(self) -> Any:
         """The local state for this message."""
+        ...
+
+    @property
+    def refs(self) -> List[Any]:
+        """Out-of-band mesh references carried alongside the message."""
         ...
 
     @property

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
@@ -24,6 +24,7 @@ class PicklingState:
         self,
         buffer: FrozenBuffer,
         tensor_engine_references: List[Any] | None = None,
+        mesh_references: List[Any] | None = None,
     ) -> None:
         """
         Create a new PicklingState from a buffer and optional tensor engine references.
@@ -35,6 +36,8 @@ class PicklingState:
             buffer: The pickled bytes as a FrozenBuffer.
             tensor_engine_references: Optional list of tensor engine references
                 to restore during unpickling.
+            mesh_references: Optional list of out-of-band mesh references to
+                restore during unpickling.
         """
         ...
 
@@ -90,6 +93,7 @@ def pickle(
     obj: Any,
     allow_pending_pickles: bool = True,
     allow_tensor_engine_references: bool = True,
+    allow_mesh_references: bool = False,
 ) -> PicklingState:
     """
     Pickle an object with support for pending pickles and tensor engine references.
@@ -146,5 +150,24 @@ def pop_pending_pickle() -> Shared[Any]:
 
     Raises:
         RuntimeError: If there is no active pickling state or no pending pickles remaining.
+    """
+    ...
+
+def pop_mesh_reference() -> Any:
+    """
+    Pop a mesh reference from the active pickling state and rebuild its
+    Python mesh wrapper.
+
+    Raises:
+        RuntimeError: If there is no active pickling state or no mesh
+            references remaining.
+    """
+    ...
+
+def reserve_mesh_reference(handle: Shared[Any]) -> bool:
+    """
+    Reserve a slot for a pending mesh, filled sender-side once the handle
+    resolves. Returns True if a slot was reserved (mesh-reference collection
+    is active), False otherwise.
     """
     ...

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
@@ -91,7 +91,6 @@ class PendingMessage:
 
 def pickle(
     obj: Any,
-    allow_pending_pickles: bool = True,
     allow_tensor_engine_references: bool = True,
     allow_mesh_references: bool = False,
 ) -> PicklingState:
@@ -104,7 +103,6 @@ def pickle(
 
     Args:
         obj: The Python object to pickle
-        allow_pending_pickles: If true, allow PyShared values to be registered as pending
         allow_tensor_engine_references: If true, allow tensor engine references to be registered
 
     Returns:
@@ -138,18 +136,6 @@ def pop_tensor_engine_reference() -> Any:
 
     Raises:
         RuntimeError: If there is no active pickling state or no references remaining.
-    """
-    ...
-
-def pop_pending_pickle() -> Shared[Any]:
-    """
-    Pop a pending pickle from the active pickling state.
-
-    Called from Python during unpickling to retrieve the PyShared
-    object that was deferred during pickling.
-
-    Raises:
-        RuntimeError: If there is no active pickling state or no pending pickles remaining.
     """
     ...
 

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pickle.pyi
@@ -171,3 +171,19 @@ def reserve_mesh_reference(handle: Shared[Any]) -> bool:
     is active), False otherwise.
     """
     ...
+
+def _get_pending_reserve_count() -> int:
+    """Test helper: number of pending-mesh slots reserved (send side)."""
+    ...
+
+def _reset_pending_reserve_count() -> None:
+    """Test helper: reset the pending-reserve counter to zero."""
+    ...
+
+def _get_mesh_pop_count() -> int:
+    """Test helper: number of mesh references reunited (decode side)."""
+    ...
+
+def _reset_mesh_pop_count() -> None:
+    """Test helper: reset the mesh-pop counter to zero."""
+    ...

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -736,7 +736,10 @@ def _create_endpoint_message(
     """
     _check_endpoint_arguments(method_name, signature, args, kwargs)
     pickling_state = pickle(
-        (args, kwargs), allow_pending_pickles=True, allow_tensor_engine_references=True
+        (args, kwargs),
+        allow_pending_pickles=True,
+        allow_tensor_engine_references=True,
+        allow_mesh_references=True,
     )
     objects = pickling_state.tensor_engine_references()
     if not objects:
@@ -1068,7 +1071,10 @@ class Port(Generic[R]):
         # This is Port.send with deferred-pickle resolution inserted before the
         # already-serialized Result message is posted.
         state = pickle(
-            result, allow_pending_pickles=True, allow_tensor_engine_references=False
+            result,
+            allow_pending_pickles=True,
+            allow_tensor_engine_references=False,
+            allow_mesh_references=True,
         )
         kind = cast(PythonMessageKind, cast(Any, PythonMessageKind.Result)(self._rank))
         message = PendingMessage(kind, state)
@@ -1200,10 +1206,7 @@ class PortReceiver(Generic[R]):
         return self._process(result)
 
     def _process(self, msg: PythonMessage) -> R:
-        # TODO: Try to do something more structured than a cast here
-        payload = cast(
-            R, PicklingState(msg.message, mesh_references=msg.refs).unpickle()
-        )
+        payload = cast(R, msg.decode())
         match msg.kind:
             # pyrefly: ignore [invalid-pattern]
             case PythonMessageKind.Result():

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1201,7 +1201,9 @@ class PortReceiver(Generic[R]):
 
     def _process(self, msg: PythonMessage) -> R:
         # TODO: Try to do something more structured than a cast here
-        payload = cast(R, PicklingState(msg.message).unpickle())
+        payload = cast(
+            R, PicklingState(msg.message, mesh_references=msg.refs).unpickle()
+        )
         match msg.kind:
             # pyrefly: ignore [invalid-pattern]
             case PythonMessageKind.Result():
@@ -1323,6 +1325,7 @@ async def _handle_queued_message(actor: Any, msg: "QueuedMessage") -> None:
         msg.bytes,
         panic_flag,  # pyre-ignore[6]: _QueuePanicFlag implements PanicFlag protocol
         msg.local_state,
+        msg.refs,
         msg.response_port,
     )
     # If a panic was signaled, re-raise it after handle() has cleaned up.
@@ -1358,6 +1361,7 @@ class _Actor:
         message: FrozenBuffer,
         panic_flag: PanicFlag,
         local_state: List[Any],
+        mesh_references: List[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         MESSAGES_HANDLED.add(1)
@@ -1373,7 +1377,9 @@ class _Actor:
 
             DebugContext.set(DebugContext())
 
-            args, kwargs = PicklingState(message, local_state).unpickle()
+            args, kwargs = PicklingState(
+                message, local_state, mesh_references
+            ).unpickle()
 
             match method:
                 # pyrefly: ignore [invalid-pattern]

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -737,7 +737,6 @@ def _create_endpoint_message(
     _check_endpoint_arguments(method_name, signature, args, kwargs)
     pickling_state = pickle(
         (args, kwargs),
-        allow_pending_pickles=True,
         allow_tensor_engine_references=True,
         allow_mesh_references=True,
     )
@@ -1068,11 +1067,10 @@ class Port(Generic[R]):
     def send_message(self, message: PythonMessage) -> None: ...
 
     async def resolve_and_send(self, result: object) -> None:
-        # This is Port.send with deferred-pickle resolution inserted before the
+        # This is Port.send with mesh-reference resolution inserted before the
         # already-serialized Result message is posted.
         state = pickle(
             result,
-            allow_pending_pickles=True,
             allow_tensor_engine_references=False,
             allow_mesh_references=True,
         )
@@ -2002,7 +2000,6 @@ class RootClientActor(Actor):
         kwargs = {}
         state = pickle(
             (args, kwargs),
-            allow_pending_pickles=False,
             allow_tensor_engine_references=False,
         )
         return state.buffer()

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -315,6 +315,23 @@ class HostMesh(MeshTrait):
 
     # pyrefly: ignore [invalid-annotation]
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
+        # A pending host mesh has no HostMeshRef yet. When mesh-reference
+        # collection is active, reserve an out-of-band slot (filled sender-side
+        # once the mesh resolves) and reconstruct from the popped mesh;
+        # otherwise fall through to the ordinary reduce.
+        if self._hy_host_mesh.poll() is None:
+            from monarch._rust_bindings.monarch_hyperactor.pickle import (
+                reserve_mesh_reference,
+            )
+            from monarch._src.actor.pickle import _MeshSlot
+
+            if reserve_mesh_reference(self._hy_host_mesh):
+                return HostMesh._from_initialized_hy_host_mesh, (
+                    _MeshSlot(),
+                    self._region,
+                    self.stream_logs,
+                    self.is_fake_in_process,
+                )
         return HostMesh, (
             self._hy_host_mesh,
             self._region,

--- a/python/monarch/_src/actor/pickle.py
+++ b/python/monarch/_src/actor/pickle.py
@@ -19,6 +19,19 @@ from typing import Any, Callable, Iterable, List, Tuple
 
 import cloudpickle
 from monarch._rust_bindings.monarch_hyperactor.buffers import Buffer, FrozenBuffer
+from monarch._rust_bindings.monarch_hyperactor.pickle import pop_mesh_reference
+
+
+class _MeshSlot:
+    """Placeholder whose unpickling pops a reserved mesh-reference slot.
+
+    A pending Proc/Host mesh reserves an out-of-band slot at pickle time and
+    emits this sentinel in its reduce; unpickling pops the resolved mesh that
+    the sender filled into that slot.
+    """
+
+    def __reduce__(self) -> Tuple[Any, Tuple[Any, ...]]:
+        return (pop_mesh_reference, ())
 
 
 def maybe_torch() -> types.ModuleType | None:

--- a/python/monarch/_src/actor/pickle.py
+++ b/python/monarch/_src/actor/pickle.py
@@ -221,26 +221,3 @@ def unflatten(data: FrozenBuffer | bytes, values: Iterable[Any]) -> Any:
             stack.enter_context(torch.utils._python_dispatch._disable_current_modes())
         up = _Unpickler(data, values)
         return up.load()
-
-
-_allow_pending_pickle: ContextVar[bool] = ContextVar("_allow_pending_pickle")
-
-
-@contextmanager
-def allow_pending_pickle_mesh() -> Generator[None, None, None]:
-    """
-    When this context manager is active, pickling a mesh that hasn't finished
-    initializing will return PendingPickle object to be resolved later. When
-    it is not active, pickling a mesh that hasn't finished initializing will
-    block the tokio runtime until the mesh is initialized.
-    """
-    prev = _allow_pending_pickle.get(False)
-    try:
-        _allow_pending_pickle.set(True)
-        yield
-    finally:
-        _allow_pending_pickle.set(prev)
-
-
-def is_pending_pickle_allowed() -> bool:
-    return _allow_pending_pickle.get(False)

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -718,6 +718,23 @@ class ProcMesh(MeshTrait):
 
     # pyrefly: ignore [invalid-annotation]
     def __reduce_ex__(self, protocol: ...) -> Tuple[Any, Tuple[Any, ...]]:
+        # A pending proc mesh has no ProcMeshRef yet. When mesh-reference
+        # collection is active, reserve an out-of-band slot (filled sender-side
+        # once the mesh resolves) and reconstruct from the popped mesh;
+        # otherwise fall through to the ordinary reduce.
+        if self._proc_mesh.poll() is None:
+            from monarch._rust_bindings.monarch_hyperactor.pickle import (
+                reserve_mesh_reference,
+            )
+            from monarch._src.actor.pickle import _MeshSlot
+
+            if reserve_mesh_reference(self._proc_mesh):
+                return ProcMesh._from_initialized_hy_proc_mesh, (
+                    _MeshSlot(),
+                    self._host_mesh,
+                    self._region,
+                    self._root_region,
+                )
         return ProcMesh, (
             self._proc_mesh,
             self._host_mesh,

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -13,6 +13,7 @@ import pytest
 from monarch._rust_bindings.monarch_hyperactor.actor import (
     MethodSpecifier,
     PanicFlag,
+    PythonMessage,
     PythonMessageKind,
 )
 from monarch._rust_bindings.monarch_hyperactor.actor_mesh import PythonActorMesh
@@ -41,6 +42,29 @@ def _to_frozen_buffer(data: bytes) -> FrozenBuffer:
     buf = Buffer()
     buf.write(data)
     return buf.freeze()
+
+
+def test_python_message_reunion_invariant() -> None:
+    """Decode cannot bypass the out-of-band refs table. The raw payload bytes
+    are not exposed, construction requires refs, and decode() is the only way
+    to read the payload back (functional mesh-ref reunion is covered end-to-end
+    by test_deferred_pickle_characterization)."""
+    # pyrefly: ignore [bad-argument-count]
+    kind = PythonMessageKind.Result(None)
+
+    # A 2-arg construction (missing refs) is rejected at runtime. Routed through
+    # an Any-typed alias so the deliberate error isn't analyzed statically.
+    ctor: Any = PythonMessage
+    with pytest.raises(TypeError):
+        ctor(kind, _to_frozen_buffer(pickle.dumps("x")))
+
+    # pyrefly: ignore [bad-argument-type]
+    msg = PythonMessage(kind, _to_frozen_buffer(pickle.dumps("payload")), [])
+
+    # No raw-bytes accessor, so a bare pickle.loads(msg.message) is impossible;
+    # decode() reunites refs (empty here) and is the only path in.
+    assert not hasattr(msg, "message")
+    assert msg.decode() == "payload"
 
 
 def run_on_tokio(
@@ -195,8 +219,7 @@ async def verify_cast_to_call(
         # pyrefly: ignore [missing-attribute]
         cast_rank = result_kind.rank
         assert cast_rank is not None
-        # pyrefly: ignore [bad-argument-type]
-        root_rank = cast(int, pickle.loads(message.message))
+        root_rank = cast(int, message.decode())
         rcv_ranks.append((cast_rank, root_rank))
     rcv_ranks.sort(key=lambda pair: pair[0])
     recv_cast_ranks, recv_root_ranks = zip(*rcv_ranks)

--- a/python/tests/_monarch/test_actor_mesh.py
+++ b/python/tests/_monarch/test_actor_mesh.py
@@ -81,6 +81,7 @@ class MyActor:
         message: bytes,
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
+        mesh_references: Iterable[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         match method:

--- a/python/tests/_monarch/test_hyperactor.py
+++ b/python/tests/_monarch/test_hyperactor.py
@@ -43,6 +43,7 @@ class MyActor:
         message: bytes,
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
+        mesh_references: Iterable[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         match method:

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -67,12 +67,10 @@ class Reducer(Generic[U]):
         self._reduce_f: Callable[[U, U], U] = reduce_f
 
     def __call__(self, left: PythonMessage, right: PythonMessage) -> PythonMessage:
-        # pyrefly: ignore [bad-argument-type]
-        l: U = cast(U, pickle.loads(left.message))
-        # pyrefly: ignore [bad-argument-type]
-        r: U = cast(U, pickle.loads(right.message))
+        l: U = cast(U, left.decode())
+        r: U = cast(U, right.decode())
         result: U = self._reduce_f(l, r)
-        return PythonMessage(left.kind, _to_frozen_buffer(pickle.dumps(result)))
+        return PythonMessage(left.kind, _to_frozen_buffer(pickle.dumps(result)), [])
 
 
 @final
@@ -90,12 +88,10 @@ class Accumulator(Generic[S, U]):
         )
 
     def __call__(self, state: PythonMessage, update: PythonMessage) -> PythonMessage:
-        # pyrefly: ignore [bad-argument-type]
-        s: S = cast(S, pickle.loads(state.message))
-        # pyrefly: ignore [bad-argument-type]
-        u: U = cast(U, pickle.loads(update.message))
+        s: S = cast(S, state.decode())
+        u: U = cast(U, update.decode())
         result: S = self._accumulate_f(s, u)
-        return PythonMessage(state.kind, _to_frozen_buffer(pickle.dumps(result)))
+        return PythonMessage(state.kind, _to_frozen_buffer(pickle.dumps(result)), [])
 
     @property
     def initial_state(self) -> PythonMessage:
@@ -107,6 +103,7 @@ class Accumulator(Generic[S, U]):
                 None,
             ),
             _to_frozen_buffer(pickle.dumps(self._initial_state)),
+            [],
         )
 
     @property
@@ -162,13 +159,13 @@ async def test_accumulator() -> None:
                     None,
                 ),
                 _to_frozen_buffer(pickle.dumps(value)),
+                [],
             ),
         )
 
     async def recv_message() -> str:
         messge = await receiver.recv_task().with_timeout(seconds=5)
-        # pyrefly: ignore [bad-argument-type]
-        value = pickle.loads(messge.message)
+        value = messge.decode()
         return cast(str, value)
 
     post_message(1)
@@ -257,8 +254,7 @@ async def test_reducer() -> None:
     )
 
     m = await receiver.recv_task().with_timeout(seconds=5)
-    # pyrefly: ignore [bad-argument-type]
-    value = pickle.loads(m.message)
+    value = m.decode()
     assert "[reduced](start+msg0)" in value
 
     #  Note: occasionally test would hang without this stop

--- a/python/tests/_monarch/test_mailbox.py
+++ b/python/tests/_monarch/test_mailbox.py
@@ -190,6 +190,7 @@ class MyActor:
         message: bytes,
         panic_flag: PanicFlag,
         local_state: Iterable[Any],
+        mesh_references: Iterable[Any],
         response_port: "PortProtocol[Any]",
     ) -> None:
         match method:

--- a/python/tests/test_deferred_pickle_characterization.py
+++ b/python/tests/test_deferred_pickle_characterization.py
@@ -1,0 +1,128 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Characterization oracle for deferred pickling.
+
+Pins today's observable behavior: a mesh reference that is still *pending*
+(spawned and sent in the same breath, before its background init finishes)
+arrives at the other side as a usable reference, on both send paths: as an
+endpoint argument (request path) and as an endpoint return value (reply path).
+Today this rides the deferred-pickle subsystem (resolve-before-send plus a
+re-pickle); a change to how pending references serialize must preserve these
+outcomes. This is the safety net such a change checks against.
+
+There is no hook to force the pending path; it relies on the
+spawn-then-immediately-send race, which the synchronous pickle wins in practice
+(the async mesh init cannot complete in the gap). The tests assert the
+end-to-end outcome, which is what must be preserved either way.
+"""
+
+from __future__ import annotations
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._src.actor.actor_mesh import Actor
+from monarch._src.actor.endpoint import endpoint
+from monarch._src.actor.host_mesh import this_host
+from monarch._src.job.process import ProcessJob
+from scoped_state import scoped_state
+
+
+class _Target(Actor):
+    @endpoint
+    async def ping(self) -> str:
+        return "pong"
+
+
+class _Receiver(Actor):
+    @endpoint
+    async def use_mesh(self, target: _Target) -> list[str]:
+        # Use the mesh we were handed (it was pending when it was sent).
+        results = await target.ping.call()
+        return [value for _, value in results]
+
+
+class _Spawner(Actor):
+    @endpoint
+    async def spawn_and_return_pending(self) -> _Target:
+        # Spawn a fresh mesh and return it without awaiting init, so it is
+        # pending when this reply is pickled.
+        return this_host().spawn_procs(name="inner_proc").spawn("inner", _Target)
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_mesh_sent_as_endpoint_argument_resolves_on_receiver() -> None:
+    """Request path: a just-spawned (pending) mesh passed as an endpoint argument
+    reaches the receiver as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        receiver = host.spawn_procs(name="recv_proc").spawn("receiver", _Receiver)
+        # Spawned and sent in the same breath: pending at pickle time.
+        target = host.spawn_procs(name="target_proc").spawn("target", _Target)
+        result = receiver.use_mesh.call_one(target).get()
+        assert result == ["pong"]
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_mesh_returned_from_endpoint_resolves_on_caller() -> None:
+    """Reply path: a just-spawned (pending) mesh returned from an endpoint reaches
+    the caller as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _Spawner)
+        returned = spawner.spawn_and_return_pending.call_one().get()
+        result = returned.ping.call_one().get()
+        assert result == "pong"
+
+
+class _ProcReceiver(Actor):
+    @endpoint
+    async def use_proc_mesh(self, proc_mesh) -> list[str]:
+        # Use the proc mesh we were handed (it was pending when it was sent).
+        actors = proc_mesh.spawn("inner", _Target)
+        results = await actors.ping.call()
+        return [value for _, value in results]
+
+
+class _ProcSpawner(Actor):
+    @endpoint
+    async def spawn_and_return_pending_proc(self):
+        # Return a fresh proc mesh without awaiting init, so it is pending when
+        # this reply is pickled.
+        return this_host().spawn_procs(name="inner_proc")
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_proc_mesh_sent_as_endpoint_argument_resolves_on_receiver() -> None:
+    """Request path: a just-spawned (pending) proc mesh passed as an endpoint
+    argument reaches the receiver as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        receiver = host.spawn_procs(name="recv_proc").spawn("receiver", _ProcReceiver)
+        # Spawned and sent in the same breath: pending at pickle time.
+        proc_mesh = host.spawn_procs(name="target_proc")
+        result = receiver.use_proc_mesh.call_one(proc_mesh).get()
+        assert result == ["pong"]
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_proc_mesh_returned_from_endpoint_resolves_on_caller() -> None:
+    """Reply path: a just-spawned (pending) proc mesh returned from an endpoint
+    reaches the caller as a working reference."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _ProcSpawner)
+        returned = spawner.spawn_and_return_pending_proc.call_one().get()
+        actors = returned.spawn("t", _Target)
+        result = actors.ping.call_one().get()
+        assert result == "pong"

--- a/python/tests/test_deferred_pickle_characterization.py
+++ b/python/tests/test_deferred_pickle_characterization.py
@@ -19,14 +19,30 @@ outcomes. This is the safety net such a change checks against.
 
 There is no hook to force the pending path; it relies on the
 spawn-then-immediately-send race, which the synchronous pickle wins in practice
-(the async mesh init cannot complete in the gap). The tests assert the
-end-to-end outcome, which is what must be preserved either way.
+(the async mesh init cannot complete in the gap). Every test asserts the
+end-to-end outcome. The argument tests also assert the reserve counter: a slot
+is reserved only for a mesh still pending at pickle, so a nonzero count proves
+the risky send-side pending path ran instead of resolving inline. That leans on
+the race timescale (init is milliseconds, the synchronous gap microseconds); if
+it ever flips the assertion goes red rather than passing hollow, and the
+hardening then is a barrier holding init until after the pickle. The return
+tests assert the pop counter, which proves the reply's reference reunited from
+the out-of-band table (received and reconstructed), not that it was pending: a
+resolved mesh also travels out-of-band, so pop cannot distinguish. Return-side
+pending-ness happens in the spawner subprocess, invisible here, so it stays
+outcome-only.
 """
 
 from __future__ import annotations
 
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.pickle import (
+    _get_mesh_pop_count,
+    _get_pending_reserve_count,
+    _reset_mesh_pop_count,
+    _reset_pending_reserve_count,
+)
 from monarch._src.actor.actor_mesh import Actor
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.host_mesh import this_host
@@ -66,8 +82,12 @@ def test_pending_mesh_sent_as_endpoint_argument_resolves_on_receiver() -> None:
         receiver = host.spawn_procs(name="recv_proc").spawn("receiver", _Receiver)
         # Spawned and sent in the same breath: pending at pickle time.
         target = host.spawn_procs(name="target_proc").spawn("target", _Target)
+        _reset_pending_reserve_count()
         result = receiver.use_mesh.call_one(target).get()
         assert result == ["pong"]
+        # A slot is reserved only for a still-pending mesh (a resolved one fills
+        # directly), so a nonzero count proves the send-side pending path ran.
+        assert _get_pending_reserve_count() > 0
 
 
 @pytest.mark.timeout(60)
@@ -78,7 +98,12 @@ def test_pending_mesh_returned_from_endpoint_resolves_on_caller() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         host = state.hosts
         spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _Spawner)
+        _reset_mesh_pop_count()
         returned = spawner.spawn_and_return_pending.call_one().get()
+        # Pop proves the reply's ref reunited from the out-of-band table
+        # (received and reconstructed); a resolved mesh rides out-of-band too,
+        # so this does not prove pending-ness.
+        assert _get_mesh_pop_count() > 0
         result = returned.ping.call_one().get()
         assert result == "pong"
 
@@ -110,8 +135,12 @@ def test_pending_proc_mesh_sent_as_endpoint_argument_resolves_on_receiver() -> N
         receiver = host.spawn_procs(name="recv_proc").spawn("receiver", _ProcReceiver)
         # Spawned and sent in the same breath: pending at pickle time.
         proc_mesh = host.spawn_procs(name="target_proc")
+        _reset_pending_reserve_count()
         result = receiver.use_proc_mesh.call_one(proc_mesh).get()
         assert result == ["pong"]
+        # A slot is reserved only for a still-pending proc mesh (a resolved one
+        # fills directly), so this proves the send-side pending path ran.
+        assert _get_pending_reserve_count() > 0
 
 
 @pytest.mark.timeout(60)
@@ -122,7 +151,30 @@ def test_pending_proc_mesh_returned_from_endpoint_resolves_on_caller() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         host = state.hosts
         spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _ProcSpawner)
+        _reset_mesh_pop_count()
         returned = spawner.spawn_and_return_pending_proc.call_one().get()
+        # Pop proves the reply's ref reunited from the out-of-band table
+        # (received and reconstructed), not that it was pending.
+        assert _get_mesh_pop_count() > 0
         actors = returned.spawn("t", _Target)
         result = actors.ping.call_one().get()
         assert result == "pong"
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_pending_mesh_returned_through_call_valuemesh_resolves_on_caller() -> None:
+    """Reply path via .call(): a just-spawned (pending) mesh returned from an
+    endpoint and collected into a valuemesh reaches the caller as a working
+    reference. Exercises the accumulated-overlay decode, where per-rank refs
+    must survive the RLE boundary."""
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        host = state.hosts
+        spawner = host.spawn_procs(name="spawner_proc").spawn("spawner", _Spawner)
+        _reset_mesh_pop_count()
+        returned = spawner.spawn_and_return_pending.call().get()
+        # Pop proves each per-rank reply's ref reunited through the valuemesh
+        # decode (received and reconstructed), not that it was pending.
+        assert _get_mesh_pop_count() > 0
+        for _, mesh in returned:
+            assert mesh.ping.call_one().get() == "pong"

--- a/python/tests/test_proc_launcher_probe.py
+++ b/python/tests/test_proc_launcher_probe.py
@@ -113,7 +113,7 @@ async def test_port_receives_result() -> None:
     # be (args_tuple, kwargs_dict) format
     args = ("test_tag",)
     kwargs = {}
-    pickling_state = pickle((args, kwargs), allow_pending_pickles=False)
+    pickling_state = pickle((args, kwargs))
 
     # Call the Rust probe and await the result
     report = await probe_exit_port_via_mesh(
@@ -172,7 +172,7 @@ async def test_port_receives_exception() -> None:
     # be (args_tuple, kwargs_dict) format
     args = ("test_tag",)
     kwargs = {}
-    pickling_state = pickle((args, kwargs), allow_pending_pickles=False)
+    pickling_state = pickle((args, kwargs))
 
     # Call the Rust probe and await the result
     report = await probe_exit_port_via_mesh(

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1341,7 +1341,7 @@ class UndeliverableMessageSender(Actor):
         port_ref.send(
             actor_instance._as_rust(),
             # pyrefly: ignore [bad-argument-count, bad-argument-type]
-            PythonMessage(PythonMessageKind.Result(None), buf.freeze()),
+            PythonMessage(PythonMessageKind.Result(None), buf.freeze(), []),
         )
 
 


### PR DESCRIPTION
Summary:

the out-of-band `refs` table made deferred pickling dead: pending meshes reserve a slot and are filled sender-side, so no `PyShared` is ever deferred and re-pickled. this removes the machinery.

- `pop_pending_pickle` / `push_pending_pickle`, the `pending_pickles` collector on `ActivePicklingState`/`PicklingStateInner` (with its accessor and the `unpickle` guard loop), and the re-pickle branch of `PicklingState::resolve` (which now only fills reserved mesh slots).
- `reduce_shared`'s defer branch: a pending non-mesh `PyShared` now blocks (the existing fallback) rather than deferring.
- the `allow_pending_pickles` gate, dropped from the `pickle()` signature and every caller.
- the orphaned Python toggles (`allow_pending_pickle_mesh`, `is_pending_pickle_allowed`) and dead `flatten`/`unflatten` `py_global!`s.

`PendingMessage` stays as the live message carrier; its `resolve` now only reunites the mesh table. behavior-preserving.

Reviewed By: zdevito

Differential Revision: D110342487
