### PR TITLE
[monarch] rdma benchmark: run RDMA and record a result

### DIFF
--- a/python/benches/rdma_orchestration/benchmark.py
+++ b/python/benches/rdma_orchestration/benchmark.py
@@ -11,10 +11,11 @@
 RDMA orchestration benchmark -- a stable speedometer for Monarch's RDMA control
 path (pytokio-removal). See pytokio-removal-rdma-benchmark-plan.md.
 
-Implemented: the analysis half (artifact schema + atomic JSON IO, `summarize`,
-`CompatiblePair`, and the comparator/verdict algebra) and the measurement helpers
-(`measure_steady`, `issue_all_then_observe`, the read/write correctness checks).
-Not implemented yet: the collector -- `bench` and `_cold-init-child` raise.
+This module is the Monarch-free half: the artifact schema + atomic JSON IO,
+`summarize`, `CompatiblePair`, the comparator/verdict algebra, the measurement
+helpers (`measure_steady`, `issue_all_then_observe`, the read/write correctness
+checks), and the collector's pure helpers (`backend_plan`, `gate_shape`, byte
+patterns). The RDMA-driving collector and the CLI live in `collector.py`.
 
 Invariant registry (ROB-*, stable + append-only; never renumber or reuse an ID):
 
@@ -44,17 +45,18 @@ Invariant registry (ROB-*, stable + append-only; never renumber or reuse an ID):
 under test.
 """
 
-import argparse
 import hashlib
 import json
 import math
 import os
-import sys
+import platform
+import socket
 import tempfile
 import time
 from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
 from enum import Enum
-from typing import Awaitable, Callable, Mapping, Protocol, Sequence
+from typing import Awaitable, Callable, Mapping, Optional, Protocol, Sequence
 
 SCHEMA_VERSION: int = 1
 
@@ -216,10 +218,22 @@ def _median_int(values: Sequence[int]) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _sha256_over_files(paths: Sequence[str]) -> str:
+    h = hashlib.sha256()
+    for path in paths:
+        with open(path, "rb") as fh:
+            h.update(fh.read())
+    return h.hexdigest()
+
+
 def benchmark_source_sha256() -> str:
-    """SHA-256 of this benchmark source file (ROB-1 artifact identity)."""
-    with open(os.path.abspath(__file__), "rb") as fh:
-        return hashlib.sha256(fh.read()).hexdigest()
+    """SHA-256 over the benchmark's source -- both modules, so a change to how a
+    measurement is produced (either file) changes artifact identity (ROB-1). The
+    analysis half alone would miss changes to the RDMA-driving collector."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    return _sha256_over_files(
+        [os.path.join(here, name) for name in ("benchmark.py", "collector.py")]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -551,45 +565,78 @@ def check_write_witness(expected_digest: bytes, holder_digest: bytes) -> None:
 
 
 # ---------------------------------------------------------------------------
-# CLI. `compare` is implemented; `bench` / `_cold-init-child` are not yet.
+# Collector-side pure helpers (backends, run shape, byte patterns). Monarch-free
+# and independently testable; consumed by `collector.py`.
 # ---------------------------------------------------------------------------
 
 
