### PR TITLE
refuse Future.get() on a tokio thread, validate timeout before spawning (#4368)

### DIFF
--- a/docs/source/actors.md
+++ b/docs/source/actors.md
@@ -256,12 +256,15 @@ Call a single actor and get response.
 ```python
 calc = this_proc().spawn("calc", Calculator)
 
-# Synchronous wait for result
+# Synchronous wait for result (blocks the calling thread)
 result = calc.add.call_one(5, 3).get()
 print(result)  # 8
 
-# Async await
+# Async await (on an asyncio event loop)
 result = await calc.add.call_one(5, 3)
+
+# Or bridge to a standard asyncio.Future explicitly
+result = await calc.add.call_one(5, 3).as_asyncio()
 ```
 
 **Use When:**

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/pytokio-appendix.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/pytokio-appendix.md
@@ -64,14 +64,11 @@ pub(crate) fn spawn(&mut self) -> PyResult<PyShared> {
     let traceback = self.traceback()?;
     let traceback1 = self.traceback()?;
     let task = self.take_task()?;
-    let handle = get_tokio_runtime().spawn(async move {
+    get_tokio_runtime().spawn(async move {
         send_result(tx, task.await, traceback1);
     });
     Ok(PyShared {
-        rx,
-        handle,
-        abort: false,
-        traceback,
+        core: HandleCore::new(rx, None, traceback),
     })
 }
 ```
@@ -82,7 +79,7 @@ What that does:
 2. consume the underlying Rust future (`take_task()`);
 3. run that future on the shared Tokio runtime (`get_tokio_runtime().spawn(...)`);
 4. when it completes, push the result into the watch channel (`send_result(...)`);
-5. return a `PyShared` that holds the receiver and the join handle.
+5. return a `PyShared` wrapping a `HandleCore` (the watch receiver, the creation-site traceback, and -- for `spawn_abortable` -- an abort handle; plain `spawn` passes `None`, so its task is detached).
 
 So the Rust future is running in the background, and Python will wait on the receiver.
 
@@ -94,14 +91,11 @@ So the Rust future is running in the background, and Python will wait on the rec
     module = "monarch._rust_bindings.monarch_hyperactor.pytokio"
 )]
 pub struct PyShared {
-    rx: watch::Receiver<Option<PyResult<PyObject>>>,
-    handle: JoinHandle<()>,
-    abort: bool,
-    traceback: Option<PyObject>,
+    core: HandleCore,
 }
 ```
 
-Its `task()` / `__await__` path just waits for `rx.changed()` — i.e. waits until the Rust side has written the result — and then hands that result back to Python. If `abort` is `true`, dropping it will cancel the Tokio task.
+`PyShared` is a thin wrapper over `HandleCore` (defined in `handle.rs`), which holds the watch receiver, an optional abort handle, and the creation-site traceback. Its `task()` / `__await__` path waits for the core's watch value to become `Some` — i.e. waits until the Rust side has written the result — and then hands that result back to Python. `HandleCore` aborts the Tokio task on drop only when it was built with an abort handle (from `spawn_abortable`).
 
 If a spawned task errors and nobody awaits it, pytokio logs the error instead of silently dropping it. If you set `ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK=1`, it will also log where the task was created, which makes "why did this background thing fail?" a lot easier to answer.
 

--- a/monarch_hyperactor/src/handle.rs
+++ b/monarch_hyperactor/src/handle.rs
@@ -293,6 +293,17 @@ pub struct PyHandle {
     core: HandleCore,
 }
 
+impl PyHandle {
+    /// Wrap an already-built `HandleCore` in a `PyHandle`.
+    ///
+    /// Producers in `pytokio.rs` build the core (watch channel + spawned task)
+    /// and hand back an observe-only `Handle` through this; `PyHandle`'s field
+    /// is private to this module.
+    pub(crate) fn from_core(core: HandleCore) -> Self {
+        Self { core }
+    }
+}
+
 #[cfg(test)]
 impl PyHandle {
     /// Construct a resolved `Handle` from `value`.

--- a/monarch_hyperactor/src/handle.rs
+++ b/monarch_hyperactor/src/handle.rs
@@ -1,0 +1,1379 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! `Handle`: an observe-only handle to a background Tokio task.
+//!
+//! A `Handle` wraps a `watch` channel that a producer fulfills exactly once with
+//! the task's `PyResult<Py<PyAny>>`. You observe its eventual result:
+//! synchronously via `get()`, on an `asyncio` loop via `as_asyncio()`/`await`, or
+//! without blocking via `poll()`. The channel is multi-observer, so a resolved
+//! value stays observable by any number of later observers.
+//!
+//! The watch-channel mechanics live in [`HandleCore`].
+//!
+//! ## Handle invariants (HDL-*)
+//!
+//! Code that relies on or enforces an invariant is tagged `// HDL-N`, and each
+//! `#[cfg(test)]` test that attests one names it; read the matching entry below
+//! before changing a tagged site.
+//!
+//! Assumed of the shared core and producer (not enforced here):
+//! - **HDL-1 (single terminal completion).** The watch value goes `None` ->
+//!   `Some(_)` exactly once and is never reset (`Some` -> `Some`, `Some` ->
+//!   `None`). Relied on by [`HandleCore::wait_future`] (wait loop + `expect`) and
+//!   [`HandleCore::poll`] (re-borrow across the GIL). Held by convention: every
+//!   producer sends once, always `Some(_)`. A send-once sender (a newtype
+//!   consuming the `watch::Sender`) could make it structural, hardening `poll`'s
+//!   re-borrow.
+//! - **HDL-2 (value encoding).** `None` is pending, `Some(Ok(_))` success,
+//!   `Some(Err(_))` a producer error.
+//!
+//! Guaranteed by this module:
+//! - **HDL-3 (non-consuming reads).** Every read clones the value out
+//!   (`clone_ref`) rather than moving it, so any number of observers see the
+//!   same result. Enforced by construction: no read path moves the value.
+//! - **HDL-4 (drop does not cancel; drop never panics).** Dropping a `Handle`
+//!   never cancels its producer; a `Handle` observes, it does not own the
+//!   producer's lifecycle. Enforced by construction: a `Handle`'s core has
+//!   `abort_on_drop: None`, and `HandleCore::Drop` aborts only when
+//!   `abort_on_drop` is set. The abort is wrapped in `catch_unwind`, so an
+//!   `abort()` that panics at interpreter shutdown (the Tokio runtime already
+//!   gone) cannot escape `Drop` and abort the process.
+//! - **HDL-5 (GIL discipline).** No Python object is touched without the GIL,
+//!   and every acquisition goes through `monarch_with_gil{,_blocking}`. Enforced
+//!   by the crate's `#![deny(clippy::disallowed_methods)]` ban on raw
+//!   `Python::with_gil`/`attach` -- a hard compile error, not a `debug_assert`.
+//! - **HDL-6 (`WouldBlockRuntime` is `get()`'s alone).** Only `get()` raises it,
+//!   and only in a Tokio runtime context; `as_asyncio()`/`__await__` off a loop
+//!   raise the native `RuntimeError` instead.
+//! - **HDL-7 (`as_asyncio` publish).** The observer waits borrow-first (via
+//!   `wait_ready`, never `changed()`-first) and sets a result only on a
+//!   non-cancelled future, swallowing `InvalidStateError`; any `StopIteration`
+//!   (including subclasses) is wrapped in `RuntimeError` first, since
+//!   `set_exception` rejects `StopIteration` (PEP 479); if the loop has closed it
+//!   logs rather than panics.
+//! - **HDL-8 (`get()` loop-warning is call-pattern, not outcome).** `get()` on a
+//!   running asyncio loop warns regardless of whether the value is ready: it
+//!   flags the blocking-call-from-a-loop anti-pattern, not whether this call
+//!   happens to block. A ready value returns after warning; under a
+//!   warnings-as-errors filter the warning escalates to an error.
+//! - **HDL-9 (GIL/watch borrow discipline).** A `watch` borrow is never held
+//!   across a GIL acquisition or an `.await`. `poll` drops its read guard before
+//!   taking the GIL and re-borrows under it (GIL-then-watch order, never the
+//!   inverse against the producer's write-lock `send`); the `wait_ready`/
+//!   `wait_future` loops drop the temporary `Ref` before each `.await`; and their
+//!   returned futures own a cloned receiver (`Send + 'static`, borrowing nothing
+//!   from `&self`), which is what lets `get()` `drop(slf)` + release the GIL
+//!   before blocking and lets `as_asyncio` `spawn` the observer. Enforced partly
+//!   by the compiler (`Send` bounds, the borrow checker on `drop(slf)`) and
+//!   partly by construction; exercised by the multi-observer/blocking tests.
+//! - **HDL-10 (dropped producer surfaces, never hangs).** If every producer drops
+//!   its sender without sending, the wait loop's `changed().await?` yields a
+//!   `RecvError` turned into a Python exception (`to_py_error`) on both the sync
+//!   (`get`/`wait_future`) and async (`as_asyncio`) paths, so an observer raises
+//!   rather than hanging forever.
+//! - **HDL-11 (`Handle` is not constructible from Python).** The pyclass has no
+//!   `#[new]` and the only `from_value` constructor is `#[cfg(test)]`-gated, so a
+//!   live `Handle` always wraps a producer-supplied core (upholding HDL-1/HDL-2);
+//!   exposing a Python constructor would let user code mint an unresolvable core.
+//! - **HDL-12 (`get()` timeout contract).** `get()` validates the timeout up
+//!   front (rejecting negative/NaN/non-finite as `ValueError` via
+//!   `try_from_secs_f64`, never panicking) and before the ready fast path, so an
+//!   invalid timeout raises deterministically even for a ready handle. A timeout
+//!   is non-cancelling: it raises `TimeoutError` while leaving the producer and
+//!   every observer untouched, so a later `poll()`/`get()`/`await` still observes
+//!   completion.
+
+use std::future::Future;
+
+use monarch_types::py_global;
+use pyo3::exceptions::PyRuntimeError;
+use pyo3::exceptions::PyStopIteration;
+use pyo3::exceptions::PyTimeoutError;
+use pyo3::exceptions::PyUserWarning;
+use pyo3::exceptions::PyValueError;
+use pyo3::prelude::*;
+use pyo3::sync::PyOnceLock;
+use pyo3::types::PyCFunction;
+use pyo3::types::PyType;
+use tokio::sync::watch;
+use tokio::task::AbortHandle;
+
+use crate::pytokio::is_tokio_thread;
+use crate::pytokio::to_py_error;
+use crate::runtime::GilSite;
+use crate::runtime::get_tokio_runtime;
+use crate::runtime::monarch_with_gil;
+use crate::runtime::monarch_with_gil_blocking;
+use crate::runtime::signal_safe_block_on;
+
+// Held so the completion callback can catch and swallow it: publishing a result
+// onto an asyncio.Future that's already settled (the awaiter cancelled it, or it
+// resolved) raises InvalidStateError, which is benign here.
+py_global!(invalid_state_error, "asyncio", "InvalidStateError");
+
+pyo3::create_exception!(
+    pytokio,
+    WouldBlockRuntime,
+    pyo3::exceptions::PyRuntimeError,
+    "raised when Handle.get() is called from a Tokio runtime context"
+);
+
+/// The watch-channel mechanics behind a `Handle`.
+///
+/// The channel starts as `None` and is fulfilled once with `Some(Ok(obj))` or
+/// `Some(Err(pyerr))`. Cloning the receiver lets multiple observers see the same
+/// completion, so observation is non-consuming.
+pub(crate) struct HandleCore {
+    /// One-shot result channel. `None` until the producer completes.
+    rx: watch::Receiver<Option<PyResult<Py<PyAny>>>>,
+
+    /// When `Some`, dropping the core aborts the producing Tokio task through
+    /// this handle; `None` leaves the producer running (a detached producer, or
+    /// a core built from a ready value). The task's result is observed only via
+    /// `rx`, so only the `AbortHandle` is kept, never the `JoinHandle`.
+    abort_on_drop: Option<AbortHandle>,
+
+    /// Optional creation-site traceback, used when logging un-awaited errors.
+    traceback: Option<Py<PyAny>>,
+}
+
+impl HandleCore {
+    /// Construct a core from its parts.
+    pub(crate) fn new(
+        rx: watch::Receiver<Option<PyResult<Py<PyAny>>>>,
+        abort_on_drop: Option<AbortHandle>,
+        traceback: Option<Py<PyAny>>,
+    ) -> Self {
+        Self {
+            rx,
+            abort_on_drop,
+            traceback,
+        }
+    }
+
+    /// Construct a core that is already resolved with `value`.
+    ///
+    /// There is no producer task, so the core never aborts on drop and carries
+    /// no traceback.
+    pub(crate) fn from_value(value: Py<PyAny>) -> PyResult<Self> {
+        let (tx, rx) = watch::channel(None);
+        tx.send(Some(Ok(value))).map_err(to_py_error)?;
+        Ok(Self {
+            rx,
+            abort_on_drop: None,
+            traceback: None,
+        })
+    }
+
+    /// Non-blocking, non-consuming check for completion.
+    ///
+    /// Returns `Ok(None)` while pending, `Ok(Some(obj))` on success, or
+    /// `Err(pyerr)` if the producer completed with an exception.
+    pub(crate) fn poll(&self) -> PyResult<Option<Py<PyAny>>> {
+        // HDL-9: release the watch read guard before taking the GIL; holding it
+        // across the GIL acquisition would invert lock order against the
+        // producer's write-lock send. Re-borrowing under the GIL is safe by HDL-1
+        // (one-shot: once `Some`, never reset or replaced).
+        if self.rx.borrow().is_none() {
+            return Ok(None);
+        }
+        monarch_with_gil_blocking(GilSite::Convert, |py| {
+            match self
+                .rx
+                .borrow()
+                .as_ref()
+                .expect("HDL-1: value is Some after the is_none check")
+            {
+                Ok(v) => Ok(Some(v.clone_ref(py))),
+                Err(err) => Err(err.clone_ref(py)),
+            }
+        })
+    }
+
+    /// Return a future that observes this core's completion.
+    ///
+    /// The receiver is cloned, so this is non-consuming: any number of waiters
+    /// can observe the same final value. The current value is checked before
+    /// awaiting `changed()`, so a core that already holds its value resolves
+    /// immediately.
+    pub(crate) fn wait_future(&self) -> impl Future<Output = PyResult<Py<PyAny>>> + Send + 'static {
+        // Reuse wait_ready's HDL-1 wait loop (single source of truth), then clone
+        // the value out under the GIL.
+        let ready = self.wait_ready();
+        async move {
+            // HDL-10: a dropped producer surfaces as a Python exception here.
+            let rx = ready.await.map_err(to_py_error)?;
+            monarch_with_gil(GilSite::Convert, |py| {
+                match rx
+                    .borrow()
+                    .as_ref()
+                    .expect("HDL-1: value is Some after wait_ready")
+                {
+                    Ok(v) => Ok(v.clone_ref(py)),
+                    Err(err) => Err(err.clone_ref(py)),
+                }
+            })
+            .await
+        }
+    }
+
+    /// Await this core's completion without touching the GIL.
+    ///
+    /// Yields the cloned receiver positioned at the completed value, or a
+    /// `RecvError` if every producer dropped its sender without sending. Unlike
+    /// `wait_future`, which clones the value out under its own GIL acquisition,
+    /// the caller clones under a GIL it holds anyway (e.g. `as_asyncio`'s
+    /// scheduling), so completion touches the GIL exactly once.
+    pub(crate) fn wait_ready(
+        &self,
+    ) -> impl Future<
+        Output = Result<watch::Receiver<Option<PyResult<Py<PyAny>>>>, watch::error::RecvError>,
+    > + Send
+    + 'static {
+        // HDL-9: the returned future owns a cloned receiver (Send + 'static,
+        // borrowing nothing from &self), so a caller can drop its PyRef / release
+        // the GIL before awaiting and can spawn this future.
+        let mut rx = self.rx.clone();
+        async move {
+            // HDL-1: loop until the value is actually `Some` (one-shot). HDL-9:
+            // the temporary borrow is dropped before each `.await`, never held
+            // across it. HDL-10: a dropped producer makes `changed()` yield a
+            // RecvError, which propagates out rather than hanging.
+            while rx.borrow().is_none() {
+                rx.changed().await?;
+            }
+            Ok(rx)
+        }
+    }
+
+    /// Clone the creation-site traceback under the GIL.
+    pub(crate) fn traceback_clone(&self) -> Option<Py<PyAny>> {
+        self.traceback
+            .as_ref()
+            .map(|t| monarch_with_gil_blocking(GilSite::Traceback, |py| t.clone_ref(py)))
+    }
+}
+
+/// Abort the producing Tokio task on drop when `abort_on_drop` is set.
+///
+/// This stops abandoned background work when no observers remain, guarded against
+/// panics during interpreter shutdown when the Tokio runtime may already be gone.
+/// A `Handle`'s core has `abort_on_drop: None` (HDL-4), so this aborts only for
+/// pytokio's `spawn_abortable`, never for a `Handle`.
+impl Drop for HandleCore {
+    fn drop(&mut self) {
+        if let Some(abort_handle) = self.abort_on_drop.as_ref() {
+            // HDL-4: catch_unwind so an abort() that panics at interpreter
+            // shutdown (the runtime already gone) cannot escape Drop and abort
+            // the process.
+            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                abort_handle.abort();
+            }));
+        }
+    }
+}
+
+/// The observe-only handle to a background Tokio task.
+///
+/// Exposed to Python as
+/// `monarch._rust_bindings.monarch_hyperactor.pytokio.Handle`. HDL-11: Python
+/// obtains a `Handle` from a producer and cannot construct one directly -- there
+/// is no `__new__`, and `from_value` is `#[cfg(test)]`-only.
+#[pyclass(
+    name = "Handle",
+    module = "monarch._rust_bindings.monarch_hyperactor.pytokio"
+)]
+pub struct PyHandle {
+    core: HandleCore,
+}
+
+#[cfg(test)]
+impl PyHandle {
+    /// Construct a resolved `Handle` from `value`.
+    ///
+    /// HDL-11: Rust-only test helper (`#[cfg(test)]`), deliberately not a
+    /// Python-visible method, so a `Handle` cannot be constructed from Python.
+    pub(crate) fn from_value(value: Py<PyAny>) -> PyResult<Self> {
+        Ok(Self {
+            core: HandleCore::from_value(value)?,
+        })
+    }
+}
+
+#[pymethods]
+impl PyHandle {
+    /// Block the calling thread until the handle resolves and return its value.
+    ///
+    /// Behavior is keyed to the calling context, not to whether the value
+    /// happens to be ready:
+    ///   - Tokio runtime context: raise `WouldBlockRuntime` unconditionally
+    ///     (blocking there would panic the runtime); use `poll()` or
+    ///     `as_asyncio()` instead.
+    ///   - running `asyncio` loop: warns (get() is a blocking call from a loop),
+    ///     then a ready value returns via the `poll()` fast path and a pending
+    ///     one blocks. Under a warnings-as-errors filter the warning is an error.
+    ///   - sync thread: a ready value fast-paths, a pending one blocks
+    ///     (Ctrl-C-safe on main).
+    ///
+    /// `get()` is non-cancelling. On timeout it raises `TimeoutError`, leaving
+    /// the producer and every observer untouched, so a later
+    /// `poll()`/`get()`/`await` still observes completion.
+    #[pyo3(signature = (timeout = None))]
+    fn get(slf: PyRef<'_, Self>, py: Python<'_>, timeout: Option<f64>) -> PyResult<Py<PyAny>> {
+        // HDL-6: get() is the sole WouldBlockRuntime raiser. It is the blocking
+        // API, and in a Tokio runtime context blocking would panic the runtime,
+        // so refuse unconditionally -- even a ready value -- keying the outcome
+        // to context, not producer timing.
+        if is_tokio_thread() {
+            return Err(WouldBlockRuntime::new_err(
+                "get() cannot be called from a Tokio runtime context; use poll() or as_asyncio()",
+            ));
+        }
+
+        // HDL-12: validate the timeout up front, so an invalid value raises
+        // ValueError deterministically rather than only when the handle happens
+        // to be pending. Reject negative/NaN/non-finite rather than panicking in
+        // Duration::from_secs_f64.
+        let duration = timeout
+            .map(|seconds| {
+                std::time::Duration::try_from_secs_f64(seconds)
+                    .map_err(|e| PyValueError::new_err(format!("invalid timeout {seconds}: {e}")))
+            })
+            .transpose()?;
+
+        // Warn regardless of readiness: get() is a blocking call, and calling it
+        // from a running asyncio loop is the anti-pattern being flagged whether or
+        // not the value happens to be ready this time (a later call may block and
+        // freeze the loop). Under a warnings-as-errors filter this escalates to an
+        // error -- the caller's chosen strictness for the anti-pattern.
+        if pyo3_async_runtimes::get_running_loop(py).is_ok() {
+            let category = py.get_type::<PyUserWarning>();
+            PyErr::warn(
+                py,
+                &category,
+                c"Blocking get() was called from a running asyncio event loop. It is a synchronous, blocking call that can freeze the loop and deadlock; use as_asyncio() (or await) instead.",
+                1,
+            )?;
+        }
+
+        // A ready value returns without blocking, in any non-Tokio context.
+        if let Some(value) = slf.core.poll()? {
+            return Ok(value);
+        }
+
+        let wait = slf.core.wait_future();
+        // HDL-9: drop the PyRef before releasing the GIL in `signal_safe_block_on`
+        // (which blocks with the GIL released), so a concurrent mutable borrow of
+        // this handle does not throw during the blocking window.
+        drop(slf);
+
+        // HDL-12: the timeout drops only the local `wait` future, leaving the
+        // producer and the watch channel untouched, so a timed-out get() stays
+        // observable (non-cancelling).
+        match duration {
+            Some(duration) => signal_safe_block_on(py, async move {
+                tokio::time::timeout(duration, wait)
+                    .await
+                    .map_err(|_| PyTimeoutError::new_err(()))?
+            })?,
+            None => signal_safe_block_on(py, wait)?,
+        }
+    }
+
+    /// Non-blocking, non-consuming check for completion.
+    ///
+    /// Returns `None` while pending, the value on success, or raises the stored
+    /// exception. A ready value stays observable by later observers.
+    fn poll(&self) -> PyResult<Option<Py<PyAny>>> {
+        self.core.poll()
+    }
+
+    /// Return a standard `asyncio.Future` that resolves when the handle does.
+    ///
+    /// Requires a running loop; off a loop this raises the native `RuntimeError`
+    /// from `asyncio.get_running_loop()`. A Tokio observer of the watch channel
+    /// publishes the completion onto the calling loop via
+    /// `loop.call_soon_threadsafe(...)`; it never drives a Python coroutine.
+    ///
+    /// The observer borrows the current watch value first, so a core that
+    /// already holds its value (or one that completes before the observer
+    /// starts) resolves rather than hangs. The result is set in a callback on
+    /// the loop thread. A cancel can race that callback: a cancelled future is
+    /// left alone and the handle continues. If the loop has closed by then,
+    /// `call_soon_threadsafe` raises, and the observer logs rather than panics.
+    ///
+    /// Each call spawns its own observer; cancelling the returned future does
+    /// not stop the observer, which exits when the handle resolves.
+    fn as_asyncio<'py>(slf: PyRef<'_, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        // HDL-6: off a loop this yields the native RuntimeError, not WouldBlockRuntime.
+        let event_loop = pyo3_async_runtimes::get_running_loop(py)?;
+        let fut = event_loop.call_method0("create_future")?;
+
+        let loop_handle = event_loop.clone().unbind();
+        let fut_handle = fut.clone().unbind();
+        let wait = slf.core.wait_ready();
+
+        get_tokio_runtime().spawn(async move {
+            let recv = wait.await;
+            let scheduled = monarch_with_gil(GilSite::Convert, move |py| {
+                // HDL-9: one GIL section that borrows the watch value under the
+                // already-held GIL (GIL-then-watch order), clones it out (or turns
+                // a dropped-producer RecvError into a PyErr), and schedules it --
+                // completion touches the GIL exactly once.
+                let result: PyResult<Py<PyAny>> = match recv {
+                    Ok(rx) => match rx
+                        .borrow()
+                        .as_ref()
+                        .expect("HDL-1: value is Some after wait_ready")
+                    {
+                        Ok(v) => Ok(v.clone_ref(py)),
+                        Err(err) => Err(err.clone_ref(py)),
+                    },
+                    // HDL-10: a dropped producer surfaces as a set_exception.
+                    Err(e) => Err(to_py_error(e)),
+                };
+                schedule_completion(py, loop_handle.bind(py), fut_handle.bind(py), result)
+            })
+            .await;
+            if let Err(err) = scheduled {
+                tracing::warn!("as_asyncio: failed to schedule completion on the loop: {err}");
+            }
+        });
+
+        Ok(fut)
+    }
+
+    /// Implement Python's `await` protocol by delegating to `as_asyncio()`.
+    fn __await__<'py>(slf: PyRef<'_, Self>, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        Self::as_asyncio(slf, py)?.call_method0("__await__")
+    }
+
+    /// Support `Handle[T]` type syntax on the Python side (no runtime effect).
+    #[classmethod]
+    fn __class_getitem__(cls: &Bound<'_, PyType>, _arg: Py<PyAny>) -> Py<PyAny> {
+        cls.clone().unbind().into()
+    }
+}
+
+/// The cached `complete_asyncio_future` callable.
+///
+/// The function is stateless, so it is wrapped once and reused for every
+/// completion rather than rebuilt (and leaked) on each `call_soon_threadsafe`.
+fn cached_completer(py: Python<'_>) -> PyResult<Bound<'_, PyCFunction>> {
+    static COMPLETER: PyOnceLock<Py<PyCFunction>> = PyOnceLock::new();
+    COMPLETER
+        .get_or_try_init(py, || {
+            Ok(wrap_pyfunction!(complete_asyncio_future, py)?.unbind())
+        })
+        .map(|f| f.bind(py).clone())
+}
+
+/// Schedule the handle's completion onto `event_loop` from the Tokio observer.
+///
+/// Runs under the GIL. The caller has already cloned the success value; an error
+/// is turned into its Python exception object here, so no Rust `PyErr` crosses
+/// into the loop callback. `complete_asyncio_future` is then scheduled via
+/// `call_soon_threadsafe`, whose error (e.g. a closed loop) is returned so the
+/// caller can log rather than panic.
+fn schedule_completion(
+    py: Python<'_>,
+    event_loop: &Bound<'_, PyAny>,
+    fut: &Bound<'_, PyAny>,
+    result: PyResult<Py<PyAny>>,
+) -> PyResult<()> {
+    let completer = cached_completer(py)?;
+    let (is_exc, value) = match result {
+        Ok(v) => (false, v),
+        Err(e) => (true, e.into_value(py).into_any()),
+    };
+    event_loop.call_method1("call_soon_threadsafe", (completer, fut, is_exc, value))?;
+    Ok(())
+}
+
+/// Complete an `asyncio.Future` on its loop thread (HDL-7).
+///
+/// The future may already be settled when this runs: a cancelled future is left
+/// alone, and an already-completed one is swallowed. Any other error propagates.
+#[pyfunction]
+fn complete_asyncio_future(fut: &Bound<'_, PyAny>, is_exc: bool, value: Py<PyAny>) -> PyResult<()> {
+    if fut.call_method0("cancelled")?.is_truthy()? {
+        return Ok(());
+    }
+    let py = fut.py();
+    let (method, value) = if is_exc {
+        // asyncio.Future.set_exception rejects a StopIteration (PEP 479) with a
+        // TypeError; running as a call_soon_threadsafe callback it would be
+        // logged and dropped, hanging the awaiter. Wrap any StopIteration
+        // (including subclasses) in a RuntimeError -- how `raise StopIteration`
+        // already surfaces out of a coroutine -- so the future can always settle.
+        let value = if value.bind(py).is_instance_of::<PyStopIteration>() {
+            PyRuntimeError::new_err("coroutine raised StopIteration")
+                .into_value(py)
+                .into_any()
+        } else {
+            value
+        };
+        ("set_exception", value)
+    } else {
+        ("set_result", value)
+    };
+    // HDL-7: publish only to a non-cancelled future (the guard above), and
+    // swallow InvalidStateError from one already settled. Any other error is a
+    // real failure and propagates.
+    match fut.call_method1(method, (value,)) {
+        Ok(_) => Ok(()),
+        Err(e) => {
+            if e.is_instance(py, &invalid_state_error(py)) {
+                Ok(())
+            } else {
+                Err(e)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pyo3::IntoPyObjectExt;
+    use pyo3::exceptions::PyRuntimeError;
+    use pyo3::exceptions::PyValueError;
+    use pyo3::types::PyModule;
+    use pyo3::types::PyTuple;
+
+    use super::*;
+    use crate::pytokio::ensure_python;
+
+    // Build a `Handle` over a controlled, still-pending watch channel and return
+    // the sender so the test drives completion explicitly.
+    fn pending_handle() -> (watch::Sender<Option<PyResult<Py<PyAny>>>>, PyHandle) {
+        let (tx, rx) = watch::channel(None);
+        let handle = PyHandle {
+            core: HandleCore::new(rx, None, None),
+        };
+        (tx, handle)
+    }
+
+    // A Python helper module providing loop drivers for the `asyncio` tests.
+    fn loop_helper(py: Python<'_>) -> Bound<'_, PyModule> {
+        let code = cr#"
+import asyncio
+import warnings
+
+async def _await(h):
+    return await h
+
+def run_await(h):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_await(h))
+    finally:
+        loop.close()
+
+async def _get_on_loop(h):
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        value = h.get()
+    return (value, any(issubclass(w.category, UserWarning) for w in caught))
+
+def run_get_on_loop(h):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_get_on_loop(h))
+    finally:
+        loop.close()
+
+async def _get_on_loop_strict(h):
+    # get() under a warnings-as-errors filter: a ready value must still return
+    # (no-warn fast path), not raise the UserWarning as an error.
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        return h.get()
+
+def run_get_on_loop_strict(h):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_get_on_loop_strict(h))
+    finally:
+        loop.close()
+
+async def _cancel(h):
+    f = h.as_asyncio()
+    f.cancel()
+    await asyncio.sleep(0.05)
+    return (f.cancelled(), h.poll())
+
+def run_cancel(h):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_cancel(h))
+    finally:
+        loop.close()
+
+async def _cancel_then_await(h):
+    # cancel the first observer, then observe again while a live producer runs
+    f1 = h.as_asyncio()
+    f1.cancel()
+    result = await h.as_asyncio()
+    # let the cancelled observer's completion callback drain (it no-ops)
+    await asyncio.sleep(0.05)
+    return (f1.cancelled(), result, h.poll())
+
+def run_cancel_then_await(h):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_cancel_then_await(h))
+    finally:
+        loop.close()
+
+async def _two(h):
+    a = h.as_asyncio()
+    b = h.as_asyncio()
+    # gather returns a list; the Rust side downcasts a tuple
+    return tuple(await asyncio.gather(a, b))
+
+def run_two(h):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_two(h))
+    finally:
+        loop.close()
+"#;
+        PyModule::from_code(py, code, c"handle_test_helper.py", c"handle_test_helper").unwrap()
+    }
+
+    // A ready value is returned via the poll fast path.
+    // Attests HDL-2.
+    #[test]
+    fn get_returns_ready_value() {
+        ensure_python();
+        let got = monarch_with_gil_blocking(GilSite::Test, |py| -> i64 {
+            let value = 42i64.into_py_any(py).unwrap();
+            let handle = PyHandle::from_value(value).unwrap();
+            let r = Py::new(py, handle).unwrap();
+            let out = PyHandle::get(r.borrow(py), py, None).unwrap();
+            out.extract::<i64>(py).unwrap()
+        });
+        assert_eq!(got, 42, "get() should return the resolved value");
+    }
+
+    // A pending handle blocks get() on a sync thread until a producer completes.
+    // Attests HDL-1, HDL-2.
+    #[test]
+    fn get_blocks_then_returns() {
+        ensure_python();
+        let value = monarch_with_gil_blocking(GilSite::Test, |py| 7i64.into_py_any(py).unwrap());
+        let (tx, handle) = pending_handle();
+        get_tokio_runtime().spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let _ = tx.send(Some(Ok(value)));
+        });
+        let got = monarch_with_gil_blocking(GilSite::Test, |py| -> i64 {
+            let r = Py::new(py, handle).unwrap();
+            let out = PyHandle::get(r.borrow(py), py, None).unwrap();
+            out.extract::<i64>(py).unwrap()
+        });
+        assert_eq!(got, 7, "get() should block then return the produced value");
+    }
+
+    // poll() transitions from None to the value once the producer completes.
+    // Attests HDL-1, HDL-2.
+    #[test]
+    fn poll_transitions_pending_to_ready() {
+        ensure_python();
+        let (tx, rx) = watch::channel(None);
+        let core = HandleCore::new(rx, None, None);
+        assert!(
+            core.poll().unwrap().is_none(),
+            "poll() should be None while pending"
+        );
+        let value = monarch_with_gil_blocking(GilSite::Test, |py| 1i64.into_py_any(py).unwrap());
+        tx.send(Some(Ok(value))).unwrap();
+        let got = core.poll().unwrap();
+        let extracted =
+            monarch_with_gil_blocking(GilSite::Test, |py| got.unwrap().extract::<i64>(py).unwrap());
+        assert_eq!(extracted, 1, "poll() should observe the produced value");
+    }
+
+    // poll() is non-consuming: after it returns ready, get() and poll() still
+    // observe the same value.
+    // Attests HDL-1, HDL-3.
+    #[test]
+    fn repeated_observation_after_poll() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let value = 5i64.into_py_any(py).unwrap();
+            let handle = PyHandle::from_value(value).unwrap();
+            let r = Py::new(py, handle).unwrap();
+
+            let first = r.borrow(py).poll().unwrap().unwrap();
+            assert_eq!(first.extract::<i64>(py).unwrap(), 5);
+
+            let via_get = PyHandle::get(r.borrow(py), py, None).unwrap();
+            assert_eq!(via_get.extract::<i64>(py).unwrap(), 5);
+
+            let again = r.borrow(py).poll().unwrap().unwrap();
+            assert_eq!(again.extract::<i64>(py).unwrap(), 5);
+        });
+    }
+
+    // Two independent observers of one still-pending core both resolve; cloning
+    // the receiver never consumes it.
+    // Attests HDL-1, HDL-3.
+    #[test]
+    fn multiple_observers_resolve() {
+        ensure_python();
+        let (tx, rx) = watch::channel(None);
+        let core = HandleCore::new(rx, None, None);
+        let f1 = core.wait_future();
+        let f2 = core.wait_future();
+        let value = monarch_with_gil_blocking(GilSite::Test, |py| 3i64.into_py_any(py).unwrap());
+        tx.send(Some(Ok(value))).unwrap();
+        let (r1, r2) = get_tokio_runtime().block_on(async move { tokio::join!(f1, f2) });
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            assert_eq!(r1.unwrap().extract::<i64>(py).unwrap(), 3);
+            assert_eq!(r2.unwrap().extract::<i64>(py).unwrap(), 3);
+        });
+    }
+
+    // A still-pending get() in a Tokio runtime context raises WouldBlockRuntime.
+    // Attests HDL-6.
+    #[test]
+    fn get_pending_in_tokio_raises_would_block() {
+        ensure_python();
+        let (_tx, handle) = pending_handle();
+        get_tokio_runtime().block_on(async {
+            monarch_with_gil(GilSite::Test, |py| {
+                let r = Py::new(py, handle).unwrap();
+                let err = PyHandle::get(r.borrow(py), py, None).unwrap_err();
+                assert!(
+                    err.is_instance_of::<WouldBlockRuntime>(py),
+                    "pending get() in a tokio context should raise WouldBlockRuntime"
+                );
+            })
+            .await
+        });
+    }
+
+    // A ready value in a Tokio runtime context still raises: get() is refused by
+    // context, not by whether the value happens to be available (HDL-6).
+    // Attests HDL-6.
+    #[test]
+    fn get_ready_in_tokio_also_raises() {
+        ensure_python();
+        get_tokio_runtime().block_on(async {
+            monarch_with_gil(GilSite::Test, |py| {
+                let value = 9i64.into_py_any(py).unwrap();
+                let handle = PyHandle::from_value(value).unwrap();
+                let r = Py::new(py, handle).unwrap();
+                let err = PyHandle::get(r.borrow(py), py, None).unwrap_err();
+                assert!(
+                    err.is_instance_of::<WouldBlockRuntime>(py),
+                    "get() in a tokio context must raise even for a ready value"
+                );
+            })
+            .await
+        });
+    }
+
+    // get(timeout) raises TimeoutError and leaves the handle pending, so a later
+    // observation still sees completion.
+    // Attests HDL-12.
+    #[test]
+    fn get_timeout_raises_and_leaves_pending() {
+        ensure_python();
+        let (tx, handle) = pending_handle();
+        let r = monarch_with_gil_blocking(GilSite::Test, |py| Py::new(py, handle).unwrap());
+
+        let is_timeout = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let err = PyHandle::get(r.borrow(py), py, Some(0.05)).unwrap_err();
+            err.is_instance_of::<PyTimeoutError>(py)
+        });
+        assert!(is_timeout, "get(timeout) should raise TimeoutError");
+
+        let still_pending =
+            monarch_with_gil_blocking(GilSite::Test, |py| r.borrow(py).poll().unwrap().is_none());
+        assert!(
+            still_pending,
+            "a timed-out get() must not resolve the handle"
+        );
+
+        let value = monarch_with_gil_blocking(GilSite::Test, |py| 4i64.into_py_any(py).unwrap());
+        tx.send(Some(Ok(value))).unwrap();
+        let observed = monarch_with_gil_blocking(GilSite::Test, |py| {
+            r.borrow(py)
+                .poll()
+                .unwrap()
+                .unwrap()
+                .extract::<i64>(py)
+                .unwrap()
+        });
+        assert_eq!(
+            observed, 4,
+            "completion is still observable after a timeout"
+        );
+    }
+
+    // as_asyncio() off a loop raises the native RuntimeError, not
+    // WouldBlockRuntime.
+    // Attests HDL-6.
+    #[test]
+    fn as_asyncio_off_loop_raises_runtime_error() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let handle = PyHandle::from_value(py.None()).unwrap();
+            let r = Py::new(py, handle).unwrap();
+            let err = PyHandle::as_asyncio(r.borrow(py), py).unwrap_err();
+            assert!(
+                err.is_instance_of::<PyRuntimeError>(py),
+                "off a loop as_asyncio() should raise RuntimeError"
+            );
+            assert!(
+                !err.is_instance_of::<WouldBlockRuntime>(py),
+                "the off-loop error must be the native RuntimeError, not WouldBlockRuntime"
+            );
+        });
+    }
+
+    // __await__ off a loop surfaces the native RuntimeError from as_asyncio().
+    // Attests HDL-6.
+    #[test]
+    fn await_off_loop_raises_runtime_error() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let handle = PyHandle::from_value(py.None()).unwrap();
+            let r = Py::new(py, handle).unwrap();
+            let err = PyHandle::__await__(r.borrow(py), py).unwrap_err();
+            assert!(
+                err.is_instance_of::<PyRuntimeError>(py),
+                "off a loop __await__ should raise RuntimeError"
+            );
+            assert!(
+                !err.is_instance_of::<WouldBlockRuntime>(py),
+                "__await__ must not raise WouldBlockRuntime"
+            );
+        });
+    }
+
+    // await on a pre-resolved handle resolves on a real loop (borrow-first, no
+    // hang) and yields the value.
+    // Attests HDL-2, HDL-7.
+    #[test]
+    fn await_resolves_ok_on_loop() {
+        ensure_python();
+        let got = monarch_with_gil_blocking(GilSite::Test, |py| -> i64 {
+            let value = 42i64.into_py_any(py).unwrap();
+            let handle = PyHandle::from_value(value).unwrap();
+            let h = Py::new(py, handle).unwrap();
+            let helper = loop_helper(py);
+            helper
+                .getattr("run_await")
+                .unwrap()
+                .call1((h,))
+                .unwrap()
+                .extract::<i64>()
+                .unwrap()
+        });
+        assert_eq!(got, 42, "await should resolve to the value on a real loop");
+    }
+
+    // await surfaces the stored error as a Python exception on a real loop.
+    // Attests HDL-2, HDL-7.
+    #[test]
+    fn await_resolves_err_on_loop() {
+        ensure_python();
+        let (tx, rx) = watch::channel(None);
+        tx.send(Some(Err(PyValueError::new_err("boom")))).unwrap();
+        let is_value_error = monarch_with_gil_blocking(GilSite::Test, |py| {
+            let handle = PyHandle {
+                core: HandleCore::new(rx, None, None),
+            };
+            let h = Py::new(py, handle).unwrap();
+            let helper = loop_helper(py);
+            let err = helper
+                .getattr("run_await")
+                .unwrap()
+                .call1((h,))
+                .unwrap_err();
+            err.is_instance_of::<PyValueError>(py)
+        });
+        assert!(is_value_error, "await should raise the stored exception");
+    }
+
+    // await resolves a still-pending handle once a producer completes it while
+    // the loop runs.
+    // Attests HDL-1, HDL-7.
+    #[test]
+    fn await_resolves_pending_on_loop() {
+        ensure_python();
+        let value = monarch_with_gil_blocking(GilSite::Test, |py| 11i64.into_py_any(py).unwrap());
+        let (tx, handle) = pending_handle();
+        get_tokio_runtime().spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            let _ = tx.send(Some(Ok(value)));
+        });
+        let got = monarch_with_gil_blocking(GilSite::Test, |py| -> i64 {
+            let h = Py::new(py, handle).unwrap();
+            let helper = loop_helper(py);
+            helper
+                .getattr("run_await")
+                .unwrap()
+                .call1((h,))
+                .unwrap()
+                .extract::<i64>()
+                .unwrap()
+        });
+        assert_eq!(got, 11, "await should resolve once the producer completes");
+    }
+
+    // Cancelling an as_asyncio() future does not cancel the handle. Here the
+    // handle is pre-resolved: the cancelled future's completion callback no-ops
+    // and the value stays observable via poll(). The live-producer case -- one
+    // observer's cancel leaves the producer running and other observers still
+    // resolving -- is `cancel_asyncio_future_does_not_stop_producer_or_observers`.
+    // Attests HDL-3, HDL-7.
+    #[test]
+    fn cancel_asyncio_future_does_not_cancel_handle() {
+        ensure_python();
+        let (cancelled, handle_resolved) =
+            monarch_with_gil_blocking(GilSite::Test, |py| -> (bool, bool) {
+                let value = 42i64.into_py_any(py).unwrap();
+                let handle = PyHandle::from_value(value).unwrap();
+                let h = Py::new(py, handle).unwrap();
+                let helper = loop_helper(py);
+                let res = helper.getattr("run_cancel").unwrap().call1((h,)).unwrap();
+                let tup = res.downcast::<PyTuple>().unwrap();
+                let cancelled = tup.get_item(0).unwrap().extract::<bool>().unwrap();
+                let poll_val = tup.get_item(1).unwrap();
+                (cancelled, !poll_val.is_none())
+            });
+        assert!(cancelled, "the asyncio future should be cancelled");
+        assert!(
+            handle_resolved,
+            "cancelling the future must not cancel the handle"
+        );
+    }
+
+    // The live-producer companion to `cancel_asyncio_future_does_not_cancel_handle`:
+    // with a still-pending handle and a real producer, cancelling one observer
+    // leaves the producer running and other observers still resolving. A second
+    // as_asyncio() future resolves to the value and the handle stays pollable; the
+    // cancelled observer still runs to completion, and the `complete_asyncio_future`
+    // it posts to the loop no-ops on the cancelled future.
+    // Attests HDL-3, HDL-7.
+    #[test]
+    fn cancel_asyncio_future_does_not_stop_producer_or_observers() {
+        ensure_python();
+        let value = monarch_with_gil_blocking(GilSite::Test, |py| 42i64.into_py_any(py).unwrap());
+        let (tx, handle) = pending_handle();
+        get_tokio_runtime().spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+            let _ = tx.send(Some(Ok(value)));
+        });
+        let (cancelled, awaited, polled) =
+            monarch_with_gil_blocking(GilSite::Test, |py| -> (bool, i64, i64) {
+                let h = Py::new(py, handle).unwrap();
+                let helper = loop_helper(py);
+                let res = helper
+                    .getattr("run_cancel_then_await")
+                    .unwrap()
+                    .call1((h,))
+                    .unwrap();
+                let tup = res.downcast::<PyTuple>().unwrap();
+                (
+                    tup.get_item(0).unwrap().extract::<bool>().unwrap(),
+                    tup.get_item(1).unwrap().extract::<i64>().unwrap(),
+                    tup.get_item(2).unwrap().extract::<i64>().unwrap(),
+                )
+            });
+        assert!(cancelled, "the cancelled future should stay cancelled");
+        assert_eq!(
+            awaited, 42,
+            "a second observer resolves even after the first future is cancelled"
+        );
+        assert_eq!(
+            polled, 42,
+            "the handle stays observable after one observer is cancelled"
+        );
+    }
+
+    // Two as_asyncio() futures from one handle both resolve on a real loop.
+    // Attests HDL-3, HDL-7.
+    #[test]
+    fn two_asyncio_observers_resolve_on_loop() {
+        ensure_python();
+        let (a, b) = monarch_with_gil_blocking(GilSite::Test, |py| -> (i64, i64) {
+            let value = 8i64.into_py_any(py).unwrap();
+            let handle = PyHandle::from_value(value).unwrap();
+            let h = Py::new(py, handle).unwrap();
+            let helper = loop_helper(py);
+            let res = helper.getattr("run_two").unwrap().call1((h,)).unwrap();
+            let tup = res.downcast::<PyTuple>().unwrap();
+            (
+                tup.get_item(0).unwrap().extract::<i64>().unwrap(),
+                tup.get_item(1).unwrap().extract::<i64>().unwrap(),
+            )
+        });
+        assert_eq!((a, b), (8, 8), "both observers should resolve to the value");
+    }
+
+    // Scheduling completion onto a closed loop returns an error rather than
+    // panicking; the observer swallows this and logs.
+    // Attests HDL-7.
+    #[test]
+    fn schedule_on_closed_loop_errs_not_panics() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let asyncio = py.import("asyncio").unwrap();
+            let event_loop = asyncio.call_method0("new_event_loop").unwrap();
+            let fut = event_loop.call_method0("create_future").unwrap();
+            event_loop.call_method0("close").unwrap();
+            let result = schedule_completion(py, &event_loop, &fut, Ok(py.None()));
+            assert!(
+                result.is_err(),
+                "call_soon_threadsafe on a closed loop should error, not panic"
+            );
+        });
+    }
+
+    // A negative, NaN, or non-finite timeout is rejected with ValueError rather
+    // than panicking in `Duration::from_secs_f64`.
+    // Attests HDL-12.
+    #[test]
+    fn get_invalid_timeout_raises_value_error() {
+        ensure_python();
+        let (_tx, handle) = pending_handle();
+        let r = monarch_with_gil_blocking(GilSite::Test, |py| Py::new(py, handle).unwrap());
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            for bad in [-1.0, f64::NAN, f64::INFINITY] {
+                let err = PyHandle::get(r.borrow(py), py, Some(bad)).unwrap_err();
+                assert!(
+                    err.is_instance_of::<PyValueError>(py),
+                    "get(timeout={bad}) should raise ValueError, not panic"
+                );
+            }
+        });
+    }
+
+    // On a running asyncio loop, get() warns (UserWarning) regardless of whether
+    // the value is ready -- calling the blocking get() from a loop is the
+    // anti-pattern being flagged. A ready value still returns after warning.
+    // Attests HDL-8.
+    #[test]
+    fn get_on_asyncio_loop_warns() {
+        ensure_python();
+        let (value, warned) = monarch_with_gil_blocking(GilSite::Test, |py| -> (i64, bool) {
+            let v = 5i64.into_py_any(py).unwrap();
+            let handle = PyHandle::from_value(v).unwrap();
+            let h = Py::new(py, handle).unwrap();
+            let helper = loop_helper(py);
+            let res = helper
+                .getattr("run_get_on_loop")
+                .unwrap()
+                .call1((h,))
+                .unwrap();
+            let tup = res.downcast::<PyTuple>().unwrap();
+            (
+                tup.get_item(0).unwrap().extract::<i64>().unwrap(),
+                tup.get_item(1).unwrap().extract::<bool>().unwrap(),
+            )
+        });
+        assert_eq!(value, 5, "a ready value still returns after warning");
+        assert!(
+            warned,
+            "get() on a running asyncio loop warns regardless of readiness"
+        );
+    }
+
+    // A producer error surfaces through the direct read paths: poll() returns it
+    // and get() raises it (the primary sync API path, previously observed only
+    // through await/as_asyncio).
+    // Attests HDL-2.
+    #[test]
+    fn poll_and_get_surface_producer_error() {
+        ensure_python();
+        let (tx, handle) = pending_handle();
+        tx.send(Some(Err(PyValueError::new_err("boom")))).unwrap();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let r = Py::new(py, handle).unwrap();
+            let poll_err = r.borrow(py).poll().unwrap_err();
+            assert!(
+                poll_err.is_instance_of::<PyValueError>(py),
+                "poll() should surface the producer error"
+            );
+            let get_err = PyHandle::get(r.borrow(py), py, None).unwrap_err();
+            assert!(
+                get_err.is_instance_of::<PyValueError>(py),
+                "get() should raise the producer error"
+            );
+        });
+    }
+
+    // A producer that drops its sender without sending surfaces a Python error
+    // through wait_future (RecvError) rather than hanging; this path also backs
+    // get()/PyShared.
+    // Attests HDL-10.
+    #[test]
+    fn dropped_producer_surfaces_error() {
+        ensure_python();
+        let (tx, handle) = pending_handle();
+        drop(tx);
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let r = Py::new(py, handle).unwrap();
+            let err = PyHandle::get(r.borrow(py), py, None).unwrap_err();
+            assert!(
+                err.is_instance_of::<pyo3::exceptions::PyException>(py),
+                "a dropped producer should surface an exception, not hang"
+            );
+        });
+    }
+
+    // complete_asyncio_future swallows InvalidStateError from an already-settled
+    // (non-cancelled) future, and propagates any other setter error.
+    // Attests HDL-7.
+    #[test]
+    fn complete_asyncio_future_swallows_and_propagates() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let event_loop = py
+                .import("asyncio")
+                .unwrap()
+                .call_method0("new_event_loop")
+                .unwrap();
+            let settled = event_loop.call_method0("create_future").unwrap();
+            settled.call_method1("set_result", (1i64,)).unwrap();
+            assert!(
+                complete_asyncio_future(&settled, false, py.None()).is_ok(),
+                "InvalidStateError from a settled future should be swallowed"
+            );
+            event_loop.call_method0("close").unwrap();
+
+            // A fake future whose setter raises a non-InvalidStateError: it must
+            // propagate rather than be swallowed.
+            let helper = PyModule::from_code(
+                py,
+                cr#"
+class RaisingFuture:
+    def cancelled(self):
+        return False
+
+    def set_result(self, value):
+        raise ValueError("nope")
+"#,
+                c"raising_future.py",
+                c"raising_future",
+            )
+            .unwrap();
+            let fake = helper.getattr("RaisingFuture").unwrap().call0().unwrap();
+            let err = complete_asyncio_future(&fake, false, py.None()).unwrap_err();
+            assert!(
+                err.is_instance_of::<PyValueError>(py),
+                "a non-InvalidStateError setter error should propagate"
+            );
+        });
+    }
+
+    // get(timeout) whose producer resolves before the deadline returns the value
+    // (the Ok branch of tokio::time::timeout, distinct from the timeout-fires and
+    // bad-float cases).
+    // Attests HDL-2, HDL-12.
+    #[test]
+    fn get_timeout_returns_value_before_deadline() {
+        ensure_python();
+        let value = monarch_with_gil_blocking(GilSite::Test, |py| 13i64.into_py_any(py).unwrap());
+        let (tx, handle) = pending_handle();
+        get_tokio_runtime().spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let _ = tx.send(Some(Ok(value)));
+        });
+        let got = monarch_with_gil_blocking(GilSite::Test, |py| -> i64 {
+            let r = Py::new(py, handle).unwrap();
+            let out = PyHandle::get(r.borrow(py), py, Some(5.0)).unwrap();
+            out.extract::<i64>(py).unwrap()
+        });
+        assert_eq!(got, 13, "a generous timeout returns the produced value");
+    }
+
+    // Under a warnings-as-errors filter, a get() on a running loop escalates the
+    // anti-pattern warning to an error -- even for a ready value -- rather than
+    // silently returning. Warn-regardless means the strict caller sees it.
+    // Attests HDL-8.
+    #[test]
+    fn get_on_loop_under_warnings_as_errors_raises() {
+        ensure_python();
+        let raised = monarch_with_gil_blocking(GilSite::Test, |py| -> bool {
+            let v = 5i64.into_py_any(py).unwrap();
+            let handle = PyHandle::from_value(v).unwrap();
+            let h = Py::new(py, handle).unwrap();
+            let helper = loop_helper(py);
+            helper
+                .getattr("run_get_on_loop_strict")
+                .unwrap()
+                .call1((h,))
+                .is_err()
+        });
+        assert!(
+            raised,
+            "get() on a loop under warnings-as-errors should raise the escalated warning"
+        );
+    }
+
+    // The timeout is validated before the ready fast path, so an invalid timeout
+    // raises ValueError even when the handle is already resolved (where get()
+    // would otherwise return without blocking).
+    // Attests HDL-12.
+    #[test]
+    fn get_invalid_timeout_on_ready_raises() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let value = 7i64.into_py_any(py).unwrap();
+            let handle = PyHandle::from_value(value).unwrap();
+            let r = Py::new(py, handle).unwrap();
+            let err = PyHandle::get(r.borrow(py), py, Some(f64::NAN)).unwrap_err();
+            assert!(
+                err.is_instance_of::<PyValueError>(py),
+                "an invalid timeout must raise ValueError even for a ready handle"
+            );
+        });
+    }
+
+    // A producer that drops its sender without sending surfaces through
+    // as_asyncio/await (wait_ready's RecvError -> set_exception) as a raised
+    // exception, not a hang -- the async mirror of dropped_producer_surfaces_error.
+    // Attests HDL-10.
+    #[test]
+    fn as_asyncio_dropped_producer_raises_on_loop() {
+        ensure_python();
+        let (tx, handle) = pending_handle();
+        drop(tx);
+        let raised = monarch_with_gil_blocking(GilSite::Test, |py| -> bool {
+            let h = Py::new(py, handle).unwrap();
+            let helper = loop_helper(py);
+            helper.getattr("run_await").unwrap().call1((h,)).is_err()
+        });
+        assert!(
+            raised,
+            "awaiting a handle whose producer dropped its sender should raise, not hang"
+        );
+    }
+
+    // A StopIteration producer error is wrapped in RuntimeError before
+    // set_exception, since asyncio.Future.set_exception rejects a StopIteration
+    // (PEP 479) with a TypeError that would hang the awaiter.
+    // Attests HDL-7.
+    #[test]
+    fn complete_asyncio_future_wraps_stop_iteration() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let event_loop = py
+                .import("asyncio")
+                .unwrap()
+                .call_method0("new_event_loop")
+                .unwrap();
+            let fut = event_loop.call_method0("create_future").unwrap();
+            let stop_iteration = py.get_type::<PyStopIteration>().call0().unwrap().unbind();
+            // Must not raise (a raw set_exception(StopIteration) would TypeError).
+            complete_asyncio_future(&fut, true, stop_iteration).unwrap();
+            let exc = fut.call_method0("exception").unwrap();
+            assert!(
+                exc.is_instance_of::<PyRuntimeError>(),
+                "a StopIteration producer error should be wrapped in RuntimeError"
+            );
+            assert!(
+                !exc.is_instance_of::<PyStopIteration>(),
+                "the wrapped error must not remain a StopIteration"
+            );
+            event_loop.call_method0("close").unwrap();
+        });
+    }
+
+    // A StopIteration SUBCLASS is also wrapped in RuntimeError: we wrap any
+    // StopIteration, not just the exact type, so the awaiter never hits the
+    // set_exception TypeError hang.
+    // Attests HDL-7.
+    #[test]
+    fn complete_asyncio_future_wraps_stop_iteration_subclass() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let event_loop = py
+                .import("asyncio")
+                .unwrap()
+                .call_method0("new_event_loop")
+                .unwrap();
+            let fut = event_loop.call_method0("create_future").unwrap();
+            let helper = PyModule::from_code(
+                py,
+                cr#"
+class MyStop(StopIteration):
+    pass
+"#,
+                c"my_stop.py",
+                c"my_stop",
+            )
+            .unwrap();
+            let subclass_exc = helper.getattr("MyStop").unwrap().call0().unwrap().unbind();
+            complete_asyncio_future(&fut, true, subclass_exc).unwrap();
+            let exc = fut.call_method0("exception").unwrap();
+            assert!(
+                exc.is_instance_of::<PyRuntimeError>(),
+                "a StopIteration subclass should be wrapped in RuntimeError"
+            );
+            assert!(
+                !exc.is_instance_of::<PyStopIteration>(),
+                "the wrapped error must not remain a StopIteration"
+            );
+            event_loop.call_method0("close").unwrap();
+        });
+    }
+
+    // Dropping a core aborts its producing task only when `abort_on_drop` is set:
+    // spawn_abortable's core aborts abandoned work, while a Handle's core
+    // (abort_on_drop = None, HDL-4) leaves the producer running.
+    // Attests HDL-4.
+    #[test]
+    fn drop_aborts_producer_only_when_abort_set() {
+        use std::sync::Arc;
+        use std::sync::atomic::AtomicBool;
+        use std::sync::atomic::Ordering;
+        use std::time::Duration;
+
+        for (abort, expect_completed) in [(true, false), (false, true)] {
+            let completed = Arc::new(AtomicBool::new(false));
+            let completed_in_task = Arc::clone(&completed);
+            let (_tx, rx) = watch::channel::<Option<PyResult<Py<PyAny>>>>(None);
+            let jh = get_tokio_runtime().spawn(async move {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+                completed_in_task.store(true, Ordering::SeqCst);
+            });
+            let core = HandleCore::new(rx, abort.then(|| jh.abort_handle()), None);
+            drop(core);
+            std::thread::sleep(Duration::from_millis(250));
+            assert_eq!(
+                completed.load(Ordering::SeqCst),
+                expect_completed,
+                "abort={abort}: producer completion after drop should be {expect_completed}"
+            );
+        }
+    }
+
+    // A Handle cannot be constructed from Python -- the pyclass has no #[new],
+    // so calling the type object raises TypeError.
+    // Attests HDL-11.
+    #[test]
+    fn handle_not_constructible_from_python() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            let handle_type = py.get_type::<PyHandle>();
+            let err = handle_type.call0().unwrap_err();
+            assert!(
+                err.is_instance_of::<pyo3::exceptions::PyTypeError>(py),
+                "constructing Handle() from Python should raise TypeError (no __new__)"
+            );
+        });
+    }
+}

