### PR TITLE
Introduce Child Actor Teardown Intent

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1923,6 +1923,11 @@ struct InstanceState<A: Actor> {
     instance_locals: ActorLocalStorage,
 }
 
+struct ActorStopped {
+    reason: String,
+    stop_mode: StopMode,
+}
+
 type DelayedPost<A> = Box<dyn FnOnce(&Instance<A>) + Send>;
 
 trait PostAfterEndpoint<A: Actor, M: Message>: Send {
@@ -3089,11 +3094,16 @@ impl<A: Actor> Instance<A> {
         // After this point, we know we won't spawn any more children,
         // so we can safely read the current child keys.
         let mut to_unlink = Vec::new();
+        let stop_mode = match &result {
+            Ok(stopped) => stopped.stop_mode,
+            Err(_) => StopMode::Stop,
+        };
+        let child_signal = match stop_mode {
+            StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
+            StopMode::Stop => Signal::Stop("parent stopping".to_string()),
+        };
         for child in self.inner.cell.child_iter() {
-            if let Err(err) = child
-                .value()
-                .signal(Signal::Stop("parent stopping".to_string()))
-            {
+            if let Err(err) = child.value().signal(child_signal.clone()) {
                 tracing::error!(
                     "{}: failed to send stop signal to child pid {}: {:?}",
                     self.self_addr(),
@@ -3178,12 +3188,12 @@ impl<A: Actor> Instance<A> {
         }
         // If the original exit was not an error, let cleanup errors be
         // surfaced.
-        result.and_then(|reason| cleanup_result.map(|_| reason))
+        result.and_then(|stopped| cleanup_result.map(|_| stopped.reason))
     }
 
     /// Initialize and run the actor until it fails or is stopped. On success,
-    /// returns the reason why the actor stopped. On failure, returns the error
-    /// that caused the failure.
+    /// returns why the actor stopped and the mode that child actors inherit.
+    /// On failure, returns the error that caused the failure.
     async fn run(
         &mut self,
         actor: &mut A,
@@ -3192,8 +3202,9 @@ impl<A: Actor> Instance<A> {
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
         work_rx: &mut ActorWorkReceiver<A>,
-    ) -> Result<String, ActorError> {
+    ) -> Result<ActorStopped, ActorError> {
         let (signal_receiver, supervision_event_receiver) = actor_loop_receivers;
+        let mut stop_mode = StopMode::Stop;
 
         self.change_status(ActorStatus::Initializing);
         self.inner
@@ -3217,6 +3228,7 @@ impl<A: Actor> Instance<A> {
                     tracing::debug!("received signal {signal:?}");
                     match signal {
                         Signal::Stop(reason) => {
+                            stop_mode = StopMode::Stop;
                             self.change_status(ActorStatus::Stopping);
                             self.inner
                                 .proc
@@ -3225,6 +3237,7 @@ impl<A: Actor> Instance<A> {
                                 .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
                         },
                         Signal::DrainAndStop(reason) => {
+                            stop_mode = StopMode::DrainAndStop;
                             self.change_status(ActorStatus::Stopping);
                             self.inner
                                 .proc
@@ -3289,7 +3302,10 @@ impl<A: Actor> Instance<A> {
             reason = stop_reason,
             "exited actor loop",
         );
-        Ok(stop_reason)
+        Ok(ActorStopped {
+            reason: stop_reason,
+            stop_mode,
+        })
     }
 
     /// Handle a supervision event using the provided actor.
@@ -6025,8 +6041,133 @@ mod tests {
                     .try_post(&client, TestActorMessage::Noop())
                     .is_err()
             );
-            assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
+            assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent draining");
         }
+    }
+
+    #[derive(Debug)]
+    struct DrainCountingActor {
+        handled: Arc<AtomicUsize>,
+    }
+
+    impl Actor for DrainCountingActor {}
+
+    #[derive(Handler, Debug)]
+    enum DrainCountingMessage {
+        Block(oneshot::Sender<()>, oneshot::Receiver<()>),
+        Count(),
+    }
+
+    #[async_trait]
+    #[crate::handle(DrainCountingMessage)]
+    impl DrainCountingMessageHandler for DrainCountingActor {
+        async fn block(
+            &mut self,
+            _cx: &crate::Context<Self>,
+            entered: oneshot::Sender<()>,
+            release: oneshot::Receiver<()>,
+        ) -> Result<(), anyhow::Error> {
+            entered.send(()).unwrap();
+            release.await.unwrap();
+            Ok(())
+        }
+
+        async fn count(&mut self, _cx: &crate::Context<Self>) -> Result<(), anyhow::Error> {
+            self.handled.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    async fn block_and_queue_counts(
+        client: &Client,
+        handle: &ActorHandle<DrainCountingActor>,
+        count: usize,
+    ) -> oneshot::Sender<()> {
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        handle.post(client, DrainCountingMessage::Block(entered_tx, release_rx));
+        entered_rx.await.unwrap();
+        for _ in 0..count {
+            handle.post(client, DrainCountingMessage::Count());
+        }
+        release_tx
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn child_inherits_drain_mode() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let handled = Arc::new(AtomicUsize::new(0));
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: handled.clone(),
+            },
+        );
+        let release = block_and_queue_counts(&client, &child, 5).await;
+
+        parent.drain_and_stop("test").unwrap();
+        release.send(()).unwrap();
+
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_eq!(handled.load(Ordering::SeqCst), 5);
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn tree_inherits_drain_mode() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let grandparent = proc.spawn(TestActor);
+        let parent = proc.spawn_child(grandparent.cell().clone(), TestActor);
+        let handled = Arc::new(AtomicUsize::new(0));
+        let grandchild = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: handled.clone(),
+            },
+        );
+        let release = block_and_queue_counts(&client, &grandchild, 7).await;
+
+        grandparent.drain_and_stop("test").unwrap();
+        release.send(()).unwrap();
+
+        assert_matches!(grandparent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_matches!(grandchild.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_eq!(handled.load(Ordering::SeqCst), 7);
+    }
+
+    #[derive(Debug)]
+    struct StopFailingActor;
+
+    #[async_trait]
+    impl Actor for StopFailingActor {
+        async fn handle_stop(
+            &mut self,
+            _this: &Instance<Self>,
+            _mode: StopMode,
+            _reason: &str,
+        ) -> Result<(), anyhow::Error> {
+            Err(anyhow::anyhow!("stop failed"))
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn failed_drain_stop_stops_children_immediately() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let parent = proc.spawn(StopFailingActor);
+        let child = proc.spawn_child(parent.cell().clone(), TestActor);
+
+        parent.drain_and_stop("test").unwrap();
+
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(err) if err.to_string().contains("stop failed")
+        );
     }
 
     #[derive(Debug)]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1928,6 +1928,29 @@ struct ActorStopped {
     stop_mode: StopMode,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ChildTeardown {
+    Cooperative(StopMode),
+    Kill,
+}
+
+impl ChildTeardown {
+    fn from_run_result(result: &Result<ActorStopped, ActorError>) -> Self {
+        match result {
+            Ok(stopped) => Self::Cooperative(stopped.stop_mode),
+            Err(err) if matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)) => Self::Kill,
+            Err(_) => Self::Cooperative(StopMode::Stop),
+        }
+    }
+
+    fn cooperative_signal(mode: StopMode) -> Signal {
+        match mode {
+            StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
+            StopMode::Stop => Signal::Stop("parent stopping".to_string()),
+        }
+    }
+}
+
 type DelayedPost<A> = Box<dyn FnOnce(&Instance<A>) + Send>;
 
 trait PostAfterEndpoint<A: Actor, M: Message>: Send {
@@ -3094,13 +3117,13 @@ impl<A: Actor> Instance<A> {
         // After this point, we know we won't spawn any more children,
         // so we can safely read the current child keys.
         let mut to_unlink = Vec::new();
-        let stop_mode = match &result {
-            Ok(stopped) => stopped.stop_mode,
-            Err(_) => StopMode::Stop,
-        };
-        let child_signal = match stop_mode {
-            StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
-            StopMode::Stop => Signal::Stop("parent stopping".to_string()),
+        let child_signal = match ChildTeardown::from_run_result(&result) {
+            ChildTeardown::Cooperative(mode) => ChildTeardown::cooperative_signal(mode),
+            ChildTeardown::Kill => {
+                // TODO: fan out kill once child teardown can detach
+                // unresponsive children without blocking this parent.
+                ChildTeardown::cooperative_signal(StopMode::Stop)
+            }
         };
         for child in self.inner.cell.child_iter() {
             if let Err(err) = child.value().signal(child_signal.clone()) {
@@ -4697,6 +4720,7 @@ mod tests {
     use crate::mailbox::MailboxClient;
     use crate::mailbox::PanickingMailboxSender;
     use crate::port::Port;
+    use crate::testing::ids::test_actor_id;
     use crate::testing::proc_supervison::ProcSupervisionCoordinator;
     use crate::testing::process_assertion::assert_termination;
 
@@ -5241,7 +5265,6 @@ mod tests {
     #[tokio::test]
     async fn test_post_routes_by_proc_id() {
         use crate::mailbox::monitored_return_handle;
-        use crate::testing::ids::test_actor_id;
 
         #[derive(Clone)]
         struct CountingSender(Arc<AtomicUsize>);
@@ -5469,7 +5492,6 @@ mod tests {
     async fn test_mailbox_muxer_delivers_by_actor_id() {
         use crate::mailbox::PortLocation;
         use crate::mailbox::monitored_return_handle;
-        use crate::testing::ids::test_actor_id;
 
         let proc = Proc::isolated();
         let instance = proc.client("worker");
@@ -5652,7 +5674,6 @@ mod tests {
     async fn test_gateway_serve_updates_location_and_stops() {
         use crate::mailbox::PortLocation;
         use crate::mailbox::monitored_return_handle;
-        use crate::testing::ids::test_actor_id;
 
         let proc = Proc::isolated();
         let gateway = proc.gateway();
@@ -5747,8 +5768,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_local_only_gateway_returns_undeliverable_messages() {
-        use crate::testing::ids::test_actor_id;
-
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (return_handle, mut undeliverable_rx) =
@@ -5781,7 +5800,6 @@ mod tests {
         use crate::mailbox::IntoBoxedMailboxSender;
         use crate::mailbox::MailboxSender as _;
         use crate::mailbox::monitored_return_handle;
-        use crate::testing::ids::test_actor_id;
 
         #[derive(Clone)]
         struct MpscSender(UnboundedSender<MessageEnvelope>);
@@ -7756,5 +7774,34 @@ mod tests {
         // would panic in debug builds if running_total had wrapped to u64::MAX.
         account_enqueue(&depth, &stats, "a");
         assert_eq!(stats.running_total(), 1);
+    }
+
+    #[test]
+    fn child_teardown_distinguishes_kill_from_failure() {
+        let actor_addr = test_actor_id("proc", "actor");
+
+        let stopped = Ok(ActorStopped {
+            reason: "test".to_string(),
+            stop_mode: StopMode::DrainAndStop,
+        });
+        assert_eq!(
+            ChildTeardown::from_run_result(&stopped),
+            ChildTeardown::Cooperative(StopMode::DrainAndStop)
+        );
+
+        let killed = Err(ActorError::new(
+            &actor_addr,
+            ActorErrorKind::Aborted("test kill".to_string()),
+        ));
+        assert_eq!(ChildTeardown::from_run_result(&killed), ChildTeardown::Kill);
+
+        let failed = Err(ActorError::new(
+            &actor_addr,
+            ActorErrorKind::Generic("test failure".to_string()),
+        ));
+        assert_eq!(
+            ChildTeardown::from_run_result(&failed),
+            ChildTeardown::Cooperative(StopMode::Stop)
+        );
     }
 }

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -41,12 +41,12 @@ use crate::token;
 type SupervisionToken = Token<ActorAddr, ActorRef<WorkerLike>>;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Named)]
-struct ParentExit;
+struct ParentExit(StopMode);
 wirevalue::register_type!(ParentExit);
 
 #[derive(Clone, Debug, Serialize, Deserialize, Named)]
 enum ParentControl {
-    Exit,
+    Exit(StopMode),
     Kill,
 }
 wirevalue::register_type!(ParentControl);
@@ -116,8 +116,11 @@ impl Handler<token::Joined<ActorRef<WorkerLike>>> for Parent {
 
 #[async_trait]
 impl Handler<ParentExit> for Parent {
-    async fn handle(&mut self, cx: &Context<Self>, _message: ParentExit) -> anyhow::Result<()> {
-        cx.drain_and_stop("parent requested exit")?;
+    async fn handle(&mut self, cx: &Context<Self>, message: ParentExit) -> anyhow::Result<()> {
+        match message.0 {
+            StopMode::Stop => cx.stop("parent requested stop")?,
+            StopMode::DrainAndStop => cx.drain_and_stop("parent requested drain and stop")?,
+        }
         Ok(())
     }
 }
@@ -157,7 +160,7 @@ impl Handler<ParentControl> for ParentRoot {
             .as_ref()
             .expect("parent must be spawned before control message");
         match message {
-            ParentControl::Exit => parent.post(cx, ParentExit),
+            ParentControl::Exit(stop_mode) => parent.post(cx, ParentExit(stop_mode)),
             ParentControl::Kill => parent.kill("test parent killed")?,
         }
         Ok(())
@@ -391,10 +394,25 @@ async fn test_token_join_parent_exit_stops_child_first() -> anyhow::Result<()> {
 
     harness
         .parent_root
-        .post(&harness.observer, ParentControl::Exit);
+        .post(&harness.observer, ParentControl::Exit(StopMode::Stop));
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
     assert_eq!(reason, "parent stopping");
+    harness.stop().await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Result<()> {
+    let mut harness = Harness::new().await?;
+
+    harness.parent_root.post(
+        &harness.observer,
+        ParentControl::Exit(StopMode::DrainAndStop),
+    );
+
+    let reason = recv(&mut harness.child_stopped_rx).await?;
+    assert_eq!(reason, "parent draining");
     harness.stop().await?;
     Ok(())
 }


### PR DESCRIPTION
Summary: Introduce ChildTeardown enum to encode teardown intent without changing any behavior.

Differential Revision: D110256943


