### PR TITLE
Freeze uv usage in OSS build paths (#4408)

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -55,20 +55,20 @@ jobs:
         # Source common setup functions
         source scripts/common-setup.sh
 
-        # Setup build environment (conda + system deps + rust + build deps)
-        # docs build will use 3.13
-        setup_build_environment 3.13
-
-        # Install PyTorch with CUDA support (matching build-cuda.yml)
-        pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu132
+        # Setup build environment (conda + system deps + rust + build deps).
+        # Keep docs CI on Python 3.11 because this OSS job installs locked
+        # PyPI deps, and locked runtime deps such as numpy 1.24.4 can still
+        # expect distutils when they build from source on Python 3.12+.
+        setup_build_environment 3.11
 
         # Setup Tensor Engine
         setup_tensor_engine
 
         # Setup Python dependencies
-        python -m pip install --upgrade pip
-        pip install -r build-requirements.txt
-        pip install -r docs/requirements.txt
+        python -m pip install --upgrade pip uv
+        uv sync --frozen --python 3.11 --inexact --group docs --extra kubernetes --no-dev --no-install-project
+        uv pip install --python .venv/bin/python -r build-requirements.txt
+        uv pip install --python .venv/bin/python --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cu132
 
         # Set environment variables for CUDA build
         export USE_CUDA=1
@@ -77,10 +77,10 @@ jobs:
         export _GLIBCXX_USE_CXX11_ABI=1
 
         # Build Monarch completely for documentation - use dedicated script
-        ./scripts/build_monarch_for_docs.sh
+        uv run --frozen --python 3.11 --no-sync --project . bash ./scripts/build_monarch_for_docs.sh
 
         # Generate documentation for all workspace crates
-        cargo doc --workspace --no-deps
+        uv run --frozen --python 3.11 --no-sync --project . cargo doc --workspace --no-deps
 
         # Prepare documentation structure for Sphinx and final output
         mkdir -p docs/source/target
@@ -91,7 +91,7 @@ jobs:
         cd docs
 
         make clean
-        make html SPHINXOPTS="-v --keep-going"
+        make html UV_SYNC=":" SPHINXBUILD="uv run --frozen --python 3.11 --no-sync --project .. sphinx-build" SPHINXOPTS="-v --keep-going"
 
         cd ..
 

--- a/examples/torchtitan_mast/setup_env.sh
+++ b/examples/torchtitan_mast/setup_env.sh
@@ -45,10 +45,11 @@ mkdir -p "$CLIENT" "$WHEEL_DIR" "$WORKSPACE" "$BOOTSTRAP_WHEEL_DIR"
 "$CLIENT/bin/python3.12" -m pip install --upgrade --disable-pip-version-check \
     libclang numpy "setuptools>=64" setuptools-rust wheel
 ( cd "$MONARCH_SRC" && \
+    uv lock --check-exists && \
     USE_TENSOR_ENGINE=0 \
     LIBCLANG_PATH="$CLIENT/lib/python3.12/site-packages/clang/native" \
     BINDGEN_EXTRA_CLANG_ARGS="-I/usr/lib/gcc/x86_64-redhat-linux/11/include" \
-    uv build --wheel --no-build-isolation \
+    UV_FROZEN=1 uv build --wheel --no-build-isolation \
         --python "$CLIENT/bin/python3.12" --out-dir "$WHEEL_DIR" )
 # Cache the freshly-built wheel where simple_mast_job.build_bootstrap looks
 # first, so `monarch apply` reuses it instead of rebuilding the slim wheel.

--- a/scripts/build_monarch_for_docs.sh
+++ b/scripts/build_monarch_for_docs.sh
@@ -16,7 +16,13 @@ export CI=true
 # BUILD MONARCH COMPLETELY - This is critical for API documentation
 echo "Building Monarch with Rust bindings..."
 export MONARCH_BUILD_MESH_ONLY=0
-python -m pip install -e ".[kubernetes]" --no-build-isolation
+# uv-created environments do not seed pip; keep this install on uv when available.
+if command -v uv >/dev/null 2>&1; then
+    python_executable=$(python -c 'import sys; print(sys.executable)')
+    uv pip install --python "$python_executable" --no-deps -e ".[kubernetes]" --no-build-isolation
+else
+    python -m pip install --no-deps -e ".[kubernetes]" --no-build-isolation
+fi
 
 # Verify Monarch installation and imports
 echo "Verifying Monarch installation..."


### PR DESCRIPTION
Summary:

Use frozen `uv` operations in docs CI and require only that `uv.lock` exists before building the torchtitan example wheel. `uv sync --frozen` and `uv run --frozen --no-sync` use the checked-in lockfile as the source of truth, so repeated docs builds use the same Sphinx version unless `uv.lock` changes. `uv lock --check-exists` avoids the stricter freshness check from `uv lock --check`, which can fail when the lock pins one valid solution and a fresh resolution would choose another valid version.

Keep docs CI on Python 3.11 because the locked OSS dependency set includes packages such as `numpy==1.24.4`, which can still expect `distutils` when building from source on Python 3.12+. Install the `kubernetes` extra through the frozen sync and run the docs editable install without dependency resolution, targeting the Python interpreter running the docs script and avoiding any requirement for `pip` to be seeded into `.venv`.

Reviewed By: shayne-fletcher

Differential Revision: D111719951


