### PR TITLE
migrate airport turnaround demo to concurrent endpoints

### DIFF
--- a/hyperactor_mesh/test/mesh_admin_integration/execution.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/execution.rs
@@ -18,9 +18,9 @@
 //! ordering, truncation, the `0` sentinel, idempotent `finish`) and the
 //! DTO json-shape tests, this proves the *real* `_Actor.handle` bracket
 //! increments the `execution` surface on entry and decrements on exit
-//! (completion and exception), across direct AND queue dispatch, visible
-//! end-to-end through `GET /v1/{actor}` and the typed
-//! `NodeProperties::Actor { execution: Some(_), .. }`.
+//! (completion and exception), across direct dispatch, queue dispatch,
+//! and `@concurrent_endpoint`, visible end-to-end through
+//! `GET /v1/{actor}` and the typed actor node payload.
 //!
 //! Cancellation is actor-fatal in the current runtime (`CancelledError`
 //! is a `BaseException` -> the `except BaseException` arm re-raises -> a
@@ -40,6 +40,9 @@
 //!     -> count drops back to the idle shape.
 //!   - queue dispatch: one held invocation -> `active_count` 1 (the
 //!     bracket fires in queue mode too).
+//!   - concurrent endpoint under queue dispatch: two held `hold`s overlap,
+//!     aggregate to one row with `active_count == 2`, and can be released by
+//!     a later control message on the same actor without deadlocking.
 //!   - idle sibling: `Some` with `active_count == 0` (EX-1: a supported
 //!     actor that is idle is `Some`, not `None`).
 
@@ -161,6 +164,7 @@ async fn run_inner(fixture: &WorkloadFixture) {
     let busy = find_actor_by_label(fixture, "busy_actor").await;
     let idle = find_actor_by_label(fixture, "idle_actor").await;
     let queue = find_actor_by_label(fixture, "queue_actor").await;
+    let concurrent = find_actor_by_label(fixture, "concurrent_actor").await;
 
     // --- Direct dispatch: one held invocation -> count 1. ---
     fixture
@@ -351,6 +355,83 @@ async fn run_inner(fixture: &WorkloadFixture) {
         exec.active_handlers[0].name, "hold",
         "execution: queue-dispatch active row name must be `hold`; got {exec:?}",
     );
+
+    // --- @concurrent_endpoint under queue dispatch: overlap + release. ---
+    // This is the queue-compatible resource-manager pattern: a held endpoint
+    // does not monopolize the actor dispatch loop, so a later control message
+    // can run on the same actor and release it.
+    fixture
+        .send_command("HOLD concurrent ca")
+        .await
+        .expect("execution: send HOLD concurrent ca");
+    fixture
+        .wait_for_stdout("EXEC_ENTERED ca", SENTINEL_TIMEOUT)
+        .await
+        .expect("execution: wait EXEC_ENTERED ca");
+    fixture
+        .send_command("HOLD concurrent cb")
+        .await
+        .expect("execution: send HOLD concurrent cb");
+    fixture
+        .wait_for_stdout("EXEC_ENTERED cb", SENTINEL_TIMEOUT)
+        .await
+        .expect("execution: wait EXEC_ENTERED cb");
+
+    let exec = execution_of(fixture, &concurrent).await;
+    assert_eq!(
+        exec.active_count, 2,
+        "execution: two held @concurrent_endpoint invocations must report \
+         active_count == 2; got {exec:?}",
+    );
+    assert_eq!(
+        exec.active_handlers.len(),
+        1,
+        "execution: two @concurrent_endpoint invocations of the SAME endpoint \
+         must aggregate into ONE row; got {exec:?}",
+    );
+    assert_eq!(
+        exec.active_handlers[0].name, "hold",
+        "execution: the @concurrent_endpoint active row name must be `hold`; got {exec:?}",
+    );
+    assert_eq!(
+        exec.active_handlers[0].active_count, 2,
+        "execution: the @concurrent_endpoint aggregated row active_count must be 2; got {exec:?}",
+    );
+
+    fixture
+        .send_command("RELEASE concurrent ca")
+        .await
+        .expect("execution: send RELEASE concurrent ca");
+    fixture
+        .wait_for_stdout("EXEC_ACK release ca", SENTINEL_TIMEOUT)
+        .await
+        .expect("execution: wait EXEC_ACK release ca");
+    let exec = poll_until(fixture, &concurrent, |e| e.active_count == 1).await;
+    assert_eq!(
+        exec.active_count, 1,
+        "execution: after releasing one @concurrent_endpoint invocation, \
+         count must drop to 1; got {exec:?}",
+    );
+    assert_eq!(
+        exec.active_handlers.len(),
+        1,
+        "execution: one @concurrent_endpoint invocation should remain in one row; got {exec:?}",
+    );
+    assert_eq!(
+        exec.active_handlers[0].active_count, 1,
+        "execution: the remaining @concurrent_endpoint row active_count must be 1; got {exec:?}",
+    );
+
+    fixture
+        .send_command("RELEASE concurrent cb")
+        .await
+        .expect("execution: send RELEASE concurrent cb");
+    fixture
+        .wait_for_stdout("EXEC_ACK release cb", SENTINEL_TIMEOUT)
+        .await
+        .expect("execution: wait EXEC_ACK release cb");
+    let exec = poll_until(fixture, &concurrent, |e| e.active_count == 0).await;
+    assert_idle_shape(&exec, "@concurrent_endpoint post-release clear");
 
     // --- Idle sibling: Some with count 0 (never invoked). ---
     let exec = execution_of(fixture, &idle).await;

--- a/python/examples/airport_turnaround_demo.py
+++ b/python/examples/airport_turnaround_demo.py
@@ -20,9 +20,10 @@ Each turnaround phase is a REAL endpoint on ``FlightActor``, driven externally
 so the active-handler name turns over in the TUI (a single internal ``run()``
 loop would only ever show ``run``). Shared resources are arbitrated by manager
 actors (``GateManager`` / ``RunwayController`` / ``FuelTruckPool`` /
-``BaggageCrewPool``), each gating capacity with an ``asyncio.Semaphore`` held
-*inside* its endpoint -- so browsing a manager shows ``request_refuel xK``
-etc.: the flights currently blocked on a busy resource, i.e. live contention.
+``BaggageCrewPool``). Capacity-holding methods use ``@concurrent_endpoint`` so
+they can wait on ``asyncio.Semaphore`` without blocking the actor's dispatch
+loop; browsing a manager shows ``request_refuel xK`` etc.: the flights
+currently blocked on a busy resource, i.e. live contention.
 
 What to watch in the TUI:
 
