### PR TITLE
ibverbs: make IbvQp and IbvCq own their backing resources (#4354)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -36,6 +36,7 @@ use typeuri::Named;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
 use super::primitives::query_device_info;
 
@@ -173,7 +174,7 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
             }
             // SAFETY: `raw_ctx` was just returned by `ibv_open_device` and is
             // non-null (checked above); this `Arc<IbvContext>` is its sole owner.
-            let ctx = Arc::new(unsafe { IbvContext::new(raw_ctx) });
+            let ctx = Arc::new(unsafe { IbvContext::from_raw(raw_ctx) });
             // Assign the device to the first impl that claims it.
             if let Some(reg) = registrations
                 .iter()
@@ -197,63 +198,6 @@ static DEVICE_NAMES_BY_IMPL: LazyLock<HashMap<&'static str, RegisteredBackend>> 
         unsafe { rdmaxcel_sys::ibv_free_device_list(device_list) };
         by_impl
     });
-
-/// RAII owner of a raw `ibv_context*`.
-///
-/// Closes the context in [`Drop`]. Held inside an `Arc` not because
-/// clones are expected to outlive the owning [`IbvDevice`], but so
-/// the raw pointer can be passed around with a lifetime safeguard
-/// where borrow-checked references aren't practical.
-#[derive(Debug)]
-pub struct IbvContext {
-    context: *mut rdmaxcel_sys::ibv_context,
-}
-
-// SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
-// operations we perform (allocation, polling, and the final close).
-unsafe impl Send for IbvContext {}
-unsafe impl Sync for IbvContext {}
-
-impl IbvContext {
-    /// Wraps a raw `ibv_context*`. A null pointer yields a no-op context
-    /// (its `Drop` does nothing).
-    ///
-    /// # Safety
-    ///
-    /// `context` must be either null or a pointer returned by
-    /// `ibv_open_device` that has not been (and will not be) closed elsewhere:
-    /// the resulting `IbvContext` takes sole ownership and its `Drop` calls
-    /// `ibv_close_device` exactly once.
-    pub(super) unsafe fn new(context: *mut rdmaxcel_sys::ibv_context) -> Self {
-        Self { context }
-    }
-
-    /// Returns the raw `ibv_context*`. The pointer is valid for
-    /// the lifetime of `&self`.
-    pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
-        self.context
-    }
-}
-
-impl Drop for IbvContext {
-    fn drop(&mut self) {
-        if self.context.is_null() {
-            return;
-        }
-        // SAFETY: `self.context` was returned by `ibv_open_device` in
-        // `IbvDevice::open` and has not been closed elsewhere. The
-        // intended ownership is a single `Arc<IbvContext>`, whose
-        // final `Drop` calls `ibv_close_device` exactly once.
-        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.context) };
-        if result != 0 {
-            tracing::error!(
-                "ibv_close_device failed for context {:p}: error code {}",
-                self.context,
-                result
-            );
-        }
-    }
-}
 
 /// An opened RDMA device.
 ///
@@ -332,6 +276,7 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             );
         }
         let mut target = std::ptr::null_mut();
+        let mut context = None;
         for i in 0..num_devices {
             // SAFETY: `device_list` is non-null with `num_devices`
             // valid entries (checked above).
@@ -349,7 +294,6 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             }
         }
         let mut failure = None;
-        let mut context: *mut crate::rdmaxcel_sys::ibv_context = std::ptr::null_mut();
         if target.is_null() {
             failure = Some(format!(
                 "ibv device with name {} not found by ibv_get_device_list",
@@ -359,13 +303,17 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             // Open while `target` still points into `device_list`, then free.
             // SAFETY: `target`, when non-null, is one of `device_list`'s
             // entries; `ibv_open_device` returns null on failure.
-            context = unsafe { rdmaxcel_sys::ibv_open_device(target) };
-            if context.is_null() {
+            let raw_context = unsafe { rdmaxcel_sys::ibv_open_device(target) };
+            if raw_context.is_null() {
                 failure = Some(format!(
                     "registered ibv device {} could not be opened: {}",
                     name,
                     std::io::Error::last_os_error(),
                 ));
+            } else {
+                // SAFETY: `raw_context` was just returned by `ibv_open_device` and is
+                // non-null (checked above); this `Arc<IbvContext>` is its sole owner.
+                context = Some(Arc::new(unsafe { IbvContext::from_raw(raw_context) }));
             }
         }
 
@@ -381,10 +329,7 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
             domains: HashMap::new(),
             device_info,
             config,
-            // SAFETY: `context` was returned by `ibv_open_device` above and is
-            // non-null (a null open set `failure`, which panics before here);
-            // this `Arc<IbvContext>` is its sole owner.
-            context: Arc::new(unsafe { IbvContext::new(context) }),
+            context: context.expect("device context opened above"),
             _marker: PhantomData,
         })
     }

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -14,18 +14,18 @@
 
 use std::ffi::c_void;
 use std::io::Error;
-use std::mem::ManuallyDrop;
 use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
 use std::result::Result;
 use std::sync::Arc;
 
-use super::device::IbvContext;
 use super::memory_region::IbvMemoryRegion;
 use super::memory_region::IbvMemoryRegionView;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
+use super::primitives::IbvPd;
 use super::queue_pair::IbvQueuePair;
 use crate::local_memory::KeepaliveLocalMemory;
 use crate::local_memory::is_device_ptr;
@@ -34,82 +34,35 @@ use crate::local_memory::is_device_ptr;
 ///
 /// # Fields
 ///
-/// * `context`: The owning [`Arc<IbvContext>`]; held (rather than a raw
-///   pointer) so the device context outlives the PD by construction. The PD is
-///   deallocated in `Drop` before this `Arc` is released.
-/// * `pd`: The protection domain pointer (private; read via [`Self::as_ptr`]),
-///   which provides isolation between connections.
 /// * `device_info`: Metadata for the device this PD is allocated on.
 /// * `domain_impl`: The backend [`IbvDomainImpl`] strategy for this PD. It may
-///   own FFI resources allocated against the PD, so `Drop` releases it before
-///   deallocating the PD. Held in a [`ManuallyDrop`] so that ordering can be
-///   enforced by hand.
+///   own FFI resources allocated against the PD, so it is declared before `pd`
+///   and thus dropped first — releasing those resources while the PD is still
+///   alive.
+/// * `pd`: The protection domain (and, through [`IbvPd`], the device context).
+///   Held in an `Arc` because the resources built against it — memory regions
+///   and queue pairs — each keep their own clone (via [`Self::pd`]) to hold the
+///   PD open for as long as they need it, independent of this domain.
 ///
 /// `I` is the backend [`IbvDomainImpl`] strategy parameterizing per-PD
 /// behavior.
 ///
-/// `IbvDomain` is not `Clone`: its `Drop` runs `ibv_dealloc_pd` and copying the
-/// pointer would lead to a double-free. Share the domain across owners via
-/// `Arc<IbvDomain>` instead.
+/// `IbvDomain` is not `Clone`: it owns the backend strategy's FFI resources.
+/// Hand out [`Self::pd`] clones to share the protection domain.
 pub struct IbvDomain<I: IbvDomainImpl> {
-    pub context: Arc<IbvContext>,
-    pd: *mut rdmaxcel_sys::ibv_pd,
     pub device_info: IbvDeviceInfo,
-    domain_impl: ManuallyDrop<I>,
+    domain_impl: I,
+    pd: Arc<IbvPd>,
 }
 
 impl<I: IbvDomainImpl> std::fmt::Debug for IbvDomain<I> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IbvDomain")
-            .field("context", &format!("{:p}", self.context.as_ptr()))
-            .field("pd", &format!("{:p}", self.pd))
+            .field("context", &format!("{:p}", self.pd.context().as_ptr()))
+            .field("pd", &format!("{:p}", self.pd.as_ptr()))
             .field("device_info", &self.device_info)
             .field("domain_impl", &self.domain_impl)
             .finish()
-    }
-}
-
-// SAFETY:
-// IbvDomain is `Send` because the raw pointers to ibverbs structs can be
-// accessed from any thread, and it is safe to drop `IbvDomain` (and run the
-// ibverbs destructors) from any thread.
-unsafe impl<I: IbvDomainImpl> Send for IbvDomain<I> {}
-
-// SAFETY:
-// IbvDomain is `Sync` because the underlying ibverbs APIs are thread-safe.
-unsafe impl<I: IbvDomainImpl> Sync for IbvDomain<I> {}
-
-/// Type-erased keepalive for an [`IbvDomain`] of any backend. Lets holders that
-/// only need to keep a domain's PD (and context) alive — standalone MR guards,
-/// queue pairs — hold an `Arc<dyn IbvDomainKeepalive>` without being generic
-/// over the backend [`IbvDomainImpl`].
-pub(super) trait IbvDomainKeepalive: std::fmt::Debug + Send + Sync {}
-
-impl<I: IbvDomainImpl> IbvDomainKeepalive for IbvDomain<I> {}
-
-impl<I: IbvDomainImpl> Drop for IbvDomain<I> {
-    fn drop(&mut self) {
-        // Drop the backend strategy first: it may own FFI resources allocated
-        // against `pd`, which must be released before the PD is deallocated.
-        // SAFETY: `domain_impl` is dropped exactly once — here — and never
-        // accessed afterward (this is `IbvDomain`'s own `Drop`).
-        unsafe {
-            ManuallyDrop::drop(&mut self.domain_impl);
-        }
-        if self.pd.is_null() {
-            return;
-        }
-        // SAFETY: `pd` was returned by `ibv_alloc_pd` and is deallocated exactly
-        // once (`IbvDomain` is not `Clone`). `context` is a separate field,
-        // dropped only after this returns, so the device is still open here.
-        let result = unsafe { rdmaxcel_sys::ibv_dealloc_pd(self.pd) };
-        if result != 0 {
-            tracing::error!(
-                "failed to deallocate protection domain {:p}: error code {}",
-                self.pd,
-                result
-            );
-        }
     }
 }
 
@@ -157,50 +110,54 @@ impl<I: IbvDomainImpl> IbvDomain<I> {
         // SAFETY: per this function's contract `context` wraps a valid, live
         // `ibv_context`, which is what `I::new` requires to query the device.
         let domain_impl = unsafe { I::new(&context, &device_info, config) };
-        // SAFETY: `context.as_ptr()` is non-null (asserted above) and, per this
-        // function's contract, a valid live `ibv_context` owned by the
-        // `Arc<IbvContext>` for the duration of this call.
-        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(context.as_ptr()) };
-        if pd.is_null() {
-            anyhow::bail!("ibv_alloc_pd failed: {}", Error::last_os_error());
-        }
+        // SAFETY: per this function's contract `context` wraps a valid, live
+        // `ibv_context`, which `IbvPd::create` allocates the PD against. The PD
+        // takes ownership of `context`; the domain reaches it via `pd.context()`.
+        let pd = Arc::new(unsafe { IbvPd::create(context) }?);
         Ok(Self {
-            context,
-            pd,
             device_info,
-            domain_impl: ManuallyDrop::new(domain_impl),
+            domain_impl,
+            pd,
         })
     }
 
     /// Test-only constructor assembling a domain from raw parts without
     /// allocating a PD, so unit tests can fabricate a domain (typically with a
-    /// null `pd`/`context` whose `Drop` is a no-op).
+    /// null `pd` whose `Drop` is a no-op).
     ///
     /// # Safety
     ///
-    /// If `pd` is non-null it must be a protection domain allocated against
-    /// `context` and owned solely by the returned domain (its `Drop` calls
-    /// `ibv_dealloc_pd` once); `context` must satisfy [`IbvContext`]'s validity
-    /// contract.
+    /// `pd` must satisfy [`IbvPd`]'s validity contract.
     #[cfg(test)]
     pub(super) unsafe fn for_test(
-        context: Arc<IbvContext>,
-        pd: *mut rdmaxcel_sys::ibv_pd,
+        pd: Arc<IbvPd>,
         device_info: IbvDeviceInfo,
         domain_impl: I,
     ) -> Self {
         Self {
-            context,
-            pd,
             device_info,
-            domain_impl: ManuallyDrop::new(domain_impl),
+            domain_impl,
+            pd,
         }
     }
 
     /// The protection domain pointer. Valid for the lifetime of `&self`.
     /// Prefer this over touching the field directly (which is private).
     pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_pd {
-        self.pd
+        self.pd.as_ptr()
+    }
+
+    /// The protection domain, shareable as a keepalive. Holders that only need
+    /// the PD (and, through it, the context) kept alive clone this rather than
+    /// the whole domain.
+    pub(super) fn pd(&self) -> &Arc<IbvPd> {
+        &self.pd
+    }
+
+    /// The device context this domain's PD was allocated against, used by the
+    /// data-path verbs.
+    pub fn context(&self) -> &Arc<IbvContext> {
+        self.pd.context()
     }
 
     /// The backend [`IbvDomainImpl`] strategy for this domain.
