### PR TITLE
position actor state by current view rank

### DIFF
--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -1273,12 +1273,14 @@ mod tests {
     use std::ops::Deref;
     use std::sync::Arc;
 
+    use hyperactor::ActorRef;
     use hyperactor::Endpoint as _;
     use hyperactor::actor::ActorErrorKind;
     use hyperactor::actor::ActorStatus;
     use hyperactor::context::Mailbox as _;
     use hyperactor::id::Label;
     use hyperactor::mailbox;
+    use hyperactor::supervision::ActorSupervisionEvent;
     use ndslice::Extent;
     use ndslice::Region;
     use ndslice::Slice;
@@ -1295,11 +1297,16 @@ mod tests {
     use crate::ProcMesh;
     use crate::host_mesh::GET_PROC_STATE_MAX_IDLE;
     use crate::host_mesh::PROC_SPAWN_MAX_IDLE;
+    use crate::mesh_controller::ActorMeshControlPlane;
+    use crate::mesh_controller::ActorMeshController;
     use crate::mesh_controller::SUPERVISION_POLL_FREQUENCY;
     use crate::mesh_id::ActorMeshId;
+    use crate::proc_agent::ActorState;
     use crate::proc_mesh::ACTOR_SPAWN_MAX_IDLE;
     use crate::proc_mesh::GET_ACTOR_STATE_MAX_IDLE;
+    use crate::resource;
     use crate::supervision::MeshFailure;
+    use crate::test_utils::local_host_mesh;
     use crate::testactor;
     use crate::testing;
 
@@ -1811,6 +1818,149 @@ mod tests {
                 panic!("actor status is not failed: {}", event.actor_status);
             }
         }
+
+        let _ = hm.shutdown(instance).await;
+    }
+
+    /// Streamed supervision over a renumbered slice must attribute a failure to
+    /// the actor's rank in *that* view, not its first-creation rank. The child
+    /// singleton is first created over the whole (so the shared proc, gpu 1, has
+    /// `create_rank` 1), then observed by a controller over the slice (gpu 1 ->
+    /// rank 0). A streamed failure at slice rank 0 must reach the owner attributed
+    /// to rank 0 even though its payload retains `create_rank` 1.
+    ///
+    /// The whole-view child is spawned controllerless and kept alive through the
+    /// assertion. The test posts the streamed update directly to the slice
+    /// controller so polling cannot mask an incorrect streamed attribution.
+    #[async_timed_test(timeout_secs = 30)]
+    #[cfg(fbcode_build)]
+    async fn test_streamed_supervision_uses_current_view_rank() {
+        let instance = testing::instance();
+        let (supervision_port, mut supervision_receiver) = instance.open_port::<MeshFailure>();
+        let supervisor = supervision_port.bind();
+
+        let mut hm = local_host_mesh(1).await;
+        let proc_mesh = hm
+            .spawn(instance, "test", extent!(gpus = 2), None, None)
+            .await
+            .unwrap();
+        let whole = proc_mesh.deref().clone();
+        // gpu 1 is rank 1 in the whole and rank 0 in this slice.
+        let slice = proc_mesh.range("gpus", 1..2).unwrap();
+
+        // One singleton id shared by the whole-view actor and slice controller.
+        let child_id = ActorMeshId::singleton(Label::strip("svc_sup"));
+
+        // Pre-create the child over the whole, controllerless so no whole-view
+        // controller also reports the panic; gpu 1's child gets create_rank 1.
+        // Keep it alive through the assertion so the shared actor persists.
+        let _whole_child: ActorMesh<testactor::TestActor> = whole
+            .spawn_with_name(instance, child_id.clone(), &(), None, true)
+            .await
+            .unwrap();
+
+        let child_slice_region = _whole_child
+            .region()
+            .range("gpus", 1..2)
+            .expect("child slice should exist");
+        let child_slice = _whole_child.sliced(child_slice_region);
+
+        let (stream_port, mut stream_rx) =
+            instance.open_port::<resource::RankedState<ActorState>>();
+        slice
+            .agent_mesh()
+            .cast(
+                instance,
+                resource::StreamState::<ActorState> {
+                    id: child_id.resource_id().clone(),
+                    subscriber_rank: resource::Rank::default(),
+                    subscriber: stream_port.bind(),
+                },
+            )
+            .unwrap();
+        let streamed = tokio::time::timeout(Duration::from_secs(10), stream_rx.recv())
+            .await
+            .expect("no initial streamed state before timeout")
+            .unwrap();
+        assert_eq!(streamed.rank.unwrap(), 0);
+        assert_eq!(
+            streamed
+                .state
+                .state
+                .as_ref()
+                .expect("running actor should carry ActorState")
+                .create_rank,
+            1,
+        );
+
+        let controller: ActorMeshController<testactor::TestActor> = ActorMeshController::new(
+            ActorMeshControlPlane::new(child_slice.clone(), slice),
+            Some("svc_sup".to_string()),
+            Some(supervisor),
+            crate::StatusMesh::from_single(child_slice.region().clone(), resource::Status::Running),
+        );
+        let controller_handle = instance.spawn_with_label("stream_rank_controller", controller);
+        controller_handle
+            .status()
+            .wait_for(|status| matches!(status, ActorStatus::Idle))
+            .await
+            .unwrap();
+        let controller: ActorRef<ActorMeshController<testactor::TestActor>> =
+            controller_handle.bind();
+
+        let actor_id = child_slice
+            .get(0)
+            .expect("slice actor should exist")
+            .actor_addr()
+            .clone();
+        let event = ActorSupervisionEvent::new(
+            actor_id.clone(),
+            None,
+            ActorStatus::generic_failure("streamed test failure"),
+            None,
+        );
+        controller.post(
+            instance,
+            resource::RankedState {
+                rank: resource::Rank::new(0),
+                state: resource::State {
+                    id: child_id.resource_id().clone(),
+                    status: resource::Status::Failed("streamed test failure".to_string()),
+                    state: Some(ActorState {
+                        actor_id,
+                        create_rank: 1,
+                        supervision_events: vec![event],
+                    }),
+                    generation: u64::MAX,
+                    timestamp: std::time::SystemTime::now(),
+                },
+            },
+        );
+
+        let failure = tokio::time::timeout(Duration::from_secs(10), supervision_receiver.recv())
+            .await
+            .expect("no supervision failure delivered before timeout")
+            .unwrap();
+        assert_eq!(
+            failure.crashed_ranks,
+            vec![0],
+            "failure attributed to slice-local rank 0: {failure:?}",
+        );
+        assert!(
+            failure
+                .actor_mesh_name
+                .as_deref()
+                .is_some_and(|name| name.contains("svc_sup")),
+            "failure names the child mesh: {:?}",
+            failure.actor_mesh_name,
+        );
+
+        controller_handle.stop("test complete").unwrap();
+        controller_handle
+            .status()
+            .wait_for(ActorStatus::is_terminal)
+            .await
+            .unwrap();
 
         let _ = hm.shutdown(instance).await;
     }

