### PR TITLE
let external runtimes register their client proc mesh (#4418)

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -241,6 +241,9 @@ impl<A: Referable> ActorMesh<A> {
                     None,
                 ),
                 crashed_ranks: vec![],
+                // MFCA-4: synthesized locally by the mesh handle, not a
+                // controller report.
+                reporting_controller: None,
             }));
 
             result?;
@@ -1083,6 +1086,9 @@ impl<A: Referable> ActorMeshRef<A> {
                             None,
                         ),
                         crashed_ranks: vec![],
+                        // MFCA-4: synthesized locally when the controller is
+                        // unreachable, not a controller report.
+                        reporting_controller: None,
                     })
                 }
             }?

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -6,17 +6,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Process-global context, root client actor, and supervision bridge.
+//! Process-global context, root client actor, external-runtime registrations,
+//! and supervision bridge.
 //!
-//! This module provides the Rust equivalent of Python's `context()`,
-//! `this_host()`, and `this_proc()`. A singleton [`Host`] is lazily
-//! created with the [`GlobalClientActor`] on its `local_proc`:
+//! This module has two separate root-context roles:
+//!
+//! - Rust callers use the lazy [`GLOBAL_CONTEXT`] path, exposed through
+//!   [`context()`], [`this_host()`], and [`this_proc()`]. A singleton
+//!   [`Host`] is created with the [`GlobalClientActor`] on its `local_proc`.
+//! - External runtimes such as Python do not use [`GLOBAL_CONTEXT`]. They
+//!   may register their already-bootstrapped client root meshes through
+//!   [`register_client_host`] and [`register_client_proc`]. Registration
+//!   getters are non-bootstrapping and must not initialize [`GLOBAL_CONTEXT`].
 //!
 //! ```rust,ignore
 //! let cx = context().await;
 //! cx.actor_instance    // c.f. Python: context().actor_instance
 //! this_host().await    // c.f. Python: this_host()
-//! this_proc().await    // c.f Python: this_proc()
+//! this_proc().await    // c.f. Python: this_proc()
 //! ```
 //!
 //! ## Undeliverables → supervision
@@ -49,6 +56,17 @@
 //! If no sink has been installed yet (early/late binding),
 //! undeliverables are logged and dropped, preserving forward progress
 //! until a mesh becomes available.
+//!
+//! ## External runtime registration
+//!
+//! **GC-2 (external registration is non-bootstrapping):** External-runtime
+//! registration lookups must never initialize the lazy Rust [`GLOBAL_CONTEXT`].
+//! They read only already-initialized cells via `.get()` (`OnceCell::get` for
+//! `GLOBAL_CONTEXT`, `OnceLock::get` for the registration slots), never a
+//! `get_or_init`. In particular, [`try_registered_client_proc`] returns only
+//! the externally registered proc mesh and deliberately ignores any coexisting
+//! Rust global context; absence is reported as `None`, not filled by
+//! bootstrapping a Rust root.
 
 use std::sync::OnceLock;
 use std::sync::RwLock;
@@ -560,7 +578,8 @@ static REGISTERED_CLIENT_HOST: std::sync::OnceLock<HostMeshRef> = std::sync::Onc
 
 /// Register the client host mesh from an external runtime (Python).
 /// Called by Python's `bootstrap_host()` so that `try_this_host()`
-/// can discover C for the A/C invariant.
+/// can discover C for the A/C invariant. First registration wins: a later
+/// call is silently ignored (the `OnceLock` is already set).
 pub fn register_client_host(host_mesh: HostMeshRef) {
     let _ = REGISTERED_CLIENT_HOST.set(host_mesh);
 }
@@ -574,6 +593,30 @@ pub fn try_this_host() -> Option<&'static HostMeshRef> {
         .get()
         .map(|state| &state.host_mesh)
         .or_else(|| REGISTERED_CLIENT_HOST.get())
