### PR TITLE
ibverbs: introduce IbvPd, hold the PD as Arc<IbvPd> (#4352)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -36,6 +36,7 @@ use typeuri::Named;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
 use super::primitives::query_device_info;
 
@@ -173,7 +174,7 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
             }
             // SAFETY: `raw_ctx` was just returned by `ibv_open_device` and is
             // non-null (checked above); this `Arc<IbvContext>` is its sole owner.
-            let ctx = Arc::new(unsafe { IbvContext::new(raw_ctx) });
+            let ctx = Arc::new(unsafe { IbvContext::from_raw(raw_ctx) });
             // Assign the device to the first impl that claims it.
             if let Some(reg) = registrations
                 .iter()
@@ -197,63 +198,6 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
         unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
         by_impl
     });
-
-/// RAII owner of a raw `ibv_context*`.
-///
-/// Closes the context in [`Drop`]. Held inside an `Arc` not because
-/// clones are expected to outlive the owning [`IbvDevice`], but so
-/// the raw pointer can be passed around with a lifetime safeguard
-/// where borrow-checked references aren't practical.
-#[derive(Debug)]
-pub struct IbvContext {
-    context: *mut rdmaxcel_sys::ibv_context,
-}
-
-// SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
-// operations we perform (allocation, polling, and the final close).
-unsafe impl Send for IbvContext {}
-unsafe impl Sync for IbvContext {}
-
-impl IbvContext {
-    /// Wraps a raw `ibv_context*`. A null pointer yields a no-op context
-    /// (its `Drop` does nothing).
-    ///
-    /// # Safety
-    ///
-    /// `context` must be either null or a pointer returned by
-    /// `ibv_open_device` that has not been (and will not be) closed elsewhere:
-    /// the resulting `IbvContext` takes sole ownership and its `Drop` calls
-    /// `ibv_close_device` exactly once.
-    pub(super) unsafe fn new(context: *mut rdmaxcel_sys::ibv_context) -> Self {
-        Self { context }
-    }
-
-    /// Returns the raw `ibv_context*`. The pointer is valid for
-    /// the lifetime of `&self`.
-    pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
-        self.context
-    }
-}
-
-impl Drop for IbvContext {
-    fn drop(&mut self) {
-        if self.context.is_null() {
-            return;
-        }
-        // SAFETY: `self.context` was returned by `ibv_open_device` in
-        // `IbvDevice::open` and has not been closed elsewhere. The
-        // intended ownership is a single `Arc<IbvContext>`, whose
-        // final `Drop` calls `ibv_close_device` exactly once.
-        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.context) };
-        if result != 0 {
-            tracing::error!(
-                "ibv_close_device failed for context {:p}: error code {}",
-                self.context,
-                result
-            );
-        }
-    }
-}
 
 /// An opened RDMA device.
 ///
@@ -332,6 +276,7 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             );
         }
         let mut target = std::ptr::null_mut();
+        let mut context = None;
         for i in 0..num_devices {
             // SAFETY: `device_list` is non-null with `num_devices`
             // valid entries (checked above).
@@ -349,7 +294,6 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             }
         }
         let mut failure = None;
-        let mut context: *mut crate::rdmaxcel_sys::ibv_context = std::ptr::null_mut();
         if target.is_null() {
             failure = Some(format!(
                 "ibv device with name {} not found by ibv_get_device_list",
@@ -359,13 +303,17 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             // Open while `target` still points into `device_list`, then free.
             // SAFETY: `target`, when non-null, is one of `device_list`'s
             // entries; `ibv_open_device` returns null on failure.
-            context = unsafe { rdmaxcel_sys::ibv_open_device(target) };
-            if context.is_null() {
+            let raw_context = unsafe { rdmaxcel_sys::ibv_open_device(target) };
+            if raw_context.is_null() {
                 failure = Some(format!(
                     "registered ibv device {} could not be opened: {}",
                     name,
                     std::io::Error::last_os_error(),
                 ));
+            } else {
+                // SAFETY: `raw_context` was just returned by `ibv_open_device` and is
+                // non-null (checked above); this `Arc<IbvContext>` is its sole owner.
+                context = Some(Arc::new(unsafe { IbvContext::from_raw(raw_context) }));
             }
         }
 
@@ -381,10 +329,7 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             domains: HashMap::new(),
             device_info,
             config,
-            // SAFETY: `context` was returned by `ibv_open_device` above and is
-            // non-null (a null open set `failure`, which panics before here);
-            // this `Arc<IbvContext>` is its sole owner.
-            context: Arc::new(unsafe { IbvContext::new(context) }),
+            context: context.expect("device context opened above"),
             _marker: PhantomData,
         })
     }

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -14,18 +14,18 @@
 
 use std::ffi::c_void;
 use std::io::Error;
