### PR TITLE
Add non zero usize newtype (#4346)

### DIFF
--- a/hyperactor_config/Cargo.toml
+++ b/hyperactor_config/Cargo.toml
@@ -15,6 +15,7 @@ arc-swap = { version = "1.9.0", features = ["weak"] }
 bincode = { version = "2", features = ["serde"] }
 bytes = { version = "1.11.1", features = ["serde"] }
 chrono = { version = "0.4.45", features = ["clock", "serde", "std"], default-features = false }
+derive_more = { version = "1.0.0", features = ["full"] }
 erased-serde = "0.4.10"
 humantime = "2.1"
 hyperactor_config_macros = { version = "0.0.0", path = "../hyperactor_config_macros" }
@@ -25,6 +26,7 @@ serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 serde_yaml = "0.9.25"
 shell-quote = "0.7.2"
+thiserror = "2.0.18"
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 typeuri = { version = "0.0.0", path = "../typeuri" }
 

--- a/hyperactor_config/src/attrs.rs
+++ b/hyperactor_config/src/attrs.rs
@@ -587,6 +587,8 @@ impl AttrValue for bool {
 
 impl DisplayNonEmpty for bool {}
 
+impl DisplayNonEmpty for crate::NonZeroUsize {}
+
 impl<T: AttrValue + DisplayNonEmpty> AttrValue for Option<T> {
     fn display(&self) -> String {
         match self {

--- a/hyperactor_config/src/lib.rs
+++ b/hyperactor_config/src/lib.rs
@@ -23,9 +23,13 @@ use std::fs::File;
 use std::io::Read;
 use std::path::Path;
 
+use derive_more::Display;
+use derive_more::From;
+use derive_more::Into;
 use serde::Deserialize;
 use serde::Serialize;
 use shell_quote::QuoteRefExt;
+use thiserror::Error;
 use typeuri::Named;
 
 pub mod attrs;
@@ -118,6 +122,74 @@ impl AttrValue for ConfigAttr {
     }
     fn parse(s: &str) -> Result<Self, anyhow::Error> {
         Ok(serde_json::from_str(s)?)
+    }
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Display,
+    From,
+    Into,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize
+)]
+#[display("{}", _0)]
+pub struct NonZeroUsize(std::num::NonZeroUsize);
+
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+#[error("expected non-zero usize")]
+pub struct NonZeroUsizeError;
+
+impl NonZeroUsize {
+    pub const MIN: Self = Self(std::num::NonZeroUsize::MIN);
+
+    pub const fn new(value: usize) -> Option<Self> {
+        match std::num::NonZeroUsize::new(value) {
+            Some(value) => Some(Self(value)),
+            None => None,
+        }
+    }
+
+    pub const fn get(self) -> usize {
+        self.0.get()
+    }
+
+    pub const fn into_std(self) -> std::num::NonZeroUsize {
+        self.0
+    }
+}
+
+impl Named for NonZeroUsize {
+    fn typename() -> &'static str {
+        "hyperactor_config::NonZeroUsize"
+    }
+}
+
+impl TryFrom<usize> for NonZeroUsize {
+    type Error = NonZeroUsizeError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Self::new(value).ok_or(NonZeroUsizeError)
+    }
+}
+
+impl From<NonZeroUsize> for usize {
+    fn from(value: NonZeroUsize) -> Self {
+        value.get()
+    }
+}
+
+impl AttrValue for NonZeroUsize {
+    fn display(&self) -> String {
+        self.to_string()
+    }
+
+    fn parse(s: &str) -> Result<Self, anyhow::Error> {
+        Ok(s.parse::<usize>()?.try_into()?)
     }
 }
 
@@ -266,8 +338,10 @@ mod tests {
 
     use indoc::indoc;
 
+    use crate::AttrValue;
     use crate::CONFIG;
     use crate::ConfigAttr;
+    use crate::NonZeroUsize;
     use crate::attrs::declare_attrs;
     use crate::from_env;
     use crate::from_yaml;
@@ -567,6 +641,28 @@ mod tests {
         );
 
         let _ = std::fs::remove_file(&temp_path);
+    }
+
+    #[test]
+    fn test_nonzero_usize_attr_value() {
+        let value = NonZeroUsize::parse("16").unwrap();
+        assert_eq!(value.get(), 16);
+        assert_eq!(value.display(), "16");
+        assert_eq!(usize::from(value), 16);
+        assert_eq!(
+            std::num::NonZeroUsize::from(value),
+            std::num::NonZeroUsize::new(16).unwrap()
+        );
+        assert_eq!(Option::<NonZeroUsize>::parse("").unwrap(), None);
+        assert_eq!(
+            Option::<NonZeroUsize>::parse("16")
+                .unwrap()
+                .map(NonZeroUsize::get),
+            Some(16)
+        );
+        assert!(NonZeroUsize::try_from(0).is_err());
+        assert!(NonZeroUsize::parse("0").is_err());
+        assert!(Option::<NonZeroUsize>::parse("0").is_err());
     }
 
     // Verify that the INTROSPECT meta-attribute attaches structured

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -24,7 +24,6 @@ use std::collections::HashMap;
 use std::fmt;
 use std::hash::Hash;
 use std::hash::Hasher;
-use std::num::NonZeroUsize;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::sync::OnceLock as OnceCell;
@@ -368,8 +367,7 @@ impl<M: Send + Sync + Clone + Default + 'static> Default for MessageOrFailure<M>
 
 fn default_cast_tiling_policy() -> TilingPolicy {
     TilingPolicy::BoundedFanout {
-        fanout: NonZeroUsize::new(hyperactor_config::global::get(MAX_CAST_FANOUT))
-            .expect("MAX_CAST_FANOUT must be > 0"),
+        fanout: hyperactor_config::global::get(MAX_CAST_FANOUT).into(),
     }
 }
 

--- a/hyperactor_mesh/src/config.rs
+++ b/hyperactor_mesh/src/config.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use hyperactor_config::AttrValue;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
+use hyperactor_config::NonZeroUsize;
 use hyperactor_config::attrs::declare_attrs;
 use serde::Deserialize;
 use serde::Serialize;
@@ -279,5 +280,6 @@ declare_attrs! {
         Some("HYPERACTOR_MESH_MAX_CAST_FANOUT".to_string()),
         Some("max_cast_fanout".to_string()),
     ))
