### PR TITLE
expose ibverbs target selection to Python

### DIFF
--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -759,8 +759,9 @@ impl PyRdmaManager {
         let proc_mesh = proc_mesh.downcast::<PyProcMesh>()?.borrow().mesh_ref()?;
         PyPythonTask::new(async move {
             let actor_mesh: ActorMesh<RdmaManagerActor> = proc_mesh
-                // Pass None to use default config - RdmaManagerActor will use default IbverbsConfig
-                // TODO - make IbverbsConfig configurable
+                // Python supplies no per-manager config. `IbvManagerActor::new`
+                // fills an absent `IbvConfig::target` from `RDMA_IBVERBS_TARGET`
+                // (`rdma_ibverbs_target` in Python).
                 .spawn_service(client.deref(), "rdma_manager", &None)
                 .await
                 .map_err(|err| PyException::new_err(err.to_string()))?;

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -9,6 +9,7 @@
 //! ibverbs-specific device selection: pairs a [`MemoryLocation`] with the
 //! RDMA NIC(s) that have the best PCIe path to it.
 
+use std::str::FromStr;
 use std::sync::LazyLock;
 
 use anyhow::Context;
@@ -50,6 +51,56 @@ impl IbvDeviceTarget {
     pub fn nic(name: impl Into<String>) -> Self {
         Self::Nic(name.into())
     }
+}
+
+impl FromStr for IbvDeviceTarget {
+    type Err = anyhow::Error;
+
+    fn from_str(spec: &str) -> Result<Self> {
+        let (kind, value) = spec.split_once(':').with_context(|| {
+            format!(
+                "ibverbs target {spec:?} must be `cpu:<numa>`, `gpu:<ordinal>`, or `nic:<name>`"
+            )
+        })?;
+
+        let parse_index = |what: &str| -> Result<u32> {
+            value
+                .parse()
+                .with_context(|| format!("{what} {value:?} must be an integer in 0..={}", u32::MAX))
+        };
+
+        match kind {
+            "cpu" => Ok(Self::cpu(parse_index("cpu target NUMA node")?)),
+            "gpu" => Ok(Self::gpu(parse_index("gpu target ordinal")?)),
+            "nic" => {
+                anyhow::ensure!(
+                    !value.is_empty(),
+                    "nic target must name a device, for example `nic:mlx5_0`"
+                );
+                Ok(Self::nic(value))
+            }
+            other => anyhow::bail!(
+                "unknown ibverbs target kind {other:?}; expected `cpu`, `gpu`, or `nic`"
+            ),
+        }
+    }
+}
+
+/// Return the configured ibverbs target, or `None` when it is unset.
+///
+/// Returns an error when the non-empty value is malformed.
+pub(crate) fn configured_ibverbs_target() -> Result<Option<IbvDeviceTarget>> {
+    let spec = hyperactor_config::global::get_cloned(crate::config::RDMA_IBVERBS_TARGET);
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Ok(None);
+    }
+    let target = spec.parse().map_err(|error| {
+        anyhow::anyhow!(
+            "invalid RDMA_IBVERBS_TARGET (`rdma_ibverbs_target` in Python) value {spec:?}: {error}"
+        )
+    })?;
+    Ok(Some(target))
 }
 
 /// The PCI address of an RDMA NIC, resolved from its sysfs device link
@@ -186,4 +237,74 @@ pub fn get_cuda_device_to_ibv_device<I: IbvDeviceImpl>() -> &'static Vec<Option<
             .collect();
         Box::leak(Box::new(result))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_each_target_kind() {
+        assert_eq!(
+            "cpu:0"
+                .parse::<IbvDeviceTarget>()
+                .expect("cpu target should parse"),
+            IbvDeviceTarget::cpu(0),
+        );
+        assert_eq!(
+            "gpu:1"
+                .parse::<IbvDeviceTarget>()
+                .expect("gpu target should parse"),
+            IbvDeviceTarget::gpu(1),
+        );
+        assert_eq!(
+            "nic:mlx5_0"
+                .parse::<IbvDeviceTarget>()
+                .expect("NIC target should parse"),
+            IbvDeviceTarget::nic("mlx5_0"),
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_targets() {
+        for invalid in ["", "cpu", "cpu:", "cpu:x", "gpu:-1", "nic:", "other:0"] {
+            assert!(
+                invalid.parse::<IbvDeviceTarget>().is_err(),
+                "expected {invalid:?} to be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn empty_configured_target_is_unset() {
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(crate::config::RDMA_IBVERBS_TARGET, String::new());
+        assert_eq!(
+            configured_ibverbs_target().expect("empty target should be valid"),
+            None,
+        );
+    }
+
+    #[test]
+    fn parses_configured_target() {
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(
+            crate::config::RDMA_IBVERBS_TARGET,
+            "  nic:mlx5_1  ".to_string(),
+        );
+
+        assert_eq!(
+            configured_ibverbs_target().expect("configured target should be valid"),
+            Some(IbvDeviceTarget::nic("mlx5_1")),
+        );
+    }
+
+    #[test]
+    fn malformed_configured_target_names_the_setting() {
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(crate::config::RDMA_IBVERBS_TARGET, "mlx5_1".to_string());
+
+        let error = configured_ibverbs_target().expect_err("malformed target should fail");
+        assert!(error.to_string().contains("RDMA_IBVERBS_TARGET"));
+    }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -265,6 +265,12 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                 config
             }
         };
+
+        // Preserve an explicit per-manager target. Otherwise parse the process
+        // default from `RDMA_IBVERBS_TARGET`; empty preserves automatic selection.
+        if config.target.is_none() {
+            config.target = super::device_selection::configured_ibverbs_target()?;
+        }
         tracing::debug!("rdma is enabled, config target: {:?}", config.target);
 
         // check config and hardware support align

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -79,4 +79,15 @@ declare_attrs! {
         Some("rdma_qp_init_timeout".to_string()),
     ))
     pub attr RDMA_QP_INIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Default ibverbs device target for managers without an explicit target.
+    ///
+    /// Accepted forms are `cpu:<numa>`, `gpu:<ordinal>`, and `nic:<name>`.
+    /// The empty default preserves automatic device selection. Non-empty value
+    /// syntax is validated when the RDMA manager starts.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_IBVERBS_TARGET".to_string()),
+        Some("rdma_ibverbs_target".to_string()),
+    ))
+    pub attr RDMA_IBVERBS_TARGET: String = String::new();
 }

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -156,6 +156,19 @@ impl RemoteSpawn for RdmaManagerActor {
 #[async_trait]
 impl Actor for RdmaManagerActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        // An explicit per-manager target takes precedence over
+        // `RDMA_IBVERBS_TARGET`. Otherwise validate the process setting here:
+        // `spawn_available` may ignore an ibverbs initialization failure when
+        // TCP starts, silently turning a malformed pin into TCP fallback.
+        if self
+            .params
+            .as_ref()
+            .and_then(|config| config.target.as_ref())
+            .is_none()
+        {
+            let _ = crate::backend::ibverbs::device_selection::configured_ibverbs_target()?;
+        }
+
         // Spawn every available backend. `spawn_available` bails when none
         // is available (e.g. no NIC and TCP fallback disabled).
         let backends = RdmaBackends::spawn_available(

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -83,6 +83,7 @@ def configure(
     rdma_allow_tcp_fallback: bool = ...,
     rdma_disable_ibverbs: bool = ...,
     rdma_max_chunk_size_mb: int = ...,
+    rdma_ibverbs_target: str = ...,
     **kwargs: object,
 ) -> None:
     """Configure Hyperactor runtime defaults for this process.
@@ -96,7 +97,7 @@ def configure(
 
     For complete parameter documentation, see the Python wrapper
     `monarch.config.configure()` which provides the same interface
-    with detailed descriptions of all 36 configuration parameters
+    with detailed descriptions of the configuration parameters
     organized into logical categories (transport, logging, message
     handling, mesh bootstrap, allocation, proc/host mesh timeouts,
     etc.).
@@ -180,6 +181,11 @@ def configure(
             causing all RDMA operations to use the TCP fallback backend.
         rdma_max_chunk_size_mb: Maximum chunk size in MiB for
             TCP-based RDMA transfers (default: 64)
+        rdma_ibverbs_target: Default ibverbs device target for managers
+            without an explicit target. Accepts "cpu:<numa>",
+            "gpu:<ordinal>", or "nic:<name>". Empty preserves automatic
+            selection. Non-empty value syntax is validated when the RDMA
+            manager starts.
         **kwargs: Reserved for future configuration keys
 
     For historical reasons, this API is named ``configure(...)``;

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
             rdma_allow_tcp_fallback: NotRequired[bool]
             rdma_disable_ibverbs: NotRequired[bool]
             rdma_max_chunk_size_mb: NotRequired[int]
+            rdma_ibverbs_target: NotRequired[str]
 
         # pyrefly: ignore [invalid-annotation]
         ConfigureKwargsType = Unpack[ConfigureArgs]
@@ -182,6 +183,11 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
                 causing all RDMA operations to use the TCP fallback backend.
             rdma_max_chunk_size_mb: Maximum chunk size in megabytes for RDMA
                 transfers.
+            rdma_ibverbs_target: Default ibverbs device target for managers
+                without an explicit target. Accepts ``"cpu:<numa>"``,
+                ``"gpu:<ordinal>"``, or ``"nic:<name>"``. Empty preserves
+                automatic selection. Non-empty value syntax is validated when
+                the RDMA manager starts.
 
         **kwargs: Reserved for future configuration keys exposed by Rust bindings.
     """

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -25,6 +25,12 @@ class Chunker(Actor):
         return len(chunks)
 
 
+class RdmaTargetProbe(Actor):
+    @endpoint
+    def rdma_ibverbs_target(self) -> str:
+        return get_global_config()["rdma_ibverbs_target"]
+
+
 def test_get_set_transport() -> None:
     for transport in (
         ChannelTransport.Unix,
@@ -87,6 +93,21 @@ def test_get_set_multiple() -> None:
     assert not config["enable_file_capture"]
     assert config["tail_log_lines"] == 0
     assert config["default_transport"] == BindSpec(ChannelTransport.Unix)
+
+
+@isolate_in_subprocess
+def test_rdma_ibverbs_target_round_trip_and_propagation() -> None:
+    assert get_global_config()["rdma_ibverbs_target"] == ""
+
+    target = "nic:mlx5_0"
+    with configured(rdma_ibverbs_target=target) as config:
+        assert config["rdma_ibverbs_target"] == target
+
+        proc = this_host().spawn_procs()
+        probe = proc.spawn("rdma_target_probe", RdmaTargetProbe)
+        assert probe.rdma_ibverbs_target.call_one().get() == target
+
+    assert get_global_config()["rdma_ibverbs_target"] == ""
 
 
 @isolate_in_subprocess

--- a/python/tests/test_rdma_unsupported.py
+++ b/python/tests/test_rdma_unsupported.py
@@ -6,11 +6,10 @@
 
 # pyre-unsafe
 """
-Tests for RDMA functionality when RDMA is not supported.
+Tests for RDMA manager initialization failures.
 
-This file contains tests that are specifically designed to run on systems
-where RDMA is NOT available. These tests verify error handling and fallback
-behavior when RDMA support is missing.
+These tests cover unsupported hosts and configuration errors that must surface
+before backend fallback.
 """
 
 import sys
@@ -29,6 +28,38 @@ needs_no_rdma = pytest.mark.skipif(
     is_ibverbs_available(),
     reason="RDMA is available, test only runs on systems without RDMA support",
 )
+
+
+async def _rdma_manager_init_fault(**config: object) -> str:
+    import asyncio
+
+    import monarch.actor
+    from monarch._rust_bindings.rdma import _RdmaManager
+    from monarch._src.actor.actor_mesh import context
+    from monarch._src.actor.future import Future
+    from monarch.actor import this_host
+
+    faults = []
+    faulted = asyncio.Event()
+
+    def fault_hook(failure):
+        faults.append(failure)
+        faulted.set()
+
+    monarch.actor.unhandled_fault_hook = fault_hook
+
+    with configured(**config):
+        proc_mesh = this_host().spawn_procs(per_host={"cpus": 1})
+        await Future(
+            coro=_RdmaManager.create_rdma_manager_nonblocking(
+                await Future(coro=proc_mesh._proc_mesh.task()),
+                context().actor_instance,
+            )
+        )
+        await asyncio.wait_for(faulted.wait(), timeout=15.0)
+
+    assert faults, "Expected a supervision fault, got none"
+    return "\n".join(str(failure) for failure in faults)
 
 
 @needs_no_rdma
@@ -50,40 +81,19 @@ async def test_rdma_manager_creation_fails_when_unsupported() -> None:
     chain (Python -> Rust -> C ibverbs library); a Python mock cannot intercept
     the native device probe.
     """
-    import asyncio
-
-    import monarch.actor
-    from monarch._rust_bindings.rdma import _RdmaManager
-    from monarch._src.actor.actor_mesh import context
-    from monarch._src.actor.future import Future
-    from monarch.actor import this_host
-
-    faults = []
-    faulted = asyncio.Event()
-
-    def fault_hook(failure):
-        faults.append(failure)
-        faulted.set()
-
-    monarch.actor.unhandled_fault_hook = fault_hook
-
-    with configured(rdma_allow_tcp_fallback=False):
-        proc_mesh = this_host().spawn_procs(per_host={"cpus": 1})
-
-        # Spawning succeeds; the RdmaManagerActor's init then fails because no
-        # NIC backend is available and TCP fallback is disabled.
-        await Future(
-            coro=_RdmaManager.create_rdma_manager_nonblocking(
-                await Future(coro=proc_mesh._proc_mesh.task()),
-                context().actor_instance,
-            )
-        )
-
-        # The init failure arrives asynchronously as a supervision fault.
-        await asyncio.wait_for(faulted.wait(), timeout=15.0)
-
-    assert len(faults) >= 1, "Expected a supervision fault, got none"
-    failure_message = str(faults[0])
+    failure_message = await _rdma_manager_init_fault(rdma_allow_tcp_fallback=False)
     assert "no RDMA backend available" in failure_message, (
         f"Expected specific failure message not found. Actual fault: {failure_message}"
+    )
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_malformed_rdma_ibverbs_target_fails_manager_creation() -> None:
+    failure_message = await _rdma_manager_init_fault(
+        rdma_allow_tcp_fallback=True,
+        rdma_ibverbs_target="mlx5_0",  # Missing the required `nic:` target kind.
+    )
+    assert "RDMA_IBVERBS_TARGET" in failure_message, (
+        f"Expected target configuration error not found. Actual fault: {failure_message}"
     )


### PR DESCRIPTION
Summary:
a later diff in this stack adds a Python RDMA benchmark for comparing performance before and after refactors. its measurements require device selection to remain fixed across runs so a different NIC does not become an uncontrolled variable.

Rust already supports selecting an ibverbs device through `IbvConfig.target`, but the Python RDMA manager is always created without a per-manager `IbvConfig`, so Python callers cannot set it. automatic selection may choose among equally suitable NICs.

this change adds the process-wide `RDMA_IBVERBS_TARGET` setting, exposed as `rdma_ibverbs_target` in Python and `MONARCH_RDMA_IBVERBS_TARGET` in the environment. it accepts `cpu:<numa>`, `gpu:<ordinal>`, or `nic:<name>`.

an explicit per-manager target still takes precedence. an empty setting preserves existing automatic device selection, and `rdma_allow_tcp_fallback` continues to control whether TCP fallback is allowed.

malformed target syntax fails when the RDMA manager starts. validation occurs before backend startup so an invalid pin cannot be mistaken for an unavailable ibverbs backend and silently fall back to TCP.

the Python configuration documentation and type stub are updated. tests cover parsing, propagation to child processes, and the malformed-target failure path.

Differential Revision: D112746012


