### PR TITLE
Remove legacy telemetry in python API

### DIFF
--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -183,7 +183,6 @@ async def async_main(
                 include_dashboard=dashboard,
                 dashboard_port=resolved_dashboard_port,
                 snapshot_interval_secs=30.0,
-                use_sidecar=True,
             )
         )
     state = job.state(cached_path=None)

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -86,9 +86,7 @@ async def async_main(num_procs: int) -> None:
     job = (
         ProcessJob({"hosts": 1})
         .enable_telemetry(
-            TelemetryConfig(
-                dashboard_port=0, snapshot_interval_secs=30.0, use_sidecar=True
-            )
+            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
         )
         .enable_admin()
     )

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -142,7 +142,6 @@ async def async_main() -> None:
             TelemetryConfig(
                 dashboard_port=0,
                 snapshot_interval_secs=30.0,
-                use_sidecar=True,
             )
         )
         .enable_admin()

--- a/python/examples/rapid_spawn_exit_stress.py
+++ b/python/examples/rapid_spawn_exit_stress.py
@@ -26,9 +26,7 @@ from monarch.mesh_controller import spawn_tensor_engine
 
 job = (
     ProcessJob({"hosts": 1})
-    .enable_telemetry(
-        TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0, use_sidecar=True)
-    )
+    .enable_telemetry(TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0))
     .enable_admin()
 )
 job_state = job.state(cached_path=None)

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -60,9 +60,7 @@ async def async_main(num_procs: int) -> None:
     job = (
         ProcessJob({"hosts": 1})
         .enable_telemetry(
-            TelemetryConfig(
-                dashboard_port=0, snapshot_interval_secs=30.0, use_sidecar=True
-            )
+            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
         )
         .enable_admin()
     )

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -47,9 +47,7 @@ async def async_main(num_procs: int) -> None:
     job = (
         ProcessJob({"hosts": 1})
         .enable_telemetry(
-            TelemetryConfig(
-                dashboard_port=0, snapshot_interval_secs=30.0, use_sidecar=True
-            )
+            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
         )
         .enable_admin()
     )

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -40,7 +40,6 @@ from monarch.actor import (
     Port,
     this_host,
 )
-from monarch.distributed_telemetry.engine import QueryEngine
 from typing_extensions import Self
 
 
@@ -312,7 +311,7 @@ class JobState:
     def __init__(
         self,
         hosts: Dict[str, HostMesh],
-        query_engine: Optional[QueryEngine] = None,
+        query_engine: Optional[Any] = None,
         query_engine_client: Optional[QueryEngineClient] = None,
         telemetry_url: Optional[str] = None,
         dashboard_url: Optional[str] = None,
@@ -1035,15 +1034,21 @@ class BatchJob(JobTrait):
         # BatchJob is a scheduler-state proxy; component config and runtime stay
         # owned by the wrapped job so there is only one source of truth.
         self._components = job._components
+        self._apply_id = job.apply_id or str(uuid.uuid4())
+
+    def _should_spawn_telemetry_worker_collector_actors(self) -> bool:
+        return self._job._should_spawn_telemetry_worker_collector_actors()
 
     def _connect_host_meshes(self, running_job: "JobTrait") -> Dict[str, HostMesh]:
-        return self._job._connect_host_meshes(running_job)
+        self._components.before_connect(self)
+        host_meshes = dict(running_job._state()._hosts)
+        return self._components.connect(self, host_meshes)
 
     def state(
         self, cached_path: Optional[str] = ".monarch/job_state.pkl"
     ) -> "JobState":
         job_state = self._connect(cached_path)
-        self._job._components.state(self._job, job_state)
+        self._components.state(self, job_state)
         return job_state
 
     def can_run(self, spec: JobTrait):

--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -45,8 +45,6 @@ from monarch._src.job.telemetry_config import (
     TelemetryConfig,
 )
 from monarch.actor import HostMesh
-from monarch.distributed_telemetry.actor import start_telemetry
-from monarch.distributed_telemetry.engine import QueryEngine
 
 if TYPE_CHECKING:
     from monarch._src.job.job import JobState, JobTrait
@@ -170,58 +168,15 @@ class MountComponent(JobComponent):
         )
 
 
-class TelemetryComponent(JobComponent):
-    """Start the legacy in-process telemetry collector once per allocation.
-
-    Owns the query engine, collector URL, and scanner. Dependent components
-    receive this component explicitly instead of reading telemetry state from
-    ``JobTrait``. ``JobComponents`` resets this runtime when config drifts so
-    the next ``state`` starts a collector with the new config.
-    """
-
-    def __init__(self, config: TelemetryConfig) -> None:
-        self._config = config
-        self._query_engine: Optional[QueryEngine] = None
-        self._telemetry_url: Optional[str] = None
-        self._scanner: Any = None
-
-    def reset_runtime(self) -> None:
-        self._query_engine = None
-        self._telemetry_url = None
-        self._scanner = None
-
-    def __getstate__(self) -> Dict[str, Any]:
-        state = self.__dict__.copy()
-        state["_query_engine"] = None
-        state["_telemetry_url"] = None
-        state["_scanner"] = None
-        return state
-
-    def state(self, job: "JobTrait", job_state: "JobState") -> None:
-        if self._query_engine is None:
-            cfg = self._config
-            self._query_engine, self._telemetry_url, self._scanner = start_telemetry(
-                batch_size=cfg.batch_size,
-                retention_secs=cfg.retention_secs,
-                include_dashboard=cfg.include_dashboard,
-                dashboard_port=cfg.dashboard_port,
-            )
-        job_state.query_engine = self._query_engine
-        job_state.telemetry_url = self._telemetry_url
-
-
 class SidecarTelemetryComponent(JobComponent):
