### PR TITLE
[monarch] rdma benchmark: measure cold start

### DIFF
--- a/python/benches/rdma_orchestration/collector.py
+++ b/python/benches/rdma_orchestration/collector.py
@@ -12,22 +12,284 @@ RDMA orchestration benchmark collector -- drives the public Monarch surface to
 produce one artifact. See `benchmark.py` for the Monarch-free analysis half and
 the ROB-* invariant registry.
 
-`bench` runs the steady-state harness -- currently distinct-proc setup, one
-validated read + write smoke, and the ping sentinel -- and writes an artifact
-(ROB-1/9). `compare` gates two artifact sets. `_cold-init-child` is private.
+`bench` runs the steady-state harness (ping sentinel, serial and concurrent
+read/write) plus the cold-start measurement, and writes an artifact. `compare`
+gates two artifact sets. `_cold-init-child` is a private, one-sample-per-process
+subcommand the parent re-invokes for the cold measurement (ROB-6).
 """
 
 import argparse
 import asyncio
 import hashlib
 import os
+import subprocess
 import sys
+import time
 from typing import Mapping, Sequence
 
-from monarch.actor import Actor, endpoint, this_host
+from monarch.actor import Actor, endpoint, ProcMesh, this_host
 from monarch.config import configured
 from monarch.python.benches.rdma_orchestration import benchmark as bm
 from monarch.rdma import is_ibverbs_available, RDMABuffer
+
+# The cold child prints its one sample on this tagged stdout line so the parent
+# can pick it out of any surrounding runtime chatter.
+_COLD_PREFIX: str = "COLD_NS "
+
+
+class _Holder(Actor):
+    """Owns the registered RDMA memory: one read source and K write targets."""
+
+    def __init__(self, payload_bytes: int, k: int) -> None:
+        self._source: bytearray = bytearray(bm.source_pattern(payload_bytes, 0))
+        self._targets: list[bytearray] = [bytearray(payload_bytes) for _ in range(k)]
+
+    @endpoint
+    async def make_buffers(self) -> tuple[RDMABuffer, list[RDMABuffer]]:
+        read_src = RDMABuffer(memoryview(self._source))
+        targets = [RDMABuffer(memoryview(t)) for t in self._targets]
+        return read_src, targets
+
+    @endpoint
+    async def source_bytes(self) -> bytes:
+        return bytes(self._source)
+
+    @endpoint
+    async def slot_digest(self, slot: int) -> bytes:
+        return hashlib.sha256(bytes(self._targets[slot])).digest()
+
+    @endpoint
+    async def ping(self, payload: bytes) -> bytes:
+        return payload
+
+    @endpoint
+    async def pid(self) -> int:
+        return os.getpid()
+
+
+class _Driver(Actor):
+    """Initiates all transfers against the holder's registered memory."""
+
+    @endpoint
+    async def pid(self) -> int:
+        return os.getpid()
+
+    @endpoint
+    async def smoke(
+        self,
+        holder: _Holder,
+        read_src: RDMABuffer,
+        write0: RDMABuffer,
+        op_timeout: int,
+    ) -> None:
+        expected = bytes(await holder.source_bytes.call_one())
+        dst = bytearray(bm.poison_pattern(read_src.size()))
+        await read_src.read_into(memoryview(dst), timeout=op_timeout)
+        bm.check_read_witness(expected, bytes(dst))
+        payload = bm.write_payload(write0.size(), 1)
+        await write0.write_from(memoryview(payload), timeout=op_timeout)
+        bm.check_write_witness(
+            hashlib.sha256(payload).digest(),
+            bytes(await holder.slot_digest.call_one(0)),
+        )
+
+    @endpoint
+    async def cold_read(self, read_src: RDMABuffer, op_timeout: int) -> bytes:
+        # one read into a poisoned local destination; the caller validates.
+        dst = bytearray(bm.poison_pattern(read_src.size()))
+        await read_src.read_into(memoryview(dst), timeout=op_timeout)
+        return bytes(dst)
+
+    @endpoint
+    async def ping_block(
+        self,
+        holder: _Holder,
+        rounds: int,
+        warmups: int,
+        samples: int,
+        payload: bytes,
+    ) -> list[int]:
+        def make_trial(_i: int) -> bm.SteadyTrial:
+            async def prepare() -> object:
+                return None
+
+            async def issue() -> object:
+                return await holder.ping.call_one(payload)
+
+            async def validate(_e: object, observed: object) -> None:
+                if observed != payload:
+                    raise bm.WitnessError("ping echo mismatch")
+
+            return bm.SteadyTrial(prepare, issue, validate)
+
+        return await bm.run_block(make_trial, rounds, warmups, samples)
+
+    @endpoint
+    async def serial_read_block(
+        self,
+        holder: _Holder,
+        read_src: RDMABuffer,
+        rounds: int,
+        warmups: int,
+        samples: int,
+        op_timeout: int,
+    ) -> list[int]:
+        expected = bytes(await holder.source_bytes.call_one())
+        dst = bytearray(read_src.size())
+
+        def make_trial(_i: int) -> bm.SteadyTrial:
+            async def prepare() -> object:
+                # poison before every sample so a no-op read is caught (ROB-5).
+                dst[:] = bm.poison_pattern(len(dst))
+                return None
+
+            async def issue() -> object:
+                await read_src.read_into(memoryview(dst), timeout=op_timeout)
+                return None
+
+            async def validate(_e: object, _o: object) -> None:
+                bm.check_read_witness(expected, bytes(dst))
+
+            return bm.SteadyTrial(prepare, issue, validate)
+
+        return await bm.run_block(make_trial, rounds, warmups, samples)
+
+    @endpoint
+    async def serial_write_block(
+        self,
+        holder: _Holder,
+        write_target: RDMABuffer,
+        slot: int,
+        rounds: int,
+        warmups: int,
+        samples: int,
+        op_timeout: int,
+    ) -> list[int]:
+        box: dict[str, bytes] = {}
+
+        def make_trial(i: int) -> bm.SteadyTrial:
+            async def prepare() -> object:
+                # a monotonic counter makes each write distinguishable (ROB-5).
+                box["payload"] = bm.write_payload(write_target.size(), i + 1)
+                return None
+
+            async def issue() -> object:
+                await write_target.write_from(
+                    memoryview(box["payload"]), timeout=op_timeout
+                )
+                return None
+
+            async def validate(_e: object, _o: object) -> None:
+                digest = bytes(await holder.slot_digest.call_one(slot))
+                bm.check_write_witness(hashlib.sha256(box["payload"]).digest(), digest)
+
+            return bm.SteadyTrial(prepare, issue, validate)
+
+        return await bm.run_block(make_trial, rounds, warmups, samples)
+
+    @endpoint
+    async def concurrent_read_block(
+        self,
+        holder: _Holder,
+        read_src: RDMABuffer,
+        k: int,
+        rounds: int,
+        warmups: int,
+        batches: int,
+        op_timeout: int,
+    ) -> list[int]:
+        # one batch of K parallel reads is one timed sample (ROB-4). K disjoint
+        # local destinations so the reads don't collide.
+        expected = bytes(await holder.source_bytes.call_one())
+        dsts = [bytearray(read_src.size()) for _ in range(k)]
+
+        def make_trial(_i: int) -> bm.SteadyTrial:
+            async def prepare() -> object:
+                for d in dsts:
+                    d[:] = bm.poison_pattern(len(d))
+                return None
+
+            async def issue() -> object:
+                def make_op(j: int) -> bm.LazyOp:
+                    return read_src.read_into(memoryview(dsts[j]), timeout=op_timeout)
+
+                await bm.issue_all_then_observe(make_op, k)
+                return None
+
+            async def validate(_e: object, _o: object) -> None:
+                for d in dsts:
+                    bm.check_read_witness(expected, bytes(d))
+
+            return bm.SteadyTrial(prepare, issue, validate)
+
+        return await bm.run_block(make_trial, rounds, warmups, batches)
+
+    @endpoint
+    async def concurrent_write_block(
+        self,
+        holder: _Holder,
+        write_targets: list[RDMABuffer],
+        k: int,
+        rounds: int,
+        warmups: int,
+        batches: int,
+        op_timeout: int,
+    ) -> list[int]:
+        # one batch of K parallel writes into K disjoint targets is one timed
+        # sample (ROB-4); each slot carries a distinct counter (ROB-5).
+        payloads: list[bytes] = [b""] * k
+
+        def make_trial(i: int) -> bm.SteadyTrial:
+            async def prepare() -> object:
+                for j in range(k):
+                    payloads[j] = bm.write_payload(
+                        write_targets[j].size(), i * k + j + 1
+                    )
+                return None
+
+            async def issue() -> object:
+                def make_op(j: int) -> bm.LazyOp:
+                    return write_targets[j].write_from(
+                        memoryview(payloads[j]), timeout=op_timeout
+                    )
+
+                await bm.issue_all_then_observe(make_op, k)
+                return None
+
+            async def validate(_e: object, _o: object) -> None:
+                for j in range(k):
+                    digest = bytes(await holder.slot_digest.call_one(j))
+                    bm.check_write_witness(hashlib.sha256(payloads[j]).digest(), digest)
+
+            return bm.SteadyTrial(prepare, issue, validate)
+
+        return await bm.run_block(make_trial, rounds, warmups, batches)
+
+
+async def _assert_distinct(holder: _Holder, driver: _Driver) -> None:
+    holder_pid = int(await holder.pid.call_one())
+    driver_pid = int(await driver.pid.call_one())
+    if len({os.getpid(), holder_pid, driver_pid}) != 3:
+        raise bm.WitnessError("holder, driver, and client must be distinct procs")
+
+
+async def _teardown(holder_procs: ProcMesh, driver_procs: ProcMesh) -> None:
+    # Stopping the workers sends them SIGTERM; folly's fatal-signal handler prints
+    # a stack trace for it even though this is a clean, intentional shutdown. Warn
+    # first so that trace is not mistaken for a crash. Goes to stderr so it never
+    # mixes with the artifact path on stdout or the cold child's COLD_NS line.
+    print(
+        "note: shutting down benchmark worker procs -- any '*** Signal 15 "
+        "(SIGTERM) ***' stack trace below is the expected teardown of the procs "
+        "this benchmark spawned, and is benign.",
+        file=sys.stderr,
+        flush=True,
+    )
+    for procs in (holder_procs, driver_procs):
+        try:
+            await asyncio.wait_for(procs.stop(), timeout=bm.TimeoutPolicy().teardown_s)
+        except Exception:
+            pass
 
 
 async def _bench_async(
@@ -38,246 +300,17 @@ async def _bench_async(
     overwrite: bool,
     label: str,
     timeout: int,
+    cold_init: list[int],
 ) -> None:
-    payload_bytes = shape.payload_bytes
-    k = shape.k
-
-    class _Holder(Actor):
-        def __init__(self) -> None:
-            self._source: bytearray = bytearray(bm.source_pattern(payload_bytes, 0))
-            self._targets: list[bytearray] = [
-                bytearray(payload_bytes) for _ in range(k)
-            ]
-
-        @endpoint
-        async def make_buffers(self) -> tuple[RDMABuffer, list[RDMABuffer]]:
-            read_src = RDMABuffer(memoryview(self._source))
-            targets = [RDMABuffer(memoryview(t)) for t in self._targets]
-            return read_src, targets
-
-        @endpoint
-        async def source_bytes(self) -> bytes:
-            return bytes(self._source)
-
-        @endpoint
-        async def slot_digest(self, slot: int) -> bytes:
-            return hashlib.sha256(bytes(self._targets[slot])).digest()
-
-        @endpoint
-        async def ping(self, payload: bytes) -> bytes:
-            return payload
-
-        @endpoint
-        async def pid(self) -> int:
-            return os.getpid()
-
-    class _Driver(Actor):
-        @endpoint
-        async def pid(self) -> int:
-            return os.getpid()
-
-        @endpoint
-        async def smoke(
-            self,
-            holder: _Holder,
-            read_src: RDMABuffer,
-            write0: RDMABuffer,
-            op_timeout: int,
-        ) -> None:
-            expected = bytes(await holder.source_bytes.call_one())
-            dst = bytearray(bm.poison_pattern(read_src.size()))
-            await read_src.read_into(memoryview(dst), timeout=op_timeout)
-            bm.check_read_witness(expected, bytes(dst))
-            payload = bm.write_payload(write0.size(), 1)
-            await write0.write_from(memoryview(payload), timeout=op_timeout)
-            bm.check_write_witness(
-                hashlib.sha256(payload).digest(),
-                bytes(await holder.slot_digest.call_one(0)),
-            )
-
-        @endpoint
-        async def ping_block(
-            self,
-            holder: _Holder,
-            rounds: int,
-            warmups: int,
-            samples: int,
-            payload: bytes,
-        ) -> list[int]:
-            def make_trial(_i: int) -> bm.SteadyTrial:
-                async def prepare() -> object:
-                    return None
-
-                async def issue() -> object:
-                    return await holder.ping.call_one(payload)
-
-                async def validate(_e: object, observed: object) -> None:
-                    if observed != payload:
-                        raise bm.WitnessError("ping echo mismatch")
-
-                return bm.SteadyTrial(prepare, issue, validate)
-
-            return await bm.run_block(make_trial, rounds, warmups, samples)
-
-        @endpoint
-        async def serial_read_block(
-            self,
-            holder: _Holder,
-            read_src: RDMABuffer,
-            rounds: int,
-            warmups: int,
-            samples: int,
-            op_timeout: int,
-        ) -> list[int]:
-            expected = bytes(await holder.source_bytes.call_one())
-            dst = bytearray(read_src.size())
-
-            def make_trial(_i: int) -> bm.SteadyTrial:
-                async def prepare() -> object:
-                    # poison before every sample so a no-op read is caught (ROB-5).
-                    dst[:] = bm.poison_pattern(len(dst))
-                    return None
-
-                async def issue() -> object:
-                    await read_src.read_into(memoryview(dst), timeout=op_timeout)
-                    return None
-
-                async def validate(_e: object, _o: object) -> None:
-                    bm.check_read_witness(expected, bytes(dst))
-
-                return bm.SteadyTrial(prepare, issue, validate)
-
-            return await bm.run_block(make_trial, rounds, warmups, samples)
-
-        @endpoint
-        async def serial_write_block(
-            self,
-            holder: _Holder,
-            write_target: RDMABuffer,
-            slot: int,
-            rounds: int,
-            warmups: int,
-            samples: int,
-            op_timeout: int,
-        ) -> list[int]:
-            box: dict[str, bytes] = {}
-
-            def make_trial(i: int) -> bm.SteadyTrial:
-                async def prepare() -> object:
-                    # a monotonic counter makes each write distinguishable (ROB-5).
-                    box["payload"] = bm.write_payload(write_target.size(), i + 1)
-                    return None
-
-                async def issue() -> object:
-                    await write_target.write_from(
-                        memoryview(box["payload"]), timeout=op_timeout
-                    )
-                    return None
-
-                async def validate(_e: object, _o: object) -> None:
-                    digest = bytes(await holder.slot_digest.call_one(slot))
-                    bm.check_write_witness(
-                        hashlib.sha256(box["payload"]).digest(), digest
-                    )
-
-                return bm.SteadyTrial(prepare, issue, validate)
-
-            return await bm.run_block(make_trial, rounds, warmups, samples)
-
-        @endpoint
-        async def concurrent_read_block(
-            self,
-            holder: _Holder,
-            read_src: RDMABuffer,
-            k: int,
-            rounds: int,
-            warmups: int,
-            batches: int,
-            op_timeout: int,
-        ) -> list[int]:
-            # one batch of K parallel reads is one timed sample (ROB-4). K disjoint
-            # local destinations so the reads don't collide.
-            expected = bytes(await holder.source_bytes.call_one())
-            dsts = [bytearray(read_src.size()) for _ in range(k)]
-
-            def make_trial(_i: int) -> bm.SteadyTrial:
-                async def prepare() -> object:
-                    for d in dsts:
-                        d[:] = bm.poison_pattern(len(d))
-                    return None
-
-                async def issue() -> object:
-                    def make_op(j: int) -> bm.LazyOp:
-                        return read_src.read_into(
-                            memoryview(dsts[j]), timeout=op_timeout
-                        )
-
-                    await bm.issue_all_then_observe(make_op, k)
-                    return None
-
-                async def validate(_e: object, _o: object) -> None:
-                    for d in dsts:
-                        bm.check_read_witness(expected, bytes(d))
-
-                return bm.SteadyTrial(prepare, issue, validate)
-
-            return await bm.run_block(make_trial, rounds, warmups, batches)
-
-        @endpoint
-        async def concurrent_write_block(
-            self,
-            holder: _Holder,
-            write_targets: list[RDMABuffer],
-            k: int,
-            rounds: int,
-            warmups: int,
-            batches: int,
-            op_timeout: int,
-        ) -> list[int]:
-            # one batch of K parallel writes into K disjoint targets is one timed
-            # sample (ROB-4); each slot carries a distinct counter (ROB-5).
-            payloads: list[bytes] = [b""] * k
-
-            def make_trial(i: int) -> bm.SteadyTrial:
-                async def prepare() -> object:
-                    for j in range(k):
-                        payloads[j] = bm.write_payload(
-                            write_targets[j].size(), i * k + j + 1
-                        )
-                    return None
-
-                async def issue() -> object:
-                    def make_op(j: int) -> bm.LazyOp:
-                        return write_targets[j].write_from(
-                            memoryview(payloads[j]), timeout=op_timeout
-                        )
-
-                    await bm.issue_all_then_observe(make_op, k)
-                    return None
-
-                async def validate(_e: object, _o: object) -> None:
-                    for j in range(k):
-                        digest = bytes(await holder.slot_digest.call_one(j))
-                        bm.check_write_witness(
-                            hashlib.sha256(payloads[j]).digest(), digest
-                        )
-
-                return bm.SteadyTrial(prepare, issue, validate)
-
-            return await bm.run_block(make_trial, rounds, warmups, batches)
-
     with configured(**cm_kwargs):
         holder_procs = this_host().spawn_procs(per_host={"processes": 1})
         driver_procs = this_host().spawn_procs(per_host={"processes": 1})
-        holder = holder_procs.spawn("rdma_bench_holder", _Holder)
+        holder = holder_procs.spawn(
+            "rdma_bench_holder", _Holder, shape.payload_bytes, shape.k
+        )
         driver = driver_procs.spawn("rdma_bench_driver", _Driver)
         try:
-            holder_pid = int(await holder.pid.call_one())
-            driver_pid = int(await driver.pid.call_one())
-            if len({os.getpid(), holder_pid, driver_pid}) != 3:
-                raise bm.WitnessError(
-                    "holder, driver, and client must be distinct procs"
-                )
+            await _assert_distinct(holder, driver)
             read_src, targets = await holder.make_buffers.call_one()
             # smoke: prove the data plane end to end and resolve lazy init.
             await driver.smoke.call_one(holder, read_src, targets[0], timeout)
@@ -329,7 +362,7 @@ async def _bench_async(
                 "serial_write": serial_write,
                 "concurrent_read": concurrent_read,
                 "concurrent_write": concurrent_write,
-                "cold_init": [],
+                "cold_init": cold_init,
             }
             artifact = bm.RunArtifact(
                 schema_version=bm.SCHEMA_VERSION,
@@ -342,13 +375,59 @@ async def _bench_async(
             )
             bm.write_artifact(artifact, out, overwrite)
         finally:
-            for procs in (holder_procs, driver_procs):
-                try:
-                    await asyncio.wait_for(
-                        procs.stop(), timeout=bm.TimeoutPolicy().teardown_s
-                    )
-                except Exception:
-                    pass
+            await _teardown(holder_procs, driver_procs)
+
+
+async def _cold_child_async(
+    payload_bytes: int, k: int, cm_kwargs: Mapping[str, object], op_timeout: int
+) -> int:
+    """One cold-start sample in this fresh process (ROB-6). The topology is proven
+    live before t0 with no RDMA; the timed interval is the first holder-side init
+    (`make_buffers`) plus the first driver read, on this process's clock."""
+    with configured(**cm_kwargs):
+        holder_procs = this_host().spawn_procs(per_host={"processes": 1})
+        driver_procs = this_host().spawn_procs(per_host={"processes": 1})
+        holder = holder_procs.spawn("rdma_cold_holder", _Holder, payload_bytes, k)
+        driver = driver_procs.spawn("rdma_cold_driver", _Driver)
+        try:
+            await _assert_distinct(holder, driver)
+            expected = bytes(await holder.source_bytes.call_one())
+            t0 = time.perf_counter_ns()
+            read_src, _targets = await holder.make_buffers.call_one()
+            observed = bytes(await driver.cold_read.call_one(read_src, op_timeout))
+            t1 = time.perf_counter_ns()
+            bm.check_read_witness(expected, observed)
+            return t1 - t0
+        finally:
+            await _teardown(holder_procs, driver_procs)
+
+
+def _collect_cold_samples(backend: str, n: int, timeout_s: int) -> list[int]:
+    """Run `n` fresh `_cold-init-child` subprocesses and collect one sample each
+    (ROB-6). Each child is bounded by `timeout_s` (ROB-9); any failure or timeout
+    aborts the whole run so no partial artifact is published."""
+    samples: list[int] = []
+    for _ in range(n):
+        proc = subprocess.run(
+            [sys.argv[0], "_cold-init-child", "--backend", backend],
+            capture_output=True,
+            text=True,
+            timeout=timeout_s,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"cold-init child failed (exit {proc.returncode}): "
+                f"{proc.stderr.strip()[-500:]}"
+            )
+        value: int | None = None
+        for line in proc.stdout.splitlines():
+            if line.startswith(_COLD_PREFIX):
+                value = int(line[len(_COLD_PREFIX) :])
+                break
+        if value is None:
+            raise RuntimeError("cold-init child produced no sample line")
+        samples.append(value)
+    return samples
 
 
 def _cmd_bench(args: argparse.Namespace) -> int:
@@ -364,6 +443,9 @@ def _cmd_bench(args: argparse.Namespace) -> int:
         print("SKIPPED: ibverbs requested but unavailable")
         return 0
     config, cm_kwargs = plan
+    cold_init = _collect_cold_samples(
+        args.backend, shape.cold_samples, bm.TimeoutPolicy().cold_child_s
+    )
     asyncio.run(
         _bench_async(
             shape,
@@ -373,6 +455,7 @@ def _cmd_bench(args: argparse.Namespace) -> int:
             args.overwrite,
             args.label,
             args.timeout,
+            cold_init,
         )
     )
     print(f"wrote {args.out}")
@@ -388,8 +471,17 @@ def _cmd_compare(args: argparse.Namespace) -> int:
     return outcome.exit_code
 
 
-def _cmd_cold_child(_args: argparse.Namespace) -> int:
-    raise SystemExit("the cold-init child is not implemented yet")
+def _cmd_cold_child(args: argparse.Namespace) -> int:
+    plan = bm.backend_plan(args.backend, is_ibverbs_available(), skip_unsupported=False)
+    if plan is None:  # pragma: no cover - the parent only spawns supported backends
+        raise SystemExit("cold-init child: backend unavailable")
+    _config, cm_kwargs = plan
+    shape = bm.gate_shape(args.backend, smoke=False)
+    ns = asyncio.run(
+        _cold_child_async(shape.payload_bytes, shape.k, cm_kwargs, args.timeout)
+    )
+    print(f"{_COLD_PREFIX}{ns}")
+    return 0
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -407,6 +499,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_bench.set_defaults(func=_cmd_bench)
 
     p_cold = sub.add_parser("_cold-init-child", help=argparse.SUPPRESS)
+    p_cold.add_argument("--backend", choices=["tcp", "ibverbs"], default="tcp")
+    p_cold.add_argument("--timeout", type=int, default=bm.TimeoutPolicy().op_timeout_s)
     p_cold.set_defaults(func=_cmd_cold_child)
 
     p_cmp = sub.add_parser("compare", help="gate two sets of artifacts")


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4458
* #4457
* #4456
* #4455
* #4454
* __->__ #4453
* #4452
* #4451
* #4450
* #4449
* #4448
* #4447

adds the last measurement: cold start -- how long the very first RDMA setup takes
in a brand-new process, which the warmed-up loops deliberately hide.

because it's a one-time cost, each sample needs a fresh process, so the benchmark
re-runs itself as a short-lived child (one sample per child) and collects them:

- each child starts the two processes, proves both are alive with a quick
  round-trip, then starts the clock, does the first buffer setup and first read,
  stops the clock, checks the bytes arrived, and prints the one timing.
- the parent runs ten such children (one in smoke), each bounded by a 180s
  timeout so a stuck first-init can't hang the run, and records them as cold_init.

to share the two actors between the normal run and the cold child, this also lifts
them to module level (the holder now takes its sizes as constructor arguments).
with cold_init filled, the result now carries every metric the gate needs;
calibrating the thresholds is the remaining step.

Differential Revision: [D112723647](https://our.internmc.facebook.com/intern/diff/D112723647/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D112723647/)!