### PR TITLE
delete PortReceiver's now-unused supervision-monitor plumbing

### DIFF
--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1183,25 +1183,7 @@ class PortReceiver(Generic[R]):
             error.endpoint = self._endpoint
 
     async def _recv(self) -> R:
-        awaitable = self._receiver.recv_task()
-        if self._monitor is None:
-            result = await awaitable
-        else:
-            try:
-                result, i = await PythonTask.select_one(
-                    # type: ignore
-                    [self._monitor.task(), awaitable]
-                )
-            except Exception as e:
-                self._tag_supervision_error(e)
-                raise e
-            if i == 0:
-                # pyrefly: ignore [bad-argument-type]
-                self._tag_supervision_error(result)
-                # pyrefly: ignore [bad-raise]
-                raise result
-        # pyrefly: ignore [bad-argument-type]
-        return self._process(result)
+        return self._process(await self._receiver.recv_task())
 
     def _process(self, msg: PythonMessage) -> R:
         payload = cast(R, msg.decode())

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -67,12 +67,9 @@ from monarch._rust_bindings.monarch_hyperactor.pickle import (
     PicklingState,
 )
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
-from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Point as HyPoint, Shape
-from monarch._rust_bindings.monarch_hyperactor.supervision import (
-    MeshFailure,
-    SupervisionError,
-)
+from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch._src.actor import config
 from monarch._src.actor.debugger.pdb_wrapper import PdbWrapper
 from monarch._src.actor.endpoint import (
@@ -1161,26 +1158,15 @@ class PortReceiver(Generic[R]):
     Receiver for messages sent through a communication channel.
 
     Handles receiving R-typed objects sent from a corresponding Port.
-    Asynchronously message reception with optional supervision
-    monitoring for error handling.
     """
 
     def __init__(
         self,
         mailbox: Mailbox,
         receiver: "PortReceiverBase",
-        monitor: "Optional[Shared[Exception]]" = None,
-        endpoint: Optional[str] = None,
     ) -> None:
         self._mailbox: Mailbox = mailbox
-        self._monitor = monitor
         self._receiver = receiver
-        self._endpoint = endpoint
-
-    def _tag_supervision_error(self, error: Exception) -> None:
-        """Tag supervision error with endpoint name if available."""
-        if self._endpoint is not None and isinstance(error, SupervisionError):
-            error.endpoint = self._endpoint
 
     async def _recv(self) -> R:
         return self._process(await self._receiver.recv_task())
@@ -1194,7 +1180,6 @@ class PortReceiver(Generic[R]):
             # pyrefly: ignore [invalid-pattern]
             case PythonMessageKind.Exception():
                 e = cast(Exception, payload)
-                self._tag_supervision_error(e)
                 raise e
             case _:
                 raise ValueError(f"Unexpected message kind: {msg.kind}")
@@ -1203,25 +1188,7 @@ class PortReceiver(Generic[R]):
         return Future(coro=self._recv())
 
     def ranked(self) -> "RankedPortReceiver[R]":
-        return RankedPortReceiver[R](
-            self._mailbox, self._receiver, self._monitor, self._endpoint
-        )
-
-    def _attach_supervision(
-        self, monitor: "Optional[Shared[Exception]]", endpoint: str
-    ) -> None:
-        """
-        Attach supervision monitoring to this port receiver.
-
-        Enables the receiver to detect and report errors on any supervision events.
-
-        Args:
-            monitor: Shared exception monitor that signals supervision errors
-                from the actor mesh. None if supervision is not enabled.
-            endpoint: Full endpoint name
-        """
-        self._monitor = monitor
-        self._endpoint = endpoint
+        return RankedPortReceiver[R](self._mailbox, self._receiver)
 
 
 class RankedPortReceiver(PortReceiver[Tuple[int, R]]):


### PR DESCRIPTION
Summary:
follow-up to the previous diff, which collapsed `PortReceiver._recv` onto the reachable `recv_task()` path. with the monitor branch gone, the plumbing that fed it is dead: this removes the `monitor=`/`endpoint=` constructor params and their `_monitor`/`_endpoint` fields, the uncalled `_attach_supervision`, the no-op `_tag_supervision_error` (it tagged an error only when `_endpoint` was set, which never happened) and its `_process` call, and the `ranked()` forwarding of those fields. it also drops the now-unused `Shared` and `SupervisionError` imports and fixes the class docstring, which advertised "optional supervision monitoring" the type never delivered.

no-caller evidence: an in-repo search finds no construction of `PortReceiver`/`RankedPortReceiver` that passes a `monitor` argument (the two call sites pass `None` or propagate the already-`None` value), no caller of `_attach_supervision`, and no read/write of `._monitor` outside this file. `monitor=`/`endpoint=` were unused, unsupported params on an internal implementation type under `python/monarch/_src/actor/`, so this removes dead internal surface, not public API. the live supervision race is elsewhere (Rust-side, in the adverbs' `endpoint.rs` select) and is untouched.

Differential Revision: D111113669


