### PR TITLE
warn in the header when the terminal hides detail panes (#4393)

### DIFF
--- a/hyperactor_mesh_admin_tui/src/format.rs
+++ b/hyperactor_mesh_admin_tui/src/format.rs
@@ -164,6 +164,16 @@ pub(crate) fn format_value(v: &Value) -> String {
     }
 }
 
+/// Replace control characters (C0/C1 controls and DEL) with the Unicode
+/// replacement character. Flight-recorder event text is less-trusted mesh data
+/// rendered straight into the operator's terminal; stripping controls keeps a
+/// crafted event from emitting escape/OSC sequences.
+pub(crate) fn sanitize_control(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_control() { '\u{fffd}' } else { c })
+        .collect()
+}
+
 /// Convert an ISO 8601 UTC timestamp (e.g.
 /// "2026-02-11T19:11:01.265Z") to a local-timezone HH:MM:SS string.
 /// Falls back to extracting the raw UTC time portion if parsing
@@ -745,5 +755,14 @@ mod tests {
     #[test]
     fn format_local_time_too_short_fallback() {
         assert_eq!(format_local_time("short"), "short");
+    }
+
+    #[test]
+    fn sanitize_control_replaces_control_bytes() {
+        assert_eq!(
+            sanitize_control("a\u{1b}]0;x\u{7}b\n"),
+            "a\u{fffd}]0;x\u{fffd}b\u{fffd}"
+        );
+        assert_eq!(sanitize_control("plain text"), "plain text");
     }
 }

--- a/hyperactor_mesh_admin_tui/src/render.rs
+++ b/hyperactor_mesh_admin_tui/src/render.rs
@@ -31,6 +31,7 @@ use ratatui::layout::Constraint;
 use ratatui::layout::Direction;
 use ratatui::layout::Layout;
 
+use self::detail_pane::detail_content_clipped;
 use self::detail_pane::render_detail_pane;
 use self::status_bar::render_footer;
 use self::status_bar::render_header;
@@ -51,7 +52,8 @@ pub(crate) fn ui(frame: &mut ratatui::Frame<'_>, app: &App) {
         ])
         .split(frame.area());
 
-    render_header(frame, chunks[0], app);
+    let detail_clipped = detail_content_clipped(app, chunks[1].height);
+    render_header(frame, chunks[0], app, detail_clipped);
     render_body(frame, chunks[1], app);
     render_footer(frame, chunks[2], app);
 }

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -41,6 +41,7 @@ use crate::format::format_system_time_iso;
 use crate::format::format_system_time_local;
 use crate::format::format_system_time_relative;
 use crate::format::format_system_time_uptime;
+use crate::format::sanitize_control;
 use crate::format_bytes;
 use crate::theme::ColorScheme;
 use crate::theme::Labels;
@@ -730,7 +731,6 @@ fn render_actor_detail(
     } else {
         recorded_events
             .iter()
-            .take(20)
             .map(|event| {
                 let level_style = match event.level.as_str() {
                     "ERROR" => scheme.error,
@@ -739,24 +739,50 @@ fn render_actor_detail(
                     "DEBUG" => scheme.info,
                     _ => scheme.detail_label,
                 };
+                // Event text is less-trusted mesh data; strip control bytes so a
+                // crafted event cannot emit terminal escape/OSC sequences into
+                // the operator's terminal.
+                let level_char = event
+                    .level
+                    .chars()
+                    .next()
+                    .filter(|c| !c.is_control())
+                    .unwrap_or('?');
                 Line::from(vec![
+                    Span::styled(format!("{level_char} "), level_style),
                     Span::styled(
-                        format!("{} ", event.level.chars().next().unwrap_or('?')),
-                        level_style,
-                    ),
-                    Span::styled(
-                        format!("{} ", format_local_time(&event.timestamp)),
+                        format!(
+                            "{} ",
+                            sanitize_control(&format_local_time(&event.timestamp))
+                        ),
                         scheme.detail_label,
                     ),
-                    Span::raw(format_event_summary(&event.name, &event.fields)),
+                    Span::raw(sanitize_control(&format_event_summary(
+                        &event.name,
+                        &event.fields,
+                    ))),
                 ])
             })
             .collect()
     };
 
-    let recorder = Paragraph::new(events)
-        .block(recorder_block)
-        .wrap(Wrap { trim: true });
+    // TUI-FR-1 (flight-recorder-autoscroll): events render chronologically
+    // (oldest at top) and auto-scroll so the newest row sits on the bottom line.
+    // Read line_count before attaching the block; a Paragraph carrying the block
+    // subtracts the border from the width again, over-counting and scrolling past
+    // the newest line.
+    let inner_width = chunks[3].width.saturating_sub(2);
+    let inner_height = chunks[3].height.saturating_sub(2);
+    let recorder = Paragraph::new(events).wrap(Wrap { trim: true });
+    // Guard the degenerate zero-width case: nothing renders at zero inner width,
+    // and line_count(0) has no well-defined wrap.
+    let total_rows = if inner_width == 0 {
+        0
+    } else {
+        recorder.line_count(inner_width) as u16
+    };
+    let scroll = total_rows.saturating_sub(inner_height);
+    let recorder = recorder.block(recorder_block).scroll((scroll, 0));
     frame.render_widget(recorder, chunks[3]);
 }
 
