### PR TITLE
Make torch CUDA Stream/Event bindings return Result (#4422)

### DIFF
--- a/monarch_tensor_worker/src/comm.rs
+++ b/monarch_tensor_worker/src/comm.rs
@@ -130,7 +130,7 @@ impl NcclCommActor {
         spawn_blocking(move || {
             let status = op(comm)?;
             match status {
-                NcclStatus::Success => Ok(stream.record_event(None)),
+                NcclStatus::Success => Ok(stream.record_event(None)?),
                 _ => bail!("nccl {op_name} failed: {status:?}"),
             }
         })
@@ -391,7 +391,7 @@ impl CommMessageHandler for NcclCommActor {
             }
             group_end(ticket)?;
             // Make an end event on this stream.
-            Ok(stream.record_event(None))
+            Ok(stream.record_event(None)?)
         })
         .await
         .unwrap()?)
@@ -466,7 +466,7 @@ mod tests {
             &client,
             cell0.clone(),
             ReduceOp::Sum,
-            Stream::get_current_stream_on_device(device0),
+            Stream::get_current_stream_on_device(device0).unwrap(),
         );
 
         let cell1 = TensorCell::new(factory_float_tensor(&[2.0], device1.into()));
@@ -475,7 +475,7 @@ mod tests {
             &client,
             cell1.clone(),
             ReduceOp::Sum,
-            Stream::get_current_stream_on_device(device1),
+            Stream::get_current_stream_on_device(device1).unwrap(),
         );
 
         let (res0, res1) = tokio::join!(fut0, fut1);
@@ -534,10 +534,10 @@ mod tests {
             vec![CommMessage::Send(
                 cell0.clone(),
                 1,
-                Stream::get_current_stream_on_device(device0),
+                Stream::get_current_stream_on_device(device0).unwrap(),
                 client.open_once_port().0,
             )],
-            Stream::get_current_stream_on_device(device0),
+            Stream::get_current_stream_on_device(device0).unwrap(),
         );
 
         let cell1 = TensorCell::new(factory_float_tensor(&[2.0], device1.into()));
@@ -547,10 +547,10 @@ mod tests {
             vec![CommMessage::Recv(
                 cell1.clone(),
                 0,
-                Stream::get_current_stream_on_device(device1),
+                Stream::get_current_stream_on_device(device1).unwrap(),
                 client.open_once_port().0,
             )],
-            Stream::get_current_stream_on_device(device1),
+            Stream::get_current_stream_on_device(device1).unwrap(),
         );
 
         let (res0, res1) = tokio::join!(fut0, fut1);
@@ -608,7 +608,7 @@ mod tests {
             cell0.clone(),
             ReduceOp::Sum,
             dest_rank,
-            Stream::get_current_stream_on_device(device0),
+            Stream::get_current_stream_on_device(device0)?,
         );
 
         let cell1 = TensorCell::new(factory_float_tensor(&[2.0], device1.into()));
@@ -618,7 +618,7 @@ mod tests {
             cell1.clone(),
             ReduceOp::Sum,
             dest_rank,
-            Stream::get_current_stream_on_device(device1),
+            Stream::get_current_stream_on_device(device1)?,
         );
 
         let (res0, res1) = tokio::join!(fut0, fut1);

--- a/monarch_tensor_worker/src/lib.rs
+++ b/monarch_tensor_worker/src/lib.rs
@@ -83,7 +83,6 @@ use monarch_messages::worker::WorkerParams;
 use monarch_types::ReduceOp;
 use monarch_types::UniqueId;
 use ndslice::Slice;
-use pyo3::Python;
 use pyo3::types::PyAnyMethods;
 use serde::Deserialize;
 use serde::Serialize;
@@ -338,7 +337,7 @@ impl WorkerMessageHandler for WorkerActor {
             cx,
             cell,
             ReduceOp::Sum,
-            torch_sys_cuda::cuda::Stream::get_current_stream(),
+            torch_sys_cuda::cuda::Stream::get_current_stream()?,
         )
         .await?;
 
