### PR TITLE
pin airport turnaround demo to direct dispatch

### DIFF
--- a/python/examples/airport_turnaround_demo.py
+++ b/python/examples/airport_turnaround_demo.py
@@ -43,6 +43,9 @@ import logging
 import os
 import random
 
+from monarch._rust_bindings.monarch_hyperactor.config import (  # @manual=//monarch/monarch_extension:monarch_extension
+    reload_config_from_env,
+)
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, context, endpoint
 from monarch.job import ProcessJob
@@ -54,6 +57,21 @@ logger.setLevel(logging.INFO)
 # Slight per-flight startup offset so the fleet does not enter in lockstep
 # bursts; steady-state spread comes from the randomized phase durations.
 _STARTUP_STAGGER_S: float = 0.4
+
+
+def _disable_queue_dispatch() -> None:
+    """Proc bootstrap: force direct dispatch for actors spawned here.
+
+    This demo currently depends on plain async endpoints overlapping: resource
+    managers can block in a capacity-acquire handler while a later release
+    message frees capacity. Queue dispatch is now the global default, so pin
+    direct dispatch locally until the demo migrates to ``@concurrent_endpoint``.
+
+    The reload is required because the environment config layer is materialized
+    before this bootstrap runs in the worker process.
+    """
+    os.environ["MONARCH_ACTOR_QUEUE_DISPATCH"] = "0"
+    reload_config_from_env()
 
 
 class GateManager(Actor):
@@ -260,11 +278,21 @@ async def async_main(args: argparse.Namespace) -> None:
     # Flights are one named proc mesh sliced per replica; each manager is its
     # own named singleton proc mesh — all distinct, findable nodes in the TUI.
     # (Without `name=`, the flight procs show up anonymous, e.g. `anon-1`.)
-    flight_procs = host.spawn_procs(per_host={"replica": args.flights}, name="flights")
-    gate_proc = host.spawn_procs(name="gate_manager")
-    runway_proc = host.spawn_procs(name="runway_controller")
-    fuel_proc = host.spawn_procs(name="fuel_truck_pool")
-    baggage_proc = host.spawn_procs(name="baggage_crew_pool")
+    flight_procs = host.spawn_procs(
+        per_host={"replica": args.flights},
+        name="flights",
+        bootstrap=_disable_queue_dispatch,
+    )
+    gate_proc = host.spawn_procs(name="gate_manager", bootstrap=_disable_queue_dispatch)
+    runway_proc = host.spawn_procs(
+        name="runway_controller", bootstrap=_disable_queue_dispatch
+    )
+    fuel_proc = host.spawn_procs(
+        name="fuel_truck_pool", bootstrap=_disable_queue_dispatch
+    )
+    baggage_proc = host.spawn_procs(
+        name="baggage_crew_pool", bootstrap=_disable_queue_dispatch
+    )
 
     gates = gate_proc.spawn("gate_manager", GateManager, args.gates)
     runways = runway_proc.spawn(
@@ -390,14 +418,6 @@ def main() -> None:
             default=[lo, hi],
         )
     args = parser.parse_args()
-
-    qd = os.environ.get("MONARCH_ACTOR_QUEUE_DISPATCH", "").strip().lower()
-    if qd in ("1", "true", "yes", "on"):
-        parser.error(
-            "this demo needs direct dispatch: its capacity gates block inside a "
-            "handler and are released by other calls, which deadlocks under queue "
-            "dispatch. Unset MONARCH_ACTOR_QUEUE_DISPATCH and rerun."
-        )
 
     for name, count in (
         ("flights", args.flights),


### PR DESCRIPTION
Summary:
the airport turnaround observability demo depends on plain async endpoints overlapping: resource managers can block in capacity-acquire handlers while later release messages free capacity. queue dispatch is now the default, which serializes those handlers and can deadlock the demo at the gate manager.

install a per-proc bootstrap that sets `MONARCH_ACTOR_QUEUE_DISPATCH=0` and reloads config before actors spawn, and apply it to the flight and manager proc meshes. this preserves the existing demo behavior until the resource endpoints are migrated to `concurrent_endpoint`.

Differential Revision: D111086342


