### PR TITLE
drive flush_async through Future so it actually flushes on an asyncio loop

### DIFF
--- a/python/monarch/_src/actor/logging.py
+++ b/python/monarch/_src/actor/logging.py
@@ -202,8 +202,15 @@ class LoggingManager:
         if self._logging_mesh_client is None:
             return
         try:
-            await (
-                self._logging_mesh_client.flush(context().actor_instance._as_rust())
+            # Drive the flush through Future so it works on an asyncio loop too:
+            # a bare `await` of the PythonTask hits the pytokio gate there and is
+            # swallowed below (a silent no-op). Future.__await__ bridges to an
+            # asyncio.Future on a loop and awaits the spawned Shared on a tokio
+            # thread. Mirrors the sync flush().
+            await Future(
+                coro=self._logging_mesh_client.flush(
+                    context().actor_instance._as_rust()
+                )
                 .spawn()
                 .task()
             )

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -1055,6 +1055,51 @@ async def test_flush_on_disable_aggregation() -> None:
         await pm.stop()
 
 
+# oss_skip: same log-forwarding rig as the sibling flush tests (broken in GitHub
+# by D86994420; passes internally).
+@pytest.mark.oss_skip
+async def test_flush_async_drives_flush_on_asyncio_loop() -> None:
+    """`LoggingManager.flush_async` must actually drive the flush when awaited on
+    an asyncio loop.
+
+    Regression guard: `flush_async` awaits the flush and swallows exceptions. If
+    it awaited a bare PythonTask, the pytokio gate would raise under a running
+    asyncio loop and the `except` would eat it -- a silent no-op. Here we buffer
+    logs under a long aggregation window, `await flush_async()` directly on the
+    test's asyncio loop, and require the aggregated lines to appear. With the
+    silent-no-op bug this assertion fails (the lines stay buffered).
+    """
+    with configured_with_redirected_stdio(
+        capture_stderr=False,
+        enable_log_forwarding=True,
+        enable_file_capture=True,
+        tail_log_lines=100,
+    ) as (_, paths):
+        pm = this_host().spawn_procs(per_host={"gpus": 2})
+        am = pm.spawn("printer", Printer)
+
+        # Long window so nothing auto-flushes; only our explicit flush_async can.
+        await pm.logging_option(stream_to_client=True, aggregate_window_sec=60)
+        for _ in range(5):
+            await am.print.call("flush_async driven log line")
+        await asyncio.sleep(1)
+
+        # System under test: flush_async on the test's asyncio loop.
+        await pm._logging_manager.flush_async()
+
+        await asyncio.sleep(1)
+        sys.stdout.flush()
+        with open(paths.stdout, "r") as f:
+            stdout_content = f.read()
+
+        # 10 = 5 log lines * 2 procs; present only if flush_async actually drove
+        # the flush (otherwise still buffered under the 60s window).
+        assert re.search(
+            r"\[10 similar log lines\].*flush_async driven log line", stdout_content
+        ), stdout_content
+        await pm.stop()
+
+
 @pytest.mark.timeout(120)
 @parametrize_config(actor_queue_dispatch={True, False})
 @isolate_in_subprocess


### PR DESCRIPTION
Summary:
this is a bug fix. in async IPython/Jupyter cells, a proc mesh's buffered ("aggregated") logs were silently dropped: the end-of-cell flush never ran, so those log lines never reached the notebook. sync cells and mesh teardown were unaffected.

how we know it is a bug, and that this fixes it, two ways. (1) the code path is a provable no-op: a bare `await` of a `PythonTask` on a running asyncio loop raises, and the surrounding `except Exception: pass` swallows it. (2) the added regression test buffers logs under a long aggregation window, awaits `flush_async()` on an asyncio loop, and requires the aggregated lines to surface, which can only happen if the flush actually ran. it is green with this change and is written to go red on the no-op (the buffered lines never appear).

`LoggingManager.flush_async` awaited a bare `PythonTask` (`flush(...).spawn().task()`) and swallowed exceptions. on a running asyncio loop, awaiting a bare `PythonTask` hits the pytokio gate (`PyPythonTask::__await__` raises when a loop is active) and the `except Exception: pass` ate it, so on the asyncio path the flush silently did nothing. this is reachable in production: the ipython `post_run_cell` hook schedules `_flush_all_proc_mesh_logs_async` on the asyncio loop (`logging.py:44-50`), so async ipython cells never flushed their proc-mesh logs. the tokio callers (`ProcMesh.stop` / `HostMesh.stop` / `shutdown`) awaited it on a tokio thread, where the bare await is legal, so they were unaffected.

route the await through `Future` (mirroring the sync `flush()`): `Future.__await__` bridges to an `asyncio.Future` on a loop and awaits the spawned `Shared` on a tokio thread, so the flush is actually driven in both contexts.

Differential Revision: D111505929


