### PR TITLE
Fix two preferred versions

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,8 +8,7 @@
   {
     "name": "v0.5.0",
     "version": "v0.5.0",
-    "url": "https://meta-pytorch.org/monarch/v0.5.0/",
-    "preferred": true
+    "url": "https://meta-pytorch.org/monarch/v0.5.0/"
   },
   {
     "name": "v0.4.1",


### PR DESCRIPTION
Accidentally left two "preferred" versions which messes up the version picker. The page content is correct but looks like it is v0.5.0 when it is not.