### PR TITLE
position resource status by delivered view rank (#4433)

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -373,6 +373,9 @@ pub enum Bootstrap {
     Host {
         /// The address on which to serve the host.
         addr: ChannelAddr,
+        /// Callback used to publish host readiness after the [`HostAgent`] and
+        /// cast actor are bound.
+        callback_addr: ChannelAddr,
         /// If specified, use the provided command instead of
         /// [`BootstrapCommand::current`].
         command: Option<BootstrapCommand>,
@@ -384,6 +387,51 @@ pub enum Bootstrap {
         /// If true, exit the process after handling a shutdown request.
         exit_on_shutdown: bool,
     },
+}
+
+/// Parent side of the host-bootstrap readiness callback.
+pub struct HostBootstrapReady {
+    host_addr: ChannelAddr,
+    callback_addr: ChannelAddr,
+    callback_rx: hyperactor::channel::ChannelRx<()>,
+}
+
+impl HostBootstrapReady {
+    pub fn new(host_addr: ChannelAddr) -> Result<Self, ChannelError> {
+        let (callback_addr, callback_rx) =
+            channel::serve(ChannelAddr::any(ChannelTransport::Unix))?;
+        Ok(Self {
+            host_addr,
+            callback_addr,
+            callback_rx,
+        })
+    }
+
+    pub fn callback_addr(&self) -> ChannelAddr {
+        self.callback_addr.clone()
+    }
+
+    pub async fn wait(mut self) -> anyhow::Result<()> {
+        let timeout = hyperactor_config::global::get(hyperactor::config::HOST_SPAWN_READY_TIMEOUT);
+        if timeout.is_zero() {
+            self.callback_rx.recv().await.with_context(|| {
+                format!("host {} closed its bootstrap callback", self.host_addr)
+            })?;
+        } else {
+            tokio::time::timeout(timeout, self.callback_rx.recv())
+                .await
+                .with_context(|| {
+                    format!(
+                        "host {} did not become ready within {:?}",
+                        self.host_addr, timeout
+                    )
+                })?
+                .with_context(|| {
+                    format!("host {} closed its bootstrap callback", self.host_addr)
+                })?;
+        }
+        Ok(())
+    }
 }
 
 impl Bootstrap {
@@ -550,6 +598,7 @@ impl Bootstrap {
             }
             Bootstrap::Host {
                 addr,
+                callback_addr,
                 command,
                 config,
                 exit_on_shutdown,
@@ -564,6 +613,10 @@ impl Bootstrap {
                     None,
                 )
                 .await?;
+                channel::dial(callback_addr)?
+                    .send(())
+                    .await
+                    .map_err(ChannelError::from)?;
                 shutdown.join().await;
                 halt().await
             }
@@ -2375,6 +2428,43 @@ mod tests {
 
     use super::*;
 
+    #[tokio::test]
+    async fn test_host_bootstrap_ready_callback() {
+        let host_addr = ChannelAddr::any(ChannelTransport::Unix);
+        let ready = HostBootstrapReady::new(host_addr).expect("open readiness callback");
+        let callback_addr = ready.callback_addr();
+        let sender = tokio::spawn(async move {
+            channel::dial(callback_addr)
+                .expect("dial readiness callback")
+                .send(())
+                .await
+                .expect("send readiness callback");
+        });
+
+        ready.wait().await.expect("receive readiness callback");
+        sender.await.expect("readiness sender task");
+    }
+
+    #[tokio::test]
+    async fn test_host_bootstrap_ready_times_out_without_callback() {
+        let config = hyperactor_config::global::lock();
+        let _timeout = config.override_key(
+            hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
+            Duration::from_millis(20),
+        );
+        let host_addr = ChannelAddr::any(ChannelTransport::Unix);
+        let ready = HostBootstrapReady::new(host_addr).expect("open readiness callback");
+
+        let error = ready
+            .wait()
+            .await
+            .expect_err("missing callback must fail closed");
+        assert!(
+            error.to_string().contains("did not become ready"),
+            "unexpected readiness error: {error:#}"
+        );
+    }
+
     #[test]
     fn test_bootstrap_mode_env_string_none_config_proc() {
         let value = Bootstrap::Proc {
@@ -2404,6 +2494,7 @@ mod tests {
     fn test_bootstrap_mode_env_string_none_config_host() {
         let value = Bootstrap::Host {
             addr: ChannelAddr::any(ChannelTransport::Unix),
+            callback_addr: ChannelAddr::any(ChannelTransport::Unix),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -2463,6 +2554,7 @@ mod tests {
         {
             let original = Bootstrap::Host {
                 addr: ChannelAddr::any(ChannelTransport::Unix),
+                callback_addr: ChannelAddr::any(ChannelTransport::Unix),
                 command: None,
                 config: Some(attrs.clone()),
                 exit_on_shutdown: false,

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -427,6 +427,28 @@ impl<M: ProcManager> Host<M> {
     pub(crate) fn take_frontend_handle(&mut self) -> Option<GatewayServeHandle> {
         self.frontend_handle.take()
     }
+
+    /// Stop and join every gateway server owned by this host.
+    pub(crate) async fn shutdown_servers(&mut self) {
+        if let Some(mut handle) = self.frontend_handle.take() {
+            handle.stop("host shutdown");
+            if let Err(error) = handle.join().await {
+                tracing::warn!(%error, "failed to join host frontend server");
+            }
+        }
+        if let Some(mut handle) = self.backend_handle.take() {
+            handle.stop("host shutdown");
+            if let Err(error) = handle.join().await {
+                tracing::warn!(%error, "failed to join host backend server");
+            }
+        }
+        if let Some(mut handle) = self.via_handle.take() {
+            handle.stop("host shutdown");
+            if let Err(error) = handle.join().await {
+                tracing::warn!(%error, "failed to join host via server");
+            }
+        }
+    }
 }
 
 impl<M> Drop for Host<M> {

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -94,6 +94,7 @@ use crate::ProcMesh;
 use crate::ValueMesh;
 use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcManager;
+use crate::bootstrap::HostBootstrapReady;
 use crate::bootstrap::ProcBind;
 use crate::host::Host;
 use crate::host::LocalProcManager;
@@ -455,11 +456,13 @@ impl HostMesh {
 
         let bind_spec = hyperactor_config::global::get_cloned(DEFAULT_TRANSPORT);
         let mut host_addrs = Vec::with_capacity(extent.num_ranks());
+        let mut ready = Vec::with_capacity(extent.num_ranks());
         for _ in 0..extent.num_ranks() {
-            // Note: this can be racy. Possibly we should have a callback channel.
             let addr = bind_spec.binding_addr();
+            let callback = HostBootstrapReady::new(addr.clone())?;
             let bootstrap = Bootstrap::Host {
                 addr: addr.clone(),
+                callback_addr: callback.callback_addr(),
                 command: Some(command.clone()),
                 config: Some(hyperactor_config::global::attrs()),
                 exit_on_shutdown: false,
@@ -469,6 +472,10 @@ impl HostMesh {
             bootstrap.to_env(&mut cmd);
             cmd.spawn()?;
             host_addrs.push(addr);
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await?;
         }
 
         let host_mesh_ref = HostMeshRef::new(
@@ -1955,10 +1962,13 @@ mod tests {
         let hosts = vec![free_localhost_addr(), free_localhost_addr()];
 
         let mut children = Vec::new();
+        let mut ready = Vec::new();
         for host in hosts.iter() {
+            let callback = HostBootstrapReady::new(host.clone()).unwrap();
             let mut cmd = Command::new(program.clone());
             let boot = Bootstrap::Host {
                 addr: host.clone(),
+                callback_addr: callback.callback_addr(),
                 command: None, // use current binary
                 config: None,
                 exit_on_shutdown: false,
@@ -1966,6 +1976,10 @@ mod tests {
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await.unwrap();
         }
 
         let instance = testing::instance();
@@ -2039,10 +2053,13 @@ mod tests {
         let hosts = vec![free_localhost_addr(), free_localhost_addr()];
 
         let mut children = Vec::new();
+        let mut ready = Vec::new();
         for host in hosts.iter() {
+            let callback = HostBootstrapReady::new(host.clone()).unwrap();
             let mut cmd = Command::new(program.clone());
             let boot = Bootstrap::Host {
                 addr: host.clone(),
+                callback_addr: callback.callback_addr(),
                 config: None,
                 // The entire purpose of this is to fail:
                 command: Some(BootstrapCommand::from("false")),
@@ -2051,6 +2068,10 @@ mod tests {
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await.unwrap();
         }
         let host_mesh =
             HostMeshRef::from_hosts(HostMeshId::singleton(Label::new("test").unwrap()), hosts);
@@ -2080,8 +2101,10 @@ mod tests {
         let hosts = vec![free_localhost_addr(), free_localhost_addr()];
 
         let mut children = Vec::new();
+        let mut ready = Vec::new();
 
         for (index, host) in hosts.iter().enumerate() {
+            let callback = HostBootstrapReady::new(host.clone()).unwrap();
             let mut cmd = Command::new(program.clone());
             let command = if index == 0 {
                 let mut command = BootstrapCommand::from("sleep");
@@ -2092,6 +2115,7 @@ mod tests {
             };
             let boot = Bootstrap::Host {
                 addr: host.clone(),
+                callback_addr: callback.callback_addr(),
                 config: None,
                 command,
                 exit_on_shutdown: false,
@@ -2099,6 +2123,10 @@ mod tests {
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await.unwrap();
         }
         let host_mesh =
             HostMeshRef::from_hosts(HostMeshId::singleton(Label::new("test").unwrap()), hosts);

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1575,7 +1575,11 @@ impl HostMeshRef {
                 initial_update_interval: None,
             },
         );
-        for proc_id in procs.into_iter() {
+        // `procs` follows the current-view `ranks` order, so the enumeration
+        // index is each proc's rank in this view (RSP-1). Direct delivery stamps
+        // it explicitly (RSP-2); each HostAgent positions its reply overlay
+        // there.
+        for (view_rank, proc_id) in procs.into_iter().enumerate() {
             let addr = proc_id.addr().clone();
             // The name stored in HostAgent is not the same as the
             // one stored in the ProcMesh. We instead take each proc id
@@ -1594,7 +1598,13 @@ impl HostMeshRef {
                 },
             );
             host_agent
-                .wait_rank_status(cx, proc_resource_id, Status::Stopped, port.bind())
+                .wait_rank_status(
+                    cx,
+                    proc_resource_id,
+                    resource::Rank::new(view_rank),
+                    Status::Stopped,
+                    port.bind(),
+                )
                 .await
                 .map_err(|e| crate::Error::CallError(host_agent.actor_addr().clone(), e))?;
 

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -953,26 +953,15 @@ impl Handler<resource::CreateOrUpdate<ProcSpec>> for HostAgent {
             self.state = HostAgentState::Attached(host);
         }
 
-        // If any WaitRankStatus messages arrived before this proc
-        // existed, their waiters were stashed with a sentinel rank.
-        // Now that we know the real rank, fix them up and start a
-        // watch bridge.
-        // Extract the proc_id before mutably borrowing pending_proc_waiters.
+        // A WaitRankStatus stashed before this proc existed carries its own reply
+        // rank (RSP-3); starting a status watch bridge for it needs the proc_id.
         let proc_id = self
             .created
             .get(&create_or_update.id)
             .and_then(|s| s.created.as_ref().ok())
             .map(|(pid, _)| pid.clone());
 
-        if let Some(waiters) = self.pending_proc_waiters.get_mut(&create_or_update.id) {
-            for (_, waiter_rank, _) in waiters.iter_mut() {
-                if *waiter_rank == usize::MAX {
-                    *waiter_rank = rank;
-                }
-            }
-        }
-
-        // Start a bridge and send ourselves an initial check.
+        // Bridge status changes to any pending waiters, then flush once now.
         if self.pending_proc_waiters.contains_key(&create_or_update.id) {
             if let Some(proc_id) = &proc_id {
                 self.start_watch_bridge(&create_or_update.id, proc_id).await;
@@ -1057,11 +1046,15 @@ impl Handler<resource::GetRankStatus> for HostAgent {
         cx: &Context<Self>,
         get_rank_status: resource::GetRankStatus,
     ) -> anyhow::Result<()> {
-        let (rank, status) = self.proc_rank_status(&get_rank_status.id).await;
-
-        let overlay = if rank == usize::MAX {
+        // `proc_rank_status` returns `usize::MAX` for a proc unknown to this
+        // host, which still yields an empty overlay (RSP-4). A *known* proc is
+        // positioned at the rank the request carries (the caller's view), not
+        // the stored creation rank (RSP-1).
+        let (found_rank, status) = self.proc_rank_status(&get_rank_status.id).await;
+        let overlay = if found_rank == usize::MAX {
             StatusOverlay::new()
         } else {
+            let rank = get_rank_status.rank.unwrap();
             StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
                 .expect("valid single-run overlay")
         };
@@ -1080,13 +1073,15 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
         use crate::StatusOverlay;
         use crate::resource::Status;
 
+        // Position from the rank the request carries (the caller's view), not the
+        // stored creation rank (RSP-1). A deferred / pre-create waiter retains it
+        // (RSP-3).
+        let rank = msg.rank.unwrap();
         match self.created.get(&msg.id) {
             Some(ProcCreationState {
-                rank,
                 created: Ok((proc_id, _)),
                 ..
             }) => {
-                let rank = *rank;
                 let status = match self.host() {
                     Some(host) => host.proc_status(proc_id).await.0,
                     None => Status::Stopped,
@@ -1110,26 +1105,24 @@ impl Handler<resource::WaitRankStatus> for HostAgent {
                 self.start_watch_bridge(&msg.id, &proc_id).await;
             }
             Some(ProcCreationState {
-                rank,
-                created: Err(e),
-                ..
+                created: Err(e), ..
             }) => {
                 // Creation failed — reply immediately with Failed status.
                 let overlay = StatusOverlay::try_from_runs(vec![(
-                    *rank..(*rank + 1),
+                    rank..(rank + 1),
                     Status::Failed(e.to_string()),
                 )])
                 .expect("valid single-run overlay");
                 let _ = msg.reply.post(cx, overlay);
             }
             None => {
-                // Proc doesn't exist yet. Stash the waiter with a
-                // sentinel rank; CreateOrUpdate will fill it in and
-                // start the watch bridge.
+                // Proc doesn't exist yet. Stash the waiter with the rank the
+                // request carries (RSP-3); `CreateOrUpdate` starts the watch
+                // bridge.
                 self.pending_proc_waiters
                     .entry(msg.id.clone())
                     .or_default()
-                    .push((msg.min_status, usize::MAX, msg.reply));
+                    .push((msg.min_status, rank, msg.reply));
             }
         }
 
@@ -1178,6 +1171,8 @@ impl HostAgent {
         let remaining = std::mem::take(waiters);
         for (min_status, rank, reply) in remaining {
             if status >= min_status {
+                // Each waiter keeps the reply rank it registered with (RSP-3),
+                // positioned in the caller's view (RSP-1).
                 let overlay =
                     StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
                         .expect("valid single-run overlay");
@@ -1938,9 +1933,49 @@ mod tests {
     use crate::host::LocalProcManager;
     use crate::mesh_id::ResourceId;
     use crate::resource::CreateOrUpdateClient;
+    use crate::resource::GetRankStatusClient;
     use crate::resource::GetStateClient;
     use crate::resource::Rank;
     use crate::resource::WaitRankStatusClient;
+
+    /// Assert `overlay` holds exactly one run covering `rank..rank+1`. The
+    /// reply must land at the message rank the caller requested, not at any
+    /// rank the proc was created under.
+    fn assert_overlay_at_rank(overlay: &crate::StatusOverlay, rank: usize) {
+        assert_eq!(overlay.len(), 1, "expected exactly one run: {overlay:?}");
+        let (range, _) = overlay.runs().next().unwrap();
+        assert_eq!(*range, rank..rank + 1, "overlay positioned at wrong rank");
+    }
+
+    /// Like [`assert_overlay_at_rank`], but also require the single run to carry
+    /// a `Failed` status.
+    fn assert_overlay_failed_at_rank(overlay: &crate::StatusOverlay, rank: usize) {
+        assert_eq!(overlay.len(), 1, "expected exactly one run: {overlay:?}");
+        let (range, status) = overlay.runs().next().unwrap();
+        assert_eq!(*range, rank..rank + 1, "overlay positioned at wrong rank");
+        assert_matches!(status, resource::Status::Failed(_));
+    }
+
+    // RSP-* coverage map for the HostAgent rank-status tests. Each deliberately
+    // uses `message_rank != creation_rank`, so a handler that read the creation
+    // rank would fail:
+    // - RSP-1 (position at the message rank, not creation rank):
+    //   `test_wait_rank_status_already_running` (immediate WaitRankStatus and
+    //   GetRankStatus on a known proc), `test_wait_rank_status_stop`,
+    //   `test_wait_rank_status_before_proc_exists`, `test_spawn_procs_many_per_host`;
+    //   `test_rank_status_created_error` covers the created-error branch (Failed
+    //   overlay at the message rank).
+    // - RSP-2 (direct delivery supplies the rank explicitly): every test above
+    //   calls the generated client with `Rank::new(...)`; the cast half
+    //   (`Rank::default()` late-bound in transit) is covered by the library
+    //   regression in `proc_mesh.rs`.
+    // - RSP-3 (deferred / pre-create waiter retains its registration rank):
+    //   `test_wait_rank_status_stop` (deferred until stop),
+    //   `test_wait_rank_status_before_proc_exists` (registered before the proc
+    //   exists, then the proc is created at a different rank; the waiter keeps its
+    //   own rank rather than adopting the creation rank).
+    // - RSP-4 (absence yields an empty overlay): the unknown-proc GetRankStatus
+    //   assertion in `test_wait_rank_status_already_running`.
 
     #[tokio::test]
     async fn test_basic() {
@@ -2060,7 +2095,12 @@ mod tests {
         );
     }
 
-    /// WaitRankStatus on a running proc replies immediately with Running.
+    /// Immediate status queries on one host fixture: WaitRankStatus and
+    /// GetRankStatus on a running proc reply immediately, each positioning the
+    /// overlay at the message rank (not the proc's creation rank); GetRankStatus
+    /// for an unknown proc replies with an empty overlay. These share a single
+    /// created proc to avoid standing up extra host/proc fixtures under parallel
+    /// test execution.
     #[tokio::test]
     async fn test_wait_rank_status_already_running() {
         let host = Host::new(
@@ -2083,6 +2123,8 @@ mod tests {
         let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
+        // Create at rank 0, but query at different message ranks so a handler that
+        // read the creation rank instead of the message rank would fail.
         host_agent
             .create_or_update(
                 &client,
@@ -2093,18 +2135,55 @@ mod tests {
             .await
             .unwrap();
 
-        // Proc is Running; wait for Running should reply immediately.
+        // Proc is Running; WaitRankStatus for Running replies immediately, at its
+        // own message rank.
+        let wait_rank = 7;
         let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
         host_agent
-            .wait_rank_status(&client, id, resource::Status::Running, port.bind())
+            .wait_rank_status(
+                &client,
+                id.clone(),
+                resource::Rank::new(wait_rank),
+                resource::Status::Running,
+                port.bind(),
+            )
             .await
             .unwrap();
-
         let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
             .await
             .expect("reply timed out")
             .expect("reply channel closed");
-        assert!(!overlay.is_empty(), "expected non-empty overlay");
+        assert_overlay_at_rank(&overlay, wait_rank);
+
+        // GetRankStatus for the same known proc positions at its own message rank.
+        let get_rank = 4;
+        let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .get_rank_status(&client, id, resource::Rank::new(get_rank), port.bind())
+            .await
+            .unwrap();
+        let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
+            .await
+            .expect("reply timed out")
+            .expect("reply channel closed");
+        assert_overlay_at_rank(&overlay, get_rank);
+
+        // GetRankStatus for an unknown proc replies with an empty overlay,
+        // regardless of the message rank.
+        let unknown = ResourceId::instance(Label::new("never-created").unwrap());
+        let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .get_rank_status(&client, unknown, resource::Rank::new(4), port.bind())
+            .await
+            .unwrap();
+        let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
+            .await
+            .expect("reply timed out")
+            .expect("reply channel closed");
+        assert!(
+            overlay.is_empty(),
+            "expected empty overlay for unknown proc: {overlay:?}",
+        );
     }
 
     /// WaitRankStatus for Stopped, then stop the proc — reply should
@@ -2131,6 +2210,9 @@ mod tests {
         let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
+        // Create at rank 0, defer at a different message rank; the deferred
+        // waiter must retain the message rank through to its flush on stop.
+        let message_rank = 5;
         host_agent
             .create_or_update(
                 &client,
@@ -2144,7 +2226,13 @@ mod tests {
         // Wait for Stopped — should not reply yet.
         let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
         host_agent
-            .wait_rank_status(&client, id.clone(), resource::Status::Stopped, port.bind())
+            .wait_rank_status(
+                &client,
+                id.clone(),
+                resource::Rank::new(message_rank),
+                resource::Status::Stopped,
+                port.bind(),
+            )
             .await
             .unwrap();
 
@@ -2158,11 +2246,14 @@ mod tests {
             .await
             .expect("reply timed out — proc did not reach Stopped")
             .expect("reply channel closed");
-        assert!(!overlay.is_empty(), "expected non-empty overlay");
+        assert_overlay_at_rank(&overlay, message_rank);
     }
 
-    /// WaitRankStatus sent before the proc is created — the waiter is
-    /// stashed and replied to once CreateOrUpdate runs.
+    /// WaitRankStatus sent before the proc is created — the waiter is stashed
+    /// and replied to once CreateOrUpdate runs. The waiter's message rank is
+    /// chosen before creation and survives unchanged even though the proc is
+    /// later created at a different rank: the reply is positioned at the waiter's
+    /// own rank, never the creation rank.
     #[tokio::test]
     async fn test_wait_rank_status_before_proc_exists() {
         let host = Host::new(
@@ -2185,16 +2276,24 @@ mod tests {
         let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
+        // Waiter rank is chosen now, before the proc exists.
+        let message_rank = 9;
 
         // Wait for Running on a proc that doesn't exist yet.
         let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
         host_agent
-            .wait_rank_status(&client, id.clone(), resource::Status::Running, port.bind())
+            .wait_rank_status(
+                &client,
+                id.clone(),
+                resource::Rank::new(message_rank),
+                resource::Status::Running,
+                port.bind(),
+            )
             .await
             .unwrap();
 
-        // Now create the proc — the stashed waiter should get its
-        // sentinel rank fixed and be flushed once the proc is Running.
+        // Now create the proc at a different rank — the stashed waiter is
+        // flushed once the proc is Running, keeping its own message rank.
         host_agent
             .create_or_update(&client, id, resource::Rank::new(0), ProcSpec::default())
             .await
@@ -2204,7 +2303,83 @@ mod tests {
             .await
             .expect("reply timed out — waiter was not flushed after CreateOrUpdate")
             .expect("reply channel closed");
-        assert!(!overlay.is_empty(), "expected non-empty overlay");
+        assert_overlay_at_rank(&overlay, message_rank);
+    }
+
+    /// A proc whose creation failed is cached as `created: Err` and reported as a
+    /// `Failed` overlay positioned at the message rank, on both immediate query
+    /// paths — GetRankStatus and (non-deferred) WaitRankStatus.
+    #[tokio::test]
+    async fn test_rank_status_created_error() {
+        // A local, in-process host whose proc spawn deterministically fails, so
+        // CreateOrUpdate caches `created: Err(..)` for the requested proc.
+        let spawn: ProcManagerSpawnFn = Box::new(|_proc| {
+            Box::pin(std::future::ready(Err::<ActorHandle<ProcAgent>, _>(
+                anyhow::anyhow!("test failure"),
+            )))
+        });
+        let host = Host::new(LocalProcManager::new(spawn), ChannelTransport::Unix.any())
+            .await
+            .unwrap();
+
+        let system_proc = host.system_proc().clone();
+        let host_agent = system_proc
+            .spawn_with_uid(
+                Uid::singleton(Label::new(HOST_MESH_AGENT_ACTOR_NAME).unwrap()),
+                HostAgent::new_local(host),
+            )
+            .unwrap();
+        HostAgent::wait_initialized(&host_agent).await.unwrap();
+
+        let client_proc = Proc::direct(ChannelTransport::Unix.any(), "client".to_string()).unwrap();
+        let client = client_proc.client("client");
+
+        let id = ResourceId::instance(Label::new("proc1").unwrap());
+        // Creation is attempted at rank 0; the spawn fails and is cached. The
+        // client call still returns Ok — the handler swallows the spawn error.
+        host_agent
+            .create_or_update(
+                &client,
+                id.clone(),
+                resource::Rank::new(0),
+                ProcSpec::default(),
+            )
+            .await
+            .unwrap();
+
+        // WaitRankStatus for a known-but-failed proc replies immediately (no
+        // deferral) with a Failed overlay at the message rank.
+        let wait_rank = 6;
+        let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .wait_rank_status(
+                &client,
+                id.clone(),
+                resource::Rank::new(wait_rank),
+                resource::Status::Running,
+                port.bind(),
+            )
+            .await
+            .unwrap();
+        let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
+            .await
+            .expect("reply timed out")
+            .expect("reply channel closed");
+        assert_overlay_failed_at_rank(&overlay, wait_rank);
+
+        // GetRankStatus for the same failed proc reports Failed at its own
+        // message rank.
+        let get_rank = 3;
+        let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .get_rank_status(&client, id, resource::Rank::new(get_rank), port.bind())
+            .await
+            .unwrap();
+        let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
+            .await
+            .expect("reply timed out")
+            .expect("reply channel closed");
+        assert_overlay_failed_at_rank(&overlay, get_rank);
     }
 
     /// DrainHost with a host_mesh_id filter only stops procs
@@ -2542,22 +2717,28 @@ mod tests {
             },
         );
 
-        // Each of the num_per_host procs should reach Running.
+        // Each of the num_per_host procs should reach Running. Query each at a
+        // message rank distinct from its creation rank to prove positioning
+        // follows the message.
         for rank in 0..num_per_host {
             let id = proc_name(&proc_mesh_id, rank);
+            let message_rank = rank + 100;
             let (port, mut rx) = client.open_port::<crate::StatusOverlay>();
             host_agent
-                .wait_rank_status(&client, id.clone(), resource::Status::Running, port.bind())
+                .wait_rank_status(
+                    &client,
+                    id.clone(),
+                    resource::Rank::new(message_rank),
+                    resource::Status::Running,
+                    port.bind(),
+                )
                 .await
                 .unwrap();
             let overlay = tokio::time::timeout(Duration::from_secs(30), rx.recv())
                 .await
                 .unwrap_or_else(|_| panic!("proc {rank} did not reach Running"))
                 .expect("reply channel closed");
-            assert!(
-                !overlay.is_empty(),
-                "expected non-empty Running overlay for proc {rank}",
-            );
+            assert_overlay_at_rank(&overlay, message_rank);
 
             assert_matches!(
                 host_agent.get_state(&client, id).await.unwrap(),

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -46,6 +46,7 @@ use hyperactor::actor::ActorStoppingReason;
 use hyperactor::context;
 use hyperactor::gateway::GatewayServeHandle;
 use hyperactor::id::Label;
+use hyperactor::mailbox::MailboxSender as _;
 use hyperactor::value_mesh::ValueOverlay;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
@@ -1406,10 +1407,6 @@ impl Handler<ShutdownHost> for HostAgent {
             self.drain(cx, msg.timeout, msg.max_in_flight).await;
         }
 
-        // Reply this host's rank after children are terminated so the
-        // caller does not tear down the host's networking prematurely.
-        msg.ack.post(cx, rank);
-
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.
         match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
@@ -1421,6 +1418,22 @@ impl Handler<ShutdownHost> for HostAgent {
                 mut host,
                 shutdown_tx: Some(tx),
             }) => {
+                // Keep the host's outbound gateway alive until the direct
+                // shutdown acknowledgment has been flushed. The bootstrap
+                // task may stop the frontend as soon as it receives the
+                // handle below.
+                msg.ack.post(cx, rank);
+                let flush_timeout =
+                    hyperactor_config::global::get(hyperactor::config::FORWARDER_FLUSH_TIMEOUT);
+                match tokio::time::timeout(flush_timeout, host.gateway().flush()).await {
+                    Ok(Err(error)) => {
+                        tracing::warn!(%error, "gateway flush failed during host shutdown");
+                    }
+                    Err(_elapsed) => {
+                        tracing::warn!("gateway flush timed out during host shutdown");
+                    }
+                    Ok(Ok(())) => {}
+                }
                 tracing::info!(
                     proc_id = %cx.self_addr().proc_addr(),
                     actor_id = %cx.self_addr(),
@@ -1432,7 +1445,23 @@ impl Handler<ShutdownHost> for HostAgent {
                     handle.stop("bootstrap shutdown receiver dropped");
                 }
             }
-            _ => {}
+            HostAgentState::Detached(HostAgentMode::Local(mut host))
+            | HostAgentState::Attached(HostAgentMode::Local(mut host)) => {
+                let procs = [host.local_proc().clone(), host.system_proc().clone()];
+                let shutdown_client = Proc::global().client("local_host_shutdown");
+                // Continue outside the system proc so the final ack can be sent
+                // after that proc has stopped.
+                tokio::spawn(async move {
+                    for mut proc in procs {
+                        let _ = proc
+                            .destroy_and_wait(msg.timeout, "local host shutdown")
+                            .await;
+                    }
+                    host.shutdown_servers().await;
+                    msg.ack.post(&shutdown_client, rank);
+                });
+            }
+            _ => msg.ack.post(cx, rank),
         }
 
         Ok(())
@@ -1906,9 +1935,11 @@ mod tests {
 
     use super::*;
     use crate::bootstrap::ProcStatus;
+    use crate::host::LocalProcManager;
     use crate::mesh_id::ResourceId;
     use crate::resource::CreateOrUpdateClient;
     use crate::resource::GetStateClient;
+    use crate::resource::Rank;
     use crate::resource::WaitRankStatusClient;
 
     #[tokio::test]
@@ -1974,6 +2005,58 @@ mod tests {
               && mesh_agent == ActorRef::attest(expected_proc_addr.actor_addr(crate::proc_agent::PROC_AGENT_ACTOR_NAME))
               && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_local_host_stops_system_actors_before_ack() {
+        let spawn: ProcManagerSpawnFn =
+            Box::new(|proc| Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None))));
+        let host = Host::new(LocalProcManager::new(spawn), ChannelTransport::Unix.any())
+            .await
+            .unwrap();
+        let system_proc = host.system_proc().clone();
+        let host_agent = system_proc
+            .spawn_with_uid(
+                Uid::singleton(Label::new(HOST_MESH_AGENT_ACTOR_NAME).unwrap()),
+                HostAgent::new_local(host),
+            )
+            .unwrap();
+        HostAgent::wait_initialized(&host_agent).await.unwrap();
+        let cast_actor = system_proc
+            .spawn_with_uid(
+                Uid::singleton(Label::strip(hyperactor_cast::cast_actor::CAST_ACTOR_NAME)),
+                hyperactor_cast::cast_actor::CastActor::default(),
+            )
+            .unwrap();
+
+        let client_proc = Proc::direct(
+            ChannelTransport::Unix.any(),
+            "shutdown_test_client".to_string(),
+        )
+        .unwrap();
+        let client = client_proc.client("shutdown_test");
+        let (ack, mut ack_rx) = client.open_port::<usize>();
+        host_agent
+            .try_post(
+                &client,
+                ShutdownHost {
+                    timeout: Duration::from_secs(5),
+                    max_in_flight: 1,
+                    rank: Rank::new(0),
+                    ack: ack.bind().unsplit(),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(ack_rx.recv().await.unwrap(), 0);
+        assert!(
+            host_agent.status().borrow().is_terminal(),
+            "local HostAgent must stop before acknowledging shutdown"
+        );
+        assert!(
+            cast_actor.status().borrow().is_terminal(),
+            "local CastActor must stop before acknowledging shutdown"
         );
     }
 

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -64,6 +64,7 @@ use std::io;
 pub use actor_mesh::ActorMesh;
 pub use actor_mesh::ActorMeshRef;
 pub use bootstrap::Bootstrap;
+pub use bootstrap::HostBootstrapReady;
 pub use bootstrap::bootstrap;
 pub use bootstrap::bootstrap_or_die;
 pub use casting::CastError;

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1837,14 +1837,17 @@ mod tests {
         let program = crate::testresource::get("monarch/hyperactor_mesh/bootstrap");
         let mut host_addrs = vec![];
         let mut children = Vec::new();
+        let mut ready = Vec::new();
         for _ in 0..n {
             host_addrs.push(ChannelTransport::Unix.any());
         }
 
         for host in host_addrs.iter() {
+            let callback = crate::bootstrap::HostBootstrapReady::new(host.clone()).unwrap();
             let mut cmd = Command::new(program.clone());
             let boot = crate::Bootstrap::Host {
                 addr: host.clone(),
+                callback_addr: callback.callback_addr(),
                 command: None,
                 config: Some(hyperactor_config::global::attrs()),
                 exit_on_shutdown: false,
@@ -1857,6 +1860,10 @@ mod tests {
                 cmd.pre_exec(crate::bootstrap::install_pdeathsig_kill);
             }
             children.push(cmd.spawn().unwrap());
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await.unwrap();
         }
 
         let host_mesh = crate::HostMeshRef::from_hosts(

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1401,8 +1401,14 @@ impl Controlled for ProcMeshRef {
         cx: &impl context::Actor,
         msg: resource::WaitRankStatus,
     ) -> anyhow::Result<()> {
-        for proc_id in self.proc_ids() {
-            crate::host_mesh::host_agent_ref(proc_id.addr().clone()).post(cx, msg.clone());
+        // Direct fan-out (not a cast): one scalar rank cannot identify every
+        // recipient, so stamp each clone with the proc's rank in this view
+        // (RSP-2). `proc_ids()` follows the current-view `ranks` order, so the
+        // enumeration index is each recipient's consuming-view rank (RSP-1).
+        for (view_rank, proc_id) in self.proc_ids().enumerate() {
+            let mut msg = msg.clone();
+            msg.rank = resource::Rank::new(view_rank);
+            crate::host_mesh::host_agent_ref(proc_id.addr().clone()).post(cx, msg);
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -166,10 +166,10 @@ struct ActorInstanceState {
     /// operation (spawn, stop, supervision event). Used for last-writer-wins
     /// ordering in the mesh controller.
     generation: u64,
-    /// Pending `WaitRankStatus` callers: each entry is the minimum
-    /// status threshold and the reply port to send once the threshold
-    /// is met.
-    pending_wait_status: Vec<(resource::Status, PortRef<crate::StatusOverlay>)>,
+    /// Pending `WaitRankStatus` callers: each entry is the minimum status
+    /// threshold, the delivered view rank at which to position the reply
+    /// overlay, and the reply port to send once the threshold is met.
+    pending_wait_status: Vec<(resource::Status, usize, PortRef<crate::StatusOverlay>)>,
 }
 
 impl ActorInstanceState {
@@ -234,20 +234,23 @@ impl ActorInstanceState {
             subscriber.post_with_headers(cx, headers, state.clone());
         }
 
-        // One-shot waiters (predicated).
+        // One-shot waiters (predicated). Each retains the reply rank it was
+        // stashed with (RSP-3), positioned in the caller's view (RSP-1).
         let status = self.status();
-        self.pending_wait_status.retain(|(min_status, reply)| {
-            if status >= *min_status {
-                let rank = self.create_rank;
-                let overlay =
-                    crate::StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status.clone())])
-                        .expect("valid single-run overlay");
-                let _ = reply.post(cx, overlay);
-                false
-            } else {
-                true
-            }
-        });
+        self.pending_wait_status
+            .retain(|(min_status, rank, reply)| {
+                if status >= *min_status {
+                    let overlay = crate::StatusOverlay::try_from_runs(vec![(
+                        *rank..(*rank + 1),
+                        status.clone(),
+                    )])
+                    .expect("valid single-run overlay");
+                    let _ = reply.post(cx, overlay);
+                    false
+                } else {
+                    true
+                }
+            });
     }
 }
 
@@ -879,7 +882,9 @@ wirevalue::register_type!(ActorSpec);
 pub struct ActorState {
     /// The actor's ID.
     pub actor_id: ActorAddr,
-    /// The rank of the proc that created the actor. This is before any slicing.
+    /// The actor's dense rank in the view it was first created over. Stable for
+    /// the actor's lifetime and independent of any later view that reuses the
+    /// actor, so it is not the actor's rank in an overlapping or sliced view.
     pub create_rank: usize,
     // TODO status: ActorStatus,
     pub supervision_events: Vec<ActorSupervisionEvent>,
@@ -1023,20 +1028,17 @@ impl Handler<resource::GetRankStatus> for ProcAgent {
         get_rank_status: resource::GetRankStatus,
     ) -> anyhow::Result<()> {
         use crate::StatusOverlay;
-        use crate::resource::Status;
 
-        let (rank, status) = match self.actor_states.get(&get_rank_status.id) {
-            Some(state) => (state.create_rank, state.status()),
-            None => (usize::MAX, Status::NotExist),
-        };
-
-        // Send a sparse overlay update. If rank is unknown, emit an
-        // empty overlay.
-        let overlay = if rank == usize::MAX {
-            StatusOverlay::new()
-        } else {
-            StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
-                .expect("valid single-run overlay")
+        // Position the overlay at the rank the request carries (the recipient's
+        // rank in the caller's view), not the actor's first-creation rank (RSP-1);
+        // an absent actor yields an empty overlay (RSP-4).
+        let overlay = match self.actor_states.get(&get_rank_status.id) {
+            Some(state) => {
+                let rank = get_rank_status.rank.unwrap();
+                StatusOverlay::try_from_runs(vec![(rank..(rank + 1), state.status())])
+                    .expect("valid single-run overlay")
+            }
+            None => StatusOverlay::new(),
         };
         get_rank_status.reply.post(cx, overlay);
         Ok(())
@@ -1051,29 +1053,31 @@ impl Handler<resource::WaitRankStatus> for ProcAgent {
         msg: resource::WaitRankStatus,
     ) -> anyhow::Result<()> {
         use crate::StatusOverlay;
-        use crate::resource::Status;
 
-        let (rank, status) = match self.actor_states.get(&msg.id) {
-            Some(state) => (state.create_rank, state.status()),
-            None => (usize::MAX, Status::NotExist),
+        // The request carries the reply rank (the recipient's rank in the
+        // caller's view) (RSP-1); a deferred waiter retains it, since the cast
+        // context is gone by flush time (RSP-3). An absent actor replies with an
+        // empty overlay (RSP-4).
+        let Some(status) = self.actor_states.get(&msg.id).map(|state| state.status()) else {
+            let _ = msg.reply.post(cx, StatusOverlay::new());
+            return Ok(());
         };
+        let rank = msg.rank.unwrap();
 
         // If already at or past the requested threshold, reply immediately.
-        if status >= msg.min_status || rank == usize::MAX {
-            let overlay = if rank == usize::MAX {
-                StatusOverlay::new()
-            } else {
-                StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
-                    .expect("valid single-run overlay")
-            };
+        if status >= msg.min_status {
+            let overlay = StatusOverlay::try_from_runs(vec![(rank..(rank + 1), status)])
+                .expect("valid single-run overlay");
             let _ = msg.reply.post(cx, overlay);
             return Ok(());
         }
 
-        // Otherwise, stash the waiter. It will be flushed when the
-        // status changes (supervision event or stop).
+        // Otherwise, stash the waiter with its reply rank. It will be flushed
+        // when the status changes (supervision event or stop).
         if let Some(state) = self.actor_states.get_mut(&msg.id) {
-            state.pending_wait_status.push((msg.min_status, msg.reply));
+            state
+                .pending_wait_status
+                .push((msg.min_status, rank, msg.reply));
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -719,6 +719,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -811,6 +812,7 @@ mod tests {
             // The bootstrap payload content doesn't matter for this test.
             let bootstrap = Bootstrap::Host {
                 addr: any_unix_addr(),
+                callback_addr: any_unix_addr(),
                 command: None,
                 config: None,
                 exit_on_shutdown: false,
@@ -850,6 +852,7 @@ mod tests {
             // The bootstrap payload content doesn't matter for this test.
             let bootstrap = Bootstrap::Host {
                 addr: any_unix_addr(),
+                callback_addr: any_unix_addr(),
                 command: None,
                 config: None,
                 exit_on_shutdown: false,
@@ -893,6 +896,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -937,6 +941,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1014,6 +1019,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1107,6 +1113,7 @@ while True:
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1194,6 +1194,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1295,6 +1296,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1342,6 +1344,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1409,6 +1412,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1584,6 +1588,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1691,6 +1696,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -825,6 +825,8 @@ impl ProcMeshRef {
             cx,
             resource::GetRankStatus {
                 id: actor_mesh_id.resource_id().clone(),
+                // Filled by the cast layer with this recipient's dense view rank.
+                rank: Default::default(),
                 reply,
             },
         )?;
@@ -1036,6 +1038,8 @@ impl ProcMeshRef {
             cx,
             resource::WaitRankStatus {
                 id: actor_mesh_id.resource_id().clone(),
+                // Filled by the cast layer with this recipient's dense view rank.
+                rank: Default::default(),
                 min_status: Status::Stopped,
                 reply: port.bind(),
             },
@@ -1151,6 +1155,8 @@ fn python_class_from_supervision_name(sdn: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     #[cfg(fbcode_build)]
+    use std::collections::HashSet;
+    #[cfg(fbcode_build)]
     use std::ops::Deref;
     #[cfg(fbcode_build)]
     use std::time::Duration;
@@ -1158,11 +1164,17 @@ mod tests {
     #[cfg(fbcode_build)]
     use hyperactor::Instance;
     #[cfg(fbcode_build)]
+    use hyperactor::accum::StreamingReducerOpts;
+    #[cfg(fbcode_build)]
     use hyperactor::config::ENABLE_DEST_ACTOR_REORDERING_BUFFER;
+    #[cfg(fbcode_build)]
+    use hyperactor::context::Mailbox;
     #[cfg(fbcode_build)]
     use ndslice::ViewExt as _;
     #[cfg(fbcode_build)]
     use ndslice::extent;
+    #[cfg(fbcode_build)]
+    use ndslice::view::Ranked as _;
     #[cfg(fbcode_build)]
     use timed_test::assert_no_process_leak;
     #[cfg(fbcode_build)]
@@ -1170,6 +1182,8 @@ mod tests {
     #[cfg(fbcode_build)]
     use uuid::Uuid;
 
+    #[cfg(fbcode_build)]
+    use super::ACTOR_SPAWN_MAX_IDLE;
     #[cfg(fbcode_build)]
     use crate::ActorMesh;
     #[cfg(fbcode_build)]
@@ -1200,6 +1214,146 @@ mod tests {
         testactor::assert_mesh_shape(actor_mesh).await;
 
         let _ = hm.shutdown(instance).await;
+    }
+
+    /// Reuse a per-proc singleton service across two overlapping proc-mesh views
+    /// whose shared proc is renumbered — a whole view and a `gpus` sub-slice, so
+    /// the shared proc (gpu 1) is rank 1 in the whole and rank 0 in the slice.
+    /// `spawn_service` creates one deduped actor per proc, so the slice must
+    /// keep the whole's actor on the shared proc.
+    ///
+    /// One `host_mesh(1)` fixture drives three uniquely-named scenarios to keep
+    /// the harness footprint minimal (one Tokio runtime, one host process, no
+    /// process-global config override): reuse whole-then-slice, reuse
+    /// slice-then-whole, and a deferred `WaitRankStatus` over the slice. Each
+    /// spawn must resolve (a reused spawn positions its readiness overlay at the
+    /// consuming-view rank, so the accumulator completes), the slice must
+    /// reference the whole's shared actor with no new actors, and a Stopped-waiter
+    /// registered while the service runs must flush at slice-local ranks.
+    /// The assertions exercise the ProcAgent readiness path; the per-view
+    /// controllers remain idle because this test does not trigger supervision.
+    #[async_timed_test(timeout_secs = 120)]
+    #[cfg(fbcode_build)]
+    async fn test_singleton_service_reuse_over_overlapping_views() {
+        let instance = testing::instance();
+        let mut hm = testing::host_mesh(1).await;
+        let proc_mesh = hm
+            .spawn(&instance, "test", extent!(gpus = 2), None, None)
+            .await
+            .unwrap();
+        let whole = proc_mesh.deref().clone();
+        let slice = proc_mesh.range("gpus", 1..2).unwrap();
+
+        // The slice reuses the whole's actor on the shared proc; no new actors.
+        fn assert_shared(
+            whole_mesh: &ActorMesh<testactor::TestActor>,
+            slice_mesh: &ActorMesh<testactor::TestActor>,
+        ) {
+            let whole_ids: HashSet<_> = whole_mesh
+                .values()
+                .map(|actor_ref| actor_ref.actor_addr().id().clone())
+                .collect();
+            let slice_ids: HashSet<_> = slice_mesh
+                .values()
+                .map(|actor_ref| actor_ref.actor_addr().id().clone())
+                .collect();
+            assert_eq!(whole_ids.len(), 2, "whole view spans two procs");
+            assert_eq!(slice_ids.len(), 1, "slice spans one proc");
+            assert!(
+                slice_ids.is_subset(&whole_ids),
+                "slice reuses the shared proc's actor: {slice_ids:?} vs {whole_ids:?}",
+            );
+            assert_eq!(
+                whole_ids.union(&slice_ids).count(),
+                2,
+                "no new actors created for the overlapping slice",
+            );
+        }
+
+        // Scenario 1: spawn over the whole, then reuse over the renumbered slice.
+        let w1 = whole
+            .spawn_service::<testactor::TestActor, _>(instance, "svc_whole_first", &())
+            .await
+            .unwrap();
+        let s1 = slice
+            .spawn_service::<testactor::TestActor, _>(instance, "svc_whole_first", &())
+            .await
+            .unwrap();
+        assert_shared(&w1, &s1);
+
+        // Scenario 2: spawn over the slice first, then reuse over the whole.
+        let s2 = slice
+            .spawn_service::<testactor::TestActor, _>(instance, "svc_slice_first", &())
+            .await
+            .unwrap();
+        let w2 = whole
+            .spawn_service::<testactor::TestActor, _>(instance, "svc_slice_first", &())
+            .await
+            .unwrap();
+        assert_shared(&w2, &s2);
+
+        // Scenario 3: a `WaitRankStatus{Stopped}` registered over the renumbered
+        // slice while the service runs is deferred and flushed on stop. The
+        // flushed overlays land at slice-local ranks, within the slice region the
+        // accumulator was opened over, so the wait completes. Registering before
+        // the stop makes the deferred branch deterministic.
+        whole
+            .spawn_service::<testactor::TestActor, _>(instance, "svc_wait", &())
+            .await
+            .unwrap();
+        let sw = slice
+            .spawn_service::<testactor::TestActor, _>(instance, "svc_wait", &())
+            .await
+            .unwrap();
+        let id = sw.id().resource_id().clone();
+        let region = slice.region().clone();
+        let num_ranks = region.num_ranks();
+        let (port, rx) = instance.mailbox().open_accum_port_opts(
+            crate::StatusMesh::from_single(region.clone(), Status::NotExist),
+            StreamingReducerOpts {
+                max_update_interval: Some(Duration::from_millis(50)),
+                initial_update_interval: None,
+            },
+        );
+        slice
+            .agent_mesh()
+            .cast(
+                instance,
+                crate::resource::WaitRankStatus {
+                    id: id.clone(),
+                    // Filled by the cast layer with this recipient's dense view rank.
+                    rank: Default::default(),
+                    min_status: Status::Stopped,
+                    reply: port.bind(),
+                },
+            )
+            .unwrap();
+        slice
+            .agent_mesh()
+            .cast(
+                instance,
+                crate::resource::Stop {
+                    id: id.clone(),
+                    reason: "test".to_string(),
+                },
+            )
+            .unwrap();
+        let statuses = crate::resource::GetRankStatus::wait(
+            rx,
+            num_ranks,
+            hyperactor_config::global::get(ACTOR_SPAWN_MAX_IDLE),
+            region,
+        )
+        .await
+        .unwrap();
+        assert!(
+            statuses.values().all(|s| s.is_terminating()),
+            "deferred waiters flushed at slice-local ranks: {statuses:?}",
+        );
+
+        hm.shutdown(instance)
+            .await
+            .expect("host mesh shutdown should complete");
     }
 
     #[async_timed_test(timeout_secs = 120)]

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -8,6 +8,32 @@
 
 //! This modules defines a set of common message types used for managing resources
 //! in hyperactor meshes.
+//!
+//! # Rank-status positioning (`RSP-*`)
+//!
+//! Status queries ([`GetRankStatus`], [`WaitRankStatus`]) reply with a
+//! [`StatusOverlay`] — a sparse, rank-indexed patch the caller merges into an
+//! accumulator over its own view. Positioning that overlay is the contract this
+//! registry names; each invariant is cited at the sites that must uphold it.
+//!
+//! - **RSP-1** — an overlay is positioned at the recipient's dense rank in the
+//!   *consuming* view (the one the caller accumulates over), never the rank the
+//!   resource was first created under. Reusing the creation rank mis-attributes
+//!   or drops the reply over a renumbered or sliced view.
+//! - **RSP-2** — the positioning rank travels as the [`Rank`] message field. Cast
+//!   sites leave it `Rank::default()` and the cast layer late-binds it in transit
+//!   with the delivered dense rank; direct (non-cast) delivery supplies it
+//!   explicitly with `Rank::new(view_rank)`.
+//! - **RSP-3** — a deferred waiter (a [`WaitRankStatus`] below its threshold, or
+//!   one registered before its resource exists) retains its registration rank
+//!   until it is flushed; the flush never rewrites it to a creation rank.
+//! - **RSP-4** — when a handler reports absence *immediately*, it returns an
+//!   empty overlay; the message's [`Rank`] is never overloaded as an absence
+//!   signal. `WaitRankStatus` may instead defer when later creation is expected
+//!   (RSP-3), replying once the resource exists.
+//!
+//! `ActorState` streaming supervision must satisfy the analogous positioning
+//! contract; extending this registry to cover `ActorState` is future work.
 
 pub mod mesh;
 
@@ -196,12 +222,12 @@ impl Rank {
     }
 }
 
-/// Get the status of a resource across the mesh.
+/// Get the status of a resource.
 ///
-/// This message is cast to all ranks; each rank replies with a sparse
-/// status **overlay**. The comm reducer merges overlays (right-wins)
-/// and the accumulator applies them to produce **full StatusMesh
-/// snapshots** on the receiver side.
+/// Delivered either by cast to every rank or by direct point-to-point send to a
+/// chosen recipient. Each recipient replies with a sparse status **overlay**.
+/// The comm reducer merges overlays (right-wins) and the accumulator applies
+/// them to produce **full StatusMesh snapshots** on the receiver side.
 #[derive(
     Clone,
     Debug,
@@ -215,6 +241,11 @@ impl Rank {
 pub struct GetRankStatus {
     /// The resource identifier.
     pub id: ResourceId,
+    /// The rank at which the recipient positions its reply overlay, in the
+    /// caller's view (RSP-1, RSP-2). Cast sites leave this `Rank::default()` and
+    /// the cast layer rewrites it in transit with the delivered dense rank;
+    /// direct (non-cast) callers set it explicitly with `Rank::new(...)`.
+    pub rank: Rank,
     /// Sparse status updates (overlays) from a rank.
     pub reply: PortRef<StatusOverlay>,
 }
@@ -235,6 +266,12 @@ pub struct GetRankStatus {
 pub struct WaitRankStatus {
     /// The resource identifier.
     pub id: ResourceId,
+    /// The rank at which the recipient positions its reply overlay, in the
+    /// caller's view (RSP-1, RSP-2). Cast sites leave this `Rank::default()` and
+    /// the cast layer rewrites it in transit with the delivered dense rank;
+    /// direct (non-cast) callers set it explicitly with `Rank::new(...)`. A
+    /// deferred waiter retains this rank until it is flushed (RSP-3).
+    pub rank: Rank,
     /// The minimum status the caller wants to observe.
     /// The handler will not reply until the resource's status
     /// is >= this threshold.

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -43,6 +43,8 @@ use crate::Bootstrap;
 #[cfg(fbcode_build)]
 use crate::HostMeshRef;
 #[cfg(fbcode_build)]
+use crate::bootstrap::HostBootstrapReady;
+#[cfg(fbcode_build)]
 use crate::host_mesh::HostMesh;
 #[cfg(fbcode_build)]
 use crate::host_mesh::HostMeshShutdownGuard;
@@ -307,10 +309,13 @@ pub async fn host_mesh(n: usize) -> HostMeshShutdownGuard {
         host_addrs.push(ChannelTransport::Unix.any());
     }
 
+    let mut ready = Vec::with_capacity(n);
     for host in host_addrs.iter() {
+        let callback = HostBootstrapReady::new(host.clone()).unwrap();
         let mut cmd = Command::new(program.clone());
         let boot = Bootstrap::Host {
             addr: host.clone(),
+            callback_addr: callback.callback_addr(),
             command: None, // use current binary
             config: None,
             exit_on_shutdown: false,
@@ -324,6 +329,10 @@ pub async fn host_mesh(n: usize) -> HostMeshShutdownGuard {
             cmd.pre_exec(crate::bootstrap::install_pdeathsig_kill);
         }
         cmd.spawn().unwrap();
+        ready.push(callback);
+    }
+    for callback in ready {
+        callback.wait().await.unwrap();
     }
 
     let host_mesh = HostMeshRef::from_hosts(

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -74,6 +74,7 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::Bootstrap;
+use hyperactor_mesh::HostBootstrapReady;
 use hyperactor_mesh::HostMeshRef;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::context;
@@ -846,10 +847,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
     let host_addrs = [free_localhost_addr(), free_localhost_addr()];
     let mut children = Vec::new();
+    let mut ready = Vec::new();
     for host in host_addrs.iter() {
+        let callback = HostBootstrapReady::new(host.clone())?;
         let mut cmd = Command::new(program.clone());
         let boot = Bootstrap::Host {
             addr: host.clone(),
+            callback_addr: callback.callback_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -857,6 +861,10 @@ pub async fn run() -> Result<(), anyhow::Error> {
         boot.to_env(&mut cmd);
         cmd.kill_on_drop(true);
         children.push(cmd.spawn().unwrap());
+        ready.push(callback);
+    }
+    for callback in ready {
+        callback.wait().await?;
     }
 
     // Create separate host meshes for each device to maintain different configs

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -73,6 +73,7 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::Bootstrap;
+use hyperactor_mesh::HostBootstrapReady;
 use hyperactor_mesh::HostMeshRef;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::context;
@@ -505,8 +506,10 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
         buck_resources::get("monarch/monarch_rdma/examples/parameter_server/bootstrap").unwrap(),
     );
     let host_addr = ChannelTransport::Unix.any();
+    let callback = HostBootstrapReady::new(host_addr.clone())?;
     let boot = Bootstrap::Host {
         addr: host_addr.clone(),
+        callback_addr: callback.callback_addr(),
         command: None, // use current binary
         config: None,
         exit_on_shutdown: false,
@@ -514,6 +517,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     boot.to_env(&mut command);
     command.kill_on_drop(true);
     let _child = command.spawn().unwrap();
+    callback.wait().await?;
 
     let host_mesh = HostMeshRef::from_hosts(
         HostMeshId::instance(Label::new("test").unwrap()),


### PR DESCRIPTION
Summary:

this is a bug fix.

`GetRankStatus` and `WaitRankStatus` handlers previously positioned reply overlays at the resource's first-creation rank. when a per-proc singleton is reused through a renumbered or sliced view, that historical rank differs from the recipient's position in the consuming view. the overlay is then mis-attributed or dropped out of bounds, leaving the readiness accumulator incomplete.

this adds `rank: resource::Rank` to both messages and positions every reply overlay from that field. cast sites use `Rank::default()` and the existing multipart rewrite fills the recipient's delivered dense rank in transit, as it already does for `CreateOrUpdate`. direct delivery through `ProcMeshRef::forward_wait_rank_status` and `HostMeshRef::stop_proc_mesh` supplies `Rank::new(view_rank)`. `ProcAgent` and `HostAgent` consume the message field, and deferred waiters retain their registration rank.

the `RSP-*` registry in `resource.rs` records the positioning, delivery, deferred-waiter, and immediate-absence contracts. differential tests exercise message ranks distinct from creation ranks.

this changes the internal wire layout of `GetRankStatus` and `WaitRankStatus`. these are same-build control-plane messages, so senders and receivers update together.

Reviewed By: thomasywang, pzhan9

Differential Revision: D112401436


