### PR TITLE
cap mlx5dv segment MRs at device max_sge

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -822,13 +822,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
     if devices.len() > 4 {
         // Use separate backend devices for H100 configuration
         device_1_ibv_config = IbvConfig {
-            target: IbvDeviceTarget::nic(devices[0].name().clone()),
+            target: Some(IbvDeviceTarget::nic(devices[0].name().clone())),
             ..Default::default()
         };
         // The second device used is the 3rd. Main reason is because 0 and 3 are both backend
         // devices on gtn H100 devices.
         device_2_ibv_config = IbvConfig {
-            target: IbvDeviceTarget::nic(devices[3].name().clone()),
+            target: Some(IbvDeviceTarget::nic(devices[3].name().clone())),
             ..Default::default()
         };
     } else {

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -476,13 +476,13 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     // Quick check for H100
     if devices.len() > 4 {
         ps_ibv_config = IbvConfig {
-            target: IbvDeviceTarget::nic(devices[0].name().clone()),
+            target: Some(IbvDeviceTarget::nic(devices[0].name().clone())),
             ..Default::default()
         };
         // The second device used is the 3rd. Main reason is because 0 and 3 are both backend
         // devices on gtn H100 devices.
         worker_ibv_config = IbvConfig {
-            target: IbvDeviceTarget::nic(devices[3].name().clone()),
+            target: Some(IbvDeviceTarget::nic(devices[3].name().clone())),
             ..Default::default()
         };
     } else {

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -17,7 +17,10 @@
 //! - Device selection and PCI-to-RDMA device mapping
 
 use std::collections::HashMap;
+use std::collections::hash_map::DefaultHasher;
 use std::fmt::Write as _;
+use std::hash::Hash;
+use std::hash::Hasher;
 use std::sync::OnceLock;
 use std::time::Duration;
 
@@ -45,13 +48,13 @@ use super::IbvOp;
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
 use super::device_selection::resolve_target;
+use super::device_selection::select_optimal_ibv_devices;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::efa_device::EfaDevice;
 use super::memory_region::IbvMemoryRegionView;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
-use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
 use super::queue_pair::IbvQueuePair;
@@ -65,6 +68,7 @@ use crate::RdmaTransportLevel;
 use crate::backend::RdmaBackend;
 use crate::backend::RdmaConfig;
 use crate::backend::ResolveRemoteBackendContext;
+use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
 use crate::local_memory::is_device_ptr;
 use crate::rdma_components::RdmaRemoteBuffer;
@@ -313,10 +317,11 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     }
 
     /// Resolve `mem` to an [`IbvMemoryRegionView`] using the slot shared by
-    /// every clone of `mem`. On a cold slot, picks the RDMA device (the
-    /// CUDA-co-located NIC for device memory, else the config fallback) and
-    /// registers the region through that device's [`IbvDomainImpl`] strategy,
-    /// installing the result; on a warm slot, returns the cached view.
+    /// every clone of `mem`. On a cold slot, picks the RDMA device (an explicit
+    /// `config.target` if set, else the CUDA-co-located NIC for device memory,
+    /// else a hash-assigned NIC for host memory) and registers the region
+    /// through that device's [`IbvDomainImpl`] strategy, installing the result;
+    /// on a warm slot, returns the cached view.
     fn resolve_local_mr(
         &mut self,
         mem: &KeepaliveLocalMemory,
@@ -326,35 +331,74 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         }
         let addr = mem.addr();
 
-        // Pick the RDMA device: for device memory, the CUDA-co-located NIC;
-        // otherwise the configured fallback.
-        let cuda_nic = if is_device_ptr(addr) {
-            let mut device_ordinal: i32 = -1;
-            // SAFETY: `addr` is a CUDA device pointer (per `is_device_ptr`); the
-            // FFI call writes the owning device ordinal through the out-pointer.
-            let err = unsafe {
-                rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
-                    &mut device_ordinal as *mut _ as *mut std::ffi::c_void,
-                    rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
-                    addr as rdmaxcel_sys::CUdeviceptr,
-                )
-            };
-            // A non-success code yields no NIC.
-            let ordinal = (err == rdmaxcel_sys::CUDA_SUCCESS).then_some(device_ordinal);
-            ordinal.filter(|o| *o >= 0).and_then(|o| {
-                super::device_selection::get_cuda_device_to_ibv_device::<I>()
-                    .get(o as usize)
-                    .and_then(|d| d.clone())
-            })
-        } else {
-            None
-        };
-        let device_name = cuda_nic.map(|info| info.name().clone()).unwrap_or_else(|| {
-            resolve_target::<I>(&self.config.target)
-                .unwrap_or_else(|| IbvDeviceInfo::default::<I>())
+        // Device selection, in priority order:
+        //   1. an explicit `config.target`, resolved to its NIC;
+        //   2. otherwise the CUDA-co-located NIC for device memory;
+        //   3. otherwise a host-memory NIC assigned by hashing (addr, size).
+        let device_name = if let Some(target) = &self.config.target {
+            resolve_target::<I>(target)
+                .ok_or_else(|| anyhow::anyhow!("configured device target {:?} not found", target))?
                 .name()
                 .clone()
-        });
+        } else {
+            let cuda_nic = if is_device_ptr(addr) {
+                let mut device_ordinal: i32 = -1;
+                // SAFETY: `addr` is a CUDA device pointer (per `is_device_ptr`);
+                // the FFI call writes the owning device ordinal through the
+                // out-pointer.
+                let err = unsafe {
+                    rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
+                        &mut device_ordinal as *mut _ as *mut std::ffi::c_void,
+                        rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                        addr as rdmaxcel_sys::CUdeviceptr,
+                    )
+                };
+                let ordinal = (err == rdmaxcel_sys::CUDA_SUCCESS)
+                    .then_some(device_ordinal)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
+                            "could not get CUDA device ordinal for device memory at 0x{:x}: {}",
+                            addr,
+                            err
+                        )
+                    })?;
+                assert!(ordinal >= 0, "CUDA device ordinal must be non-negative");
+                Some(
+                    super::device_selection::get_cuda_device_to_ibv_device::<I>()
+                        .get(ordinal as usize)
+                        .and_then(|d| d.clone())
+                        .ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "no RDMA device found for CUDA device ordinal {}",
+                                ordinal
+                            )
+                        })?,
+                )
+            } else {
+                None
+            };
+            match cuda_nic {
+                Some(info) => info.name().clone(),
+                None => {
+                    // Host memory has no co-located GPU NIC. Rather than funnel
+                    // every host registration through a single device, spread them
+                    // across all NICs that tie for the best CPU path by hashing the
+                    // region's (addr, size); the NICs share the load for host
+                    // memory, increasing aggregate throughput.
+                    let devices = select_optimal_ibv_devices::<I>(MemoryLocation::Cpu(None));
+                    match devices.len() {
+                        0 => anyhow::bail!("no RDMA devices found"),
+                        n => {
+                            let mut hasher = DefaultHasher::new();
+                            (mem.addr(), mem.size()).hash(&mut hasher);
+                            devices[(hasher.finish() % n as u64) as usize]
+                                .name()
+                                .clone()
+                        }
+                    }
+                }
+            }
+        };
         tracing::debug!(
             "Using RDMA device: {} for memory at 0x{:x}",
             device_name,

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -153,9 +153,10 @@ pub(super) trait MlxDomainOps: Send + Sync + 'static {
         config: &IbvConfig,
     ) -> anyhow::Result<IbvQp>;
 