--- a/hyperactor_mesh/src/host_mesh.rs
+++ b/hyperactor_mesh/src/host_mesh.rs
@@ -1086,11 +1086,16 @@ impl HostMeshRef {
         &self,
         cx: &impl context::Actor,
         id: ResourceId,
-        subscriber: hyperactor::PortRef<resource::State<ProcState>>,
+        subscriber: hyperactor::PortRef<resource::RankedState<ProcState>>,
     ) -> anyhow::Result<()> {
-        Ok(self
-            .host_agent_mesh
-            .cast(cx, resource::StreamState::<ProcState> { id, subscriber })?)
+        Ok(self.host_agent_mesh.cast(
+            cx,
+            resource::StreamState::<ProcState> {
+                id,
+                subscriber_rank: resource::Rank::default(),
+                subscriber,
+            },
+        )?)
     }
 
     /// Returns the host entries as `(addr_string, ActorRef<HostAgent>)` pairs.

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1153,11 +1153,9 @@ impl HostAgent {
                 None => Status::Stopped,
             },
             Some(ProcCreationState {
-                created: Err(_), ..
-            }) => {
-                // Already replied with Failed when they were stashed.
-                return;
-            }
+                created: Err(error),
+                ..
+            }) => Status::Failed(error.to_string()),
             None => {
                 // Proc not created yet, nothing to flush.
                 return;
@@ -1973,7 +1971,8 @@ mod tests {
     //   `test_wait_rank_status_stop` (deferred until stop),
     //   `test_wait_rank_status_before_proc_exists` (registered before the proc
     //   exists, then the proc is created at a different rank; the waiter keeps its
-    //   own rank rather than adopting the creation rank).
+    //   own rank rather than adopting the creation rank), and
+    //   `test_rank_status_created_error` (registered before a failed creation).
     // - RSP-4 (absence yields an empty overlay): the unknown-proc GetRankStatus
     //   assertion in `test_wait_rank_status_already_running`.
 
@@ -2306,9 +2305,9 @@ mod tests {
         assert_overlay_at_rank(&overlay, message_rank);
     }
 
-    /// A proc whose creation failed is cached as `created: Err` and reported as a
-    /// `Failed` overlay positioned at the message rank, on both immediate query
-    /// paths — GetRankStatus and (non-deferred) WaitRankStatus.
+    /// A failed creation flushes a waiter registered before the creation attempt,
+    /// and subsequent status queries report the cached failure immediately. Each
+    /// reply is positioned at the rank carried by its request.
     #[tokio::test]
     async fn test_rank_status_created_error() {
         // A local, in-process host whose proc spawn deterministically fails, so
@@ -2335,8 +2334,23 @@ mod tests {
         let client = client_proc.client("client");
 
         let id = ResourceId::instance(Label::new("proc1").unwrap());
+        // Register a waiter before the proc exists. It must be retained through
+        // the failed creation attempt and resolved with the cached failure.
+        let deferred_rank = 8;
+        let (port, mut deferred_rx) = client.open_port::<crate::StatusOverlay>();
+        host_agent
+            .wait_rank_status(
+                &client,
+                id.clone(),
+                resource::Rank::new(deferred_rank),
+                resource::Status::Running,
+                port.bind(),
+            )
+            .await
+            .unwrap();
+
         // Creation is attempted at rank 0; the spawn fails and is cached. The
-        // client call still returns Ok — the handler swallows the spawn error.
+        // client call still returns Ok because status queries carry the failure.
         host_agent
             .create_or_update(
                 &client,
@@ -2346,6 +2360,12 @@ mod tests {
             )
             .await
             .unwrap();
+
+        let overlay = tokio::time::timeout(Duration::from_secs(30), deferred_rx.recv())
+            .await
+            .expect("pre-create waiter was not resolved after creation failed")
+            .expect("reply channel closed");
+        assert_overlay_failed_at_rank(&overlay, deferred_rank);
 
         // WaitRankStatus for a known-but-failed proc replies immediately (no
         // deferral) with a Failed overlay at the message rank.

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1769,9 +1769,14 @@ impl Handler<resource::StreamState<ProcState>> for HostAgent {
                 },
             };
 
-            stream_state
-                .subscriber
-                .post_with_headers(cx, headers.clone(), state);
+            stream_state.subscriber.post_with_headers(
+                cx,
+                headers.clone(),
+                resource::RankedState {
+                    rank: resource::Rank::new(proc.rank),
+                    state,
+                },
+            );
         }
         Ok(())
     }

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -13,6 +13,7 @@ use std::time::SystemTime;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::ActorAddr;
 use hyperactor::Context;
 use hyperactor::Endpoint as _;
 use hyperactor::Handler;
@@ -187,20 +188,23 @@ impl HealthState {
     }
 
     /// Apply status updates from polled resource states and invoke `on_change`
-    /// for each rank whose status actually changed. The point passed to
-    /// `on_change` is the created rank, *not* the rank of the possibly sliced
-    /// input mesh. Returns `true` if `on_change` reported at least one
-    /// notification (used to decide whether a heartbeat is needed).
+    /// for each rank whose status actually changed. The `Point` passed to
+    /// `on_change` is the rank in the *current* (possibly sliced) view — the
+    /// same key used to update health state — so callers position notifications
+    /// by it rather than by the payload's first-creation rank. Returns `true`
+    /// if `on_change` reported at least one notification (used to decide whether
+    /// a heartbeat is needed).
     pub(crate) fn apply_updates_and_notify<S: Clone + 'static>(
         &mut self,
         states: &ValueMesh<resource::State<S>>,
-        mut on_change: impl FnMut(resource::State<S>, &mut HealthState) -> bool,
+        mut on_change: impl FnMut(Point, resource::State<S>, &mut HealthState) -> bool,
     ) -> bool {
         let mut did_notify = false;
         for (point, state) in states.iter() {
             let status = state.status.clone();
             let generation = state.generation;
-            if self.maybe_update(point, status, generation) && on_change(state, self) {
+            if self.maybe_update(point.clone(), status, generation) && on_change(point, state, self)
+            {
                 did_notify = true;
             }
         }
@@ -362,42 +366,53 @@ fn send_poll_failure(
 
 fn actor_state_to_supervision_events(
     state: resource::State<ActorState>,
-) -> (usize, Vec<ActorSupervisionEvent>) {
-    let (rank, actor_id, events) = match state.state {
-        Some(inner) => (
-            inner.create_rank,
-            Some(inner.actor_id),
-            inner.supervision_events.clone(),
-        ),
-        None => (0, None, vec![]),
+    expected_actor_id: Option<ActorAddr>,
+) -> Vec<ActorSupervisionEvent> {
+    // Prefer the payload's actor id; fall back to the controller's expected
+    // actor at this rank when the payload carries no `ActorState` (a missing or
+    // spawn-failed proc), so a failure is still attributed to the right actor.
+    let (actor_id, events) = match state.state {
+        Some(inner) => (Some(inner.actor_id), inner.supervision_events.clone()),
+        None => (expected_actor_id, vec![]),
     };
-    let events = match state.status {
-        // If the actor was killed, it might not have a Failed status
-        // or supervision events, and it can't tell us which rank
+    if !events.is_empty() {
+        return events;
+    }
+    // No reported events: synthesize one for terminal/failed statuses. Without
+    // any actor identity there is nothing to attribute, so emit nothing.
+    let Some(actor_id) = actor_id else {
+        return vec![];
+    };
+    match state.status {
+        // Killed/stopped/missing/timeout: the actor may not report a Failed
+        // status or events, and can't tell us which rank it was.
         resource::Status::NotExist | resource::Status::Stopped | resource::Status::Timeout(_) => {
-            // it was.
-            if !events.is_empty() {
-                events
-            } else {
-                vec![ActorSupervisionEvent::new(
-                    actor_id.expect("actor_id is None"),
-                    None,
-                    ActorStatus::Stopped(
-                        format!(
-                            "actor status is {}; actor may have been killed",
-                            state.status
-                        )
-                        .to_string(),
-                    ),
-                    None,
-                )]
-            }
+            vec![ActorSupervisionEvent::new(
+                actor_id,
+                None,
+                ActorStatus::Stopped(
+                    format!(
+                        "actor status is {}; actor may have been killed",
+                        state.status
+                    )
+                    .to_string(),
+                ),
+                None,
+            )]
         }
-        resource::Status::Failed(_) => events,
+        // Failed with no reported event: synthesize one so the failure is not
+        // silently swallowed while health is updated.
+        resource::Status::Failed(ref reason) => {
+            vec![ActorSupervisionEvent::new(
+                actor_id,
+                None,
+                ActorStatus::generic_failure(reason.clone()),
+                None,
+            )]
+        }
         // All other states are successful.
         _ => vec![],
-    };
-    (rank, events)
+    }
 }
 
 /// Map a process-level [`ProcStatus`] to an actor-level [`ActorStatus`].
@@ -479,12 +494,12 @@ pub trait Controlled: Clone + Debug + Send + Sync + 'static {
     /// The region of ranks in this mesh.
     fn region(&self) -> &ndslice::Region;
 
-    /// Subscribe the given port to `StreamState<StateInner>` updates from
-    /// the underlying agents.
+    /// Subscribe the given port to positioned state updates from the
+    /// underlying agents.
     fn subscribe_to_stream(
         &self,
         cx: &impl context::Actor,
-        subscriber: hyperactor::PortRef<resource::State<Self::StateInner>>,
+        subscriber: hyperactor::PortRef<resource::RankedState<Self::StateInner>>,
     ) -> anyhow::Result<()>;
 
     /// Forward a `WaitRankStatus` message to the underlying agents.
@@ -512,7 +527,7 @@ pub trait Controlled: Clone + Debug + Send + Sync + 'static {
     fn process_state(
         &self,
         cx: &impl context::Actor,
-        state: resource::State<Self::StateInner>,
+        state: resource::RankedState<Self::StateInner>,
         health_state: &mut HealthState,
     ) -> bool;
 
@@ -543,7 +558,8 @@ pub trait Controlled: Clone + Debug + Send + Sync + 'static {
 /// outer layer: callers of `GetState` on the controller want the
 /// per-rank statuses and the mesh-wide status that `resource::mesh::State`
 /// already carries, not the inner `T::StateInner` payload (which is
-/// available rank-by-rank via the `resource::State<T::StateInner>` stream).
+/// available rank-by-rank via the
+/// `resource::RankedState<T::StateInner>` stream).
 /// The unit type is the explicit "no extra payload" choice.
 #[hyperactor::export(
     handlers=[
@@ -555,7 +571,7 @@ pub trait Controlled: Clone + Debug + Send + Sync + 'static {
         resource::CreateOrUpdate<resource::mesh::Spec<()>>,
         resource::GetState<resource::mesh::State<()>>,
         resource::Stop,
-        resource::State<T::StateInner>,
+        resource::RankedState<T::StateInner>,
     ]
 )]
 pub struct ResourceController<T: Controlled> {
@@ -1060,14 +1076,14 @@ where
 }
 
 #[async_trait]
-impl<T: Controlled> Handler<resource::State<T::StateInner>> for ResourceController<T>
+impl<T: Controlled> Handler<resource::RankedState<T::StateInner>> for ResourceController<T>
 where
-    resource::State<T::StateInner>: RemoteMessage,
+    resource::RankedState<T::StateInner>: RemoteMessage,
 {
     async fn handle(
         &mut self,
         cx: &Context<Self>,
-        state: resource::State<T::StateInner>,
+        state: resource::RankedState<T::StateInner>,
     ) -> anyhow::Result<()> {
         self.mesh.process_state(cx, state, &mut self.health_state);
         self.stop_if_all_terminating();
@@ -1095,12 +1111,13 @@ impl<A: Referable> Controlled for ActorMeshControlPlane<A> {
     fn subscribe_to_stream(
         &self,
         cx: &impl context::Actor,
-        subscriber: hyperactor::PortRef<resource::State<ActorState>>,
+        subscriber: hyperactor::PortRef<resource::RankedState<ActorState>>,
     ) -> anyhow::Result<()> {
         self.proc_mesh.agent_mesh().cast(
             cx,
             resource::StreamState::<ActorState> {
                 id: self.actor_mesh.id().resource_id().clone(),
+                subscriber_rank: resource::Rank::default(),
                 subscriber,
             },
         )?;
@@ -1205,14 +1222,20 @@ impl<A: Referable> Controlled for ActorMeshControlPlane<A> {
             ),
             Ok(states) => {
                 let did_notify =
-                    health_state.apply_updates_and_notify(&states, |state, health_state| {
-                        let (rank, events) = actor_state_to_supervision_events(state);
+                    health_state.apply_updates_and_notify(&states, |point, state, health_state| {
+                        let expected_actor_id = self
+                            .actor_mesh
+                            .get(point.rank())
+                            .map(|r| r.actor_addr().clone());
+                        let events = actor_state_to_supervision_events(state, expected_actor_id);
                         if events.is_empty() {
                             return false;
                         }
+                        // Notify at this update's current-view rank, not the
+                        // payload's historical `create_rank`.
                         send_state_change(
                             cx,
-                            rank,
+                            point.rank(),
                             events[0].clone(),
                             mesh_name,
                             false,
@@ -1228,13 +1251,18 @@ impl<A: Referable> Controlled for ActorMeshControlPlane<A> {
     fn process_state(
         &self,
         cx: &impl context::Actor,
-        state: resource::State<ActorState>,
+        state: resource::RankedState<ActorState>,
         health_state: &mut HealthState,
     ) -> bool {
-        let (rank, events) = actor_state_to_supervision_events(state.clone());
+        let resource::RankedState { rank, state } = state;
+        let rank = rank.unwrap();
         let Ok(point) = Controlled::region(self).extent().point_of_rank(rank) else {
             return false;
         };
+        // The controller's expected actor at this rank, used as the fallback
+        // identity when the payload carries no `ActorState`.
+        let expected_actor_id = self.actor_mesh.get(rank).map(|r| r.actor_addr().clone());
+        let events = actor_state_to_supervision_events(state.clone(), expected_actor_id);
 
         let changed = health_state.maybe_update(point, state.status, state.generation);
 
@@ -1377,7 +1405,7 @@ impl Controlled for ProcMeshRef {
     fn subscribe_to_stream(
         &self,
         cx: &impl context::Actor,
-        subscriber: hyperactor::PortRef<resource::State<Self::StateInner>>,
+        subscriber: hyperactor::PortRef<resource::RankedState<Self::StateInner>>,
     ) -> anyhow::Result<()> {
         // A `ProcMeshController` is only ever created for host-backed proc
         // meshes (host_mesh.rs spawn path), so a host mesh should always be
@@ -1438,15 +1466,17 @@ impl Controlled for ProcMeshRef {
             ),
             Ok(None) => PollResult::Processed { did_notify: false },
             Ok(Some(states)) => {
-                let did_notify =
-                    health_state.apply_updates_and_notify(&states, |state, health_state| {
+                let did_notify = health_state.apply_updates_and_notify(
+                    &states,
+                    |_point, state, health_state| {
                         self.notify_proc_state_change(
                             cx,
                             supervision_display_name,
                             state,
                             health_state,
                         )
-                    });
+                    },
+                );
                 PollResult::Processed { did_notify }
             }
         }
@@ -1455,16 +1485,14 @@ impl Controlled for ProcMeshRef {
     fn process_state(
         &self,
         cx: &impl context::Actor,
-        state: resource::State<Self::StateInner>,
+        state: resource::RankedState<Self::StateInner>,
         health_state: &mut HealthState,
     ) -> bool {
-        let Ok(point) = Controlled::region(self).extent().point_of_rank(
-            state
-                .state
-                .as_ref()
-                .map(|s| s.create_rank)
-                .unwrap_or(usize::MAX),
-        ) else {
+        let resource::RankedState { rank, state } = state;
+        let Ok(point) = Controlled::region(self)
+            .extent()
+            .point_of_rank(rank.unwrap())
+        else {
             return false;
         };
         let changed = health_state.maybe_update(point, state.status.clone(), state.generation);
@@ -1608,11 +1636,13 @@ mod tests {
     use hyperactor::supervision::ActorSupervisionEvent;
     use ndslice::Extent;
     use ndslice::ViewExt;
+    use ndslice::view::CollectMeshExt;
 
     use super::HealthState;
     use super::PollResult;
     #[cfg(fbcode_build)]
     use super::SUPERVISION_POLL_FREQUENCY;
+    use super::actor_state_to_supervision_events;
     use super::proc_status_to_actor_status;
     use super::send_poll_failure;
     use super::send_state_change;
@@ -1624,6 +1654,7 @@ mod tests {
     #[cfg(fbcode_build)]
     use crate::mesh_id::HostMeshId;
     use crate::mesh_id::ResourceId;
+    use crate::proc_agent::ActorState;
     use crate::proc_agent::MESH_ORPHAN_TIMEOUT;
     use crate::resource;
     use crate::supervision::MeshFailure;
@@ -1718,6 +1749,60 @@ mod tests {
             ActorStatus::Failed(ActorErrorKind::Generic(message.to_string())),
             None,
         )
+    }
+
+    #[test]
+    fn polled_actor_state_uses_current_view_point() {
+        let region: ndslice::Region = ndslice::extent!(gpus = 1).into();
+        let point = region.extent().point_of_rank(0).unwrap();
+        let actor_id = failed_event(0, "actor id").actor_id;
+        let states = vec![resource::State {
+            id: ResourceId::instance(Label::new("worker").unwrap()),
+            status: resource::Status::Running,
+            state: Some(ActorState {
+                actor_id,
+                create_rank: 9,
+                supervision_events: vec![],
+            }),
+            generation: 1,
+            timestamp: std::time::SystemTime::now(),
+        }]
+        .into_iter()
+        .collect_mesh::<crate::ValueMesh<_>>(region.clone())
+        .unwrap();
+        let mut health_state = HealthState::new(
+            vec![(point, resource::Status::Initializing)]
+                .into_iter()
+                .collect(),
+            None,
+        );
+        let mut observed_rank = None;
+
+        health_state.apply_updates_and_notify(&states, |point, state, _| {
+            observed_rank = Some(point.rank());
+            assert_eq!(state.state.unwrap().create_rank, 9);
+            true
+        });
+
+        assert_eq!(observed_rank, Some(0));
+    }
+
+    #[test]
+    fn failed_actor_state_without_payload_uses_expected_actor() {
+        let actor_id = failed_event(4, "actor id").actor_id;
+        let state = resource::State {
+            id: ResourceId::instance(Label::new("worker").unwrap()),
+            status: resource::Status::Failed("spawn failed".to_string()),
+            state: None,
+            generation: 1,
+            timestamp: std::time::SystemTime::now(),
+        };
+
+        let events = actor_state_to_supervision_events(state, Some(actor_id.clone()));
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].actor_id, actor_id);
+        assert!(matches!(events[0].actor_status, ActorStatus::Failed(_)));
     }
 
     /// Wraps a host mesh's shutdown guard and the spawned host child

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -156,9 +156,10 @@ struct ActorInstanceState {
     /// The supervision event observed for this actor, if it has reached
     /// terminal state.
     supervision_event: Option<ActorSupervisionEvent>,
-    /// Streaming subscribers that receive `State<ActorState>` on every
-    /// state change. Dead subscribers are removed via undeliverable handling.
-    subscribers: Vec<PortRef<resource::State<ActorState>>>,
+    /// Streaming subscribers that receive `RankedState<ActorState>` on every
+    /// state change, paired with the actor's rank in that subscriber's view.
+    /// Dead subscribers are removed via undeliverable handling.
+    subscribers: Vec<(usize, PortRef<resource::RankedState<ActorState>>)>,
     /// The time at which the actor should be considered expired if no further
     /// keepalive is received. `None` meaning it will never expire.
     expiry_time: Option<std::time::SystemTime>,
@@ -228,10 +229,17 @@ impl ActorInstanceState {
     fn notify_status_changed(&mut self, cx: &impl hyperactor::context::Actor, id: &ResourceId) {
         // Streaming subscribers (persistent).
         let state = self.to_state(id);
-        for subscriber in &self.subscribers {
+        for (view_rank, subscriber) in &self.subscribers {
             let mut headers = Flattrs::new();
             headers.set(STREAM_STATE_SUBSCRIBER, true);
-            subscriber.post_with_headers(cx, headers, state.clone());
+            subscriber.post_with_headers(
+                cx,
+                headers,
+                resource::RankedState {
+                    rank: resource::Rank::new(*view_rank),
+                    state: state.clone(),
+                },
+            );
         }
 
         // One-shot waiters (predicated). Each retains the reply rank it was
@@ -681,10 +689,10 @@ impl Actor for ProcAgent {
         };
         if let Some(true) = returned.headers().get(STREAM_STATE_SUBSCRIBER) {
             let dest_port_id: PortAddr = returned.dest().clone();
-            let port = PortRef::<resource::State<ActorState>>::attest(dest_port_id);
+            let port = PortRef::<resource::RankedState<ActorState>>::attest(dest_port_id);
             // Remove this subscriber from whichever actor instance holds it.
             for instance in self.actor_states.values_mut() {
-                instance.subscribers.retain(|s| s != &port);
+                instance.subscribers.retain(|(_, s)| s != &port);
             }
             Ok(())
         } else {
@@ -703,9 +711,9 @@ impl Actor for ProcAgent {
         };
         if let Some(true) = returned.headers().get(STREAM_STATE_SUBSCRIBER) {
             let dest_port_id: PortAddr = returned.dest().clone();
-            let port = PortRef::<resource::State<ActorState>>::attest(dest_port_id);
+            let port = PortRef::<resource::RankedState<ActorState>>::attest(dest_port_id);
             for instance in self.actor_states.values_mut() {
-                instance.subscribers.retain(|s| s != &port);
+                instance.subscribers.retain(|(_, s)| s != &port);
             }
             Ok(())
         } else {
@@ -1113,10 +1121,17 @@ impl Handler<resource::StreamState<ActorState>> for ProcAgent {
         cx: &Context<Self>,
         stream_state: resource::StreamState<ActorState>,
     ) -> anyhow::Result<()> {
+        // The cast layer fills each recipient's rank in the subscriber's view.
+        // Retain it because later notifications are direct posts, outside the
+        // subscription cast context.
+        let view_rank = stream_state.subscriber_rank.unwrap();
+
         let state = match self.actor_states.get_mut(&stream_state.id) {
             Some(instance) => {
                 let state = instance.to_state(&stream_state.id);
-                instance.subscribers.push(stream_state.subscriber.clone());
+                instance
+                    .subscribers
+                    .push((view_rank, stream_state.subscriber.clone()));
                 state
             }
             None => resource::State {
@@ -1128,12 +1143,17 @@ impl Handler<resource::StreamState<ActorState>> for ProcAgent {
             },
         };
 
-        // Send the current state immediately.
+        // Send the current state immediately at the subscriber's view rank.
         let mut headers = Flattrs::new();
         headers.set(STREAM_STATE_SUBSCRIBER, true);
-        stream_state
-            .subscriber
-            .post_with_headers(cx, headers, state);
+        stream_state.subscriber.post_with_headers(
+            cx,
+            headers,
+            resource::RankedState {
+                rank: resource::Rank::new(view_rank),
+                state,
+            },
+        );
         Ok(())
     }
 }
@@ -1523,6 +1543,26 @@ mod tests {
         let client = proc.client("client");
         let agent_ref: ActorRef<ProcAgent> = agent_handle.bind();
 
+        // A missing actor has no `ActorState` payload, so the streamed message
+        // itself must retain the subscription rank.
+        let missing_name =
+            ResourceId::singleton(hyperactor::id::Label::new("missing-actor").unwrap());
+        let (missing_port, mut missing_rx) =
+            client.open_port::<resource::RankedState<ActorState>>();
+        agent_ref
+            .stream_state(
+                &client,
+                missing_name,
+                resource::Rank::new(6),
+                missing_port.bind(),
+            )
+            .await
+            .unwrap();
+        let missing = missing_rx.recv().await.expect("missing state reply");
+        assert_eq!(missing.rank.unwrap(), 6);
+        assert_eq!(missing.state.status, resource::Status::NotExist);
+        assert_eq!(missing.state.state, None);
+
         let actor_type = hyperactor::actor::remote::Remote::collect()
             .name_of::<ExtraActor>()
             .unwrap()
@@ -1546,16 +1586,23 @@ mod tests {
             .unwrap();
 
         // 2. Subscribe to state updates.
-        let (sub_port, mut sub_rx) = client.open_port::<resource::State<ActorState>>();
+        let subscriber_rank = 7;
+        let (sub_port, mut sub_rx) = client.open_port::<resource::RankedState<ActorState>>();
         agent_ref
-            .stream_state(&client, actor_name.clone(), sub_port.bind())
+            .stream_state(
+                &client,
+                actor_name.clone(),
+                resource::Rank::new(subscriber_rank),
+                sub_port.bind(),
+            )
             .await
             .unwrap();
 
         // 3. Should receive the initial state (Running).
         let initial = sub_rx.recv().await.expect("subscriber channel error");
-        assert_eq!(initial.status, resource::Status::Running);
-        assert!(initial.state.is_some());
+        assert_eq!(initial.rank.unwrap(), subscriber_rank);
+        assert_eq!(initial.state.status, resource::Status::Running);
+        assert!(initial.state.state.is_some());
 
         // 4. Send Stop — should receive Stopping.
         agent_ref
@@ -1564,11 +1611,13 @@ mod tests {
             .unwrap();
 
         let stopping = sub_rx.recv().await.expect("subscriber channel error");
-        assert_eq!(stopping.status, resource::Status::Stopping);
+        assert_eq!(stopping.rank.unwrap(), subscriber_rank);
+        assert_eq!(stopping.state.status, resource::Status::Stopping);
 
         // 5. Wait for the Stopped supervision event update.
         let stopped = sub_rx.recv().await.expect("subscriber channel error");
-        assert_eq!(stopped.status, resource::Status::Stopped);
+        assert_eq!(stopped.rank.unwrap(), subscriber_rank);
+        assert_eq!(stopped.state.status, resource::Status::Stopped);
 
         // 6. Test implicit unsubscription via undeliverable.
         let actor_name_2 =
@@ -1586,14 +1635,20 @@ mod tests {
             .await
             .unwrap();
 
-        let (sub_port_2, mut sub_rx_2) = client.open_port::<resource::State<ActorState>>();
+        let (sub_port_2, mut sub_rx_2) = client.open_port::<resource::RankedState<ActorState>>();
         agent_ref
-            .stream_state(&client, actor_name_2.clone(), sub_port_2.bind())
+            .stream_state(
+                &client,
+                actor_name_2.clone(),
+                resource::Rank::new(8),
+                sub_port_2.bind(),
+            )
             .await
             .unwrap();
 
         let initial_2 = sub_rx_2.recv().await.expect("subscriber 2 channel error");
-        assert_eq!(initial_2.status, resource::Status::Running);
+        assert_eq!(initial_2.rank.unwrap(), 8);
+        assert_eq!(initial_2.state.status, resource::Status::Running);
 
         // Drop the receiver so the next send bounces as undeliverable.
         drop(sub_rx_2);
@@ -1611,14 +1666,20 @@ mod tests {
             .unwrap();
 
         // Wait for actor_2 to reach terminal state via a new stream subscription.
-        let (sub_port_3, mut sub_rx_3) = client.open_port::<resource::State<ActorState>>();
+        let (sub_port_3, mut sub_rx_3) = client.open_port::<resource::RankedState<ActorState>>();
         agent_ref
-            .stream_state(&client, actor_name_2.clone(), sub_port_3.bind())
+            .stream_state(
+                &client,
+                actor_name_2.clone(),
+                resource::Rank::new(9),
+                sub_port_3.bind(),
+            )
             .await
             .unwrap();
         loop {
             let state = sub_rx_3.recv().await.expect("subscriber 3 channel error");
-            if state.status.is_terminating() {
+            assert_eq!(state.rank.unwrap(), 9);
+            if state.state.status.is_terminating() {
                 break;
             }
         }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -7,6 +7,7 @@
  */
 
 use std::any::type_name;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fmt;
 use std::hash::Hash;
@@ -491,6 +492,17 @@ impl ProcMeshRef {
             self.proc_agent_mesh.cast(cx, get_state)?;
         }
         let expected = self.ranks.len();
+        // Map each managed-actor `ActorAddr` to its rank in *this* (current)
+        // view, so a reply is positioned by the current view rather than the
+        // payload's historical `create_rank` (a reused singleton's `create_rank`
+        // is its rank in the view it was first spawned over). Built once per
+        // query: O(N) to build, O(1) per reply.
+        let rank_of_actor: HashMap<ActorAddr, usize> = self
+            .ranks
+            .iter()
+            .enumerate()
+            .map(|(rank, proc_ref)| (proc_ref.actor_addr(&id), rank))
+            .collect();
         let mut states = Vec::with_capacity(expected);
         let timeout = hyperactor_config::global::get(GET_ACTOR_STATE_MAX_IDLE);
         for _ in 0..expected {
@@ -505,9 +517,20 @@ impl ProcMeshRef {
                 let state = state?;
                 match state.state {
                     Some(ref inner) => {
-                        states.push((inner.create_rank, state));
+                        // Position by this actor's rank in the current view, not
+                        // its historical `create_rank`.
+                        let rank = *rank_of_actor.get(&inner.actor_id).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "state reply from {} is not a member of the queried view",
+                                inner.actor_id,
+                            )
+                        })?;
+                        states.push((rank, state));
                     }
                     None => {
+                        // A received `None` is a definitive NotExist answer;
+                        // return immediately rather than waiting for the timeout
+                        // padding (which is only for ranks that never reply).
                         return Err(Error::NotExist(state.id));
                     }
                 }
@@ -1232,6 +1255,8 @@ mod tests {
     /// registered while the service runs must flush at slice-local ranks.
     /// The assertions exercise the ProcAgent readiness path; the per-view
     /// controllers remain idle because this test does not trigger supervision.
+    /// Snapshot assertions also verify that both reuse orders return actor state
+    /// in the queried view's rank order.
     #[async_timed_test(timeout_secs = 120)]
     #[cfg(fbcode_build)]
     async fn test_singleton_service_reuse_over_overlapping_views() {
@@ -1280,6 +1305,17 @@ mod tests {
             .await
             .unwrap();
         assert_shared(&w1, &s1);
+        let s1_states = slice.actor_states(instance, s1.id().clone()).await.unwrap();
+        for rank in 0..slice.region().num_ranks() {
+            assert_eq!(
+                s1_states
+                    .get(rank)
+                    .and_then(|state| state.state.as_ref())
+                    .map(|state| &state.actor_id),
+                s1.get(rank).map(|actor| actor.actor_addr()),
+                "whole-first state is positioned at slice rank {rank}",
+            );
+        }
 
         // Scenario 2: spawn over the slice first, then reuse over the whole.
         let s2 = slice
@@ -1291,6 +1327,17 @@ mod tests {
             .await
             .unwrap();
         assert_shared(&w2, &s2);
+        let w2_states = whole.actor_states(instance, w2.id().clone()).await.unwrap();
+        for rank in 0..whole.region().num_ranks() {
+            assert_eq!(
+                w2_states
+                    .get(rank)
+                    .and_then(|state| state.state.as_ref())
+                    .map(|state| &state.actor_id),
+                w2.get(rank).map(|actor| actor.actor_addr()),
+                "slice-first state is positioned at whole-view rank {rank}",
+            );
+        }
 
         // Scenario 3: a `WaitRankStatus{Stopped}` registered over the renumbered
         // slice while the service runs is deferred and flushed on stop. The

--- a/hyperactor_mesh/src/resource.rs
+++ b/hyperactor_mesh/src/resource.rs
@@ -479,15 +479,19 @@ where
 }
 
 /// Subscribe to streaming state updates for a named resource.
-/// The subscriber port will receive `State<S>` whenever the resource's
+/// The subscriber port will receive `RankedState<S>` whenever the resource's
 /// state changes. The current state is sent immediately upon subscription.
 #[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]
 #[serde(bound(serialize = "S: Named", deserialize = "S: Named"))]
 pub struct StreamState<S> {
     /// The resource identifier.
     pub id: ResourceId,
+    /// The recipient's rank in the subscriber's view. Cast callers leave this
+    /// unset so the comm layer can fill it for each recipient; direct callers
+    /// set it explicitly.
+    pub subscriber_rank: Rank,
     /// A streaming port that will receive state updates.
-    pub subscriber: PortRef<State<S>>,
+    pub subscriber: PortRef<RankedState<S>>,
 }
 wirevalue::register_type!(StreamState<ActorState>);
 wirevalue::register_type!(StreamState<ProcState>);
@@ -499,10 +503,22 @@ where
     fn clone(&self) -> Self {
         Self {
             id: self.id.clone(),
+            subscriber_rank: self.subscriber_rank.clone(),
             subscriber: self.subscriber.clone(),
         }
     }
 }
+
+/// A state update positioned in the subscriber's current view.
+#[derive(Clone, Debug, Serialize, Deserialize, Named, PartialEq, Eq, Handler)]
+pub struct RankedState<S> {
+    /// The resource's rank in the consuming view.
+    pub rank: Rank,
+    /// The state observed at that rank.
+    pub state: State<S>,
+}
+wirevalue::register_type!(RankedState<ActorState>);
+wirevalue::register_type!(RankedState<ProcState>);
 
 /// List the set of resources managed by the controller.
 #[derive(Debug, Serialize, Deserialize, Named, Handler, HandleClient, RefClient)]


### PR DESCRIPTION
Summary:
this is a bug fix.

`ActorState.create_rank` is the actor's position in the view where it was first created. it is stable creation metadata, not a coordinate in every later view. when a singleton actor is reused through an overlapping or renumbered slice, its current view rank can differ.

three paths incorrectly treated `create_rank` as a current-view coordinate:

- `.actor_states()` used it to order replies and track which ranks completed before a timeout;
- polled supervision used it again after the state was already positioned in a current-view `ValueMesh`;
- streamed supervision used it for health-state placement and failure attribution, while an update with no `ActorState` payload defaulted to rank `0`.

one-shot `.actor_states()` calls(, as opposed to streaming updates) now build one `ActorAddr` to current-view-rank index and use it for reply placement and timeout bookkeeping. this is `O(N)` to construct and `O(1)` per reply.

polled supervision now uses the `Point` supplied by the current-view `ValueMesh`.

streamed supervision uses a typed, header-free contract. the cast layer fills `StreamState.subscriber_rank` for each recipient using the existing `Rank` multipart rewrite. the producer retains that rank per subscriber and returns it on every `RankedState`, so updates remain positionable even when `state` is `None`.

this changes the internal wire layout of `StreamState` and its subscriber message. these are same-build control-plane messages, so their producers and consumers update together.

Differential Revision: D112568111