@@ -1113,7 +1112,6 @@ mod tests {
     use monarch_messages::controller::WorkerError;
     use monarch_messages::worker::WorkerMessageClient;
     use monarch_types::PickledPyObject;
-    use pyo3::Python;
     use pyo3::prelude::*;
     use pyo3::types::PyList;
     use pyo3::types::PyString;

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -516,8 +516,8 @@ impl Actor for StreamActor {
                 .ok()
         });
         // Set the current stream for this actor thread.
-        if let Some(stream) = self.cuda_stream() {
-            Stream::set_current_stream(stream);
+        if let Some(stream) = self.cuda_stream()? {
+            Stream::set_current_stream(stream)?;
         }
         Ok(())
     }
@@ -630,17 +630,25 @@ impl StreamActor {
         Ok(TensorCell::new(tensor))
     }
 
-    fn cuda_stream(&self) -> Option<&Stream> {
-        self.cuda_stream
-            .get_or_init(|| {
-                self.device.map(|device| match self.creation_mode {
+    fn cuda_stream(&self) -> PyResult<Option<&Stream>> {
+        if self.cuda_stream.get().is_none() {
+            let stream = match self.device {
+                Some(device) => Some(match self.creation_mode {
                     StreamCreationMode::UseDefaultStream => {
-                        Stream::get_current_stream_on_device(device)
+                        Stream::get_current_stream_on_device(device)?
                     }
-                    StreamCreationMode::CreateNewStream => Stream::new_with_device(device),
-                })
-            })
-            .as_ref()
+                    StreamCreationMode::CreateNewStream => Stream::new_with_device(device)?,
+                }),
+                None => None,
+            };
+            // Another thread may have won the initialization race; keep whichever value is stored.
+            let _ = self.cuda_stream.set(stream);
+        }
+        Ok(self
+            .cuda_stream
+            .get()
+            .expect("stream initialized above")
+            .as_ref())
     }
 
     fn ref_to_pyobject(&self, ref_: &Ref) -> Result<Py<PyAny>, CallFunctionError> {
@@ -1092,7 +1100,10 @@ impl StreamMessageHandler for StreamActor {
             Err(e) => Err(e.clone()),
         };
 
-        let event = self.cuda_stream().map(|stream| stream.record_event(None));
+        let event = self
+            .cuda_stream()?
+            .map(|stream| stream.record_event(None))
+            .transpose()?;
         first_use_sender.post(cx, (event, result));
         Ok(())
     }
@@ -1127,10 +1138,10 @@ impl StreamMessageHandler for StreamActor {
                     )
                 })?;
 
-        if let Some(stream) = self.cuda_stream() {
+        if let Some(stream) = self.cuda_stream()? {
             stream.wait_event(
                 &mut first_use_event.expect("sent borrow to CUDA stream, expected a CUDA event"),
-            );
+            )?;
         }
         match cell {
             Ok(cell) => {
@@ -1160,7 +1171,10 @@ impl StreamMessageHandler for StreamActor {
             return Ok(());
         }
 
-        let event = self.cuda_stream().map(|stream| stream.record_event(None));
+        let event = self
+            .cuda_stream()?
+            .map(|stream| stream.record_event(None))
+            .transpose()?;
         let pyobj_or_err = self.env.remove(&result).ok_or(anyhow!(
             "Invalid reference for borrow_last_use: {result:#?}"
         ))?;
@@ -1205,10 +1219,10 @@ impl StreamMessageHandler for StreamActor {
                 )
             })?;
 
-        if let Some(stream) = self.cuda_stream() {
+        if let Some(stream) = self.cuda_stream()? {
             stream.wait_event(
                 &mut last_use_event.expect("sent borrow to CUDA stream, expected a CUDA event"),
-            );
+            )?;
         }
         // let the cell drop.
         Ok(())
@@ -1276,7 +1290,7 @@ impl StreamMessageHandler for StreamActor {
         }
 
         let stream = self
