### PR TITLE
make TLS setup fail-closed; honor the addr scheme

### DIFF
--- a/hyperactor_mesh_admin_tui/bin/admin_tui.rs
+++ b/hyperactor_mesh_admin_tui/bin/admin_tui.rs
@@ -66,6 +66,10 @@ struct Args {
     /// Run diagnostics and print a JSON report to stdout, then exit.
     #[arg(long)]
     diagnose: bool,
+
+    /// Disable TLS and use plain HTTP (for a server with no cert, e.g. public infra).
+    #[arg(long, conflicts_with_all = ["tls_ca", "tls_cert", "tls_key"])]
+    plaintext: bool,
 }
 
 #[cfg(fbcode_build)]
@@ -102,6 +106,7 @@ async fn run() -> io::Result<()> {
         tls_cert: args.tls_cert,
         tls_key: args.tls_key,
         diagnose: args.diagnose,
+        plaintext: args.plaintext,
     };
 
     hyperactor_mesh_admin_tui_lib::run(config).await

--- a/hyperactor_mesh_admin_tui/src/client.rs
+++ b/hyperactor_mesh_admin_tui/src/client.rs
@@ -18,29 +18,27 @@
 //! concrete URL: `https://host:port`, or `http://host:port` for an
 //! explicit `http` scheme.
 //!
-//! # Address handling
+//! # Transport selection (highest priority first)
 //!
-//! - `--addr` may be `host:port` (no scheme) or an explicit
-//!   `http://...` / `https://...`.
-//! - An explicit `https://` uses TLS; an explicit `http://` is a hint
-//!   that auto-detected TLS material can still upgrade. `--plaintext`
-//!   forces plain HTTP unconditionally.
+//! 0. `--plaintext`: plain HTTP, ignoring any TLS material.
+//! 1. Explicit `http://` scheme: plain HTTP. Combining it with
+//!    `--tls-ca` / `--tls-cert` / `--tls-key` is a hard error.
+//! 2. Explicit `--tls-ca` (with optional `--tls-cert` + `--tls-key`
+//!    for mutual TLS): an unreadable or invalid CA, a cert/key that
+//!    cannot be read, or only one of cert/key, is a hard error.
+//!    `--tls-cert`/`--tls-key` without `--tls-ca` is also an error,
+//!    since they are unusable without a CA.
+//! 3. Auto-detection via [`hyperactor::channel::try_tls_pem_bundle`]
+//!    (OSS config first, then Meta well-known paths).
+//! 4. If no CA is found and TLS is expected (an `https://` scheme or,
+//!    at Meta, the default), that is a hard error; otherwise (OSS with
+//!    no certs) fall back to plain HTTP.
 //!
-//! # TLS configuration (highest priority first)
-//!
-//! 0. `--plaintext`: disable TLS entirely and use plain HTTP.
-//! 1. Explicit CLI paths: `--tls-ca` (required to enable TLS), with
-//!    optional `--tls-cert` + `--tls-key` for mutual TLS.
-//! 2. Auto-detection via [`hyperactor::channel::try_tls_pem_bundle`],
-//!    which probes configured paths (OSS) and Meta well-known
-//!    locations.
-//! 3. Fallback to plain HTTP when no usable CA is found.
-//!
-//! **Note:** At Meta (`fbcode_build`), the mesh admin server requires
-//! mutual TLS. If the client cannot load a CA certificate or fails to
-//! parse a client identity, the connection will be rejected at the TLS
-//! handshake. In OSS, the server falls back to plain HTTP when no
-//! certs are available, so the client's HTTP fallback still works.
+//! Transport is **fail-closed**: when TLS is expected but cannot be
+//! configured, [`build_client`] returns an error rather than silently
+//! downgrading to plain HTTP.
+
+use std::io;
 
 use crate::TuiConfig;
 
