### PR TITLE
migrate mesh-admin example demos to job.kill() teardown

### DIFF
--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -185,40 +185,40 @@ async def async_main(
                 snapshot_interval_secs=30.0,
             )
         )
-    state = job.state(cached_path=None)
-    host = state.hosts
-
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print("\nPress Ctrl+C to stop.\n", flush=True)
-
-    # Spawn philosopher processes and actors.
-    procs = host.spawn_procs(per_host={"replica": NUM_PHILOSOPHERS})
-
-    # Spawn waiter on its own proc mesh so it appears in the dashboard hierarchy.
-    waiter_proc = host.spawn_procs(name="waiter")
-    philosophers = procs.spawn("philosopher", Philosopher, NUM_PHILOSOPHERS)
-    waiter = waiter_proc.spawn("waiter", Waiter, philosophers)
-
-    # Start all philosophers — each will begin requesting chopsticks.
-    philosophers.start.broadcast(waiter)
-
-    # Run until interrupted.
     try:
+        state = job.state(cached_path=None)
+        host = state.hosts
+
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print("\nPress Ctrl+C to stop.\n", flush=True)
+
+        # Spawn philosopher processes and actors.
+        procs = host.spawn_procs(per_host={"replica": NUM_PHILOSOPHERS})
+
+        # Spawn waiter on its own proc mesh so it appears in the dashboard hierarchy.
+        waiter_proc = host.spawn_procs(name="waiter")
+        philosophers = procs.spawn("philosopher", Philosopher, NUM_PHILOSOPHERS)
+        waiter = waiter_proc.spawn("waiter", Waiter, philosophers)
+
+        # Start all philosophers — each will begin requesting chopsticks.
+        philosophers.start.broadcast(waiter)
+
+        # Run until interrupted.
         if kill_waiter_after is not None:
             await asyncio.sleep(kill_waiter_after)
             print("Killing the waiter...")