-            .cuda_stream()
+            .cuda_stream()?
             .expect("reductions not yet supported for non-CUDA workers")
             .clone();
         let input_cell = self.get_or_fake_on_err(local_tensor, &factory)?;
@@ -1431,7 +1445,7 @@ impl StreamMessageHandler for StreamActor {
             messages.push(CommMessage::Send(
                 input_cell,
                 to_rank.try_into().unwrap(),
-                self.cuda_stream()
+                self.cuda_stream()?
                     .expect("tried to send_tensor on non-cuda stream")
                     .clone(),
                 cx.open_once_port().0,
@@ -1448,7 +1462,7 @@ impl StreamMessageHandler for StreamActor {
             messages.push(CommMessage::Recv(
                 output_cell.clone(),
                 from_rank.try_into().unwrap(),
-                self.cuda_stream()
+                self.cuda_stream()?
                     .expect("tried to send_tensor on non-cuda stream")
                     .clone(),
                 cx.open_once_port().0,
@@ -1460,7 +1474,7 @@ impl StreamMessageHandler for StreamActor {
         comm.group(
             cx,
             messages,
-            self.cuda_stream()
+            self.cuda_stream()?
                 .expect("tried to send_tensor on non-cuda stream")
                 .clone(),
         )

--- a/torch-sys-cuda/src/cuda.rs
+++ b/torch-sys-cuda/src/cuda.rs
@@ -46,12 +46,12 @@ impl Clone for Stream {
 
 impl Stream {
     /// Create a new stream on the current device, at priority 0.
-    pub fn new() -> Self {
+    pub fn new() -> PyResult<Self> {
         Python::attach(|py| {
-            let stream = cuda_stream_class(py).call0().unwrap();
-            Self {
+            let stream = cuda_stream_class(py).call0()?;
+            Ok(Self {
                 inner: stream.into(),
-            }
+            })
         })
     }
 
@@ -63,68 +63,62 @@ impl Stream {
     }
 
     /// Create a new stream on the specified device, at priority 0.
-    pub fn new_with_device(device: CudaDevice) -> Self {
+    pub fn new_with_device(device: CudaDevice) -> PyResult<Self> {
         Python::attach(|py| {
             let device_idx: i8 = device.index().into();
-            let stream = cuda_stream_class(py).call1((device_idx,)).unwrap();
-            Self {
+            let stream = cuda_stream_class(py).call1((device_idx,))?;
+            Ok(Self {
                 inner: stream.into(),
-            }
+            })
         })
     }
 
     /// Get the current stream on the current device.
-    pub fn get_current_stream() -> Self {
+    pub fn get_current_stream() -> PyResult<Self> {
         Python::attach(|py| {
-            let stream = cuda_current_stream(py).call0().unwrap();
-            Self {
+            let stream = cuda_current_stream(py).call0()?;
+            Ok(Self {
                 inner: stream.into(),
-            }
+            })
         })
     }
 
     /// Get the current stream on the specified device.
-    pub fn get_current_stream_on_device(device: CudaDevice) -> Self {
+    pub fn get_current_stream_on_device(device: CudaDevice) -> PyResult<Self> {
         Python::attach(|py| {
             let device_idx: i8 = device.index().into();
-            let stream = cuda_current_stream(py).call1((device_idx,)).unwrap();
-            Self {
+            let stream = cuda_current_stream(py).call1((device_idx,))?;
+            Ok(Self {
                 inner: stream.into(),
-            }
+            })
         })
     }
 
     /// Set the provided stream as the current stream. Also sets the current
     /// device to be the same as the stream's device.
-    pub fn set_current_stream(stream: &Stream) {
+    pub fn set_current_stream(stream: &Stream) -> PyResult<()> {
         Python::attach(|py| {
             let stream_obj = stream.inner.bind(py);
 
             // Get current device and stream device
-            let current_device = cuda_current_device(py)
-                .call0()
-                .unwrap()
-                .extract::<i64>()
-                .unwrap();
+            let current_device = cuda_current_device(py).call0()?.extract::<i64>()?;
 
-            let stream_device = stream_obj
-                .getattr("device_index")
-                .unwrap()
-                .extract::<i64>()
-                .unwrap();
+            let stream_device = stream_obj.getattr("device_index")?.extract::<i64>()?;
 
             // Set device if different
             if current_device != stream_device {
-                cuda_set_device(py).call1((stream_device,)).unwrap();
+                cuda_set_device(py).call1((stream_device,))?;
             }
 
             // Set the stream
-            cuda_set_stream(py).call1((stream_obj,)).unwrap();
+            cuda_set_stream(py).call1((stream_obj,))?;
+
+            Ok(())
         })
     }
 
     /// Make all future work submitted to this stream wait for an event.
-    pub fn wait_event(&self, event: &mut Event) {
+    pub fn wait_event(&self, event: &mut Event) -> PyResult<()> {
         event.wait(Some(self))
     }
 
@@ -132,49 +126,49 @@ impl Stream {
     ///
     /// All future work submitted to this stream will wait until all kernels
     /// submitted to a given stream at the time of call entry complete.
-    pub fn wait_stream(&self, stream: &Stream) {
-        self.wait_event(&mut stream.record_event(None))
+    pub fn wait_stream(&self, stream: &Stream) -> PyResult<()> {
+        self.wait_event(&mut stream.record_event(None)?)
     }
 
     /// Record an event on this stream. If no event is provided one will be
     /// created.
-    pub fn record_event(&self, event: Option<Event>) -> Event {
-        let mut event = event.unwrap_or(Event::new());
-        event.record(Some(self));
-        event
+    pub fn record_event(&self, event: Option<Event>) -> PyResult<Event> {
+        let mut event = match event {
+            Some(event) => event,
+            None => Event::new()?,
+        };
+        event.record(Some(self))?;
+        Ok(event)
     }
 
     /// Check if all work submitted to this stream has completed.
-    pub fn query(&self) -> bool {
+    pub fn query(&self) -> PyResult<bool> {
         Python::attach(|py| {
             let stream_obj = self.inner.bind(py);
-            stream_obj
-                .call_method0("query")
-                .unwrap()
-                .extract::<bool>()
-                .unwrap()
+            stream_obj.call_method0("query")?.extract::<bool>()
         })
     }
 
     /// Wait for all kernels in this stream to complete.
-    pub fn synchronize(&self) {
+    pub fn synchronize(&self) -> PyResult<()> {
         Python::attach(|py| {
             let stream_obj = self.inner.bind(py);
-            stream_obj.call_method0("synchronize").unwrap();
+            stream_obj.call_method0("synchronize")?;
+            Ok(())
         })
     }
 
     /// Get the raw CUDA stream pointer. Only available with the `cuda` feature.
     #[cfg(feature = "cuda")]
-    pub fn stream(&self) -> nccl_sys::cudaStream_t {
+    pub fn stream(&self) -> PyResult<nccl_sys::cudaStream_t> {
         Python::attach(|py| {
             let stream_obj = self.inner.bind(py);
-            let cuda_stream = stream_obj.getattr("cuda_stream").unwrap();
+            let cuda_stream = stream_obj.getattr("cuda_stream")?;
 
             // Extract the raw pointer
-            let ptr = cuda_stream.extract::<usize>().unwrap();
+            let ptr = cuda_stream.extract::<usize>()?;
 
-            ptr as nccl_sys::cudaStream_t
+            Ok(ptr as nccl_sys::cudaStream_t)
         })
     }
 }
@@ -183,7 +177,11 @@ impl PartialEq for Stream {
     fn eq(&self, other: &Self) -> bool {
         #[cfg(feature = "cuda")]
         {
-            self.stream() == other.stream()
+            self.stream()
+                .expect("cuda_stream attribute should be readable")
+                == other
+                    .stream()
+                    .expect("cuda_stream attribute should be readable")
         }
 
         #[cfg(not(feature = "cuda"))]
@@ -221,62 +219,62 @@ impl Clone for Event {
 impl Event {
     /// Create a new event.
     // TODO: add support for flags.
-    pub fn new() -> Self {
+    pub fn new() -> PyResult<Self> {
         Python::attach(|py| {
-            let event = cuda_event_class(py).call0().unwrap();
-            Self {
+            let event = cuda_event_class(py).call0()?;
+            Ok(Self {
                 inner: event.into(),
-            }
+            })
         })
     }
 
     /// Record the event on the current stream.
     ///
     /// Uses the current stream if no stream is provided.
-    pub fn record(&mut self, stream: Option<&Stream>) {
+    pub fn record(&mut self, stream: Option<&Stream>) -> PyResult<()> {
         Python::attach(|py| {
             let event_obj = self.inner.bind(py);
 
             match stream {
                 Some(stream) => {
                     let stream_obj = stream.inner.bind(py);
-                    event_obj.call_method1("record", (stream_obj,)).unwrap();
+                    event_obj.call_method1("record", (stream_obj,))?;
                 }
                 None => {
-                    event_obj.call_method0("record").unwrap();
+                    event_obj.call_method0("record")?;
                 }
             }
+
+            Ok(())
         })
     }
 
     /// Make all future work submitted to the given stream wait for this event.
     ///
     /// Uses the current stream if no stream is specified.
-    pub fn wait(&mut self, stream: Option<&Stream>) {
+    pub fn wait(&mut self, stream: Option<&Stream>) -> PyResult<()> {
         Python::attach(|py| {
             let event_obj = self.inner.bind(py);
 
             match stream {
                 Some(stream) => {
                     let stream_obj = stream.inner.bind(py);
-                    event_obj.call_method1("wait", (stream_obj,)).unwrap();
+                    event_obj.call_method1("wait", (stream_obj,))?;
                 }
                 None => {
-                    event_obj.call_method0("wait").unwrap();
+                    event_obj.call_method0("wait")?;
                 }
             }
+
+            Ok(())
         })
     }
 
     /// Check if all work currently captured by event has completed.
-    pub fn query(&self) -> bool {
+    pub fn query(&self) -> PyResult<bool> {
         Python::attach(|py| {
             let event_obj = self.inner.bind(py);
-            event_obj
-                .call_method0("query")
-                .unwrap()
-                .extract::<bool>()
-                .unwrap()
+            event_obj.call_method0("query")?.extract::<bool>()
         })
     }
 
@@ -284,28 +282,27 @@ impl Event {
     ///
     /// Time reported in after the event was recorded and before the end_event
     /// was recorded.
-    pub fn elapsed_time(&self, end_event: &Event) -> Duration {
+    pub fn elapsed_time(&self, end_event: &Event) -> PyResult<Duration> {
         Python::attach(|py| {
             let event_obj = self.inner.bind(py);
             let end_event_obj = end_event.inner.bind(py);
 
             let elapsed_ms = event_obj
-                .call_method1("elapsed_time", (end_event_obj,))
-                .unwrap()
-                .extract::<f64>()
-                .unwrap();
+                .call_method1("elapsed_time", (end_event_obj,))?
+                .extract::<f64>()?;
 
-            Duration::from_millis(elapsed_ms as u64)
+            Ok(Duration::from_millis(elapsed_ms as u64))
         })
     }
 
     /// Wait for the event to complete.
     /// Waits until the completion of all work currently captured in this event.
     /// This prevents the CPU thread from proceeding until the event completes.
-    pub fn synchronize(&self) {
+    pub fn synchronize(&self) -> PyResult<()> {
         Python::attach(|py| {
             let event_obj = self.inner.bind(py);
-            event_obj.call_method0("synchronize").unwrap();
+            event_obj.call_method0("synchronize")?;
+            Ok(())
         })
     }
 }

--- a/torch-sys-cuda/src/nccl.rs
+++ b/torch-sys-cuda/src/nccl.rs
@@ -261,7 +261,9 @@ impl Communicator {
                 data_type.into(),
                 reduce_op_to_nccl(reduce_op),
                 self.inner,
-                stream.stream(),
+                stream
+                    .stream()
+                    .expect("cuda_stream attribute should be readable"),
             ))?)
         }
     }
@@ -287,7 +289,9 @@ impl Communicator {
                 data_type.into(),
                 root,
                 self.inner,
-                stream.stream(),
+                stream
+                    .stream()
+                    .expect("cuda_stream attribute should be readable"),
             ))?)
         }
     }
@@ -319,7 +323,9 @@ impl Communicator {
                 reduce_op_to_nccl(reduce_op),
                 root,
                 self.inner,
-                stream.stream(),
+                stream
+                    .stream()
+                    .expect("cuda_stream attribute should be readable"),
             ))?)
         }
     }
@@ -372,7 +378,9 @@ impl Communicator {
                         data_type.into(),
                         rank,
                         self.inner,
-                        stream.stream(),
+                        stream
+                            .stream()
+                            .expect("cuda_stream attribute should be readable"),
                     ))?;
                 } else {
                     nccl_check(ncclBroadcast(
@@ -382,7 +390,9 @@ impl Communicator {
                         data_type.into(),
                         rank,
                         self.inner,
-                        stream.stream(),
+                        stream
+                            .stream()
+                            .expect("cuda_stream attribute should be readable"),
                     ))?;
                 }
             }
@@ -427,7 +437,9 @@ impl Communicator {
                 input.numel() as usize,
                 data_type.into(),
                 self.inner,
-                stream.stream(),
+                stream
+                    .stream()
+                    .expect("cuda_stream attribute should be readable"),
             ))?)
         }
     }
@@ -475,7 +487,9 @@ impl Communicator {
                 data_type.into(),
                 reduce_op_to_nccl(reduce_op),
                 self.inner,
-                stream.stream(),
+                stream
+                    .stream()
+                    .expect("cuda_stream attribute should be readable"),
             ))?)
         }
     }
@@ -500,7 +514,9 @@ impl Communicator {
                 data_type.into(),
                 dst,
                 self.inner,
-                stream.stream(),
+                stream
+                    .stream()
+                    .expect("cuda_stream attribute should be readable"),
             ))?)
         }
     }
@@ -525,7 +541,9 @@ impl Communicator {
                 data_type.into(),
                 src,
                 self.inner,
-                stream.stream(),
+                stream
+                    .stream()
+                    .expect("cuda_stream attribute should be readable"),
             ))?)
         }
     }