@@ -87,131 +85,156 @@ fn add_tls(
 /// supplied via CLI (`--tls-ca`, and optionally `--tls-cert` +
 /// `--tls-key`).
 ///
-/// Reads `ca_path` and installs it as the root trust anchor. If the
-/// CA file cannot be read, returns `(builder, false)` with no
-/// changes.
-///
-/// If `cert_path`/`key_path` are provided, attempts to read them and
-/// pass the bytes through to [`add_tls`] to configure an mTLS
-/// identity; failures to read these optional files simply omit the
-/// identity (the CA may still be applied).
-///
-/// Returns `(updated_builder, ca_installed)`.
+/// Fail-closed: an unreadable or invalid CA is an error, as is a
+/// `--tls-cert`/`--tls-key` that cannot be read or that is supplied
+/// without its counterpart. (A cert/key that reads but fails to parse
+/// is handled by [`add_tls`], which keeps CA-only TLS; that still fails
+/// the handshake against an mTLS server rather than downgrading to
+/// plain HTTP.)
 fn add_tls_from_paths(
     builder: reqwest::ClientBuilder,
     ca_path: &str,
     cert_path: Option<&str>,
     key_path: Option<&str>,
-) -> (reqwest::ClientBuilder, bool) {
-    let ca_bytes = match std::fs::read(ca_path) {
-        Ok(b) => b,
-        Err(e) => {
-            eprintln!("TLS: cannot read CA file {}: {}", ca_path, e);
-            return (builder, false);
+) -> io::Result<reqwest::ClientBuilder> {
+    let ca_bytes = std::fs::read(ca_path)
+        .map_err(|e| io::Error::other(format!("cannot read TLS CA file {ca_path}: {e}")))?;
+
+    let (cert_bytes, key_bytes) = match (cert_path, key_path) {
+        (Some(cert), Some(key)) => {
+            let cert_bytes = std::fs::read(cert)
+                .map_err(|e| io::Error::other(format!("cannot read TLS cert file {cert}: {e}")))?;
+            let key_bytes = std::fs::read(key)
+                .map_err(|e| io::Error::other(format!("cannot read TLS key file {key}: {e}")))?;
+            (Some(cert_bytes), Some(key_bytes))
+        }
+        (None, None) => (None, None),
+        _ => {
+            return Err(io::Error::other(
+                "--tls-cert and --tls-key must be provided together",
+            ));
         }
     };
-    let cert_bytes = cert_path.and_then(|p| std::fs::read(p).ok());
-    let key_bytes = key_path.and_then(|p| std::fs::read(p).ok());
-    add_tls(builder, &ca_bytes, cert_bytes, key_bytes)
+
+    let (builder, ca_installed) = add_tls(builder, &ca_bytes, cert_bytes, key_bytes);
+    if !ca_installed {
+        return Err(io::Error::other(format!(
+            "TLS CA file {ca_path} is not a valid PEM certificate"
+        )));
+    }
+    Ok(builder)
 }
 
-/// Configure TLS on a `reqwest::ClientBuilder` using a hyperactor
-/// [`PemBundle`](hyperactor::config::PemBundle).
+/// Configure TLS on a `reqwest::ClientBuilder` using an auto-detected
+/// hyperactor [`PemBundle`](hyperactor::config::PemBundle).
 ///
-/// The bundle provides a CA (`bundle.ca`) and optionally a client
-/// certificate and key (`bundle.cert`, `bundle.key`). This reads the
-/// CA via [`read_pem`] and installs it as a root trust anchor. If the
-/// CA is missing, unreadable, or empty, returns `(builder, false)`
-/// with no changes.
-///
-/// If both client cert and key are readable, they are combined and
-/// passed to [`add_tls`] to configure an mTLS identity; otherwise the
-/// client identity is omitted (CA-only TLS verification still
-/// applies).
-///
-/// Returns `(updated_builder, ca_installed)`.
+/// Fail-closed: a bundle whose CA is missing or is not a valid PEM is
+/// an error. A client cert/key are applied when both are readable.
 fn add_tls_from_bundle(
     builder: reqwest::ClientBuilder,
     bundle: &hyperactor::config::PemBundle,
-) -> (reqwest::ClientBuilder, bool) {
-    let ca_bytes = match read_pem(&bundle.ca) {
-        Some(b) => b,
-        None => {
-            eprintln!("TLS: CA not readable from PemBundle");
-            return (builder, false);
-        }
-    };
-    add_tls(
+) -> io::Result<reqwest::ClientBuilder> {
+    let ca_bytes = read_pem(&bundle.ca)
+        .ok_or_else(|| io::Error::other("auto-detected TLS CA is missing or unreadable"))?;
+
+    let (builder, ca_installed) = add_tls(
         builder,
         &ca_bytes,
         read_pem(&bundle.cert),
         read_pem(&bundle.key),
-    )
+    );
+    if !ca_installed {
+        return Err(io::Error::other(
+            "auto-detected TLS CA is not a valid PEM certificate",
+        ));
+    }
+    Ok(builder)
 }
 
 /// Build a `reqwest` client and a base URL from CLI arguments.
 ///
-/// `args.addr` may be either a bare `host:port` or an explicit URL
-/// (`http://host:port` / `https://host:port`). If an explicit scheme
-/// is provided, that scheme is honored.
-///
-/// TLS configuration is applied in priority order:
-/// 0. If `config.plaintext` is set, disable TLS and use plain HTTP.
-/// 1. If `--tls-ca` is provided, attempt to load the CA (and
-///    optionally `--tls-cert` + `--tls-key` for a client identity)
-///    from those paths.
-/// 2. Otherwise, if no `--tls-ca` was given, try auto-detection via
-///    [`hyperactor::channel::try_tls_pem_bundle`] (OSS config first,
-///    then Meta well-known paths). This runs even when the user
-///    provides an explicit `https://` scheme, so the mTLS client
-///    identity is picked up from well-known paths.
-/// 3. If no CA can be loaded, fall back to plain HTTP.
-///
 /// Returns `(base_url, client)` where `base_url` always includes the
-/// scheme selected (`http://...` or `https://...`).
-pub(crate) fn build_client(config: &TuiConfig) -> (String, reqwest::Client) {
+/// selected scheme (`http://...` or `https://...`). See the module
+/// docs for the transport-selection order.
+///
+/// Transport is **fail-closed**: when TLS is expected (an `https://`
+/// scheme, an explicit `--tls-ca`, or the Meta default) but no usable
+/// CA can be configured, this returns an error instead of silently
+/// using plain HTTP.
+pub(crate) fn build_client(config: &TuiConfig) -> io::Result<(String, reqwest::Client)> {
     let (explicit_scheme, host) = parse_addr(&config.addr);
+    let has_tls_paths =
+        config.tls_ca.is_some() || config.tls_cert.is_some() || config.tls_key.is_some();
 
     // TP-7: no client-level timeout. All timeout enforcement is
     // per-operation via tokio::time::timeout at the call boundary.
-    let mut builder = reqwest::Client::builder();
-    let mut use_tls = !config.plaintext && explicit_scheme == Some("https");
 
-    // 1. Explicit CLI cert paths (skipped when --plaintext).
-    if !config.plaintext
-        && let Some(ca_path) = &config.tls_ca
-    {
-        let (b, ok) = add_tls_from_paths(
+    // --plaintext is the explicit override: plain HTTP, ignore any TLS material.
+    if config.plaintext {
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(io::Error::other)?;
+        return Ok((format!("http://{host}"), client));
+    }
+
+    // An explicit http:// scheme also selects plain HTTP; combining it with TLS
+    // paths is contradictory.
+    if explicit_scheme == Some("http") {
+        if has_tls_paths {
+            return Err(io::Error::other(
+                "http:// scheme requested but TLS certificate paths were also given; use https:// or drop --tls-*",
+            ));
+        }
+        let client = reqwest::Client::builder()
+            .build()
+            .map_err(io::Error::other)?;
+        return Ok((format!("http://{host}"), client));
+    }
+
+    // A client cert/key is only consumed alongside a --tls-ca; without one the
+    // paths would be silently ignored, so reject the combination outright.
+    if config.tls_ca.is_none() && (config.tls_cert.is_some() || config.tls_key.is_some()) {
+        return Err(io::Error::other("--tls-cert/--tls-key require --tls-ca"));
+    }
+
+    // TLS is expected for an https:// scheme, an explicit CA, or (at Meta) by
+    // default. In OSS with no CA, plain HTTP is a legitimate fallback.
+    let tls_expected =
+        explicit_scheme == Some("https") || config.tls_ca.is_some() || cfg!(fbcode_build);
+
+    let mut builder = reqwest::Client::builder();
+    let use_tls = if let Some(ca_path) = &config.tls_ca {
+        builder = add_tls_from_paths(
             builder,
             ca_path,
             config.tls_cert.as_deref(),
             config.tls_key.as_deref(),
-        );
-        builder = b;
-        use_tls = use_tls || ok;
-    }
+        )?;
+        true
+    } else if let Some(bundle) = hyperactor::channel::try_tls_pem_bundle() {
+        builder = add_tls_from_bundle(builder, &bundle)?;
+        true
+    } else {
+        false
+    };
 
-    // 2. Auto-detect (when no CLI certs were provided).
-    // This runs even with an explicit https:// scheme, so the client
-    // picks up the mTLS identity from Meta well-known paths.
-    if !config.plaintext
-        && config.tls_ca.is_none()
-        && let Some(bundle) = hyperactor::channel::try_tls_pem_bundle()
-    {
-        let (b, ok) = add_tls_from_bundle(builder, &bundle);
-        builder = b;
-        use_tls = use_tls || ok;
+    if !use_tls && tls_expected {
+        return Err(io::Error::other(
+            "TLS is required (an https:// scheme or the Meta default) but no CA certificate was found; pass --tls-ca or use --plaintext",
+        ));
     }
 
     let scheme = if use_tls { "https" } else { "http" };
-    let base_url = format!("{}://{}", scheme, host);
-    let client = builder.build().unwrap_or_else(|_| reqwest::Client::new());
-
-    (base_url, client)
+    let client = builder.build().map_err(io::Error::other)?;
+    Ok((format!("{scheme}://{host}"), client))
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+    use std::sync::atomic::AtomicU64;
+    use std::sync::atomic::Ordering;
+
     use super::*;
 
     /// A valid self-signed CA PEM, copied from hyperactor's test suite.
@@ -238,15 +261,52 @@ sgomYHxvxrU2hWx+7k53CRdjfaIvT9Ie44z9sSdsU/+blw2S8f/ZTmuECoIAAXYO
 -----END CERTIFICATE-----
 ";
 
+    /// A temp PEM file removed on drop, so a panicking assertion never
+    /// leaks it (RAII cleanup, no `tempfile` dep).
+    struct TempPem(PathBuf);
+
+    impl TempPem {
+        fn new(contents: &str) -> Self {
+            static N: AtomicU64 = AtomicU64::new(0);
+            let path = std::env::temp_dir().join(format!(
+                "tui_admin_test_{}_{}.pem",
+                std::process::id(),
+                N.fetch_add(1, Ordering::Relaxed)
+            ));
+            std::fs::write(&path, contents).expect("write temp file");
+            Self(path)
+        }
+
+        fn path(&self) -> String {
+            self.0.to_string_lossy().into_owned()
+        }
+    }
+
+    impl Drop for TempPem {
+        fn drop(&mut self) {
+            std::fs::remove_file(&self.0).ok();
+        }
+    }
+
     fn config(addr: &str, plaintext: bool, tls_ca: Option<String>) -> TuiConfig {
+        config_full(addr, plaintext, tls_ca, None, None)
+    }
+
+    fn config_full(
+        addr: &str,
+        plaintext: bool,
+        tls_ca: Option<String>,
+        tls_cert: Option<String>,
+        tls_key: Option<String>,
+    ) -> TuiConfig {
         TuiConfig {
             addr: addr.to_string(),
             refresh_ms: 2000,
             theme: crate::ThemeName::Nord,
             lang: crate::theme::LangName::En,
             tls_ca,
-            tls_cert: None,
-            tls_key: None,
+            tls_cert,
+            tls_key,
             diagnose: false,
             plaintext,
         }
@@ -255,7 +315,8 @@ sgomYHxvxrU2hWx+7k53CRdjfaIvT9Ie44z9sSdsU/+blw2S8f/ZTmuECoIAAXYO
     #[test]
     fn plaintext_forces_http_over_https_scheme() {
         // upholds: TUI-T1 -- --plaintext is the top-priority transport override.
-        let (base_url, _) = build_client(&config("https://host:1729", true, None));
+        let (base_url, _) =
+            build_client(&config("https://host:1729", true, None)).expect("plaintext");
         assert!(
             base_url.starts_with("http://"),
             "plaintext must force plain HTTP even for an https:// addr, got {base_url}"
@@ -263,37 +324,97 @@ sgomYHxvxrU2hWx+7k53CRdjfaIvT9Ie44z9sSdsU/+blw2S8f/ZTmuECoIAAXYO
     }
 
     #[test]
-    fn without_plaintext_https_scheme_stays_https() {
-        // negative: default posture is unchanged when the flag is off.
-        let (base_url, _) = build_client(&config("https://host:1729", false, None));
+    fn plaintext_ignores_a_valid_tls_ca() {
+        // --plaintext wins over explicit TLS material (the CLI also rejects the
+        // combination via conflicts_with; this covers direct callers).
+        let ca = TempPem::new(TEST_CA_CERT);
+        let (base_url, _) =
+            build_client(&config("host:1729", true, Some(ca.path()))).expect("plaintext");
         assert!(
-            base_url.starts_with("https://"),
-            "https:// must stay TLS when --plaintext is unset, got {base_url}"
+            base_url.starts_with("http://"),
+            "plaintext must win over a --tls-ca, got {base_url}"
         );
     }
 
     #[test]
-    fn plaintext_beats_a_valid_explicit_ca() {
-        // A genuinely loadable CA sets use_tls without the guard, so a bogus
-        // path would pass vacuously; the CA must actually parse to prove
-        // --plaintext wins.
-        let path =
-            std::env::temp_dir().join(format!("tui_admin_test_ca_{}.pem", std::process::id()));
-        std::fs::write(&path, TEST_CA_CERT).expect("write temp CA");
-        let ca = path.to_string_lossy().into_owned();
-
-        let (tls_url, _) = build_client(&config("host:1729", false, Some(ca.clone())));
+    fn https_with_valid_ca_uses_tls() {
+        // A genuinely loadable CA enables TLS; a bogus path would fall back to
+        // http, so the CA must actually parse to prove the TLS path.
+        let ca = TempPem::new(TEST_CA_CERT);
+        let (base_url, _) =
+            build_client(&config("https://host:1729", false, Some(ca.path()))).expect("tls");
         assert!(
-            tls_url.starts_with("https://"),
-            "a valid --tls-ca should enable TLS, got {tls_url}"
+            base_url.starts_with("https://"),
+            "a valid --tls-ca on an https:// addr must use TLS, got {base_url}"
         );
+    }
 
-        let (plain_url, _) = build_client(&config("host:1729", true, Some(ca)));
+    #[test]
+    fn http_scheme_forces_plain_http() {
+        // scheme is authoritative: explicit http:// is plain HTTP, no auto-upgrade.
+        let (base_url, _) = build_client(&config("http://host:1729", false, None)).expect("http");
         assert!(
-            plain_url.starts_with("http://"),
-            "plaintext must win over a valid --tls-ca, got {plain_url}"
+            base_url.starts_with("http://"),
+            "http:// must stay plain HTTP, got {base_url}"
         );
+    }
 
-        std::fs::remove_file(&path).ok();
+    #[test]
+    fn http_scheme_with_tls_ca_is_error() {
+        let result = build_client(&config(
+            "http://host:1729",
+            false,
+            Some("/x/ca.pem".to_string()),
+        ));
+        assert!(
+            result.is_err(),
+            "http:// combined with --tls-ca must be a hard error"
+        );
+    }
+
+    #[test]
+    fn unreadable_tls_ca_is_error() {
+        let result = build_client(&config(
+            "host:1729",
+            false,
+            Some("/nonexistent/tui-admin-test/ca.pem".to_string()),
+        ));
+        assert!(
+            result.is_err(),
+            "an unreadable --tls-ca must be a hard error, not a plaintext downgrade"
+        );
+    }
+
+    #[test]
+    fn tls_cert_without_key_is_error() {
+        let ca = TempPem::new(TEST_CA_CERT);
+        let result = build_client(&config_full(
+            "host:1729",
+            false,
+            Some(ca.path()),
+            Some("/some/cert.pem".to_string()),
+            None,
+        ));
+        assert!(
+            result.is_err(),
+            "--tls-cert without --tls-key must be a hard error"
+        );
+    }
+
+    #[test]
+    fn tls_cert_and_key_without_ca_is_error() {
+        // cert/key are unusable without a CA; the combination must be rejected
+        // rather than silently ignored (which would downgrade to plain HTTP).
+        let result = build_client(&config_full(
+            "host:1729",
+            false,
+            None,
+            Some("/some/cert.pem".to_string()),
+            Some("/some/key.pem".to_string()),
+        ));
+        assert!(
+            result.is_err(),
+            "--tls-cert/--tls-key without --tls-ca must be a hard error"
+        );
     }
 }

--- a/hyperactor_mesh_admin_tui/src/client.rs
+++ b/hyperactor_mesh_admin_tui/src/client.rs
@@ -14,17 +14,21 @@
 //!
 //! Admin handle resolution (`mast_conda:///` and bare `host:port`) is
 //! performed in the binary via `AdminHandle::parse` before calling
-//! this library. By the time [`build_client`] is called, `addr` is
-//! always a concrete `https://host:port` URL.
+//! this library. By the time [`build_client`] is called, `addr` is a
+//! concrete URL: `https://host:port`, or `http://host:port` for an
+//! explicit `http` scheme.
 //!
 //! # Address handling
 //!
 //! - `--addr` may be `host:port` (no scheme) or an explicit
 //!   `http://...` / `https://...`.
-//! - If a scheme is provided, it is treated as authoritative.
+//! - An explicit `https://` uses TLS; an explicit `http://` is a hint
+//!   that auto-detected TLS material can still upgrade. `--plaintext`
+//!   forces plain HTTP unconditionally.
 //!
 //! # TLS configuration (highest priority first)
 //!
+//! 0. `--plaintext`: disable TLS entirely and use plain HTTP.
 //! 1. Explicit CLI paths: `--tls-ca` (required to enable TLS), with
 //!    optional `--tls-cert` + `--tls-key` for mutual TLS.
 //! 2. Auto-detection via [`hyperactor::channel::try_tls_pem_bundle`],
@@ -152,6 +156,7 @@ fn add_tls_from_bundle(
 /// is provided, that scheme is honored.
 ///
 /// TLS configuration is applied in priority order:
+/// 0. If `config.plaintext` is set, disable TLS and use plain HTTP.
 /// 1. If `--tls-ca` is provided, attempt to load the CA (and
 ///    optionally `--tls-cert` + `--tls-key` for a client identity)
 ///    from those paths.
@@ -170,10 +175,12 @@ pub(crate) fn build_client(config: &TuiConfig) -> (String, reqwest::Client) {
     // TP-7: no client-level timeout. All timeout enforcement is
     // per-operation via tokio::time::timeout at the call boundary.
     let mut builder = reqwest::Client::builder();
-    let mut use_tls = explicit_scheme == Some("https");
+    let mut use_tls = !config.plaintext && explicit_scheme == Some("https");
 
-    // 1. Explicit CLI cert paths.
-    if let Some(ca_path) = &config.tls_ca {
+    // 1. Explicit CLI cert paths (skipped when --plaintext).
+    if !config.plaintext
+        && let Some(ca_path) = &config.tls_ca
+    {
         let (b, ok) = add_tls_from_paths(
             builder,
             ca_path,
@@ -187,7 +194,8 @@ pub(crate) fn build_client(config: &TuiConfig) -> (String, reqwest::Client) {
     // 2. Auto-detect (when no CLI certs were provided).
     // This runs even with an explicit https:// scheme, so the client
     // picks up the mTLS identity from Meta well-known paths.
-    if config.tls_ca.is_none()
+    if !config.plaintext
+        && config.tls_ca.is_none()
         && let Some(bundle) = hyperactor::channel::try_tls_pem_bundle()
     {
         let (b, ok) = add_tls_from_bundle(builder, &bundle);
@@ -200,4 +208,92 @@ pub(crate) fn build_client(config: &TuiConfig) -> (String, reqwest::Client) {
     let client = builder.build().unwrap_or_else(|_| reqwest::Client::new());
 
     (base_url, client)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A valid self-signed CA PEM, copied from hyperactor's test suite.
+    /// `reqwest::Certificate::from_pem` parses it regardless of expiry, so
+    /// it exercises the real "CA installs, TLS enabled" path.
+    const TEST_CA_CERT: &str = "-----BEGIN CERTIFICATE-----
+MIIDBTCCAe2gAwIBAgIUaGNmboiIosG+8Up0vgDr/+cg+2IwDQYJKoZIhvcNAQEL
+BQAwEjEQMA4GA1UEAwwHVGVzdCBDQTAeFw0yNjAxMjgxNzA4MzlaFw0yNzAxMjgx
+NzA4MzlaMBIxEDAOBgNVBAMMB1Rlc3QgQ0EwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQC9RBoMYXCajklswt8Vi1JI1lEYzic0WNOmz45vG/7H6jTWkgL3
+K5Ri+Seg3MobDNc48YHWXYm4hP9wCzkx8ih3ntT5XiY1My/G3jLUuoIEE9pF/BoJ
+YQwZVoPNFhA9WhXNRsINf1cXFf8NzRfXpxBfKWtQJxYXU4JiDBQ6rLnQQABo8JmQ
+vYFhJbBaYip5jTSiVNn7mB1zNr5jsVxuoSF53Pb7xQ76bwBdOq4zd6PSxL5/lr4G
+cHSoxwZQdZMG7PL6hbxDQ2S2YI2lYVET1zwc2WPKCfjbEXBC/jzx828CInQtuksk
+18gJt6xHkTFEA8CSA29GM3lejnwYWf51xyyBAgMBAAGjUzBRMB0GA1UdDgQWBBRX
+cbxSZ70NsUkAS3Hhy6irugywJDAfBgNVHSMEGDAWgBRXcbxSZ70NsUkAS3Hhy6ir
+ugywJDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQA7aAFfyW67
+Z+uGSVYhpsT/uH/3Z3nr7X1smTz5CGEfq2czEcTC7gbYI2l8GZ47GPfnAvHTBZVm
+V/XncBCsj7/thOh2jYEHFyCbPckoaSCRyCOnK7LPUlr4HN5uP9EFe45qBLCJDEoY
+GTTw7MtzwdovfjchNfKQCTtkBJCXQ95WLCf6UOh02Sn28UTlgfXzF0X0FrcWqWa3
+uJZd4XOo4O6hKKlHaBaQPiEr++1xc3SWPV7jZHbckI/vKBnDdEZ9JQX5fFZuypUI
+sgomYHxvxrU2hWx+7k53CRdjfaIvT9Ie44z9sSdsU/+blw2S8f/ZTmuECoIAAXYO
+0qpzlxZMdr7T
+-----END CERTIFICATE-----
+";
+
+    fn config(addr: &str, plaintext: bool, tls_ca: Option<String>) -> TuiConfig {
+        TuiConfig {
+            addr: addr.to_string(),
+            refresh_ms: 2000,
+            theme: crate::ThemeName::Nord,
+            lang: crate::theme::LangName::En,
+            tls_ca,
+            tls_cert: None,
+            tls_key: None,
+            diagnose: false,
+            plaintext,
+        }
+    }
+
+    #[test]
+    fn plaintext_forces_http_over_https_scheme() {
+        // upholds: TUI-T1 -- --plaintext is the top-priority transport override.
+        let (base_url, _) = build_client(&config("https://host:1729", true, None));
+        assert!(
+            base_url.starts_with("http://"),
+            "plaintext must force plain HTTP even for an https:// addr, got {base_url}"
+        );
+    }
+
+    #[test]
+    fn without_plaintext_https_scheme_stays_https() {
+        // negative: default posture is unchanged when the flag is off.
+        let (base_url, _) = build_client(&config("https://host:1729", false, None));
+        assert!(
+            base_url.starts_with("https://"),
+            "https:// must stay TLS when --plaintext is unset, got {base_url}"
+        );
+    }
+
+    #[test]
+    fn plaintext_beats_a_valid_explicit_ca() {
+        // A genuinely loadable CA sets use_tls without the guard, so a bogus
+        // path would pass vacuously; the CA must actually parse to prove
+        // --plaintext wins.
+        let path =
+            std::env::temp_dir().join(format!("tui_admin_test_ca_{}.pem", std::process::id()));
+        std::fs::write(&path, TEST_CA_CERT).expect("write temp CA");
+        let ca = path.to_string_lossy().into_owned();
+
+        let (tls_url, _) = build_client(&config("host:1729", false, Some(ca.clone())));
+        assert!(
+            tls_url.starts_with("https://"),
+            "a valid --tls-ca should enable TLS, got {tls_url}"
+        );
+
+        let (plain_url, _) = build_client(&config("host:1729", true, Some(ca)));
+        assert!(
+            plain_url.starts_with("http://"),
+            "plaintext must win over a valid --tls-ca, got {plain_url}"
+        );
+
+        std::fs::remove_file(&path).ok();
+    }
 }

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -323,7 +323,7 @@ async fn run_diagnose(
 /// or diagnostics complete.
 pub async fn run(config: TuiConfig) -> io::Result<()> {
     let policy = timeouts::TuiTimeoutPolicy::from_config(&config);
-    let (base_url, client) = client::build_client(&config);
+    let (base_url, client) = client::build_client(&config)?;
 
     if config.diagnose {
         return run_diagnose(client, base_url, policy).await;

--- a/hyperactor_mesh_admin_tui/src/lib.rs
+++ b/hyperactor_mesh_admin_tui/src/lib.rs
@@ -81,9 +81,9 @@
 //!
 //! TLS and transport invariants:
 //!
-//! - **TUI-T1 (tls-auto-detect):** `client::build_client` probes
-//!   for TLS material in priority order: explicit CLI paths →
-//!   `try_tls_pem_bundle` → plain HTTP fallback.
+//! - **TUI-T1 (tls-auto-detect):** `client::build_client` selects the
+//!   transport in priority order: `--plaintext` (force plain HTTP) →
+//!   explicit CLI paths → `try_tls_pem_bundle` → plain HTTP fallback.
 //! - **TUI-T2 (prebuilt-client):** `App::new` receives a pre-built
 //!   `reqwest::Client` and `base_url` (including scheme). TLS
 //!   configuration is external to the app state.
@@ -243,6 +243,8 @@ pub struct TuiConfig {
     pub tls_cert: Option<String>,
     pub tls_key: Option<String>,
     pub diagnose: bool,
+    /// Disable TLS and use plain HTTP, overriding TLS auto-detection.
+    pub plaintext: bool,
 }
 
 // Terminal setup / teardown

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -35,6 +35,7 @@ fn test_policy() -> TuiTimeoutPolicy {
         tls_cert: None,
         tls_key: None,
         diagnose: false,
+        plaintext: false,
     })
 }
 

--- a/hyperactor_mesh_admin_tui/src/timeouts.rs
+++ b/hyperactor_mesh_admin_tui/src/timeouts.rs
@@ -189,6 +189,7 @@ mod tests {
             tls_cert: None,
             tls_key: None,
             diagnose: false,
+            plaintext: false,
         }
     }
 


### PR DESCRIPTION
Summary:
stacked on D111295317. `build_client` was fail-open: `use_tls` is an OR of best-effort detections, so any TLS-setup failure (an unreadable/typo'd `--tls-ca`, or no CA found where TLS is expected) silently downgraded to plain HTTP. that is what let the `THRIFT_TLS_SRV_CA_PATH=/nonexistent` workaround downgrade a Meta client to plaintext.

make it fail-closed: `build_client` returns `io::Result` and errors, instead of downgrading, when TLS is expected (an `https://` scheme, an explicit `--tls-ca`, or the Meta default via `cfg!(fbcode_build)`, mirroring the server's MA-T1 in `mesh_admin.rs`) but no usable CA can be configured. an unreadable `--tls-ca` (or one reqwest rejects as a PEM certificate), a `--tls-cert`/`--tls-key` that cannot be read, is supplied without its counterpart, or is supplied without a `--tls-ca`, and a failed `Client::build()` are all hard errors.

also make the addr scheme authoritative: an explicit `http://` selects plain HTTP with no auto-upgrade, and combining `http://` with `--tls-*` is a hard error. OSS-without-certs still defaults to plain HTTP. this retires the env-var workaround, since a bogus CA now errors.

a client cert/key that reads but fails to parse is left to the shared `mesh_admin_client::add_tls` (it warns and keeps CA-only TLS); that fails the handshake against an mTLS server rather than downgrading to plain HTTP, so it is not a plaintext hole.

Reviewed By: thedavekwon

Differential Revision: D111311409


