### PR TITLE
fix: ProcessJob reaps detached worker session on kill  Summary @allow-mixed-users-changes (#4398)

### DIFF
--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import contextlib
 import logging
 import os
 import shutil
@@ -14,7 +15,8 @@ import subprocess
 import sys
 import tempfile
 import threading
-from typing import Dict, List, Optional, Union
+import time
+from typing import Callable, Dict, List, Optional, Union
 
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.future import Future
@@ -30,6 +32,72 @@ except ImportError:
     _IN_PAR = False
 
 _PROCESS_WORKER_MODULE = "monarch._src.job._process_worker"
+_KILL_GRACE_SECONDS = 1.0
+
+
+def _group_alive(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _live_worker_pids(session_ids: "set[int]") -> Optional[List[int]]:
+    """Live (non-zombie) pids whose session id is one of ``session_ids``, or
+    ``None`` when ``/proc`` cannot be enumerated.
+
+    Full reaping is Linux-only. Workers launch with ``start_new_session=True``,
+    so a worker's pid is its session id and the procs it spawns stay in that
+    session while sitting in their own process groups -- ``killpg`` of the worker
+    alone cannot reach them. Matching on session id (via ``/proc`` and
+    ``os.getsid``) catches the worker and its whole subtree, including procs
+    already reparented to init (session membership outlives the parent). Where
+    ``/proc`` is missing or unreadable this returns ``None`` so callers fall back
+    to best-effort signalling of the tracked worker pids, which does not reach
+    the spawned procs.
+    """
+    own = os.getpid()
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return None
+    pids: List[int] = []
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        if pid == own:
+            continue
+        try:
+            if os.getsid(pid) not in session_ids:
+                continue
+            with open(f"/proc/{pid}/stat") as stat:
+                state = stat.read().rsplit(")", 1)[1].split()[0]
+        except OSError:
+            continue
+        if state not in ("Z", "X", "x"):  # skip procs that are already dead
+            pids.append(pid)
+    return pids
+
+
+def _terminate_with_grace(
+    live_pids: Callable[[], List[int]],
+    signal_pids: Callable[[List[int], int], None],
+    grace: float = _KILL_GRACE_SECONDS,
+) -> None:
+    """SIGTERM the live targets, wait up to ``grace`` for them to exit, then
+    SIGKILL any stragglers.
+
+    Factored out so the poll-with-sleep is not copied around, and so it can be
+    swapped for an await-based wait later. ``live_pids`` is re-evaluated each
+    round so procs spawned mid-teardown are still caught before the SIGKILL.
+    """
+    signal_pids(live_pids(), signal.SIGTERM)
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline and live_pids():
+        time.sleep(0.05)
+    signal_pids(live_pids(), signal.SIGKILL)
 
 
 class ProcessJob(JobTrait):
@@ -111,7 +179,9 @@ class ProcessJob(JobTrait):
                         addr,
                     )
                     self._watch_process(proc, mesh_name, i, addr)
-        except Exception:
+        except BaseException:
+            # BaseException, not Exception: a Ctrl-C / cancellation mid-startup
+            # must still reap the workers already spawned above, or they leak.
             self._kill()
             raise
 
@@ -198,14 +268,36 @@ class ProcessJob(JobTrait):
         return True
 
     def _kill(self) -> None:
-        # Use SIGTERM to allow worker processes to shut down gracefully.
-        # The HostMesh objects are not stored here (they're returned to callers),
-        # so we rely on the worker processes handling SIGTERM for clean shutdown.
-        for p in self._host_to_pid.values():
-            try:
-                os.kill(p.pid, signal.SIGTERM)
-            except OSError:
-                pass
+        # Reap each worker's whole session, not just its process group. Workers
+        # run in detached sessions (start_new_session=True), and the procs they
+        # spawn stay in that session but in their own process groups -- so
+        # signalling only the worker's group would orphan them. Session reaping
+        # needs /proc; without it we fall back to best-effort signalling of the
+        # tracked worker pids, which does not reach the spawned procs.
+        worker_pids = [p.pid for p in self._host_to_pid.values()]
+        session_ids = set(worker_pids)
+
+        def remaining() -> List[int]:
+            live = _live_worker_pids(session_ids)
+            if live is None:
+                # /proc missing or unreadable: signal the worker pids we hold.
+                return [pid for pid in worker_pids if _group_alive(pid)]
+            return live
+
+        def signal_all(pids: List[int], sig: int) -> None:
+            # killpg reaps each enumerated group leader's whole group (catching
+            # children forked after the scan); the os.kill fallback covers pids
+            # that are not group leaders. A pid reaped and reused between scan and
+            # signal is at worst a stray no-op via the OSError fallback.
+            for pid in pids:
+                try:
+                    os.killpg(pid, sig)
+                except OSError:
+                    with contextlib.suppress(OSError):
+                        os.kill(pid, sig)
+
+        _terminate_with_grace(remaining, signal_all)
+
         self._host_to_pid.clear()
         if self._tmpdir is not None:
             shutil.rmtree(self._tmpdir, ignore_errors=True)

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -9,11 +9,14 @@
 import contextlib
 import os
 import pickle
+import shutil
+import signal
 import socket
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 import types
 from dataclasses import dataclass
 from typing import cast, Dict, Optional, Sequence
@@ -32,6 +35,7 @@ from monarch._src.job.job import (
     JobTrait,
     LocalJob,
     MeshAdminConfig,
+    ProcessState,
     TelemetryConfig,
 )
 from monarch._src.job.job_components import JobComponent, JobComponents, MountComponent
@@ -573,6 +577,74 @@ def test_kill():
     # kill_called should now be True
     assert job.kill_called
     stop_sidecar.assert_called_once_with(apply_id)
+
+
+def test_process_job_kill_reaps_worker_session():
+    """_kill reaps the worker's whole session, including procs the worker spawns
+    into their own process groups -- which killpg of the worker alone orphans."""
+    if not os.path.isdir("/proc"):
+        pytest.skip("session reap requires /proc")
+
+    def session_members(sid):
+        alive = []
+        for entry in os.listdir("/proc"):
+            if not entry.isdigit():
+                continue
+            pid = int(entry)
+            try:
+                if os.getsid(pid) != sid:
+                    continue
+                with open(f"/proc/{pid}/stat") as stat:
+                    state = stat.read().rsplit(")", 1)[1].split()[0]
+            except OSError:
+                continue
+            if state not in ("Z", "X", "x"):
+                alive.append(pid)
+        return alive
+
+    # A worker mimicking ProcessJob's: its own session (start_new_session=True)
+    # with children in their own process groups, all ignoring SIGTERM so _kill
+    # must escalate to SIGKILL to reap them.
+    worker_src = (
+        "import os, signal, time\n"
+        "for _ in range(3):\n"
+        "    if os.fork() == 0:\n"
+        "        os.setpgid(0, 0)\n"
+        "        signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "        while True: time.sleep(0.5)\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "while True: time.sleep(0.5)\n"
+    )
+    proc = subprocess.Popen([sys.executable, "-c", worker_src], start_new_session=True)
+    worker = proc.pid
+    tmpdir = None
+
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and len(session_members(worker)) < 4:
+            time.sleep(0.05)
+        assert len(session_members(worker)) == 4  # worker + 3 children
+
+        tmpdir = tempfile.mkdtemp(prefix="test_process_job_kill_")
+        job = ProcessJob({"hosts": 1})
+        job._host_to_pid = {"h_0": ProcessState(worker, f"ipc://{tmpdir}/h_0")}
+        job._tmpdir = tmpdir
+
+        job._kill()
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and session_members(worker):
+            time.sleep(0.05)
+        assert session_members(worker) == []
+        assert not os.path.isdir(tmpdir)
+    finally:
+        for pid in session_members(worker):
+            with contextlib.suppress(OSError):
+                os.kill(pid, signal.SIGKILL)
+        with contextlib.suppress(OSError, subprocess.TimeoutExpired):
+            proc.wait(timeout=2)
+        if tmpdir is not None:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_state_query_engine_none_without_telemetry():


### PR DESCRIPTION
Summary:


allow-mixed-users-changes

`ProcessJob` workers launch with `start_new_session=True`, and the procs a worker spawns stay in that session but in their own process groups. `_kill` previously signalled only the tracked worker pids with `os.kill`, reaching the worker processes alone -- the procs they spawned were left running, orphaned and reparented to init. `_kill` now reaps the worker's whole session: it enumerates every live pid whose session id matches a tracked worker (via `/proc` and `os.getsid`), sends `SIGTERM`, waits a short grace period, then `SIGKILL`s any straggler. session ids outlive reparenting, so procs already orphaned to init are reaped too. `_create` catches `BaseException` so an interrupt mid-startup still runs cleanup, and the demo tears down through a plain `job.kill()` in `finally`.

Reviewed By: dulinriley

Differential Revision: D111755273