-use std::mem::ManuallyDrop;
 use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
 use std::result::Result;
 use std::sync::Arc;
 
-use super::device::IbvContext;
 use super::memory_region::IbvMemoryRegion;
 use super::memory_region::IbvMemoryRegionView;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
+use super::primitives::IbvPd;
 use super::queue_pair::IbvQueuePair;
 use crate::local_memory::KeepaliveLocalMemory;
 use crate::local_memory::is_device_ptr;
@@ -34,82 +34,35 @@ use crate::local_memory::is_device_ptr;
 ///
 /// # Fields
 ///
-/// * `context`: The owning [`Arc<IbvContext>`]; held (rather than a raw
-///   pointer) so the device context outlives the PD by construction. The PD is
-///   deallocated in `Drop` before this `Arc` is released.
-/// * `pd`: The protection domain pointer (private; read via [`Self::as_ptr`]),
-///   which provides isolation between connections.
 /// * `device_info`: Metadata for the device this PD is allocated on.
 /// * `domain_impl`: The backend [`IbvDomainImpl`] strategy for this PD. It may
-///   own FFI resources allocated against the PD, so `Drop` releases it before
-///   deallocating the PD. Held in a [`ManuallyDrop`] so that ordering can be
-///   enforced by hand.
+///   own FFI resources allocated against the PD, so it is declared before `pd`
+///   and thus dropped first — releasing those resources while the PD is still
+///   alive.
+/// * `pd`: The protection domain (and, through [`IbvPd`], the device context).
+///   Held in an `Arc` because the resources built against it — memory regions
+///   and queue pairs — each keep their own clone (via [`Self::pd`]) to hold the
+///   PD open for as long as they need it, independent of this domain.
 ///
 /// `I` is the backend [`IbvDomainImpl`] strategy parameterizing per-PD
 /// behavior.
 ///
-/// `IbvDomain` is not `Clone`: its `Drop` runs `ibv_dealloc_pd` and copying the
-/// pointer would lead to a double-free. Share the domain across owners via
-/// `Arc<IbvDomain>` instead.
+/// `IbvDomain` is not `Clone`: it owns the backend strategy's FFI resources.
+/// Hand out [`Self::pd`] clones to share the protection domain.
 pub struct IbvDomain<I: IbvDomainImpl> {
-    pub context: Arc<IbvContext>,
-    pd: *mut rdmaxcel_sys::ibv_pd,
     pub device_info: IbvDeviceInfo,
-    domain_impl: ManuallyDrop<I>,
+    domain_impl: I,
+    pd: Arc<IbvPd>,
 }
 
 impl<I: IbvDomainImpl> std::fmt::Debug for IbvDomain<I> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IbvDomain")
-            .field("context", &format!("{:p}", self.context.as_ptr()))
-            .field("pd", &format!("{:p}", self.pd))
+            .field("context", &format!("{:p}", self.pd.context().as_ptr()))
+            .field("pd", &format!("{:p}", self.pd.as_ptr()))
             .field("device_info", &self.device_info)
             .field("domain_impl", &self.domain_impl)
             .finish()
-    }
-}
-
-// SAFETY:
-// IbvDomain is `Send` because the raw pointers to ibverbs structs can be
-// accessed from any thread, and it is safe to drop `IbvDomain` (and run the
-// ibverbs destructors) from any thread.
-unsafe impl<I: IbvDomainImpl> Send for IbvDomain<I> {}
-
-// SAFETY:
-// IbvDomain is `Sync` because the underlying ibverbs APIs are thread-safe.
-unsafe impl<I: IbvDomainImpl> Sync for IbvDomain<I> {}
-
-/// Type-erased keepalive for an [`IbvDomain`] of any backend. Lets holders that
-/// only need to keep a domain's PD (and context) alive — standalone MR guards,
-/// queue pairs — hold an `Arc<dyn IbvDomainKeepalive>` without being generic
-/// over the backend [`IbvDomainImpl`].
-pub(super) trait IbvDomainKeepalive: std::fmt::Debug + Send + Sync {}
-
-impl<I: IbvDomainImpl> IbvDomainKeepalive for IbvDomain<I> {}
-
-impl<I: IbvDomainImpl> Drop for IbvDomain<I> {
-    fn drop(&mut self) {
-        // Drop the backend strategy first: it may own FFI resources allocated
-        // against `pd`, which must be released before the PD is deallocated.
-        // SAFETY: `domain_impl` is dropped exactly once — here — and never
-        // accessed afterward (this is `IbvDomain`'s own `Drop`).
-        unsafe {
-            ManuallyDrop::drop(&mut self.domain_impl);
-        }
-        if self.pd.is_null() {
-            return;
-        }
-        // SAFETY: `pd` was returned by `ibv_alloc_pd` and is deallocated exactly
-        // once (`IbvDomain` is not `Clone`). `context` is a separate field,
-        // dropped only after this returns, so the device is still open here.
-        let result = unsafe { rdmaxcel_sys::ibv_dealloc_pd(self.pd) };
-        if result != 0 {
-            tracing::error!(
-                "failed to deallocate protection domain {:p}: error code {}",
-                self.pd,
-                result
-            );
-        }
     }
 }
 
