### PR TITLE
[monarch] rdma benchmark: time the read and write operations

### DIFF
--- a/python/benches/rdma_orchestration/benchmark.py
+++ b/python/benches/rdma_orchestration/benchmark.py
@@ -545,6 +545,27 @@ async def issue_all_then_observe(make_op: Callable[[int], LazyOp], k: int) -> No
         await aw
 
 
+async def run_block(
+    make_trial: Callable[[int], SteadyTrial],
+    rounds: int,
+    warmups: int,
+    samples: int,
+) -> list[int]:
+    """Drive one metric's block: `rounds` x (`warmups` discarded, then `samples`
+    recorded), each through `measure_steady`. The trial index is monotonic across
+    the whole block so per-sample write counters stay unique (ROB-5)."""
+    out_ns: list[int] = []
+    index = 0
+    for _ in range(rounds):
+        for _ in range(warmups):
+            await measure_steady(make_trial(index))
+            index += 1
+        for _ in range(samples):
+            out_ns.append(await measure_steady(make_trial(index)))
+            index += 1
+    return out_ns
+
+
 class WitnessError(AssertionError):
     """A measured transfer failed its correctness witness (ROB-5)."""
 

--- a/python/benches/rdma_orchestration/collector.py
+++ b/python/benches/rdma_orchestration/collector.py
@@ -104,26 +104,85 @@ async def _bench_async(
             samples: int,
             payload: bytes,
         ) -> list[int]:
-            def trial() -> bm.SteadyTrial:
+            def make_trial(_i: int) -> bm.SteadyTrial:
                 async def prepare() -> object:
-                    return payload
+                    return None
 
                 async def issue() -> object:
                     return await holder.ping.call_one(payload)
 
-                async def validate(expected: object, observed: object) -> None:
-                    if observed != expected:
+                async def validate(_e: object, observed: object) -> None:
+                    if observed != payload:
                         raise bm.WitnessError("ping echo mismatch")
 
                 return bm.SteadyTrial(prepare, issue, validate)
 
-            out_ns: list[int] = []
-            for _ in range(rounds):
-                for _ in range(warmups):
-                    await bm.measure_steady(trial())
-                for _ in range(samples):
-                    out_ns.append(await bm.measure_steady(trial()))
-            return out_ns
+            return await bm.run_block(make_trial, rounds, warmups, samples)
+
+        @endpoint
+        async def serial_read_block(
+            self,
+            holder: _Holder,
+            read_src: RDMABuffer,
+            rounds: int,
+            warmups: int,
+            samples: int,
+            op_timeout: int,
+        ) -> list[int]:
+            expected = bytes(await holder.source_bytes.call_one())
+            dst = bytearray(read_src.size())
+
+            def make_trial(_i: int) -> bm.SteadyTrial:
+                async def prepare() -> object:
+                    # poison before every sample so a no-op read is caught (ROB-5).
+                    dst[:] = bm.poison_pattern(len(dst))
+                    return None
+
+                async def issue() -> object:
+                    await read_src.read_into(memoryview(dst), timeout=op_timeout)
+                    return None
+
+                async def validate(_e: object, _o: object) -> None:
+                    bm.check_read_witness(expected, bytes(dst))
+
+                return bm.SteadyTrial(prepare, issue, validate)
+
+            return await bm.run_block(make_trial, rounds, warmups, samples)
+
+        @endpoint
+        async def serial_write_block(
+            self,
+            holder: _Holder,
+            write_target: RDMABuffer,
+            slot: int,
+            rounds: int,
+            warmups: int,
+            samples: int,
+            op_timeout: int,
+        ) -> list[int]:
+            box: dict[str, bytes] = {}
+
+            def make_trial(i: int) -> bm.SteadyTrial:
+                async def prepare() -> object:
+                    # a monotonic counter makes each write distinguishable (ROB-5).
+                    box["payload"] = bm.write_payload(write_target.size(), i + 1)
+                    return None
+
+                async def issue() -> object:
+                    await write_target.write_from(
+                        memoryview(box["payload"]), timeout=op_timeout
+                    )
+                    return None
+
+                async def validate(_e: object, _o: object) -> None:
+                    digest = bytes(await holder.slot_digest.call_one(slot))
+                    bm.check_write_witness(
+                        hashlib.sha256(box["payload"]).digest(), digest
+                    )
+
+                return bm.SteadyTrial(prepare, issue, validate)
+
+            return await bm.run_block(make_trial, rounds, warmups, samples)
 
     with configured(**cm_kwargs):
         holder_procs = this_host().spawn_procs(per_host={"processes": 1})
