### PR TITLE
make host test lifecycles deterministic (#4436)

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -373,6 +373,9 @@ pub enum Bootstrap {
     Host {
         /// The address on which to serve the host.
         addr: ChannelAddr,
+        /// Callback used to publish host readiness after the [`HostAgent`] and
+        /// cast actor are bound.
+        callback_addr: ChannelAddr,
         /// If specified, use the provided command instead of
         /// [`BootstrapCommand::current`].
         command: Option<BootstrapCommand>,
@@ -384,6 +387,51 @@ pub enum Bootstrap {
         /// If true, exit the process after handling a shutdown request.
         exit_on_shutdown: bool,
     },
+}
+
+/// Parent side of the host-bootstrap readiness callback.
+pub struct HostBootstrapReady {
+    host_addr: ChannelAddr,
+    callback_addr: ChannelAddr,
+    callback_rx: hyperactor::channel::ChannelRx<()>,
+}
+
+impl HostBootstrapReady {
+    pub fn new(host_addr: ChannelAddr) -> Result<Self, ChannelError> {
+        let (callback_addr, callback_rx) =
+            channel::serve(ChannelAddr::any(ChannelTransport::Unix))?;
+        Ok(Self {
+            host_addr,
+            callback_addr,
+            callback_rx,
+        })
+    }
+
+    pub fn callback_addr(&self) -> ChannelAddr {
+        self.callback_addr.clone()
+    }
+
+    pub async fn wait(mut self) -> anyhow::Result<()> {
+        let timeout = hyperactor_config::global::get(hyperactor::config::HOST_SPAWN_READY_TIMEOUT);
+        if timeout.is_zero() {
+            self.callback_rx.recv().await.with_context(|| {
+                format!("host {} closed its bootstrap callback", self.host_addr)
+            })?;
+        } else {
+            tokio::time::timeout(timeout, self.callback_rx.recv())
+                .await
+                .with_context(|| {
+                    format!(
+                        "host {} did not become ready within {:?}",
+                        self.host_addr, timeout
+                    )
+                })?
+                .with_context(|| {
+                    format!("host {} closed its bootstrap callback", self.host_addr)
+                })?;
+        }
+        Ok(())
+    }
 }
 
 impl Bootstrap {
@@ -550,6 +598,7 @@ impl Bootstrap {
             }
             Bootstrap::Host {
                 addr,
+                callback_addr,
                 command,
                 config,
                 exit_on_shutdown,
@@ -564,6 +613,10 @@ impl Bootstrap {
                     None,
                 )
                 .await?;
+                channel::dial(callback_addr)?
+                    .send(())
+                    .await
+                    .map_err(ChannelError::from)?;
                 shutdown.join().await;
                 halt().await
             }
@@ -2375,6 +2428,43 @@ mod tests {
 
     use super::*;
 
+    #[tokio::test]
+    async fn test_host_bootstrap_ready_callback() {
+        let host_addr = ChannelAddr::any(ChannelTransport::Unix);
+        let ready = HostBootstrapReady::new(host_addr).expect("open readiness callback");
+        let callback_addr = ready.callback_addr();
+        let sender = tokio::spawn(async move {
+            channel::dial(callback_addr)
+                .expect("dial readiness callback")
+                .send(())
+                .await
+                .expect("send readiness callback");
+        });
+
+        ready.wait().await.expect("receive readiness callback");
+        sender.await.expect("readiness sender task");
+    }
+
+    #[tokio::test]
+    async fn test_host_bootstrap_ready_times_out_without_callback() {
+        let config = hyperactor_config::global::lock();
+        let _timeout = config.override_key(
+            hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
+            Duration::from_millis(20),
+        );
+        let host_addr = ChannelAddr::any(ChannelTransport::Unix);
+        let ready = HostBootstrapReady::new(host_addr).expect("open readiness callback");
+
+        let error = ready
+            .wait()
+            .await
+            .expect_err("missing callback must fail closed");
+        assert!(
+            error.to_string().contains("did not become ready"),
+            "unexpected readiness error: {error:#}"
+        );
+    }
+
     #[test]
     fn test_bootstrap_mode_env_string_none_config_proc() {
         let value = Bootstrap::Proc {
@@ -2404,6 +2494,7 @@ mod tests {
     fn test_bootstrap_mode_env_string_none_config_host() {
         let value = Bootstrap::Host {
             addr: ChannelAddr::any(ChannelTransport::Unix),
+            callback_addr: ChannelAddr::any(ChannelTransport::Unix),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -2463,6 +2554,7 @@ mod tests {
         {
             let original = Bootstrap::Host {
                 addr: ChannelAddr::any(ChannelTransport::Unix),
+                callback_addr: ChannelAddr::any(ChannelTransport::Unix),
                 command: None,
                 config: Some(attrs.clone()),
                 exit_on_shutdown: false,

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -427,6 +427,28 @@ impl<M: ProcManager> Host<M> {
     pub(crate) fn take_frontend_handle(&mut self) -> Option<GatewayServeHandle> {
         self.frontend_handle.take()
     }
+
+    /// Stop and join every gateway server owned by this host.
+    pub(crate) async fn shutdown_servers(&mut self) {
+        if let Some(mut handle) = self.frontend_handle.take() {
+            handle.stop("host shutdown");
+            if let Err(error) = handle.join().await {
+                tracing::warn!(%error, "failed to join host frontend server");
+            }
+        }
+        if let Some(mut handle) = self.backend_handle.take() {
+            handle.stop("host shutdown");
+            if let Err(error) = handle.join().await {
+                tracing::warn!(%error, "failed to join host backend server");
+            }
+        }
+        if let Some(mut handle) = self.via_handle.take() {
+            handle.stop("host shutdown");
+            if let Err(error) = handle.join().await {
+                tracing::warn!(%error, "failed to join host via server");
+            }
+        }
+    }
 }
 
 impl<M> Drop for Host<M> {

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -94,6 +94,7 @@ use crate::ProcMesh;
 use crate::ValueMesh;
 use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcManager;
+use crate::bootstrap::HostBootstrapReady;
 use crate::bootstrap::ProcBind;
 use crate::host::Host;
 use crate::host::LocalProcManager;
@@ -455,11 +456,13 @@ impl HostMesh {
 
         let bind_spec = hyperactor_config::global::get_cloned(DEFAULT_TRANSPORT);
         let mut host_addrs = Vec::with_capacity(extent.num_ranks());
+        let mut ready = Vec::with_capacity(extent.num_ranks());
         for _ in 0..extent.num_ranks() {
-            // Note: this can be racy. Possibly we should have a callback channel.
             let addr = bind_spec.binding_addr();
+            let callback = HostBootstrapReady::new(addr.clone())?;
             let bootstrap = Bootstrap::Host {
                 addr: addr.clone(),
+                callback_addr: callback.callback_addr(),
                 command: Some(command.clone()),
                 config: Some(hyperactor_config::global::attrs()),
                 exit_on_shutdown: false,
@@ -469,6 +472,10 @@ impl HostMesh {
             bootstrap.to_env(&mut cmd);
             cmd.spawn()?;
             host_addrs.push(addr);
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await?;
         }
 
         let host_mesh_ref = HostMeshRef::new(
@@ -1955,10 +1962,13 @@ mod tests {
         let hosts = vec![free_localhost_addr(), free_localhost_addr()];
 
         let mut children = Vec::new();
+        let mut ready = Vec::new();
         for host in hosts.iter() {
+            let callback = HostBootstrapReady::new(host.clone()).unwrap();
             let mut cmd = Command::new(program.clone());
             let boot = Bootstrap::Host {
                 addr: host.clone(),
+                callback_addr: callback.callback_addr(),
                 command: None, // use current binary
                 config: None,
                 exit_on_shutdown: false,
@@ -1966,6 +1976,10 @@ mod tests {
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await.unwrap();
         }
 
         let instance = testing::instance();
@@ -2039,10 +2053,13 @@ mod tests {
         let hosts = vec![free_localhost_addr(), free_localhost_addr()];
 
         let mut children = Vec::new();
+        let mut ready = Vec::new();
         for host in hosts.iter() {
+            let callback = HostBootstrapReady::new(host.clone()).unwrap();
             let mut cmd = Command::new(program.clone());
             let boot = Bootstrap::Host {
                 addr: host.clone(),
+                callback_addr: callback.callback_addr(),
                 config: None,
                 // The entire purpose of this is to fail:
                 command: Some(BootstrapCommand::from("false")),
@@ -2051,6 +2068,10 @@ mod tests {
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await.unwrap();
         }
         let host_mesh =
             HostMeshRef::from_hosts(HostMeshId::singleton(Label::new("test").unwrap()), hosts);
@@ -2080,8 +2101,10 @@ mod tests {
         let hosts = vec![free_localhost_addr(), free_localhost_addr()];
 
         let mut children = Vec::new();
+        let mut ready = Vec::new();
 
         for (index, host) in hosts.iter().enumerate() {
+            let callback = HostBootstrapReady::new(host.clone()).unwrap();
             let mut cmd = Command::new(program.clone());
             let command = if index == 0 {
                 let mut command = BootstrapCommand::from("sleep");
@@ -2092,6 +2115,7 @@ mod tests {
             };
             let boot = Bootstrap::Host {
                 addr: host.clone(),
+                callback_addr: callback.callback_addr(),
                 config: None,
                 command,
                 exit_on_shutdown: false,
@@ -2099,6 +2123,10 @@ mod tests {
             boot.to_env(&mut cmd);
             cmd.kill_on_drop(true);
             children.push(cmd.spawn().unwrap());
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await.unwrap();
         }
         let host_mesh =
             HostMeshRef::from_hosts(HostMeshId::singleton(Label::new("test").unwrap()), hosts);

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -46,6 +46,7 @@ use hyperactor::actor::ActorStoppingReason;
 use hyperactor::context;
 use hyperactor::gateway::GatewayServeHandle;
 use hyperactor::id::Label;
+use hyperactor::mailbox::MailboxSender as _;
 use hyperactor::value_mesh::ValueOverlay;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::Attrs;
@@ -1406,10 +1407,6 @@ impl Handler<ShutdownHost> for HostAgent {
             self.drain(cx, msg.timeout, msg.max_in_flight).await;
         }
 
-        // Reply this host's rank after children are terminated so the
-        // caller does not tear down the host's networking prematurely.
-        msg.ack.post(cx, rank);
-
         // Drop the host and signal the bootstrap loop to drain the
         // mailbox and exit.
         match std::mem::replace(&mut self.state, HostAgentState::Shutdown) {
@@ -1421,6 +1418,22 @@ impl Handler<ShutdownHost> for HostAgent {
                 mut host,
                 shutdown_tx: Some(tx),
             }) => {
+                // Keep the host's outbound gateway alive until the direct
+                // shutdown acknowledgment has been flushed. The bootstrap
+                // task may stop the frontend as soon as it receives the
+                // handle below.
+                msg.ack.post(cx, rank);
+                let flush_timeout =
+                    hyperactor_config::global::get(hyperactor::config::FORWARDER_FLUSH_TIMEOUT);
+                match tokio::time::timeout(flush_timeout, host.gateway().flush()).await {
+                    Ok(Err(error)) => {
+                        tracing::warn!(%error, "gateway flush failed during host shutdown");
+                    }
+                    Err(_elapsed) => {
+                        tracing::warn!("gateway flush timed out during host shutdown");
+                    }
+                    Ok(Ok(())) => {}
+                }
                 tracing::info!(
                     proc_id = %cx.self_addr().proc_addr(),
                     actor_id = %cx.self_addr(),
@@ -1432,7 +1445,23 @@ impl Handler<ShutdownHost> for HostAgent {
                     handle.stop("bootstrap shutdown receiver dropped");
                 }
             }
-            _ => {}
+            HostAgentState::Detached(HostAgentMode::Local(mut host))
+            | HostAgentState::Attached(HostAgentMode::Local(mut host)) => {
+                let procs = [host.local_proc().clone(), host.system_proc().clone()];
+                let shutdown_client = Proc::global().client("local_host_shutdown");
+                // Continue outside the system proc so the final ack can be sent
+                // after that proc has stopped.
+                tokio::spawn(async move {
+                    for mut proc in procs {
+                        let _ = proc
+                            .destroy_and_wait(msg.timeout, "local host shutdown")
+                            .await;
+                    }
+                    host.shutdown_servers().await;
+                    msg.ack.post(&shutdown_client, rank);
+                });
+            }
+            _ => msg.ack.post(cx, rank),
         }
 
         Ok(())
@@ -1906,9 +1935,11 @@ mod tests {
 
     use super::*;
     use crate::bootstrap::ProcStatus;
+    use crate::host::LocalProcManager;
     use crate::mesh_id::ResourceId;
     use crate::resource::CreateOrUpdateClient;
     use crate::resource::GetStateClient;
+    use crate::resource::Rank;
     use crate::resource::WaitRankStatusClient;
 
     #[tokio::test]
@@ -1974,6 +2005,58 @@ mod tests {
               && mesh_agent == ActorRef::attest(expected_proc_addr.actor_addr(crate::proc_agent::PROC_AGENT_ACTOR_NAME))
               && bootstrap_command == Some(BootstrapCommand::test())
               && mesh_agent == proc_status_mesh_agent
+        );
+    }
+
+    #[tokio::test]
+    async fn shutdown_local_host_stops_system_actors_before_ack() {
+        let spawn: ProcManagerSpawnFn =
+            Box::new(|proc| Box::pin(std::future::ready(ProcAgent::boot_v1(proc, None))));
+        let host = Host::new(LocalProcManager::new(spawn), ChannelTransport::Unix.any())
+            .await
+            .unwrap();
+        let system_proc = host.system_proc().clone();
+        let host_agent = system_proc
+            .spawn_with_uid(
+                Uid::singleton(Label::new(HOST_MESH_AGENT_ACTOR_NAME).unwrap()),
+                HostAgent::new_local(host),
+            )
+            .unwrap();
+        HostAgent::wait_initialized(&host_agent).await.unwrap();
+        let cast_actor = system_proc
+            .spawn_with_uid(
+                Uid::singleton(Label::strip(hyperactor_cast::cast_actor::CAST_ACTOR_NAME)),
+                hyperactor_cast::cast_actor::CastActor::default(),
+            )
+            .unwrap();
+
+        let client_proc = Proc::direct(
+            ChannelTransport::Unix.any(),
+            "shutdown_test_client".to_string(),
+        )
+        .unwrap();
+        let client = client_proc.client("shutdown_test");
+        let (ack, mut ack_rx) = client.open_port::<usize>();
+        host_agent
+            .try_post(
+                &client,
+                ShutdownHost {
+                    timeout: Duration::from_secs(5),
+                    max_in_flight: 1,
+                    rank: Rank::new(0),
+                    ack: ack.bind().unsplit(),
+                },
+            )
+            .unwrap();
+
+        assert_eq!(ack_rx.recv().await.unwrap(), 0);
+        assert!(
+            host_agent.status().borrow().is_terminal(),
+            "local HostAgent must stop before acknowledging shutdown"
+        );
+        assert!(
+            cast_actor.status().borrow().is_terminal(),
+            "local CastActor must stop before acknowledging shutdown"
         );
     }
 

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -64,6 +64,7 @@ use std::io;
 pub use actor_mesh::ActorMesh;
 pub use actor_mesh::ActorMeshRef;
 pub use bootstrap::Bootstrap;
+pub use bootstrap::HostBootstrapReady;
 pub use bootstrap::bootstrap;
 pub use bootstrap::bootstrap_or_die;
 pub use casting::CastError;

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -1837,14 +1837,17 @@ mod tests {
         let program = crate::testresource::get("monarch/hyperactor_mesh/bootstrap");
         let mut host_addrs = vec![];
         let mut children = Vec::new();
+        let mut ready = Vec::new();
         for _ in 0..n {
             host_addrs.push(ChannelTransport::Unix.any());
         }
 
         for host in host_addrs.iter() {
+            let callback = crate::bootstrap::HostBootstrapReady::new(host.clone()).unwrap();
             let mut cmd = Command::new(program.clone());
             let boot = crate::Bootstrap::Host {
                 addr: host.clone(),
+                callback_addr: callback.callback_addr(),
                 command: None,
                 config: Some(hyperactor_config::global::attrs()),
                 exit_on_shutdown: false,
@@ -1857,6 +1860,10 @@ mod tests {
                 cmd.pre_exec(crate::bootstrap::install_pdeathsig_kill);
             }
             children.push(cmd.spawn().unwrap());
+            ready.push(callback);
+        }
+        for callback in ready {
+            callback.wait().await.unwrap();
         }
 
         let host_mesh = crate::HostMeshRef::from_hosts(

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -719,6 +719,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -811,6 +812,7 @@ mod tests {
             // The bootstrap payload content doesn't matter for this test.
             let bootstrap = Bootstrap::Host {
                 addr: any_unix_addr(),
+                callback_addr: any_unix_addr(),
                 command: None,
                 config: None,
                 exit_on_shutdown: false,
@@ -850,6 +852,7 @@ mod tests {
             // The bootstrap payload content doesn't matter for this test.
             let bootstrap = Bootstrap::Host {
                 addr: any_unix_addr(),
+                callback_addr: any_unix_addr(),
                 command: None,
                 config: None,
                 exit_on_shutdown: false,
@@ -893,6 +896,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -937,6 +941,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1014,6 +1019,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1107,6 +1113,7 @@ while True:
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,

--- a/hyperactor_mesh/src/proc_launcher/systemd.rs
+++ b/hyperactor_mesh/src/proc_launcher/systemd.rs
@@ -1194,6 +1194,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1295,6 +1296,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1342,6 +1344,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1409,6 +1412,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1584,6 +1588,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -1691,6 +1696,7 @@ mod tests {
         // The bootstrap payload content doesn't matter for this test.
         let bootstrap = Bootstrap::Host {
             addr: any_unix_addr(),
+            callback_addr: any_unix_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,

--- a/hyperactor_mesh/src/testing.rs
+++ b/hyperactor_mesh/src/testing.rs
@@ -43,6 +43,8 @@ use crate::Bootstrap;
 #[cfg(fbcode_build)]
 use crate::HostMeshRef;
 #[cfg(fbcode_build)]
+use crate::bootstrap::HostBootstrapReady;
+#[cfg(fbcode_build)]
 use crate::host_mesh::HostMesh;
 #[cfg(fbcode_build)]
 use crate::host_mesh::HostMeshShutdownGuard;
@@ -307,10 +309,13 @@ pub async fn host_mesh(n: usize) -> HostMeshShutdownGuard {
         host_addrs.push(ChannelTransport::Unix.any());
     }
 
+    let mut ready = Vec::with_capacity(n);
     for host in host_addrs.iter() {
+        let callback = HostBootstrapReady::new(host.clone()).unwrap();
         let mut cmd = Command::new(program.clone());
         let boot = Bootstrap::Host {
             addr: host.clone(),
+            callback_addr: callback.callback_addr(),
             command: None, // use current binary
             config: None,
             exit_on_shutdown: false,
@@ -324,6 +329,10 @@ pub async fn host_mesh(n: usize) -> HostMeshShutdownGuard {
             cmd.pre_exec(crate::bootstrap::install_pdeathsig_kill);
         }
         cmd.spawn().unwrap();
+        ready.push(callback);
+    }
+    for callback in ready {
+        callback.wait().await.unwrap();
     }
 
     let host_mesh = HostMeshRef::from_hosts(

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -74,6 +74,7 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::Bootstrap;
+use hyperactor_mesh::HostBootstrapReady;
 use hyperactor_mesh::HostMeshRef;
 use hyperactor_mesh::ProcMesh;
 use hyperactor_mesh::context;
@@ -846,10 +847,13 @@ pub async fn run() -> Result<(), anyhow::Error> {
 
     let host_addrs = [free_localhost_addr(), free_localhost_addr()];
     let mut children = Vec::new();
+    let mut ready = Vec::new();
     for host in host_addrs.iter() {
+        let callback = HostBootstrapReady::new(host.clone())?;
         let mut cmd = Command::new(program.clone());
         let boot = Bootstrap::Host {
             addr: host.clone(),
+            callback_addr: callback.callback_addr(),
             command: None,
             config: None,
             exit_on_shutdown: false,
@@ -857,6 +861,10 @@ pub async fn run() -> Result<(), anyhow::Error> {
         boot.to_env(&mut cmd);
         cmd.kill_on_drop(true);
         children.push(cmd.spawn().unwrap());
+        ready.push(callback);
+    }
+    for callback in ready {
+        callback.wait().await?;
     }
 
     // Create separate host meshes for each device to maintain different configs

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -73,6 +73,7 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::Bootstrap;
+use hyperactor_mesh::HostBootstrapReady;
 use hyperactor_mesh::HostMeshRef;
 use hyperactor_mesh::comm::multicast::CastInfo;
 use hyperactor_mesh::context;
@@ -505,8 +506,10 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
         buck_resources::get("monarch/monarch_rdma/examples/parameter_server/bootstrap").unwrap(),
     );
     let host_addr = ChannelTransport::Unix.any();
+    let callback = HostBootstrapReady::new(host_addr.clone())?;
     let boot = Bootstrap::Host {
         addr: host_addr.clone(),
+        callback_addr: callback.callback_addr(),
         command: None, // use current binary
         config: None,
         exit_on_shutdown: false,
@@ -514,6 +517,7 @@ pub async fn run(num_workers: usize, num_steps: usize) -> Result<(), anyhow::Err
     boot.to_env(&mut command);
     command.kill_on_drop(true);
     let _child = command.spawn().unwrap();
+    callback.wait().await?;
 
     let host_mesh = HostMeshRef::from_hosts(
         HostMeshId::instance(Label::new("test").unwrap()),


### PR DESCRIPTION
Summary:

this is a bug fix that hardens `hyperactor_mesh` test reliability.

tests that start a `Bootstrap::Host` child previously treated its listening socket as a readiness signal. the socket can accept connections before the child has bound `HostAgent` and its cast actor, so the first control message can be returned as undeliverable and leave the test waiting for a reply that will never arrive.

`Bootstrap::Host` now requires a readiness callback. the child sends it only after both actors are ready, and every in-tree subprocess launcher waits for it before using the host. this affects the subprocess bootstrap path used by `hyperactor_mesh` tests and two RDMA examples. pre-provisioned hosts and the Jobs API use the lower-level `host(...)` path and are unchanged.

teardown now keeps the required communication paths alive until their final acknowledgement is safe to send. local hosts stop their local and system procs and join their gateway servers before acknowledging. process hosts post the shutdown acknowledgement and perform a bounded outbound-gateway flush before handing the frontend back to the bootstrap task.

Reviewed By: thomasywang

Differential Revision: D112486567


