### PR TITLE
[monarch] rdma benchmark: timing and correctness-check helpers

### DIFF
--- a/python/benches/rdma_orchestration/benchmark.py
+++ b/python/benches/rdma_orchestration/benchmark.py
@@ -11,10 +11,10 @@
 RDMA orchestration benchmark -- a stable speedometer for Monarch's RDMA control
 path (pytokio-removal). See pytokio-removal-rdma-benchmark-plan.md.
 
-This diff (Diff A) implements the **pure analysis half** only: the artifact
-schema + atomic IO, `summarize`, `CompatiblePair`, and the comparator/verdict
-algebra. The collector (`bench` / `_cold-init-child`) lands in Diff B; those
-subcommands raise here.
+Implemented: the analysis half (artifact schema + atomic JSON IO, `summarize`,
+`CompatiblePair`, and the comparator/verdict algebra) and the measurement helpers
+(`measure_steady`, `issue_all_then_observe`, the read/write correctness checks).
+Not implemented yet: the collector -- `bench` and `_cold-init-child` raise.
 
 Invariant registry (ROB-*, stable + append-only; never renumber or reuse an ID):
 
@@ -51,9 +51,10 @@ import math
 import os
 import sys
 import tempfile
+import time
 from dataclasses import asdict, dataclass
 from enum import Enum
-from typing import Mapping, Sequence
+from typing import Awaitable, Callable, Mapping, Protocol, Sequence
 
 SCHEMA_VERSION: int = 1
 
@@ -490,7 +491,67 @@ def render(outcome: GateOutcome) -> str:
 
 
 # ---------------------------------------------------------------------------
-# CLI. `compare` is implemented here; `bench` / `_cold-init-child` land in Diff B.
+# Steady-state measurement (ROB-3/4/5). Harness-level and Monarch-free; the
+# actors and the RDMA data plane are lazily imported inside the collector so
+# importing this module for `compare` never pulls in Monarch.
+# ---------------------------------------------------------------------------
+
+
+class LazyOp(Protocol):
+    """A lazy Monarch future: calling `.as_asyncio()` is what dispatches it."""
+
+    def as_asyncio(self) -> Awaitable[object]: ...
+
+
+@dataclass(frozen=True)
+class SteadyTrial:
+    prepare: Callable[[], Awaitable[object]]
+    issue_and_observe: Callable[[], Awaitable[object]]
+    validate: Callable[[object, object], Awaitable[None]]
+
+
+async def measure_steady(trial: SteadyTrial) -> int:
+    """The sole steady-state clock seam (ROB-3): prepare, clock, issue/observe,
+    clock, validate. Preparation and validation sit outside the timed region."""
+    expected = await trial.prepare()
+    t0 = time.perf_counter_ns()
+    observed = await trial.issue_and_observe()
+    sample_ns = time.perf_counter_ns() - t0
+    await trial.validate(expected, observed)
+    return sample_ns
+
+
+async def issue_all_then_observe(make_op: Callable[[int], LazyOp], k: int) -> None:
+    """ROB-4: dispatch all K lazy ops before observing the first
+    (`issue^K ; observe_all`), never `fold(issue ; observe)`. Monarch futures are
+    lazy, so `.as_asyncio()` is what starts each op; hoisting the K calls above the
+    drain is what makes the batch concurrent rather than K serial ops."""
+    pending = [make_op(i).as_asyncio() for i in range(k)]
+    for aw in pending:
+        await aw
+
+
+class WitnessError(AssertionError):
+    """A measured transfer failed its correctness witness (ROB-5)."""
+
+
+def check_read_witness(expected: bytes, observed: bytes) -> None:
+    """ROB-5: a read destination is poisoned (to a pattern != source) before every
+    timed sample and must equal the source afterward; a dropped/no-op read leaves
+    the poison and fails here."""
+    if observed != expected:
+        raise WitnessError("read destination does not match the source pattern")
+
+
+def check_write_witness(expected_digest: bytes, holder_digest: bytes) -> None:
+    """ROB-5: the holder's digest of the written slot must match the payload's
+    digest; a dropped write leaves the prior bytes and fails here."""
+    if holder_digest != expected_digest:
+        raise WitnessError("write target digest does not match the payload")
+
+
+# ---------------------------------------------------------------------------
+# CLI. `compare` is implemented; `bench` / `_cold-init-child` are not yet.
 # ---------------------------------------------------------------------------
 
 
@@ -504,7 +565,7 @@ def _cmd_compare(args: argparse.Namespace) -> int:
 
 
 def _cmd_not_yet(_args: argparse.Namespace) -> int:
-    raise SystemExit("this subcommand lands in Diff B (the collector)")
+    raise SystemExit("the bench collector is not implemented yet")
 
 
 def build_parser() -> argparse.ArgumentParser:

--- a/python/benches/rdma_orchestration/tests/test_benchmark.py
+++ b/python/benches/rdma_orchestration/tests/test_benchmark.py
@@ -6,18 +6,22 @@
 
 # pyre-strict
 