@@ -147,10 +206,27 @@ async def _bench_async(
                 shape.serial_samples,
                 bm.PING_PAYLOAD,
             )
+            serial_read = await driver.serial_read_block.call_one(
+                holder,
+                read_src,
+                shape.rounds,
+                shape.serial_warmups,
+                shape.serial_samples,
+                timeout,
+            )
+            serial_write = await driver.serial_write_block.call_one(
+                holder,
+                targets[0],
+                0,
+                shape.rounds,
+                shape.serial_warmups,
+                shape.serial_samples,
+                timeout,
+            )
             samples: dict[str, list[int]] = {
                 "ping": ping,
-                "serial_read": [],
-                "serial_write": [],
+                "serial_read": serial_read,
+                "serial_write": serial_write,
                 "concurrent_read": [],
                 "concurrent_write": [],
                 "cold_init": [],

--- a/python/benches/rdma_orchestration/tests/test_benchmark.py
+++ b/python/benches/rdma_orchestration/tests/test_benchmark.py
@@ -42,6 +42,7 @@ from monarch.python.benches.rdma_orchestration.benchmark import (
     poison_pattern,
     read_artifact,
     ROUNDS,
+    run_block,
     RunArtifact,
     RunShape,
     SERIAL_SAMPLES,
@@ -325,6 +326,29 @@ class WitnessTest(unittest.TestCase):
         check_write_witness(good, good)
         with self.assertRaises(WitnessError):
             check_write_witness(good, hashlib.sha256(b"stale").digest())
+
+
+class RunBlockTest(unittest.TestCase):
+    def test_records_samples_not_warmups_monotonic_index(self) -> None:
+        # rounds x (warmups discarded, samples recorded); index monotonic (ROB-5).
+        seen: list[int] = []
+
+        def make_trial(i: int) -> SteadyTrial:
+            async def prepare() -> object:
+                return None
+
+            async def issue() -> object:
+                seen.append(i)
+                return None
+
+            async def validate(_e: object, _o: object) -> None:
+                return None
+
+            return SteadyTrial(prepare, issue, validate)
+
+        out = asyncio.run(run_block(make_trial, rounds=2, warmups=1, samples=3))
+        self.assertEqual(len(out), 6)  # 2 rounds x 3 recorded samples
+        self.assertEqual(seen, list(range(8)))  # 2 x (1 warmup + 3), monotonic
 
 
 class BackendPlanTest(unittest.TestCase):


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4458
* #4457
* #4456
* #4455
* #4454
* #4453
* #4452
* __->__ #4451
* #4450
* #4449
* #4448
* #4447

adds the real read and write timing loops. the previous diff only timed a
back-and-forth message and did a single read + write to prove the path worked;
this one measures the reads and writes themselves.

- each read sample: fill the destination with junk, time just the read, then check
  the destination now matches the source. a read that quietly did nothing is left
  holding junk and fails the check.
- each write sample: stamp the data with a counter, time just the write, then have
  the holder hash what it received and check it matches. a dropped write leaves the
  old bytes and fails the check.
- both run over several rounds with the first few samples discarded as warmup, and
  the filling/stamping and checking happen outside the timer, so only the transfer
  itself is measured.

the read and write timings now show up in the result file alongside the ping. the
concurrent (many-at-once) loops and the cold-start measurement are still to come.

Differential Revision: [D112723649](https://our.internmc.facebook.com/intern/diff/D112723649/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D112723649/)!