### PR TITLE
stop bundling py-spy in monarch wheels

### DIFF
--- a/docs/source/admin-tui.md
+++ b/docs/source/admin-tui.md
@@ -68,7 +68,10 @@ stacks with frame-level detail, GIL ownership, and thread names. Each press
 fetches a fresh trace — useful for diagnosing hangs in C extensions and CUDA
 calls.
 
-`py-spy` is included as a default dependency of `torchmonarch`.
+`py-spy` is not bundled with `torchmonarch`; it must be resolvable on the
+target host — either on `PATH` or via the `PYSPY_BIN` environment variable. If
+it cannot be found, the stack-trace request reports that py-spy is unavailable
+rather than failing the proc.
 
 ```{image} _static/tui-pyspy.png
 :alt: Py-spy overlay showing per-thread Python stack traces with native frames

--- a/python/monarch/_src/actor/bootstrap_main.py
+++ b/python/monarch/_src/actor/bootstrap_main.py
@@ -11,8 +11,6 @@ This is the main function for the boostrapping a new Proc.
 """
 
 import asyncio
-import importlib.resources
-import logging
 import multiprocessing
 import os
 import platform
@@ -63,18 +61,6 @@ def invoke_main() -> None:
             # we can stream python logs now; no need to forward them to rust processes
             pass
             # install opentelemetry tracing
-
-        try:
-            with (
-                importlib.resources.as_file(
-                    importlib.resources.files("monarch") / "py-spy"
-                ) as pyspy,
-            ):
-                if pyspy.exists():
-                    os.environ["PYSPY_BIN"] = str(pyspy)
-                # fallback to using local py-spy
-        except Exception as e:
-            logging.warning(f"Failed to set up py-spy: {e}")
 
         from monarch._src.actor.debugger.breakpoint import remote_breakpointhook
 


### PR DESCRIPTION
Summary:
monarch's wheels shipped a `py-spy` binary and `bootstrap_main.py` pointed
`PYSPY_BIN` at it. we have no confidence the bundled binary even works — the
evidence is that it doesn't — and shipping a profiler isn't monarch's business.
removing the bundling is simply better all around.

removed:
- the `py-spy` `configured_alias` and both wheel `resources = {"monarch/py-spy":
  ":py-spy"}` entries in `monarch/python/monarch/BUCK` (buildifier drops the now
  unused `configured_alias`/`FBCODE`/`get_default_target_platform` loads)
- the `bootstrap_main.py` block that set `os.environ["PYSPY_BIN"]` from the
  bundled resource, plus its now-orphaned `importlib.resources`/`logging` imports

the mesh-admin py-spy dump/profile subsystem (`hyperactor_mesh/src/pyspy.rs`) is
unchanged: `resolve_candidates()` already falls back to `py-spy` on `PATH` when
`PYSPY_BIN` is empty, and returns a handled `BinaryNotFound`/503 if it isn't
found — no crash. `admin-tui.md` is updated to state py-spy must be on `PATH` (or
`PYSPY_BIN`) rather than claiming it's a bundled dependency.

Differential Revision: D112698766


