### PR TITLE
remove job.exec_command's _Tokio producers (#4404)

### DIFF
--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -7,8 +7,11 @@
 # pyre-strict
 
 import asyncio
+import contextlib
 import logging
 import math
+import os
+import sys
 import warnings
 from typing import (
     Any,
@@ -103,6 +106,86 @@ _ALREADY_TOKIO_MSG = (
     "already converted into a pytokio.Shared object, use 'await' from a "
     "PythonTask coroutine to get the value."
 )
+
+
+# Record-only instrument for the pytokio-removal migration: it records the
+# callsite each time the `_Tokio` state is produced (the sole production site is
+# the tokio branch of `Future.__await__` below), so the migration can prove per
+# callsite that no production path still produces `_Tokio`. Off by default, so it
+# is a no-op with no behavior change; enable in a test with `enable_tokio_oracle()`
+# or process-wide with MONARCH_TOKIO_ORACLE=1 (record) / =raise. Raise mode is
+# opt-in and never on by default.
+class TokioOracleRecord(NamedTuple):
+    module: str
+    filename: str
+    lineno: int
+    function: str
+
+
+_tokio_oracle_mode: str = os.environ.get("MONARCH_TOKIO_ORACLE", "")
+_tokio_oracle_records: list[TokioOracleRecord] = []
+
+
+def enable_tokio_oracle(*, raise_on_produce: bool = False) -> None:
+    global _tokio_oracle_mode
+    _tokio_oracle_mode = "raise" if raise_on_produce else "record"
+
+
+def disable_tokio_oracle() -> None:
+    global _tokio_oracle_mode
+    _tokio_oracle_mode = ""
+
+
+def reset_tokio_oracle() -> None:
+    _tokio_oracle_records.clear()
+
+
+def tokio_oracle_records() -> list[TokioOracleRecord]:
+    return list(_tokio_oracle_records)
+
+
+@contextlib.contextmanager
+def tokio_oracle(
+    *, raise_on_produce: bool = False
+) -> Generator[list[TokioOracleRecord], None, None]:
+    """Scoped `_Tokio`-production oracle for tests: records (or, with
+    `raise_on_produce`, raises on) every `_Tokio` production for the duration
+    and yields the live records list, then restores the prior mode and records.
+    The save/restore keeps a process-wide oracle (e.g. `MONARCH_TOKIO_ORACLE`)
+    intact, and the scope guarantees cleanup so a caller cannot leak enabled
+    state by forgetting to disable it. Prefer this over the bare
+    `enable_tokio_oracle`/`reset_tokio_oracle`/`disable_tokio_oracle` trio.
+    """
+    global _tokio_oracle_mode
+    prev_mode = _tokio_oracle_mode
+    prev_records = _tokio_oracle_records.copy()
+    _tokio_oracle_mode = "raise" if raise_on_produce else "record"
+    _tokio_oracle_records.clear()
+    try:
+        yield _tokio_oracle_records
+    finally:
+        _tokio_oracle_mode = prev_mode
+        _tokio_oracle_records[:] = prev_records
+
+
+def _record_tokio_production() -> None:
+    # The callsite we want is the coroutine that awaited the Future: two frames
+    # up (this fn -> Future.__await__ -> awaiter).
+    if not _tokio_oracle_mode:
+        return
+    f = sys._getframe(2)
+    record = TokioOracleRecord(
+        module=str(f.f_globals.get("__name__", "<unknown>")),
+        filename=f.f_code.co_filename,
+        lineno=f.f_lineno,
+        function=f.f_code.co_name,
+    )
+    _tokio_oracle_records.append(record)
+    if _tokio_oracle_mode == "raise":
+        raise RuntimeError(
+            f"_Tokio produced at {record.filename}:{record.lineno} "
+            f"in {record.module}.{record.function}"
+        )
 
 
 class Future(Generic[R]):
@@ -259,6 +342,7 @@ class Future(Generic[R]):
         elif is_tokio_thread():
             match self._status:
                 case _Unawaited(coro=coro):
+                    _record_tokio_production()
                     shared = coro.spawn()
                     self._status = _Tokio(shared)
                     return shared.__await__()

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -887,7 +887,7 @@ def exec_command(
                     workdir=workdir,
                     client_cwd=client_cwd,
                     output_dir=output_dir,
-                )
+                )._take_inner()
             else:
                 lines: List[str] = ["#!/bin/bash"]
                 if env:
