### PR TITLE
Fix telemetry benchmark merge conflict

### DIFF
--- a/python/benches/telemetry_self_message_benchmark/benchmark.py
+++ b/python/benches/telemetry_self_message_benchmark/benchmark.py
@@ -336,7 +336,6 @@ def main() -> None:
             TelemetryConfig(
                 include_dashboard=True,
                 dashboard_port=0,
-                use_sidecar=True,
             )
         )
     payload = bytes(args.payload_bytes)


### PR DESCRIPTION
Summary: merge conflict was introduced when benchmark was landing and when we were removing legacy path. remove the `use_sidecar` param in benchmark

Differential Revision: D111780924