+}
+
+/// Separate storage for the client *proc* mesh registered by non-Rust
+/// runtimes (e.g. Python's `bootstrap_host()`), mirroring
+/// `REGISTERED_CLIENT_HOST`. Read by `try_registered_client_proc()`.
+static REGISTERED_CLIENT_PROC: std::sync::OnceLock<ProcMeshRef> = std::sync::OnceLock::new();
+
+/// Register the client proc mesh from an external runtime (Python).
+/// Mirrors `register_client_host`; called from Python's `bootstrap_host()`
+/// so `try_registered_client_proc` can discover the client proc. First
+/// registration wins: a later call is silently ignored (the `OnceLock` is
+/// already set).
+pub fn register_client_proc(proc_mesh: ProcMeshRef) {
+    let _ = REGISTERED_CLIENT_PROC.set(proc_mesh);
+}
+
+/// Returns the externally-registered client proc mesh, or `None` if none
+/// was registered. Non-bootstrapping: reads only the registration
+/// (`.get()`, never `get_or_init`), so it never spins up `GLOBAL_CONTEXT`.
+/// This getter has a single source of truth: it reads only the external
+/// registration; a coexisting Rust `GLOBAL_CONTEXT` root is ignored, with no
+/// fallback (unlike `try_this_host`, which does consult `GLOBAL_CONTEXT`).
+pub fn try_registered_client_proc() -> Option<&'static ProcMeshRef> {
+    REGISTERED_CLIENT_PROC.get()
 }
 
 #[cfg(test)]
