### PR TITLE
[monarch] rdma benchmark: require an ibverbs target

### DIFF
--- a/python/benches/rdma_orchestration/benchmark.py
+++ b/python/benches/rdma_orchestration/benchmark.py
@@ -749,19 +749,42 @@ PING_PAYLOAD: bytes = bytes(range(PAYLOAD_BYTES))
 
 
 def backend_plan(
-    backend: str, ibverbs_available: bool, skip_unsupported: bool
+    backend: str,
+    ibverbs_available: bool,
+    skip_unsupported: bool,
+    ibverbs_target: Optional[str] = None,
 ) -> Optional[tuple[dict[str, str], dict[str, object]]]:
     """Pure backend resolution: returns (recorded config, `configured` kwargs), or
     None to skip (ibverbs unavailable under --skip-unsupported). Raises for an
     unsupported request without --skip-unsupported -- silent TCP fallback is
-    forbidden."""
+    forbidden.
+
+    ibverbs pins one explicit device (`ibverbs_target`, e.g. `cpu:0` or
+    `nic:mlx5_0`). This is required, not optional: with no target Monarch
+    hash-spreads host-memory registrations across every tied-best NIC, so two
+    peers (or two runs) can land on different NICs -- an unreproducible data
+    plane, and on a multi-NIC host a cross-NIC QP that cannot loopback. The
+    target is recorded in the artifact config so it is part of gate
+    compatibility (ROB-2)."""
     if backend == "tcp":
         return ({"rdma_disable_ibverbs": "true"}, {"rdma_disable_ibverbs": True})
     if backend == "ibverbs":
         if ibverbs_available:
+            if not ibverbs_target:
+                raise ValueError(
+                    "ibverbs requires an explicit device target (e.g. cpu:0 or "
+                    "nic:mlx5_0); without one Monarch hash-spreads host memory "
+                    "across NICs, which is not a reproducible data plane"
+                )
             return (
-                {"rdma_allow_tcp_fallback": "false"},
-                {"rdma_allow_tcp_fallback": False},
+                {
+                    "rdma_allow_tcp_fallback": "false",
+                    "rdma_ibverbs_target": ibverbs_target,
+                },
+                {
+                    "rdma_allow_tcp_fallback": False,
+                    "rdma_ibverbs_target": ibverbs_target,
+                },
             )
         if skip_unsupported:
             return None

--- a/python/benches/rdma_orchestration/collector.py
+++ b/python/benches/rdma_orchestration/collector.py
@@ -402,14 +402,20 @@ async def _cold_child_async(
             await _teardown(holder_procs, driver_procs)
 
 
-def _collect_cold_samples(backend: str, n: int, timeout_s: int) -> list[int]:
+def _collect_cold_samples(
+    backend: str, n: int, timeout_s: int, ibverbs_target: str | None
+) -> list[int]:
     """Run `n` fresh `_cold-init-child` subprocesses and collect one sample each
     (ROB-6). Each child is bounded by `timeout_s` (ROB-9); any failure or timeout