@@ -228,12 +228,9 @@ async def async_main(
         pass
     finally:
         print("\nShutting down...", flush=True)
-        await waiter_proc.stop()
-        await procs.stop()
-        # Tear down the host last: ProcessJob spawns a host subprocess
-        # (run_worker_loop_forever) that stopping the proc meshes alone leaves
-        # orphaned; shutdown() stops the host and every process on it.
-        await host.shutdown()
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 def main() -> None:

--- a/python/examples/execution_demo.py
+++ b/python/examples/execution_demo.py
@@ -128,61 +128,60 @@ async def async_main(args: argparse.Namespace) -> None:
     eat_ms = (args.eat_ms_min, args.eat_ms_max)
 
     job = ProcessJob({"hosts": 1}).enable_admin()
-    state = job.state(cached_path=None)
-    host = state.hosts
-
-    # N philosophers (one per replica) + a single fork manager on its own proc
-    # so it is a distinct, easy-to-find node in the TUI tree.
-    phil_procs = host.spawn_procs(per_host={"replica": n})
-    fork_proc = host.spawn_procs(name="fork_manager")
-
-    fork_manager = fork_proc.spawn("fork_manager", ForkManager, n)
-    philosophers = phil_procs.spawn(
-        "philosopher", Philosopher, fork_manager, n, think_ms, eat_ms
-    )
-
-    fork_ref = await fork_manager.whoami.call_one()
-    phil0_ref = await philosophers.slice(replica=0).whoami.call_one()
-
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    tui = (
-        "buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui"
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Mesh tree:  curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - TUI:        {tui} -- --addr {admin_url}")
-    print("\nWatch list (find these in the TUI tree by label):")
-    print(
-        "  - actor `fork_manager`  -> Execution: `acquire xK` (live contention) + flight recorder"
-    )
-    print(
-        f"  - actor `philosopher` (replicas 0..{n - 1}) -> Execution: `think`/`eat` turnover + flight recorder"
-    )
-    print(f"  raw ids: fork_manager={fork_ref}  philosopher[0]={phil0_ref}")
-    print(
-        f"\n{n} philosophers; think {think_ms[0]}-{think_ms[1]}ms, "
-        f"eat {eat_ms[0]}-{eat_ms[1]}ms. Press Ctrl+C to stop.\n",
-        flush=True,
-    )
-
-    async def run_philosopher(i: int) -> None:
-        seat = philosophers.slice(replica=i)
-        while True:
-            await seat.think.call_one(i)
-            await seat.eat.call_one(i)
-
-    # Fail-fast: gather propagates the first loop's failure and tears the demo
-    # down, surfacing bugs loudly rather than silently degrading.
-    loops = [asyncio.ensure_future(run_philosopher(i)) for i in range(n)]
+    loops = []
     try:
+        state = job.state(cached_path=None)
+        host = state.hosts
+
+        # N philosophers (one per replica) + a single fork manager on its own proc
+        # so it is a distinct, easy-to-find node in the TUI tree.
+        phil_procs = host.spawn_procs(per_host={"replica": n})
+        fork_proc = host.spawn_procs(name="fork_manager")
+
+        fork_manager = fork_proc.spawn("fork_manager", ForkManager, n)
+        philosophers = phil_procs.spawn(
+            "philosopher", Philosopher, fork_manager, n, think_ms, eat_ms
+        )
+
+        fork_ref = await fork_manager.whoami.call_one()
+        phil0_ref = await philosophers.slice(replica=0).whoami.call_one()
+
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        tui = "buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui"
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Mesh tree:  curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - TUI:        {tui} -- --addr {admin_url}")
+        print("\nWatch list (find these in the TUI tree by label):")
+        print(
+            "  - actor `fork_manager`  -> Execution: `acquire xK` (live contention) + flight recorder"
+        )
+        print(
+            f"  - actor `philosopher` (replicas 0..{n - 1}) -> Execution: `think`/`eat` turnover + flight recorder"
+        )
+        print(f"  raw ids: fork_manager={fork_ref}  philosopher[0]={phil0_ref}")
+        print(
+            f"\n{n} philosophers; think {think_ms[0]}-{think_ms[1]}ms, "
+            f"eat {eat_ms[0]}-{eat_ms[1]}ms. Press Ctrl+C to stop.\n",
+            flush=True,
+        )
+
+        async def run_philosopher(i: int) -> None:
+            seat = philosophers.slice(replica=i)
+            while True:
+                await seat.think.call_one(i)
+                await seat.eat.call_one(i)
+
+        # Fail-fast: gather propagates the first loop's failure and tears the demo
+        # down, surfacing bugs loudly rather than silently degrading.
+        loops = [asyncio.create_task(run_philosopher(i)) for i in range(n)]
         await asyncio.gather(*loops)
     except (KeyboardInterrupt, asyncio.CancelledError):
         pass
@@ -190,8 +189,10 @@ async def async_main(args: argparse.Namespace) -> None:
         print("\nShutting down...", flush=True)
         for loop in loops:
             loop.cancel()
-        await phil_procs.stop()
-        await fork_proc.stop()
+        await asyncio.gather(*loops, return_exceptions=True)
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 def main() -> None:

--- a/python/examples/execution_workload.py
+++ b/python/examples/execution_workload.py
@@ -235,72 +235,73 @@ async def _hold_task(actor, id: str, entered_port: "Port[str]") -> None:
 
 async def async_main() -> None:
     job = ProcessJob({"hosts": 1}).enable_admin()
-    state = job.state(cached_path=None)
-    host = state.hosts
-
-    busy_proc = host.spawn_procs(
-        name="execution_busy", bootstrap=_disable_queue_dispatch
-    )
-    idle_proc = host.spawn_procs(
-        name="execution_idle", bootstrap=_disable_queue_dispatch
-    )
-    queue_proc = host.spawn_procs(
-        name="execution_queue", bootstrap=_enable_queue_dispatch
-    )
-    concurrent_proc = host.spawn_procs(
-        name="execution_concurrent", bootstrap=_enable_queue_dispatch
-    )
-    deadlock_proc = host.spawn_procs(
-        name="execution_deadlock", bootstrap=_enable_queue_dispatch
-    )
-
-    busy = busy_proc.spawn("busy_actor", BusyActor)
-    idle = idle_proc.spawn("idle_actor", BusyActor)
-    queue = queue_proc.spawn("queue_actor", QueueActor)
-    concurrent = concurrent_proc.spawn("concurrent_actor", ConcurrentActor)
-    # A queue-dispatch BusyActor: its blocking plain @endpoint `hold`
-    # monopolizes the serial dispatch loop, so a later `control` release
-    # queues behind it and can never run -- a deadlock the admin API surfaces.
-    deadlock = deadlock_proc.spawn("deadlock_actor", BusyActor)
-
-    actors = {
-        "busy": busy,
-        "queue": queue,
-        "concurrent": concurrent,
-        "deadlock": deadlock,
-    }
-
-    busy_ref = await busy.whoami.call_one()
-    idle_ref = await idle.whoami.call_one()
-    queue_ref = await queue.whoami.call_one()
-    concurrent_ref = await concurrent.whoami.call_one()
-    deadlock_ref = await deadlock.whoami.call_one()
-
-    # Held invocations send their id over this port from inside the handler
-    # body; a background task drains it and echoes EXEC_ENTERED to stdout.
-    entered_port: Port[str]
-    entered_recv: PortReceiver[str]
-    entered_port, entered_recv = Channel[str].open()
-
-    async def drain_entered() -> None:
-        while True:
-            entered_id = await entered_recv.recv()
-            print(f"EXEC_ENTERED {entered_id}", flush=True)
-
-    drainer = asyncio.ensure_future(drain_entered())
-
-    print(f"Mesh admin server listening on {state.admin_url}", flush=True)
-    print(f"  - Busy actor:  {busy_ref}", flush=True)
-    print(f"  - Idle actor:  {idle_ref}", flush=True)
-    print(f"  - Queue actor: {queue_ref}", flush=True)
-    print(f"  - Concurrent actor: {concurrent_ref}", flush=True)
-    print(f"  - Deadlock actor: {deadlock_ref}", flush=True)
-
-    reader = await _stdin_reader()
     # In-flight held invocations, tracked so they can be cancelled at
     # shutdown.
     holds: dict[str, asyncio.Task] = {}
+    drainer: asyncio.Task | None = None
     try:
+        state = job.state(cached_path=None)
+        host = state.hosts
+
+        busy_proc = host.spawn_procs(
+            name="execution_busy", bootstrap=_disable_queue_dispatch
+        )
+        idle_proc = host.spawn_procs(
+            name="execution_idle", bootstrap=_disable_queue_dispatch
+        )
+        queue_proc = host.spawn_procs(
+            name="execution_queue", bootstrap=_enable_queue_dispatch
+        )
+        concurrent_proc = host.spawn_procs(
+            name="execution_concurrent", bootstrap=_enable_queue_dispatch
+        )
+        deadlock_proc = host.spawn_procs(
+            name="execution_deadlock", bootstrap=_enable_queue_dispatch
+        )
+
+        busy = busy_proc.spawn("busy_actor", BusyActor)
+        idle = idle_proc.spawn("idle_actor", BusyActor)
+        queue = queue_proc.spawn("queue_actor", QueueActor)
+        concurrent = concurrent_proc.spawn("concurrent_actor", ConcurrentActor)
+        # A queue-dispatch BusyActor: its blocking plain @endpoint `hold`
+        # monopolizes the serial dispatch loop, so a later `control` release
+        # queues behind it and can never run -- a deadlock the admin API surfaces.
+        deadlock = deadlock_proc.spawn("deadlock_actor", BusyActor)
+
+        actors = {
+            "busy": busy,
+            "queue": queue,
+            "concurrent": concurrent,
+            "deadlock": deadlock,
+        }
+
+        busy_ref = await busy.whoami.call_one()
+        idle_ref = await idle.whoami.call_one()
+        queue_ref = await queue.whoami.call_one()
+        concurrent_ref = await concurrent.whoami.call_one()
+        deadlock_ref = await deadlock.whoami.call_one()
+
+        # Held invocations send their id over this port from inside the handler
+        # body; a background task drains it and echoes EXEC_ENTERED to stdout.
+        entered_port: Port[str]
+        entered_recv: PortReceiver[str]
+        entered_port, entered_recv = Channel[str].open()
+
+        async def drain_entered() -> None:
+            while True:
+                entered_id = await entered_recv.recv()
+                print(f"EXEC_ENTERED {entered_id}", flush=True)
+
+        drainer = asyncio.create_task(drain_entered())
+
+        print(f"Mesh admin server listening on {state.admin_url}", flush=True)
+        print(f"  - Busy actor:  {busy_ref}", flush=True)
+        print(f"  - Idle actor:  {idle_ref}", flush=True)
+        print(f"  - Queue actor: {queue_ref}", flush=True)
+        print(f"  - Concurrent actor: {concurrent_ref}", flush=True)
+        print(f"  - Deadlock actor: {deadlock_ref}", flush=True)
+
+        reader = await _stdin_reader()
         while True:
             raw = await reader.readline()
             if not raw:
@@ -315,7 +316,7 @@ async def async_main() -> None:
                 # hold blocks until released, so run it as a background task
                 # (via call_one -- see _hold_task). The "entered" signal
                 # still arrives mid-handler over entered_port.
-                holds[id] = asyncio.ensure_future(
+                holds[id] = asyncio.create_task(
                     _hold_task(actors[which], id, entered_port)
                 )
                 print(f"EXEC_ACK HOLD {id}", flush=True)
@@ -336,12 +337,11 @@ async def async_main() -> None:
         print("\nShutting down...", flush=True)
         for task in holds.values():
             task.cancel()
-        drainer.cancel()
-        await busy_proc.stop()
-        await idle_proc.stop()
-        await queue_proc.stop()
-        await concurrent_proc.stop()
-        await deadlock_proc.stop()
+        if drainer is not None:
+            drainer.cancel()
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 def main() -> None:

--- a/python/examples/inbound_ordering_workload.py
+++ b/python/examples/inbound_ordering_workload.py
@@ -103,81 +103,81 @@ class Sender(Actor):
 
 async def async_main(args: argparse.Namespace) -> None:
     job = ProcessJob({"hosts": 1}).enable_admin()
-    state = job.state(cached_path=None)
-    host = state.hosts
-
-    receiver_proc = host.spawn_procs(name="inbound_ordering_receiver")
-    # Two separate singleton proc meshes for the two senders so each
-    # sender has its own Instance (and therefore its own Sequencer and
-    # SEQ_INFO session_id) by construction. Using one shared proc mesh
-    # with two spawns relies on subtler ActorMesh semantics; two procs
-    # makes the "two distinct session owners" promise structural.
-    sender_a_proc = host.spawn_procs(name="inbound_ordering_sender_a")
-    sender_b_proc = host.spawn_procs(name="inbound_ordering_sender_b")
-
-    receiver = receiver_proc.spawn("stalled_receiver", StalledReceiver)
-    # Get the receiver's address by asking it -- there's no direct
-    # Python-side accessor on ``ActorMesh`` that returns a rank's
-    # ``ActorAddr``. ``PyActorAddr`` is picklable via ``__reduce__``,
-    # so it can be passed back over the endpoint result and forward
-    # as a constructor argument to the senders.
-    receiver_addr = await receiver.whoami.call_one()
-
-    sender_a = sender_a_proc.spawn("sender_a", Sender, receiver, receiver_addr)
-    sender_b = sender_b_proc.spawn("sender_b", Sender, receiver, receiver_addr)
-
-    # Two distinct senders -> receiver shows 2 stalled sessions
-    # (different session_ids, one per sender Instance's Sequencer).
-    await sender_a.stall_and_send.call_one(skip_count=1, send_count=5)
-    await sender_b.stall_and_send.call_one(skip_count=1, send_count=3)
-
-    # Match pyspy_workload.py: emit mTLS flags conditionally when the
-    # admin URL is HTTPS so the printed commands are paste-ready in
-    # both local and production environments.
-    mtls_flags = (
-        " --cacert /var/facebook/rootcanal/ca.pem"
-        " --cert /var/facebook/x509_identities/server.pem"
-        " --key /var/facebook/x509_identities/server.pem"
-        if state.admin_url.startswith("https://")
-        else ""
-    )
-
-    # Actor refs contain '/' and must be percent-encoded in URL path
-    # positions. Single source of truth is the ``receiver_addr``
-    # PyActorAddr obtained from ``whoami`` above; Python ``ActorMesh``
-    # does not expose an ``actor_addr()`` accessor.
-    receiver_ref = str(receiver_addr)
-    receiver_ref_encoded = urllib.parse.quote(receiver_ref, safe="")
-
-    print(f"Mesh admin server listening on {state.admin_url}", flush=True)
-    print(f"  - Stalled receiver: {receiver_ref}", flush=True)
-    print(
-        f"  - curl: curl{mtls_flags} {state.admin_url}/v1/{receiver_ref_encoded}",
-        flush=True,
-    )
-    print(
-        "  - TUI:   "
-        f"buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui "
-        f"-- --addr {state.admin_url}",
-        flush=True,
-    )
-    print(
-        "  - Verifier: "
-        f"buck2 run fbcode//monarch/python/examples:verify_inbound_ordering "
-        f"-- --admin-url {state.admin_url}"
-        f"{mtls_flags}",
-        flush=True,
-    )
-
     try:
+        state = job.state(cached_path=None)
+        host = state.hosts
+
+        receiver_proc = host.spawn_procs(name="inbound_ordering_receiver")
+        # Two separate singleton proc meshes for the two senders so each
+        # sender has its own Instance (and therefore its own Sequencer and
+        # SEQ_INFO session_id) by construction. Using one shared proc mesh
+        # with two spawns relies on subtler ActorMesh semantics; two procs
+        # makes the "two distinct session owners" promise structural.
+        sender_a_proc = host.spawn_procs(name="inbound_ordering_sender_a")
+        sender_b_proc = host.spawn_procs(name="inbound_ordering_sender_b")
+
+        receiver = receiver_proc.spawn("stalled_receiver", StalledReceiver)
+        # Get the receiver's address by asking it -- there's no direct
+        # Python-side accessor on ``ActorMesh`` that returns a rank's
+        # ``ActorAddr``. ``PyActorAddr`` is picklable via ``__reduce__``,
+        # so it can be passed back over the endpoint result and forward
+        # as a constructor argument to the senders.
+        receiver_addr = await receiver.whoami.call_one()
+
+        sender_a = sender_a_proc.spawn("sender_a", Sender, receiver, receiver_addr)
+        sender_b = sender_b_proc.spawn("sender_b", Sender, receiver, receiver_addr)
+
+        # Two distinct senders -> receiver shows 2 stalled sessions
+        # (different session_ids, one per sender Instance's Sequencer).
+        await sender_a.stall_and_send.call_one(skip_count=1, send_count=5)
+        await sender_b.stall_and_send.call_one(skip_count=1, send_count=3)
+
+        # Match pyspy_workload.py: emit mTLS flags conditionally when the
+        # admin URL is HTTPS so the printed commands are paste-ready in
+        # both local and production environments.
+        mtls_flags = (
+            " --cacert /var/facebook/rootcanal/ca.pem"
+            " --cert /var/facebook/x509_identities/server.pem"
+            " --key /var/facebook/x509_identities/server.pem"
+            if state.admin_url.startswith("https://")
+            else ""
+        )
+
+        # Actor refs contain '/' and must be percent-encoded in URL path
+        # positions. Single source of truth is the ``receiver_addr``
+        # PyActorAddr obtained from ``whoami`` above; Python ``ActorMesh``
+        # does not expose an ``actor_addr()`` accessor.
+        receiver_ref = str(receiver_addr)
+        receiver_ref_encoded = urllib.parse.quote(receiver_ref, safe="")
+
+        print(f"Mesh admin server listening on {state.admin_url}", flush=True)
+        print(f"  - Stalled receiver: {receiver_ref}", flush=True)
+        print(
+            f"  - curl: curl{mtls_flags} {state.admin_url}/v1/{receiver_ref_encoded}",
+            flush=True,
+        )
+        print(
+            "  - TUI:   "
+            f"buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui "
+            f"-- --addr {state.admin_url}",
+            flush=True,
+        )
+        print(
+            "  - Verifier: "
+            f"buck2 run fbcode//monarch/python/examples:verify_inbound_ordering "
+            f"-- --admin-url {state.admin_url}"
+            f"{mtls_flags}",
+            flush=True,
+        )
+
         await asyncio.sleep(float("inf"))
     except (KeyboardInterrupt, asyncio.CancelledError):
         pass
     finally:
         print("\nShutting down...", flush=True)
-        await sender_a_proc.stop()
-        await sender_b_proc.stop()
-        await receiver_proc.stop()
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 def main() -> None:

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -90,56 +90,58 @@ async def async_main(num_procs: int) -> None:
         )
         .enable_admin()
     )
-    state = job.state(cached_path=None)
-    host = state.hosts
-
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print(flush=True)
-
-    procs = host.spawn_procs(per_host={"replica": num_procs})
-    workers = procs.spawn("worker", Worker)
-
-    # Let every worker do some work first.
-    await workers.work.call()
-    print(f"\n{num_procs} workers alive and working.", flush=True)
-
-    # Crash worker at rank 0.  The BaseException subclass bypasses the
-    # endpoint handler's Exception catch, killing the actor and
-    # triggering supervision.
-    print("\nCrashing worker[0] with 'GPU memory corruption'...", flush=True)
     try:
-        await workers.slice(replica=0).crash.call_one("GPU memory corruption")
-    except Exception:
-        pass  # Expected — the actor died
+        state = job.state(cached_path=None)
+        host = state.hosts
 
-    # Give supervision time to propagate.
-    await asyncio.sleep(3)
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print(flush=True)
 
-    print("\nFailure injected. Point the TUI at this mesh to inspect.")
-    print("Press Ctrl+C to exit.\n", flush=True)
+        procs = host.spawn_procs(per_host={"replica": num_procs})
+        workers = procs.spawn("worker", Worker)
 
-    try:
+        # Let every worker do some work first.
+        await workers.work.call()
+        print(f"\n{num_procs} workers alive and working.", flush=True)
+
+        # Crash worker at rank 0.  The BaseException subclass bypasses the
+        # endpoint handler's Exception catch, killing the actor and
+        # triggering supervision.
+        print("\nCrashing worker[0] with 'GPU memory corruption'...", flush=True)
+        try:
+            await workers.slice(replica=0).crash.call_one("GPU memory corruption")
+        except Exception:
+            pass  # Expected — the actor died
+
+        # Give supervision time to propagate.
+        await asyncio.sleep(3)
+
+        print("\nFailure injected. Point the TUI at this mesh to inspect.")
+        print("Press Ctrl+C to exit.\n", flush=True)
+
         await asyncio.sleep(float("inf"))
     except (KeyboardInterrupt, asyncio.CancelledError):
         pass
     finally:
         print("\nShutting down...", flush=True)
-        await procs.stop()
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 def main() -> None:

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -146,49 +146,51 @@ async def async_main() -> None:
         )
         .enable_admin()
     )
