### PR TITLE
monarch OSS CI: retry torch/libtorch downloads to survive transient pytorch-CDN TLS flakes

### DIFF
--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -9,6 +9,29 @@
 
 set -ex
 
+# Retry a command with a fixed backoff. CI fetches from download.pytorch.org
+# (the torch wheels and libtorch) intermittently fail the TLS handshake on the
+# self-hosted runners' network path to the CDN (SSLV3_ALERT_HANDSHAKE_FAILURE);
+# pip/wget exhaust their own retries inside a single bad window, so re-run the
+# whole command a few times spaced far enough apart to outlast a transient one.
+retry() {
+    local -r -i max_attempts=5
+    local -r -i delay_secs=30
+    local -i attempt=1
+    local -i status=0
+    while (( attempt <= max_attempts )); do
+        "$@" && return 0
+        status=$?
+        if (( attempt < max_attempts )); then
+            echo "retry: attempt ${attempt}/${max_attempts} of '$*' failed (exit ${status}); retrying in ${delay_secs}s" >&2
+            sleep "${delay_secs}"
+        fi
+        attempt=$(( attempt + 1 ))
+    done
+    echo "retry: '$*' failed after ${max_attempts} attempts (last exit ${status})" >&2
+    return "${status}"
+}
+
 # Ensure conda is available. Checks common locations first, then
 # installs Miniconda if conda is not found anywhere.
 initialize_conda() {
@@ -218,7 +241,7 @@ setup_pytorch_with_headers() {
     local libtorch_url="https://download.pytorch.org/libtorch/nightly/${libtorch_variant}/${libtorch_filename}"
 
     echo "Downloading libtorch from: ${libtorch_url}"
-    wget -q "${libtorch_url}"
+    retry wget -q "${libtorch_url}"
     unzip -q "${libtorch_filename}"
 
     # Set environment variables for libtorch
@@ -228,7 +251,9 @@ setup_pytorch_with_headers() {
 
     # Install PyTorch Python package using provided torch-spec
     echo "Installing PyTorch Python package with: ${torch_spec}"
-    pip install ${torch_spec}
+    # torch_spec is a multi-word install spec (flags + index URL); it must word-split.
+    # shellcheck disable=SC2086
+    retry pip install ${torch_spec}
 
     # Verify installation
     echo "LibTorch C++ headers available at: $LIBTORCH_ROOT/include"


### PR DESCRIPTION
Summary:
The self-hosted GPU and build CI runners intermittently fail to fetch the torch wheel and `libtorch` from `download.pytorch.org` with `SSL: SSLV3_ALERT_HANDSHAKE_FAILURE`. This is a transport-layer TLS handshake failure on the runner's network path to the Cloudflare CDN, not a monarch problem: it reproduces on `main`, the CDN and the exact artifacts are healthy (curling the failing `.whl.metadata` URLs, including the `download-r2.pytorch.org` redirect target, returns `200`), and it hits both `pip install` (GPU Python lane) and `wget` (GPU Rust lane), so it is not tool-specific. `pip` and `wget` exhaust their own built-in retries inside a single bad window.

Add a small `retry()` helper to `common-setup.sh` and wrap the two `download.pytorch.org` fetches in `setup_pytorch_with_headers` (the `wget` of `libtorch` and `pip install \${torch_spec}`): 5 attempts spaced 30s apart, enough to outlast a transient window. This mitigates the intermittent handshake flakes; it does not paper over a sustained CDN or runner-network outage.

Scoped to the shared `common-setup.sh` helper, which the failing GPU lanes reach via `setup_pytorch_with_headers`, to keep it independent of in-flight diffs. The inline `pip install --pre torch` steps in `build-cpu.yml` and `test-fuse-python.yml` hit the same endpoint and can be hardened in a follow-up.

Differential Revision: D110797338