@@ -40,14 +41,10 @@ import argparse
 import asyncio
 import collections
 import logging
-import os
 import random
 
-from monarch._rust_bindings.monarch_hyperactor.config import (  # @manual=//monarch/monarch_extension:monarch_extension
-    reload_config_from_env,
-)
 from monarch._src.actor.telemetry import TracingForwarder
-from monarch.actor import Actor, context, endpoint
+from monarch.actor import Actor, concurrent_endpoint, context, endpoint
 from monarch.job import ProcessJob
 
 logger: logging.Logger = logging.getLogger("airport_turnaround_demo")
@@ -57,21 +54,6 @@ logger.setLevel(logging.INFO)
 # Slight per-flight startup offset so the fleet does not enter in lockstep
 # bursts; steady-state spread comes from the randomized phase durations.
 _STARTUP_STAGGER_S: float = 0.4
-
-
-def _disable_queue_dispatch() -> None:
-    """Proc bootstrap: force direct dispatch for actors spawned here.
-
-    This demo currently depends on plain async endpoints overlapping: resource
-    managers can block in a capacity-acquire handler while a later release
-    message frees capacity. Queue dispatch is now the global default, so pin
-    direct dispatch locally until the demo migrates to ``@concurrent_endpoint``.
-
-    The reload is required because the environment config layer is materialized
-    before this bootstrap runs in the worker process.
-    """
-    os.environ["MONARCH_ACTOR_QUEUE_DISPATCH"] = "0"
-    reload_config_from_env()
 
 
 class GateManager(Actor):
@@ -88,7 +70,7 @@ class GateManager(Actor):
         self._sem = asyncio.Semaphore(num_gates)
         self._free: "collections.deque[int]" = collections.deque(range(num_gates))
 
-    @endpoint
+    @concurrent_endpoint
     async def assign_gate(self) -> int:
         await self._sem.acquire()
         # No await between acquire and popleft: the only cancellation point is
@@ -127,11 +109,11 @@ class RunwayController(Actor):
             # leaks a runway slot and wedges the demo.
             self._sem.release()
 
