### PR TITLE
Add dashboard relay for mast in monarch-launch CLI (#4344)

### DIFF
--- a/python/monarch/monarch_dashboard/relay.py
+++ b/python/monarch/monarch_dashboard/relay.py
@@ -1,0 +1,259 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+from __future__ import annotations
+
+import functools
+import http.client
+import logging
+import socket
+import ssl
+from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Iterable
+from urllib.parse import ParseResult, urlparse
+
+logger: logging.Logger = logging.getLogger(__name__)
+
+DEFAULT_DASHBOARD_PORT: int = 8265
+# Hop-by-hop headers are connection-specific and must not be forwarded by a
+# proxy (RFC 9110 sec. 7.6.1); the relay strips them in both directions.
+_HOP_BY_HOP_HEADERS: frozenset[str] = frozenset(
+    {
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    }
+)
+
+
+@dataclass
+class DashboardRelayServer:
+    url: str
+    server: ThreadingHTTPServer
+
+    def serve_forever(self) -> None:
+        self.server.serve_forever()
+
+    def shutdown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+
+
+class _ThreadingHTTPServerV6(ThreadingHTTPServer):
+    # Bind over IPv6 so the Nest Dev Proxy edge (which reaches dev hosts over
+    # IPv6) can connect; dual-stack still accepts IPv4 via v4-mapped addresses.
+    address_family = socket.AF_INET6
+
+
+def create_dashboard_relay_server(
+    upstream_url: str,
+    host: str = "::",
+    port: int = DEFAULT_DASHBOARD_PORT,
+    *,
+    use_tls: bool = True,
+) -> DashboardRelayServer:
+    upstream = _parse_upstream_url(upstream_url)
+    handler = _make_relay_handler(upstream)
+    server_cls = _ThreadingHTTPServerV6 if ":" in host else ThreadingHTTPServer
+    server = server_cls((host, port), handler)
+    actual_port = server.server_port
+
+    url = f"http://{_local_url_host(host)}:{actual_port}"
+    meta_tls = _meta_tls() if use_tls else None
+    if meta_tls is not None:
+        tls_result = meta_tls.try_meta_tls_context()
+        if tls_result is not None:
+            ssl_ctx, tls_hostname = tls_result
+            server.socket = ssl_ctx.wrap_socket(server.socket, server_side=True)
+            url = meta_tls.nest_dev_proxy_url(tls_hostname, actual_port)
+
+    return DashboardRelayServer(url=url, server=server)
+
+
+def serve_dashboard_relay(
+    upstream_url: str,
+    host: str = "::",
+    port: int = DEFAULT_DASHBOARD_PORT,
+    *,
+    use_tls: bool = True,
+) -> None:
+    relay = create_dashboard_relay_server(
+        upstream_url=upstream_url,
+        host=host,
+        port=port,
+        use_tls=use_tls,
+    )
+    _write_relay_banner(relay)
+    try:
+        relay.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Stopped Monarch dashboard relay.")
+    finally:
+        relay.shutdown()
+
+
+def _write_relay_banner(relay: DashboardRelayServer) -> None:
+    print(f"Monarch Dashboard: {relay.url}")
+    print("Keep this process running while using the dashboard.")
+
+
+def _meta_tls() -> Any | None:
+    """Return the optional Meta TLS module, or None outside Meta-internal builds."""
+    try:
+        from monarch.monarch_dashboard.meta import tls
+    except ImportError:
+        return None
+    return tls
+
+
+def _local_url_host(host: str) -> str:
+    if host in {"", "0.0.0.0", "::"}:
+        return "localhost"
+    if ":" in host and not host.startswith("["):
+        return f"[{host}]"
+    return host
+
+
+def probe_dashboard_url(
+    url: str,
+    *,
+    timeout: float = 3.0,
+) -> None:
+    parsed = _parse_upstream_url(url)
+    path = parsed.path or "/"
+    if parsed.query:
+        path = f"{path}?{parsed.query}"
+    conn = _upstream_connection(
+        parsed,
+        timeout=timeout,
+    )
+    try:
+        conn.request("HEAD", path)
+        response = conn.getresponse()
+        response.read()
+        # A 4xx still proves the dashboard is up and reachable; only a 5xx or a
+        # transport error means it is not serving.
+        if response.status >= 500:
+            raise OSError(f"dashboard probe returned HTTP {response.status}")
+    except http.client.HTTPException as error:
+        raise OSError("dashboard probe failed") from error
+    finally:
+        conn.close()
+
+
+def _parse_upstream_url(upstream_url: str) -> ParseResult:
+    parsed = urlparse(upstream_url.rstrip("/"))
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError(f"Unsupported dashboard upstream URL: {upstream_url!r}")
+    return parsed
+
+
+def _make_relay_handler(upstream: ParseResult) -> type[BaseHTTPRequestHandler]:
+    class DashboardRelayHandler(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+
+        def do_GET(self) -> None:
+            self._proxy()
+
+        do_HEAD = do_GET
+        do_POST = do_GET
+        do_PUT = do_GET
+        do_PATCH = do_GET
+        do_DELETE = do_GET
+        do_OPTIONS = do_GET
+
+        def log_message(self, format: str, *args: object) -> None:
+            logger.debug("dashboard relay: " + format, *args)
+
+        def _proxy(self) -> None:
+            body = self._read_request_body()
+            conn = _upstream_connection(upstream)
+            try:
+                conn.request(
+                    method=self.command,
+                    url=self.path,
+                    body=body,
+                    headers=dict(_request_headers(self.headers.items(), upstream)),
+                )
+                response = conn.getresponse()
+                response_body = response.read()
+            except OSError as error:
+                logger.warning("dashboard relay upstream request failed", exc_info=True)
+                self.send_error(502, f"dashboard upstream unavailable: {error}")
+                return
+            finally:
+                conn.close()
+
+            self.send_response(response.status, response.reason)
+            for key, value in _response_headers(response.getheaders()):
+                self.send_header(key, value)
+            self.send_header("Content-Length", str(len(response_body)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(response_body)
+
+        def _read_request_body(self) -> bytes | None:
+            content_length = self.headers.get("Content-Length")
+            if content_length is None:
+                return None
+            return self.rfile.read(int(content_length))
+
+    return DashboardRelayHandler
+
+
+def _response_headers(headers: Iterable[tuple[str, str]]) -> Iterable[tuple[str, str]]:
+    for key, value in headers:
+        lowered = key.lower()
+        if lowered in _HOP_BY_HOP_HEADERS or lowered == "content-length":
+            continue
+        yield key, value
+
+
+def _request_headers(
+    headers: Iterable[tuple[str, str]],
+    upstream: ParseResult,
+) -> Iterable[tuple[str, str]]:
+    for key, value in headers:
+        lowered = key.lower()
+        if lowered in _HOP_BY_HOP_HEADERS or lowered == "host":
+            continue
+        yield key, value
+    # Send the upstream's own Host so its virtual-host / TLS SNI routing
+    # targets the dashboard rather than this relay.
+    yield "Host", upstream.netloc
+
+
+def _upstream_connection(
+    upstream: ParseResult,
+    *,
+    timeout: float = 30.0,
+) -> http.client.HTTPConnection:
+    hostname = upstream.hostname
+    if hostname is None:
+        raise ValueError(f"Unsupported dashboard upstream URL: {upstream.geturl()!r}")
+    port = upstream.port
+    if upstream.scheme == "https":
+        return http.client.HTTPSConnection(
+            hostname,
+            port=port,
+            timeout=timeout,
+            context=_upstream_ssl_context(),
+        )
+    return http.client.HTTPConnection(hostname, port=port, timeout=timeout)
+
+
+@functools.cache
+def _upstream_ssl_context() -> ssl.SSLContext:
+    # Cached so the system trust store is loaded once, not per proxied request.
+    return ssl.create_default_context()

--- a/python/monarch/monarch_dashboard/server/tests/test_relay.py
+++ b/python/monarch/monarch_dashboard/server/tests/test_relay.py
@@ -1,0 +1,252 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import json
+import threading
+import unittest
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from unittest.mock import MagicMock, patch
+
+from monarch.monarch_dashboard.meta.mast import resolve_mast_dashboard_target
+from monarch.monarch_dashboard.relay import (
+    create_dashboard_relay_server,
+    DashboardRelayServer,
+)
+
+
+class ResolveMastDashboardTargetTest(unittest.TestCase):
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_resolves_role_hostname(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        mock_role_dashboard_is_reachable.return_value = True
+        role_info = MagicMock()
+        role_info.name = "worker"
+        role_info.hostnames = ["worker001.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [role_info]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        target = resolve_mast_dashboard_target("sample-mast-job")
+
+        self.assertEqual("sample-mast-job", target.job_name)
+        self.assertEqual("worker", target.role_name)
+        self.assertEqual(
+            "https://worker001.region.facebook.com:8265",
+            target.upstream_url,
+        )
+        mock_attach_to_existing_mast_job.assert_called_once_with(
+            app_handle="mast:///sample-mast-job",
+            role_names=[],
+        )
+        job._wait_for_job_ready.assert_called_once()
+        mock_role_dashboard_is_reachable.assert_called_once_with(
+            role_info,
+            dashboard_port=8265,
+        )
+
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_resolves_custom_dashboard_port(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        mock_role_dashboard_is_reachable.return_value = True
+        role_info = MagicMock()
+        role_info.name = "worker"
+        role_info.hostnames = ["worker001.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [role_info]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        target = resolve_mast_dashboard_target(
+            "sample-mast-job",
+            dashboard_port=9000,
+        )
+
+        self.assertEqual(
+            "https://worker001.region.facebook.com:9000",
+            target.upstream_url,
+        )
+        mock_role_dashboard_is_reachable.assert_called_once_with(
+            role_info,
+            dashboard_port=9000,
+        )
+
+    def test_rejects_mast_handle(self) -> None:
+        with self.assertRaisesRegex(ValueError, "direct MAST job name"):
+            resolve_mast_dashboard_target("mast:///sample-mast-job")
+
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_requires_role_name_for_multi_role_job(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        mock_role_dashboard_is_reachable.return_value = True
+        worker = MagicMock()
+        worker.name = "worker"
+        worker.hostnames = ["worker001.region"]
+        evaluator = MagicMock()
+        evaluator.name = "evaluator"
+        evaluator.hostnames = ["worker002.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [worker, evaluator]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        with self.assertRaisesRegex(ValueError, "Multiple MAST roles"):
+            resolve_mast_dashboard_target("sample-mast-job")
+        self.assertEqual(2, mock_role_dashboard_is_reachable.call_count)
+
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_infers_single_reachable_role(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        def is_reachable(role_info: MagicMock, **kwargs: object) -> bool:
+            return role_info.name == "evaluator"
+
+        mock_role_dashboard_is_reachable.side_effect = is_reachable
+        worker = MagicMock()
+        worker.name = "worker"
+        worker.hostnames = ["worker001.region"]
+        evaluator = MagicMock()
+        evaluator.name = "evaluator"
+        evaluator.hostnames = ["worker002.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [worker, evaluator]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        target = resolve_mast_dashboard_target("sample-mast-job")
+
+        self.assertEqual("evaluator", target.role_name)
+        self.assertEqual(
+            "https://worker002.region.facebook.com:8265",
+            target.upstream_url,
+        )
+
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_uses_explicit_role_name(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        worker = MagicMock()
+        worker.name = "worker"
+        worker.hostnames = ["worker001.region"]
+        evaluator = MagicMock()
+        evaluator.name = "evaluator"
+        evaluator.hostnames = ["worker002.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [worker, evaluator]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        target = resolve_mast_dashboard_target(
+            "sample-mast-job",
+            role_name="evaluator",
+        )
+
+        self.assertEqual("evaluator", target.role_name)
+        self.assertEqual(
+            "https://worker002.region.facebook.com:8265",
+            target.upstream_url,
+        )
+        mock_attach_to_existing_mast_job.assert_called_once_with(
+            app_handle="mast:///sample-mast-job",
+            role_names=["evaluator"],
+        )
+        mock_role_dashboard_is_reachable.assert_not_called()
+
+
+class _UpstreamHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:
+        body = json.dumps(
+            {
+                "method": "GET",
+                "path": self.path,
+                "host": self.headers.get("Host"),
+            }
+        ).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        request_body = self.rfile.read(content_length).decode("utf-8")
+        body = json.dumps({"method": "POST", "body": request_body}).encode("utf-8")
+        self.send_response(201)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        pass
+
+
+class DashboardRelayServerTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        self.upstream = ThreadingHTTPServer(("127.0.0.1", 0), _UpstreamHandler)
+        self.upstream_thread = threading.Thread(
+            target=self.upstream.serve_forever,
+            daemon=True,
+        )
+        self.upstream_thread.start()
+
+    def tearDown(self) -> None:
+        self.upstream.shutdown()
+        self.upstream.server_close()
+
+    def _start_relay(self) -> DashboardRelayServer:
+        relay = create_dashboard_relay_server(
+            upstream_url=f"http://127.0.0.1:{self.upstream.server_port}",
+            host="127.0.0.1",
+            port=0,
+            use_tls=False,
+        )
+        threading.Thread(target=relay.serve_forever, daemon=True).start()
+        self.addCleanup(relay.shutdown)
+        return relay
+
+    def test_relay_proxies_get(self) -> None:
+        relay = self._start_relay()
+        with self.opener.open(f"{relay.url}/api/query?x=1") as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        self.assertEqual("GET", payload["method"])
+        self.assertEqual("/api/query?x=1", payload["path"])
+        self.assertEqual(f"127.0.0.1:{self.upstream.server_port}", payload["host"])
+
+    def test_relay_proxies_post(self) -> None:
+        relay = self._start_relay()
+        request = urllib.request.Request(
+            f"{relay.url}/api/query",
+            data=b'{"sql": "SELECT 1"}',
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with self.opener.open(request) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            status = response.status
+
+        self.assertEqual(201, status)
+        self.assertEqual("POST", payload["method"])
+        self.assertEqual('{"sql": "SELECT 1"}', payload["body"])

--- a/python/monarch/monarch_dashboard/server/tests/test_relay.py
+++ b/python/monarch/monarch_dashboard/server/tests/test_relay.py
@@ -1,0 +1,246 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import asyncio
+import unittest
+from collections.abc import AsyncIterator
+from unittest.mock import MagicMock, patch
+from urllib.parse import urlparse
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+from monarch.monarch_dashboard.meta.mast import resolve_mast_dashboard_target
+from monarch.monarch_dashboard.meta.relay import create_dashboard_relay_app
+
+
+class ResolveMastDashboardTargetTest(unittest.TestCase):
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_resolves_role_hostname(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        mock_role_dashboard_is_reachable.return_value = True
+        role_info = MagicMock()
+        role_info.name = "worker"
+        role_info.hostnames = ["worker001.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [role_info]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        target = resolve_mast_dashboard_target("sample-mast-job")
+
+        self.assertEqual("sample-mast-job", target.job_name)
+        self.assertEqual("worker", target.role_name)
+        self.assertEqual(
+            "https://worker001.region.facebook.com:8265",
+            target.upstream_url,
+        )
+        mock_attach_to_existing_mast_job.assert_called_once_with(
+            app_handle="mast:///sample-mast-job",
+            role_names=[],
+        )
+        job._wait_for_job_ready.assert_called_once()
+        mock_role_dashboard_is_reachable.assert_called_once_with(
+            role_info,
+            dashboard_port=8265,
+        )
+
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_resolves_custom_dashboard_port(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        mock_role_dashboard_is_reachable.return_value = True
+        role_info = MagicMock()
+        role_info.name = "worker"
+        role_info.hostnames = ["worker001.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [role_info]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        target = resolve_mast_dashboard_target(
+            "sample-mast-job",
+            dashboard_port=9000,
+        )
+
+        self.assertEqual(
+            "https://worker001.region.facebook.com:9000",
+            target.upstream_url,
+        )
+        mock_role_dashboard_is_reachable.assert_called_once_with(
+            role_info,
+            dashboard_port=9000,
+        )
+
+    def test_rejects_mast_handle(self) -> None:
+        with self.assertRaisesRegex(ValueError, "direct MAST job name"):
+            resolve_mast_dashboard_target("mast:///sample-mast-job")
+
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_requires_role_name_for_multi_role_job(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        mock_role_dashboard_is_reachable.return_value = True
+        worker = MagicMock()
+        worker.name = "worker"
+        worker.hostnames = ["worker001.region"]
+        evaluator = MagicMock()
+        evaluator.name = "evaluator"
+        evaluator.hostnames = ["worker002.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [worker, evaluator]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        with self.assertRaisesRegex(ValueError, "Multiple MAST roles"):
+            resolve_mast_dashboard_target("sample-mast-job")
+        self.assertEqual(2, mock_role_dashboard_is_reachable.call_count)
+
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_infers_single_reachable_role(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        def is_reachable(role_info: MagicMock, **kwargs: object) -> bool:
+            return role_info.name == "evaluator"
+
+        mock_role_dashboard_is_reachable.side_effect = is_reachable
+        worker = MagicMock()
+        worker.name = "worker"
+        worker.hostnames = ["worker001.region"]
+        evaluator = MagicMock()
+        evaluator.name = "evaluator"
+        evaluator.hostnames = ["worker002.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [worker, evaluator]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        target = resolve_mast_dashboard_target("sample-mast-job")
+
+        self.assertEqual("evaluator", target.role_name)
+        self.assertEqual(
+            "https://worker002.region.facebook.com:8265",
+            target.upstream_url,
+        )
+
+    @patch("monarch.monarch_dashboard.meta.mast._role_dashboard_is_reachable")
+    @patch("monarch.monarch_dashboard.meta.mast._attach_to_existing_mast_job")
+    def test_uses_explicit_role_name(
+        self,
+        mock_attach_to_existing_mast_job: MagicMock,
+        mock_role_dashboard_is_reachable: MagicMock,
+    ) -> None:
+        worker = MagicMock()
+        worker.name = "worker"
+        worker.hostnames = ["worker001.region"]
+        evaluator = MagicMock()
+        evaluator.name = "evaluator"
+        evaluator.hostnames = ["worker002.region"]
+        job = MagicMock()
+        job._get_role_infos.return_value = [worker, evaluator]
+        mock_attach_to_existing_mast_job.return_value = job
+
+        target = resolve_mast_dashboard_target(
+            "sample-mast-job",
+            role_name="evaluator",
+        )
+
+        self.assertEqual("evaluator", target.role_name)
+        self.assertEqual(
+            "https://worker002.region.facebook.com:8265",
+            target.upstream_url,
+        )
+        mock_attach_to_existing_mast_job.assert_called_once_with(
+            app_handle="mast:///sample-mast-job",
+            role_names=["evaluator"],
+        )
+        mock_role_dashboard_is_reachable.assert_not_called()
+
+
+class DashboardRelayAppTest(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.release_stream = asyncio.Event()
+        upstream_app = web.Application()
+        upstream_app.router.add_route("*", "/{path:.*}", self._handle_upstream)
+        self.upstream = TestServer(upstream_app)
+        await self.upstream.start_server()
+        self.upstream_url = str(self.upstream.make_url("/")).rstrip("/")
+
+        relay_app = create_dashboard_relay_app(self.upstream_url)
+        self.client = TestClient(TestServer(relay_app))
+        await self.client.start_server()
+
+    async def asyncTearDown(self) -> None:
+        self.release_stream.set()
+        await self.client.close()
+        await self.upstream.close()
+
+    async def _handle_upstream(self, request: web.Request) -> web.StreamResponse:
+        if request.path == "/stream":
+            response = web.StreamResponse()
+            await response.prepare(request)
+            await response.write(b"first")
+            await self.release_stream.wait()
+            await response.write(b"second")
+            await response.write_eof()
+            return response
+
+        body = await request.read()
+        return web.json_response(
+            {
+                "method": request.method,
+                "path": request.raw_path,
+                "host": request.headers.get("Host"),
+                "body": body.decode("utf-8"),
+            },
+            status=201 if request.method == "POST" else 200,
+        )
+
+    async def test_relay_proxies_get(self) -> None:
+        async with self.client.get("/api/query?x=1") as response:
+            payload = await response.json()
+
+        self.assertEqual("GET", payload["method"])
+        self.assertEqual("/api/query?x=1", payload["path"])
+        self.assertEqual(urlparse(self.upstream_url).netloc, payload["host"])
+
+    async def test_relay_proxies_post(self) -> None:
+        async with self.client.post(
+            "/api/query",
+            data=b'{"sql": "SELECT 1"}',
+            headers={"Content-Type": "application/json"},
+        ) as response:
+            payload = await response.json()
+            status = response.status
+
+        self.assertEqual(201, status)
+        self.assertEqual("POST", payload["method"])
+        self.assertEqual('{"sql": "SELECT 1"}', payload["body"])
+
+    async def test_relay_proxies_chunked_request(self) -> None:
+        async def chunks() -> AsyncIterator[bytes]:
+            yield b"SELECT "
+            yield b"1"
+
+        async with self.client.post("/api/query", data=chunks()) as response:
+            payload = await response.json()
+
+        self.assertEqual("SELECT 1", payload["body"])
+
+    async def test_relay_streams_response(self) -> None:
+        response = await self.client.get("/stream")
+        self.assertEqual(b"first", await response.content.readexactly(5))
+
+        self.release_stream.set()
+        self.assertEqual(b"second", await response.read())

--- a/python/monarch/tools/cli.py
+++ b/python/monarch/tools/cli.py
@@ -12,6 +12,7 @@ import sys
 from pathlib import Path
 
 from monarch.actor import shutdown_context
+from monarch.monarch_dashboard.relay import DEFAULT_DASHBOARD_PORT
 from monarch.tools.commands import (
     apply_job,
     context_create,
@@ -236,6 +237,59 @@ class KillCmd:
         print("Killed job")
 
 
+class DashboardCmd:
+    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        subparser.set_defaults(_dashboard_subparser=subparser)
+        sub = subparser.add_subparsers(title="DASHBOARD COMMANDS", dest="dashboard_cmd")
+        mast = sub.add_parser(
+            "mast",
+            help="Relay an existing MAST job's Monarch dashboard through this host",
+        )
+        mast.add_argument(
+            "job",
+            type=str,
+            help="Direct MAST job name.",
+        )
+        mast.add_argument(
+            "--role-name",
+            type=str,
+            default=None,
+            help=(
+                "MAST task group / Monarch host mesh role that hosts the dashboard. "
+                "If omitted, Monarch probes every role and uses the single reachable dashboard."
+            ),
+        )
+        mast.add_argument(
+            "--dashboard-port",
+            type=int,
+            default=DEFAULT_DASHBOARD_PORT,
+            help="Dashboard port on the MAST task.",
+        )
+        mast.set_defaults(dashboard_func=self._run_mast)
+
+    def run(self, args: argparse.Namespace) -> None:
+        if not hasattr(args, "dashboard_func"):
+            args._dashboard_subparser.print_help()
+            sys.exit(1)
+        args.dashboard_func(args)
+
+    def _run_mast(self, args: argparse.Namespace) -> None:
+        try:
+            from monarch.monarch_dashboard.meta.mast import serve_mast_dashboard_relay
+        except ImportError:
+            sys.stderr.write(
+                "Error: `monarch-launch dashboard mast` is only available in "
+                "Meta-internal builds.\n"
+            )
+            sys.exit(1)
+
+        serve_mast_dashboard_relay(
+            job_name=args.job,
+            role_name=args.role_name,
+            dashboard_port=args.dashboard_port,
+        )
+
+
 def _load_skill_md() -> str:
     """Load SKILL.md as the help text."""
     skill_file = importlib.resources.files("monarch.tools").joinpath("SKILL.md")
@@ -265,6 +319,7 @@ def get_parser() -> argparse.ArgumentParser:
         ),
         ("kill", KillCmd(), "Kill the active job"),
         ("debug", DebugCmd(), "Connect to the debug server"),
+        ("dashboard", DashboardCmd(), "Serve Monarch dashboards"),
     ]:
         cmd_parser = subparser.add_parser(cmd_name, help=cmd_help)
         cmd.add_arguments(cmd_parser)

--- a/python/monarch/tools/cli.py
+++ b/python/monarch/tools/cli.py
@@ -24,6 +24,8 @@ from monarch.tools.commands import (
 )
 from monarch.tools.debug_env import _get_debug_server_host, _get_debug_server_port
 
+_DEFAULT_DASHBOARD_PORT: int = 8265
+
 
 class DebugCmd:
     def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
@@ -285,6 +287,59 @@ class KillCmd:
         print("Killed job")
 
 
+class DashboardCmd:
+    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        subparser.set_defaults(_dashboard_subparser=subparser)
+        sub = subparser.add_subparsers(title="DASHBOARD COMMANDS", dest="dashboard_cmd")
+        mast = sub.add_parser(
+            "mast",
+            help="Relay an existing MAST job's Monarch dashboard through this host",
+        )
+        mast.add_argument(
+            "job",
+            type=str,
+            help="Direct MAST job name.",
+        )
+        mast.add_argument(
+            "--role-name",
+            type=str,
+            default=None,
+            help=(
+                "MAST task group / Monarch host mesh role that hosts the dashboard. "
+                "If omitted, Monarch probes every role and uses the single reachable dashboard."
+            ),
+        )
+        mast.add_argument(
+            "--dashboard-port",
+            type=int,
+            default=_DEFAULT_DASHBOARD_PORT,
+            help="Dashboard port on the MAST task.",
+        )
+        mast.set_defaults(dashboard_func=self._run_mast)
+
+    def run(self, args: argparse.Namespace) -> None:
+        if not hasattr(args, "dashboard_func"):
+            args._dashboard_subparser.print_help()
+            sys.exit(1)
+        args.dashboard_func(args)
+
+    def _run_mast(self, args: argparse.Namespace) -> None:
+        try:
+            from monarch.monarch_dashboard.meta.mast import serve_mast_dashboard_relay
+        except ImportError:
+            sys.stderr.write(
+                "Error: `monarch-launch dashboard mast` is only available in "
+                "Meta-internal builds.\n"
+            )
+            sys.exit(1)
+
+        serve_mast_dashboard_relay(
+            job_name=args.job,
+            role_name=args.role_name,
+            dashboard_port=args.dashboard_port,
+        )
+
+
 def _load_skill_md() -> str:
     """Load SKILL.md as the help text."""
     skill_file = importlib.resources.files("monarch.tools").joinpath("SKILL.md")
@@ -315,6 +370,7 @@ def get_parser() -> argparse.ArgumentParser:
         ("shell", ShellCmd(), "Open an interactive shell on one worker"),
         ("kill", KillCmd(), "Kill the active job"),
         ("debug", DebugCmd(), "Connect to the debug server"),
+        ("dashboard", DashboardCmd(), "Serve Monarch dashboards"),
     ]:
         cmd_parser = subparser.add_parser(cmd_name, help=cmd_help)
         cmd.add_arguments(cmd_parser)

--- a/python/tests/tools/test_cli.py
+++ b/python/tests/tools/test_cli.py
@@ -27,6 +27,40 @@ class TestCli(unittest.TestCase):
         args = parser.parse_args(["context", "use", "myjob"])
         self.assertEqual(args.name, "myjob")
 
+    def test_dashboard_mast_command(self) -> None:
+        parser = get_parser()
+        args = parser.parse_args(["dashboard", "mast", "sample-mast-job"])
+        self.assertEqual(args.job, "sample-mast-job")
+        self.assertIsNone(args.role_name)
+        self.assertEqual(8265, args.dashboard_port)
+        self.assertFalse(hasattr(args, "relay_port"))
+
+    def test_dashboard_mast_accepts_role_name(self) -> None:
+        parser = get_parser()
+        args = parser.parse_args(
+            [
+                "dashboard",
+                "mast",
+                "sample-mast-job",
+                "--role-name",
+                "worker",
+            ]
+        )
+        self.assertEqual("worker", args.role_name)
+
+    def test_dashboard_mast_accepts_dashboard_port(self) -> None:
+        parser = get_parser()
+        args = parser.parse_args(
+            [
+                "dashboard",
+                "mast",
+                "sample-mast-job",
+                "--dashboard-port",
+                "9000",
+            ]
+        )
+        self.assertEqual(9000, args.dashboard_port)
+
     def test_exec_run_all_default(self) -> None:
         parser = get_parser()
         args = parser.parse_args(["exec", "echo", "hi"])

--- a/python/tests/tools/test_cli.py
+++ b/python/tests/tools/test_cli.py
@@ -28,6 +28,40 @@ class TestCli(unittest.TestCase):
         args = parser.parse_args(["context", "use", "myjob"])
         self.assertEqual(args.name, "myjob")
 
+    def test_dashboard_mast_command(self) -> None:
+        parser = get_parser()
+        args = parser.parse_args(["dashboard", "mast", "sample-mast-job"])
+        self.assertEqual(args.job, "sample-mast-job")
+        self.assertIsNone(args.role_name)
+        self.assertEqual(8265, args.dashboard_port)
+        self.assertFalse(hasattr(args, "relay_port"))
+
+    def test_dashboard_mast_accepts_role_name(self) -> None:
+        parser = get_parser()
+        args = parser.parse_args(
+            [
+                "dashboard",
+                "mast",
+                "sample-mast-job",
+                "--role-name",
+                "worker",
+            ]
+        )
+        self.assertEqual("worker", args.role_name)
+
+    def test_dashboard_mast_accepts_dashboard_port(self) -> None:
+        parser = get_parser()
+        args = parser.parse_args(
+            [
+                "dashboard",
+                "mast",
+                "sample-mast-job",
+                "--dashboard-port",
+                "9000",
+            ]
+        )
+        self.assertEqual(9000, args.dashboard_port)
+
     def test_exec_run_all_default(self) -> None:
         parser = get_parser()
         args = parser.parse_args(["exec", "echo", "hi"])


### PR DESCRIPTION
Summary:

Add dashboard relay for when client is running on the MAST so that users can easily access dashboard from their browser. CLI command basically makes the devserver as a relay to client host in MAST and expose it as nest proxy so that you can easily access from the browser.

Reviewed By: dulinriley

Differential Revision: D110286181