-    """Host telemetry in the job sidecar instead of in-process.
+    """Host telemetry in the job sidecar.
 
-    Opted into via ``TelemetryConfig.use_sidecar``; mutually exclusive with
-    ``TelemetryComponent``. ``before_connect`` opens the sidecar's
-    telemetry handle and installs the client-process Unix socket sink *before*
-    raw host meshes are materialized so host-mesh creation events are captured.
-    ``connect`` asks the sidecar to fan worker collectors out across the
-    materialized host meshes. Config drift clears parent-side handles, but
-    the sidecar keeps its in-memory telemetry store for the same ``apply_id``.
-    Switching between sidecar and in-process telemetry replaces the telemetry
-    component slot.
+    ``before_connect`` opens the sidecar's telemetry handle and installs the
+    client-process Unix socket sink *before* raw host meshes are materialized
+    so host-mesh creation events are captured. ``connect`` asks the sidecar to
+    fan worker collectors out across the materialized host meshes. Config drift
+    clears parent-side handles, but the sidecar keeps its in-memory telemetry
+    store for the same ``apply_id``.
     Telemetry is best-effort: any failure is logged and leaves telemetry
     disabled for this job rather than failing ``state()``.
     """
@@ -320,7 +275,7 @@ class AdminComponent(JobComponent):
     def __init__(
         self,
         config: MeshAdminConfig,
-        telemetry: Optional[TelemetryComponent | SidecarTelemetryComponent],
+        telemetry: Optional[SidecarTelemetryComponent],
     ) -> None:
         self._config = config
         self._telemetry = telemetry
@@ -371,7 +326,7 @@ class SnapshotComponent(JobComponent):
 
     def __init__(
         self,
-        telemetry: TelemetryComponent | SidecarTelemetryComponent,
+        telemetry: SidecarTelemetryComponent,
         admin: AdminComponent,
     ) -> None:
         self._telemetry = telemetry
@@ -399,34 +354,15 @@ class SnapshotComponent(JobComponent):
         from monarch.actor import context
 
         instance = context().actor_instance._as_rust()
-        if isinstance(self._telemetry, SidecarTelemetryComponent):
-            # Sidecar telemetry has no in-process scanner; publish snapshots to
-            # the sidecar over HTTP instead.
-            telemetry_url = self._telemetry._telemetry_url
-            if telemetry_url is None:
-                return
-            from monarch._rust_bindings.monarch_extension.snapshot_integration import (
-                _start_periodic_snapshots_http,
-            )
-
-            _start_periodic_snapshots_http(
-                base_url=telemetry_url,
-                admin_ref=admin_ref,
-                instance=instance,
-                interval_secs=snapshot_interval_secs,
-            )
-            self._started = True
-            return
-
-        scanner = self._telemetry._scanner
-        if scanner is None:
+        telemetry_url = self._telemetry._telemetry_url
+        if telemetry_url is None:
             return
         from monarch._rust_bindings.monarch_extension.snapshot_integration import (
-            _start_periodic_snapshots,
+            _start_periodic_snapshots_http,
         )
 
-        _start_periodic_snapshots(
-            scanner=scanner,
+        _start_periodic_snapshots_http(
+            base_url=telemetry_url,
             admin_ref=admin_ref,
             instance=instance,
             interval_secs=snapshot_interval_secs,
@@ -443,7 +379,7 @@ class JobComponents:
     """
 
     mounts: MountComponent = field(default_factory=MountComponent)
-    telemetry: Optional[TelemetryComponent | SidecarTelemetryComponent] = None
+    telemetry: Optional[SidecarTelemetryComponent] = None
     admin: Optional[AdminComponent] = None
     snapshot: Optional[SnapshotComponent] = None
 
@@ -477,13 +413,8 @@ class JobComponents:
             component.reset_runtime()
 
     def configure_telemetry(self, config: TelemetryConfig) -> None:
-        target_cls = (
-            SidecarTelemetryComponent if config.use_sidecar else TelemetryComponent
-        )
-        if not isinstance(self.telemetry, target_cls):
-            if self.telemetry is not None:
-                self.telemetry.reset_runtime()
-            self.telemetry = target_cls(config)
+        if self.telemetry is None:
+            self.telemetry = SidecarTelemetryComponent(config)
             telemetry_changed = True
         else:
             telemetry_changed = self.telemetry._config != config

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -76,7 +76,6 @@ class TelemetryConfig:
     (and optionally a dashboard) is started when ``state()`` is called.
 
     Args:
-        batch_size: Number of rows to buffer before flushing to a RecordBatch.
         retention_secs: Retention window in seconds for message tables.
             0 disables retention.
         include_dashboard: Whether to start the monarch dashboard web server.
