### PR TITLE
Remove the actor cleanup timeout (#4362)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -190,7 +190,6 @@ class FileWriter(Actor):
 **When It Runs:**
 - Called automatically in both normal and error termination
 - *Not* called on fatal failures such as OOMs, panics, or fatal signals (e.g., `SIGSEGV`)
-- Cancelled if it exceeds `HYPERACTOR_CLEANUP_TIMEOUT`, which puts the actor in an error state
 
 **What Has Already Happened:**
 - Every mesh this actor owns has already been stopped recursively

--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -190,11 +190,10 @@ class FileWriter(Actor):
 **When It Runs:**
 - Called automatically in both normal and error termination
 - *Not* called on fatal failures such as OOMs, panics, or fatal signals (e.g., `SIGSEGV`)
-- Cancelled if it exceeds `HYPERACTOR_CLEANUP_TIMEOUT`, which puts the actor in an error state
 
 **What Has Already Happened:**
-- Every mesh this actor owns has already been stopped recursively
-- Each owned actor's `__cleanup__` has already run
+- On graceful shutdown, owned actors normally finish first
+- On failure or forced teardown, residual direct children are transferred to proc supervision and aborted; each child repeats this for its own direct children, and their cleanup may not run
 - Owned actor meshes and proc meshes are no longer usable from this method
 - For shutdown work that needs an owned mesh, expose a dedicated endpoint and call it before `stop()`
 

--- a/docs/source/api/monarch.config.rst
+++ b/docs/source/api/monarch.config.rst
@@ -173,13 +173,6 @@ Timeouts
     - **Default**: ``"10s"``
     - **Environment**: ``HYPERACTOR_STOP_ACTOR_TIMEOUT``
 
-``cleanup_timeout``
-    Timeout for cleanup operations during shutdown.
-
-    - **Type**: ``str`` (duration format)
-    - **Default**: ``"3s"``
-    - **Environment**: ``HYPERACTOR_CLEANUP_TIMEOUT``
-
 ``actor_spawn_max_idle``
     Maximum idle time between updates while spawning actors in a proc mesh.
 

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -719,9 +719,6 @@ pub enum Signal {
     /// Exit the actor loop with the provided stop reason.
     ExitRequested(String),
 
-    /// The direct child with the given uid was stopped.
-    ChildStopped(crate::id::Uid),
-
     /// Kill the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
     /// hierarchy.
@@ -734,7 +731,6 @@ impl fmt::Display for Signal {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
             Signal::ExitRequested(reason) => write!(f, "ExitRequested({})", reason),
-            Signal::ChildStopped(uid) => write!(f, "ChildStopped({})", uid),
             Signal::Kill(reason) => write!(f, "Kill({})", reason),
         }
     }

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -103,12 +103,13 @@ pub trait Actor: Sized + Send + 'static {
 
     /// Handle a stop request from the runtime.
     ///
-    /// The default implementation closes handler ingress and then
-    /// either exits immediately or queues an exit after already
-    /// accepted handler work drains. Actors that need to coordinate
-    /// asynchronous shutdown work can override this method and call
-    /// `Instance::exit()` / `Instance::exit_after_drain()` later,
-    /// once they are ready to terminate.
+    /// The default implementation closes handler ingress, propagates the stop
+    /// mode to direct children, and requests exit after all of them stop.
+    /// Actors that override this hook control their own shutdown policy and
+    /// must call [`Instance::exit`] when they are ready to terminate.
+    ///
+    /// Return from this hook if shutdown depends on ordinary messages or child
+    /// supervision events so the actor loop can continue delivering them.
     async fn handle_stop(
         &mut self,
         this: &Instance<Self>,
@@ -116,6 +117,17 @@ pub trait Actor: Sized + Send + 'static {
         reason: &str,
     ) -> Result<(), anyhow::Error> {
         handle_stop(this, mode, reason)
+    }
+
+    /// Handle completion of a directly supervised child before the terminal
+    /// event is passed to [`Actor::handle_supervision_event`].
+    ///
+    /// The default implementation completes a stop initiated by the default
+    /// [`Actor::handle_stop`] implementation once no direct children remain.
+    /// Overrides that retain the default stop policy must delegate to
+    /// [`crate::actor::handle_child_stopped`].
+    async fn handle_child_stopped(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        handle_child_stopped(this)
     }
 
     /// Cleanup things used by this actor before shutting down. Notably this function
@@ -299,18 +311,21 @@ pub fn handle_expired_delivery<A: Actor>(
 /// Default implementation of [`Actor::handle_stop`]. Defined as a free
 /// function so that `Actor` implementations that override
 /// [`Actor::handle_stop`] can fall back to this default.
+///
+/// This closes handler ingress, retains the original mode and reason, and
+/// forwards the stop request to direct children. Child completion events drive
+/// the eventual actor exit.
 pub fn handle_stop<A: Actor>(
     this: &Instance<A>,
     mode: StopMode,
     reason: &str,
 ) -> Result<(), anyhow::Error> {
-    // After `close`, no more messages may be enqueued.
-    // exit_after_drain will drain any pending messages before exiting.
-    this.close();
-    match mode {
-        StopMode::Stop => this.exit(reason).map_err(anyhow::Error::from),
-        StopMode::DrainAndStop => this.exit_after_drain(reason).map_err(anyhow::Error::from),
-    }
+    this.handle_stop(mode, reason).map_err(anyhow::Error::from)
+}
+
+/// Default implementation of [`Actor::handle_child_stopped`].
+pub fn handle_child_stopped<A: Actor>(this: &Instance<A>) -> Result<(), anyhow::Error> {
+    this.handle_child_stopped().map_err(anyhow::Error::from)
 }
 
 /// An actor that does nothing. It is used to represent "client only" actors,
@@ -1051,6 +1066,11 @@ pub struct AnyActorHandle {
 }
 
 impl AnyActorHandle {
+    /// Create a lifecycle-only handle without changing supervision ownership.
+    pub(crate) fn new(cell: InstanceCell) -> Self {
+        Self { cell }
+    }
+
     /// The [`ActorAddr`] of the actor represented by this handle.
     pub fn actor_id(&self) -> &ActorAddr {
         self.cell.actor_addr()

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -719,10 +719,10 @@ pub enum Signal {
     /// Exit the actor loop with the provided stop reason.
     ExitRequested(String),
 
-    /// Kill the actor. This will exit the actor loop with an error,
+    /// Abort the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
     /// hierarchy.
-    Kill(String),
+    Abort(String),
 }
 
 impl fmt::Display for Signal {
@@ -731,7 +731,7 @@ impl fmt::Display for Signal {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
             Signal::ExitRequested(reason) => write!(f, "ExitRequested({})", reason),
-            Signal::Kill(reason) => write!(f, "Kill({})", reason),
+            Signal::Abort(reason) => write!(f, "Abort({})", reason),
         }
     }
 }
@@ -780,7 +780,7 @@ impl fmt::Display for HandlerInfo {
 pub enum ActorStoppingReason {
     /// The actor is stopping through the normal cooperative shutdown path.
     Requested,
-    /// The actor did not respond to hard kill, and teardown stopped waiting on
+    /// The actor did not respond to abort, and teardown stopped waiting on
     /// it normally.
     Zombie(String),
 }
@@ -940,10 +940,9 @@ impl<A: Actor> ActorHandle<A> {
         self.cell.signal(Signal::Stop(reason.to_string()))
     }
 
-    /// Signal the actor to terminate immediately.
-    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
-        tracing::info!("actor handle kill called: {}", self.actor_addr());
-        self.cell.signal(Signal::Kill(reason.to_string()))
+    /// Signal the actor to abort immediately.
+    pub fn abort(&self, reason: &str) -> Result<(), ActorError> {
+        self.cell.signal(Signal::Abort(reason.to_string()))
     }
 
     /// A watch that observes the lifecycle state of the actor.
@@ -1067,9 +1066,9 @@ impl AnyActorHandle {
         self.cell.signal(Signal::Stop(reason.to_string()))
     }
 
-    /// Signal the actor to terminate immediately.
-    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
-        self.cell.signal(Signal::Kill(reason.to_string()))
+    /// Signal the actor to abort immediately.
+    pub fn abort(&self, reason: &str) -> Result<(), ActorError> {
+        self.cell.signal(Signal::Abort(reason.to_string()))
     }
 
     /// A watch that observes the lifecycle state of the actor.

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -173,14 +173,6 @@ declare_attrs! {
     ))
     pub attr STOP_ACTOR_TIMEOUT: Duration = Duration::from_secs(10);
 
-    /// Timeout used by proc for running the cleanup callback on an actor.
-    /// Should be less than the timeout for STOP_ACTOR_TIMEOUT.
-    @meta(CONFIG = ConfigAttr::new(
-        Some("HYPERACTOR_CLEANUP_TIMEOUT".to_string()),
-        Some("cleanup_timeout".to_string()),
-    ))
-    pub attr CLEANUP_TIMEOUT: Duration = Duration::from_secs(3);
-
     /// How often to check for full MPSC channel on NetRx.
     @meta(CONFIG = ConfigAttr::new(
         Some("HYPERACTOR_CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL".to_string()),
@@ -353,7 +345,6 @@ mod tests {
             export HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT=1m
             # export HYPERACTOR_CODEC_MAX_FRAME_LENGTH=10737418240
             export HYPERACTOR_CODEC_MAX_FRAME_LENGTH=1024
-            # export HYPERACTOR_CLEANUP_TIMEOUT=3s
             # export HYPERACTOR_SPLIT_MAX_BUFFER_AGE=50ms
             # export HYPERACTOR_DEFAULT_ENCODING=serde_multipart
             # export HYPERACTOR_HOST_SPAWN_READY_TIMEOUT=30s

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -174,14 +174,6 @@ declare_attrs! {
     ))
     pub attr STOP_ACTOR_TIMEOUT: Duration = Duration::from_secs(10);
 
-    /// Timeout used by proc for running the cleanup callback on an actor.
-    /// Should be less than the timeout for STOP_ACTOR_TIMEOUT.
-    @meta(CONFIG = ConfigAttr::new(
-        Some("HYPERACTOR_CLEANUP_TIMEOUT".to_string()),
-        Some("cleanup_timeout".to_string()),
-    ))
-    pub attr CLEANUP_TIMEOUT: Duration = Duration::from_secs(3);
-
     /// How often to check for full MPSC channel on NetRx.
     @meta(CONFIG = ConfigAttr::new(
         Some("HYPERACTOR_CHANNEL_NET_RX_BUFFER_FULL_CHECK_INTERVAL".to_string()),
@@ -382,7 +374,6 @@ mod tests {
             export HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT=1m
             # export HYPERACTOR_CODEC_MAX_FRAME_LENGTH=10737418240
             export HYPERACTOR_CODEC_MAX_FRAME_LENGTH=1024
-            # export HYPERACTOR_CLEANUP_TIMEOUT=3s
             # export HYPERACTOR_SPLIT_MAX_BUFFER_AGE=50ms
             # export HYPERACTOR_DEFAULT_ENCODING=serde_multipart
             # export HYPERACTOR_HOST_SPAWN_READY_TIMEOUT=30s

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -109,15 +109,15 @@
 //!   is derived from root-cause actor identity; a parent that failed
 //!   due to a child's event must report `failure_is_propagated ==
 //!   true`.
-//! - **FI-9 (stored-terminal vs delivered-zombie):** For an actor
+//! - **FI-9 (detached-zombie completion suppression):** For an actor
 //!   marked `Zombie` during teardown that then reaches a terminal
 //!   status, `InstanceCell::supervision_event` records the true
-//!   terminal event (`Stopped`/`Failed`, for introspection) while
-//!   the supervision event delivered to the parent/proc remains the
-//!   non-error `Zombie` verdict (for supervision policy). The two
-//!   intentionally diverge; enforced in `proc.rs` `serve()`, where
-//!   the stored `event` and the delivered `event_to_deliver` are
-//!   computed separately.
+//!   terminal event (`Stopped`/`Failed`, for introspection), and the
+//!   terminal status replaces `Zombie`. Because detachment already
+//!   removed the actor from its parent's completion barrier and
+//!   transferred it to proc ownership, the terminal event does not
+//!   re-enter supervision. `try_send_completion_event_to_parent` makes this
+//!   decision while holding the supervision ownership lock.
 //!
 //! ## Attrs view invariants (AV-*)
 //!

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3092,30 +3092,15 @@ impl<A: Actor> Instance<A> {
             }
         }
         // Run the actor cleanup function before the actor stops to delete
-        // resources. If it times out, continue with stopping the actor.
-        // Don't call it if there was a panic, because the actor may
+        // resources. Don't call it if there was a panic, because the actor may
         // be in an invalid state and unable to access anything, for example
         // the GIL.
         let cleanup_result = if !did_panic {
-            let cleanup_timeout = hyperactor_config::global::get(config::CLEANUP_TIMEOUT);
-            match tokio::time::timeout(
-                cleanup_timeout,
-                self.inner
-                    .proc
-                    .with_current(actor.cleanup(self, result.as_ref().err())),
-            )
-            .await
-            {
-                Ok(Ok(x)) => Ok(x),
-                Ok(Err(e)) => Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::cleanup(e),
-                )),
-                Err(e) => Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::cleanup(e.into()),
-                )),
-            }
+            self.inner
+                .proc
+                .with_current(actor.cleanup(self, result.as_ref().err()))
+                .await
+                .map_err(|e| ActorError::new(self.self_addr(), ActorErrorKind::cleanup(e)))
         } else {
             Ok(())
         };

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3038,59 +3038,56 @@ impl<A: Actor> Instance<A> {
             tracing::error!("{}: actor failure: {}", self.self_addr(), err);
         }
 
-        // After this point, we know we won't spawn any more children,
-        // so we can safely read the current child keys.
-        let mut to_unlink = Vec::new();
-        let child_signal = match ChildTeardown::from_run_result(&result) {
-            ChildTeardown::Cooperative(mode) => ChildTeardown::cooperative_signal(mode),
-            ChildTeardown::Kill => {
-                // TODO: fan out kill once child teardown can detach
-                // unresponsive children without blocking this parent.
-                ChildTeardown::cooperative_signal(StopMode::Stop)
-            }
-        };
-        for child in self.inner.cell.child_iter() {
-            if let Err(err) = child.value().signal(child_signal.clone()) {
-                tracing::error!(
-                    "{}: failed to send stop signal to child pid {}: {:?}",
-                    self.self_addr(),
-                    child.key(),
-                    err
-                );
-                to_unlink.push(child.value().clone());
-            }
-        }
-        // Manually unlink children that have already been stopped.
-        for child in to_unlink {
-            self.inner.cell.unlink(&child);
-        }
-
         let (mut signal_receiver, _) = actor_loop_receivers;
-        while self.inner.cell.child_count() > 0 {
-            match tokio::time::timeout(Duration::from_millis(500), signal_receiver.recv()).await {
-                Ok(Some(Signal::ChildStopped(uid))) => {
-                    assert!(self.inner.cell.get_child(&uid).is_none());
+        // Cooperative teardown preserves parent-child ordering. Kill teardown
+        // breaks that wait by promoting unresponsive children out of this
+        // subtree.
+        match ChildTeardown::from_run_result(&result) {
+            ChildTeardown::Kill => {
+                self.kill_and_promote_children("parent killed");
+            }
+            ChildTeardown::Cooperative(mode) => {
+                // After this point, we know we won't spawn any more children,
+                // so we can safely read the current child keys.
+                let mut to_unlink = Vec::new();
+                let child_signal = ChildTeardown::cooperative_signal(mode);
+                for child in self.inner.cell.child_iter() {
+                    if let Err(err) = child.value().signal(child_signal.clone()) {
+                        tracing::error!(
+                            "{}: failed to send stop signal to child pid {}: {:?}",
+                            self.self_addr(),
+                            child.key(),
+                            err
+                        );
+                        to_unlink.push(child.value().clone());
+                    }
                 }
-                // Drain only tracks child termination; other signals are
-                // intentionally swallowed here.
-                Ok(Some(_)) => {}
-                Ok(None) => {
-                    // Signal channel closed: no further ChildStopped will
-                    // arrive, so we can no longer track child termination.
-                    // Drop remaining links and exit the drain loop, mirroring
-                    // the timeout branch below.
-                    self.inner.cell.unlink_all();
-                    break;
+                // Manually unlink children that have already been stopped.
+                for child in to_unlink {
+                    self.inner.cell.unlink(&child);
                 }
-                Err(_) => {
-                    tracing::warn!(
-                        "timeout waiting for ChildStopped signal from child on actor: {}, ignoring",
-                        self.self_addr()
-                    );
-                    // No more waiting to receive messages. Unlink all remaining
-                    // children.
-                    self.inner.cell.unlink_all();
-                    break;
+
+                while self.inner.cell.child_count() > 0 {
+                    match signal_receiver.recv().await {
+                        Some(Signal::ChildStopped(uid)) => {
+                            assert!(self.inner.cell.get_child(&uid).is_none());
+                        }
+                        Some(Signal::Kill(_)) => {
+                            self.kill_and_promote_children(
+                                "parent killed while waiting for children",
+                            );
+                            break;
+                        }
+                        // Drain only tracks child termination; other signals are
+                        // intentionally swallowed here.
+                        Some(_) => {}
+                        None => {
+                            // Signal channel closed: no further ChildStopped will
+                            // arrive, so we can no longer track child termination.
+                            self.inner.cell.unlink_all();
+                            break;
+                        }
+                    }
                 }
             }
         }
@@ -3136,6 +3133,41 @@ impl<A: Actor> Instance<A> {
         // If the original exit was not an error, let cleanup errors be
         // surfaced.
         result.and_then(|stopped| cleanup_result.map(|_| stopped.reason))
+    }
+
+    fn kill_and_promote_children(&self, reason: &str) {
+        let children: Vec<InstanceCell> = self
+            .inner
+            .cell
+            .child_iter()
+            .map(|child| child.value().clone())
+            .collect();
+        let mut children_to_kill = Vec::new();
+
+        for child in children {
+            if child.status().borrow().is_terminal() {
+                continue;
+            }
+            child.promote_to_root();
+            child.change_status(ActorStatus::zombie(format!(
+                "{}; child {} unresponsive to kill",
+                reason,
+                child.actor_addr()
+            )));
+            children_to_kill.push(child);
+        }
+
+        let signal = Signal::Kill(reason.to_string());
+        for child in children_to_kill {
+            if let Err(err) = child.signal(signal.clone()) {
+                tracing::error!(
+                    "{}: failed to send kill to child {}: {:?}",
+                    self.self_addr(),
+                    child.actor_addr(),
+                    err
+                );
+            }
+        }
     }
 
     /// Initialize and run the actor until it fails or is stopped. On success,
@@ -3545,7 +3577,7 @@ impl<A: Actor> Instance<A> {
 
     /// Return a handle to this instance's parent actor, if it has one.
     pub fn parent_handle<P: Actor>(&self) -> Option<ActorHandle<P>> {
-        let parent_cell = self.inner.cell.inner.parent.upgrade()?;
+        let parent_cell = self.inner.cell.inner.parent.read().unwrap().upgrade()?;
         let ports = if let Ok(ports) = parent_cell.inner.ports.clone().downcast() {
             ports
         } else {
@@ -3757,7 +3789,7 @@ struct InstanceCellState {
     status: watch::Receiver<ActorStatus>,
 
     /// A weak reference to this instance's parent.
-    parent: WeakInstanceCell,
+    parent: RwLock<WeakInstanceCell>,
 
     /// This instance's children by their uids.
     children: DashMap<crate::id::Uid, InstanceCell>,
@@ -3865,6 +3897,8 @@ impl InstanceCellState {
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
         self.parent
+            .read()
+            .unwrap()
             .upgrade()
             .filter(|parent| parent.inner.unlink(self))
     }
@@ -3982,7 +4016,9 @@ impl InstanceCell {
                 actor_loop,
                 status_tx,
                 status,
-                parent: parent.map_or_else(WeakInstanceCell::new, |cell| cell.downgrade()),
+                parent: RwLock::new(
+                    parent.map_or_else(WeakInstanceCell::new, |cell| cell.downgrade()),
+                ),
                 children: DashMap::new(),
                 actor_task_handle: OnceLock::new(),
                 exported_named_ports: DashMap::new(),
@@ -4281,7 +4317,7 @@ impl InstanceCell {
 
     /// Link this instance to its parent, if it has one.
     fn maybe_link_parent(&self) {
-        if let Some(parent) = self.inner.parent.upgrade() {
+        if let Some(parent) = self.inner.parent.read().unwrap().upgrade() {
             parent.link(self.clone());
         }
     }
@@ -4407,7 +4443,20 @@ impl InstanceCell {
 
     /// Get parent instance cell, if it exists.
     pub fn parent(&self) -> Option<InstanceCell> {
-        self.inner.parent.upgrade()
+        self.inner.parent.read().unwrap().upgrade()
+    }
+
+    pub(crate) fn promote_to_root(&self) {
+        // Promotion detaches a wedged child from a stopping parent so the
+        // parent can finish while the proc still owns and can later abort the
+        // child task.
+        let _ = self.maybe_unlink_parent();
+        *self.inner.parent.write().unwrap() = WeakInstanceCell::new();
+        self.inner
+            .proc
+            .inner
+            .root_actors
+            .insert(self.actor_addr().id().clone());
     }
 
     /// The actor's type name.
@@ -6119,7 +6168,14 @@ mod tests {
             parent.actor_addr().proc_addr()
         );
         assert_eq!(
-            child.inner.parent.upgrade().unwrap().actor_addr(),
+            child
+                .inner
+                .parent
+                .read()
+                .unwrap()
+                .upgrade()
+                .unwrap()
+                .actor_addr(),
             parent.actor_addr()
         );
         assert_matches!(
@@ -6179,7 +6235,16 @@ mod tests {
         // Supervision tree is constructed correctly.
         validate_link(third.cell(), second.cell());
         validate_link(second.cell(), first.cell());
-        assert!(first.cell().inner.parent.upgrade().is_none());
+        assert!(
+            first
+                .cell()
+                .inner
+                .parent
+                .read()
+                .unwrap()
+                .upgrade()
+                .is_none()
+        );
 
         // Supervision tree is torn down correctly.
         // Once each actor is stopped, it should have no linked children.
@@ -6442,6 +6507,155 @@ mod tests {
         assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
         assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent draining");
         assert_eq!(handled.load(Ordering::SeqCst), 5);
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn draining_parent_waits_for_blocked_child() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let handled = Arc::new(AtomicUsize::new(0));
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: handled.clone(),
+            },
+        );
+        let release = block_and_queue_counts(&client, &child, 1).await;
+        let mut parent_status = parent.status();
+
+        parent.drain_and_stop("test").unwrap();
+        parent_status
+            .wait_for(ActorStatus::is_stopping)
+            .await
+            .unwrap();
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(750),
+            parent_status.wait_for(ActorStatus::is_terminal),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "parent must wait for blocked child instead of unlinking it"
+        );
+
+        release.send(()).unwrap();
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_eq!(handled.load(Ordering::SeqCst), 1);
+    }
+
+    #[derive(Debug)]
+    struct SupervisingTestActor;
+
+    #[async_trait]
+    impl Actor for SupervisingTestActor {
+        async fn handle_supervision_event(
+            &mut self,
+            _this: &Instance<Self>,
+            _event: &ActorSupervisionEvent,
+        ) -> Result<bool, anyhow::Error> {
+            Ok(true)
+        }
+    }
+
+    #[derive(Debug)]
+    struct CleanupStatusActor {
+        cleanup_status: Option<oneshot::Sender<ActorStatus>>,
+    }
+
+    #[async_trait]
+    impl Actor for CleanupStatusActor {
+        async fn cleanup(
+            &mut self,
+            this: &Instance<Self>,
+            _err: Option<&ActorError>,
+        ) -> Result<(), anyhow::Error> {
+            let status = this.inner.cell.status().borrow().clone();
+            let _ = self
+                .cleanup_status
+                .take()
+                .expect("cleanup status sender should be present")
+                .send(status);
+            Ok(())
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_marks_responsive_child_zombie_before_signalling() {
+        let proc = Proc::isolated();
+        let grandparent = proc.spawn(SupervisingTestActor);
+        let parent = proc.spawn_child(grandparent.cell().clone(), TestActor);
+        let (cleanup_status_tx, cleanup_status_rx) = oneshot::channel();
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            CleanupStatusActor {
+                cleanup_status: Some(cleanup_status_tx),
+            },
+        );
+        child
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_idle)
+            .await
+            .expect("child should become idle");
+
+        parent.kill("test").unwrap();
+
+        let cleanup_status = cleanup_status_rx
+            .await
+            .expect("responsive child should report its cleanup status");
+        assert!(
+            cleanup_status.is_zombie(),
+            "child must be marked zombie before it receives kill"
+        );
+        assert_matches!(parent.await, ActorStatus::Failed(_));
+        assert_matches!(child.await, ActorStatus::Failed(_));
+
+        grandparent.drain_and_stop("test").unwrap();
+        assert_matches!(grandparent.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_promotes_unresponsive_child_to_root() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let grandparent = proc.spawn(SupervisingTestActor);
+        let parent = proc.spawn_child(grandparent.cell().clone(), TestActor);
+        let parent_cell = parent.cell().clone();
+        let handled = Arc::new(AtomicUsize::new(0));
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: handled.clone(),
+            },
+        );
+        let child_addr = child.cell().actor_addr().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.kill("test").unwrap();
+        assert_matches!(parent.await, ActorStatus::Failed(_));
+
+        child
+            .cell()
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_zombie)
+            .await
+            .expect("child should be marked zombie");
+        assert!(child.cell().parent().is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(!grandparent.cell().child_actor_ids().contains(&child_addr));
+        assert!(proc.root_actor_ids().contains(&child_addr));
+        assert!(proc.get_instance(&child_addr).is_some());
+
+        release.send(()).unwrap();
+        assert_matches!(child.await, ActorStatus::Failed(_));
+
+        grandparent.drain_and_stop("test").unwrap();
+        assert_matches!(grandparent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_eq!(handled.load(Ordering::SeqCst), 0);
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2937,11 +2937,10 @@ impl<A: Actor> Instance<A> {
             },
         };
 
-        // Supervision policy is driven by the event status, not the live cell status.
-        // After teardown marks an actor zombie, publish that lifecycle verdict instead
-        // of a late task failure so default supervision treats it as non-error.
         let current_status = self.inner.cell.status().borrow().clone();
-        let event = if current_status.is_zombie() {
+        // Supervisors observe the zombie lifecycle verdict, while the event
+        // stored below must describe the terminal status for introspection.
+        let event_to_deliver = if current_status.is_zombie() {
             Some(ActorSupervisionEvent::new(
                 self.inner.cell.actor_addr().clone(),
                 actor.display_name(),
@@ -2949,7 +2948,7 @@ impl<A: Actor> Instance<A> {
                 None,
             ))
         } else {
-            event
+            event.clone()
         };
 
         self.mailbox().close(terminal_status.clone());
@@ -2963,7 +2962,7 @@ impl<A: Actor> Instance<A> {
         // terminal state can only see it once the event has been
         // enqueued at its destination.
         if let Some(parent) = self.inner.cell.maybe_unlink_parent() {
-            if let Some(event) = event {
+            if let Some(event) = event_to_deliver {
                 // Parent exists, failure should be propagated to the parent.
                 parent.send_supervision_event_or_crash(event);
             }
@@ -2983,7 +2982,7 @@ impl<A: Actor> Instance<A> {
             //
             // Note that orphaned actor is unexpected and would only happen if
             // there is a bug.
-            if let Some(event) = event {
+            if let Some(event) = event_to_deliver {
                 self.inner
                     .proc
                     .handle_unhandled_supervision_event(&self, event);
@@ -6291,12 +6290,14 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 30)]
-    async fn zombie_task_failure_reports_non_error_supervision_event() {
+    async fn zombie_task_failure_stores_terminal_event_and_reports_zombie() {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (mut reported_event, _coordinator) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let handle = proc.spawn_with_label::<TestActor>("alive", TestActor);
+        let actor_id = handle.actor_addr().clone();
+        let cell = handle.cell().clone();
         handle
             .status()
             .clone()
@@ -6311,18 +6312,41 @@ mod tests {
             .fail(&client, anyhow::anyhow!("zombie failure"))
             .await
             .unwrap();
-        assert_matches!(handle.await, ActorStatus::Failed(_));
+        let terminal_status = handle.await;
+        assert!(
+            terminal_status.is_failed(),
+            "zombie task failure should reach a failed terminal status"
+        );
 
-        let event = tokio::time::timeout(Duration::from_secs(1), reported_event.recv())
+        let event = cell
+            .supervision_event()
+            .expect("failed zombie must store its terminal supervision event");
+        assert!(
+            event.actor_status.is_failed(),
+            "zombie terminal event should preserve the failed status"
+        );
+        assert_eq!(event.actor_status, terminal_status);
+
+        let propagated = tokio::time::timeout(Duration::from_secs(1), reported_event.recv())
             .await
             .expect("zombie supervision event should arrive");
         assert!(
-            event.actor_status.is_zombie(),
-            "zombie actor task failure should report zombie status"
+            propagated.actor_status.is_zombie(),
+            "zombie task failure should report its zombie lifecycle verdict"
         );
         assert!(
-            !event.is_error(),
-            "zombie actor task failure should report a non-error supervision event"
+            !propagated.is_error(),
+            "zombie supervision event should remain non-error"
+        );
+
+        let snapshot = wait_for_terminated_snapshot(&proc, &actor_id).await;
+        let attrs: hyperactor_config::Attrs =
+            serde_json::from_str(&snapshot.attrs).expect("snapshot attrs must be valid");
+        assert!(
+            attrs
+                .get(crate::introspect::FAILURE_ERROR_MESSAGE)
+                .is_some(),
+            "failed zombie snapshot must retain failure information"
         );
     }
 

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2055,14 +2055,14 @@ struct ActorStopped {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum ChildTeardown {
     Cooperative(StopMode),
-    Kill,
+    Abort,
 }
 
 impl ChildTeardown {
     fn from_run_result(result: &Result<ActorStopped, ActorError>) -> Self {
         match result {
             Ok(stopped) => Self::Cooperative(stopped.stop_mode),
-            Err(err) if matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)) => Self::Kill,
+            Err(err) if matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)) => Self::Abort,
             Err(_) => Self::Cooperative(StopMode::Stop),
         }
     }
@@ -2789,24 +2789,9 @@ impl<A: Actor> Instance<A> {
             .signal(Signal::DrainAndStop(reason.to_string()))
     }
 
-    /// Signal the actor to terminate immediately with a provided reason.
-    pub fn kill(&self, reason: &str) -> Result<(), ActorError> {
-        tracing::info!(
-            actor_id = %self.inner.cell.actor_addr(),
-            reason,
-            "instance kill called",
-        );
-        self.inner.cell.signal(Signal::Kill(reason.to_string()))
-    }
-
-    /// Backward-compatible alias for `kill()`.
+    /// Signal the actor to abort immediately with a provided reason.
     pub fn abort(&self, reason: &str) -> Result<(), ActorError> {
-        tracing::info!(
-            actor_id = %self.inner.cell.actor_addr(),
-            reason,
-            "instance abort called",
-        );
-        self.kill(reason)
+        self.inner.cell.signal(Signal::Abort(reason.to_string()))
     }
 
     /// Close handler ingress for this actor.
@@ -3178,8 +3163,8 @@ impl<A: Actor> Instance<A> {
         let mut to_unlink = Vec::new();
         let child_signal = match ChildTeardown::from_run_result(&result) {
             ChildTeardown::Cooperative(mode) => ChildTeardown::cooperative_signal(mode),
-            ChildTeardown::Kill => {
-                // TODO: fan out kill once child teardown can detach
+            ChildTeardown::Abort => {
+                // TODO: fan out abort once child teardown can detach
                 // unresponsive children without blocking this parent.
                 ChildTeardown::cooperative_signal(StopMode::Stop)
             }
@@ -3334,7 +3319,7 @@ impl<A: Actor> Instance<A> {
                         Signal::ExitRequested(reason) => {
                             break 'messages reason;
                         }
-                        Signal::Kill(reason) => {
+                        Signal::Abort(reason) => {
                             return Err(ActorError { actor_id: Box::new(self.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) });
                         }
                     }
@@ -8517,7 +8502,7 @@ mod tests {
     }
 
     #[test]
-    fn child_teardown_distinguishes_kill_from_failure() {
+    fn child_teardown_distinguishes_abort_from_failure() {
         let actor_addr = test_actor_id("proc", "actor");
 
         let stopped = Ok(ActorStopped {
@@ -8529,11 +8514,14 @@ mod tests {
             ChildTeardown::Cooperative(StopMode::DrainAndStop)
         );
 
-        let killed = Err(ActorError::new(
+        let aborted = Err(ActorError::new(
             &actor_addr,
-            ActorErrorKind::Aborted("test kill".to_string()),
+            ActorErrorKind::Aborted("test abort".to_string()),
         ));
-        assert_eq!(ChildTeardown::from_run_result(&killed), ChildTeardown::Kill);
+        assert_eq!(
+            ChildTeardown::from_run_result(&aborted),
+            ChildTeardown::Abort
+        );
 
         let failed = Err(ActorError::new(
             &actor_addr,

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2026,6 +2026,9 @@ struct InstanceState<A: Actor> {
     /// Runtime-owned delayed-post scheduler.
     delayed_posts: DelayedPosts<A>,
 
+    /// Stop request retained while direct children terminate.
+    pending_stop: Mutex<Option<StopRequest>>,
+
     /// Shutdown signal for the runtime-owned introspection task.
     introspect_shutdown_tx: Mutex<Option<oneshot::Sender<ActorStatus>>>,
 
@@ -2047,32 +2050,13 @@ struct InstanceState<A: Actor> {
     instance_locals: ActorLocalStorage,
 }
 
-struct ActorStopped {
+/// A cooperative stop request retained until direct children terminate.
+#[derive(Debug)]
+struct StopRequest {
+    /// The requested child shutdown mode.
+    mode: StopMode,
+    /// The caller-supplied reason that becomes the clean terminal reason.
     reason: String,
-    stop_mode: StopMode,
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ChildTeardown {
-    Cooperative(StopMode),
-    Abort,
-}
-
-impl ChildTeardown {
-    fn from_run_result(result: &Result<ActorStopped, ActorError>) -> Self {
-        match result {
-            Ok(stopped) => Self::Cooperative(stopped.stop_mode),
-            Err(err) if matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)) => Self::Abort,
-            Err(_) => Self::Cooperative(StopMode::Stop),
-        }
-    }
-
-    fn cooperative_signal(mode: StopMode) -> Signal {
-        match mode {
-            StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
-            StopMode::Stop => Signal::Stop("parent stopping".to_string()),
-        }
-    }
 }
 
 type DelayedPost<A> = Box<dyn FnOnce(&Instance<A>) + Send>;
@@ -2510,6 +2494,7 @@ impl<A: Actor> Instance<A> {
             mailbox,
             ports,
             delayed_posts: DelayedPosts::new(),
+            pending_stop: Mutex::new(None),
             introspect_shutdown_tx: Mutex::new(None),
             introspect_task_handle: Mutex::new(None),
             detached_introspect_shutdown_tx: Mutex::new(None),
@@ -2800,6 +2785,15 @@ impl<A: Actor> Instance<A> {
         self.inner.mailbox.drain();
     }
 
+    /// Return a point-in-time snapshot of direct children.
+    pub(crate) fn children(&self) -> Vec<AnyActorHandle> {
+        self.inner
+            .cell
+            .child_iter()
+            .map(|child| AnyActorHandle::new(child.value().clone()))
+            .collect()
+    }
+
     /// Subscribe to this actor's status changes.
     pub fn status(&self) -> watch::Receiver<ActorStatus> {
         self.inner.cell.status().clone()
@@ -2831,6 +2825,63 @@ impl<A: Actor> Instance<A> {
             Box::pin(async move {
                 this.exit(&reason).map_err(anyhow::Error::from)?;
                 Ok(())
+            })
+        });
+        self.enqueue_runtime_work(work)
+    }
+
+    /// Handle a stop request by stopping direct children before exiting.
+    pub(crate) fn handle_stop(&self, mode: StopMode, reason: &str) -> Result<(), ActorError> {
+        self.close();
+        {
+            let mut pending = self.inner.pending_stop.lock().unwrap();
+            if pending.is_some() {
+                return Ok(());
+            }
+            *pending = Some(StopRequest {
+                mode,
+                reason: reason.to_string(),
+            });
+        }
+
+        for child in self.children() {
+            let result = match mode {
+                StopMode::Stop => child.stop(reason),
+                StopMode::DrainAndStop => child.drain_and_stop(reason),
+            };
+            if let Err(err) = result {
+                tracing::debug!(
+                    child = %child.actor_id(),
+                    "failed to forward stop request to child: {err:?}"
+                );
+            }
+        }
+        self.handle_child_stopped()
+    }
+
+    /// Handle direct-child completion while a stop request is pending.
+    pub(crate) fn handle_child_stopped(&self) -> Result<(), ActorError> {
+        if self.inner.cell.child_count() != 0 {
+            return Ok(());
+        }
+        let Some(request) = self.inner.pending_stop.lock().unwrap().take() else {
+            return Ok(());
+        };
+        match request.mode {
+            StopMode::Stop => self.exit(&request.reason),
+            StopMode::DrainAndStop => self.exit_after_drain(&request.reason),
+        }
+    }
+
+    /// Queue the actor's stop hook behind already accepted ordinary work.
+    fn handle_stop_after_drain(&self, reason: String) -> Result<(), ActorError> {
+        let work = WorkCell::new(move |actor: &mut A, instance: &Instance<A>| {
+            Box::pin(async move {
+                instance
+                    .inner
+                    .proc
+                    .with_current(actor.handle_stop(instance, StopMode::DrainAndStop, &reason))
+                    .await
             })
         });
         self.enqueue_runtime_work(work)
@@ -3161,14 +3212,9 @@ impl<A: Actor> Instance<A> {
         // After this point, we know we won't spawn any more children,
         // so we can safely read the current child keys.
         let mut to_unlink = Vec::new();
-        let child_signal = match ChildTeardown::from_run_result(&result) {
-            ChildTeardown::Cooperative(mode) => ChildTeardown::cooperative_signal(mode),
-            ChildTeardown::Abort => {
-                // TODO: fan out abort once child teardown can detach
-                // unresponsive children without blocking this parent.
-                ChildTeardown::cooperative_signal(StopMode::Stop)
-            }
-        };
+        // TODO: Detach and abort residual children instead of initiating another
+        // cooperative stop after the parent actor loop has exited.
+        let child_signal = Signal::Stop("parent stopping".to_string());
         for child in self.inner.cell.child_iter() {
             if let Err(err) = child.value().signal(child_signal.clone()) {
                 tracing::error!(
@@ -3194,6 +3240,8 @@ impl<A: Actor> Instance<A> {
             .await
             {
                 Ok(Some(event)) => {
+                    // TODO: Remove this post-loop event drain when residual
+                    // children are detached and aborted instead of awaited.
                     if let Some(child_id) = &event.child_to_unlink {
                         self.inner.cell.inner.unlink_child_by_id(child_id);
                     }
@@ -3201,9 +3249,6 @@ impl<A: Actor> Instance<A> {
                 Ok(None) => {
                     // The supervision channel closed, so no further child
                     // completion events can arrive.
-                    // Drop remaining links and exit the drain loop, mirroring
-                    // the timeout branch below.
-                    self.inner.cell.unlink_all();
                     break;
                 }
                 Err(_) => {
@@ -3211,12 +3256,14 @@ impl<A: Actor> Instance<A> {
                         "timeout waiting for child supervision event on actor: {}, ignoring",
                         self.self_addr()
                     );
-                    // No more waiting to receive messages. Unlink all remaining
-                    // children.
-                    self.inner.cell.unlink_all();
                     break;
                 }
             }
+        }
+        // TODO: Remove this fallback unlink when residual children are detached
+        // and aborted instead of discarded from the parent topology.
+        for child in self.children() {
+            self.inner.cell.inner.unlink_child_by_id(child.actor_id());
         }
         // Run the actor cleanup function before the actor stops to delete
         // resources. If it times out, continue with stopping the actor.
@@ -3259,12 +3306,25 @@ impl<A: Actor> Instance<A> {
         }
         // If the original exit was not an error, let cleanup errors be
         // surfaced.
-        result.and_then(|stopped| cleanup_result.map(|_| stopped.reason))
+        result.and_then(|reason| cleanup_result.map(|_| reason))
+    }
+
+    /// Deliver all queued supervision events before committing a competing
+    /// terminal result.
+    async fn process_queued_supervision_events(
+        &self,
+        actor: &mut A,
+        supervision_event_receiver: &mut mpsc::UnboundedReceiver<ActorSupervisionEvent>,
+    ) -> Result<(), ActorError> {
+        while let Ok(supervision_event) = supervision_event_receiver.try_recv() {
+            self.handle_supervision_event(actor, supervision_event)
+                .await?;
+        }
+        Ok(())
     }
 
     /// Initialize and run the actor until it fails or is stopped. On success,
-    /// returns why the actor stopped and the mode that child actors inherit.
-    /// On failure, returns the error that caused the failure.
+    /// returns why the actor stopped. On failure, returns the error that caused the failure.
     async fn run(
         &mut self,
         actor: &mut A,
@@ -3273,9 +3333,8 @@ impl<A: Actor> Instance<A> {
             mpsc::UnboundedReceiver<ActorSupervisionEvent>,
         ),
         work_rx: &mut ActorWorkReceiver<A>,
-    ) -> Result<ActorStopped, ActorError> {
+    ) -> Result<String, ActorError> {
         let (signal_receiver, supervision_event_receiver) = actor_loop_receivers;
-        let mut stop_mode = StopMode::Stop;
 
         self.change_status(ActorStatus::Initializing);
         self.inner
@@ -3284,6 +3343,7 @@ impl<A: Actor> Instance<A> {
             .await
             .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::init(err)))?;
         let actor_id_str = self.self_addr().to_string();
+        let mut stop_requested = false;
         let stop_reason = 'messages: loop {
             if !self.is_stopping() {
                 self.change_status(ActorStatus::Idle);
@@ -3299,27 +3359,36 @@ impl<A: Actor> Instance<A> {
                     tracing::debug!("received signal {signal:?}");
                     match signal {
                         Signal::Stop(reason) => {
-                            stop_mode = StopMode::Stop;
+                            if stop_requested {
+                                continue 'messages;
+                            }
+                            stop_requested = true;
                             self.change_status(ActorStatus::stopping());
                             self.inner
                                 .proc
                                 .with_current(actor.handle_stop(self, StopMode::Stop, &reason))
                                 .await
-                                .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
+                                .map_err(|err| {
+                                    ActorError::new(
+                                        self.self_addr(),
+                                        ActorErrorKind::processing(err),
+                                    )
+                                })?;
                         },
                         Signal::DrainAndStop(reason) => {
-                            stop_mode = StopMode::DrainAndStop;
+                            if stop_requested {
+                                continue 'messages;
+                            }
+                            stop_requested = true;
                             self.change_status(ActorStatus::stopping());
-                            self.inner
-                                .proc
-                                .with_current(actor.handle_stop(self, StopMode::DrainAndStop, &reason))
-                                .await
-                                .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
+                            self.handle_stop_after_drain(reason)?;
                         },
                         Signal::ExitRequested(reason) => {
                             break 'messages reason;
                         }
                         Signal::Abort(reason) => {
+                            // TODO: Move Abort out of the signal queue so it can
+                            // preempt an in-progress actor hook.
                             return Err(ActorError { actor_id: Box::new(self.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) });
                         }
                     }
@@ -3330,9 +3399,8 @@ impl<A: Actor> Instance<A> {
                     let _ = ACTOR_MESSAGE_HANDLER_DURATION.start(metric_pairs);
                     let work = work.expect("inconsistent work queue state");
                     if let Err(err) = work.handle(actor, self).await {
-                        while let Ok(supervision_event) = supervision_event_receiver.try_recv() {
-                            self.handle_supervision_event(actor, supervision_event).await?;
-                        }
+                        self.process_queued_supervision_events(actor, supervision_event_receiver)
+                            .await?;
                         let kind = ActorErrorKind::processing(err);
                         return Err(ActorError {
                             actor_id: Box::new(self.self_addr().clone()),
@@ -3370,10 +3438,7 @@ impl<A: Actor> Instance<A> {
             reason = stop_reason,
             "exited actor loop",
         );
-        Ok(ActorStopped {
-            reason: stop_reason,
-            stop_mode,
-        })
+        Ok(stop_reason)
     }
 
     /// Handle a supervision event using the provided actor.
@@ -3384,8 +3449,24 @@ impl<A: Actor> Instance<A> {
     ) -> Result<(), ActorError> {
         // `actor_id` may identify a propagated descendant. `child_to_unlink`
         // identifies the local ownership edge for this delivery.
-        if let Some(child_id) = &supervision_event.child_to_unlink {
-            self.inner.cell.inner.unlink_child_by_id(child_id);
+        if supervision_event
+            .child_to_unlink
+            .as_ref()
+            .is_some_and(|child_id| self.inner.cell.inner.unlink_child_by_id(child_id))
+        {
+            self.inner
+                .proc
+                .with_current(actor.handle_child_stopped(self))
+                .await
+                .map_err(|err| {
+                    ActorError::new(
+                        self.self_addr(),
+                        ActorErrorKind::ErrorDuringHandlingSupervision(
+                            err.to_string(),
+                            Box::new(supervision_event.clone()),
+                        ),
+                    )
+                })?;
         }
 
         if supervision_event.is_locally_cancelled() {
@@ -4495,11 +4576,6 @@ impl InstanceCell {
     fn unlink(&self, child: &InstanceCell) {
         assert_eq!(self.actor_addr().proc_id(), child.actor_addr().proc_id());
         self.inner.children.remove(child.uid());
-    }
-
-    /// Unlink this instance from all children.
-    fn unlink_all(&self) {
-        self.inner.children.clear();
     }
 
     /// Link this instance to its parent, if it has one.
@@ -6565,7 +6641,7 @@ mod tests {
 
         parent.drain_and_stop("test").unwrap();
         assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
-        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -6710,7 +6786,7 @@ mod tests {
                     .try_post(&client, TestActorMessage::Noop())
                     .is_err()
             );
-            assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+            assert_matches!(actor.await, ActorStatus::Stopped(reason) if reason == "test");
         }
     }
 
@@ -6725,6 +6801,7 @@ mod tests {
     enum DrainCountingMessage {
         Block(oneshot::Sender<()>, oneshot::Receiver<()>),
         Count(),
+        Spawn(oneshot::Sender<ActorHandle<TestActor>>),
     }
 
     #[async_trait]
@@ -6743,6 +6820,15 @@ mod tests {
 
         async fn count(&mut self, _cx: &crate::Context<Self>) -> Result<(), anyhow::Error> {
             self.handled.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn spawn(
+            &mut self,
+            cx: &crate::Context<Self>,
+            child: oneshot::Sender<ActorHandle<TestActor>>,
+        ) -> Result<(), anyhow::Error> {
+            child.send(cx.spawn(TestActor)).unwrap();
             Ok(())
         }
     }
@@ -6780,8 +6866,64 @@ mod tests {
         release.send(()).unwrap();
 
         assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
-        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
         assert_eq!(handled.load(Ordering::SeqCst), 5);
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn drain_includes_children_spawned_by_accepted_work() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let parent = proc.spawn(DrainCountingActor {
+            handled: Arc::new(AtomicUsize::new(0)),
+        });
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        parent.post(&client, DrainCountingMessage::Block(entered_tx, release_rx));
+        entered_rx.await.unwrap();
+        let (child_tx, child_rx) = oneshot::channel();
+        parent.post(&client, DrainCountingMessage::Spawn(child_tx));
+
+        parent.drain_and_stop("test").unwrap();
+        release_tx.send(()).unwrap();
+        let child = child_rx.await.unwrap();
+
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn stopping_parent_waits_for_blocked_child() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let release = block_and_queue_counts(&client, &child, 0).await;
+        let mut parent_status = parent.status();
+
+        parent.stop("test").unwrap();
+        parent_status
+            .wait_for(ActorStatus::is_stopping)
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(
+                Duration::from_millis(100),
+                parent_status.wait_for(ActorStatus::is_terminal),
+            )
+            .await
+            .is_err(),
+            "parent stopped before its child"
+        );
+
+        release.send(()).unwrap();
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -6803,8 +6945,8 @@ mod tests {
         release.send(()).unwrap();
 
         assert_matches!(grandparent.await, ActorStatus::Stopped(reason) if reason == "test");
-        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "parent draining");
-        assert_matches!(grandchild.await, ActorStatus::Stopped(reason) if reason == "parent draining");
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(grandchild.await, ActorStatus::Stopped(reason) if reason == "test");
         assert_eq!(handled.load(Ordering::SeqCst), 7);
     }
 
@@ -6833,6 +6975,25 @@ mod tests {
         parent.drain_and_stop("test").unwrap();
 
         assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(err) if err.to_string().contains("stop failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn parent_observes_child_failure_during_stop() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let parent = proc.spawn(TestActor);
+        let child = proc.spawn_child(parent.cell().clone(), StopFailingActor);
+
+        parent.stop("test").unwrap();
+
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(err) if err.to_string().contains("stop failed")
+        );
         assert_matches!(
             parent.await,
             ActorStatus::Failed(err) if err.to_string().contains("stop failed")
@@ -6893,6 +7054,74 @@ mod tests {
 
         release_stop.notify_one();
         assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[derive(Debug)]
+    struct MessageDrivenStopActor {
+        stop_started: Option<oneshot::Sender<()>>,
+    }
+
+    #[async_trait]
+    impl Actor for MessageDrivenStopActor {
+        async fn handle_stop(
+            &mut self,
+            _this: &Instance<Self>,
+            _mode: StopMode,
+            _reason: &str,
+        ) -> Result<(), anyhow::Error> {
+            self.stop_started
+                .take()
+                .expect("stop hook should run once")
+                .send(())
+                .expect("test should wait for stop hook");
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<()> for MessageDrivenStopActor {
+        async fn handle(&mut self, cx: &crate::Context<Self>, _message: ()) -> anyhow::Result<()> {
+            cx.exit("shutdown message handled")?;
+            Ok(())
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn continuing_stop_processes_ordinary_work() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (stop_started_tx, stop_started_rx) = oneshot::channel();
+        let actor = proc.spawn(MessageDrivenStopActor {
+            stop_started: Some(stop_started_tx),
+        });
+
+        actor.stop("test").unwrap();
+        stop_started_rx.await.unwrap();
+        actor.post(&client, ());
+
+        assert_matches!(
+            actor.await,
+            ActorStatus::Stopped(reason) if reason == "shutdown message handled"
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn continuing_drain_and_stop_processes_ordinary_work() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let (stop_started_tx, stop_started_rx) = oneshot::channel();
+        let actor = proc.spawn(MessageDrivenStopActor {
+            stop_started: Some(stop_started_tx),
+        });
+
+        actor.drain_and_stop("test").unwrap();
+        stop_started_rx.await.unwrap();
+        actor.post(&client, ());
+
+        assert_matches!(
+            actor.await,
+            ActorStatus::Stopped(reason) if reason == "shutdown message handled"
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -8499,38 +8728,6 @@ mod tests {
         // would panic in debug builds if running_total had wrapped to u64::MAX.
         account_enqueue(&depth, &stats, "a");
         assert_eq!(stats.running_total(), 1);
-    }
-
-    #[test]
-    fn child_teardown_distinguishes_abort_from_failure() {
-        let actor_addr = test_actor_id("proc", "actor");
-
-        let stopped = Ok(ActorStopped {
-            reason: "test".to_string(),
-            stop_mode: StopMode::DrainAndStop,
-        });
-        assert_eq!(
-            ChildTeardown::from_run_result(&stopped),
-            ChildTeardown::Cooperative(StopMode::DrainAndStop)
-        );
-
-        let aborted = Err(ActorError::new(
-            &actor_addr,
-            ActorErrorKind::Aborted("test abort".to_string()),
-        ));
-        assert_eq!(
-            ChildTeardown::from_run_result(&aborted),
-            ChildTeardown::Abort
-        );
-
-        let failed = Err(ActorError::new(
-            &actor_addr,
-            ActorErrorKind::Generic("test failure".to_string()),
-        ));
-        assert_eq!(
-            ChildTeardown::from_run_result(&failed),
-            ChildTeardown::Cooperative(StopMode::Stop)
-        );
     }
 
     hyperactor_config::attrs::declare_attrs! {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3127,34 +3127,15 @@ impl<A: Actor> Instance<A> {
             },
         };
 
-        let current_status = self.inner.cell.status().borrow().clone();
-        // FI-9: supervisors observe the zombie lifecycle verdict, while the event
-        // stored below must describe the terminal status for introspection.
-        let event_to_deliver = if current_status.is_zombie() {
-            ActorSupervisionEvent::new(
-                self.inner.cell.actor_addr().clone(),
-                actor.display_name(),
-                current_status,
-                None,
-            )
-        } else {
-            event.clone()
-        };
-
         self.mailbox().close(terminal_status.clone());
         // FI-1: store supervision_event BEFORE change_status.
-        *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event);
+        *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
 
-        // Deliver the supervision event to the parent/proc BEFORE
-        // change_status so that any observer waiting for this actor's
-        // terminal state can only see it once the event has been
-        // enqueued at its destination. A returned event had no owning parent
-        // — the root actor, or an orphaned child, which would be a bug.
-        if let Some(event) = self
-            .inner
-            .cell
-            .try_send_completion_event_to_parent(event_to_deliver)
-        {
+        // Resolve completion routing BEFORE change_status so that any observer
+        // waiting for this actor's terminal state cannot race the supervision
+        // decision. A returned event had no owning parent and must follow the
+        // proc's unhandled-supervision path.
+        if let Some(event) = self.inner.cell.try_send_completion_event_to_parent(event) {
             self.inner
                 .proc
                 .handle_unhandled_supervision_event(&self, event);
@@ -3164,9 +3145,36 @@ impl<A: Actor> Instance<A> {
         self.change_status(terminal_status);
     }
 
-    /// Runs the actor, and manages its supervision tree. When the function returns,
-    /// the whole tree rooted at this actor has stopped. On success, returns the reason
-    /// why the actor stopped. On failure, returns the error that caused the failure.
+    fn abort_residual_children(&self, reason: &str) {
+        // Clone child cells before detaching so no `children` map guard is held while
+        // detachment removes from that map. Completion and detachment both lock the
+        // child's parent link before accessing the parent's children map.
+        let children: Vec<_> = self
+            .inner
+            .cell
+            .child_iter()
+            .map(|child| child.value().clone())
+            .collect();
+        for child in children {
+            if !child.detach_to_proc_as_zombie(format!(
+                "detached during forced parent teardown: {reason}"
+            )) {
+                continue;
+            }
+            if let Err(err) = child.signal(Signal::Abort(reason.to_string())) {
+                tracing::debug!(
+                    actor_id = %self.self_addr(),
+                    child_id = %child.actor_addr(),
+                    "detached child already stopped during forced teardown: {}",
+                    err,
+                );
+            }
+        }
+    }
+
+    /// Runs the actor and initiates teardown of its supervision tree. On success,
+    /// returns the reason why the actor stopped. On failure, returns the error that
+    /// caused the failure after transferring residual children to the proc.
     async fn run_actor_tree(
         &mut self,
         actor: &mut A,
@@ -3209,62 +3217,11 @@ impl<A: Actor> Instance<A> {
             tracing::error!("{}: actor failure: {}", self.self_addr(), err);
         }
 
-        // After this point, we know we won't spawn any more children,
-        // so we can safely read the current child keys.
-        let mut to_unlink = Vec::new();
-        // TODO: Detach and abort residual children instead of initiating another
-        // cooperative stop after the parent actor loop has exited.
-        let child_signal = Signal::Stop("parent stopping".to_string());
-        for child in self.inner.cell.child_iter() {
-            if let Err(err) = child.value().signal(child_signal.clone()) {
-                tracing::error!(
-                    "{}: failed to send stop signal to child pid {}: {:?}",
-                    self.self_addr(),
-                    child.key(),
-                    err
-                );
-                to_unlink.push(child.value().clone());
-            }
-        }
-        // Manually unlink children that have already been stopped.
-        for child in to_unlink {
-            self.inner.cell.unlink(&child);
-        }
-
-        let (_, mut supervision_event_receiver) = actor_loop_receivers;
-        while self.inner.cell.child_count() > 0 {
-            match tokio::time::timeout(
-                Duration::from_millis(500),
-                supervision_event_receiver.recv(),
-            )
-            .await
-            {
-                Ok(Some(event)) => {
-                    // TODO: Remove this post-loop event drain when residual
-                    // children are detached and aborted instead of awaited.
-                    if let Some(child_id) = &event.child_to_unlink {
-                        self.inner.cell.inner.unlink_child_by_id(child_id);
-                    }
-                }
-                Ok(None) => {
-                    // The supervision channel closed, so no further child
-                    // completion events can arrive.
-                    break;
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        "timeout waiting for child supervision event on actor: {}, ignoring",
-                        self.self_addr()
-                    );
-                    break;
-                }
-            }
-        }
-        // TODO: Remove this fallback unlink when residual children are detached
-        // and aborted instead of discarded from the parent topology.
-        for child in self.children() {
-            self.inner.cell.inner.unlink_child_by_id(child.actor_id());
-        }
+        let teardown_reason = match &result {
+            Ok(reason) => format!("parent exited: {reason}"),
+            Err(err) => format!("parent failed: {err}"),
+        };
+        self.abort_residual_children(&teardown_reason);
         // Run the actor cleanup function before the actor stops to delete
         // resources. If it times out, continue with stopping the actor.
         // Don't call it if there was a panic, because the actor may
@@ -3280,14 +3237,14 @@ impl<A: Actor> Instance<A> {
             )
             .await
             {
-                Ok(Ok(x)) => Ok(x),
-                Ok(Err(e)) => Err(ActorError::new(
+                Ok(Ok(result)) => Ok(result),
+                Ok(Err(err)) => Err(ActorError::new(
                     self.self_addr(),
-                    ActorErrorKind::cleanup(e),
+                    ActorErrorKind::cleanup(err),
                 )),
-                Err(e) => Err(ActorError::new(
+                Err(err) => Err(ActorError::new(
                     self.self_addr(),
-                    ActorErrorKind::cleanup(e.into()),
+                    ActorErrorKind::cleanup(err.into()),
                 )),
             }
         } else {
@@ -4010,8 +3967,9 @@ struct InstanceCellState {
     /// An observer that stores the current status of the actor.
     status: watch::Receiver<ActorStatus>,
 
-    /// A weak reference to this instance's parent.
-    parent: WeakInstanceCell,
+    /// A weak reference to this instance's parent. An empty reference means
+    /// this instance is supervised directly by the proc.
+    parent: Mutex<WeakInstanceCell>,
 
     /// This instance's children by their uids.
     children: DashMap<crate::id::Uid, InstanceCell>,
@@ -4117,25 +4075,47 @@ struct InstanceCellState {
 }
 
 impl InstanceCellState {
-    /// Route this instance's terminal event according to current supervision
-    /// ownership.
+    /// Routes this instance's terminal event while holding supervision
+    /// ownership against forced detachment.
     ///
     /// If the parent still owns this child, enqueue the event while retaining
-    /// that ownership. The parent removes the child when it consumes the event,
-    /// so a queued terminal event remains visible to its shutdown policy.
+    /// that ownership. The child-map entry guard prevents concurrent parent
+    /// teardown from removing the ownership before enqueue. The parent removes
+    /// the child when it consumes the event, so a queued terminal event remains
+    /// visible to its shutdown policy. If detachment already made the child a
+    /// zombie, suppress the event; otherwise return an unowned event so the
+    /// caller can route it through proc supervision.
     /// Returns the event when no parent owns the child so the caller can route
     /// it through proc supervision.
     fn try_send_completion_event_to_parent(
         &self,
         event: ActorSupervisionEvent,
     ) -> Option<ActorSupervisionEvent> {
-        let Some(parent) = self.parent.upgrade() else {
+        let parent = self.parent.lock().unwrap();
+        // FI-9: detachment already removed a zombie from its parent's completion
+        // barrier. Preserve its terminal event for introspection without
+        // re-entering supervision.
+        if self.status.borrow().is_zombie() {
+            assert!(
+                self.proc
+                    .inner
+                    .root_instances
+                    .contains_key(self.actor_id.id()),
+                "zombie actor {} is not proc-supervised",
+                self.actor_id
+            );
+            return None;
+        }
+
+        let Some(parent) = parent.upgrade() else {
             return Some(event);
         };
         let Some(child_entry) = parent.inner.children.get(self.actor_id.uid()) else {
             return Some(event);
         };
 
+        // Keep completion delivery in the child's ownership critical section so
+        // forced teardown cannot retarget the event before it is enqueued.
         parent.send_supervision_event_or_crash(event.with_child_to_unlink(self.actor_id.clone()));
         drop(child_entry);
         None
@@ -4144,9 +4124,8 @@ impl InstanceCellState {
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.parent
-            .upgrade()
-            .filter(|parent| parent.inner.unlink(self))
+        let parent = self.parent.lock().unwrap().upgrade();
+        parent.filter(|parent| parent.inner.unlink(self))
     }
 
     /// Unlink this instance from a child.
@@ -4280,7 +4259,9 @@ impl InstanceCell {
                 actor_loop,
                 status_tx,
                 status,
-                parent: parent.map_or_else(WeakInstanceCell::new, |cell| cell.downgrade()),
+                parent: Mutex::new(
+                    parent.map_or_else(WeakInstanceCell::new, |cell| cell.downgrade()),
+                ),
                 children: DashMap::new(),
                 actor_task_handle: OnceLock::new(),
                 exported_named_ports: DashMap::new(),
@@ -4352,13 +4333,22 @@ impl InstanceCell {
     /// the last status was active for.
     #[track_caller]
     fn change_status(&self, new: ActorStatus) {
+        let actor_linked = new.is_zombie() && self.parent().is_some();
+        self.change_status_inner(new, actor_linked);
+    }
+
+    /// `change_status`, with the parent link already classified by the caller.
+    /// The parent lock is not reentrant, so a caller that holds it must pass
+    /// `actor_linked` instead of letting `change_status` re-lock.
+    #[track_caller]
+    fn change_status_inner(&self, new: ActorStatus, actor_linked: bool) -> bool {
         let mut old_status = None;
         let mut illegal_status = None;
         let actor_id = self.actor_addr().id().clone();
         let changed = self.inner.status_tx.send_if_modified(|status| {
             let old = status.clone();
             let mut status_change = classify_status_change(&old, &new);
-            if status_change == StatusChange::Apply && new.is_zombie() && self.parent().is_some() {
+            if status_change == StatusChange::Apply && new.is_zombie() && actor_linked {
                 status_change = StatusChange::Illegal(IllegalStatusChange::LinkedZombie);
             }
 
@@ -4408,7 +4398,7 @@ impl InstanceCell {
         }
 
         if !changed {
-            return;
+            return false;
         }
         let old = old_status.expect("status change should capture previous status");
         // Idle/Processing transitions are omitted because they occur for every
@@ -4417,7 +4407,7 @@ impl InstanceCell {
             || (old.is_processing() && new.is_idle())
             || old == new
         {
-            return;
+            return true;
         }
 
         let actor_id = hash_to_u64(self.actor_addr().id());
@@ -4445,6 +4435,7 @@ impl InstanceCell {
             new_status: new_status.to_string(),
             reason: change_reason,
         });
+        true
     }
 
     fn publish_dropped_status(&self, terminal_status: ActorStatus) {
@@ -4573,14 +4564,14 @@ impl InstanceCell {
     }
 
     /// Unlink this instance from a child.
-    fn unlink(&self, child: &InstanceCell) {
-        assert_eq!(self.actor_addr().proc_id(), child.actor_addr().proc_id());
-        self.inner.children.remove(child.uid());
+    fn unlink(&self, child: &InstanceCell) -> bool {
+        self.inner.unlink(child.inner.as_ref())
     }
 
     /// Link this instance to its parent, if it has one.
     fn maybe_link_parent(&self) {
-        if let Some(parent) = self.inner.parent.upgrade() {
+        let parent = self.inner.parent.lock().unwrap().upgrade();
+        if let Some(parent) = parent {
             parent.link(self.clone());
         }
     }
@@ -4590,6 +4581,44 @@ impl InstanceCell {
         event: ActorSupervisionEvent,
     ) -> Option<ActorSupervisionEvent> {
         self.inner.try_send_completion_event_to_parent(event)
+    }
+
+    /// Removes this child from its parent while holding the completion-routing
+    /// lock. A non-terminal child is transferred to proc supervision and marked
+    /// as a zombie.
+    ///
+    /// If detachment wins a completion race, the later terminal event remains
+    /// available to introspection but does not re-enter supervision.
+    ///
+    /// Returns whether the child was promoted and should receive Abort. A
+    /// terminal child is only unlinked. The method also returns `false` when
+    /// the parent no longer owns the child edge, including when another
+    /// detachment has already won.
+    fn detach_to_proc_as_zombie(&self, reason: String) -> bool {
+        let mut parent_link = self.inner.parent.lock().unwrap();
+        // TODO: Enforce the eventual-consistency invariant that every non-terminal
+        // actor without a live parent is registered in `root_instances`.
+        let Some(parent) = parent_link.upgrade() else {
+            return false;
+        };
+        if !parent.unlink(self) {
+            return false;
+        }
+        *parent_link = WeakInstanceCell::new();
+        if !self.change_status_inner(ActorStatus::zombie(reason), false) {
+            return false;
+        }
+        assert!(
+            self.inner
+                .proc
+                .inner
+                .root_instances
+                .insert(self.actor_addr().id().clone(), self.downgrade())
+                .is_none(),
+            "actor {} is already registered as a proc root",
+            self.actor_addr()
+        );
+        true
     }
 
     /// Return an iterator over this instance's children. This may deadlock if the
@@ -4720,7 +4749,7 @@ impl InstanceCell {
 
     /// Get parent instance cell, if it exists.
     pub fn parent(&self) -> Option<InstanceCell> {
-        self.inner.parent.upgrade()
+        self.inner.parent.lock().unwrap().upgrade()
     }
 
     /// The actor's type name.
@@ -5182,31 +5211,31 @@ mod tests {
             ),
             (
                 ActorStatus::stopping(),
-                ActorStatus::zombie("hard kill did not finish"),
+                ActorStatus::zombie("abort did not finish"),
                 StatusChange::Apply,
                 "non-terminal to zombie",
             ),
             (
-                ActorStatus::zombie("hard kill did not finish"),
+                ActorStatus::zombie("abort did not finish"),
                 ActorStatus::Stopped("done".to_string()),
                 StatusChange::Apply,
                 "zombie to terminal",
             ),
             (
-                ActorStatus::zombie("hard kill did not finish"),
+                ActorStatus::zombie("abort did not finish"),
                 ActorStatus::Idle,
                 StatusChange::Ignore,
                 "zombie to idle",
             ),
             (
-                ActorStatus::zombie("hard kill did not finish"),
+                ActorStatus::zombie("abort did not finish"),
                 ActorStatus::stopping(),
                 StatusChange::Ignore,
                 "zombie to stopping",
             ),
             (
                 ActorStatus::Stopped("done".to_string()),
-                ActorStatus::zombie("hard kill did not finish"),
+                ActorStatus::zombie("abort did not finish"),
                 StatusChange::Ignore,
                 "terminal to zombie",
             ),
@@ -6597,7 +6626,7 @@ mod tests {
             .unwrap();
         alive
             .cell()
-            .change_status(ActorStatus::zombie("hard kill did not finish"));
+            .change_status(ActorStatus::zombie("abort did not finish"));
         assert!(alive.cell().status().borrow().is_zombie());
 
         alive.cell().change_status(ActorStatus::Idle);
@@ -6609,7 +6638,7 @@ mod tests {
         let terminal_status = stopped.await;
         assert!(terminal_status.is_terminal());
 
-        stopped_cell.change_status(ActorStatus::zombie("hard kill did not finish"));
+        stopped_cell.change_status(ActorStatus::zombie("abort did not finish"));
         assert_eq!(*stopped_cell.status().borrow(), terminal_status);
 
         alive.drain_and_stop("test").unwrap();
@@ -6632,7 +6661,7 @@ mod tests {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             child
                 .cell()
-                .change_status(ActorStatus::zombie("hard kill did not finish"));
+                .change_status(ActorStatus::zombie("abort did not finish"));
         }));
         assert!(
             result.is_err(),
@@ -6656,7 +6685,7 @@ mod tests {
             .unwrap();
         handle
             .cell()
-            .change_status(ActorStatus::zombie("hard kill did not finish"));
+            .change_status(ActorStatus::zombie("abort did not finish"));
 
         let await_handle = handle.clone();
         let result = tokio::time::timeout(
@@ -6672,12 +6701,12 @@ mod tests {
         assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
-    // FI-9: stored-terminal and delivered-zombie intentionally diverge.
+    // FI-9: a detached zombie stores its terminal event without propagating it.
     #[async_timed_test(timeout_secs = 60)]
-    async fn zombie_task_failure_stores_terminal_event_and_reports_zombie() {
+    async fn zombie_task_failure_stores_terminal_event_without_propagation() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let (mut reported_event, _coordinator) =
+        let (mut reported_event, coordinator) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let handle = proc.spawn_with_label::<TestActor>("alive", TestActor);
         let actor_id = handle.actor_addr().clone();
@@ -6690,7 +6719,7 @@ mod tests {
             .unwrap();
         handle
             .cell()
-            .change_status(ActorStatus::zombie("hard kill did not finish"));
+            .change_status(ActorStatus::zombie("abort did not finish"));
 
         handle
             .fail(&client, anyhow::anyhow!("zombie failure"))
@@ -6711,17 +6740,16 @@ mod tests {
         );
         assert_eq!(event.actor_status, terminal_status);
 
-        let propagated = tokio::time::timeout(Duration::from_secs(1), reported_event.recv())
-            .await
-            .expect("zombie supervision event should arrive");
-        assert!(
-            propagated.actor_status.is_zombie(),
-            "zombie task failure should report its zombie lifecycle verdict"
+        // The marker is posted after the zombie reaches terminal status. Receiving
+        // it first proves that the earlier zombie completion was not propagated.
+        let marker = ActorSupervisionEvent::new(
+            coordinator.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("completion barrier".to_string()),
+            None,
         );
-        assert!(
-            !propagated.is_error(),
-            "zombie supervision event should remain non-error"
-        );
+        coordinator.post(&client, marker.clone());
+        assert_eq!(reported_event.recv().await, marker);
 
         let view = wait_for_terminated_actor_view(&proc, &actor_id).await;
         assert_eq!(
@@ -6752,7 +6780,7 @@ mod tests {
             .wait_for(ActorStatus::is_idle)
             .await
             .unwrap();
-        cell.change_status(ActorStatus::zombie("hard kill did not finish"));
+        cell.change_status(ActorStatus::zombie("abort did not finish"));
         assert!(cell.status().borrow().is_zombie());
 
         handle.drain_and_stop("test").unwrap();
@@ -6966,7 +6994,7 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 30)]
-    async fn failed_drain_stop_stops_children_immediately() {
+    async fn failed_stop_aborts_children() {
         let proc = Proc::isolated();
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let parent = proc.spawn(StopFailingActor);
@@ -6974,7 +7002,11 @@ mod tests {
 
         parent.drain_and_stop("test").unwrap();
 
-        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
         assert_matches!(
             parent.await,
             ActorStatus::Failed(err) if err.to_string().contains("stop failed")
@@ -6998,6 +7030,243 @@ mod tests {
             parent.await,
             ActorStatus::Failed(err) if err.to_string().contains("stop failed")
         );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn abort_detaches_blocked_child() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let child_cell = child.cell().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.abort("abort").unwrap();
+
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: abort"
+        );
+        child_cell
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_zombie)
+            .await
+            .unwrap();
+        assert!(child_cell.parent().is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(
+            proc.state()
+                .root_instances
+                .contains_key(child_cell.actor_addr().id())
+        );
+
+        release.send(()).unwrap();
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn abort_interrupts_parent_waiting_for_child() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let child_cell = child.cell().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.stop("stop").unwrap();
+        parent
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_stopping)
+            .await
+            .unwrap();
+        parent.abort("abort").unwrap();
+
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: abort"
+        );
+        child_cell
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_zombie)
+            .await
+            .unwrap();
+        assert!(child_cell.parent().is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(
+            proc.state()
+                .root_instances
+                .contains_key(child_cell.actor_addr().id())
+        );
+
+        release.send(()).unwrap();
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn abort_detaches_only_direct_child() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let child_cell = child.cell().clone();
+        let grandchild = proc.spawn_child(child_cell.clone(), TestActor);
+        let grandchild_cell = grandchild.cell().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.abort("abort").unwrap();
+
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: abort"
+        );
+
+        child_cell
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_zombie)
+            .await
+            .unwrap();
+        assert_eq!(child_cell.child_count(), 1);
+        assert_eq!(
+            grandchild_cell.parent().unwrap().actor_addr(),
+            child_cell.actor_addr()
+        );
+        assert!(
+            !proc
+                .state()
+                .root_instances
+                .contains_key(grandchild_cell.actor_addr().id())
+        );
+
+        release.send(()).unwrap();
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+        assert_matches!(
+            grandchild.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn queued_completion_retains_parent_link_until_teardown() {
+        let proc = Proc::isolated();
+        let mut parent = proc.actor_instance::<TestActor>("parent").unwrap();
+        let parent_cell = parent.handle.cell().clone();
+        let child = parent.instance.spawn(TestActor);
+        let child_cell = child.cell().clone();
+        let event = ActorSupervisionEvent::new(
+            child_cell.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("test completion".to_string()),
+            None,
+        );
+
+        assert!(
+            child_cell
+                .try_send_completion_event_to_parent(event)
+                .is_none()
+        );
+        assert_eq!(parent_cell.child_count(), 1);
+        assert!(child_cell.detach_to_proc_as_zombie("forced teardown".to_string()));
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(parent.supervision.try_recv().is_ok());
+
+        child.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn terminal_completion_is_unlinked_during_parent_teardown() {
+        let proc = Proc::isolated();
+        let mut parent = proc.actor_instance::<TestActor>("parent").unwrap();
+        let parent_cell = parent.handle.cell().clone();
+        let child = parent.instance.spawn(TestActor);
+        let child_cell = child.cell().clone();
+
+        child.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_eq!(parent_cell.child_count(), 1);
+
+        parent.instance.abort_residual_children("test parent exit");
+
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(child_cell.parent().is_none());
+        assert!(
+            !proc
+                .state()
+                .root_instances
+                .contains_key(child_cell.actor_addr().id())
+        );
+        assert!(parent.supervision.try_recv().is_ok());
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn detach_suppresses_racing_completion() {
+        let proc = Proc::isolated();
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(parent_cell.clone(), TestActor);
+        let child_cell = child.cell().clone();
+
+        // Model completion creating its terminal event before forced teardown
+        // wins the ownership race.
+        let event = ActorSupervisionEvent::new(
+            child_cell.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("test completion".to_string()),
+            None,
+        );
+        assert!(child_cell.detach_to_proc_as_zombie("forced teardown".to_string()));
+        assert!(
+            child_cell
+                .try_send_completion_event_to_parent(event)
+                .is_none()
+        );
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(child_cell.parent().is_none());
+
+        child.drain_and_stop("test").unwrap();
+        parent.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
     #[derive(Debug)]
@@ -7170,15 +7439,20 @@ mod tests {
             ActorStatus::Failed(err) if err.to_string() == "some random failure"
         );
 
-        // TODO: should we provide finer-grained stop reasons, e.g., to indicate it was
-        // stopped by a parent failure?
-        // Currently the parent fails with an error related to the child's failure.
         assert_matches!(
             root.await,
             ActorStatus::Failed(err) if err.to_string().contains("some random failure")
         );
-        assert_matches!(root_2_1.await, ActorStatus::Stopped(_));
-        assert_matches!(root_1.await, ActorStatus::Stopped(_));
+        assert_matches!(
+            root_2_1.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+        assert_matches!(
+            root_1.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3223,30 +3223,15 @@ impl<A: Actor> Instance<A> {
         };
         self.abort_residual_children(&teardown_reason);
         // Run the actor cleanup function before the actor stops to delete
-        // resources. If it times out, continue with stopping the actor.
-        // Don't call it if there was a panic, because the actor may
+        // resources. Don't call it if there was a panic, because the actor may
         // be in an invalid state and unable to access anything, for example
         // the GIL.
         let cleanup_result = if !did_panic {
-            let cleanup_timeout = hyperactor_config::global::get(config::CLEANUP_TIMEOUT);
-            match tokio::time::timeout(
-                cleanup_timeout,
-                self.inner
-                    .proc
-                    .with_current(actor.cleanup(self, result.as_ref().err())),
-            )
-            .await
-            {
-                Ok(Ok(result)) => Ok(result),
-                Ok(Err(err)) => Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::cleanup(err),
-                )),
-                Err(err) => Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::cleanup(err.into()),
-                )),
-            }
+            self.inner
+                .proc
+                .with_current(actor.cleanup(self, result.as_ref().err()))
+                .await
+                .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::cleanup(err)))
         } else {
             Ok(())
         };

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3055,14 +3055,14 @@ impl<A: Actor> Instance<A> {
                     status.clone(),
                     None,
                 );
-                (status, Some(event))
+                (status, event)
             }
             Err(err) => match *err.kind {
                 ActorErrorKind::UnhandledSupervisionEvent(box event) => {
                     // We use the event's actor_status as this actor's terminal status.
                     assert!(event.actor_status.is_terminal());
                     let status = event.actor_status.clone();
-                    (status, Some(event))
+                    (status, event)
                 }
                 ActorErrorKind::SyntheticSupervision(synthetic) => {
                     let local_fence = synthetic.local_fence.clone();
@@ -3075,7 +3075,7 @@ impl<A: Actor> Instance<A> {
                         None,
                     )
                     .with_local_fence(local_fence);
-                    (status, Some(event))
+                    (status, event)
                 }
                 _ => {
                     let error_kind = ActorErrorKind::Generic(err.kind.to_string());
@@ -3086,7 +3086,7 @@ impl<A: Actor> Instance<A> {
                         status.clone(),
                         None,
                     );
-                    (status, Some(event))
+                    (status, event)
                 }
             },
         };
@@ -3095,52 +3095,33 @@ impl<A: Actor> Instance<A> {
         // FI-9: supervisors observe the zombie lifecycle verdict, while the event
         // stored below must describe the terminal status for introspection.
         let event_to_deliver = if current_status.is_zombie() {
-            Some(ActorSupervisionEvent::new(
+            ActorSupervisionEvent::new(
                 self.inner.cell.actor_addr().clone(),
                 actor.display_name(),
                 current_status,
                 None,
-            ))
+            )
         } else {
             event.clone()
         };
 
         self.mailbox().close(terminal_status.clone());
         // FI-1: store supervision_event BEFORE change_status.
-        if let Some(event) = &event {
-            *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
-        }
+        *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event);
 
         // Deliver the supervision event to the parent/proc BEFORE
         // change_status so that any observer waiting for this actor's
         // terminal state can only see it once the event has been
-        // enqueued at its destination.
-        if let Some(parent) = self.inner.cell.maybe_unlink_parent() {
-            if let Some(event) = event_to_deliver {
-                // Parent exists, failure should be propagated to the parent.
-                parent.send_supervision_event_or_crash(event);
-            }
-            // TODO: we should get rid of this signal, and use *only* supervision events for
-            // the purpose of conveying lifecycle changes
-            if let Err(err) = parent.signal(Signal::ChildStopped(self.inner.cell.uid().clone())) {
-                tracing::error!(
-                    "{}: failed to send stop message to parent uid {}: {:?}",
-                    self.self_addr(),
-                    parent.uid(),
-                    err
-                );
-            }
-        } else {
-            // Failure happened to the root actor or orphaned child actors.
-            // In either case, the failure should be propagated to proc.
-            //
-            // Note that orphaned actor is unexpected and would only happen if
-            // there is a bug.
-            if let Some(event) = event_to_deliver {
-                self.inner
-                    .proc
-                    .handle_unhandled_supervision_event(&self, event);
-            }
+        // enqueued at its destination. A returned event had no owning parent
+        // — the root actor, or an orphaned child, which would be a bug.
+        if let Some(event) = self
+            .inner
+            .cell
+            .try_send_completion_event_to_parent(event_to_deliver)
+        {
+            self.inner
+                .proc
+                .handle_unhandled_supervision_event(&self, event);
         }
 
         self.stop_introspect(terminal_status.clone()).await;
@@ -3219,18 +3200,22 @@ impl<A: Actor> Instance<A> {
             self.inner.cell.unlink(&child);
         }
 
-        let (mut signal_receiver, _) = actor_loop_receivers;
+        let (_, mut supervision_event_receiver) = actor_loop_receivers;
         while self.inner.cell.child_count() > 0 {
-            match tokio::time::timeout(Duration::from_millis(500), signal_receiver.recv()).await {
-                Ok(Some(Signal::ChildStopped(uid))) => {
-                    assert!(self.inner.cell.get_child(&uid).is_none());
+            match tokio::time::timeout(
+                Duration::from_millis(500),
+                supervision_event_receiver.recv(),
+            )
+            .await
+            {
+                Ok(Some(event)) => {
+                    if let Some(child_id) = &event.child_to_unlink {
+                        self.inner.cell.inner.unlink_child_by_id(child_id);
+                    }
                 }
-                // Drain only tracks child termination; other signals are
-                // intentionally swallowed here.
-                Ok(Some(_)) => {}
                 Ok(None) => {
-                    // Signal channel closed: no further ChildStopped will
-                    // arrive, so we can no longer track child termination.
+                    // The supervision channel closed, so no further child
+                    // completion events can arrive.
                     // Drop remaining links and exit the drain loop, mirroring
                     // the timeout branch below.
                     self.inner.cell.unlink_all();
@@ -3238,7 +3223,7 @@ impl<A: Actor> Instance<A> {
                 }
                 Err(_) => {
                     tracing::warn!(
-                        "timeout waiting for ChildStopped signal from child on actor: {}, ignoring",
+                        "timeout waiting for child supervision event on actor: {}, ignoring",
                         self.self_addr()
                     );
                     // No more waiting to receive messages. Unlink all remaining
@@ -3346,9 +3331,6 @@ impl<A: Actor> Instance<A> {
                                 .await
                                 .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
                         },
-                        Signal::ChildStopped(uid) => {
-                            assert!(self.inner.cell.get_child(&uid).is_none());
-                        },
                         Signal::ExitRequested(reason) => {
                             break 'messages reason;
                         }
@@ -3415,6 +3397,12 @@ impl<A: Actor> Instance<A> {
         actor: &mut A,
         supervision_event: ActorSupervisionEvent,
     ) -> Result<(), ActorError> {
+        // `actor_id` may identify a propagated descendant. `child_to_unlink`
+        // identifies the local ownership edge for this delivery.
+        if let Some(child_id) = &supervision_event.child_to_unlink {
+            self.inner.cell.inner.unlink_child_by_id(child_id);
+        }
+
         if supervision_event.is_locally_cancelled() {
             return Ok(());
         }
@@ -4063,6 +4051,30 @@ struct InstanceCellState {
 }
 
 impl InstanceCellState {
+    /// Route this instance's terminal event according to current supervision
+    /// ownership.
+    ///
+    /// If the parent still owns this child, enqueue the event while retaining
+    /// that ownership. The parent removes the child when it consumes the event,
+    /// so a queued terminal event remains visible to its shutdown policy.
+    /// Returns the event when no parent owns the child so the caller can route
+    /// it through proc supervision.
+    fn try_send_completion_event_to_parent(
+        &self,
+        event: ActorSupervisionEvent,
+    ) -> Option<ActorSupervisionEvent> {
+        let Some(parent) = self.parent.upgrade() else {
+            return Some(event);
+        };
+        let Some(child_entry) = parent.inner.children.get(self.actor_id.uid()) else {
+            return Some(event);
+        };
+
+        parent.send_supervision_event_or_crash(event.with_child_to_unlink(self.actor_id.clone()));
+        drop(child_entry);
+        None
+    }
+
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
@@ -4075,6 +4087,20 @@ impl InstanceCellState {
     fn unlink(&self, child: &InstanceCellState) -> bool {
         assert_eq!(self.actor_id.proc_id(), child.actor_id.proc_id());
         self.children.remove(child.actor_id.uid()).is_some()
+    }
+
+    /// Unlink a child when its terminal event is consumed by this actor.
+    fn unlink_child_by_id(&self, child_id: &ActorAddr) -> bool {
+        if self.actor_id.proc_id() != child_id.proc_id() {
+            return false;
+        }
+        match self.children.entry(child_id.uid().clone()) {
+            Entry::Occupied(entry) if entry.get().actor_addr() == child_id => {
+                entry.remove();
+                true
+            }
+            _ => false,
+        }
     }
 }
 
@@ -4498,10 +4524,11 @@ impl InstanceCell {
         }
     }
 
-    /// Unlink this instance from its parent, if it has one. If it was unlinked,
-    /// the parent is returned.
-    fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.inner.maybe_unlink_parent()
+    fn try_send_completion_event_to_parent(
+        &self,
+        event: ActorSupervisionEvent,
+    ) -> Option<ActorSupervisionEvent> {
+        self.inner.try_send_completion_event_to_parent(event)
     }
 
     /// Return an iterator over this instance's children. This may deadlock if the
@@ -4524,7 +4551,7 @@ impl InstanceCell {
             .collect()
     }
 
-    /// Get a child by its uid.
+    #[cfg(test)]
     fn get_child(&self, uid: &crate::id::Uid) -> Option<InstanceCell> {
         self.inner.children.get(uid).map(|child| child.clone())
     }
@@ -6435,7 +6462,13 @@ mod tests {
             third_cell.parent().unwrap().actor_addr(),
             second.actor_addr()
         );
-        assert!(second.cell().get_child(third_cell.uid()).is_none());
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while second.cell().get_child(third_cell.uid()).is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("parent must consume the terminal event and unlink the child");
         drop(third_cell);
         validate_link(second.cell(), first.cell());
 
@@ -7205,6 +7238,40 @@ mod tests {
         assert!(!root_1_1_1_state.load(Ordering::SeqCst));
         assert!(!root_2_state.load(Ordering::SeqCst));
         assert!(!root_2_1_state.load(Ordering::SeqCst));
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn terminal_event_unlinks_child_when_consumed() {
+        let proc = Proc::isolated();
+        let mut parent = proc.actor_instance::<TestActor>("parent").unwrap();
+        let parent_cell = parent.handle.cell().clone();
+        let child = parent.instance.spawn(TestActor);
+        let child_addr = child.actor_addr().clone();
+
+        child.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_eq!(
+            parent_cell.child_count(),
+            1,
+            "child must remain linked until its terminal event is consumed"
+        );
+
+        let event = parent
+            .supervision
+            .recv()
+            .await
+            .expect("child must publish a terminal supervision event");
+        assert_eq!(event.child_to_unlink.as_ref(), Some(&child_addr));
+        parent
+            .instance
+            .handle_supervision_event(&mut TestActor, event)
+            .await
+            .expect("clean child completion should be handled");
+        assert_eq!(
+            parent_cell.child_count(),
+            0,
+            "consuming the terminal event must unlink the child"
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor/src/supervision.rs
+++ b/hyperactor/src/supervision.rs
@@ -71,6 +71,11 @@ pub struct ActorSupervisionEvent {
     #[serde(skip, default = "local_fence")]
     #[derivative(PartialEq = "ignore")]
     pub(crate) local_fence: Arc<AtomicBool>,
+    /// Direct child whose ownership edge the receiver must remove. This is
+    /// hop-local bookkeeping and is not part of the propagated event.
+    #[serde(skip)]
+    #[derivative(PartialEq = "ignore")]
+    pub(crate) child_to_unlink: Option<ActorAddr>,
 }
 wirevalue::register_type!(ActorSupervisionEvent);
 
@@ -93,11 +98,17 @@ impl ActorSupervisionEvent {
             actor_status,
             message_headers,
             local_fence: local_fence(),
+            child_to_unlink: None,
         }
     }
 
     pub(crate) fn with_local_fence(mut self, local_fence: Arc<AtomicBool>) -> Self {
         self.local_fence = local_fence;
+        self
+    }
+
+    pub(crate) fn with_child_to_unlink(mut self, child_to_unlink: ActorAddr) -> Self {
+        self.child_to_unlink = Some(child_to_unlink);
         self
     }
 

--- a/hyperactor_remote/example/remote_spawner.rs
+++ b/hyperactor_remote/example/remote_spawner.rs
@@ -122,12 +122,7 @@ impl Actor for Calculator {
         reason: &str,
     ) -> anyhow::Result<()> {
         println!("calculator stopping before driver exits: {reason}");
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
+        hyperactor::actor::handle_stop(this, mode, reason)
     }
 }
 
@@ -205,26 +200,6 @@ impl Actor for SpawnerBootstrap {
         write_text(&self.token_file, &token.to_string()).await?;
         println!("proc spawner token {}", token);
         self.proc_spawner = Some(proc_spawner);
-        Ok(())
-    }
-
-    async fn handle_stop(
-        &mut self,
-        this: &Instance<Self>,
-        mode: StopMode,
-        reason: &str,
-    ) -> anyhow::Result<()> {
-        if let Some(proc_spawner) = &self.proc_spawner {
-            let _ = match mode {
-                StopMode::Stop => proc_spawner.stop(reason),
-                StopMode::DrainAndStop => proc_spawner.drain_and_stop(reason),
-            };
-        }
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
         Ok(())
     }
 }
@@ -352,7 +327,7 @@ impl Handler<CalculationResult> for Driver {
             result.lhs, result.rhs, result.sum
         );
         println!("driver exiting through this.exit(); calculator should stop first");
-        cx.exit("demo complete")?;
+        cx.drain_and_stop("demo complete")?;
         Ok(())
     }
 }

--- a/hyperactor_remote/example/token_supervision.rs
+++ b/hyperactor_remote/example/token_supervision.rs
@@ -170,12 +170,7 @@ impl Actor for DemoChild {
         if let Some(path) = &self.stopped_file {
             write_text(path, reason).await?;
         }
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
+        hyperactor::actor::handle_stop(this, mode, reason)
     }
 }
 

--- a/hyperactor_remote/src/keepalive.rs
+++ b/hyperactor_remote/src/keepalive.rs
@@ -315,7 +315,7 @@ impl Handler<KeepaliveAck> for KeepaliveWorker {
 impl Handler<AckDeadline> for KeepaliveWorker {
     async fn handle(&mut self, cx: &Context<Self>, message: AckDeadline) -> anyhow::Result<()> {
         if self.acked_generation < message.generation {
-            cx.kill("keepalive acknowledgment missed")?;
+            cx.abort("keepalive acknowledgment missed")?;
         }
         Ok(())
     }
@@ -382,7 +382,7 @@ impl Handler<Deadline> for KeepaliveSupervisor {
         // cannot be produced by this actor before it observes that generation.
         if message.generation == self.generation {
             let reason = format!("keepalive missed for generation {}", message.generation);
-            cx.kill(&reason)?;
+            cx.abort(&reason)?;
         }
         Ok(())
     }

--- a/hyperactor_remote/src/link.rs
+++ b/hyperactor_remote/src/link.rs
@@ -144,7 +144,7 @@ mod tests {
         async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
             let link = self.link.take().unwrap();
             let handle = link.spawn_worker(this).await?;
-            handle.kill("link failed")?;
+            handle.abort("link failed")?;
             Ok(())
         }
 

--- a/hyperactor_remote/src/proc_spawner/unix.rs
+++ b/hyperactor_remote/src/proc_spawner/unix.rs
@@ -77,6 +77,7 @@ use hyperactor::ProcAddr;
 use hyperactor::Uid;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::StopMode;
+use hyperactor::actor::handle_stop as default_handle_stop;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
 use hyperactor::context;
@@ -310,29 +311,6 @@ impl Actor for UnixProcSpawner {
             self.procs.remove(&uid);
         }
         Ok(!event.is_error())
-    }
-
-    async fn handle_stop(
-        &mut self,
-        this: &Instance<Self>,
-        mode: StopMode,
-        reason: &str,
-    ) -> anyhow::Result<()> {
-        // The caller-side supervision tree owns each spawned actor-spawn endpoint.
-        // `UnixProcSpawner` also owns the OS child processes, so spawner shutdown must
-        // stop every worker even if no individual caller has requested it.
-        for worker in self.procs.values() {
-            let _ = match mode {
-                StopMode::Stop => worker.stop(reason),
-                StopMode::DrainAndStop => worker.drain_and_stop(reason),
-            };
-        }
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
     }
 }
 
@@ -885,12 +863,7 @@ impl Actor for UnixProcWorker {
             // the OS process directly.
             self.signal_child(Signal::SIGTERM, reason);
         }
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
+        default_handle_stop(this, mode, reason)
     }
 }
 

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -1252,10 +1252,10 @@ mod tests {
     //         └── supervisor: Supervisor
     //             └── supervisor-side liveness actor: KeepaliveSupervisor
     //
-    // Killing Parent still tears down its local supervision subtree. Grandparent
+    // Killing Parent hard-kills its local supervision subtree. Grandparent
     // handles the parent failure so the test process does not treat it as an
-    // unhandled root failure. Parent stops Supervisor, Supervisor forwards the
-    // stop to Worker, and Worker stops TestChild.
+    // unhandled root failure. Since Supervisor does not run its graceful stop
+    // handler, Worker stops TestChild through the liveness orphan policy.
     #[tokio::test]
     async fn test_parent_kill_stops_remote_child() {
         let proc = Proc::isolated();
@@ -1289,7 +1289,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(reason, "parent stopping");
+        assert_eq!(reason, "supervision liveness failed");
 
         let event = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
             .await

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -804,8 +804,8 @@ mod tests {
     wirevalue::register_type!(TestChildCommand);
 
     #[derive(Clone, Debug, Serialize, Deserialize, Named)]
-    struct KillParent;
-    wirevalue::register_type!(KillParent);
+    struct AbortParent;
+    wirevalue::register_type!(AbortParent);
 
     #[derive(Debug)]
     enum TestChildAction {
@@ -869,7 +869,7 @@ mod tests {
             message: TestChildCommand,
         ) -> anyhow::Result<()> {
             match message {
-                TestChildCommand::Fail => cx.kill("test child failed")?,
+                TestChildCommand::Fail => cx.abort("test child failed")?,
                 TestChildCommand::Drain(tag) => {
                     if let Some(ref port) = self.drain_observer {
                         port.post(cx, tag);
@@ -908,7 +908,7 @@ mod tests {
     }
 
     #[derive(Debug)]
-    #[hyperactor::export(KillParent)]
+    #[hyperactor::export(AbortParent)]
     struct Grandparent {
         parent: Option<Parent>,
         parent_addr: PortHandle<ActorAddr>,
@@ -940,16 +940,16 @@ mod tests {
     }
 
     #[async_trait]
-    impl Handler<KillParent> for Grandparent {
+    impl Handler<AbortParent> for Grandparent {
         async fn handle(
             &mut self,
             _cx: &Context<Self>,
-            _message: KillParent,
+            _message: AbortParent,
         ) -> anyhow::Result<()> {
             self.parent_handle
                 .as_ref()
-                .expect("parent must be spawned before kill")
-                .kill("test parent killed")?;
+                .expect("parent must be spawned before abort")
+                .abort("test parent aborted")?;
             Ok(())
         }
     }
@@ -1245,12 +1245,12 @@ mod tests {
     //         └── supervisor: Supervisor
     //             └── supervisor-side liveness actor: KeepaliveSupervisor
     //
-    // Killing Parent still tears down its local supervision subtree. Grandparent
+    // Aborting Parent still tears down its local supervision subtree. Grandparent
     // handles the parent failure so the test process does not treat it as an
     // unhandled root failure. Parent stops Supervisor, Supervisor forwards the
     // stop to Worker, and Worker stops TestChild.
     #[tokio::test]
-    async fn test_parent_kill_stops_remote_child() {
+    async fn test_parent_abort_stops_remote_child() {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let (ready, mut ready_rx) = client.open_port::<ActorAddr>();
@@ -1276,7 +1276,7 @@ mod tests {
         let parent_addr = parent_addr_rx.recv().await.unwrap();
 
         tokio::time::sleep(Duration::from_millis(100)).await;
-        grandparent.post(&client, KillParent);
+        grandparent.post(&client, AbortParent);
 
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
             .await

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -304,8 +304,7 @@ impl Handler<SupervisorEvent> for Supervisor {
                     child,
                     display_name,
                 });
-                self.send_pending_worker_stop(cx)?;
-                Ok(())
+                self.send_pending_worker_stop(cx)
             }
             SupervisorEvent::SuperviseRejected { session_id, reason } => {
                 self.ensure_session(&session_id)?;
@@ -321,8 +320,12 @@ impl Handler<SupervisorEvent> for Supervisor {
             }
             SupervisorEvent::Unlinked { session_id, reason } => {
                 self.ensure_session(&session_id)?;
-                cx.exit(&reason)?;
-                Ok(())
+                cx.close();
+                if let Some(liveness) = self.liveness_handle.take() {
+                    let _ = liveness.stop("remote supervision ended");
+                    let _ = liveness.await;
+                }
+                cx.exit(&reason).map_err(Into::into)
             }
         }
     }
@@ -852,12 +855,7 @@ mod tests {
             reason: &str,
         ) -> anyhow::Result<()> {
             self.stopped.post(this, reason.to_string());
-            this.close();
-            match mode {
-                StopMode::Stop => this.exit(reason)?,
-                StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-            }
-            Ok(())
+            hyperactor::actor::handle_stop(this, mode, reason)
         }
     }
 
@@ -1016,6 +1014,7 @@ mod tests {
         link_started: PortHandle<()>,
         release_link: Arc<Notify>,
         received_stop: PortHandle<String>,
+        unlink_reason: Option<String>,
         session: Option<(hyperactor::Uid, PortRef<SupervisorEvent>)>,
     }
 
@@ -1051,8 +1050,10 @@ mod tests {
                     anyhow::bail!("stop received before supervise");
                 };
                 anyhow::ensure!(session_id == expected_session_id, "unexpected session id");
-                self.received_stop.post(cx, reason.clone());
-                let _ = supervisor.post(cx, SupervisorEvent::Unlinked { session_id, reason });
+                self.received_stop.post(cx, reason);
+                if let Some(reason) = self.unlink_reason.take() {
+                    let _ = supervisor.post(cx, SupervisorEvent::Unlinked { session_id, reason });
+                }
             }
             Ok(())
         }
@@ -1111,7 +1112,7 @@ mod tests {
     // ├── client instance
     // │   ├── ready port: receives the child address
     // │   ├── stopped port: receives the child stop reason
-    // │   └── events port: present but not expected to receive an event
+    // │   └── events port: receives the remote child's terminal event
     // ├── worker: Worker
     // │   ├── child: TestChild
     // │   └── worker-side liveness actor: KeepaliveWorker
@@ -1122,13 +1123,12 @@ mod tests {
     // Stopping Parent stops Supervisor, Supervisor forwards the same stop mode
     // and reason to Worker, Worker stops TestChild, and TestChild reports the
     // reason through the client stopped port before the handles complete.
-    #[tokio::test]
-    async fn test_parent_stop_stops_remote_child_before_parent_finishes() {
+    async fn assert_parent_stop_stops_remote_child_before_parent_finishes(mode: StopMode) {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let session_id = Uid::anonymous();
 
-        let (_child_addr, worker, parent, mut stopped_rx, _event_rx) = spawn_supervised_pair(
+        let (child_addr, worker, parent, mut stopped_rx, mut event_rx) = spawn_supervised_pair(
             &proc,
             &client,
             session_id.clone(),
@@ -1138,13 +1138,23 @@ mod tests {
         .await;
 
         tokio::time::sleep(Duration::from_millis(100)).await;
-        parent.stop("test parent stopping").unwrap();
+        match mode {
+            StopMode::Stop => parent.stop("test parent stopping").unwrap(),
+            StopMode::DrainAndStop => parent.drain_and_stop("test parent stopping").unwrap(),
+        }
 
         let reason = tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(reason, "parent stopping");
+        assert_eq!(reason, "test parent stopping");
+
+        let event = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(event.actor_id, child_addr);
+        assert!(matches!(event.actor_status, ActorStatus::Stopped(_)));
 
         tokio::time::timeout(Duration::from_secs(5), parent)
             .await
@@ -1152,6 +1162,16 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(5), worker)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_parent_stop_stops_remote_child_before_parent_finishes() {
+        assert_parent_stop_stops_remote_child_before_parent_finishes(StopMode::Stop).await;
+    }
+
+    #[tokio::test]
+    async fn test_parent_drain_and_stop_stops_remote_child_before_parent_finishes() {
+        assert_parent_stop_stops_remote_child_before_parent_finishes(StopMode::DrainAndStop).await;
     }
 
     // proc
@@ -1690,29 +1710,31 @@ mod tests {
     //     └── supervisor: Supervisor (constructed with a known session id)
     //         └── supervisor-side liveness actor: KeepaliveSupervisor
     //
-    // Protocol-surface test for `Supervisor::pending_stop`. The
+    // Protocol-surface test for pending remote shutdown. The
     // fake worker records the session, signals link_started, and
     // blocks on a Notify the test holds. The test calls
     // `parent.stop` while the worker is still in Handler<Supervise>,
     // then releases the worker. The pending_stop machinery must
     // have already queued `WorkerCommand::Stop` carrying the
     // parent's reason and the matching session_id. The worker
-    // validates the session_id, sends the reason via
-    // `received_stop`, then emits a synthetic `Unlinked` so the
-    // supervisor exits cleanly via cx.exit (the Unlinked arm only
-    // checks session_id; it does not require a prior Linked).
+    // validates the session_id, sends the stop reason via
+    // `received_stop`, then emits a synthetic `Unlinked` with a distinct
+    // reason. Once Stop is forwarded, the unlink reason determines the
+    // supervisor event (the Unlinked arm only checks session_id; it does not
+    // require a prior Linked).
     #[tokio::test]
     async fn test_stop_before_linked_propagates_via_pending_stop() {
         let proc = Proc::isolated();
         let inst = proc.client("inst");
         let (link_started, mut link_started_rx) = inst.open_port::<()>();
         let (received_stop, mut received_stop_rx) = inst.open_port::<String>();
-        let (events, _events_rx) = inst.open_port::<ActorSupervisionEvent>();
+        let (events, mut events_rx) = inst.open_port::<ActorSupervisionEvent>();
         let release_link = Arc::new(Notify::new());
         let worker = proc.spawn(TestSlowWorker {
             link_started,
             release_link: Arc::clone(&release_link),
             received_stop,
+            unlink_reason: Some("test unlink".to_string()),
             session: None,
         });
         let session_id = Uid::anonymous();
@@ -1743,11 +1765,89 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(stop_reason, "parent stopping");
+        assert_eq!(stop_reason, "test stop");
 
-        tokio::time::timeout(Duration::from_secs(5), parent)
+        let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            matches!(&event.actor_status, ActorStatus::Stopped(reason) if reason == "test unlink"),
+            "expected stopped supervisor event, got: {event}"
+        );
+
+        let status = tokio::time::timeout(Duration::from_secs(5), parent)
             .await
             .unwrap();
+        assert!(
+            matches!(&status, ActorStatus::Stopped(reason) if reason == "test stop"),
+            "expected stopped parent, got: {status:?}"
+        );
+        worker.stop("test").unwrap();
+        tokio::time::timeout(Duration::from_secs(5), worker)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_liveness_failure_while_stop_pending_remains_a_failure() {
+        let proc = Proc::isolated();
+        let inst = proc.client("inst");
+        let (link_started, mut link_started_rx) = inst.open_port::<()>();
+        let (received_stop, mut received_stop_rx) = inst.open_port::<String>();
+        let (events, mut events_rx) = inst.open_port::<ActorSupervisionEvent>();
+        let release_link = Arc::new(Notify::new());
+        let worker = proc.spawn(TestSlowWorker {
+            link_started,
+            release_link: Arc::clone(&release_link),
+            received_stop,
+            unlink_reason: None,
+            session: None,
+        });
+        let session_id = Uid::anonymous();
+        let parent = proc.spawn(Parent {
+            supervisor: Some(Supervisor::new_uid(
+                worker.bind::<WorkerLike>(),
+                KeepaliveLink::new(Duration::from_millis(5), Duration::from_millis(300)),
+                SupervisionOptions::default(),
+                session_id,
+            )),
+            events,
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), link_started_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        parent.stop("test stop").unwrap();
+        release_link.notify_one();
+
+        let stop_reason = tokio::time::timeout(Duration::from_secs(5), received_stop_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stop_reason, "test stop");
+
+        let event = tokio::time::timeout(Duration::from_secs(5), events_rx.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            matches!(&event.actor_status, ActorStatus::Failed(_)),
+            "expected failed supervisor event, got: {event}"
+        );
+        assert!(
+            event.to_string().contains("supervision liveness failed"),
+            "expected liveness failure, got: {event}"
+        );
+
+        let status = tokio::time::timeout(Duration::from_secs(5), parent)
+            .await
+            .unwrap();
+        assert!(
+            matches!(&status, ActorStatus::Stopped(reason) if reason == "test stop"),
+            "expected stopped parent, got: {status:?}"
+        );
         worker.stop("test").unwrap();
         tokio::time::timeout(Duration::from_secs(5), worker)
             .await

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -1265,10 +1265,10 @@ mod tests {
     //         └── supervisor: Supervisor
     //             └── supervisor-side liveness actor: KeepaliveSupervisor
     //
-    // Aborting Parent still tears down its local supervision subtree. Grandparent
+    // Aborting Parent aborts its local supervision subtree. Grandparent
     // handles the parent failure so the test process does not treat it as an
-    // unhandled root failure. Parent stops Supervisor, Supervisor forwards the
-    // stop to Worker, and Worker stops TestChild.
+    // unhandled root failure. Since Supervisor does not run its graceful stop
+    // handler, Worker stops TestChild through the liveness orphan policy.
     #[tokio::test]
     async fn test_parent_abort_stops_remote_child() {
         let proc = Proc::isolated();
@@ -1302,7 +1302,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(reason, "parent stopping");
+        assert_eq!(reason, "supervision liveness failed");
 
         let event = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
             .await

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -419,9 +419,9 @@ async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Re
 
 // Same topology as `test_token_join_parent_exit_stops_child_first`.
 //
-// Killing the parent actor is the in-process hard-stop path. The parent still
-// owns a local supervision tree, so the runtime stops Supervisor while cleaning
-// up that tree, and Supervisor forwards the stop to Worker.
+// Killing the parent actor is the in-process hard-stop path. The runtime kills
+// the local Supervisor instead of running its graceful stop handler, so the
+// worker-side orphan policy stops the child when the liveness link fails.
 #[tokio::test]
 async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
@@ -431,7 +431,7 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
         .post(&harness.observer, ParentControl::Kill);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
-    assert_eq!(reason, "parent stopping");
+    assert_eq!(reason, "supervision liveness failed");
     harness.stop().await?;
     Ok(())
 }

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -47,7 +47,7 @@ wirevalue::register_type!(ParentExit);
 #[derive(Clone, Debug, Serialize, Deserialize, Named)]
 enum ParentControl {
     Exit(StopMode),
-    Kill,
+    Abort,
 }
 wirevalue::register_type!(ParentControl);
 
@@ -161,7 +161,7 @@ impl Handler<ParentControl> for ParentRoot {
             .expect("parent must be spawned before control message");
         match message {
             ParentControl::Exit(stop_mode) => parent.post(cx, ParentExit(stop_mode)),
-            ParentControl::Kill => parent.kill("test parent killed")?,
+            ParentControl::Abort => parent.abort("test parent aborted")?,
         }
         Ok(())
     }
@@ -251,7 +251,7 @@ impl Handler<WorkerControl> for WorkerRoot {
         self.worker
             .as_ref()
             .expect("worker must be spawned before control message")
-            .kill("test worker killed")?;
+            .abort("test worker aborted")?;
         Ok(())
     }
 }
@@ -419,16 +419,16 @@ async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Re
 
 // Same topology as `test_token_join_parent_exit_stops_child_first`.
 //
-// Killing the parent actor is the in-process hard-stop path. The parent still
+// Aborting the parent actor is the in-process hard-stop path. The parent still
 // owns a local supervision tree, so the runtime stops Supervisor while cleaning
 // up that tree, and Supervisor forwards the stop to Worker.
 #[tokio::test]
-async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
+async fn test_token_join_parent_abort_stops_child() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
 
     harness
         .parent_root
-        .post(&harness.observer, ParentControl::Kill);
+        .post(&harness.observer, ParentControl::Abort);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
     assert_eq!(reason, "parent stopping");
@@ -438,12 +438,12 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
 
 // Same topology as `test_token_join_parent_exit_stops_child_first`.
 //
-// Killing the worker actor is the in-process equivalent of the child-side
+// Aborting the worker actor is the in-process equivalent of the child-side
 // process disappearing. The worker can no longer report the child lifecycle
 // directly, so the parent side observes a synthesized supervision event through
 // the keepalive link.
 #[tokio::test]
-async fn test_token_join_worker_kill_notifies_parent() -> anyhow::Result<()> {
+async fn test_token_join_worker_abort_notifies_parent() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
 
     harness.worker_root.post(&harness.observer, WorkerControl);

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -191,12 +191,7 @@ impl Actor for SupervisedChild {
         reason: &str,
     ) -> anyhow::Result<()> {
         self.stopped.post(this, reason.to_string());
-        this.close();
-        match mode {
-            StopMode::Stop => this.exit(reason)?,
-            StopMode::DrainAndStop => this.exit_after_drain(reason)?,
-        }
-        Ok(())
+        hyperactor::actor::handle_stop(this, mode, reason)
     }
 }
 
@@ -397,7 +392,7 @@ async fn test_token_join_parent_exit_stops_child_first() -> anyhow::Result<()> {
         .post(&harness.observer, ParentControl::Exit(StopMode::Stop));
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
-    assert_eq!(reason, "parent stopping");
+    assert_eq!(reason, "parent requested stop");
     harness.stop().await?;
     Ok(())
 }
@@ -412,7 +407,7 @@ async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Re
     );
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
-    assert_eq!(reason, "parent draining");
+    assert_eq!(reason, "parent requested drain and stop");
     harness.stop().await?;
     Ok(())
 }

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -414,9 +414,9 @@ async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Re
 
 // Same topology as `test_token_join_parent_exit_stops_child_first`.
 //
-// Aborting the parent actor is the in-process hard-stop path. The parent still
-// owns a local supervision tree, so the runtime stops Supervisor while cleaning
-// up that tree, and Supervisor forwards the stop to Worker.
+// Aborting the parent actor is the in-process forced-stop path. The runtime aborts
+// the local Supervisor instead of running its graceful stop handler, so the
+// worker-side orphan policy stops the child when the liveness link fails.
 #[tokio::test]
 async fn test_token_join_parent_abort_stops_child() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
@@ -426,7 +426,7 @@ async fn test_token_join_parent_abort_stops_child() -> anyhow::Result<()> {
         .post(&harness.observer, ParentControl::Abort);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
-    assert_eq!(reason, "parent stopping");
+    assert_eq!(reason, "supervision liveness failed");
     harness.stop().await?;
     Ok(())
 }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1276,7 +1276,6 @@ impl PythonActor {
                                 break None;
                             },
                             Some(Signal::ExitRequested(_)) => break None,
-                            Some(Signal::ChildStopped(_)) => {},
                             Some(Signal::Kill(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
                             },

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1276,7 +1276,7 @@ impl PythonActor {
                                 break None;
                             },
                             Some(Signal::ExitRequested(_)) => break None,
-                            Some(Signal::Kill(reason)) => {
+                            Some(Signal::Abort(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
                             },
                             None => {

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -100,12 +100,6 @@ impl PyInstance {
     }
 
     #[pyo3(signature = (reason = None))]
-    fn kill(&self, reason: Option<&str>) -> PyResult<()> {
-        let reason = reason.unwrap_or("(no reason provided)");
-        Ok(self.inner.kill(reason).map_err(anyhow::Error::from)?)
-    }
-
-    #[pyo3(signature = (reason = None))]
     fn stop(&self, reason: Option<&str>) -> PyResult<()> {
         tracing::info!(actor_id = %self.inner.self_addr(), "stopping PyInstance");
         let reason = reason.unwrap_or("(no reason provided)");

--- a/monarch_rdma/src/rdma_manager_owner.rs
+++ b/monarch_rdma/src/rdma_manager_owner.rs
@@ -1794,7 +1794,7 @@ mod tests {
     /// and unknown reporters resolve nothing (asserted BEFORE the match, so a
     /// regression cannot hide behind the later resolution). The identical report
     /// through the subscriber route is a late duplicate that cannot rewrite the
-    /// cached error. Finally, killing the already-`Failed` source's real
+    /// cached error. Finally, aborting the already-`Failed` source's real
     /// controller (a `Failed` controller terminal) invalidates the overlapping
     /// pending view by proc-view overlap, with the sibling's own subscription
     /// removed. A dropped waiter's drained reply must not bounce into the owner
@@ -1998,22 +1998,22 @@ mod tests {
         );
 
         let ctrl_a_handle = ctrl_a.downcast_handle(client).expect("local A controller");
-        ctrl_a_handle.kill("test: kill A controller")?;
+        ctrl_a_handle.abort("test: abort A controller")?;
         let b_err = timeout(Duration::from_secs(30), rxb.recv())
             .await
-            .expect("B resolved after A-controller kill")?
+            .expect("B resolved after A-controller abort")?
             .expect_err("B fails via overlap from the Failed source");
         assert!(
             matches!(b_err, RdmaInitError::Supervision(_)),
             "B: {b_err:?}"
         );
-        // A is already a `Failed` source; killing its controller drives the
+        // A is already a `Failed` source; aborting its controller drives the
         // Failed-source + Failed-controller cell of RMO-17. A's controller
         // completes `Failed`.
         let a_status = ctrl_a_handle.await;
         assert!(
             matches!(a_status, ActorStatus::Failed(_)),
-            "A controller failed after kill: {a_status:?}",
+            "A controller failed after abort: {a_status:?}",
         );
         assert_eq!(
             probe(&owner_handle, client, view_c.clone()).await.state,
@@ -2294,7 +2294,7 @@ mod tests {
     /// real cleanup path. Cleanly stopping a `Ready` controller invalidates every
     /// still-`Pending` view sharing one of its per-proc managers, and only those;
     /// sibling subscriptions are removed first so the overlap cannot leak through
-    /// the subscriber stream. Killing a disjoint pending view's controller then
+    /// the subscriber stream. Aborting a disjoint pending view's controller then
     /// proves the error-terminal branch (RMO-14). Every terminal input keeps the
     /// owner alive (RMO-4) and leaves a terminal source and disjoint views
     /// unchanged (RMO-2).
@@ -2481,15 +2481,15 @@ mod tests {
             .await?;
         assert_eq!(ra2rx.recv().await?, Ok(()), "A source stays cached Ready");
 
-        // Self-termination path, error-terminal branch: kill D's own controller
+        // Self-termination path, error-terminal branch: abort D's own controller
         // so it completes as `Failed` (a crash, not a clean stop). The owner gates
         // on `is_terminal()`, so `Failed` drives the same resolution A's clean
         // `Stopped` did; D resolves directly (RMO-14).
         let ctrl_d_handle = ctrl_d.downcast_handle(client).expect("local D controller");
-        ctrl_d_handle.kill("test: kill D controller")?;
+        ctrl_d_handle.abort("test: abort D controller")?;
         let d_err = timeout(Duration::from_secs(30), rxd.recv())
             .await
-            .expect("D resolved after its controller was killed")?
+            .expect("D resolved after its controller was aborted")?
             .expect_err("D fails on its own controller termination");
         assert!(
             matches!(d_err, RdmaInitError::Supervision(_)),
@@ -2499,7 +2499,7 @@ mod tests {
         let d_status = ctrl_d_handle.await;
         assert!(
             matches!(d_status, ActorStatus::Failed(_)),
-            "D controller failed after kill: {d_status:?}",
+            "D controller failed after abort: {d_status:?}",
         );
 
         owner_handle.stop("test complete")?;

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -55,7 +55,6 @@ def configure(
     split_max_buffer_size: int = ...,
     split_max_buffer_age: str = ...,
     stop_actor_timeout: str = ...,
-    cleanup_timeout: str = ...,
     default_encoding: Encoding = ...,
     channel_net_rx_buffer_full_check_interval: str = ...,
     message_latency_sampling_rate: float = ...,
@@ -126,7 +125,6 @@ def configure(
         split_max_buffer_age: Maximum age for split message buffers
             (humantime)
         stop_actor_timeout: Timeout for stopping actors (humantime)
-        cleanup_timeout: Timeout for cleanup operations (humantime)
         default_encoding: Default message encoding (Encoding.Bincode,
             Encoding.Json, or Encoding.Multipart)
         channel_net_rx_buffer_full_check_interval: Network receive buffer

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -55,7 +55,6 @@ def configure(
     split_max_buffer_size: int = ...,
     split_max_buffer_age: str = ...,
     stop_actor_timeout: str = ...,
-    cleanup_timeout: str = ...,
     default_encoding: Encoding = ...,
     channel_net_rx_buffer_full_check_interval: str = ...,
     message_latency_sampling_rate: float = ...,
@@ -128,7 +127,6 @@ def configure(
         split_max_buffer_age: Maximum age for split message buffers
             (humantime)
         stop_actor_timeout: Timeout for stopping actors (humantime)
-        cleanup_timeout: Timeout for cleanup operations (humantime)
         default_encoding: Default message encoding (Encoding.Bincode,
             Encoding.Json, or Encoding.Multipart)
         channel_net_rx_buffer_full_check_interval: Network receive buffer

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1702,8 +1702,7 @@ class Actor(MeshTrait):
         because of an error. The same ``__cleanup__`` runs in both cases;
         ``exc`` is ``None`` on a normal stop and carries the exception on an
         error stop. It is *not* called on fatal failures such as OOMs, panics,
-        or signals like ``SIGSEGV``. If it exceeds ``HYPERACTOR_CLEANUP_TIMEOUT``,
-        it is cancelled and the actor is placed in an error state.
+        or signals like ``SIGSEGV``.
 
         By the time this runs, every mesh this actor owns has already been
         stopped recursively, and each owned actor's ``__cleanup__`` has already

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -279,14 +279,6 @@ class Instance(abc.ABC):
         ...
 
     @abstractmethod
-    def kill(self, reason: Optional[str] = None) -> None:
-        """
-        Terminate the current actor with a failure. A supervision error
-        propagates to its creator.
-        """
-        ...
-
-    @abstractmethod
     def stop(self, reason: Optional[str] = None) -> None:
         """
         Stop this actor instance and its children gracefully. The
@@ -1295,7 +1287,7 @@ async def _dispatch_loop(
     Args:
         actor: The Python actor object that implements ``handle``.
         receiver: Channel receiver for queued messages.
-        self_instance: The actor's own Instance, used to kill self on
+        self_instance: The actor's own Instance, used to abort self on
             an unhandled exception.
     """
     while True:
@@ -1306,7 +1298,7 @@ async def _dispatch_loop(
             return
         except BaseException as e:
             reason = "".join(TracebackException.from_exception(e).format())
-            self_instance.kill(reason)
+            self_instance.abort(reason)
             raise
 
 

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1734,14 +1734,15 @@ class Actor(MeshTrait):
         because of an error. The same ``__cleanup__`` runs in both cases;
         ``exc`` is ``None`` on a normal stop and carries the exception on an
         error stop. It is *not* called on fatal failures such as OOMs, panics,
-        or signals like ``SIGSEGV``. If it exceeds ``HYPERACTOR_CLEANUP_TIMEOUT``,
-        it is cancelled and the actor is placed in an error state.
+        or signals like ``SIGSEGV``.
 
-        By the time this runs, every mesh this actor owns has already been
-        stopped recursively, and each owned actor's ``__cleanup__`` has already
-        run. Owned actor meshes and proc meshes are no longer usable from this
-        method. For shutdown work that needs an owned mesh, expose a dedicated
-        endpoint and call it before ``stop()``.
+        On graceful shutdown, owned actors normally finish first. On failure or
+        forced teardown, residual direct children are transferred to proc
+        supervision and aborted. Each child repeats this for its own direct
+        children, and their cleanup may not run. Owned actor meshes and proc
+        meshes are no longer usable from this method. For shutdown work that
+        needs an owned mesh, expose a dedicated endpoint and call it before
+        ``stop()``.
 
         Use ``__cleanup__`` to release resources the actor owns directly: open
         files, network connections, background threads, asyncio tasks, and the

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -296,10 +296,10 @@ class Instance(abc.ABC):
         lifecycle pattern (map-reduce shards, batch processing,
         worker pools, etc.; see ``sleep_actors.py`` for an example).
 
-        This is observable in the mesh: on exit the actor emits
-        ``Signal::ChildStopped`` to its parent (always), so
-        ProcAgent *does* see the stop, and terminated snapshots
-        preserve post‑mortem state for introspection.
+        This is observable in the mesh: on exit the runtime emits an
+        ``ActorSupervisionEvent`` to the actor's supervisor, so ProcAgent
+        *does* see the stop, and terminated snapshots preserve post‑mortem
+        state for introspection.
 
         Use ``ActorMesh.stop()`` when you need coordinated, mesh-wide
         shutdown.

--- a/python/monarch/_src/actor/concurrent.py
+++ b/python/monarch/_src/actor/concurrent.py
@@ -60,7 +60,7 @@ def _cancelled_for_cleanup(record: _TaskRecord | None) -> bool:
 def _fail_actor(actor_instance: Any, exception: BaseException) -> None:
     reason = "".join(TracebackException.from_exception(exception).format())
     try:
-        actor_instance.kill(reason)
+        actor_instance.abort(reason)
     except Exception:
         # The actor's signal channel may already be closed if it has finished
         # stopping; there is then nothing left to fail.

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
             split_max_buffer_size: NotRequired[int]
             split_max_buffer_age: NotRequired[str]
             stop_actor_timeout: NotRequired[str]
-            cleanup_timeout: NotRequired[str]
             default_encoding: NotRequired[Encoding]
             channel_net_rx_buffer_full_check_interval: NotRequired[str]
             message_latency_sampling_rate: NotRequired[float]
@@ -128,7 +127,6 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
             split_max_buffer_size: Maximum buffer size for message splitting (bytes).
             split_max_buffer_age: Maximum age for split message buffers (humantime).
             stop_actor_timeout: Timeout for stopping actors (humantime).
-            cleanup_timeout: Timeout for cleanup operations (humantime).
             default_encoding: Default message encoding (Encoding.Bincode, Encoding.Json, or Encoding.Multipart).
             channel_net_rx_buffer_full_check_interval: Network receive buffer check interval (humantime).
             message_latency_sampling_rate: Sampling rate for message latency tracking (0.0 to 1.0).

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -58,7 +58,6 @@ if TYPE_CHECKING:
             split_max_buffer_size: NotRequired[int]
             split_max_buffer_age: NotRequired[str]
             stop_actor_timeout: NotRequired[str]
-            cleanup_timeout: NotRequired[str]
             default_encoding: NotRequired[Encoding]
             channel_net_rx_buffer_full_check_interval: NotRequired[str]
             channel_tcp_congestion: NotRequired[str]
@@ -132,7 +131,6 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
             split_max_buffer_size: Maximum buffer size for message splitting (bytes).
             split_max_buffer_age: Maximum age for split message buffers (humantime).
             stop_actor_timeout: Timeout for stopping actors (humantime).
-            cleanup_timeout: Timeout for cleanup operations (humantime).
             default_encoding: Default message encoding (Encoding.Bincode, Encoding.Json, or Encoding.Multipart).
             channel_net_rx_buffer_full_check_interval: Network receive buffer check interval (humantime).
             channel_tcp_congestion: TCP congestion control: ``"cubic"``, ``"reno"``, ``"bbr"`` (OS-dependent); empty keeps the host default.

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -306,14 +306,14 @@ def test_actor_init_exception_sync(mesh, actor_class, num_procs) -> None:
 @pytest.mark.timeout(60)
 @pytest.mark.parametrize("actor_class", [ExceptionActor, ExceptionActorSync])
 @isolate_in_subprocess
-async def test_broadcast_exception_with_no_reply_port_kills_actor(actor_class) -> None:
+async def test_broadcast_exception_with_no_reply_port_aborts_actor(actor_class) -> None:
     """A plain `Exception` from an endpoint invoked with *no reply port*
     (fire-and-forget `broadcast()`) fails the actor: the return is dropped, the
-    exception escapes through `DroppingPort.exception`, and the actor is killed,
+    exception escapes through `DroppingPort.exception`, and the actor is aborted,
     surfacing as a supervision fault at the client. Parametrized over both
-    dispatch modes because the kill reaches `Signal::Kill` by different paths
-    (direct: the endpoint task resolves `Err`; queue: `_dispatch_loop` calls
-    `self_instance.kill`). The existing broadcast-failure coverage uses a
+    dispatch modes because Abort reaches the actor by different paths (direct:
+    the endpoint task resolves `Err`; queue: `_dispatch_loop` calls
+    `self_instance.abort`). The existing broadcast-failure coverage uses a
     `BaseException`; this pins the plain-`Exception` path."""
     faults = []
     faulted = asyncio.Event()

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -228,7 +228,6 @@ def test_duration_config_multiple() -> None:
         ("message_ack_time_interval", "2s", "2s", "500ms"),
         ("split_max_buffer_age", "100ms", "100ms", "50ms"),
         ("stop_actor_timeout", "15s", "15s", "10s"),
-        ("cleanup_timeout", "25s", "25s", "3s"),
         ("channel_net_rx_buffer_full_check_interval", "200ms", "200ms", "5s"),
         # Mesh bootstrap config
         ("mesh_terminate_timeout", "20s", "20s", "10s"),
@@ -383,7 +382,6 @@ def test_all_params_together():
         split_max_buffer_size=2048,
         split_max_buffer_age="100ms",
         stop_actor_timeout="15s",
-        cleanup_timeout="25s",
         default_encoding=Encoding.Json,
         channel_net_rx_buffer_full_check_interval="200ms",
         message_latency_sampling_rate=0.5,
@@ -422,7 +420,6 @@ def test_all_params_together():
         assert config["split_max_buffer_size"] == 2048
         assert config["split_max_buffer_age"] == "100ms"
         assert config["stop_actor_timeout"] == "15s"
-        assert config["cleanup_timeout"] == "25s"
         assert config["default_encoding"] == Encoding.Json
         assert config["channel_net_rx_buffer_full_check_interval"] == "200ms"
         assert config["message_latency_sampling_rate"] == pytest.approx(0.5, rel=1e-5)
@@ -453,7 +450,6 @@ def test_all_params_together():
     assert config["split_max_buffer_size"] == 5
     assert config["split_max_buffer_age"] == "50ms"
     assert config["stop_actor_timeout"] == "10s"
-    assert config["cleanup_timeout"] == "3s"
     assert config["default_encoding"] == Encoding.Multipart
     assert config["channel_net_rx_buffer_full_check_interval"] == "5s"
     assert config["message_latency_sampling_rate"] == pytest.approx(0.01, rel=1e-5)

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -287,7 +287,6 @@ def test_duration_config_multiple() -> None:
         ("message_ack_time_interval", "2s", "2s", "500ms"),
         ("split_max_buffer_age", "100ms", "100ms", "50ms"),
         ("stop_actor_timeout", "15s", "15s", "10s"),
-        ("cleanup_timeout", "25s", "25s", "3s"),
         ("channel_net_rx_buffer_full_check_interval", "200ms", "200ms", "5s"),
         # Mesh bootstrap config
         ("mesh_terminate_timeout", "20s", "20s", "10s"),
@@ -440,7 +439,6 @@ def test_all_params_together():
         split_max_buffer_size=2048,
         split_max_buffer_age="100ms",
         stop_actor_timeout="15s",
-        cleanup_timeout="25s",
         default_encoding=Encoding.Json,
         channel_net_rx_buffer_full_check_interval="200ms",
         message_latency_sampling_rate=0.5,
@@ -477,7 +475,6 @@ def test_all_params_together():
         assert config["split_max_buffer_size"] == 2048
         assert config["split_max_buffer_age"] == "100ms"
         assert config["stop_actor_timeout"] == "15s"
-        assert config["cleanup_timeout"] == "25s"
         assert config["default_encoding"] == Encoding.Json
         assert config["channel_net_rx_buffer_full_check_interval"] == "200ms"
         assert config["message_latency_sampling_rate"] == pytest.approx(0.5, rel=1e-5)
@@ -507,7 +504,6 @@ def test_all_params_together():
     assert config["split_max_buffer_size"] == 5
     assert config["split_max_buffer_age"] == "50ms"
     assert config["stop_actor_timeout"] == "10s"
-    assert config["cleanup_timeout"] == "3s"
     assert config["default_encoding"] == Encoding.Multipart
     assert config["channel_net_rx_buffer_full_check_interval"] == "5s"
     assert config["message_latency_sampling_rate"] == pytest.approx(0.01, rel=1e-5)

--- a/python/tests/test_supervision_hierarchy.py
+++ b/python/tests/test_supervision_hierarchy.py
@@ -15,7 +15,7 @@ import monarch.actor
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch.actor import Actor, endpoint, this_host
-from monarch.config import parametrize_config
+from monarch.config import configured, parametrize_config
 
 
 T = TypeVar("T")
@@ -119,9 +119,12 @@ def test_proc_failure():
     """
     If a proc dies, the client should receive an unhandled fault.
     """
-    with FaultCapture() as capture:
-        actor = this_host().spawn_procs().spawn("top", Nest)
-        actor.kill_nest.call_one().get()
+    # Fault propagation waits for proc-death detection and mesh cleanup. Use
+    # short caller-level waits so this test does not race FaultCapture's 30s wait.
+    with configured(message_delivery_timeout="5s", actor_spawn_max_idle="5s"):
+        with FaultCapture() as capture:
+            actor = this_host().spawn_procs().spawn("top", Nest)
+            actor.kill_nest.call_one().get()
 
     # Any actors on the proc mesh can report the proc failure, so it might be
     # "nested" or it might be other broken actors such as "logger".


### PR DESCRIPTION
Summary:

Remove the per-actor cleanup deadline and its Rust, Python, documentation, and test configuration surface. Transport flush timeouts remain unchanged.

Design invariant: cleanup is ordinary user code, not a separate teardown phase with its own runtime timeout policy. Graceful and failure exits await cleanup normally; the following Abort-aware lifecycle diff is solely responsible for skipping or preempting cleanup during forced termination.

This leaves deadline and escalation policy with explicit teardown callers

Reviewed By: mariusae

Differential Revision: D110433730