--- a/monarch_hyperactor/src/lib.rs
+++ b/monarch_hyperactor/src/lib.rs
@@ -19,6 +19,7 @@ pub mod code_sync;
 pub mod config;
 pub mod context;
 pub mod endpoint;
+pub mod handle;
 pub mod host_mesh;
 pub mod local_state_broker;
 pub mod logging;

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -117,8 +117,8 @@ use pyo3::types::PyTuple;
 use pyo3::types::PyType;
 use tokio::sync::Mutex;
 use tokio::sync::watch;
-use tokio::task::JoinHandle;
 
+use crate::handle::HandleCore;
 use crate::pickle::reduce_shared;
 use crate::runtime::GilSite;
 use crate::runtime::get_tokio_runtime;
@@ -362,7 +362,7 @@ impl PyPythonTask {
 }
 
 // Helper: convert a Rust error into a generic Python ValueError.
-fn to_py_error<T>(e: T) -> PyErr
+pub(crate) fn to_py_error<T>(e: T) -> PyErr
 where
     T: Error,
 {
@@ -416,16 +416,18 @@ impl PyPythonTask {
     pub(crate) fn spawn_abortable(&mut self) -> PyResult<PyShared> {
         let (tx, rx) = watch::channel(None);
         let traceback = self.traceback()?;
-        let traceback1 = self.traceback()?;
+        // Clone the second owned copy under the same (single) GIL section, and
+        // only when a traceback was actually captured -- avoids a second GIL
+        // round-trip per spawn in the common (capture-disabled) case.
+        let traceback1 = traceback
+            .as_ref()
+            .map(|t| monarch_with_gil_blocking(GilSite::Traceback, |py| t.clone_ref(py)));
         let task = self.take_task()?;
         let handle = get_tokio_runtime().spawn(async move {
             send_result(tx, task.await, traceback1);
         });
         Ok(PyShared {
-            rx,
-            handle: Some(handle),
-            abort: true,
-            traceback,
+            core: HandleCore::new(rx, Some(handle.abort_handle()), traceback),
         })
     }
 }
@@ -490,16 +492,18 @@ impl PyPythonTask {
     pub(crate) fn spawn(&mut self) -> PyResult<PyShared> {
         let (tx, rx) = watch::channel(None);
         let traceback = self.traceback()?;
-        let traceback1 = self.traceback()?;
+        // Clone the second owned copy under the same (single) GIL section, and
+        // only when a traceback was actually captured -- avoids a second GIL
+        // round-trip per spawn in the common (capture-disabled) case.
+        let traceback1 = traceback
+            .as_ref()
+            .map(|t| monarch_with_gil_blocking(GilSite::Traceback, |py| t.clone_ref(py)));
         let task = self.take_task()?;
-        let handle = get_tokio_runtime().spawn(async move {
+        get_tokio_runtime().spawn(async move {
             send_result(tx, task.await, traceback1);
         });
         Ok(PyShared {
-            rx,
-            handle: Some(handle),
-            abort: false,
-            traceback,
+            core: HandleCore::new(rx, None, traceback),
         })
     }
 
@@ -615,11 +619,16 @@ impl PyPythonTask {
     /// Consumes the original task. If it does not complete within
     /// `seconds`, the returned task fails with `TimeoutError`.
     fn with_timeout(&mut self, seconds: f64) -> PyResult<PyPythonTask> {
+        // Reject a negative, NaN, or non-finite timeout with ValueError up front
+        // rather than panicking in Duration::from_secs_f64 on a Tokio worker
+        // thread (matching Handle.get(timeout)).
+        let duration = std::time::Duration::try_from_secs_f64(seconds)
+            .map_err(|e| PyValueError::new_err(format!("invalid timeout {seconds}: {e}")))?;
         let tb = self.traceback()?;
         let task = self.take_task()?;
         PyPythonTask::new_with_traceback(
             async move {
-                tokio::time::timeout(std::time::Duration::from_secs_f64(seconds), task)
+                tokio::time::timeout(duration, task)
                     .await
                     .map_err(|_| PyTimeoutError::new_err(()))?
             },
@@ -642,15 +651,14 @@ impl PyPythonTask {
     fn spawn_blocking(py: Python<'_>, f: Py<PyAny>) -> PyResult<PyShared> {
         let (tx, rx) = watch::channel(None);
         let traceback = current_traceback()?;
-        let traceback1 = traceback.as_ref().map_or_else(
-            || None,
-            |t| monarch_with_gil_blocking(GilSite::Traceback, |py| Some(t.clone_ref(py))),
-        );
+        let traceback1 = traceback
+            .as_ref()
+            .map(|t| monarch_with_gil_blocking(GilSite::Traceback, |py| t.clone_ref(py)));
         let monarch_context = context(py).call0()?.unbind();
         // The `_context` contextvar needs to be propagated through to the thread that
         // runs the blocking tokio task. Upon completion, the original value of `_context`
         // is restored.
-        let handle = get_tokio_runtime().spawn_blocking(move || {
+        get_tokio_runtime().spawn_blocking(move || {
             let result = monarch_with_gil_blocking(GilSite::AwaitDrive, |py| {
                 let _context = actor_mesh_module(py).getattr("_context")?;
                 let old_context = _context.call_method1("get", (PyNone::get(py),))?;
@@ -666,10 +674,7 @@ impl PyPythonTask {
             send_result(tx, result, traceback1);
         });
         Ok(PyShared {
-            rx,
-            handle: Some(handle),
-            abort: false,
-            traceback,
+            core: HandleCore::new(rx, None, traceback),
         })
     }
 
@@ -731,43 +736,8 @@ impl PyPythonTask {
     module = "monarch._rust_bindings.monarch_hyperactor.pytokio"
 )]
 pub struct PyShared {
-    /// One-shot result channel. Starts as `None`; becomes
-    /// `Some(Ok(obj))` or `Some(Err(pyerr))` when the background task
-    /// completes.
-    rx: watch::Receiver<Option<PyResult<Py<PyAny>>>>,
-
-    /// Handle for the spawned Tokio task that is producing `rx`’s
-    /// result. `None` for `Shared.from_value(...)`.
-    handle: Option<JoinHandle<()>>,
-
-    /// If true, dropping `Shared` aborts the background task via
-    /// `handle.abort()`. This is set by `spawn_abortable()`.
-    abort: bool,
-
-    /// Optional creation-site traceback (captured when enabled) used
-    /// when logging un-awaited errors / for derived tasks.
-    traceback: Option<Py<PyAny>>,
-}
-
-/// If this `Shared` was created via `spawn_abortable()`, abort the
-/// underlying Tokio task on drop.
-///
-/// This prevents abandoned background work from running forever when
-/// no receivers remain. We guard against panics during interpreter
-/// shutdown / runtime teardown.
-impl Drop for PyShared {
-    fn drop(&mut self) {
-        if self.abort {
-            // When the PyShared is dropped, we don't want the background task to go
-            // forever, because nothing will wait on the rx.
-            if let Some(h) = self.handle.as_ref() {
-                // Guard against panics during interpreter shutdown when tokio runtime may be gone
-                let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    h.abort();
-                }));
-            }
-        }
-    }
+    /// The watch-channel core.
+    core: HandleCore,
 }
 
 #[pymethods]
@@ -784,35 +754,7 @@ impl PyShared {
     /// Cloning the receiver allows multiple independent awaiters to
     /// observe the same completion.
     pub(crate) fn task(&self) -> PyResult<PyPythonTask> {
-        // watch channels start unchanged, and when a value is sent to them signal
-        // the receivers `changed` future.
-        // By cloning the rx before awaiting it,
-        // we can have multiple awaiters get triggered by the same change.
-        // self.rx will always be in the state where it hasn't see the change yet.
-        let mut rx = self.rx.clone();
-        PyPythonTask::new_with_traceback(
-            async move {
-                // Check if a value is already available (not None).
-                // The channel is initialized with None, and the sender sets it to Some(result).
-                // If it's still None, wait for a change. Otherwise, the value is ready.
-                if rx.borrow().is_none() {
-                    rx.changed().await.map_err(to_py_error)?;
-                }
-                // We need to hold the GIL when cloning Python objects (Py<PyAny> and PyErr).
-                monarch_with_gil(GilSite::Convert, |py| {
-                    let borrowed = rx.borrow();
-                    match borrowed.as_ref().unwrap() {
-                        Ok(v) => Ok(v.bind(py).clone().unbind()),
-                        Err(err) => Err(err.clone_ref(py)),
-                    }
-                })
-                .await
-            },
-            self.traceback.as_ref().map_or_else(
-                || None,
-                |t| monarch_with_gil_blocking(GilSite::Traceback, |py| Some(t.clone_ref(py))),
-            ),
-        )
+        PyPythonTask::new_with_traceback(self.core.wait_future(), self.core.traceback_clone())
     }
 
     /// Implement Python's `await` protocol for `Shared`.
@@ -848,11 +790,18 @@ impl PyShared {
             return Ok(value);
         }
 
-        let task = slf.task()?.take_task()?;
+        // Unlike `Handle::get()`, block_on() deliberately does NOT raise
+        // WouldBlockRuntime for a still-pending value inside a Tokio runtime.
+        // Blocking there panics the runtime loudly, which is preferable to a
+        // silent deadlock for the pending mesh bare-pickle path that relies on
+        // this (`reduce_shared` blocks a pending `Shared` during pickling), and
+        // the common multiprocessing case is unaffected. This trade was
+        // deliberately chosen; do not change it to raise.
+        let wait = slf.core.wait_future();
         // Explicitly drop the reference so that if another thread attempts to borrow
         // this object mutably during signal_safe_block_on, it won't throw an exception.
         drop(slf);
-        signal_safe_block_on(py, task)?
+        signal_safe_block_on(py, wait)?
     }
 
     /// Support `Shared[T]` type syntax on the Python side (no runtime
@@ -871,15 +820,7 @@ impl PyShared {
     ///
     /// This does not wait; it only inspects the current watch value.
     pub(crate) fn poll(&self) -> PyResult<Option<Py<PyAny>>> {
-        let b = self.rx.borrow();
-        let r = b.as_ref();
-        match r {
-            None => Ok(None),
-            Some(r) => monarch_with_gil_blocking(GilSite::Convert, |py| match r {
-                Ok(v) => Ok(Some(v.clone_ref(py))),
-                Err(err) => Err(err.clone_ref(py)),
-            }),
-        }
+        self.core.poll()
     }
 
     /// Construct a `Shared` that is already completed with `value`.
@@ -890,13 +831,8 @@ impl PyShared {
     /// `await` (inside `from_coroutine`), or `block_on()`.
     #[classmethod]
     fn from_value(_cls: &Bound<'_, PyType>, value: Py<PyAny>) -> PyResult<Self> {
-        let (tx, rx) = watch::channel(None);
-        tx.send(Some(Ok(value))).map_err(to_py_error)?;
         Ok(Self {
-            rx,
-            handle: None,
-            abort: false,
-            traceback: None,
+            core: HandleCore::from_value(value)?,
         })
     }
 
@@ -922,17 +858,27 @@ impl PyShared {
 /// This checks whether `tokio::runtime::Handle::try_current()`
 /// succeeds.
 #[pyfunction]
-fn is_tokio_thread() -> bool {
+pub(crate) fn is_tokio_thread() -> bool {
     tokio::runtime::Handle::try_current().is_ok()
 }
 
 /// Register the pytokio Python bindings into the given module.
 ///
-/// This wires up the exported pyclasses (`PythonTask`, `Shared`)
-/// and module-level functions used by the Monarch Python layer.
+/// This wires up the exported pyclasses (`PythonTask`, `Shared`,
+/// `Handle`), the `WouldBlockRuntime` exception, and module-level
+/// functions used by the Monarch Python layer.
 pub fn register_python_bindings(hyperactor_mod: &Bound<'_, PyModule>) -> PyResult<()> {
     hyperactor_mod.add_class::<PyPythonTask>()?;
     hyperactor_mod.add_class::<PyShared>()?;
+    hyperactor_mod.add_class::<crate::handle::PyHandle>()?;
+    let would_block = hyperactor_mod
+        .py()
+        .get_type::<crate::handle::WouldBlockRuntime>();
+    would_block.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.pytokio",
+    )?;
+    hyperactor_mod.add("WouldBlockRuntime", would_block)?;
     let f = wrap_pyfunction!(is_tokio_thread, hyperactor_mod)?;
     f.setattr(
         "__module__",
@@ -1010,5 +956,31 @@ impl AwaitPyExt for PyPythonTask {
         drop(py_any);
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // with_timeout validates the seconds up front, raising ValueError for a
+    // negative/NaN/non-finite timeout rather than panicking in
+    // Duration::from_secs_f64 on a worker thread (matching Handle.get(timeout)).
+    #[test]
+    fn with_timeout_rejects_invalid_seconds() {
+        ensure_python();
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            for bad in [-1.0, f64::NAN, f64::INFINITY] {
+                let mut task = PyPythonTask::sleep(3600.0).unwrap();
+                let err = task
+                    .with_timeout(bad)
+                    .err()
+                    .expect("with_timeout should reject an invalid timeout");
+                assert!(
+                    err.is_instance_of::<PyValueError>(py),
+                    "with_timeout({bad}) should raise ValueError, not panic"
+                );
+            }
+        });
     }
 }

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -119,6 +119,7 @@ use tokio::sync::Mutex;
 use tokio::sync::watch;
 
 use crate::handle::HandleCore;
+use crate::handle::PyHandle;
 use crate::pickle::reduce_shared;
 use crate::runtime::GilSite;
 use crate::runtime::get_tokio_runtime;
@@ -414,6 +415,18 @@ impl PyPythonTask {
     /// Like `spawn()`, this consumes the `PyPythonTask` (it can only
     /// be spawned once).
     pub(crate) fn spawn_abortable(&mut self) -> PyResult<PyShared> {
+        Ok(PyShared {
+            core: self.spawn_core(true)?,
+        })
+    }
+
+    /// Spawn this task onto the Tokio runtime and return the shared
+    /// `HandleCore` that observes its completion via the `watch` channel.
+    ///
+    /// `abort` decides whether dropping the core aborts the producing task
+    /// (`spawn_abortable`) or leaves it running (`spawn`/`spawn_handle`).
+    /// Consumes the task. Shared by `spawn`/`spawn_abortable`/`spawn_handle`.
+    fn spawn_core(&mut self, abort: bool) -> PyResult<HandleCore> {
         let (tx, rx) = watch::channel(None);
         let traceback = self.traceback()?;
         // Clone the second owned copy under the same (single) GIL section, and
@@ -426,9 +439,11 @@ impl PyPythonTask {
         let handle = get_tokio_runtime().spawn(async move {
             send_result(tx, task.await, traceback1);
         });
-        Ok(PyShared {
-            core: HandleCore::new(rx, Some(handle.abort_handle()), traceback),
-        })
+        Ok(HandleCore::new(
+            rx,
+            abort.then(|| handle.abort_handle()),
+            traceback,
+        ))
     }
 }
 
@@ -490,21 +505,19 @@ impl PyPythonTask {
     /// `from_coroutine` world, or may be waited on synchronously via
     /// `Shared.block_on()`. Consumes the task.
     pub(crate) fn spawn(&mut self) -> PyResult<PyShared> {
-        let (tx, rx) = watch::channel(None);
-        let traceback = self.traceback()?;
-        // Clone the second owned copy under the same (single) GIL section, and
-        // only when a traceback was actually captured -- avoids a second GIL
-        // round-trip per spawn in the common (capture-disabled) case.
-        let traceback1 = traceback
-            .as_ref()
-            .map(|t| monarch_with_gil_blocking(GilSite::Traceback, |py| t.clone_ref(py)));
-        let task = self.take_task()?;
-        get_tokio_runtime().spawn(async move {
-            send_result(tx, task.await, traceback1);
-        });
         Ok(PyShared {
-            core: HandleCore::new(rx, None, traceback),
+            core: self.spawn_core(false)?,
         })
+    }
+
+    /// Spawn this task onto the Tokio runtime and return an observe-only
+    /// `Handle`.
+    ///
+    /// Like `spawn`, but hands back the clean `Handle` (`get`/`poll`/
+    /// `as_asyncio`/`await`) rather than `Shared`; non-abortable on drop.
+    /// Consumes the task.
+    pub(crate) fn spawn_handle(&mut self) -> PyResult<PyHandle> {
+        Ok(PyHandle::from_core(self.spawn_core(false)?))
     }
 
     /// Implement Python's `await` protocol for `PythonTask`.

--- a/python/monarch/_rust_bindings/monarch_hyperactor/endpoint.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/endpoint.pyi
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import asyncio
 from typing import (
     Any,
     final,
@@ -36,6 +37,7 @@ _T = TypeVar("_T")
 
 class Future(Generic[_T]):
     def get(self, timeout: Optional[float] = None) -> _T: ...
+    def as_asyncio(self) -> "asyncio.Future[_T]": ...
     def __await__(self) -> Generator[Any, Any, _T]: ...
 
 if TYPE_CHECKING:

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
@@ -42,6 +42,13 @@ class PythonTask(Generic[T], Awaitable[T]):
         """
         ...
 
+    def spawn_handle(self) -> "Handle[T]":
+        """
+        Spawn this task on the tokio runtime and return an observe-only Handle
+        (get/poll/as_asyncio/await). Consumes the PythonTask.
+        """
+        ...
+
     @staticmethod
     def from_coroutine(coro: Coroutine[Any, Any, T]) -> PythonTask[T]:
         """

--- a/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/pytokio.pyi
@@ -6,6 +6,7 @@
 
 # pyre-strict
 
+import asyncio
 from typing import (
     Any,
     Awaitable,
@@ -109,6 +110,53 @@ class Shared(Generic[T]):
         value the first time poll is called.
         """
         ...
+
+class Handle(Generic[T]):
+    """
+    An observe-only handle to a background task. It resolves once and stays
+    observable by any number of later observers. Unlike Shared, a Handle never
+    drives a Python coroutine.
+    """
+
+    def get(self, timeout: Optional[float] = None) -> T:
+        """
+        Block the calling thread until the handle resolves and return its value.
+        Behavior is keyed to the calling context, not to whether the value is
+        ready: in a tokio runtime context it always raises WouldBlockRuntime, even
+        for a ready value (blocking there would panic the runtime) -- use poll() or
+        as_asyncio(); on a running asyncio loop it warns, since get() can freeze
+        the loop; on a sync thread it blocks until resolved. On timeout it raises
+        TimeoutError without cancelling the handle, so a later get()/poll()/await
+        still observes completion.
+        """
+        ...
+
+    def poll(self) -> Optional[T]:
+        """
+        If the handle has resolved, return the value; otherwise return None.
+        Non-consuming: the value stays observable by later observers.
+        """
+        ...
+
+    def as_asyncio(self) -> "asyncio.Future[T]":
+        """
+        Return a standard asyncio.Future that resolves when the handle does.
+        Requires a running event loop; off a loop it raises RuntimeError.
+        """
+        ...
+
+    def __await__(self) -> Generator[Any, Any, T]:
+        """
+        Await the handle on a running asyncio loop, delegating to as_asyncio().
+        """
+        ...
+
+class WouldBlockRuntime(RuntimeError):
+    """
+    Raised when Handle.get() is called from a Tokio runtime context.
+    """
+
+    ...
 
 def is_tokio_thread() -> bool:
     """

--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -21,6 +21,7 @@ from typing import (
 )
 
 from monarch._rust_bindings.monarch_hyperactor.pytokio import (
+    Handle,
     is_tokio_thread,
     PythonTask,
     Shared,
@@ -78,8 +79,8 @@ class _Exception(NamedTuple):
     exe: Exception
 
 
-class _Asyncio(NamedTuple):
-    fut: asyncio.Future
+class _Handle(NamedTuple):
+    handle: Handle[Any]
 
 
 class _Tokio(NamedTuple):
@@ -90,7 +91,16 @@ class _Taken(NamedTuple):
     pass
 
 
-_Status = _Unawaited | _Complete | _Exception | _Asyncio | _Tokio | _Taken
+_Status = _Unawaited | _Complete | _Exception | _Handle | _Tokio | _Taken
+
+
+# The `_Tokio` state means the task was bridged to a pytokio `Shared` on a
+# tokio-thread await; `get()` and `as_asyncio()` both refuse it because that
+# value is only awaitable from a PythonTask coroutine.
+_ALREADY_TOKIO_MSG = (
+    "already converted into a pytokio.Shared object, use 'await' from a "
+    "PythonTask coroutine to get the value."
+)
 
 
 class Future(Generic[R]):
@@ -129,9 +139,11 @@ class Future(Generic[R]):
         Caveats:
 
         This method is designed to be used in places where event loops are not available. Besides that, you should
-        avoid using this method if possible. Instead, use `await`. This is because when Future.get() is called from
+        avoid using this method if possible. Instead, use `as_asyncio()` (or `await`). This is because when Future.get() is called from
         within an active event loop, it blocks synchronously and does not yield control. That may degrade performance
         by preventing other tasks from running, and can potentially cause deadlocks if this future depends on them.
+
+        A `timeout` never consumes the Future: on `TimeoutError` the underlying task keeps running, so a later `get()`/`await` still observes its result.
 
         examples:
 
@@ -159,17 +171,14 @@ class Future(Generic[R]):
         in_asyncio = asyncio._get_running_loop() is not None
         in_tokio = is_tokio_thread()
         if in_asyncio or in_tokio:
-            warnings.warn(
-                "Future.get() was called from within an active event loop. Because this method blocks "
-                "synchronously and does not yield control, it may degrade performance by preventing "
-                "other tasks from running, and can potentially cause deadlocks if this future depends "
-                "on them. It is encouraged to use 'await' instead.",
-                UserWarning,
-                stacklevel=2,
-            )
-            # Forward the event directly to Rust tracing so we capture it in
-            # non-actor driver processes too, where no `TracingForwarder`
-            # handler is attached to the Python logging chain.
+            # Forward the event to Rust tracing for every in-loop/tokio caller,
+            # including non-actor driver processes where no `TracingForwarder`
+            # handler is on the Python logging chain. The UserWarning (separate
+            # from this trace) is emitted at most once, never doubled: the inline
+            # `warnings.warn` below for the no-timeout `_Unawaited` path, else
+            # `Handle.get()` for the `get(timeout=...)`/`_Handle` paths -- which
+            # on a Tokio thread raise `WouldBlockRuntime` before warning, so no
+            # UserWarning fires there.
             log_with_tracing(
                 logging.WARNING,
                 "Future.get() called from within an active event loop",
@@ -178,27 +187,52 @@ class Future(Generic[R]):
             )
         match self._status:
             case _Unawaited(coro=coro):
+                if timeout is not None:
+                    # A timeout must not destroy the Future. Observe the task
+                    # through a Handle, which is non-cancelling on timeout, so a
+                    # later get()/poll()/await still resolves. Handle.get()
+                    # applies the context policy and emits the warning itself.
+                    handle = coro.spawn_handle()
+                    self._status = _Handle(handle)
+                    return cast("R", handle.get(timeout))
+                if in_asyncio:
+                    warnings.warn(
+                        "Future.get() was called from within an active event loop. Because this method blocks "
+                        "synchronously and does not yield control, it may degrade performance by preventing "
+                        "other tasks from running, and can potentially cause deadlocks if this future depends "
+                        "on them. It is encouraged to use as_asyncio() (or await) instead.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
+                elif in_tokio:
+                    # as_asyncio() needs an asyncio loop, which a Tokio worker
+                    # thread lacks; the only in-context option is to await inside
+                    # a PythonTask coroutine (block_on() below then raises).
+                    warnings.warn(
+                        "Future.get() was called from within a Tokio runtime; it cannot block there "
+                        "and will raise. Await the Future inside a PythonTask coroutine instead.",
+                        UserWarning,
+                        stacklevel=2,
+                    )
                 try:
-                    if timeout is not None:
-                        coro = coro.with_timeout(timeout)
                     v = coro.block_on()
                     self._status = _Complete(v)
                     return cast("R", v)
                 except Exception as e:
                     self._status = _Exception(e)
                     raise e from None
-            case _Asyncio(_):
-                raise ValueError(
-                    "already converted into an asyncio.Future, use 'await' to get the value."
-                )
+            case _Handle(handle=handle):
+                # Observe the shared Handle. `Handle.get()` applies its own
+                # context policy (warn on a live loop, `WouldBlockRuntime` in a
+                # Tokio runtime context, block on a sync thread) and emits the
+                # Python warning itself, so we do not warn again here.
+                return cast("R", handle.get(timeout))
             case _Complete(value=value):
                 return cast("R", value)
             case _Exception(exe=exe):
                 raise exe
             case _Tokio(_):
-                raise ValueError(
-                    "already converted into a pytokio.Shared object, use 'await' from a PythonTask coroutine to get the value."
-                )
+                raise ValueError(_ALREADY_TOKIO_MSG)
             case _Taken():
                 raise ValueError("Future was consumed.")
             case _:
@@ -206,42 +240,9 @@ class Future(Generic[R]):
 
     def __await__(self) -> Generator[Any, Any, R]:
         if asyncio._get_running_loop() is not None:
-            match self._status:
-                case _Unawaited(coro=coro):
-                    loop = asyncio.get_running_loop()
-                    fut = loop.create_future()
-                    self._status = _Asyncio(fut)
-
-                    def set_result(fut: asyncio.Future[R], value: R) -> None:
-                        if not fut.cancelled():
-                            fut.set_result(value)
-
-                    def set_exception(fut: asyncio.Future[R], e: Exception) -> None:
-                        if not fut.cancelled():
-                            fut.set_exception(e)
-
-                    async def mark_complete() -> None:
-                        try:
-                            func, value = set_result, await coro
-                        except Exception as e:
-                            func, value = set_exception, e
-                        # pyrefly: ignore [bad-argument-type]
-                        loop.call_soon_threadsafe(func, fut, value)
-
-                    PythonTask.from_coroutine(mark_complete()).spawn()
-                    return fut.__await__()
-                case _Asyncio(fut=fut):
-                    return fut.__await__()
-                case _Tokio(_):
-                    raise ValueError(
-                        "already converted into a tokio future, but being awaited from the asyncio loop."
-                    )
-                case _Taken():
-                    raise ValueError("Future was consumed.")
-                case _:
-                    raise ValueError(
-                        "already converted into a synchronous future, use 'get' to get the value."
-                    )
+            # Asyncio callers observe through the Handle; `__await__` delegates
+            # to `as_asyncio()`.
+            return self.as_asyncio().__await__()
         elif is_tokio_thread():
             match self._status:
                 case _Unawaited(coro=coro):
@@ -250,9 +251,10 @@ class Future(Generic[R]):
                     return shared.__await__()
                 case _Tokio(shared=shared):
                     return shared.__await__()
-                case _Asyncio(_):
+                case _Handle(_):
                     raise ValueError(
-                        "already converted into asyncio future, but being awaited from the tokio loop."
+                        "Future is backed by a Handle and is not awaitable on a tokio thread; "
+                        "use get() or as_asyncio() from a sync/asyncio context."
                     )
                 case _Taken():
                     raise ValueError("Future was consumed.")
@@ -264,6 +266,50 @@ class Future(Generic[R]):
             raise ValueError(
                 "__await__ with no active event loop (either asyncio or tokio)"
             )
+
+    def as_asyncio(self) -> "asyncio.Future[R]":
+        """Return a standard ``asyncio.Future`` that resolves when this Future
+        does.
+
+        Requires a running event loop; off a loop it raises ``RuntimeError``
+        **without** consuming the underlying task (the Future stays unawaited, so
+        a later ``get()`` still drives it). Observation is non-consuming:
+        repeated ``as_asyncio()``/``await`` each return a fresh loop-local future
+        observing the same result.
+        """
+        loop = asyncio._get_running_loop()
+        if loop is None:
+            raise RuntimeError("as_asyncio() requires a running asyncio event loop.")
+        match self._status:
+            case _Unawaited(coro=coro):
+                # The loop is confirmed above, so spawning is safe: an off-loop
+                # call raised already, leaving the Future in `_Unawaited`.
+                handle = coro.spawn_handle()
+                self._status = _Handle(handle)
+                return handle.as_asyncio()
+            case _Handle(handle=handle):
+                return handle.as_asyncio()
+            case _Complete(value=value):
+                done = loop.create_future()
+                done.set_result(value)
+                return cast("asyncio.Future[R]", done)
+            case _Exception(exe=exe):
+                failed = loop.create_future()
+                # asyncio.Future.set_exception rejects StopIteration (PEP 479);
+                # surface it as `raise StopIteration` already does out of a
+                # coroutine, matching the Handle observer path.
+                failed.set_exception(
+                    RuntimeError("coroutine raised StopIteration")
+                    if isinstance(exe, StopIteration)
+                    else exe
+                )
+                return cast("asyncio.Future[R]", failed)
+            case _Tokio(_):
+                raise ValueError(_ALREADY_TOKIO_MSG)
+            case _Taken():
+                raise ValueError("Future was consumed.")
+            case _:
+                raise RuntimeError("unknown status")
 
     # compatibility with old tensor engine Future objects
     # hopefully we do not need done(), add_callback because

--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -8,6 +8,7 @@
 
 import asyncio
 import logging
+import math
 import warnings
 from typing import (
     Any,
@@ -25,6 +26,7 @@ from monarch._rust_bindings.monarch_hyperactor.pytokio import (
     is_tokio_thread,
     PythonTask,
     Shared,
+    WouldBlockRuntime,
 )
 from monarch._src.actor.telemetry import log_with_tracing
 
@@ -173,12 +175,13 @@ class Future(Generic[R]):
         if in_asyncio or in_tokio:
             # Forward the event to Rust tracing for every in-loop/tokio caller,
             # including non-actor driver processes where no `TracingForwarder`
-            # handler is on the Python logging chain. The UserWarning (separate
-            # from this trace) is emitted at most once, never doubled: the inline
-            # `warnings.warn` below for the no-timeout `_Unawaited` path, else
-            # `Handle.get()` for the `get(timeout=...)`/`_Handle` paths -- which
-            # on a Tokio thread raise `WouldBlockRuntime` before warning, so no
-            # UserWarning fires there.
+            # handler is on the Python logging chain. A UserWarning (separate
+            # from this trace) fires only on a running asyncio loop, never on a
+            # Tokio thread: the blocking `_Unawaited`/`_Handle` paths raise
+            # `WouldBlockRuntime` before warning, and cached `_Complete`/
+            # `_Exception` reads don't block or warn. On asyncio it fires once,
+            # inline below for the no-timeout `_Unawaited` path, else via
+            # `Handle.get()` for the `get(timeout=...)`/`_Handle` paths.
             log_with_tracing(
                 logging.WARNING,
                 "Future.get() called from within an active event loop",
@@ -187,11 +190,31 @@ class Future(Generic[R]):
             )
         match self._status:
             case _Unawaited(coro=coro):
+                if in_tokio:
+                    # Cannot block inside a Tokio runtime. Refuse cleanly BEFORE
+                    # spawning or consuming the task (mirroring Handle.get()), for
+                    # BOTH the timeout and no-timeout paths, so a rejected call
+                    # never starts work or flips state and a later get()/await
+                    # from a valid context still drives the Future. (Otherwise the
+                    # no-timeout path's block_on() takes the task then panics, and
+                    # the timeout path spawns a Handle then raises -- both mutate.)
+                    raise WouldBlockRuntime(
+                        "Future.get() cannot block from within a Tokio runtime; "
+                        "await the Future inside a PythonTask coroutine instead."
+                    )
                 if timeout is not None:
+                    # Validate the timeout BEFORE spawning: an invalid value must
+                    # not start work or flip state to _Handle. Handle.get()
+                    # re-validates authoritatively; this only avoids the spawn on
+                    # a bad argument.
+                    if not math.isfinite(timeout) or timeout < 0:
+                        raise ValueError(
+                            f"invalid timeout {timeout}: expected a non-negative, finite number of seconds"
+                        )
                     # A timeout must not destroy the Future. Observe the task
                     # through a Handle, which is non-cancelling on timeout, so a
-                    # later get()/poll()/await still resolves. Handle.get()
-                    # applies the context policy and emits the warning itself.
+                    # later get()/poll()/await still resolves. Handle.get() applies
+                    # the context policy and emits the warning itself.
                     handle = coro.spawn_handle()
                     self._status = _Handle(handle)
                     return cast("R", handle.get(timeout))
@@ -201,16 +224,6 @@ class Future(Generic[R]):
                         "synchronously and does not yield control, it may degrade performance by preventing "
                         "other tasks from running, and can potentially cause deadlocks if this future depends "
                         "on them. It is encouraged to use as_asyncio() (or await) instead.",
-                        UserWarning,
-                        stacklevel=2,
-                    )
-                elif in_tokio:
-                    # as_asyncio() needs an asyncio loop, which a Tokio worker
-                    # thread lacks; the only in-context option is to await inside
-                    # a PythonTask coroutine (block_on() below then raises).
-                    warnings.warn(
-                        "Future.get() was called from within a Tokio runtime; it cannot block there "
-                        "and will raise. Await the Future inside a PythonTask coroutine instead.",
                         UserWarning,
                         stacklevel=2,
                     )

--- a/python/tests/test_future_characterization.py
+++ b/python/tests/test_future_characterization.py
@@ -19,8 +19,10 @@ import asyncio
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.pytokio import (
+    Handle,
     is_tokio_thread,
     PythonTask,
+    WouldBlockRuntime,
 )
 from monarch._src.actor import future as future_mod
 from monarch._src.actor.future import Future
@@ -263,6 +265,13 @@ def test_get_in_tokio_thread_warns_then_cannot_block(monkeypatch):
         _run_in_tokio(attempt())
     assert len(calls) == 1
     assert calls[0]["extra"]["context"] == "tokio"
+
+
+def test_handle_and_would_block_runtime_are_importable():
+    """``Handle`` and ``WouldBlockRuntime`` import from the pytokio bindings, and
+    ``WouldBlockRuntime`` subclasses ``RuntimeError``."""
+    assert issubclass(WouldBlockRuntime, RuntimeError)
+    assert isinstance(Handle, type)
 
 
 # ---------------------------------------------------------------------------

--- a/python/tests/test_future_characterization.py
+++ b/python/tests/test_future_characterization.py
@@ -338,13 +338,13 @@ def test_get_in_asyncio_loop_warns_and_still_returns(monkeypatch):
     assert calls[0]["extra"]["context"] == "asyncio"
 
 
-def test_get_in_tokio_thread_warns_then_cannot_block(monkeypatch):
-    """On a real tokio thread get() warns (context='tokio') but then cannot
-    block within the runtime, so it raises rather than returning -- the
-    asymmetry with the asyncio branch, and precisely the case WouldBlockRuntime
-    is meant to replace. The warning must advise awaiting inside a PythonTask
-    coroutine, NOT as_asyncio() (which needs an asyncio loop a tokio thread
-    lacks)."""
+def test_get_in_tokio_thread_raises_would_block_and_is_non_consuming(monkeypatch):
+    """On a real tokio thread no-timeout get() raises WouldBlockRuntime up front
+    (aligned with Handle.get()) WITHOUT consuming the task: no UserWarning fires,
+    the tracing event still forwards (context='tokio'), the Future stays
+    _Unawaited, and a later get() from a sync context still drives it to a
+    value. (Previously it warned, then block_on() consumed the task and panicked
+    'from within a runtime', losing the work and bricking the Future.)"""
     calls = []
     warned = []
     monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
@@ -357,24 +357,23 @@ def test_get_in_tokio_thread_warns_then_cannot_block(monkeypatch):
         assert is_tokio_thread()
         return fut.get()
 
-    with pytest.raises(BaseException, match="from within a runtime"):
+    with pytest.raises(WouldBlockRuntime):
         _run_in_tokio(attempt())
     assert len(calls) == 1
     assert calls[0]["extra"]["context"] == "tokio"
-    # filter to get()'s own warning; the global warnings.warn patch also catches
-    # the incidental "coroutine '_value' was never awaited" warning from the task
-    # that block_on() abandons when it panics.
-    tokio_warnings = [w for w in warned if "Tokio runtime" in w]
-    assert len(tokio_warnings) == 1
-    assert "PythonTask coroutine" in tokio_warnings[0]
-    assert "as_asyncio" not in tokio_warnings[0]
+    assert warned == []  # tokio get() refuses instead of warning
+    assert isinstance(fut._status, future_mod._Unawaited)  # task not consumed
+    assert fut.get() == 5  # still drivable from a sync context
 
 
-def test_get_timeout_in_tokio_thread_raises_would_block_without_warning(monkeypatch):
-    """get(timeout=...) on a tokio thread routes through a Handle, so Handle.get()
-    refuses with WouldBlockRuntime up front. The tracing event still forwards
-    (context='tokio'), but -- unlike the no-timeout path -- NO UserWarning fires,
-    because Handle.get() raises before it would warn."""
+def test_get_timeout_in_tokio_thread_raises_would_block_and_is_non_consuming(
+    monkeypatch,
+):
+    """get(timeout=...) on a tokio thread is refused by the in_tokio check up
+    front -- BEFORE spawning a Handle -- so it raises WouldBlockRuntime without
+    starting work or flipping state: no UserWarning, the trace still forwards
+    (context='tokio'), the Future stays _Unawaited, and a later sync get() still
+    drives it."""
     calls = []
     warned = []
     monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
@@ -392,6 +391,20 @@ def test_get_timeout_in_tokio_thread_raises_would_block_without_warning(monkeypa
     assert len(calls) == 1
     assert calls[0]["extra"]["context"] == "tokio"
     assert warned == []
+    assert isinstance(fut._status, future_mod._Unawaited)  # not spawned/consumed
+    assert fut.get() == 5  # still drivable from a sync context
+
+
+def test_get_invalid_timeout_does_not_spawn_or_mutate():
+    """An invalid timeout (NaN/negative/non-finite) is rejected with ValueError
+    BEFORE spawning a Handle, so a bad argument never starts work or flips state:
+    the Future stays _Unawaited and a later valid get() still drives it."""
+    for bad in (float("nan"), -1.0, float("inf")):
+        fut: Future[int] = Future(coro=_value(8))
+        with pytest.raises(ValueError, match="invalid timeout"):
+            fut.get(timeout=bad)
+        assert isinstance(fut._status, future_mod._Unawaited)
+        assert fut.get() == 8  # still drivable after a rejected bad-timeout call
 
 
 def test_get_on_handle_in_asyncio_loop_warns_and_forwards_once(monkeypatch):

--- a/python/tests/test_future_characterization.py
+++ b/python/tests/test_future_characterization.py
@@ -8,14 +8,16 @@
 
 """Characterization oracle for the public ``monarch`` ``Future`` state machine.
 
-Pins the *current* behavior of ``monarch._src.actor.future.Future`` -- its
-internal states and every transition between them, its conversion-error
-strings, the ``get()``-inside-a-loop warning, and the ``_take_inner()``
-accessor with its ``_Taken`` terminal state -- so that any change to that
-behavior is caught here and made explicit.
+Pins the behavior of ``monarch._src.actor.future.Future`` -- its internal
+states and the transitions between them, ``as_asyncio()`` and the ``__await__``
+shim over it, the residual ``_Tokio`` cross-world guards, the
+``get()``-inside-a-loop warning, and the ``_take_inner()`` accessor with its
+``_Taken`` terminal state -- so that any change to that behavior is caught here
+and made explicit.
 """
 
 import asyncio
+import warnings
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.pytokio import (
@@ -36,6 +38,11 @@ async def _raise(exc: BaseException):
     raise exc
 
 
+async def _sleep_then(seconds: float, v):
+    await PythonTask.sleep(seconds)
+    return v
+
+
 async def _await_once(fut: Future):
     return await fut
 
@@ -52,12 +59,10 @@ def _run_in_tokio(coro):
 # States and transitions
 #
 # A fresh Future is _Unawaited; the first access drives the underlying task
-# exactly once and moves it to a terminal/converted state (_Complete,
-# _Exception, _Asyncio, or _Tokio). These pin that lifecycle and its
-# idempotency. The two-state redesign must preserve resolve-and-cache for
-# results and errors; the two *awaitable* branches (_Asyncio/_Tokio) are the
-# dual-world machinery it removes -- after D1 a Future is not awaitable and
-# callers use as_asyncio().
+# exactly once. Sync get() caches into _Complete/_Exception; as_asyncio() and
+# the asyncio __await__ shim spawn a Handle and move to the observe-only
+# _Handle; a tokio-thread await still spawns a Shared and moves to _Tokio.
+# These pin that lifecycle and its idempotency.
 # ---------------------------------------------------------------------------
 
 
@@ -88,29 +93,52 @@ def test_get_exception_transitions_to_exception_and_reraises_stored():
 
 
 def test_get_timeout_raises_timeout_error():
-    """get(timeout=...) wraps the task in with_timeout, so an unfinished task
-    surfaces a TimeoutError (caught, stored as _Exception, raised) rather than
-    hanging."""
+    """get(timeout=...) observes the task through a Handle with the given
+    deadline, so an unfinished task surfaces a TimeoutError rather than hanging.
+    The timeout is non-cancelling (state becomes _Handle); the sibling
+    test_get_timeout_is_non_poisoning_and_reobservable pins re-observation."""
     fut: Future[None] = Future(coro=PythonTask.sleep(3600))
     with pytest.raises(TimeoutError):
         fut.get(timeout=0.1)
 
 
-async def test_await_asyncio_transitions_to_asyncio_and_is_idempotent():
-    """Awaiting under an asyncio loop transitions _Unawaited -> _Asyncio
-    (bridging the task to an asyncio.Future) and yields the value; re-awaiting
-    reuses the _Asyncio future. This is one of the two awaitable branches the
-    redesign removes."""
+def test_get_timeout_is_non_poisoning_and_reobservable():
+    """get(timeout=...) that times out routes through a Handle and does NOT
+    poison the Future: it transitions to _Handle, and a later get() (no timeout)
+    still resolves the same task (the timeout is non-cancelling)."""
+    fut: Future[int] = Future(coro=_sleep_then(0.2, 11))
+    with pytest.raises(TimeoutError):
+        fut.get(timeout=0.01)  # too short: task still running
+    assert isinstance(fut._status, future_mod._Handle)
+    assert fut.get() == 11  # later get() still observes completion
+
+
+def test_get_timeout_success_returns_and_transitions_to_handle():
+    """get(timeout=...) whose task finishes within the timeout returns the value
+    and transitions to the observe-only _Handle (not _Complete): the timed get
+    routes through a Handle, so a later no-timeout get() re-observes the result."""
+    fut: Future[int] = Future(coro=_sleep_then(0.01, 7))
+    assert fut.get(timeout=5) == 7
+    assert isinstance(fut._status, future_mod._Handle)
+    assert fut.get() == 7
+
+
+async def test_await_asyncio_transitions_to_handle_and_is_reobservable():
+    """Awaiting under an asyncio loop bridges through as_asyncio(), transitions
+    _Unawaited -> the observe-only _Handle, and yields the value; re-awaiting
+    observes the same Handle (a fresh loop-local future each time)."""
     fut: Future[int] = Future(coro=_value(7))
-    assert await fut == 7  # _Unawaited -> _Asyncio
-    assert await fut == 7  # idempotent re-await of the _Asyncio state
+    assert await fut == 7  # _Unawaited -> _Handle
+    assert isinstance(fut._status, future_mod._Handle)
+    assert await fut == 7  # re-observe the same Handle
 
 
 def test_await_tokio_transitions_to_tokio_and_is_idempotent():
     """Awaiting on a tokio thread (inside from_coroutine, where
     is_tokio_thread() is True) transitions _Unawaited -> _Tokio (spawning a
-    Shared) and yields the value; re-awaiting reuses it. The _Asyncio-vs-_Tokio
-    split is exactly the "which async world am I in" duality P1/D1 collapse."""
+    Shared) and yields the value; re-awaiting reuses it. The _Handle-vs-_Tokio
+    split is by which async world the await runs in (asyncio loop vs tokio
+    thread)."""
     fut: Future[int] = Future(coro=_value(9))
 
     async def driver():
@@ -123,34 +151,46 @@ def test_await_tokio_transitions_to_tokio_and_is_idempotent():
 
 
 # ---------------------------------------------------------------------------
-# Conversion errors -- the seven state-tied raises, pinned verbatim. (The
-# numbers follow the source's raises; #3, the unreachable RuntimeError
-# "unknown status" fallthrough, is intentionally not pinned.)
-#
-# These are the five-state machine's "which async world / already-converted"
-# mixing guards -- the errors the RFC's Motivation quotes ("already converted
-# into an asyncio.Future, ..."). Each is keyed off the *state*, not the data: a
-# Future can hold a fully-resolved value and still refuse the wrong accessor.
-# The two-state, non-awaitable redesign deletes all of them (no _Asyncio/_Tokio
-# states and no await => none of these errors); this oracle is what flags any
-# change to them before stage 6 intends it.
+# Observation is non-consuming now: get()/as_asyncio()/await mix freely on the
+# asyncio+sync side (get after await, await after get, repeated as_asyncio all
+# resolve). The only remaining "already converted" guards are the cross-world
+# ones involving the residual _Tokio state (and _Handle-awaited-on-a-tokio-
+# thread), which remain while the pytokio-driving from_coroutine path exists.
+# These pin that: the formerly-erroring same-world cases now resolve; the
+# cross-world ones still raise.
 # ---------------------------------------------------------------------------
 
 
-def test_error1_get_after_asyncio_conversion():
-    """get() after an asyncio await (_Asyncio). The value is fully available in
-    the bridged asyncio.Future, yet get() refuses it and says to use 'await' --
-    the guard is on state, not data."""
+def test_get_after_asyncio_await_returns():
+    """get() after an asyncio await (_Handle) now returns the value instead of
+    raising -- observation is non-consuming, so the sync get() observes the same
+    Handle."""
     fut: Future[int] = Future(coro=_value(1))
-    asyncio.run(_await_once(fut))  # -> _Asyncio
-    with pytest.raises(ValueError, match=r"already converted into an asyncio\.Future"):
+    asyncio.run(_await_once(fut))  # -> _Handle
+    assert fut.get() == 1
+
+
+def test_get_after_asyncio_await_error_reraises():
+    """Failure mirror of the previous: get() on a _Handle whose live producer
+    FAILED re-raises the stored exception through handle.get(). Drives the live
+    spawn_handle producer (not a pre-resolved get())."""
+    fut: Future[int] = Future(coro=_raise(ValueError("boom")))
+
+    async def bridge():
+        # Drive _Unawaited -> _Handle via the live producer; swallow the failure
+        # so we can re-observe it via get() below.
+        with pytest.raises(ValueError, match="boom"):
+            await fut
+
+    asyncio.run(bridge())
+    assert isinstance(fut._status, future_mod._Handle)
+    with pytest.raises(ValueError, match="boom"):
         fut.get()
 
 
-def test_error2_get_after_tokio_conversion():
-    """get() after a tokio await (_Tokio): symmetric to error1 -- once converted
-    to a pytokio Shared, get() refuses and points at awaiting inside a
-    from_coroutine coroutine."""
+def test_get_after_tokio_conversion_raises():
+    """get() after a tokio await (_Tokio): once converted to a pytokio Shared,
+    get() refuses and points at awaiting inside a from_coroutine coroutine."""
     fut: Future[int] = Future(coro=_value(1))
     _run_in_tokio(_await_once(fut))  # -> _Tokio
     with pytest.raises(
@@ -159,50 +199,82 @@ def test_error2_get_after_tokio_conversion():
         fut.get()
 
 
-def test_error4_await_asyncio_on_tokio_converted():
-    """Cross-runtime: convert on tokio (_Tokio), then await under asyncio -- the
-    asyncio branch refuses a tokio-converted Future."""
+def test_await_asyncio_on_tokio_converted_raises():
+    """Cross-world: convert on tokio (_Tokio), then await under asyncio -- the
+    asyncio path (as_asyncio) refuses a tokio-converted Future."""
     fut: Future[int] = Future(coro=_value(1))
     _run_in_tokio(_await_once(fut))  # -> _Tokio
 
     async def attempt():
-        with pytest.raises(ValueError, match="already converted into a tokio future"):
-            await fut
-
-    asyncio.run(attempt())
-
-
-def test_error5_await_asyncio_after_resolved():
-    """await under asyncio after a sync get() resolved it (_Complete): the
-    synchronous world was already chosen, so the asyncio await is refused."""
-    fut: Future[int] = Future(coro=_value(1))
-    assert fut.get() == 1  # -> _Complete
-
-    async def attempt():
         with pytest.raises(
-            ValueError, match="already converted into a synchronous future"
+            ValueError, match=r"already converted into a pytokio\.Shared object"
         ):
             await fut
 
     asyncio.run(attempt())
 
 
-def test_error6_await_tokio_on_asyncio_converted():
-    """Cross-runtime mirror of error4: convert on asyncio (_Asyncio), then await
-    on a tokio thread -- the tokio branch refuses an asyncio-converted Future."""
+def test_await_asyncio_after_get_returns():
+    """await under asyncio after a sync get() resolved it (_Complete) now returns
+    the value -- as_asyncio() hands back a settled loop future instead of
+    raising."""
     fut: Future[int] = Future(coro=_value(1))
-    asyncio.run(_await_once(fut))  # -> _Asyncio
+    assert fut.get() == 1  # -> _Complete
+
+    async def attempt():
+        return await fut
+
+    assert asyncio.run(attempt()) == 1
+
+
+def test_await_asyncio_after_get_exception_reraises_stored():
+    """Failure mirror of the previous: await under asyncio after a failed sync
+    get() (_Exception) hands back a settled failed loop future that re-raises the
+    *same* stored exception object."""
+    boom = ValueError("boom")
+    fut: Future[int] = Future(coro=_raise(boom))
+    with pytest.raises(ValueError, match="boom"):
+        fut.get()  # -> _Exception
+
+    async def attempt():
+        with pytest.raises(ValueError, match="boom") as caught:
+            await fut
+        return caught.value
+
+    assert asyncio.run(attempt()) is boom
+
+
+def test_await_asyncio_live_handle_error_propagates():
+    """A failing coroutine driven LIVE through the Handle producer (spawn_handle
+    via as_asyncio, from _Unawaited -- not pre-resolved) surfaces the exception
+    through the bridged asyncio future: exercises send_result(Err) -> observer ->
+    set_exception, which the pre-resolved settled-future path does not."""
+    fut: Future[int] = Future(coro=_raise(ValueError("boom")))
+
+    async def attempt():
+        with pytest.raises(ValueError, match="boom"):
+            await fut  # _Unawaited -> live _Handle, error via the observer
+
+    asyncio.run(attempt())
+
+
+def test_await_tokio_on_handle_bridged_raises():
+    """Convert on asyncio (_Handle), then await on a tokio thread: the tokio
+    branch intentionally refuses a Future already bridged to asyncio."""
+    fut: Future[int] = Future(coro=_value(1))
+    asyncio.run(_await_once(fut))  # -> _Handle
 
     async def attempt():
         await fut
 
-    with pytest.raises(ValueError, match="already converted into asyncio future"):
+    with pytest.raises(ValueError, match="not awaitable on a tokio thread"):
         _run_in_tokio(attempt())
 
 
-def test_error7_await_tokio_after_resolved():
+def test_await_tokio_after_get_raises_synchronous_future():
     """await on a tokio thread after a sync get() resolved it (_Complete): the
-    same refusal as error5 (same message), reached from the tokio branch."""
+    tokio branch refuses with the 'already converted into a synchronous future'
+    guard."""
     fut: Future[int] = Future(coro=_value(1))
     assert fut.get() == 1  # -> _Complete
 
@@ -213,7 +285,22 @@ def test_error7_await_tokio_after_resolved():
         _run_in_tokio(attempt())
 
 
-def test_error8_await_with_no_event_loop():
+def test_await_tokio_after_get_exception_raises_synchronous_future():
+    """Failure mirror of test_await_tokio_after_get_raises_synchronous_future:
+    await on a tokio thread after a failed sync get() (_Exception) hits the same
+    'synchronous future' guard as _Complete."""
+    fut: Future[int] = Future(coro=_raise(ValueError("boom")))
+    with pytest.raises(ValueError, match="boom"):
+        fut.get()  # -> _Exception
+
+    async def attempt():
+        await fut
+
+    with pytest.raises(ValueError, match="already converted into a synchronous future"):
+        _run_in_tokio(attempt())
+
+
+def test_await_with_no_event_loop_raises():
     """await with neither an asyncio loop nor a tokio runtime active: there is no
     driver, so __await__ refuses outright."""
     fut: Future[int] = Future(coro=_value(1))
@@ -240,8 +327,11 @@ def test_get_in_asyncio_loop_warns_and_still_returns(monkeypatch):
 
     async def runner():
         fut: Future[int] = Future(coro=_value(5))
-        with pytest.warns(UserWarning, match="active event loop"):
-            return fut.get()
+        with pytest.warns(UserWarning, match="active event loop") as record:
+            value = fut.get()
+        # the asyncio-context advice is as_asyncio()/await (both valid on a loop)
+        assert any("as_asyncio" in str(w.message) for w in record)
+        return value
 
     assert asyncio.run(runner()) == 5
     assert len(calls) == 1
@@ -252,9 +342,15 @@ def test_get_in_tokio_thread_warns_then_cannot_block(monkeypatch):
     """On a real tokio thread get() warns (context='tokio') but then cannot
     block within the runtime, so it raises rather than returning -- the
     asymmetry with the asyncio branch, and precisely the case WouldBlockRuntime
-    is meant to replace."""
+    is meant to replace. The warning must advise awaiting inside a PythonTask
+    coroutine, NOT as_asyncio() (which needs an asyncio loop a tokio thread
+    lacks)."""
     calls = []
+    warned = []
     monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
+    monkeypatch.setattr(
+        future_mod.warnings, "warn", lambda msg, *a, **k: warned.append(str(msg))
+    )
     fut: Future[int] = Future(coro=_value(5))
 
     async def attempt():
@@ -265,6 +361,88 @@ def test_get_in_tokio_thread_warns_then_cannot_block(monkeypatch):
         _run_in_tokio(attempt())
     assert len(calls) == 1
     assert calls[0]["extra"]["context"] == "tokio"
+    # filter to get()'s own warning; the global warnings.warn patch also catches
+    # the incidental "coroutine '_value' was never awaited" warning from the task
+    # that block_on() abandons when it panics.
+    tokio_warnings = [w for w in warned if "Tokio runtime" in w]
+    assert len(tokio_warnings) == 1
+    assert "PythonTask coroutine" in tokio_warnings[0]
+    assert "as_asyncio" not in tokio_warnings[0]
+
+
+def test_get_timeout_in_tokio_thread_raises_would_block_without_warning(monkeypatch):
+    """get(timeout=...) on a tokio thread routes through a Handle, so Handle.get()
+    refuses with WouldBlockRuntime up front. The tracing event still forwards
+    (context='tokio'), but -- unlike the no-timeout path -- NO UserWarning fires,
+    because Handle.get() raises before it would warn."""
+    calls = []
+    warned = []
+    monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
+    monkeypatch.setattr(
+        future_mod.warnings, "warn", lambda msg, *a, **k: warned.append(str(msg))
+    )
+    fut: Future[int] = Future(coro=_value(5))
+
+    async def attempt():
+        assert is_tokio_thread()
+        return fut.get(timeout=0.1)
+
+    with pytest.raises(WouldBlockRuntime):
+        _run_in_tokio(attempt())
+    assert len(calls) == 1
+    assert calls[0]["extra"]["context"] == "tokio"
+    assert warned == []
+
+
+def test_get_on_handle_in_asyncio_loop_warns_and_forwards_once(monkeypatch):
+    """get() on an already-bridged Future (_Handle) from inside an asyncio loop
+    forwards exactly one tracing event (context='asyncio') and warns exactly
+    once: Future.get() forwards the trace, Handle.get() emits the UserWarning,
+    and the _Handle branch does not re-warn."""
+    calls = []
+    monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
+
+    async def runner():
+        fut: Future[int] = Future(coro=_value(5))
+        fut.as_asyncio()  # -> _Handle
+        with pytest.warns(UserWarning) as caught:
+            value = fut.get()
+        user_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        return value, len(user_warnings)
+
+    value, n_user_warnings = asyncio.run(runner())
+    assert value == 5
+    assert n_user_warnings == 1
+    assert len(calls) == 1
+    assert calls[0]["extra"]["context"] == "asyncio"
+
+
+def test_get_in_loop_on_cached_state_traces_without_warning(monkeypatch):
+    """get() inside an asyncio loop on an already-cached Future (_Complete or
+    _Exception) forwards exactly one tracing event per call and emits NO
+    UserWarning: the warning is reserved for paths that actually block the loop,
+    and a cached read does not."""
+    calls = []
+    monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
+
+    done: Future[int] = Future(coro=_value(5))
+    assert done.get() == 5  # off loop -> _Complete
+    failed: Future[int] = Future(coro=_raise(ValueError("boom")))
+    with pytest.raises(ValueError, match="boom"):
+        failed.get()  # off loop -> _Exception
+    calls.clear()
+
+    async def runner():
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            assert done.get() == 5  # cached _Complete, inside the loop
+            with pytest.raises(ValueError, match="boom"):
+                failed.get()  # cached _Exception, inside the loop
+        return [w for w in caught if issubclass(w.category, UserWarning)]
+
+    assert asyncio.run(runner()) == []
+    assert len(calls) == 2  # one tracing forward per in-loop get()
+    assert all(c["extra"]["context"] == "asyncio" for c in calls)
 
 
 def test_handle_and_would_block_runtime_are_importable():
@@ -344,10 +522,10 @@ def test_take_inner_after_get_raises():
 
 
 def test_take_inner_after_asyncio_await_raises():
-    """Once an asyncio await has converted the Future (_Asyncio), _take_inner()
-    is refused."""
+    """Once an asyncio await has bridged the Future (_Handle), _take_inner() is
+    refused."""
     fut: Future[int] = Future(coro=_value(1))
-    asyncio.run(_await_once(fut))  # -> _Asyncio
+    asyncio.run(_await_once(fut))  # -> _Handle
     with pytest.raises(ValueError, match="already been awaited"):
         fut._take_inner()
 
@@ -359,3 +537,69 @@ def test_take_inner_after_tokio_await_raises():
     _run_in_tokio(_await_once(fut))  # -> _Tokio
     with pytest.raises(ValueError, match="already been awaited"):
         fut._take_inner()
+
+
+# ---------------------------------------------------------------------------
+# as_asyncio() observation semantics
+#
+# as_asyncio() spawns a Handle once and observes it: observation is
+# non-consuming, each call returns a fresh loop-local future, it requires a
+# running loop, and it must not consume the task when there is none.
+# ---------------------------------------------------------------------------
+
+
+def test_as_asyncio_off_loop_raises_and_is_non_consuming():
+    """Off a running loop, as_asyncio() raises RuntimeError WITHOUT spawning: the
+    Future stays _Unawaited, so a later get() still drives the task."""
+    fut: Future[int] = Future(coro=_value(3))
+    with pytest.raises(RuntimeError):
+        fut.as_asyncio()
+    assert isinstance(fut._status, future_mod._Unawaited)
+    assert fut.get() == 3
+
+
+async def test_as_asyncio_twice_same_loop_both_resolve():
+    """Two as_asyncio() futures from one Future on the same loop both resolve to
+    the value (ordinary multi-observer case); the Future is _Handle after the
+    first."""
+    fut: Future[int] = Future(coro=_value(4))
+    f1 = fut.as_asyncio()
+    assert isinstance(fut._status, future_mod._Handle)
+    f2 = fut.as_asyncio()
+    assert await f1 == 4
+    assert await f2 == 4
+
+
+async def test_as_asyncio_cancel_one_then_await_again_resolves():
+    """Cancelling one as_asyncio() observer does not poison the Future: a later
+    await still resolves (each observer is a fresh loop-local future)."""
+    fut: Future[int] = Future(coro=_value(5))
+    f1 = fut.as_asyncio()
+    f1.cancel()
+    assert await fut == 5
+
+
+def test_as_asyncio_across_two_loops_both_resolve():
+    """The same Future observed from two different event loops resolves in each
+    (each as_asyncio() binds a fresh future to the current loop)."""
+    fut: Future[int] = Future(coro=_value(6))
+
+    async def observe():
+        return await fut
+
+    assert asyncio.run(observe()) == 6
+    assert asyncio.run(observe()) == 6
+
+
+async def test_as_asyncio_on_cached_stop_iteration_wraps_in_runtime_error():
+    """as_asyncio() on a cached _Exception must wrap a StopIteration in
+    RuntimeError before set_exception: asyncio.Future.set_exception rejects
+    StopIteration (PEP 479) with TypeError, which would otherwise brick the
+    returned future. Mirrors the Handle observer path (HDL-7). A StopIteration
+    can't reach _Exception via from_coroutine (it becomes a normal return), so
+    the cached state is set directly."""
+    fut: Future[int] = Future(coro=_value(1))
+    fut._status = future_mod._Exception(StopIteration("done"))
+    settled = fut.as_asyncio()
+    with pytest.raises(RuntimeError, match="StopIteration"):
+        await settled


### PR DESCRIPTION
Summary:

on an `_Unawaited` `Future`, a `get()` call that will be rejected now refuses BEFORE spawning a `Handle` or consuming the task, so it never starts work or flips state:

- on a Tokio worker thread, `get()` (timeout and no-timeout alike) raises `WouldBlockRuntime` up front, matching `Handle.get()`. previously the no-timeout path warned and then `block_on()` consumed the task and panicked (`"from within a runtime"`), losing the work and leaving the `Future` spent; the timeout path spawned a `Handle` and flipped `_status` before `Handle.get()` raised.
- an invalid timeout (`NaN`/negative/non-finite) is rejected with `ValueError` before `spawn_handle()` (`Handle.get()` still re-validates authoritatively), so a bad argument no longer starts a background task or flips state.

cached `_Complete`/`_Exception` reads on a tokio thread are unchanged (they don't block). re-baselines the tokio oracle tests to pin the typed refusal and non-consumption, and adds an invalid-timeout non-mutation test.

Reviewed By: zdevito

Differential Revision: D111055841