-    aborts the whole run so no partial artifact is published."""
+    aborts the whole run so no partial artifact is published. The child inherits
+    `ibverbs_target` so cold samples pin the same NIC as the steady-state ones."""
+    cmd = [sys.argv[0], "_cold-init-child", "--backend", backend]
+    if ibverbs_target is not None:
+        cmd += ["--ibverbs-target", ibverbs_target]
     samples: list[int] = []
     for _ in range(n):
         proc = subprocess.run(
-            [sys.argv[0], "_cold-init-child", "--backend", backend],
+            cmd,
             capture_output=True,
             text=True,
             timeout=timeout_s,
@@ -434,7 +440,10 @@ def _cmd_bench(args: argparse.Namespace) -> int:
     shape = bm.gate_shape(args.backend, args.smoke)
     try:
         plan = bm.backend_plan(
-            args.backend, is_ibverbs_available(), args.skip_unsupported
+            args.backend,
+            is_ibverbs_available(),
+            args.skip_unsupported,
+            args.ibverbs_target,
         )
     except bm.UnsupportedBackend as e:
         print(f"error: {e}")
@@ -443,8 +452,26 @@ def _cmd_bench(args: argparse.Namespace) -> int:
         print("SKIPPED: ibverbs requested but unavailable")
         return 0
     config, cm_kwargs = plan
+    if args.backend == "ibverbs":
+        # This benchmark registers host (CPU) memory, so RdmaXcel finds no CUDA
+        # context and logs "[RdmaXcel] Failed to get current CUDA context" once
+        # per registration. That is expected on the host-memory path and is
+        # benign -- the ibverbs data plane is unaffected. Warn once so the noise
+        # is not mistaken for a failure. Goes to stderr so it never mixes with
+        # the artifact path on stdout.
+        print(
+            "note: the '[RdmaXcel] Failed to get current CUDA context' lines "
+            "below are expected -- this benchmark registers host (CPU) memory, "
+            "which has no CUDA context. The ibverbs transfers still run over the "
+            "NIC; the messages are benign.",
+            file=sys.stderr,
+            flush=True,
+        )
     cold_init = _collect_cold_samples(
-        args.backend, shape.cold_samples, bm.TimeoutPolicy().cold_child_s
+        args.backend,
+        shape.cold_samples,
+        bm.TimeoutPolicy().cold_child_s,
+        args.ibverbs_target,
     )
     asyncio.run(
         _bench_async(
@@ -491,7 +518,12 @@ def _cmd_calibrate(args: argparse.Namespace) -> int:
 
 
 def _cmd_cold_child(args: argparse.Namespace) -> int:
-    plan = bm.backend_plan(args.backend, is_ibverbs_available(), skip_unsupported=False)
+    plan = bm.backend_plan(
+        args.backend,
+        is_ibverbs_available(),
+        skip_unsupported=False,
+        ibverbs_target=args.ibverbs_target,
+    )
     if plan is None:  # pragma: no cover - the parent only spawns supported backends
         raise SystemExit("cold-init child: backend unavailable")
     _config, cm_kwargs = plan
@@ -515,11 +547,22 @@ def build_parser() -> argparse.ArgumentParser:
     p_bench.add_argument("--skip-unsupported", action="store_true")
     p_bench.add_argument("--label", default="")
     p_bench.add_argument("--timeout", type=int, default=bm.TimeoutPolicy().op_timeout_s)
+    p_bench.add_argument(
+        "--ibverbs-target",
+        default=None,
+        help=(
+            "ibverbs device to pin: cpu:<numa>, gpu:<ordinal>, or nic:<name> "
+            "(e.g. nic:mlx5_0). Required for --backend ibverbs; without it host "
+            "memory is hash-spread across NICs and the data plane is not "
+            "reproducible."
+        ),
+    )
     p_bench.set_defaults(func=_cmd_bench)
 
     p_cold = sub.add_parser("_cold-init-child", help=argparse.SUPPRESS)
     p_cold.add_argument("--backend", choices=["tcp", "ibverbs"], default="tcp")
     p_cold.add_argument("--timeout", type=int, default=bm.TimeoutPolicy().op_timeout_s)
+    p_cold.add_argument("--ibverbs-target", default=None)
     p_cold.set_defaults(func=_cmd_cold_child)
 
     p_cmp = sub.add_parser("compare", help="gate two sets of artifacts")

--- a/python/benches/rdma_orchestration/tests/test_benchmark.py
+++ b/python/benches/rdma_orchestration/tests/test_benchmark.py
@@ -363,11 +363,28 @@ class BackendPlanTest(unittest.TestCase):
         self.assertEqual(kwargs, {"rdma_disable_ibverbs": True})
         self.assertEqual(config, {"rdma_disable_ibverbs": "true"})
 
-    def test_ibverbs_when_available(self) -> None:
-        result = backend_plan("ibverbs", ibverbs_available=True, skip_unsupported=False)
+    def test_ibverbs_pins_target(self) -> None:
+        # ibverbs pins the explicit device in both the recorded config and the
+        # `configured()` kwargs so the data plane is reproducible (ROB-2).
+        result = backend_plan(
+            "ibverbs",
+            ibverbs_available=True,
+            skip_unsupported=False,
+            ibverbs_target="cpu:0",
+        )
         assert result is not None
-        _config, kwargs = result
-        self.assertEqual(kwargs, {"rdma_allow_tcp_fallback": False})
+        config, kwargs = result
+        self.assertEqual(
+            kwargs,
+            {"rdma_allow_tcp_fallback": False, "rdma_ibverbs_target": "cpu:0"},
+        )
+        self.assertEqual(config["rdma_ibverbs_target"], "cpu:0")
+
+    def test_ibverbs_requires_target(self) -> None:
+        # no target -> refuse: automatic host-memory selection hash-spreads
+        # across NICs and is not a reproducible data plane.
+        with self.assertRaises(ValueError):
+            backend_plan("ibverbs", ibverbs_available=True, skip_unsupported=False)
 
     def test_ibverbs_unavailable_skips(self) -> None:
         # --skip-unsupported turns an unavailable backend into a clean skip.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4458
* #4457
* __->__ #4456
* #4455
* #4454
* #4453
* #4452
* #4451
* #4450
* #4449
* #4448
* #4447

ibverbs runs aren't reproducible unless they pin a NIC, so `bench --backend
ibverbs` now requires `--ibverbs-target` and records it in each result's config.

Differential Revision: [D112723642](https://our.internmc.facebook.com/intern/diff/D112723642/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D112723642/)!