### PR TITLE
move mesh-admin examples to scoped ProcessJob teardown (#4390)

### DIFF
--- a/python/examples/airport_turnaround_demo.py
+++ b/python/examples/airport_turnaround_demo.py
@@ -35,6 +35,7 @@ What to watch in the TUI:
 Usage::
 
     buck2 run fbcode//monarch/python/examples:airport_turnaround_demo -- --flights 8
+    buck2 run fbcode//monarch/python/examples:airport_turnaround_demo -- --startup-check
 """
 
 import argparse
@@ -45,7 +46,13 @@ import random
 
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, concurrent_endpoint, context, endpoint
-from monarch.job import ProcessJob
+from monarch.config import configure
+from monarch.job import (
+    cancel_async_tasks,
+    ProcessJob,
+    run_async_main,
+    scoped_async_state,
+)
 
 logger: logging.Logger = logging.getLogger("airport_turnaround_demo")
 logger.addHandler(TracingForwarder())
@@ -253,113 +260,121 @@ class FlightActor(Actor):
 
 
 async def async_main(args: argparse.Namespace) -> None:
+    configure(mesh_proc_spawn_max_idle="120s")
     job = ProcessJob({"hosts": 1}).enable_admin()
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        tui = "buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui"
+        print(f"\nMesh admin server listening on {admin_url}", flush=True)
+        print(f"  - Mesh tree:  curl {mtls_flags}{admin_url}/v1/tree", flush=True)
+        print(f"  - TUI:        {tui} -- --addr {admin_url}", flush=True)
 
-    # Flights are one named proc mesh sliced per replica; each manager is its
-    # own named singleton proc mesh — all distinct, findable nodes in the TUI.
-    # (Without `name=`, the flight procs show up anonymous, e.g. `anon-1`.)
-    flight_procs = host.spawn_procs(per_host={"replica": args.flights}, name="flights")
-    gate_proc = host.spawn_procs(name="gate_manager")
-    runway_proc = host.spawn_procs(name="runway_controller")
-    fuel_proc = host.spawn_procs(name="fuel_truck_pool")
-    baggage_proc = host.spawn_procs(name="baggage_crew_pool")
+        host = state.hosts
+        loops = []
+        try:
+            gate_proc = host.spawn_procs(name="gate_manager")
+            gates = gate_proc.spawn("gate_manager", GateManager, args.gates)
+            gate_ref = await gates.whoami.call_one()
 
-    gates = gate_proc.spawn("gate_manager", GateManager, args.gates)
-    runways = runway_proc.spawn(
-        "runway_controller", RunwayController, args.runways, tuple(args.runway)
-    )
-    fuel = fuel_proc.spawn(
-        "fuel_truck_pool", FuelTruckPool, args.fuel_trucks, tuple(args.refuel)
-    )
-    baggage = baggage_proc.spawn(
-        "baggage_crew_pool", BaggageCrewPool, args.baggage_crews, tuple(args.baggage)
-    )
+            runway_proc = host.spawn_procs(name="runway_controller")
+            runways = runway_proc.spawn(
+                "runway_controller", RunwayController, args.runways, tuple(args.runway)
+            )
+            await runways.whoami.call_one()
 
-    durations = {
-        "approach": tuple(args.approach),
-        "taxi": tuple(args.taxi),
-        "deplane": tuple(args.deplane),
-        "board": tuple(args.board),
-        "depart": tuple(args.depart),
-    }
-    flights = flight_procs.spawn(
-        "flight", FlightActor, gates, runways, fuel, baggage, durations
-    )
+            fuel_proc = host.spawn_procs(name="fuel_truck_pool")
+            fuel = fuel_proc.spawn(
+                "fuel_truck_pool", FuelTruckPool, args.fuel_trucks, tuple(args.refuel)
+            )
+            await fuel.whoami.call_one()
 
-    gate_ref = await gates.whoami.call_one()
-    flight0_ref = await flights.slice(replica=0).whoami.call_one()
+            baggage_proc = host.spawn_procs(name="baggage_crew_pool")
+            baggage = baggage_proc.spawn(
+                "baggage_crew_pool",
+                BaggageCrewPool,
+                args.baggage_crews,
+                tuple(args.baggage),
+            )
+            await baggage.whoami.call_one()
 
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    tui = (
-        "buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui"
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Mesh tree:  curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - TUI:        {tui} -- --addr {admin_url}")
-    print("\nOpen these nodes in the TUI tree (by label):")
-    print(f"  - flight (replicas 0..{args.flights - 1}) -> Execution: phase turnover")
-    print("  - gate_manager        -> Execution: assign_gate xK when gates are full")
-    print("  - runway_controller   -> Execution: request_landing / request_takeoff xK")
-    print("  - fuel_truck_pool     -> Execution: request_refuel xK")
-    print("  - baggage_crew_pool   -> Execution: request_baggage_service xK")
-    print(f"  raw ids: gate_manager={gate_ref}  flight[0]={flight0_ref}")
-    print(
-        f"\n{args.flights} flights; {args.gates} gates, {args.runways} runways, "
-        f"{args.fuel_trucks} fuel trucks, {args.baggage_crews} baggage crews. "
-        "Press Ctrl+C to stop.\n",
-        flush=True,
-    )
+            # Flights are one named proc mesh sliced per replica. Spawn them after the
+            # singleton managers so later manager readiness waits do not time out while
+            # queued behind the larger flight mesh.
+            flight_procs = host.spawn_procs(
+                per_host={"replica": args.flights},
+                name="flights",
+            )
 
-    async def run_flight(i: int) -> None:
-        f = flights.slice(replica=i)
-        await asyncio.sleep(i * _STARTUP_STAGGER_S)
-        while True:
-            await f.approach.call_one()
-            await f.request_landing.call_one()
-            await f.taxi_to_gate.call_one()
-            await f.acquire_gate.call_one()
-            await f.deplane.call_one()
-            await f.request_refuel.call_one()
-            await f.request_baggage_service.call_one()
-            await f.board.call_one()
-            await f.release_gate.call_one()
-            await f.request_takeoff.call_one()
-            await f.depart.call_one()
+            durations = {
+                "approach": tuple(args.approach),
+                "taxi": tuple(args.taxi),
+                "deplane": tuple(args.deplane),
+                "board": tuple(args.board),
+                "depart": tuple(args.depart),
+            }
+            flights = flight_procs.spawn(
+                "flight", FlightActor, gates, runways, fuel, baggage, durations
+            )
+            flight0_ref = await flights.slice(replica=0).whoami.call_one()
 
-    # Fail-fast: gather propagates the first loop's failure and tears the demo
-    # down, surfacing bugs loudly rather than silently degrading.
-    loops = [asyncio.ensure_future(run_flight(i)) for i in range(args.flights)]
-    try:
-        await asyncio.gather(*loops)
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        # Fixed order: cancel and drain the drivers, then stop flights, then the
-        # managers -- so a flight blocked in a request_* call never has its
-        # manager vanish first (which would make shutdown look broken).
-        for loop in loops:
-            loop.cancel()
-        await asyncio.gather(*loops, return_exceptions=True)
-        await flight_procs.stop()
-        await gate_proc.stop()
-        await runway_proc.stop()
-        await fuel_proc.stop()
-        await baggage_proc.stop()
-        # Tear down the host last: ProcessJob spawns a host subprocess
-        # (run_worker_loop_forever) that stopping the proc meshes alone leaves
-        # orphaned; shutdown() stops the host and every process on it.
-        await host.shutdown()
+            print("\nOpen these nodes in the TUI tree (by label):")
+            print(
+                f"  - flight (replicas 0..{args.flights - 1}) -> Execution: phase turnover"
+            )
+            print(
+                "  - gate_manager        -> Execution: assign_gate xK when gates are full"
+            )
+            print(
+                "  - runway_controller   -> Execution: request_landing / request_takeoff xK"
+            )
+            print("  - fuel_truck_pool     -> Execution: request_refuel xK")
+            print("  - baggage_crew_pool   -> Execution: request_baggage_service xK")
+            print(f"  raw ids: gate_manager={gate_ref}  flight[0]={flight0_ref}")
+            print(
+                f"\n{args.flights} flights; {args.gates} gates, {args.runways} runways, "
+                f"{args.fuel_trucks} fuel trucks, {args.baggage_crews} baggage crews. "
+                "Press Ctrl+C to stop.\n",
+                flush=True,
+            )
+
+            if args.startup_check:
+                print("Startup check complete.", flush=True)
+                return
+
+            async def run_flight(i: int) -> None:
+                f = flights.slice(replica=i)
+                await asyncio.sleep(i * _STARTUP_STAGGER_S)
+                while True:
+                    await f.approach.call_one()
+                    await f.request_landing.call_one()
+                    await f.taxi_to_gate.call_one()
+                    await f.acquire_gate.call_one()
+                    await f.deplane.call_one()
+                    await f.request_refuel.call_one()
+                    await f.request_baggage_service.call_one()
+                    await f.board.call_one()
+                    await f.release_gate.call_one()
+                    await f.request_takeoff.call_one()
+                    await f.depart.call_one()
+
+            # Fail-fast: gather propagates the first loop's failure and tears the demo
+            # down, surfacing bugs loudly rather than silently degrading.
+            loops = [asyncio.ensure_future(run_flight(i)) for i in range(args.flights)]
+            await asyncio.gather(*loops)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
+            if loops:
+                await cancel_async_tasks(loops)
 
 
 def main() -> None:
@@ -371,6 +386,11 @@ def main() -> None:
     parser.add_argument("--runways", type=int, default=2)
     parser.add_argument("--fuel-trucks", type=int, default=2)
     parser.add_argument("--baggage-crews", type=int, default=2)
+    parser.add_argument(
+        "--startup-check",
+        action="store_true",
+        help="start the mesh, resolve one manager and flight actor, then exit",
+    )
     # Per-phase duration ranges, in seconds, given as MIN MAX.
     for flag, lo, hi in (
         ("approach", 1.0, 3.0),
@@ -415,7 +435,7 @@ def main() -> None:
             parser.error(f"--{name} MIN must be > 0 and <= MAX")
 
     try:
-        asyncio.run(async_main(args))
+        run_async_main(async_main(args))
     except KeyboardInterrupt:
         pass
 

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -47,7 +47,7 @@ from typing import Any, cast
 from monarch._src.actor.actor_mesh import ActorMesh
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, current_rank, endpoint
-from monarch.job import ProcessJob, TelemetryConfig
+from monarch.job import ProcessJob, run_async_main, scoped_async_state, TelemetryConfig
 
 logger = logging.getLogger("dining_philosophers")
 logger.addHandler(TracingForwarder())
@@ -185,55 +185,48 @@ async def async_main(
                 snapshot_interval_secs=30.0,
             )
         )
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print("\nPress Ctrl+C to stop.\n", flush=True)
 
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print("\nPress Ctrl+C to stop.\n", flush=True)
+        # Spawn philosopher processes and actors.
+        host = state.hosts
+        procs = host.spawn_procs(per_host={"replica": NUM_PHILOSOPHERS})
 
-    # Spawn philosopher processes and actors.
-    procs = host.spawn_procs(per_host={"replica": NUM_PHILOSOPHERS})
+        # Spawn waiter on its own proc mesh so it appears in the dashboard hierarchy.
+        waiter_proc = host.spawn_procs(name="waiter")
+        philosophers = procs.spawn("philosopher", Philosopher, NUM_PHILOSOPHERS)
+        waiter = waiter_proc.spawn("waiter", Waiter, philosophers)
 
-    # Spawn waiter on its own proc mesh so it appears in the dashboard hierarchy.
-    waiter_proc = host.spawn_procs(name="waiter")
-    philosophers = procs.spawn("philosopher", Philosopher, NUM_PHILOSOPHERS)
-    waiter = waiter_proc.spawn("waiter", Waiter, philosophers)
+        # Start all philosophers — each will begin requesting chopsticks.
+        philosophers.start.broadcast(waiter)
 
-    # Start all philosophers — each will begin requesting chopsticks.
-    philosophers.start.broadcast(waiter)
-
-    # Run until interrupted.
-    try:
-        if kill_waiter_after is not None:
-            await asyncio.sleep(kill_waiter_after)
-            print("Killing the waiter...")
-            cast(ActorMesh[Waiter], waiter).stop().get()
-        await asyncio.sleep(float("inf"))
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        await waiter_proc.stop()
-        await procs.stop()
-        # Tear down the host last: ProcessJob spawns a host subprocess
-        # (run_worker_loop_forever) that stopping the proc meshes alone leaves
-        # orphaned; shutdown() stops the host and every process on it.
-        await host.shutdown()
+        # Run until interrupted.
+        try:
+            if kill_waiter_after is not None:
+                await asyncio.sleep(kill_waiter_after)
+                print("Killing the waiter...")
+                cast(ActorMesh[Waiter], waiter).stop().get()
+            await asyncio.sleep(float("inf"))
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
 
 
 def main() -> None:
@@ -263,7 +256,7 @@ def main() -> None:
     args = parser.parse_args()
 
     try:
-        asyncio.run(
+        run_async_main(
             async_main(
                 dashboard=args.dashboard,
                 dashboard_port=args.dashboard_port,

--- a/python/examples/execution_demo.py
+++ b/python/examples/execution_demo.py
@@ -39,7 +39,12 @@ import random
 
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, context, endpoint
-from monarch.job import ProcessJob
+from monarch.job import (
+    cancel_async_tasks,
+    ProcessJob,
+    run_async_main,
+    scoped_async_state,
+)
 
 logger: logging.Logger = logging.getLogger("execution_demo")
 logger.addHandler(TracingForwarder())
@@ -128,70 +133,65 @@ async def async_main(args: argparse.Namespace) -> None:
     eat_ms = (args.eat_ms_min, args.eat_ms_max)
 
     job = ProcessJob({"hosts": 1}).enable_admin()
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        host = state.hosts
+        # N philosophers (one per replica) + a single fork manager on its own proc
+        # so it is a distinct, easy-to-find node in the TUI tree.
+        phil_procs = host.spawn_procs(per_host={"replica": n})
+        fork_proc = host.spawn_procs(name="fork_manager")
 
-    # N philosophers (one per replica) + a single fork manager on its own proc
-    # so it is a distinct, easy-to-find node in the TUI tree.
-    phil_procs = host.spawn_procs(per_host={"replica": n})
-    fork_proc = host.spawn_procs(name="fork_manager")
+        fork_manager = fork_proc.spawn("fork_manager", ForkManager, n)
+        philosophers = phil_procs.spawn(
+            "philosopher", Philosopher, fork_manager, n, think_ms, eat_ms
+        )
 
-    fork_manager = fork_proc.spawn("fork_manager", ForkManager, n)
-    philosophers = phil_procs.spawn(
-        "philosopher", Philosopher, fork_manager, n, think_ms, eat_ms
-    )
+        fork_ref = await fork_manager.whoami.call_one()
+        phil0_ref = await philosophers.slice(replica=0).whoami.call_one()
 
-    fork_ref = await fork_manager.whoami.call_one()
-    phil0_ref = await philosophers.slice(replica=0).whoami.call_one()
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        tui = "buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui"
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Mesh tree:  curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - TUI:        {tui} -- --addr {admin_url}")
+        print("\nWatch list (find these in the TUI tree by label):")
+        print(
+            "  - actor `fork_manager`  -> Execution: `acquire xK` (live contention) + flight recorder"
+        )
+        print(
+            f"  - actor `philosopher` (replicas 0..{n - 1}) -> Execution: `think`/`eat` turnover + flight recorder"
+        )
+        print(f"  raw ids: fork_manager={fork_ref}  philosopher[0]={phil0_ref}")
+        print(
+            f"\n{n} philosophers; think {think_ms[0]}-{think_ms[1]}ms, "
+            f"eat {eat_ms[0]}-{eat_ms[1]}ms. Press Ctrl+C to stop.\n",
+            flush=True,
+        )
 
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    tui = (
-        "buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui"
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Mesh tree:  curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - TUI:        {tui} -- --addr {admin_url}")
-    print("\nWatch list (find these in the TUI tree by label):")
-    print(
-        "  - actor `fork_manager`  -> Execution: `acquire xK` (live contention) + flight recorder"
-    )
-    print(
-        f"  - actor `philosopher` (replicas 0..{n - 1}) -> Execution: `think`/`eat` turnover + flight recorder"
-    )
-    print(f"  raw ids: fork_manager={fork_ref}  philosopher[0]={phil0_ref}")
-    print(
-        f"\n{n} philosophers; think {think_ms[0]}-{think_ms[1]}ms, "
-        f"eat {eat_ms[0]}-{eat_ms[1]}ms. Press Ctrl+C to stop.\n",
-        flush=True,
-    )
+        async def run_philosopher(i: int) -> None:
+            seat = philosophers.slice(replica=i)
+            while True:
+                await seat.think.call_one(i)
+                await seat.eat.call_one(i)
 
-    async def run_philosopher(i: int) -> None:
-        seat = philosophers.slice(replica=i)
-        while True:
-            await seat.think.call_one(i)
-            await seat.eat.call_one(i)
-
-    # Fail-fast: gather propagates the first loop's failure and tears the demo
-    # down, surfacing bugs loudly rather than silently degrading.
-    loops = [asyncio.ensure_future(run_philosopher(i)) for i in range(n)]
-    try:
-        await asyncio.gather(*loops)
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        for loop in loops:
-            loop.cancel()
-        await phil_procs.stop()
-        await fork_proc.stop()
+        # Fail-fast: gather propagates the first loop's failure and tears the demo
+        # down, surfacing bugs loudly rather than silently degrading.
+        loops = [asyncio.ensure_future(run_philosopher(i)) for i in range(n)]
+        try:
+            await asyncio.gather(*loops)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
+            if loops:
+                await cancel_async_tasks(loops)
 
 
 def main() -> None:
@@ -216,7 +216,7 @@ def main() -> None:
         if lo <= 0 or lo > hi:
             parser.error(f"--{name}-ms-min must be > 0 and <= --{name}-ms-max")
     try:
-        asyncio.run(async_main(args))
+        run_async_main(async_main(args))
     except KeyboardInterrupt:
         pass
 

--- a/python/examples/execution_workload.py
+++ b/python/examples/execution_workload.py
@@ -76,7 +76,12 @@ from monarch._rust_bindings.monarch_hyperactor.config import (  # @manual=//mona
 from monarch._src.actor.actor_mesh import Channel, Port, PortReceiver
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, concurrent_endpoint, context, endpoint
-from monarch.job import ProcessJob
+from monarch.job import (
+    cancel_async_tasks,
+    ProcessJob,
+    run_async_main,
+    scoped_async_state,
+)
 
 logger: logging.Logger = logging.getLogger("execution_workload")
 logger.addHandler(TracingForwarder())
@@ -235,118 +240,112 @@ async def _hold_task(actor, id: str, entered_port: "Port[str]") -> None:
 
 async def async_main() -> None:
     job = ProcessJob({"hosts": 1}).enable_admin()
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        host = state.hosts
+        busy_proc = host.spawn_procs(
+            name="execution_busy", bootstrap=_disable_queue_dispatch
+        )
+        idle_proc = host.spawn_procs(
+            name="execution_idle", bootstrap=_disable_queue_dispatch
+        )
+        queue_proc = host.spawn_procs(
+            name="execution_queue", bootstrap=_enable_queue_dispatch
+        )
+        concurrent_proc = host.spawn_procs(
+            name="execution_concurrent", bootstrap=_enable_queue_dispatch
+        )
+        deadlock_proc = host.spawn_procs(
+            name="execution_deadlock", bootstrap=_enable_queue_dispatch
+        )
 
-    busy_proc = host.spawn_procs(
-        name="execution_busy", bootstrap=_disable_queue_dispatch
-    )
-    idle_proc = host.spawn_procs(
-        name="execution_idle", bootstrap=_disable_queue_dispatch
-    )
-    queue_proc = host.spawn_procs(
-        name="execution_queue", bootstrap=_enable_queue_dispatch
-    )
-    concurrent_proc = host.spawn_procs(
-        name="execution_concurrent", bootstrap=_enable_queue_dispatch
-    )
-    deadlock_proc = host.spawn_procs(
-        name="execution_deadlock", bootstrap=_enable_queue_dispatch
-    )
+        busy = busy_proc.spawn("busy_actor", BusyActor)
+        idle = idle_proc.spawn("idle_actor", BusyActor)
+        queue = queue_proc.spawn("queue_actor", QueueActor)
+        concurrent = concurrent_proc.spawn("concurrent_actor", ConcurrentActor)
+        # A queue-dispatch BusyActor: its blocking plain @endpoint `hold`
+        # monopolizes the serial dispatch loop, so a later `control` release
+        # queues behind it and can never run -- a deadlock the admin API surfaces.
+        deadlock = deadlock_proc.spawn("deadlock_actor", BusyActor)
 
-    busy = busy_proc.spawn("busy_actor", BusyActor)
-    idle = idle_proc.spawn("idle_actor", BusyActor)
-    queue = queue_proc.spawn("queue_actor", QueueActor)
-    concurrent = concurrent_proc.spawn("concurrent_actor", ConcurrentActor)
-    # A queue-dispatch BusyActor: its blocking plain @endpoint `hold`
-    # monopolizes the serial dispatch loop, so a later `control` release
-    # queues behind it and can never run -- a deadlock the admin API surfaces.
-    deadlock = deadlock_proc.spawn("deadlock_actor", BusyActor)
+        actors = {
+            "busy": busy,
+            "queue": queue,
+            "concurrent": concurrent,
+            "deadlock": deadlock,
+        }
 
-    actors = {
-        "busy": busy,
-        "queue": queue,
-        "concurrent": concurrent,
-        "deadlock": deadlock,
-    }
+        busy_ref = await busy.whoami.call_one()
+        idle_ref = await idle.whoami.call_one()
+        queue_ref = await queue.whoami.call_one()
+        concurrent_ref = await concurrent.whoami.call_one()
+        deadlock_ref = await deadlock.whoami.call_one()
 
-    busy_ref = await busy.whoami.call_one()
-    idle_ref = await idle.whoami.call_one()
-    queue_ref = await queue.whoami.call_one()
-    concurrent_ref = await concurrent.whoami.call_one()
-    deadlock_ref = await deadlock.whoami.call_one()
+        # Held invocations send their id over this port from inside the handler
+        # body; a background task drains it and echoes EXEC_ENTERED to stdout.
+        entered_port: Port[str]
+        entered_recv: PortReceiver[str]
+        entered_port, entered_recv = Channel[str].open()
 
-    # Held invocations send their id over this port from inside the handler
-    # body; a background task drains it and echoes EXEC_ENTERED to stdout.
-    entered_port: Port[str]
-    entered_recv: PortReceiver[str]
-    entered_port, entered_recv = Channel[str].open()
+        async def drain_entered() -> None:
+            while True:
+                entered_id = await entered_recv.recv()
+                print(f"EXEC_ENTERED {entered_id}", flush=True)
 
-    async def drain_entered() -> None:
-        while True:
-            entered_id = await entered_recv.recv()
-            print(f"EXEC_ENTERED {entered_id}", flush=True)
+        drainer = asyncio.ensure_future(drain_entered())
 
-    drainer = asyncio.ensure_future(drain_entered())
+        print(f"Mesh admin server listening on {state.admin_url}", flush=True)
+        print(f"  - Busy actor:  {busy_ref}", flush=True)
+        print(f"  - Idle actor:  {idle_ref}", flush=True)
+        print(f"  - Queue actor: {queue_ref}", flush=True)
+        print(f"  - Concurrent actor: {concurrent_ref}", flush=True)
+        print(f"  - Deadlock actor: {deadlock_ref}", flush=True)
 
-    print(f"Mesh admin server listening on {state.admin_url}", flush=True)
-    print(f"  - Busy actor:  {busy_ref}", flush=True)
-    print(f"  - Idle actor:  {idle_ref}", flush=True)
-    print(f"  - Queue actor: {queue_ref}", flush=True)
-    print(f"  - Concurrent actor: {concurrent_ref}", flush=True)
-    print(f"  - Deadlock actor: {deadlock_ref}", flush=True)
-
-    reader = await _stdin_reader()
-    # In-flight held invocations, tracked so they can be cancelled at
-    # shutdown.
-    holds: dict[str, asyncio.Task] = {}
-    try:
-        while True:
-            raw = await reader.readline()
-            if not raw:
-                break  # stdin EOF
-            line = raw.decode().strip()
-            if not line:
-                continue
-            parts = line.split()
-            cmd = parts[0].upper()
-            if cmd == "HOLD":
-                _, which, id = parts
-                # hold blocks until released, so run it as a background task
-                # (via call_one -- see _hold_task). The "entered" signal
-                # still arrives mid-handler over entered_port.
-                holds[id] = asyncio.ensure_future(
-                    _hold_task(actors[which], id, entered_port)
-                )
-                print(f"EXEC_ACK HOLD {id}", flush=True)
-            elif cmd in ("RELEASE", "RAISE"):
-                _, which, id = parts
-                op = cmd.lower()
-                # Signal dispatch *before* the call: under queue dispatch a
-                # release can wedge behind a blocked hold and never return, so
-                # this positive sentinel lets the test rule out "never sent".
-                print(f"EXEC_SENDING {op} {id}", flush=True)
-                await actors[which].control.call_one(id, op)
-                print(f"EXEC_ACK {op} {id}", flush=True)
-            else:
-                print(f"EXEC_ERR unknown command {cmd}", flush=True)
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        for task in holds.values():
-            task.cancel()
-        drainer.cancel()
-        await busy_proc.stop()
-        await idle_proc.stop()
-        await queue_proc.stop()
-        await concurrent_proc.stop()
-        await deadlock_proc.stop()
+        reader = await _stdin_reader()
+        # In-flight held invocations, tracked so they can be cancelled at
+        # shutdown.
+        holds: dict[str, asyncio.Task] = {}
+        try:
+            while True:
+                raw = await reader.readline()
+                if not raw:
+                    break  # stdin EOF
+                line = raw.decode().strip()
+                if not line:
+                    continue
+                parts = line.split()
+                cmd = parts[0].upper()
+                if cmd == "HOLD":
+                    _, which, id = parts
+                    # hold blocks until released, so run it as a background task
+                    # (via call_one -- see _hold_task). The "entered" signal
+                    # still arrives mid-handler over entered_port.
+                    holds[id] = asyncio.ensure_future(
+                        _hold_task(actors[which], id, entered_port)
+                    )
+                    print(f"EXEC_ACK HOLD {id}", flush=True)
+                elif cmd in ("RELEASE", "RAISE"):
+                    _, which, id = parts
+                    op = cmd.lower()
+                    # Signal dispatch *before* the call: under queue dispatch a
+                    # release can wedge behind a blocked hold and never return, so
+                    # this positive sentinel lets the test rule out "never sent".
+                    print(f"EXEC_SENDING {op} {id}", flush=True)
+                    # pyre-ignore[16]: only control-capable actors reach RELEASE/RAISE; queue is hold-only
+                    await actors[which].control.call_one(id, op)
+                    print(f"EXEC_ACK {op} {id}", flush=True)
+                else:
+                    print(f"EXEC_ERR unknown command {cmd}", flush=True)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
+            tasks = list(holds.values()) + [drainer]
+            await cancel_async_tasks(tasks)
 
 
 def main() -> None:
     try:
-        asyncio.run(async_main())
+        run_async_main(async_main())
     except KeyboardInterrupt:
         pass
 

--- a/python/examples/inbound_ordering_workload.py
+++ b/python/examples/inbound_ordering_workload.py
@@ -51,7 +51,7 @@ import urllib.parse
 
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, context, endpoint
-from monarch.job import ProcessJob
+from monarch.job import ProcessJob, run_async_main, scoped_async_state
 
 logger: logging.Logger = logging.getLogger("inbound_ordering_workload")
 logger.addHandler(TracingForwarder())
@@ -103,88 +103,86 @@ class Sender(Actor):
 
 async def async_main(args: argparse.Namespace) -> None:
     job = ProcessJob({"hosts": 1}).enable_admin()
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        host = state.hosts
+        receiver_proc = host.spawn_procs(name="inbound_ordering_receiver")
+        # Two separate singleton proc meshes for the two senders so each
+        # sender has its own Instance (and therefore its own Sequencer and
+        # SEQ_INFO session_id) by construction. Using one shared proc mesh
+        # with two spawns relies on subtler ActorMesh semantics; two procs
+        # makes the "two distinct session owners" promise structural.
+        sender_a_proc = host.spawn_procs(name="inbound_ordering_sender_a")
+        sender_b_proc = host.spawn_procs(name="inbound_ordering_sender_b")
 
-    receiver_proc = host.spawn_procs(name="inbound_ordering_receiver")
-    # Two separate singleton proc meshes for the two senders so each
-    # sender has its own Instance (and therefore its own Sequencer and
-    # SEQ_INFO session_id) by construction. Using one shared proc mesh
-    # with two spawns relies on subtler ActorMesh semantics; two procs
-    # makes the "two distinct session owners" promise structural.
-    sender_a_proc = host.spawn_procs(name="inbound_ordering_sender_a")
-    sender_b_proc = host.spawn_procs(name="inbound_ordering_sender_b")
+        receiver = receiver_proc.spawn("stalled_receiver", StalledReceiver)
+        # Get the receiver's address by asking it -- there's no direct
+        # Python-side accessor on ``ActorMesh`` that returns a rank's
+        # ``ActorAddr``. ``PyActorAddr`` is picklable via ``__reduce__``,
+        # so it can be passed back over the endpoint result and forward
+        # as a constructor argument to the senders.
+        receiver_addr = await receiver.whoami.call_one()
 
-    receiver = receiver_proc.spawn("stalled_receiver", StalledReceiver)
-    # Get the receiver's address by asking it -- there's no direct
-    # Python-side accessor on ``ActorMesh`` that returns a rank's
-    # ``ActorAddr``. ``PyActorAddr`` is picklable via ``__reduce__``,
-    # so it can be passed back over the endpoint result and forward
-    # as a constructor argument to the senders.
-    receiver_addr = await receiver.whoami.call_one()
+        sender_a = sender_a_proc.spawn("sender_a", Sender, receiver, receiver_addr)
+        sender_b = sender_b_proc.spawn("sender_b", Sender, receiver, receiver_addr)
 
-    sender_a = sender_a_proc.spawn("sender_a", Sender, receiver, receiver_addr)
-    sender_b = sender_b_proc.spawn("sender_b", Sender, receiver, receiver_addr)
+        # Two distinct senders -> receiver shows 2 stalled sessions
+        # (different session_ids, one per sender Instance's Sequencer).
+        await sender_a.stall_and_send.call_one(skip_count=1, send_count=5)
+        await sender_b.stall_and_send.call_one(skip_count=1, send_count=3)
 
-    # Two distinct senders -> receiver shows 2 stalled sessions
-    # (different session_ids, one per sender Instance's Sequencer).
-    await sender_a.stall_and_send.call_one(skip_count=1, send_count=5)
-    await sender_b.stall_and_send.call_one(skip_count=1, send_count=3)
+        admin_url = state.admin_url
+        assert admin_url is not None
+        # Match pyspy_workload.py: emit mTLS flags conditionally when the
+        # admin URL is HTTPS so the printed commands are paste-ready in
+        # both local and production environments.
+        mtls_flags = (
+            " --cacert /var/facebook/rootcanal/ca.pem"
+            " --cert /var/facebook/x509_identities/server.pem"
+            " --key /var/facebook/x509_identities/server.pem"
+            if admin_url.startswith("https")
+            else ""
+        )
 
-    # Match pyspy_workload.py: emit mTLS flags conditionally when the
-    # admin URL is HTTPS so the printed commands are paste-ready in
-    # both local and production environments.
-    mtls_flags = (
-        " --cacert /var/facebook/rootcanal/ca.pem"
-        " --cert /var/facebook/x509_identities/server.pem"
-        " --key /var/facebook/x509_identities/server.pem"
-        if state.admin_url.startswith("https://")
-        else ""
-    )
+        # Actor refs contain '/' and must be percent-encoded in URL path
+        # positions. Single source of truth is the ``receiver_addr``
+        # PyActorAddr obtained from ``whoami`` above; Python ``ActorMesh``
+        # does not expose an ``actor_addr()`` accessor.
+        receiver_ref = str(receiver_addr)
+        receiver_ref_encoded = urllib.parse.quote(receiver_ref, safe="")
 
-    # Actor refs contain '/' and must be percent-encoded in URL path
-    # positions. Single source of truth is the ``receiver_addr``
-    # PyActorAddr obtained from ``whoami`` above; Python ``ActorMesh``
-    # does not expose an ``actor_addr()`` accessor.
-    receiver_ref = str(receiver_addr)
-    receiver_ref_encoded = urllib.parse.quote(receiver_ref, safe="")
+        print(f"Mesh admin server listening on {admin_url}", flush=True)
+        print(f"  - Stalled receiver: {receiver_ref}", flush=True)
+        print(
+            f"  - curl: curl{mtls_flags} {admin_url}/v1/{receiver_ref_encoded}",
+            flush=True,
+        )
+        print(
+            "  - TUI:   "
+            f"buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui "
+            f"-- --addr {admin_url}",
+            flush=True,
+        )
+        print(
+            "  - Verifier: "
+            f"buck2 run fbcode//monarch/python/examples:verify_inbound_ordering "
+            f"-- --admin-url {admin_url}"
+            f"{mtls_flags}",
+            flush=True,
+        )
 
-    print(f"Mesh admin server listening on {state.admin_url}", flush=True)
-    print(f"  - Stalled receiver: {receiver_ref}", flush=True)
-    print(
-        f"  - curl: curl{mtls_flags} {state.admin_url}/v1/{receiver_ref_encoded}",
-        flush=True,
-    )
-    print(
-        "  - TUI:   "
-        f"buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui "
-        f"-- --addr {state.admin_url}",
-        flush=True,
-    )
-    print(
-        "  - Verifier: "
-        f"buck2 run fbcode//monarch/python/examples:verify_inbound_ordering "
-        f"-- --admin-url {state.admin_url}"
-        f"{mtls_flags}",
-        flush=True,
-    )
-
-    try:
-        await asyncio.sleep(float("inf"))
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        await sender_a_proc.stop()
-        await sender_b_proc.stop()
-        await receiver_proc.stop()
+        try:
+            await asyncio.sleep(float("inf"))
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
 
 
 def main() -> None:
     parser = argparse.ArgumentParser()
     args = parser.parse_args()
     try:
-        asyncio.run(async_main(args))
+        run_async_main(async_main(args))
     except KeyboardInterrupt:
         pass
 

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -38,7 +38,7 @@ import sys
 
 import monarch.actor
 from monarch.actor import Actor, current_rank, endpoint
-from monarch.job import ProcessJob, TelemetryConfig
+from monarch.job import ProcessJob, run_async_main, scoped_async_state, TelemetryConfig
 
 
 def _fault_hook(failure) -> None:
@@ -90,56 +90,54 @@ async def async_main(num_procs: int) -> None:
         )
         .enable_admin()
     )
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print(flush=True)
 
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print(flush=True)
+        host = state.hosts
+        procs = host.spawn_procs(per_host={"replica": num_procs})
+        workers = procs.spawn("worker", Worker)
 
-    procs = host.spawn_procs(per_host={"replica": num_procs})
-    workers = procs.spawn("worker", Worker)
+        # Let every worker do some work first.
+        await workers.work.call()
+        print(f"\n{num_procs} workers alive and working.", flush=True)
 
-    # Let every worker do some work first.
-    await workers.work.call()
-    print(f"\n{num_procs} workers alive and working.", flush=True)
+        # Crash worker at rank 0.  The BaseException subclass bypasses the
+        # endpoint handler's Exception catch, killing the actor and
+        # triggering supervision.
+        print("\nCrashing worker[0] with 'GPU memory corruption'...", flush=True)
+        try:
+            await workers.slice(replica=0).crash.call_one("GPU memory corruption")
+        except Exception:
+            pass  # Expected — the actor died
 
-    # Crash worker at rank 0.  The BaseException subclass bypasses the
-    # endpoint handler's Exception catch, killing the actor and
-    # triggering supervision.
-    print("\nCrashing worker[0] with 'GPU memory corruption'...", flush=True)
-    try:
-        await workers.slice(replica=0).crash.call_one("GPU memory corruption")
-    except Exception:
-        pass  # Expected — the actor died
+        # Give supervision time to propagate.
+        await asyncio.sleep(3)
 
-    # Give supervision time to propagate.
-    await asyncio.sleep(3)
+        print("\nFailure injected. Point the TUI at this mesh to inspect.")
+        print("Press Ctrl+C to exit.\n", flush=True)
 
-    print("\nFailure injected. Point the TUI at this mesh to inspect.")
-    print("Press Ctrl+C to exit.\n", flush=True)
-
-    try:
-        await asyncio.sleep(float("inf"))
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        await procs.stop()
+        try:
+            await asyncio.sleep(float("inf"))
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
 
 
 def main() -> None:
@@ -149,7 +147,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     try:
-        asyncio.run(async_main(args.procs))
+        run_async_main(async_main(args.procs))
     except KeyboardInterrupt:
         pass
 

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -42,7 +42,7 @@ import time
 
 from monarch._src.actor.telemetry import TracingForwarder
 from monarch.actor import Actor, endpoint
-from monarch.job import ProcessJob, TelemetryConfig
+from monarch.job import ProcessJob, run_async_main, scoped_async_state, TelemetryConfig
 
 logger = logging.getLogger("pyspy_workload")
 logger.addHandler(TracingForwarder())
@@ -146,54 +146,52 @@ async def async_main() -> None:
         )
         .enable_admin()
     )
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(
+            f"\npy-spy workload: mode={args.mode}, "
+            f"work_ms={args.work_ms}, concurrency={args.concurrency}"
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print("\nVerify with:")
+        print("  buck2 run fbcode//monarch/python/examples:verify_pyspy -- \\")
+        if mtls_flags:
+            print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10 \\")
+            print(f"    {mtls_flags.strip()}")
+        else:
+            print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10")
+        print("\nPress Ctrl+C to stop.\n", flush=True)
 
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(
-        f"\npy-spy workload: mode={args.mode}, "
-        f"work_ms={args.work_ms}, concurrency={args.concurrency}"
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print("\nVerify with:")
-    print("  buck2 run fbcode//monarch/python/examples:verify_pyspy -- \\")
-    if mtls_flags:
-        print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10 \\")
-        print(f"    {mtls_flags.strip()}")
-    else:
-        print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10")
-    print("\nPress Ctrl+C to stop.\n", flush=True)
+        host = state.hosts
+        # Spawn worker procs. The actor name pyspy_worker lets the
+        # verifier filter to workload procs by prefix.
+        procs = host.spawn_procs(per_host={"replica": args.concurrency})
+        workers = procs.spawn("pyspy_worker", Worker, args.mode, args.work_ms)
 
-    # Spawn worker procs. The actor name pyspy_worker lets the
-    # verifier filter to workload procs by prefix.
-    procs = host.spawn_procs(per_host={"replica": args.concurrency})
-    workers = procs.spawn("pyspy_worker", Worker, args.mode, args.work_ms)
+        # Start all workers.
+        workers.work_forever.broadcast()
 
-    # Start all workers.
-    workers.work_forever.broadcast()
-
-    try:
-        await asyncio.sleep(float("inf"))
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        await procs.stop()
+        try:
+            await asyncio.sleep(float("inf"))
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
 
 
 def main() -> None:
     try:
-        asyncio.run(async_main())
+        run_async_main(async_main())
     except KeyboardInterrupt:
         pass
 

--- a/python/examples/rapid_spawn_exit_stress.py
+++ b/python/examples/rapid_spawn_exit_stress.py
@@ -21,16 +21,8 @@ import time
 
 import monarch.actor
 from monarch.actor import Actor, endpoint
-from monarch.job import ProcessJob, TelemetryConfig
+from monarch.job import ProcessJob, run_async_main, scoped_async_state, TelemetryConfig
 from monarch.mesh_controller import spawn_tensor_engine
-
-job = (
-    ProcessJob({"hosts": 1})
-    .enable_telemetry(TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0))
-    .enable_admin()
-)
-job_state = job.state(cached_path=None)
-proc_mesh = job_state.hosts.spawn_procs(per_host={"gpus": 1})
 
 
 def unhandled_fault(fault):
@@ -48,14 +40,7 @@ class SimpleActor(Actor):
         return "pong"
 
 
-# for i in range(1000):
-#     actor = proc_mesh.spawn("simple", SimpleActor)
-#     actor.ping.call_one().get()
-#     actor.stop().get()
-#     print(f"actor iter {i}", flush=True)
-
-
-async def main():
+async def async_main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--sleep",
@@ -71,30 +56,52 @@ async def main():
     )
     args = parser.parse_args()
 
-    admin_url = job_state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
+    job = (
+        ProcessJob({"hosts": 1})
+        .enable_telemetry(
+            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
+        )
+        .enable_admin()
     )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print("\nPress Ctrl+C to stop.\n", flush=True)
+    async with scoped_async_state(job, cached_path=None) as state:
+        proc_mesh = state.hosts.spawn_procs(per_host={"gpus": 1})
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print("\nPress Ctrl+C to stop.\n", flush=True)
 
-    for i in range(args.iterations):
-        dm = spawn_tensor_engine(proc_mesh)
-        if args.sleep > 0:
-            await asyncio.sleep(args.sleep)
-        dm.exit()
-        print(f"iter {i}", flush=True)
+        try:
+            for i in range(args.iterations):
+                dm = spawn_tensor_engine(proc_mesh)
+                if args.sleep > 0:
+                    await asyncio.sleep(args.sleep)
+                dm.exit()
+                print(f"iter {i}", flush=True)
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
 
 
-asyncio.run(main())
+def main() -> None:
+    try:
+        run_async_main(async_main())
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -31,7 +31,7 @@ import asyncio
 import random
 
 from monarch.actor import Actor, context, current_rank, endpoint
-from monarch.job import ProcessJob, TelemetryConfig
+from monarch.job import ProcessJob, run_async_main, scoped_async_state, TelemetryConfig
 
 
 class Sleeper(Actor):
@@ -64,54 +64,52 @@ async def async_main(num_procs: int) -> None:
         )
         .enable_admin()
     )
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print(f"\nSpawning batches of sleepers across {num_procs} procs.")
+        print("Press Ctrl+C to stop.\n", flush=True)
 
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print(f"\nSpawning batches of sleepers across {num_procs} procs.")
-    print("Press Ctrl+C to stop.\n", flush=True)
+        host = state.hosts
+        procs = host.spawn_procs(per_host={"replica": num_procs})
 
-    procs = host.spawn_procs(per_host={"replica": num_procs})
+        batch = 0
+        # Keep references alive so actors aren't torn down prematurely.
+        batches = []
+        try:
+            while True:
+                name = f"sleeper_batch_{batch}"
+                actors = procs.spawn(name, Sleeper, MIN_SLEEP, MAX_SLEEP)
+                batches.append(actors)
+                print(
+                    f"batch {batch}: spawned {num_procs} sleepers",
+                    flush=True,
+                )
 
-    batch = 0
-    # Keep references alive so actors aren't torn down prematurely.
-    batches = []
-    try:
-        while True:
-            name = f"sleeper_batch_{batch}"
-            actors = procs.spawn(name, Sleeper, MIN_SLEEP, MAX_SLEEP)
-            batches.append(actors)
-            print(
-                f"batch {batch}: spawned {num_procs} sleepers",
-                flush=True,
-            )
+                # Fire-and-forget: tell each actor to sleep then exit.
+                actors.go.broadcast()
 
-            # Fire-and-forget: tell each actor to sleep then exit.
-            actors.go.broadcast()
-
-            # Wait a bit before the next batch so waves overlap.
-            await asyncio.sleep(2.0)
-            batch += 1
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        await procs.stop()
+                # Wait a bit before the next batch so waves overlap.
+                await asyncio.sleep(2.0)
+                batch += 1
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
 
 
 def main() -> None:
@@ -121,7 +119,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     try:
-        asyncio.run(async_main(args.procs))
+        run_async_main(async_main(args.procs))
     except KeyboardInterrupt:
         pass
 

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -31,7 +31,7 @@ import argparse
 import asyncio
 
 from monarch.actor import Actor, current_rank, endpoint
-from monarch.job import ProcessJob, TelemetryConfig
+from monarch.job import ProcessJob, run_async_main, scoped_async_state, TelemetryConfig
 
 
 class Worker(Actor):
@@ -51,48 +51,46 @@ async def async_main(num_procs: int) -> None:
         )
         .enable_admin()
     )
-    state = job.state(cached_path=None)
-    host = state.hosts
+    async with scoped_async_state(job, cached_path=None) as state:
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print(flush=True)
 
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print(flush=True)
+        host = state.hosts
+        procs = host.spawn_procs(per_host={"replica": num_procs})
+        workers = procs.spawn("worker", Worker)
 
-    procs = host.spawn_procs(per_host={"replica": num_procs})
-    workers = procs.spawn("worker", Worker)
+        # Let each actor announce itself.
+        await workers.hello.call()
+        print(f"\n{num_procs} workers alive. Stopping the actor mesh...", flush=True)
 
-    # Let each actor announce itself.
-    await workers.hello.call()
-    print(f"\n{num_procs} workers alive. Stopping the actor mesh...", flush=True)
+        # Coordinated mesh-level stop.
+        # pyre-ignore[16]: `stop` is on `ActorMesh`, not the proxy type.
+        await workers.stop("mesh stopped by example")
 
-    # Coordinated mesh-level stop.
-    # pyre-ignore[16]: `stop` is on `ActorMesh`, not the proxy type.
-    await workers.stop("mesh stopped by example")
+        print("Actor mesh stopped. Tombstones are now visible in the TUI (press h).")
+        print("Press Ctrl+C to exit.\n", flush=True)
 
-    print("Actor mesh stopped. Tombstones are now visible in the TUI (press h).")
-    print("Press Ctrl+C to exit.\n", flush=True)
-
-    try:
-        await asyncio.sleep(float("inf"))
-    except (KeyboardInterrupt, asyncio.CancelledError):
-        pass
-    finally:
-        print("\nShutting down...", flush=True)
-        await procs.stop()
+        try:
+            await asyncio.sleep(float("inf"))
+        except (KeyboardInterrupt, asyncio.CancelledError):
+            pass
+        finally:
+            print("\nShutting down...", flush=True)
 
 
 def main() -> None:
@@ -102,7 +100,7 @@ def main() -> None:
     )
     args = parser.parse_args()
     try:
-        asyncio.run(async_main(args.procs))
+        run_async_main(async_main(args.procs))
     except KeyboardInterrupt:
         pass
 

--- a/python/monarch/_src/job/_process_job_async_lifecycle.py
+++ b/python/monarch/_src/job/_process_job_async_lifecycle.py
@@ -1,0 +1,196 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+import asyncio
+import contextlib
+import logging
+from typing import Any, AsyncIterator, Awaitable, Coroutine, Optional, Sequence, TypeVar
+
+from monarch._src.job.job import DEFAULT_JOB_PATH, JobState, JobTrait
+
+logger = logging.getLogger(__name__)
+_T = TypeVar("_T")
+
+
+def _silence_destroy_pending(task: "asyncio.Task[Any]") -> None:
+    with contextlib.suppress(Exception):
+        # pyre-ignore[16]: `_log_destroy_pending` is a private asyncio.Task attribute
+        task._log_destroy_pending = False
+
+
+def _drain_task_results(tasks: Sequence["asyncio.Task[Any]"]) -> None:
+    for task in tasks:
+        if task.done():
+            # Exit-path drain: consume each done task's result/exception so it is
+            # "retrieved" (silences asyncio's "exception was never retrieved").
+            # Suppress BaseException deliberately -- this runs during bounded
+            # Ctrl-C teardown, where a stray interrupt arriving mid-drain must not
+            # turn a clean exit into a traceback. Narrowing it to Exception makes
+            # a second Ctrl-C escape here and dump a stack.
+            with contextlib.suppress(BaseException):
+                task.result()
+
+
+def _kill_quietly(job: JobTrait) -> None:
+    """Best-effort ``job.kill()`` for teardown paths that must not raise.
+
+    Suppresses BaseException on purpose: a stray Ctrl-C landing inside the
+    synchronous kill (e.g. during its grace poll) must be absorbed, not allowed
+    to escape the teardown context manager -- an interrupt escaping here breaks
+    the manager's athrow unwinding ("generator didn't stop after athrow()") and
+    leaves the process up. Callers that need the original interrupt to propagate
+    re-raise it themselves after this returns.
+    """
+    with contextlib.suppress(BaseException):
+        job.kill()
+
+
+async def _await_bounded(awaitable: Awaitable[_T], timeout: float) -> _T:
+    task = asyncio.ensure_future(awaitable)
+    try:
+        done, pending = await asyncio.wait({task}, timeout=timeout)
+    except BaseException:
+        if not task.done():
+            task.cancel()
+            _silence_destroy_pending(task)
+        raise
+    if pending:
+        task.cancel()
+        _silence_destroy_pending(task)
+        raise asyncio.TimeoutError()
+    _drain_task_results(list(done))
+    return task.result()
+
+
+async def cancel_async_tasks(
+    tasks: Sequence["asyncio.Task[Any]"],
+    timeout: float = 2.0,
+) -> None:
+    """Cancel tasks, but do not let uncooperative cancellation block exit."""
+    task_set = set(tasks)
+    if not task_set:
+        return
+    for task in task_set:
+        task.cancel()
+    done, pending = await asyncio.wait(task_set, timeout=timeout)
+    _drain_task_results(list(done))
+    for task in pending:
+        _silence_destroy_pending(task)
+
+
+def _cancel_loop_tasks(loop: asyncio.AbstractEventLoop, timeout: float) -> None:
+    tasks = [task for task in asyncio.all_tasks(loop) if not task.done()]
+    if not tasks:
+        return
+    for task in tasks:
+        task.cancel()
+    done, pending = loop.run_until_complete(asyncio.wait(tasks, timeout=timeout))
+    _drain_task_results(list(done))
+    for task in pending:
+        _silence_destroy_pending(task)
+
+
+def run_async_main(
+    coro: Coroutine[Any, Any, _T],
+    *,
+    interrupt_timeout: float = 15.0,
+    cancel_timeout: float = 2.0,
+) -> Optional[_T]:
+    """Run an async demo main with bounded Ctrl-C and pending-task cleanup.
+
+    ``asyncio.run`` waits for every pending task to acknowledge cancellation.
+    That is reasonable for libraries, but wrong for local ProcessJob demos that
+    intentionally create wedged calls: foreground exit must be bounded so the
+    owning job cleanup can run and detached workers are not orphaned.
+    """
+    loop = asyncio.new_event_loop()
+    try:
+        asyncio.set_event_loop(loop)
+        main_task = loop.create_task(coro)
+        try:
+            return loop.run_until_complete(main_task)
+        except KeyboardInterrupt:
+            if main_task.done():
+                raise
+            main_task.cancel()
+            done, pending = loop.run_until_complete(
+                asyncio.wait({main_task}, timeout=interrupt_timeout)
+            )
+            if pending:
+                _silence_destroy_pending(main_task)
+                raise
+            if main_task.cancelled():
+                raise KeyboardInterrupt()
+            return main_task.result()
+        finally:
+            _cancel_loop_tasks(loop, cancel_timeout)
+            with contextlib.suppress(Exception):
+                loop.run_until_complete(
+                    asyncio.wait_for(
+                        loop.shutdown_asyncgens(),
+                        timeout=cancel_timeout,
+                    )
+                )
+            with contextlib.suppress(Exception):
+                loop.run_until_complete(
+                    asyncio.wait_for(
+                        loop.shutdown_default_executor(),
+                        timeout=cancel_timeout,
+                    )
+                )
+    finally:
+        asyncio.set_event_loop(None)
+        loop.close()
+
+
+@contextlib.asynccontextmanager
+async def scoped_async_state(
+    job: JobTrait,
+    cached_path: Optional[str] = DEFAULT_JOB_PATH,
+    shutdown_timeout: float = 10.0,
+) -> AsyncIterator[JobState]:
+    """Yield job state and always release job-owned hosts on exit.
+
+    This is the async counterpart of the test ``scoped_state`` helper: callers
+    get a bounded graceful host shutdown first, and if that cannot be proven the
+    owning job is killed. This matters for local ``ProcessJob`` workers because
+    they run in detached process groups and terminal Ctrl-C will not reap them.
+    """
+    try:
+        state = job.state(cached_path=cached_path)
+    except BaseException:
+        _kill_quietly(job)
+        raise
+
+    try:
+        yield state
+    finally:
+        try:
+            for host_mesh in state.host_meshes():
+                await _await_bounded(
+                    host_mesh.shutdown(),
+                    shutdown_timeout,
+                )
+        except asyncio.CancelledError:
+            _kill_quietly(job)
+            raise
+        except (KeyboardInterrupt, SystemExit):
+            _kill_quietly(job)
+            raise
+        except Exception:
+            logger.warning(
+                "job host shutdown did not complete; killing job",
+                exc_info=True,
+            )
+            _kill_quietly(job)
+        else:
+            # Graceful shutdown released the meshes; also release the job's local
+            # scratch (tmpdir / ipc sockets), which otherwise only the kill path
+            # frees.
+            with contextlib.suppress(Exception):
+                job.cleanup()

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -336,12 +336,19 @@ class JobState:
     def __repr__(self) -> str:
         return f"JobState(hosts={self._hosts})"
 
+    def host_meshes(self) -> List[HostMesh]:
+        """All host meshes in this state, e.g. for teardown to enumerate."""
+        return list(self._hosts.values())
+
 
 class CachedRunning(NamedTuple):
     job: "JobTrait"
 
 
 logger = logging.getLogger(__name__)
+DEFAULT_JOB_PATH: str = ".monarch/job_state.pkl"
+
+
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler(sys.stderr))
 logger.propagate = False
@@ -610,12 +617,40 @@ class JobTrait(ABC):
     def kill(self):
         apply_id = self.apply_id
         running = self._running
-        self._components.reset_runtime()
-        if apply_id is not None:
-            stop_job_sidecar(apply_id)
-        if running is not None:
-            running._kill()
-        self._status = "not_running"
+        # Run every teardown step, but do not let a later bookkeeping failure
+        # mask a worker-reap failure, and keep running state when the reap itself
+        # failed (workers may still be alive) so a caller can retry.
+        errors: List[Exception] = []
+        kill_ok = True
+        try:
+            if running is not None:
+                running._kill()
+        except Exception as e:
+            kill_ok = False
+            errors.append(e)
+        try:
+            self._components.reset_runtime()
+        except Exception as e:
+            errors.append(e)
+        try:
+            if apply_id is not None:
+                stop_job_sidecar(apply_id)
+        except Exception as e:
+            errors.append(e)
+        if kill_ok:
+            self._status = "not_running"
+        if len(errors) == 1:
+            raise errors[0]
+        if errors:
+            raise ExceptionGroup("job kill failed", errors)
+
+    def cleanup(self) -> None:  # noqa: B027 - optional override hook; default no-op
+        """Release job-owned local resources after a graceful teardown.
+
+        Default is a no-op; subclasses that hold local scratch (e.g.
+        ``ProcessJob`` with its tmpdir/sockets) override this so the graceful
+        path releases them too, not only ``kill()``.
+        """
 
     def remote_mount(
         self,
@@ -721,9 +756,6 @@ def job_loads(data: bytes) -> JobTrait:
     """
     # @lint-ignore PYTHONPICKLEISBAD
     return pickle.loads(data)
-
-
-DEFAULT_JOB_PATH: str = ".monarch/job_state.pkl"
 
 
 def job_load(filename: str = DEFAULT_JOB_PATH) -> JobTrait:

--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import contextlib
 import logging
 import os
 import shutil
@@ -14,6 +15,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import time
 from typing import Dict, List, Optional, Union
 
 from monarch._src.actor.bootstrap import attach_to_workers
@@ -30,6 +32,20 @@ except ImportError:
     _IN_PAR = False
 
 _PROCESS_WORKER_MODULE = "monarch._src.job._process_worker"
+_KILL_GRACE_SECONDS = 1.0
+
+
+def _group_active(pgid: int) -> bool:
+    # Liveness of the whole process group, not just the leader. A group leader
+    # can exit on SIGTERM while children that ignored it keep running, and
+    # os.kill(leader, 0) would wrongly report the group gone (and reads a
+    # not-yet-reaped zombie leader as alive). os.killpg(pgid, 0) succeeds while
+    # any process in the group remains.
+    try:
+        os.killpg(pgid, 0)
+    except OSError:
+        return False
+    return True
 
 
 class ProcessJob(JobTrait):
@@ -111,7 +127,7 @@ class ProcessJob(JobTrait):
                         addr,
                     )
                     self._watch_process(proc, mesh_name, i, addr)