@@ -901,7 +901,9 @@ def exec_command(
                     )
                 lines.append(shlex.join(cmd))
                 script = "\n".join(lines) + "\n"
-                results = await bash_actors.run.call(script, output_dir=output_dir)
+                results = await bash_actors.run.call(
+                    script, output_dir=output_dir
+                )._take_inner()
             max_rc = 0
             for _rank_key, result in results:
                 rc = result.get("returncode", 1)
@@ -916,7 +918,7 @@ def exec_command(
             # pyrefly: ignore [bad-return]
             return max_rc
         finally:
-            await procs.stop()
+            await procs.stop()._take_inner()
 
     return Future(coro=_impl())
 

--- a/python/tests/test_actor_driver_characterization.py
+++ b/python/tests/test_actor_driver_characterization.py
@@ -1,0 +1,89 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-unsafe
+
+"""
+Characterization oracle for the actor endpoint driver.
+
+Pins the load-bearing runtime fact the pytokio-removal Stage 3 audit rests on:
+an ``@endpoint`` body runs on a real asyncio event loop (driven by the Rust
+dispatcher via ``into_future_with_locals``), NOT on a bare tokio worker thread.
+Concretely, inside an endpoint:
+
+  - ``asyncio.get_running_loop()`` succeeds (a loop is running); and
+  - a bare ``await PythonTask.sleep(0)`` raises (pytokio refuses to await a raw
+    ``PythonTask`` while an asyncio loop is active); and
+  - awaiting a monarch ``Future`` takes the ``_Handle`` (asyncio) path, never
+    ``_Tokio`` -- the Step-3.0 ``_Tokio``-production oracle records zero entries
+    for the endpoint body.
+
+This is why the reverted "A1" reroute (replacing ``await Future(...)`` in the
+reply path with a bare ``await PythonTask``) was wrong: under the loop the bare
+await raises. If a future change switches the dispatcher to drive endpoints on
+the tokio runtime (``PythonTask.from_coroutine``), these assertions flip -- which
+is the exact signal that such reroutes become valid. Pinned for both dispatch
+modes (queue and direct).
+"""
+
+import asyncio
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+from monarch._src.actor.future import Future, tokio_oracle
+from monarch._src.actor.host_mesh import this_host
+from monarch.actor import Actor, endpoint
+from monarch.config import parametrize_config
+
+
+class _DriverProbe(Actor):
+    @endpoint
+    async def probe(self) -> tuple[bool, bool, int]:
+        # (1) The endpoint body runs under a real asyncio loop.
+        try:
+            asyncio.get_running_loop()
+            has_loop = True
+        except RuntimeError:
+            has_loop = False
+
+        # (2) A bare PythonTask cannot be awaited while a loop is running.
+        bare_await_raised = False
+        try:
+            await PythonTask.sleep(0)
+        except RuntimeError:
+            bare_await_raised = True
+
+        # (3) Awaiting a monarch Future here takes the _Handle (asyncio) path,
+        # not _Tokio. Scope the oracle (so a process-wide oracle is left
+        # intact) and count only _Tokio attributed to this probe body, so
+        # unrelated concurrent activity on the loop can't perturb the count.
+        with tokio_oracle() as records:
+            await Future(coro=PythonTask.sleep(0))
+            tokio_count = sum(
+                1 for r in records if r.module == __name__ and r.function == "probe"
+            )
+
+        return (has_loop, bare_await_raised, tokio_count)
+
+
+@pytest.mark.timeout(120)
+@parametrize_config(actor_queue_dispatch={True, False})
+@isolate_in_subprocess
+async def test_actor_endpoint_is_asyncio_driven() -> None:
+    proc = this_host().spawn_procs(per_host={"gpus": 1})
+    probe = proc.spawn("driver_probe", _DriverProbe)
+    has_loop, bare_await_raised, tokio_count = await probe.probe.call_one()
+    assert has_loop, "an @endpoint body must run under a real asyncio loop"
+    assert bare_await_raised, (
+        "a bare `await PythonTask` inside an @endpoint must raise: pytokio "
+        "refuses to await a raw PythonTask while an asyncio loop is active"
+    )
+    assert tokio_count == 0, (
+        "awaiting a monarch Future inside an @endpoint must take the _Handle "
+        f"(asyncio) path, not _Tokio; oracle recorded {tokio_count} _Tokio entries"
+    )
+    await proc.stop()

--- a/python/tests/test_deferred_pickle_characterization.py
+++ b/python/tests/test_deferred_pickle_characterization.py
@@ -7,15 +7,20 @@
 # pyre-unsafe
 
 """
-Characterization oracle for deferred pickling.
+Characterization oracle for pending mesh-reference reserve/fill during
+serialization.
 
 Pins today's observable behavior: a mesh reference that is still *pending*
 (spawned and sent in the same breath, before its background init finishes)
 arrives at the other side as a usable reference, on both send paths: as an
 endpoint argument (request path) and as an endpoint return value (reply path).
-Today this rides the deferred-pickle subsystem (resolve-before-send plus a
-re-pickle); a change to how pending references serialize must preserve these
-outcomes. This is the safety net such a change checks against.
+The live mechanism is pending mesh-reference reserve/fill, NOT a generic
+deferred pickle or re-pickle: ``pickle(..., allow_mesh_references=True)``
+reserves out-of-band ref slots for still-pending meshes, and
+``PicklingState::resolve()`` (``monarch_hyperactor/src/pickle.rs``) awaits those
+handles and fills the slots with the payload bytes unchanged (no re-pickle). A
+change to how pending references serialize must preserve these outcomes. This is
+the safety net such a change checks against.
 
 There is no hook to force the pending path; it relies on the
 spawn-then-immediately-send race, which the synchronous pickle wins in practice

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -25,6 +25,7 @@ from unittest.mock import MagicMock, patch
 import monarch._src.job._job_sidecar_worker as js_worker
 import monarch._src.job.job_sidecar as js
 import pytest
+from monarch._src.actor.future import tokio_oracle
 
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import (
@@ -1845,3 +1846,30 @@ def test_exec_command_output_dir_suppresses_printing(capsys):
     )
     exec_command(host_mesh, ["echo", "hi"], output_dir="/tmp/out").get()
     assert "SHOULD_NOT_PRINT" not in capsys.readouterr().out
+
+
+def test_exec_command_produces_no_tokio():
+    """Gate A (job cluster): exec_command produces no `_Tokio` state.
+
+    Drives exec_command with the record-only `_Tokio` oracle enabled and asserts
+    job.py produced no `_Tokio` (no `await <Future>` on the tokio thread). Before
+    the `_take_inner()` migration this recorded the three job producers
+    (run_python.call, run.call, procs.stop); after it, zero.
+    """
+    with tokio_oracle() as records:
+        # shell branch: exercises run.call + the procs.stop finally
+        host_mesh, _procs, bash_actors, _markers = _exec_env()
+        bash_actors.run.call.return_value = _results_future(
+            [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+        )
+        exec_command(host_mesh, ["echo", "hi"]).get()
+
+        # python branch: exercises run_python.call + the procs.stop finally
+        host_mesh, _procs, bash_actors, _markers = _exec_env()
+        bash_actors.run_python.call.return_value = _results_future(
+            [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+        )
+        exec_command(host_mesh, ["train.py"]).get()
+
+        job_records = [r for r in records if r.filename.endswith("job.py")]
+        assert job_records == [], f"exec_command still produces _Tokio: {job_records}"

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -29,6 +29,7 @@ import pytest
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import (
     BatchJob,
+    exec_command,
     job_load,
     job_loads,
     JobState,
@@ -42,7 +43,7 @@ from monarch._src.job.job_components import JobComponent, JobComponents, MountCo
 from monarch._src.job.mount_config import Mounts
 from monarch._src.job.process import ProcessJob
 from monarch._src.job.process_guard import _Shutdown, _wait_for_socket
-from monarch.actor import HostMesh
+from monarch.actor import Future, HostMesh
 
 
 def _append_line(path: str, line: str) -> None:
@@ -1697,3 +1698,150 @@ def test_mast_job_get_runner_is_lazy():
     source = inspect.getsource(MASTJob._get_runner)
     # The import must be inside the method, not at module level.
     assert "from monarch._src.tools.commands import torchx_runner" in source
+
+
+# ── exec_command tests ─────────────────────────────────────────────────────
+
+
+def _exec_env():
+    """Mock host_mesh -> procs -> bash_actors for driving exec_command.
+
+    procs.stop() returns a real Future whose coroutine flips
+    markers["stop_driven"] only when it is actually awaited/driven, so a test can
+    prove the finally ran to completion rather than merely that stop() was called.
+    Each test configures the endpoint calls (bash_actors.run / run_python).
+    """
+    markers = {"stop_driven": False}
+
+    async def _stop_impl() -> None:
+        markers["stop_driven"] = True
+
+    bash_actors = MagicMock()
+    procs = MagicMock()
+    procs.spawn.return_value = bash_actors
+    procs.stop.return_value = Future(coro=_stop_impl())
+    host_mesh = MagicMock()
+    host_mesh.spawn_procs.return_value = procs
+    return host_mesh, procs, bash_actors, markers
+
+
+def _results_future(pairs):
+    """A real Future resolving to pairs, an iterable of (rank_key, result)."""
+
+    async def _impl():
+        return pairs
+
+    return Future(coro=_impl())
+
+
+def test_exec_command_returns_max_returncode():
+    """exec_command returns the maximum return code across ranks."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run.call.return_value = _results_future(
+        [
+            ("rank0", {"returncode": 0, "stdout": "", "stderr": ""}),
+            ("rank1", {"returncode": 7, "stdout": "", "stderr": ""}),
+        ]
+    )
+    assert exec_command(host_mesh, ["echo", "hi"]).get() == 7
+
+
+def test_exec_command_drives_cleanup_on_success():
+    """procs.stop() is driven to completion on the happy path."""
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+    exec_command(host_mesh, ["echo", "hi"]).get()
+    assert markers["stop_driven"]
+    procs.stop.assert_called_once()
+
+
+def test_exec_command_drives_cleanup_on_error():
+    """The finally must drive procs.stop() to completion even when the run raises."""
+
+    class _Boom(Exception):
+        pass
+
+    host_mesh, procs, bash_actors, markers = _exec_env()
+    bash_actors.run.call.side_effect = _Boom("run failed")
+    with pytest.raises(_Boom):
+        exec_command(host_mesh, ["echo", "hi"]).get()
+    # Proves the finally did real async work, not merely that stop() was called.
+    assert markers["stop_driven"]
+    procs.stop.assert_called_once()
+
+
+def test_exec_command_dispatches_to_run_python_for_py_scripts():
+    """A .py command routes to run_python.call, not run.call."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run_python.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+    exec_command(host_mesh, ["train.py", "--flag"]).get()
+    bash_actors.run_python.call.assert_called_once()
+    bash_actors.run.call.assert_not_called()
+
+
+def test_exec_command_dispatches_to_run_for_shell_commands():
+    """A non-.py command builds a bash script and routes to run.call."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+    exec_command(host_mesh, ["echo", "hi"]).get()
+    bash_actors.run.call.assert_called_once()
+    bash_actors.run_python.call.assert_not_called()
+    script = bash_actors.run.call.call_args.args[0]
+    assert script.startswith("#!/bin/bash")
+    assert "echo hi" in script
+
+
+def test_exec_command_slices_by_point():
+    """point= selects a sub-mesh via host_mesh.slice(**point)."""
+    host_mesh, procs, bash_actors, _markers = _exec_env()
+    sliced = MagicMock()
+    sliced.spawn_procs.return_value = procs
+    host_mesh.slice.return_value = sliced
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+    exec_command(host_mesh, ["echo", "hi"], point={"gpu": 2}).get()
+    host_mesh.slice.assert_called_once_with(gpu=2)
+    sliced.spawn_procs.assert_called_once()
+
+
+def test_exec_command_slices_by_rank():
+    """rank= selects a single rank via flatten('rank').slice(rank=...)."""
+    host_mesh, procs, bash_actors, _markers = _exec_env()
+    flattened = MagicMock()
+    sliced = MagicMock()
+    host_mesh.flatten.return_value = flattened
+    flattened.slice.return_value = sliced
+    sliced.spawn_procs.return_value = procs
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
+    )
+    exec_command(host_mesh, ["echo", "hi"], rank=3).get()
+    host_mesh.flatten.assert_called_once_with("rank")
+    flattened.slice.assert_called_once_with(rank=3)
+
+
+def test_exec_command_prints_output_when_no_output_dir(capsys):
+    """With no output_dir, each rank's stdout is echoed to the caller."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "HELLO", "stderr": ""})]
+    )
+    exec_command(host_mesh, ["echo", "hi"]).get()
+    assert "HELLO" in capsys.readouterr().out
+
+
+def test_exec_command_output_dir_suppresses_printing(capsys):
+    """With output_dir set, stdout/stderr are not echoed to the caller."""
+    host_mesh, _procs, bash_actors, _markers = _exec_env()
+    bash_actors.run.call.return_value = _results_future(
+        [("rank0", {"returncode": 0, "stdout": "SHOULD_NOT_PRINT", "stderr": ""})]
+    )
+    exec_command(host_mesh, ["echo", "hi"], output_dir="/tmp/out").get()
+    assert "SHOULD_NOT_PRINT" not in capsys.readouterr().out


### PR DESCRIPTION
Summary:

this removes the three places where `job.exec_command` drives a `Future` into the pytokio `_Tokio` state, by awaiting the underlying raw `PythonTask` (`await <Future>._take_inner()`) instead of the `Future` itself. behavior is unchanged; the characterization tests added in the previous diff (D111923818) stay green.

what and why: `exec_command`'s internal coroutine `_impl` runs in the pytokio world — it is wrapped by `Future(coro=...)` and driven by the caller's blocking `.get()` on a tokio thread. on that thread, `await <Future>` takes `Future.__await__`'s tokio branch, which spawns a `Shared` and leaves the residual `_Tokio` cross-world state. those were 3 of the 10 `_Tokio` producers that the pytokio-removal work (Stage 3) is eliminating. `_take_inner()` surrenders the `Future`'s raw `PythonTask`; awaiting that never enters `Future.__await__`, so no `_Tokio` is produced. it is legal here because `_impl` already runs under `from_coroutine`, where awaiting a raw `PythonTask` is the sanctioned move, and each awaited value is a fresh, single-use `Future` (the `_take_inner()` precondition).

the outer `Future(coro=_impl())` return is deliberately kept — it is migration surface removed in Stage 6, not a `_Tokio` producer. the caller's `.get()` and the `finally: await procs.stop()` cleanup are preserved. do not collapse these back to `await <Future>`; that reintroduces `_Tokio`.

sites (`job.py`): `run_python.call(...)`, `run.call(...)`, and `procs.stop()` in the `finally`. this diff also adds `test_exec_command_produces_no_tokio`, which enables the Step 3.0 `_Tokio` oracle, drives `exec_command`, and asserts zero `_Tokio` records from `job.py` — Gate A for the job cluster, self-verifying.

Reviewed By: thedavekwon

Differential Revision: D111925590


