### PR TITLE
Add cookbook.md with 2 recipes (#4365)

### DIFF
--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -6,6 +6,7 @@
 |----------|----------|
 | **Getting Started Tutorial** | `docs/source/examples/getting_started.py` |
 | **Actors Complete Guide** | `docs/source/actors.md` |
+| **Cookbook** (task-oriented recipes) | `docs/source/cookbook.md` (snippets from `python/tests/test_cookbook.py`) |
 | **Debugging Guide** | `docs/source/examples/debugging.py` |
 | **Installation** | `docs/source/installation.md` |
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -328,9 +328,70 @@ def truncate_gallery_index_file(app):
         )
 
 
+# GITHUB_SHA is set in CI, pinning links to the exact embedded commit; local
+# builds fall back to main.
+_COOKBOOK_REF = os.getenv("GITHUB_SHA", "main")
+_COOKBOOK_BLOB = (
+    f"https://github.com/meta-pytorch/monarch/blob/{_COOKBOOK_REF}"
+    "/python/tests/test_cookbook.py"
+)
+
+
+def _cookbook_region_ranges(test_path):
+    """Map each ``# cookbook: <slug>`` region to its (start, end) line range.
+
+    The range excludes the marker lines themselves, matching the
+    ``literalinclude`` ``start-after``/``end-before`` bounds so the linked lines
+    are exactly the embedded snippet.
+    """
+    import re
+
+    ranges = {}
+    pending = None
+    with open(test_path, encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            stripped = line.strip()
+            if stripped == "# cookbook: end":
+                if pending is not None:
+                    slug, start = pending
+                    ranges[slug] = (start + 1, lineno - 1)
+                    pending = None
+            elif re.fullmatch(r"# cookbook: [\w-]+", stripped):
+                pending = (stripped.removeprefix("# cookbook: "), lineno)
+    return ranges
+
+
+def expand_cookbook_source_links(app, docname, source):
+    """Replace ``%%SRC:<slug>%%`` tokens with a line-anchored GitHub URL.
+
+    Line numbers are computed from the marker positions at build time, so they
+    cannot go stale as the test file changes.
+    """
+    import re
+
+    if "%%SRC:" not in source[0]:
+        return
+    test_path = os.path.abspath(
+        os.path.join(app.srcdir, "..", "..", "python", "tests", "test_cookbook.py")
+    )
+    ranges = _cookbook_region_ranges(test_path)
+
+    def replace(match):
+        slug = match.group(1)
+        if slug not in ranges:
+            raise ValueError(f"unknown cookbook slug in {docname}: {slug}")
+        start, end = ranges[slug]
+        return f"{_COOKBOOK_BLOB}#L{start}-L{end}"
+
+    source[0] = re.sub(r"%%SRC:([\w-]+)%%", replace, source[0])
+
+
 def setup(app):
     # Connect to the builder-inited event, which runs at the beginning of the build process
     app.connect("builder-inited", truncate_gallery_index_file)
+
+    # Expand cookbook source-link tokens using live marker line numbers
+    app.connect("source-read", expand_cookbook_source_links)
 
     # Also connect to the build-finished event as a backup
     app.connect(

--- a/docs/source/cookbook.md
+++ b/docs/source/cookbook.md
@@ -1,0 +1,89 @@
+# Monarch Cookbook
+
+Task-oriented recipes for common Monarch patterns. Each recipe is small,
+self-contained, and answers a single "how do I ...?" question.
+
+Every snippet below is embedded directly from a test in
+[`python/tests/test_cookbook.py`](https://github.com/meta-pytorch/monarch/blob/main/python/tests/test_cookbook.py)
+and runs in CI, so the code here stays in sync with the API. To add a recipe,
+write a test with a `# cookbook: <slug>` / `# cookbook: end` marker pair and
+embed the region here with `literalinclude`.
+
+## Meshes and Slicing
+
+### Get the rank-0 actor of a mesh
+
+You often need the rank-0 actor of a mesh, for example to use it as the coordinator
+of the SPMD job running on the mesh. Do:
+
+```{literalinclude} ../../python/tests/test_cookbook.py
+---
+language: python
+start-after: "# cookbook: rank-0-slice"
+end-before: "# cookbook: end"
+dedent: 4
+caption: "[View source](%%SRC:rank-0-slice%%)"
+---
+```
+
+* `flatten` collapses every dimension into one named dimension, so this works
+regardless of the mesh's original shape. This is more robust than slicing by the
+original dimension names (e.g. `generator.slice(hosts=0, gpus=0)`), which breaks
+if those names change.
+* `slice` then selects a single rank. The result is a singleton mesh, so
+`call_one` applies.
+
+See [Slicing Operations](actors.md#slicing-operations) in the Actors guide for the full slicing API.
+
+## Intra-mesh Communication
+
+### Call a specific rank of your own mesh
+
+An actor often needs to reach another rank of its own mesh — for example, a
+coordinator at rank 0. Give each actor a handle to its mesh after spawning, then
+slice that handle to the target rank inside an endpoint:
+
+```{literalinclude} ../../python/tests/test_cookbook.py
+---
+language: python
+start-after: "# cookbook: inter-rank-call"
+end-before: "# cookbook: end"
+dedent: 8
+caption: "[View source](%%SRC:inter-rank-call%%)"
+---
+```
+
+`self.mesh` is the actor's own `ActorMesh`. An actor cannot reference its own
+mesh at construction time, so we pass the handle to every member through a
+`set_mesh` endpoint once the mesh is spawned. Slicing that handle yields a
+reference to the chosen rank, so the call is a direct point-to-point message.
+
+### Return results asynchronously with a port
+
+The previous recipe returns synchronously because `call` (and `call_one`) hand
+back the endpoint's return value inline. A port is the asynchronous counterpart.
+The coordinator opens a `Channel` and `broadcast`s the sending half (a `Port`) to
+the other ranks, which send or stream results back to it whenever they are ready:
+
+```{literalinclude} ../../python/tests/test_cookbook.py
+---
+language: python
+start-after: "# cookbook: port-open"
+end-before: "# cookbook: end"
+dedent: 8
+caption: "[View source](%%SRC:port-open%%)"
+---
+```
+
+Each rank's `produce` endpoint launches a background task and returns
+immediately; the task sends its values to the port over time:
+
+```{literalinclude} ../../python/tests/test_cookbook.py
+---
+language: python
+start-after: "# cookbook: port-send"
+end-before: "# cookbook: end"
+dedent: 8
+caption: "[View source](%%SRC:port-send%%)"
+---
+```

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -44,11 +44,12 @@ Here are some suggested steps to get started with Monarch:
 1. **Installation**: Check out the [Install guide](installation) for getting monarch installed.
 2. **Getting Started**: The [getting started](./generated/examples/getting_started) provides an introduction to Monarch's core API
 3. **Explore Examples**: Review the [Examples](./generated/examples/index) to see Monarch in action
-4. **Dive Deeper**: Explore the API Documentation for more detailed information:
+4. **Cookbook**: Browse the [Cookbook](cookbook) for short, task-oriented recipes.
+5. **Dive Deeper**: Explore the API Documentation for more detailed information:
     - [Python API](api/index)
     - [Rust API](rust-api)
-5. **Deep Understanding of Actors**: Gain comprehensive knowledge of [Actors](actors), the foundational building blocks of Monarch.
-6. **Monitoring Tools**: Inspect running meshes with the [Admin TUI](admin-tui) (terminal) or the [Monarch Dashboard](monarch-dashboard) (web GUI).
+6. **Deep Understanding of Actors**: Gain comprehensive knowledge of [Actors](actors), the foundational building blocks of Monarch.
+7. **Monitoring Tools**: Inspect running meshes with the [Admin TUI](admin-tui) (terminal) or the [Monarch Dashboard](monarch-dashboard) (web GUI).
 
 ```{toctree}
 :maxdepth: 2
@@ -57,6 +58,7 @@ Here are some suggested steps to get started with Monarch:
 installation
 ./generated/examples/getting_started
 ./generated/examples/index
+cookbook
 api/index
 rust-api
 actors

--- a/python/tests/test_cookbook.py
+++ b/python/tests/test_cookbook.py
@@ -1,0 +1,137 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""Runnable sources for the recipes in ``docs/source/cookbook.md``.
+
+Each recipe is a region delimited by ``# cookbook: <slug>`` and ``# cookbook: end``
+markers. The cookbook embeds these regions verbatim with Sphinx ``literalinclude``,
+so the documented snippets are exactly the code exercised here. Keep the region
+bodies self-contained and free of test scaffolding.
+"""
+
+import asyncio
+from typing import AsyncIterator
+
+import pytest
+from monarch.actor import Actor, Channel, context, endpoint, Port, this_host
+
+pytestmark = pytest.mark.timeout(60)
+
+
+class Counter(Actor):
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    @endpoint
+    async def increment(self) -> None:
+        self.value += 1
+
+    @endpoint
+    async def get_value(self) -> int:
+        return self.value
+
+
+@pytest.fixture
+async def counters() -> AsyncIterator[Counter]:
+    procs = this_host().spawn_procs(per_host={"gpus": 4})
+    yield procs.spawn("counters", Counter, 0)
+    await procs.stop()
+
+
+async def test_rank_0_slice(counters: Counter) -> None:
+    # cookbook: rank-0-slice
+    rank_0 = counters.flatten("rank").slice(rank=0)
+    await rank_0.increment.call_one()
+    # cookbook: end
+
+    assert await rank_0.get_value.call_one() == 1
+
+
+class Worker(Actor):
+    mesh: "Worker"
+
+    def __init__(self) -> None:
+        self.pings = 0
+
+    @endpoint
+    async def set_mesh(self, mesh: "Worker") -> None:
+        self.mesh = mesh
+
+    @endpoint
+    async def ping(self) -> str:
+        self.pings += 1
+        return "pong"
+
+    @endpoint
+    async def ping_count(self) -> int:
+        return self.pings
+
+    @endpoint
+    async def call_coordinator(self) -> str:
+        # cookbook: inter-rank-call
+        coordinator = self.mesh.flatten("rank").slice(rank=0)
+        return await coordinator.ping.call_one()
+        # cookbook: end
+
+
+async def test_inter_rank_call() -> None:
+    procs = this_host().spawn_procs(per_host={"gpus": 4})
+    workers = procs.spawn("workers", Worker)
+    await workers.set_mesh.call(workers)
+
+    others = workers.flatten("rank").slice(rank=slice(1, None))
+    await others.call_coordinator.call()
+
+    coordinator = workers.flatten("rank").slice(rank=0)
+    assert await coordinator.ping_count.call_one() == 3
+
+    await procs.stop()
+
+
+STREAM_LEN = 3
+
+
+class Aggregator(Actor):
+    mesh: "Aggregator"
+
+    @endpoint
+    async def set_mesh(self, mesh: "Aggregator") -> None:
+        self.mesh = mesh
+
+    @endpoint
+    async def collect(self) -> list[int]:
+        # cookbook: port-open
+        port, receiver = Channel[int].open()
+        others = self.mesh.flatten("rank").slice(rank=slice(1, None))
+        others.produce.broadcast(port)
+        expected = others.size() * STREAM_LEN
+        return sorted([await receiver.recv() for _ in range(expected)])
+        # cookbook: end
+
+    @endpoint
+    async def produce(self, port: Port[int]) -> None:
+        # cookbook: port-send
+        rank = context().actor_instance.rank["gpus"]
+
+        async def stream() -> None:
+            for step in range(STREAM_LEN):
+                port.send(rank * 10 + step)
+
+        self.task = asyncio.create_task(stream())
+        # cookbook: end
+
+
+async def test_port_fan_in() -> None:
+    procs = this_host().spawn_procs(per_host={"gpus": 4})
+    aggregators = procs.spawn("aggregators", Aggregator)
+    await aggregators.set_mesh.call(aggregators)
+
+    coordinator = aggregators.flatten("rank").slice(rank=0)
+    assert await coordinator.collect.call_one() == [10, 11, 12, 20, 21, 22, 30, 31, 32]
+
+    await procs.stop()


### PR DESCRIPTION
Summary:

Sometimes we get questions on what is the best way to do x,y or z in Monarch. We want to provide code examples for these questions, by the code snippets are too small to fit [the  examples section](https://meta-pytorch.org/monarch/stable/generated/examples/index.html). Therefore, this diff adds a cookbook page, which is targets for this gap.

In this diff, we scaffold the cookbook structure, and added two recipes.

Reviewed By: zdevito

Differential Revision: D110895109