@@ -590,6 +633,21 @@ mod tests {
     use super::*;
     #[cfg(fbcode_build)]
     use crate::testing;
+
+    /// GC-2: the lookup ignores an initialized Rust `GLOBAL_CONTEXT` root and
+    /// returns `None` when there is no external registration.
+    #[tokio::test]
+    async fn test_try_registered_client_proc_ignores_rust_global_context() {
+        let _ = context().await;
+        assert!(
+            GLOBAL_CONTEXT.get().is_some(),
+            "test must initialize the Rust global context",
+        );
+        assert!(
+            try_registered_client_proc().is_none(),
+            "registered-client-proc lookup must not fall back to Rust GLOBAL_CONTEXT",
+        );
+    }
 
     /// Helper: send an `Undeliverable<MessageEnvelope>` to the global
     /// root client's well-known undeliverable port via the runtime's

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -328,6 +328,9 @@ fn send_state_change(
         actor_mesh_name: Some(mesh_name.to_string()),
         event: event.clone(),
         crashed_ranks: vec![rank],
+        // MFCA-1/MFCA-2: stamp this controller's id so the owner attributes the
+        // failure by controller, whatever the event subject is.
+        reporting_controller: Some(cx.instance().self_addr().id().clone()),
     };
     health_state.crashed_ranks.insert(rank, event.clone());
     health_state.unhealthy_event = Some(if is_proc_stopped {
@@ -1316,6 +1319,8 @@ impl<A: Referable> Controlled for ActorMeshControlPlane<A> {
             actor_mesh_name: Some(mesh_name.to_string()),
             event,
             crashed_ranks: vec![],
+            // MFCA-1: controller-generated stop report.
+            reporting_controller: Some(cx.instance().self_addr().id().clone()),
         };
         health_state.unhealthy_event = Some(Unhealthy::StreamClosed(failure_message.clone()));
         // We don't send a message to the owner on stops, because only the owner
@@ -1527,6 +1532,8 @@ impl Controlled for ProcMeshRef {
             actor_mesh_name: Some(mesh_name.to_string()),
             event,
             crashed_ranks: vec![],
+            // MFCA-1: controller-generated stop report.
+            reporting_controller: Some(cx.instance().self_addr().id().clone()),
         };
         health_state.unhealthy_event = Some(Unhealthy::StreamClosed(failure_message.clone()));
         for subscriber in health_state.subscribers.iter() {
@@ -1739,6 +1746,61 @@ mod tests {
 
         assert_eq!(health_state.first_non_terminating_rank(), None);
         assert_eq!(owner_rx.try_recv().unwrap(), None);
+    }
+
+    // MFCA-1/MFCA-3: `send_state_change` stamps the reporting controller's id on
+    // the owner post (and the subscriber copy) even when the event subject is a
+    // ProcAgent rather than the controller or a mesh member.
+    #[tokio::test]
+    async fn owner_post_carries_reporting_controller_with_procagent_subject() {
+        let instance = testing::instance();
+        let (owner_port, mut owner_rx) = instance.open_port::<MeshFailure>();
+        let (sub_port, mut sub_rx) = instance.open_port::<Option<MeshFailure>>();
+        let mesh_name = ResourceId::instance(Label::new("workers").unwrap());
+        let region: ndslice::Region = ndslice::extent!(gpus = 1).into();
+        let statuses = std::iter::once((
+            region.extent().point_of_rank(0).unwrap(),
+            resource::Status::Running,
+        ))
+        .collect();
+        let mut health_state = HealthState::new(statuses, Some(owner_port.bind()));
+        health_state.subscribers.insert(sub_port.bind());
+
+        // Event subject is a ProcAgent, distinct from the controller (the
+        // synthesized-timeout shape that defeats event-subject inference).
+        let procagent = ResourceId::proc_addr_from_name(ChannelAddr::Local(0), "agent_proc")
+            .actor_addr("proc_agent");
+        let event = ActorSupervisionEvent::new(
+            procagent.clone(),
+            None,
+            ActorStatus::Failed(ActorErrorKind::Generic(
+                "unable to query for actor states".to_string(),
+            )),
+            None,
+        );
+        assert!(
+            health_state.mark_rank_terminating(0, resource::Status::Failed("boom".to_string()))
+        );
+        send_state_change(&instance, 0, event, &mesh_name, false, &mut health_state);
+
+        let controller_id = instance.self_addr().id().clone();
+        let owner_failure = owner_rx.recv().await.unwrap();
+        // MFCA-1: the owner post carries the controller id.
+        assert_eq!(
+            owner_failure.reporting_controller,
+            Some(controller_id.clone())
+        );
+        // MFCA-3: the event subject stays the ProcAgent, distinct from the reporter.
+        assert_eq!(owner_failure.event.actor_id, procagent);
+        assert_ne!(owner_failure.event.actor_id.id(), &controller_id);
+
+        // The subscriber copy carries the same reporter after the clone.
+        let sub_failure = sub_rx
+            .recv()
+            .await
+            .unwrap()
+            .expect("subscriber failure is Some");
+        assert_eq!(sub_failure.reporting_controller, Some(controller_id));
     }
 
     fn failed_event(rank: usize, message: &str) -> ActorSupervisionEvent {

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -727,6 +727,57 @@ impl ProcMeshRef {
         self.spawn_with_name(cx, id, params, None, false).await
     }
 
+    /// Spawn a controllerless 'service' actor.
+    ///
+    /// Like [`spawn_service`](Self::spawn_service), this spawns a singleton
+    /// service actor (a reserved name, deduped to one). Unlike `spawn_service`,
+    /// the resulting mesh has **no** `ActorMeshController`: no per-caller
+    /// controller actor is spawned, and the caller `C` is therefore **not**
+    /// required to implement `Handler<MeshFailure>`.
+    ///
+    /// This is for coordinators that own their own supervision — e.g. a
+    /// controllerless singleton that itself spawns controller-ful children —
+    /// where a per-caller controller would be redundant.
+    #[hyperactor::instrument(fields(
+        host_mesh=self.host_mesh_id().map(|id| id.to_string()),
+        proc_mesh=self.id.to_string(),
+        actor_name=name.to_string(),
+    ))]
+    pub async fn spawn_controllerless_service<A: RemoteSpawn, C: context::Actor>(
+        &self,
+        cx: &C,
+        name: &str,
+        params: &A::Params,
+    ) -> crate::Result<ActorMesh<A>>
+    where
+        A::Params: RemoteMessage,
+    {
+        tracing::info!(
+            name = "ProcMeshStatus",
+            status = "ActorMesh::Spawn::Attempt",
+        );
+        tracing::info!(name = "ActorMeshStatus", status = "Spawn::Attempt");
+        let id = ActorMeshId::singleton(Label::strip(name));
+        let result = self
+            .spawn_mesh_inner(cx, id, params, None)
+            .await
+            .map(|(mesh, _statuses)| mesh);
+        match &result {
+            Ok(_) => {
+                tracing::info!(
+                    name = "ProcMeshStatus",
+                    status = "ActorMesh::Spawn::Success",
+                );
+                tracing::info!(name = "ActorMeshStatus", status = "Spawn::Success");
+            }
+            Err(error) => {
+                tracing::error!(name = "ProcMeshStatus", status = "ActorMesh::Spawn::Failed", %error);
+                tracing::error!(name = "ActorMeshStatus", status = "Spawn::Failed", %error);
+            }
+        }
+        result
+    }
+
     /// Spawn an actor on all procs in this mesh under the given
     /// [`ActorMeshId`](crate::mesh_id::ActorMeshId), returning a new `ActorMesh`.
     ///
@@ -796,6 +847,55 @@ impl ProcMeshRef {
     where
         C::A: Handler<MeshFailure>,
     {
+        let (mut mesh, statuses) = self
+            .spawn_mesh_inner(cx, actor_mesh_id, params, supervision_display_name.clone())
+            .await?;
+        // System actors are managed by their owning runtime, not an
+        // ActorMeshController.
+        if !is_system_actor {
+            // Spawn a unique mesh manager for each actor mesh, so the type of the
+            // mesh can be preserved.
+            let controller: ActorMeshController<A> = ActorMeshController::new(
+                ActorMeshControlPlane::new(mesh.deref().clone(), self.clone()),
+                supervision_display_name,
+                Some(cx.instance().port().bind()),
+                statuses,
+            );
+            // hyperactor::proc AI-3: controller name must include mesh
+            // identity for proc-wide ActorAddr uniqueness. A fixed base name alone
+            // collides across parents because pid allocation is
+            // parent-scoped.
+            let controller_name = format!(
+                "{}_{}",
+                crate::mesh_controller::ACTOR_MESH_CONTROLLER_NAME,
+                mesh.id()
+            );
+            let controller = cx.spawn_with_label(&controller_name, controller);
+            // Controller and ActorMesh both depend on references from each other, break
+            // the cycle by setting the controller after the fact.
+            mesh.set_controller(Some(controller.bind()));
+        }
+        Ok(mesh)
+    }
+
+    /// The common spawn path shared by
+    /// [`spawn_with_name_inner`](Self::spawn_with_name_inner) and
+    /// [`spawn_controllerless_service`](Self::spawn_controllerless_service): the
+    /// create/update cast, the accumulator port, the bounded
+    /// `GetRankStatus::wait` with terminal / timeout mapping, mesh
+    /// materialization, and telemetry. It carries **no**
+    /// `C::A: Handler<MeshFailure>` bound — that is required only by the
+    /// controller construction (`cx.instance().port().bind()`), which the
+    /// bounded caller layers on afterward. Returns the mesh together with the
+    /// final `StatusMesh` (moved into the controller for non-system actors;
+    /// discarded otherwise — system actors and the controllerless path).
+    async fn spawn_mesh_inner<A: RemoteSpawn, C: context::Actor>(
+        &self,
+        cx: &C,
+        actor_mesh_id: ActorMeshId,
+        params: &A::Params,
+        supervision_display_name: Option<String>,
+    ) -> crate::Result<(ActorMesh<A>, crate::StatusMesh)> {
         let remote = Remote::collect();
         // `RemoteSpawn` + `register_spawnable!(A)` ensure that `A` has a
         // `SpawnableActor` entry in this registry, so
@@ -911,37 +1011,12 @@ impl ProcMeshRef {
                 .map_err(|error| crate::Error::ConfigurationError(error.into()))?,
         );
 
-        let mut mesh = ActorMesh::new(
+        let mesh = ActorMesh::new(
             self.clone(),
             actor_mesh_id.clone(),
             None,
             actor_mesh_members,
         );
-        // System actors are managed by their owning runtime, not an
-        // ActorMeshController.
-        if !is_system_actor {
-            // Spawn a unique mesh manager for each actor mesh, so the type of the
-            // mesh can be preserved.
-            let controller: ActorMeshController<A> = ActorMeshController::new(
-                ActorMeshControlPlane::new(mesh.deref().clone(), self.clone()),
-                supervision_display_name.clone(),
-                Some(cx.instance().port().bind()),
-                statuses,
-            );
-            // hyperactor::proc AI-3: controller name must include mesh
-            // identity for proc-wide ActorAddr uniqueness. A fixed base name alone
-            // collides across parents because pid allocation is
-            // parent-scoped.
-            let controller_name = format!(
-                "{}_{}",
-                crate::mesh_controller::ACTOR_MESH_CONTROLLER_NAME,
-                mesh.id()
-            );
-            let controller = cx.spawn_with_label(&controller_name, controller);
-            // Controller and ActorMesh both depend on references from each other, break
-            // the cycle by setting the controller after the fact.
-            mesh.set_controller(Some(controller.bind()));
-        }
         // Notify telemetry that an actor mesh was created.
         {
             let id_str = mesh.id().to_string();
@@ -990,7 +1065,7 @@ impl ProcMeshRef {
             }
         }
 
-        Ok(mesh)
+        Ok((mesh, statuses))
     }
 
     /// Send stop actors message to all mesh agents for a specific actor mesh id.
@@ -1676,6 +1751,46 @@ mod tests {
         let _ = hm.shutdown(instance).await;
     }
 
+    #[cfg(fbcode_build)]
+    #[assert_no_process_leak]
+    #[tokio::test]
+    async fn test_failing_spawn_controllerless() {
+        hyperactor_telemetry::initialize_logging(hyperactor_telemetry::DefaultTelemetryClock {});
+
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(60));
+        let _guard2 = config.override_key(
+            hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
+            Duration::from_secs(60),
+        );
+
+        let instance = testing::instance();
+
+        let mut hm = testing::host_mesh(1).await;
+        let proc_mesh = hm
+            .spawn(&instance, "test", extent!(gpus = 1), None, None)
+            .await
+            .unwrap();
+        // The controllerless path shares spawn_mesh_inner, so it must still run
+        // the bounded spawn wait and surface the same ActorSpawnError shape on a
+        // terminal init failure — identical to spawn/spawn_service.
+        let err = proc_mesh
+            .spawn_controllerless_service::<testactor::FailingCreateTestActor, _>(
+                instance,
+                "testfail_controllerless",
+                &(),
+            )
+            .await
+            .unwrap_err();
+        let statuses = err.into_actor_spawn_error().unwrap();
+        assert_eq!(
+            statuses,
+            RankedValues::from((0..1, Status::Failed("test failure".to_string()))),
+        );
+
+        let _ = hm.shutdown(instance).await;
+    }
+
     #[async_timed_test(timeout_secs = 60)]
     #[cfg(fbcode_build)]
     async fn test_spawn_actor_on_proc_mesh_slice_only_spawns_slice_members() {
@@ -1818,5 +1933,80 @@ mod tests {
             python_class_from_supervision_name("instance0.<NoModule mesh>"),
             None,
         );
+    }
+
+    // Compile-only proof that `spawn_controllerless_service` does NOT require
+    // `C::A: Handler<MeshFailure>` — the whole point of the controllerless
+    // path. This generic wrapper omits that bound and still type-checks; the
+    // identical wrapper over `spawn_service` would fail to compile. (Generic
+    // fn bodies are type-checked at definition, so this holds without ever
+    // being called.)
+    #[allow(dead_code)]
+    async fn _spawn_controllerless_needs_no_mesh_failure_handler<A, C>(
+        pm: &super::ProcMeshRef,
+        cx: &C,
+        name: &str,
+        params: &A::Params,
+    ) -> crate::Result<crate::ActorMesh<A>>
+    where
+        A: hyperactor::RemoteSpawn,
+        A::Params: hyperactor::RemoteMessage,
+        C: hyperactor::context::Actor,
+    {
+        pm.spawn_controllerless_service::<A, C>(cx, name, params)
+            .await
+    }
+
+    #[cfg(fbcode_build)]
+    async fn execute_spawn_controllerless() {
+        hyperactor_telemetry::initialize_logging(hyperactor_telemetry::DefaultTelemetryClock {});
+
+        let instance = testing::instance();
+
+        let mut hm = testing::host_mesh(2).await;
+        let proc_mesh = hm
+            .spawn(&instance, "test", extent!(gpus = 1), None, None)
+            .await
+            .unwrap();
+
+        // A controllerless service mesh has no ActorMeshController...
+        let controllerless = proc_mesh
+            .spawn_controllerless_service::<testactor::TestActor, _>(
+                instance,
+                "svc_controllerless",
+                &(),
+            )
+            .await
+            .unwrap();
+        assert!(
+            controllerless.controller().is_none(),
+            "spawn_controllerless_service must not create a controller",
+        );
+
+        // ...whereas an ordinary service mesh does (contrast).
+        let with_controller = proc_mesh
+            .spawn_service::<testactor::TestActor, _>(instance, "svc_with_controller", &())
+            .await
+            .unwrap();
+        assert!(
+            with_controller.controller().is_some(),
+            "spawn_service must create a controller",
+        );
+
+        let _ = hm.shutdown(instance).await;
+    }
+
+    #[async_timed_test(timeout_secs = 120)]
+    #[cfg(fbcode_build)]
+    async fn test_spawn_controllerless_service() {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(ENABLE_NATIVE_V1_CASTING, true);
+        let _guard2 = config.override_key(ENABLE_DEST_ACTOR_REORDERING_BUFFER, true);
+        let _guard3 = config.override_key(PROC_SPAWN_MAX_IDLE, Duration::from_secs(120));
+        let _guard4 = config.override_key(
+            hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
+            Duration::from_secs(120),
+        );
+        execute_spawn_controllerless().await;
     }
 }

--- a/hyperactor_mesh/src/supervision.rs
+++ b/hyperactor_mesh/src/supervision.rs
@@ -23,7 +23,30 @@
 //! Python-spawned actor ends up with a mesh base-name string to
 //! supply — lives in `monarch_hyperactor/src/actor.rs`
 //! (`PythonActorParams.mesh_base_name`).
+//!
+//! ## Mesh failure controller-attribution invariants (MFCA-*)
+//!
+//! `MeshFailure.reporting_controller` names the mesh controller that
+//! observed and reported the failure, distinct from `event.actor_id`
+//! (the actor the event concerns).
+//!
+//! - **MFCA-1 (complete controller reports):** every `MeshFailure` a
+//!   controller constructs stamps `reporting_controller =
+//!   Some(controller_id)`; `send_state_change` is the sole controller-to-owner
+//!   failure post and stamps before posting.
+//! - **MFCA-2 (same identity):** the stamped id is
+//!   `cx.instance().self_addr().id()`, which equals the id a consumer reads
+//!   from the mesh's controller ref (`ActorMesh::controller`, or the proc-mesh
+//!   controller).
+//! - **MFCA-3 (subject/source separation):** `event.actor_id` (the event
+//!   subject/root cause) and `reporting_controller` (the reporter) are separate
+//!   roles; their values may coincide on a controller-originated event, but
+//!   neither is overloaded to mean the other.
+//! - **MFCA-4 (non-controller absence):** `None` is reserved for construction
+//!   paths with no reporting mesh controller; such a failure carries no
+//!   controller attribution.
 
+use hyperactor::ActorId;
 use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::context;
@@ -47,6 +70,12 @@ pub struct MeshFailure {
     /// The set of crashed ranks in the mesh. Empty means the event
     /// applies to the whole mesh (e.g. mesh stop, controller timeout).
     pub crashed_ranks: Vec<usize>,
+    /// Identity of the mesh controller that reported this failure, when
+    /// one did (MFCA-3, MFCA-4). A separate role from `event.actor_id`
+    /// (the event subject); the two may hold the same `ActorId` on a
+    /// controller-originated event. `None` on construction paths with no
+    /// reporting controller, which carry no controller attribution.
+    pub reporting_controller: Option<ActorId>,
 }
 wirevalue::register_type!(MeshFailure);
 
@@ -61,7 +90,12 @@ impl MeshFailure {
     /// it to the next owner.
     pub fn default_handler(&self, cx: &impl context::Actor) -> Result<(), anyhow::Error> {
         // If an actor spawned by this one fails, we can't handle it. We fail
-        // ourselves with a chained error and bubble up to the next owner.
+        // ourselves with a chained error and bubble up to the next owner. This
+        // converts the mesh failure into a supervision event, keeping only
+        // `event`; the mesh-level fields (`actor_mesh_name`, `crashed_ranks`,
+        // `reporting_controller`) are dropped and the next controller
+        // re-attributes (MFCA-1). Only a direct clone/re-post of a `MeshFailure`
+        // preserves `reporting_controller`; this conversion is not one.
         let err = ActorErrorKind::UnhandledSupervisionEvent(Box::new(ActorSupervisionEvent::new(
             cx.instance().self_addr().clone(),
             None,
@@ -144,6 +178,7 @@ mod tests {
             actor_mesh_name: Some("training".to_string()),
             event: test_event("actor_a", None),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let rendered = format!("{}", failure);
         assert!(
@@ -161,6 +196,7 @@ mod tests {
             actor_mesh_name: None,
             event: test_event("actor_a", None),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let rendered = format!("{}", failure);
         assert!(
@@ -182,6 +218,7 @@ mod tests {
                 Some("instance0.<my_module.Philosopher training>".to_string()),
             ),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let rendered = format!("{}", failure);
         assert!(
@@ -230,11 +267,13 @@ mod tests {
             actor_mesh_name: None,
             event: undeliverable_synthesized_event(),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let with_mesh_name = MeshFailure {
             actor_mesh_name: Some("training".to_string()),
             event: undeliverable_synthesized_event(),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let expected_without = "failure with event: Supervision event: \
                                 actor worker_proc@inproc://0,dead_actor failed:\n  \
@@ -291,11 +330,13 @@ mod tests {
             actor_mesh_name: None,
             event: panicked_event.clone(),
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let with_mesh_name = MeshFailure {
             actor_mesh_name: Some("training".to_string()),
             event: panicked_event,
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let expected_without = "failure with event: Supervision event: actor \
                                 instance0.<monarch_examples.dining.Philosopher \
@@ -337,6 +378,7 @@ mod tests {
             actor_mesh_name: Some("training".to_string()),
             event: controller_timeout_event,
             crashed_ranks: vec![],
+            reporting_controller: None,
         };
         let expected = "failure on mesh \"training\" with event: \
                         Supervision event: actor \
@@ -345,5 +387,56 @@ mod tests {
                         timed out reaching controller ... Assuming \
                         controller's proc is dead";
         assert_eq!(format!("{}", failure), expected);
+    }
+
+    // Distinct actor id for use as a controller identity or an event subject.
+    fn mk_actor_id(proc: &str, name: &str) -> ActorId {
+        ResourceId::proc_addr_from_name(ChannelAddr::Local(0), proc)
+            .actor_addr(name)
+            .id()
+            .clone()
+    }
+
+    // MFCA-4 + wire format: `reporting_controller` round-trips through bincode
+    // for both `Some` and `None`.
+    #[test]
+    fn reporting_controller_serde_round_trips() {
+        for reporting_controller in [Some(mk_actor_id("ctrl_proc", "controller")), None] {
+            let failure = MeshFailure {
+                actor_mesh_name: Some("training".to_string()),
+                event: test_event("actor_a", None),
+                crashed_ranks: vec![0],
+                reporting_controller: reporting_controller.clone(),
+            };
+            let bytes = bincode::serde::encode_to_vec(&failure, bincode::config::legacy()).unwrap();
+            let (decoded, _): (MeshFailure, usize) =
+                bincode::serde::decode_from_slice(&bytes, bincode::config::legacy()).unwrap();
+            assert_eq!(decoded, failure);
+            assert_eq!(decoded.reporting_controller, reporting_controller);
+        }
+    }
+
+    // MFCA-3: the reporter and the event subject are separate roles carried
+    // independently. Here they hold different ids (a ProcAgent subject, a
+    // distinct controller reporter); on a controller-originated event they may
+    // instead hold the same id.
+    #[test]
+    fn reporting_controller_and_event_subject_are_independent() {
+        let controller = mk_actor_id("ctrl_proc", "controller");
+        let subject = ResourceId::proc_addr_from_name(ChannelAddr::Local(0), "agent_proc")
+            .actor_addr("proc_agent");
+        let failure = MeshFailure {
+            actor_mesh_name: Some("training".to_string()),
+            event: ActorSupervisionEvent::new(
+                subject.clone(),
+                None,
+                ActorStatus::Failed(ActorErrorKind::Generic("boom".to_string())),
+                None,
+            ),
+            crashed_ranks: Vec::new(),
+            reporting_controller: Some(controller.clone()),
+        };
+        assert_eq!(failure.reporting_controller, Some(controller));
+        assert_eq!(failure.event.actor_id, subject);
     }
 }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1600,6 +1600,9 @@ impl Actor for PythonActor {
                 actor_mesh_name: self.mesh_base_name.clone(),
                 event: event.clone(),
                 crashed_ranks: vec![],
+                // MFCA-4: direct actor-handled supervision conversion, not a
+                // controller report.
+                reporting_controller: None,
             },
         )
         .await

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -753,6 +753,18 @@ pub struct PyShared {
     core: HandleCore,
 }
 
+impl PyShared {
+    /// Await this `Shared`'s result from Rust, yielding the resolved
+    /// `Py<PyAny>` (or the producer's `PyErr`).
+    ///
+    /// Returns the same future the Python `await` path drives, so a Rust
+    /// caller in another crate can resolve a `Shared[T]` inside an `async fn`
+    /// without a pickle round-trip or a blocking `block_on`.
+    pub fn wait_future(&self) -> impl Future<Output = PyResult<Py<PyAny>>> + Send + 'static {
+        self.core.wait_future()
+    }
+}
+
 #[pymethods]
 impl PyShared {
     /// Convert this `Shared` handle into a `PythonTask` that waits

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -873,7 +873,7 @@ class Accumulator(Generic[P, R, A]):
         async def impl() -> A:
             value = self._identity
             for x in gen:
-                value = self._combine(value, await x)
+                value = self._combine(value, await x._take_inner())
             return value
 
         return Future(coro=impl())

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -44,7 +44,13 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
-from monarch._src.actor.future import Future
+from monarch._src.actor.future import (
+    disable_tokio_oracle,
+    enable_tokio_oracle,
+    Future,
+    reset_tokio_oracle,
+    tokio_oracle_records,
+)
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
 from monarch._src.actor.logging import _pending_flush_tasks
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
@@ -2297,3 +2303,26 @@ def test_accumulate_forwards_args_to_stream():
     ep = _stream_endpoint([1])
     Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
     ep.stream.assert_called_once_with("a", k=1)
+
+
+def test_accumulate_produces_no_tokio():
+    """Gate A (accumulate cluster): accumulate produces no `_Tokio` state.
+
+    Drives accumulate with the record-only `_Tokio` oracle enabled and asserts
+    actor_mesh.py produced no `_Tokio` (no `await <Future>` on the tokio thread).
+    Before the `_take_inner()` migration this recorded the impl producer at 876;
+    after it, zero.
+    """
+    disable_tokio_oracle()
+    reset_tokio_oracle()
+    enable_tokio_oracle()
+    try:
+        acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
+        assert acc.accumulate().get() == 6
+        records = [
+            r for r in tokio_oracle_records() if r.filename.endswith("actor_mesh.py")
+        ]
+        assert records == [], f"accumulate still produces _Tokio: {records}"
+    finally:
+        disable_tokio_oracle()
+        reset_tokio_oracle()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -2253,3 +2253,47 @@ async def test_del_runs_on_proc_mesh_stop() -> None:
             f"file {marker_path} should have contents 'finalized' if the finalizers were run"
         )
     os.unlink(marker_path)
+
+
+# ── Accumulator.accumulate characterization tests ──────────────────────────
+
+
+def _future_of(value):
+    """A real, single-use monarch Future resolving to value."""
+
+    async def _v():
+        return value
+
+    return Future(coro=_v())
+
+
+def _stream_endpoint(values):
+    """A fake Endpoint whose .stream() yields one real Future per value."""
+    ep = unittest.mock.MagicMock()
+    ep.stream.return_value = iter([_future_of(v) for v in values])
+    return ep
+
+
+def test_accumulate_folds_with_combine():
+    """accumulate reduces the per-rank stream through combine from identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
+    assert acc.accumulate().get() == 6
+
+
+def test_accumulate_empty_stream_returns_identity():
+    """With no streamed values, accumulate returns the identity seed."""
+    acc = Accumulator(_stream_endpoint([]), 42, operator.add)
+    assert acc.accumulate().get() == 42
+
+
+def test_accumulate_folds_left_to_right():
+    """combine is applied left-to-right over the stream, seeded by identity."""
+    acc = Accumulator(_stream_endpoint([1, 2, 3]), [], lambda a, r: a + [r])
+    assert acc.accumulate().get() == [1, 2, 3]
+
+
+def test_accumulate_forwards_args_to_stream():
+    """accumulate forwards its args/kwargs to endpoint.stream()."""
+    ep = _stream_endpoint([1])
+    Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
+    ep.stream.assert_called_once_with("a", k=1)


### PR DESCRIPTION
Summary:

Rust discovers the process's client meshes through a lazy global context (`this_host()` / `this_proc()`). Python doesn't use that path — it bootstraps its own client and already registers its client host mesh so Rust can look it up (`register_client_host`). this adds the same for the client proc mesh: `register_client_proc` stores it and `try_registered_client_proc` reads it back.

the getter reads only what was registered: it never triggers the lazy Rust bootstrap, and — unlike the host lookup — it does not fall back to the Rust global context. Python-root discovery must return the Python-registered proc or `None`, never an unrelated Rust root.

there's no caller yet — that's intentional, not dead code: the callsite lands in the next diff (B-pyroot), which wires Python's `bootstrap_host` to `register_client_proc` and adds the RDMA client-root consumer that reads it back via `try_registered_client_proc`.

Differential Revision: D112158618