-    state = job.state(cached_path=None)
-    host = state.hosts
-
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(
-        f"\npy-spy workload: mode={args.mode}, "
-        f"work_ms={args.work_ms}, concurrency={args.concurrency}"
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print("\nVerify with:")
-    print("  buck2 run fbcode//monarch/python/examples:verify_pyspy -- \\")
-    if mtls_flags:
-        print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10 \\")
-        print(f"    {mtls_flags.strip()}")
-    else:
-        print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10")
-    print("\nPress Ctrl+C to stop.\n", flush=True)
-
-    # Spawn worker procs. The actor name pyspy_worker lets the
-    # verifier filter to workload procs by prefix.
-    procs = host.spawn_procs(per_host={"replica": args.concurrency})
-    workers = procs.spawn("pyspy_worker", Worker, args.mode, args.work_ms)
-
-    # Start all workers.
-    workers.work_forever.broadcast()
-
     try:
+        state = job.state(cached_path=None)
+        host = state.hosts
+
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(
+            f"\npy-spy workload: mode={args.mode}, "
+            f"work_ms={args.work_ms}, concurrency={args.concurrency}"
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print("\nVerify with:")
+        print("  buck2 run fbcode//monarch/python/examples:verify_pyspy -- \\")
+        if mtls_flags:
+            print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10 \\")
+            print(f"    {mtls_flags.strip()}")
+        else:
+            print(f"    --admin-url {admin_url} --mode {args.mode} --samples 10")
+        print("\nPress Ctrl+C to stop.\n", flush=True)
+
+        # Spawn worker procs. The actor name pyspy_worker lets the
+        # verifier filter to workload procs by prefix.
+        procs = host.spawn_procs(per_host={"replica": args.concurrency})
+        workers = procs.spawn("pyspy_worker", Worker, args.mode, args.work_ms)
+
+        # Start all workers.
+        workers.work_forever.broadcast()
+
         await asyncio.sleep(float("inf"))
     except (KeyboardInterrupt, asyncio.CancelledError):
         pass
     finally:
         print("\nShutting down...", flush=True)
-        await procs.stop()
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 def main() -> None:

--- a/python/examples/rapid_spawn_exit_stress.py
+++ b/python/examples/rapid_spawn_exit_stress.py
@@ -24,14 +24,6 @@ from monarch.actor import Actor, endpoint
 from monarch.job import ProcessJob, TelemetryConfig
 from monarch.mesh_controller import spawn_tensor_engine
 
-job = (
-    ProcessJob({"hosts": 1})
-    .enable_telemetry(TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0))
-    .enable_admin()
-)
-job_state = job.state(cached_path=None)
-proc_mesh = job_state.hosts.spawn_procs(per_host={"gpus": 1})
-
 
 def unhandled_fault(fault):
     print(f"Unhandled fault: {fault}", flush=True)
@@ -71,30 +63,48 @@ async def main():
     )
     args = parser.parse_args()
 