@@ -87,19 +86,12 @@ class TelemetryConfig:
             (default). When ``include_dashboard`` is True and this is 0,
             it is automatically set to 30s because the dashboard requires
             snapshot data for system actor filtering.
-        use_sidecar: Opt in to telemetry hosted by the job sidecar, which
-            *replaces* the legacy in-process collector for this job (the two
-            never run together). Transitional flag for the migration; defaults
-            to the legacy path. When True, ``state.query_engine`` is None and
-            ``state.query_engine_client`` serves queries instead.
     """
 
-    batch_size: int = 1000
     retention_secs: int = 600
     include_dashboard: bool = False
     dashboard_port: int = 8265
     snapshot_interval_secs: float = 0  # 0 = disabled
-    use_sidecar: bool = False
 
     def __post_init__(self) -> None:
         if self.include_dashboard and self.snapshot_interval_secs <= 0:

--- a/python/monarch/distributed_telemetry/__init__.py
+++ b/python/monarch/distributed_telemetry/__init__.py
@@ -18,8 +18,8 @@ Usage:
     from monarch.job import ProcessJob, TelemetryConfig
 
     state = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig()).state()
-    engine = state.query_engine
-    assert engine is not None
+    client = state.query_engine_client
+    assert client is not None
     # ... spawn procs, they're automatically tracked ...
-    result = engine.query("SELECT * FROM metrics")
+    result = client.query("SELECT * FROM metrics")
 """

--- a/python/monarch/monarch_dashboard/server/query_engine_adapter.py
+++ b/python/monarch/monarch_dashboard/server/query_engine_adapter.py
@@ -24,14 +24,8 @@ class QueryEngineAdapter(DBAdapter):
     Provides the same query interface as db.py's _query() but backed by
     the distributed telemetry system instead of a local SQLite file.
 
