### PR TITLE
Add ActorRef Into impl for checked behavior view

### DIFF
--- a/hyperactor/src/ref_.rs
+++ b/hyperactor/src/ref_.rs
@@ -33,6 +33,7 @@ use crate::RemoteHandles;
 use crate::RemoteMessage;
 use crate::accum::ReducerSpec;
 use crate::accum::StreamingReducerOpts;
+use crate::actor::Binds;
 use crate::actor::Referable;
 use crate::context;
 use crate::context::MailboxExt;
@@ -88,6 +89,16 @@ impl<A: Referable> ActorRef<A> {
         A: Actor,
     {
         cx.instance().proc().resolve_actor_ref(self)
+    }
+}
+
+impl<A, B> From<&ActorRef<A>> for ActorRef<B>
+where
+    A: Actor + Referable,
+    B: Binds<A>,
+{
+    fn from(value: &ActorRef<A>) -> Self {
+        ActorRef::attest(value.actor_addr().clone())
     }
 }
 


### PR DESCRIPTION
Summary:
`ActorRef::attest` reinterprets an address at a new type with no verification that the actor actually handles the behavior; it is hyperactor's explicit unchecked escape hatch. The checked alternative, `ActorHandle::bind::<B>()`, mutates the actor's live handler-port table and so is only callable by the actor's owner — it is unavailable from a bare `ActorRef` such as a deserialized one.

This adds a From impl. The `B: Binds<A>` bound — same as `ActorHandle::bind` and `assert_behaves!` — makes the compiler verify `A` handles every message of behavior `B`. Unlike `ActorHandle::bind` this registers no ports; it only re-types an existing reference, so it works from a bare ref.

This is a standalone primitive with no dependency on anything else. Later uses become `ActorRef::<MeshSupervision>::from(&controller_ref)` so a mesh ref can only be built from a controller that actually answers the supervision protocol, instead of a raw `attest`.

Reviewed By: shayne-fletcher

Differential Revision: D110850249


