### PR TITLE
add a focused RDMA benchmark for pytokio removal

### DIFF
--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -759,8 +759,9 @@ impl PyRdmaManager {
         let proc_mesh = proc_mesh.downcast::<PyProcMesh>()?.borrow().mesh_ref()?;
         PyPythonTask::new(async move {
             let actor_mesh: ActorMesh<RdmaManagerActor> = proc_mesh
-                // Pass None to use default config - RdmaManagerActor will use default IbverbsConfig
-                // TODO - make IbverbsConfig configurable
+                // Python supplies no per-manager config. `IbvManagerActor::new`
+                // fills an absent `IbvConfig::target` from `RDMA_IBVERBS_TARGET`
+                // (`rdma_ibverbs_target` in Python).
                 .spawn_service(client.deref(), "rdma_manager", &None)
                 .await
                 .map_err(|err| PyException::new_err(err.to_string()))?;

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -9,6 +9,7 @@
 //! ibverbs-specific device selection: pairs a [`MemoryLocation`] with the
 //! RDMA NIC(s) that have the best PCIe path to it.
 
+use std::str::FromStr;
 use std::sync::LazyLock;
 
 use anyhow::Context;
@@ -50,6 +51,56 @@ impl IbvDeviceTarget {
     pub fn nic(name: impl Into<String>) -> Self {
         Self::Nic(name.into())
     }
+}
+
+impl FromStr for IbvDeviceTarget {
+    type Err = anyhow::Error;
+
+    fn from_str(spec: &str) -> Result<Self> {
+        let (kind, value) = spec.split_once(':').with_context(|| {
+            format!(
+                "ibverbs target {spec:?} must be `cpu:<numa>`, `gpu:<ordinal>`, or `nic:<name>`"
+            )
+        })?;
+
+        let parse_index = |what: &str| -> Result<u32> {
+            value
+                .parse()
+                .with_context(|| format!("{what} {value:?} must be an integer in 0..={}", u32::MAX))
+        };
+
+        match kind {
+            "cpu" => Ok(Self::cpu(parse_index("cpu target NUMA node")?)),
+            "gpu" => Ok(Self::gpu(parse_index("gpu target ordinal")?)),
+            "nic" => {
+                anyhow::ensure!(
+                    !value.is_empty(),
+                    "nic target must name a device, for example `nic:mlx5_0`"
+                );
+                Ok(Self::nic(value))
+            }
+            other => anyhow::bail!(
+                "unknown ibverbs target kind {other:?}; expected `cpu`, `gpu`, or `nic`"
+            ),
+        }
+    }
+}
+
+/// Return the configured ibverbs target, or `None` when it is unset.
+///
+/// Returns an error when the non-empty value is malformed.
+pub(crate) fn configured_ibverbs_target() -> Result<Option<IbvDeviceTarget>> {
+    let spec = hyperactor_config::global::get_cloned(crate::config::RDMA_IBVERBS_TARGET);
+    let spec = spec.trim();
+    if spec.is_empty() {
+        return Ok(None);
+    }
+    let target = spec.parse().map_err(|error| {
+        anyhow::anyhow!(
+            "invalid RDMA_IBVERBS_TARGET (`rdma_ibverbs_target` in Python) value {spec:?}: {error}"
+        )
+    })?;
+    Ok(Some(target))
 }
 
 /// The PCI address of an RDMA NIC, resolved from its sysfs device link
@@ -186,4 +237,74 @@ pub fn get_cuda_device_to_ibv_device<I: IbvDeviceImpl>() -> &'static Vec<Option<
             .collect();
         Box::leak(Box::new(result))
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_each_target_kind() {
+        assert_eq!(
+            "cpu:0"
+                .parse::<IbvDeviceTarget>()
+                .expect("cpu target should parse"),
+            IbvDeviceTarget::cpu(0),
+        );
+        assert_eq!(
+            "gpu:1"
+                .parse::<IbvDeviceTarget>()
+                .expect("gpu target should parse"),
+            IbvDeviceTarget::gpu(1),
+        );
+        assert_eq!(
+            "nic:mlx5_0"
+                .parse::<IbvDeviceTarget>()
+                .expect("NIC target should parse"),
+            IbvDeviceTarget::nic("mlx5_0"),
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_targets() {
+        for invalid in ["", "cpu", "cpu:", "cpu:x", "gpu:-1", "nic:", "other:0"] {
+            assert!(
+                invalid.parse::<IbvDeviceTarget>().is_err(),
+                "expected {invalid:?} to be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn empty_configured_target_is_unset() {
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(crate::config::RDMA_IBVERBS_TARGET, String::new());
+        assert_eq!(
+            configured_ibverbs_target().expect("empty target should be valid"),
+            None,
+        );
+    }
+
+    #[test]
+    fn parses_configured_target() {
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(
+            crate::config::RDMA_IBVERBS_TARGET,
+            "  nic:mlx5_1  ".to_string(),
+        );
+
+        assert_eq!(
+            configured_ibverbs_target().expect("configured target should be valid"),
+            Some(IbvDeviceTarget::nic("mlx5_1")),
+        );
+    }
+
+    #[test]
+    fn malformed_configured_target_names_the_setting() {
+        let lock = hyperactor_config::global::lock();
+        let _guard = lock.override_key(crate::config::RDMA_IBVERBS_TARGET, "mlx5_1".to_string());
+
+        let error = configured_ibverbs_target().expect_err("malformed target should fail");
+        assert!(error.to_string().contains("RDMA_IBVERBS_TARGET"));
+    }
 }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -265,6 +265,12 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                 config
             }
         };
+
+        // Preserve an explicit per-manager target. Otherwise parse the process
+        // default from `RDMA_IBVERBS_TARGET`; empty preserves automatic selection.
+        if config.target.is_none() {
+            config.target = super::device_selection::configured_ibverbs_target()?;
+        }
         tracing::debug!("rdma is enabled, config target: {:?}", config.target);
 
         // check config and hardware support align

--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -79,4 +79,15 @@ declare_attrs! {
         Some("rdma_qp_init_timeout".to_string()),
     ))
     pub attr RDMA_QP_INIT_TIMEOUT: Duration = Duration::from_secs(30);
+
+    /// Default ibverbs device target for managers without an explicit target.
+    ///
+    /// Accepted forms are `cpu:<numa>`, `gpu:<ordinal>`, and `nic:<name>`.
+    /// The empty default preserves automatic device selection. Non-empty value
+    /// syntax is validated when the RDMA manager starts.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_IBVERBS_TARGET".to_string()),
+        Some("rdma_ibverbs_target".to_string()),
+    ))
+    pub attr RDMA_IBVERBS_TARGET: String = String::new();
 }

