### PR TITLE
Fix macOS telemetry thread ID build

### DIFF
--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -7,6 +7,7 @@
  */
 
 #![allow(internal_features)]
+#![cfg_attr(target_os = "macos", feature(thread_id_value))]
 #![feature(sync_unsafe_cell)]
 #![feature(mpmc_channel)]
 #![feature(formatting_options)]


### PR DESCRIPTION
Summary:
There was a macOS build failure in `hyperactor_telemetry` because the non-Linux `get_thread_info()` path calls `ThreadId::as_u64()`, which is gated behind `thread_id_value` on the pinned nightly.

This change enables `thread_id_value` only on macOS with `cfg_attr(target_os = "macos", ...)`, so Linux does not enable an unused unstable feature.

Test Plan:
- `RUSTFLAGS="--cfg tracing_unstable" cargo check -p hyperactor_telemetry -j2`
- `RUSTFLAGS="--cfg tracing_unstable" cargo build -p hyperactor_telemetry -j2`