### PR TITLE
[monarch] rdma benchmark: turn a set of runs into pass/fail thresholds

### DIFF
--- a/python/benches/rdma_orchestration/benchmark.py
+++ b/python/benches/rdma_orchestration/benchmark.py
@@ -46,10 +46,12 @@ under test.
 """
 
 import hashlib
+import itertools
 import json
 import math
 import os
 import platform
+import random
 import socket
 import tempfile
 import time
@@ -271,20 +273,27 @@ def _artifact_from_dict(d: Mapping[str, object]) -> RunArtifact:
     )
 
 
-def write_artifact(artifact: RunArtifact, path: str, overwrite: bool) -> None:
-    """Atomically write one artifact; refuse an existing path unless overwrite."""
+def _atomic_write_json(
+    payload: Mapping[str, object], path: str, overwrite: bool
+) -> None:
+    """Write JSON atomically; refuse an existing path unless overwrite (ROB-7)."""
     if os.path.exists(path) and not overwrite:
         raise FileExistsError(f"{path} exists; pass --overwrite to replace it")
     directory = os.path.dirname(os.path.abspath(path)) or "."
     fd, tmp = tempfile.mkstemp(dir=directory, suffix=".tmp")
     try:
         with os.fdopen(fd, "w") as fh:
-            json.dump(_artifact_to_dict(artifact), fh, indent=1, sort_keys=True)
+            json.dump(dict(payload), fh, indent=1, sort_keys=True)
         os.replace(tmp, path)
     except BaseException:
         if os.path.exists(tmp):
             os.unlink(tmp)
         raise
+
+
+def write_artifact(artifact: RunArtifact, path: str, overwrite: bool) -> None:
+    """Atomically write one artifact; refuse an existing path unless overwrite."""
+    _atomic_write_json(_artifact_to_dict(artifact), path, overwrite)
 
 
 def read_artifact(path: str) -> RunArtifact:
@@ -398,6 +407,132 @@ def _check_policy_applies(pair: CompatiblePair, policy: ThresholdPolicy) -> None
         for stat in stats:
             if stat not in policy.floors.get(metric, {}):
                 raise GateRefused(f"policy is missing a floor for {metric}.{stat}")
+
+
+# ---------------------------------------------------------------------------
+# Calibration: derive a backend's policy from a homogeneous artifact set, in the
+# gate's own median-of-five estimator space (matches `_aggregate`). Pure.
+# ---------------------------------------------------------------------------
+
+# Provisional sensitivity policy (revisit once real TCP/ibverbs data exists): the
+# noise envelope is at least 1 us, at least 1% of the metric's median, and 1.5x
+# the largest median-of-five split disagreement observed during calibration.
+CALIB_MIN_ABSOLUTE_NS: int = 1000
+CALIB_REL_OF_MEDIAN: float = 0.01
+CALIB_SAFETY: float = 1.5
+# Evaluate every disjoint 5-vs-5 split at or below this many (252 at n=10),
+# otherwise a deterministic resample of this size.
+CALIB_MAX_SPLITS: int = 5000
+CALIB_SPLIT_SEED: int = 0
+
+
+@dataclass(frozen=True)
+class StatCalibration:
+    """Per-statistic calibration diagnostics (reported, not stored in the policy)."""
+
+    metric: str
+    stat: str
+    median_ns: int
+    dmax_ns: int  # largest median-of-five split disagreement seen
+    floor: Floor
+    mde: float  # minimum detectable effect (relative), given the floor
+
+
+def _five_five_splits(n: int) -> list[tuple[tuple[int, ...], tuple[int, ...]]]:
+    """All disjoint (baseline-of-5, candidate-of-5) index splits -- the shape a real
+    gate compares. Exhaustive when the count is <= CALIB_MAX_SPLITS (252 at n=10),
+    otherwise a deterministic resample."""
+    half = MIN_ARTIFACTS_PER_SIDE
+    if n < 2 * half:
+        raise GateRefused(f"calibration needs >= {2 * half} artifacts, has {n}")
+    total = math.comb(n, half) * math.comb(n - half, half)
+    if total <= CALIB_MAX_SPLITS:
+        out: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+        for base in itertools.combinations(range(n), half):
+            rest = [i for i in range(n) if i not in base]
+            for cand in itertools.combinations(rest, half):
+                out.append((base, cand))
+        return out
+    rng = random.Random(CALIB_SPLIT_SEED)
+    seen: set[tuple[tuple[int, ...], tuple[int, ...]]] = set()
+    while len(seen) < CALIB_MAX_SPLITS:
+        perm = list(range(n))
+        rng.shuffle(perm)
+        seen.add((tuple(sorted(perm[:half])), tuple(sorted(perm[half : 2 * half]))))
+    return sorted(seen)
+
+
+def calibrate(
+    artifacts: Sequence[RunArtifact], version: str
+) -> tuple[ThresholdPolicy, tuple[StatCalibration, ...]]:
+    """Derive a backend's threshold policy from a homogeneous artifact set in the
+    gate's median-of-five estimator space. Returns the policy plus per-statistic
+    diagnostics (including each statistic's minimum detectable effect)."""
+    if len(artifacts) < 2 * MIN_ARTIFACTS_PER_SIDE:
+        raise GateRefused(
+            f"calibration needs >= {2 * MIN_ARTIFACTS_PER_SIDE} artifacts, "
+            f"has {len(artifacts)}"
+        )
+    if len({_compat_key(a) for a in artifacts}) != 1:
+        raise GateRefused("calibration artifacts are not mutually compatible")
+    for a in artifacts:
+        if a.run_shape.smoke:
+            raise GateRefused("smoke artifact is never calibratable")
+        _require_reportable(a)
+    ref = artifacts[0]
+    splits = _five_five_splits(len(artifacts))
+    floors: dict[str, dict[str, Floor]] = {}
+    diagnostics: list[StatCalibration] = []
+    for metric, stats in GATED_STATS.items():
+        floors[metric] = {}
+        for stat in stats:
+            values = [summarize(a)[metric][stat] for a in artifacts]
+            m = _median_int(values)
+            dmax = 0
+            for base_idx, cand_idx in splits:
+                b = _median_int([values[i] for i in base_idx])
+                c = _median_int([values[i] for i in cand_idx])
+                dmax = max(dmax, abs(c - b))
+            absolute_ns = math.ceil(
+                max(
+                    float(CALIB_MIN_ABSOLUTE_NS),
+                    CALIB_REL_OF_MEDIAN * m,
+                    CALIB_SAFETY * dmax,
+                )
+            )
+            relative = absolute_ns / m if m > 0 else math.inf
+            floor = Floor(relative=relative, absolute_ns=absolute_ns)
+            floors[metric][stat] = floor
+            mde = (max(absolute_ns, relative * m) / m) if m > 0 else math.inf
+            diagnostics.append(StatCalibration(metric, stat, m, dmax, floor, mde))
+    policy = ThresholdPolicy(
+        version=version,
+        backend=ref.run_shape.backend,
+        source_sha256=ref.source_sha256,
+        run_shape=ref.run_shape,
+        floors=floors,
+        calibration_artifacts=tuple(a.environment.timestamp_utc for a in artifacts),
+    )
+    return policy, tuple(diagnostics)
+
+
+def dump_threshold_policy(policy: ThresholdPolicy) -> dict[str, object]:
+    return {
+        "version": policy.version,
+        "backend": policy.backend,
+        "source_sha256": policy.source_sha256,
+        "run_shape": asdict(policy.run_shape),
+        "floors": {
+            metric: {stat: asdict(f) for stat, f in stat_map.items()}
+            for metric, stat_map in policy.floors.items()
+        },
+        "calibration_artifacts": list(policy.calibration_artifacts),
+    }
+
+
+def write_threshold_policy(policy: ThresholdPolicy, path: str, overwrite: bool) -> None:
+    """Atomically write a calibrated policy; refuse an existing path unless overwrite."""
+    _atomic_write_json(dump_threshold_policy(policy), path, overwrite)
 
 
 # ---------------------------------------------------------------------------

--- a/python/benches/rdma_orchestration/collector.py
+++ b/python/benches/rdma_orchestration/collector.py
@@ -471,6 +471,25 @@ def _cmd_compare(args: argparse.Namespace) -> int:
     return outcome.exit_code
 
 
+def _cmd_calibrate(args: argparse.Namespace) -> int:
+    artifacts = [bm.read_artifact(p) for p in args.artifacts]
+    try:
+        policy, diagnostics = bm.calibrate(artifacts, args.version)
+    except bm.GateRefused as e:
+        print(f"error: {e}")
+        return 1
+    bm.write_threshold_policy(policy, args.out, args.overwrite)
+    print(f"wrote {args.out} ({policy.backend}, {len(artifacts)} artifacts)")
+    print("minimum detectable effect per statistic:")
+    for d in diagnostics:
+        print(
+            f"  {d.metric}.{d.stat}: MDE {d.mde:.2%} "
+            f"(floor {d.floor.absolute_ns} ns / {d.floor.relative:.2%}, "
+            f"median {d.median_ns} ns, Dmax {d.dmax_ns} ns)"
+        )
+    return 0
+
+
 def _cmd_cold_child(args: argparse.Namespace) -> int:
     plan = bm.backend_plan(args.backend, is_ibverbs_available(), skip_unsupported=False)
     if plan is None:  # pragma: no cover - the parent only spawns supported backends
@@ -508,6 +527,13 @@ def build_parser() -> argparse.ArgumentParser:
     p_cmp.add_argument("--candidate", nargs="+", required=True)
     p_cmp.add_argument("--policy", required=True, help="threshold policy JSON")
     p_cmp.set_defaults(func=_cmd_compare)
+
+    p_cal = sub.add_parser("calibrate", help="derive a threshold policy from artifacts")
+    p_cal.add_argument("--artifacts", nargs="+", required=True)
+    p_cal.add_argument("--out", required=True, help="output threshold policy JSON")
+    p_cal.add_argument("--version", required=True, help="policy version label")
+    p_cal.add_argument("--overwrite", action="store_true")
+    p_cal.set_defaults(func=_cmd_calibrate)
     return parser
 
 

--- a/python/benches/rdma_orchestration/tests/test_benchmark.py
+++ b/python/benches/rdma_orchestration/tests/test_benchmark.py
@@ -19,9 +19,11 @@ import unittest
 from typing import Awaitable, Mapping, Optional
 
 from monarch.python.benches.rdma_orchestration.benchmark import (
+    _five_five_splits,
     _percentile_nearest_rank,
     _sha256_over_files,
     backend_plan,
+    calibrate,
     check_read_witness,
     check_write_witness,
     COLD_SAMPLES,
@@ -36,6 +38,7 @@ from monarch.python.benches.rdma_orchestration.benchmark import (
     GateRefused,
     issue_all_then_observe,
     K,
+    load_threshold_policy,
     measure_steady,
     MIN_ARTIFACTS_PER_SIDE,
     PAYLOAD_BYTES,
@@ -57,6 +60,7 @@ from monarch.python.benches.rdma_orchestration.benchmark import (
     WitnessError,
     write_artifact,
     write_payload,
+    write_threshold_policy,
 )
 
 # Realized sample counts per metric in the gate shape (5 rounds).
@@ -415,6 +419,59 @@ class SourceHashTest(unittest.TestCase):
             with open(b, "wb") as fh:
                 fh.write(b"bbb-changed")
             self.assertNotEqual(before, _sha256_over_files([a, b]))
+
+
+class FiveFiveSplitsTest(unittest.TestCase):
+    def test_exhaustive_at_ten(self) -> None:
+        # C(10,5) = 252 disjoint 5-vs-5 splits, matching the gate's shape.
+        splits = _five_five_splits(10)
+        self.assertEqual(len(splits), 252)
+        for base, cand in splits:
+            self.assertEqual(len(base), 5)
+            self.assertEqual(len(cand), 5)
+            self.assertEqual(set(base) & set(cand), set())
+
+
+class CalibrateTest(unittest.TestCase):
+    def test_identical_runs_hit_the_minimum_floor(self) -> None:
+        # no spread -> Dmax=0, so the floor is the 1% / 1us minimum envelope.
+        policy, diags = calibrate([_artifact() for _ in range(10)], "v1")
+        floor = policy.floors["serial_read"]["p50"]
+        self.assertEqual(floor.absolute_ns, 1000)  # 0.01 * 100_000
+        self.assertAlmostEqual(floor.relative, 0.01)
+        self.assertEqual(len(diags), sum(len(s) for s in GATED_STATS.values()))
+
+    def test_spread_drives_the_floor(self) -> None:
+        # five low + five high -> the all-low vs all-high split gives Dmax=20us;
+        # 1.5x that (30us) dominates the minimum envelope.
+        low = [_artifact({"serial_read": 100_000}) for _ in range(5)]
+        high = [_artifact({"serial_read": 120_000}) for _ in range(5)]
+        policy, _d = calibrate(low + high, "v1")
+        self.assertEqual(policy.floors["serial_read"]["p50"].absolute_ns, 30_000)
+        # a metric with no spread stays at the minimum.
+        self.assertEqual(policy.floors["ping"]["p50"].absolute_ns, 1000)
+
+    def test_refuses_too_few(self) -> None:
+        with self.assertRaises(GateRefused):
+            calibrate([_artifact() for _ in range(9)], "v1")
+
+    def test_refuses_smoke(self) -> None:
+        with self.assertRaises(GateRefused):
+            calibrate([_artifact(smoke=True) for _ in range(10)], "v1")
+
+    def test_refuses_incompatible(self) -> None:
+        arts = [_artifact() for _ in range(9)] + [_artifact(source="other")]
+        with self.assertRaises(GateRefused):
+            calibrate(arts, "v1")
+
+
+class PolicyRoundTripTest(unittest.TestCase):
+    def test_write_then_load(self) -> None:
+        policy, _d = calibrate([_artifact() for _ in range(10)], "v1")
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "policy.json")
+            write_threshold_policy(policy, p, overwrite=False)
+            self.assertEqual(load_threshold_policy(p), policy)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4458
* #4457
* #4456
* #4455
* __->__ #4454
* #4453
* #4452
* #4451
* #4450
* #4449
* #4448
* #4447

adds the calibration step: turn a batch of baseline runs into the pass/fail
thresholds the gate uses. until now compare had no thresholds to check against;
this produces them.

how it sets each threshold:
- the gate decides pass/fail by comparing the median of five runs on each side, so
  calibration works in that same space: it takes all the baseline runs, tries every
  way of splitting them into two groups of five, and measures how far the two group
  medians drift apart from run-to-run noise alone.
- the threshold for a metric is set above that observed noise (1.5x the worst
  drift), with a floor of at least 1% and at least 1 microsecond so tiny or noisy
  metrics don't get a hair-trigger. it also reports, per metric, the smallest
  regression it could actually catch, so you can see whether the measurement is
  sharp enough before trusting it.

the thresholds are backend-specific -- TCP and the RDMA hardware path are
calibrated separately -- and are written to a small JSON file checked in apart
from the benchmark code. generating that file for each backend is the next step,
run on the matching hardware.

a new `calibrate` subcommand reads a set of result files and writes the threshold
file. the 1% / 1us / 1.5x numbers are deliberate starting points, to be revisited
once we have real data from both backends.

Differential Revision: [D112723648](https://our.internmc.facebook.com/intern/diff/D112723648/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D112723648/)!