-def _cmd_compare(args: argparse.Namespace) -> int:
-    baseline = [read_artifact(p) for p in args.baseline]
-    candidate = [read_artifact(p) for p in args.candidate]
-    policy = load_threshold_policy(args.policy)
-    outcome = evaluate(baseline, candidate, policy)
-    print(render(outcome))
-    return outcome.exit_code
+class UnsupportedBackend(Exception):
+    """The requested backend is unavailable and no fallback is allowed."""
 
 
-def _cmd_not_yet(_args: argparse.Namespace) -> int:
-    raise SystemExit("the bench collector is not implemented yet")
+def source_pattern(nbytes: int, seed: int) -> bytes:
+    return bytes((seed * 31 + i) & 0xFF for i in range(nbytes))
 
 
-def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description=__doc__)
-    sub = parser.add_subparsers(dest="command", required=True)
-
-    p_bench = sub.add_parser("bench", help="collect one artifact (Diff B)")
-    p_bench.set_defaults(func=_cmd_not_yet)
-
-    p_cold = sub.add_parser("_cold-init-child", help=argparse.SUPPRESS)
-    p_cold.set_defaults(func=_cmd_not_yet)
-
-    p_cmp = sub.add_parser("compare", help="gate two sets of artifacts")
-    p_cmp.add_argument("--baseline", nargs="+", required=True)
-    p_cmp.add_argument("--candidate", nargs="+", required=True)
-    p_cmp.add_argument("--policy", required=True, help="threshold policy JSON")
-    p_cmp.set_defaults(func=_cmd_compare)
-    return parser
+def poison_pattern(nbytes: int) -> bytes:
+    return b"\xa5" * nbytes
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
-    return int(args.func(args))
+def write_payload(nbytes: int, counter: int) -> bytes:
+    """A write payload stamped with an 8-byte counter (ROB-5), in a byte family
+    distinct from the source and poison patterns."""
+    body = bytes((0xC0 ^ (i & 0xFF)) for i in range(max(nbytes - 8, 0)))
+    return (counter.to_bytes(8, "little") + body)[:nbytes]
 
 
-if __name__ == "__main__":
-    sys.exit(main())
+PING_PAYLOAD: bytes = bytes(range(PAYLOAD_BYTES))
+
+
+def backend_plan(
+    backend: str, ibverbs_available: bool, skip_unsupported: bool
+) -> Optional[tuple[dict[str, str], dict[str, object]]]:
+    """Pure backend resolution: returns (recorded config, `configured` kwargs), or
+    None to skip (ibverbs unavailable under --skip-unsupported). Raises for an
+    unsupported request without --skip-unsupported -- silent TCP fallback is
+    forbidden."""
+    if backend == "tcp":
+        return ({"rdma_disable_ibverbs": "true"}, {"rdma_disable_ibverbs": True})
+    if backend == "ibverbs":
+        if ibverbs_available:
+            return (
+                {"rdma_allow_tcp_fallback": "false"},
+                {"rdma_allow_tcp_fallback": False},
+            )
+        if skip_unsupported:
+            return None
+        raise UnsupportedBackend("ibverbs requested but not available")
+    raise ValueError(f"unknown backend {backend!r}")
+
+
+def gate_shape(backend: str, smoke: bool) -> RunShape:
+    if smoke:
+        return RunShape(backend, PAYLOAD_BYTES, K, 1, 2, 20, 1, 5, 1, True)
+    return RunShape(
+        backend,
+        PAYLOAD_BYTES,
+        K,
+        ROUNDS,
+        SERIAL_WARMUPS,
+        SERIAL_SAMPLES,
+        CONCURRENT_WARMUPS,
+        CONCURRENT_BATCHES,
+        COLD_SAMPLES,
+        False,
+    )
+
+
+def environment(label: str) -> Environment:
+    return Environment(
+        hostname=socket.gethostname(),
+        platform=platform.platform(),
+        cpu=platform.processor() or "unknown",
+        python_version=platform.python_version(),
+        monarch_revision="",
+        timestamp_utc=datetime.now(timezone.utc).isoformat(),
+        label=label,
+    )