-    @endpoint
+    @concurrent_endpoint
     async def request_landing(self, flight: int) -> None:
         await self._occupy("landing", flight)
 
-    @endpoint
+    @concurrent_endpoint
     async def request_takeoff(self, flight: int) -> None:
         await self._occupy("takeoff", flight)
 
@@ -148,7 +130,7 @@ class FuelTruckPool(Actor):
         self._sem = asyncio.Semaphore(num_trucks)
         self._service_s = service_s
 
-    @endpoint
+    @concurrent_endpoint
     async def request_refuel(self, flight: int) -> None:
         await self._sem.acquire()
         try:
@@ -169,7 +151,7 @@ class BaggageCrewPool(Actor):
         self._sem = asyncio.Semaphore(num_crews)
         self._service_s = service_s
 
-    @endpoint
+    @concurrent_endpoint
     async def request_baggage_service(self, flight: int) -> None:
         await self._sem.acquire()
         try:
@@ -278,21 +260,11 @@ async def async_main(args: argparse.Namespace) -> None:
     # Flights are one named proc mesh sliced per replica; each manager is its
     # own named singleton proc mesh — all distinct, findable nodes in the TUI.
     # (Without `name=`, the flight procs show up anonymous, e.g. `anon-1`.)
-    flight_procs = host.spawn_procs(
-        per_host={"replica": args.flights},
-        name="flights",
-        bootstrap=_disable_queue_dispatch,
-    )
-    gate_proc = host.spawn_procs(name="gate_manager", bootstrap=_disable_queue_dispatch)
-    runway_proc = host.spawn_procs(
-        name="runway_controller", bootstrap=_disable_queue_dispatch
-    )
-    fuel_proc = host.spawn_procs(
-        name="fuel_truck_pool", bootstrap=_disable_queue_dispatch
-    )
-    baggage_proc = host.spawn_procs(
-        name="baggage_crew_pool", bootstrap=_disable_queue_dispatch
-    )
+    flight_procs = host.spawn_procs(per_host={"replica": args.flights}, name="flights")
+    gate_proc = host.spawn_procs(name="gate_manager")
+    runway_proc = host.spawn_procs(name="runway_controller")
+    fuel_proc = host.spawn_procs(name="fuel_truck_pool")
+    baggage_proc = host.spawn_procs(name="baggage_crew_pool")
 
     gates = gate_proc.spawn("gate_manager", GateManager, args.gates)
     runways = runway_proc.spawn(

--- a/python/examples/execution_workload.py
+++ b/python/examples/execution_workload.py
@@ -26,6 +26,10 @@ Actors:
     so a held invocation is never released through a second endpoint call
     (that would deadlock the dispatch loop); the test asserts
     ``count == 1`` then tears the proc down.
+  - ``ConcurrentActor`` (queue dispatch): ``hold`` uses
+    ``@concurrent_endpoint``, so multiple held invocations overlap and
+    ``control`` can release them while they wait. This covers the
+    queue-dispatch-compatible pattern used by resource managers.
 
 Each proc pins its dispatch mode explicitly via a ``bootstrap`` callable
 that sets ``MONARCH_ACTOR_QUEUE_DISPATCH`` and calls
@@ -41,15 +45,15 @@ Stdin command protocol, one command per line::
     RELEASE <actor> <id>  let a held invocation return; prints EXEC_ACK release <id>
     RAISE <actor> <id>    make a held invocation raise; prints EXEC_ACK raise <id>
 
-``<actor>`` is ``busy`` or ``queue``. Each ``hold`` signals "entered"
-from inside the handler body -- after the framework's ``_execution_start``
-has recorded the invocation and before the handler blocks -- so the
-signal means "mesh-admin now reports this invocation", not merely "user
-code started". The signal travels over a monarch ``Port`` rather than
-handler stdout: a spawned proc's stdout reaches the client on a
-multi-second aggregation window, too coarse for a handshake. The main
-task receives on the port and echoes ``EXEC_ENTERED <id>`` to its own
-unbuffered stdout.
+``<actor>`` is ``busy``, ``queue``, or ``concurrent``. Each ``hold`` signals
+"entered" from inside the handler body -- after the framework's
+``_execution_start`` has recorded the invocation and before the handler
+blocks -- so the signal means "mesh-admin now reports this invocation", not
+merely "user code started". The signal travels over a monarch ``Port`` rather
+than handler stdout: a spawned proc's stdout reaches the client on a
+multi-second aggregation window, too coarse for a handshake. The main task
+receives on the port and echoes ``EXEC_ENTERED <id>`` to its own unbuffered
+stdout.
 """
 
 import asyncio
@@ -62,7 +66,7 @@ from monarch._rust_bindings.monarch_hyperactor.config import (  # @manual=//mona
 )
 from monarch._src.actor.actor_mesh import Channel, Port, PortReceiver
 from monarch._src.actor.telemetry import TracingForwarder
-from monarch.actor import Actor, context, endpoint
+from monarch.actor import Actor, concurrent_endpoint, context, endpoint
 from monarch.job import ProcessJob
 
 logger: logging.Logger = logging.getLogger("execution_workload")
@@ -159,6 +163,39 @@ class QueueActor(Actor):
         return str(context().actor_instance.actor_id)
 
 
+class ConcurrentActor(Actor):
+    """Queue-dispatch actor whose held work runs through @concurrent_endpoint."""
+
+    def __init__(self) -> None:
+        self._events: dict[str, asyncio.Event] = {}
+        self._raise: dict[str, bool] = {}
+
+    @concurrent_endpoint
+    async def hold(self, id: str, entered: "Port[str]") -> None:
+        self._events[id] = asyncio.Event()
+        self._raise[id] = False
+        logger.info("concurrent hold %s", id)
+        entered.send(id)
+        await self._events[id].wait()
+        if self._raise[id]:
+            raise RuntimeError("requested")
+
+    @endpoint
+    async def control(self, id: str, op: str) -> None:
+        logger.info("concurrent control %s %s", op, id)
+        if op == "release":
+            self._events[id].set()
+        elif op == "raise":
+            self._raise[id] = True
+            self._events[id].set()
+        else:
+            raise ValueError(f"unknown op: {op}")
+
+    @endpoint
+    async def whoami(self) -> str:
+        return str(context().actor_instance.actor_id)
+
+
 async def _stdin_reader() -> asyncio.StreamReader:
     """An asyncio reader over this process's stdin."""
     loop = asyncio.get_running_loop()
@@ -201,16 +238,21 @@ async def async_main() -> None:
     queue_proc = host.spawn_procs(
         name="execution_queue", bootstrap=_enable_queue_dispatch
     )
+    concurrent_proc = host.spawn_procs(
+        name="execution_concurrent", bootstrap=_enable_queue_dispatch
+    )
 
     busy = busy_proc.spawn("busy_actor", BusyActor)
     idle = idle_proc.spawn("idle_actor", BusyActor)
     queue = queue_proc.spawn("queue_actor", QueueActor)
+    concurrent = concurrent_proc.spawn("concurrent_actor", ConcurrentActor)
 
-    actors = {"busy": busy, "queue": queue}
+    actors = {"busy": busy, "queue": queue, "concurrent": concurrent}
 
     busy_ref = await busy.whoami.call_one()
     idle_ref = await idle.whoami.call_one()
     queue_ref = await queue.whoami.call_one()
+    concurrent_ref = await concurrent.whoami.call_one()
 
     # Held invocations send their id over this port from inside the handler
     # body; a background task drains it and echoes EXEC_ENTERED to stdout.
@@ -229,6 +271,7 @@ async def async_main() -> None:
     print(f"  - Busy actor:  {busy_ref}", flush=True)
     print(f"  - Idle actor:  {idle_ref}", flush=True)
     print(f"  - Queue actor: {queue_ref}", flush=True)
+    print(f"  - Concurrent actor: {concurrent_ref}", flush=True)
 
     reader = await _stdin_reader()
     # In-flight held invocations, tracked so they can be cancelled at
@@ -270,6 +313,7 @@ async def async_main() -> None:
         await busy_proc.stop()
         await idle_proc.stop()
         await queue_proc.stop()
+        await concurrent_proc.stop()
 
 
 def main() -> None:


### PR DESCRIPTION
Summary:
airport_turnaround_demo no longer needs direct dispatch. its capacity-holding resource manager methods now use `concurrent_endpoint`. release and identity endpoints remain plain endpoint.

execution_workload now includes a queue-dispatch `ConcurrentActor` and the mesh-admin integration test observes two held `concurrent_endpoint` calls through `/v1/{actor}`. this pins the execution surface and the same-actor release behavior that the airport resource managers rely on.

Differential Revision: D111096457