@@ -157,50 +110,54 @@ impl<I: IbvDomainImpl> IbvDomain<I> {
         // SAFETY: per this function's contract `context` wraps a valid, live
         // `ibv_context`, which is what `I::new` requires to query the device.
         let domain_impl = unsafe { I::new(&context, &device_info, config) };
-        // SAFETY: `context.as_ptr()` is non-null (asserted above) and, per this
-        // function's contract, a valid live `ibv_context` owned by the
-        // `Arc<IbvContext>` for the duration of this call.
-        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(context.as_ptr()) };
-        if pd.is_null() {
-            anyhow::bail!("ibv_alloc_pd failed: {}", Error::last_os_error());
-        }
+        // SAFETY: per this function's contract `context` wraps a valid, live
+        // `ibv_context`, which `IbvPd::create` allocates the PD against. The PD
+        // takes ownership of `context`; the domain reaches it via `pd.context()`.
+        let pd = Arc::new(unsafe { IbvPd::create(context) }?);
         Ok(Self {
-            context,
-            pd,
             device_info,
-            domain_impl: ManuallyDrop::new(domain_impl),
+            domain_impl,
+            pd,
         })
     }
 
     /// Test-only constructor assembling a domain from raw parts without
     /// allocating a PD, so unit tests can fabricate a domain (typically with a
-    /// null `pd`/`context` whose `Drop` is a no-op).
+    /// null `pd` whose `Drop` is a no-op).
     ///
     /// # Safety
     ///
-    /// If `pd` is non-null it must be a protection domain allocated against
-    /// `context` and owned solely by the returned domain (its `Drop` calls
-    /// `ibv_dealloc_pd` once); `context` must satisfy [`IbvContext`]'s validity
-    /// contract.
+    /// `pd` must satisfy [`IbvPd`]'s validity contract.
     #[cfg(test)]
     pub(super) unsafe fn for_test(
-        context: Arc<IbvContext>,
-        pd: *mut rdmaxcel_sys::ibv_pd,
+        pd: Arc<IbvPd>,
         device_info: IbvDeviceInfo,
         domain_impl: I,
     ) -> Self {
         Self {
-            context,
-            pd,
             device_info,
-            domain_impl: ManuallyDrop::new(domain_impl),
+            domain_impl,
+            pd,
         }
     }
 
     /// The protection domain pointer. Valid for the lifetime of `&self`.
     /// Prefer this over touching the field directly (which is private).
     pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_pd {
-        self.pd
+        self.pd.as_ptr()
+    }
+
+    /// The protection domain, shareable as a keepalive. Holders that only need
+    /// the PD (and, through it, the context) kept alive clone this rather than
+    /// the whole domain.
+    pub(super) fn pd(&self) -> &Arc<IbvPd> {
+        &self.pd
+    }
+
+    /// The device context this domain's PD was allocated against, used by the
+    /// data-path verbs.
+    pub fn context(&self) -> &Arc<IbvContext> {
+        self.pd.context()
     }
 
     /// The backend [`IbvDomainImpl`] strategy for this domain.
