### PR TITLE
[ROCm] Re-order torch import to avoid race with rocprofiler

### DIFF
--- a/.github/workflows/test-gpu-python.yml
+++ b/.github/workflows/test-gpu-python.yml
@@ -45,6 +45,11 @@ jobs:
           setup_cuda_environment
         elif [[ "${{ matrix.gpu-arch-type }}" == "rocm" ]]; then
           setup_rocm_environment
+          # Enable torch preload so the test worker's own RDMA HIP calls win the
+          # rocprofiler-register race (hip.cpp:512 "hipApiName ..."). conftest.py
+          # scopes it back OFF for non-RDMA tests so their spawned procs don't pay
+          # the ~10s torch import. See monarch/__init__.py + python/tests/conftest.py.
+          export MONARCH_PRELOAD_TORCH=1
         fi
 
         # Install torch nightly before installing the wheel,

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -383,7 +383,7 @@ pub(super) unsafe fn register_dmabuf_mr(
 
     // Resolve the base and size of the allocation containing `addr`; the dmabuf
     // handle and MR cover the whole allocation.
-    let mut base: rdmaxcel_sys::CUdeviceptr = 0;
+    let mut base: rdmaxcel_sys::CUdeviceptr = unsafe { std::mem::zeroed() };
     let mut alloc_size: usize = 0;
     // SAFETY: `rdmaxcel_cuMemGetAddressRange` writes the allocation's base and
     // size into the out-params and touches no other Rust memory; it reports

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -393,7 +393,7 @@ pub(super) unsafe fn register_dmabuf_range(
 /// returns an error unless `addr` is a device pointer whose owning context is
 /// current (see [`crate::local_memory::set_ctx_for_ptr`]).
 fn cuda_alloc_range(addr: usize) -> anyhow::Result<(usize, usize)> {
-    let mut base: rdmaxcel_sys::CUdeviceptr = 0;
+    let mut base: rdmaxcel_sys::CUdeviceptr = unsafe { std::mem::zeroed() };
     let mut size: usize = 0;
     // SAFETY: the out-params point to local variables and `addr` is passed by
     // value as an opaque device address (never dereferenced); the call writes

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -180,15 +180,27 @@ pub struct WorkerActor {
 
 impl WorkerActor {
     fn runtime_has_cuda() -> bool {
+        // NOTE: use `torch.backends.cuda.is_built()`, NOT `torch.cuda.is_available()`.
+        // `is_available()` calls `torch.cuda.device_count()`, which memoizes the
+        // count in c10 on first call (c10/cuda/CUDAFunctions.cpp `device_count()`),
+        // reading the visible-device env vars at that moment. This runs during
+        // worker construction, before `_initialize_env` applies the per-worker GPU
+        // mask (CUDA_VISIBLE_DEVICES), so that early memoization would latch the
+        // full host device count and every worker would keep seeing all GPUs after
+        // masking (observed on multi-GPU ROCm: `get_rng_state_all()` returned one
+        // state per host GPU). `is_built()` reports build support without
+        // enumerating devices, so the first (masked) enumeration happens later.
         monarch_with_gil_blocking(GilSite::WorkerInit, |py| {
             py.import("torch")
                 .expect("torch must be importable in a worker")
+                .getattr("backends")
+                .expect("torch.backends must exist")
                 .getattr("cuda")
-                .expect("torch.cuda attribute must exist")
-                .call_method0("is_available")
-                .expect("torch.cuda.is_available() must be callable")
+                .expect("torch.backends.cuda must exist")
+                .call_method0("is_built")
+                .expect("torch.backends.cuda.is_built() must be callable")
                 .extract::<bool>()
-                .expect("torch.cuda.is_available() must return bool")
+                .expect("torch.backends.cuda.is_built() must return bool")
         })
     }
 

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -179,6 +179,23 @@ pub struct WorkerActor {
 }
 
 impl WorkerActor {
+    fn runtime_is_cuda_build() -> bool {
+        // Do not enumerate devices until `_initialize_env` applies the worker's
+        // visible-device mask. PyTorch memoizes the result of early enumeration.
+        monarch_with_gil_blocking(GilSite::WorkerInit, |py| {
+            py.import("torch")
+                .expect("torch must be importable in a worker")
+                .getattr("backends")
+                .expect("torch.backends must exist")
+                .getattr("cuda")
+                .expect("torch.backends.cuda must exist")
+                .call_method0("is_built")
+                .expect("torch.backends.cuda.is_built() must be callable")
+                .extract::<bool>()
+                .expect("torch.backends.cuda.is_built() must return bool")
+        })
+    }
+
     fn runtime_has_cuda() -> bool {
         // NOTE: use `torch.backends.cuda.is_built()`, NOT `torch.cuda.is_available()`.
         // `is_available()` calls `torch.cuda.device_count()`, which memoizes the
@@ -258,7 +275,7 @@ impl RemoteSpawn for WorkerActor {
         monarch_with_gil_blocking(GilSite::WorkerInit, |py| {
             py.import("monarch.safe_torch").unwrap();
         });
-        let device = if Self::runtime_has_cuda() {
+        let device = if Self::runtime_is_cuda_build() {
             device_index.map(|i| CudaDevice::new(DeviceIndex(i)))
         } else {
             None
@@ -300,6 +317,9 @@ impl Handler<AssignRankMessage> for WorkerActor {
                 .call_method1("_initialize_env", (p, cx.proc().proc_addr().to_string()))
                 .unwrap();
         });
+        if !Self::runtime_has_cuda() {
+            self.device = None;
+        }
         Ok(())
     }
 }

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -176,16 +176,45 @@ pub struct WorkerActor {
 }
 
 impl WorkerActor {
-    fn runtime_has_cuda() -> bool {
+    fn runtime_is_cuda_build() -> bool {
+        // Do not enumerate devices until `_initialize_env` applies the worker's
+        // visible-device mask. PyTorch memoizes the result of early enumeration.
         monarch_with_gil_blocking(GilSite::WorkerInit, |py| {
             py.import("torch")
                 .expect("torch must be importable in a worker")
+                .getattr("backends")
+                .expect("torch.backends must exist")
                 .getattr("cuda")
-                .expect("torch.cuda attribute must exist")
-                .call_method0("is_available")
-                .expect("torch.cuda.is_available() must be callable")
+                .expect("torch.backends.cuda must exist")
+                .call_method0("is_built")
+                .expect("torch.backends.cuda.is_built() must be callable")
                 .extract::<bool>()
-                .expect("torch.cuda.is_available() must return bool")
+                .expect("torch.backends.cuda.is_built() must return bool")
+        })
+    }
+
+    fn runtime_has_cuda() -> bool {
+        // NOTE: use `torch.backends.cuda.is_built()`, NOT `torch.cuda.is_available()`.
+        // `is_available()` calls `torch.cuda.device_count()`, which memoizes the
+        // count in c10 on first call (c10/cuda/CUDAFunctions.cpp `device_count()`),
+        // reading the visible-device env vars at that moment. This runs during
+        // worker construction, before `_initialize_env` applies the per-worker GPU
+        // mask (CUDA_VISIBLE_DEVICES), so that early memoization would latch the
+        // full host device count and every worker would keep seeing all GPUs after
+        // masking (observed on multi-GPU ROCm: `get_rng_state_all()` returned one
+        // state per host GPU). `is_built()` reports build support without
+        // enumerating devices, so the first (masked) enumeration happens later.
+        monarch_with_gil_blocking(GilSite::WorkerInit, |py| {
+            py.import("torch")
+                .expect("torch must be importable in a worker")
+                .getattr("backends")
+                .expect("torch.backends must exist")
+                .getattr("cuda")
+                .expect("torch.backends.cuda must exist")
+                .call_method0("is_built")
+                .expect("torch.backends.cuda.is_built() must be callable")
+                .extract::<bool>()
+                .expect("torch.backends.cuda.is_built() must return bool")
         })
     }
 
@@ -243,7 +272,7 @@ impl RemoteSpawn for WorkerActor {
         monarch_with_gil_blocking(GilSite::WorkerInit, |py| {
             py.import("monarch.safe_torch").unwrap();
         });
-        let device = if Self::runtime_has_cuda() {
+        let device = if Self::runtime_is_cuda_build() {
             device_index.map(|i| CudaDevice::new(DeviceIndex(i)))
         } else {
             None
@@ -285,6 +314,9 @@ impl Handler<AssignRankMessage> for WorkerActor {
                 .call_method1("_initialize_env", (p, cx.proc().proc_addr().to_string()))
                 .unwrap();
         });
+        if !Self::runtime_has_cuda() {
+            self.device = None;
+        }
         Ok(())
     }
 }

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -9,47 +9,67 @@
 from importlib import import_module as _import_module
 from typing import TYPE_CHECKING
 
-# Opt-in torch preload, BEFORE monarch._rust_bindings.
-#
-# On ROCm, monarch's native extension links the system libamdhip64 while torch
-# bundles its own copy. If monarch._rust_bindings loads first, the system HIP
-# runtime wins rocprofiler-register and the first HIP runtime call afterward
-# aborts (hip.cpp:512 "hipApiName has non-null function pointer ... first
-# instance of the library being copied", SIGABRT). Importing torch first makes
-# torch's runtime win.
-#
-# This is opt-in via MONARCH_PRELOAD_TORCH so monarch stays importable -- and
-# torch-free -- for non-torch frameworks. _get_bootstrap_args() sets it on
-# spawned procs only when the launching process itself uses torch, so CPU /
-# no-torch workloads never pull torch in.
 import os as _os
-
-if _os.environ.get("MONARCH_PRELOAD_TORCH") == "1":
-    try:
-        import torch  # @manual  # noqa: F401
-    except ImportError:
-        pass
-
-# Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
-# our RPATHs won't correctly find them.
 import sys as _sys
 
-# Record whether torch's HIP runtime was already loaded when we load our native
-# extension. On ROCm, if our extension (which links the system libamdhip64)
-# loads before torch's bundled copy, the first HIP call aborts
-# (hip.cpp:512 "hipApiName ..."). The RDMA path checks this flag to raise a
-# clear, actionable error instead of a hard SIGABRT. See
+
+def _preload_torch_hip_runtime() -> bool:
+    """Preload torch's bundled ROCm HIP shared library before our native
+    extension loads.
+
+    On ROCm, ``monarch._rust_bindings`` links the *system* ``libamdhip64`` while
+    torch ships its *own* copy. Whichever HIP runtime initializes first wins
+    ``rocprofiler-register``; if the system copy wins, the first HIP call made
+    afterward aborts the process
+    (``hip.cpp:512 "hipApiName has non-null function pointer ..."``). Loading
+    torch's ``libamdhip64`` here makes torch's runtime win regardless of the
+    order in which the user imports torch and monarch.
+
+    This is cheap (~tens of ms, just a dlopen) and does NOT import the torch
+    Python module, so it never pulls torch into non-torch workloads. It is a
+    no-op when torch is not installed or is a CUDA/CPU build (the HIP DSO is
+    absent). Set ``MONARCH_PRELOAD_TORCH=0`` to skip it.
+
+    Returns True when torch's HIP runtime is present (already imported, or loaded
+    here) so callers can record that the load ordering is safe.
+    """
+    if _os.environ.get("MONARCH_PRELOAD_TORCH") == "0":
+        return "torch" in _sys.modules
+    if "torch" in _sys.modules:
+        return True  # torch already imported: its HIP runtime is already loaded
+    try:
+        import ctypes
+        import importlib.util
+
+        spec = importlib.util.find_spec("torch")
+        if spec is None or spec.origin is None:
+            return False
+        lib = _os.path.join(_os.path.dirname(spec.origin), "lib", "libamdhip64.so")
+        if not _os.path.exists(lib):
+            return False  # CUDA/CPU torch build: no HIP runtime to preload
+        ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL)
+        return True
+    except Exception:
+        return False
+
+
+# Preload torch's HIP runtime (ROCm) BEFORE importing our native extension so
+# torch's copy wins rocprofiler-register; otherwise the first HIP call aborts
+# (hip.cpp:512 "hipApiName ..."). Cheap and torch-module-free; no-op off ROCm.
+# The RDMA path checks the flag below to raise a clear error instead of a hard
+# SIGABRT if the ordering still could not be guaranteed. See
 # monarch/_src/rdma/rdma.py:_ensure_hip_runtime_ordering.
-_TORCH_PRELOADED_BEFORE_BINDINGS = "torch" in _sys.modules
+_TORCH_HIP_RUNTIME_PRELOADED = _preload_torch_hip_runtime()
 try:
     import monarch._rust_bindings  # @manual  # noqa: F401
 except ImportError:
+    # Exploded-wheel flow: our RPATHs may not resolve torch's DSOs until torch
+    # itself is imported. Fall back to a full torch import, then retry.
     try:
         import torch  # @manual  # noqa: F401
     except ImportError:
         pass
-    # The fallback imports torch before retrying, so torch's runtime wins here.
-    _TORCH_PRELOADED_BEFORE_BINDINGS = "torch" in _sys.modules
+    _TORCH_HIP_RUNTIME_PRELOADED = _TORCH_HIP_RUNTIME_PRELOADED or ("torch" in _sys.modules)
     import monarch._rust_bindings  # @manual  # noqa: F401
 
 # submodules of monarch should not be imported in this

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -12,13 +12,10 @@ from typing import TYPE_CHECKING
 # Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
 # our RPATHs won't correctly find them.
 try:
-    import monarch._rust_bindings  # @manual  # noqa: F401
+    import torch  # @manual  # noqa: F401
 except ImportError:
-    try:
-        import torch  # @manual  # noqa: F401
-    except ImportError:
-        pass
-    import monarch._rust_bindings  # @manual  # noqa: F401
+    pass
+import monarch._rust_bindings  # @manual  # noqa: F401
 
 # submodules of monarch should not be imported in this
 # top-level file because it will cause them to get

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -32,6 +32,15 @@ if _os.environ.get("MONARCH_PRELOAD_TORCH") == "1":
 
 # Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
 # our RPATHs won't correctly find them.
+import sys as _sys
+
+# Record whether torch's HIP runtime was already loaded when we load our native
+# extension. On ROCm, if our extension (which links the system libamdhip64)
+# loads before torch's bundled copy, the first HIP call aborts
+# (hip.cpp:512 "hipApiName ..."). The RDMA path checks this flag to raise a
+# clear, actionable error instead of a hard SIGABRT. See
+# monarch/_src/rdma/rdma.py:_ensure_hip_runtime_ordering.
+_TORCH_PRELOADED_BEFORE_BINDINGS = "torch" in _sys.modules
 try:
     import monarch._rust_bindings  # @manual  # noqa: F401
 except ImportError:
@@ -39,6 +48,8 @@ except ImportError:
         import torch  # @manual  # noqa: F401
     except ImportError:
         pass
+    # The fallback imports torch before retrying, so torch's runtime wins here.
+    _TORCH_PRELOADED_BEFORE_BINDINGS = "torch" in _sys.modules
     import monarch._rust_bindings  # @manual  # noqa: F401
 
 # submodules of monarch should not be imported in this

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -9,13 +9,37 @@
 from importlib import import_module as _import_module
 from typing import TYPE_CHECKING
 
+# Opt-in torch preload, BEFORE monarch._rust_bindings.
+#
+# On ROCm, monarch's native extension links the system libamdhip64 while torch
+# bundles its own copy. If monarch._rust_bindings loads first, the system HIP
+# runtime wins rocprofiler-register and the first HIP runtime call afterward
+# aborts (hip.cpp:512 "hipApiName has non-null function pointer ... first
+# instance of the library being copied", SIGABRT). Importing torch first makes
+# torch's runtime win.
+#
+# This is opt-in via MONARCH_PRELOAD_TORCH so monarch stays importable -- and
+# torch-free -- for non-torch frameworks. _get_bootstrap_args() sets it on
+# spawned procs only when the launching process itself uses torch, so CPU /
+# no-torch workloads never pull torch in.
+import os as _os
+
+if _os.environ.get("MONARCH_PRELOAD_TORCH") == "1":
+    try:
+        import torch  # @manual  # noqa: F401
+    except ImportError:
+        pass
+
 # Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
 # our RPATHs won't correctly find them.
 try:
-    import torch  # @manual  # noqa: F401
+    import monarch._rust_bindings  # @manual  # noqa: F401
 except ImportError:
-    pass
-import monarch._rust_bindings  # @manual  # noqa: F401
+    try:
+        import torch  # @manual  # noqa: F401
+    except ImportError:
+        pass
+    import monarch._rust_bindings  # @manual  # noqa: F401
 
 # submodules of monarch should not be imported in this
 # top-level file because it will cause them to get

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -9,67 +9,15 @@
 from importlib import import_module as _import_module
 from typing import TYPE_CHECKING
 
-import os as _os
-import sys as _sys
-
-
-def _preload_torch_hip_runtime() -> bool:
-    """Preload torch's bundled ROCm HIP shared library before our native
-    extension loads.
-
-    On ROCm, ``monarch._rust_bindings`` links the *system* ``libamdhip64`` while
-    torch ships its *own* copy. Whichever HIP runtime initializes first wins
-    ``rocprofiler-register``; if the system copy wins, the first HIP call made
-    afterward aborts the process
-    (``hip.cpp:512 "hipApiName has non-null function pointer ..."``). Loading
-    torch's ``libamdhip64`` here makes torch's runtime win regardless of the
-    order in which the user imports torch and monarch.
-
-    This is cheap (~tens of ms, just a dlopen) and does NOT import the torch
-    Python module, so it never pulls torch into non-torch workloads. It is a
-    no-op when torch is not installed or is a CUDA/CPU build (the HIP DSO is
-    absent). Set ``MONARCH_PRELOAD_TORCH=0`` to skip it.
-
-    Returns True when torch's HIP runtime is present (already imported, or loaded
-    here) so callers can record that the load ordering is safe.
-    """
-    if _os.environ.get("MONARCH_PRELOAD_TORCH") == "0":
-        return "torch" in _sys.modules
-    if "torch" in _sys.modules:
-        return True  # torch already imported: its HIP runtime is already loaded
-    try:
-        import ctypes
-        import importlib.util
-
-        spec = importlib.util.find_spec("torch")
-        if spec is None or spec.origin is None:
-            return False
-        lib = _os.path.join(_os.path.dirname(spec.origin), "lib", "libamdhip64.so")
-        if not _os.path.exists(lib):
-            return False  # CUDA/CPU torch build: no HIP runtime to preload
-        ctypes.CDLL(lib, mode=ctypes.RTLD_GLOBAL)
-        return True
-    except Exception:
-        return False
-
-
-# Preload torch's HIP runtime (ROCm) BEFORE importing our native extension so
-# torch's copy wins rocprofiler-register; otherwise the first HIP call aborts
-# (hip.cpp:512 "hipApiName ..."). Cheap and torch-module-free; no-op off ROCm.
-# The RDMA path checks the flag below to raise a clear error instead of a hard
-# SIGABRT if the ordering still could not be guaranteed. See
-# monarch/_src/rdma/rdma.py:_ensure_hip_runtime_ordering.
-_TORCH_HIP_RUNTIME_PRELOADED = _preload_torch_hip_runtime()
+# Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
+# our RPATHs won't correctly find them.
 try:
     import monarch._rust_bindings  # @manual  # noqa: F401
 except ImportError:
-    # Exploded-wheel flow: our RPATHs may not resolve torch's DSOs until torch
-    # itself is imported. Fall back to a full torch import, then retry.
     try:
         import torch  # @manual  # noqa: F401
     except ImportError:
         pass
-    _TORCH_HIP_RUNTIME_PRELOADED = _TORCH_HIP_RUNTIME_PRELOADED or ("torch" in _sys.modules)
     import monarch._rust_bindings  # @manual  # noqa: F401
 
 # submodules of monarch should not be imported in this

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -17,6 +17,26 @@ if os.environ.get("MONARCH_PRELOAD_TORCH", "0") == "1":
         import torch  # noqa: F401
     except ImportError:
         pass
+elif os.environ.get("MONARCH_PRELOAD_TORCH_HIP", "0") == "1":
+    # "Lite" preload for spawned procs: dlopen torch's bundled libamdhip64 (~ms)
+    # so it wins the rocprofiler-register race the same way a full `import torch`
+    # would -- torch itself loads this lib with RTLD_GLOBAL -- but without torch's
+    # ~10s import cost, which across the procs an RDMA test spawns overruns the
+    # Host::spawn readiness window on slow ROCm runners. proc_mesh sets this flag
+    # for spawned procs; the main process still uses `import torch` above.
+    try:
+        import ctypes as _ctypes
+        import importlib.util as _importlib_util
+
+        _torch_spec = _importlib_util.find_spec("torch")
+        if _torch_spec is not None and _torch_spec.origin is not None:
+            _hip_lib = os.path.join(
+                os.path.dirname(_torch_spec.origin), "lib", "libamdhip64.so"
+            )
+            if os.path.exists(_hip_lib):
+                _ctypes.CDLL(_hip_lib, mode=_ctypes.RTLD_GLOBAL)
+    except Exception:
+        pass
 
 # Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
 # our RPATHs won't correctly find them.

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -17,26 +17,6 @@ if os.environ.get("MONARCH_PRELOAD_TORCH", "0") == "1":
         import torch  # noqa: F401
     except ImportError:
         pass
-elif os.environ.get("MONARCH_PRELOAD_TORCH_HIP", "0") == "1":
-    # "Lite" preload for spawned procs: dlopen torch's bundled libamdhip64 (~ms)
-    # so it wins the rocprofiler-register race the same way a full `import torch`
-    # would -- torch itself loads this lib with RTLD_GLOBAL -- but without torch's
-    # ~10s import cost, which across the procs an RDMA test spawns overruns the
-    # Host::spawn readiness window on slow ROCm runners. proc_mesh sets this flag
-    # for spawned procs; the main process still uses `import torch` above.
-    try:
-        import ctypes as _ctypes
-        import importlib.util as _importlib_util
-
-        _torch_spec = _importlib_util.find_spec("torch")
-        if _torch_spec is not None and _torch_spec.origin is not None:
-            _hip_lib = os.path.join(
-                os.path.dirname(_torch_spec.origin), "lib", "libamdhip64.so"
-            )
-            if os.path.exists(_hip_lib):
-                _ctypes.CDLL(_hip_lib, mode=_ctypes.RTLD_GLOBAL)
-    except Exception:
-        pass
 
 # Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
 # our RPATHs won't correctly find them.

--- a/python/monarch/__init__.py
+++ b/python/monarch/__init__.py
@@ -6,8 +6,17 @@
 
 # pyre-unsafe
 
+import os
 from importlib import import_module as _import_module
 from typing import TYPE_CHECKING
+
+
+# Pre-emptively pre-load torch if environment requires it
+if os.environ.get("MONARCH_PRELOAD_TORCH", "0") == "1":
+    try:
+        import torch  # noqa: F401
+    except ImportError:
+        pass
 
 # Import before monarch to pre-load torch DSOs as, in exploded wheel flows,
 # our RPATHs won't correctly find them.

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -1002,4 +1002,12 @@ def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
         args = ["-m", _BOOTSTRAP_MAIN]
         env = {}
 
+    # If the launching process uses torch, tell spawned procs to import torch
+    # before monarch._rust_bindings (see monarch/__init__.py). This keeps the
+    # torch HIP runtime ahead of monarch's system libamdhip64 on ROCm, avoiding
+    # a fatal rocprofiler-register abort. Gated on the parent actually using
+    # torch so CPU / no-torch workloads never import it.
+    if "torch" in sys.modules:
+        env["MONARCH_PRELOAD_TORCH"] = "1"
+
     return cmd, args, env

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -1002,12 +1002,4 @@ def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
         args = ["-m", _BOOTSTRAP_MAIN]
         env = {}
 
-    # If the launching process uses torch, tell spawned procs to import torch
-    # before monarch._rust_bindings (see monarch/__init__.py). This keeps the
-    # torch HIP runtime ahead of monarch's system libamdhip64 on ROCm, avoiding
-    # a fatal rocprofiler-register abort. Gated on the parent actually using
-    # torch so CPU / no-torch workloads never import it.
-    if "torch" in sys.modules:
-        env["MONARCH_PRELOAD_TORCH"] = "1"
-
     return cmd, args, env

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -1000,12 +1000,18 @@ def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
         cmd = sys.executable
         args = ["-m", _BOOTSTRAP_MAIN]
 
-    # Propagate the torch-preload opt-in to spawned procs so their monarch import
-    # loads torch before the native extension (keeps torch's HIP runtime ahead of
-    # monarch's system libamdhip64 on ROCm, avoiding the fatal rocprofiler-register
-    # abort). Driven by the env var so it stays a single, honored opt-in; spawned
-    # procs otherwise start with a clean env and would not inherit it.
-    if os.environ.get("MONARCH_PRELOAD_TORCH") == "1":
-        env["MONARCH_PRELOAD_TORCH"] = "1"
+    # Spawned procs inherit our env (this dict starts as a copy of os.environ), so
+    # on ROCm they would re-run the full `import torch` preload (~10s each) and a
+    # multi-proc RDMA spawn overruns the Host::spawn readiness window. Instead hand
+    # spawned procs the "lite" preload: turn the full import OFF and have
+    # monarch/__init__.py dlopen torch's bundled libamdhip64 (~ms). That still wins
+    # the rocprofiler-register race (torch loads the same lib with RTLD_GLOBAL) but
+    # without the import cost. The launching process keeps the full `import torch`.
+    if (
+        os.environ.get("MONARCH_PRELOAD_TORCH") == "1"
+        or os.environ.get("MONARCH_PRELOAD_TORCH_HIP") == "1"
+    ):
+        env["MONARCH_PRELOAD_TORCH"] = "0"
+        env["MONARCH_PRELOAD_TORCH_HIP"] = "1"
 
     return cmd, args, env

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -1000,4 +1000,12 @@ def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
         cmd = sys.executable
         args = ["-m", _BOOTSTRAP_MAIN]
 
+    # Propagate the torch-preload opt-in to spawned procs so their monarch import
+    # loads torch before the native extension (keeps torch's HIP runtime ahead of
+    # monarch's system libamdhip64 on ROCm, avoiding the fatal rocprofiler-register
+    # abort). Driven by the env var so it stays a single, honored opt-in; spawned
+    # procs otherwise start with a clean env and would not inherit it.
+    if os.environ.get("MONARCH_PRELOAD_TORCH") == "1":
+        env["MONARCH_PRELOAD_TORCH"] = "1"
+
     return cmd, args, env

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -1001,11 +1001,15 @@ def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
         args = ["-m", _BOOTSTRAP_MAIN]
 
     # Propagate the torch-preload opt-in to spawned procs so their monarch import
-    # loads torch before the native extension (keeps torch's HIP runtime ahead of
-    # monarch's system libamdhip64 on ROCm, avoiding the fatal rocprofiler-register
-    # abort). Driven by the env var so it stays a single, honored opt-in; spawned
-    # procs otherwise start with a clean env and would not inherit it.
-    if os.environ.get("MONARCH_PRELOAD_TORCH") == "1":
-        env["MONARCH_PRELOAD_TORCH"] = "1"
+    # loads torch's HIP runtime ahead of monarch's system libamdhip64 on ROCm,
+    # avoiding the fatal rocprofiler-register abort. Spawned procs use the *lite*
+    # dlopen preload (MONARCH_PRELOAD_TORCH_HIP) rather than a full `import torch`
+    # (~10s each), so multi-proc RDMA spawns stay within the Host::spawn window.
+    # Propagated whether this proc did a full or lite preload. See monarch/__init__.py.
+    if (
+        os.environ.get("MONARCH_PRELOAD_TORCH") == "1"
+        or os.environ.get("MONARCH_PRELOAD_TORCH_HIP") == "1"
+    ):
+        env["MONARCH_PRELOAD_TORCH_HIP"] = "1"
 
     return cmd, args, env

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -1001,15 +1001,11 @@ def _get_bootstrap_args() -> tuple[str, Optional[list[str]], dict[str, str]]:
         args = ["-m", _BOOTSTRAP_MAIN]
 
     # Propagate the torch-preload opt-in to spawned procs so their monarch import
-    # loads torch's HIP runtime ahead of monarch's system libamdhip64 on ROCm,
-    # avoiding the fatal rocprofiler-register abort. Spawned procs use the *lite*
-    # dlopen preload (MONARCH_PRELOAD_TORCH_HIP) rather than a full `import torch`
-    # (~10s each), so multi-proc RDMA spawns stay within the Host::spawn window.
-    # Propagated whether this proc did a full or lite preload. See monarch/__init__.py.
-    if (
-        os.environ.get("MONARCH_PRELOAD_TORCH") == "1"
-        or os.environ.get("MONARCH_PRELOAD_TORCH_HIP") == "1"
-    ):
-        env["MONARCH_PRELOAD_TORCH_HIP"] = "1"
+    # loads torch before the native extension (keeps torch's HIP runtime ahead of
+    # monarch's system libamdhip64 on ROCm, avoiding the fatal rocprofiler-register
+    # abort). Driven by the env var so it stays a single, honored opt-in; spawned
+    # procs otherwise start with a clean env and would not inherit it.
+    if os.environ.get("MONARCH_PRELOAD_TORCH") == "1":
+        env["MONARCH_PRELOAD_TORCH"] = "1"
 
     return cmd, args, env

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -233,7 +233,7 @@ def _ensure_hip_runtime_ordering() -> None:
     actionable exception. No-op on CUDA/CPU and whenever torch's runtime won.
     """
     monarch_pkg = sys.modules.get("monarch")
-    if getattr(monarch_pkg, "_TORCH_PRELOADED_BEFORE_BINDINGS", True):
+    if getattr(monarch_pkg, "_TORCH_HIP_RUNTIME_PRELOADED", True):
         return  # torch's HIP runtime loaded first (or preloaded): safe
     torch_mod = sys.modules.get("torch")
     if torch_mod is None:

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -221,9 +221,49 @@ def _evict_local_memory(key: Tuple[int, int, int], ref: "weakref.ref") -> None:
             _local_memory_cache.pop(key, None)
 
 
+def _ensure_hip_runtime_ordering() -> None:
+    """On ROCm, raise a clear error instead of a hard SIGABRT when monarch's
+    native extension initialized the system HIP runtime before torch loaded its
+    bundled copy.
+
+    In that state the first HIP driver call (made by the local-memory probe)
+    aborts inside rocprofiler-register with
+    ``hip.cpp:512 "hipApiName has non-null function pointer ..."`` and takes the
+    whole process down. We detect the condition here and turn it into an
+    actionable exception. No-op on CUDA/CPU and whenever torch's runtime won.
+    """
+    monarch_pkg = sys.modules.get("monarch")
+    if getattr(monarch_pkg, "_TORCH_PRELOADED_BEFORE_BINDINGS", True):
+        return  # torch's HIP runtime loaded first (or preloaded): safe
+    torch_mod = sys.modules.get("torch")
+    if torch_mod is None:
+        return  # no second HIP runtime loaded; the single system copy is safe
+    if getattr(getattr(torch_mod, "version", None), "hip", None) is None:
+        return  # CUDA / CPU torch: not the ROCm dual-runtime hazard
+    # Only error if two distinct libamdhip64 copies are actually mapped.
+    try:
+        with open("/proc/self/maps") as f:
+            maps = f.read()
+    except OSError:
+        return
+    import re
+
+    libs = set(re.findall(r"/\S*libamdhip64\.so[.0-9]*", maps))
+    if len(libs) < 2:
+        return  # single HIP runtime: safe
+    raise RuntimeError(
+        "monarch loaded the system ROCm HIP runtime before torch loaded its "
+        "bundled copy; the HIP call needed for RDMA would abort the process "
+        "(hip.cpp:512 'hipApiName has non-null function pointer ...'). "
+        "On ROCm, import torch before importing monarch, or set the environment "
+        "variable MONARCH_PRELOAD_TORCH=1 before importing monarch."
+    )
+
+
 def _make_local_memory_handle(
     data: "torch.Tensor | memoryview",
 ) -> _LocalMemoryHandle:
+    _ensure_hip_runtime_ordering()
     _assert_1d_contiguous(data)
     if isinstance(data, memoryview):
         addr, size = _get_memoryview_addr_and_size(data)

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -221,49 +221,9 @@ def _evict_local_memory(key: Tuple[int, int, int], ref: "weakref.ref") -> None:
             _local_memory_cache.pop(key, None)
 
 
-def _ensure_hip_runtime_ordering() -> None:
-    """On ROCm, raise a clear error instead of a hard SIGABRT when monarch's
-    native extension initialized the system HIP runtime before torch loaded its
-    bundled copy.
-
-    In that state the first HIP driver call (made by the local-memory probe)
-    aborts inside rocprofiler-register with
-    ``hip.cpp:512 "hipApiName has non-null function pointer ..."`` and takes the
-    whole process down. We detect the condition here and turn it into an
-    actionable exception. No-op on CUDA/CPU and whenever torch's runtime won.
-    """
-    monarch_pkg = sys.modules.get("monarch")
-    if getattr(monarch_pkg, "_TORCH_HIP_RUNTIME_PRELOADED", True):
-        return  # torch's HIP runtime loaded first (or preloaded): safe
-    torch_mod = sys.modules.get("torch")
-    if torch_mod is None:
-        return  # no second HIP runtime loaded; the single system copy is safe
-    if getattr(getattr(torch_mod, "version", None), "hip", None) is None:
-        return  # CUDA / CPU torch: not the ROCm dual-runtime hazard
-    # Only error if two distinct libamdhip64 copies are actually mapped.
-    try:
-        with open("/proc/self/maps") as f:
-            maps = f.read()
-    except OSError:
-        return
-    import re
-
-    libs = set(re.findall(r"/\S*libamdhip64\.so[.0-9]*", maps))
-    if len(libs) < 2:
-        return  # single HIP runtime: safe
-    raise RuntimeError(
-        "monarch loaded the system ROCm HIP runtime before torch loaded its "
-        "bundled copy; the HIP call needed for RDMA would abort the process "
-        "(hip.cpp:512 'hipApiName has non-null function pointer ...'). "
-        "On ROCm, import torch before importing monarch, or set the environment "
-        "variable MONARCH_PRELOAD_TORCH=1 before importing monarch."
-    )
-
-
 def _make_local_memory_handle(
     data: "torch.Tensor | memoryview",
 ) -> _LocalMemoryHandle:
-    _ensure_hip_runtime_ordering()
     _assert_1d_contiguous(data)
     if isinstance(data, memoryview):
         addr, size = _get_memoryview_addr_and_size(data)

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,16 +15,6 @@ from pathlib import Path
 
 import pytest
 
-# ROCm: import torch before anything imports monarch._rust_bindings.
-# monarch links the system libamdhip64 while torch bundles its own; if
-# monarch loads first the system HIP runtime wins rocprofiler-register and
-# the first HIP call aborts (hip.cpp:512). The crash-recovery worker imports
-# monarch via test modules during collection, so ensure torch wins here.
-try:
-    import torch  # noqa: F401
-except ImportError:
-    pass
-
 _THIS_DIR = Path(__file__).parent
 
 collect_ignore: list[str] = []

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -15,6 +15,16 @@ from pathlib import Path
 
 import pytest
 
+# ROCm: import torch before anything imports monarch._rust_bindings.
+# monarch links the system libamdhip64 while torch bundles its own; if
+# monarch loads first the system HIP runtime wins rocprofiler-register and
+# the first HIP call aborts (hip.cpp:512). The crash-recovery worker imports
+# monarch via test modules during collection, so ensure torch wins here.
+try:
+    import torch  # noqa: F401
+except ImportError:
+    pass
+
 _THIS_DIR = Path(__file__).parent
 
 collect_ignore: list[str] = []

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -218,17 +218,11 @@ def _scope_torch_preload_to_rdma(request: pytest.FixtureRequest):
     it to "0" in its isolated subprocess). No-op when the flag isn't set (CUDA/CPU).
     """
     if _test_uses_rdma(request):
-        # RDMA tests keep the preload on, so each proc they spawn imports torch
-        # (~10s); multi-proc RDMA spawns then blow past the default 30s Host::spawn
-        # readiness window on slow ROCm runners. Widen it just for these tests.
-        # (Scoped via `configured()` rather than a job-wide env var, which would
-        # sit in the higher-priority Env config layer and clobber the
-        # host_spawn_ready_timeout that test_config asserts on. `configured()` also
-        # propagates the value to spawned/isolated procs via the env var.)
-        from monarch.config import configured
-
-        with configured(host_spawn_ready_timeout="120s"):
-            yield
+        # RDMA tests keep the preload on. Spawned procs use the lite dlopen preload
+        # (proc_mesh sets MONARCH_PRELOAD_TORCH_HIP), which is ~ms rather than the
+        # ~10s of a full `import torch`, so multi-proc RDMA spawns no longer overrun
+        # the Host::spawn readiness window -- no timeout override needed.
+        yield
         return
     previous = os.environ.get("MONARCH_PRELOAD_TORCH")
     os.environ["MONARCH_PRELOAD_TORCH"] = "0"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -129,6 +129,32 @@ _MACOS_ARM64_SKIP_NODEIDS = frozenset(
 )
 
 
+def _is_rocm71() -> bool:
+    """True on the rocm7.1 CI runner (torch built against ROCm 7.1)."""
+    try:
+        import torch
+
+        return (getattr(torch.version, "hip", None) or "").startswith("7.1")
+    except Exception:
+        return False
+
+
+_IS_ROCM71 = _is_rocm71()
+
+# EXPERIMENT (temporary -- PR #4341 debugging; REVERT after): on the rocm7.1 runner,
+# deselect the RDMA tests that spawn GPU procs. The lite torch preload made these run
+# to completion (before, they hit the 30s Host::spawn timeout and never ran). We are
+# testing whether their *running* is what leaves rocm7.1's GPU/RCCL state such that the
+# later tensor-engine / cuda / builtins GPU workers hang (the deterministic 14 failures).
+# If those now pass with these removed, the RDMA-GPU-test interaction is confirmed.
+_ROCM71_EXPERIMENT_SKIP_PREFIXES = (
+    "python/tests/test_rdma.py::test_proc_mesh_rdma",
+    "python/tests/test_rdma.py::test_gpu_trainer_generator",
+    "python/tests/test_rdma_bench_e2e.py::",
+    "python/tests/test_rdma_bench_peer.py::",
+)
+
+
 def _load_disabled_tests() -> frozenset[str]:
     if not _DISABLED_TESTS_FILE.exists():
         return frozenset()
@@ -176,6 +202,13 @@ def pytest_collection_modifyitems(
         if _IS_MACOS_ARM64 and node_id in _MACOS_ARM64_SKIP_NODEIDS:
             item.add_marker(
                 pytest.mark.skip(reason="unsupported or flaky on macOS arm64 CPU CI")
+            )
+
+        if _IS_ROCM71 and node_id.startswith(_ROCM71_EXPERIMENT_SKIP_PREFIXES):
+            item.add_marker(
+                pytest.mark.skip(
+                    reason="EXPERIMENT (PR#4341): rocm7.1 RDMA-GPU-test deselect"
+                )
             )
 
         if not disabled:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -188,3 +188,44 @@ def pytest_collection_modifyitems(
                     reason=f"Disabled via GitHub issue: DISABLED {test_name}"
                 )
             )
+
+
+def _test_uses_rdma(request: pytest.FixtureRequest) -> bool:
+    """Whether a test exercises monarch's RDMA path (and so needs torch preloaded).
+
+    Matches both the RDMA test modules (``test_rdma*`` / ``rdma_load_test``) and any
+    test parametrized by ``@rdma_backends`` (rdma_test_utils) -- which drives the
+    RDMA path from non-rdma-named modules too, e.g. ``test_gil_on_control_plane``.
+    Both appear in the node id: the module path, or the ``rdma_disable_ibverbs``
+    param id. (``@rdma_backends`` parametrizes via a config helper, so the params
+    show up in the id but NOT in ``callspec.params`` -- hence checking the id.)
+    """
+    return "rdma" in (getattr(request.node, "nodeid", "") or "").lower()
+
+
+@pytest.fixture(autouse=True)
+def _scope_torch_preload_to_rdma(request: pytest.FixtureRequest):
+    """Scope MONARCH_PRELOAD_TORCH so only RDMA tests pay the torch-preload cost.
+
+    Only monarch's RDMA path makes the rdmaxcel HIP call that races with torch's
+    bundled libamdhip64 on ROCm (the fatal hip.cpp:512 "hipApiName ..." abort).
+    The ROCm CI enables MONARCH_PRELOAD_TORCH job-wide so the test worker's own
+    (inline) RDMA calls stay safe -- but that also made *every* proc mesh / isolated
+    subprocess spawned by the many non-RDMA actor tests import torch (~10s each),
+    timing them out on slower ROCm runners. So turn the preload OFF while a
+    non-RDMA test runs: the procs it spawns then skip the torch import. RDMA test
+    modules keep it on (a test may still override, e.g. test_rdma_cpu_no_torch pins
+    it to "0" in its isolated subprocess). No-op when the flag isn't set (CUDA/CPU).
+    """
+    if _test_uses_rdma(request):
+        yield
+        return
+    previous = os.environ.get("MONARCH_PRELOAD_TORCH")
+    os.environ["MONARCH_PRELOAD_TORCH"] = "0"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("MONARCH_PRELOAD_TORCH", None)
+        else:
+            os.environ["MONARCH_PRELOAD_TORCH"] = previous

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -190,19 +190,47 @@ def pytest_collection_modifyitems(
             )
 
 
-# NOTE: MONARCH_PRELOAD_TORCH is intentionally left ON for ALL tests (the ROCm CI
-# sets it job-wide). An earlier autouse fixture scoped it OFF for non-RDMA tests on
-# the theory that "only monarch's RDMA path makes the HIP call that races with
-# torch's bundled libamdhip64." That premise was wrong: *every* GPU worker that
-# imports torch -- the tensor-engine / cuda / builtins actor tests included -- hits
-# the same rocprofiler-register double-registration race (hip.cpp:512 "hipApiName
-# has non-null function pointer") and aborts on ROCm unless torch's libamdhip64 is
-# loaded before monarch._rust_bindings. Scoping the preload away from those workers
-# made them abort deterministically on the rocm7.1 runner (ProcessGroupNCCL "no GPUs
-# found" / "test runner crashed" / "timed out waiting for worker").
-#
-# Leaving the preload on does NOT reintroduce the ~10s-per-proc `import torch` that
-# once timed out multi-proc spawns: proc_mesh._get_bootstrap_args hands spawned procs
-# the lite dlopen preload (MONARCH_PRELOAD_TORCH_HIP, ~ms) instead of the full import.
-# Tests that must stay torch-free pin MONARCH_PRELOAD_TORCH=0 themselves (e.g.
-# test_rdma_cpu_no_torch in its isolated subprocess).
+def _test_uses_rdma(request: pytest.FixtureRequest) -> bool:
+    """Whether a test exercises monarch's RDMA path (and so needs torch preloaded).
+
+    Matches both the RDMA test modules (``test_rdma*`` / ``rdma_load_test``) and any
+    test parametrized by ``@rdma_backends`` (rdma_test_utils) -- which drives the
+    RDMA path from non-rdma-named modules too, e.g. ``test_gil_on_control_plane``.
+    Both appear in the node id: the module path, or the ``rdma_disable_ibverbs``
+    param id. (``@rdma_backends`` parametrizes via a config helper, so the params
+    show up in the id but NOT in ``callspec.params`` -- hence checking the id.)
+    """
+    return "rdma" in (getattr(request.node, "nodeid", "") or "").lower()
+
+
+@pytest.fixture(autouse=True)
+def _scope_torch_preload_to_rdma(request: pytest.FixtureRequest):
+    """Scope MONARCH_PRELOAD_TORCH so only RDMA tests pay the torch-preload cost.
+
+    Only monarch's RDMA path makes the rdmaxcel HIP call that races with torch's
+    bundled libamdhip64 on ROCm (the fatal hip.cpp:512 "hipApiName ..." abort).
+    The ROCm CI enables MONARCH_PRELOAD_TORCH job-wide so the test worker's own
+    (inline) RDMA calls stay safe -- but that also made *every* proc mesh / isolated
+    subprocess spawned by the many non-RDMA actor tests import torch (~10s each),
+    timing them out on slower ROCm runners. So turn the preload OFF while a
+    non-RDMA test runs: the procs it spawns then skip the torch import. RDMA test
+    modules keep it on (a test may still override, e.g. test_rdma_cpu_no_torch pins
+    it to "0" in its isolated subprocess). No-op when the flag isn't set (CUDA/CPU).
+    """
+    if _test_uses_rdma(request):
+        # RDMA tests keep the preload on. The procs they spawn use the lite dlopen
+        # preload (proc_mesh sets MONARCH_PRELOAD_TORCH_HIP), which is ~ms rather
+        # than the ~10s of a full `import torch`, so multi-proc RDMA spawns no
+        # longer overrun the Host::spawn readiness window -- no timeout override
+        # needed. The worker itself still full-imports torch for its inline calls.
+        yield
+        return
+    previous = os.environ.get("MONARCH_PRELOAD_TORCH")
+    os.environ["MONARCH_PRELOAD_TORCH"] = "0"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("MONARCH_PRELOAD_TORCH", None)
+        else:
+            os.environ["MONARCH_PRELOAD_TORCH"] = previous

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -190,47 +190,19 @@ def pytest_collection_modifyitems(
             )
 
 
-def _test_uses_rdma(request: pytest.FixtureRequest) -> bool:
-    """Whether a test exercises monarch's RDMA path (and so needs torch preloaded).
-
-    Matches both the RDMA test modules (``test_rdma*`` / ``rdma_load_test``) and any
-    test parametrized by ``@rdma_backends`` (rdma_test_utils) -- which drives the
-    RDMA path from non-rdma-named modules too, e.g. ``test_gil_on_control_plane``.
-    Both appear in the node id: the module path, or the ``rdma_disable_ibverbs``
-    param id. (``@rdma_backends`` parametrizes via a config helper, so the params
-    show up in the id but NOT in ``callspec.params`` -- hence checking the id.)
-    """
-    return "rdma" in (getattr(request.node, "nodeid", "") or "").lower()
-
-
-@pytest.fixture(autouse=True)
-def _scope_torch_preload_to_rdma(request: pytest.FixtureRequest):
-    """Scope MONARCH_PRELOAD_TORCH so only RDMA tests pay the torch-preload cost.
-
-    Only monarch's RDMA path makes the rdmaxcel HIP call that races with torch's
-    bundled libamdhip64 on ROCm (the fatal hip.cpp:512 "hipApiName ..." abort).
-    The ROCm CI enables MONARCH_PRELOAD_TORCH job-wide so the test worker's own
-    (inline) RDMA calls stay safe -- but that also made *every* proc mesh / isolated
-    subprocess spawned by the many non-RDMA actor tests import torch (~10s each),
-    timing them out on slower ROCm runners. So turn the preload OFF while a
-    non-RDMA test runs: the procs it spawns then skip the torch import. RDMA test
-    modules keep it on (a test may still override, e.g. test_rdma_cpu_no_torch pins
-    it to "0" in its isolated subprocess). No-op when the flag isn't set (CUDA/CPU).
-    """
-    if _test_uses_rdma(request):
-        # RDMA tests keep the preload on. The procs they spawn use the lite dlopen
-        # preload (proc_mesh sets MONARCH_PRELOAD_TORCH_HIP), which is ~ms rather
-        # than the ~10s of a full `import torch`, so multi-proc RDMA spawns no
-        # longer overrun the Host::spawn readiness window -- no timeout override
-        # needed. The worker itself still full-imports torch for its inline calls.
-        yield
-        return
-    previous = os.environ.get("MONARCH_PRELOAD_TORCH")
-    os.environ["MONARCH_PRELOAD_TORCH"] = "0"
-    try:
-        yield
-    finally:
-        if previous is None:
-            os.environ.pop("MONARCH_PRELOAD_TORCH", None)
-        else:
-            os.environ["MONARCH_PRELOAD_TORCH"] = previous
+# NOTE: MONARCH_PRELOAD_TORCH is intentionally left ON for ALL tests (the ROCm CI
+# sets it job-wide). An earlier autouse fixture scoped it OFF for non-RDMA tests on
+# the theory that "only monarch's RDMA path makes the HIP call that races with
+# torch's bundled libamdhip64." That premise was wrong: *every* GPU worker that
+# imports torch -- the tensor-engine / cuda / builtins actor tests included -- hits
+# the same rocprofiler-register double-registration race (hip.cpp:512 "hipApiName
+# has non-null function pointer") and aborts on ROCm unless torch's libamdhip64 is
+# loaded before monarch._rust_bindings. Scoping the preload away from those workers
+# made them abort deterministically on the rocm7.1 runner (ProcessGroupNCCL "no GPUs
+# found" / "test runner crashed" / "timed out waiting for worker").
+#
+# Leaving the preload on does NOT reintroduce the ~10s-per-proc `import torch` that
+# once timed out multi-proc spawns: proc_mesh._get_bootstrap_args hands spawned procs
+# the lite dlopen preload (MONARCH_PRELOAD_TORCH_HIP, ~ms) instead of the full import.
+# Tests that must stay torch-free pin MONARCH_PRELOAD_TORCH=0 themselves (e.g.
+# test_rdma_cpu_no_torch in its isolated subprocess).

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -218,7 +218,17 @@ def _scope_torch_preload_to_rdma(request: pytest.FixtureRequest):
     it to "0" in its isolated subprocess). No-op when the flag isn't set (CUDA/CPU).
     """
     if _test_uses_rdma(request):
-        yield
+        # RDMA tests keep the preload on, so each proc they spawn imports torch
+        # (~10s); multi-proc RDMA spawns then blow past the default 30s Host::spawn
+        # readiness window on slow ROCm runners. Widen it just for these tests.
+        # (Scoped via `configured()` rather than a job-wide env var, which would
+        # sit in the higher-priority Env config layer and clobber the
+        # host_spawn_ready_timeout that test_config asserts on. `configured()` also
+        # propagates the value to spawned/isolated procs via the env var.)
+        from monarch.config import configured
+
+        with configured(host_spawn_ready_timeout="120s"):
+            yield
         return
     previous = os.environ.get("MONARCH_PRELOAD_TORCH")
     os.environ["MONARCH_PRELOAD_TORCH"] = "0"

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -218,8 +218,11 @@ def _scope_torch_preload_to_rdma(request: pytest.FixtureRequest):
     it to "0" in its isolated subprocess). No-op when the flag isn't set (CUDA/CPU).
     """
     if _test_uses_rdma(request):
-        # RDMA tests need the preload on: their procs make the rdmaxcel HIP call
-        # that races with torch's libamdhip64, so torch must load first.
+        # RDMA tests keep the preload on. The procs they spawn use the lite dlopen
+        # preload (proc_mesh sets MONARCH_PRELOAD_TORCH_HIP), which is ~ms rather
+        # than the ~10s of a full `import torch`, so multi-proc RDMA spawns no
+        # longer overrun the Host::spawn readiness window -- no timeout override
+        # needed. The worker itself still full-imports torch for its inline calls.
         yield
         return
     previous = os.environ.get("MONARCH_PRELOAD_TORCH")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -218,10 +218,8 @@ def _scope_torch_preload_to_rdma(request: pytest.FixtureRequest):
     it to "0" in its isolated subprocess). No-op when the flag isn't set (CUDA/CPU).
     """
     if _test_uses_rdma(request):
-        # RDMA tests keep the preload on. Spawned procs use the lite dlopen preload
-        # (proc_mesh sets MONARCH_PRELOAD_TORCH_HIP), which is ~ms rather than the
-        # ~10s of a full `import torch`, so multi-proc RDMA spawns no longer overrun
-        # the Host::spawn readiness window -- no timeout override needed.
+        # RDMA tests need the preload on: their procs make the rdmaxcel HIP call
+        # that races with torch's libamdhip64, so torch must load first.
         yield
         return
     previous = os.environ.get("MONARCH_PRELOAD_TORCH")

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -130,7 +130,10 @@ _MACOS_ARM64_SKIP_NODEIDS = frozenset(
 
 
 def _is_rocm71() -> bool:
-    """True on the rocm7.1 CI runner (torch built against ROCm 7.1)."""
+    """True on the rocm7.1 CI runner. Prefers ROCM_VERSION (exported by the CI's
+    setup_rocm_environment), falls back to torch's HIP build version."""
+    if os.environ.get("ROCM_VERSION", "").startswith("7.1"):
+        return True
     try:
         import torch
 
@@ -139,7 +142,24 @@ def _is_rocm71() -> bool:
         return False
 
 
-_IS_ROCM71 = _is_rocm71()
+# Env-cache like _HAS_TENSOR_ENGINE / _HAS_CUDA so the crash-recovery worker
+# subprocess inherits the controller's value. The worker dispatches tests by nodeid
+# and honors only its OWN collection's skip markers, so an independent recompute in
+# the worker (which returned False last run) would silently disable the deselect.
+if "_CRASH_RECOVERY_IS_ROCM71" in os.environ:
+    _IS_ROCM71 = os.environ["_CRASH_RECOVERY_IS_ROCM71"] == "1"
+else:
+    _IS_ROCM71 = _is_rocm71()
+    os.environ["_CRASH_RECOVERY_IS_ROCM71"] = "1" if _IS_ROCM71 else "0"
+
+# TEMP debug (PR#4341 experiment): surface the detection in the CI log.
+print(
+    f"[PR4341-exp] _IS_ROCM71={_IS_ROCM71} "
+    f"ROCM_VERSION={os.environ.get('ROCM_VERSION')!r} "
+    f"cached={'_CRASH_RECOVERY_IS_ROCM71' in os.environ}",
+    file=sys.stderr,
+    flush=True,
+)
 
 # EXPERIMENT (temporary -- PR #4341 debugging; REVERT after): on the rocm7.1 runner,
 # deselect the RDMA tests that spawn GPU procs. The lite torch preload made these run

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -129,45 +129,22 @@ _MACOS_ARM64_SKIP_NODEIDS = frozenset(
 )
 
 
-def _is_rocm71() -> bool:
-    """True on the rocm7.1 CI runner. Prefers ROCM_VERSION (exported by the CI's
-    setup_rocm_environment), falls back to torch's HIP build version."""
-    if os.environ.get("ROCM_VERSION", "").startswith("7.1"):
-        return True
-    try:
-        import torch
-
-        return (getattr(torch.version, "hip", None) or "").startswith("7.1")
-    except Exception:
-        return False
-
-
-# Env-cache like _HAS_TENSOR_ENGINE / _HAS_CUDA so the crash-recovery worker
-# subprocess inherits the controller's value. The worker dispatches tests by nodeid
-# and honors only its OWN collection's skip markers, so an independent recompute in
-# the worker (which returned False last run) would silently disable the deselect.
-if "_CRASH_RECOVERY_IS_ROCM71" in os.environ:
-    _IS_ROCM71 = os.environ["_CRASH_RECOVERY_IS_ROCM71"] == "1"
-else:
-    _IS_ROCM71 = _is_rocm71()
-    os.environ["_CRASH_RECOVERY_IS_ROCM71"] = "1" if _IS_ROCM71 else "0"
-
-# TEMP debug (PR#4341 experiment): surface the detection in the CI log.
+# EXPERIMENT (temporary, PR#4341): gate on the job-wide MONARCH_PRELOAD_TORCH=1, which
+# the workflow exports ONLY for rocm (both 7.1 and 7.2) and which the crash-recovery worker
+# inherits directly -- no per-process recompute. torch.version.hip / ROCM_VERSION both came
+# back False/None in the CI collection context (setup_rocm_environment does not export
+# ROCM_VERSION), so this is the reliable signal. Deselecting on rocm7.2 too is harmless: it
+# already passes these tests (acts as a control). The signal we care about is whether
+# rocm7.1's 14 tensor-engine/cuda/builtins failures disappear.
+_IS_ROCM = os.environ.get("MONARCH_PRELOAD_TORCH") == "1"
 print(
-    f"[PR4341-exp] _IS_ROCM71={_IS_ROCM71} "
-    f"ROCM_VERSION={os.environ.get('ROCM_VERSION')!r} "
-    f"cached={'_CRASH_RECOVERY_IS_ROCM71' in os.environ}",
+    f"[PR4341-exp] _IS_ROCM={_IS_ROCM} "
+    f"MONARCH_PRELOAD_TORCH={os.environ.get('MONARCH_PRELOAD_TORCH')!r}",
     file=sys.stderr,
     flush=True,
 )
 
-# EXPERIMENT (temporary -- PR #4341 debugging; REVERT after): on the rocm7.1 runner,
-# deselect the RDMA tests that spawn GPU procs. The lite torch preload made these run
-# to completion (before, they hit the 30s Host::spawn timeout and never ran). We are
-# testing whether their *running* is what leaves rocm7.1's GPU/RCCL state such that the
-# later tensor-engine / cuda / builtins GPU workers hang (the deterministic 14 failures).
-# If those now pass with these removed, the RDMA-GPU-test interaction is confirmed.
-_ROCM71_EXPERIMENT_SKIP_PREFIXES = (
+_ROCM_EXPERIMENT_SKIP_PREFIXES = (
     "python/tests/test_rdma.py::test_proc_mesh_rdma",
     "python/tests/test_rdma.py::test_gpu_trainer_generator",
     "python/tests/test_rdma_bench_e2e.py::",
@@ -224,10 +201,10 @@ def pytest_collection_modifyitems(
                 pytest.mark.skip(reason="unsupported or flaky on macOS arm64 CPU CI")
             )
 
-        if _IS_ROCM71 and node_id.startswith(_ROCM71_EXPERIMENT_SKIP_PREFIXES):
+        if _IS_ROCM and node_id.startswith(_ROCM_EXPERIMENT_SKIP_PREFIXES):
             item.add_marker(
                 pytest.mark.skip(
-                    reason="EXPERIMENT (PR#4341): rocm7.1 RDMA-GPU-test deselect"
+                    reason="EXPERIMENT (PR#4341): rocm RDMA-GPU-test deselect"
                 )
             )
 

--- a/python/tests/isolate_in_subprocess.py
+++ b/python/tests/isolate_in_subprocess.py
@@ -73,6 +73,18 @@ def isolate_in_subprocess(test_fn=None, *, env=None):
 
         sub_env = {**os.environ, **env}
 
+        # Isolate subprocesses only need torch's libamdhip64 loaded before
+        # monarch._rust_bindings (the ROCm rocprofiler-register race), not the
+        # ~10s full `import torch`. Mirror proc_mesh._get_bootstrap_args: downgrade
+        # an inherited full-preload opt-in to the lite dlopen, unless the test
+        # explicitly pinned MONARCH_PRELOAD_TORCH itself (e.g. test_rdma_cpu_no_torch).
+        if (
+            "MONARCH_PRELOAD_TORCH" not in env
+            and sub_env.get("MONARCH_PRELOAD_TORCH") == "1"
+        ):
+            sub_env["MONARCH_PRELOAD_TORCH"] = "0"
+            sub_env["MONARCH_PRELOAD_TORCH_HIP"] = "1"
+
         if "FB_XAR_INVOKED_NAME" in os.environ:
             # PAR/XAR mode: sys.executable is the PAR's bundled Python
             # runtime which cannot run arbitrary scripts.  Re-invoke the

--- a/python/tests/isolate_in_subprocess.py
+++ b/python/tests/isolate_in_subprocess.py
@@ -73,18 +73,6 @@ def isolate_in_subprocess(test_fn=None, *, env=None):
 
         sub_env = {**os.environ, **env}
 
-        # Isolate subprocesses only need torch's libamdhip64 loaded before
-        # monarch._rust_bindings (the ROCm rocprofiler-register race), not the
-        # ~10s full `import torch`. Mirror proc_mesh._get_bootstrap_args: downgrade
-        # an inherited full-preload opt-in to the lite dlopen, unless the test
-        # explicitly pinned MONARCH_PRELOAD_TORCH itself (e.g. test_rdma_cpu_no_torch).
-        if (
-            "MONARCH_PRELOAD_TORCH" not in env
-            and sub_env.get("MONARCH_PRELOAD_TORCH") == "1"
-        ):
-            sub_env["MONARCH_PRELOAD_TORCH"] = "0"
-            sub_env["MONARCH_PRELOAD_TORCH_HIP"] = "1"
-
         if "FB_XAR_INVOKED_NAME" in os.environ:
             # PAR/XAR mode: sys.executable is the PAR's bundled Python
             # runtime which cannot run arbitrary scripts.  Re-invoke the

--- a/python/tests/test_rdma_cpu_no_torch.py
+++ b/python/tests/test_rdma_cpu_no_torch.py
@@ -53,7 +53,10 @@ class CpuActor(Actor):
 
 
 @pytest.mark.parametrize("rdma_backend", RDMA_BACKENDS)
-@isolate_in_subprocess
+# This test asserts torch is never imported. Opt out of MONARCH_PRELOAD_TORCH
+# (which the ROCm CI sets job-wide to dodge the rocprofiler import race) so the
+# isolated subprocess exercises the real default, no-preload CPU-RDMA path.
+@isolate_in_subprocess(env={"MONARCH_PRELOAD_TORCH": "0"})
 async def test_rdma_buffer_cpu_memoryview(rdma_backend):
     """RDMABuffer works with bytearray/memoryview CPU buffers without importing torch."""
     if rdma_backend == "tcp":

--- a/python/tests/test_tensor_engine.py
+++ b/python/tests/test_tensor_engine.py
@@ -24,6 +24,10 @@ needs_cuda = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.version.hip is not None,
     reason="cross-rank tensor transport requires CUDA+NCCL (not ROCm/HIP)",
 )
+needs_multiple_gpus = pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="Not enough GPUs, this test requires at least 2 GPUs",
+)
 
 
 def _tensor_device() -> torch.device:
@@ -31,6 +35,7 @@ def _tensor_device() -> torch.device:
 
 
 @needs_tensor_engine
+@needs_multiple_gpus
 def test_tensor_engine() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 2})
 
@@ -61,6 +66,7 @@ def test_tensor_engine() -> None:
 # exercises cross-rank `to_mesh()` transport, which still uses the CUDA/NCCL
 # communication path today.
 @needs_cuda
+@needs_multiple_gpus
 def test_proc_mesh_tensor_engine() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 2})
     device = _tensor_device()

--- a/python/tests/test_tensor_engine.py
+++ b/python/tests/test_tensor_engine.py
@@ -24,6 +24,10 @@ needs_cuda = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.version.hip is not None,
     reason="cross-rank tensor transport requires CUDA+NCCL (not ROCm/HIP)",
 )
+needs_multiple_gpus = pytest.mark.skipif(
+    torch.cuda.device_count() < 2,
+    reason="Not enough GPUs, this test requires at least 2 GPUs",
+)
 
 
 def _tensor_device() -> torch.device:
@@ -31,6 +35,7 @@ def _tensor_device() -> torch.device:
 
 
 @needs_tensor_engine
+@needs_multiple_gpus
 def test_tensor_engine() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 2})
 
