### PR TITLE
scatter host-memory RDMA registrations across NICs (#4357)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -822,13 +822,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
     if devices.len() > 4 {
         // Use separate backend devices for H100 configuration
         device_1_ibv_config = IbvConfig {
-            target: IbvDeviceTarget::nic(devices[0].name().clone()),
+            target: Some(IbvDeviceTarget::nic(devices[0].name().clone())),
             ..Default::default()
         };
         // The second device used is the 3rd. Main reason is because 0 and 3 are both backend
         // devices on gtn H100 devices.
         device_2_ibv_config = IbvConfig {
-            target: IbvDeviceTarget::nic(devices[3].name().clone()),
+            target: Some(IbvDeviceTarget::nic(devices[3].name().clone())),
             ..Default::default()
         };
     } else {

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -476,13 +476,13 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     // Quick check for H100
     if devices.len() > 4 {
         ps_ibv_config = IbvConfig {
-            target: IbvDeviceTarget::nic(devices[0].name().clone()),
+            target: Some(IbvDeviceTarget::nic(devices[0].name().clone())),
             ..Default::default()
         };
         // The second device used is the 3rd. Main reason is because 0 and 3 are both backend
         // devices on gtn H100 devices.
         worker_ibv_config = IbvConfig {
-            target: IbvDeviceTarget::nic(devices[3].name().clone()),
+            target: Some(IbvDeviceTarget::nic(devices[3].name().clone())),
             ..Default::default()
         };
     } else {

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -17,7 +17,10 @@
 //! - Device selection and PCI-to-RDMA device mapping
 
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
 use std::fmt::Write as _;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -45,13 +48,13 @@ use super::IbvOp;
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
 use super::device_selection::resolve_target;
+use super::device_selection::select_optimal_ibv_devices;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::efa_device::EfaDevice;
 use super::memory_region::IbvMemoryRegionView;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
-use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
 use super::queue_pair::IbvQueuePair;
@@ -65,6 +68,7 @@ use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
 use crate::backend::RdmaConfig;
 use crate::backend::ResolveRemoteBackendContext;
+use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
 use crate::local_memory::is_device_ptr;
 use crate::rdma_components::RdmaRemoteBuffer;
@@ -313,10 +317,11 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     }
 
     /// Resolve `mem` to an [`IbvMemoryRegionView`] using the slot shared by
-    /// every clone of `mem`. On a cold slot, picks the RDMA device (the
-    /// CUDA-co-located NIC for device memory, else the config fallback) and
-    /// registers the region through that device's [`IbvDomainImpl`] strategy,
-    /// installing the result; on a warm slot, returns the cached view.
+    /// every clone of `mem`. On a cold slot, picks the RDMA device (an explicit
+    /// `config.target` if set, else the CUDA-co-located NIC for device memory,
+    /// else a hash-assigned NIC for host memory) and registers the region
+    /// through that device's [`IbvDomainImpl`] strategy, installing the result;
+    /// on a warm slot, returns the cached view.
     fn resolve_local_mr(
         &mut self,
         mem: &KeepaliveLocalMemory,
@@ -326,35 +331,74 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         }
         let addr = mem.addr();
 
-        // Pick the RDMA device: for device memory, the CUDA-co-located NIC;
-        // otherwise the configured fallback.
-        let cuda_nic = if is_device_ptr(addr) {
-            let mut device_ordinal: i32 = -1;
-            // SAFETY: `addr` is a CUDA device pointer (per `is_device_ptr`); the
-            // FFI call writes the owning device ordinal through the out-pointer.
-            let err = unsafe {
-                rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
-                    &mut device_ordinal as *mut _ as *mut std::ffi::c_void,
-                    rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
-                    addr as rdmaxcel_sys::CUdeviceptr,
-                )
-            };
-            // A non-success code yields no NIC.
-            let ordinal = (err == rdmaxcel_sys::CUDA_SUCCESS).then_some(device_ordinal);
-            ordinal.filter(|o| *o >= 0).and_then(|o| {
-                super::device_selection::get_cuda_device_to_ibv_device::<I>()
-                    .get(o as usize)
-                    .and_then(|d| d.clone())
-            })
-        } else {
-            None
-        };
-        let device_name = cuda_nic.map(|info| info.name().clone()).unwrap_or_else(|| {
-            resolve_target::<I>(&self.config.target)
-                .unwrap_or_else(|| IbvDeviceInfo::default::<I>())
+        // Device selection, in priority order:
+        //   1. an explicit `config.target`, resolved to its NIC;
+        //   2. otherwise the CUDA-co-located NIC for device memory;
+        //   3. otherwise a host-memory NIC assigned by hashing (addr, size).
+        let device_name = if let Some(target) = &self.config.target {
+            resolve_target::<I>(target)
+                .ok_or_else(|| anyhow::anyhow!("configured device target {:?} not found", target))?
                 .name()
                 .clone()
-        });
+        } else {
+            let cuda_nic = if is_device_ptr(addr) {
+                let mut device_ordinal: i32 = -1;
+                // SAFETY: `addr` is a CUDA device pointer (per `is_device_ptr`);
+                // the FFI call writes the owning device ordinal through the
+                // out-pointer.
+                let err = unsafe {
+                    rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
+                        &mut device_ordinal as *mut _ as *mut std::ffi::c_void,
+                        rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                        addr as rdmaxcel_sys::CUdeviceptr,
+                    )
+                };
+                let ordinal = (err == rdmaxcel_sys::CUDA_SUCCESS)
+                    .then_some(device_ordinal)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "could not get CUDA device ordinal for device memory at 0x{:x}: {}",
+                            addr,
+                            err
+                        )
+                    })?;
+                assert!(ordinal >= 0, "CUDA device ordinal must be non-negative");
+                Some(
+                    super::device_selection::get_cuda_device_to_ibv_device::<I>()
+                        .get(ordinal as usize)
+                        .and_then(|d| d.clone())
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "no RDMA device found for CUDA device ordinal {}",
+                                ordinal
+                            )
+                        })?,
+                )
+            } else {
+                None
+            };
+            match cuda_nic {
+                Some(info) => info.name().clone(),
+                None => {
+                    // Host memory has no co-located GPU NIC. Rather than funnel
+                    // every host registration through a single device, spread them
+                    // across all NICs that tie for the best CPU path by hashing the
+                    // region's (addr, size); the NICs share the load for host
+                    // memory, increasing aggregate throughput.
+                    let devices = select_optimal_ibv_devices::<I>(MemoryLocation::Cpu(None));
+                    match devices.len() {
+                        0 => anyhow::bail!("no RDMA devices found"),
+                        n => {
+                            let mut hasher = DefaultHasher::new();
+                            (mem.addr(), mem.size()).hash(&mut hasher);
+                            devices[(hasher.finish() % n as u64) as usize]
+                                .name()
+                                .clone()
+                        }
+                    }
+                }
+            }
+        };
         tracing::debug!(
             "Using RDMA device: {} for memory at 0x{:x}",
             device_name,

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -257,9 +257,11 @@ pub fn resolve_qp_type(qp_type: IbvQpType) -> u32 {
 /// parameters.
 #[derive(Debug, Named, Clone, Serialize, Deserialize)]
 pub struct IbvConfig {
-    /// `target` - Which RDMA device to use. A consumer resolves this to a
-    /// concrete device for its backend via [`resolve_target`].
-    pub target: IbvDeviceTarget,
+    /// `target` - An explicit RDMA device target, resolved to a concrete
+    /// device via [`resolve_target`]. When `None`, the consumer picks the
+    /// device itself (the co-located NIC for GPU memory, or a hash-assigned
+    /// NIC for host memory).
+    pub target: Option<IbvDeviceTarget>,
     /// `cq_entries` - The number of completion queue entries.
     pub cq_entries: i32,
     /// `port_num` - The physical port number on the device.
@@ -306,12 +308,12 @@ wirevalue::register_type!(IbvConfig);
 
 /// rdma-core defaults below come from common rdma-core examples; tune for
 /// production based on `ibv_query_device()` results and workload
-/// characteristics. The default target is CPU NUMA node 0; a consumer
-/// resolves it to a concrete device for its backend via [`resolve_target`].
+/// characteristics. The default target is `None`, leaving device selection to
+/// the consumer.
 impl Default for IbvConfig {
     fn default() -> Self {
         Self {
-            target: IbvDeviceTarget::MemoryLocation(MemoryLocation::Cpu(Some(0))),
+            target: None,
             cq_entries: 1024,
             port_num: 1,
             max_send_wr: 512,
@@ -340,7 +342,7 @@ impl IbvConfig {
     /// [`target`](Self::target) is `target` (see [`IbvDeviceTarget`]).
     pub fn targeting(target: IbvDeviceTarget) -> Self {
         Self {
-            target,
+            target: Some(target),
             ..Default::default()
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1347,6 +1347,7 @@ mod tests {
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::device::list_all_devices;
+    use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
     use crate::backend::ibverbs::device_selection::resolve_target;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
@@ -1362,7 +1363,7 @@ mod tests {
             use_gpu_direct: false,
             ..Default::default()
         };
-        let device_info = resolve_target::<MlxDevice>(&config.target).unwrap();
+        let device_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
         let mut device = IbvDevice::<MlxDevice>::open(device_info.name(), config.clone())
             .expect("resolved device should open");
         let domain = device
@@ -1388,14 +1389,14 @@ mod tests {
             ..Default::default()
         };
 
-        let server_info = resolve_target::<MlxDevice>(&server_config.target).unwrap();
+        let server_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
         let mut server_device =
             IbvDevice::<MlxDevice>::open(server_info.name(), server_config.clone())
                 .expect("server device should open");
         let server_domain = server_device
             .get_or_create_domain("test")
             .expect("server domain creation should succeed");
-        let client_info = resolve_target::<MlxDevice>(&client_config.target).unwrap();
+        let client_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
         let mut client_device =
             IbvDevice::<MlxDevice>::open(client_info.name(), client_config.clone())
                 .expect("client device should open");


### PR DESCRIPTION
Summary:

Host (CPU) memory has no CUDA-co-located NIC, so `resolve_local_mr` funneled every host-memory registration onto a single default device, bottlenecking host RDMA on one NIC. This instead selects the device by hashing the region's `(addr, size)` across all NICs that tie for the best CPU path (`select_optimal_ibv_devices::<I>(MemoryLocation::Cpu(None))`), spreading registrations over every equally-good NIC to recover aggregate multi-NIC bandwidth. GPU memory is mostly unchanged, with slightly updated error handling: it still binds to its CUDA-co-located NIC.

Differential Revision: D110615569