@@ -572,7 +590,9 @@ impl Communicator {
                     data_type.into(),
                     r,
                     self.inner,
-                    stream.stream(),
+                    stream
+                        .stream()
+                        .expect("cuda_stream attribute should be readable"),
                 ))?;
                 nccl_check(ncclRecv(
                     recv_buff.offset(r as isize * rank_stride),
@@ -580,7 +600,9 @@ impl Communicator {
                     data_type.into(),
                     r,
                     self.inner,
-                    stream.stream(),
+                    stream
+                        .stream()
+                        .expect("cuda_stream attribute should be readable"),
                 ))?;
             }
 
@@ -607,7 +629,9 @@ impl Communicator {
                 data_type.into(),
                 reduce_op_to_nccl(ReduceOp::Sum),
                 self.inner,
-                stream.stream(),
+                stream
+                    .stream()
+                    .expect("cuda_stream attribute should be readable"),
             ))?)
         }
     }
@@ -649,14 +673,14 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 let device = CudaDevice::new(DeviceIndex(i));
                 set_device(device).unwrap();
-                let stream = Stream::new();
+                let stream = Stream::new().unwrap();
                 let tensor = cuda_full(&[2, 2], 1.0);
                 let expected = cuda_full(&[2, 2], 2.0);
 
                 let cell = TensorCell::new(tensor);
                 let mut comm = Communicator::new(device, 2, unique_id, i.into()).unwrap();
                 comm.all_reduce(&cell, ReduceOp::Sum, &stream).unwrap();