-    /// Bind `mrs` to a freshly created indirect key using `qp`'s work-request
-    /// builder, returning it as a [`Mlx5dvMkey`] owning those MR references. On
-    /// failure the `mrs` are dropped.
+    /// Bind `mrs` to a freshly created indirect key (sized to hold
+    /// `mkey_max_entries` MRs) using `qp`'s work-request builder, returning it
+    /// as a [`Mlx5dvMkey`] owning those MR references. On failure the `mrs` are
+    /// dropped.
     ///
     /// # Safety
     ///
@@ -168,6 +169,7 @@ pub(super) trait MlxDomainOps: Send + Sync + 'static {
         qp: &IbvQp,
         access: i32,
         mrs: Vec<Arc<IbvMr>>,
+        mkey_max_entries: usize,
     ) -> anyhow::Result<Mlx5dvMkey>;
 }
 
@@ -274,6 +276,7 @@ impl MlxDomainOps for ProdMlxDomainOps {
         qp: &IbvQp,
         access: i32,
         mrs: Vec<Arc<IbvMr>>,
+        mkey_max_entries: usize,
     ) -> anyhow::Result<Mlx5dvMkey> {
         if pd.as_ptr().is_null() || qp.as_ptr().is_null() {
             anyhow::bail!("bind_mr_list called with a null protection domain or queue pair");
@@ -302,6 +305,7 @@ impl MlxDomainOps for ProdMlxDomainOps {
                 access,
                 ptrs.as_ptr() as *mut *mut rdmaxcel_sys::ibv_mr,
                 ptrs.len(),
+                mkey_max_entries,
                 &mut mkey,
             )
         };
@@ -422,6 +426,8 @@ struct RegisteredSegmentState {
 struct RegisteredSegment {
     ops: Arc<dyn MlxDomainOps>,
     base_virtual_addr: usize,
+    /// The most MRs that can bind to this segment's indirect key.
+    mkey_max_entries: usize,
     state: Mutex<RegisteredSegmentState>,
 }
 
@@ -439,11 +445,17 @@ impl std::fmt::Debug for RegisteredSegment {
 
 impl RegisteredSegment {
     /// An unbound segment for `base_virtual_addr`: no MRs, no key, zero size.
-    /// [`Self::grow`] binds its first generation.
-    fn empty(ops: Arc<dyn MlxDomainOps>, base_virtual_addr: usize) -> Self {
+    /// [`Self::grow`] binds its first generation. `mkey_max_entries` caps the
+    /// MRs bound to the segment's key.
+    fn empty(
+        ops: Arc<dyn MlxDomainOps>,
+        base_virtual_addr: usize,
+        mkey_max_entries: usize,
+    ) -> Self {
         Self {
             ops,
             base_virtual_addr,
+            mkey_max_entries,
             state: Mutex::new(RegisteredSegmentState {
                 stale_mkeys: Vec::new(),
                 mkey: None,
@@ -524,8 +536,23 @@ impl RegisteredSegment {
             .map(|k| k.mrs().clone())
             .unwrap_or_default();
         all.extend(new_tail);
+        // A single indirect key binds at most `mkey_max_entries` MRs; exceeding
+        // it would fault at transfer time. Fail here instead; the caller falls
+        // back to per-region dmabuf registration. The freshly-registered tail
+        // drops as `all` unwinds, leaving the segment unchanged.
+        if all.len() > self.mkey_max_entries {
+            anyhow::bail!(
+                "segment at 0x{:x} needs {} MRs, exceeding mkey max entries {}",
+                self.base_virtual_addr,
+                all.len(),
+                self.mkey_max_entries
+            );
+        }
         // SAFETY: same contract; `all` are this segment's live MRs.
-        let new_mkey = unsafe { self.ops.bind_mr_list(pd, qp, access, all) }?;
+        let new_mkey = unsafe {
+            self.ops
+                .bind_mr_list(pd, qp, access, all, self.mkey_max_entries)
+        }?;
 
         // Retire the prior key (kept for in-flight ops built against it) and
         // install the new one.
@@ -624,6 +651,8 @@ pub struct MlxDomain {
     /// CUDA ordinals whose optimal NIC is this device. Only segments on
     /// these ordinals are bound here.
     cuda_ordinals: Vec<i32>,
+    /// Caps the MRs bound to each segment's indirect key.
+    mkey_max_entries: usize,
     /// Lazily-created loopback QP (an [`IbvQp`] owning its completion queues and
     /// PD) used to post key-binding work requests, destroyed when this domain
     /// drops.
@@ -646,8 +675,13 @@ impl std::fmt::Debug for MlxDomain {
 
 impl MlxDomain {
     /// Build a domain over the given ops, deriving mlx5dv support and the
-    /// served CUDA ordinals from them.
-    fn new_with_ops(ops: Arc<dyn MlxDomainOps>, config: IbvConfig) -> Self {
+    /// served CUDA ordinals from them. `mkey_max_entries` caps the MRs bound to
+    /// every segment's indirect key.
+    fn new_with_ops(
+        ops: Arc<dyn MlxDomainOps>,
+        config: IbvConfig,
+        mkey_max_entries: usize,
+    ) -> Self {
         let mlx5dv_enabled = ops.mlx5dv_enabled();
         let cuda_ordinals = ops.assigned_cuda_devices();
         Self {
@@ -655,6 +689,7 @@ impl MlxDomain {
             config,
             mlx5dv_enabled,
             cuda_ordinals,
+            mkey_max_entries,
             loopback: OnceLock::new(),
             segments: Mutex::new(HashMap::new()),
         }
@@ -730,6 +765,7 @@ impl MlxDomain {
                     let fresh = Arc::new(RegisteredSegment::empty(
                         self.ops.clone(),
                         scanned_seg.address,
+                        self.mkey_max_entries,
                     ));
                     // SAFETY: as above.
                     unsafe { fresh.grow(pd, qp, access, scanned_seg) }?;
@@ -766,6 +802,8 @@ impl IbvDomainImpl for MlxDomain {
         Self::new_with_ops(
             Arc::new(ProdMlxDomainOps::new(context, device_info)),
             config.clone(),
+            // An indirect mkey cannot bind more MRs than its device's `max_sge`.
+            device_info.max_sge().max(0) as usize,
         )
     }
 
@@ -941,6 +979,7 @@ mod tests {
             _qp: &IbvQp,
             _access: i32,
             mrs: Vec<Arc<IbvMr>>,
+            _mkey_max_entries: usize,
         ) -> anyhow::Result<Mlx5dvMkey> {
             let mut s = self.lock();
             if s.fail_bind {
@@ -954,11 +993,15 @@ mod tests {
         }
     }
 
+    /// `mkey_max_entries` for tests: large enough that the small MR counts here
+    /// never trip the segment cap (that limit has its own test).
+    const TEST_MKEY_MAX_ENTRIES: usize = 32;
+
     /// A domain wrapping the mock-driven [`MlxDomain`] under test. Its `pd`
     /// (and, through it, its context) is null (no-op `Drop`). Drive the strategy
     /// via [`IbvDomain::domain_impl`].
     fn domain(mock: Arc<MockOps>) -> Arc<IbvDomain<MlxDomain>> {
-        let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default());
+        let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default(), TEST_MKEY_MAX_ENTRIES);
         // SAFETY: `IbvPd::null()` holds a null PD (and, through it, a null
         // context) whose `Drop`s are no-ops.
         unsafe {
@@ -1001,7 +1044,11 @@ mod tests {
 
     /// Bind a fresh segment `[base, base + size)`: an empty segment grown once.
     fn bind_fresh(ops: &Arc<MockOps>, base: usize, size: usize) -> Arc<RegisteredSegment> {
-        let segment = Arc::new(RegisteredSegment::empty(dyn_ops(ops), base));
+        let segment = Arc::new(RegisteredSegment::empty(
+            dyn_ops(ops),
+            base,
+            TEST_MKEY_MAX_ENTRIES,
+        ));
         // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
         unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, size, 0)) }
             .expect("fresh bind should succeed");
@@ -1237,7 +1284,7 @@ mod tests {
         let ops = MockOps::new(SERVED_NIC, true, &[0]);
         ops.lock().fail_dmabuf_after = Some(1);
         let base = 0x10_0000_0000;
-        let segment = RegisteredSegment::empty(dyn_ops(&ops), base);
+        let segment = RegisteredSegment::empty(dyn_ops(&ops), base, TEST_MKEY_MAX_ENTRIES);
 
         // Two chunks; the second dmabuf registration fails.
         // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
@@ -1261,7 +1308,7 @@ mod tests {
         let ops = MockOps::new(SERVED_NIC, true, &[0]);
         ops.lock().fail_bind = true;
         let base = 0x10_0000_0000;
-        let segment = RegisteredSegment::empty(dyn_ops(&ops), base);
+        let segment = RegisteredSegment::empty(dyn_ops(&ops), base, TEST_MKEY_MAX_ENTRIES);
 
         // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
         let result = unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, MIB2, 0)) };
@@ -1270,6 +1317,27 @@ mod tests {
         assert!(
             segment.state.lock().unwrap().mkey.is_none(),
             "no key installed on bind failure"
+        );
+    }
+
+    #[test]
+    fn test_grow_exceeding_mkey_max_entries_errors() {
+        let ops = MockOps::new(SERVED_NIC, true, &[0]);
+        let base = 0x10_0000_0000;
+        // Cap at one MR; a two-chunk segment needs two, so grow must reject it
+        // rather than bind an over-capacity (and silently truncated) key.
+        let segment = RegisteredSegment::empty(dyn_ops(&ops), base, 1);
+        // SAFETY: `MockOps` ignores the `pd`/`qp`; the nulls are never deref'd.
+        let result =
+            unsafe { segment.grow(&null_pd(), &null_qp(), 0, &seg(base, MAX_MR_SIZE + MIB2, 0)) };
+        assert!(
+            result.is_err(),
+            "grow must reject a segment needing more MRs than mkey max entries"
+        );
+        assert_eq!(segment.size(), 0, "the segment is left unchanged");
+        assert!(
+            ops.lock().bind_calls.is_empty(),
+            "no bind attempted past the cap"
         );
     }
 

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -257,9 +257,11 @@ pub fn resolve_qp_type(qp_type: IbvQpType) -> u32 {
 /// parameters.
 #[derive(Debug, Named, Clone, Serialize, Deserialize)]
 pub struct IbvConfig {
-    /// `target` - Which RDMA device to use. A consumer resolves this to a
-    /// concrete device for its backend via [`resolve_target`].
-    pub target: IbvDeviceTarget,
+    /// `target` - An explicit RDMA device target, resolved to a concrete
+    /// device via [`resolve_target`]. When `None`, the consumer picks the
+    /// device itself (the co-located NIC for GPU memory, or a hash-assigned
+    /// NIC for host memory).
+    pub target: Option<IbvDeviceTarget>,
     /// `cq_entries` - The number of completion queue entries.
     pub cq_entries: i32,
     /// `port_num` - The physical port number on the device.
@@ -306,12 +308,12 @@ wirevalue::register_type!(IbvConfig);
 
 /// rdma-core defaults below come from common rdma-core examples; tune for
 /// production based on `ibv_query_device()` results and workload
-/// characteristics. The default target is CPU NUMA node 0; a consumer
-/// resolves it to a concrete device for its backend via [`resolve_target`].
+/// characteristics. The default target is `None`, leaving device selection to
+/// the consumer.
 impl Default for IbvConfig {
     fn default() -> Self {
         Self {
-            target: IbvDeviceTarget::MemoryLocation(MemoryLocation::Cpu(Some(0))),
+            target: None,
             cq_entries: 1024,
             port_num: 1,
             max_send_wr: 512,
@@ -340,7 +342,7 @@ impl IbvConfig {
     /// [`target`](Self::target) is `target` (see [`IbvDeviceTarget`]).
     pub fn targeting(target: IbvDeviceTarget) -> Self {
         Self {
-            target,
+            target: Some(target),
             ..Default::default()
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1347,6 +1347,7 @@ mod tests {
     use super::*;
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::device::list_all_devices;
+    use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
     use crate::backend::ibverbs::device_selection::resolve_target;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvConfig;
@@ -1362,7 +1363,7 @@ mod tests {
             use_gpu_direct: false,
             ..Default::default()
         };
-        let device_info = resolve_target::<MlxDevice>(&config.target).unwrap();
+        let device_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
         let mut device = IbvDevice::<MlxDevice>::open(device_info.name(), config.clone())
             .expect("resolved device should open");
         let domain = device
@@ -1388,14 +1389,14 @@ mod tests {
             ..Default::default()
         };
 
-        let server_info = resolve_target::<MlxDevice>(&server_config.target).unwrap();
+        let server_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
         let mut server_device =
             IbvDevice::<MlxDevice>::open(server_info.name(), server_config.clone())
                 .expect("server device should open");
         let server_domain = server_device
             .get_or_create_domain("test")
             .expect("server domain creation should succeed");
-        let client_info = resolve_target::<MlxDevice>(&client_config.target).unwrap();
+        let client_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
         let mut client_device =
             IbvDevice::<MlxDevice>::open(client_info.name(), client_config.clone())
                 .expect("client device should open");

--- a/rdmaxcel-sys/src/rdmaxcel.cpp
+++ b/rdmaxcel-sys/src/rdmaxcel.cpp
@@ -218,6 +218,7 @@ int bind_mrs(
     struct ibv_qp* qp,
     int access_flags,
     const std::vector<ibv_mr*>& mrs,
+    size_t mkey_max_entries,
     struct mlx5dv_mkey** mkey) {
   auto mrs_cnt = mrs.size();
   // Defensive: these are passed across the C ABI from Rust; validate rather
@@ -256,7 +257,8 @@ int bind_mrs(
     struct mlx5dv_mkey_init_attr mkey_attr = {};
     mkey_attr.pd = pd;
     mkey_attr.create_flags = MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT;
-    mkey_attr.max_entries = 32;
+    mkey_attr.max_entries =
+        static_cast<decltype(mkey_attr.max_entries)>(mkey_max_entries);
     auto new_mkey = mlx5dv_create_mkey(&mkey_attr);
     if (!new_mkey) {
       return RDMAXCEL_MKEY_CREATE_FAILED;
@@ -307,6 +309,7 @@ int rdmaxcel_bind_mr_list(
     int access_flags,
     struct ibv_mr** mrs,
     size_t mrs_cnt,
+    size_t mkey_max_entries,
     struct mlx5dv_mkey** mkey) noexcept {
   // The vector copy and `bind_mrs` allocate; catch every exception and return
   // an error code so none unwinds across the C ABI into Rust (UB).
@@ -318,7 +321,7 @@ int rdmaxcel_bind_mr_list(
     std::vector<ibv_mr*> mr_vec(mrs, mrs + mrs_cnt);
     // `bind_mrs` validates the remaining pointers and, on failure, cleans up
     // any mkey it created.
-    return bind_mrs(pd, qp, access_flags, mr_vec, mkey);
+    return bind_mrs(pd, qp, access_flags, mr_vec, mkey_max_entries, mkey);
   } catch (const std::exception& e) {
     fprintf(stderr, "[RdmaXcel] rdmaxcel_bind_mr_list failed: %s\n", e.what());
     return RDMAXCEL_EXCEPTION;
@@ -525,7 +528,7 @@ int register_segments(
     // bind_mrs creates the mkey when `mkey` is null and, on failure, destroys
     // any mkey it created (clearing `mkey`), so we only clean up the MRs we
     // registered here on failure.
-    auto err = bind_mrs(pd, qp->ibv_qp, access_flags, all_mrs, &mkey);
+    auto err = bind_mrs(pd, qp->ibv_qp, access_flags, all_mrs, max_sge, &mkey);
     if (err != 0) {
       return fail(err);
     }

--- a/rdmaxcel-sys/src/rdmaxcel.h
+++ b/rdmaxcel-sys/src/rdmaxcel.h
@@ -176,18 +176,19 @@ int deregister_segments();
 //
 // Binds the given MR list onto an indirect mkey using `qp`'s WR builder (a
 // connected loopback QP), so the bound MRs are addressable as a single flat
-// zero-based region. Creates the mkey when `*mkey` is NULL and writes it
-// back through `mkey`; the caller reads `lkey`/`rkey` off the returned
-// `mlx5dv_mkey`. Returns 0 on success, otherwise a negative
-// `rdmaxcel_error_code_t`; the body catches any C++ exception and reports it
-// as `RDMAXCEL_EXCEPTION`. Declared `noexcept` as a hard backstop so an escape
-// terminates rather than unwinding across the C ABI into Rust.
+// zero-based region. Creates the mkey sized to hold `mkey_max_entries` entries
+// when `*mkey` is NULL and writes it back through `mkey`; the caller reads
+// `lkey`/`rkey` off the returned `mlx5dv_mkey`. Returns 0 on success, otherwise
+// a negative `rdmaxcel_error_code_t`; the body catches any C++ exception and
+// reports it as `RDMAXCEL_EXCEPTION`. Declared `noexcept` as a hard backstop so
+// an escape terminates rather than unwinding across the C ABI into Rust.
 int rdmaxcel_bind_mr_list(
     struct ibv_pd* pd,
     struct ibv_qp* qp,
     int access_flags,
     struct ibv_mr** mrs,
     size_t mrs_cnt,
+    size_t mkey_max_entries,
     struct mlx5dv_mkey** mkey) RDMAXCEL_NOEXCEPT;
 
 // Destroy an mkey created by `rdmaxcel_bind_mr_list`. No-op when NULL.


### PR DESCRIPTION
Summary: On mlx5dv NICs a whole allocator segment's memory regions are bound into one indirect key via `mlx5dv_wr_mr_list`. The maximum number of MRs a single mkey can bind is related to the rdma device's max supported SGE. Previously, the key was created with a hardcoded 32 max entries and we never checked if this was exceeded; registration appeared to succeed, but transfers against the tail MRs faulted at runtime with `IBV_WC_REM_ACCESS_ERR` (read) or `IBV_WC_LOC_PROT_ERR` (write). This threads the device `max_sge` from its `IbvDeviceInfo` through `MlxDomain::new` to each `RegisteredSegment`, sizes the indirect mkey to `max_sge` (instead of 32) by passing it into `bind_mrs`, and makes `grow` reject a bind that would exceed it. `register_mr` already falls back to per-region dmabuf registration on error, so the result is a graceful fallback with a clear message instead of silent corruption.

Differential Revision: D110653740