@@ -61,6 +66,7 @@ def test_tensor_engine() -> None:
 # exercises cross-rank `to_mesh()` transport, which still uses the CUDA/NCCL
 # communication path today.
 @needs_cuda
+@needs_multiple_gpus
 def test_proc_mesh_tensor_engine() -> None:
     pm = this_host().spawn_procs(per_host={"gpus": 2})
     device = _tensor_device()
@@ -94,7 +100,7 @@ def test_actor_with_tensors() -> None:
     with pm.activate():
         x = pm.spawn("adder", AddWithState, torch.ones((), device=_tensor_device()))
         y = torch.ones((), device=_tensor_device())
-        assert x.forward.call(y).get(timeout=5).item(gpus=0).item() == 2
+        assert x.forward.call(y).get(timeout=10).item(gpus=0).item() == 2
 
 
 class Counter(Actor):

--- a/python/tests/test_tensor_engine.py
+++ b/python/tests/test_tensor_engine.py
@@ -94,7 +94,7 @@ def test_actor_with_tensors() -> None:
     with pm.activate():
         x = pm.spawn("adder", AddWithState, torch.ones((), device=_tensor_device()))
         y = torch.ones((), device=_tensor_device())
-        assert x.forward.call(y).get(timeout=5).item(gpus=0).item() == 2
+        assert x.forward.call(y).get(timeout=10).item(gpus=0).item() == 2
 
 
 class Counter(Actor):


### PR DESCRIPTION
monarch's native extension links the system libamdhip64 while torch bundles its own; when monarch._rust_bindings was imported before torch, the system HIP runtime won rocprofiler-register and   caused `hipApiName has non-null function pointer 1 despite this being the first instance of the library being copies`. In this PR we ensure torch is imported first. The comments above the original lines insinuated this was supposed to already happen, but the code was written in the reverse.

Additionally, we fix a CUdeviceptr bug:
CUdeviceptr is an integer on CUDA but a raw pointer (hipDeviceptr_t) on ROCm, so initialize portably with zeroed (0 / null)