-                stream.synchronize();
+                stream.synchronize().unwrap();
                 assert!(allclose(&cell.borrow(), &expected).unwrap());
             }));
         }
@@ -675,13 +699,13 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 let device = CudaDevice::new(DeviceIndex(i));
                 set_device(device).unwrap();
-                let stream = Stream::new();
+                let stream = Stream::new().unwrap();
                 let tensor = cuda_full(&[2, 2], i as f32);
 
                 let cell = TensorCell::new(tensor);
                 let mut comm = Communicator::new(device, 2, unique_id, i.into()).unwrap();
                 comm.broadcast(&cell, 1, &stream).unwrap();
-                stream.synchronize();
+                stream.synchronize().unwrap();
                 assert!(allclose(&cell.borrow(), &cuda_full(&[2, 2], 1.0)).unwrap());
             }));
         }
@@ -700,13 +724,13 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 let device = CudaDevice::new(DeviceIndex(i));
                 set_device(device).unwrap();
-                let stream = Stream::new();
+                let stream = Stream::new().unwrap();
                 let tensor = cuda_full(&[2, 2], 2.0);
 
                 let cell = TensorCell::new(tensor);
                 let mut comm = Communicator::new(device, 2, unique_id, i.into()).unwrap();
                 comm.reduce(&cell, ReduceOp::Sum, 0, &stream).unwrap();
