### PR TITLE
[monarch_rdma] pin the ibverbs device from config

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -9,6 +9,7 @@
 //! ibverbs-specific device selection: pairs a [`MemoryLocation`] with the
 //! RDMA NIC(s) that have the best PCIe path to it.
 
+use std::str::FromStr;
 use std::sync::LazyLock;
 
 use anyhow::Context;
@@ -49,6 +50,63 @@ impl IbvDeviceTarget {
     /// Target the NIC with the given device name.
     pub fn nic(name: impl Into<String>) -> Self {
         Self::Nic(name.into())
+    }
+}
+
+impl FromStr for IbvDeviceTarget {
+    type Err = anyhow::Error;
+
+    /// Parse a `kind:value` spec: `cpu:<numa>`, `gpu:<ordinal>`, or
+    /// `nic:<name>` (e.g. `nic:mlx5_0`). This is the string form the
+    /// `rdma_ibverbs_target` runtime config accepts.
+    fn from_str(s: &str) -> Result<Self> {
+        let (kind, value) = s.split_once(':').with_context(|| {
+            format!("ibverbs target {s:?} must be `cpu:<numa>`, `gpu:<ordinal>`, or `nic:<name>`")
+        })?;
+        match kind {
+            "cpu" => Ok(Self::cpu(value.parse().with_context(|| {
+                format!("cpu target numa node {value:?} is not a u32")
+            })?)),
+            "gpu" => Ok(Self::gpu(value.parse().with_context(|| {
+                format!("gpu target ordinal {value:?} is not a u32")
+            })?)),
+            "nic" => {
+                anyhow::ensure!(
+                    !value.is_empty(),
+                    "nic target must name a device, e.g. `nic:mlx5_0`"
+                );
+                Ok(Self::nic(value))
+            }
+            other => {
+                anyhow::bail!(
+                    "unknown ibverbs target kind {other:?}; expected `cpu`, `gpu`, or `nic`"
+                )
+            }
+        }
+    }
+}
+
+/// The ibverbs device target from the `RDMA_IBVERBS_TARGET` runtime config,
+/// parsed from its `cpu:<numa>` / `gpu:<ordinal>` / `nic:<name>` form, or
+/// `None` when the attr is empty (leaving device selection to the consumer).
+pub fn runtime_ibverbs_target() -> Result<Option<IbvDeviceTarget>> {
+    let spec = hyperactor_config::global::get_cloned(crate::config::RDMA_IBVERBS_TARGET);
+    if spec.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(spec.parse()?))
+}
+
+/// The effective ibverbs target: a caller-provided `explicit` target wins;
+/// otherwise fall back to the runtime `RDMA_IBVERBS_TARGET` config. This is the
+/// precedence [`super::manager_actor::IbvManagerActor::new`] applies, so a
+/// caller that sets `IbvConfig::target` is never overridden by config.
+pub fn effective_ibverbs_target(
+    explicit: Option<IbvDeviceTarget>,
+) -> Result<Option<IbvDeviceTarget>> {
+    match explicit {
+        Some(target) => Ok(Some(target)),
+        None => runtime_ibverbs_target(),
     }
 }
 
@@ -186,4 +244,71 @@ pub fn get_cuda_device_to_ibv_device<I: IbvDeviceImpl>() -> &'static Vec<Option<
             .collect();
         Box::leak(Box::new(result))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_each_target_kind() {
+        assert_eq!(
+            "cpu:0".parse::<IbvDeviceTarget>().unwrap(),
+            IbvDeviceTarget::cpu(0),
+        );
+        assert_eq!(
+            "gpu:1".parse::<IbvDeviceTarget>().unwrap(),
+            IbvDeviceTarget::gpu(1),
+        );
+        assert_eq!(
+            "nic:mlx5_0".parse::<IbvDeviceTarget>().unwrap(),
+            IbvDeviceTarget::nic("mlx5_0"),
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_targets() {
+        // No separator, unknown kind, missing or non-numeric value, and an
+        // empty NIC name must all fail rather than silently misparse.
+        for bad in ["", "cpu", "cpu:", "cpu:x", "gpu:-1", "nic:", "bogus:0"] {
+            assert!(
+                bad.parse::<IbvDeviceTarget>().is_err(),
+                "expected {bad:?} to fail to parse",
+            );
+        }
+    }
+
+    #[test]
+    fn runtime_target_reflects_config() {
+        let lock = hyperactor_config::global::lock();
+        // Empty by default: selection is left to the consumer.
+        assert_eq!(runtime_ibverbs_target().unwrap(), None);
+        {
+            let _guard =
+                lock.override_key(crate::config::RDMA_IBVERBS_TARGET, "nic:mlx5_0".to_string());
+            assert_eq!(
+                runtime_ibverbs_target().unwrap(),
+                Some(IbvDeviceTarget::nic("mlx5_0")),
+            );
+        }
+        // Once the override is dropped the target is unset again.
+        assert_eq!(runtime_ibverbs_target().unwrap(), None);
+    }
+
+    #[test]
+    fn explicit_target_beats_runtime_config() {
+        let lock = hyperactor_config::global::lock();
+        let _guard =
+            lock.override_key(crate::config::RDMA_IBVERBS_TARGET, "nic:mlx5_1".to_string());
+        // A caller-provided target wins over the runtime config.
+        assert_eq!(
+            effective_ibverbs_target(Some(IbvDeviceTarget::nic("mlx5_0"))).unwrap(),
+            Some(IbvDeviceTarget::nic("mlx5_0")),
+        );
+        // With no explicit target, the runtime config fills in.
+        assert_eq!(
+            effective_ibverbs_target(None).unwrap(),
+            Some(IbvDeviceTarget::nic("mlx5_1")),
+        );
+    }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -265,6 +265,12 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                 config
             }
         };
