### PR TITLE
Build wheels through the Python build frontend (#4468)

### DIFF
--- a/.github/workflows/build-cpu-macos.yml
+++ b/.github/workflows/build-cpu-macos.yml
@@ -57,7 +57,7 @@ jobs:
           python -m pip install --upgrade "setuptools>=77" wheel
           python -m pip install -r build-requirements.txt
           python -m pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu
-          python setup.py bdist_wheel
+          python -m build --wheel --no-isolation
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-cpu.yml
+++ b/.github/workflows/build-cpu.yml
@@ -41,7 +41,7 @@ jobs:
         pip install -r build-requirements.txt
 
         # Build monarch (No tensor engine, CPU version)
-        USE_TENSOR_ENGINE=0 python setup.py bdist_wheel
+        USE_TENSOR_ENGINE=0 python -m build --wheel --no-isolation
 
         echo "=== sccache stats ==="
         sccache --show-stats || true

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -95,7 +95,7 @@ jobs:
         else
           export MONARCH_VERSION=0.6.0.dev$(date +'%Y%m%d')
         fi
-        python setup.py bdist_wheel
+        python -m build --wheel --no-isolation
 
         echo "=== sccache stats ==="
         sccache --show-stats || true

--- a/.github/workflows/build-gpu.yml
+++ b/.github/workflows/build-gpu.yml
@@ -34,4 +34,4 @@ jobs:
         pip install ${{ matrix.torch-spec }}
         pip install -r build-requirements.txt
         setup_tensor_engine
-        python setup.py bdist_wheel
+        python -m build --wheel --no-isolation

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -72,7 +72,7 @@ jobs:
             export MONARCH_VERSION=0.6.0.dev$(date +'%Y%m%d')
           fi
 
-          python setup.py bdist_wheel
+          python -m build --wheel --no-isolation
           ls -la dist/
           python -m pip install dist/*.whl
           python -c "import monarch"

--- a/.github/workflows/test-fuse-python.yml
+++ b/.github/workflows/test-fuse-python.yml
@@ -54,7 +54,7 @@ jobs:
         command -v nvcc &> /dev/null || setup_cuda_toolkit
 
         # Build monarch (No tensor engine, CPU version)
-        USE_TENSOR_ENGINE=0 python setup.py bdist_wheel
+        USE_TENSOR_ENGINE=0 python -m build --wheel --no-isolation
 
         echo "=== sccache stats ==="
         sccache --show-stats || true

--- a/MONARCH_INFO.md
+++ b/MONARCH_INFO.md
@@ -88,11 +88,11 @@ For external/open-source development:
 ```bash
 # Build with tensor_engine (CUDA/GPU support) - default
 uv sync
-python setup.py bdist_wheel
+uv build --wheel --no-build-isolation
 
 # Build without tensor_engine (CPU-only)
 USE_TENSOR_ENGINE=0 uv sync
-USE_TENSOR_ENGINE=0 python setup.py bdist_wheel
+USE_TENSOR_ENGINE=0 uv build --wheel --no-build-isolation
 
 # Development installation
 pip install -e .
@@ -139,7 +139,7 @@ The `check` script provides a unified workflow for linting, typechecking, and te
 ```bash
 # Full build with GPU support (requires CUDA, torch, RDMA libraries)
 uv sync
-python setup.py bdist_wheel
+uv build --wheel --no-build-isolation
 
 # CPU-only build (no CUDA/RDMA required)
 USE_TENSOR_ENGINE=0 uv sync
@@ -312,7 +312,7 @@ Default pytest timeout is 5 minutes (configured in `pyproject.toml`).
 ### OSS Contribution Workflow
 
 1. Make changes to Rust or Python code
-2. Build: `uv sync && python setup.py develop`
+2. Build: `uv sync`
 3. Test: `uv run pytest python/tests/ -v -m "not oss_skip"`
 4. Run Rust tests: `uv run cargo nextest run`
 5. Format: `cargo fmt` (Rust), ensure `.flake8` compliance (Python)

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,3 +1,4 @@
+build
 setuptools>=77
 setuptools-rust
 wheel

--- a/docs/DOCUMENTATION_GUIDE.md
+++ b/docs/DOCUMENTATION_GUIDE.md
@@ -265,7 +265,7 @@ Key configuration sections:
 
 ### Common Issues
 
-1. **Import Errors**: Ensure Monarch is properly installed with `python setup.py develop`
+1. **Import Errors**: Ensure Monarch is properly installed with `python -m pip install -e .`
 2. **Missing Rust Docs**: Run `cargo doc --workspace --no-deps` before building
 3. **Theme Issues**: Check that all theme dependencies are installed
 4. **Build Failures**: Use `make clean` then `make html` for a fresh build

--- a/python/monarch/monarch_dashboard/__main__.py
+++ b/python/monarch/monarch_dashboard/__main__.py
@@ -28,7 +28,8 @@ def start_dashboard(db_path, host="0.0.0.0", port=5000):
     else:
         print(
             ">> WARNING: No frontend build found. Serving API-only.\n"
-            ">> To build the frontend, run: python setup.py build_frontend or run uv build --wheel --no-build-isolation"
+            ">> To build the frontend, run: "
+            "python -m build --wheel --no-isolation"
         )
 
     app = create_app(SQLiteAdapter(db_path))
@@ -95,9 +96,8 @@ def main():
     )
     args = parser.parse_args()
 
-    sim_proc = None
     if args.simulate:
-        sim_proc = _launch_simulator(args.db, args.interval, args.failure_at)
+        _launch_simulator(args.db, args.interval, args.failure_at)
     elif not os.path.exists(args.db):
         print(f"Database not found: {args.db}")
         exit(1)


### PR DESCRIPTION
Summary:

Use `python -m build --wheel --no-isolation` for GitHub Actions wheel builds, install `build` with the shared build requirements, and replace the remaining deprecated `setup.py` command guidance with modern build and editable-install interfaces.

Using direct `setup.py` commands is deprecated, and the build frontend also lets us change build backends later.

Keep releases wheel-only because the current sdist manifest does not cover the full Rust workspace and should not be published until it is independently buildable.

Differential Revision: D113029102