--- a/monarch_rdma/src/rdma_manager_actor.rs
+++ b/monarch_rdma/src/rdma_manager_actor.rs
@@ -156,6 +156,19 @@ impl RemoteSpawn for RdmaManagerActor {
 #[async_trait]
 impl Actor for RdmaManagerActor {
     async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+        // An explicit per-manager target takes precedence over
+        // `RDMA_IBVERBS_TARGET`. Otherwise validate the process setting here:
+        // `spawn_available` may ignore an ibverbs initialization failure when
+        // TCP starts, silently turning a malformed pin into TCP fallback.
+        if self
+            .params
+            .as_ref()
+            .and_then(|config| config.target.as_ref())
+            .is_none()
+        {
+            let _ = crate::backend::ibverbs::device_selection::configured_ibverbs_target()?;
+        }
+
         // Spawn every available backend. `spawn_available` bails when none
         // is available (e.g. no NIC and TCP fallback disabled).
         let backends = RdmaBackends::spawn_available(

--- a/python/benches/rdma_orchestration/README.md
+++ b/python/benches/rdma_orchestration/README.md
@@ -1,0 +1,32 @@
+# pytokio-removal RDMA benchmark
+
+This tool answers one question: did the pytokio-removal refactor change RDMA
+performance? It is not a general RDMA benchmark or an automated regression
+gate.
+
+## Run
+
+Use the same idle host for both revisions. Run both backends on the baseline
+revision:
+
+```bash
+buck run fbcode//monarch/python/benches/rdma_orchestration:bench -- --backend tcp
+buck run fbcode//monarch/python/benches/rdma_orchestration:bench -- --backend ibverbs --target nic:mlx5_0
+```
+
+Move to the refactored revision and run the same two commands. Use the same NIC
+for both ibverbs runs.
+
+Compare TCP with TCP and ibverbs with ibverbs. For each backend, inspect both:
+
+- `cold_init`, which covers buffer setup, backend initialization, readiness,
+  and the first validated read in a fresh process; and
+- the warmed serial read/write and K=32 concurrent read/write statistics.
+
+If a difference is close to ordinary run-to-run variation, repeat that command
+on both revisions and inspect the spread.
+
+The benchmark validates every transfer, requires ibverbs when that backend is
+selected, prints its measurements to stdout, and writes no result files. It
+rejects conflicting `MONARCH_RDMA_*` environment settings rather than measuring
+a different backend than the command requested.

--- a/python/benches/rdma_orchestration/benchmark.py
+++ b/python/benches/rdma_orchestration/benchmark.py
@@ -1,0 +1,513 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Measure RDMA startup and transfers before and after pytokio removal.
+
+Each run uses one host and two Monarch procs, with one actor in each proc. The
+holder actor provides the memory being accessed, and the driver actor initiates
+the transfers. A separate client process coordinates their endpoint calls but
+does not move the data. The benchmark checks that all three processes have
+different process IDs.
+
+The holder proc backs 33 RDMA-accessible buffers: one 64-byte source containing
+known data and 32 independent 64-byte targets. Each is an ordinary bytearray
+exposed through an `RDMABuffer` handle. The client receives those handles from
+`holder.make_buffers()` and passes the relevant handles to the driver actor.
+The handles identify the registered memory; they are not extra buffers, and
+the underlying bytearrays stay in the holder proc.
+
+The driver creates separate local scratch memory: one buffer for serial work
+or 32 buffers for concurrent work. Operations are named from the driver's
+point of view. A read pulls data from the holder's source into driver memory. A
+write pushes data from driver memory into a holder target. Concurrent reads
+share the holder's source, while concurrent writes use its 32 distinct targets.
+The benchmark checks the transferred bytes after each timed operation or batch.
+
+In ibverbs mode, creating the holder's `RDMABuffer` handles registers its
+memory with the NIC. The driver's scratch memory is registered when its
+`memoryview` is first used. Warmups pay the driver's registration cost, and
+steady-state measurements reuse the same memoryviews. Both procs' RDMA managers
+use the same requested NIC. In TCP mode, both procs use TCP instead.
+
+Cold samples use fresh procs and time creation of the holder's 33 RDMA buffers
+plus the first read, including registration of the driver's first local buffer.
+Steady-state samples warm both directions, then measure serial operations and
+groups of 32 concurrent operations. This same-host fixture measures the
+orchestration affected by the refactor, not network-fabric throughput.
+"""
+
+import argparse
+import asyncio
+import math
+import os
+import re
+import subprocess
+import sys
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+from monarch.actor import Actor, endpoint, ProcMesh, this_host
+from monarch.config import configured
+from monarch.rdma import is_ibverbs_available, RDMABuffer
+
+
+_PAYLOAD_BYTES = 64
+_CONCURRENCY = 32
+_COLD_SAMPLES = 5
+_SERIAL_WARMUPS = 20
+_SERIAL_SAMPLES = 400
+_CONCURRENT_WARMUPS = 1
+_CONCURRENT_BATCHES = 50
+_OP_TIMEOUT_S = 60
+_COLD_CHILD_TIMEOUT_S = 180
+_TEARDOWN_TIMEOUT_S = 30
+_COLD_PREFIX = "RDMA_COLD_NS "
+
+
+def _source_pattern(size: int) -> bytes:
+    return bytes(i & 0xFF for i in range(size))
+
+
+def _write_payload(size: int, counter: int) -> bytes:
+    body = bytes(0xC0 ^ (i & 0xFF) for i in range(max(size - 8, 0)))
+    return (counter.to_bytes(8, "little") + body)[:size]
+
+
+def _check_read(expected: bytes, observed: bytes) -> None:
+    if observed != expected:
+        raise AssertionError("read destination does not match the source")
+
+
+def _check_write(expected: bytes, observed: bytes) -> None:
+    if observed != expected:
+        raise AssertionError("write target does not match the payload")
+
+
+class _Holder(Actor):
+    def __init__(self) -> None:
+        self._source = bytearray(_source_pattern(_PAYLOAD_BYTES))
+        self._targets = [bytearray(_PAYLOAD_BYTES) for _ in range(_CONCURRENCY)]
+
+    @endpoint
+    async def make_buffers(self) -> tuple[RDMABuffer, list[RDMABuffer]]:
+        source = RDMABuffer(memoryview(self._source))
+        targets = [RDMABuffer(memoryview(target)) for target in self._targets]
+        return source, targets
+
+    @endpoint
+    async def source_bytes(self) -> bytes:
+        return bytes(self._source)
+
+    @endpoint
+    async def target_bytes(self, index: int) -> bytes:
+        return bytes(self._targets[index])
+
+    @endpoint
+    async def pid(self) -> int:
+        return os.getpid()
+
+
+class _Driver(Actor):
+    """Runs transfers while retaining memoryviews across steady-state samples.
+
+    Local-memory registration is cached by memoryview identity, so recreating a
+    view inside a timed loop would measure registration instead of steady state.
+    """
+
+    @endpoint
+    async def pid(self) -> int:
+        return os.getpid()
+
+    @endpoint
+    async def initialize(
+        self,
+        holder: _Holder,
+        source: RDMABuffer,
+        target: RDMABuffer,
+    ) -> None:
+        expected = bytes(await holder.source_bytes.call_one())
+        destination = bytearray(b"\xa5" * source.size())
+        await source.read_into(memoryview(destination), timeout=_OP_TIMEOUT_S)
+        _check_read(expected, bytes(destination))
+
+        payload = _write_payload(target.size(), 0)
+        await target.write_from(memoryview(payload), timeout=_OP_TIMEOUT_S)
+        observed = bytes(await holder.target_bytes.call_one(0))
+        _check_write(payload, observed)
+
+    @endpoint
+    async def cold_read(self, source: RDMABuffer) -> bytes:
+        destination = bytearray(b"\xa5" * source.size())
+        await source.read_into(memoryview(destination), timeout=_OP_TIMEOUT_S)
+        return bytes(destination)
+
+    @endpoint
+    async def serial_reads(self, holder: _Holder, source: RDMABuffer) -> list[int]:
+        expected = bytes(await holder.source_bytes.call_one())
+        poison = b"\xa5" * source.size()
+        destination = bytearray(source.size())
+        destination_view = memoryview(destination)
+        samples: list[int] = []
+        for index in range(_SERIAL_WARMUPS + _SERIAL_SAMPLES):
+            destination[:] = poison
+            start = time.perf_counter_ns()
+            await source.read_into(destination_view, timeout=_OP_TIMEOUT_S)
+            elapsed = time.perf_counter_ns() - start
+            _check_read(expected, bytes(destination))
+            if index >= _SERIAL_WARMUPS:
+                samples.append(elapsed)
+        return samples
+
+    @endpoint
+    async def serial_writes(
+        self,
+        holder: _Holder,
+        target: RDMABuffer,
+    ) -> list[int]:
+        payload = bytearray(target.size())
+        payload_view = memoryview(payload)
+        samples: list[int] = []
+        for index in range(_SERIAL_WARMUPS + _SERIAL_SAMPLES):
+            payload[:] = _write_payload(target.size(), index + 1)
+            start = time.perf_counter_ns()
+            await target.write_from(payload_view, timeout=_OP_TIMEOUT_S)
+            elapsed = time.perf_counter_ns() - start
+            observed = bytes(await holder.target_bytes.call_one(0))
+            _check_write(bytes(payload), observed)
+            if index >= _SERIAL_WARMUPS:
+                samples.append(elapsed)
+        return samples
+
+    @endpoint
+    async def concurrent_reads(
+        self,
+        holder: _Holder,
+        source: RDMABuffer,
+    ) -> list[int]:
+        expected = bytes(await holder.source_bytes.call_one())
+        poison = b"\xa5" * source.size()
+        destinations = [bytearray(source.size()) for _ in range(_CONCURRENCY)]
+        destination_views = [memoryview(destination) for destination in destinations]
+        samples: list[int] = []
+        for index in range(_CONCURRENT_WARMUPS + _CONCURRENT_BATCHES):
+            for destination in destinations:
+                destination[:] = poison
+            start = time.perf_counter_ns()
+            pending = [
+                source.read_into(destination, timeout=_OP_TIMEOUT_S).as_asyncio()
+                for destination in destination_views
+            ]
+            for operation in pending:
+                await operation
+            elapsed = time.perf_counter_ns() - start
+            for destination in destinations:
+                _check_read(expected, bytes(destination))
+            if index >= _CONCURRENT_WARMUPS:
+                samples.append(elapsed)
+        return samples
+
+    @endpoint
+    async def concurrent_writes(
+        self,
+        holder: _Holder,
+        targets: list[RDMABuffer],
+    ) -> list[int]:
+        payloads = [bytearray(target.size()) for target in targets]
+        payload_views = [memoryview(payload) for payload in payloads]
+        samples: list[int] = []
+        for index in range(_CONCURRENT_WARMUPS + _CONCURRENT_BATCHES):
+            for slot, (target, payload) in enumerate(zip(targets, payloads)):
+                payload[:] = _write_payload(
+                    target.size(), index * _CONCURRENCY + slot + 1
+                )
+            start = time.perf_counter_ns()
+            pending = [
+                target.write_from(payload, timeout=_OP_TIMEOUT_S).as_asyncio()
+                for target, payload in zip(targets, payload_views)
+            ]
+            for operation in pending:
+                await operation
+            elapsed = time.perf_counter_ns() - start
+            for slot, payload in enumerate(payloads):
+                observed = bytes(await holder.target_bytes.call_one(slot))
+                _check_write(bytes(payload), observed)
+            if index >= _CONCURRENT_WARMUPS:
+                samples.append(elapsed)
+        return samples
+
+
+@dataclass(frozen=True)
+class _Results:
+    cold_init: list[int]
+    serial_read: list[int]
+    serial_write: list[int]
+    concurrent_read: list[int]
+    concurrent_write: list[int]
+
+
+async def _assert_distinct(holder: _Holder, driver: _Driver) -> None:
+    holder_pid = int(await holder.pid.call_one())
+    driver_pid = int(await driver.pid.call_one())
+    if len({os.getpid(), holder_pid, driver_pid}) != 3:
+        raise RuntimeError("client, holder, and driver must be separate processes")
+
+
+async def _teardown(holder_procs: ProcMesh, driver_procs: ProcMesh) -> None:
+    errors: list[Exception] = []
+    for procs in (holder_procs, driver_procs):
+        try:
+            await asyncio.wait_for(procs.stop(), timeout=_TEARDOWN_TIMEOUT_S)
+        except Exception as error:
+            errors.append(error)
+    if errors:
+        raise errors[0]
+
+
+async def _steady_body() -> tuple[list[int], list[int], list[int], list[int]]:
+    holder_procs = this_host().spawn_procs(per_host={"processes": 1})
+    driver_procs = this_host().spawn_procs(per_host={"processes": 1})
+    holder = holder_procs.spawn("rdma_bench_holder", _Holder)
+    driver = driver_procs.spawn("rdma_bench_driver", _Driver)
+    try:
+        await _assert_distinct(holder, driver)
+        source, targets = await holder.make_buffers.call_one()
+        await driver.initialize.call_one(holder, source, targets[0])
+        serial_read = list(await driver.serial_reads.call_one(holder, source))
+        serial_write = list(await driver.serial_writes.call_one(holder, targets[0]))
+        concurrent_read = list(await driver.concurrent_reads.call_one(holder, source))
+        concurrent_write = list(
+            await driver.concurrent_writes.call_one(holder, targets)
+        )
+        return serial_read, serial_write, concurrent_read, concurrent_write
+    finally:
+        await _teardown(holder_procs, driver_procs)
+
+
+async def _cold_body() -> int:
+    holder_procs = this_host().spawn_procs(per_host={"processes": 1})
+    driver_procs = this_host().spawn_procs(per_host={"processes": 1})
+    holder = holder_procs.spawn("rdma_cold_holder", _Holder)
+    driver = driver_procs.spawn("rdma_cold_driver", _Driver)
+    try:
+        await _assert_distinct(holder, driver)
+        expected = bytes(await holder.source_bytes.call_one())
+        start = time.perf_counter_ns()
+        source, _targets = await holder.make_buffers.call_one()
+        observed = bytes(await driver.cold_read.call_one(source))
+        elapsed = time.perf_counter_ns() - start
+        _check_read(expected, observed)
+        return elapsed
+    finally:
+        await _teardown(holder_procs, driver_procs)
+
+
+def _require_effective_config(
+    config: Mapping[str, object], backend: str, target: str | None
+) -> None:
+    expected: dict[str, object] = {
+        "rdma_allow_tcp_fallback": backend == "tcp",
+        "rdma_disable_ibverbs": backend == "tcp",
+        "rdma_ibverbs_target": "" if target is None else target,
+    }
+    mismatches = [
+        f"{key}={config.get(key)!r} (expected {value!r})"
+        for key, value in expected.items()
+        if config.get(key) != value
+    ]
+    if mismatches:
+        raise RuntimeError(
+            f"effective configuration does not select {backend}: "
+            f"{', '.join(mismatches)}; unset conflicting MONARCH_RDMA_* settings"
+        )
+
+
+async def _configured_steady(
+    backend: str, target: str | None
+) -> tuple[list[int], list[int], list[int], list[int]]:
+    if backend == "tcp":
+        with configured(
+            rdma_allow_tcp_fallback=True,
+            rdma_disable_ibverbs=True,
+            rdma_ibverbs_target="",
+        ) as config:
+            _require_effective_config(config, backend, target)
+            return await _steady_body()
+    assert target is not None
+    with configured(
+        rdma_allow_tcp_fallback=False,
+        rdma_disable_ibverbs=False,
+        rdma_ibverbs_target=target,
+    ) as config:
+        _require_effective_config(config, backend, target)
+        return await _steady_body()
+
+
+async def _configured_cold(backend: str, target: str | None) -> int:
+    if backend == "tcp":
+        with configured(
+            rdma_allow_tcp_fallback=True,
+            rdma_disable_ibverbs=True,
+            rdma_ibverbs_target="",
+        ) as config:
+            _require_effective_config(config, backend, target)
+            return await _cold_body()
+    assert target is not None
+    with configured(
+        rdma_allow_tcp_fallback=False,
+        rdma_disable_ibverbs=False,
+        rdma_ibverbs_target=target,
+    ) as config:
+        _require_effective_config(config, backend, target)
+        return await _cold_body()
+
+
+def _cold_command(backend: str, target: str | None) -> list[str]:
+    command = [sys.argv[0], "--backend", backend, "--_cold-child"]
+    if target is not None:
+        command.extend(["--target", target])
+    return command
+
+
+def _collect_cold(backend: str, target: str | None) -> list[int]:
+    samples: list[int] = []
+    for _ in range(_COLD_SAMPLES):
+        completed = subprocess.run(
+            _cold_command(backend, target),
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=_COLD_CHILD_TIMEOUT_S,
+        )
+        if completed.returncode != 0:
+            detail = completed.stderr.strip()[-1000:]
+            raise RuntimeError(
+                f"cold-init child failed with exit {completed.returncode}: {detail}"
+            )
+        sample = next(
+            (
+                int(line.removeprefix(_COLD_PREFIX))
+                for line in completed.stdout.splitlines()
+                if line.startswith(_COLD_PREFIX)
+            ),
+            None,
+        )
+        if sample is None:
+            raise RuntimeError("cold-init child produced no timing")
+        samples.append(sample)
+    return samples
+
+
+def _percentile(samples: Sequence[int], percentile: int) -> int:
+    if not samples:
+        raise ValueError("cannot summarize an empty sample set")
+    ordered = sorted(samples)
+    rank = math.ceil((percentile / 100.0) * len(ordered))
+    return ordered[max(rank, 1) - 1]
+
+
+def _microseconds(value_ns: int) -> str:
+    return f"{value_ns / 1_000:,.2f} us"
+
+
+def _print_results(backend: str, target: str | None, results: _Results) -> None:
+    print(f"backend: {backend}")
+    if target is not None:
+        print(f"target: {target}")
+    print(
+        f"shape: {_PAYLOAD_BYTES} bytes, K={_CONCURRENCY}, "
+        f"serial={_SERIAL_SAMPLES}, concurrent={_CONCURRENT_BATCHES}, "
+        f"cold={_COLD_SAMPLES}"
+    )
+    cold = results.cold_init
+    print(
+        "cold_init: "
+        f"min={_microseconds(min(cold))} "
+        f"p50={_microseconds(_percentile(cold, 50))} "
+        f"max={_microseconds(max(cold))}"
+    )
+    for name, samples in (
+        ("serial_read", results.serial_read),
+        ("serial_write", results.serial_write),
+    ):
+        print(
+            f"{name}: "
+            f"p50={_microseconds(_percentile(samples, 50))} "
+            f"p90={_microseconds(_percentile(samples, 90))} "
+            f"p99={_microseconds(_percentile(samples, 99))}"
+        )
+    for name, samples in (
+        ("concurrent_read_makespan", results.concurrent_read),
+        ("concurrent_write_makespan", results.concurrent_write),
+    ):
+        print(
+            f"{name}: "
+            f"p50={_microseconds(_percentile(samples, 50))} "
+            f"p90={_microseconds(_percentile(samples, 90))}"
+        )
+
+
+def _validate_target(
+    parser: argparse.ArgumentParser, backend: str, target: str | None
+) -> None:
+    if backend == "tcp":
+        if target is not None:
+            parser.error("--target is only valid with --backend ibverbs")
+        return
+    if target is None:
+        parser.error("--backend ibverbs requires --target nic:<name>")
+    if re.fullmatch(r"nic:[A-Za-z0-9_.-]+", target) is None:
+        parser.error("--target must be an exact NIC target such as nic:mlx5_0")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", choices=("tcp", "ibverbs"), required=True)
+    parser.add_argument(
+        "--target", help="ibverbs device target, for example nic:mlx5_0"
+    )
+    parser.add_argument("--_cold-child", action="store_true", help=argparse.SUPPRESS)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _parser()
+    args = parser.parse_args(argv)
+    backend = str(args.backend)
+    target = str(args.target) if args.target is not None else None
+    _validate_target(parser, backend, target)
+
+    if bool(args._cold_child):
+        sample = asyncio.run(_configured_cold(backend, target))
+        print(f"{_COLD_PREFIX}{sample}")
+        return 0
+
+    if backend == "ibverbs" and not is_ibverbs_available():
+        parser.error("ibverbs is not available on this host")
+
+    cold = _collect_cold(backend, target)
+    serial_read, serial_write, concurrent_read, concurrent_write = asyncio.run(
+        _configured_steady(backend, target)
+    )
+    _print_results(
+        backend,
+        target,
+        _Results(
+            cold,
+            serial_read,
+            serial_write,
+            concurrent_read,
+            concurrent_write,
+        ),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -83,6 +83,7 @@ def configure(
     rdma_allow_tcp_fallback: bool = ...,
     rdma_disable_ibverbs: bool = ...,
     rdma_max_chunk_size_mb: int = ...,
+    rdma_ibverbs_target: str = ...,
     **kwargs: object,
 ) -> None:
     """Configure Hyperactor runtime defaults for this process.
@@ -96,7 +97,7 @@ def configure(
 
     For complete parameter documentation, see the Python wrapper
     `monarch.config.configure()` which provides the same interface
-    with detailed descriptions of all 36 configuration parameters
+    with detailed descriptions of the configuration parameters
     organized into logical categories (transport, logging, message
     handling, mesh bootstrap, allocation, proc/host mesh timeouts,
     etc.).
@@ -180,6 +181,11 @@ def configure(
             causing all RDMA operations to use the TCP fallback backend.
         rdma_max_chunk_size_mb: Maximum chunk size in MiB for
             TCP-based RDMA transfers (default: 64)
+        rdma_ibverbs_target: Default ibverbs device target for managers
+            without an explicit target. Accepts "cpu:<numa>",
+            "gpu:<ordinal>", or "nic:<name>". Empty preserves automatic
+            selection. Non-empty value syntax is validated when the RDMA
+            manager starts.
         **kwargs: Reserved for future configuration keys
 
     For historical reasons, this API is named ``configure(...)``;

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -86,6 +86,7 @@ if TYPE_CHECKING:
             rdma_allow_tcp_fallback: NotRequired[bool]
             rdma_disable_ibverbs: NotRequired[bool]
             rdma_max_chunk_size_mb: NotRequired[int]
+            rdma_ibverbs_target: NotRequired[str]
 
         # pyrefly: ignore [invalid-annotation]
         ConfigureKwargsType = Unpack[ConfigureArgs]
@@ -182,6 +183,11 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
                 causing all RDMA operations to use the TCP fallback backend.
             rdma_max_chunk_size_mb: Maximum chunk size in megabytes for RDMA
                 transfers.
+            rdma_ibverbs_target: Default ibverbs device target for managers
+                without an explicit target. Accepts ``"cpu:<numa>"``,
+                ``"gpu:<ordinal>"``, or ``"nic:<name>"``. Empty preserves
+                automatic selection. Non-empty value syntax is validated when
+                the RDMA manager starts.
 
         **kwargs: Reserved for future configuration keys exposed by Rust bindings.
     """

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -25,6 +25,12 @@ class Chunker(Actor):
         return len(chunks)
 
 
+class RdmaTargetProbe(Actor):
+    @endpoint
+    def rdma_ibverbs_target(self) -> str:
+        return get_global_config()["rdma_ibverbs_target"]
+
+
 def test_get_set_transport() -> None:
     for transport in (
         ChannelTransport.Unix,
@@ -87,6 +93,21 @@ def test_get_set_multiple() -> None:
     assert not config["enable_file_capture"]
     assert config["tail_log_lines"] == 0
     assert config["default_transport"] == BindSpec(ChannelTransport.Unix)
+
+
+@isolate_in_subprocess
+def test_rdma_ibverbs_target_round_trip_and_propagation() -> None:
+    assert get_global_config()["rdma_ibverbs_target"] == ""
+
+    target = "nic:mlx5_0"
+    with configured(rdma_ibverbs_target=target) as config:
+        assert config["rdma_ibverbs_target"] == target
+
+        proc = this_host().spawn_procs()
+        probe = proc.spawn("rdma_target_probe", RdmaTargetProbe)
+        assert probe.rdma_ibverbs_target.call_one().get() == target
+
+    assert get_global_config()["rdma_ibverbs_target"] == ""
 
 
 @isolate_in_subprocess

--- a/python/tests/test_rdma_unsupported.py
+++ b/python/tests/test_rdma_unsupported.py
@@ -6,11 +6,10 @@
 
 # pyre-unsafe
 """
-Tests for RDMA functionality when RDMA is not supported.
+Tests for RDMA manager initialization failures.
 
-This file contains tests that are specifically designed to run on systems
-where RDMA is NOT available. These tests verify error handling and fallback
-behavior when RDMA support is missing.
+These tests cover unsupported hosts and configuration errors that must surface
+before backend fallback.
 """
 
 import sys
@@ -29,6 +28,38 @@ needs_no_rdma = pytest.mark.skipif(
     is_ibverbs_available(),
     reason="RDMA is available, test only runs on systems without RDMA support",
 )
+
+
+async def _rdma_manager_init_fault(**config: object) -> str:
+    import asyncio
+
+    import monarch.actor
+    from monarch._rust_bindings.rdma import _RdmaManager
+    from monarch._src.actor.actor_mesh import context
+    from monarch._src.actor.future import Future
+    from monarch.actor import this_host
+
+    faults = []
+    faulted = asyncio.Event()
+
+    def fault_hook(failure):
+        faults.append(failure)
+        faulted.set()
+
+    monarch.actor.unhandled_fault_hook = fault_hook
+
+    with configured(**config):
+        proc_mesh = this_host().spawn_procs(per_host={"cpus": 1})
+        await Future(
+            coro=_RdmaManager.create_rdma_manager_nonblocking(
+                await Future(coro=proc_mesh._proc_mesh.task()),
+                context().actor_instance,
+            )
+        )
+        await asyncio.wait_for(faulted.wait(), timeout=15.0)
+
+    assert faults, "Expected a supervision fault, got none"
+    return "\n".join(str(failure) for failure in faults)
 
 
 @needs_no_rdma
@@ -50,40 +81,19 @@ async def test_rdma_manager_creation_fails_when_unsupported() -> None:
     chain (Python -> Rust -> C ibverbs library); a Python mock cannot intercept
     the native device probe.
     """
-    import asyncio
-
-    import monarch.actor
-    from monarch._rust_bindings.rdma import _RdmaManager
-    from monarch._src.actor.actor_mesh import context
-    from monarch._src.actor.future import Future
-    from monarch.actor import this_host
-
-    faults = []
-    faulted = asyncio.Event()
-
-    def fault_hook(failure):
-        faults.append(failure)
-        faulted.set()
-
-    monarch.actor.unhandled_fault_hook = fault_hook
-
-    with configured(rdma_allow_tcp_fallback=False):
-        proc_mesh = this_host().spawn_procs(per_host={"cpus": 1})
-
-        # Spawning succeeds; the RdmaManagerActor's init then fails because no
-        # NIC backend is available and TCP fallback is disabled.
-        await Future(
-            coro=_RdmaManager.create_rdma_manager_nonblocking(
-                await Future(coro=proc_mesh._proc_mesh.task()),
-                context().actor_instance,
-            )
-        )
-
-        # The init failure arrives asynchronously as a supervision fault.
-        await asyncio.wait_for(faulted.wait(), timeout=15.0)
-
-    assert len(faults) >= 1, "Expected a supervision fault, got none"
-    failure_message = str(faults[0])
+    failure_message = await _rdma_manager_init_fault(rdma_allow_tcp_fallback=False)
     assert "no RDMA backend available" in failure_message, (
         f"Expected specific failure message not found. Actual fault: {failure_message}"
+    )
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_malformed_rdma_ibverbs_target_fails_manager_creation() -> None:
+    failure_message = await _rdma_manager_init_fault(
+        rdma_allow_tcp_fallback=True,
+        rdma_ibverbs_target="mlx5_0",  # Missing the required `nic:` target kind.
+    )
+    assert "RDMA_IBVERBS_TARGET" in failure_message, (
+        f"Expected target configuration error not found. Actual fault: {failure_message}"
     )


### PR DESCRIPTION
Summary:
a later diff will remove pytokio from the Python RDMA orchestration path. we need to confirm that the refactor preserves both startup and transfer performance; the existing functional tests do not measure either.

this change adds a focused command-line benchmark for comparing the code before and after that refactor. it measures cold initialization in fresh processes and warmed serial and concurrent reads and writes with a fixed workload. it runs against either TCP or ibverbs. ibverbs requires an explicit `nic:<name>` target and disables TCP fallback so both revisions use the same device.

the procedure is deliberately manual: run the same command on the baseline revision and the refactor revision, then compare the printed statistics separately for TCP and ibverbs. the tool writes no artifacts and has no calibration, stored baseline, threshold, or CI gate.

Differential Revision: D112751043