+
+        // A caller-provided target wins; otherwise honor the runtime
+        // `RDMA_IBVERBS_TARGET` so every registration uses one deterministic
+        // NIC instead of the per-region hash spread, which can otherwise place
+        // two host-memory peers on different NICs.
+        config.target = super::device_selection::effective_ibverbs_target(config.target.take())?;
         tracing::debug!("rdma is enabled, config target: {:?}", config.target);
 
         // check config and hardware support align

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -79,4 +79,20 @@ declare_attrs! {
         Some("rdma_qp_init_timeout".to_string()),
     ))
     pub attr RDMA_QP_INIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Explicit ibverbs device target for RDMA registrations.
+    ///
+    /// A caller-supplied `IbvConfig::target` wins; otherwise this
+    /// runtime value pins every registration to one deterministic
+    /// NIC. Its forms mirror the backend's test vocabulary:
+    /// `cpu:<numa>`, `gpu:<ordinal>`, or `nic:<name>` (e.g.
+    /// `nic:mlx5_0`). When empty (the default), the consumer picks the
+    /// device itself -- the CUDA-co-located NIC for device memory, or a
+    /// per-region hash-assigned NIC for host memory, which on a
+    /// multi-NIC host can place two peers on different NICs.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_IBVERBS_TARGET".to_string()),
+        Some("rdma_ibverbs_target".to_string()),
+    ))
+    pub attr RDMA_IBVERBS_TARGET: String = String::new();
 }

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -83,6 +83,7 @@ def configure(
     rdma_allow_tcp_fallback: bool = ...,
     rdma_disable_ibverbs: bool = ...,
     rdma_max_chunk_size_mb: int = ...,
+    rdma_ibverbs_target: str = ...,
     **kwargs: object,
 ) -> None:
     """Configure Hyperactor runtime defaults for this process.
@@ -180,6 +181,11 @@ def configure(
             causing all RDMA operations to use the TCP fallback backend.
         rdma_max_chunk_size_mb: Maximum chunk size in MiB for
             TCP-based RDMA transfers (default: 64)
+        rdma_ibverbs_target: Pin ibverbs registrations to one explicit
+            device ("cpu:<numa>", "gpu:<ordinal>", or "nic:<name>", e.g.
+            "nic:mlx5_0"). When unset, device selection is automatic and
+            host memory is hash-spread across NICs, which on a multi-NIC
+            host can place two peers on different NICs.
         **kwargs: Reserved for future configuration keys
 
     For historical reasons, this API is named ``configure(...)``;

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
             rdma_allow_tcp_fallback: NotRequired[bool]
             rdma_disable_ibverbs: NotRequired[bool]
             rdma_max_chunk_size_mb: NotRequired[int]
+            rdma_ibverbs_target: NotRequired[str]
 
         # pyrefly: ignore [invalid-annotation]
         ConfigureKwargsType = Unpack[ConfigureArgs]
@@ -182,6 +183,13 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
                 causing all RDMA operations to use the TCP fallback backend.
             rdma_max_chunk_size_mb: Maximum chunk size in megabytes for RDMA
                 transfers.
+            rdma_ibverbs_target: Pin ibverbs registrations to one explicit
+                device. Accepts ``"cpu:<numa>"``, ``"gpu:<ordinal>"``, or
+                ``"nic:<name>"`` (e.g. ``"nic:mlx5_0"``). When unset, device
+                selection is automatic: the CUDA-co-located NIC for GPU
+                memory, or a per-region hash-assigned NIC for host memory,
+                which on a multi-NIC host can place two peers on different
+                NICs. Set this for a deterministic data plane.
 
         **kwargs: Reserved for future configuration keys exposed by Rust bindings.
     """


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4458
* #4457
* #4456
* #4455
* #4454
* #4453
* #4452
* #4451
* #4450
* #4449
* #4448
* __->__ #4447

host-memory ibverbs device selection spreads each CPU-memory registration
across the tied-best NICs by hashing its address, so two peers can pick
different NICs and their transfer times out. add `rdma_ibverbs_target`
(`cpu:0` / `nic:mlx5_0`) to pin one device; unset keeps today's automatic
selection.

Differential Revision: [D112723644](https://our.internmc.facebook.com/intern/diff/D112723644/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D112723644/)!