### PR TITLE
drop the dead supervision-monitor branch in PortReceiver._recv

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1183,25 +1183,7 @@ class PortReceiver(Generic[R]):
             error.endpoint = self._endpoint
 
     async def _recv(self) -> R:
-        awaitable = self._receiver.recv_task()
-        if self._monitor is None:
-            result = await awaitable
-        else:
-            try:
-                result, i = await PythonTask.select_one(
-                    # type: ignore
-                    [self._monitor.task(), awaitable]
-                )
-            except Exception as e:
-                self._tag_supervision_error(e)
-                raise e
-            if i == 0:
-                # pyrefly: ignore [bad-argument-type]
-                self._tag_supervision_error(result)
-                # pyrefly: ignore [bad-raise]
-                raise result
-        # pyrefly: ignore [bad-argument-type]
-        return self._process(result)
+        return self._process(await self._receiver.recv_task())
 
     def _process(self, msg: PythonMessage) -> R:
         payload = cast(R, msg.decode())


### PR DESCRIPTION
Summary:
`PortReceiver._recv` only used pytokio's `PythonTask.select_one` in an `else` branch reached when `self._monitor` is non-None, but `self._monitor` is never set to a non-None value in checked-in code: both constructors (`Channel.open` and `PortReceiver.ranked`) pass `None` or propagate the already-`None` value, and the sole other writer `_attach_supervision` has no callers. the branch is therefore dead in production, and its `select_one` call is the only production caller of that pytokio primitive.

collapse `_recv` onto the reachable `recv_task()` path. this is behavior-preserving (the taken branch is unchanged) and removes the last production use of `PythonTask.select_one`, clearing the way to delete the primitive once pytokio is retired. the live supervision race is unaffected: it runs Rust-side in the adverbs (`endpoint.rs` `collect_value` / `collect_valuemesh`), not through this receiver path.

the now-idle monitor plumbing (`_monitor`, `_attach_supervision`, `_tag_supervision_error`, and the `monitor=`/`endpoint=` params) stays in place here and is removed in a follow-up.

Differential Revision: D111113672