-    admin_url = job_state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
+    job = (
+        ProcessJob({"hosts": 1})
+        .enable_telemetry(
+            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
+        )
+        .enable_admin()
     )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print("\nPress Ctrl+C to stop.\n", flush=True)
+    try:
+        job_state = job.state(cached_path=None)
+        proc_mesh = job_state.hosts.spawn_procs(per_host={"gpus": 1})
 
-    for i in range(args.iterations):
-        dm = spawn_tensor_engine(proc_mesh)
-        if args.sleep > 0:
-            await asyncio.sleep(args.sleep)
-        dm.exit()
-        print(f"iter {i}", flush=True)
+        admin_url = job_state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print("\nPress Ctrl+C to stop.\n", flush=True)
+
+        for i in range(args.iterations):
+            dm = spawn_tensor_engine(proc_mesh)
+            if args.sleep > 0:
+                await asyncio.sleep(args.sleep)
+            dm.exit()
+            print(f"iter {i}", flush=True)
+    except (KeyboardInterrupt, asyncio.CancelledError):
+        pass
+    finally:
+        print("\nShutting down...", flush=True)
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 asyncio.run(main())

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -64,34 +64,34 @@ async def async_main(num_procs: int) -> None:
         )
         .enable_admin()
     )
-    state = job.state(cached_path=None)
-    host = state.hosts
-
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print(f"\nSpawning batches of sleepers across {num_procs} procs.")
-    print("Press Ctrl+C to stop.\n", flush=True)
-
-    procs = host.spawn_procs(per_host={"replica": num_procs})
-
-    batch = 0
-    # Keep references alive so actors aren't torn down prematurely.
-    batches = []
     try:
+        state = job.state(cached_path=None)
+        host = state.hosts
+
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print(f"\nSpawning batches of sleepers across {num_procs} procs.")
+        print("Press Ctrl+C to stop.\n", flush=True)
+
+        procs = host.spawn_procs(per_host={"replica": num_procs})
+
+        batch = 0
+        # Keep references alive so actors aren't torn down prematurely.
+        batches = []
         while True:
             name = f"sleeper_batch_{batch}"
             actors = procs.spawn(name, Sleeper, MIN_SLEEP, MAX_SLEEP)
@@ -111,7 +111,9 @@ async def async_main(num_procs: int) -> None:
         pass
     finally:
         print("\nShutting down...", flush=True)
-        await procs.stop()
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 def main() -> None:

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -51,48 +51,50 @@ async def async_main(num_procs: int) -> None:
         )
         .enable_admin()
     )
-    state = job.state(cached_path=None)
-    host = state.hosts
-
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-    print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-    print(
-        f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-    )
-    print(flush=True)
-
-    procs = host.spawn_procs(per_host={"replica": num_procs})
-    workers = procs.spawn("worker", Worker)
-
-    # Let each actor announce itself.
-    await workers.hello.call()
-    print(f"\n{num_procs} workers alive. Stopping the actor mesh...", flush=True)
-
-    # Coordinated mesh-level stop.
-    # pyre-ignore[16]: `stop` is on `ActorMesh`, not the proxy type.
-    await workers.stop("mesh stopped by example")
-
-    print("Actor mesh stopped. Tombstones are now visible in the TUI (press h).")
-    print("Press Ctrl+C to exit.\n", flush=True)
-
     try:
+        state = job.state(cached_path=None)
+        host = state.hosts
+
+        admin_url = state.admin_url
+        assert admin_url is not None
+        mtls_flags = (
+            "--cacert /var/facebook/rootcanal/ca.pem "
+            "--cert /var/facebook/x509_identities/server.pem "
+            "--key /var/facebook/x509_identities/server.pem "
+            if admin_url.startswith("https")
+            else ""
+        )
+        print(f"\nMesh admin server listening on {admin_url}")
+        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
+        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
+        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
+        print(
+            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
+        )
+        print(flush=True)
+
+        procs = host.spawn_procs(per_host={"replica": num_procs})
+        workers = procs.spawn("worker", Worker)
+
+        # Let each actor announce itself.
+        await workers.hello.call()
+        print(f"\n{num_procs} workers alive. Stopping the actor mesh...", flush=True)
+
+        # Coordinated mesh-level stop.
+        # pyre-ignore[16]: `stop` is on `ActorMesh`, not the proxy type.
+        await workers.stop("mesh stopped by example")
+
+        print("Actor mesh stopped. Tombstones are now visible in the TUI (press h).")
+        print("Press Ctrl+C to exit.\n", flush=True)
+
         await asyncio.sleep(float("inf"))
     except (KeyboardInterrupt, asyncio.CancelledError):
         pass
     finally:
         print("\nShutting down...", flush=True)