@@ -2002,6 +2028,113 @@ mod tests {
         assert!(
             text.contains("Flight Recorder"),
             "expected flight recorder pane still visible under cramped height: {text}"
+        );
+    }
+
+    /// Serialize `count` flight-recorder events named `evt000`..`evt{count-1}`
+    /// (oldest first). Empty `fields` make `format_event_summary` fall back to
+    /// the name, so each event renders as its own identifier.
+    fn recorder_json(count: usize) -> String {
+        let events: Vec<serde_json::Value> = (0..count)
+            .map(|i| {
+                serde_json::json!({
+                    "timestamp": "2026-07-11T00:00:00.000Z",
+                    "level": "INFO",
+                    "name": format!("evt{i:03}"),
+                    "fields": {},
+                })
+            })
+            .collect();
+        serde_json::to_string(&events).unwrap()
+    }
+
+    fn actor_payload_with_recorder(json: String) -> NodePayload {
+        let mut payload = actor_payload(None);
+        if let NodeProperties::Actor {
+            flight_recorder, ..
+        } = &mut payload.properties
+        {
+            *flight_recorder = Some(json);
+        }
+        payload
+    }
+
+    // TUI-FR-1: with more events than fit, the recorder drops the old take(20)
+    // cap, renders every event, and auto-scrolls so the newest sits on the
+    // bottom line while the oldest scrolls off. Height 24 leaves the recorder
+    // 9 inner rows for 30 events, so rows evt021..evt029 are visible.
+    #[test]
+    fn flight_recorder_autoscrolls_to_newest() {
+        let text = render_detail_to_string_with_size(
+            &actor_payload_with_recorder(recorder_json(30)),
+            120,
+            24,
+        );
+        assert!(
+            text.contains("evt029"),
+            "newest event pinned to the bottom line: {text}"
+        );
+        assert!(
+            text.contains("evt025"),
+            "an event past the old take(20) cap surfaces: {text}"
+        );
+        assert!(
+            !text.contains("evt000"),
+            "oldest event scrolled off the top: {text}"
+        );
+    }
+
+    // TUI-FR-1: when every event fits, none scroll off and they render
+    // chronologically (oldest above newest).
+    #[test]
+    fn flight_recorder_renders_chronological_without_scroll() {
+        let text = render_detail_to_string_with_size(
+            &actor_payload_with_recorder(recorder_json(3)),
+            120,
+            40,
+        );
+        let oldest = text
+            .find("evt000")
+            .expect("oldest event visible when it fits");
+        let newest = text
+            .find("evt002")
+            .expect("newest event visible when it fits");
+        assert!(
+            oldest < newest,
+            "oldest renders above newest (chronological order): {text}"
+        );
+    }
+
+    // TUI-FR-1: event text is less-trusted, so control/escape bytes are replaced
+    // with a sentinel and cannot drive the operator's terminal.
+    #[test]
+    fn flight_recorder_sanitizes_control_bytes() {
+        let json = serde_json::to_string(&vec![serde_json::json!({
+            "timestamp": "2026-07-11T00:00:00.000Z",
+            "level": "INFO",
+            "name": "n",
+            "fields": {"message": "a\u{1b}]0;pwn\u{7}b"},
+        })])
+        .unwrap();
+        let text = render_detail_to_string_with_size(&actor_payload_with_recorder(json), 120, 24);
+        assert!(
+            !text.contains('\u{1b}'),
+            "ESC byte must not reach the terminal: {text:?}"
+        );
+        assert!(
+            text.contains('\u{fffd}'),
+            "control bytes replaced with the sentinel: {text:?}"
+        );
+    }
+
+    // TUI-FR-1: a terminal so narrow the recorder has zero inner width must not
+    // panic (line_count(0) is guarded).
+    #[test]
+    fn flight_recorder_survives_zero_inner_width() {
+        let _ = render_detail_to_string_with_size(
+            &actor_payload_with_recorder(recorder_json(5)),
+            2,
+            24,
         );
     }
 }

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -786,33 +786,50 @@ fn render_actor_detail(
     frame.render_widget(recorder, chunks[3]);
 }
 