--- a/python/benches/rdma_orchestration/collector.py
+++ b/python/benches/rdma_orchestration/collector.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+RDMA orchestration benchmark collector -- drives the public Monarch surface to
+produce one artifact. See `benchmark.py` for the Monarch-free analysis half and
+the ROB-* invariant registry.
+
+`bench` runs the steady-state harness -- currently distinct-proc setup, one
+validated read + write smoke, and the ping sentinel -- and writes an artifact
+(ROB-1/9). `compare` gates two artifact sets. `_cold-init-child` is private.
+"""
+
+import argparse
+import asyncio
+import hashlib
+import os
+import sys
+from typing import Mapping, Sequence
+
+from monarch.actor import Actor, endpoint, this_host
+from monarch.config import configured
+from monarch.python.benches.rdma_orchestration import benchmark as bm
+from monarch.rdma import is_ibverbs_available, RDMABuffer
+
+
+async def _bench_async(
+    shape: bm.RunShape,
+    config: Mapping[str, str],
+    cm_kwargs: Mapping[str, object],
+    out: str,
+    overwrite: bool,
+    label: str,
+    timeout: int,
+) -> None:
+    payload_bytes = shape.payload_bytes
+    k = shape.k
+
+    class _Holder(Actor):
+        def __init__(self) -> None:
+            self._source: bytearray = bytearray(bm.source_pattern(payload_bytes, 0))
+            self._targets: list[bytearray] = [
+                bytearray(payload_bytes) for _ in range(k)
+            ]
+
+        @endpoint
+        async def make_buffers(self) -> tuple[RDMABuffer, list[RDMABuffer]]:
+            read_src = RDMABuffer(memoryview(self._source))
+            targets = [RDMABuffer(memoryview(t)) for t in self._targets]
+            return read_src, targets
+
+        @endpoint
+        async def source_bytes(self) -> bytes:
+            return bytes(self._source)
+
+        @endpoint
+        async def slot_digest(self, slot: int) -> bytes:
+            return hashlib.sha256(bytes(self._targets[slot])).digest()
+
+        @endpoint
+        async def ping(self, payload: bytes) -> bytes:
+            return payload
+
+        @endpoint
+        async def pid(self) -> int:
+            return os.getpid()
+
+    class _Driver(Actor):
+        @endpoint
+        async def pid(self) -> int:
+            return os.getpid()
+
+        @endpoint
+        async def smoke(
+            self,
+            holder: _Holder,
+            read_src: RDMABuffer,
+            write0: RDMABuffer,
+            op_timeout: int,
+        ) -> None:
+            expected = bytes(await holder.source_bytes.call_one())
+            dst = bytearray(bm.poison_pattern(read_src.size()))
+            await read_src.read_into(memoryview(dst), timeout=op_timeout)
+            bm.check_read_witness(expected, bytes(dst))
+            payload = bm.write_payload(write0.size(), 1)
+            await write0.write_from(memoryview(payload), timeout=op_timeout)
+            bm.check_write_witness(
+                hashlib.sha256(payload).digest(),
+                bytes(await holder.slot_digest.call_one(0)),
+            )
+
+        @endpoint
+        async def ping_block(
+            self,
+            holder: _Holder,
+            rounds: int,
+            warmups: int,
+            samples: int,
+            payload: bytes,
+        ) -> list[int]:
+            def trial() -> bm.SteadyTrial:
+                async def prepare() -> object:
+                    return payload
+
+                async def issue() -> object:
+                    return await holder.ping.call_one(payload)
+
+                async def validate(expected: object, observed: object) -> None:
+                    if observed != expected:
+                        raise bm.WitnessError("ping echo mismatch")
+
+                return bm.SteadyTrial(prepare, issue, validate)
+
+            out_ns: list[int] = []
+            for _ in range(rounds):
+                for _ in range(warmups):
+                    await bm.measure_steady(trial())
+                for _ in range(samples):
+                    out_ns.append(await bm.measure_steady(trial()))
+            return out_ns
+
+    with configured(**cm_kwargs):
+        holder_procs = this_host().spawn_procs(per_host={"processes": 1})
+        driver_procs = this_host().spawn_procs(per_host={"processes": 1})
+        holder = holder_procs.spawn("rdma_bench_holder", _Holder)
+        driver = driver_procs.spawn("rdma_bench_driver", _Driver)
+        try:
+            holder_pid = int(await holder.pid.call_one())
+            driver_pid = int(await driver.pid.call_one())
+            if len({os.getpid(), holder_pid, driver_pid}) != 3:
+                raise bm.WitnessError(
+                    "holder, driver, and client must be distinct procs"
+                )
+            read_src, targets = await holder.make_buffers.call_one()
+            # smoke: prove the data plane end to end and resolve lazy init.
+            await driver.smoke.call_one(holder, read_src, targets[0], timeout)
+            ping = await driver.ping_block.call_one(
+                holder,
+                shape.rounds,
+                shape.serial_warmups,
+                shape.serial_samples,
+                bm.PING_PAYLOAD,
+            )
+            samples: dict[str, list[int]] = {
+                "ping": ping,
+                "serial_read": [],
+                "serial_write": [],
+                "concurrent_read": [],
+                "concurrent_write": [],
+                "cold_init": [],
+            }
+            artifact = bm.RunArtifact(
+                schema_version=bm.SCHEMA_VERSION,
+                source_sha256=bm.benchmark_source_sha256(),
+                run_shape=shape,
+                config=dict(config),
+                environment=bm.environment(label),
+                timeout_policy=bm.TimeoutPolicy(),
+                samples=samples,
+            )
+            bm.write_artifact(artifact, out, overwrite)
+        finally:
+            for procs in (holder_procs, driver_procs):
+                try:
+                    await asyncio.wait_for(
+                        procs.stop(), timeout=bm.TimeoutPolicy().teardown_s
+                    )
+                except Exception:
+                    pass
+
+
+def _cmd_bench(args: argparse.Namespace) -> int:
+    shape = bm.gate_shape(args.backend, args.smoke)
+    try:
+        plan = bm.backend_plan(
+            args.backend, is_ibverbs_available(), args.skip_unsupported
+        )
+    except bm.UnsupportedBackend as e:
+        print(f"error: {e}")
+        return 1
+    if plan is None:
+        print("SKIPPED: ibverbs requested but unavailable")
+        return 0
+    config, cm_kwargs = plan
+    asyncio.run(
+        _bench_async(
+            shape,
+            config,
+            cm_kwargs,
+            args.out,
+            args.overwrite,
+            args.label,
+            args.timeout,
+        )
+    )
+    print(f"wrote {args.out}")
+    return 0
+
+
+def _cmd_compare(args: argparse.Namespace) -> int:
+    baseline = [bm.read_artifact(p) for p in args.baseline]
+    candidate = [bm.read_artifact(p) for p in args.candidate]
+    policy = bm.load_threshold_policy(args.policy)
+    outcome = bm.evaluate(baseline, candidate, policy)
+    print(bm.render(outcome))
+    return outcome.exit_code
+
+
+def _cmd_cold_child(_args: argparse.Namespace) -> int:
+    raise SystemExit("the cold-init child is not implemented yet")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_bench = sub.add_parser("bench", help="collect one artifact")
+    p_bench.add_argument("--out", required=True)
+    p_bench.add_argument("--overwrite", action="store_true")
+    p_bench.add_argument("--backend", choices=["tcp", "ibverbs"], default="tcp")
+    p_bench.add_argument("--smoke", action="store_true")
+    p_bench.add_argument("--skip-unsupported", action="store_true")
+    p_bench.add_argument("--label", default="")
+    p_bench.add_argument("--timeout", type=int, default=bm.TimeoutPolicy().op_timeout_s)
+    p_bench.set_defaults(func=_cmd_bench)
+
+    p_cold = sub.add_parser("_cold-init-child", help=argparse.SUPPRESS)
+    p_cold.set_defaults(func=_cmd_cold_child)
+
+    p_cmp = sub.add_parser("compare", help="gate two sets of artifacts")
+    p_cmp.add_argument("--baseline", nargs="+", required=True)
+    p_cmp.add_argument("--candidate", nargs="+", required=True)
+    p_cmp.add_argument("--policy", required=True, help="threshold policy JSON")
+    p_cmp.set_defaults(func=_cmd_compare)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    return int(args.func(args))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/benches/rdma_orchestration/tests/test_benchmark.py
+++ b/python/benches/rdma_orchestration/tests/test_benchmark.py
@@ -20,6 +20,8 @@ from typing import Awaitable, Mapping, Optional
 
 from monarch.python.benches.rdma_orchestration.benchmark import (
     _percentile_nearest_rank,
+    _sha256_over_files,
+    backend_plan,
     check_read_witness,
     check_write_witness,
     COLD_SAMPLES,
@@ -29,6 +31,7 @@ from monarch.python.benches.rdma_orchestration.benchmark import (
     Environment,
     evaluate,
     Floor,
+    gate_shape,
     GATED_STATS,
     GateRefused,
     issue_all_then_observe,
@@ -36,19 +39,23 @@ from monarch.python.benches.rdma_orchestration.benchmark import (
     measure_steady,
     MIN_ARTIFACTS_PER_SIDE,
     PAYLOAD_BYTES,
+    poison_pattern,
     read_artifact,
     ROUNDS,
     RunArtifact,
     RunShape,
     SERIAL_SAMPLES,
     SERIAL_WARMUPS,
+    source_pattern,
     SteadyTrial,
     summarize,
     ThresholdPolicy,
     TimeoutPolicy,
+    UnsupportedBackend,
     Verdict,
     WitnessError,
     write_artifact,
+    write_payload,
 )
 
 # Realized sample counts per metric in the gate shape (5 rounds).
@@ -318,6 +325,72 @@ class WitnessTest(unittest.TestCase):
         check_write_witness(good, good)
         with self.assertRaises(WitnessError):
             check_write_witness(good, hashlib.sha256(b"stale").digest())
+
+
+class BackendPlanTest(unittest.TestCase):
+    def test_tcp_disables_ibverbs(self) -> None:
+        result = backend_plan("tcp", ibverbs_available=False, skip_unsupported=False)
+        assert result is not None
+        config, kwargs = result
+        self.assertEqual(kwargs, {"rdma_disable_ibverbs": True})
+        self.assertEqual(config, {"rdma_disable_ibverbs": "true"})
+
+    def test_ibverbs_when_available(self) -> None:
+        result = backend_plan("ibverbs", ibverbs_available=True, skip_unsupported=False)
+        assert result is not None
+        _config, kwargs = result
+        self.assertEqual(kwargs, {"rdma_allow_tcp_fallback": False})
+
+    def test_ibverbs_unavailable_skips(self) -> None:
+        # --skip-unsupported turns an unavailable backend into a clean skip.
+        self.assertIsNone(
+            backend_plan("ibverbs", ibverbs_available=False, skip_unsupported=True)
+        )
+
+    def test_ibverbs_unavailable_without_skip_raises(self) -> None:
+        # no silent TCP fallback: an unsupported request is an error.
+        with self.assertRaises(UnsupportedBackend):
+            backend_plan("ibverbs", ibverbs_available=False, skip_unsupported=False)
+
+
+class ShapeAndPayloadTest(unittest.TestCase):
+    def test_smoke_shape_is_smaller(self) -> None:
+        gate = gate_shape("tcp", smoke=False)
+        smoke = gate_shape("tcp", smoke=True)
+        self.assertFalse(gate.smoke)
+        self.assertTrue(smoke.smoke)
+        self.assertLess(smoke.serial_samples, gate.serial_samples)
+
+    def test_write_payload_stamps_counter(self) -> None:
+        # ROB-5: the 8-byte counter prefix makes each write distinguishable.
+        p7 = write_payload(PAYLOAD_BYTES, 7)
+        p8 = write_payload(PAYLOAD_BYTES, 8)
+        self.assertEqual(len(p7), PAYLOAD_BYTES)
+        self.assertEqual(int.from_bytes(p7[:8], "little"), 7)
+        self.assertNotEqual(p7, p8)
+
+    def test_poison_differs_from_source(self) -> None:
+        # ROB-5: poison must differ from the source so a no-op read is caught.
+        self.assertNotEqual(
+            source_pattern(PAYLOAD_BYTES, 0), poison_pattern(PAYLOAD_BYTES)
+        )
+
+
+class SourceHashTest(unittest.TestCase):
+    def test_every_file_affects_the_hash(self) -> None:
+        # ROB-1: the identity hash must cover every source file, so a change in any
+        # one of them changes it -- this is what a single-file hash missed.
+        with tempfile.TemporaryDirectory() as d:
+            a = os.path.join(d, "a.py")
+            b = os.path.join(d, "b.py")
+            with open(a, "wb") as fh:
+                fh.write(b"aaa")
+            with open(b, "wb") as fh:
+                fh.write(b"bbb")
+            before = _sha256_over_files([a, b])
+            with open(b, "wb") as fh:
+                fh.write(b"bbb-changed")
+            self.assertNotEqual(before, _sha256_over_files([a, b]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4458
* #4457
* #4456
* #4455
* #4454
* #4453
* #4452
* #4451
* __->__ #4450
* #4449
* #4448
* #4447

this is the part of the benchmark that actually runs RDMA and records what it
measured. the earlier diffs were pure analysis with no RDMA; this one drives it.

what a run does:
- starts two separate processes: one holds the memory, the other reads and writes
  it over RDMA. it checks the two really are separate processes (and separate from
  the process launching them), so we can't accidentally measure a local shortcut.
- does one read and one write and checks they actually moved the bytes, to prove
  the path works before timing anything.
- times a simple back-and-forth message a few thousand times as a baseline, writes
  everything to a result file, and always shuts the two processes down at the end.
- picks the network path: plain TCP by default, or the faster hardware path when
  asked (and it either fails or cleanly skips when that hardware is missing,
  instead of quietly falling back).

it also splits the code into two files: a pure half (the analysis and result
format, no Monarch) that the unit tests import and run anywhere, and this half
that pulls in Monarch to drive the hardware, exposed as a small runnable target.
the result file's source fingerprint covers both files, so a later change to how a
measurement is produced can't be mistaken for the same benchmark.

the timing loops for the real read/write operations, and the cold-start
measurement, come in follow-up diffs.

Differential Revision: [D112723645](https://our.internmc.facebook.com/intern/diff/D112723645/)