@@ -500,7 +457,7 @@ pub(super) unsafe fn register_host_or_dmabuf_mr<I: IbvDomainImpl>(
     // the PD past that deregistration; it coerces to `Arc<dyn IbvMemoryRegionKeepalive>`.
     let guard = Arc::new(IbvMemoryRegion {
         mr,
-        _domain: domain,
+        _pd: domain.pd().clone(),
     });
     Ok(IbvMemoryRegionView::new(
         addr,
@@ -583,7 +540,7 @@ mod tests {
         // the assertions below do.
         let region = IbvMemoryRegion {
             mr,
-            _domain: domain.clone(),
+            _pd: domain.pd().clone(),
         };
         // SAFETY: `region` owns `mr` and has not been dropped.
         let (iova, length) = unsafe { mr_extent(region.as_ptr()) };
@@ -600,7 +557,7 @@ mod tests {
             unsafe { register_dmabuf_mr(pd, alloc.ptr() + unaligned, access) }.unwrap();
         let region = IbvMemoryRegion {
             mr,
-            _domain: domain.clone(),
+            _pd: domain.pd().clone(),
         };
         // SAFETY: `region` owns `mr` and has not been dropped.
         let (iova, length) = unsafe { mr_extent(region.as_ptr()) };
@@ -627,7 +584,7 @@ mod tests {
         let mr = unsafe { register_dmabuf_range(pd, alloc.ptr() + offset, size, access) }.unwrap();
         let region = IbvMemoryRegion {
             mr,
-            _domain: domain.clone(),
+            _pd: domain.pd().clone(),
         };
         // SAFETY: `region` owns `mr` and has not been dropped.
         let (iova, length) = unsafe { mr_extent(region.as_ptr()) };

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -12,10 +12,10 @@ use std::sync::Arc;
 
 use typeuri::Named;
 
-use super::device::IbvContext;
 use super::device::IbvDeviceImpl;
 use super::efa_domain::EfaDomain;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use crate::register_ibv_device_impl;
 
 /// AWS EFA (Elastic Fabric Adapter) backend.

--- a/monarch_rdma/src/backend/ibverbs/efa_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_domain.rs
@@ -10,10 +10,10 @@
 
 use std::sync::Arc;
 
-use super::device::IbvContext;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
 use super::queue_pair::legacy::IbvQueuePair;
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -309,7 +309,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         let domain = device.get_or_create_domain(DEFAULT_DOMAIN)?;
 
         // Print device info if MONARCH_DEBUG_RDMA=1 is set.
-        crate::print_device_info_if_debug_enabled(domain.context.as_ptr());
+        crate::print_device_info_if_debug_enabled(domain.context().as_ptr());
 
         self.devices.insert(device_name.to_string(), device);
         Ok(domain)

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use super::domain::IbvDomainKeepalive;
+use super::primitives::IbvPd;
 
 /// Guards the resources behind a registered MR, releasing them when the last
 /// [`IbvMemoryRegionView`] over it drops. Each implementor frees whatever it
@@ -27,19 +27,18 @@ use super::domain::IbvDomainKeepalive;
 pub(super) trait IbvMemoryRegionKeepalive: std::fmt::Debug + Send + Sync {}
 
 /// Guard for a standalone MR registered via `ibv_reg_mr` / `ibv_reg_dmabuf_mr`;
-/// its `Drop` runs `ibv_dereg_mr`. Owns the domain so the PD outlives that
-/// call.
+/// its `Drop` runs `ibv_dereg_mr`. Holds the PD so it outlives that call.
 #[derive(Debug)]
 pub(super) struct IbvMemoryRegion {
     pub(super) mr: *mut rdmaxcel_sys::ibv_mr,
     /// Keepalive for the PD `mr` was registered against; dropped only after
     /// this struct's `Drop` returns, so the PD is alive during `ibv_dereg_mr`.
     /// Never read directly.
-    pub(super) _domain: Arc<dyn IbvDomainKeepalive>,
+    pub(super) _pd: Arc<IbvPd>,
 }
 
 // SAFETY: `mr` is only handed to `ibv_dereg_mr` (which libibverbs treats as
-// thread-safe) and is owned exclusively by this guard; `domain` is itself
+// thread-safe) and is owned exclusively by this guard; `_pd` is itself
 // `Send + Sync`.
 unsafe impl Send for IbvMemoryRegion {}
 unsafe impl Sync for IbvMemoryRegion {}

--- a/monarch_rdma/src/backend/ibverbs/mlx_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_device.rs
@@ -12,10 +12,10 @@ use std::sync::Arc;
 
 use typeuri::Named;
 
-use super::device::IbvContext;
 use super::device::IbvDeviceImpl;
 use super::mlx_domain::MlxDomain;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use crate::register_ibv_device_impl;
 
 /// PCI vendor ID for Mellanox Technologies.

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -27,7 +27,6 @@ use std::sync::OnceLock;
 
 use anyhow::Context;
 
-use super::device::IbvContext;
 use super::device_selection::get_cuda_device_to_ibv_device;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
@@ -39,6 +38,7 @@ use super::mlx_queue_pair::MlxQueuePair;
 use super::primitives::GidScope;
 use super::primitives::GidType;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvQp;
 use super::queue_pair::QpParts;
@@ -277,7 +277,7 @@ impl MlxDomainOps for ProdMlxDomainOps {
         // down in the right order.
         let parts = MlxQueuePair::create_raw_parts(&domain, config)
             .context("could not create loopback QP for mkey binding")?;
-        let context = domain.context.as_ptr();
+        let context = domain.context().as_ptr();
         let access_flags = domain.access_flags();
         let gid = domain.device_info().select_gid(
             config.port_num,
@@ -836,6 +836,7 @@ mod tests {
 
     use super::super::primitives::IbvCq;
     use super::super::primitives::IbvDeviceInfo;
+    use super::super::primitives::IbvPd;
     use super::*;
 
     const MIB2: usize = 2 * 1024 * 1024;
@@ -1040,18 +1041,17 @@ mod tests {
         }
     }
 
-    /// A domain wrapping the mock-driven [`MlxDomain`] under test. Its
-    /// `pd`/`context` are null (no-op `Drop`); the segment views built against
-    /// it hold it only as a keepalive. Drive the strategy via
+    /// A domain wrapping the mock-driven [`MlxDomain`] under test. Its `pd`
+    /// (and, through it, its context) is null (no-op `Drop`); the segment views
+    /// built against it hold it only as a keepalive. Drive the strategy via
     /// [`IbvDomain::domain_impl`].
     fn domain(mock: Arc<MockOps>) -> Arc<IbvDomain<MlxDomain>> {
         let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default());
-        // SAFETY: null `ibv_context*`/`pd` are explicitly allowed — both
-        // `IbvContext` and `IbvDomain` skip their FFI destructors for null.
+        // SAFETY: `IbvPd::null()` holds a null PD (and, through it, a null
+        // context) whose `Drop`s are no-ops.
         unsafe {
             Arc::new(IbvDomain::for_test(
-                Arc::new(IbvContext::new(std::ptr::null_mut())),
-                std::ptr::null_mut(),
+                Arc::new(IbvPd::null()),
                 IbvDeviceInfo::for_test_named("test"),
                 mlx,
             ))

--- a/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
@@ -47,7 +47,7 @@ impl MlxQueuePair {
         domain: &IbvDomain<I>,
         config: &IbvConfig,
     ) -> Result<QpParts, anyhow::Error> {
-        let context = domain.context.as_ptr();
+        let context = domain.context().as_ptr();
         let pd = domain.as_ptr();
         if pd.is_null() {
             anyhow::bail!("cannot create an MlxQueuePair on a null protection domain");
@@ -128,14 +128,22 @@ impl IbvQueuePair for MlxQueuePair {
             Some(GidType::RoCEv2),
         )?;
         let parts = Self::create_raw_parts(&domain, &config)?;
-        let context = domain.context.clone();
+        let context = domain.context().clone();
         let access_flags = domain.access_flags();
 
         // SAFETY: `parts` wraps a live RC QP just created against `domain`'s
         // context/PD with its completion queues; ownership transfers to the
         // inner `RCQueuePair`.
-        let inner =
-            unsafe { RCQueuePair::from_parts(parts, context, config, gid, access_flags, domain) };
+        let inner = unsafe {
+            RCQueuePair::from_parts(
+                parts,
+                context,
+                config,
+                gid,
+                access_flags,
+                domain.pd().clone(),
+            )
+        };
         Ok(MlxQueuePair(inner))
     }
 

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -29,6 +29,7 @@ use std::ffi::CStr;
 use std::fmt;
 use std::io::Error;
 use std::net::Ipv6Addr;
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use anyhow::Context;
@@ -1264,6 +1265,144 @@ impl Drop for IbvQp {
             tracing::error!(
                 "failed to destroy queue pair {:p}: error code {}",
                 self.0,
+                ret
+            );
+        }
+    }
+}
+
+/// RAII owner of a raw `ibv_context*`, closing it in [`Drop`] (a no-op if
+/// null).
+#[derive(Debug)]
+pub struct IbvContext(*mut rdmaxcel_sys::ibv_context);
+
+// SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
+// operations we perform.
+unsafe impl Send for IbvContext {}
+unsafe impl Sync for IbvContext {}
+
+impl IbvContext {
+    /// Wraps a raw `ibv_context*`. A null pointer yields a no-op context
+    /// (its `Drop` does nothing).
+    ///
+    /// # Safety
+    ///
+    /// `context` must be either null or a pointer returned by
+    /// `ibv_open_device` that has not been (and will not be) closed elsewhere:
+    /// the resulting `IbvContext` takes sole ownership and its `Drop` calls
+    /// `ibv_close_device` exactly once.
+    pub(super) unsafe fn from_raw(context: *mut rdmaxcel_sys::ibv_context) -> Self {
+        Self(context)
+    }
+
+    /// Returns the raw `ibv_context*`. The pointer is valid for
+    /// the lifetime of `&self`.
+    pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
+        self.0
+    }
+
+    /// A placeholder holding no context: `as_ptr` returns null and `Drop` is a
+    /// no-op. Used by the test-only `null()` constructors of the pointer
+    /// wrappers that hold a context.
+    #[cfg(test)]
+    pub(super) fn null() -> Self {
+        // SAFETY: a null context is explicitly allowed; `Drop` skips
+        // `ibv_close_device` for null.
+        unsafe { Self::from_raw(std::ptr::null_mut()) }
+    }
+}
+
+impl Drop for IbvContext {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            return;
+        }
+        // SAFETY: `self.0` was returned by `ibv_open_device` and
+        // has not been closed elsewhere.
+        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.0) };
+        if result != 0 {
+            tracing::error!(
+                "ibv_close_device failed for context {:p}: error code {}",
+                self.0,
+                result
+            );
+        }
+    }
+}
+
+/// Owns an `ibv_pd` together with the `Arc<IbvContext>` it was allocated
+/// against, deallocating the PD on drop (a no-op if null) before releasing the
+/// context.
+#[derive(Debug)]
+pub(super) struct IbvPd {
+    pd: *mut rdmaxcel_sys::ibv_pd,
+    /// The context the PD was allocated against, kept open until after
+    /// `ibv_dealloc_pd` and reached by holders via [`Self::context`].
+    context: Arc<IbvContext>,
+}
+
+// SAFETY: the only raw member is the `ibv_pd` pointer. The ibverbs PD it names is
+// not thread-affine — it may be allocated on one thread and used or deallocated
+// on another (`Send`) — and `IbvPd` exposes no operation that mutates the PD
+// through a shared `&` (`as_ptr` only hands back the pointer value), so sharing a
+// `&IbvPd` cannot race (`Sync`).
+unsafe impl Send for IbvPd {}
+// SAFETY: as for `Send` above.
+unsafe impl Sync for IbvPd {}
+
+impl IbvPd {
+    /// Allocates a protection domain against `context`.
+    ///
+    /// # Safety
+    ///
+    /// `context` must wrap a live `ibv_context`; a null context yields `Err`.
+    pub(super) unsafe fn create(context: Arc<IbvContext>) -> Result<Self, anyhow::Error> {
+        if context.as_ptr().is_null() {
+            anyhow::bail!("cannot allocate a protection domain on a null context");
+        }
+        // SAFETY: `context.as_ptr()` is non-null (checked above) and live (caller
+        // contract); `ibv_alloc_pd` returns null on failure.
+        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(context.as_ptr()) };
+        if pd.is_null() {
+            anyhow::bail!("ibv_alloc_pd failed: {}", Error::last_os_error());
+        }
+        Ok(Self { pd, context })
+    }
+
+    /// The raw `ibv_pd`; null for a placeholder that holds no protection domain.
+    pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_pd {
+        self.pd
+    }
+
+    /// The context this PD was allocated against.
+    pub(super) fn context(&self) -> &Arc<IbvContext> {
+        &self.context
+    }
+
+    /// A placeholder holding no protection domain (and a no-op context): both
+    /// `Drop`s are no-ops.
+    #[cfg(test)]
+    pub(super) fn null() -> Self {
+        Self {
+            pd: std::ptr::null_mut(),
+            context: Arc::new(IbvContext::null()),
+        }
+    }
+}
+
+impl Drop for IbvPd {
+    fn drop(&mut self) {
+        if self.pd.is_null() {
+            return;
+        }
+        // SAFETY: a non-null `self.pd` was returned by `ibv_alloc_pd` and, since
+        // `IbvPd` is not `Clone`, is deallocated exactly once. `context` is
+        // dropped only after this returns, so the device is still open here.
+        let ret = unsafe { rdmaxcel_sys::ibv_dealloc_pd(self.pd) };
+        if ret != 0 {
+            tracing::error!(
+                "failed to deallocate protection domain {:p}: error code {}",
+                self.pd,
                 ret
             );
         }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -45,18 +45,18 @@ use typeuri::Named;
 
 use super::IbvBuffer;
 use super::IbvOp;
-use super::device::IbvContext;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
-use super::domain::IbvDomainKeepalive;
 use super::manager_actor::CreatePeerQueuePair;
 use super::memory_region::IbvMemoryRegionView;
 use super::primitives::Gid;
 use super::primitives::GidScope;
 use super::primitives::GidType;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvCq;
 use super::primitives::IbvOperation;
+use super::primitives::IbvPd;
 use super::primitives::IbvQp;
 use super::primitives::IbvQpInfo;
 use super::primitives::IbvWc;
@@ -491,9 +491,9 @@ pub struct RCQueuePair {
     /// Monotonic work-request id, handed out one per posted WR. Standard
     /// ibverbs carries no internal counter, so the QP tracks its own.
     next_wr_id: u64,
-    /// The domain this QP was built against, kept alive so its PD outlives the
-    /// QP. Never read directly.
-    _domain: Arc<dyn IbvDomainKeepalive>,
+    /// The protection domain this QP was built against, kept alive so the PD
+    /// outlives the QP. Never read directly.
+    _pd: Arc<IbvPd>,
 }
 
 impl RCQueuePair {
@@ -505,15 +505,15 @@ impl RCQueuePair {
     ///
     /// `context` must wrap a non-null, live `ibv_context` (the data-path verbs
     /// invoke it without re-checking). `parts.qp` must wrap a live RC `ibv_qp`
-    /// created against that context's device and `domain`'s protection domain,
-    /// with `parts.send_cq`/`parts.recv_cq` as its completion queues.
+    /// created against that context's device and `pd`, with
+    /// `parts.send_cq`/`parts.recv_cq` as its completion queues.
     pub(super) unsafe fn from_parts(
         parts: QpParts,
         context: Arc<IbvContext>,
         config: IbvConfig,
         gid: Gid,
         access_flags: i32,
-        domain: Arc<dyn IbvDomainKeepalive>,
+        pd: Arc<IbvPd>,
     ) -> Self {
         let QpParts {
             qp,
@@ -529,7 +529,7 @@ impl RCQueuePair {
             gid,
             access_flags,
             next_wr_id: 0,
-            _domain: domain,
+            _pd: pd,
         }
     }
 
@@ -623,7 +623,7 @@ impl IbvQueuePair for RCQueuePair {
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an RCQueuePair from config {}", config);
-        let context = domain.context.clone();
+        let context = domain.context().clone();
         let context_ptr = context.as_ptr();
         // `IbvDomain`'s `pd` accessor permits null (e.g. a test domain); a real
         // QP needs one, so reject null up front (`IbvCq::create` likewise rejects
@@ -687,7 +687,16 @@ impl IbvQueuePair for RCQueuePair {
 
         // SAFETY: `parts` wraps a live RC QP just created against `pd`/`context`
         // with its completion queues; ownership transfers to the returned value.
-        Ok(unsafe { Self::from_parts(parts, context, config, gid, access_flags, domain) })
+        Ok(unsafe {
+            Self::from_parts(
+                parts,
+                context,
+                config,
+                gid,
+                access_flags,
+                domain.pd().clone(),
+            )
+        })
     }
 
     fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
@@ -1391,8 +1400,6 @@ mod tests {
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::device_selection::resolve_target;
-    use crate::backend::ibverbs::domain::IbvDomain;
-    use crate::backend::ibverbs::efa_domain::EfaDomain;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
 
@@ -2033,29 +2040,15 @@ mod tests {
     // QueuePairActor op processing
     // =================================================================
 
-    use crate::backend::ibverbs::device::IbvContext;
     use crate::backend::ibverbs::memory_region::IbvMemoryRegion;
-    use crate::backend::ibverbs::primitives::IbvDeviceInfo;
+    use crate::backend::ibverbs::primitives::IbvPd;
     use crate::local_memory::Keepalive;
     use crate::local_memory::KeepaliveLocalMemory;
 
-    /// A throwaway [`IbvDomain`] with null `context`/`pd`, used as the
-    /// `_domain` keepalive of [`fake_mrv`]'s region; its `Drop` deallocs
-    /// nothing (null `pd`).
-    fn null_domain() -> Arc<IbvDomain<EfaDomain>> {
-        // SAFETY: a null `ibv_context*` is explicitly allowed — `IbvContext`'s
-        // `Drop` is a no-op for null, so nothing is ever closed.
-        let context = Arc::new(unsafe { IbvContext::new(std::ptr::null_mut()) });
-        // SAFETY: a null `pd` is allowed — `IbvDomain`'s `Drop` skips
-        // `ibv_dealloc_pd` for null, so nothing is ever freed.
-        Arc::new(unsafe {
-            IbvDomain::for_test(
-                context,
-                std::ptr::null_mut(),
-                IbvDeviceInfo::for_test_named("null_domain"),
-                EfaDomain,
-            )
-        })
+    /// A null [`Arc<IbvPd>`] keepalive for [`fake_mrv`]'s region; its `Drop`
+    /// deallocates nothing (null `pd`/`context`).
+    fn null_pd() -> Arc<IbvPd> {
+        Arc::new(IbvPd::null())
     }
 
     /// No-op [`Keepalive`] for tests that mint a [`KeepaliveLocalMemory`]
@@ -2087,7 +2080,7 @@ mod tests {
             "dev0".to_string(),
             Arc::new(IbvMemoryRegion {
                 mr: std::ptr::null_mut(),
-                _domain: null_domain(),
+                _pd: null_pd(),
             }),
         )
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
@@ -43,10 +43,10 @@ pub struct IbvQueuePair {
     // otherwise the first global RoCE v2 GID on `config.port_num`.
     gid: Gid,
     is_efa: bool,
-    // Keepalive for the domain whose `context`/`pd` this QP was built
-    // against, so it outlives the QP regardless of other owners (the
-    // manager, registered MRs, etc.). Never read directly.
-    _domain: Arc<dyn IbvDomainKeepalive>,
+    // Keepalive for the protection domain this QP was built against, so the PD
+    // outlives the QP regardless of other owners (the manager, registered MRs,
+    // etc.). Never read directly.
+    _pd: Arc<IbvPd>,
 }
 
 impl Drop for IbvQueuePair {
@@ -127,7 +127,7 @@ impl IbvQueuePair {
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an IbvQueuePair from config {}", config);
-        let context = domain.context.as_ptr();
+        let context = domain.context().as_ptr();
         let pd = domain.as_ptr();
         // Resolve Auto to a concrete QP type based on device capabilities.
         let resolved_qp_type = resolve_qp_type(config.qp_type);
@@ -179,7 +179,7 @@ impl IbvQueuePair {
                     config,
                     gid,
                     is_efa: true,
-                    _domain: domain,
+                    _pd: domain.pd().clone(),
                 });
             }
 
@@ -219,7 +219,7 @@ impl IbvQueuePair {
                 config,
                 gid,
                 is_efa: false,
-                _domain: domain,
+                _pd: domain.pd().clone(),
             })
         }
     }


### PR DESCRIPTION
Summary:

Raw ibverbs resources are handled inconsistently today: some (`IbvContext`, `IbvQp`, `IbvCq`) are wrapped in RAII guards, while others are passed around as raw pointers (the domain stores an `ibv_pd*`, and the mlx5dv segment code stores `ibv_mr*`). And where guards do exist, the invariants tying their lifetimes together — for example, a completion queue must outlive the queue pairs that reference it, and a PD must outlive all memory regions registered against it — are enforced ad hoc by higher-level types (`IbvQueuePair`, `IbvDomain`, `IbvMemoryRegionKeepalive`) rather than by the primitives themselves.

This stack makes that handling consistent on two axes: (1) every raw ibverbs pointer type gets a RAII guard, so we store and pass guards everywhere except when calling into the C FFI; and (2) each guard owns the guards it depends on (`IbvPd` an `Arc<IbvContext>`, `IbvMr` an `Arc<IbvPd>`, `Mlx5dvMkey` its `Arc<IbvMr>`s, `IbvQp` its `IbvCq`s and `Arc<IbvPd>`), so correct teardown order holds by construction rather than being tracked by higher-level code.

This first diff adds `IbvPd` (owning the `Arc<IbvContext>` it was allocated against), replacing the raw `ibv_pd*` the domain stored; moves `IbvContext` into `primitives` alongside the other guards; and has `IbvDomain` source its device context from the PD rather than keeping a separate copy.

Reviewed By: zdevito

Differential Revision: D110426795


