### PR TITLE
Build PyTorch extensions with C++20

### DIFF
--- a/python/monarch/gradient/_gradient_generator.cpp
+++ b/python/monarch/gradient/_gradient_generator.cpp
@@ -86,12 +86,16 @@ struct Arena {
       : next_free_(inline_buffer_), remaining_size_(sizeof(inline_buffer_)) {}
   template <typename T, typename... Args>
   T* allocate(Args&&... args) {
-    static_assert(std::is_pod<T>::value, "T must be a POD type.");
+    static_assert(
+        std::is_standard_layout_v<T> && std::is_trivial_v<T>,
+        "T must be a POD type.");
     return allocate_slice<T>(1, std::forward<Args>(args)...).begin();
   }
   template <typename T, typename... Args>
   Slice<T> allocate_slice(size_t n, Args&&... args) {
-    static_assert(std::is_pod<T>::value, "T must be a POD type.");
+    static_assert(
+        std::is_standard_layout_v<T> && std::is_trivial_v<T>,
+        "T must be a POD type.");
     size_t alignment = alignof(T);
     size_t bytes_needed = n * sizeof(T);
     size_t to_align = 0;

--- a/setup.py
+++ b/setup.py
@@ -341,7 +341,7 @@ def create_cpp_extension(
     return Extension(
         name,
         sources,
-        extra_compile_args=["-std=c++17", "-g", "-O3"],
+        extra_compile_args=["-std=c++20", "-g", "-O3"],
         extra_link_args=extra_link_args,
         define_macros=define_macros or [],
         libraries=libraries,


### PR DESCRIPTION
Summary: PyTorch 2.12 requires C++20 for ATen consumers. Compile Monarch setuptools C++ extensions in C++20 mode and replace deprecated `std::is_pod` checks with their standard-layout and trivial equivalents.

Differential Revision: D112868639