-/// Compute the desired height for the inbound-ordering section, capped
-/// against the available area so the flight recorder's minimum height
-/// (`MIN_FLIGHT_RECORDER_HEIGHT`) is preserved even when the desired
-/// height would otherwise overflow.
+/// TUI-IO-1 (ordering-visibility): the inbound-ordering pane is drawn iff
+/// buffering is enabled AND either a session is stalled (`buffered_count > 0`) or
+/// the snapshot is partial. The partial case matters: the sessions we could not
+/// read (mutex held at snapshot time) may be the stalled ones, so the
+/// "(partial: N skipped)" warning must still surface. This is the single source
+/// of truth for `render_inbound_ordering` and `compute_ordering_height` so their
+/// visibility decisions cannot drift. It is a TUI presentation invariant (like
+/// the execution pane's EX-1), distinct from the external `IO-1` whose "not
+/// available" placeholder this stack removed.
+fn ordering_has_content(io: &InboundOrdering) -> bool {
+    io.enabled && (io.sessions.iter().any(|s| s.buffered_count > 0) || !io.snapshot_complete)
+}
+
+/// Compute the desired height for the inbound-ordering section, or 0 to hide it
+/// (per `ordering_has_content`), capped so the flight recorder keeps
+/// `MIN_FLIGHT_RECORDER_HEIGHT`. The row budget mirrors `build_inbound_ordering_lines`
+/// exactly, the way `compute_execution_height` mirrors `build_execution_lines`.
 fn compute_ordering_height(
     area_height: u16,
     info_height: u16,
     inbound_ordering: Option<&InboundOrdering>,
 ) -> u16 {
+    let Some(io) = inbound_ordering else {
+        return 0;
+    };
+    if !ordering_has_content(io) {
+        return 0;
+    }
+    let stalled = io.sessions.iter().filter(|s| s.buffered_count > 0).count();
+    // border(2) + rollup line 1(1) + rollup line 2(0/1). A partial snapshot with
+    // no returned stalls stops there; otherwise add the table: spacer(1) +
+    // header(1) + rows + more(0/1) + footer spacer(1) + footer(1).
+    let rollup2 = u16::from(io.returned_buffered_message_count > 0);
+    let table = if stalled == 0 {
+        0
+    } else {
+        let rows = stalled.min(TOP_N) as u16;
+        let more_row = u16::from(stalled > TOP_N);
+        1 + 1 + rows + more_row + 1 + 1
+    };
+    let want = 2 + 1 + rollup2 + table;
     let budget = area_height
         .saturating_sub(info_height)
         .saturating_sub(MIN_FLIGHT_RECORDER_HEIGHT);
-    let want: u16 = match inbound_ordering {
-        None => 3,
-        Some(io) if !io.enabled => 3,
-        Some(io) => {
-            let stalled = io.sessions.iter().filter(|s| s.buffered_count > 0).count();
-            if stalled == 0 {
-                3 // border(2) + rollup line 1 only
-            } else {
-                let rows = stalled.min(TOP_N) as u16;
-                let more_row = if stalled > TOP_N { 1 } else { 0 };
-                // border(2) + rollup(2) + spacer(1) + header(1) + rows + footer(3)
-                2 + 2 + 1 + 1 + rows + more_row + 3
-            }
-        }
-    };
     want.min(budget)
 }
 
@@ -936,6 +953,9 @@ fn build_execution_lines<'a>(
 const OWNER_COL_WIDTH: usize = 30;
 const NEED_SEQ_COL_WIDTH: usize = 8;
 
+/// Drawn only when `ordering_has_content` (enabled, and either a stalled session
+/// or a partial snapshot); the caller gives this a zero-height chunk otherwise,
+/// mirroring the execution pane. Hidden states show no placeholder line.
 fn render_inbound_ordering(
     frame: &mut ratatui::Frame<'_>,
     area: Rect,
@@ -943,32 +963,25 @@ fn render_inbound_ordering(
     scheme: &ColorScheme,
     l: &Labels,
 ) {
+    let Some(io) = inbound_ordering else {
+        return;
+    };
+    if !ordering_has_content(io) {
+        return;
+    }
     // Red border when actionable stalls are present; otherwise
     // matches the rest of the chrome.
-    let border_style = match inbound_ordering {
-        Some(io) if io.enabled && io.returned_buffered_session_count > 0 => {
-            scheme.detail_alert_border
-        }
-        _ => scheme.border,
+    let border_style = if io.returned_buffered_session_count > 0 {
+        scheme.detail_alert_border
+    } else {
+        scheme.border
     };
     let block = Block::default()
         .title(l.pane_inbound_ordering)
         .borders(Borders::ALL)
         .border_style(border_style);
 
-    let lines: Vec<Line> = match inbound_ordering {
-        None => vec![Line::from(Span::styled(
-            l.ordering_not_available,
-            scheme.detail_label,
-        ))],
-        Some(io) if !io.enabled => vec![Line::from(Span::styled(
-            l.ordering_buffering_disabled,
-            scheme.detail_label,
-        ))],
-        Some(io) => build_inbound_ordering_lines(io, scheme, l),
-    };
-
-    let p = Paragraph::new(lines)
+    let p = Paragraph::new(build_inbound_ordering_lines(io, scheme, l))
         .block(block)
         .wrap(Wrap { trim: false });
     frame.render_widget(p, area);
@@ -1021,8 +1034,8 @@ fn build_inbound_ordering_lines<'a>(
         )),
     ]));
 
-    // Rollup line 2 only when there's actually something buffered;
-    // for clean snapshots line 1 already conveys "0 of N stalled".
+    // Rollup line 2 only when something is buffered; a partial snapshot with no
+    // returned stalls shows just line 1 ("0 of N stalled (partial: M skipped)").
     if io.returned_buffered_message_count > 0 {
         lines.push(Line::from(Span::raw(format!(
             "{} {}, {} {}{}",
@@ -1034,6 +1047,9 @@ fn build_inbound_ordering_lines<'a>(
         ))));
     }
 
+    // Partial snapshot with nothing returned as stalled: the rollup (with its
+    // "(partial: N skipped)" suffix) is why the pane is shown, so stop before the
+    // per-session table.
     if stalled.is_empty() {
         return lines;
     }
@@ -1508,7 +1524,7 @@ mod tests {
         );
     }
 