@@ -500,7 +457,7 @@ pub(super) unsafe fn register_host_or_dmabuf_mr<I: IbvDomainImpl>(
     // the PD past that deregistration; it coerces to `Arc<dyn IbvMemoryRegionKeepalive>`.
     let guard = Arc::new(IbvMemoryRegion {
         mr,
-        _domain: domain,
+        _pd: domain.pd().clone(),
     });
     Ok(IbvMemoryRegionView::new(
         addr,
@@ -583,7 +540,7 @@ mod tests {
         // the assertions below do.
         let region = IbvMemoryRegion {
             mr,
-            _domain: domain.clone(),
+            _pd: domain.pd().clone(),
         };
         // SAFETY: `region` owns `mr` and has not been dropped.
         let (iova, length) = unsafe { mr_extent(region.as_ptr()) };
@@ -600,7 +557,7 @@ mod tests {
             unsafe { register_dmabuf_mr(pd, alloc.ptr() + unaligned, access) }.unwrap();
         let region = IbvMemoryRegion {
             mr,
-            _domain: domain.clone(),
+            _pd: domain.pd().clone(),
         };
         // SAFETY: `region` owns `mr` and has not been dropped.
         let (iova, length) = unsafe { mr_extent(region.as_ptr()) };
@@ -627,7 +584,7 @@ mod tests {
         let mr = unsafe { register_dmabuf_range(pd, alloc.ptr() + offset, size, access) }.unwrap();
         let region = IbvMemoryRegion {
             mr,
-            _domain: domain.clone(),
+            _pd: domain.pd().clone(),
         };
         // SAFETY: `region` owns `mr` and has not been dropped.
         let (iova, length) = unsafe { mr_extent(region.as_ptr()) };

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -20,11 +20,11 @@ use std::os::fd::OwnedFd;
 use std::result::Result;
 use std::sync::Arc;
 
-use super::memory_region::IbvMemoryRegion;
 use super::memory_region::IbvMemoryRegionView;
 use super::primitives::IbvConfig;
 use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
+use super::primitives::IbvMr;
 use super::primitives::IbvPd;
 use super::queue_pair::IbvQueuePair;
 use crate::local_memory::KeepaliveLocalMemory;
@@ -255,8 +255,7 @@ pub trait IbvDomainImpl: std::fmt::Debug + Send + Sync + 'static + Sized {
     }
 }
 
-/// Register host memory as a standard MR via `ibv_reg_mr`. Returns the raw
-/// `ibv_mr`; the caller wraps it in an [`IbvMemoryRegion`] guard.
+/// Register host memory as a standard MR via `ibv_reg_mr`.
 ///
 /// # Safety
 ///
@@ -264,27 +263,29 @@ pub trait IbvDomainImpl: std::fmt::Debug + Send + Sync + 'static + Sized {
 /// outlives this call. `[addr, addr + size)` must name a host mapping that
 /// stays valid for the lifetime of the returned MR.
 pub(super) unsafe fn register_host_mr(
-    pd: *mut rdmaxcel_sys::ibv_pd,
+    pd: &Arc<IbvPd>,
     addr: usize,
     size: usize,
     access_flags: i32,
-) -> anyhow::Result<*mut rdmaxcel_sys::ibv_mr> {
-    if pd.is_null() {
+) -> anyhow::Result<IbvMr> {
+    if pd.as_ptr().is_null() {
         anyhow::bail!("register_host_mr called with a null protection domain");
     }
     // SAFETY: `pd` is non-null (checked above) and, per this function's
     // contract, a live protection domain; `[addr, addr + size)` is a
     // caller-guaranteed valid mapping. `ibv_reg_mr` returns null on failure,
     // which we check before returning the pointer.
-    let mr = unsafe { rdmaxcel_sys::ibv_reg_mr(pd, addr as *mut c_void, size, access_flags) };
+    let mr =
+        unsafe { rdmaxcel_sys::ibv_reg_mr(pd.as_ptr(), addr as *mut c_void, size, access_flags) };
     if mr.is_null() {
         anyhow::bail!("failed to register standard MR");
     }
-    Ok(mr)
+    // SAFETY: `mr` is a non-null `ibv_mr` just registered against `pd`.
+    Ok(unsafe { IbvMr::from_raw(mr, pd.clone()) })
 }
 
 /// Register exactly `[addr, addr + size)` of device memory as a dmabuf MR via
-/// `ibv_reg_dmabuf_mr`, mapped at iova 0. Returns the raw `ibv_mr`.
+/// `ibv_reg_dmabuf_mr`, mapped at iova 0.
 ///
 /// `cuMemGetHandleForAddressRange` requires both `addr` and `size` to be
 /// host-page aligned, so this errors if either is not.
@@ -295,12 +296,12 @@ pub(super) unsafe fn register_host_mr(
 /// outlives this call. `[addr, addr + size)` must name device memory that
 /// stays valid for the lifetime of the returned MR.
 pub(super) unsafe fn register_dmabuf_range(
-    pd: *mut rdmaxcel_sys::ibv_pd,
+    pd: &Arc<IbvPd>,
     addr: usize,
     size: usize,
     access_flags: i32,
-) -> anyhow::Result<*mut rdmaxcel_sys::ibv_mr> {
-    if pd.is_null() {
+) -> anyhow::Result<IbvMr> {
+    if pd.as_ptr().is_null() {
         anyhow::bail!("register_dmabuf_range called with a null protection domain");
     }
     // SAFETY: `sysconf` reads a process-global parameter and takes no pointers.
@@ -346,12 +347,14 @@ pub(super) unsafe fn register_dmabuf_range(
     // a live context; `fd` is a valid dmabuf descriptor kept open by the
     // `OwnedFd` across this call; `size` matches the range queried above.
     // `ibv_reg_dmabuf_mr` returns null on failure, which we check.
-    let mr =
-        unsafe { rdmaxcel_sys::ibv_reg_dmabuf_mr(pd, 0, size, 0, fd.as_raw_fd(), access_flags) };
+    let mr = unsafe {
+        rdmaxcel_sys::ibv_reg_dmabuf_mr(pd.as_ptr(), 0, size, 0, fd.as_raw_fd(), access_flags)
+    };
     if mr.is_null() {
         anyhow::bail!("failed to register dmabuf MR");
     }
-    Ok(mr)
+    // SAFETY: `mr` is a non-null `ibv_mr` just registered against `pd`.
+    Ok(unsafe { IbvMr::from_raw(mr, pd.clone()) })
 }
 
 /// Register the CUDA allocation containing `addr` as a dmabuf MR.
@@ -367,10 +370,10 @@ pub(super) unsafe fn register_dmabuf_range(
 /// outlives this call. `addr` must belong to a CUDA device allocation
 /// that stays valid for the lifetime of the returned MR.
 pub(super) unsafe fn register_dmabuf_mr(
-    pd: *mut rdmaxcel_sys::ibv_pd,
+    pd: &Arc<IbvPd>,
     addr: usize,
     access_flags: i32,
-) -> anyhow::Result<(*mut rdmaxcel_sys::ibv_mr, usize)> {
+) -> anyhow::Result<(IbvMr, usize)> {
     // `cuMemGetAddressRange` resolves the pointer in the *current* CUDA context,
     // so make the pointer's own device context current first. Without this, in a
     // multi-GPU process it fails with `CUDA_ERROR_NOT_FOUND` whenever the active
@@ -436,29 +439,26 @@ pub(super) unsafe fn register_host_or_dmabuf_mr<I: IbvDomainImpl>(
     // the returned MR's lifetime.
     let (mr, mr_offset) = unsafe {
         if is_device_ptr(addr) {
-            register_dmabuf_mr(domain.as_ptr(), addr, access_flags)?
+            register_dmabuf_mr(domain.pd(), addr, access_flags)?
         } else {
-            (
-                register_host_mr(domain.as_ptr(), addr, size, access_flags)?,
-                0,
-            )
+            (register_host_mr(domain.pd(), addr, size, access_flags)?, 0)
         }
     };
 
     // SAFETY: `mr` is non-null — `register_dmabuf_mr`/`register_host_mr` only
     // return `Ok` with a non-null, freshly-registered `ibv_mr` — so reading its
     // `addr`/`lkey`/`rkey` here is sound.
-    let (mr_addr, lkey, rkey) = unsafe { ((*mr).addr as usize, (*mr).lkey, (*mr).rkey) };
+    let (mr_addr, lkey, rkey) = unsafe {
+        let p = mr.as_ptr();
+        ((*p).addr as usize, (*p).lkey, (*p).rkey)
+    };
     // The view addresses the requested sub-range, which sits at `mr_offset`
     // within the MR's zero-based address space.
     let rdma_addr = mr_addr + mr_offset;
     let device_name = domain.device_info().name().to_string();
-    // The `IbvMemoryRegion` guard owns the MR (deregistered on its `Drop`) and anchors
-    // the PD past that deregistration; it coerces to `Arc<dyn IbvMemoryRegionKeepalive>`.
-    let guard = Arc::new(IbvMemoryRegion {
-        mr,
-        _pd: domain.pd().clone(),
-    });
+    // The `IbvMr` guard owns the MR (deregistered on its `Drop`) and anchors the
+    // PD past that deregistration; it coerces to `Arc<dyn IbvMemoryRegionKeepalive>`.
+    let guard = Arc::new(mr);
     Ok(IbvMemoryRegionView::new(
         addr,
         rdma_addr,
@@ -513,8 +513,7 @@ mod tests {
     ///
     /// # Safety
     ///
-    /// `mr` must be a live MR (e.g. owned by a not-yet-dropped
-    /// [`IbvMemoryRegion`]).
+    /// `mr` must be a live MR (e.g. owned by a not-yet-dropped [`IbvMr`]).
     unsafe fn mr_extent(mr: *mut rdmaxcel_sys::ibv_mr) -> (usize, usize) {
         // SAFETY: per this function's contract `mr` is a live MR.
         unsafe { ((*mr).addr as usize, (*mr).length) }
@@ -526,24 +525,18 @@ mod tests {
     #[test]
     fn register_dmabuf_mr_covers_whole_allocation() {
         let domain = open_domain_for_cuda_device(0);
-        let pd = domain.as_ptr();
+        let pd = domain.pd();
         let access = domain.access_flags();
         let alloc = committed_allocation();
         let alloc_size = alloc.size();
 
         // At the allocation base: offset 0, MR spans the whole allocation at iova
-        // 0.
+        // 0. `mr` deregisters on drop, after the assertions below.
         // SAFETY: `pd` is a live PD; `alloc.ptr()` is a live CUDA allocation kept
         // mapped by `alloc` for the MR's lifetime.
         let (mr, offset) = unsafe { register_dmabuf_mr(pd, alloc.ptr(), access) }.unwrap();
-        // Wrap immediately so the MR is deregistered on drop regardless of what
-        // the assertions below do.
-        let region = IbvMemoryRegion {
-            mr,
-            _pd: domain.pd().clone(),
-        };
-        // SAFETY: `region` owns `mr` and has not been dropped.
-        let (iova, length) = unsafe { mr_extent(region.as_ptr()) };
+        // SAFETY: `mr` owns a live MR and has not been dropped.
+        let (iova, length) = unsafe { mr_extent(mr.as_ptr()) };
         assert_eq!(offset, 0, "base address sits at offset 0");
         assert_eq!(iova, 0, "dmabuf MR is mapped at iova 0");
         assert_eq!(length, alloc_size, "MR covers the whole allocation");
@@ -555,12 +548,8 @@ mod tests {
         // SAFETY: as above; `alloc.ptr() + unaligned` is inside the allocation.
         let (mr, offset) =
             unsafe { register_dmabuf_mr(pd, alloc.ptr() + unaligned, access) }.unwrap();
-        let region = IbvMemoryRegion {
-            mr,
-            _pd: domain.pd().clone(),
-        };
-        // SAFETY: `region` owns `mr` and has not been dropped.
-        let (iova, length) = unsafe { mr_extent(region.as_ptr()) };
+        // SAFETY: `mr` owns a live MR and has not been dropped.
+        let (iova, length) = unsafe { mr_extent(mr.as_ptr()) };
         assert_eq!(offset, unaligned, "offset locates the requested address");
         assert_eq!(iova, 0, "dmabuf MR is mapped at iova 0");
         assert_eq!(length, alloc_size, "MR covers the whole allocation");
@@ -571,7 +560,7 @@ mod tests {
     #[test]
     fn register_dmabuf_range_registers_exact_range() {
         let domain = open_domain_for_cuda_device(0);
-        let pd = domain.as_ptr();
+        let pd = domain.pd();
         let access = domain.access_flags();
         let alloc = committed_allocation();
 
@@ -582,12 +571,8 @@ mod tests {
         // SAFETY: `pd` is a live PD; `[alloc.ptr() + offset, ... + size)` is a
         // host-page-aligned range within the fully mapped allocation.
         let mr = unsafe { register_dmabuf_range(pd, alloc.ptr() + offset, size, access) }.unwrap();
-        let region = IbvMemoryRegion {
-            mr,
-            _pd: domain.pd().clone(),
-        };
-        // SAFETY: `region` owns `mr` and has not been dropped.
-        let (iova, length) = unsafe { mr_extent(region.as_ptr()) };
+        // SAFETY: `mr` owns a live MR and has not been dropped.
+        let (iova, length) = unsafe { mr_extent(mr.as_ptr()) };
         assert_eq!(iova, 0, "dmabuf MR is mapped at iova 0");
         assert_eq!(length, size, "MR covers exactly the requested sub-range");
     }
@@ -597,7 +582,7 @@ mod tests {
     #[test]
     fn register_dmabuf_range_rejects_unaligned_addr() {
         let domain = open_domain_for_cuda_device(0);
-        let pd = domain.as_ptr();
+        let pd = domain.pd();
         let access = domain.access_flags();
         let alloc = committed_allocation();
 
@@ -617,7 +602,7 @@ mod tests {
     #[test]
     fn register_dmabuf_range_rejects_unaligned_size() {
         let domain = open_domain_for_cuda_device(0);
-        let pd = domain.as_ptr();
+        let pd = domain.pd();
         let access = domain.access_flags();
         let alloc = committed_allocation();
 
@@ -635,9 +620,9 @@ mod tests {
     #[test]
     fn register_dmabuf_range_rejects_null_pd() {
         let page = host_page_size();
+        let null_pd = Arc::new(IbvPd::null());
         // SAFETY: a null PD is the documented error path; no memory is touched.
-        let err =
-            unsafe { register_dmabuf_range(std::ptr::null_mut(), page, page, 0) }.unwrap_err();
+        let err = unsafe { register_dmabuf_range(&null_pd, page, page, 0) }.unwrap_err();
         assert!(
             err.to_string().contains("null protection domain"),
             "unexpected error: {err}"

--- a/monarch_rdma/src/backend/ibverbs/efa_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_device.rs
@@ -12,10 +12,10 @@ use std::sync::Arc;
 
 use typeuri::Named;
 
-use super::device::IbvContext;
 use super::device::IbvDeviceImpl;
 use super::efa_domain::EfaDomain;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use crate::register_ibv_device_impl;
 
 /// AWS EFA (Elastic Fabric Adapter) backend.

--- a/monarch_rdma/src/backend/ibverbs/efa_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_domain.rs
@@ -10,10 +10,10 @@
 
 use std::sync::Arc;
 
-use super::device::IbvContext;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
 use super::queue_pair::legacy::IbvQueuePair;
 

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -309,7 +309,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         let domain = device.get_or_create_domain(DEFAULT_DOMAIN)?;
 
         // Print device info if MONARCH_DEBUG_RDMA=1 is set.
-        crate::print_device_info_if_debug_enabled(domain.context.as_ptr());
+        crate::print_device_info_if_debug_enabled(domain.context().as_ptr());
 
         self.devices.insert(device_name.to_string(), device);
         Ok(domain)

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use super::primitives::IbvPd;
+use super::primitives::IbvMr;
 
 /// Guards the resources behind a registered MR, releasing them when the last
 /// [`IbvMemoryRegionView`] over it drops. Each implementor frees whatever it
@@ -26,53 +26,9 @@ use super::primitives::IbvPd;
 /// `Arc<dyn IbvMemoryRegionKeepalive>`.
 pub(super) trait IbvMemoryRegionKeepalive: std::fmt::Debug + Send + Sync {}
 
-/// Guard for a standalone MR registered via `ibv_reg_mr` / `ibv_reg_dmabuf_mr`;
-/// its `Drop` runs `ibv_dereg_mr`. Holds the PD so it outlives that call.
-#[derive(Debug)]
-pub(super) struct IbvMemoryRegion {
-    pub(super) mr: *mut rdmaxcel_sys::ibv_mr,
-    /// Keepalive for the PD `mr` was registered against; dropped only after
-    /// this struct's `Drop` returns, so the PD is alive during `ibv_dereg_mr`.
-    /// Never read directly.
-    pub(super) _pd: Arc<IbvPd>,
-}
-
-// SAFETY: `mr` is only handed to `ibv_dereg_mr` (which libibverbs treats as
-// thread-safe) and is owned exclusively by this guard; `_pd` is itself
-// `Send + Sync`.
-unsafe impl Send for IbvMemoryRegion {}
-unsafe impl Sync for IbvMemoryRegion {}
-
-impl IbvMemoryRegionKeepalive for IbvMemoryRegion {}
-
-#[cfg(test)]
-impl IbvMemoryRegion {
-    /// The raw `ibv_mr` this guard owns. Valid until the guard drops (which
-    /// deregisters it).
-    pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_mr {
-        self.mr
-    }
-}
-
-impl Drop for IbvMemoryRegion {
-    fn drop(&mut self) {
-        if self.mr.is_null() {
-            return;
-        }
-        // SAFETY: `mr` is non-null (checked above), was returned by
-        // `ibv_reg_mr` / `ibv_reg_dmabuf_mr`, and is deregistered exactly once
-        // (a value's `Drop` runs once). The PD it was registered against is
-        // still alive: `domain` is dropped only after this returns.
-        let result = unsafe { rdmaxcel_sys::ibv_dereg_mr(self.mr) };
-        if result != 0 {
-            tracing::error!(
-                "failed to deregister MR at {:p}: error code {}",
-                self.mr,
-                result
-            );
-        }
-    }
-}
+/// A standalone [`IbvMr`] guards its own registration: its `Drop` runs
+/// `ibv_dereg_mr` against the PD it owns.
+impl IbvMemoryRegionKeepalive for IbvMr {}
 
 /// A cloneable handle to a slice of registered memory: the keys and addresses
 /// a peer needs, plus an `Arc<dyn IbvMemoryRegionKeepalive>` keepalive.

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -17,7 +17,7 @@
 
 use std::sync::Arc;
 
-use super::domain::IbvDomainKeepalive;
+use super::primitives::IbvPd;
 
 /// Guards the resources behind a registered MR, releasing them when the last
 /// [`IbvMemoryRegionView`] over it drops. Each implementor frees whatever it
@@ -27,19 +27,18 @@ use super::domain::IbvDomainKeepalive;
 pub(super) trait IbvMemoryRegionKeepalive: std::fmt::Debug + Send + Sync {}
 
 /// Guard for a standalone MR registered via `ibv_reg_mr` / `ibv_reg_dmabuf_mr`;
-/// its `Drop` runs `ibv_dereg_mr`. Owns the domain so the PD outlives that
-/// call.
+/// its `Drop` runs `ibv_dereg_mr`. Holds the PD so it outlives that call.
 #[derive(Debug)]
 pub(super) struct IbvMemoryRegion {
     pub(super) mr: *mut rdmaxcel_sys::ibv_mr,
     /// Keepalive for the PD `mr` was registered against; dropped only after
     /// this struct's `Drop` returns, so the PD is alive during `ibv_dereg_mr`.
     /// Never read directly.
-    pub(super) _domain: Arc<dyn IbvDomainKeepalive>,
+    pub(super) _pd: Arc<IbvPd>,
 }
 
 // SAFETY: `mr` is only handed to `ibv_dereg_mr` (which libibverbs treats as
-// thread-safe) and is owned exclusively by this guard; `domain` is itself
+// thread-safe) and is owned exclusively by this guard; `_pd` is itself
 // `Send + Sync`.
 unsafe impl Send for IbvMemoryRegion {}
 unsafe impl Sync for IbvMemoryRegion {}

--- a/monarch_rdma/src/backend/ibverbs/mlx_device.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_device.rs
@@ -12,10 +12,10 @@ use std::sync::Arc;
 
 use typeuri::Named;
 
-use super::device::IbvContext;
 use super::device::IbvDeviceImpl;
 use super::mlx_domain::MlxDomain;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use crate::register_ibv_device_impl;
 
 /// PCI vendor ID for Mellanox Technologies.

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -27,7 +27,6 @@ use std::sync::OnceLock;
 
 use anyhow::Context;
 
-use super::device::IbvContext;
 use super::device_selection::get_cuda_device_to_ibv_device;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
@@ -39,6 +38,7 @@ use super::mlx_queue_pair::MlxQueuePair;
 use super::primitives::GidScope;
 use super::primitives::GidType;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvQp;
 use super::queue_pair::QpParts;
@@ -277,7 +277,7 @@ impl MlxDomainOps for ProdMlxDomainOps {
         // down in the right order.
         let parts = MlxQueuePair::create_raw_parts(&domain, config)
             .context("could not create loopback QP for mkey binding")?;
-        let context = domain.context.as_ptr();
+        let context = domain.context().as_ptr();
         let access_flags = domain.access_flags();
         let gid = domain.device_info().select_gid(
             config.port_num,
@@ -836,6 +836,7 @@ mod tests {
 
     use super::super::primitives::IbvCq;
     use super::super::primitives::IbvDeviceInfo;
+    use super::super::primitives::IbvPd;
     use super::*;
 
     const MIB2: usize = 2 * 1024 * 1024;
@@ -1040,18 +1041,17 @@ mod tests {
         }
     }
 
-    /// A domain wrapping the mock-driven [`MlxDomain`] under test. Its
-    /// `pd`/`context` are null (no-op `Drop`); the segment views built against
-    /// it hold it only as a keepalive. Drive the strategy via
+    /// A domain wrapping the mock-driven [`MlxDomain`] under test. Its `pd`
+    /// (and, through it, its context) is null (no-op `Drop`); the segment views
+    /// built against it hold it only as a keepalive. Drive the strategy via
     /// [`IbvDomain::domain_impl`].
     fn domain(mock: Arc<MockOps>) -> Arc<IbvDomain<MlxDomain>> {
         let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default());
-        // SAFETY: null `ibv_context*`/`pd` are explicitly allowed — both
-        // `IbvContext` and `IbvDomain` skip their FFI destructors for null.
+        // SAFETY: `IbvPd::null()` holds a null PD (and, through it, a null
+        // context) whose `Drop`s are no-ops.
         unsafe {
             Arc::new(IbvDomain::for_test(
-                Arc::new(IbvContext::new(std::ptr::null_mut())),
-                std::ptr::null_mut(),
+                Arc::new(IbvPd::null()),
                 IbvDeviceInfo::for_test_named("test"),
                 mlx,
             ))

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -13,11 +13,12 @@
 //! to an indirect mlx5dv memory key so a whole allocator segment is
 //! addressable through a single key.
 //!
-//! The segment scanning + binding bookkeeping lives here in Rust. Every
-//! device/FFI touch goes through [`MlxDomainOps`] so the (intricate)
-//! scan/bind/teardown logic can be unit-tested against a mock; the
-//! production implementation ([`ProdMlxDomainOps`]) delegates to the real
-//! functions and the [`rdmaxcel_sys::rdmaxcel_bind_mr_list`] shim.
+//! The segment scanning + binding bookkeeping lives here in Rust. Resource
+//! creation goes through [`MlxDomainOps`] so the (intricate) scan/bind logic
+//! can be unit-tested against a mock; the production implementation
+//! ([`ProdMlxDomainOps`]) delegates to the real functions and the
+//! [`rdmaxcel_sys::rdmaxcel_bind_mr_list`] shim. Teardown is the `Drop` of the
+//! owning RAII wrappers ([`IbvMr`], [`Mlx5dvMkey`]), correct by construction.
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -40,6 +41,8 @@ use super::primitives::GidType;
 use super::primitives::IbvConfig;
 use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
+use super::primitives::IbvMr;
+use super::primitives::IbvPd;
 use super::primitives::IbvQp;
 use super::queue_pair::QpParts;
 use super::queue_pair::connect;
@@ -104,9 +107,11 @@ fn scan_cuda_segments() -> Vec<ScannedSegment> {
 // ===========================================================================
 
 /// Device/FFI operations the mlx5dv binding logic depends on. Production
-/// uses [`ProdMlxDomainOps`]; tests substitute a mock so the scan/bind/
-/// teardown algorithm can be exercised without hardware. The raw FFI
-/// pointer types are used directly — the mock fabricates fake pointers.
+/// uses [`ProdMlxDomainOps`]; tests substitute a mock so the scan/bind
+/// algorithm can be exercised without hardware. Creation returns the owning
+/// RAII wrappers ([`IbvMr`], [`Mlx5dvMkey`]), which free their resources in the
+/// right order on `Drop`; the mock fabricates null-handle wrappers whose `Drop`
+/// is a no-op.
 pub(super) trait MlxDomainOps: Send + Sync + 'static {
     /// Name of the RDMA device this domain drives.
     fn device_name(&self) -> String;
@@ -121,27 +126,19 @@ pub(super) trait MlxDomainOps: Send + Sync + 'static {
     /// Enumerate the currently-live CUDA segments.
     fn scan_segments(&self) -> Vec<ScannedSegment>;
 
-    /// Register `[addr, addr + size)` of device memory as a dmabuf MR.
+    /// Register `[addr, addr + size)` of device memory as a dmabuf MR, returned
+    /// as an [`IbvMr`] (owning `pd`) that deregisters it on drop.
     ///
     /// # Safety
     ///
-    /// If `pd` is non-null it must be a live protection domain whose context
-    /// outlives this call.
+    /// `pd`, if non-null, must wrap a live protection domain.
     unsafe fn register_dmabuf_range(
         &self,
-        pd: *mut rdmaxcel_sys::ibv_pd,
+        pd: &Arc<IbvPd>,
         addr: usize,
         size: usize,
         access: i32,
-    ) -> anyhow::Result<*mut rdmaxcel_sys::ibv_mr>;
-
-    /// Deregister an MR returned by [`Self::register_dmabuf_range`].
-    ///
-    /// # Safety
-    ///
-    /// `mr` must be null or an MR returned by [`Self::register_dmabuf_range`] that
-    /// has not already been deregistered.
-    unsafe fn dereg_mr(&self, mr: *mut rdmaxcel_sys::ibv_mr);
+    ) -> anyhow::Result<IbvMr>;
 
     /// Creates a loopback-connected queue pair against `domain`'s PD, returning
     /// it and the two completion queues backing it bundled in a [`QpParts`]. The
@@ -158,35 +155,21 @@ pub(super) trait MlxDomainOps: Send + Sync + 'static {
     ) -> anyhow::Result<QpParts>;
 
     /// Bind `mrs` to a freshly created indirect key using `qp`'s work-request
-    /// builder, returning the new key.
+    /// builder, returning it as a [`Mlx5dvMkey`] owning those MR references. On
+    /// failure the `mrs` are dropped.
     ///
     /// # Safety
     ///
     /// `pd` (if non-null) must be a live protection domain, `qp` a valid queue
-    /// pair, and every element of `mrs` a live MR — all valid for this call.
+    /// pair, and each MR in `mrs` null or a live MR allocated against `pd` — all
+    /// valid for this call.
     unsafe fn bind_mr_list(
         &self,
-        pd: *mut rdmaxcel_sys::ibv_pd,
+        pd: &IbvPd,
         qp: &IbvQp,
         access: i32,
-        mrs: &[*mut rdmaxcel_sys::ibv_mr],
-    ) -> anyhow::Result<*mut rdmaxcel_sys::mlx5dv_mkey>;
-
-    /// Destroy a key created by [`Self::bind_mr_list`].
-    ///
-    /// # Safety
-    ///
-    /// `mkey` must be null or a key returned by [`Self::bind_mr_list`] that has
-    /// not already been destroyed.
-    unsafe fn destroy_mkey(&self, mkey: *mut rdmaxcel_sys::mlx5dv_mkey);
-
-    /// The `(lkey, rkey)` of a bound key, or `None` if `mkey` is null.
-    ///
-    /// # Safety
-    ///
-    /// If `mkey` is non-null it must be a live key returned by
-    /// [`Self::bind_mr_list`].
-    unsafe fn mkey_keys(&self, mkey: *mut rdmaxcel_sys::mlx5dv_mkey) -> Option<(u32, u32)>;
+        mrs: Vec<Arc<IbvMr>>,
+    ) -> anyhow::Result<Mlx5dvMkey>;
 }
 
 /// Production [`MlxDomainOps`] backed by the real ibverbs / mlx5dv FFI.
@@ -246,25 +229,13 @@ impl MlxDomainOps for ProdMlxDomainOps {
 
     unsafe fn register_dmabuf_range(
         &self,
-        pd: *mut rdmaxcel_sys::ibv_pd,
+        pd: &Arc<IbvPd>,
         addr: usize,
         size: usize,
         access: i32,
-    ) -> anyhow::Result<*mut rdmaxcel_sys::ibv_mr> {
+    ) -> anyhow::Result<IbvMr> {
         // SAFETY: forwards this method's contract (non-null `pd` is a live PD).
         unsafe { register_dmabuf_range(pd, addr, size, access) }
-    }
-
-    unsafe fn dereg_mr(&self, mr: *mut rdmaxcel_sys::ibv_mr) {
-        if mr.is_null() {
-            return;
-        }
-        // SAFETY: `mr` was returned by `register_dmabuf_range` and is dereg'd
-        // exactly once.
-        let result = unsafe { rdmaxcel_sys::ibv_dereg_mr(mr) };
-        if result != 0 {
-            tracing::error!("failed to deregister MR at {:p}: error code {}", mr, result);
-        }
     }
 
     unsafe fn create_loopback_qp_parts(
@@ -300,51 +271,127 @@ impl MlxDomainOps for ProdMlxDomainOps {
 
     unsafe fn bind_mr_list(
         &self,
-        pd: *mut rdmaxcel_sys::ibv_pd,
+        pd: &IbvPd,
         qp: &IbvQp,
         access: i32,
-        mrs: &[*mut rdmaxcel_sys::ibv_mr],
-    ) -> anyhow::Result<*mut rdmaxcel_sys::mlx5dv_mkey> {
-        if pd.is_null() || qp.as_ptr().is_null() {
+        mrs: Vec<Arc<IbvMr>>,
+    ) -> anyhow::Result<Mlx5dvMkey> {
+        if pd.as_ptr().is_null() || qp.as_ptr().is_null() {
             anyhow::bail!("bind_mr_list called with a null protection domain or queue pair");
         }
-        // `rdmaxcel_bind_mr_list` creates the indirect key in place when the
-        // `mkey` out-param starts null, which it always does here.
+        let ptrs: Vec<*mut rdmaxcel_sys::ibv_mr> = mrs
+            .iter()
+            .map(|m| {
+                let p = m.as_ptr();
+                if p.is_null() {
+                    Err(anyhow::anyhow!(
+                        "bind_mr_list called with a null memory region"
+                    ))
+                } else {
+                    Ok(p)
+                }
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        // A null out-param makes `rdmaxcel_bind_mr_list` create the key in place.
         let mut mkey: *mut rdmaxcel_sys::mlx5dv_mkey = std::ptr::null_mut();
-        // SAFETY: `pd` and `qp` are non-null (checked above) and valid; `mrs` is
-        // a contiguous array of `mrs.len()` non-null MRs; `mkey` is created in
-        // place. `rdmaxcel_bind_mr_list` reports any failure via its return code.
+        // SAFETY: `pd`/`qp` are non-null (checked above) and valid, `ptrs` holds
+        // the MRs' pointers, and failure is reported via the return code.
         let ret = unsafe {
             rdmaxcel_sys::rdmaxcel_bind_mr_list(
-                pd,
+                pd.as_ptr(),
                 qp.as_ptr(),
                 access,
-                mrs.as_ptr() as *mut *mut rdmaxcel_sys::ibv_mr,
-                mrs.len(),
+                ptrs.as_ptr() as *mut *mut rdmaxcel_sys::ibv_mr,
+                ptrs.len(),
                 &mut mkey,
             )
         };
         if ret != 0 {
             anyhow::bail!("rdmaxcel_bind_mr_list failed: error code {}", ret);
         }
-        Ok(mkey)
+        // SAFETY: `mkey` is a live key freshly bound over `mrs` (`ret == 0`).
+        Ok(unsafe { Mlx5dvMkey::from_raw(mkey, mrs) })
+    }
+}
+
+/// Owns an `mlx5dv_mkey` together with the [`Arc<IbvMr>`]s it binds, destroying
+/// the key on drop (a no-op if null). Caches the `(lkey, rkey)` read at bind
+/// time so a view can address through the key without further FFI.
+///
+/// The MRs are `Arc` because successive keys over a growing segment bind
+/// overlapping sets; an MR is deregistered only once the last key referencing it
+/// drops.
+#[derive(Debug)]
+pub(super) struct Mlx5dvMkey {
+    mkey: *mut rdmaxcel_sys::mlx5dv_mkey,
+    lkey: u32,
+    rkey: u32,
+    mrs: Vec<Arc<IbvMr>>,
+}
+
+// SAFETY: the only raw member is the `mlx5dv_mkey` pointer (the MRs are already
+// `Send`/`Sync`), which the mlx5dv API treats as usable and destroyable from any
+// thread (`Send`); `Mlx5dvMkey` exposes no operation that mutates the key
+// through a shared `&` (`keys` reads immutable fields), so sharing a
+// `&Mlx5dvMkey` cannot race (`Sync`).
+unsafe impl Send for Mlx5dvMkey {}
+// SAFETY: as for `Send` above.
+unsafe impl Sync for Mlx5dvMkey {}
+
+impl Mlx5dvMkey {
+    /// Takes ownership of a raw `mlx5dv_mkey` bound over `mrs`, reading its
+    /// `(lkey, rkey)` and destroying it on drop.
+    ///
+    /// # Safety
+    ///
+    /// `mkey` must be a live key returned by `rdmaxcel_bind_mr_list` over `mrs`,
+    /// owned solely by the returned value.
+    pub(super) unsafe fn from_raw(
+        mkey: *mut rdmaxcel_sys::mlx5dv_mkey,
+        mrs: Vec<Arc<IbvMr>>,
+    ) -> Self {
+        // SAFETY: per this function's contract `mkey` is a live bound key, so its
+        // `lkey`/`rkey` fields are initialized.
+        let (lkey, rkey) = unsafe { ((*mkey).lkey, (*mkey).rkey) };
+        Self {
+            mkey,
+            lkey,
+            rkey,
+            mrs,
+        }
     }
 
-    unsafe fn destroy_mkey(&self, mkey: *mut rdmaxcel_sys::mlx5dv_mkey) {
-        if mkey.is_null() {
-            return;
-        }
-        // SAFETY: `mkey` was created by `rdmaxcel_bind_mr_list` and is
-        // destroyed exactly once.
-        unsafe { rdmaxcel_sys::rdmaxcel_destroy_mkey(mkey) };
+    /// The `(lkey, rkey)` to address memory through this key.
+    fn keys(&self) -> (u32, u32) {
+        (self.lkey, self.rkey)
     }
 
-    unsafe fn mkey_keys(&self, mkey: *mut rdmaxcel_sys::mlx5dv_mkey) -> Option<(u32, u32)> {
-        if mkey.is_null() {
-            return None;
+    /// The MRs this key binds.
+    fn mrs(&self) -> &Vec<Arc<IbvMr>> {
+        &self.mrs
+    }
+
+    /// Fabricates a key with the given `(lkey, rkey)` over a null `mkey` (whose
+    /// `Drop` is a no-op), binding `mrs`. Lets the mock hand back a usable key
+    /// without touching the FFI.
+    #[cfg(test)]
+    pub(super) fn with_test_keys(lkey: u32, rkey: u32, mrs: Vec<Arc<IbvMr>>) -> Self {
+        Self {
+            mkey: std::ptr::null_mut(),
+            lkey,
+            rkey,
+            mrs,
         }
-        // SAFETY: `mkey` is non-null (checked above), a key bound by `bind_mr_list`.
-        Some(unsafe { ((*mkey).lkey, (*mkey).rkey) })
+    }
+}
+
+impl Drop for Mlx5dvMkey {
+    fn drop(&mut self) {
+        if !self.mkey.is_null() {
+            // SAFETY: a non-null `self.mkey` came from `rdmaxcel_bind_mr_list`
+            // and, since `Mlx5dvMkey` is not `Clone`, is destroyed exactly once.
+            unsafe { rdmaxcel_sys::rdmaxcel_destroy_mkey(self.mkey) };
+        }
     }
 }
 
@@ -352,53 +399,24 @@ impl MlxDomainOps for ProdMlxDomainOps {
 // RegisteredSegment: a CUDA segment bound to an indirect key
 // ===========================================================================
 
-/// [`IbvMemoryRegionKeepalive`] for a segment-bound mlx5dv MR: a no-op (no
-/// `Drop`). It pins the owning [`RegisteredSegment`] — which deregisters its MRs
-/// and destroys its keys on its own `Drop` — and the domain (PD keepalive).
-///
-/// `_segment` is declared before `_domain` so it drops first (struct fields
-/// drop in declaration order). Each [`IbvDomain`] stores its [`IbvDomainImpl`]
-/// (here, [`MlxDomain`]), so an `IbvDomain<MlxDomain>` itself holds a strong
-/// reference to every `Arc<RegisteredSegment>` it has bound. Were `_domain`
-/// dropped before `_segment`, the PD could be deallocated before a segment
-/// registered against it — wrong. Dropping `_segment` first won't actually free
-/// the segment (the domain still references it), but it ensures that once the
-/// last `_domain` reference drops, the segment is freed before the PD is
-/// deallocated.
-#[derive(Debug)]
-struct Mlx5dvMemoryRegion {
-    _segment: Arc<RegisteredSegment>,
-    _domain: Arc<IbvDomain<MlxDomain>>,
-}
-
-impl IbvMemoryRegionKeepalive for Mlx5dvMemoryRegion {}
-
-/// The mutable state of a [`RegisteredSegment`], behind one `Mutex` so the MRs,
-/// current key, size, and superseded keys all change together.
+/// The mutable state of a [`RegisteredSegment`], behind one `Mutex` so the
+/// current key, superseded keys, and size all change together.
 #[derive(Debug)]
 struct RegisteredSegmentState {
-    /// Active dmabuf MRs covering `[base_virtual_addr, base_virtual_addr +
-    /// size)`, in order; all bound to `mkey`. Appended to (never replaced) as
-    /// the segment grows.
-    mrs: Vec<*mut rdmaxcel_sys::ibv_mr>,
-    /// Current indirect key over `mrs`. Swapped on growth; the prior key moves
-    /// to `stale_mkeys`.
-    mkey: *mut rdmaxcel_sys::mlx5dv_mkey,
-    /// Bytes currently covered by `mrs` and bound to `mkey`.
+    /// Keys superseded by growth, each still owning the MRs it bound, kept alive
+    /// so views built against an earlier key stay valid.
+    stale_mkeys: Vec<Mlx5dvMkey>,
+    /// Current indirect key over the segment's MRs. `None` until the first bind;
+    /// swapped on growth, the prior key moved to `stale_mkeys`.
+    mkey: Option<Mlx5dvMkey>,
+    /// Bytes currently covered by `mkey`.
     size: usize,
-    /// Keys superseded by growth, kept alive so views built against an earlier
-    /// key stay valid; all destroyed when the segment drops.
-    stale_mkeys: Vec<*mut rdmaxcel_sys::mlx5dv_mkey>,
 }
 
 /// A CUDA segment bound to the device via an indirect mlx5dv key, covering
 /// `[base_virtual_addr, base_virtual_addr + size)`. Shared as
-/// `Arc<RegisteredSegment>` by [`MlxDomain`] and every view over it. On growth
-/// it reuses its existing MRs (registering only the new tail), binds those plus
-/// the new MRs to a fresh key, and parks the prior key in `stale_mkeys` so
-/// views built against it stay valid; the MRs and every key are released on
-/// [`Drop`] (keys first), once nothing — neither [`MlxDomain`] nor any live
-/// view — references the segment.
+/// `Arc<RegisteredSegment>` by [`MlxDomain`] and every view over it, so it (and
+/// the keys, MRs, and PD it owns) lives until nothing references it.
 ///
 /// All mutation is serialized by the owning [`MlxDomain`]'s `segments` lock;
 /// `state` is behind a `Mutex` only to allow mutation through the shared `Arc`.
@@ -420,16 +438,6 @@ impl std::fmt::Debug for RegisteredSegment {
     }
 }
 
-// SAFETY: the only members that aren't already `Send`/`Sync` are the raw
-// `ibv_mr`/`mlx5dv_mkey` pointers in `state`. The ibverbs/mlx5dv objects they
-// name are not thread-affine — any thread may use or destroy them (Send) — and
-// all access to them is serialized behind `state`'s `Mutex` (Sync). The sole
-// lock-free use reads `lkey`/`rkey` off a bound mkey, which are immutable once
-// bound (growth binds a new key and parks the old one rather than mutating it),
-// so that read is race-free.
-unsafe impl Send for RegisteredSegment {}
-unsafe impl Sync for RegisteredSegment {}
-
 impl RegisteredSegment {
     /// An unbound segment for `base_virtual_addr`: no MRs, no key, zero size.
     /// [`Self::grow`] binds its first generation.
@@ -438,10 +446,9 @@ impl RegisteredSegment {
             ops,
             base_virtual_addr,
             state: Mutex::new(RegisteredSegmentState {
-                mrs: Vec::new(),
-                mkey: std::ptr::null_mut(),
-                size: 0,
                 stale_mkeys: Vec::new(),
+                mkey: None,
+                size: 0,
             }),
         }
     }
@@ -471,7 +478,7 @@ impl RegisteredSegment {
     /// queue pair, both valid for this call.
     unsafe fn grow(
         &self,
-        pd: *mut rdmaxcel_sys::ibv_pd,
+        pd: &Arc<IbvPd>,
         qp: &IbvQp,
         access: i32,
         scanned_seg: &ScannedSegment,
@@ -498,7 +505,7 @@ impl RegisteredSegment {
         }
         // SAFETY: per this function's contract `pd` is null or a live PD and
         // `qp` a valid QP; the tail MRs registered here belong to this segment.
-        let new_mrs = unsafe {
+        let new_tail = unsafe {
             register_range(
                 &self.ops,
                 pd,
@@ -508,57 +515,48 @@ impl RegisteredSegment {
             )
         }?;
 
-        // Bind the existing + new MRs to a brand-new key; clean up the new MRs
-        // (and leave the segment untouched) if it fails.
-        let mut all = state.mrs.clone();
-        all.extend(new_mrs.iter().copied());
-        // SAFETY: same contract; `all` are this segment's live MRs (existing +
-        // freshly registered above).
-        let new_mkey = match unsafe { self.ops.bind_mr_list(pd, qp, access, &all) } {
-            Ok(mkey) => mkey,
-            Err(e) => {
-                // SAFETY: `new_mrs` were just returned by `register_range` and
-                // are deregistered exactly once here.
-                new_mrs
-                    .iter()
-                    .for_each(|mr| unsafe { self.ops.dereg_mr(*mr) });
-                return Err(e);
-            }
-        };
+        // Bind the existing MRs (reused from the current key) plus the new tail
+        // to a fresh key. On failure `all` is dropped by `bind_mr_list`: the new
+        // tail's MRs deregister while the existing ones survive via the current
+        // key, leaving the segment unchanged.
+        let mut all = state
+            .mkey
+            .as_ref()
+            .map(|k| k.mrs().clone())
+            .unwrap_or_default();
+        all.extend(new_tail);
+        // SAFETY: same contract; `all` are this segment's live MRs.
+        let new_mkey = unsafe { self.ops.bind_mr_list(pd, qp, access, all) }?;
 
-        // Commit: keep the new MRs, retire the prior key (the first bind from
-        // `empty` has none), advance the size.
-        state.mrs.extend(new_mrs);
-        let prior = std::mem::replace(&mut state.mkey, new_mkey);
-        if !prior.is_null() {
+        // Retire the prior key (kept for in-flight ops built against it) and
+        // install the new one.
+        if let Some(prior) = state.mkey.replace(new_mkey) {
             state.stale_mkeys.push(prior);
         }
         state.size = scanned_seg.size;
         Ok(())
     }
 
-    /// Build a view anchored at `addr`. The view's guard pins `seg` (and
-    /// `domain`) alive for its lifetime, so the bound key stays valid while the
-    /// view is in use. Indirect keys present their MRs as a flat zero-based
-    /// space, so `rdma_addr` is the offset from the segment base.
-    fn view(
-        seg: &Arc<Self>,
-        addr: usize,
-        size: usize,
-        domain: Arc<IbvDomain<MlxDomain>>,
-    ) -> IbvMemoryRegionView {
-        let mkey = seg.state.lock().expect("segment state lock poisoned").mkey;
-        // SAFETY: `view` is only called on a segment that covers the request,
-        // which means it has been bound, so `mkey` is a live key from
-        // `bind_mr_list`. If `mkey` is null, `mkey_keys` will just return `None`.
-        let (lkey, rkey) =
-            unsafe { seg.ops.mkey_keys(mkey) }.expect("view of a segment with no bound key");
-        // `Arc<Mlx5dvMemoryRegion>` coerces to `Arc<dyn IbvMemoryRegionKeepalive>`; it pins this segment
-        // (which owns the MRs + keys) and the domain (PD) for the view's life.
-        let guard = Arc::new(Mlx5dvMemoryRegion {
-            _segment: Arc::clone(seg),
-            _domain: domain,
-        });
+    /// Build a view anchored at `addr`. The view's guard is the segment itself,
+    /// pinning it (and thus its current key, the key's MRs, and the PD they own)
+    /// alive for the view's lifetime, so the bound key stays valid while the view
+    /// is in use. Indirect keys present their MRs as a flat zero-based space, so
+    /// `rdma_addr` is the offset from the segment base.
+    fn view(seg: &Arc<Self>, addr: usize, size: usize) -> IbvMemoryRegionView {
+        let (lkey, rkey) = {
+            let state = seg.state.lock().expect("segment state lock poisoned");
+            // `view` is only called on a segment that covers the request, which
+            // means it has been bound, so the current key is `Some`.
+            state
+                .mkey
+                .as_ref()
+                .map(Mlx5dvMkey::keys)
+                .expect("view of a segment with no bound key")
+        };
+        // The segment is its own keepalive: cloning the `Arc<RegisteredSegment>`
+        // pins the current key (which owns the MRs, which own the PD) for the
+        // view's life.
+        let guard: Arc<dyn IbvMemoryRegionKeepalive> = seg.clone();
         IbvMemoryRegionView::new(
             addr,
             addr - seg.base_virtual_addr,
@@ -571,31 +569,13 @@ impl RegisteredSegment {
     }
 }
 
-impl Drop for RegisteredSegment {
-    fn drop(&mut self) {
-        // Destroy the current and every superseded key before the MRs they
-        // reference, so no key briefly points at a deregistered MR.
-        // TODO: invalidate keys before destroying them, to fence in-flight
-        // remote access.
-        let state = self.state.get_mut().expect("segment state lock poisoned");
-        // SAFETY: `state.mkey`, `stale_mkeys`, and `mrs` are this segment's own
-        // keys/MRs from `bind_mr_list`/`register_dmabuf_range` (or null), each
-        // destroyed/deregistered exactly once here.
-        unsafe {
-            self.ops.destroy_mkey(state.mkey);
-            for mkey in state.stale_mkeys.drain(..) {
-                self.ops.destroy_mkey(mkey);
-            }
-            for mr in state.mrs.drain(..) {
-                self.ops.dereg_mr(mr);
-            }
-        }
-    }
-}
+// A `RegisteredSegment` is its own MR keepalive: it owns the current key, which
+// owns the bound MRs, which own the PD — all freed in order on its `Drop`.
+impl IbvMemoryRegionKeepalive for RegisteredSegment {}
 
 /// Register `[start, start + len)` of device memory as dmabuf MRs in
 /// `<= MAX_MR_SIZE` chunks. All-or-nothing: on any failure the MRs registered
-/// so far are deregistered before returning the error.
+/// so far drop (deregistering) as the returned `Vec` unwinds.
 ///
 /// # Safety
 ///
@@ -603,12 +583,12 @@ impl Drop for RegisteredSegment {
 /// outlives this call.
 unsafe fn register_range(
     ops: &Arc<dyn MlxDomainOps>,
-    pd: *mut rdmaxcel_sys::ibv_pd,
+    pd: &Arc<IbvPd>,
     access: i32,
     start: usize,
     len: usize,
-) -> anyhow::Result<Vec<*mut rdmaxcel_sys::ibv_mr>> {
-    let mut mrs: Vec<*mut rdmaxcel_sys::ibv_mr> = Vec::new();
+) -> anyhow::Result<Vec<Arc<IbvMr>>> {
+    let mut mrs: Vec<Arc<IbvMr>> = Vec::new();
     let mut chunk_start = start;
     let mut remaining = len;
     while remaining > 0 {
@@ -623,15 +603,9 @@ unsafe fn register_range(
                 MR_ALIGNMENT
             ))
         };
-        match result {
-            Ok(mr) => mrs.push(mr),
-            Err(e) => {
-                // SAFETY: the MRs in `mrs` were returned by `register_dmabuf_range`
-                // above and are deregistered exactly once here.
-                mrs.iter().for_each(|mr| unsafe { ops.dereg_mr(*mr) });
-                return Err(e);
-            }
-        }
+        // On error, return early; the MRs collected so far drop here,
+        // deregistering them.
+        mrs.push(Arc::new(result?));
         chunk_start += chunk;
         remaining -= chunk;
     }
@@ -720,7 +694,7 @@ impl MlxDomain {
         addr: usize,
         size: usize,
     ) -> anyhow::Result<IbvMemoryRegionView> {
-        let pd = domain.as_ptr();
+        let pd = domain.pd();
         let access = self.access_flags();
         let mut segments = self
             .segments
@@ -729,7 +703,7 @@ impl MlxDomain {
 
         // Fast path: a current binding already covers the request.
         if let Some(seg) = segments.values().find(|s| s.covers(addr, size)) {
-            return Ok(RegisteredSegment::view(seg, addr, size, Arc::clone(domain)));
+            return Ok(RegisteredSegment::view(seg, addr, size));
         }
 
         // Pull live segments and keep only the ones on ordinals we serve.
@@ -776,7 +750,7 @@ impl MlxDomain {
         segments
             .values()
             .find(|s| s.covers(addr, size))
-            .map(|s| RegisteredSegment::view(s, addr, size, Arc::clone(domain)))
+            .map(|s| RegisteredSegment::view(s, addr, size))
             .ok_or_else(|| {
                 anyhow::anyhow!(
                     "CUDA address 0x{:x} + size {} is not covered by any scanned segment on the CUDA ordinals {:?} mapped to this NIC",
@@ -830,13 +804,11 @@ impl IbvDomainImpl for MlxDomain {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
     use std::sync::Mutex;
     use std::sync::MutexGuard;
 
     use super::super::primitives::IbvCq;
     use super::super::primitives::IbvDeviceInfo;
-    use super::super::primitives::IbvPd;
     use super::*;
 
     const MIB2: usize = 2 * 1024 * 1024;
@@ -859,18 +831,20 @@ mod tests {
         access: i32,
     }
 
-    /// A recorded (successful) `bind_mr_list` call: the MR handles bound, as
-    /// `usize`.
-    #[derive(Debug, Clone, PartialEq, Eq)]
+    /// A recorded (successful) `bind_mr_list` call: the MRs it bound (compared
+    /// by `Arc::ptr_eq`, since the mock's MRs wrap null pointers).
+    #[derive(Debug, Clone)]
     struct BindCall {
-        mrs: Vec<usize>,
+        mrs: Vec<Arc<IbvMr>>,
     }
 
-    /// Recorded state + scripted behavior for [`MockOps`]. FFI pointers are
-    /// fabricated as incrementing integers cast to the real pointer types.
-    /// `live_*` track outstanding registrations for leak assertions; the
-    /// `*_calls` / `*_log` vectors record each call's arguments in order so
-    /// tests can assert on them.
+    /// Recorded state + scripted behavior for [`MockOps`]. Creation calls
+    /// (`dmabuf_calls`, `bind_calls`, `scan_calls`, `loopback_created`) are
+    /// recorded so tests can assert on the scan/bind algorithm. The returned
+    /// [`IbvMr`]/[`Mlx5dvMkey`] wrap null handles, and the loopback [`QpParts`]
+    /// holds null [`IbvQp`]/[`IbvCq`]s, so their `Drop` is a no-op and FFI
+    /// teardown is not observed here — that ordering is structurally guaranteed
+    /// by ownership and exercised by the hardware tests.
     #[derive(Default)]
     struct MockState {
         device_name: String,
@@ -878,11 +852,8 @@ mod tests {
         served_ordinals: Vec<i32>,
         scan: Vec<ScannedSegment>,
         next_handle: usize,
-        live_mrs: HashSet<usize>,
-        live_mkeys: HashSet<usize>,
-        /// Number of `create_loopback_qp_parts` calls. The mock returns a null
-        /// [`IbvQp`] (RAII destruction is type-guaranteed, not observable here),
-        /// so this counter is how tests check the QP is created once and reused.
+        /// Number of `create_loopback_qp_parts` calls; tests check the QP is
+        /// created once and reused.
         loopback_created: usize,
         fail_dmabuf_after: Option<usize>,
         fail_bind: bool,
@@ -891,20 +862,6 @@ mod tests {
         dmabuf_calls: Vec<DmabufCall>,
         /// Every successful `bind_mr_list` call.
         bind_calls: Vec<BindCall>,
-        /// `mr` handle passed to each `dereg_mr`, in order.
-        dereg_log: Vec<usize>,
-        /// `mkey` handle passed to each `destroy_mkey`, in order.
-        destroy_log: Vec<usize>,
-        /// Teardown events in order: "mkey" on `destroy_mkey`, "mr" on
-        /// `dereg_mr`. Lets a test assert keys are destroyed before MRs.
-        teardown_order: Vec<&'static str>,
-        /// When set, `dereg_mr` records whether this (weakly-held) domain is
-        /// still alive at each MR deregistration. Lets a test assert a
-        /// segment's MRs are freed while its domain's PD is still alive.
-        domain_probe: Option<std::sync::Weak<IbvDomain<MlxDomain>>>,
-        /// One entry per `dereg_mr` while `domain_probe` is set: whether the
-        /// probed domain was still alive.
-        domain_alive_at_dereg: Vec<bool>,
     }
 
     impl MockState {
@@ -957,11 +914,11 @@ mod tests {
 
         unsafe fn register_dmabuf_range(
             &self,
-            _pd: *mut rdmaxcel_sys::ibv_pd,
+            _pd: &Arc<IbvPd>,
             addr: usize,
             size: usize,
             access: i32,
-        ) -> anyhow::Result<*mut rdmaxcel_sys::ibv_mr> {
+        ) -> anyhow::Result<IbvMr> {
             let mut s = self.lock();
             s.dmabuf_calls.push(DmabufCall { addr, size, access });
             if let Some(n) = s.fail_dmabuf_after
@@ -969,22 +926,8 @@ mod tests {
             {
                 anyhow::bail!("mock dmabuf registration failure");
             }
-            let h = s.mint();
-            s.live_mrs.insert(h);
-            Ok(h as *mut rdmaxcel_sys::ibv_mr)
-        }
-
-        unsafe fn dereg_mr(&self, mr: *mut rdmaxcel_sys::ibv_mr) {
-            let mut s = self.lock();
-            let v = mr as usize;
-            s.live_mrs.remove(&v);
-            s.dereg_log.push(v);
-            s.teardown_order.push("mr");
-            let probe = s.domain_probe.clone();
-            if let Some(probe) = probe {
-                let alive = probe.upgrade().is_some();
-                s.domain_alive_at_dereg.push(alive);
-            }
+            // A null MR: its `Drop` is a no-op, so the mock need not track it.
+            Ok(IbvMr::null())
         }
 
         unsafe fn create_loopback_qp_parts(
@@ -992,8 +935,7 @@ mod tests {
             _domain: Arc<IbvDomain<MlxDomain>>,
             _config: &IbvConfig,
         ) -> anyhow::Result<QpParts> {
-            // The mock has no live context to back a real QP or CQs, so it
-            // returns null placeholders and just counts the call.
+            // Null placeholders (their `Drop` is a no-op); just count the call.
             self.lock().loopback_created += 1;
             Ok(QpParts {
                 qp: IbvQp::null(),
@@ -1004,47 +946,26 @@ mod tests {
 
         unsafe fn bind_mr_list(
             &self,
-            _pd: *mut rdmaxcel_sys::ibv_pd,
+            _pd: &IbvPd,
             _qp: &IbvQp,
             _access: i32,
-            mrs: &[*mut rdmaxcel_sys::ibv_mr],
-        ) -> anyhow::Result<*mut rdmaxcel_sys::mlx5dv_mkey> {
+            mrs: Vec<Arc<IbvMr>>,
+        ) -> anyhow::Result<Mlx5dvMkey> {
             let mut s = self.lock();
             if s.fail_bind {
                 anyhow::bail!("mock bind failure");
             }
-            s.bind_calls.push(BindCall {
-                mrs: mrs.iter().map(|mr| *mr as usize).collect(),
-            });
-            let h = s.mint();
-            s.live_mkeys.insert(h);
-            Ok(h as *mut rdmaxcel_sys::mlx5dv_mkey)
-        }
-
-        unsafe fn destroy_mkey(&self, mkey: *mut rdmaxcel_sys::mlx5dv_mkey) {
-            if mkey.is_null() {
-                return;
-            }
-            let mut s = self.lock();
-            let v = mkey as usize;
-            s.live_mkeys.remove(&v);
-            s.destroy_log.push(v);
-            s.teardown_order.push("mkey");
-        }
-
-        unsafe fn mkey_keys(&self, mkey: *mut rdmaxcel_sys::mlx5dv_mkey) -> Option<(u32, u32)> {
-            if mkey.is_null() {
-                return None;
-            }
-            let v = mkey as usize as u32;
-            Some((v, v ^ 0xffff))
+            s.bind_calls.push(BindCall { mrs: mrs.clone() });
+            // Derive distinct keys from a freshly minted handle so tests can tell
+            // segments and generations apart; the key wraps a null `mkey`.
+            let v = s.mint() as u32;
+            Ok(Mlx5dvMkey::with_test_keys(v, v ^ 0xffff, mrs))
         }
     }
 
     /// A domain wrapping the mock-driven [`MlxDomain`] under test. Its `pd`
-    /// (and, through it, its context) is null (no-op `Drop`); the segment views
-    /// built against it hold it only as a keepalive. Drive the strategy via
-    /// [`IbvDomain::domain_impl`].
+    /// (and, through it, its context) is null (no-op `Drop`). Drive the strategy
+    /// via [`IbvDomain::domain_impl`].
     fn domain(mock: Arc<MockOps>) -> Arc<IbvDomain<MlxDomain>> {
         let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default());
         // SAFETY: `IbvPd::null()` holds a null PD (and, through it, a null
@@ -1072,8 +993,10 @@ mod tests {
         }
     }
 
-    fn null_pd() -> *mut rdmaxcel_sys::ibv_pd {
-        std::ptr::null_mut()
+    /// A null `Arc<IbvPd>` for driving [`RegisteredSegment::grow`] directly; the
+    /// `MockOps` never dereference it.
+    fn null_pd() -> Arc<IbvPd> {
+        Arc::new(IbvPd::null())
     }
 
     fn null_qp() -> IbvQp {
@@ -1088,8 +1011,8 @@ mod tests {
     /// Bind a fresh segment `[base, base + size)`: an empty segment grown once.
     fn bind_fresh(ops: &Arc<MockOps>, base: usize, size: usize) -> Arc<RegisteredSegment> {
         let segment = Arc::new(RegisteredSegment::empty(dyn_ops(ops), base));
-        // SAFETY: `MockOps` ignores the raw `pd`/`qp`; the nulls are never deref'd.
-        unsafe { segment.grow(null_pd(), &null_qp(), 0, &seg(base, size, 0)) }
+        // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
+        unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, size, 0)) }
             .expect("fresh bind should succeed");
         segment
     }
@@ -1117,6 +1040,11 @@ mod tests {
             rs.state.lock().unwrap().stale_mkeys.is_empty(),
             "a fresh segment has no superseded keys"
         );
+        assert_eq!(
+            rs.state.lock().unwrap().mkey.as_ref().unwrap().mrs().len(),
+            1,
+            "the current key binds the one MR"
+        );
         let s = ops.lock();
         assert_eq!(
             s.dmabuf_calls,
@@ -1129,8 +1057,6 @@ mod tests {
         );
         assert_eq!(s.bind_calls.len(), 1);
         assert_eq!(s.bind_calls[0].mrs.len(), 1, "one MR bound");
-        assert_eq!(s.live_mrs.len(), 1);
-        assert_eq!(s.live_mkeys.len(), 1, "one mkey created");
     }
 
     #[test]
@@ -1141,7 +1067,10 @@ mod tests {
         // both bound to a single key.
         let rs = bind_fresh(&ops, base, MAX_MR_SIZE + MIB2);
 
-        assert_eq!(rs.state.lock().unwrap().mrs.len(), 2);
+        assert_eq!(
+            rs.state.lock().unwrap().mkey.as_ref().unwrap().mrs().len(),
+            2
+        );
         let s = ops.lock();
         assert_eq!(
             s.dmabuf_calls,
@@ -1165,8 +1094,6 @@ mod tests {
             2,
             "both chunk MRs bound to one key"
         );
-        assert_eq!(s.live_mrs.len(), 2);
-        assert_eq!(s.live_mkeys.len(), 1);
     }
 
     #[test]
@@ -1174,16 +1101,16 @@ mod tests {
         let ops = MockOps::new(SERVED_NIC, true, &[0]);
         let base = 0x10_0000_0000;
         let rs = bind_fresh(&ops, base, MIB2);
-        let mkey_a = *ops.lock().live_mkeys.iter().next().unwrap();
-        let mr_a = ops.lock().bind_calls[0].mrs[0];
+        let mkey_a = rs.state.lock().unwrap().mkey.as_ref().unwrap().keys();
+        let mr_a = ops.lock().bind_calls[0].mrs[0].clone();
 
-        // SAFETY: `MockOps` ignores the raw `pd`/`qp`; the nulls are never deref'd.
-        unsafe { rs.grow(null_pd(), &null_qp(), 0, &seg(base, 2 * MIB2, 0)) }
+        // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
+        unsafe { rs.grow(&null_pd(), &null_qp(), 0, &seg(base, 2 * MIB2, 0)) }
             .expect("growth should succeed");
 
         assert_eq!(rs.size(), 2 * MIB2);
         assert_eq!(
-            rs.state.lock().unwrap().mrs.len(),
+            rs.state.lock().unwrap().mkey.as_ref().unwrap().mrs().len(),
             2,
             "the original MR is reused and one tail MR appended"
         );
@@ -1191,6 +1118,11 @@ mod tests {
             rs.state.lock().unwrap().stale_mkeys.len(),
             1,
             "the prior key is parked as stale"
+        );
+        assert_eq!(
+            rs.state.lock().unwrap().stale_mkeys[0].keys(),
+            mkey_a,
+            "the parked key is the original, not a fresh one"
         );
         let s = ops.lock();
         // Only the new tail is registered; the original MR is reused.
@@ -1211,30 +1143,16 @@ mod tests {
             "growth registers only the new tail, at base + MIB2"
         );
         assert_eq!(s.bind_calls.len(), 2);
-        assert_eq!(
-            s.bind_calls[0].mrs,
-            vec![mr_a],
+        assert_eq!(s.bind_calls[0].mrs.len(), 1);
+        assert!(
+            Arc::ptr_eq(&s.bind_calls[0].mrs[0], &mr_a),
             "the first bind covered just the original MR"
         );
-        let mr_tail = s.bind_calls[1].mrs[1];
-        assert_eq!(
-            s.bind_calls[1].mrs,
-            vec![mr_a, mr_tail],
-            "the second bind reuses the original MR and adds the tail"
-        );
-        assert_eq!(
-            s.live_mrs.len(),
-            2,
-            "only one new MR registered (tail reuse)"
-        );
-        assert_eq!(
-            s.live_mkeys.len(),
-            2,
-            "the prior key is kept alongside the new current key"
-        );
+        assert_eq!(s.bind_calls[1].mrs.len(), 2);
         assert!(
-            s.live_mkeys.contains(&mkey_a),
-            "the prior key was parked, not destroyed"
+            Arc::ptr_eq(&s.bind_calls[1].mrs[0], &mr_a)
+                && !Arc::ptr_eq(&s.bind_calls[1].mrs[1], &mr_a),
+            "the second bind reuses the original MR and adds a new tail"
         );
     }
 
@@ -1246,10 +1164,10 @@ mod tests {
         // The fresh bind used one dmabuf call; fail the second tail chunk.
         ops.lock().fail_dmabuf_after = Some(2);
 
-        // SAFETY: `MockOps` ignores the raw `pd`/`qp`; the nulls are never deref'd.
+        // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
         let result = unsafe {
             rs.grow(
-                null_pd(),
+                &null_pd(),
                 &null_qp(),
                 0,
                 &seg(base, MAX_MR_SIZE + 2 * MIB2, 0),
@@ -1262,7 +1180,7 @@ mod tests {
 
         assert_eq!(rs.size(), MIB2, "size unchanged after a failed growth");
         assert_eq!(
-            rs.state.lock().unwrap().mrs.len(),
+            rs.state.lock().unwrap().mkey.as_ref().unwrap().mrs().len(),
             1,
             "no tail MRs committed"
         );
@@ -1270,14 +1188,8 @@ mod tests {
             rs.state.lock().unwrap().stale_mkeys.is_empty(),
             "no key retired"
         );
-        let s = ops.lock();
         assert_eq!(
-            s.live_mrs.len(),
-            1,
-            "the partially-registered tail MR was cleaned up"
-        );
-        assert_eq!(
-            s.bind_calls.len(),
+            ops.lock().bind_calls.len(),
             1,
             "only the original bind happened; the growth bind was never reached"
         );
@@ -1291,14 +1203,14 @@ mod tests {
         let binds_before = ops.lock().bind_calls.len();
 
         // A scan reporting the same size must be a no-op rather than re-binding.
-        // SAFETY: `MockOps` ignores the raw `pd`/`qp`; the nulls are never deref'd.
-        unsafe { rs.grow(null_pd(), &null_qp(), 0, &seg(base, 2 * MIB2, 0)) }
+        // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
+        unsafe { rs.grow(&null_pd(), &null_qp(), 0, &seg(base, 2 * MIB2, 0)) }
             .expect("equal-size grow is a no-op");
 
         assert_eq!(rs.size(), 2 * MIB2, "size is unchanged");
         let s = ops.lock();
         assert_eq!(s.bind_calls.len(), binds_before, "no new bind performed");
-        assert_eq!(s.live_mrs.len(), 1, "no new MR registered");
+        assert_eq!(s.dmabuf_calls.len(), 1, "no new MR registered");
     }
 
     #[test]
@@ -1308,7 +1220,7 @@ mod tests {
         let rs = bind_fresh(&ops, base, MIB2);
 
         assert!(rs.covers(base + 0x400, 4096));
-        let view = RegisteredSegment::view(&rs, base + 0x400, 4096, domain(ops.clone()));
+        let view = RegisteredSegment::view(&rs, base + 0x400, 4096);
         assert_eq!(
             view.rdma_addr, 0x400,
             "rdma_addr is the offset from the segment base"
@@ -1337,19 +1249,20 @@ mod tests {
         let segment = RegisteredSegment::empty(dyn_ops(&ops), base);
 
         // Two chunks; the second dmabuf registration fails.
-        // SAFETY: `MockOps` ignores the raw `pd`/`qp`; the nulls are never deref'd.
+        // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
         let result =
-            unsafe { segment.grow(null_pd(), &null_qp(), 0, &seg(base, MAX_MR_SIZE + MIB2, 0)) };
+            unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, MAX_MR_SIZE + MIB2, 0)) };
         assert!(
             result.is_err(),
             "the first bind fails when a chunk registration fails"
         );
         assert_eq!(segment.size(), 0, "the segment is left empty");
+        assert!(
+            segment.state.lock().unwrap().mkey.is_none(),
+            "no key installed"
+        );
         let s = ops.lock();
-        assert_eq!(s.dereg_log.len(), 1, "the first chunk's MR is cleaned up");
-        assert!(s.live_mrs.is_empty(), "no MR leaks after partial failure");
         assert!(s.bind_calls.is_empty(), "no bind performed");
-        assert!(s.live_mkeys.is_empty(), "no mkey created");
     }
 
     #[test]
@@ -1359,77 +1272,13 @@ mod tests {
         let base = 0x10_0000_0000;
         let segment = RegisteredSegment::empty(dyn_ops(&ops), base);
 
-        // SAFETY: `MockOps` ignores the raw `pd`/`qp`; the nulls are never deref'd.
-        let result = unsafe { segment.grow(null_pd(), &null_qp(), 0, &seg(base, MIB2, 0)) };
+        // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
+        let result = unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, MIB2, 0)) };
         assert!(result.is_err(), "the bind fails when bind_mr_list fails");
         assert_eq!(segment.size(), 0, "the segment is left empty");
-        let s = ops.lock();
-        assert_eq!(
-            s.dereg_log.len(),
-            1,
-            "the freshly-registered MR is cleaned up"
-        );
-        assert!(s.live_mrs.is_empty(), "no MR leaks after bind failure");
-        assert!(s.live_mkeys.is_empty(), "no mkey created on bind failure");
-    }
-
-    #[test]
-    fn test_drop_destroys_all_keys_before_mrs() {
-        let ops = MockOps::new(SERVED_NIC, true, &[0]);
-        let base = 0x10_0000_0000;
-        let rs = bind_fresh(&ops, base, MIB2);
-        // Grow once so the segment carries a parked (stale) key plus its
-        // current key, and two MRs.
-        // SAFETY: `MockOps` ignores the raw `pd`/`qp`; the nulls are never deref'd.
-        unsafe { rs.grow(null_pd(), &null_qp(), 0, &seg(base, 2 * MIB2, 0)) }
-            .expect("growth should succeed");
-        assert_eq!(ops.lock().live_mrs.len(), 2);
-        assert_eq!(ops.lock().live_mkeys.len(), 2);
-
-        drop(rs); // last `Arc` ref → `RegisteredSegment::drop`
-
-        let s = ops.lock();
-        assert!(s.live_mrs.is_empty(), "drop frees the MRs");
         assert!(
-            s.live_mkeys.is_empty(),
-            "drop destroys the current + stale keys"
-        );
-        assert_eq!(
-            s.teardown_order,
-            vec!["mkey", "mkey", "mr", "mr"],
-            "every key is destroyed before any MR it might reference"
-        );
-    }
-
-    #[test]
-    fn test_view_guard_drops_segment_before_domain() {
-        // The `Mlx5dvMemoryRegion` guard inside a view declares `_segment` before
-        // `_domain`, so the segment's MRs are deregistered while the domain's
-        // PD is still alive. Drive a real view through drop and confirm that at
-        // each MR deregistration the weakly-probed domain is still alive.
-        let ops = MockOps::new(SERVED_NIC, true, &[0]);
-        let base = 0x10_0000_0000;
-        let rs = bind_fresh(&ops, base, MIB2);
-        let domain = domain(ops.clone());
-        ops.lock().domain_probe = Some(Arc::downgrade(&domain));
-
-        let view = RegisteredSegment::view(&rs, base, 4096, Arc::clone(&domain));
-
-        // Make the view's guard the sole owner of both the segment and the
-        // domain, so dropping the view drops each exactly once, in field order.
-        drop(rs);
-        drop(domain);
-
-        drop(view);
-
-        let s = ops.lock();
-        assert!(
-            !s.domain_alive_at_dereg.is_empty(),
-            "dropping the view deregistered the segment's MR"
-        );
-        assert!(
-            s.domain_alive_at_dereg.iter().all(|&alive| alive),
-            "the segment's MRs are freed before the domain is dropped"
+            segment.state.lock().unwrap().mkey.is_none(),
+            "no key installed on bind failure"
         );
     }
 
@@ -1457,7 +1306,7 @@ mod tests {
         assert_eq!(view.rdma_addr, 0, "view is anchored at the segment base");
         assert_eq!(view.size, 4096);
         assert_eq!(view.device_name, SERVED_NIC);
-        assert_eq!(mock.lock().live_mkeys.len(), 1, "one segment bound");
+        assert_eq!(mock.lock().bind_calls.len(), 1, "one segment bound");
     }
 
     #[test]
@@ -1494,15 +1343,10 @@ mod tests {
             register_cuda(&domain, base + MIB2, 4096).expect("growth registration should succeed");
 
         assert_eq!(view.rdma_addr, MIB2, "the view anchors into the grown tail");
-        let s = mock.lock();
         assert_eq!(
-            s.live_mkeys.len(),
+            mock.lock().bind_calls.len(),
             2,
-            "growth created a new key and retired (kept) the prior one"
-        );
-        assert!(
-            s.destroy_log.is_empty(),
-            "nothing freed while the segment lives"
+            "growth created a new key (a second bind), retiring the prior one"
         );
     }
 
@@ -1521,35 +1365,6 @@ mod tests {
         assert!(
             mock.lock().bind_calls.is_empty(),
             "no bind attempted for an unserved ordinal"
-        );
-    }
-
-    #[test]
-    fn test_drop_frees_segment_keys() {
-        let base = 0x10_0000_0000;
-        let mock = MockOps::new(SERVED_NIC, true, &[0]);
-        mock.lock().scan = vec![seg(base, MIB2, 0)];
-        let domain = domain(mock.clone());
-
-        // Bind then grow, so the segment carries a retired key plus its current
-        // key, and two MRs. Views are dropped immediately.
-        register_cuda(&domain, base, 4096).unwrap();
-        mock.lock().scan = vec![seg(base, 2 * MIB2, 0)];
-        register_cuda(&domain, base + MIB2, 4096).unwrap();
-
-        assert_eq!(mock.lock().live_mrs.len(), 2);
-        assert_eq!(mock.lock().live_mkeys.len(), 2, "current + retired key");
-
-        drop(domain);
-
-        let s = mock.lock();
-        assert!(
-            s.live_mrs.is_empty(),
-            "dropping the domain frees all segment MRs"
-        );
-        assert!(
-            s.live_mkeys.is_empty(),
-            "dropping the domain destroys the current + retired keys"
         );
     }
 
@@ -1605,10 +1420,10 @@ mod tests {
         let access = domain.domain_impl().access_flags();
 
         // Validate every field of a returned view: its address fields, its
-        // size, the serving NIC's name, and the keys. The mock's `mkey_keys`
-        // derives `(lkey, rkey)` from the segment's current mkey as
-        // `(handle, handle ^ 0xffff)`, so a bound view always has a non-zero
-        // lkey and an rkey that is its lkey xor 0xffff.
+        // size, the serving NIC's name, and the keys. The mock binds each key
+        // with `(lkey, rkey) = (handle, handle ^ 0xffff)` for a freshly minted
+        // handle, so a bound view always has a non-zero lkey and an rkey that is
+        // its lkey xor 0xffff.
         let assert_view =
             |view: &IbvMemoryRegionView, virtual_addr: usize, rdma_addr: usize, size: usize| {
                 assert_eq!(
@@ -1636,8 +1451,6 @@ mod tests {
         assert_view(&view_a, a, 0, 0x2000);
         let (mr_a, mr_c) = {
             let s = mock.lock();
-            assert_eq!(s.live_mkeys.len(), 2, "only the two served segments bound");
-            assert_eq!(s.live_mrs.len(), 2);
             assert_eq!(s.bind_calls.len(), 2, "one bind per served segment");
             // Each served segment fits in a single MR, so each bind got a
             // one-element MR list.
@@ -1663,8 +1476,11 @@ mod tests {
                 "a and c are each registered once, covering their full extent"
             );
             assert_eq!(s.scan_calls, 1);
-            let (mr_a, mr_c) = (s.bind_calls[0].mrs[0], s.bind_calls[1].mrs[0]);
-            assert_ne!(mr_a, mr_c, "a and c are backed by distinct MRs");
+            let (mr_a, mr_c) = (
+                s.bind_calls[0].mrs[0].clone(),
+                s.bind_calls[1].mrs[0].clone(),
+            );
+            assert!(!Arc::ptr_eq(&mr_a, &mr_c), "a and c are distinct MRs");
             (mr_a, mr_c)
         };
 
@@ -1717,17 +1533,6 @@ mod tests {
         );
         {
             let s = mock.lock();
-            // a: current + retired key (2 MRs); c: unchanged (1); a2: new (1).
-            assert_eq!(
-                s.live_mkeys.len(),
-                4,
-                "a retired+current, c, and the new a2 segment"
-            );
-            assert_eq!(s.live_mrs.len(), 4, "a's reused MR + tail, c, a2");
-            assert!(
-                s.destroy_log.is_empty(),
-                "nothing vanished, so nothing is freed"
-            );
             // Two binds added: a's growth rebind and a2's fresh bind (c was
             // already full-size, so it is not rebound).
             assert_eq!(s.bind_calls.len(), 4);
@@ -1738,25 +1543,28 @@ mod tests {
                 2,
                 "a's growth binds the reused original MR plus the new tail"
             );
-            assert_eq!(
-                s.bind_calls[2].mrs[0], mr_a,
+            assert!(
+                Arc::ptr_eq(&s.bind_calls[2].mrs[0], &mr_a),
                 "the original MR is reused, not re-registered"
             );
-            let mr_a_tail = s.bind_calls[2].mrs[1];
+            let mr_a_tail = s.bind_calls[2].mrs[1].clone();
             // a2's fresh bind passes a single new MR.
             assert_eq!(
                 s.bind_calls[3].mrs.len(),
                 1,
                 "the new segment a2 binds a single MR"
             );
-            let mr_a2 = s.bind_calls[3].mrs[0];
-            // a's original + tail, c, and a2 are four distinct MR handles.
-            let distinct: HashSet<usize> = [mr_a, mr_c, mr_a_tail, mr_a2].into_iter().collect();
-            assert_eq!(
-                distinct.len(),
-                4,
-                "a, a-tail, c, and a2 are four distinct MRs"
-            );
+            let mr_a2 = s.bind_calls[3].mrs[0].clone();
+            // a's original + tail, c, and a2 are four distinct MRs.
+            let all = [&mr_a, &mr_c, &mr_a_tail, &mr_a2];
+            for (i, x) in all.iter().enumerate() {
+                for y in &all[i + 1..] {
+                    assert!(
+                        !Arc::ptr_eq(x, y),
+                        "a, a-tail, c, and a2 are four distinct MRs"
+                    );
+                }
+            }
             // Growth registered only a's new tail (at a + MIB2, covering the 2
             // MiB it grew by) and a2's single MR; c was left untouched and the
             // first two registrations are unchanged. MR extents track segment

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -44,7 +44,6 @@ use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMr;
 use super::primitives::IbvPd;
 use super::primitives::IbvQp;
-use super::queue_pair::QpParts;
 use super::queue_pair::connect;
 use super::queue_pair::get_qp_info;
 use crate::backend::ibverbs::mlx_device::MlxDevice;
@@ -140,19 +139,19 @@ pub(super) trait MlxDomainOps: Send + Sync + 'static {
         access: i32,
     ) -> anyhow::Result<IbvMr>;
 
-    /// Creates a loopback-connected queue pair against `domain`'s PD, returning
-    /// it and the two completion queues backing it bundled in a [`QpParts`]. The
-    /// caller stores the bundle for the domain's lifetime.
+    /// Creates a loopback-connected queue pair against `domain`'s PD, returned
+    /// as an [`IbvQp`] owning its completion queues and PD. The caller stores it
+    /// for the domain's lifetime.
     ///
     /// # Safety
     ///
     /// `domain`'s context and PD, if non-null, must be live. A null context or
     /// PD yields `Err`.
-    unsafe fn create_loopback_qp_parts(
+    unsafe fn create_loopback_qp(
         &self,
         domain: Arc<IbvDomain<MlxDomain>>,
         config: &IbvConfig,
-    ) -> anyhow::Result<QpParts>;
+    ) -> anyhow::Result<IbvQp>;
 
     /// Bind `mrs` to a freshly created indirect key using `qp`'s work-request
     /// builder, returning it as a [`Mlx5dvMkey`] owning those MR references. On
@@ -238,17 +237,17 @@ impl MlxDomainOps for ProdMlxDomainOps {
         unsafe { register_dmabuf_range(pd, addr, size, access) }
     }
 
-    unsafe fn create_loopback_qp_parts(
+    unsafe fn create_loopback_qp(
         &self,
         domain: Arc<IbvDomain<MlxDomain>>,
         config: &IbvConfig,
-    ) -> anyhow::Result<QpParts> {
-        // Kept bundled in the `QpParts` (rather than split into locals) across
-        // the fallible connect below, so an early return or panic still tears it
-        // down in the right order.
-        let parts = MlxQueuePair::create_raw_parts(&domain, config)
+    ) -> anyhow::Result<IbvQp> {
+        // The `IbvQp` owns its completion queues and PD, so an early return or
+        // panic in the connect below still tears everything down in order.
+        // SAFETY: an `IbvDomain` holds a null-or-live context and PD.
+        let qp = unsafe { MlxQueuePair::create_ibv_qp(&domain, config) }
             .context("could not create loopback QP for mkey binding")?;
-        let context = domain.context().as_ptr();
+        let context = qp.context().as_ptr();
         let access_flags = domain.access_flags();
         let gid = domain.device_info().select_gid(
             config.port_num,
@@ -258,15 +257,15 @@ impl MlxDomainOps for ProdMlxDomainOps {
 
         // Connect the QP to itself (loopback) so it reaches RTS, the state
         // required to post work requests.
-        // SAFETY: `parts.qp` wraps the live QP just created above and `context`
-        // is its live device context.
-        let info = unsafe { get_qp_info(parts.qp.as_ptr(), context, config, gid) }
+        // SAFETY: `qp` wraps the live QP just created above and `context` is its
+        // live device context.
+        let info = unsafe { get_qp_info(qp.as_ptr(), context, config, gid) }
             .context("could not query loopback QP info for mkey binding")?;
         // SAFETY: as above.
-        unsafe { connect(parts.qp.as_ptr(), config, access_flags, &info, gid.index()) }
+        unsafe { connect(qp.as_ptr(), config, access_flags, &info, gid.index()) }
             .context("could not connect loopback QP for mkey binding")?;
 
-        Ok(parts)
+        Ok(qp)
     }
 
     unsafe fn bind_mr_list(
@@ -625,9 +624,10 @@ pub struct MlxDomain {
     /// CUDA ordinals whose optimal NIC is this device. Only segments on
     /// these ordinals are bound here.
     cuda_ordinals: Vec<i32>,
-    /// Lazily-created loopback QP (with its completion queues) used to post
-    /// key-binding work requests, destroyed when this domain drops.
-    loopback: OnceLock<QpParts>,
+    /// Lazily-created loopback QP (an [`IbvQp`] owning its completion queues and
+    /// PD) used to post key-binding work requests, destroyed when this domain
+    /// drops.
+    loopback: OnceLock<IbvQp>,
     /// Currently-bound segments, keyed by `(base address, CUDA ordinal)`. Each
     /// grows in place (reusing its MRs, retiring superseded keys internally);
     /// a key whose base vanishes from the scan is dropped (a live view keeps
@@ -665,17 +665,17 @@ impl MlxDomain {
         // `OnceLock::get_or_try_init` would fit here but is still unstable
         // (`once_cell_try`); calls are serialized under the `segments` lock,
         // so this check-then-set is race-free.
-        if let Some(parts) = self.loopback.get() {
-            return Ok(&parts.qp);
+        if let Some(qp) = self.loopback.get() {
+            return Ok(qp);
         }
         // SAFETY: an `IbvDomain` guarantees its context and PD are null or live;
-        // `create_loopback_qp_parts` rejects null.
-        let parts = unsafe {
+        // `create_loopback_qp` rejects null.
+        let qp = unsafe {
             self.ops
-                .create_loopback_qp_parts(Arc::clone(domain), &self.config)
+                .create_loopback_qp(Arc::clone(domain), &self.config)
         }?;
-        let _ = self.loopback.set(parts);
-        Ok(&self.loopback.get().expect("loopback just set").qp)
+        let _ = self.loopback.set(qp);
+        Ok(self.loopback.get().expect("loopback just set"))
     }
 
     /// Bind CUDA `[addr, addr + size)` via an indirect mlx5dv key. Scans for
@@ -807,7 +807,6 @@ mod tests {
     use std::sync::Mutex;
     use std::sync::MutexGuard;
 
-    use super::super::primitives::IbvCq;
     use super::super::primitives::IbvDeviceInfo;
     use super::*;
 
@@ -841,10 +840,9 @@ mod tests {
     /// Recorded state + scripted behavior for [`MockOps`]. Creation calls
     /// (`dmabuf_calls`, `bind_calls`, `scan_calls`, `loopback_created`) are
     /// recorded so tests can assert on the scan/bind algorithm. The returned
-    /// [`IbvMr`]/[`Mlx5dvMkey`] wrap null handles, and the loopback [`QpParts`]
-    /// holds null [`IbvQp`]/[`IbvCq`]s, so their `Drop` is a no-op and FFI
-    /// teardown is not observed here — that ordering is structurally guaranteed
-    /// by ownership and exercised by the hardware tests.
+    /// [`IbvMr`]/[`Mlx5dvMkey`]/[`IbvQp`] wrap null handles, so their `Drop` is a
+    /// no-op and FFI teardown is not observed here — that ordering is
+    /// structurally guaranteed by ownership and exercised by the hardware tests.
     #[derive(Default)]
     struct MockState {
         device_name: String,
@@ -852,7 +850,7 @@ mod tests {
         served_ordinals: Vec<i32>,
         scan: Vec<ScannedSegment>,
         next_handle: usize,
-        /// Number of `create_loopback_qp_parts` calls; tests check the QP is
+        /// Number of `create_loopback_qp` calls; tests check the QP is
         /// created once and reused.
         loopback_created: usize,
         fail_dmabuf_after: Option<usize>,
@@ -930,18 +928,14 @@ mod tests {
             Ok(IbvMr::null())
         }
 
-        unsafe fn create_loopback_qp_parts(
+        unsafe fn create_loopback_qp(
             &self,
             _domain: Arc<IbvDomain<MlxDomain>>,
             _config: &IbvConfig,
-        ) -> anyhow::Result<QpParts> {
-            // Null placeholders (their `Drop` is a no-op); just count the call.
+        ) -> anyhow::Result<IbvQp> {
+            // A null QP placeholder (its `Drop` is a no-op); just count the call.
             self.lock().loopback_created += 1;
-            Ok(QpParts {
-                qp: IbvQp::null(),
-                send_cq: IbvCq::null(),
-                recv_cq: IbvCq::null(),
-            })
+            Ok(IbvQp::null())
         }
 
         unsafe fn bind_mr_list(

--- a/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
@@ -25,7 +25,6 @@ use super::primitives::IbvWc;
 use super::queue_pair::IbvQueuePair;
 use super::queue_pair::PollCompletionError;
 use super::queue_pair::PollTarget;
-use super::queue_pair::QpParts;
 use super::queue_pair::RCQueuePair;
 use super::queue_pair::WorkRequestError;
 
@@ -40,26 +39,32 @@ pub struct MlxQueuePair(RCQueuePair);
 
 impl MlxQueuePair {
     /// Creates the `mlx5dv` RC QP and the two completion queues backing it,
-    /// against `domain`'s context and PD, bundled in a [`QpParts`]. The QP
-    /// carries the mlx5dv send-ops flags that arm its extended work-request
-    /// builder. A null context or PD on `domain` yields `Err`.
-    pub(super) fn create_raw_parts<I: IbvDomainImpl>(
+    /// against `domain`'s context and PD, returned as an [`IbvQp`] that owns the
+    /// CQs and PD. The QP carries the mlx5dv send-ops flags that arm its
+    /// extended work-request builder. A null context or PD on `domain` yields
+    /// `Err`.
+    ///
+    /// # Safety
+    ///
+    /// `domain`'s context and PD, if non-null, must be live.
+    pub(super) unsafe fn create_ibv_qp<I: IbvDomainImpl>(
         domain: &IbvDomain<I>,
         config: &IbvConfig,
-    ) -> Result<QpParts, anyhow::Error> {
+    ) -> Result<IbvQp, anyhow::Error> {
         let context = domain.context().as_ptr();
         let pd = domain.as_ptr();
         if pd.is_null() {
             anyhow::bail!("cannot create an MlxQueuePair on a null protection domain");
         }
 
-        // Separate send/recv completion queues. Each `IbvCq` destroys its queue
-        // on drop, so an early return below cleans them up.
-        // SAFETY: `context`, if non-null, is live (an `IbvDomain` holds a
-        // null-or-live context); `IbvCq::create` rejects a null context.
-        let send_cq = unsafe { IbvCq::create(context, config.cq_entries) }?;
+        // Separate send/recv completion queues, each owning a clone of the
+        // device context. Each `IbvCq` destroys its queue on drop, so an early
+        // return below cleans them up.
+        // SAFETY: `domain`'s context is live (an `IbvDomain` holds a null-or-live
+        // context); `IbvCq::create` rejects a null context.
+        let send_cq = unsafe { IbvCq::create(domain.context().clone(), config.cq_entries) }?;
         // SAFETY: as for `send_cq` above.
-        let recv_cq = unsafe { IbvCq::create(context, config.cq_entries) }?;
+        let recv_cq = unsafe { IbvCq::create(domain.context().clone(), config.cq_entries) }?;
 
         // An mlx5dv extended RC QP with the caps from `config`. The
         // `SEND_OPS_FLAGS` enable the mlx5dv extended work-request builder; the
@@ -104,15 +109,10 @@ impl MlxQueuePair {
                 Error::last_os_error()
             );
         }
-        // SAFETY: `qp` is a live RC QP just created above; `IbvQp` takes
-        // ownership and destroys it on drop.
-        let qp = unsafe { IbvQp::from_raw(qp) };
-
-        Ok(QpParts {
-            qp,
-            send_cq,
-            recv_cq,
-        })
+        // SAFETY: `qp` is a live RC QP just created against `pd` with
+        // `send_cq`/`recv_cq`; `IbvQp` takes ownership of all of them plus the PD
+        // and destroys them in order on drop.
+        Ok(unsafe { IbvQp::from_raw(qp, send_cq, recv_cq, domain.pd().clone()) })
     }
 }
 
@@ -127,24 +127,15 @@ impl IbvQueuePair for MlxQueuePair {
             Some(GidScope::Global),
             Some(GidType::RoCEv2),
         )?;
-        let parts = Self::create_raw_parts(&domain, &config)?;
-        let context = domain.context().clone();
+        // SAFETY: an `IbvDomain` holds a null-or-live context and PD, which is
+        // `create_ibv_qp`'s contract.
+        let qp = unsafe { Self::create_ibv_qp(&domain, &config) }?;
         let access_flags = domain.access_flags();
-
-        // SAFETY: `parts` wraps a live RC QP just created against `domain`'s
-        // context/PD with its completion queues; ownership transfers to the
-        // inner `RCQueuePair`.
-        let inner = unsafe {
-            RCQueuePair::from_parts(
-                parts,
-                context,
-                config,
-                gid,
-                access_flags,
-                domain.pd().clone(),
-            )
-        };
-        Ok(MlxQueuePair(inner))
+        // SAFETY: `create_ibv_qp` returns a live, fully non-null `IbvQp` (it
+        // bails on any null handle).
+        Ok(MlxQueuePair(unsafe {
+            RCQueuePair::from_qp(qp, config, gid, access_flags)
+        }))
     }
 
     fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {

--- a/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
@@ -47,7 +47,7 @@ impl MlxQueuePair {
         domain: &IbvDomain<I>,
         config: &IbvConfig,
     ) -> Result<QpParts, anyhow::Error> {
-        let context = domain.context.as_ptr();
+        let context = domain.context().as_ptr();
         let pd = domain.as_ptr();
         if pd.is_null() {
             anyhow::bail!("cannot create an MlxQueuePair on a null protection domain");
@@ -128,14 +128,22 @@ impl IbvQueuePair for MlxQueuePair {
             Some(GidType::RoCEv2),
         )?;
         let parts = Self::create_raw_parts(&domain, &config)?;
-        let context = domain.context.clone();
+        let context = domain.context().clone();
         let access_flags = domain.access_flags();
 
         // SAFETY: `parts` wraps a live RC QP just created against `domain`'s
         // context/PD with its completion queues; ownership transfers to the
         // inner `RCQueuePair`.
-        let inner =
-            unsafe { RCQueuePair::from_parts(parts, context, config, gid, access_flags, domain) };
+        let inner = unsafe {
+            RCQueuePair::from_parts(
+                parts,
+                context,
+                config,
+                gid,
+                access_flags,
+                domain.pd().clone(),
+            )
+        };
         Ok(MlxQueuePair(inner))
     }
 

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -29,6 +29,7 @@ use std::ffi::CStr;
 use std::fmt;
 use std::io::Error;
 use std::net::Ipv6Addr;
+use std::sync::Arc;
 use std::sync::OnceLock;
 
 use anyhow::Context;
@@ -1264,6 +1265,144 @@ impl Drop for IbvQp {
             tracing::error!(
                 "failed to destroy queue pair {:p}: error code {}",
                 self.0,
+                ret
+            );
+        }
+    }
+}
+
+/// RAII owner of a raw `ibv_context*`, closing it in [`Drop`] (a no-op if
+/// null).
+#[derive(Debug)]
+pub struct IbvContext(*mut rdmaxcel_sys::ibv_context);
+
+// SAFETY: libibverbs treats `ibv_context*` as thread-safe for the
+// operations we perform.
+unsafe impl Send for IbvContext {}
+unsafe impl Sync for IbvContext {}
+
+impl IbvContext {
+    /// Wraps a raw `ibv_context*`. A null pointer yields a no-op context
+    /// (its `Drop` does nothing).
+    ///
+    /// # Safety
+    ///
+    /// `context` must be either null or a pointer returned by
+    /// `ibv_open_device` that has not been (and will not be) closed elsewhere:
+    /// the resulting `IbvContext` takes sole ownership and its `Drop` calls
+    /// `ibv_close_device` exactly once.
+    pub(super) unsafe fn from_raw(context: *mut rdmaxcel_sys::ibv_context) -> Self {
+        Self(context)
+    }
+
+    /// Returns the raw `ibv_context*`. The pointer is valid for
+    /// the lifetime of `&self`.
+    pub fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_context {
+        self.0
+    }
+
+    /// A placeholder holding no context: `as_ptr` returns null and `Drop` is a
+    /// no-op. Used by the test-only `null()` constructors of the pointer
+    /// wrappers that hold a context.
+    #[cfg(test)]
+    pub(super) fn null() -> Self {
+        // SAFETY: a null context is explicitly allowed; `Drop` skips
+        // `ibv_close_device` for null.
+        unsafe { Self::from_raw(std::ptr::null_mut()) }
+    }
+}
+
+impl Drop for IbvContext {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            return;
+        }
+        // SAFETY: `self.0` was returned by `ibv_open_device` and
+        // has not been closed elsewhere.
+        let result = unsafe { rdmaxcel_sys::ibv_close_device(self.0) };
+        if result != 0 {
+            tracing::error!(
+                "ibv_close_device failed for context {:p}: error code {}",
+                self.0,
+                result
+            );
+        }
+    }
+}
+
+/// Owns an `ibv_pd` together with the `Arc<IbvContext>` it was allocated
+/// against, deallocating the PD on drop (a no-op if null) before releasing the
+/// context.
+#[derive(Debug)]
+pub(super) struct IbvPd {
+    pd: *mut rdmaxcel_sys::ibv_pd,
+    /// The context the PD was allocated against, kept open until after
+    /// `ibv_dealloc_pd` and reached by holders via [`Self::context`].
+    context: Arc<IbvContext>,
+}
+
+// SAFETY: the only raw member is the `ibv_pd` pointer. The ibverbs PD it names is
+// not thread-affine — it may be allocated on one thread and used or deallocated
+// on another (`Send`) — and `IbvPd` exposes no operation that mutates the PD
+// through a shared `&` (`as_ptr` only hands back the pointer value), so sharing a
+// `&IbvPd` cannot race (`Sync`).
+unsafe impl Send for IbvPd {}
+// SAFETY: as for `Send` above.
+unsafe impl Sync for IbvPd {}
+
+impl IbvPd {
+    /// Allocates a protection domain against `context`.
+    ///
+    /// # Safety
+    ///
+    /// `context` must wrap a live `ibv_context`; a null context yields `Err`.
+    pub(super) unsafe fn create(context: Arc<IbvContext>) -> Result<Self, anyhow::Error> {
+        if context.as_ptr().is_null() {
+            anyhow::bail!("cannot allocate a protection domain on a null context");
+        }
+        // SAFETY: `context.as_ptr()` is non-null (checked above) and live (caller
+        // contract); `ibv_alloc_pd` returns null on failure.
+        let pd = unsafe { rdmaxcel_sys::ibv_alloc_pd(context.as_ptr()) };
+        if pd.is_null() {
+            anyhow::bail!("ibv_alloc_pd failed: {}", Error::last_os_error());
+        }
+        Ok(Self { pd, context })
+    }
+
+    /// The raw `ibv_pd`; null for a placeholder that holds no protection domain.
+    pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_pd {
+        self.pd
+    }
+
+    /// The context this PD was allocated against.
+    pub(super) fn context(&self) -> &Arc<IbvContext> {
+        &self.context
+    }
+
+    /// A placeholder holding no protection domain (and a no-op context): both
+    /// `Drop`s are no-ops.
+    #[cfg(test)]
+    pub(super) fn null() -> Self {
+        Self {
+            pd: std::ptr::null_mut(),
+            context: Arc::new(IbvContext::null()),
+        }
+    }
+}
+
+impl Drop for IbvPd {
+    fn drop(&mut self) {
+        if self.pd.is_null() {
+            return;
+        }
+        // SAFETY: a non-null `self.pd` was returned by `ibv_alloc_pd` and, since
+        // `IbvPd` is not `Clone`, is deallocated exactly once. `context` is
+        // dropped only after this returns, so the device is still open here.
+        let ret = unsafe { rdmaxcel_sys::ibv_dealloc_pd(self.pd) };
+        if ret != 0 {
+            tracing::error!(
+                "failed to deallocate protection domain {:p}: error code {}",
+                self.pd,
                 ret
             );
         }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1134,13 +1134,17 @@ impl IbvWc {
     }
 }
 
-/// Owns an `ibv_cq`, destroying it on drop (a no-op if null). Lets callers
-/// create completion queues without hand-rolling cleanup on the error or drop
-/// paths.
+/// Owns an `ibv_cq` together with the `Arc<IbvContext>` it was created on,
+/// destroying the CQ on drop (a no-op if null) before releasing the context.
+/// Holding the context keeps it open across `ibv_destroy_cq`.
 #[derive(Debug)]
-pub(super) struct IbvCq(*mut rdmaxcel_sys::ibv_cq);
+pub(super) struct IbvCq {
+    cq: *mut rdmaxcel_sys::ibv_cq,
+    /// Keeps the context open until after `ibv_destroy_cq`. Never read.
+    _context: Arc<IbvContext>,
+}
 
-// SAFETY: the only field is the raw `ibv_cq` pointer. The ibverbs CQ it names is
+// SAFETY: the only raw member is the `ibv_cq` pointer. The ibverbs CQ it names is
 // not thread-affine — it may be created on one thread and used or destroyed on
 // another (`Send`) — and `IbvCq` exposes no operation that mutates the CQ through
 // a shared `&` (`as_ptr` only hands back the pointer value), so sharing a
@@ -1150,24 +1154,24 @@ unsafe impl Send for IbvCq {}
 unsafe impl Sync for IbvCq {}
 
 impl IbvCq {
-    /// Creates a completion queue with `cq_entries` entries on `context`.
+    /// Creates a completion queue with `cq_entries` entries on `context`,
+    /// retaining `context` for the CQ's lifetime.
     ///
     /// # Safety
     ///
-    /// `context`, if non-null, must be a live `ibv_context`; a null `context`
-    /// yields `Err`.
+    /// `context` must wrap a live `ibv_context`; a null context yields `Err`.
     pub(super) unsafe fn create(
-        context: *mut rdmaxcel_sys::ibv_context,
+        context: Arc<IbvContext>,
         cq_entries: i32,
     ) -> Result<Self, anyhow::Error> {
-        if context.is_null() {
+        if context.as_ptr().is_null() {
             anyhow::bail!("cannot create a completion queue on a null context");
         }
-        // SAFETY: `context` is non-null (checked above) and live (caller
+        // SAFETY: `context.as_ptr()` is non-null (checked above) and live (caller
         // contract); `ibv_create_cq` returns null on failure.
         let cq = unsafe {
             rdmaxcel_sys::ibv_create_cq(
-                context,
+                context.as_ptr(),
                 cq_entries,
                 std::ptr::null_mut(),
                 std::ptr::null_mut(),
@@ -1180,91 +1184,140 @@ impl IbvCq {
                 Error::last_os_error()
             );
         }
-        Ok(Self(cq))
+        Ok(Self {
+            cq,
+            _context: context,
+        })
     }
 
     /// The raw `ibv_cq`; null for a placeholder that holds no queue.
     pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_cq {
-        self.0
+        self.cq
     }
 
     /// A placeholder holding no completion queue: `as_ptr` returns null and
     /// `Drop` is a no-op.
     #[cfg(test)]
     pub(super) fn null() -> Self {
-        Self(std::ptr::null_mut())
+        Self {
+            cq: std::ptr::null_mut(),
+            _context: Arc::new(IbvContext::null()),
+        }
     }
 }
 
 impl Drop for IbvCq {
     fn drop(&mut self) {
-        if self.0.is_null() {
+        if self.cq.is_null() {
             return;
         }
-        // SAFETY: a non-null `self.0` was returned by `ibv_create_cq` and, since
-        // `IbvCq` is not `Clone`, is destroyed exactly once.
-        let ret = unsafe { rdmaxcel_sys::ibv_destroy_cq(self.0) };
+        // SAFETY: a non-null `self.cq` was returned by `ibv_create_cq` and, since
+        // `IbvCq` is not `Clone`, is destroyed exactly once. `_context` drops only
+        // after this returns, so the device is still open here.
+        let ret = unsafe { rdmaxcel_sys::ibv_destroy_cq(self.cq) };
         if ret != 0 {
             tracing::error!(
                 "failed to destroy completion queue {:p}: error code {}",
-                self.0,
+                self.cq,
                 ret
             );
         }
     }
 }
 
-/// Owns an `ibv_qp`, destroying it on drop (a no-op if null), so a queue pair is
-/// carried by value rather than as a raw pointer and its destruction runs even
-/// on an early return or panic.
+/// Owns an `ibv_qp` together with the resources it is built against: its two
+/// completion queues and the protection domain. The QP is destroyed on drop (a
+/// no-op if null) before the CQs and PD, so the destruction order is correct by
+/// construction and holders need not track the CQs or PD separately.
 #[derive(Debug)]
-pub(super) struct IbvQp(*mut rdmaxcel_sys::ibv_qp);
+pub(super) struct IbvQp {
+    qp: *mut rdmaxcel_sys::ibv_qp,
+    /// Declared after `qp` so the QP is destroyed before its completion queues.
+    send_cq: IbvCq,
+    recv_cq: IbvCq,
+    /// Keeps the PD alive for the QP's lifetime and is the source of the QP's
+    /// device context (via [`IbvPd::context`]).
+    pd: Arc<IbvPd>,
+}
 
-// SAFETY: the only field is the raw `ibv_qp` pointer. The ibverbs QP it names is
-// not thread-affine — it may be created on one thread and used or destroyed on
-// another (`Send`) — and `IbvQp` exposes no operation that mutates the QP through
-// a shared `&` (`as_ptr` only hands back the pointer value), so sharing a
-// `&IbvQp` cannot race (`Sync`).
+// SAFETY: the only raw member is the `ibv_qp` pointer (the other fields are
+// already `Send`/`Sync`). The ibverbs QP it names is not thread-affine — it may
+// be created on one thread and used or destroyed on another (`Send`) — and
+// `IbvQp` exposes no operation that mutates the QP through a shared `&`, so
+// sharing a `&IbvQp` cannot race (`Sync`).
 unsafe impl Send for IbvQp {}
 // SAFETY: as for `Send` above.
 unsafe impl Sync for IbvQp {}
 
 impl IbvQp {
-    /// Takes ownership of a raw `ibv_qp`, destroying it on drop.
+    /// Takes ownership of a raw `ibv_qp` and the `send_cq`/`recv_cq`/`pd` it was
+    /// built against, destroying the QP on drop.
     ///
     /// # Safety
     ///
     /// `qp`, if non-null, must be a live `ibv_qp` owned solely by the returned
-    /// value (its `Drop` calls `ibv_destroy_qp` once).
-    pub(super) unsafe fn from_raw(qp: *mut rdmaxcel_sys::ibv_qp) -> Self {
-        Self(qp)
+    /// value (its `Drop` calls `ibv_destroy_qp` once), built against `pd` with
+    /// `send_cq`/`recv_cq` as its completion queues.
+    pub(super) unsafe fn from_raw(
+        qp: *mut rdmaxcel_sys::ibv_qp,
+        send_cq: IbvCq,
+        recv_cq: IbvCq,
+        pd: Arc<IbvPd>,
+    ) -> Self {
+        Self {
+            qp,
+            send_cq,
+            recv_cq,
+            pd,
+        }
     }
 
     /// The raw `ibv_qp`; null for a placeholder that holds no queue pair.
     pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_qp {
-        self.0
+        self.qp
+    }
+
+    /// The send completion queue.
+    pub(super) fn send_cq(&self) -> &IbvCq {
+        &self.send_cq
+    }
+
+    /// The receive completion queue.
+    pub(super) fn recv_cq(&self) -> &IbvCq {
+        &self.recv_cq
+    }
+
+    /// The device context this QP was created on, sourced from its PD.
+    pub(super) fn context(&self) -> &IbvContext {
+        self.pd.context()
     }
 
     /// A placeholder holding no queue pair: `as_ptr` returns null and `Drop` is
     /// a no-op.
     #[cfg(test)]
     pub(super) fn null() -> Self {
-        Self(std::ptr::null_mut())
+        Self {
+            qp: std::ptr::null_mut(),
+            send_cq: IbvCq::null(),
+            recv_cq: IbvCq::null(),
+            pd: Arc::new(IbvPd::null()),
+        }
     }
 }
 
 impl Drop for IbvQp {
     fn drop(&mut self) {
-        if self.0.is_null() {
+        if self.qp.is_null() {
             return;
         }
-        // SAFETY: a non-null `self.0` was handed to `from_raw` as a live `ibv_qp`
-        // and, since `IbvQp` is not `Clone`, is destroyed exactly once.
-        let ret = unsafe { rdmaxcel_sys::ibv_destroy_qp(self.0) };
+        // SAFETY: a non-null `self.qp` was handed to `from_raw` as a live `ibv_qp`
+        // and, since `IbvQp` is not `Clone`, is destroyed exactly once. Its CQs
+        // and PD drop only after this returns, so they outlive the destruction.
+        let ret = unsafe { rdmaxcel_sys::ibv_destroy_qp(self.qp) };
         if ret != 0 {
             tracing::error!(
                 "failed to destroy queue pair {:p}: error code {}",
-                self.0,
+                self.qp,
                 ret
             );
         }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1409,6 +1409,70 @@ impl Drop for IbvPd {
     }
 }
 
+/// Owns an `ibv_mr` together with the `Arc<IbvPd>` it was registered against,
+/// deregistering the MR on drop (a no-op if null) before releasing the PD.
+/// Holding the PD keeps it (and, through it, the context) alive across
+/// `ibv_dereg_mr`, so an `IbvMr` is a self-contained registration callers can
+/// keep alive on its own.
+#[derive(Debug)]
+pub(super) struct IbvMr {
+    mr: *mut rdmaxcel_sys::ibv_mr,
+    /// Keeps the PD open until after `ibv_dereg_mr`. Never read.
+    _pd: Arc<IbvPd>,
+}
+
+// SAFETY: the only raw member is the `ibv_mr` pointer. The ibverbs MR it names is
+// not thread-affine — it may be registered on one thread and used or
+// deregistered on another (`Send`) — and `IbvMr` exposes no operation that
+// mutates the MR through a shared `&` (`as_ptr` only hands back the pointer
+// value), so sharing a `&IbvMr` cannot race (`Sync`).
+unsafe impl Send for IbvMr {}
+// SAFETY: as for `Send` above.
+unsafe impl Sync for IbvMr {}
+
+impl IbvMr {
+    /// Takes ownership of a raw `ibv_mr` and the `pd` it was registered against,
+    /// deregistering the MR on drop.
+    ///
+    /// # Safety
+    ///
+    /// `mr`, if non-null, must be a live `ibv_mr` owned solely by the returned
+    /// value (its `Drop` calls `ibv_dereg_mr` once), registered against `pd`.
+    pub(super) unsafe fn from_raw(mr: *mut rdmaxcel_sys::ibv_mr, pd: Arc<IbvPd>) -> Self {
+        Self { mr, _pd: pd }
+    }
+
+    /// The raw `ibv_mr`; null for a placeholder that holds no region.
+    pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_mr {
+        self.mr
+    }
+
+    /// A placeholder holding no memory region (and a no-op PD): both `Drop`s are
+    /// no-ops.
+    #[cfg(test)]
+    pub(super) fn null() -> Self {
+        Self {
+            mr: std::ptr::null_mut(),
+            _pd: Arc::new(IbvPd::null()),
+        }
+    }
+}
+
+impl Drop for IbvMr {
+    fn drop(&mut self) {
+        if self.mr.is_null() {
+            return;
+        }
+        // SAFETY: a non-null `self.mr` was handed to `from_raw` as a live
+        // `ibv_mr` and, since `IbvMr` is not `Clone`, is deregistered exactly
+        // once. `_pd` drops only after this returns, so the PD is still alive.
+        let ret = unsafe { rdmaxcel_sys::ibv_dereg_mr(self.mr) };
+        if ret != 0 {
+            tracing::error!("failed to deregister MR {:p}: error code {}", self.mr, ret);
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -53,7 +53,6 @@ use super::primitives::Gid;
 use super::primitives::GidScope;
 use super::primitives::GidType;
 use super::primitives::IbvConfig;
-use super::primitives::IbvContext;
 use super::primitives::IbvCq;
 use super::primitives::IbvOperation;
 use super::primitives::IbvPd;
@@ -451,35 +450,16 @@ pub(super) unsafe fn connect(
     Ok(())
 }
 
-/// The owned ibverbs handles backing a queue pair: the queue pair and its two
-/// completion queues.
-///
-/// `qp` is declared before the CQs so it is destroyed first whenever a
-/// `QpParts` is dropped — a CQ cannot be destroyed while a queue pair still
-/// references it. Because struct fields drop in declaration order, this holds
-/// however the value is moved, stored, or unwound; keep the parts bundled in
-/// this struct across any fallible step rather than splitting them into
-/// separate locals (whose drop order would not be guaranteed).
-pub(super) struct QpParts {
-    pub(super) qp: IbvQp,
-    pub(super) send_cq: IbvCq,
-    pub(super) recv_cq: IbvCq,
-}
-
 /// An RDMA reliable-connected (RC) queue pair built on plain ibverbs
 /// (`ibv_post_send`), independent of any device-specific verbs.
 ///
-/// Single-owner: it owns the QP and its two completion queues and destroys them
-/// on drop, so the type is intentionally `!Clone`. Its fields are declared
-/// QP-before-CQs (see [`QpParts`]). The device context comes from the held
-/// `Arc<IbvContext>`.
+/// Single-owner: it owns the [`IbvQp`] — which in turn owns its two completion
+/// queues and the protection domain — and destroys them on drop, so the type is
+/// intentionally `!Clone`. The device context and completion queues are reached
+/// through the [`IbvQp`].
 #[derive(Debug)]
 pub struct RCQueuePair {
     qp: IbvQp,
-    send_cq: IbvCq,
-    recv_cq: IbvCq,
-    /// The device context, used for the data-path verbs.
-    context: Arc<IbvContext>,
     config: IbvConfig,
     /// The source GID (carrying its table index), resolved from the owning
     /// device's `IbvDeviceInfo` at construction: the first global RoCE v2 GID on
@@ -491,45 +471,32 @@ pub struct RCQueuePair {
     /// Monotonic work-request id, handed out one per posted WR. Standard
     /// ibverbs carries no internal counter, so the QP tracks its own.
     next_wr_id: u64,
-    /// The protection domain this QP was built against, kept alive so the PD
-    /// outlives the QP. Never read directly.
-    _pd: Arc<IbvPd>,
 }
 
 impl RCQueuePair {
-    /// Assembles an `RCQueuePair` that owns the already-created queue pair and
-    /// completion queues in `parts`. `access_flags` is granted to peers at
-    /// [`Self::connect`]; it is taken from the owning domain by the caller.
+    /// Assembles an `RCQueuePair` that owns `qp` (and, through it, its
+    /// completion queues, protection domain, and device context). `access_flags`
+    /// is granted to peers at [`Self::connect`]; it is taken from the owning
+    /// domain by the caller.
     ///
     /// # Safety
     ///
-    /// `context` must wrap a non-null, live `ibv_context` (the data-path verbs
-    /// invoke it without re-checking). `parts.qp` must wrap a live RC `ibv_qp`
-    /// created against that context's device and `pd`, with
-    /// `parts.send_cq`/`parts.recv_cq` as its completion queues.
-    pub(super) unsafe fn from_parts(
-        parts: QpParts,
-        context: Arc<IbvContext>,
+    /// `qp` must wrap a live, non-null `ibv_qp`, and everything reached through
+    /// it — its send/recv completion queues, protection domain, and device
+    /// context — must likewise be non-null and valid: the data-path verbs invoke
+    /// them without re-checking.
+    pub(super) unsafe fn from_qp(
+        qp: IbvQp,
         config: IbvConfig,
         gid: Gid,
         access_flags: i32,
-        pd: Arc<IbvPd>,
     ) -> Self {
-        let QpParts {
-            qp,
-            send_cq,
-            recv_cq,
-        } = parts;
         RCQueuePair {
             qp,
-            send_cq,
-            recv_cq,
-            context,
             config,
             gid,
             access_flags,
             next_wr_id: 0,
-            _pd: pd,
         }
     }
 
@@ -572,7 +539,7 @@ impl RCQueuePair {
         wr_id: u64,
     ) -> Result<(), anyhow::Error> {
         let qp = self.qp.as_ptr();
-        let context = self.context.as_ptr();
+        let context = self.qp.context().as_ptr();
         let mut sge = rdmaxcel_sys::ibv_sge {
             addr: laddr as u64,
             length: length as u32,
@@ -595,10 +562,9 @@ impl RCQueuePair {
         wr.wr.rdma.remote_addr = raddr as u64;
         wr.wr.rdma.rkey = rkey;
         let mut bad_wr: *mut rdmaxcel_sys::ibv_send_wr = std::ptr::null_mut();
-        // SAFETY: `context` is the QP's live device context, non-null per
-        // `from_parts`'s contract; we invoke its `post_send` verb through the ops
-        // table. `qp` is live and `wr`/`sge`/`bad_wr` are valid for the duration
-        // of the call.
+        // SAFETY: `context` is the QP's live device context (read from the live
+        // `qp`); we invoke its `post_send` verb through the ops table. `qp` is
+        // live and `wr`/`sge`/`bad_wr` are valid for the duration of the call.
         let errno = unsafe {
             let post_send = (*context)
                 .ops
@@ -623,8 +589,6 @@ impl IbvQueuePair for RCQueuePair {
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an RCQueuePair from config {}", config);
-        let context = domain.context().clone();
-        let context_ptr = context.as_ptr();
         // `IbvDomain`'s `pd` accessor permits null (e.g. a test domain); a real
         // QP needs one, so reject null up front (`IbvCq::create` likewise rejects
         // a null context).
@@ -643,11 +607,11 @@ impl IbvQueuePair for RCQueuePair {
 
         // Separate send/recv completion queues. Each `IbvCq` destroys its queue
         // on drop, so an early return below (or a panic) cleans them up.
-        // SAFETY: `context_ptr`, if non-null, is live (kept alive by `context`);
-        // `IbvCq::create` rejects a null context.
-        let send_cq = unsafe { IbvCq::create(context_ptr, config.cq_entries) }?;
+        // SAFETY: `domain`'s context is null or live; `IbvCq::create` rejects
+        // a null context.
+        let send_cq = unsafe { IbvCq::create(domain.context().clone(), config.cq_entries) }?;
         // SAFETY: as for `send_cq` above.
-        let recv_cq = unsafe { IbvCq::create(context_ptr, config.cq_entries) }?;
+        let recv_cq = unsafe { IbvCq::create(domain.context().clone(), config.cq_entries) }?;
 
         // A standard RC QP with the caps from `config`.
         let mut init_attr = rdmaxcel_sys::ibv_qp_init_attr {
@@ -675,28 +639,14 @@ impl IbvQueuePair for RCQueuePair {
                 Error::last_os_error()
             );
         }
-        // SAFETY: `qp` is a live RC QP just created above; `IbvQp` takes
-        // ownership and destroys it on drop.
-        let qp = unsafe { IbvQp::from_raw(qp) };
-        let parts = QpParts {
-            qp,
-            send_cq,
-            recv_cq,
-        };
+        // SAFETY: `qp` is a live RC QP just created against `pd` with
+        // `send_cq`/`recv_cq`; `IbvQp` takes ownership of all of them plus the
+        // PD and destroys them in order on drop.
+        let qp = unsafe { IbvQp::from_raw(qp, send_cq, recv_cq, domain.pd().clone()) };
         let access_flags = domain.access_flags();
-
-        // SAFETY: `parts` wraps a live RC QP just created against `pd`/`context`
-        // with its completion queues; ownership transfers to the returned value.
-        Ok(unsafe {
-            Self::from_parts(
-                parts,
-                context,
-                config,
-                gid,
-                access_flags,
-                domain.pd().clone(),
-            )
-        })
+        // SAFETY: `qp` and its `send_cq`/`recv_cq`/PD/context were all created
+        // non-null.
+        Ok(unsafe { Self::from_qp(qp, config, gid, access_flags) })
     }
 
     fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
@@ -713,7 +663,7 @@ impl IbvQueuePair for RCQueuePair {
     }
 
     fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
-        let context = self.context.as_ptr();
+        let context = self.qp.context().as_ptr();
         // SAFETY: `self.qp` is the live QP and `context` its non-null device
         // context (validated inside `new`), both valid for `self`'s lifetime.
         unsafe { get_qp_info(self.qp.as_ptr(), context, &self.config, self.gid) }
@@ -773,13 +723,12 @@ impl IbvQueuePair for RCQueuePair {
         target: PollTarget,
     ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
         let (cq, cq_type) = match target {
-            PollTarget::Send => (self.send_cq.as_ptr(), "send"),
-            PollTarget::Recv => (self.recv_cq.as_ptr(), "recv"),
+            PollTarget::Send => (self.qp.send_cq().as_ptr(), "send"),
+            PollTarget::Recv => (self.qp.recv_cq().as_ptr(), "recv"),
         };
-        let context = self.context.as_ptr();
-        // SAFETY: `context` is non-null (per `from_parts`'s contract) and the
-        // QP's live device context; we invoke its `poll_cq` verb through the ops
-        // table.
+        let context = self.qp.context().as_ptr();
+        // SAFETY: `context` is the QP's live device context (read from the live
+        // `qp`); we invoke its `poll_cq` verb through the ops table.
         let poll_cq = unsafe {
             (*context)
                 .ops

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -2040,16 +2040,9 @@ mod tests {
     // QueuePairActor op processing
     // =================================================================
 
-    use crate::backend::ibverbs::memory_region::IbvMemoryRegion;
-    use crate::backend::ibverbs::primitives::IbvPd;
+    use crate::backend::ibverbs::primitives::IbvMr;
     use crate::local_memory::Keepalive;
     use crate::local_memory::KeepaliveLocalMemory;
-
-    /// A null [`Arc<IbvPd>`] keepalive for [`fake_mrv`]'s region; its `Drop`
-    /// deallocates nothing (null `pd`/`context`).
-    fn null_pd() -> Arc<IbvPd> {
-        Arc::new(IbvPd::null())
-    }
 
     /// No-op [`Keepalive`] for tests that mint a [`KeepaliveLocalMemory`]
     /// from a fake address never actually read or written through.
@@ -2078,10 +2071,8 @@ mod tests {
             0x1234,
             0x5678,
             "dev0".to_string(),
-            Arc::new(IbvMemoryRegion {
-                mr: std::ptr::null_mut(),
-                _pd: null_pd(),
-            }),
+            // A null MR keepalive: its `Drop` is a no-op.
+            Arc::new(IbvMr::null()),
         )
     }
 

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -45,18 +45,18 @@ use typeuri::Named;
 
 use super::IbvBuffer;
 use super::IbvOp;
-use super::device::IbvContext;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
-use super::domain::IbvDomainKeepalive;
 use super::manager_actor::CreatePeerQueuePair;
 use super::memory_region::IbvMemoryRegionView;
 use super::primitives::Gid;
 use super::primitives::GidScope;
 use super::primitives::GidType;
 use super::primitives::IbvConfig;
+use super::primitives::IbvContext;
 use super::primitives::IbvCq;
 use super::primitives::IbvOperation;
+use super::primitives::IbvPd;
 use super::primitives::IbvQp;
 use super::primitives::IbvQpInfo;
 use super::primitives::IbvWc;
@@ -491,9 +491,9 @@ pub struct RCQueuePair {
     /// Monotonic work-request id, handed out one per posted WR. Standard
     /// ibverbs carries no internal counter, so the QP tracks its own.
     next_wr_id: u64,
-    /// The domain this QP was built against, kept alive so its PD outlives the
-    /// QP. Never read directly.
-    _domain: Arc<dyn IbvDomainKeepalive>,
+    /// The protection domain this QP was built against, kept alive so the PD
+    /// outlives the QP. Never read directly.
+    _pd: Arc<IbvPd>,
 }
 
 impl RCQueuePair {
@@ -505,15 +505,15 @@ impl RCQueuePair {
     ///
     /// `context` must wrap a non-null, live `ibv_context` (the data-path verbs
     /// invoke it without re-checking). `parts.qp` must wrap a live RC `ibv_qp`
-    /// created against that context's device and `domain`'s protection domain,
-    /// with `parts.send_cq`/`parts.recv_cq` as its completion queues.
+    /// created against that context's device and `pd`, with
+    /// `parts.send_cq`/`parts.recv_cq` as its completion queues.
     pub(super) unsafe fn from_parts(
         parts: QpParts,
         context: Arc<IbvContext>,
         config: IbvConfig,
         gid: Gid,
         access_flags: i32,
-        domain: Arc<dyn IbvDomainKeepalive>,
+        pd: Arc<IbvPd>,
     ) -> Self {
         let QpParts {
             qp,
@@ -529,7 +529,7 @@ impl RCQueuePair {
             gid,
             access_flags,
             next_wr_id: 0,
-            _domain: domain,
+            _pd: pd,
         }
     }
 
@@ -623,7 +623,7 @@ impl IbvQueuePair for RCQueuePair {
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an RCQueuePair from config {}", config);
-        let context = domain.context.clone();
+        let context = domain.context().clone();
         let context_ptr = context.as_ptr();
         // `IbvDomain`'s `pd` accessor permits null (e.g. a test domain); a real
         // QP needs one, so reject null up front (`IbvCq::create` likewise rejects
@@ -687,7 +687,16 @@ impl IbvQueuePair for RCQueuePair {
 
         // SAFETY: `parts` wraps a live RC QP just created against `pd`/`context`
         // with its completion queues; ownership transfers to the returned value.
-        Ok(unsafe { Self::from_parts(parts, context, config, gid, access_flags, domain) })
+        Ok(unsafe {
+            Self::from_parts(
+                parts,
+                context,
+                config,
+                gid,
+                access_flags,
+                domain.pd().clone(),
+            )
+        })
     }
 
     fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
@@ -1391,8 +1400,6 @@ mod tests {
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::device_selection::resolve_target;
-    use crate::backend::ibverbs::domain::IbvDomain;
-    use crate::backend::ibverbs::efa_domain::EfaDomain;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
 
@@ -2033,29 +2040,15 @@ mod tests {
     // QueuePairActor op processing
     // =================================================================
 
-    use crate::backend::ibverbs::device::IbvContext;
     use crate::backend::ibverbs::memory_region::IbvMemoryRegion;
-    use crate::backend::ibverbs::primitives::IbvDeviceInfo;
+    use crate::backend::ibverbs::primitives::IbvPd;
     use crate::local_memory::Keepalive;
     use crate::local_memory::KeepaliveLocalMemory;
 
-    /// A throwaway [`IbvDomain`] with null `context`/`pd`, used as the
-    /// `_domain` keepalive of [`fake_mrv`]'s region; its `Drop` deallocs
-    /// nothing (null `pd`).
-    fn null_domain() -> Arc<IbvDomain<EfaDomain>> {
-        // SAFETY: a null `ibv_context*` is explicitly allowed — `IbvContext`'s
-        // `Drop` is a no-op for null, so nothing is ever closed.
-        let context = Arc::new(unsafe { IbvContext::new(std::ptr::null_mut()) });
-        // SAFETY: a null `pd` is allowed — `IbvDomain`'s `Drop` skips
-        // `ibv_dealloc_pd` for null, so nothing is ever freed.
-        Arc::new(unsafe {
-            IbvDomain::for_test(
-                context,
-                std::ptr::null_mut(),
-                IbvDeviceInfo::for_test_named("null_domain"),
-                EfaDomain,
-            )
-        })
+    /// A null [`Arc<IbvPd>`] keepalive for [`fake_mrv`]'s region; its `Drop`
+    /// deallocates nothing (null `pd`/`context`).
+    fn null_pd() -> Arc<IbvPd> {
+        Arc::new(IbvPd::null())
     }
 
     /// No-op [`Keepalive`] for tests that mint a [`KeepaliveLocalMemory`]
@@ -2087,7 +2080,7 @@ mod tests {
             "dev0".to_string(),
             Arc::new(IbvMemoryRegion {
                 mr: std::ptr::null_mut(),
-                _domain: null_domain(),
+                _pd: null_pd(),
             }),
         )
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
@@ -43,10 +43,10 @@ pub struct IbvQueuePair {
     // otherwise the first global RoCE v2 GID on `config.port_num`.
     gid: Gid,
     is_efa: bool,
-    // Keepalive for the domain whose `context`/`pd` this QP was built
-    // against, so it outlives the QP regardless of other owners (the
-    // manager, registered MRs, etc.). Never read directly.
-    _domain: Arc<dyn IbvDomainKeepalive>,
+    // Keepalive for the protection domain this QP was built against, so the PD
+    // outlives the QP regardless of other owners (the manager, registered MRs,
+    // etc.). Never read directly.
+    _pd: Arc<IbvPd>,
 }
 
 impl Drop for IbvQueuePair {
@@ -127,7 +127,7 @@ impl IbvQueuePair {
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {
         tracing::debug!("creating an IbvQueuePair from config {}", config);
-        let context = domain.context.as_ptr();
+        let context = domain.context().as_ptr();
         let pd = domain.as_ptr();
         // Resolve Auto to a concrete QP type based on device capabilities.
         let resolved_qp_type = resolve_qp_type(config.qp_type);
@@ -179,7 +179,7 @@ impl IbvQueuePair {
                     config,
                     gid,
                     is_efa: true,
-                    _domain: domain,
+                    _pd: domain.pd().clone(),
                 });
             }
 
@@ -219,7 +219,7 @@ impl IbvQueuePair {
                 config,
                 gid,
                 is_efa: false,
-                _domain: domain,
+                _pd: domain.pd().clone(),
             })
         }
     }


### PR DESCRIPTION
Summary:

Continues the ibverbs RAII cleanup begun at the base of this stack.

Makes `IbvCq` own the `Arc<IbvContext>` it was created on, and `IbvQp` own its two completion queues and its `Arc<IbvPd>`. This pulls the invariants that a completion queue must outlive the queue pairs referencing it, and that the PD must outlive the queue pair, out of the higher-level `RCQueuePair`/`IbvQueuePair` and down into the primitives themselves, so a queue pair is self-contained (and the `QpParts` bundle is no longer needed).

Reviewed By: zdevito

Differential Revision: D110426796