-        except Exception:
+        except BaseException:
             self._kill()
             raise
 
@@ -198,14 +214,39 @@ class ProcessJob(JobTrait):
         return True
 
     def _kill(self) -> None:
-        # Use SIGTERM to allow worker processes to shut down gracefully.
-        # The HostMesh objects are not stored here (they're returned to callers),
-        # so we rely on the worker processes handling SIGTERM for clean shutdown.
-        for p in self._host_to_pid.values():
+        # Workers are launched with start_new_session=True, so the root worker
+        # pid is also the process-group id. Signal the group so fallback cleanup
+        # matches the detached topology rather than only nudging the leader.
+        pids = [p.pid for p in self._host_to_pid.values()]
+        for pid in pids:
             try:
-                os.kill(p.pid, signal.SIGTERM)
+                os.killpg(pid, signal.SIGTERM)
             except OSError:
-                pass
+                with contextlib.suppress(OSError):
+                    os.kill(pid, signal.SIGTERM)
+
+        deadline = time.monotonic() + _KILL_GRACE_SECONDS
+        remaining = pids
+        while remaining and time.monotonic() < deadline:
+            remaining = [pid for pid in remaining if _group_active(pid)]
+            if remaining:
+                time.sleep(0.05)
+        for pid in remaining:
+            try:
+                os.killpg(pid, signal.SIGKILL)
+            except OSError:
+                with contextlib.suppress(OSError):
+                    os.kill(pid, signal.SIGKILL)
+        self.cleanup()
+
+    def cleanup(self) -> None:
+        """Release job-owned local resources: worker bookkeeping and the scratch
+        tmpdir (which holds the ipc:// sockets).
+
+        Signals no processes, so it is safe to run after a graceful mesh
+        shutdown as well as from ``_kill``. This closes the tmpdir/socket leak
+        on the graceful teardown path, where ``_kill`` never runs.
+        """
         self._host_to_pid.clear()
         if self._tmpdir is not None:
             shutil.rmtree(self._tmpdir, ignore_errors=True)

