### PR TITLE
fix the unsanctioned control-plane GIL test under mode/opt

### DIFF
--- a/monarch_gil/src/lib.rs
+++ b/monarch_gil/src/lib.rs
@@ -356,7 +356,7 @@ mod tests {
     // GIL-1 (outermost-entry-accountable): reentrant_unsanctioned_is_skipped.
     // GIL-2 (off-control-plane-exempt): unsanctioned_site_off_control_plane_is_silent.
     // GIL-3 (allowlist-exhaustive): allowed_classification; structural (wildcard-free match, no catch-all).
-    // GIL-4 (unsanctioned-accounted): unsanctioned_site_on_control_plane_panics; allowed_site_on_control_plane_is_silent.
+    // GIL-4 (unsanctioned-accounted): unsanctioned_site_on_control_plane_is_accounted; allowed_site_on_control_plane_is_silent.
 
     // The classification is the source of truth for the net: dispatch is
     // sanctioned; Rdma is not (it must run on the data plane).
@@ -386,21 +386,27 @@ mod tests {
         assert_eq!(after, before, "allowed site must not bump the counter");
     }
 
-    // An unsanctioned site (Rdma) on a control-plane thread trips the
-    // debug_assert (which fires in test builds).
+    // An unsanctioned site (Rdma) on a control-plane thread is accounted: the
+    // counter bumps in `check_gil_site` before the debug_assert, in every build
+    // mode. `catch_unwind` absorbs the debug-build assert panic so the delta is
+    // observable regardless of `debug_assertions` (under `mode/opt`, which CI
+    // runs, the assert is compiled out and there is nothing to absorb). Run on a
+    // freshly tagged thread and assert a delta so concurrent tests on the global
+    // counter do not interfere.
     // GIL-4:
     #[test]
-    fn unsanctioned_site_on_control_plane_panics() {
-        // Run on a throwaway thread so the ControlPlane tag never leaks into a
-        // sibling test; the debug_assert fires inside it, so join() returns Err.
-        let res = std::thread::spawn(|| {
+    fn unsanctioned_site_on_control_plane_is_accounted() {
+        let before = GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed);
+        std::thread::spawn(|| {
             tag_current_thread(RuntimeKind::ControlPlane);
-            check_gil_site(GilSite::Rdma);
+            let _ = std::panic::catch_unwind(|| check_gil_site(GilSite::Rdma));
         })
-        .join();
+        .join()
+        .unwrap();
+        let after = GIL_ON_CONTROL_PLANE.load(Ordering::Relaxed);
         assert!(
-            res.is_err(),
-            "unsanctioned control-plane GIL must trip the debug_assert"
+            after > before,
+            "unsanctioned control-plane GIL must bump the counter"
         );
     }
 


### PR DESCRIPTION
Summary:
`unsanctioned_site_on_control_plane_panics` asserted the spawned thread panics, but the only panic there is the `debug_assert!` in `check_gil_site`, which `mode/opt` compiles out. So in continuous CI (mode/opt) the thread returns cleanly, `join()` is `Ok`, and the test fails; it never passed on that platform.

Renamed to `unsanctioned_site_on_control_plane_is_accounted` and switched to assert the `GIL_ON_CONTROL_PLANE` counter delta (bumped before the debug_assert, in every build mode; the call is wrapped in `catch_unwind` to absorb the debug-build assert), matching the sibling tests that already assert deltas.

Swept the monarch tree: this was the only test whose asserted panic came from a `debug_assert!`. Every other should_panic / catch_unwind / join-is-err test asserts a real `panic!` / `unimplemented!` / `.expect()` / `assert!`, which fire under opt too, so they're correct.

Differential Revision: D110349072


