### PR TITLE
Preserve multicast sender telemetry identity (#4444)

### DIFF
--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -2242,13 +2242,10 @@ impl MailboxSender for Mailbox {
         let to_actor_id = hash_to_u64(dest.actor_addr().id());
         let message_id = hyperactor_telemetry::generate_message_id(to_actor_id);
         headers.set(crate::mailbox::headers::TELEMETRY_MESSAGE_ID, message_id);
-        // Only set sender hash if not already present (cast path
-        // pre-sets it with the originating actor).
+        // A cast leaf stamps its trusted logical origin before this boundary.
+        // For other deliveries, the envelope sender is the logical origin.
         if !headers.contains_key(crate::mailbox::headers::SENDER_ACTOR_ID_HASH) {
-            headers.set(
-                crate::mailbox::headers::SENDER_ACTOR_ID_HASH,
-                hash_to_u64(sender.id()),
-            );
+            crate::mailbox::headers::stamp_sender_actor_id_hash(&mut headers, &sender);
         }
         headers.set(crate::mailbox::headers::TELEMETRY_PORT_INDEX, dest.index());
 

--- a/hyperactor/src/mailbox/headers.rs
+++ b/hyperactor/src/mailbox/headers.rs
@@ -18,6 +18,7 @@ use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::OPERATION_CONTEXT_HEADER;
 use hyperactor_config::attrs::declare_attrs;
 use hyperactor_config::global;
+use hyperactor_telemetry::hash_to_u64;
 
 use crate::ActorAddr;
 use crate::PortAddr;
@@ -95,6 +96,15 @@ pub fn set_send_timestamp(headers: &mut Flattrs) {
 /// Set the send timestamp for latency tracking if timestamp not already set.
 pub fn set_rust_message_type<M>(headers: &mut Flattrs) {
     headers.set(RUST_MESSAGE_TYPE, type_name::<M>().to_string());
+}
+
+/// Stamp the logical sender hash at a framework-owned delivery boundary.
+///
+/// This overwrites caller-supplied values so trusted routing state determines
+/// the sender recorded by received-message telemetry.
+#[doc(hidden)]
+pub fn stamp_sender_actor_id_hash(headers: &mut Flattrs, sender: &ActorAddr) {
+    headers.set(SENDER_ACTOR_ID_HASH, hash_to_u64(sender.id()));
 }
 
 /// Stamp `SENDER_ACTOR_ID` into `headers` if the gate conditions are met.
@@ -205,6 +215,20 @@ mod tests {
     // so its port is a handler port distinct from bypass ports.
     #[derive(typeuri::Named)]
     struct TestHandlerMsg;
+
+    #[test]
+    fn test_stamp_sender_actor_id_hash_overwrites_existing_value() {
+        let owner: ActorAddr = test_actor_id("test_0", "worker");
+        let mut headers = Flattrs::new();
+        headers.set(SENDER_ACTOR_ID_HASH, 123);
+
+        stamp_sender_actor_id_hash(&mut headers, &owner);
+
+        assert_eq!(
+            headers.get(SENDER_ACTOR_ID_HASH),
+            Some(hash_to_u64(owner.id()))
+        );
+    }
 
     #[test]
     fn test_stamp_helper_sets_sender_on_seq_1() {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -4262,21 +4262,20 @@ impl InstanceCell {
         let old = old_status.expect("status change should capture previous status");
         let actor_id = hash_to_u64(self.actor_addr().id());
 
-        // Actor status changes between Idle and Processing when handling every
-        // message. It creates too many logs if we want to log these 2 states.
-        // Also, sometimes the actor transitions from Processing -> Processing.
-        // Therefore we skip the status changes between them.
+        let new_status = new.arm().unwrap_or("unknown");
+        let change_reason = match &new {
+            ActorStatus::Failed(reason) => Some(reason.to_string()),
+            ActorStatus::Stopping(ActorStoppingReason::Zombie(reason)) => Some(reason.clone()),
+            ActorStatus::Stopped(reason) => Some(reason.clone()),
+            _ => None,
+        };
+
+        // Idle/Processing transitions are persisted but omitted from logs because
+        // they occur for every message.
         if !((old.is_idle() && new.is_processing())
             || (old.is_processing() && new.is_idle())
             || old == new)
         {
-            let new_status = new.arm().unwrap_or("unknown");
-            let change_reason = match &new {
-                ActorStatus::Failed(reason) => reason.to_string(),
-                ActorStatus::Stopping(ActorStoppingReason::Zombie(reason)) => reason.clone(),
-                ActorStatus::Stopped(reason) => reason.clone(),
-                _ => "".to_string(),
-            };
             tracing::info!(
                 name = "ActorStatus",
                 actor_id = %self.actor_addr(),
@@ -4284,20 +4283,16 @@ impl InstanceCell {
                 status = new_status,
                 prev_status = old.arm().unwrap_or("unknown"),
                 caller = %PanicLocation::caller(),
-                change_reason,
+                change_reason = change_reason.as_deref().unwrap_or(""),
             );
-            notify_actor_status_changed(ActorStatusEvent {
-                id: generate_actor_status_event_id(actor_id),
-                timestamp: std::time::SystemTime::now(),
-                actor_id,
-                new_status: new_status.to_string(),
-                reason: if change_reason.is_empty() {
-                    None
-                } else {
-                    Some(change_reason)
-                },
-            });
         }
+        notify_actor_status_changed(ActorStatusEvent {
+            id: generate_actor_status_event_id(actor_id),
+            timestamp: std::time::SystemTime::now(),
+            actor_id,
+            new_status: new_status.to_string(),
+            reason: change_reason,
+        });
     }
 
     fn publish_dropped_status(&self, terminal_status: ActorStatus) {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2464,6 +2464,14 @@ impl<A: Actor> Instance<A> {
             queue_depth,
             inbound_ordering_snapshot,
         );
+        let actor_id = hash_to_u64(cell.actor_addr().id());
+        notify_actor_status_changed(ActorStatusEvent {
+            id: generate_actor_status_event_id(actor_id),
+            timestamp: cell.created_at(),
+            actor_id,
+            new_status: ActorStatus::Created.arm().unwrap_or("unknown").to_string(),
+            reason: None,
+        });
         let inner = Arc::new(InstanceState {
             proc,
             cell,
@@ -4252,6 +4260,7 @@ impl InstanceCell {
             return;
         }
         let old = old_status.expect("status change should capture previous status");
+        let actor_id = hash_to_u64(self.actor_addr().id());
 
         // Actor status changes between Idle and Processing when handling every
         // message. It creates too many logs if we want to log these 2 states.
@@ -4277,7 +4286,6 @@ impl InstanceCell {
                 caller = %PanicLocation::caller(),
                 change_reason,
             );
-            let actor_id = hash_to_u64(self.actor_addr().id());
             notify_actor_status_changed(ActorStatusEvent {
                 id: generate_actor_status_event_id(actor_id),
                 timestamp: std::time::SystemTime::now(),
@@ -4931,8 +4939,12 @@ impl<A: Actor> HandlerPorts<A> {
 mod tests {
     use std::assert_matches;
     use std::sync::atomic::AtomicBool;
+    use std::sync::mpsc as std_mpsc;
 
     use hyperactor_macros::export;
+    use hyperactor_telemetry::EntityEvent;
+    use hyperactor_telemetry::TraceEvent;
+    use hyperactor_telemetry::TraceEventSink;
     use serde_json::json;
     use timed_test::async_timed_test;
     use tokio::sync::Barrier;
@@ -4961,6 +4973,26 @@ mod tests {
     struct TestActor;
 
     impl Actor for TestActor {}
+
+    struct ActorStatusSink {
+        actor_id: u64,
+        sender: std_mpsc::Sender<ActorStatusEvent>,
+    }
+
+    impl TraceEventSink for ActorStatusSink {
+        fn consume(&mut self, event: &TraceEvent) -> Result<(), anyhow::Error> {
+            if let TraceEvent::Entity(EntityEvent::ActorStatus(status)) = event
+                && status.actor_id == self.actor_id
+            {
+                let _ = self.sender.send(status.clone());
+            }
+            Ok(())
+        }
+
+        fn flush(&mut self) -> Result<(), anyhow::Error> {
+            Ok(())
+        }
+    }
 
     async fn get_status(client: &Client, actor_addr: &ActorAddr) -> Option<ActorStatus> {
         let (reply_port, reply_rx) = client.open_once_port::<Option<ActorStatus>>();
@@ -5054,6 +5086,28 @@ mod tests {
                 "{label}: {old} -> {new}"
             );
         }
+    }
+
+    #[test]
+    fn instance_creation_emits_created_status() {
+        hyperactor_telemetry::initialize_logging_for_test();
+        let proc = Proc::isolated();
+        let actor_addr = proc.allocate_root_type::<TestActor>();
+        let actor_id = hash_to_u64(actor_addr.id());
+        let (sender, receiver) = std_mpsc::channel();
+        hyperactor_telemetry::register_sink(Box::new(ActorStatusSink { actor_id, sender }));
+
+        let (instance, _receivers) =
+            Instance::<TestActor>::new(proc, actor_addr, false, None, ActorEnvironment::default());
+
+        assert_eq!(*instance.status().borrow(), ActorStatus::Created);
+        let event = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect("created status should be emitted during instance construction");
+        assert_eq!(event.actor_id, actor_id);
+        assert_eq!(event.timestamp, instance.inner.cell.created_at());
+        assert_eq!(event.new_status, "Created");
+        assert_eq!(event.reason, None);
     }
 
     #[derive(Debug)]

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -860,6 +860,7 @@ impl Handler<CastMessage> for CastActor {
             let dest = domain
                 .local_actor
                 .port_addr(Port::handler_id(message.dest_port, None));
+            hyperactor::mailbox::headers::stamp_sender_actor_id_hash(&mut headers, &message.sender);
             hyperactor::mailbox::headers::stamp_sender_actor_id(
                 &mut headers,
                 &seq_info,

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -15,6 +15,7 @@ import time
 import types
 import unittest.mock
 import uuid
+from collections import Counter
 from typing import Any, cast
 
 import monarch._src.job.telemetry_actor as job_telemetry_actor
@@ -23,7 +24,7 @@ import pytest
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
-from monarch._src.actor.actor_mesh import Actor, ActorMesh
+from monarch._src.actor.actor_mesh import Actor, ActorMesh, current_rank
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.proc_mesh import (
     _proc_mesh_spawn_callbacks,
@@ -100,6 +101,37 @@ class _FailureTestTelemetryRoot(job_telemetry_actor.TelemetryActor):
         return len(self._worker_collectors)
 
 
+class TelemetryWorkerActor(Actor):
+    """Worker that exercises multi-hop actor messaging."""
+
+    @endpoint
+    def start(self, coordinator: Any) -> None:
+        coordinator.request.call_one(current_rank().rank).get()
+
+    @endpoint
+    def reply(self) -> None:
+        pass
+
+
+class TelemetryCoordinatorActor(Actor):
+    """Coordinator that replies to the requesting worker."""
+
+    def __init__(self, workers: Any) -> None:
+        self.workers = workers
+
+    @endpoint
+    def request(self, rank: int) -> None:
+        self.workers.slice(replica=rank).reply.broadcast()
+
+
+class TelemetryFailureActor(Actor):
+    """Actor whose fire-and-forget endpoint fails the actor."""
+
+    @endpoint
+    def fail(self) -> None:
+        raise RuntimeError("telemetry failure")
+
+
 def _telemetry_config(**kwargs: Any) -> TelemetryConfig:
     kwargs.setdefault("dashboard_port", 0)
     return TelemetryConfig(**kwargs)
@@ -125,6 +157,16 @@ def _rows_to_pydict(rows: list[dict[str, Any]]) -> dict[str, list[Any]]:
     if not rows:
         return {}
     return {column: [row.get(column) for row in rows] for column in rows[0].keys()}
+
+
+def _pydict_to_rows(columns: dict[str, list[Any]]) -> list[dict[str, Any]]:
+    if not columns:
+        return []
+    names = list(columns)
+    return [
+        dict(zip(names, values, strict=True))
+        for values in zip(*(columns[name] for name in names), strict=True)
+    ]
 
 
 def _query(
@@ -195,6 +237,54 @@ def _sample_pyspy_dump_json() -> str:
             }
         }
     )
+
+
+_TELEMETRY_WORKER_MESH = "telemetry_worker"
+_TELEMETRY_COORDINATOR_MESH = "telemetry_coordinator"
+_TELEMETRY_FAILURE_MESH = "telemetry_failure"
+
+
+def _start_telemetry_workload(state) -> None:
+    hosts = state.hosts
+    worker_procs = hosts.spawn_procs(
+        per_host={"replica": 2}, name="telemetry_worker_procs"
+    )
+    coordinator_proc = hosts.spawn_procs(name=_TELEMETRY_COORDINATOR_MESH)
+    workers = worker_procs.spawn(_TELEMETRY_WORKER_MESH, TelemetryWorkerActor)
+    coordinator = coordinator_proc.spawn(
+        _TELEMETRY_COORDINATOR_MESH, TelemetryCoordinatorActor, workers
+    )
+    workers.initialized.get()
+    coordinator.initialized.get()
+    workers.start.broadcast(coordinator)
+
+
+def _start_failed_actor(state) -> tuple[int, int]:
+    monarch.actor.unhandled_fault_hook = lambda failure: None
+    failure_procs = state.hosts.spawn_procs(name="telemetry_failure_procs")
+    failure_actor = failure_procs.spawn(_TELEMETRY_FAILURE_MESH, TelemetryFailureActor)
+    failure_actor.initialized.get()
+    actor_id = _query(
+        state,
+        "SELECT a.id FROM actors a JOIN meshes m ON a.mesh_id = m.id "
+        f"WHERE m.given_name = '{_TELEMETRY_FAILURE_MESH}'",
+    )["id"][0]
+
+    failure_actor.fail.broadcast()
+    _query(
+        state,
+        "SELECT id FROM actor_status_events "
+        f"WHERE actor_id = {actor_id} AND new_status = 'Failed'",
+    )
+    message_id = _query(
+        state,
+        "SELECT msg.id FROM messages msg "
+        "JOIN actors a ON msg.to_actor_id = a.id "
+        "JOIN meshes m ON a.mesh_id = m.id "
+        f"WHERE m.given_name = '{_TELEMETRY_FAILURE_MESH}' "
+        "AND msg.endpoint = 'fail'",
+    )["id"][0]
+    return actor_id, message_id
 
 
 @pytest.mark.timeout(30)
@@ -388,6 +478,47 @@ def test_actors_table() -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
+def test_telemetry_workload_actor_topology() -> None:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+        _start_telemetry_workload(state)
+
+        result = _query(
+            state,
+            "SELECT a.id, a.timestamp_us, a.rank, a.full_name, "
+            "m.given_name, m.class FROM actors a "
+            "JOIN meshes m ON a.mesh_id = m.id "
+            f"WHERE m.given_name IN ('{_TELEMETRY_WORKER_MESH}', "
+            f"'{_TELEMETRY_COORDINATOR_MESH}')",
+            min_rows=4,
+        )
+        rows = _pydict_to_rows(result)
+        assert len(rows) == 4, rows
+        assert Counter(row["class"] for row in rows) == {
+            "Proc": 1,
+            "Python<TelemetryWorkerActor>": 2,
+            "Python<TelemetryCoordinatorActor>": 1,
+        }
+
+        workers = [
+            row for row in rows if row["class"] == "Python<TelemetryWorkerActor>"
+        ]
+        assert sorted(row["rank"] for row in workers) == [0, 1]
+        assert [
+            row["rank"]
+            for row in rows
+            if row["class"] == "Python<TelemetryCoordinatorActor>"
+        ] == [0]
+        assert len({row["id"] for row in rows}) == 4
+        assert all(row["timestamp_us"] > 0 for row in rows)
+        assert all(ActorAddr.from_string(row["full_name"]) for row in rows)
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
 def test_meshes_table() -> None:
     """Test that the meshes table is populated when actor meshes are spawned."""
     # Spawn some worker actors - this should trigger notify_mesh_created
@@ -480,6 +611,51 @@ def test_meshes_table() -> None:
                 assert sizes[workers_idx] == 2, (
                     f"Expected 2 workers in shape, got: {sizes[workers_idx]}"
                 )
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_telemetry_workload_mesh_topology() -> None:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+        _start_telemetry_workload(state)
+
+        rows = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT id, timestamp_us, class, given_name, shape_json, "
+                "parent_mesh_id FROM meshes "
+                f"WHERE given_name IN ('{_TELEMETRY_WORKER_MESH}', "
+                f"'{_TELEMETRY_COORDINATOR_MESH}')",
+                min_rows=3,
+            )
+        )
+        assert len(rows) == 3, rows
+        assert Counter(row["class"] for row in rows) == {
+            "Proc": 1,
+            "Python<TelemetryWorkerActor>": 1,
+            "Python<TelemetryCoordinatorActor>": 1,
+        }
+        assert len({row["id"] for row in rows}) == 3
+        assert all(row["timestamp_us"] > 0 for row in rows)
+
+        worker_mesh = next(
+            row for row in rows if row["class"] == "Python<TelemetryWorkerActor>"
+        )
+        worker_shape = json.loads(worker_mesh["shape_json"])["inner"]
+        assert worker_shape == {
+            "labels": ["hosts", "replica"],
+            "sizes": [1, 2],
+        }
+
+        coordinator_proc = next(row for row in rows if row["class"] == "Proc")
+        coordinator_actor_mesh = next(
+            row for row in rows if row["class"] == "Python<TelemetryCoordinatorActor>"
+        )
+        assert coordinator_actor_mesh["parent_mesh_id"] == coordinator_proc["id"]
 
 
 @pytest.mark.timeout(120)
@@ -757,7 +933,6 @@ def test_all_actors_in_host_mesh(cleanup_callbacks) -> None:
 @isolate_in_subprocess
 def test_actor_status_events_table() -> None:
     """Test that the actor_status_events table is populated when actors change status."""
-    # Spawn worker actors — actors go through status transitions during spawn
     with scoped_state(
         ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
@@ -768,13 +943,7 @@ def test_actor_status_events_table() -> None:
         workers = worker_procs.spawn("status_test_worker", WorkerActor)
         workers.initialized.get()
 
-        # Query the actor_status_events table
-        result_dict = _query(
-            state,
-            "SELECT * FROM actor_status_events",
-        )
-
-        # Verify the schema has the expected columns
+        result_dict = _query(state, "SELECT * FROM actor_status_events")
         expected_columns = {
             "id",
             "timestamp_us",
@@ -787,26 +956,38 @@ def test_actor_status_events_table() -> None:
             f"Expected columns {expected_columns}, got {actual_columns}"
         )
 
-        # We should have at least some status events (actors transition through
-        # Created -> Initializing -> Idle at minimum)
-        event_count = len(result_dict.get("timestamp_us", []))
-        assert event_count > 0, (
-            f"Expected at least one actor status event, got {event_count}"
+        worker_rows = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT ase.actor_id, ase.new_status, ase.reason "
+                "FROM actor_status_events ase "
+                "JOIN actors a ON ase.actor_id = a.id "
+                "JOIN meshes m ON a.mesh_id = m.id "
+                "WHERE m.given_name = 'status_test_worker'",
+                min_rows=4,
+            )
         )
+        statuses_by_actor = {
+            actor_id: {
+                row["new_status"] for row in worker_rows if row["actor_id"] == actor_id
+            }
+            for actor_id in {row["actor_id"] for row in worker_rows}
+        }
+        assert len(statuses_by_actor) == 2
+        assert all(
+            statuses == {"Initializing", "Idle"}
+            for statuses in statuses_by_actor.values()
+        ), statuses_by_actor
+        assert all(row["reason"] is None for row in worker_rows)
 
-        joined = _query(
+        client_rows = _query(
             state,
             "SELECT ase.id FROM actor_status_events ase "
-            "INNER JOIN actors a ON ase.actor_id = a.id "
-            "WHERE a.display_name LIKE '%status_test_worker%'",
+            "JOIN actors a ON ase.actor_id = a.id "
+            "WHERE a.display_name = '<root>' AND ase.new_status = 'Client'",
         )
-        joined_count = len(joined.get("id", []))
-        assert joined_count > 0, (
-            "Expected actor_status_events.actor_id to join actors.id for "
-            f"status_test_worker, got {joined_count} joined rows"
-        )
+        assert client_rows["id"]
 
-        # Verify new_status values are valid ActorStatus arm names
         valid_statuses = {
             "Unknown",
             "Created",
@@ -814,16 +995,105 @@ def test_actor_status_events_table() -> None:
             "Client",
             "Idle",
             "Processing",
-            "Saving",
-            "Loading",
             "Stopping",
             "Stopped",
             "Failed",
         }
-        new_statuses = set(result_dict.get("new_status", []))
+        new_statuses = set(
+            _query(state, "SELECT DISTINCT new_status FROM actor_status_events")[
+                "new_status"
+            ]
+        )
         assert new_statuses.issubset(valid_statuses), (
             f"Found unexpected status values: {new_statuses - valid_statuses}"
         )
+        assert "Unknown" not in new_statuses
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.xfail(
+    strict=True,
+    reason="User actors omit the Created or Processing transition",
+)
+@isolate_in_subprocess
+@pytest.mark.parametrize("required_status", ["Created", "Processing"])
+def test_user_actor_status_missing_transition(required_status: str) -> None:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+        _start_telemetry_workload(state)
+
+        _query(
+            state,
+            "SELECT msg.id FROM messages msg "
+            "JOIN actors a ON msg.to_actor_id = a.id "
+            "JOIN meshes m ON a.mesh_id = m.id "
+            f"WHERE m.given_name IN ('{_TELEMETRY_WORKER_MESH}', "
+            f"'{_TELEMETRY_COORDINATOR_MESH}') "
+            "AND msg.endpoint IN ('start', 'request', 'reply')",
+            min_rows=6,
+        )
+        actors = _query(
+            state,
+            "SELECT a.id FROM actors a JOIN meshes m ON a.mesh_id = m.id "
+            f"WHERE m.given_name IN ('{_TELEMETRY_WORKER_MESH}', "
+            f"'{_TELEMETRY_COORDINATOR_MESH}') AND m.class LIKE 'Python<%'",
+            min_rows=3,
+        )["id"]
+        actor_ids = ", ".join(str(actor_id) for actor_id in actors)
+        status_rows = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT actor_id, new_status, reason FROM actor_status_events "
+                f"WHERE actor_id IN ({actor_ids})",
+                min_rows=6,
+            )
+        )
+
+        statuses_by_actor = {
+            actor_id: {
+                row["new_status"] for row in status_rows if row["actor_id"] == actor_id
+            }
+            for actor_id in actors
+        }
+        missing = {
+            actor_id: statuses
+            for actor_id, statuses in statuses_by_actor.items()
+            if required_status not in statuses
+        }
+        assert not missing, missing
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_actor_status_events_failed_actor() -> None:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+        actor_id, _ = _start_failed_actor(state)
+
+        rows = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT new_status, reason FROM actor_status_events "
+                f"WHERE actor_id = {actor_id}",
+                min_rows=4,
+            )
+        )
+        assert {row["new_status"] for row in rows} == {
+            "Initializing",
+            "Idle",
+            "Stopping",
+            "Failed",
+        }, rows
+        failed_reason = next(
+            row["reason"] for row in rows if row["new_status"] == "Failed"
+        )
+        assert "telemetry failure" in failed_reason
 
 
 @pytest.mark.timeout(120)
@@ -970,15 +1240,16 @@ def test_sent_messages_table(
                 "SELECT column_name FROM information_schema.columns "
                 "WHERE table_name = 'sent_messages' ORDER BY ordinal_position",
             )
-            column_names = result.get("column_name", [])
-            assert column_names == [
+            required_columns = {
                 "id",
                 "timestamp_us",
                 "sender_actor_id",
                 "actor_mesh_id",
                 "view_json",
                 "shape_json",
-            ], f"Unexpected columns: {column_names}"
+            }
+            column_names = set(result.get("column_name", []))
+            assert required_columns.issubset(column_names), column_names
 
         # Verify 42 sent_messages join with the correct mesh
         joined = _query(
@@ -1043,6 +1314,40 @@ def test_sent_messages_table(
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
+def test_telemetry_workload_sent_message_fanout() -> None:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+        _start_telemetry_workload(state)
+
+        rows = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT sm.id, sm.timestamp_us, m.given_name "
+                "FROM sent_messages sm JOIN meshes m ON sm.actor_mesh_id = m.id "
+                f"WHERE m.given_name IN ('{_TELEMETRY_WORKER_MESH}', "
+                f"'{_TELEMETRY_COORDINATOR_MESH}') "
+                "AND m.class LIKE 'Python<%'",
+                min_rows=5,
+            )
+        )
+        assert len(rows) == 5, rows
+        assert Counter(row["given_name"] for row in rows) == {
+            _TELEMETRY_WORKER_MESH: 3,
+            _TELEMETRY_COORDINATOR_MESH: 2,
+        }
+        assert len({row["id"] for row in rows}) == 5
+        assert all(row["timestamp_us"] > 0 for row in rows)
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.xfail(
+    strict=True,
+    reason="Received multicast rows do not preserve the logical sender actor ID",
+)
+@isolate_in_subprocess
 def test_messages_table(cleanup_callbacks) -> None:
     """Test that the messages table is populated when messages are received."""
     with scoped_state(
@@ -1085,7 +1390,7 @@ def test_messages_table(cleanup_callbacks) -> None:
         # Verify to_actor_id joins with actors table (receiver is a known actor)
         joined = _query(
             state,
-            "SELECT m.id FROM messages m "
+            "SELECT m.id, m.from_actor_id FROM messages m "
             "JOIN actors a ON m.to_actor_id = a.id "
             "JOIN meshes mesh ON a.mesh_id = mesh.id "
             "WHERE mesh.given_name = 'msg_test_worker'",
@@ -1096,6 +1401,21 @@ def test_messages_table(cleanup_callbacks) -> None:
         assert joined_count == 10, (
             f"Expected 10 messages received by msg_test_worker, got {joined_count}"
         )
+
+        sent = _query(
+            state,
+            "SELECT sm.sender_actor_id FROM sent_messages sm "
+            "JOIN meshes mesh ON sm.actor_mesh_id = mesh.id "
+            "WHERE mesh.given_name = 'msg_test_worker'",
+            min_rows=5,
+        )
+        assert len(sent["sender_actor_id"]) == 5, sent
+        expected_sender_ids = set(sent["sender_actor_id"])
+        assert len(expected_sender_ids) == 1, sent
+        assert set(joined["from_actor_id"]) == expected_sender_ids, {
+            "expected_sender_ids": expected_sender_ids,
+            "received_sender_ids": set(joined["from_actor_id"]),
+        }
 
         ports_by_actor = _query(
             state,
@@ -1113,6 +1433,41 @@ def test_messages_table(cleanup_callbacks) -> None:
         assert len(ports_by_actor["to_actor_id"]) == 2, ports_by_actor
         assert ports_by_actor["message_count"] == [5, 5], ports_by_actor
         assert ports_by_actor["port_count"] == [1, 1], ports_by_actor
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_telemetry_workload_message_fanout() -> None:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+        _start_telemetry_workload(state)
+
+        rows = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT msg.endpoint, target.given_name "
+                "FROM messages msg "
+                "JOIN actors receiver ON msg.to_actor_id = receiver.id "
+                "JOIN meshes target ON receiver.mesh_id = target.id "
+                f"WHERE target.given_name IN ('{_TELEMETRY_WORKER_MESH}', "
+                f"'{_TELEMETRY_COORDINATOR_MESH}') "
+                "AND msg.endpoint IN ('start', 'request', 'reply')",
+                min_rows=6,
+            )
+        )
+        assert len(rows) == 6, rows
+        assert Counter(row["endpoint"] for row in rows) == {
+            "start": 2,
+            "request": 2,
+            "reply": 2,
+        }
+        assert Counter(row["given_name"] for row in rows) == {
+            _TELEMETRY_WORKER_MESH: 4,
+            _TELEMETRY_COORDINATOR_MESH: 2,
+        }
 
 
 @pytest.mark.timeout(120)
@@ -1156,23 +1511,15 @@ def test_messages_endpoint(cleanup_callbacks) -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
-def test_message_status_events_table(cleanup_callbacks) -> None:
-    """Test that message_status_events captures queued/active/complete transitions."""
+def test_message_status_events_table() -> None:
+    """Test the complete status lifecycle for successful received messages."""
     with scoped_state(
         ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
     ) as state:
         _assert_sidecar(state)
-        hosts = state.hosts
-        worker_procs = hosts.spawn_procs(
-            per_host={"workers": 1}, name="status_workers_procs"
-        )
-        workers = worker_procs.spawn("status_test_worker", WorkerActor)
-        workers.initialized.get()
+        _start_telemetry_workload(state)
 
-        workers.ping.call().get()
-
-        # Verify schema
         result = _query(
             state,
             "SELECT column_name FROM information_schema.columns "
@@ -1186,25 +1533,82 @@ def test_message_status_events_table(cleanup_callbacks) -> None:
             "status",
         ], f"Unexpected columns: {column_names}"
 
-        # Verify status values include queued, active, complete
-        result = _query(state, "SELECT DISTINCT status FROM message_status_events")
-        statuses = set(result.get("status", []))
-        expected_statuses = {"queued", "active", "complete"}
-        assert expected_statuses.issubset(statuses), (
-            f"Expected statuses {expected_statuses} to be subset of {statuses}"
+        messages = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT msg.id, msg.timestamp_us FROM messages msg "
+                "JOIN actors receiver ON msg.to_actor_id = receiver.id "
+                "JOIN meshes target ON receiver.mesh_id = target.id "
+                f"WHERE target.given_name IN ('{_TELEMETRY_WORKER_MESH}', "
+                f"'{_TELEMETRY_COORDINATOR_MESH}') "
+                "AND msg.endpoint IN ('start', 'request', 'reply')",
+                min_rows=6,
+            )
         )
+        assert len(messages) == 6, messages
+        message_timestamps = {
+            message["id"]: message["timestamp_us"] for message in messages
+        }
+        message_ids = ", ".join(str(message_id) for message_id in message_timestamps)
 
-        # Verify at least one message has all 3 status events (queued, active, complete)
-        result_dict = _query(
-            state,
-            "SELECT message_id, COUNT(*) as cnt "
-            "FROM message_status_events "
-            "GROUP BY message_id "
-            "HAVING COUNT(*) = 3",
+        events = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT id, timestamp_us, message_id, status "
+                "FROM message_status_events "
+                f"WHERE message_id IN ({message_ids})",
+                min_rows=18,
+            )
         )
-        assert len(result_dict.get("message_id", [])) > 0, (
-            "Expected at least one message with all 3 status events"
+        assert len(events) == 18, events
+        assert len({event["id"] for event in events}) == 18
+        assert Counter(event["status"] for event in events) == {
+            "queued": 6,
+            "active": 6,
+            "complete": 6,
+        }
+        assert {event["message_id"] for event in events} == set(message_timestamps)
+
+        for message_id, message_timestamp in message_timestamps.items():
+            message_events = [
+                event for event in events if event["message_id"] == message_id
+            ]
+            assert Counter(event["status"] for event in message_events) == {
+                "queued": 1,
+                "active": 1,
+                "complete": 1,
+            }
+            timestamps = {
+                event["status"]: event["timestamp_us"] for event in message_events
+            }
+            assert timestamps["active"] == message_timestamp
+            assert timestamps["complete"] >= timestamps["active"]
+
+
+@pytest.mark.timeout(120)
+@pytest.mark.xfail(
+    strict=True,
+    reason="A failed handler is recorded as complete instead of failed",
+)
+@isolate_in_subprocess
+def test_message_status_events_failed_handler() -> None:
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+        _, message_id = _start_failed_actor(state)
+
+        events = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT status, timestamp_us FROM message_status_events "
+                f"WHERE message_id = {message_id}",
+                min_rows=3,
+            )
         )
+        statuses = {event["status"] for event in events}
+        assert "failed" in statuses and "complete" not in statuses, events
 
 
 @pytest.mark.timeout(120)
@@ -1569,26 +1973,75 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
         assert pre_stop_msg_count > 0, (
             "Expected received messages for actor_stop_worker before stopping"
         )
+        pre_stop_statuses = _query(
+            state,
+            "SELECT mse.id FROM message_status_events mse "
+            "JOIN messages msg ON mse.message_id = msg.id "
+            "JOIN actors a ON msg.to_actor_id = a.id "
+            "JOIN meshes mesh ON a.mesh_id = mesh.id "
+            "WHERE mesh.given_name = 'actor_stop_worker'",
+            min_rows=6,
+        )
+        pre_stop_status_count = len(pre_stop_statuses["id"])
 
         # Stop only the user ActorMesh, not the ProcMesh.
         # The telemetry actors on the ProcMesh remain alive.
         cast(ActorMesh[WorkerActor], workers).stop().get()
 
-        # The actor_status_events table should show a Stopped status for the
-        # stopped actors. This event fires on the child process, and is
-        # queryable because the ProcMesh (and its telemetry actor) is still alive.
-        status_result = _query(
+        status_rows = _pydict_to_rows(
+            _query(
+                state,
+                "SELECT ase.actor_id, ase.new_status, ase.reason "
+                "FROM actor_status_events ase "
+                "JOIN actors a ON ase.actor_id = a.id "
+                "JOIN meshes m ON a.mesh_id = m.id "
+                "WHERE m.given_name = 'actor_stop_worker'",
+                min_rows=8,
+            )
+        )
+        statuses_by_actor = {
+            actor_id: {
+                row["new_status"] for row in status_rows if row["actor_id"] == actor_id
+            }
+            for actor_id in {row["actor_id"] for row in status_rows}
+        }
+        assert all(
+            statuses == {"Initializing", "Idle", "Stopping", "Stopped"}
+            for statuses in statuses_by_actor.values()
+        ), statuses_by_actor
+        assert all(
+            row["reason"] for row in status_rows if row["new_status"] == "Stopped"
+        )
+
+        sent_after_stop = _query(
             state,
-            "SELECT ase.new_status FROM actor_status_events ase "
+            "SELECT sm.id FROM sent_messages sm "
+            "JOIN meshes m ON sm.actor_mesh_id = m.id "
+            "WHERE m.given_name = 'actor_stop_worker'",
+        )
+        sent_after_stop_count = len(sent_after_stop["id"])
+
+        monarch.actor.unhandled_fault_hook = lambda failure: None
+        with pytest.raises(SupervisionError, match="stopped"):
+            workers.ping.call().get()
+
+        failed_send = _query(
+            state,
+            "SELECT sm.id FROM sent_messages sm "
+            "JOIN meshes m ON sm.actor_mesh_id = m.id "
+            "WHERE m.given_name = 'actor_stop_worker'",
+            min_rows=sent_after_stop_count + 1,
+        )
+        assert len(failed_send["id"]) == sent_after_stop_count + 1
+
+        client_processing = _query(
+            state,
+            "SELECT ase.id FROM actor_status_events ase "
             "JOIN actors a ON ase.actor_id = a.id "
-            "JOIN meshes m ON a.mesh_id = m.id "
-            "WHERE m.given_name = 'actor_stop_worker' AND ase.new_status = 'Stopped'",
+            "WHERE a.display_name = '<root>' "
+            "AND ase.new_status = 'Processing'",
         )
-        statuses = set(status_result.get("new_status", []))
-        assert "Stopped" in statuses, (
-            f"Expected 'Stopped' in actor status events after ActorMesh.stop(), "
-            f"got: {statuses}"
-        )
+        assert client_processing["id"]
 
         # Query should still work — the telemetry children are unaffected
         result_dict = _query(state, "SELECT * FROM actors")
@@ -1624,6 +2077,16 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
             f"Expected {pre_stop_msg_count} received messages after stopping ActorMesh, "
             f"got {post_stop_msg_count} (data should be preserved)"
         )
+        post_stop_statuses = _query(
+            state,
+            "SELECT mse.id FROM message_status_events mse "
+            "JOIN messages msg ON mse.message_id = msg.id "
+            "JOIN actors a ON msg.to_actor_id = a.id "
+            "JOIN meshes mesh ON a.mesh_id = mesh.id "
+            "WHERE mesh.given_name = 'actor_stop_worker'",
+            min_rows=pre_stop_status_count,
+        )
+        assert len(post_stop_statuses["id"]) == pre_stop_status_count
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -1012,20 +1012,8 @@ def test_actor_status_events_table() -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
-@pytest.mark.parametrize(
-    "required_status",
-    [
-        "Created",
-        pytest.param(
-            "Processing",
-            marks=pytest.mark.xfail(
-                strict=True,
-                reason="User actor Processing transitions are suppressed",
-            ),
-        ),
-    ],
-)
-def test_user_actor_status_missing_transition(required_status: str) -> None:
+@pytest.mark.parametrize("required_status", ["Created", "Processing"])
+def test_user_actor_status_lifecycle(required_status: str) -> None:
     with scoped_state(
         ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
@@ -1051,12 +1039,32 @@ def test_user_actor_status_missing_transition(required_status: str) -> None:
             min_rows=3,
         )["id"]
         actor_ids = ", ".join(str(actor_id) for actor_id in actors)
+        required_count = 3 if required_status == "Created" else 6
+        _query(
+            state,
+            "SELECT ase.id FROM actor_status_events ase "
+            "JOIN actors a ON ase.actor_id = a.id "
+            "JOIN meshes m ON a.mesh_id = m.id "
+            f"WHERE m.given_name IN ('{_TELEMETRY_WORKER_MESH}', "
+            f"'{_TELEMETRY_COORDINATOR_MESH}') "
+            f"AND ase.new_status = '{required_status}'",
+            min_rows=required_count,
+        )
+        if required_status == "Processing":
+            _query(
+                state,
+                "SELECT ase.id FROM actor_status_events ase "
+                "WHERE ase.new_status = 'Idle' "
+                f"AND ase.actor_id IN ({actor_ids})",
+                min_rows=9,
+            )
         status_rows = _pydict_to_rows(
             _query(
                 state,
-                "SELECT actor_id, new_status, reason FROM actor_status_events "
+                "SELECT actor_id, timestamp_us, new_status, reason "
+                "FROM actor_status_events "
                 f"WHERE actor_id IN ({actor_ids})",
-                min_rows=6,
+                min_rows=9,
             )
         )
 
@@ -1072,6 +1080,19 @@ def test_user_actor_status_missing_transition(required_status: str) -> None:
             if required_status not in statuses
         }
         assert not missing, missing
+        if required_status == "Processing":
+            for actor_id in actors:
+                processing_at = max(
+                    row["timestamp_us"]
+                    for row in status_rows
+                    if row["actor_id"] == actor_id and row["new_status"] == "Processing"
+                )
+                idle_at = max(
+                    row["timestamp_us"]
+                    for row in status_rows
+                    if row["actor_id"] == actor_id and row["new_status"] == "Idle"
+                )
+                assert idle_at >= processing_at
 
 
 @pytest.mark.timeout(120)
@@ -1089,13 +1110,14 @@ def test_actor_status_events_failed_actor() -> None:
                 state,
                 "SELECT new_status, reason FROM actor_status_events "
                 f"WHERE actor_id = {actor_id}",
-                min_rows=5,
+                min_rows=7,
             )
         )
         assert {row["new_status"] for row in rows} == {
             "Created",
             "Initializing",
             "Idle",
+            "Processing",
             "Stopping",
             "Failed",
         }, rows
@@ -2005,7 +2027,7 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
                 "JOIN actors a ON ase.actor_id = a.id "
                 "JOIN meshes m ON a.mesh_id = m.id "
                 "WHERE m.given_name = 'actor_stop_worker'",
-                min_rows=10,
+                min_rows=14,
             )
         )
         statuses_by_actor = {
@@ -2015,7 +2037,8 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
             for actor_id in {row["actor_id"] for row in status_rows}
         }
         assert all(
-            statuses == {"Created", "Initializing", "Idle", "Stopping", "Stopped"}
+            statuses
+            == {"Created", "Initializing", "Idle", "Processing", "Stopping", "Stopped"}
             for statuses in statuses_by_actor.values()
         ), statuses_by_actor
         assert all(

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -964,7 +964,7 @@ def test_actor_status_events_table() -> None:
                 "JOIN actors a ON ase.actor_id = a.id "
                 "JOIN meshes m ON a.mesh_id = m.id "
                 "WHERE m.given_name = 'status_test_worker'",
-                min_rows=4,
+                min_rows=6,
             )
         )
         statuses_by_actor = {
@@ -975,7 +975,7 @@ def test_actor_status_events_table() -> None:
         }
         assert len(statuses_by_actor) == 2
         assert all(
-            statuses == {"Initializing", "Idle"}
+            statuses == {"Created", "Initializing", "Idle"}
             for statuses in statuses_by_actor.values()
         ), statuses_by_actor
         assert all(row["reason"] is None for row in worker_rows)
@@ -1011,12 +1011,20 @@ def test_actor_status_events_table() -> None:
 
 
 @pytest.mark.timeout(120)
-@pytest.mark.xfail(
-    strict=True,
-    reason="User actors omit the Created or Processing transition",
-)
 @isolate_in_subprocess
-@pytest.mark.parametrize("required_status", ["Created", "Processing"])
+@pytest.mark.parametrize(
+    "required_status",
+    [
+        "Created",
+        pytest.param(
+            "Processing",
+            marks=pytest.mark.xfail(
+                strict=True,
+                reason="User actor Processing transitions are suppressed",
+            ),
+        ),
+    ],
+)
 def test_user_actor_status_missing_transition(required_status: str) -> None:
     with scoped_state(
         ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
@@ -1081,10 +1089,11 @@ def test_actor_status_events_failed_actor() -> None:
                 state,
                 "SELECT new_status, reason FROM actor_status_events "
                 f"WHERE actor_id = {actor_id}",
-                min_rows=4,
+                min_rows=5,
             )
         )
         assert {row["new_status"] for row in rows} == {
+            "Created",
             "Initializing",
             "Idle",
             "Stopping",
@@ -1996,7 +2005,7 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
                 "JOIN actors a ON ase.actor_id = a.id "
                 "JOIN meshes m ON a.mesh_id = m.id "
                 "WHERE m.given_name = 'actor_stop_worker'",
-                min_rows=8,
+                min_rows=10,
             )
         )
         statuses_by_actor = {
@@ -2006,7 +2015,7 @@ def test_query_after_stopping_actor_mesh(cleanup_callbacks) -> None:
             for actor_id in {row["actor_id"] for row in status_rows}
         }
         assert all(
-            statuses == {"Initializing", "Idle", "Stopping", "Stopped"}
+            statuses == {"Created", "Initializing", "Idle", "Stopping", "Stopped"}
             for statuses in statuses_by_actor.values()
         ), statuses_by_actor
         assert all(

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -1374,10 +1374,6 @@ def test_telemetry_workload_sent_message_fanout() -> None:
 
 
 @pytest.mark.timeout(120)
-@pytest.mark.xfail(
-    strict=True,
-    reason="Received multicast rows do not preserve the logical sender actor ID",
-)
 @isolate_in_subprocess
 def test_messages_table(cleanup_callbacks) -> None:
     """Test that the messages table is populated when messages are received."""


### PR DESCRIPTION
Summary:

Received multicast telemetry used each leaf's internal cast actor for
`messages.from_actor_id`. Falling back to `SENDER_ACTOR_ID` was incomplete
because that header is sparse ordering metadata and is absent after sequence 4.

Add a framework-owned helper for stamping `SENDER_ACTOR_ID_HASH`. Every cast
leaf now overwrites the hash from the private `CastMessage.sender` before
mailbox delivery, while ordinary deliveries derive it from their envelope
sender when no trusted cast hash is present. The end-to-end test sends five
messages to two workers and requires all ten received rows to match the single
logical sender recorded by the five sent rows.

Reviewed By: zdevito

Differential Revision: D112643168