--- a/python/monarch/job/__init__.py
+++ b/python/monarch/job/__init__.py
@@ -5,6 +5,11 @@
 # LICENSE file in the root directory of this source tree.
 
 # Re-export the job module directly
+from monarch._src.job._process_job_async_lifecycle import (
+    cancel_async_tasks,
+    run_async_main,
+    scoped_async_state,
+)
 from monarch._src.job.job import (
     DEFAULT_JOB_PATH,
     exec_command,
@@ -24,6 +29,7 @@ from monarch._src.job.slurm import SlurmJob
 # Define exports
 __all__ = [
     "DEFAULT_JOB_PATH",
+    "cancel_async_tasks",
     "exec_command",
     "JobTrait",
     "job_load",
@@ -33,6 +39,8 @@ __all__ = [
     "LocalJob",
     "MeshAdminConfig",
     "ProcessJob",
+    "run_async_main",
+    "scoped_async_state",
     "set_current_job",
     "SlurmJob",
     "TelemetryConfig",

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -6,14 +6,17 @@
 
 # pyre-unsafe
 
+import asyncio
 import contextlib
 import os
 import pickle
+import signal
 import socket
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 import types
 from dataclasses import dataclass
 from typing import cast, Dict, Optional, Sequence
@@ -24,6 +27,11 @@ import monarch._src.job.job_sidecar as js
 import pytest
 
 # Import directly from _src since job module isn't properly exposed
+from monarch._src.job._process_job_async_lifecycle import (
+    cancel_async_tasks,
+    run_async_main,
+    scoped_async_state,
+)
 from monarch._src.job.job import (
     BatchJob,
     job_load,
@@ -32,6 +40,7 @@ from monarch._src.job.job import (
     JobTrait,
     LocalJob,
     MeshAdminConfig,
+    ProcessState,
     TelemetryConfig,
 )
 from monarch._src.job.job_components import JobComponent, JobComponents, MountComponent
@@ -573,6 +582,271 @@ def test_kill():
     # kill_called should now be True
     assert job.kill_called
     stop_sidecar.assert_called_once_with(apply_id)
+
+
+def test_kill_stops_running_job_even_if_runtime_reset_fails():
+    """The scheduler/job kill must not be skipped by metadata cleanup failure."""
+    job = MockJobTrait()
+    job.apply()
+    apply_id = job.apply_id
+    assert apply_id is not None
+
+    with (
+        patch.object(
+            job._components,
+            "reset_runtime",
+            side_effect=RuntimeError("reset failed"),
+        ),
+        patch("monarch._src.job.job.stop_job_sidecar") as stop_sidecar,
+        pytest.raises(RuntimeError, match="reset failed"),
+    ):
+        job.kill()
+
+    assert job.kill_called
+    assert not job.active
+    stop_sidecar.assert_called_once_with(apply_id)
+
+
+def test_process_job_create_cleans_up_on_baseexception():
+    """Interrupts during ProcessJob._create must not leak spawned workers."""
+    job = ProcessJob({"hosts": 2})
+
+    with (
+        patch(
+            "monarch._src.job.process.subprocess.Popen",
+            side_effect=[types.SimpleNamespace(pid=987654321), KeyboardInterrupt],
+        ),
+        patch.object(ProcessJob, "_watch_process"),
+        pytest.raises(KeyboardInterrupt),
+    ):
+        job._create(client_script=None)
+
+    assert job._host_to_pid == {}
+    assert job._tmpdir is None
+
+
+def test_kill_preserves_running_state_when_reap_fails():
+    """A failed worker reap keeps the job's running state so a caller can retry,
+    and surfaces the reap error rather than masking it with later cleanup."""
+    job = MockJobTrait()
+    job.apply()
+    apply_id = job.apply_id
+    assert apply_id is not None
+    assert job.active
+
+    with (
+        patch.object(MockJobTrait, "_kill", side_effect=RuntimeError("reap failed")),
+        patch.object(job._components, "reset_runtime"),
+        patch("monarch._src.job.job.stop_job_sidecar") as stop_sidecar,
+        pytest.raises(RuntimeError, match="reap failed"),
+    ):
+        job.kill()
+
+    # Reap failed: running state is preserved so the caller can retry the kill.
+    assert job.active
+    # The remaining teardown steps still ran best-effort.
+    stop_sidecar.assert_called_once_with(apply_id)
+
+
+def test_process_kill_escalates_to_sigkill_for_surviving_group():
+    """SIGKILL escalation fires while the worker process GROUP is still alive,
+    even when the bare leader pid would look dead -- liveness is per-group."""
+    job = ProcessJob({"hosts": 1})
+    job._host_to_pid = {"hosts_0": ProcessState(4242, "ipc://x")}
+    job._tmpdir = None
+    killpg_calls: list[tuple[int, int]] = []
+
+    def fake_killpg(pgid: int, sig: int) -> None:
+        # signal 0 is the liveness probe; the group stays alive through the grace
+        # window, so escalation must reach SIGKILL.
+        if sig != 0:
+            killpg_calls.append((pgid, sig))
+
+    def fake_kill(pid: int, sig: int) -> None:
+        # The bare leader pid reads dead; only the per-group probe keeps it
+        # pending -- exactly the case the fix addresses.
+        raise ProcessLookupError()
+
+    with (
+        patch("monarch._src.job.process.os.killpg", side_effect=fake_killpg),
+        patch("monarch._src.job.process.os.kill", side_effect=fake_kill),
+        patch("monarch._src.job.process._KILL_GRACE_SECONDS", 0.01),
+        patch("monarch._src.job.process.time.sleep"),
+    ):
+        job._kill()
+
+    assert (4242, signal.SIGTERM) in killpg_calls
+    assert (4242, signal.SIGKILL) in killpg_calls
+    assert job._host_to_pid == {}
+
+
+def test_scoped_async_state_graceful_shutdown_does_not_kill():
+    """The async state helper shuts down owned hosts without killing the job."""
+
+    class ShutdownHost:
+        shutdown_called = False
+
+        async def _shutdown(self) -> None:
+            self.shutdown_called = True
+
+        def shutdown(self):
+            return self._shutdown()
+
+    host = ShutdownHost()
+
+    class AsyncStateJob(MockJobTrait):
+        def _state(self) -> JobState:
+            return JobState({"hosts": cast("HostMesh", host)})
+
+    async def run() -> None:
+        job = AsyncStateJob()
+        async with scoped_async_state(job, cached_path=None) as state:
+            assert state.hosts is host
+        assert host.shutdown_called
+        assert not job.kill_called
+
+    asyncio.run(run())
+
+
+def test_scoped_async_state_kills_job_when_shutdown_hangs():
+    """If graceful host shutdown cannot finish, the owning job is killed."""
+
+    class HangingHost:
+        def shutdown(self):
+            return asyncio.sleep(3600)
+
+    host = HangingHost()
+
+    class AsyncStateJob(MockJobTrait):
+        def _state(self) -> JobState:
+            return JobState({"hosts": cast("HostMesh", host)})
+
+    async def run() -> None:
+        job = AsyncStateJob()
+        async with scoped_async_state(
+            job,
+            cached_path=None,
+            shutdown_timeout=0.01,
+        ):
+            pass
+        assert job.kill_called
+
+    asyncio.run(run())
+
+
+def test_scoped_async_state_kills_job_when_shutdown_ignores_cancellation():
+    """The shutdown timeout does not depend on cooperative cancellation."""
+
+    class StubbornHost:
+        async def _shutdown(self) -> None:
+            while True:
+                try:
+                    await asyncio.sleep(3600)
+                except asyncio.CancelledError:
+                    pass
+
+        def shutdown(self):
+            return self._shutdown()
+
+    host = StubbornHost()
+
+    class AsyncStateJob(MockJobTrait):
+        def _state(self) -> JobState:
+            return JobState({"hosts": cast("HostMesh", host)})
+
+    async def run() -> None:
+        job = AsyncStateJob()
+        async with scoped_async_state(
+            job,
+            cached_path=None,
+            shutdown_timeout=0.01,
+        ):
+            pass
+        assert job.kill_called
+
+    start = time.monotonic()
+    run_async_main(run(), cancel_timeout=0.01)
+    assert time.monotonic() - start < 2.0
+
+
+def test_scoped_async_state_kills_and_reraises_cleanup_cancellation():
+    """Second-interrupt style cancellation kills the job and keeps propagating."""
+
+    class CancellingHost:
+        async def _shutdown(self) -> None:
+            raise asyncio.CancelledError()
+
+        def shutdown(self):
+            return self._shutdown()
+
+    host = CancellingHost()
+
+    class AsyncStateJob(MockJobTrait):
+        def _state(self) -> JobState:
+            return JobState({"hosts": cast("HostMesh", host)})
+
+    async def run() -> None:
+        job = AsyncStateJob()
+        with pytest.raises(asyncio.CancelledError):
+            async with scoped_async_state(job, cached_path=None):
+                pass
+        assert job.kill_called
+
+    asyncio.run(run())
+
+
+def test_run_async_main_bounds_pending_task_cancellation():
+    """Pending tasks that ignore cancellation cannot hang process teardown."""
+
+    async def stubborn() -> None:
+        while True:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                pass
+
+    async def run() -> None:
+        asyncio.create_task(stubborn())
+
+    start = time.monotonic()
+    run_async_main(run(), cancel_timeout=0.01)
+    assert time.monotonic() - start < 2.0
+
+
+def test_cancel_async_tasks_bounds_uncooperative_task_cancellation():
+    """Demo cleanup drains what it can without waiting forever."""
+
+    async def stubborn() -> None:
+        while True:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                pass
+
+    async def run() -> None:
+        task = asyncio.create_task(stubborn())
+        await cancel_async_tasks([task], timeout=0.01)
+
+    start = time.monotonic()
+    run_async_main(run(), cancel_timeout=0.01)
+    assert time.monotonic() - start < 2.0
+
+
+def test_scoped_async_state_kills_job_when_state_fails_after_apply():
+    """A state construction failure after apply must not leak job resources."""
+
+    class FailingStateJob(MockJobTrait):
+        def _state(self) -> JobState:
+            raise RuntimeError("failed to build state")
+
+    async def run() -> None:
+        job = FailingStateJob()
+        with pytest.raises(RuntimeError, match="failed to build state"):
+            async with scoped_async_state(job, cached_path=None):
+                pass
+        assert job.kill_called
+
+    asyncio.run(run())
 
 
 def test_state_query_engine_none_without_telemetry():


### PR DESCRIPTION
Summary:

this diff moves the remaining mesh-admin example demos that own a local `ProcessJob` onto the scoped lifecycle introduced in the parent diff.

these demos all create their own host through `ProcessJob(...).enable_admin()`, then spawn proc meshes from `state.hosts`. without an owner around that startup and runtime work, exceptions, stdin exit, or `CTRL-C` can leave the detached local host and workers behind.

the demos now use `scoped_async_state()` and `run_async_main()` so state construction, startup, runtime, and exit all flow through bounded host shutdown with `ProcessJob.kill()` as fallback. demo-local driver tasks and drainers are still cancelled explicitly with `cancel_async_tasks()`; final `proc.stop()` cleanup is left to host shutdown, while observable mid-demo stops stay in place.

`rapid_spawn_exit_stress.py` had module-level `job.state()` work, so this diff moves that setup under `async_main()` before applying the same lifecycle. no behavior change is intended beyond making teardown owned and bounded.

Differential Revision: D111563916