-        await procs.stop()
+        # Each ProcessJob worker runs in its own detached session; job.kill()
+        # reaps the whole session -- the worker and every proc it spawned.
+        job.kill()
 
 
 def main() -> None:

--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -6,6 +6,7 @@
 
 # pyre-unsafe
 
+import contextlib
 import logging
 import os
 import shutil
@@ -14,7 +15,8 @@ import subprocess
 import sys
 import tempfile
 import threading
-from typing import Dict, List, Optional, Union
+import time
+from typing import Callable, Dict, List, Optional, Union
 
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.future import Future
@@ -30,6 +32,72 @@ except ImportError:
     _IN_PAR = False
 
 _PROCESS_WORKER_MODULE = "monarch._src.job._process_worker"
+_KILL_GRACE_SECONDS = 1.0
+
+
+def _group_alive(pgid: int) -> bool:
+    try:
+        os.killpg(pgid, 0)
+    except OSError:
+        return False
+    return True
+
+
+def _live_worker_pids(session_ids: "set[int]") -> Optional[List[int]]:
+    """Live (non-zombie) pids whose session id is one of ``session_ids``, or
+    ``None`` when ``/proc`` cannot be enumerated.
+
+    Full reaping is Linux-only. Workers launch with ``start_new_session=True``,
+    so a worker's pid is its session id and the procs it spawns stay in that
+    session while sitting in their own process groups -- ``killpg`` of the worker
+    alone cannot reach them. Matching on session id (via ``/proc`` and
+    ``os.getsid``) catches the worker and its whole subtree, including procs
+    already reparented to init (session membership outlives the parent). Where
+    ``/proc`` is missing or unreadable this returns ``None`` so callers fall back
+    to best-effort signalling of the tracked worker pids, which does not reach
+    the spawned procs.
+    """
+    own = os.getpid()
+    try:
+        entries = os.listdir("/proc")
+    except OSError:
+        return None
+    pids: List[int] = []
+    for entry in entries:
+        if not entry.isdigit():
+            continue
+        pid = int(entry)
+        if pid == own:
+            continue
+        try:
+            if os.getsid(pid) not in session_ids:
+                continue
+            with open(f"/proc/{pid}/stat") as stat:
+                state = stat.read().rsplit(")", 1)[1].split()[0]
+        except OSError:
+            continue
+        if state not in ("Z", "X", "x"):  # skip procs that are already dead
+            pids.append(pid)
+    return pids
+
+
+def _terminate_with_grace(
+    live_pids: Callable[[], List[int]],
+    signal_pids: Callable[[List[int], int], None],
+    grace: float = _KILL_GRACE_SECONDS,
+) -> None:
+    """SIGTERM the live targets, wait up to ``grace`` for them to exit, then
+    SIGKILL any stragglers.
+
+    Factored out so the poll-with-sleep is not copied around, and so it can be
+    swapped for an await-based wait later. ``live_pids`` is re-evaluated each
+    round so procs spawned mid-teardown are still caught before the SIGKILL.
+    """
+    signal_pids(live_pids(), signal.SIGTERM)
+    deadline = time.monotonic() + grace
+    while time.monotonic() < deadline and live_pids():
+        time.sleep(0.05)
+    signal_pids(live_pids(), signal.SIGKILL)
 
 
 class ProcessJob(JobTrait):
@@ -111,7 +179,9 @@ class ProcessJob(JobTrait):
                         addr,
                     )
                     self._watch_process(proc, mesh_name, i, addr)
-        except Exception:
+        except BaseException:
+            # BaseException, not Exception: a Ctrl-C / cancellation mid-startup
+            # must still reap the workers already spawned above, or they leak.
             self._kill()
             raise
 
@@ -198,14 +268,36 @@ class ProcessJob(JobTrait):
         return True
 
     def _kill(self) -> None:
-        # Use SIGTERM to allow worker processes to shut down gracefully.
-        # The HostMesh objects are not stored here (they're returned to callers),
-        # so we rely on the worker processes handling SIGTERM for clean shutdown.
-        for p in self._host_to_pid.values():
-            try:
-                os.kill(p.pid, signal.SIGTERM)
-            except OSError:
-                pass
+        # Reap each worker's whole session, not just its process group. Workers
+        # run in detached sessions (start_new_session=True), and the procs they
+        # spawn stay in that session but in their own process groups -- so
+        # signalling only the worker's group would orphan them. Session reaping
+        # needs /proc; without it we fall back to best-effort signalling of the
+        # tracked worker pids, which does not reach the spawned procs.
+        worker_pids = [p.pid for p in self._host_to_pid.values()]
+        session_ids = set(worker_pids)
+
+        def remaining() -> List[int]:
+            live = _live_worker_pids(session_ids)
+            if live is None:
+                # /proc missing or unreadable: signal the worker pids we hold.
+                return [pid for pid in worker_pids if _group_alive(pid)]
+            return live
+
+        def signal_all(pids: List[int], sig: int) -> None:
+            # killpg reaps each enumerated group leader's whole group (catching
+            # children forked after the scan); the os.kill fallback covers pids
+            # that are not group leaders. A pid reaped and reused between scan and
+            # signal is at worst a stray no-op via the OSError fallback.
+            for pid in pids:
+                try:
+                    os.killpg(pid, sig)
+                except OSError:
+                    with contextlib.suppress(OSError):
+                        os.kill(pid, sig)
+
+        _terminate_with_grace(remaining, signal_all)
+
         self._host_to_pid.clear()
         if self._tmpdir is not None:
             shutil.rmtree(self._tmpdir, ignore_errors=True)

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -9,11 +9,14 @@
 import contextlib
 import os
 import pickle