-"""Pure law tests for the RDMA orchestration benchmark's analysis half (Diff A).
-
-Each test cites the ROB-* law it witnesses. No Monarch/RDMA import; runs anywhere.
+"""Pure tests for the RDMA orchestration benchmark: the analysis half and the
+measurement helpers. Each test cites the ROB-* law it witnesses. No Monarch/RDMA
+import; runs anywhere.
 """
 
+import asyncio
+import hashlib
 import os
 import tempfile
 import unittest
-from typing import Mapping, Optional
+from typing import Awaitable, Mapping, Optional
 
 from monarch.python.benches.rdma_orchestration.benchmark import (
     _percentile_nearest_rank,
+    check_read_witness,
+    check_write_witness,
     COLD_SAMPLES,
     CompatiblePair,
     CONCURRENT_BATCHES,
@@ -27,7 +31,9 @@ from monarch.python.benches.rdma_orchestration.benchmark import (
     Floor,
     GATED_STATS,
     GateRefused,
+    issue_all_then_observe,
     K,
+    measure_steady,
     MIN_ARTIFACTS_PER_SIDE,
     PAYLOAD_BYTES,
     read_artifact,
@@ -36,10 +42,12 @@ from monarch.python.benches.rdma_orchestration.benchmark import (
     RunShape,
     SERIAL_SAMPLES,
     SERIAL_WARMUPS,
+    SteadyTrial,
     summarize,
     ThresholdPolicy,
     TimeoutPolicy,
     Verdict,
+    WitnessError,
     write_artifact,
 )
 
@@ -247,6 +255,69 @@ class EligibilityTest(unittest.TestCase):
     def test_compatible_pair_raises_on_smoke(self) -> None:
         with self.assertRaises(GateRefused):
             CompatiblePair.build(_side(smoke=True), _side())
+
+
+class SteadyMeasurementTest(unittest.TestCase):
+    def test_measure_steady_orders_phases(self) -> None:
+        # ROB-3: prepare -> clock -> issue/observe -> clock -> validate.
+        events: list[str] = []
+
+        async def prep() -> object:
+            events.append("prepare")
+            return "exp"
+
+        async def issue() -> object:
+            events.append("issue")
+            return "obs"
+
+        async def val(expected: object, observed: object) -> None:
+            events.append("validate")
+            self.assertEqual((expected, observed), ("exp", "obs"))
+
+        ns = asyncio.run(measure_steady(SteadyTrial(prep, issue, val)))
+        self.assertEqual(events, ["prepare", "issue", "validate"])
+        self.assertGreaterEqual(ns, 0)
+
+    def test_all_k_dispatched_before_first_observed(self) -> None:
+        # ROB-4: every op is dispatched (.as_asyncio) before any is observed.
+        order: list[tuple[str, int]] = []
+
+        class FakeOp:
+            def __init__(self, i: int) -> None:
+                self._i = i
+
+            def as_asyncio(self) -> Awaitable[object]:
+                order.append(("dispatch", self._i))
+
+                async def _observe() -> object:
+                    order.append(("observe", self._i))
+                    return None
+
+                return _observe()
+
+        asyncio.run(issue_all_then_observe(lambda i: FakeOp(i), 3))
+        first_observe = next(idx for idx, ev in enumerate(order) if ev[0] == "observe")
+        dispatch_idxs = [idx for idx, ev in enumerate(order) if ev[0] == "dispatch"]
+        self.assertEqual(len(dispatch_idxs), 3)
+        self.assertTrue(all(idx < first_observe for idx in dispatch_idxs))
+
+
+class WitnessTest(unittest.TestCase):
+    def test_read_witness_detects_noop(self) -> None:
+        # ROB-5: a poisoned destination left unchanged by a no-op read fails.
+        source = bytes(range(64))
+        poison = bytes([0xFF] * 64)
+        check_read_witness(source, source)
+        with self.assertRaises(WitnessError):
+            check_read_witness(source, poison)
+
+    def test_write_witness_detects_drop(self) -> None:
+        # ROB-5: a dropped write leaves prior bytes; the digest mismatches.
+        payload = b"payload-with-counter"
+        good = hashlib.sha256(payload).digest()
+        check_write_witness(good, good)
+        with self.assertRaises(WitnessError):
+            check_write_witness(good, hashlib.sha256(b"stale").digest())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4458
* #4457
* #4456
* #4455
* #4454
* #4453
* #4452
* #4451
* #4450
* __->__ #4449
* #4448
* #4447

more of the benchmark that will tell us whether moving RDMA setup out of Python
and into Rust makes it faster or slower. this diff adds three small helpers it
will use, plus their tests. there's still no code that actually runs RDMA.

- one helper times a single operation: set up, start the timer, run the
  operation, stop the timer, then check the result -- so setup and checking never
  count toward the measured time.
- one helper runs a batch of operations together: it starts all of them before
  waiting on any. Monarch only starts an operation when you wait on it, so
  starting them all up front is what makes them run at once instead of one after
  another.
- two helpers make sure a transfer really happened: before a read we fill the
  destination with junk, and a write stamps a number into its data -- so a
  transfer that quietly did nothing fails a check instead of looking fast.

the tests cover all three.

Differential Revision: [D112723652](https://our.internmc.facebook.com/intern/diff/D112723652/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D112723652/)!