### PR TITLE
expose PyShared::wait_future to Rust callers (#4414)

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -241,6 +241,9 @@ impl<A: Referable> ActorMesh<A> {
                     None,
                 ),
                 crashed_ranks: vec![],
+                // MFCA-4: synthesized locally by the mesh handle, not a
+                // controller report.
+                reporting_controller: None,
             }));
 
             result?;
@@ -1083,6 +1086,9 @@ impl<A: Referable> ActorMeshRef<A> {
                             None,
                         ),
                         crashed_ranks: vec![],
+                        // MFCA-4: synthesized locally when the controller is
+                        // unreachable, not a controller report.
+                        reporting_controller: None,
                     })
                 }
             }?

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -328,6 +328,9 @@ fn send_state_change(
         actor_mesh_name: Some(mesh_name.to_string()),
         event: event.clone(),
         crashed_ranks: vec![rank],
+        // MFCA-1/MFCA-2: stamp this controller's id so the owner attributes the
+        // failure by controller, whatever the event subject is.
+        reporting_controller: Some(cx.instance().self_addr().id().clone()),
     };
     health_state.crashed_ranks.insert(rank, event.clone());
     health_state.unhealthy_event = Some(if is_proc_stopped {
@@ -1316,6 +1319,8 @@ impl<A: Referable> Controlled for ActorMeshControlPlane<A> {
             actor_mesh_name: Some(mesh_name.to_string()),
             event,
             crashed_ranks: vec![],
+            // MFCA-1: controller-generated stop report.
+            reporting_controller: Some(cx.instance().self_addr().id().clone()),
         };
         health_state.unhealthy_event = Some(Unhealthy::StreamClosed(failure_message.clone()));
         // We don't send a message to the owner on stops, because only the owner
@@ -1527,6 +1532,8 @@ impl Controlled for ProcMeshRef {
             actor_mesh_name: Some(mesh_name.to_string()),
             event,
             crashed_ranks: vec![],
+            // MFCA-1: controller-generated stop report.
+            reporting_controller: Some(cx.instance().self_addr().id().clone()),
         };
         health_state.unhealthy_event = Some(Unhealthy::StreamClosed(failure_message.clone()));
         for subscriber in health_state.subscribers.iter() {
@@ -1739,6 +1746,61 @@ mod tests {
 
         assert_eq!(health_state.first_non_terminating_rank(), None);
         assert_eq!(owner_rx.try_recv().unwrap(), None);
+    }
+
+    // MFCA-1/MFCA-3: `send_state_change` stamps the reporting controller's id on
+    // the owner post (and the subscriber copy) even when the event subject is a
+    // ProcAgent rather than the controller or a mesh member.
+    #[tokio::test]
+    async fn owner_post_carries_reporting_controller_with_procagent_subject() {
+        let instance = testing::instance();
+        let (owner_port, mut owner_rx) = instance.open_port::<MeshFailure>();
+        let (sub_port, mut sub_rx) = instance.open_port::<Option<MeshFailure>>();
+        let mesh_name = ResourceId::instance(Label::new("workers").unwrap());
+        let region: ndslice::Region = ndslice::extent!(gpus = 1).into();
+        let statuses = std::iter::once((
+            region.extent().point_of_rank(0).unwrap(),
+            resource::Status::Running,
+        ))
+        .collect();
+        let mut health_state = HealthState::new(statuses, Some(owner_port.bind()));
+        health_state.subscribers.insert(sub_port.bind());
+
+        // Event subject is a ProcAgent, distinct from the controller (the
+        // synthesized-timeout shape that defeats event-subject inference).
+        let procagent = ResourceId::proc_addr_from_name(ChannelAddr::Local(0), "agent_proc")
+            .actor_addr("proc_agent");
+        let event = ActorSupervisionEvent::new(
+            procagent.clone(),
+            None,
+            ActorStatus::Failed(ActorErrorKind::Generic(
+                "unable to query for actor states".to_string(),
+            )),
+            None,
+        );
+        assert!(
+            health_state.mark_rank_terminating(0, resource::Status::Failed("boom".to_string()))
+        );
+        send_state_change(&instance, 0, event, &mesh_name, false, &mut health_state);
+
+        let controller_id = instance.self_addr().id().clone();
+        let owner_failure = owner_rx.recv().await.unwrap();
+        // MFCA-1: the owner post carries the controller id.
+        assert_eq!(
+            owner_failure.reporting_controller,
+            Some(controller_id.clone())
+        );
+        // MFCA-3: the event subject stays the ProcAgent, distinct from the reporter.
+        assert_eq!(owner_failure.event.actor_id, procagent);
+        assert_ne!(owner_failure.event.actor_id.id(), &controller_id);
+
+        // The subscriber copy carries the same reporter after the clone.
+        let sub_failure = sub_rx
+            .recv()
+            .await
+            .unwrap()
+            .expect("subscriber failure is Some");
+        assert_eq!(sub_failure.reporting_controller, Some(controller_id));
     }
 
     fn failed_event(rank: usize, message: &str) -> ActorSupervisionEvent {

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -23,7 +23,30 @@
 //! Python-spawned actor ends up with a mesh base-name string to
 //! supply — lives in `monarch_hyperactor/src/actor.rs`
 //! (`PythonActorParams.mesh_base_name`).
+//!
+//! ## Mesh failure controller-attribution invariants (MFCA-*)
+//!
+//! `MeshFailure.reporting_controller` names the mesh controller that
+//! observed and reported the failure, distinct from `event.actor_id`
+//! (the actor the event concerns).
+//!
+//! - **MFCA-1 (complete controller reports):** every `MeshFailure` a
+//!   controller constructs stamps `reporting_controller =
+//!   Some(controller_id)`; `send_state_change` is the sole controller-to-owner
+//!   failure post and stamps before posting.
+//! - **MFCA-2 (same identity):** the stamped id is
+//!   `cx.instance().self_addr().id()`, which equals the id a consumer reads
+//!   from the mesh's controller ref (`ActorMesh::controller`, or the proc-mesh
+//!   controller).
+//! - **MFCA-3 (subject/source separation):** `event.actor_id` (the event
+//!   subject/root cause) and `reporting_controller` (the reporter) are separate
+//!   roles; their values may coincide on a controller-originated event, but
+//!   neither is overloaded to mean the other.
+//! - **MFCA-4 (non-controller absence):** `None` is reserved for construction
+//!   paths with no reporting mesh controller; such a failure carries no
+//!   controller attribution.
 
+use hyperactor::ActorId;
 use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::context;
@@ -47,6 +70,12 @@ pub struct MeshFailure {
     /// The set of crashed ranks in the mesh. Empty means the event
     /// applies to the whole mesh (e.g. mesh stop, controller timeout).
     pub crashed_ranks: Vec<usize>,
+    /// Identity of the mesh controller that reported this failure, when
+    /// one did (MFCA-3, MFCA-4). A separate role from `event.actor_id`
+    /// (the event subject); the two may hold the same `ActorId` on a
+    /// controller-originated event. `None` on construction paths with no
+    /// reporting controller, which carry no controller attribution.
+    pub reporting_controller: Option<ActorId>,
 }
 wirevalue::register_type!(MeshFailure);
 
@@ -61,7 +90,12 @@ impl MeshFailure {
     /// it to the next owner.
     pub fn default_handler(&self, cx: &impl context::Actor) -> Result<(), anyhow::Error> {
         // If an actor spawned by this one fails, we can't handle it. We fail
-        // ourselves with a chained error and bubble up to the next owner.
+        // ourselves with a chained error and bubble up to the next owner. This
+        // converts the mesh failure into a supervision event, keeping only
+        // `event`; the mesh-level fields (`actor_mesh_name`, `crashed_ranks`,
+        // `reporting_controller`) are dropped and the next controller
+        // re-attributes (MFCA-1). Only a direct clone/re-post of a `MeshFailure`
+        // preserves `reporting_controller`; this conversion is not one.
         let err = ActorErrorKind::UnhandledSupervisionEvent(Box::new(ActorSupervisionEvent::new(
             cx.instance().self_addr().clone(),
             None,
@@ -144,6 +178,7 @@ mod tests {
             actor_mesh_name: Some("training".to_string()),
             event: test_event("actor_a", None),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let rendered = format!("{}", failure);
         assert!(
@@ -161,6 +196,7 @@ mod tests {
             actor_mesh_name: None,
             event: test_event("actor_a", None),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let rendered = format!("{}", failure);
         assert!(
@@ -182,6 +218,7 @@ mod tests {
                 Some("instance0.<my_module.Philosopher training>".to_string()),
             ),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let rendered = format!("{}", failure);
         assert!(
@@ -230,11 +267,13 @@ mod tests {
             actor_mesh_name: None,
             event: undeliverable_synthesized_event(),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let with_mesh_name = MeshFailure {
             actor_mesh_name: Some("training".to_string()),
             event: undeliverable_synthesized_event(),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let expected_without = "failure with event: Supervision event: \
                                 actor worker_proc@inproc://0,dead_actor failed:\n  \
@@ -291,11 +330,13 @@ mod tests {
             actor_mesh_name: None,
             event: panicked_event.clone(),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let with_mesh_name = MeshFailure {
             actor_mesh_name: Some("training".to_string()),
             event: panicked_event,
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let expected_without = "failure with event: Supervision event: actor \
                                 instance0.<monarch_examples.dining.Philosopher \
@@ -337,6 +378,7 @@ mod tests {
             actor_mesh_name: Some("training".to_string()),
             event: controller_timeout_event,
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let expected = "failure on mesh \"training\" with event: \
                         Supervision event: actor \
@@ -345,5 +387,56 @@ mod tests {
                         timed out reaching controller ... Assuming \
                         controller's proc is dead";
         assert_eq!(format!("{}", failure), expected);
+    }
+
+    // Distinct actor id for use as a controller identity or an event subject.
+    fn mk_actor_id(proc: &str, name: &str) -> ActorId {
+        ResourceId::proc_addr_from_name(ChannelAddr::Local(0), proc)
+            .actor_addr(name)
+            .id()
+            .clone()
+    }
+
+    // MFCA-4 + wire format: `reporting_controller` round-trips through bincode
+    // for both `Some` and `None`.
+    #[test]
+    fn reporting_controller_serde_round_trips() {
+        for reporting_controller in [Some(mk_actor_id("ctrl_proc", "controller")), None] {
+            let failure = MeshFailure {
+                actor_mesh_name: Some("training".to_string()),
+                event: test_event("actor_a", None),
+                crashed_ranks: vec![0],
+                reporting_controller: reporting_controller.clone(),
+            };
+            let bytes = bincode::serde::encode_to_vec(&failure, bincode::config::legacy()).unwrap();
+            let (decoded, _): (MeshFailure, usize) =
+                bincode::serde::decode_from_slice(&bytes, bincode::config::legacy()).unwrap();
+            assert_eq!(decoded, failure);
+            assert_eq!(decoded.reporting_controller, reporting_controller);
+        }
+    }
+
+    // MFCA-3: the reporter and the event subject are separate roles carried
+    // independently. Here they hold different ids (a ProcAgent subject, a
+    // distinct controller reporter); on a controller-originated event they may
+    // instead hold the same id.
+    #[test]
+    fn reporting_controller_and_event_subject_are_independent() {
+        let controller = mk_actor_id("ctrl_proc", "controller");
+        let subject = ResourceId::proc_addr_from_name(ChannelAddr::Local(0), "agent_proc")
+            .actor_addr("proc_agent");
+        let failure = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: ActorSupervisionEvent::new(
+                subject.clone(),
+                None,
+                ActorStatus::Failed(ActorErrorKind::Generic("boom".to_string())),
+                None,
+            ),
+            crashed_ranks: Vec::new(),
+            reporting_controller: Some(controller.clone()),
+        };
+        assert_eq!(failure.reporting_controller, Some(controller));
+        assert_eq!(failure.event.actor_id, subject);
     }
 }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1600,6 +1600,9 @@ impl Actor for PythonActor {
                 actor_mesh_name: self.mesh_base_name.clone(),
                 event: event.clone(),
                 crashed_ranks: vec![],
+                // MFCA-4: direct actor-handled supervision conversion, not a
+                // controller report.
+                reporting_controller: None,
             },
         )
         .await

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -753,6 +753,18 @@ pub struct PyShared {
     core: HandleCore,
 }
 
+impl PyShared {
+    /// Await this `Shared`'s result from Rust, yielding the resolved
+    /// `Py<PyAny>` (or the producer's `PyErr`).
+    ///
+    /// Returns the same future the Python `await` path drives, so a Rust
+    /// caller in another crate can resolve a `Shared[T]` inside an `async fn`
+    /// without a pickle round-trip or a blocking `block_on`.
+    pub fn wait_future(&self) -> impl Future<Output = PyResult<Py<PyAny>>> + Send + 'static {
+        self.core.wait_future()
+    }
+}
+
 #[pymethods]
 impl PyShared {
     /// Convert this `Shared` handle into a `PythonTask` that waits

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -873,7 +873,7 @@ class Accumulator(Generic[P, R, A]):
         async def impl() -> A:
             value = self._identity
             for x in gen:
-                value = self._combine(value, await x)
+                value = self._combine(value, await x._take_inner())
             return value
 
         return Future(coro=impl())

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -44,7 +44,13 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
-from monarch._src.actor.future import Future
+from monarch._src.actor.future import (
+    disable_tokio_oracle,
+    enable_tokio_oracle,
+    Future,
+    reset_tokio_oracle,
+    tokio_oracle_records,
+)
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
 from monarch._src.actor.logging import _pending_flush_tasks
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
@@ -2297,3 +2303,26 @@ def test_accumulate_forwards_args_to_stream():
     ep = _stream_endpoint([1])
     Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
     ep.stream.assert_called_once_with("a", k=1)
+
+
+def test_accumulate_produces_no_tokio():
+    """Gate A (accumulate cluster): accumulate produces no `_Tokio` state.
+
+    Drives accumulate with the record-only `_Tokio` oracle enabled and asserts
+    actor_mesh.py produced no `_Tokio` (no `await <Future>` on the tokio thread).
+    Before the `_take_inner()` migration this recorded the impl producer at 876;
+    after it, zero.
+    """
+    disable_tokio_oracle()
+    reset_tokio_oracle()
+    enable_tokio_oracle()
+    try:
+        acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
+        assert acc.accumulate().get() == 6
+        records = [
+            r for r in tokio_oracle_records() if r.filename.endswith("actor_mesh.py")
+        ]
+        assert records == [], f"accumulate still produces _Tokio: {records}"
+    finally:
+        disable_tokio_oracle()
+        reset_tokio_oracle()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -2253,3 +2253,47 @@ async def test_del_runs_on_proc_mesh_stop() -> None:
             f"file {marker_path} should have contents 'finalized' if the finalizers were run"
         )
     os.unlink(marker_path)
+
+
+# ── Accumulator.accumulate characterization tests ──────────────────────────
+
+
+def _future_of(value):
+    """A real, single-use monarch Future resolving to value."""
+
+    async def _v():
+        return value
+
+    return Future(coro=_v())
+
+
+def _stream_endpoint(values):
+    """A fake Endpoint whose .stream() yields one real Future per value."""
+    ep = unittest.mock.MagicMock()
+    ep.stream.return_value = iter([_future_of(v) for v in values])
+    return ep
+
+
+def test_accumulate_folds_with_combine():
+    """accumulate reduces the per-rank stream through combine from identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
+    assert acc.accumulate().get() == 6
+
+
+def test_accumulate_empty_stream_returns_identity():
+    """With no streamed values, accumulate returns the identity seed."""
+    acc = Accumulator(_stream_endpoint([]), 42, operator.add)
+    assert acc.accumulate().get() == 42
+
+
+def test_accumulate_folds_left_to_right():
+    """combine is applied left-to-right over the stream, seeded by identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), [], lambda a, r: a + [r])
+    assert acc.accumulate().get() == [1, 2, 3]
+
+
+def test_accumulate_forwards_args_to_stream():
+    """accumulate forwards its args/kwargs to endpoint.stream()."""
+    ep = _stream_endpoint([1])
+    Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
+    ep.stream.assert_called_once_with("a", k=1)


### PR DESCRIPTION
Summary:

`Shared` (`PyShared`) already lets Python await a background result. this exposes that same wait to Rust as `PyShared::wait_future`, so Rust code can await a `Shared`'s result directly instead of only from Python. it returns the future the Python `await` path already uses, so nothing changes behaviorally.

it's needed by upcoming RDMA setup that runs in Rust and has to wait on a proc-mesh handle without round-tripping through Python.

Reviewed By: zdevito

Differential Revision: D112132403