+import shutil
+import signal
 import socket
 import subprocess
 import sys
 import tempfile
 import threading
+import time
 import types
 from dataclasses import dataclass
 from typing import cast, Dict, Optional, Sequence
@@ -32,6 +35,7 @@ from monarch._src.job.job import (
     JobTrait,
     LocalJob,
     MeshAdminConfig,
+    ProcessState,
     TelemetryConfig,
 )
 from monarch._src.job.job_components import JobComponent, JobComponents, MountComponent
@@ -573,6 +577,74 @@ def test_kill():
     # kill_called should now be True
     assert job.kill_called
     stop_sidecar.assert_called_once_with(apply_id)
+
+
+def test_process_job_kill_reaps_worker_session():
+    """_kill reaps the worker's whole session, including procs the worker spawns
+    into their own process groups -- which killpg of the worker alone orphans."""
+    if not os.path.isdir("/proc"):
+        pytest.skip("session reap requires /proc")
+
+    def session_members(sid):
+        alive = []
+        for entry in os.listdir("/proc"):
+            if not entry.isdigit():
+                continue
+            pid = int(entry)
+            try:
+                if os.getsid(pid) != sid:
+                    continue
+                with open(f"/proc/{pid}/stat") as stat:
+                    state = stat.read().rsplit(")", 1)[1].split()[0]
+            except OSError:
+                continue
+            if state not in ("Z", "X", "x"):
+                alive.append(pid)
+        return alive
+
+    # A worker mimicking ProcessJob's: its own session (start_new_session=True)
+    # with children in their own process groups, all ignoring SIGTERM so _kill
+    # must escalate to SIGKILL to reap them.
+    worker_src = (
+        "import os, signal, time\n"
+        "for _ in range(3):\n"
+        "    if os.fork() == 0:\n"
+        "        os.setpgid(0, 0)\n"
+        "        signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "        while True: time.sleep(0.5)\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "while True: time.sleep(0.5)\n"
+    )
+    proc = subprocess.Popen([sys.executable, "-c", worker_src], start_new_session=True)
+    worker = proc.pid
+    tmpdir = None
+
+    try:
+        deadline = time.monotonic() + 10.0
+        while time.monotonic() < deadline and len(session_members(worker)) < 4:
+            time.sleep(0.05)
+        assert len(session_members(worker)) == 4  # worker + 3 children
+
+        tmpdir = tempfile.mkdtemp(prefix="test_process_job_kill_")
+        job = ProcessJob({"hosts": 1})
+        job._host_to_pid = {"h_0": ProcessState(worker, f"ipc://{tmpdir}/h_0")}
+        job._tmpdir = tmpdir
+
+        job._kill()
+
+        deadline = time.monotonic() + 3.0
+        while time.monotonic() < deadline and session_members(worker):
+            time.sleep(0.05)
+        assert session_members(worker) == []
+        assert not os.path.isdir(tmpdir)
+    finally:
+        for pid in session_members(worker):
+            with contextlib.suppress(OSError):
+                os.kill(pid, signal.SIGKILL)
+        with contextlib.suppress(OSError, subprocess.TimeoutExpired):
+            proc.wait(timeout=2)
+        if tmpdir is not None:
+            shutil.rmtree(tmpdir, ignore_errors=True)
 
 
 def test_state_query_engine_none_without_telemetry():


### PR DESCRIPTION
Summary:
these mesh-admin example demos each own a local `ProcessJob(...).enable_admin()` and spawn proc meshes from `state.hosts`, but tear down with `proc.stop()` / `host.shutdown()` -- which leaves the detached host and the procs it spawned behind when a `Ctrl-C` or exception lands during startup. move each demo's startup and run under a single `try` whose `finally` calls `job.kill()`, which now reaps the worker's whole session (the host subprocess and every proc it spawned). driver tasks are still cancelled explicitly; the `proc.stop()` / `host.shutdown()` calls are removed. `rapid_spawn_exit_stress.py` had module-level `job.state()` setup, so that moves into the async main under the same lifecycle, and `asyncio.ensure_future` is switched to `asyncio.create_task`. no behavior change beyond owned, bounded teardown.

this replaces the scoped-lifecycle approach of the abandoned D111563916 with the landed `ProcessJob.kill()` session reap, so it needs none of the `scoped_async_state` / `run_async_main` scaffolding.

Differential Revision: D111772394