-    Usage::
-
-        from monarch.job import ProcessJob, TelemetryConfig
-        state = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig()).state()
-        engine = state.query_engine
-        assert engine is not None
-        adapter = QueryEngineAdapter(engine)
-        rows = adapter.query("SELECT * FROM actors LIMIT 10")
+    The job sidecar constructs this adapter with the internal query engine
+    that backs the dashboard HTTP API.
     """
 
     def __init__(self, engine: QueryEngine) -> None:

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -18,7 +18,6 @@ import uuid
 from typing import Any, cast
 
 import monarch._src.job.telemetry_actor as job_telemetry_actor
-import monarch.distributed_telemetry.actor as telemetry_actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
@@ -56,9 +55,8 @@ def _telemetry_config(**kwargs: Any) -> TelemetryConfig:
 
 
 def _sidecar_telemetry_config(**kwargs: Any) -> TelemetryConfig:
-    kwargs.setdefault("batch_size", 10)
     kwargs.setdefault("retention_secs", 0)
-    return _telemetry_config(use_sidecar=True, **kwargs)
+    return _telemetry_config(**kwargs)
 
 
 def _assert_sidecar(state) -> None:
@@ -212,11 +210,6 @@ def cleanup_callbacks():
     ]
     for fn in startup_to_remove:
         SetupActor._startup_functions.remove(fn)
-    # Reset module-level state for next test
-    telemetry_actor._scanner = None
-    telemetry_actor._scanner_startup_impl = None
-    telemetry_actor._spawned_procs = []
-    telemetry_actor._spawn_callback_registered = False
 
 
 @pytest.mark.timeout(60)
@@ -321,44 +314,6 @@ def test_actors_table() -> None:
         assert "<root>" in root_display_names, (
             f"Expected bootstrap client actor with display_name '<root>', got: {root_display_names}"
         )
-
-
-@pytest.mark.timeout(120)
-@isolate_in_subprocess
-def test_legacy_query_engine_receives_entity_events(cleanup_callbacks) -> None:
-    """Legacy `DatabaseScanner` still consumes `TraceEvent::Entity`."""
-    with scoped_state(
-        ProcessJob({"hosts": 1}).enable_telemetry(
-            _telemetry_config(batch_size=1, retention_secs=0)
-        ),
-        cached_path=None,
-    ) as state:
-        engine = state.query_engine
-        assert engine is not None
-        assert state.query_engine_client is None
-
-        hosts = state.hosts
-        worker_procs = hosts.spawn_procs(
-            per_host={"workers": 2}, name="legacy_workers_procs"
-        )
-        workers = worker_procs.spawn("legacy_worker", WorkerActor)
-        workers.initialized.get()
-        workers.ping.call().get()
-
-        actors = engine.query(
-            "SELECT a.id FROM actors a "
-            "JOIN meshes mesh ON a.mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'legacy_worker'"
-        ).to_pydict()
-        assert len(actors.get("id", [])) == 2, actors
-
-        sent_messages = engine.query(
-            "SELECT COUNT(*) AS cnt FROM sent_messages sm "
-            "JOIN meshes mesh ON sm.actor_mesh_id = mesh.id "
-            "WHERE mesh.given_name = 'legacy_worker' "
-            "HAVING COUNT(*) = 1"
-        ).to_pydict()
-        assert sent_messages["cnt"][0] == 1, sent_messages
 
 
 @pytest.mark.timeout(120)
@@ -1855,7 +1810,7 @@ def test_per_table_row_retention(cleanup_callbacks) -> None:
     # Use a 1-second retention window so rows expire quickly.
     with scoped_state(
         ProcessJob({"hosts": 1}).enable_telemetry(
-            _sidecar_telemetry_config(batch_size=2, retention_secs=1)
+            _sidecar_telemetry_config(retention_secs=1)
         ),
         cached_path=None,
     ) as state:
@@ -1928,7 +1883,7 @@ def test_scan_timeout_on_dead_child(cleanup_callbacks) -> None:
 
         # Patch the timeout to a short value so the test doesn't wait 10s
         with unittest.mock.patch.object(
-            telemetry_actor, "_SCAN_CHILD_TIMEOUT_SECS", 1.0
+            job_telemetry_actor, "_SCAN_WORKER_TIMEOUT_SECS", 1.0
         ):
             start = time.monotonic()
             result_dict = _query(state, "SELECT * FROM actors")
@@ -2024,9 +1979,7 @@ def test_snapshot_periodic_capture_populates_tables(cleanup_callbacks) -> None:
     """
     with scoped_state(
         ProcessJob({"hosts": 1})
-        .enable_telemetry(
-            _sidecar_telemetry_config(batch_size=10, snapshot_interval_secs=5)
-        )
+        .enable_telemetry(_sidecar_telemetry_config(snapshot_interval_secs=5))
         .enable_admin(
             MeshAdminConfig(
                 # Use an ephemeral admin port so concurrent --stress-runs

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -583,40 +583,33 @@ def test_state_query_engine_none_without_telemetry():
     assert state.telemetry_url is None
 
 
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_state_query_engine_set_with_telemetry(mock_start):
-    """Test that query_engine is set when telemetry is configured."""
-    mock_engine = MagicMock()
-    mock_url = "http://localhost:8265"
-    mock_start.return_value = (mock_engine, mock_url, MagicMock())
+def test_state_query_client_set_with_telemetry():
+    """Test that the sidecar query client is set when telemetry is configured."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(TelemetryConfig())
+        state = job.state(cached_path=None)
 
-    job = MockJobTrait().enable_telemetry(TelemetryConfig())
-    state = job.state(cached_path=None)
-
-    assert state.query_engine is not None
-    assert state.query_engine is mock_engine
-    assert state.telemetry_url == mock_url
+    assert state.query_engine is None
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
+    assert state.telemetry_url == "http://sidecar"
 
 
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_component_configuration_after_apply_adds_telemetry(mock_start):
-    mock_engine = MagicMock()
-    mock_url = "http://localhost:8265"
-    mock_start.return_value = (mock_engine, mock_url, MagicMock())
+def test_component_configuration_after_apply_adds_telemetry():
+    with _patched_sidecar() as m:
+        job = MockJobTrait()
+        job.apply()
+        components = job._components
+        assert components is not None
+        assert components.telemetry is None
 
-    job = MockJobTrait()
-    job.apply()
-    components = job._components
-    assert components is not None
-    assert components.telemetry is None
-
-    job.enable_telemetry(TelemetryConfig())
-    state = job.state(cached_path=None)
+        job.enable_telemetry(TelemetryConfig())
+        state = job.state(cached_path=None)
 
     assert job._components is components
     assert components.telemetry is not None
-    assert state.query_engine is mock_engine
-    assert state.telemetry_url == mock_url
+    assert state.query_engine is None
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
+    assert state.telemetry_url == "http://sidecar"
 
 
 def test_mount_configuration_after_apply_reuses_mount_component_on_connect():
@@ -636,36 +629,27 @@ def test_mount_configuration_after_apply_reuses_mount_component_on_connect():
     ensure_open.assert_called_once()
 
 
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_telemetry_config_change_restarts_telemetry_runtime(mock_start):
-    mock_start.return_value = (MagicMock(), "http://localhost:8265", MagicMock())
+def test_telemetry_config_change_restarts_telemetry_runtime():
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(TelemetryConfig(retention_secs=1))
+        job.state(cached_path=None)
+        components = job._components
+        assert components is not None
+        mount_component = components.mounts
+        telemetry_component = components.telemetry
+        assert telemetry_component is not None
 
-    job = MockJobTrait().enable_telemetry(TelemetryConfig(batch_size=1))
-    job.state(cached_path=None)
-    components = job._components
-    assert components is not None
-    mount_component = components.mounts
-    telemetry_component = components.telemetry
-    assert telemetry_component is not None
-
-    job.enable_telemetry(TelemetryConfig(batch_size=2))
-    job.state(cached_path=None)
+        job.enable_telemetry(TelemetryConfig(retention_secs=2))
+        job.state(cached_path=None)
 
     assert job._components is components
     assert components.mounts is mount_component
     assert components.telemetry is telemetry_component
-    assert mock_start.call_count == 2
+    assert m.query_engine_client_cls.call_count == 2
 
 
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_cached_running_job_uses_current_component_configuration(mock_start):
-    mock_engine = MagicMock()
-    mock_url = "http://current-telemetry"
-    mock_start.return_value = (mock_engine, mock_url, MagicMock())
-
-    cached_job = MockJobTrait(host_names=["cached"]).enable_telemetry(
-        TelemetryConfig(batch_size=1)
-    )
+def test_cached_running_job_uses_current_component_configuration():
+    cached_job = MockJobTrait(host_names=["cached"]).enable_telemetry(TelemetryConfig())
     cached_job.apply()
 
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
@@ -674,42 +658,34 @@ def test_cached_running_job_uses_current_component_configuration(mock_start):
     try:
         cached_job.dump(cache_path)
 
-        new_job = MockJobTrait(host_names=["new"]).enable_telemetry(
-            TelemetryConfig(batch_size=2)
-        )
-        state = new_job.state(cached_path=cache_path)
+        with _patched_sidecar() as m:
+            new_job = MockJobTrait(host_names=["new"]).enable_telemetry(
+                TelemetryConfig(retention_secs=2)
+            )
+            state = new_job.state(cached_path=cache_path)
 
         assert not new_job.create_called
         assert state.cached.name == "cached"
-        assert state.query_engine is mock_engine
-        assert state.telemetry_url == mock_url
-        mock_start.assert_called_once_with(
-            batch_size=2,
-            retention_secs=600,
-            include_dashboard=False,
-            dashboard_port=8265,
-        )
+        assert state.query_engine is None
+        assert state.query_engine_client is m.query_engine_client_cls.return_value
+        m.telemetry_cls.assert_any_call(TelemetryConfig(retention_secs=2))
     finally:
         if os.path.exists(cache_path):
             os.unlink(cache_path)
 
 
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_unpickled_running_job_accepts_component_configuration(mock_start):
-    mock_engine = MagicMock()
-    mock_url = "http://localhost:8265"
-    mock_start.return_value = (mock_engine, mock_url, MagicMock())
-
+def test_unpickled_running_job_accepts_component_configuration():
     original_job = MockJobTrait()
     original_job.apply()
     loaded_job = job_loads(original_job.dumps())
 
-    loaded_job.enable_telemetry(TelemetryConfig())
-    state = loaded_job.state(cached_path=None)
+    with _patched_sidecar() as m:
+        loaded_job.enable_telemetry(TelemetryConfig())
+        state = loaded_job.state(cached_path=None)
 
-    mock_start.assert_called_once()
-    assert state.query_engine is mock_engine
-    assert state.telemetry_url == mock_url
+    assert state.query_engine is None
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
+    assert state.telemetry_url == "http://sidecar"
 
 
 def test_lifecycle_component_hooks_use_job_context():
@@ -820,52 +796,51 @@ def test_batch_job_runs_component_lifecycle_on_wrapped_job():
     state = batch.state(cached_path=None)
 
     assert state.raw.name == "raw"
-    assert all(seen_job is job for seen_job in probe.jobs)
+    assert all(seen_job is batch for seen_job in probe.jobs)
+    assert batch.apply_id is not None
     assert probe.events == ["before_connect", "connect", "state"]
 
 
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_lifecycle_component_runtime_reset_on_job_teardown(mock_start):
+def test_lifecycle_component_runtime_reset_on_job_teardown():
     """Job teardown resets component runtime while preserving config."""
-    mock_start.return_value = (MagicMock(), "http://localhost:8265", MagicMock())
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(TelemetryConfig())
+        job.state(cached_path=None)
+        components = job._components
+        apply_id = job.apply_id
 
-    job = MockJobTrait().enable_telemetry(TelemetryConfig())
-    job.state(cached_path=None)
-    components = job._components
-    apply_id = job.apply_id
+        job.state(cached_path=None)
+        assert job._components is components
+        assert m.query_engine_client_cls.call_count == 1
 
-    job.state(cached_path=None)
-    assert job._components is components
-    mock_start.assert_called_once()
-
-    with patch("monarch._src.job.job.stop_job_sidecar") as stop_sidecar:
-        job.kill()
+        with patch("monarch._src.job.job.stop_job_sidecar") as stop_sidecar:
+            job.kill()
 
     stop_sidecar.assert_called_once_with(apply_id)
     assert job._components is components
 
-    job.state(cached_path=None)
+    with _patched_sidecar() as m:
+        job.state(cached_path=None)
     assert job._components is components
-    assert mock_start.call_count == 2
+    assert m.query_engine_client_cls.call_count == 1
 
 
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_telemetry_dropped_on_pickle(mock_start):
-    """Test that query_engine is dropped during pickling and restored after."""
-    mock_start.return_value = (MagicMock(), "http://localhost:8265", MagicMock())
-
-    job = MockJobTrait().enable_telemetry(TelemetryConfig())
-    job.state(cached_path=None)
-    assert mock_start.call_count == 1
+def test_telemetry_dropped_on_pickle():
+    """Test that query client is dropped during pickling and restored after."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(TelemetryConfig())
+        job.state(cached_path=None)
+        assert m.query_engine_client_cls.call_count == 1
 
     # Serialize and deserialize — live handles should be dropped
     loaded_job = job_loads(job.dumps())
     assert loaded_job._components.telemetry is not None
 
     # Getting state again should re-initialize telemetry
-    state = loaded_job.state(cached_path=None)
-    assert mock_start.call_count == 2
-    assert state.query_engine is not None
+    with _patched_sidecar() as m:
+        state = loaded_job.state(cached_path=None)
+    assert m.query_engine_client_cls.call_count == 1
+    assert state.query_engine_client is not None
 
 
 def test_state_admin_url_none_without_mesh_admin():
@@ -943,39 +918,29 @@ def test_mesh_admin_receives_custom_addr(mock_spawn):
 
 
 @patch("monarch._src.job.job_components._spawn_admin")
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_mesh_admin_receives_telemetry_url(mock_start, mock_spawn):
+def test_mesh_admin_receives_telemetry_url(mock_spawn):
     """Test that admin links to telemetry when both are configured."""
-    mock_engine = MagicMock()
-    mock_scanner = MagicMock()
-    mock_start.return_value = (mock_engine, "http://localhost:8265", mock_scanner)
-
     mock_future = MagicMock()
     mock_admin_ref = MagicMock()
     mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
     mock_spawn.return_value = mock_future
 
-    job = (
-        MockJobTrait()
-        .enable_telemetry(TelemetryConfig())
-        .enable_admin(MeshAdminConfig())
-    )
-    state = job.state(cached_path=None)
+    with _patched_sidecar():
+        job = (
+            MockJobTrait()
+            .enable_telemetry(TelemetryConfig())
+            .enable_admin(MeshAdminConfig())
+        )
+        state = job.state(cached_path=None)
 
     _, kwargs = mock_spawn.call_args
-    assert kwargs.get("telemetry_url") == "http://localhost:8265"
-    assert state.telemetry_url == "http://localhost:8265"
+    assert kwargs.get("telemetry_url") == "http://sidecar"
+    assert state.telemetry_url == "http://sidecar"
     assert state.admin_url == "http://localhost:1729"
 
 
 @patch("monarch._src.job.job_components._spawn_admin")
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_mesh_admin_restarts_when_telemetry_config_changes(mock_start, mock_spawn):
-    mock_start.side_effect = [
-        (MagicMock(), "http://telemetry-one", MagicMock()),
-        (MagicMock(), "http://telemetry-two", MagicMock()),
-    ]
-
+def test_mesh_admin_restarts_when_telemetry_config_changes(mock_spawn):
     mock_future = MagicMock()
     mock_admin_ref = MagicMock()
     mock_future.get.side_effect = [
@@ -983,22 +948,39 @@ def test_mesh_admin_restarts_when_telemetry_config_changes(mock_start, mock_spaw
         ("http://admin-two", mock_admin_ref),
     ]
     mock_spawn.return_value = mock_future
+    telemetry_one = {
+        "telemetry_url": "http://telemetry-one",
+        "dashboard_url": "http://dashboard-one",
+        "socket_path": "/tmp/telemetry-one.sock",
+    }
+    telemetry_two = {
+        "telemetry_url": "http://telemetry-two",
+        "dashboard_url": "http://dashboard-two",
+        "socket_path": "/tmp/telemetry-two.sock",
+    }
 
-    job = (
-        MockJobTrait()
-        .enable_telemetry(TelemetryConfig(batch_size=1))
-        .enable_admin(MeshAdminConfig())
-    )
-    state = job.state(cached_path=None)
-    assert state.telemetry_url == "http://telemetry-one"
-    assert state.admin_url == "http://admin-one"
+    with _patched_sidecar(
+        ensure_open_side_effect=[
+            telemetry_one,
+            telemetry_one,
+            telemetry_two,
+            telemetry_two,
+        ]
+    ):
+        job = (
+            MockJobTrait()
+            .enable_telemetry(TelemetryConfig(retention_secs=1))
+            .enable_admin(MeshAdminConfig())
+        )
+        state = job.state(cached_path=None)
+        assert state.telemetry_url == "http://telemetry-one"
+        assert state.admin_url == "http://admin-one"
 
-    job.enable_telemetry(TelemetryConfig(batch_size=2))
-    state = job.state(cached_path=None)
+        job.enable_telemetry(TelemetryConfig(retention_secs=2))
+        state = job.state(cached_path=None)
 
     assert state.telemetry_url == "http://telemetry-two"
     assert state.admin_url == "http://admin-two"
-    assert mock_start.call_count == 2
     assert mock_spawn.call_count == 2
     assert [call.kwargs["telemetry_url"] for call in mock_spawn.call_args_list] == [
         "http://telemetry-one",
@@ -1007,36 +989,33 @@ def test_mesh_admin_restarts_when_telemetry_config_changes(mock_start, mock_spaw
 
 
 @patch(
-    "monarch._rust_bindings.monarch_extension.snapshot_integration._start_periodic_snapshots"
+    "monarch._rust_bindings.monarch_extension.snapshot_integration._start_periodic_snapshots_http"
 )
 @patch("monarch.actor.context")
 @patch("monarch._src.job.job_components._spawn_admin")
-@patch("monarch._src.job.job_components.start_telemetry")
 def test_snapshot_component_starts_once_after_telemetry_and_admin(
-    mock_start,
     mock_spawn,
     mock_context,
     mock_start_snapshots,
 ):
-    mock_scanner = MagicMock()
     mock_admin_ref = MagicMock()
     mock_instance = MagicMock()
-    mock_start.return_value = (MagicMock(), "http://localhost:8265", mock_scanner)
     mock_future = MagicMock()
     mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
     mock_spawn.return_value = mock_future
     mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
 
-    job = (
-        MockJobTrait()
-        .enable_telemetry(TelemetryConfig(snapshot_interval_secs=5.0))
-        .enable_admin(MeshAdminConfig())
-    )
-    job.state(cached_path=None)
-    job.state(cached_path=None)
+    with _patched_sidecar():
+        job = (
+            MockJobTrait()
+            .enable_telemetry(TelemetryConfig(snapshot_interval_secs=5.0))
+            .enable_admin(MeshAdminConfig())
+        )
+        job.state(cached_path=None)
+        job.state(cached_path=None)
 
     mock_start_snapshots.assert_called_once_with(
-        scanner=mock_scanner,
+        base_url="http://sidecar",
         admin_ref=mock_admin_ref,
         instance=mock_instance,
         interval_secs=5.0,
@@ -1044,33 +1023,30 @@ def test_snapshot_component_starts_once_after_telemetry_and_admin(
 
 
 @patch("monarch._src.job.job_components._spawn_admin")
-@patch("monarch._src.job.job_components.start_telemetry")
-def test_batch_job_shares_component_runtime_with_wrapped_job(mock_start, mock_spawn):
-    mock_engine = MagicMock()
-    mock_scanner = MagicMock()
-    mock_start.return_value = (mock_engine, "http://localhost:8265", mock_scanner)
-
+def test_batch_job_shares_component_runtime_with_wrapped_job(mock_spawn):
     mock_future = MagicMock()
     mock_admin_ref = MagicMock()
     mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
     mock_spawn.return_value = mock_future
 
-    job = (
-        MockJobTrait(host_names=["hosts"])
-        .enable_telemetry(TelemetryConfig())
-        .enable_admin(MeshAdminConfig())
-    )
-    batch = BatchJob(job)
-    batch_state = batch.state(cached_path=None)
-    job_state = job.state(cached_path=None)
+    with _patched_sidecar() as m:
+        job = (
+            MockJobTrait(host_names=["hosts"])
+            .enable_telemetry(TelemetryConfig())
+            .enable_admin(MeshAdminConfig())
+        )
+        batch = BatchJob(job)
+        batch_state = batch.state(cached_path=None)
+        job_state = job.state(cached_path=None)
 
-    assert batch_state.query_engine is mock_engine
-    assert batch_state.telemetry_url == "http://localhost:8265"
+    assert batch_state.query_engine is None
+    assert batch_state.query_engine_client is m.query_engine_client_cls.return_value
+    assert batch_state.telemetry_url == "http://sidecar"
     assert batch_state.admin_url == "http://localhost:1729"
-    assert job_state.query_engine is mock_engine
-    assert job_state.telemetry_url == "http://localhost:8265"
+    assert job_state.query_engine is None
+    assert job_state.query_engine_client is m.query_engine_client_cls.return_value
+    assert job_state.telemetry_url == "http://sidecar"
     assert job_state.admin_url == "http://localhost:1729"
-    mock_start.assert_called_once()
     mock_spawn.assert_called_once()
 
 
@@ -1082,9 +1058,7 @@ def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
             "monarch._src.job.job_components.install_sidecar_socket_sink"
         ) as install_sink,
         patch("monarch._src.job.job_components.QueryEngineClient") as qec_cls,
-        patch("monarch._src.job.job_components.start_telemetry") as start_legacy,
     ):
-        start_legacy.return_value = (MagicMock(), "http://legacy", MagicMock())
         ensure_open = telemetry_cls.return_value.ensure_open
         if ensure_open_side_effect is not None:
             ensure_open.side_effect = ensure_open_side_effect
@@ -1098,14 +1072,14 @@ def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
             ensure_open=ensure_open,
             install_sink=install_sink,
             query_engine_client_cls=qec_cls,
-            start_legacy=start_legacy,
+            telemetry_cls=telemetry_cls,
         )
 
 
 def test_mesh_admin_receives_sidecar_telemetry_url():
     """Admin links to sidecar telemetry when the sidecar path is configured."""
     with (
-        _patched_sidecar() as m,
+        _patched_sidecar(),
         patch("monarch._src.job.job_components._spawn_admin") as mock_spawn,
     ):
         mock_future = MagicMock()
@@ -1115,29 +1089,23 @@ def test_mesh_admin_receives_sidecar_telemetry_url():
 
         job = (
             MockJobTrait(host_names=["hosts"])
-            .enable_telemetry(TelemetryConfig(use_sidecar=True))
+            .enable_telemetry(TelemetryConfig())
             .enable_admin(MeshAdminConfig())
         )
         state = job.state(cached_path=None)
 
-    m.start_legacy.assert_not_called()
     _, kwargs = mock_spawn.call_args
     assert kwargs.get("telemetry_url") == "http://sidecar"
     assert state.telemetry_url == "http://sidecar"
     assert state.admin_url == "http://localhost:1729"
 
 
-def test_sidecar_replaces_legacy_when_opted_in():
-    """use_sidecar=True exposes the sidecar query client and skips the legacy
-    in-process collector (the two are mutually exclusive)."""
+def test_telemetry_uses_sidecar():
+    """Telemetry exposes the sidecar query client."""
     with _patched_sidecar() as m:
-        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
-            TelemetryConfig(use_sidecar=True)
-        )
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)
 
-    # Legacy path skipped; sidecar client exposed instead.
-    m.start_legacy.assert_not_called()
     assert state.query_engine is None
     assert state.query_engine_client is m.query_engine_client_cls.return_value
     assert state.telemetry_url == "http://sidecar"
@@ -1150,9 +1118,7 @@ def test_sidecar_bootstrap_then_fanout_carry_host_meshes():
     """state() bootstraps the sidecar with empty host_meshes, then fans out
     workers with the materialized host meshes."""
     with _patched_sidecar() as m:
-        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
-            TelemetryConfig(use_sidecar=True)
-        )
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         job.state(cached_path=None)
 
     assert m.ensure_open.call_count == 2
@@ -1167,9 +1133,7 @@ def test_sidecar_bootstrap_then_fanout_carry_host_meshes():
 def test_local_job_sidecar_skips_worker_collector_actors():
     """Local sidecar telemetry keeps fan-out procs without collector actors."""
     with _patched_sidecar() as m:
-        job = LocalJob(hosts=["hosts"]).enable_telemetry(
-            TelemetryConfig(use_sidecar=True)
-        )
+        job = LocalJob(hosts=["hosts"]).enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)
 
     assert m.ensure_open.call_count == 2
@@ -1194,9 +1158,7 @@ def test_process_job_sidecar_skips_worker_collector_actors():
             return_value=JobState({"hosts": mock_host_mesh}),
         ),
     ):
