### PR TITLE
move queue pair management into IbvDomain

### DIFF
--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -76,6 +76,9 @@ impl From<&memory_region::IbvMemoryRegionView> for IbvBuffer {
 /// mock; production code uses the default `IbvOp<IbvManagerActor>`.
 #[derive(Debug, Named)]
 pub struct IbvOp<M: Referable = IbvManagerActor<MlxDevice>> {
+    /// Index of this op within its originating batch, carried through so the
+    /// per-op completion reply can be correlated back to the caller.
+    pub op_idx: usize,
     pub op_type: RdmaOpType,
     pub local_memory: KeepaliveLocalMemory,
     pub remote_buffer: IbvBuffer,
@@ -87,6 +90,7 @@ pub struct IbvOp<M: Referable = IbvManagerActor<MlxDevice>> {
 impl<M: Referable> Clone for IbvOp<M> {
     fn clone(&self) -> Self {
         Self {
+            op_idx: self.op_idx,
             op_type: self.op_type,
             local_memory: self.local_memory.clone(),
             remote_buffer: self.remote_buffer.clone(),

--- a/monarch_rdma/src/backend/ibverbs/device.rs
+++ b/monarch_rdma/src/backend/ibverbs/device.rs
@@ -46,7 +46,7 @@ pub trait IbvDeviceImpl: Named + std::fmt::Debug + Send + Sync + 'static {
     /// The per-domain strategy used by this backend (how memory regions
     /// are registered and queue pairs built against a PD). [`IbvDomain`] is
     /// generic over this.
-    type Domain: IbvDomainImpl;
+    type Domain: IbvDomainImpl<Device = Self>;
 
     /// Human-readable display name for the backend this impl
     /// drives (e.g., `"mellanox"`, `"efa"`). Surfaced in
@@ -354,7 +354,10 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
 
     /// Returns the [`IbvDomain`] registered under `name`, creating (and
     /// caching) a new one via [`IbvDomain::new`] on first access.
-    pub fn get_or_create_domain(&mut self, name: &str) -> anyhow::Result<&IbvDomain<I::Domain>> {
+    pub fn get_or_create_domain(
+        &mut self,
+        name: &str,
+    ) -> anyhow::Result<&mut IbvDomain<I::Domain>> {
         if !self.domains.contains_key(name) {
             // SAFETY: `self.context` wraps the live `ibv_context` opened by
             // `IbvDevice::open`, valid for this device's lifetime.
@@ -369,7 +372,7 @@ impl<I: IbvDeviceImpl> IbvDevice<I> {
         }
         Ok(self
             .domains
-            .get(name)
+            .get_mut(name)
             .expect("domain just inserted or already present"))
     }
 

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -20,13 +20,23 @@ use std::os::fd::OwnedFd;
 use std::result::Result;
 use std::sync::Arc;
 
+use hyperactor::Actor;
+use hyperactor::ActorHandle;
+use hyperactor::ActorId;
+use hyperactor::ActorRef;
+use hyperactor::Context;
+use hyperactor::Handler;
+
+use super::device::IbvDeviceImpl;
+use super::manager_actor::IbvManagerActor;
 use super::memory_region::IbvMemoryRegionView;
 use super::primitives::IbvConfig;
 use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMr;
 use super::primitives::IbvPd;
-use super::queue_pair::IbvQueuePair;
+use super::primitives::IbvQpInfo;
+use super::queue_pair::ProcessOps;
 use crate::local_memory::KeepaliveLocalMemory;
 use crate::local_memory::is_device_ptr;
 
@@ -35,6 +45,8 @@ use crate::local_memory::is_device_ptr;
 /// # Fields
 ///
 /// * `device_info`: Metadata for the device this PD is allocated on.
+/// * `config`: The [`IbvConfig`] this domain — and every queue pair built
+///   against it — is created with.
 /// * `domain_impl`: The backend [`IbvDomainImpl`] strategy for this PD. It may
 ///   own FFI resources allocated against the PD, so it is declared before `pd`
 ///   and thus dropped first — releasing those resources while the PD is still
@@ -51,6 +63,7 @@ use crate::local_memory::is_device_ptr;
 /// Hand out [`Self::pd`] clones to share the protection domain.
 pub struct IbvDomain<I: IbvDomainImpl> {
     pub device_info: IbvDeviceInfo,
+    config: IbvConfig,
     domain_impl: I,
     pd: Arc<IbvPd>,
 }
@@ -116,6 +129,7 @@ impl<I: IbvDomainImpl> IbvDomain<I> {
         let pd = Arc::new(unsafe { IbvPd::create(context) }?);
         Ok(Self {
             device_info,
+            config: config.clone(),
             domain_impl,
             pd,
         })
@@ -135,6 +149,7 @@ impl<I: IbvDomainImpl> IbvDomain<I> {
     ) -> Self {
         Self {
             device_info,
+            config: IbvConfig::default(),
             domain_impl,
             pd,
         }
@@ -164,9 +179,19 @@ impl<I: IbvDomainImpl> IbvDomain<I> {
         &self.domain_impl
     }
 
+    /// Mutable access to the backend [`IbvDomainImpl`] strategy.
+    pub(super) fn domain_impl_mut(&mut self) -> &mut I {
+        &mut self.domain_impl
+    }
+
     /// Metadata for the device this domain's PD is allocated on.
     pub fn device_info(&self) -> &IbvDeviceInfo {
         &self.device_info
+    }
+
+    /// The [`IbvConfig`] this domain and its queue pairs are created with.
+    pub fn config(&self) -> &IbvConfig {
+        &self.config
     }
 
     /// Access flags used when registering memory regions and creating queue pairs
@@ -184,10 +209,27 @@ impl<I: IbvDomainImpl> IbvDomain<I> {
         unsafe { I::register_mr(self, mem) }
     }
 
-    /// Create a queue pair against this domain, dispatching to the backend
-    /// [`IbvDomainImpl`] strategy.
-    pub fn create_queue_pair(&self, config: &IbvConfig) -> anyhow::Result<I::QueuePair> {
-        I::create_queue_pair(self, config)
+    /// Get or create the queue pair actor responsible for DMAing the peer
+    /// `peer_ref`/`peer_device`, dispatching to the backend [`IbvDomainImpl`]
+    /// strategy.
+    pub(crate) fn get_or_create_queue_pair(
+        &mut self,
+        cx: &Context<IbvManagerActor<I::Device>>,
+        peer_ref: ActorRef<IbvManagerActor<I::Device>>,
+        peer_device: String,
+    ) -> anyhow::Result<ActorHandle<I::QueuePair>> {
+        I::get_or_create_queue_pair(self, cx, peer_ref, peer_device)
+    }
+
+    /// Process an incoming connection request from a peer, returning the local
+    /// endpoint the peer needs to complete the connection.
+    pub(crate) fn process_conn_request(
+        &mut self,
+        sender_id: ActorId,
+        sender_device: String,
+        sender_qp_info: &IbvQpInfo,
+    ) -> anyhow::Result<IbvQpInfo> {
+        I::process_conn_request(self, sender_id, sender_device, sender_qp_info)
     }
 }
 
@@ -197,11 +239,16 @@ impl<I: IbvDomainImpl> IbvDomain<I> {
 /// One strategy is constructed per domain via [`Self::new`], which
 /// inspects the device behind the context to decide backend-specific behavior
 /// up front, and is then stored in the [`IbvDomain`] it drives. The per-op
-/// methods are associated functions taking `&IbvDomain<Self>` and reach the
-/// strategy itself through [`IbvDomain::domain_impl`].
+/// methods are associated functions taking the [`IbvDomain<Self>`] they act on
+/// and reach the strategy itself through [`IbvDomain::domain_impl`].
 pub trait IbvDomainImpl: std::fmt::Debug + Send + Sync + 'static + Sized {
-    /// The concrete queue-pair type built against this domain's PD.
-    type QueuePair: IbvQueuePair;
+    /// The device backend type that owns this domain.
+    type Device: IbvDeviceImpl<Domain = Self>;
+
+    /// The queue pair actor this backend drives. The manager posts ops to a
+    /// handle of this type as [`ProcessOps`], without knowing the concrete
+    /// actor behind it.
+    type QueuePair: Actor + Handler<ProcessOps<IbvManagerActor<Self::Device>>>;
 
     /// Build the strategy for the device behind `context` (whose queried
     /// metadata is `device_info`), using `config` for any setup it performs.
@@ -239,16 +286,26 @@ pub trait IbvDomainImpl: std::fmt::Debug + Send + Sync + 'static + Sized {
         unsafe { register_host_or_dmabuf_mr(domain, mem) }
     }
 
-    /// Create a queue pair against `domain`. The default builds [`Self::QueuePair`]
-    /// directly; backends override to construct their own queue-pair type.
-    fn create_queue_pair(
-        domain: &IbvDomain<Self>,
-        config: &IbvConfig,
-    ) -> anyhow::Result<Self::QueuePair> {
-        // SAFETY: a fully-constructed `IbvDomain` holds a null-or-live PD per
-        // its construction contract, which is what `IbvQueuePair::new` requires.
-        unsafe { Self::QueuePair::new(domain, config.clone()) }
-    }
+    /// Get or create (and cache) the queue pair actor responsible for DMAing
+    /// the peer identified by `peer_ref`/`peer_device`, returning a handle to
+    /// it. The actor drives this backend's queue pair; the manager posts ops to
+    /// the returned handle.
+    fn get_or_create_queue_pair(
+        domain: &mut IbvDomain<Self>,
+        cx: &Context<IbvManagerActor<Self::Device>>,
+        peer_ref: ActorRef<IbvManagerActor<Self::Device>>,
+        peer_device: String,
+    ) -> anyhow::Result<ActorHandle<Self::QueuePair>>;
+
+    /// Process an incoming connection request from a peer whose queue pair
+    /// endpoint is `sender_qp_info`, returning the local endpoint the peer
+    /// needs to complete the connection.
+    fn process_conn_request(
+        domain: &mut IbvDomain<Self>,
+        sender_id: ActorId,
+        sender_device: String,
+        sender_qp_info: &IbvQpInfo,
+    ) -> anyhow::Result<IbvQpInfo>;
 }
 
 /// Register host memory as a standard MR via `ibv_reg_mr`.

--- a/monarch_rdma/src/backend/ibverbs/efa_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_domain.rs
@@ -8,27 +8,64 @@
 
 //! EFA domain strategy for [`IbvDomainImpl`].
 
+use std::collections::HashMap;
+
+use hyperactor::ActorHandle;
+use hyperactor::ActorId;
+use hyperactor::ActorRef;
+
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
+use super::efa_device::EfaDevice;
+use super::manager_actor::IbvManagerActor;
 use super::primitives::IbvConfig;
 use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
-use super::queue_pair::legacy::IbvQueuePair;
+use super::primitives::IbvQpInfo;
+use super::queue_pair::QpKey;
+use super::queue_pair::QueuePairActor;
+use super::queue_pair::legacy;
 
-/// EFA [`IbvDomainImpl`]. Uses the default host/dmabuf MR registration;
-/// EFA has no device-specific memory-key binding to add.
-#[derive(Debug)]
-pub struct EfaDomain;
+/// The raw queue pair EFA builds for now: the legacy single-type QP. It will
+/// become an EFA-specific queue pair in a follow-up.
+type EfaQueuePair = legacy::IbvQueuePair;
+
+/// EFA [`IbvDomainImpl`]. Uses the default host/dmabuf MR registration; EFA has
+/// no device-specific memory-key binding to add.
+pub struct EfaDomain {
+    /// Active-side QP actors spawned for peers reached through this domain.
+    qp_handles:
+        HashMap<QpKey, ActorHandle<QueuePairActor<IbvManagerActor<EfaDevice>, EfaQueuePair>>>,
+    /// Passive mirror QPs created for peers that RDMA into this domain.
+    peer_created_qps: HashMap<QpKey, EfaQueuePair>,
+}
+
+impl std::fmt::Debug for EfaDomain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EfaDomain").finish_non_exhaustive()
+    }
+}
+
+impl EfaDomain {
+    /// Build a fresh, unconnected raw EFA queue pair against `domain`'s PD.
+    fn create_raw_qp(domain: &IbvDomain<EfaDomain>) -> anyhow::Result<EfaQueuePair> {
+        legacy::IbvQueuePair::new(domain, domain.config().clone())
+    }
+}
 
 impl IbvDomainImpl for EfaDomain {
-    type QueuePair = IbvQueuePair;
+    type Device = EfaDevice;
+    type QueuePair = QueuePairActor<IbvManagerActor<EfaDevice>, EfaQueuePair>;
 
     unsafe fn new(
         _context: &IbvContext,
         _device_info: &IbvDeviceInfo,
         _config: &IbvConfig,
     ) -> Self {
-        EfaDomain
+        EfaDomain {
+            qp_handles: HashMap::new(),
+            peer_created_qps: HashMap::new(),
+        }
     }
 
     fn access_flags(&self) -> i32 {
@@ -39,12 +76,73 @@ impl IbvDomainImpl for EfaDomain {
             .0 as i32
     }
 
-    fn create_queue_pair(
-        domain: &IbvDomain<Self>,
-        config: &IbvConfig,
-    ) -> anyhow::Result<Self::QueuePair> {
-        // EFA builds the legacy single-type queue pair for now; it will
-        // become an EFA-specific queue pair.
-        IbvQueuePair::new(domain, config.clone())
+    fn get_or_create_queue_pair(
+        domain: &mut IbvDomain<EfaDomain>,
+        cx: &hyperactor::Context<IbvManagerActor<EfaDevice>>,
+        peer_ref: ActorRef<IbvManagerActor<EfaDevice>>,
+        peer_device: String,
+    ) -> anyhow::Result<ActorHandle<Self::QueuePair>> {
+        let qp_key = QpKey {
+            peer_id: peer_ref.actor_addr().id().clone(),
+            peer_device,
+        };
+        if let Some(handle) = domain.domain_impl().qp_handles.get(&qp_key).cloned() {
+            return Ok(handle);
+        }
+        let qp = Self::create_raw_qp(domain)
+            .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair for {qp_key:?}: {e}"))?;
+        let local_device = domain.device_info().name().to_string();
+        let local_manager: ActorRef<IbvManagerActor<EfaDevice>> = cx.bind();
+        let is_loopback = local_manager.actor_addr() == peer_ref.actor_addr()
+            && local_device == qp_key.peer_device;
+        let actor = cx.spawn(QueuePairActor::new(
+            qp_key.clone(),
+            local_device,
+            local_manager,
+            peer_ref,
+            qp,
+            is_loopback,
+            domain.config().max_send_wr,
+            domain.config().max_rd_atomic as u32,
+        ));
+        domain
+            .domain_impl_mut()
+            .qp_handles
+            .insert(qp_key, actor.clone());
+        Ok(actor)
+    }
+
+    fn process_conn_request(
+        domain: &mut IbvDomain<EfaDomain>,
+        sender_id: ActorId,
+        sender_device: String,
+        sender_qp_info: &IbvQpInfo,
+    ) -> anyhow::Result<IbvQpInfo> {
+        let qp_key = QpKey {
+            peer_id: sender_id,
+            peer_device: sender_device,
+        };
+        if domain.domain_impl().peer_created_qps.contains_key(&qp_key) {
+            anyhow::bail!("queue pair already exists for {qp_key:?}");
+        }
+        let mut qp = Self::create_raw_qp(domain)
+            .map_err(|e| anyhow::anyhow!("could not create queue pair: {e}"))?;
+        let local_info = qp
+            .get_qp_info()
+            .map_err(|e| anyhow::anyhow!("could not extract QP info: {e}"))?;
+        qp.connect(sender_qp_info)
+            .map_err(|e| anyhow::anyhow!("could not connect QP: {e}"))?;
+        domain.domain_impl_mut().peer_created_qps.insert(qp_key, qp);
+        Ok(local_info)
+    }
+}
+
+impl Drop for EfaDomain {
+    fn drop(&mut self) {
+        // Drain the active-side QP actors before this domain's FFI resources
+        // tear down; each finishes its in-flight ops and drops its owned QP.
+        for (_key, handle) in self.qp_handles.drain() {
+            let _ = handle.drain_and_stop("EfaDomain dropped");
+        }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -50,18 +50,14 @@ use super::device::IbvDeviceImpl;
 use super::device_selection::resolve_target;
 use super::device_selection::select_optimal_ibv_devices;
 use super::domain::IbvDomain;
-use super::domain::IbvDomainImpl;
 use super::efa_device::EfaDevice;
 use super::memory_region::IbvMemoryRegionView;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
 use super::primitives::IbvQpInfo;
 use super::primitives::ibverbs_supported;
-use super::queue_pair::IbvQueuePair;
 use super::queue_pair::OpResult;
 use super::queue_pair::ProcessOps;
-use super::queue_pair::QpKey;
-use super::queue_pair::QueuePairActor;
 use super::queue_pair::legacy;
 use crate::RdmaOp;
 use crate::RdmaTransportLevel;
@@ -75,26 +71,26 @@ use crate::rdma_components::RdmaRemoteBuffer;
 use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::validate_execution_context;
 
-/// Cross-proc message: the active side asks the peer's manager to
-/// create and connect a mirror QP for an in-flight [`QueuePairActor`].
-/// Generic over the manager actor type so test code can swap in a
-/// mock.
+/// Cross-proc connection request: the active side asks a peer's manager to
+/// process a connection from an in-flight [`QueuePairActor`] and return the
+/// peer's endpoint. Generic over the manager actor type so test code can swap
+/// in a mock.
 #[derive(Debug, Serialize, Deserialize, Named)]
 #[serde(bound(serialize = "", deserialize = ""))]
-pub(super) struct CreatePeerQueuePair<M: Referable> {
+pub struct Connect<M: Referable> {
     /// The active side's manager.
     pub(super) sender: ActorRef<M>,
     /// Device the active side picked for its QP.
     pub(super) sender_device: String,
-    /// Device the peer should create its mirror QP on.
+    /// Device the peer should use for its side of the connection.
     pub(super) receiver_device: String,
     /// Active side's endpoint, captured right after QP creation.
-    pub(super) sender_info: IbvQpInfo,
+    pub(super) sender_qp_info: IbvQpInfo,
     /// One-shot reply carrying the peer's endpoint, or an error.
     pub(super) reply: OncePortRef<Result<IbvQpInfo, String>>,
 }
-wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<MlxDevice>>);
-wirevalue::register_type!(CreatePeerQueuePair<IbvManagerActor<EfaDevice>>);
+wirevalue::register_type!(Connect<IbvManagerActor<MlxDevice>>);
+wirevalue::register_type!(Connect<IbvManagerActor<EfaDevice>>);
 
 /// Local-only message: submit a batch of RDMA ops for end-to-end
 /// execution. The manager iterates the batch, resolves each op's
@@ -167,31 +163,15 @@ const DEFAULT_DOMAIN: &str = "default";
 #[hyperactor::export(
     handlers = [
         IbvManagerMessage,
-        CreatePeerQueuePair<IbvManagerActor<I>>,
+        Connect<IbvManagerActor<I>>,
     ],
 )]
 pub struct IbvManagerActor<I: IbvDeviceImpl> {
     owner: OnceLock<ActorHandle<RdmaManagerActor>>,
 
-    /// Active-side [`QueuePairActor`] children, keyed from this
-    /// manager's perspective. Lazily populated on the first
-    /// [`SubmitOps`] that targets a new `(self_device, peer,
-    /// other_device)` triple.
-    qp_handles: HashMap<
-        QpKey,
-        ActorHandle<QueuePairActor<IbvManagerActor<I>, <I::Domain as IbvDomainImpl>::QueuePair>>,
-    >,
-
-    /// Passive-side mirror QPs, created in response to a peer's
-    /// [`CreatePeerQueuePair`]. The peer's [`QueuePairActor`] owns
-    /// the active side; we hold the connected mirror here so the
-    /// peer can read/write our memory. The map's `Drop` destroys
-    /// each QP via its own `Drop`.
-    peer_created_qps: HashMap<QpKey, <I::Domain as IbvDomainImpl>::QueuePair>,
-
     /// Map of RDMA device names to their opened [`IbvDevice<I>`], each of
     /// which owns the per-device `Arc<IbvContext>` and the `DEFAULT_DOMAIN`
-    /// `Arc<IbvDomain>`.
+    /// [`IbvDomain`].
     devices: HashMap<String, IbvDevice<I>>,
 
     config: IbvConfig,
@@ -227,22 +207,6 @@ impl<I: IbvDeviceImpl> Actor for IbvManagerActor<I> {
         F::Output: Send + 'static,
     {
         crate::rdma_runtime::spawn_on_rdma_runtime(future)
-    }
-}
-
-impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
-    fn drop(&mut self) {
-        // Drain active-side QP actors. Each child owns its
-        // `IbvQueuePair`; `drain_and_stop` schedules the actor to
-        // finish in-flight ops and exit, dropping the QP via its
-        // own `Drop`.
-        for (_key, handle) in self.qp_handles.drain() {
-            let _ = handle.drain_and_stop("IbvManagerActor dropped");
-        }
-
-        // The remaining fields (`peer_created_qps`,
-        // `buffer_registrations`, `devices`) free their FFI resources
-        // through their elements' `Drop`s when this struct is dropped.
     }
 }
 
@@ -285,8 +249,6 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
 
         let actor = Self {
             owner: OnceLock::new(),
-            qp_handles: HashMap::new(),
-            peer_created_qps: HashMap::new(),
             devices: HashMap::new(),
             config,
             buffer_registrations: HashMap::new(),
@@ -300,7 +262,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
     fn get_or_create_device_domain(
         &mut self,
         device_name: &str,
-    ) -> Result<&IbvDomain<I::Domain>, anyhow::Error> {
+    ) -> Result<&mut IbvDomain<I::Domain>, anyhow::Error> {
         if !self.devices.contains_key(device_name) {
             let device =
                 IbvDevice::<I>::open(device_name, self.config.clone()).ok_or_else(|| {
@@ -411,72 +373,6 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         let mrv = domain.register_mr(mem)?;
         Ok(mem.mr_slot().get_or_init(|| mrv).clone())
     }
-
-    /// Build a passive-side mirror QP for `qp_key`, connect it to
-    /// `sender_info`, and store it in [`Self::peer_created_qps`].
-    /// Returns the local endpoint the active side needs to finish
-    /// its own `connect`. Called from
-    /// [`Handler<CreatePeerQueuePair>`].
-    fn create_peer_qp(
-        &mut self,
-        qp_key: &QpKey,
-        sender_info: &IbvQpInfo,
-    ) -> Result<IbvQpInfo, anyhow::Error> {
-        if self.peer_created_qps.contains_key(qp_key) {
-            anyhow::bail!("peer queue pair already exists for {qp_key:?}");
-        }
-        let self_device = &qp_key.self_device;
-        let config = self.config.clone();
-        let domain = self.get_or_create_device_domain(self_device)?;
-        let mut qp = domain
-            .create_queue_pair(&config)
-            .map_err(|e| anyhow::anyhow!("could not create peer IbvQueuePair: {}", e))?;
-        let local_info = qp
-            .get_qp_info()
-            .map_err(|e| anyhow::anyhow!("could not extract peer QP info: {}", e))?;
-        qp.connect(sender_info)
-            .map_err(|e| anyhow::anyhow!("could not connect peer QP: {}", e))?;
-        self.peer_created_qps.insert(qp_key.clone(), qp);
-        Ok(local_info)
-    }
-
-    /// Lazy active-side QP actor: if `qp_key` is absent from
-    /// [`Self::qp_handles`], create an [`IbvQueuePair`] on the
-    /// requested device and spawn a [`QueuePairActor`] to drive its
-    /// handshake + data path. Returns a clone of the actor handle.
-    fn ensure_qp_actor(
-        &mut self,
-        cx: &Context<'_, Self>,
-        qp_key: &QpKey,
-        peer_manager: ActorRef<Self>,
-    ) -> Result<
-        ActorHandle<QueuePairActor<Self, <I::Domain as IbvDomainImpl>::QueuePair>>,
-        anyhow::Error,
-    > {
-        if let Some(h) = self.qp_handles.get(qp_key) {
-            return Ok(h.clone());
-        }
-        let self_device = &qp_key.self_device;
-        let config = self.config.clone();
-        let domain = self.get_or_create_device_domain(self_device)?;
-        let qp = domain
-            .create_queue_pair(&config)
-            .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair for {qp_key:?}: {}", e))?;
-        let local_manager: ActorRef<Self> = cx.bind();
-        let is_loopback = local_manager.actor_addr() == peer_manager.actor_addr()
-            && qp_key.self_device == qp_key.other_device;
-        let actor = cx.spawn(QueuePairActor::new(
-            qp_key.clone(),
-            local_manager,
-            peer_manager,
-            qp,
-            is_loopback,
-            config.max_send_wr,
-            config.max_rd_atomic as u32,
-        ));
-        self.qp_handles.insert(qp_key.clone(), actor.clone());
-        Ok(actor)
-    }
 }
 
 #[async_trait]
@@ -513,50 +409,38 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
     async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps<I>) -> Result<(), anyhow::Error> {
         let SubmitOps { ops, reply } = msg;
 
-        // Interleave MR resolution with QP dispatch: as soon as op `i`'s
-        // local MR is resolved and its QP actor is in place, ship a
-        // one-item `ProcessOps` to that QP. The QP can then post and
-        // poll op `i` while we run `resolve_local_mr` for op `i+1`.
-        for (i, op) in ops.into_iter().enumerate() {
-            let mrv = match self.resolve_local_mr(&op.local_memory) {
-                Ok(mrv) => mrv,
-                Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
-                    continue;
-                }
-            };
-            let qp_key = QpKey {
-                self_device: mrv.device_name.clone(),
-                other_id: op.remote_manager.actor_addr().id().clone(),
-                other_device: op.remote_buffer.device_name.clone(),
-            };
-            let peer_manager = op.remote_manager.clone();
-            let handle = match self.ensure_qp_actor(cx, &qp_key, peer_manager) {
-                Ok(h) => h,
-                Err(e) => {
-                    reply.try_post(
-                        cx,
-                        OpResult {
-                            op_idx: i,
-                            result: Err(e.to_string()),
-                        },
-                    )?;
-                    continue;
-                }
-            };
-            handle.try_post(
-                cx,
-                ProcessOps {
-                    items: vec![(i, op, mrv)],
-                    reply: reply.clone(),
-                },
-            )?;
+        // Interleave MR resolution with per-QP dispatch: resolving an op's
+        // local MR fixes its device, so we ask that device's [`IbvDomain`] for
+        // the peer's queue pair actor (spawning it on first use) and post the op
+        // to it as a one-item `ProcessOps`. That QP posts one op while we run
+        // `resolve_local_mr` for the next.
+        for op in ops {
+            let op_idx = op.op_idx;
+            let peer_ref = op.remote_manager.clone();
+            let peer_device = op.remote_buffer.device_name.clone();
+            let dispatch = (|| -> Result<(), anyhow::Error> {
+                let mrv = self.resolve_local_mr(&op.local_memory)?;
+                let handle = self
+                    .get_or_create_device_domain(&mrv.device_name)?
+                    .get_or_create_queue_pair(cx, peer_ref, peer_device)?;
+                handle.try_post(
+                    cx,
+                    ProcessOps {
+                        items: vec![op],
+                        reply: reply.clone(),
+                    },
+                )?;
+                Ok(())
+            })();
+            if let Err(e) = dispatch {
+                reply.try_post(
+                    cx,
+                    OpResult {
+                        op_idx,
+                        result: Err(e.to_string()),
+                    },
+                )?;
+            }
         }
         Ok(())
     }
@@ -579,25 +463,26 @@ impl<I: IbvDeviceImpl> Handler<RawQueuePair> for IbvManagerActor<I> {
 }
 
 #[async_trait]
-impl<I: IbvDeviceImpl> Handler<CreatePeerQueuePair<IbvManagerActor<I>>> for IbvManagerActor<I> {
+impl<I: IbvDeviceImpl> Handler<Connect<IbvManagerActor<I>>> for IbvManagerActor<I> {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
-        msg: CreatePeerQueuePair<IbvManagerActor<I>>,
+        msg: Connect<IbvManagerActor<I>>,
     ) -> Result<(), anyhow::Error> {
-        let CreatePeerQueuePair {
+        let Connect {
             sender,
             sender_device,
             receiver_device,
-            sender_info,
+            sender_qp_info,
             reply,
         } = msg;
-        let qp_key = QpKey {
-            self_device: receiver_device,
-            other_id: sender.actor_addr().id().clone(),
-            other_device: sender_device,
-        };
-        match self.create_peer_qp(&qp_key, &sender_info) {
+        let sender_id = sender.actor_addr().id().clone();
+        let result = self
+            .get_or_create_device_domain(&receiver_device)
+            .and_then(|domain| {
+                domain.process_conn_request(sender_id, sender_device, &sender_qp_info)
+            });
+        match result {
             Ok(local_info) => reply.post(cx, Ok(local_info)),
             Err(e) => reply.post(cx, Err(e.to_string())),
         }
@@ -775,12 +660,13 @@ where
         timeout: Duration,
     ) -> Result<(), anyhow::Error> {
         let mut ibv_ops = Vec::with_capacity(ops.len());
-        for op in ops {
+        for (i, op) in ops.into_iter().enumerate() {
             let ctx = <RdmaRemoteBuffer as ResolveRemoteBackendContext<IbvBackend<I>>>::resolve(
                 &op.remote,
             )
             .expect("op routed to incompatible backend");
             ibv_ops.push(IbvOp {
+                op_idx: i,
                 op_type: op.op_type,
                 local_memory: op.local.clone(),
                 remote_buffer: ctx.buffer,

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -27,12 +27,16 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 use anyhow::Context;
+use hyperactor::ActorHandle;
+use hyperactor::ActorId;
+use hyperactor::ActorRef;
 
 use super::device_selection::get_cuda_device_to_ibv_device;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::domain::register_dmabuf_range;
 use super::domain::register_host_or_dmabuf_mr;
+use super::manager_actor::IbvManagerActor;
 use super::memory_region::IbvMemoryRegionKeepalive;
 use super::memory_region::IbvMemoryRegionView;
 use super::mlx_queue_pair::MlxQueuePair;
@@ -44,6 +48,10 @@ use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMr;
 use super::primitives::IbvPd;
 use super::primitives::IbvQp;
+use super::primitives::IbvQpInfo;
+use super::queue_pair::IbvQueuePair;
+use super::queue_pair::QpKey;
+use super::queue_pair::QueuePairActor;
 use super::queue_pair::connect;
 use super::queue_pair::get_qp_info;
 use crate::backend::ibverbs::mlx_device::MlxDevice;
@@ -662,6 +670,13 @@ pub struct MlxDomain {
     /// a key whose base vanishes from the scan is dropped (a live view keeps
     /// its own `Arc` alive regardless).
     segments: Mutex<HashMap<(usize, i32), Arc<RegisteredSegment>>>,
+    /// Active-side QP actors spawned for peers reached through this domain.
+    /// Temporary: exposed via [`IbvDomainImpl::qp_handles_mut`].
+    qp_handles:
+        HashMap<QpKey, ActorHandle<QueuePairActor<IbvManagerActor<MlxDevice>, MlxQueuePair>>>,
+    /// Passive mirror QPs created for peers that RDMA into this domain.
+    /// Temporary: exposed via [`IbvDomainImpl::peer_created_qps_mut`].
+    peer_created_qps: HashMap<QpKey, MlxQueuePair>,
 }
 
 impl std::fmt::Debug for MlxDomain {
@@ -692,6 +707,8 @@ impl MlxDomain {
             mkey_max_entries,
             loopback: OnceLock::new(),
             segments: Mutex::new(HashMap::new()),
+            qp_handles: HashMap::new(),
+            peer_created_qps: HashMap::new(),
         }
     }
 
@@ -793,10 +810,18 @@ impl MlxDomain {
                 )
             })
     }
+
+    /// Build a fresh, unconnected raw mlx5 queue pair against `domain`'s PD.
+    fn create_raw_qp(domain: &IbvDomain<MlxDomain>) -> anyhow::Result<MlxQueuePair> {
+        // SAFETY: a fully-constructed `IbvDomain` holds a null-or-live PD, which
+        // is what `MlxQueuePair::new` requires.
+        unsafe { <MlxQueuePair as IbvQueuePair>::new(domain, domain.config().clone()) }
+    }
 }
 
 impl IbvDomainImpl for MlxDomain {
-    type QueuePair = MlxQueuePair;
+    type Device = MlxDevice;
+    type QueuePair = QueuePairActor<IbvManagerActor<MlxDevice>, MlxQueuePair>;
 
     unsafe fn new(context: &IbvContext, device_info: &IbvDeviceInfo, config: &IbvConfig) -> Self {
         Self::new_with_ops(
@@ -834,6 +859,76 @@ impl IbvDomainImpl for MlxDomain {
         // contract; `register_host_or_dmabuf_mr` errors on null), and the caller
         // keeps `mem`'s backing memory valid for the MR's lifetime.
         unsafe { register_host_or_dmabuf_mr(domain, mem) }
+    }
+
+    fn get_or_create_queue_pair(
+        domain: &mut IbvDomain<MlxDomain>,
+        cx: &hyperactor::Context<IbvManagerActor<MlxDevice>>,
+        peer_ref: ActorRef<IbvManagerActor<MlxDevice>>,
+        peer_device: String,
+    ) -> anyhow::Result<ActorHandle<Self::QueuePair>> {
+        let qp_key = QpKey {
+            peer_id: peer_ref.actor_addr().id().clone(),
+            peer_device,
+        };
+        if let Some(handle) = domain.domain_impl().qp_handles.get(&qp_key).cloned() {
+            return Ok(handle);
+        }
+        let qp = Self::create_raw_qp(domain)
+            .map_err(|e| anyhow::anyhow!("could not create IbvQueuePair for {qp_key:?}: {e}"))?;
+        let local_device = domain.device_info().name().to_string();
+        let local_manager: ActorRef<IbvManagerActor<MlxDevice>> = cx.bind();
+        let is_loopback = local_manager.actor_addr() == peer_ref.actor_addr()
+            && local_device == qp_key.peer_device;
+        let actor = cx.spawn(QueuePairActor::new(
+            qp_key.clone(),
+            local_device,
+            local_manager,
+            peer_ref,
+            qp,
+            is_loopback,
+            domain.config().max_send_wr,
+            domain.config().max_rd_atomic as u32,
+        ));
+        domain
+            .domain_impl_mut()
+            .qp_handles
+            .insert(qp_key, actor.clone());
+        Ok(actor)
+    }
+
+    fn process_conn_request(
+        domain: &mut IbvDomain<MlxDomain>,
+        sender_id: ActorId,
+        sender_device: String,
+        sender_qp_info: &IbvQpInfo,
+    ) -> anyhow::Result<IbvQpInfo> {
+        let qp_key = QpKey {
+            peer_id: sender_id,
+            peer_device: sender_device,
+        };
+        if domain.domain_impl().peer_created_qps.contains_key(&qp_key) {
+            anyhow::bail!("queue pair already exists for {qp_key:?}");
+        }
+        let mut qp = Self::create_raw_qp(domain)
+            .map_err(|e| anyhow::anyhow!("could not create queue pair: {e}"))?;
+        let local_info = qp
+            .get_qp_info()
+            .map_err(|e| anyhow::anyhow!("could not extract QP info: {e}"))?;
+        qp.connect(sender_qp_info)
+            .map_err(|e| anyhow::anyhow!("could not connect QP: {e}"))?;
+        domain.domain_impl_mut().peer_created_qps.insert(qp_key, qp);
+        Ok(local_info)
+    }
+}
+
+impl Drop for MlxDomain {
+    fn drop(&mut self) {
+        // Drain the active-side QP actors before this domain's FFI resources
+        // tear down; each finishes its in-flight ops and drops its owned QP.
+        for (_key, handle) in self.qp_handles.drain() {
+            let _ = handle.drain_and_stop("MlxDomain dropped");
+        }
     }
 }
 

--- a/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
@@ -116,7 +116,7 @@ impl MlxQueuePair {
 }
 
 impl IbvQueuePair for MlxQueuePair {
-    unsafe fn new<I: IbvDomainImpl<QueuePair = Self>>(
+    unsafe fn new<I: IbvDomainImpl>(
         domain: &IbvDomain<I>,
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -47,7 +47,7 @@ use super::IbvBuffer;
 use super::IbvOp;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
-use super::manager_actor::CreatePeerQueuePair;
+use super::manager_actor::Connect;
 use super::memory_region::IbvMemoryRegionView;
 use super::primitives::Gid;
 use super::primitives::GidScope;
@@ -148,16 +148,13 @@ pub enum PollTarget {
 /// the [`IbvQueuePair`] trait.
 pub mod legacy;
 
-/// Identifies a per-peer queue pair held by one
-/// [`super::manager_actor::IbvManagerActor`]. The same conceptual
-/// QP is referenced by two distinct keys, one from each side: each
-/// manager stores the local view (its own device, the peer's actor
-/// id, the peer's device).
+/// Identifies a per-peer queue pair within one device's
+/// [`super::domain::IbvDomain`]. The domain already fixes the local device, so
+/// the key only names the peer: its manager's actor id and the device it uses.
 #[derive(Clone, Hash, Eq, PartialEq, Debug, Serialize, Deserialize, Named)]
-pub(super) struct QpKey {
-    pub(super) self_device: String,
-    pub(super) other_id: ActorId,
-    pub(super) other_device: String,
+pub struct QpKey {
+    pub(crate) peer_id: ActorId,
+    pub(crate) peer_device: String,
 }
 
 // =====================================================================
@@ -172,10 +169,8 @@ pub(super) struct QpKey {
 // locally, which creates a fresh pair the same way.
 
 /// A NIC-backend queue pair: the unit of RDMA communication between two
-/// endpoints, and the operations a [`QueuePairActor`] performs on it. Each
-/// [`IbvDomainImpl`] names its concrete queue-pair type via
-/// [`IbvDomainImpl::QueuePair`](super::domain::IbvDomainImpl::QueuePair) and builds
-/// it through [`Self::new`].
+/// endpoints, and the low-level operations performed on it. Each backend builds
+/// its concrete implementation through [`Self::new`].
 pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// Creates a queue pair against `domain` in the RESET state;
     /// [`Self::connect`] transitions it to RTS before use.
@@ -186,7 +181,7 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// domain. Callers must ensure the PD outlives the QP; the easiest way to
     /// do this is for implementers to store a clone of `domain.pd()` (an
     /// `Arc<IbvPd>`) inside the QP.
-    unsafe fn new<I: IbvDomainImpl<QueuePair = Self>>(
+    unsafe fn new<I: IbvDomainImpl>(
         domain: &IbvDomain<I>,
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error>;
@@ -236,7 +231,7 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
 }
 
 impl IbvQueuePair for legacy::IbvQueuePair {
-    unsafe fn new<I: IbvDomainImpl<QueuePair = Self>>(
+    unsafe fn new<I: IbvDomainImpl>(
         domain: &IbvDomain<I>,
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {
@@ -583,7 +578,7 @@ impl RCQueuePair {
 }
 
 impl IbvQueuePair for RCQueuePair {
-    unsafe fn new<I: IbvDomainImpl<QueuePair = Self>>(
+    unsafe fn new<I: IbvDomainImpl>(
         domain: &IbvDomain<I>,
         config: IbvConfig,
     ) -> Result<Self, anyhow::Error> {
@@ -832,13 +827,10 @@ impl PollSleepPolicy {
 }
 
 /// Bundle of trait bounds for an actor type that can serve as the
-/// peer manager — i.e. the recipient of [`CreatePeerQueuePair`].
-pub(super) trait Manager:
-    Actor + Referable + RemoteHandles<CreatePeerQueuePair<Self>>
-{
-}
+/// peer manager — i.e. the recipient of [`Connect`].
+pub trait Manager: Actor + Referable + RemoteHandles<Connect<Self>> {}
 
-impl<T> Manager for T where T: Actor + Referable + RemoteHandles<CreatePeerQueuePair<T>> {}
+impl<T> Manager for T where T: Actor + Referable + RemoteHandles<Connect<T>> {}
 
 /// Per-op completion reply emitted by [`QueuePairActor`] back to the
 /// manager via [`ProcessOps::reply`]. A named newtype (rather than a
@@ -846,9 +838,8 @@ impl<T> Manager for T where T: Actor + Referable + RemoteHandles<CreatePeerQueue
 /// undeliverable `OpResult`s by type name in
 /// `handle_undeliverable_message` and absorb them when the original
 /// caller has gone away (typical at test teardown).
-#[allow(dead_code)] // not yet referenced by IbvManagerActor
 #[derive(Debug)]
-pub(super) struct OpResult {
+pub struct OpResult {
     pub(super) op_idx: usize,
     pub(super) result: Result<(), String>,
 }
@@ -863,8 +854,8 @@ pub(super) struct OpResult {
 /// observed (held back until the op's other WRs also report, so the
 /// MR registration outlives the data path).
 #[derive(Debug)]
-pub(super) struct ProcessOps<M: Referable> {
-    pub(super) items: Vec<(usize, IbvOp<M>, IbvMemoryRegionView)>,
+pub struct ProcessOps<M: Referable> {
+    pub(super) items: Vec<IbvOp<M>>,
     pub(super) reply: PortHandle<OpResult>,
 }
 
@@ -902,20 +893,21 @@ struct PostedOpEntry {
     first_error: Option<String>,
 }
 
-/// Per-peer queue-pair actor.
+/// Per-peer queue pair actor.
 ///
 /// Generic over the manager actor type `M` (so tests can swap in a
-/// mock) and the queue-pair type `Qp` (so unit tests run without
+/// mock) and the queue pair type `Qp` (so unit tests run without
 /// RDMA hardware). The QP is constructed by the spawning manager
 /// and handed in as a spawn param; the actor owns it for life and
 /// drops it when the actor stops.
 #[derive(Debug)]
-pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
+pub struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     qp_key: QpKey,
-    /// Filled into [`CreatePeerQueuePair::sender`] so the peer can
-    /// build its own [`QpKey`] from our identity.
+    local_device: String,
+    /// Filled into [`Connect::sender`] so the peer can build its own [`QpKey`]
+    /// from our identity.
     local_manager: ActorRef<M>,
-    /// Recipient of [`CreatePeerQueuePair`].
+    /// Recipient of [`Connect`].
     peer_manager: ActorRef<M>,
     qp: Qp,
     /// `true` when the peer QP is colocated with this actor's QP —
@@ -957,6 +949,7 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
 impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     pub(super) fn new(
         qp_key: QpKey,
+        local_device: String,
         local_manager: ActorRef<M>,
         peer_manager: ActorRef<M>,
         qp: Qp,
@@ -975,6 +968,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         };
         Self {
             qp_key,
+            local_device,
             local_manager,
             peer_manager,
             qp,
@@ -1227,11 +1221,11 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
             let (reply, rx) = this.mailbox().open_once_port::<Result<IbvQpInfo, String>>();
             self.peer_manager.post(
                 this,
-                CreatePeerQueuePair {
+                Connect {
                     sender: self.local_manager.clone(),
-                    sender_device: self.qp_key.self_device.clone(),
-                    receiver_device: self.qp_key.other_device.clone(),
-                    sender_info: local_info,
+                    sender_device: self.local_device.clone(),
+                    receiver_device: self.qp_key.peer_device.clone(),
+                    sender_qp_info: local_info,
                     reply: reply.bind(),
                 },
             );
@@ -1242,7 +1236,7 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
                         qp_key = ?self.qp_key,
                         peer_manager = ?self.peer_manager,
                         error = %e,
-                        "QueuePairActor init: peer manager rejected CreatePeerQueuePair",
+                        "QueuePairActor init: peer manager rejected connection request",
                     );
                     return Err(anyhow::anyhow!("peer manager rejected QP request: {e}"));
                 }
@@ -1301,11 +1295,19 @@ impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps<M>> for QueuePairActor<M, 
         cx: &Context<Self>,
         msg: ProcessOps<M>,
     ) -> Result<(), anyhow::Error> {
-        for (op_idx, op, mrv) in msg.items.into_iter() {
+        for op in msg.items.into_iter() {
+            // `resolve_local_mr` populated the op's shared MR slot before
+            // dispatch; read the view back to drive the transfer.
+            let mrv = op
+                .local_memory
+                .mr_slot()
+                .get()
+                .cloned()
+                .expect("resolve_local_mr populates the MR slot before dispatch");
             let wrs = Self::wr_count(op.local_memory.size());
             let is_read = matches!(op.op_type, RdmaOpType::ReadIntoLocal);
             self.queue.push_back(PendingOp {
-                op_idx,
+                op_idx: op.op_idx,
                 op,
                 mrv,
                 reply: msg.reply.clone(),
@@ -1420,9 +1422,8 @@ mod tests {
     // QueuePairActor init handshake
     // =================================================================
 
-    /// Captured fields from a `CreatePeerQueuePair` message; we
-    /// can't keep the original because the `reply` port is consumed
-    /// to send the response.
+    /// Captured fields from a `Connect` message; we can't keep the original
+    /// because the `reply` port is consumed to send the response.
     #[derive(Debug, Clone)]
     struct CreateCapture {
         sender_id: hyperactor::ActorId,
@@ -1447,9 +1448,9 @@ mod tests {
     /// Plays two roles:
     /// 1. As the *parent*, it spawns `QueuePairActor` children via
     ///    [`SpawnQpaChild`].
-    /// 2. As the *peer*, it handles `CreatePeerQueuePair`.
+    /// 2. As the *peer*, it handles `Connect`.
     #[derive(Debug)]
-    #[hyperactor::export(handlers = [CreatePeerQueuePair<QpaMockManager>])]
+    #[hyperactor::export(handlers = [Connect<QpaMockManager>])]
     struct QpaMockManager {
         state: Arc<Mutex<QpaMockState>>,
     }
@@ -1472,19 +1473,15 @@ mod tests {
     }
 
     #[async_trait]
-    impl Handler<CreatePeerQueuePair<QpaMockManager>> for QpaMockManager {
-        async fn handle(
-            &mut self,
-            cx: &Context<Self>,
-            msg: CreatePeerQueuePair<QpaMockManager>,
-        ) -> Result<()> {
+    impl Handler<Connect<QpaMockManager>> for QpaMockManager {
+        async fn handle(&mut self, cx: &Context<Self>, msg: Connect<QpaMockManager>) -> Result<()> {
             let response = {
                 let mut state = self.state.lock().unwrap();
                 state.creates.push(CreateCapture {
                     sender_id: msg.sender.actor_addr().id().clone(),
                     sender_device: msg.sender_device.clone(),
                     receiver_device: msg.receiver_device.clone(),
-                    sender_qp_num: msg.sender_info.qp_num,
+                    sender_qp_num: msg.sender_qp_info.qp_num,
                 });
                 state.response.take()
             };
@@ -1503,6 +1500,7 @@ mod tests {
     #[derive(Debug)]
     struct SpawnQpaChild {
         qp_key: QpKey,
+        local_device: String,
         peer_manager: ActorRef<QpaMockManager>,
         qp: MockQp,
         is_loopback: bool,
@@ -1517,6 +1515,7 @@ mod tests {
             let local_manager = cx.bind::<QpaMockManager>();
             let actor = QueuePairActor::new(
                 msg.qp_key,
+                msg.local_device,
                 local_manager,
                 msg.peer_manager,
                 msg.qp,
@@ -1635,7 +1634,7 @@ mod tests {
     }
 
     impl IbvQueuePair for MockQp {
-        unsafe fn new<I: IbvDomainImpl<QueuePair = Self>>(
+        unsafe fn new<I: IbvDomainImpl>(
             _domain: &IbvDomain<I>,
             _config: IbvConfig,
         ) -> Result<Self> {
@@ -1795,17 +1794,19 @@ mod tests {
         async fn spawn_actor(
             &self,
             qp_key: QpKey,
+            local_device: String,
             peer_manager: ActorRef<QpaMockManager>,
             qp: MockQp,
             is_loopback: bool,
         ) -> Result<ActorHandle<QueuePairActor<QpaMockManager, MockQp>>> {
-            self.spawn_actor_with_caps(qp_key, peer_manager, qp, is_loopback, 4, 2)
+            self.spawn_actor_with_caps(qp_key, local_device, peer_manager, qp, is_loopback, 4, 2)
                 .await
         }
 
         async fn spawn_actor_with_caps(
             &self,
             qp_key: QpKey,
+            local_device: String,
             peer_manager: ActorRef<QpaMockManager>,
             qp: MockQp,
             is_loopback: bool,
@@ -1817,6 +1818,7 @@ mod tests {
                 &self.client,
                 SpawnQpaChild {
                     qp_key,
+                    local_device,
                     peer_manager,
                     qp,
                     is_loopback,
@@ -1851,13 +1853,13 @@ mod tests {
 
         let (qp, _posted_rx) = MockQp::new(0x1234, 0xdead);
         let qp_key = QpKey {
-            self_device: "mlx5_0".into(),
-            other_id: harness.peer_id(),
-            other_device: "mlx5_1".into(),
+            peer_id: harness.peer_id(),
+            peer_device: "mlx5_1".into(),
         };
         let handle = harness
             .spawn_actor(
                 qp_key.clone(),
+                "mlx5_0".into(),
                 harness.peer.bind::<QpaMockManager>(),
                 qp.clone(),
                 false,
@@ -1892,13 +1894,13 @@ mod tests {
 
         let (qp, _posted_rx) = MockQp::new(0xaaa, 0xbbb);
         let qp_key = QpKey {
-            self_device: "mlx5_0".into(),
-            other_id: harness.parent_id(),
-            other_device: "mlx5_0".into(),
+            peer_id: harness.parent_id(),
+            peer_device: "mlx5_0".into(),
         };
         let handle = harness
             .spawn_actor(
                 qp_key,
+                "mlx5_0".into(),
                 harness.peer.bind::<QpaMockManager>(),
                 qp.clone(),
                 true,
@@ -1926,13 +1928,18 @@ mod tests {
             Some(Err("peer rejected, no domain on receiver_device".into()));
 
         let qp_key = QpKey {
-            self_device: "mlx5_0".into(),
-            other_id: harness.peer_id(),
-            other_device: "mlx5_99".into(),
+            peer_id: harness.peer_id(),
+            peer_device: "mlx5_99".into(),
         };
         let (qp, _posted_rx) = MockQp::new(1, 2);
         let handle = harness
-            .spawn_actor(qp_key, harness.peer.bind::<QpaMockManager>(), qp, false)
+            .spawn_actor(
+                qp_key,
+                "mlx5_0".into(),
+                harness.peer.bind::<QpaMockManager>(),
+                qp,
+                false,
+            )
             .await?;
 
         let event = harness.next_supervision_failure().await;
@@ -1961,13 +1968,18 @@ mod tests {
         let mut harness = QpaHarness::build()?;
 
         let qp_key = QpKey {
-            self_device: "mlx5_0".into(),
-            other_id: harness.peer_id(),
-            other_device: "mlx5_1".into(),
+            peer_id: harness.peer_id(),
+            peer_device: "mlx5_1".into(),
         };
         let (qp, _posted_rx) = MockQp::new(1, 2);
         let handle = harness
-            .spawn_actor(qp_key, harness.peer.bind::<QpaMockManager>(), qp, false)
+            .spawn_actor(
+                qp_key,
+                "mlx5_0".into(),
+                harness.peer.bind::<QpaMockManager>(),
+                qp,
+                false,
+            )
             .await?;
 
         let event = harness.next_supervision_failure().await;
@@ -2039,10 +2051,23 @@ mod tests {
         ActorRef::attest(proc_addr.actor_addr("remote-mgr"))
     }
 
-    fn make_op(op_type: RdmaOpType, addr: usize, size: usize) -> IbvOp<QpaMockManager> {
+    fn make_op(
+        op_idx: usize,
+        op_type: RdmaOpType,
+        addr: usize,
+        size: usize,
+    ) -> IbvOp<QpaMockManager> {
+        let local_memory = fake_local_memory(addr, size);
+        // Mirror `resolve_local_mr`: install the op's MR view in its shared slot
+        // so the actor can read it back at dispatch.
+        local_memory
+            .mr_slot()
+            .set(fake_mrv(addr, size))
+            .expect("fresh MR slot");
         IbvOp {
+            op_idx,
             op_type,
-            local_memory: fake_local_memory(addr, size),
+            local_memory,
             remote_buffer: IbvBuffer {
                 lkey: 0,
                 rkey: 0,
@@ -2070,13 +2095,13 @@ mod tests {
         )> {
             let (qp, posted_rx) = MockQp::new(0x1, 0x2);
             let qp_key = QpKey {
-                self_device: "mlx5_0".into(),
-                other_id: self.parent_id(),
-                other_device: "mlx5_0".into(),
+                peer_id: self.parent_id(),
+                peer_device: "mlx5_0".into(),
             };
             let handle = self
                 .spawn_actor_with_caps(
                     qp_key,
+                    "mlx5_0".into(),
                     self.peer.bind::<QpaMockManager>(),
                     qp.clone(),
                     true,
@@ -2138,7 +2163,7 @@ mod tests {
     fn submit_ops(
         harness: &QpaHarness,
         actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
-        items: Vec<(usize, IbvOp<QpaMockManager>, IbvMemoryRegionView)>,
+        items: Vec<IbvOp<QpaMockManager>>,
     ) -> Result<hyperactor::mailbox::PortReceiver<OpResult>> {
         let (reply, rx) = harness.client.mailbox().open_port::<OpResult>();
         actor.try_post(&harness.client, ProcessOps { items, reply })?;
@@ -2181,11 +2206,7 @@ mod tests {
         let harness = QpaHarness::build()?;
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
-        let items = vec![(
-            7usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(0x1000, 4096),
-        )];
+        let items = vec![make_op(7, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
         // wr_ids start at 0 (fresh MockQp), so the single WR is wr 0.
@@ -2214,10 +2235,11 @@ mod tests {
 
         // A 3-chunk write (3 * MAX_RDMA_MSG_SIZE) splits into 3 WRs;
         // the op's reply must be held back until all 3 complete.
-        let items = vec![(
-            11usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-            fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
+        let items = vec![make_op(
+            11,
+            RdmaOpType::WriteFromLocal,
+            0x1000,
+            3 * MAX_RDMA_MSG_SIZE,
         )];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2250,10 +2272,11 @@ mod tests {
         // 3-WR write: simulate the second WR failing first; the op's
         // Err must not fire until the other 2 WRs have also reported
         // so the MR registration outlives every in-flight WR.
-        let items = vec![(
-            42usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-            fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
+        let items = vec![make_op(
+            42,
+            RdmaOpType::WriteFromLocal,
+            0x1000,
+            3 * MAX_RDMA_MSG_SIZE,
         )];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2298,16 +2321,8 @@ mod tests {
         // op_idx 1 is single-WR. One of op_idx 0's WRs fails;
         // op_idx 1's WR succeeds independently.
         let items = vec![
-            (
-                0usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
-            ),
-            (
-                1usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
+            make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+            make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2347,13 +2362,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8, 2).await?;
 
         let items = (0..3usize)
-            .map(|i| {
-                (
-                    i,
-                    make_op(RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096),
-                    fake_mrv(0x1000 + i * 0x1000, 4096),
-                )
-            })
+            .map(|i| make_op(i, RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096))
             .collect();
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2386,13 +2395,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(2, 0).await?;
 
         let items = (0..3usize)
-            .map(|i| {
-                (
-                    i,
-                    make_op(RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096),
-                    fake_mrv(0x1000 + i * 0x1000, 4096),
-                )
-            })
+            .map(|i| make_op(i, RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096))
             .collect();
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2424,13 +2427,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(2, 8).await?;
 
         let items = (0..4usize)
-            .map(|i| {
-                (
-                    i,
-                    make_op(RdmaOpType::WriteFromLocal, 0x1000 + i * 0x1000, 4096),
-                    fake_mrv(0x1000 + i * 0x1000, 4096),
-                )
-            })
+            .map(|i| make_op(i, RdmaOpType::WriteFromLocal, 0x1000 + i * 0x1000, 4096))
             .collect();
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2472,31 +2469,11 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
         let items = vec![
-            (
-                0usize,
-                make_op(RdmaOpType::ReadIntoLocal, 0x1000, 4096),
-                fake_mrv(0x1000, 4096),
-            ),
-            (
-                1usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
-            (
-                2usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x3000, 4096),
-                fake_mrv(0x3000, 4096),
-            ),
-            (
-                3usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x4000, 4096),
-                fake_mrv(0x4000, 4096),
-            ),
-            (
-                4usize,
-                make_op(RdmaOpType::ReadIntoLocal, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(0x5000, 2 * MAX_RDMA_MSG_SIZE),
-            ),
+            make_op(0, RdmaOpType::ReadIntoLocal, 0x1000, 4096),
+            make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
+            make_op(2, RdmaOpType::WriteFromLocal, 0x3000, 4096),
+            make_op(3, RdmaOpType::WriteFromLocal, 0x4000, 4096),
+            make_op(4, RdmaOpType::ReadIntoLocal, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2545,32 +2522,16 @@ mod tests {
 
         // Batch A: 2 writes with op_idx 10, 11.
         let batch_a = vec![
-            (
-                10usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-                fake_mrv(0x1000, 4096),
-            ),
-            (
-                11usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
+            make_op(10, RdmaOpType::WriteFromLocal, 0x1000, 4096),
+            make_op(11, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
         let mut rx_a = submit_ops(&harness, &actor, batch_a)?;
 
         // Batch B: 2 writes with op_idx 20, 21. Shares the QP with
         // Batch A — together they sit at 4/4 max_send_wr.
         let batch_b = vec![
-            (
-                20usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x3000, 4096),
-                fake_mrv(0x3000, 4096),
-            ),
-            (
-                21usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x4000, 4096),
-                fake_mrv(0x4000, 4096),
-            ),
+            make_op(20, RdmaOpType::WriteFromLocal, 0x3000, 4096),
+            make_op(21, RdmaOpType::WriteFromLocal, 0x4000, 4096),
         ];
         let mut rx_b = submit_ops(&harness, &actor, batch_b)?;
 
@@ -2599,16 +2560,8 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(1, 1).await?;
 
         let items = vec![
-            (
-                0usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(0x1000, 2 * MAX_RDMA_MSG_SIZE),
-            ),
-            (
-                1usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
+            make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
+            make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2637,11 +2590,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
         // Post one op so the next poll has something to look at.
-        let items = vec![(
-            0usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(0x1000, 4096),
-        )];
+        let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let _rx = submit_ops(&harness, &actor, items)?;
         let _ = recv_posted(&mut posted_rx).await;
         qp.queue_poll_error(PollCompletionError::for_test("simulated CQ poison"));
@@ -2667,11 +2616,7 @@ mod tests {
         let (actor, qp, _posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
         qp.queue_post_error("simulated post failure");
-        let items = vec![(
-            0usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(0x1000, 4096),
-        )];
+        let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let _rx = submit_ops(&harness, &actor, items)?;
 
         let event = harness.next_supervision_failure().await;


### PR DESCRIPTION
Summary:
Moves per-peer queue pair management out of `IbvManagerActor` into the per-device `IbvDomain`/`IbvDomainImpl` strategy. Each domain now owns its device's active-side `QueuePairActor` handles and its passive mirror queue pairs, and exposes two operations: `get_or_create_queue_pair`, which returns (creating and caching on first use) the queue pair actor responsible for DMAing a given peer, and `process_conn_request`, which handles an incoming connection request from a peer.

`IbvManagerActor` keeps ownership of op routing: its `SubmitOps` handler resolves each op's local MR, asks the resolved device's `IbvDomain` for the peer's queue pair actor, and posts the op to that actor. Its connection-request handler delegates to `process_conn_request`.

This is groundwork for EFA/SRD, whose connection semantics differ from RC: Mellanox and EFA share the default behavior for now, and EFA will diverge in a follow-up.

Differential Revision: D112046984


