### PR TITLE
Add language tags to docs code blocks for syntax highlighting

### DIFF
--- a/docs/source/admin-tui.md
+++ b/docs/source/admin-tui.md
@@ -23,7 +23,7 @@ python python/examples/dining_philosophers.py
 
 The example prints the admin server address on startup:
 
-```
+```text
 Mesh admin server listening on http://127.0.0.1:1729
 ```
 
@@ -97,7 +97,7 @@ calls.
 
 ## CLI Options
 
-```
+```text
 monarch-tui [OPTIONS] --addr <ADDR>
 ```
 

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -10,26 +10,28 @@ actor messaging. It provides:
 
 Monarch code imperatively describes how to create processes and actors using a simple python API:
 
-    from monarch.actor import Actor, endpoint, this_host
+```python
+from monarch.actor import Actor, endpoint, this_host
 
-    # spawn 8 trainer processes one for each gpu
-    training_procs = this_host().spawn_procs({"gpus": 8})
-
-
-    # define the actor to run on each process
-    class Trainer(Actor):
-        @endpoint
-        def train(self, step: int): ...
+# spawn 8 trainer processes one for each gpu
+training_procs = this_host().spawn_procs({"gpus": 8})
 
 
-    # create the trainers
-    trainers = training_procs.spawn("trainers", Trainer)
+# define the actor to run on each process
+class Trainer(Actor):
+    @endpoint
+    def train(self, step: int): ...
 
-    # tell all the trainers to take a step
-    fut = trainers.train.call(step=0)
 
-    # wait for all trainers to complete
-    fut.get()
+# create the trainers
+trainers = training_procs.spawn("trainers", Trainer)
+
+# tell all the trainers to take a step
+fut = trainers.train.call(step=0)
+
+# wait for all trainers to complete
+fut.get()
+```
 
 Note: Monarch runs on Linux and macOS.
   - The CPU-only tensor engine works on macOS and on Linux hosts without a GPU

--- a/docs/source/monarch-dashboard.md
+++ b/docs/source/monarch-dashboard.md
@@ -27,7 +27,7 @@ python python/examples/dining_philosophers.py --dashboard
 
 The example prints the dashboard URL on startup:
 
-```
+```text
 Monarch Dashboard: http://localhost:8265
 ```
 
@@ -70,7 +70,7 @@ the top to jump back to a parent level.
 
 The navigation levels are:
 
-```
+```text
 Host Meshes
   └─ Host Units (individual hosts)
        └─ Proc Meshes
@@ -97,7 +97,7 @@ Selecting an individual actor opens its detail page with three sections:
 
 The DAG view renders the entire job as an interactive directed graph, helping you to understand your job better.  It also shows message flows between your user actors.
 
-```
+```text
 Host → Proc → Actor
 ```
 


### PR DESCRIPTION
Summary: Tag the previously untagged code blocks in the Monarch docs so Sphinx/Pygments applies syntax highlighting: the Python example in `index.md` was an indented literal block and is now a fenced `python` block. Program output and ASCII diagrams in `admin-tui.md` and `monarch-dashboard.md` are tagged `text` so Sphinx does not mis-apply its default Python lexer to non-code content.

Differential Revision: D110786956


