### PR TITLE
Update ignore crate to 0.4.29 in third-party/rust

### DIFF
--- a/monarch_conda/Cargo.toml
+++ b/monarch_conda/Cargo.toml
@@ -22,7 +22,7 @@ digest = { version = "0.10", features = ["rand_core"] }
 filetime = "0.2.29"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
 globset = { version = "0.4.13", features = ["serde1"] }
-ignore = "0.4.28"
+ignore = "0.4.29"
 itertools = "0.15.0"
 memmap2 = "0.9.11"
 rattler_conda_types = "0.28.3"


### PR DESCRIPTION
Summary: Bumps the third-party Rust `ignore` crate from 0.4.28 to 0.4.29. This is a semver-compatible patch update with no first-party API changes required.

Differential Revision: D112215197