-    pub attr MAX_CAST_FANOUT: usize = 16;
+    pub attr MAX_CAST_FANOUT: NonZeroUsize =
+        NonZeroUsize::new(16).expect("16 is non-zero");
 }

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -332,6 +332,13 @@ fn set_runtime_config_py<T: AttrValue + Debug>(
     Ok(())
 }
 
+fn py_value_repr(py: Python<'_>, val: &Py<PyAny>) -> String {
+    val.bind(py)
+        .repr()
+        .map(|repr| repr.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| "<unprintable>".to_string())
+}
+
 /// Bridge a single Python kwarg into a typed Runtime config update.
 ///
 /// This is the write-path behind `configure(**kwargs)`:
@@ -457,12 +464,20 @@ macro_rules! declare_py_config_type {
             PythonConfigTypeInfo {
                 typehash: <Option<$ty> as Named>::typehash,
                 set_runtime_config: |py, key, val| {
-                    let val: Option<$ty> = val.extract::<Option<$py_ty>>(py)
+                    let val_repr = py_value_repr(py, &val);
+                    let val: Option<$py_ty> = val.extract::<Option<$py_ty>>(py)
                         .map_err(|err| PyTypeError::new_err(format!(
                             "invalid value `{}` for configuration key `{}` ({})",
-                            val, key.name(), err
-                        )))?
-                        .map(Into::into);
+                            val_repr, key.name(), err
+                        )))?;
+                    // Python extraction checks shape; TryInto checks Rust-side invariants.
+                    let val: Option<$ty> = val
+                        .map(TryInto::try_into)
+                        .transpose()
+                        .map_err(|err| PyValueError::new_err(format!(
+                            "invalid value `{}` for configuration key `{}` ({})",
+                            val_repr, key.name(), err
+                        )))?;
                     set_runtime_config_py(key, val)
                 },
                 get_global_config: |py, key| {
@@ -499,10 +514,16 @@ macro_rules! declare_py_config_type {
                 PythonConfigTypeInfo {
                     typehash: $ty::typehash,
                     set_runtime_config: |py, key, val| {
-                        let val: $ty = val.extract::<$py_ty>(py).map_err(|err| PyTypeError::new_err(format!(
+                        let val_repr = py_value_repr(py, &val);
+                        let val: $py_ty = val.extract::<$py_ty>(py).map_err(|err| PyTypeError::new_err(format!(
                             "invalid value `{}` for configuration key `{}` ({})",
-                            val, key.name(), err
-                        )))?.into();
+                            val_repr, key.name(), err
+                        )))?;
+                        // Python extraction checks shape; TryInto checks Rust-side invariants.
+                        let val: $ty = val.try_into().map_err(|err| PyValueError::new_err(format!(
+                            "invalid value `{}` for configuration key `{}` ({})",
+                            val_repr, key.name(), err
+                        )))?;
                         set_runtime_config_py(key, val)
                     },
                     get_global_config: |py, key| {
@@ -523,6 +544,7 @@ declare_py_config_type!(Option<PyDuration> as Option<Duration>);
 declare_py_config_type!(PyEncoding as wirevalue::Encoding);
 declare_py_config_type!(PyPortRange as std::ops::Range::<u16>);
 declare_py_config_type!(String as hyperactor_mesh::config::SocketAddrStr);
+declare_py_config_type!(usize as hyperactor_config::NonZeroUsize);
 declare_py_config_type!(
     i8, i16, i32, i64, u8, u16, u32, u64, usize, f32, f64, bool, String
 );
@@ -712,8 +734,11 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::time::Duration;
 
+    use hyperactor_config::attrs::declare_attrs;
+    use pyo3::exceptions::PyValueError;
     use pyo3::prelude::*;
     use pyo3::types::PyString;
     use pyo3::types::PyTuple;
@@ -721,6 +746,15 @@ mod tests {
     use super::*;
     use crate::runtime::GilSite;
     use crate::runtime::monarch_with_gil_blocking;
+
+    declare_attrs! {
+        @meta(CONFIG = ConfigAttr::new(
+            None,
+            Some("test_nonzero_usize".to_string()),
+        ))
+        attr TEST_NONZERO_USIZE: hyperactor_config::NonZeroUsize =
+            hyperactor_config::NonZeroUsize::MIN;
+    }
 
     #[test]
     fn test_pyduration_parse_valid_formats() {
@@ -818,6 +852,37 @@ mod tests {
                 PyEncoding::from(wirevalue::Encoding::Multipart),
                 PyEncoding::Multipart
             );
+        });
+    }
+
+    #[test]
+    fn test_nonzero_usize_config_rejects_zero_from_python() {
+        Python::initialize();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            clear_runtime_config(py).expect("clear runtime config before test");
+
+            let kwargs = HashMap::from([(
+                "test_nonzero_usize".to_string(),
+                0usize.into_py_any(py).expect("convert integer to python"),
+            )]);
+            let err = configure(py, Some(kwargs)).expect_err("zero value should be rejected");
+
+            assert!(err.is_instance_of::<PyValueError>(py));
+            let err_msg = err.to_string();
+            assert!(
+                err_msg.contains(
+                    "invalid value `0` for configuration key `monarch_hyperactor::config::tests::test_nonzero_usize`"
+                ),
+                "unexpected error message: {}",
+                err_msg
+            );
+            assert!(
+                err_msg.contains("expected non-zero usize"),
+                "unexpected error message: {}",
+                err_msg
+            );
+
+            clear_runtime_config(py).expect("clear runtime config after test");
         });
     }
 


### PR DESCRIPTION
Summary:

 std::num::NonZeroUsize cannot be used directly as a config value type because it does not satisfy our AttrValue requirements like Named, and we cannot add those impls to a std type, but it is useful because the type system can enforce nonzero values, so we added our own local wrapper type that implements the config traits and converts to/from NonZeroUsize.

Reviewed By: shayne-fletcher

Differential Revision: D110377770