-                stream.synchronize();
+                stream.synchronize().unwrap();
                 match i {
                     0 => assert!(allclose(&cell.borrow(), &cuda_full(&[2, 2], 4.0)).unwrap()),
                     1 => assert!(allclose(&cell.borrow(), &cuda_full(&[2, 2], 2.0)).unwrap()),
@@ -729,7 +753,7 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 let device = CudaDevice::new(DeviceIndex(i));
                 set_device(device).unwrap();
-                let stream = Stream::new();
+                let stream = Stream::new().unwrap();
                 let input_tensor = cuda_full(&[2, 2], i as f32);
                 let output_tensor = cuda_full(&[2, 2, 2], 0.0);
 
@@ -745,7 +769,7 @@ mod tests {
                 let mut comm = Communicator::new(device, 2, unique_id, i.into()).unwrap();
                 comm.all_gather_into_tensor(&output_cell, &input_cell, &stream)
                     .unwrap();
-                stream.synchronize();
+                stream.synchronize().unwrap();
                 assert!(allclose(&output_cell.borrow(), &expected).unwrap());
             }));
         }
@@ -763,26 +787,26 @@ mod tests {
         handles.push(std::thread::spawn(move || {
             let device = CudaDevice::new(DeviceIndex(0));
             set_device(device).unwrap();
-            let stream = Stream::new();
+            let stream = Stream::new().unwrap();
             let tensor = cuda_full(&[2, 2], 0.0);
 
             let cell = TensorCell::new(tensor);
             let mut comm = Communicator::new(device, 2, unique_id_, 0).unwrap();
             comm.send(&cell, 1, &stream).unwrap();
-            stream.synchronize();
+            stream.synchronize().unwrap();
         }));
         let unique_id_ = unique_id.clone();
         handles.push(std::thread::spawn(move || {
             let device = CudaDevice::new(DeviceIndex(1));
             set_device(device).unwrap();
-            let stream = Stream::new();
+            let stream = Stream::new().unwrap();
             let tensor = cuda_full(&[2, 2], 1.1);
             let expected = cuda_full(&[2, 2], 0.0);
 
             let cell = TensorCell::new(tensor);
             let mut comm = Communicator::new(device, 2, unique_id_, 1).unwrap();
             comm.recv(&cell, 0, &stream).unwrap();
-            stream.synchronize();
+            stream.synchronize().unwrap();
             assert!(allclose(&cell.borrow(), &expected).unwrap());
         }));
         for handle in handles {
@@ -800,7 +824,7 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 let device = CudaDevice::new(DeviceIndex(i));
                 set_device(device).unwrap();
-                let stream = Stream::new();
+                let stream = Stream::new().unwrap();
                 let input = match i {
                     0 => factory_float_tensor(&[0.0, 1.0], device.into()),
                     1 => factory_float_tensor(&[2.0, 3.0], device.into()),
@@ -813,7 +837,7 @@ mod tests {
 
                 let mut comm = Communicator::new(device, 2, unique_id, i.into()).unwrap();
                 comm.all_to_all_single(&output, &input, &stream).unwrap();
-                stream.synchronize();
+                stream.synchronize().unwrap();
 
                 let expected = match i {
                     0 => factory_float_tensor(&[0.0, 2.0], device.into()),
@@ -838,7 +862,7 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 let device = CudaDevice::new(DeviceIndex(i));
                 set_device(device).unwrap();
-                let stream = Stream::new();
+                let stream = Stream::new().unwrap();
                 let input = factory_float_tensor(&[0.0, 1.0, 2.0, 3.0], device.into());
                 let output = cuda_full(&[2], 1.0);
 
@@ -848,7 +872,7 @@ mod tests {
                 let mut comm = Communicator::new(device, 2, unique_id, i.into()).unwrap();
                 comm.reduce_scatter_tensor(&output, &input, ReduceOp::Sum, &stream)
                     .unwrap();
-                stream.synchronize();
+                stream.synchronize().unwrap();
 
                 let expected = match i {
                     0 => factory_float_tensor(&[0.0, 2.0], device.into()),
@@ -873,7 +897,7 @@ mod tests {
             handles.push(std::thread::spawn(move || {
                 let device = CudaDevice::new(DeviceIndex(i));
                 set_device(device).unwrap();
-                let stream = Stream::new();
+                let stream = Stream::new().unwrap();
                 let tensor = cuda_full(&[2, 2], 1.0);
                 let cell = TensorCell::new(tensor);
                 let mut comm = Communicator::new(device, 2, unique_id, i.into()).unwrap();
@@ -893,7 +917,7 @@ mod tests {
                             .unwrap()
                             .all_reduce(&cell, ReduceOp::Sum, &stream)
                             .unwrap();
-                        stream.synchronize();
+                        stream.synchronize().unwrap();
                         let expected = cuda_full(&[2, 2], 1.0);
                         assert!(allclose(&cell.borrow(), &expected).unwrap());
                     }


### PR DESCRIPTION
Summary:

The torch CUDA bindings in `torch-sys-cuda` wrap `torch.cuda` Python APIs, and every wrapper `.unwrap()`'d the result of its Python call. Any exception raised by torch (a CUDA OOM, a driver error, etc. surfaced through `torch.cuda`) therefore turned into a Rust panic instead of an error a caller could handle.

This change makes the fallible `Stream` and `Event` methods return `PyResult` and propagate with `?`, so callers can decide how to handle a Python exception rather than crashing the process.

- `Stream`: `new`, `new_with_device`, `get_current_stream`, `get_current_stream_on_device`, `set_current_stream`, `wait_event`, `wait_stream`, `record_event`, `query`, `synchronize`, and `stream` now return `PyResult`.
- `Event`: `new`, `record`, `wait`, `query`, `elapsed_time`, and `synchronize` now return `PyResult`.
- Callers in `monarch_tensor_worker` and `nccl.rs` propagate with `?` where they already return a `Result`, and `.unwrap()` in tests.

Two call sites can't propagate a `Result` and use `.expect(...)` instead:
- `PartialEq for Stream` compares raw stream pointers via `Stream::stream()`, but `eq` must return `bool`.
- The NCCL `Communicator` methods return `Result<_, NcclError>`. Rather than widen `NcclError`, `stream.stream()` is `.expect(...)`'d there too; reading the `cuda_stream` attribute of a live stream should never fail.

`StreamActor::cuda_stream()` lazily initializes a cached `Stream` in a `OnceLock`. Since `OnceLock::get_or_try_init` is not stable, it now checks `get()`, computes the fallible value, and stores it with `set()`.

Reviewed By: thedavekwon

Differential Revision: D112153157