-        job = ProcessJob({"hosts": 1}).enable_telemetry(
-            TelemetryConfig(use_sidecar=True)
-        )
+        job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)
 
     assert m.ensure_open.call_count == 2
@@ -1214,9 +1176,7 @@ def test_sidecar_worker_fanout_uses_configured_host_meshes():
     mesh configuration that state() returns to user code."""
     python_exe = "/mnt/app/.venv/bin/python"
     with _patched_sidecar() as m:
-        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
-            TelemetryConfig(use_sidecar=True)
-        )
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         job._components.mounts._default_python_exe = python_exe
         state = job.state(cached_path=None)
 
@@ -1228,13 +1188,11 @@ def test_sidecar_worker_fanout_uses_configured_host_meshes():
 def test_sidecar_bootstrap_failure_is_isolated():
     """A sidecar bootstrap failure disables telemetry and never fails state()."""
     with _patched_sidecar(ensure_open_side_effect=RuntimeError("boom")) as m:
-        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
-            TelemetryConfig(use_sidecar=True)
-        )
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)  # must not raise
 
     assert state.query_engine_client is None
-    assert state.query_engine is None  # legacy stays skipped under use_sidecar
+    assert state.query_engine is None
     m.query_engine_client_cls.assert_not_called()
 
 
@@ -1249,35 +1207,29 @@ def test_sidecar_worker_fanout_failure_is_isolated():
     with _patched_sidecar(
         ensure_open_side_effect=[good, RuntimeError("fanout boom")]
     ) as m:
-        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
-            TelemetryConfig(use_sidecar=True)
-        )
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)  # must not raise
 
     assert m.ensure_open.call_count == 2
     assert state.query_engine_client is m.query_engine_client_cls.return_value
 
 
-def test_sidecar_not_bootstrapped_without_opt_in():
-    """Default (use_sidecar=False) never touches the sidecar; legacy runs."""
+def test_telemetry_bootstraps_sidecar_by_default():
+    """Telemetry always uses the sidecar."""
     with _patched_sidecar() as m:
         job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)
 
-    m.ensure_open.assert_not_called()
-    m.query_engine_client_cls.assert_not_called()
-    assert state.query_engine_client is None
-    m.start_legacy.assert_called_once()  # legacy collector ran instead
-    assert state.query_engine is not None
+    assert m.ensure_open.call_count == 2
+    assert state.query_engine is None
+    assert state.query_engine_client is m.query_engine_client_cls.return_value
 
 
 def test_sidecar_query_client_dropped_on_pickle():
     """The sidecar query client is dropped on pickle and re-bootstrapped on the
     next state() (mirrors the legacy query_engine behavior)."""
     with _patched_sidecar() as m:
-        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
-            TelemetryConfig(use_sidecar=True)
-        )
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)
         assert state.query_engine_client is m.query_engine_client_cls.return_value
 


### PR DESCRIPTION
Summary: Remove the transitional non-sidecar job telemetry path by deleting `TelemetryConfig.use_sidecar`, `TelemetryConfig.batch_size`, and the in-process `TelemetryComponent`. `enable_telemetry()` now always configures `SidecarTelemetryComponent`, snapshots publish through the sidecar HTTP API, examples and tests no longer pass `use_sidecar=True`, and docs point callers at `state.query_engine_client` instead of `state.query_engine`. Autodeps removes the now-unused test dependency on `monarch.distributed_telemetry:actor`; the file-level BUCKLINT ignores preserve existing scheduling and network behavior for legacy targets in that BUCK file.

Differential Revision: D111198239