-    // ---- inbound-ordering render tests (IO-1 / IO-2 / IO-6 / IO-7) ----
+    // ---- inbound-ordering render tests (TUI-IO-1 / IO-2 / IO-6 / IO-7) ----
 
     fn mock_actor_addr(name: &str, proc_name: &str) -> hyperactor::ActorAddr {
         let proc_id = hyperactor_mesh::mesh_id::ResourceId::proc_addr_from_name(
@@ -1657,21 +1673,18 @@ mod tests {
         }
     }
 
-    // IO-1: structural absence renders "not available".
+    // TUI-IO-1: the pane is shown iff enabled AND (a session is stalled OR the
+    // snapshot is partial); every other state hides it. This arm: None hides it.
     #[test]
     fn render_actor_detail_inbound_ordering_none() {
         let text = render_detail_to_string_with_size(&actor_payload(None), 120, 45);
         assert!(
-            text.contains("not available"),
-            "expected 'not available' in output: {text}"
-        );
-        assert!(
-            !text.contains("Owner"),
-            "no per-session header in None state: {text}"
+            !text.contains("Inbound ordering"),
+            "None hides the inbound-ordering pane: {text}"
         );
     }
 
-    // IO-1 enabled=false: shows compact "disabled (direct_send)" line.
+    // TUI-IO-1: buffering disabled hides the pane (nothing to surface).
     #[test]
     fn render_actor_detail_inbound_ordering_disabled() {
         let io = InboundOrdering {
@@ -1686,16 +1699,13 @@ mod tests {
         };
         let text = render_detail_to_string_with_size(&actor_payload(Some(Box::new(io))), 120, 45);
         assert!(
-            text.contains("disabled (direct_send)"),
-            "expected compact disabled message: {text}"
-        );
-        assert!(
-            !text.contains("Need seq"),
-            "no per-session header in disabled state: {text}"
+            !text.contains("Inbound ordering"),
+            "buffering disabled hides the inbound-ordering pane: {text}"
         );
     }
 
-    // Enabled but no stalled sessions: line 1 only; no buffered totals line; no table.
+    // TUI-IO-1: enabled, a complete snapshot, and no stalled sessions hides the pane,
+    // mirroring the execution pane. (Contrast the partial-snapshot case below.)
     #[test]
     fn render_actor_detail_inbound_ordering_enabled_no_stalled() {
         let io = InboundOrdering {
@@ -1712,15 +1722,92 @@ mod tests {
             ],
         };
         let text = render_detail_to_string_with_size(&actor_payload(Some(Box::new(io))), 120, 45);
-        assert!(text.contains("enabled"), "expected enabled label: {text}");
         assert!(
-            text.contains("0 of 2 sessions stalled"),
-            "expected rollup '0 of 2 sessions stalled': {text}"
+            !text.contains("Inbound ordering"),
+            "no stalled sessions hides the inbound-ordering pane: {text}"
+        );
+        assert!(
+            !text.contains("sessions stalled"),
+            "no rollup line when the pane is hidden: {text}"
+        );
+    }
+
+    // TUI-IO-1: a partial snapshot with no returned stalls still shows the pane so the
+    // "(partial: N skipped)" warning survives -- the sessions we could not read
+    // may be the stalled ones.
+    #[test]
+    fn render_actor_detail_inbound_ordering_partial_no_stalls_shown() {
+        let io = InboundOrdering {
+            enabled: true,
+            snapshot_complete: false,
+            skipped_session_count: 2,
+            known_session_count: 3,
+            returned_buffered_session_count: 0,
+            returned_buffered_message_count: 0,
+            returned_max_buffered_count: 0,
+            sessions: vec![session(uuid::Uuid::nil(), None, 0, 5, None, None)],
+        };
+        let text = render_detail_to_string_with_size(&actor_payload(Some(Box::new(io))), 120, 45);
+        assert!(
+            text.contains("Inbound ordering"),
+            "partial snapshot keeps the pane visible: {text}"
+        );
+        assert!(
+            text.contains("(partial: 2 skipped)"),
+            "the skipped-session warning survives: {text}"
         );
         assert!(
             !text.contains("Need seq"),
-            "no per-session table header in clean state: {text}"
+            "no per-session table when nothing returned is stalled: {text}"
         );
+    }
+
+    // TUI-IO-1: buffering disabled hides the pane even when a session still carries a
+    // buffered count, so the enabled gate stays load-bearing.
+    #[test]
+    fn render_actor_detail_inbound_ordering_disabled_with_buffered() {
+        let io = InboundOrdering {
+            enabled: false,
+            snapshot_complete: true,
+            skipped_session_count: 0,
+            known_session_count: 1,
+            returned_buffered_session_count: 1,
+            returned_buffered_message_count: 5,
+            returned_max_buffered_count: 5,
+            sessions: vec![session(uuid::Uuid::nil(), None, 5, 0, Some(2), Some(6))],
+        };
+        let text = render_detail_to_string_with_size(&actor_payload(Some(Box::new(io))), 120, 45);
+        assert!(
+            !text.contains("Inbound ordering"),
+            "disabled buffering hides the pane regardless of buffered sessions: {text}"
+        );
+    }
+
+    // TUI-IO-1 height side: compute_ordering_height must agree with
+    // render_inbound_ordering's visibility (0 when hidden, > 0 when shown) so a
+    // reserve-but-hide layout drift cannot slip past the render-only string tests.
+    #[test]
+    fn compute_ordering_height_matches_visibility() {
+        let mk = |enabled: bool, complete: bool, buffered: usize| InboundOrdering {
+            enabled,
+            snapshot_complete: complete,
+            skipped_session_count: if complete { 0 } else { 1 },
+            known_session_count: 1,
+            returned_buffered_session_count: if buffered > 0 { 1 } else { 0 },
+            returned_buffered_message_count: 0,
+            returned_max_buffered_count: 0,
+            sessions: vec![session(uuid::Uuid::nil(), None, buffered, 0, None, None)],
+        };
+        // Hidden -> 0.
+        assert_eq!(compute_ordering_height(45, 13, None), 0);
+        assert_eq!(
+            compute_ordering_height(45, 13, Some(&mk(false, true, 0))),
+            0
+        );
+        assert_eq!(compute_ordering_height(45, 13, Some(&mk(true, true, 0))), 0);
+        // Shown -> non-zero: a stalled session, or a partial snapshot.
+        assert!(compute_ordering_height(45, 13, Some(&mk(true, true, 5))) > 0);
+        assert!(compute_ordering_height(45, 13, Some(&mk(true, false, 0))) > 0);
     }
 
     // One stalled session: rollup, table row, footer all present.

--- a/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
+++ b/hyperactor_mesh_admin_tui/src/render/detail_pane.rs
@@ -595,6 +595,9 @@ fn render_proc_detail(
 /// compact, timestamped list of recent events.
 const TOP_N: usize = 10;
 const MIN_FLIGHT_RECORDER_HEIGHT: u16 = 5;
+/// A bordered pane needs border(2) + 1 row to show any content; below this it
+/// draws only a border sliver, so treat it as hidden (0 height + clip alert).
+const MIN_VISIBLE_PANE_HEIGHT: u16 = 3;
 const RED_STALL_THRESHOLD: usize = 100; // placeholder; tune later.
 
 #[allow(clippy::too_many_arguments)]
@@ -617,9 +620,7 @@ fn render_actor_detail(
     scheme: &ColorScheme,
     l: &Labels,
 ) {
-    // info_height grew from 11/15 to 13/17 to accommodate two new
-    // lines (Instance, Queue depth) in the info block.
-    let info_height: u16 = if failure_info.is_some() { 17 } else { 13 };
+    let info_height = actor_info_height(failure_info);
     let ordering_height = compute_ordering_height(area.height, info_height, inbound_ordering);
     // Execution section is hidden (height 0) when the actor reports no
     // execution (None = unsupported) or nothing is in flight; its budget
@@ -799,11 +800,68 @@ fn ordering_has_content(io: &InboundOrdering) -> bool {
     io.enabled && (io.sessions.iter().any(|s| s.buffered_count > 0) || !io.snapshot_complete)
 }
 
+/// Height of the actor info block. Base = 13: 10 content rows (status, instance,
+/// queue depth, data-as-of, type, messages, processing time, created, last
+/// handler, children) + 2 borders + 1 slack row. A failure block adds 5 rows
+/// (spacer, error message, root cause, failed-at, propagated) and absorbs the
+/// slack: 15 content + 2 borders = 17.
+pub(crate) fn actor_info_height(failure_info: Option<&FailureInfo>) -> u16 {
+    if failure_info.is_some() { 17 } else { 13 }
+}
+
+/// TUI-CLIP-1 (content-clipped-alert): true when a content-bearing detail pane
+/// was starved below its content-visible height by a short terminal -- Execution
+/// with live handlers, or Inbound Ordering per `ordering_has_content`. Uses the
+/// same height math as `render_actor_detail` (which floors a pane with no room to
+/// 0), so the header alert can never disagree with what the layout draws.
+pub(crate) fn actor_detail_clipped(
+    area_height: u16,
+    inbound_ordering: Option<&InboundOrdering>,
+    execution: Option<&Execution>,
+    failure_info: Option<&FailureInfo>,
+) -> bool {
+    let info_height = actor_info_height(failure_info);
+    let ordering_height = compute_ordering_height(area_height, info_height, inbound_ordering);
+    let execution_height =
+        compute_execution_height(area_height, info_height, ordering_height, execution);
+    let execution_hidden = execution.is_some_and(|e| e.active_count > 0) && execution_height == 0;
+    let ordering_hidden =
+        inbound_ordering.is_some_and(ordering_has_content) && ordering_height == 0;
+    execution_hidden || ordering_hidden
+}
+
+/// Whether the current selection's detail view has content a short terminal
+/// starved to zero height (drives the header alert). False for non-actor
+/// selections and while help / an overlay replaces the detail pane.
+pub(crate) fn detail_content_clipped(app: &App, detail_height: u16) -> bool {
+    if app.show_help || app.overlay.is_some() {
+        return false;
+    }
+    let Some(payload) = app.detail.as_ref() else {
+        return false;
+    };
+    let NodeProperties::Actor {
+        inbound_ordering,
+        execution,
+        failure_info,
+        ..
+    } = &payload.properties
+    else {
+        return false;
+    };
+    actor_detail_clipped(
+        detail_height,
+        inbound_ordering.as_deref(),
+        execution.as_deref(),
+        failure_info.as_ref(),
+    )
+}
+
 /// Compute the desired height for the inbound-ordering section, or 0 to hide it
 /// (per `ordering_has_content`), capped so the flight recorder keeps
 /// `MIN_FLIGHT_RECORDER_HEIGHT`. The row budget mirrors `build_inbound_ordering_lines`
 /// exactly, the way `compute_execution_height` mirrors `build_execution_lines`.
-fn compute_ordering_height(
+pub(crate) fn compute_ordering_height(
     area_height: u16,
     info_height: u16,
     inbound_ordering: Option<&InboundOrdering>,
@@ -830,7 +888,14 @@ fn compute_ordering_height(
     let budget = area_height
         .saturating_sub(info_height)
         .saturating_sub(MIN_FLIGHT_RECORDER_HEIGHT);
-    want.min(budget)
+    let height = want.min(budget);
+    // Below one content row it is a border-only sliver -> hide it (0), so the
+    // header clip-alert fires instead of drawing a content-less box.
+    if height < MIN_VISIBLE_PANE_HEIGHT {
+        0
+    } else {
+        height
+    }
 }
 
 /// Compute the desired height for the Execution section.
@@ -840,7 +905,7 @@ fn compute_ordering_height(
 /// Otherwise sizes to the rendered line count, capped against the remaining
 /// budget so the flight recorder keeps its minimum height. Must match the
 /// line count produced by `build_execution_lines`.
-fn compute_execution_height(
+pub(crate) fn compute_execution_height(
     area_height: u16,
     info_height: u16,
     ordering_height: u16,
@@ -862,7 +927,14 @@ fn compute_execution_height(
     let rows = e.active_handlers.len() as u16;
     let more_row = u16::from(e.truncated);
     let want = 2 + 1 + oldest_line + rows + more_row;
-    want.min(budget)
+    let height = want.min(budget);
+    // Below one content row it is a border-only sliver -> hide it (0), so the
+    // header clip-alert fires instead of drawing a content-less box.
+    if height < MIN_VISIBLE_PANE_HEIGHT {
+        0
+    } else {
+        height
+    }
 }
 
 /// Render the Execution section: the second plane to lifecycle status,
@@ -2223,5 +2295,84 @@ mod tests {
             2,
             24,
         );
+    }
+
+    // A short terminal that starves the Execution pane to zero height must set
+    // the header "content hidden" flag; a roomy terminal must not; and an idle
+    // actor (no live handlers) must never flag, even when tiny.
+    #[test]
+    fn actor_detail_clipped_flags_starved_execution() {
+        let active = Execution {
+            active_count: 2,
+            active_handlers: vec![ActiveHandler {
+                name: "hold".to_string(),
+                active_count: 2,
+                oldest_since: SystemTime::now(),
+            }],
+            complete: true,
+            truncated: false,
+        };
+        // area 18 = info(13) + min_flight(5): no budget left, Execution starved.
+        assert!(actor_detail_clipped(18, None, Some(&active), None));
+        // Roomy terminal: Execution fits, no alert.
+        assert!(!actor_detail_clipped(45, None, Some(&active), None));
+        // Idle actor has nothing to hide -- never alert, even when tiny.
+        let idle = Execution {
+            active_count: 0,
+            active_handlers: vec![],
+            complete: true,
+            truncated: false,
+        };
+        assert!(!actor_detail_clipped(18, None, Some(&idle), None));
+    }
+
+    // TUI-CLIP-1: the ordering arm must track render_inbound_ordering
+    // (ordering_has_content) -- a stalled pane AND a partial-but-clean pane are
+    // both content-bearing; starved to zero height each flags, a roomy terminal
+    // does not, and disabled buffering never flags.
+    #[test]
+    fn actor_detail_clipped_flags_starved_ordering() {
+        let stalled = InboundOrdering {
+            enabled: true,
+            snapshot_complete: true,
+            skipped_session_count: 0,
+            known_session_count: 1,
+            returned_buffered_session_count: 1,
+            returned_buffered_message_count: 5,
+            returned_max_buffered_count: 5,
+            sessions: vec![session(uuid::Uuid::nil(), None, 5, 0, Some(2), Some(6))],
+        };
+        // area 18 = info(13) + min_flight(5): no budget, ordering starved.
+        assert!(actor_detail_clipped(18, Some(&stalled), None, None));
+        assert!(!actor_detail_clipped(45, Some(&stalled), None, None));
+
+        // Partial-but-clean snapshot is content-bearing (the "(partial: N
+        // skipped)" warning), so a starved one must also flag.
+        let partial = InboundOrdering {
+            enabled: true,
+            snapshot_complete: false,
+            skipped_session_count: 2,
+            known_session_count: 3,
+            returned_buffered_session_count: 0,
+            returned_buffered_message_count: 0,
+            returned_max_buffered_count: 0,
+            sessions: vec![],
+        };
+        assert!(actor_detail_clipped(18, Some(&partial), None, None));
+        assert!(!actor_detail_clipped(45, Some(&partial), None, None));
+
+        // Floor boundary (pins MIN_VISIBLE_PANE_HEIGHT): the partial pane wants 3
+        // rows. area 20 -> budget 2 -> a content-less sliver floored to 0 ->
+        // clipped (fails without the floor); area 21 -> budget 3 -> one content
+        // row shown -> not clipped (pins the threshold at < 3, not <= 3).
+        assert!(actor_detail_clipped(20, Some(&partial), None, None));
+        assert!(!actor_detail_clipped(21, Some(&partial), None, None));
+
+        // Disabled buffering is never content-bearing.
+        let disabled = InboundOrdering {
+            enabled: false,
+            ..partial
+        };
+        assert!(!actor_detail_clipped(18, Some(&disabled), None, None));
     }
 }

--- a/hyperactor_mesh_admin_tui/src/render/status_bar.rs
+++ b/hyperactor_mesh_admin_tui/src/render/status_bar.rs
@@ -8,6 +8,7 @@
 
 use hyperactor_mesh::introspect::NodeProperties;
 use ratatui::layout::Rect;
+use ratatui::style::Modifier;
 use ratatui::style::Style;
 use ratatui::text::Line;
 use ratatui::text::Span;
@@ -26,7 +27,12 @@ use crate::theme::ThemeName;
 /// Displays a colorful, information-dense header with topology stats,
 /// selection context, and system state. Uses semantic colors from the
 /// scheme for visual hierarchy and readability.
-pub(crate) fn render_header(frame: &mut ratatui::Frame<'_>, area: Rect, app: &App) {
+pub(crate) fn render_header(
+    frame: &mut ratatui::Frame<'_>,
+    area: Rect,
+    app: &App,
+    detail_clipped: bool,
+) {
     let l = &app.theme.labels;
 
     // Error state overrides normal display
@@ -139,6 +145,25 @@ pub(crate) fn render_header(frame: &mut ratatui::Frame<'_>, area: Rect, app: &Ap
             Span::styled(l.refresh_icon, app.theme.scheme.stat_timing),
             Span::styled(&app.refresh_interval_label, app.theme.scheme.stat_timing),
         ]);
+    }
+
+    // Terminal too short to show all detail panes. Prepend the warning -- line 1
+    // truncates from the right, so a segment at the end is the first thing a
+    // narrow terminal loses -- and make it loud (reversed + blink) so a size
+    // problem is not mistaken for missing data.
+    if detail_clipped {
+        let mut alert = vec![
+            Span::styled(
+                l.header_content_clipped,
+                app.theme
+                    .scheme
+                    .error
+                    .add_modifier(Modifier::REVERSED | Modifier::BOLD | Modifier::SLOW_BLINK),
+            ),
+            Span::styled(l.separator, app.theme.scheme.stat_label),
+        ];
+        alert.append(&mut line1_spans);
+        line1_spans = alert;
     }
 
     // Line 2: Selection context

--- a/hyperactor_mesh_admin_tui/src/tests/mod.rs
+++ b/hyperactor_mesh_admin_tui/src/tests/mod.rs
@@ -2641,3 +2641,115 @@ fn footer_zh_idle_contains_help_hint() {
     assert!(zh.footer_help_text.contains("帮助"));
     assert!(zh.footer_help_text.contains("?"));
 }
+
+// TUI-CLIP-1: detail_content_clipped fires the header alert only for a starved
+// actor detail; it suppresses the alert while help or an overlay owns the pane,
+// and for absent / non-actor selections.
+#[test]
+fn detail_content_clipped_guards() {
+    use hyperactor_mesh::introspect::Execution;
+
+    use crate::render::detail_pane::detail_content_clipped;
+
+    let mut app = make_app_with_cursor(vec![actor_node("a")], 0);
+    app.detail = Some(NodePayload {
+        identity: actor("a"),
+        properties: NodeProperties::Actor {
+            actor_status: "running".into(),
+            actor_type: "TestActor".into(),
+            instance_id: String::new(),
+            messages_processed: 0,
+            created_at: Some(SystemTime::UNIX_EPOCH),
+            last_message_handler: None,
+            total_processing_time_us: 0,
+            queue_depth: 0,
+            flight_recorder: None,
+            is_system: false,
+            inbound_ordering: None,
+            failure_info: None,
+            execution: Some(Box::new(Execution {
+                active_count: 2,
+                active_handlers: vec![],
+                complete: true,
+                truncated: false,
+            })),
+        },
+        children: vec![],
+        parent: Some(proc_ref("worker")),
+        as_of: SystemTime::now(),
+    });
+    // Live execution starved to zero height -> alert; roomy -> no alert.
+    assert!(detail_content_clipped(&app, 18));
+    assert!(!detail_content_clipped(&app, 45));
+
+    // Help glossary owns the pane -> suppressed even when starved.
+    app.show_help = true;
+    assert!(!detail_content_clipped(&app, 18));
+    app.show_help = false;
+
+    // An overlay (diagnostics / py-spy) owns the pane -> suppressed.
+    app.set_job(ActiveJob::Diagnostics {
+        results: Vec::new(),
+        running: true,
+        rx: None,
+        completed_at: None,
+    });
+    assert!(app.overlay.is_some());
+    assert!(!detail_content_clipped(&app, 18));
+
+    // No selection detail -> no alert.
+    let no_detail = make_app_with_cursor(vec![], 0);
+    assert!(!detail_content_clipped(&no_detail, 18));
+
+    // Non-actor selection -> no alert.
+    let mut host_app = make_app_with_cursor(vec![], 0);
+    host_app.detail = Some(NodePayload {
+        identity: host("h"),
+        properties: NodeProperties::Host {
+            addr: "10.0.0.1:8080".into(),
+            num_procs: 1,
+            system_children: vec![],
+            memory: hyperactor_mesh::introspect::ProcessMemoryStats {
+                process_rss_bytes: None,
+                process_vm_size_bytes: None,
+            },
+        },
+        children: vec![],
+        parent: Some(NodeRef::Root),
+        as_of: SystemTime::now(),
+    });
+    assert!(!detail_content_clipped(&host_app, 18));
+}
+
+// TUI-CLIP-1: render_header prepends the content-hidden alert to line 1 when
+// detail_clipped is set, and omits it otherwise.
+#[test]
+fn render_header_shows_content_clipped_alert() {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
+    let app = make_app_with_cursor(vec![], 0);
+    let render = |clipped: bool| {
+        let backend = TestBackend::new(120, 3);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal
+            .draw(|f| crate::render::status_bar::render_header(f, f.area(), &app, clipped))
+            .unwrap();
+        let buf = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..buf.area.height {
+            for x in 0..buf.area.width {
+                text.push(buf[(x, y)].symbol().chars().next().unwrap_or(' '));
+            }
+        }
+        text
+    };
+    assert!(
+        render(true).contains("content hidden"),
+        "alert present when detail is clipped"
+    );
+    assert!(
+        !render(false).contains("content hidden"),
+        "no alert when detail is not clipped"
+    );
+}

--- a/hyperactor_mesh_admin_tui/src/theme.rs
+++ b/hyperactor_mesh_admin_tui/src/theme.rs
@@ -74,6 +74,7 @@ pub(crate) struct Labels {
     pub(crate) stopped: &'static str,
     pub(crate) stopped_on: &'static str,
     pub(crate) stopped_off: &'static str,
+    pub(crate) header_content_clipped: &'static str,
 
     // Detail pane labels
     pub(crate) hosts: &'static str,
@@ -198,6 +199,7 @@ impl Labels {
             stopped: "stopped:",
             stopped_on: "on",
             stopped_off: "off",
+            header_content_clipped: "⚠ content hidden — resize",
             hosts: "Hosts: ",
             started_by: "Started by: ",
             uptime_detail: "Uptime: ",
@@ -301,6 +303,7 @@ impl Labels {
             stopped: "已停止:",
             stopped_on: "开",
             stopped_off: "关",
+            header_content_clipped: "⚠ 内容已隐藏 — 请放大终端",
             hosts: "主机: ",
             started_by: "启动者: ",
             uptime_detail: "运行时间: ",

--- a/hyperactor_mesh_admin_tui/src/theme.rs
+++ b/hyperactor_mesh_admin_tui/src/theme.rs
@@ -106,8 +106,6 @@ pub(crate) struct Labels {
     // Inbound ordering pane labels. `{n}` / `{id}` placeholders are
     // substituted with `String::replace` at render time.
     pub(crate) pane_inbound_ordering: &'static str,
-    pub(crate) ordering_not_available: &'static str,
-    pub(crate) ordering_buffering_disabled: &'static str,
     pub(crate) ordering_buffering_enabled: &'static str,
     pub(crate) ordering_sessions_label: &'static str,
     pub(crate) ordering_sessions_known: &'static str,
@@ -223,8 +221,6 @@ impl Labels {
             last_busy: "Last busy: ",
             instance_id_label: "Instance: ",
             pane_inbound_ordering: "Inbound ordering",
-            ordering_not_available: "not available",
-            ordering_buffering_disabled: "disabled (direct_send)",
             ordering_buffering_enabled: "enabled",
             ordering_sessions_label: "sessions",
             ordering_sessions_known: "of",
@@ -328,8 +324,6 @@ impl Labels {
             last_busy: "最近繁忙: ",
             instance_id_label: "实例: ",
             pane_inbound_ordering: "入站排序",
-            ordering_not_available: "不可用",
-            ordering_buffering_disabled: "已禁用 (direct_send)",
             ordering_buffering_enabled: "已启用",
             ordering_sessions_label: "会话",
             ordering_sessions_known: "共",


### PR DESCRIPTION
Summary:

on a short terminal the detail column drops its lowest-priority content -- Execution goes first, since it's the only content pane with no height floor. that degradation is fine, but it happens silently, so a size problem reads as a missing feature: a bug report claimed python execution wasn't tracked when the reporter's terminal was just too short to show the Execution pane.

keep the graceful degradation; make it legible. `ui()` computes, from the body height it already has, whether a content-bearing pane was starved to zero height (Execution with live handlers, or Inbound Ordering with stalls, allocated no room), reusing the layout's own `compute_ordering_height` / `compute_execution_height` so the check can't disagree with what's drawn. when so, the header shows a loud `⚠ content hidden — resize` segment (reversed + blink), prepended to line 1 so a narrow terminal -- which truncates from the right -- can't clip it off. it lives in the header because that's the one region always rendered no matter how squeezed the body gets.

Differential Revision: D111567906


