### PR TITLE
Re-enable some tests in test_job.py

### DIFF
--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -1365,8 +1365,6 @@ def test_local_job_compatibility():
 train_script = os.path.join(os.path.dirname(__file__), "job_train.py")
 
 
-# TODO(https://github.com/meta-pytorch/monarch/issues/2213): Occasional GIL release failure.
-@pytest.mark.oss_skip
 def test_train_script_job_state_regular():
     """
     Test that the train.py script picks up the default 'hosts' in regular mode.
@@ -1404,8 +1402,6 @@ def test_train_script_job_state_regular():
         assert "batch_launched_hosts False" in result.stdout
 
 
-# TODO(https://github.com/meta-pytorch/monarch/issues/2213): Occasional GIL release failure.
-@pytest.mark.oss_skip
 def test_train_script_job_state_batch():
     """
     Test that the train.py script picks up the 'batch_launched_hosts' in batch mode.


### PR DESCRIPTION
Summary:
Fixes: https://github.com/meta-pytorch/monarch/issues/2213

These tests have been passing internally for a while, re-enable them in CI.

Differential Revision: D113083531


