### PR TITLE
add a Rust-produced Handle: PyHandle::spawn and wait_completion (#4474)

### DIFF
--- a/monarch_hyperactor/src/handle.rs
+++ b/monarch_hyperactor/src/handle.rs
@@ -25,18 +25,22 @@
 //! Assumed of the shared core and producer (not enforced here):
 //! - **HDL-1 (single terminal completion).** The watch value goes `None` ->
 //!   `Some(_)` exactly once and is never reset (`Some` -> `Some`, `Some` ->
-//!   `None`). Relied on by [`HandleCore::wait_future`] (wait loop + `expect`) and
-//!   [`HandleCore::poll`] (re-borrow across the GIL). Held by convention: every
-//!   producer sends once, always `Some(_)`. A send-once sender (a newtype
+//!   `None`). Relied on by [`HandleCore::wait_future`] (wait loop + `expect`),
+//!   [`HandleCore::poll`] (re-borrow across the GIL), and
+//!   [`PyHandle::wait_completion`] (discriminant check then GIL re-borrow). Held
+//!   by convention: every producer sends once, always `Some(_)` (including the
+//!   direct [`PyHandle::spawn`] producer). A send-once sender (a newtype
 //!   consuming the `watch::Sender`) could make it structural, hardening `poll`'s
 //!   re-borrow.
 //! - **HDL-2 (value encoding).** `None` is pending, `Some(Ok(_))` success,
 //!   `Some(Err(_))` a producer error.
 //!
 //! Guaranteed by this module:
-//! - **HDL-3 (non-consuming reads).** Every read clones the value out
-//!   (`clone_ref`) rather than moving it, so any number of observers see the
-//!   same result. Enforced by construction: no read path moves the value.
+//! - **HDL-3 (non-consuming reads).** No read moves the value out: a
+//!   value-extracting read clones it (`clone_ref`), and a discriminant-only read
+//!   (`wait_completion`'s success fast path) borrows just the `Ok`/`Err` tag and
+//!   clones nothing. Either way any number of observers see the same result.
+//!   Enforced by construction: no read path moves the value.
 //! - **HDL-4 (drop does not cancel; drop never panics).** Dropping a `Handle`
 //!   never cancels its producer; a `Handle` observes, it does not own the
 //!   producer's lifecycle. Enforced by construction: a `Handle`'s core has
@@ -63,9 +67,10 @@
 //!   happens to block. A ready value returns after warning; under a
 //!   warnings-as-errors filter the warning escalates to an error.
 //! - **HDL-9 (GIL/watch borrow discipline).** A `watch` borrow is never held
-//!   across a GIL acquisition or an `.await`. `poll` drops its read guard before
-//!   taking the GIL and re-borrows under it (GIL-then-watch order, never the
-//!   inverse against the producer's write-lock `send`); the `wait_ready`/
+//!   across a GIL acquisition or an `.await`. `poll` and `wait_completion`'s error
+//!   path drop their read guard before taking the GIL and re-borrow under it
+//!   (GIL-then-watch order, never the inverse against the producer's write-lock
+//!   `send`); the `wait_ready`/
 //!   `wait_future` loops drop the temporary `Ref` before each `.await`; and their
 //!   returned futures own a cloned receiver (`Send + 'static`, borrowing nothing
 //!   from `&self`), which is what lets `get()` `drop(slf)` + release the GIL
@@ -74,9 +79,9 @@
 //!   partly by construction; exercised by the multi-observer/blocking tests.
 //! - **HDL-10 (dropped producer surfaces, never hangs).** If every producer drops
 //!   its sender without sending, the wait loop's `changed().await?` yields a
-//!   `RecvError` turned into a Python exception (`to_py_error`) on both the sync
-//!   (`get`/`wait_future`) and async (`as_asyncio`) paths, so an observer raises
-//!   rather than hanging forever.
+//!   `RecvError` turned into a Python exception (`to_py_error`) on the sync
+//!   (`get`/`wait_future`) path, the async (`as_asyncio`) path, and
+//!   `wait_completion`, so an observer raises rather than hanging forever.
 //! - **HDL-11 (`Handle` is not constructible from Python).** The pyclass has no
 //!   `#[new]` and the only `from_value` constructor is `#[cfg(test)]`-gated, so a
 //!   live `Handle` always wraps a producer-supplied core (upholding HDL-1/HDL-2);
@@ -88,10 +93,22 @@
 //!   is non-cancelling: it raises `TimeoutError` while leaving the producer and
 //!   every observer untouched, so a later `poll()`/`get()`/`await` still observes
 //!   completion.
+//! - **HDL-13 (direct Rust producer).** A Rust caller can eagerly produce a
+//!   `Handle` from a `Send + 'static` future via [`PyHandle::spawn`], without a
+//!   `PyPythonTask`: it spawns one producer that converts the terminal value to
+//!   `Py<PyAny>` under `monarch_with_gil` and publishes it once through the shared
+//!   `send_result` helper (same one-shot core and unobserved-error policy as
+//!   pytokio's producers, HDL-1/HDL-2), with `abort_on_drop: None` (HDL-4).
+//!   [`PyHandle::wait_completion`] is the matching observer: it projects the
+//!   terminal value to `PyResult<()>`, touching neither the GIL nor the Python
+//!   value on the ready-success fast path (a discriminant-only read, HDL-3) and
+//!   cloning the `PyErr` under the HDL-9 borrow order only on the error path. Both
+//!   are `pub` Rust-only methods outside `#[pymethods]` (HDL-11).
 
 use std::future::Future;
 
 use monarch_types::py_global;
+use pyo3::IntoPyObjectExt;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::exceptions::PyStopIteration;
 use pyo3::exceptions::PyTimeoutError;
@@ -105,6 +122,7 @@ use tokio::sync::watch;
 use tokio::task::AbortHandle;
 
 use crate::pytokio::is_tokio_thread;
+use crate::pytokio::send_result;
 use crate::pytokio::to_py_error;
 use crate::runtime::GilSite;
 use crate::runtime::get_tokio_runtime;
@@ -301,6 +319,83 @@ impl PyHandle {
     /// is private to this module.
     pub(crate) fn from_core(core: HandleCore) -> Self {
         Self { core }
+    }
+
+    /// Eagerly drive a Rust future to completion and return an observe-only
+    /// `Handle` over its result (HDL-13).
+    ///
+    /// The producer spawns immediately on the shared Tokio runtime; the returned
+    /// `Handle` observes already-running work rather than starting it lazily on
+    /// first observation. On completion the terminal `PyResult<T>` is converted
+    /// to `Py<PyAny>` under `monarch_with_gil` and published exactly once through
+    /// the shared `send_result` helper (HDL-1/HDL-2). The core carries
+    /// `abort_on_drop: None`, so dropping the `Handle` never cancels the producer
+    /// (HDL-4). Rust-only and outside `#[pymethods]`, so Python still cannot mint
+    /// a core (HDL-11).
+    pub fn spawn<F, T>(fut: F) -> Self
+    where
+        F: Future<Output = PyResult<T>> + Send + 'static,
+        T: for<'py> IntoPyObject<'py> + Send,
+    {
+        let (tx, rx) = watch::channel(None);
+        get_tokio_runtime().spawn(async move {
+            // Convert the terminal value to a Python object under the GIL, the
+            // same shape as `PyPythonTask` producers.
+            let result = async {
+                let value = fut.await?;
+                monarch_with_gil(GilSite::Convert, |py| value.into_py_any(py)).await
+            }
+            .await;
+            // HDL-1/HDL-2/HDL-13: publish exactly once via the shared helper; a
+            // direct Rust producer carries no creation traceback.
+            send_result(tx, result, None);
+        });
+        // HDL-4: a `Handle`'s core never aborts its producer on drop.
+        PyHandle::from_core(HandleCore::new(rx, None, None))
+    }
+
+    /// Observe whether this handle completed successfully, projecting the terminal
+    /// value to `PyResult<()>` (HDL-13).
+    ///
+    /// Returns an owned `Send + 'static` future over a cloned receiver (HDL-9),
+    /// so multiple Rust callers can observe the same terminal state and dropping
+    /// the `Handle` after taking an observer does not abort the producer (HDL-4).
+    /// The ready-success fast path touches neither the GIL nor the Python value
+    /// (a discriminant-only read, HDL-3); only the error path clones the stored
+    /// `PyErr`. This is the readiness surface for callers that need only the
+    /// success/error discriminant, not the value.
+    pub fn wait_completion(&self) -> impl Future<Output = PyResult<()>> + Send + 'static {
+        let ready = self.core.wait_ready();
+        async move {
+            // HDL-10: a dropped producer surfaces as a Python exception here.
+            let rx = ready.await.map_err(to_py_error)?;
+            // Read only the success/error discriminant under a watch borrow that
+            // holds no GIL, then drop it. HDL-1: the value is `Some` and, once
+            // set, never changes.
+            let is_err = rx
+                .borrow()
+                .as_ref()
+                .expect("HDL-1: value is Some after wait_ready")
+                .is_err();
+            if !is_err {
+                return Ok(());
+            }
+            // Error path only. HDL-9: acquire the GIL first, then re-borrow the
+            // watch value (GIL-then-watch order, never the inverse); the
+            // discriminant borrow above is already dropped, so the two are never
+            // held together, and HDL-1 guarantees the same terminal `Err` is still
+            // there to clone.
+            monarch_with_gil(GilSite::Convert, move |py| -> PyResult<()> {
+                Err(rx
+                    .borrow()
+                    .as_ref()
+                    .expect("HDL-1: value is Some after wait_ready")
+                    .as_ref()
+                    .expect_err("HDL-1: error branch, discriminant already checked")
+                    .clone_ref(py))
+            })
+            .await
+        }
     }
 }
 
@@ -1385,6 +1480,119 @@ class MyStop(StopIteration):
                 err.is_instance_of::<pyo3::exceptions::PyTypeError>(py),
                 "constructing Handle() from Python should raise TypeError (no __new__)"
             );
+        });
+    }
+
+    // spawn() eagerly runs its producer -- before any observer exists -- and
+    // resolves the converted value; no PyPythonTask is involved.
+    // Attests HDL-1, HDL-2, HDL-13.
+    #[test]
+    fn rust_spawn_eagerly_resolves_handle() {
+        ensure_python();
+        let (started_tx, started_rx) = tokio::sync::oneshot::channel::<()>();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = PyHandle::spawn(async move {
+            let _ = started_tx.send(());
+            let _ = release_rx.await;
+            Ok::<i64, PyErr>(42)
+        });
+        // Eager: the producer starts before we create any observer.
+        get_tokio_runtime()
+            .block_on(started_rx)
+            .expect("spawn() must start its producer eagerly, before observation");
+        let _ = release_tx.send(());
+        let out = get_tokio_runtime().block_on(handle.core.wait_future());
+        let got =
+            monarch_with_gil_blocking(GilSite::Test, |py| out.unwrap().extract::<i64>(py).unwrap());
+        assert_eq!(
+            got, 42,
+            "spawn() should resolve the converted producer value"
+        );
+    }
+
+    // Two wait_completion() observers of one handle both see the same terminal
+    // outcome; observation is non-consuming, and success projects to Ok(()).
+    // Attests HDL-3, HDL-13.
+    #[test]
+    fn rust_wait_completion_is_non_consuming() {
+        ensure_python();
+
+        // Success: two observers of one pending handle both resolve to Ok(()).
+        let (tx, handle) = pending_handle();
+        let ok1 = handle.wait_completion();
+        let ok2 = handle.wait_completion();
+        let value = monarch_with_gil_blocking(GilSite::Test, |py| 1i64.into_py_any(py).unwrap());
+        tx.send(Some(Ok(value))).unwrap();
+        let (r1, r2) = get_tokio_runtime().block_on(async move { tokio::join!(ok1, ok2) });
+        assert!(
+            r1.is_ok() && r2.is_ok(),
+            "both completion observers should project success to Ok(())"
+        );
+
+        // Error: two observers of one failed handle both surface the stored error.
+        let (etx, ehandle) = pending_handle();
+        let err1 = ehandle.wait_completion();
+        let err2 = ehandle.wait_completion();
+        etx.send(Some(Err(PyValueError::new_err("boom")))).unwrap();
+        let (e1, e2) = get_tokio_runtime().block_on(async move { tokio::join!(err1, err2) });
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            assert!(
+                e1.unwrap_err().is_instance_of::<PyValueError>(py),
+                "the error projection should clone the stored PyErr"
+            );
+            assert!(e2.unwrap_err().is_instance_of::<PyValueError>(py));
+        });
+    }
+
+    // Dropping the returned Handle before the producer completes does not cancel
+    // it (HDL-4: a spawn()-produced core has abort_on_drop = None).
+    // Attests HDL-4, HDL-13.
+    #[test]
+    fn rust_spawn_survives_handle_drop() {
+        ensure_python();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel::<()>();
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+        let handle = PyHandle::spawn(async move {
+            let _ = release_rx.await;
+            let _ = done_tx.send(());
+            Ok::<i64, PyErr>(7)
+        });
+        // Drop the observer before releasing the producer.
+        drop(handle);
+        let _ = release_tx.send(());
+        // The producer still runs to completion despite the dropped Handle.
+        get_tokio_runtime()
+            .block_on(done_rx)
+            .expect("dropping the Handle must not cancel the spawn() producer");
+    }
+
+    // The real spawn() -> wait_completion() pair: a spawn()-produced future that
+    // returns Err surfaces the exact exception (type + message) through
+    // wait_completion, and observing twice sequentially returns the same cached
+    // error -- proving non-consuming error projection over a real producer.
+    // Attests HDL-1, HDL-2, HDL-3, HDL-13.
+    #[test]
+    fn rust_spawn_error_observed_by_wait_completion_twice() {
+        ensure_python();
+        let handle =
+            PyHandle::spawn(async move { Err::<(), PyErr>(PyValueError::new_err("boom")) });
+        // Observe the same terminal error twice, sequentially, over the real
+        // spawn()-produced core.
+        let first = get_tokio_runtime().block_on(handle.wait_completion());
+        let second = get_tokio_runtime().block_on(handle.wait_completion());
+        monarch_with_gil_blocking(GilSite::Test, |py| {
+            for (label, res) in [("first", first), ("second", second)] {
+                let err = res.expect_err("wait_completion should surface the producer error");
+                assert!(
+                    err.is_instance_of::<PyValueError>(py),
+                    "{label}: expected PyValueError"
+                );
+                let msg = err.value(py).to_string();
+                assert!(
+                    msg.contains("boom"),
+                    "{label}: cached error message should be preserved, got {msg}"
+                );
+            }
         });
     }
 }

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -447,16 +447,17 @@ impl PyPythonTask {
     }
 }
 
-/// Publish a completed task result to the `watch` channel.
+/// Publish a completed background-task result to the `watch` channel.
 ///
-/// If the receiver has already been dropped, `watch::Sender::send`
-/// returns the unsent value as `SendError`. We treat that as "nobody
-/// will ever observe this result".
+/// Shared by `PyPythonTask` spawns and the direct [`PyHandle::spawn`] producer
+/// (HDL-13). If the receiver has already been dropped, `watch::Sender::send`
+/// returns the unsent value as `SendError`. We treat that as "nobody will ever
+/// observe this result".
 ///
-/// In the special case where the unobserved result is an error, we
-/// log it (and include the task creation traceback when available) to
-/// avoid silently losing failures from background tasks.
-fn send_result(
+/// In the special case where the unobserved result is an error, we log it (and
+/// include the creation-site traceback when available) to avoid silently losing
+/// failures from background tasks.
+pub(crate) fn send_result(
     tx: tokio::sync::watch::Sender<Option<PyResult<Py<PyAny>>>>,
     result: PyResult<Py<PyAny>>,
     traceback: Option<Py<PyAny>>,
@@ -467,11 +468,17 @@ fn send_result(
             let tb = if let Some(tb) = traceback {
                 format_traceback(py, &tb).unwrap()
             } else {
-                "None (run with `MONARCH_HYPERACTOR_ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK=1` to see a traceback here)\n".into()
+                // No creation traceback was captured: either a capture-disabled
+                // `PythonTask` (the default when the env var is unset) or the
+                // direct `PyHandle::spawn` producer, which never captures one.
+                "creation traceback unavailable (PythonTask producers can set \
+                 `MONARCH_HYPERACTOR_ENABLE_UNAWAITED_PYTHON_TASK_TRACEBACK=1` to capture one)\n"
+                    .into()
             };
             tracing::error!(
-                "PythonTask errored but is not being awaited; this will not crash your program, but indicates that \
-                something went wrong.\n{}\nTraceback where the task was created (most recent call last):\n{}",
+                "a background task errored but is not being awaited; this will not crash your \
+                program, but indicates that something went wrong.\n{}\nTraceback where the task \
+                was created (most recent call last):\n{}",
                 SerializablePyErr::from(py, &pyerr),
                 tb
             );

--- a/monarch_rdma/src/rdma_manager_owner.rs
+++ b/monarch_rdma/src/rdma_manager_owner.rs
@@ -49,55 +49,112 @@
 //!   (the Python client root) where it is spawned with the stable client-root
 //!   context; not caller-owned; torn down only when that process exits.
 //! - **RMO-2** (terminal-absorbing): `Ready`/`Failed` are terminal — an
-//!   `EnsureRdmaManager` for a resolved view replies from cache, and `ReadyAck`
-//!   / [`RdmaManagerOwnerActor::transition`] no-op on a non-`Pending` entry.
+//!   `EnsureRdmaManager` for a resolved view replies from cache, and every
+//!   resolution path (`ReadyAck`, a live controller report, or controller-child
+//!   supervision, all through [`RdmaManagerOwnerActor::transition`]) no-ops on a
+//!   non-`Pending` entry. A terminal controller-child event may use its retained
+//!   controller id to recover the source view, whose proc overlap then selects
+//!   pending siblings, without changing the source (RMO-17).
 //! - **RMO-3** (single-transition guard): [`RdmaManagerOwnerActor::transition`]
 //!   is the sole `Pending -> terminal` mutator; it drains `waiters` on resolve.
-//! - **RMO-4** (never handler-`Err`; owner never fails): A failure resolves the
-//!   affected entry through its `Result` reply rather than terminating the
-//!   owner. Spawn and cast failures resolve the entry to `Failed`; handlers
-//!   return `Ok`.
+//! - **RMO-4** (operational inputs never fail the owner): spawn, cast, a live
+//!   controller report, direct controller-child termination, an invalid-reference
+//!   return, and a departed waiter all resolve their entry or are absorbed
+//!   without returning a handler error. This is not immunity from unrelated
+//!   runtime faults (e.g. the default oversized-frame undeliverable path).
 //! - **RMO-5** (non-returning replies): Every reply ref gets
 //!   `return_undeliverable(false)` before it is posted or stashed.
 //! - **RMO-6** (readiness-after-init): `Ready` is set only once every rank's
 //!   post-`init()` `ReadyAck` has arrived (`remaining_acks == 0`).
+//! - **RMO-7** (typed controller attribution): A live controller report — on the
+//!   owner sink or the subscriber stream — is matched to its pending source only
+//!   by `MeshFailure.reporting_controller` (an `ActorId`), compared against the
+//!   entry's recorded `controller_id`. Event subject, headers, mesh names, and
+//!   ranks are never attribution inputs. Proc identities are used only for a
+//!   terminal controller, after its id has selected the source view.
 //! - **RMO-8** (manager per-proc-shared): Each target proc has at most one
-//!   `rdma_manager` service actor. Overlapping proc-mesh views reuse the
-//!   per-proc actor on shared procs while retaining distinct logical owner
-//!   entries.
+//!   `rdma_manager` service actor, so manager intersection is exactly
+//!   `ProcMeshRef` intersection. Overlapping views reuse the per-proc actor while
+//!   keeping distinct owner entries; the existing `by_mesh` membership drives
+//!   cold-path overlap without a per-rank index.
+//! - **RMO-9** (no artificial timer): Readiness has no timeout; a view resolves
+//!   only from a spawn/cast outcome, its `ReadyAck`s, a controller report, or
+//!   controller supervision. This barrier covers *delivered* terminal inputs: a
+//!   live controller that stays up but stops servicing its mailbox emits no
+//!   report, heartbeat, or terminal child event, so its entry can remain
+//!   `Pending` indefinitely. TODO: evaluate an external actor monitor if
+//!   silent-stall detection ever becomes a requirement; none is added here.
 //! - **RMO-10** (bounded-spawn is the only block): `spawn_service().await` is
 //!   the sole await; the ack gather is message-driven.
 //! - **RMO-11** (retain-to-message, not teardown): The retained manager mesh is
 //!   kept to cast to; its `Drop` is inert, so retention is not teardown.
 //! - **RMO-13** (controller topology): The owner service is controllerless;
 //!   every manager mesh it creates is controller-ful, with its controller owned
-//!   as a child of the owner.
+//!   as a direct child of the owner — which is why a controller's own terminal
+//!   status arrives on the owner's `handle_supervision_event` channel.
+//! - **RMO-14** (delivered terminal-input coverage): The owner resolves on every
+//!   *delivered, attributable* terminal input — an error owner-sink `MeshFailure`
+//!   or a subscriber `Some(MeshFailure)` (error or clean
+//!   `Stopped`/`NotExist`/`Timeout`) carrying a known `reporting_controller`, and
+//!   any terminal controller-child supervision event for a known controller —
+//!   routing each through the source (RMO-7) or overlap (RMO-17) reduction. A
+//!   delivered input with no or unknown attribution is absorbed, not resolved,
+//!   and no claim is made about a controller that never delivers such an input
+//!   (the RMO-9 liveness boundary).
+//! - **RMO-15** (registration ordering): a new view inserts `Pending`, then posts
+//!   `Subscribe`, then casts readiness. The controller replays a latched terminal
+//!   on `Subscribe` and broadcasts a later one, so no terminal state races
+//!   registration.
+//! - **RMO-16** (pending-only subscription): at most one subscription per
+//!   controller while its entry is pending; a `None` heartbeat is inert; the sole
+//!   `Pending -> terminal` transition posts a non-returning `Unsubscribe`, applied
+//!   asynchronously by the controller (which may itself be the failed subject).
+//! - **RMO-17** (controller-view overlap): the controller id is retained across
+//!   `Pending`, `Ready`, and controller-backed `Failed`, associated with the
+//!   existing `ProcMeshRef` key. A live report stays source-local; controller
+//!   termination fails every pending view intersecting the source's full proc
+//!   view. Terminal sources and disjoint pending views are left unchanged.
 //! - **RMR-1** (ack-after-init): Each per-proc manager posts `ReadyAck` from
 //!   its `RdmaManagerReady` handler, which runs strictly after `init()`.
 //!
-//! The owner implements `Handler<MeshFailure>` because it calls
-//! `spawn_service` to spawn or reuse a mesh of `RdmaManagerActor`s, one per
-//! target proc. `spawn_service` creates an `ActorMeshController` for that mesh,
-//! and its caller must handle the supervision events that controller forwards.
-//! The owner itself is spawned controllerless, so spawning the owner imposes no
-//! such bound.
+//! (`RMO-12`, a retired header-stamping premise, is intentionally left unused.)
+//!
+//! The owner implements `Handler<MeshFailure>` (the error-only owner sink
+//! required by `spawn_service`) and `Handler<Option<MeshFailure>>` (the manager
+//! controller's subscriber stream, which also carries clean terminal states and
+//! `None` heartbeats). As the controller's parent it additionally receives the
+//! controller's own terminal supervision events. Together these three inputs
+//! cover the delivered terminal inputs of the initialization-barrier failure
+//! algebra (RMO-14); a live but silent controller is out of scope (RMO-9). The
+//! owner is spawned controllerless, so spawning it imposes no such bound.
 
 use std::collections::HashMap;
 
 use async_trait::async_trait;
 use hyperactor::Actor;
-use hyperactor::ActorAddr;
+use hyperactor::ActorId;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Endpoint;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
+use hyperactor::Instance;
 use hyperactor::OncePortRef;
+use hyperactor::PortRef;
+use hyperactor::ProcId;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
+use hyperactor::context;
+use hyperactor::context::Actor as _;
+use hyperactor::mailbox::InvalidReference;
+use hyperactor::mailbox::MessageEnvelope;
+use hyperactor::mailbox::Undeliverable;
+use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::ActorMesh;
 use hyperactor_mesh::ProcMeshRef;
+use hyperactor_mesh::mesh_controller::Subscribe;
+use hyperactor_mesh::mesh_controller::Unsubscribe;
 use hyperactor_mesh::supervision::MeshFailure;
 use ndslice::view::Ranked;
 use serde::Deserialize;
@@ -156,6 +213,10 @@ wirevalue::register_type!(EnsureRdmaManager);
 
 /// Per-view coordination state, held in `entries` keyed by [`EntryId`].
 #[derive(Debug)]
+#[expect(
+    clippy::large_enum_variant,
+    reason = "Pending is the common active state and entries live behind a HashMap; boxing it to shrink the rarer terminal variants would obscure the state machine for no material gain (the owner holds a handful of entries)."
+)]
 enum MeshState {
     Pending {
         /// The manager-mesh view returned by `spawn_service`, containing one
@@ -164,18 +225,75 @@ enum MeshState {
         /// `Ready` state; `Drop` is inert and does not control teardown
         /// (RMO-11).
         manager_mesh: ActorMesh<RdmaManagerActor>,
-        /// Controller `ActorAddr` for this mesh view, captured at spawn.
-        /// Readiness is correlated by the small `EntryId`; this address is the
-        /// separate key that attributes a `MeshFailure` to its sending
-        /// controller.
-        controller_addr: ActorAddr,
+        /// Controller `ActorId` for this mesh view, captured at spawn.
+        /// Readiness is correlated by the small `EntryId`; this id is the
+        /// separate key that attributes a controller failure — a typed
+        /// `MeshFailure` (RMO-7) or the controller child's own supervision event
+        /// (RMO-14) — to this entry, and drives overlap invalidation (RMO-17).
+        controller_id: ActorId,
+        /// The exact owner `Handler<Option<MeshFailure>>` port registered with
+        /// this controller's subscriber set while pending (RMO-15/RMO-16). The
+        /// sole terminal transition posts `Unsubscribe` to request its removal;
+        /// the controller applies that removal asynchronously when it handles the
+        /// message.
+        subscriber: PortRef<Option<MeshFailure>>,
+        /// Outstanding post-`init()` `ReadyAck`s (RMO-6, RMR-1): decremented as
+        /// each rank acks; the entry resolves to `Ready` when it reaches 0.
         remaining_acks: usize,
+        /// Callers awaiting this view's result. Each reply ref is non-returning
+        /// (RMO-5) and drained exactly once by `transition` on resolution (RMO-3).
         waiters: Vec<OncePortRef<Result<(), RdmaInitError>>>,
     },
     Ready {
+        /// Retained after resolution so its `Drop` stays inert (RMO-11); the
+        /// per-proc service actors are not torn down when the view is `Ready`.
         manager_mesh: ActorMesh<RdmaManagerActor>,
+        /// Retained so a later terminal of this controller can invalidate other
+        /// still-`Pending` views sharing its per-proc managers (RMO-17), without
+        /// rewriting this cached success (RMO-2).
+        controller_id: ActorId,
     },
-    Failed(RdmaInitError),
+    Failed {
+        /// The cached terminal error, returned to every later `EnsureRdmaManager`
+        /// for this view and never rewritten once set (RMO-2).
+        err: RdmaInitError,
+        /// `Some` for a controller-backed failure; `None` only for a
+        /// pre-controller `spawn_service` failure. Retained for RMO-17 overlap.
+        controller_id: Option<ActorId>,
+    },
+}
+
+impl MeshState {
+    /// The retained controller id for any controller-backed state; `None` only
+    /// for a pre-controller `spawn_service` failure. Locates the source entry of
+    /// a terminal controller event (RMO-17).
+    fn controller_id(&self) -> Option<&ActorId> {
+        match self {
+            MeshState::Pending { controller_id, .. } | MeshState::Ready { controller_id, .. } => {
+                Some(controller_id)
+            }
+            MeshState::Failed { controller_id, .. } => controller_id.as_ref(),
+        }
+    }
+}
+
+/// The logical `ProcId`s spanned by a `ProcMeshRef`. Per RMO-8 (`rdma_manager`
+/// is a per-proc singleton), two views share a manager iff their proc-id sets
+/// intersect, so this drives cold-path overlap without a per-rank index.
+fn proc_ids(mesh: &ProcMeshRef) -> std::collections::HashSet<ProcId> {
+    let n = Ranked::region(mesh).num_ranks();
+    (0..n)
+        .filter_map(|rank| Ranked::get(mesh, rank).map(|p| p.proc_addr().id().clone()))
+        .collect()
+}
+
+/// Whether any proc in `mesh` is in `procs`. Per RMO-8 (`rdma_manager` is a
+/// per-proc singleton) this is exactly shared-manager overlap. Scanning each
+/// candidate view against the single materialized source set avoids allocating a
+/// fresh `HashSet` per view on the cold controller-termination path.
+fn view_intersects(mesh: &ProcMeshRef, procs: &std::collections::HashSet<ProcId>) -> bool {
+    let n = Ranked::region(mesh).num_ranks();
+    (0..n).any(|rank| Ranked::get(mesh, rank).is_some_and(|p| procs.contains(p.proc_addr().id())))
 }
 
 #[derive(Debug)]
@@ -184,6 +302,7 @@ enum MeshState {
         EnsureRdmaManager,
         ReadyAck,
         MeshFailure,
+        Option<MeshFailure>,
     ],
 )]
 #[hyperactor::spawnable]
@@ -194,7 +313,9 @@ pub struct RdmaManagerOwnerActor {
     by_mesh: HashMap<ProcMeshRef, EntryId>,
     /// Per-entry coordination state, keyed by the small `EntryId`.
     entries: HashMap<EntryId, MeshState>,
-    /// Monotonic source of `EntryId`s.
+    /// Monotonic source of `EntryId`s. The actor runs one `&mut self` handler at
+    /// a time (the borrow is held across the handler's awaits), so this counter
+    /// is bumped without races and needs no atomic or lock.
     next_entry_id: u64,
 }
 
@@ -213,7 +334,7 @@ impl RdmaManagerOwnerActor {
     /// the entry is absent or already terminal (RMO-2).
     fn transition(
         &mut self,
-        cx: &Context<Self>,
+        cx: &impl context::Actor<A = Self>,
         entry: EntryId,
         result: Result<(), RdmaInitError>,
     ) {
@@ -224,7 +345,8 @@ impl RdmaManagerOwnerActor {
         }
         let Some(MeshState::Pending {
             manager_mesh,
-            controller_addr,
+            controller_id,
+            subscriber,
             waiters,
             ..
         }) = self.entries.remove(&entry)
@@ -234,11 +356,22 @@ impl RdmaManagerOwnerActor {
 
         tracing::debug!(
             entry = entry.0,
-            controller = %controller_addr,
+            controller = %controller_id,
             ok = result.is_ok(),
             waiters = waiters.len(),
             "RdmaManagerOwnerActor draining Pending owner entry",
         );
+
+        // Post `Unsubscribe` for this entry's subscription (RMO-16) before
+        // installing the terminal state; the controller applies the removal
+        // asynchronously when it handles the message. The controller may itself
+        // be the failed subject, so the post is made non-returning and cannot
+        // bounce into the owner.
+        if let Some(controller) = manager_mesh.controller().as_ref() {
+            let mut unsub = controller.port();
+            unsub.return_undeliverable(false);
+            let _ = unsub.post(cx, Unsubscribe(subscriber));
+        }
 
         // Every waiter was made non-returning before storage (RMO-5), so a
         // departed caller drops its reply instead of bouncing it to the owner.
@@ -246,15 +379,158 @@ impl RdmaManagerOwnerActor {
             reply.post(cx, result.clone());
         }
 
+        // Retain the controller id across the terminal state (RMO-17): a later
+        // terminal of this controller can invalidate other pending views sharing
+        // its managers, without rewriting this cached result (RMO-2).
         let next = match result {
-            Ok(()) => MeshState::Ready { manager_mesh },
-            Err(e) => MeshState::Failed(e),
+            Ok(()) => MeshState::Ready {
+                manager_mesh,
+                controller_id,
+            },
+            Err(e) => MeshState::Failed {
+                err: e,
+                controller_id: Some(controller_id),
+            },
         };
         self.entries.insert(entry, next);
         debug_assert!(
             !matches!(self.entries.get(&entry), Some(MeshState::Pending { .. })),
             "RMO-3: entry must be terminal after a transition",
         );
+    }
+
+    /// Resolve a **live** controller report (RMO-7): fail only the `Pending`
+    /// entry whose recorded `controller_id` matches, through [`transition`]
+    /// (RMO-3). A live report is source-local — it never fans out to overlapping
+    /// views (only controller *termination* does, see
+    /// [`resolve_controller_termination`]). Returns whether a `Pending` entry
+    /// matched, so callers can distinguish a resolution from an unrelated, late,
+    /// or already-terminal report (which they only log).
+    ///
+    /// [`resolve_controller_termination`]: Self::resolve_controller_termination
+    fn resolve_live_report(
+        &mut self,
+        cx: &impl context::Actor<A = Self>,
+        controller_id: &ActorId,
+        err: RdmaInitError,
+    ) -> bool {
+        debug_assert!(
+            self.entries
+                .values()
+                .filter(|s| matches!(
+                    s,
+                    MeshState::Pending { controller_id: c, .. } if c == controller_id
+                ))
+                .count()
+                <= 1,
+            "RMO-7: two pending entries must not share a controller id",
+        );
+        // Cold path over a small set of views: a linear scan avoids a second
+        // `controller_id -> EntryId` index whose consistency would be another
+        // invariant to uphold on every terminal path. Copy the matching
+        // `EntryId` out before the terminal mutation so no map borrow is live
+        // across `transition`.
+        let matched = self.entries.iter().find_map(|(id, state)| match state {
+            MeshState::Pending {
+                controller_id: c, ..
+            } if c == controller_id => Some(*id),
+            _ => None,
+        });
+        match matched {
+            Some(entry) => {
+                self.transition(cx, entry, Err(err));
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Resolve a terminal controller event (RMO-14/RMO-17). Locate the source
+    /// entry by `controller_id` across *every* controller-backed state (via
+    /// [`MeshState::controller_id`]); using that source's retained `ProcMeshRef`
+    /// view, fail every still-`Pending` entry whose proc view intersects it. A
+    /// terminal source is left unchanged (RMO-2); disjoint pending views are
+    /// untouched. By RMO-8 (per-proc singleton managers) proc-view intersection
+    /// is exactly shared-manager intersection. Returns `None` when no source
+    /// view can be recovered, or `Some(n)` with the number of entries
+    /// transitioned.
+    fn resolve_controller_termination(
+        &mut self,
+        cx: &impl context::Actor<A = Self>,
+        controller_id: &ActorId,
+        err: RdmaInitError,
+    ) -> Option<usize> {
+        debug_assert!(
+            self.entries
+                .values()
+                .filter(|s| s.controller_id() == Some(controller_id))
+                .count()
+                <= 1,
+            "RMO-17: a controller id must be unique across all entries",
+        );
+        // 1. Find the source entry id by controller id (any state).
+        let source_id = self
+            .entries
+            .iter()
+            .find_map(|(id, s)| (s.controller_id() == Some(controller_id)).then_some(*id))?;
+        // 2. Recover the source's proc view via the existing `by_mesh` key.
+        let source_procs = self
+            .by_mesh
+            .iter()
+            .find_map(|(mesh, id)| (*id == source_id).then(|| proc_ids(mesh)))?;
+        // 3. Collect every still-`Pending` entry whose view intersects the
+        //    source view. Scan each candidate against the single source set (no
+        //    per-view `HashSet`), and build the target list before any transition
+        //    so no map borrow is live across the terminal mutation.
+        let targets: Vec<EntryId> = self
+            .by_mesh
+            .iter()
+            .filter(|(mesh, id)| {
+                matches!(self.entries.get(id), Some(MeshState::Pending { .. }))
+                    && view_intersects(mesh, &source_procs)
+            })
+            .map(|(_, id)| *id)
+            .collect();
+        let n = targets.len();
+        for entry in targets {
+            self.transition(cx, entry, Err(err.clone()));
+        }
+        Some(n)
+    }
+
+    /// Attribute a live controller report (owner sink or subscriber `Some`) by
+    /// its typed `reporting_controller` and fail that source entry if pending
+    /// (RMO-7, source-local). `None`/unknown/already-terminal reporters are
+    /// logged and ignored.
+    fn handle_live_report(&mut self, cx: &impl context::Actor<A = Self>, message: &MeshFailure) {
+        let Some(controller_id) = message.reporting_controller.as_ref() else {
+            tracing::warn!(
+                ?message,
+                "live report without a reporting controller; ignoring"
+            );
+            return;
+        };
+        let controller_id = controller_id.clone();
+        let err = RdmaInitError::InitFailed(message.to_string());
+        if self.resolve_live_report(cx, &controller_id, err) {
+            return;
+        }
+        // No pending source matched. A report for a controller whose entry is
+        // already terminal is expected — it may be a late report, or the same
+        // error arriving on both the owner sink and the subscriber stream (RMO-2);
+        // only a report for a wholly unknown controller is anomalous.
+        if self
+            .entries
+            .values()
+            .any(|s| s.controller_id() == Some(&controller_id))
+        {
+            tracing::debug!(
+                %controller_id,
+                "late or duplicate live report for an already-resolved controller; absorbing",
+            );
+        } else {
+            tracing::warn!(%controller_id, "live report from an unknown controller; ignoring");
+        }
     }
 }
 
@@ -272,7 +548,71 @@ impl RemoteSpawn for RdmaManagerOwnerActor {
 }
 
 #[async_trait]
-impl Actor for RdmaManagerOwnerActor {}
+impl Actor for RdmaManagerOwnerActor {
+    /// The manager-mesh controller is a direct child of the owner, so any
+    /// *terminal* status of the controller itself — clean `Stopped` as well as
+    /// `Failed` — is delivered here (RMO-14). It is matched by `event.actor_id`
+    /// on this direct parent/child channel (deliberately distinct from
+    /// `MeshFailure` attribution). Because a terminating controller's cleanup can
+    /// affect per-proc managers shared with other pending views, this
+    /// conservatively fails every pending view intersecting the source
+    /// controller's retained proc view (RMO-17), leaving a terminal source and
+    /// disjoint pending views unchanged.
+    /// Non-terminal events are absorbed. Every event returns `Ok(true)` so no
+    /// child event terminates this singleton (RMO-1/RMO-4); the owner's only
+    /// children are manager controllers.
+    async fn handle_supervision_event(
+        &mut self,
+        this: &Instance<Self>,
+        event: &ActorSupervisionEvent,
+    ) -> Result<bool, anyhow::Error> {
+        if event.actor_status.is_terminal() {
+            let controller_id = event.actor_id.id().clone();
+            let err = RdmaInitError::Supervision(event.to_string());
+            match self.resolve_controller_termination(this, &controller_id, err) {
+                Some(0) => {
+                    // A known controller with no overlapping pending view is the
+                    // expected teardown case (e.g. a `Ready` source stopping with no
+                    // pending sibling to fail).
+                    tracing::debug!(
+                        %controller_id,
+                        "terminal controller with no overlapping pending view; nothing to resolve",
+                    );
+                }
+                None => {
+                    tracing::warn!(
+                        %controller_id,
+                        "terminal supervision event could not be attributed to a controller view; absorbing",
+                    );
+                }
+                Some(_) => {}
+            }
+        }
+        Ok(true)
+    }
+
+    /// Initialization control traffic — the readiness cast to a manager, or the
+    /// `Subscribe` to a controller — can return to the owner as an invalid
+    /// reference if its target has already died; the default policy would `bail!`
+    /// and terminate the owner. Swallow it (RMO-4). The authoritative terminal
+    /// signal is the controller report (RMO-7) or the controller-child event
+    /// (RMO-14), never the returned envelope — which is not parsed.
+    /// `handle_undeliverable_message` is deliberately left at its default (benign
+    /// except for an oversized frame).
+    async fn handle_invalid_reference(
+        &mut self,
+        _cx: &Instance<Self>,
+        invalid: InvalidReference,
+        undeliverable: Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        tracing::warn!(
+            ?invalid,
+            ?undeliverable,
+            "RdmaManagerOwnerActor swallowing an invalid-reference return from initialization control traffic",
+        );
+        Ok(())
+    }
+}
 
 // Implements the get-or-initialize barrier for one proc-mesh view. Existing
 // entries reply from terminal state or join the pending waiter set. New entries
@@ -299,15 +639,15 @@ impl Handler<EnsureRdmaManager> for RdmaManagerOwnerActor {
         // this borrow of `by_mesh` ends before `entries` is touched.
         if let Some(&entry) = self.by_mesh.get(&proc_mesh) {
             match self.entries.get_mut(&entry) {
-                Some(MeshState::Ready { manager_mesh }) => {
+                Some(MeshState::Ready { manager_mesh, .. }) => {
                     debug_assert!(
                         manager_mesh.controller().is_some(),
                         "RMO-13: a Ready manager mesh is controller-ful",
                     );
                     reply.post(cx, Ok(()));
                 }
-                Some(MeshState::Failed(e)) => {
-                    reply.post(cx, Err(e.clone()));
+                Some(MeshState::Failed { err, .. }) => {
+                    reply.post(cx, Err(err.clone()));
                 }
                 Some(MeshState::Pending { waiters, .. }) => {
                     waiters.push(reply);
@@ -341,39 +681,56 @@ impl Handler<EnsureRdmaManager> for RdmaManagerOwnerActor {
                 // Spawn failure is cached terminally (RMO-2): no `Pending`
                 // exists yet, so insert `Failed` directly and reply inline.
                 let err = RdmaInitError::SpawnFailed(e.to_string());
-                self.entries.insert(entry, MeshState::Failed(err.clone()));
+                self.entries.insert(
+                    entry,
+                    MeshState::Failed {
+                        err: err.clone(),
+                        controller_id: None,
+                    },
+                );
                 self.by_mesh.insert(proc_mesh, entry);
                 reply.post(cx, Err(err));
                 return Ok(());
             }
         };
-        // Capture the controller address for this mesh view. A controller-ful
-        // `spawn_service` always sets one (RMO-13), so `expect` here asserts
-        // that invariant. It is the key that attributes a `MeshFailure` to its
-        // sending controller.
-        let controller_addr = mesh
+        // Capture the controller ref (cloned so it outlives the `mesh` move) and
+        // derive its id — the attribution/overlap key (RMO-7/RMO-14/RMO-17). A
+        // controller-ful `spawn_service` always sets one (RMO-13), so `expect`
+        // here asserts that invariant.
+        let controller = mesh
             .controller()
             .as_ref()
             .expect("controller-ful spawn_service always sets a controller")
-            .actor_addr()
             .clone();
+        let controller_id = controller.actor_addr().id().clone();
+        // The owner's shared `Handler<Option<MeshFailure>>` port; each pending
+        // entry registers this same port with its own controller's subscriber
+        // set (RMO-16). Reports are demultiplexed by typed `reporting_controller`.
+        let subscriber = cx.instance().port::<Option<MeshFailure>>().bind();
         let remaining_acks = mesh.region().num_ranks();
         let manager_for_cast = mesh.clone();
 
-        // Record `Pending` BEFORE casting so a cast failure has an entry to
-        // drain terminally (RMO-2).
+        // Record `Pending` BEFORE subscribing and casting, so a replayed terminal
+        // or a cast failure has an entry to drain terminally (RMO-2/RMO-15).
         self.entries.insert(
             entry,
             MeshState::Pending {
                 manager_mesh: mesh,
-                controller_addr,
+                controller_id,
+                subscriber: subscriber.clone(),
                 remaining_acks,
                 waiters: vec![reply],
             },
         );
         self.by_mesh.insert(proc_mesh, entry);
 
-        // 0-rank mesh: no ack will ever come, so resolve immediately.
+        // Subscribe to the controller's lifecycle stream before casting (RMO-15):
+        // `Subscribe` replays any latched terminal and later ones are broadcast
+        // to the now-inserted port, so no terminal state races registration.
+        controller.post(cx, Subscribe(subscriber));
+
+        // 0-rank mesh: no ack will ever come, so resolve immediately (the
+        // transition also posts `Unsubscribe`).
         if remaining_acks == 0 {
             self.transition(cx, entry, Ok(()));
             return Ok(());
@@ -419,18 +776,37 @@ impl ReadyAckHandler for RdmaManagerOwnerActor {
     }
 }
 
-// `spawn_service` creates an `ActorMeshController` for each manager-mesh view
-// as a child of this owner and registers the owner's `MeshFailure` port as its
-// failure sink. The handler logs and ignores the event, returning `Ok` so a
-// supervision report does not terminate the owner.
+// The two live-report routes. The owner sink `Handler<MeshFailure>` (required by
+// `spawn_service`) carries only *error* reports; the subscriber
+// `Handler<Option<MeshFailure>>` additionally carries *clean* terminal states
+// (`Stopped`/`NotExist`/`Timeout`) and `None` heartbeats (RMO-14). Both attribute
+// by the typed `reporting_controller` and fail only the source pending entry
+// (RMO-7); an error that arrives on both is absorbed by the terminal-absorbing
+// transition (RMO-2). Neither returns `Err`, so a report cannot terminate the
+// owner (RMO-4).
 #[async_trait]
 impl Handler<MeshFailure> for RdmaManagerOwnerActor {
     async fn handle(
         &mut self,
-        _cx: &Context<Self>,
+        cx: &Context<Self>,
         message: MeshFailure,
     ) -> Result<(), anyhow::Error> {
-        tracing::warn!(?message, "RdmaManagerOwnerActor ignoring MeshFailure");
+        self.handle_live_report(cx, &message);
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Handler<Option<MeshFailure>> for RdmaManagerOwnerActor {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: Option<MeshFailure>,
+    ) -> Result<(), anyhow::Error> {
+        // `None` is a healthy heartbeat (RMO-16); only `Some` is a report.
+        if let Some(message) = message {
+            self.handle_live_report(cx, &message);
+        }
         Ok(())
     }
 }
@@ -440,26 +816,45 @@ mod tests {
     use std::time::Duration;
 
     use async_trait::async_trait;
+    use hyperactor::ActorAddr;
     use hyperactor::ActorHandle;
     use hyperactor::ActorId;
     use hyperactor::ActorRef;
     use hyperactor::Context;
     use hyperactor::Endpoint;
     use hyperactor::Handler;
+    use hyperactor::PortRef;
     use hyperactor::RemoteSpawn;
+    use hyperactor::actor::ActorStatus;
+    use hyperactor::context::Actor as _;
+    use hyperactor::mailbox::DeliveryFailure;
+    use hyperactor::mailbox::InvalidReference;
+    use hyperactor::mailbox::InvalidReferenceReason;
+    use hyperactor::mailbox::MessageEnvelope;
+    use hyperactor::mailbox::Undeliverable;
+    use hyperactor::supervision::ActorSupervisionEvent;
     use hyperactor_config::Flattrs;
     use hyperactor_mesh::ActorMesh;
     use hyperactor_mesh::ProcMeshRef;
     use hyperactor_mesh::context;
     use hyperactor_mesh::host_mesh::HostMesh;
+    use hyperactor_mesh::mesh_controller::ActorMeshController;
+    use hyperactor_mesh::mesh_controller::GetSubscriberCount;
+    use hyperactor_mesh::mesh_controller::Subscribe;
+    use hyperactor_mesh::mesh_controller::Unsubscribe;
+    use hyperactor_mesh::mesh_id::ResourceId;
+    use hyperactor_mesh::resource;
+    use hyperactor_mesh::supervision::MeshFailure;
     use ndslice::ViewExt;
     use ndslice::view::Ranked;
     use tokio::sync::oneshot;
     use tokio::time::timeout;
 
     use super::EnsureRdmaManagerClient;
+    use super::EntryId;
     use super::MeshState;
     use super::RdmaManagerOwnerActor;
+    use super::ReadyAck;
     use crate::RdmaManagerActor;
     use crate::errors::RdmaInitError;
 
@@ -520,6 +915,7 @@ mod tests {
         waiter_count: usize,
         remaining_acks: Option<usize>,
         manager_ids: Vec<ActorId>,
+        controller_id: Option<ActorId>,
     }
 
     /// Reports a view's entry state, the owner's total entry count, and (when
@@ -534,31 +930,43 @@ mod tests {
     impl Handler<Probe> for RdmaManagerOwnerActor {
         async fn handle(&mut self, _cx: &Context<Self>, msg: Probe) -> Result<(), anyhow::Error> {
             let entry_count = self.entries.len();
-            let (state, waiter_count, remaining_acks, manager_ids) = match self
+            let (state, waiter_count, remaining_acks, manager_ids, controller_id) = match self
                 .by_mesh
                 .get(&msg.key)
                 .copied()
                 .and_then(|id| self.entries.get(&id))
             {
-                None => (EntryStateTag::Absent, 0, None, Vec::new()),
+                None => (EntryStateTag::Absent, 0, None, Vec::new(), None),
                 Some(MeshState::Pending {
                     waiters,
                     remaining_acks,
                     manager_mesh,
-                    controller_addr: _,
+                    controller_id,
+                    ..
                 }) => (
                     EntryStateTag::Pending,
                     waiters.len(),
                     Some(*remaining_acks),
                     manager_mesh_ids(manager_mesh),
+                    Some(controller_id.clone()),
                 ),
-                Some(MeshState::Ready { manager_mesh }) => (
+                Some(MeshState::Ready {
+                    manager_mesh,
+                    controller_id,
+                }) => (
                     EntryStateTag::Ready,
                     0,
                     None,
                     manager_mesh_ids(manager_mesh),
+                    Some(controller_id.clone()),
                 ),
-                Some(MeshState::Failed(_)) => (EntryStateTag::Failed, 0, None, Vec::new()),
+                Some(MeshState::Failed { controller_id, .. }) => (
+                    EntryStateTag::Failed,
+                    0,
+                    None,
+                    Vec::new(),
+                    controller_id.clone(),
+                ),
             };
             let _ = msg.reply.send(ProbeResult {
                 state,
@@ -566,6 +974,7 @@ mod tests {
                 waiter_count,
                 remaining_acks,
                 manager_ids,
+                controller_id,
             });
             Ok(())
         }
@@ -1057,6 +1466,1124 @@ mod tests {
         })
         .await
         .expect("shutdown elapsed: overlapping controller cleanup")?;
+        Ok(())
+    }
+
+    // Failure-path fixtures, helpers, and tests.
+    //
+    // The failure tests reuse production-created entries rather than fabricating
+    // `MeshState`s. `HoldPending` adds one sentinel to `remaining_acks` on a real
+    // `Pending` entry so its real per-rank `ReadyAck`s cannot resolve it, keeping
+    // the entry deterministically `Pending` for failure injection; it preserves
+    // `by_mesh`/`entries` consistency and the entry's non-returning waiter
+    // (RMO-5), and returns the real controller ref for tests that drive the
+    // controller's own lifecycle.
+
+    /// Build a `MeshFailure` the way a controller posts one: `reporting_controller`
+    /// is the attribution key (RMO-7); the event subject is deliberately
+    /// unrelated to the controller.
+    fn make_mesh_failure(reporter: Option<ActorId>, subject: ActorAddr) -> MeshFailure {
+        MeshFailure {
+            actor_mesh_name: Some("rdma_manager".to_string()),
+            event: ActorSupervisionEvent::new(
+                subject,
+                None,
+                ActorStatus::generic_failure("injected manager failure"),
+                None,
+            ),
+            crashed_ranks: vec![0],
+            reporting_controller: reporter,
+        }
+    }
+
+    /// Poll the entry for `key` until `remaining_acks == want`, giving the real
+    /// per-rank `ReadyAck` time to land behind the held sentinel.
+    async fn wait_for_remaining(
+        handle: &ActorHandle<RdmaManagerOwnerActor>,
+        cx: &impl hyperactor::context::Actor,
+        key: ProcMeshRef,
+        want: usize,
+    ) {
+        for _ in 0..400 {
+            if probe(handle, cx, key.clone()).await.remaining_acks == Some(want) {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("entry did not reach remaining_acks == {want}");
+    }
+
+    /// Hold a real `Pending` entry open (sentinel) and report its `EntryId`,
+    /// recorded `controller_id`, and the real manager-mesh controller ref, so a
+    /// test can drive that controller's own lifecycle via `downcast_handle` or
+    /// query it with `GetSubscriberCount`.
+    #[derive(Debug)]
+    struct HoldPending {
+        key: ProcMeshRef,
+        reply: oneshot::Sender<
+            Option<(
+                EntryId,
+                ActorId,
+                ActorRef<ActorMeshController<RdmaManagerActor>>,
+            )>,
+        >,
+    }
+
+    #[async_trait]
+    impl Handler<HoldPending> for RdmaManagerOwnerActor {
+        async fn handle(
+            &mut self,
+            _cx: &Context<Self>,
+            msg: HoldPending,
+        ) -> Result<(), anyhow::Error> {
+            let held = self.by_mesh.get(&msg.key).copied().and_then(|id| {
+                match self.entries.get_mut(&id) {
+                    Some(MeshState::Pending {
+                        remaining_acks,
+                        controller_id,
+                        manager_mesh,
+                        ..
+                    }) => {
+                        *remaining_acks += 1;
+                        let controller = manager_mesh
+                            .controller()
+                            .as_ref()
+                            .expect("controller-ful manager mesh")
+                            .clone();
+                        Some((id, controller_id.clone(), controller))
+                    }
+                    _ => None,
+                }
+            });
+            let _ = msg.reply.send(held);
+            Ok(())
+        }
+    }
+
+    /// Poll the entry for `key` until it reaches `want`.
+    async fn wait_until_state(
+        handle: &ActorHandle<RdmaManagerOwnerActor>,
+        cx: &impl hyperactor::context::Actor,
+        key: ProcMeshRef,
+        want: EntryStateTag,
+    ) {
+        for _ in 0..400 {
+            if probe(handle, cx, key.clone()).await.state == want {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        panic!("entry did not reach state {want:?}");
+    }
+
+    /// Test-only owner op: remove the owner's shared `Option<MeshFailure>`
+    /// subscription from `controller`, using the exact well-known handler port
+    /// the owner registers. Owner-originated so a following owner-originated
+    /// `CountSubscribers` is ordered behind it at the controller.
+    #[derive(Debug)]
+    struct UnsubscribeController {
+        controller: ActorRef<ActorMeshController<RdmaManagerActor>>,
+        ack: oneshot::Sender<()>,
+    }
+
+    #[async_trait]
+    impl Handler<UnsubscribeController> for RdmaManagerOwnerActor {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: UnsubscribeController,
+        ) -> Result<(), anyhow::Error> {
+            let port = cx.instance().port::<Option<MeshFailure>>().bind();
+            let mut unsub = msg.controller.port();
+            unsub.return_undeliverable(false);
+            let _ = unsub.post(cx, Unsubscribe(port));
+            let _ = msg.ack.send(());
+            Ok(())
+        }
+    }
+
+    /// Test-only owner op: query `controller`'s subscriber count from the owner,
+    /// so the query is ordered behind any prior owner-posted `Subscribe`/
+    /// `Unsubscribe`/`transition` unsubscribe to that same controller (RMO-16).
+    #[derive(Debug)]
+    struct CountSubscribers {
+        controller: ActorRef<ActorMeshController<RdmaManagerActor>>,
+        count_port: PortRef<usize>,
+    }
+
+    #[async_trait]
+    impl Handler<CountSubscribers> for RdmaManagerOwnerActor {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: CountSubscribers,
+        ) -> Result<(), anyhow::Error> {
+            // Owner-originated: this `GetSubscriberCount` is ordered behind any
+            // prior owner post to the same controller (Subscribe / Unsubscribe /
+            // the transition drop), so the reported count reflects them.
+            msg.controller.post(cx, GetSubscriberCount(msg.count_port));
+            Ok(())
+        }
+    }
+
+    /// Post an owner-originated subscriber-count query and await the answer. The
+    /// reply port lives on the caller's mailbox; the owner only forwards it, so
+    /// the query is ordered behind the owner's prior posts to that controller.
+    async fn owner_subscriber_count(
+        owner: &ActorHandle<RdmaManagerOwnerActor>,
+        cx: &impl hyperactor::context::Actor,
+        controller: ActorRef<ActorMeshController<RdmaManagerActor>>,
+    ) -> usize {
+        let (tx, mut rx) = cx.instance().open_port::<usize>();
+        owner.post(
+            cx,
+            CountSubscribers {
+                controller,
+                count_port: tx.bind(),
+            },
+        );
+        rx.recv()
+            .await
+            .expect("controller replied to GetSubscriberCount")
+    }
+
+    /// Test-only owner op that drives the replay-before-insert path (RMO-15)
+    /// deterministically, without any timing. All four messages are owner-posted
+    /// to the same controller, so they are FIFO-ordered there: remove the owner's
+    /// subscription, report the count at that midpoint (must be `0`), latch a
+    /// whole-view non-error report via `resource::Stop`, then re-subscribe the
+    /// same owner handler port. Only the `Subscribe` replay can then resolve the
+    /// held entry, since the latched report carries the controller id it recorded.
+    #[derive(Debug)]
+    struct ReplaySequence {
+        controller: ActorRef<ActorMeshController<RdmaManagerActor>>,
+        midpoint_port: PortRef<usize>,
+    }
+
+    #[async_trait]
+    impl Handler<ReplaySequence> for RdmaManagerOwnerActor {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: ReplaySequence,
+        ) -> Result<(), anyhow::Error> {
+            let port = cx.instance().port::<Option<MeshFailure>>().bind();
+            msg.controller.post(cx, Unsubscribe(port.clone()));
+            msg.controller
+                .post(cx, GetSubscriberCount(msg.midpoint_port));
+            msg.controller.post(
+                cx,
+                resource::Stop {
+                    id: ResourceId::from_name("rdma-owner-test-stop"),
+                    reason: "test: latch a whole-view stop for replay".to_string(),
+                },
+            );
+            msg.controller.post(cx, Subscribe(port));
+            Ok(())
+        }
+    }
+
+    /// A manager with no available backend (ibverbs disabled, TCP fallback off)
+    /// fails to initialize: the barrier terminates with a typed error, caches
+    /// it, and the owner survives. The spawn-boundary race means the typed error
+    /// is `SpawnFailed` if failure is visible before `spawn_service` returns, or
+    /// `InitFailed` from the controller report otherwise (RMO-2/4/7).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn initialization_failure_resolves_and_is_cached() -> anyhow::Result<()> {
+        let config = hyperactor_config::global::lock();
+        let _no_tcp = config.override_key(crate::config::RDMA_ALLOW_TCP_FALLBACK, false);
+        let _no_ib = config.override_key(crate::config::RDMA_DISABLE_IBVERBS, true);
+
+        let cx = context().await;
+        let client = cx.actor_instance;
+
+        let mut host_mesh = HostMesh::local_in_process().await?;
+        let proc_mesh = host_mesh
+            .spawn(
+                client,
+                "rdma_procs",
+                hyperactor_mesh::extent!(procs = 1),
+                None,
+                None,
+            )
+            .await?;
+        let key: ProcMeshRef = (*proc_mesh).clone();
+
+        let owner = RdmaManagerOwnerActor::new((), Flattrs::default()).await?;
+        let owner_handle = client.spawn(owner);
+
+        let (r1, rx1) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, key.clone(), r1.bind())
+            .await?;
+        let err = rx1
+            .recv()
+            .await?
+            .expect_err("init with no available backend must fail");
+        match &err {
+            // Both delivery paths carry the forced cause. If the failure is
+            // visible after `Pending` is installed, the controller report renders
+            // it through the `MeshFailure` display (InitFailed); if it is visible
+            // during the bounded spawn-wait, it surfaces as `Status::Failed(reason)`
+            // inside `ActorSpawnError`, whose display SpawnFailed captures. The
+            // only failure source in this config is the missing backend, so the
+            // substring must appear either way.
+            RdmaInitError::InitFailed(msg) | RdmaInitError::SpawnFailed(msg) => assert!(
+                msg.contains("no RDMA backend available"),
+                "the forced no-backend cause must ride through on both the \
+                 InitFailed (controller report) and SpawnFailed (spawn-wait) \
+                 paths, got: {msg}",
+            ),
+            other => panic!("expected InitFailed or SpawnFailed, got {other:?}"),
+        }
+
+        // Terminal + cached: a second ensure replies from cache without
+        // spawning again (RMO-2).
+        let (r2, rx2) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, key.clone(), r2.bind())
+            .await?;
+        let cached = rx2.recv().await?.expect_err("cached terminal error");
+        assert_eq!(
+            cached, err,
+            "second ensure must reply the exact cached terminal error, not just \
+             the same enum discriminant",
+        );
+
+        let observed = probe(&owner_handle, client, key.clone()).await;
+        assert_eq!(observed.state, EntryStateTag::Failed);
+        assert_eq!(observed.entry_count, 1, "a failure must not add an entry");
+
+        owner_handle.stop("test complete")?;
+        let _ = owner_handle.await;
+        host_mesh.shutdown(client).await?;
+        Ok(())
+    }
+
+    /// Typed source attribution (RMO-7, the linchpin) plus the `Failed`-source
+    /// half of RMO-17. A live `MeshFailure` is source-local: it fails only the
+    /// view whose recorded `controller_id` matches its `reporting_controller`,
+    /// even though its `crashed_ranks` name a proc another pending view shares —
+    /// so a stale rank-fanout implementation fails this test. `None`, missing,
+    /// and unknown reporters resolve nothing (asserted BEFORE the match, so a
+    /// regression cannot hide behind the later resolution). The identical report
+    /// through the subscriber route is a late duplicate that cannot rewrite the
+    /// cached error. Finally, killing the already-`Failed` source's real
+    /// controller (a `Failed` controller terminal) invalidates the overlapping
+    /// pending view by proc-view overlap, with the sibling's own subscription
+    /// removed. A dropped waiter's drained reply must not bounce into the owner
+    /// (RMO-5).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn mesh_failure_resolves_only_typed_source() -> anyhow::Result<()> {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(crate::config::RDMA_ALLOW_TCP_FALLBACK, true);
+
+        let cx = context().await;
+        let client = cx.actor_instance;
+
+        let mut host_mesh = HostMesh::local_in_process().await?;
+        let proc_mesh = host_mesh
+            .spawn(
+                client,
+                "rdma_procs",
+                hyperactor_mesh::extent!(procs = 3),
+                None,
+                None,
+            )
+            .await?;
+        let view_a: ProcMeshRef = proc_mesh.range("procs", 0..2)?; // [0, 1], source
+        let view_b: ProcMeshRef = proc_mesh.range("procs", 0..1)?; // [0], overlaps A
+        let view_c: ProcMeshRef = proc_mesh.range("procs", 2..3)?; // [2], disjoint
+
+        let owner = RdmaManagerOwnerActor::new((), Flattrs::default()).await?;
+        let owner_handle = client.spawn(owner);
+        let subject = owner_handle.actor_addr().clone();
+
+        // Prequeue every ensure and hold behind a pause so each entry is created
+        // and held before any real ack can resolve it.
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            Pause {
+                entered: entered_tx,
+                release: release_rx,
+            },
+        );
+        entered_rx.await.expect("owner entered Pause");
+
+        let (ra, rxa) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_a.clone(), ra.bind())
+            .await?;
+        let (rb, rxb) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_b.clone(), rb.bind())
+            .await?;
+        let (rc, _rxc) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_c.clone(), rc.bind())
+            .await?;
+        let (hta, hrxa) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: view_a.clone(),
+                reply: hta,
+            },
+        );
+        let (htb, hrxb) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: view_b.clone(),
+                reply: htb,
+            },
+        );
+        let (htc, hrxc) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: view_c.clone(),
+                reply: htc,
+            },
+        );
+        let _ = release_tx.send(());
+
+        let (_entry_a, controller_a, ctrl_a) = hrxa.await?.expect("view A held pending");
+        let (_entry_b, controller_b, ctrl_b) = hrxb.await?.expect("view B held pending");
+        let (_entry_c, controller_c, _ctrl_c) = hrxc.await?.expect("view C held pending");
+        assert_ne!(
+            controller_a, controller_b,
+            "distinct views, distinct controllers"
+        );
+        assert_ne!(
+            controller_a, controller_c,
+            "distinct views, distinct controllers"
+        );
+
+        // A second waiter joins A; drop its receiver so its drained reply is
+        // undeliverable and must not bounce into the owner (RMO-5).
+        let (ra2, rxa2) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_a.clone(), ra2.bind())
+            .await?;
+        wait_for_remaining(&owner_handle, client, view_a.clone(), 1).await;
+        let a_probe = probe(&owner_handle, client, view_a.clone()).await;
+        assert_eq!(
+            a_probe.waiter_count, 2,
+            "second ensure joined A as a waiter"
+        );
+        assert_eq!(
+            a_probe.controller_id,
+            Some(controller_a.clone()),
+            "probe exposes A's recorded controller id (the RMO-7 match key)",
+        );
+        drop(rxa2);
+
+        // Ignore-before-match: an outer `None` heartbeat, a missing reporter, and
+        // an unknown reporter resolve nothing. An owner round-trip drains the
+        // queue behind them, then every view must still be pending.
+        owner_handle.post(client, None::<MeshFailure>);
+        owner_handle.post(client, make_mesh_failure(None, subject.clone()));
+        let unknown = owner_handle.actor_addr().id().clone();
+        owner_handle.post(client, make_mesh_failure(Some(unknown), subject.clone()));
+        let _ = owner_subscriber_count(&owner_handle, client, ctrl_a.clone()).await;
+        for v in [&view_a, &view_b, &view_c] {
+            assert_eq!(
+                probe(&owner_handle, client, v.clone()).await.state,
+                EntryStateTag::Pending,
+                "no pending view resolves on None / missing / unknown reporters",
+            );
+        }
+        assert_eq!(
+            probe(&owner_handle, client, view_a.clone())
+                .await
+                .waiter_count,
+            2,
+            "A's waiters are intact before the matching report",
+        );
+
+        // The matching report resolves ONLY A, draining both its waiters. Its
+        // `crashed_ranks = [0]` name B's proc; source-local attribution must
+        // leave B (and disjoint C) pending.
+        owner_handle.post(
+            client,
+            make_mesh_failure(Some(controller_a.clone()), subject.clone()),
+        );
+        let a_err = rxa
+            .recv()
+            .await?
+            .expect_err("view A resolves to a typed failure");
+        assert!(
+            matches!(a_err, RdmaInitError::InitFailed(_)),
+            "controller report resolves as InitFailed, got {a_err:?}",
+        );
+        assert_eq!(
+            probe(&owner_handle, client, view_a.clone()).await.state,
+            EntryStateTag::Failed,
+        );
+        assert_eq!(
+            probe(&owner_handle, client, view_b.clone()).await.state,
+            EntryStateTag::Pending,
+            "B (overlapping proc) is untouched by A's live report",
+        );
+        assert_eq!(
+            probe(&owner_handle, client, view_c.clone()).await.state,
+            EntryStateTag::Pending,
+        );
+
+        // The identical report through the subscriber route is a late duplicate:
+        // A is terminal, so its cached error is unchanged.
+        owner_handle.post(
+            client,
+            Some(make_mesh_failure(
+                Some(controller_a.clone()),
+                subject.clone(),
+            )),
+        );
+        let (rca, rcarx) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_a.clone(), rca.bind())
+            .await?;
+        assert_eq!(
+            rcarx.recv().await?.expect_err("A cached terminal error"),
+            a_err,
+            "A's cached error is immutable across a late subscriber-route duplicate",
+        );
+
+        // `Failed`-source half of RMO-17: unsubscribe B so it cannot fail via its
+        // own subscriber, then terminate A's real controller. The owner uses A's
+        // retained controller id and A's `ProcMeshRef` to fail B by proc-view
+        // overlap; disjoint C stays pending.
+        let (ack_tx, ack_rx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            UnsubscribeController {
+                controller: ctrl_b.clone(),
+                ack: ack_tx,
+            },
+        );
+        ack_rx.await?;
+        assert_eq!(
+            owner_subscriber_count(&owner_handle, client, ctrl_b).await,
+            0,
+            "B unsubscribed before the overlap proof",
+        );
+
+        let ctrl_a_handle = ctrl_a.downcast_handle(client).expect("local A controller");
+        ctrl_a_handle.kill("test: kill A controller")?;
+        let b_err = timeout(Duration::from_secs(30), rxb.recv())
+            .await
+            .expect("B resolved after A-controller kill")?
+            .expect_err("B fails via overlap from the Failed source");
+        assert!(
+            matches!(b_err, RdmaInitError::Supervision(_)),
+            "B: {b_err:?}"
+        );
+        // A is already a `Failed` source; killing its controller drives the
+        // Failed-source + Failed-controller cell of RMO-17. A's controller
+        // completes `Failed`.
+        let a_status = ctrl_a_handle.await;
+        assert!(
+            matches!(a_status, ActorStatus::Failed(_)),
+            "A controller failed after kill: {a_status:?}",
+        );
+        assert_eq!(
+            probe(&owner_handle, client, view_c.clone()).await.state,
+            EntryStateTag::Pending,
+            "disjoint C untouched by A-controller overlap",
+        );
+
+        // A's cached error is still exactly the original InitFailed.
+        let (rca2, rca2rx) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_a.clone(), rca2.bind())
+            .await?;
+        assert_eq!(rca2rx.recv().await?.expect_err("A cached"), a_err);
+
+        owner_handle.stop("test complete")?;
+        let _ = owner_handle.await;
+        host_mesh.shutdown(client).await?;
+        Ok(())
+    }
+
+    /// Once a view is `Ready`, a live failure naming its controller is absorbed
+    /// and the cached `Ok` is unchanged — the owner is an initialization barrier,
+    /// not a health oracle (RMO-2). `Ready` retains its `controller_id` (for
+    /// RMO-17 overlap), but a live report is source-local and acts only on a
+    /// `Pending` entry, so it resolves nothing on either delivery route. Also
+    /// pins the subscription lifetime around the success transition: exactly one
+    /// subscriber while `Pending`, none once `Ready` (RMO-16).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn ready_absorbs_late_mesh_failure() -> anyhow::Result<()> {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(crate::config::RDMA_ALLOW_TCP_FALLBACK, true);
+
+        let cx = context().await;
+        let client = cx.actor_instance;
+
+        let mut host_mesh = HostMesh::local_in_process().await?;
+        let proc_mesh = host_mesh
+            .spawn(
+                client,
+                "rdma_procs",
+                hyperactor_mesh::extent!(procs = 1),
+                None,
+                None,
+            )
+            .await?;
+        let key: ProcMeshRef = (*proc_mesh).clone();
+
+        let owner = RdmaManagerOwnerActor::new((), Flattrs::default()).await?;
+        let owner_handle = client.spawn(owner);
+        let subject = owner_handle.actor_addr().clone();
+
+        // Capture the controller id while `Pending` (it is also retained in
+        // `Ready`), then let the entry resolve to `Ready`.
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            Pause {
+                entered: entered_tx,
+                release: release_rx,
+            },
+        );
+        entered_rx.await.expect("owner entered Pause");
+
+        let (r, rx) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, key.clone(), r.bind())
+            .await?;
+        let (ht, hrx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: key.clone(),
+                reply: ht,
+            },
+        );
+        let _ = release_tx.send(());
+
+        let (entry, controller, ctrl) = hrx.await?.expect("held pending");
+        // Held `Pending`: exactly one subscriber (the owner) is registered.
+        assert_eq!(
+            owner_subscriber_count(&owner_handle, client, ctrl.clone()).await,
+            1,
+            "a held pending entry has exactly one subscriber",
+        );
+        wait_for_remaining(&owner_handle, client, key.clone(), 1).await;
+        owner_handle.post(client, ReadyAck { entry });
+        assert_eq!(rx.recv().await?, Ok(()));
+        assert_eq!(
+            probe(&owner_handle, client, key.clone()).await.state,
+            EntryStateTag::Ready,
+        );
+        // The success transition posted `Unsubscribe`; an owner-ordered count
+        // query, FIFO behind it at the controller, now reports 0.
+        assert_eq!(
+            owner_subscriber_count(&owner_handle, client, ctrl).await,
+            0,
+            "reaching Ready removes the controller subscription",
+        );
+
+        // A late failure naming the former controller is absorbed on both routes.
+        owner_handle.post(
+            client,
+            make_mesh_failure(Some(controller.clone()), subject.clone()),
+        );
+        owner_handle.post(client, Some(make_mesh_failure(Some(controller), subject)));
+        assert_eq!(
+            probe(&owner_handle, client, key.clone()).await.state,
+            EntryStateTag::Ready,
+        );
+
+        let (r2, rx2) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, key.clone(), r2.bind())
+            .await?;
+        assert_eq!(rx2.recv().await?, Ok(()), "Ready is cached");
+
+        owner_handle.stop("test complete")?;
+        let _ = owner_handle.await;
+        host_mesh.shutdown(client).await?;
+        Ok(())
+    }
+
+    /// Subscription lifetime end to end (RMO-15/16), proved without timing. A held
+    /// pending entry has one subscriber and ignores an outer `None` heartbeat.
+    /// Driving `Unsubscribe -> count -> resource::Stop -> Subscribe` from the
+    /// owner to the same controller latches a whole-view non-error report with no
+    /// subscriber present, so only the `Subscribe` replay-before-insert resolves
+    /// the waiter; the midpoint count is `0`. The resolving `transition` then
+    /// removes that re-subscription (final owner-ordered count `0`). Capturing the
+    /// exact latched report through a temporary test subscription lets us replay
+    /// it through both handler routes as late duplicates that leave the cached
+    /// error and the owner unchanged.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn subscription_lifetime_handles_heartbeat_replay_and_duplicates() -> anyhow::Result<()> {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(crate::config::RDMA_ALLOW_TCP_FALLBACK, true);
+
+        let cx = context().await;
+        let client = cx.actor_instance;
+
+        let mut host_mesh = HostMesh::local_in_process().await?;
+        let proc_mesh = host_mesh
+            .spawn(
+                client,
+                "rdma_procs",
+                hyperactor_mesh::extent!(procs = 1),
+                None,
+                None,
+            )
+            .await?;
+        let key: ProcMeshRef = (*proc_mesh).clone();
+
+        let owner = RdmaManagerOwnerActor::new((), Flattrs::default()).await?;
+        let owner_handle = client.spawn(owner);
+
+        // Prequeue ensure + hold behind a pause so the entry is created and held
+        // (sentinel added) before any real `ReadyAck` can resolve it (RMO-15).
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            Pause {
+                entered: entered_tx,
+                release: release_rx,
+            },
+        );
+        entered_rx.await.expect("owner entered Pause");
+
+        // Hold a real pending entry and capture its real controller.
+        let (r, rx) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, key.clone(), r.bind())
+            .await?;
+        let (ht, hrx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: key.clone(),
+                reply: ht,
+            },
+        );
+        let _ = release_tx.send(());
+        let (_entry, _controller_id, controller) = hrx.await?.expect("held pending");
+
+        // The production ensure path registered exactly one subscriber (RMO-15/16).
+        assert_eq!(
+            owner_subscriber_count(&owner_handle, client, controller.clone()).await,
+            1,
+            "ensure registered the owner as the sole subscriber",
+        );
+
+        // An outer `None` heartbeat resolves nothing.
+        owner_handle.post(client, None::<MeshFailure>);
+        assert_eq!(
+            probe(&owner_handle, client, key.clone()).await.state,
+            EntryStateTag::Pending,
+        );
+
+        // Replay path (no timing): only the final `Subscribe` replay can resolve
+        // the held entry; the midpoint count proves the owner was unsubscribed
+        // before the latch.
+        let (mid_tx, mut mid_rx) = client.open_port::<usize>();
+        owner_handle.post(
+            client,
+            ReplaySequence {
+                controller: controller.clone(),
+                midpoint_port: mid_tx.bind(),
+            },
+        );
+        assert_eq!(
+            mid_rx.recv().await?,
+            0,
+            "subscriber removed before the latch"
+        );
+
+        let err = timeout(Duration::from_secs(30), rx.recv())
+            .await
+            .expect("replay resolved the waiter")?
+            .expect_err("replayed whole-view stop resolves the barrier");
+        assert!(
+            matches!(err, RdmaInitError::InitFailed(_)),
+            "replay: {err:?}"
+        );
+        assert_eq!(
+            probe(&owner_handle, client, key.clone()).await.state,
+            EntryStateTag::Failed,
+        );
+
+        // `transition` posted `Unsubscribe` on resolution; the final owner-ordered
+        // count is `0`, proving replay-before-insert did not leak the
+        // re-subscription.
+        assert_eq!(
+            owner_subscriber_count(&owner_handle, client, controller.clone()).await,
+            0,
+            "transition's Unsubscribe removed the replay subscription",
+        );
+
+        // Capture the exact latched report with a temporary test subscription,
+        // then remove it, and prove both late-duplicate routes are absorbed.
+        let (cap_tx, mut cap_rx) = client.open_port::<Option<MeshFailure>>();
+        controller.post(client, Subscribe(cap_tx.bind()));
+        let latched = timeout(Duration::from_secs(30), cap_rx.recv())
+            .await
+            .expect("controller replayed the latched report")?
+            .expect("latched report is Some");
+        controller.post(client, Unsubscribe(cap_tx.bind()));
+        // Removal barrier: a client-originated count query is FIFO-ordered behind
+        // the client's `Unsubscribe(cap_tx)` at the controller, so it observes the
+        // capture port removed before the duplicates are replayed.
+        let (cap_cnt_tx, mut cap_cnt_rx) = client.open_port::<usize>();
+        controller.post(client, GetSubscriberCount(cap_cnt_tx.bind()));
+        assert_eq!(
+            cap_cnt_rx.recv().await?,
+            0,
+            "capture subscription removed before replaying duplicates",
+        );
+
+        owner_handle.post(client, latched.clone());
+        owner_handle.post(client, Some(latched));
+        let (r2, r2rx) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, key.clone(), r2.bind())
+            .await?;
+        assert_eq!(
+            r2rx.recv().await?.expect_err("cached"),
+            err,
+            "cached error immutable across late duplicates on both routes",
+        );
+
+        owner_handle.stop("test complete")?;
+        let _ = owner_handle.await;
+        host_mesh.shutdown(client).await?;
+        Ok(())
+    }
+
+    /// The load-bearing RMO-17 proof, on the real manager-mesh controller and its
+    /// real cleanup path. Cleanly stopping a `Ready` controller invalidates every
+    /// still-`Pending` view sharing one of its per-proc managers, and only those;
+    /// sibling subscriptions are removed first so the overlap cannot leak through
+    /// the subscriber stream. Killing a disjoint pending view's controller then
+    /// proves the error-terminal branch (RMO-14). Every terminal input keeps the
+    /// owner alive (RMO-4) and leaves a terminal source and disjoint views
+    /// unchanged (RMO-2).
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn ready_controller_termination_resolves_only_overlapping_pending_views()
+    -> anyhow::Result<()> {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(crate::config::RDMA_ALLOW_TCP_FALLBACK, true);
+
+        let cx = context().await;
+        let client = cx.actor_instance;
+
+        let mut host_mesh = HostMesh::local_in_process().await?;
+        let proc_mesh = host_mesh
+            .spawn(
+                client,
+                "rdma_procs",
+                hyperactor_mesh::extent!(procs = 3),
+                None,
+                None,
+            )
+            .await?;
+        let view_a: ProcMeshRef = proc_mesh.range("procs", 0..2)?; // [0, 1]
+        let view_b: ProcMeshRef = proc_mesh.range("procs", 0..1)?; // [0]
+        let view_c: ProcMeshRef = proc_mesh.range("procs", 1..2)?; // [1]
+        let view_d: ProcMeshRef = proc_mesh.range("procs", 2..3)?; // [2]
+
+        let owner = RdmaManagerOwnerActor::new((), Flattrs::default()).await?;
+        let owner_handle = client.spawn(owner);
+
+        // Hold A pending to capture its real controller, then release its
+        // sentinel so A reaches `Ready` (which unsubscribes it). Prequeue ensure
+        // + hold behind a pause so A is held before any real `ReadyAck` lands.
+        let (a_entered_tx, a_entered_rx) = oneshot::channel();
+        let (a_release_tx, a_release_rx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            Pause {
+                entered: a_entered_tx,
+                release: a_release_rx,
+            },
+        );
+        a_entered_rx.await.expect("owner entered Pause (A)");
+        let (ra, _rxa) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_a.clone(), ra.bind())
+            .await?;
+        let (hta, hrxa) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: view_a.clone(),
+                reply: hta,
+            },
+        );
+        let _ = a_release_tx.send(());
+        let (entry_a, _ctrl_a_id, ctrl_a) = hrxa.await?.expect("A held pending");
+        wait_for_remaining(&owner_handle, client, view_a.clone(), 1).await;
+        owner_handle.post(client, ReadyAck { entry: entry_a });
+        wait_until_state(&owner_handle, client, view_a.clone(), EntryStateTag::Ready).await;
+        assert_eq!(
+            owner_subscriber_count(&owner_handle, client, ctrl_a.clone()).await,
+            0,
+            "a Ready controller is unsubscribed (RMO-16)",
+        );
+        let ctrl_a_handle = ctrl_a.downcast_handle(client).expect("local A controller");
+
+        // Hold B[0], C[1] (both share a proc with A) and disjoint D[2] pending.
+        // Prequeue their ensures + holds behind a pause so each is held before
+        // any real `ReadyAck` lands.
+        let (bcd_entered_tx, bcd_entered_rx) = oneshot::channel();
+        let (bcd_release_tx, bcd_release_rx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            Pause {
+                entered: bcd_entered_tx,
+                release: bcd_release_rx,
+            },
+        );
+        bcd_entered_rx.await.expect("owner entered Pause (B/C/D)");
+        let (rb, rxb) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_b.clone(), rb.bind())
+            .await?;
+        let (rc, rxc) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_c.clone(), rc.bind())
+            .await?;
+        let (rd, rxd) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_d.clone(), rd.bind())
+            .await?;
+        let (htb, hrxb) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: view_b.clone(),
+                reply: htb,
+            },
+        );
+        let (htc, hrxc) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: view_c.clone(),
+                reply: htc,
+            },
+        );
+        let (htd, hrxd) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: view_d.clone(),
+                reply: htd,
+            },
+        );
+        let _ = bcd_release_tx.send(());
+        let (_eb, _cb_id, ctrl_b) = hrxb.await?.expect("B held pending");
+        let (_ec, _cc_id, ctrl_c) = hrxc.await?.expect("C held pending");
+        let (_ed, _cd_id, ctrl_d) = hrxd.await?.expect("D held pending");
+
+        // Remove B and C subscriptions (owner-originated) so their failure can
+        // only come from A-controller overlap, not their own subscriber stream.
+        for ctrl in [ctrl_b.clone(), ctrl_c.clone()] {
+            let (ack_tx, ack_rx) = oneshot::channel();
+            owner_handle.post(
+                client,
+                UnsubscribeController {
+                    controller: ctrl,
+                    ack: ack_tx,
+                },
+            );
+            ack_rx.await?;
+        }
+        assert_eq!(
+            owner_subscriber_count(&owner_handle, client, ctrl_b.clone()).await,
+            0,
+            "B unsubscribed before the overlap proof",
+        );
+        assert_eq!(
+            owner_subscriber_count(&owner_handle, client, ctrl_c).await,
+            0,
+            "C unsubscribed before the overlap proof",
+        );
+
+        // Cleanly stop A's real controller; its cleanup stops the managers shared
+        // with B[0] and C[1]. The owner learns of A's terminal via direct child
+        // supervision and fails B and C by proc-view overlap (RMO-17).
+        ctrl_a_handle.stop("test: stop A controller")?;
+        let b_err = timeout(Duration::from_secs(30), rxb.recv())
+            .await
+            .expect("B resolved after A-controller stop")?
+            .expect_err("B fails via overlap");
+        assert!(
+            matches!(b_err, RdmaInitError::Supervision(_)),
+            "B: {b_err:?}"
+        );
+        let c_err = timeout(Duration::from_secs(30), rxc.recv())
+            .await
+            .expect("C resolved after A-controller stop")?
+            .expect_err("C fails via overlap");
+        assert!(
+            matches!(c_err, RdmaInitError::Supervision(_)),
+            "C: {c_err:?}"
+        );
+        // A's controller completed a clean stop (the clean-terminal branch). The
+        // B/C waiter errors above, not this join, are the proof that the owner
+        // processed A's terminal child event.
+        let a_status = ctrl_a_handle.await;
+        assert!(
+            matches!(a_status, ActorStatus::Stopped(_)),
+            "A controller stopped cleanly: {a_status:?}",
+        );
+
+        // D is disjoint ([2]) and stays pending; A stays cached `Ready`.
+        assert_eq!(
+            probe(&owner_handle, client, view_d.clone()).await.state,
+            EntryStateTag::Pending,
+            "disjoint D untouched by A-controller overlap",
+        );
+        let (ra2, ra2rx) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, view_a.clone(), ra2.bind())
+            .await?;
+        assert_eq!(ra2rx.recv().await?, Ok(()), "A source stays cached Ready");
+
+        // Self-termination path, error-terminal branch: kill D's own controller
+        // so it completes as `Failed` (a crash, not a clean stop). The owner gates
+        // on `is_terminal()`, so `Failed` drives the same resolution A's clean
+        // `Stopped` did; D resolves directly (RMO-14).
+        let ctrl_d_handle = ctrl_d.downcast_handle(client).expect("local D controller");
+        ctrl_d_handle.kill("test: kill D controller")?;
+        let d_err = timeout(Duration::from_secs(30), rxd.recv())
+            .await
+            .expect("D resolved after its controller was killed")?
+            .expect_err("D fails on its own controller termination");
+        assert!(
+            matches!(d_err, RdmaInitError::Supervision(_)),
+            "D: {d_err:?}"
+        );
+        // D's controller completed as `Failed` (the error-terminal branch).
+        let d_status = ctrl_d_handle.await;
+        assert!(
+            matches!(d_status, ActorStatus::Failed(_)),
+            "D controller failed after kill: {d_status:?}",
+        );
+
+        owner_handle.stop("test complete")?;
+        let _ = owner_handle.await;
+        host_mesh.shutdown(client).await?;
+        Ok(())
+    }
+
+    /// An invalid-reference return (such as a readiness-cast bounce to a dead
+    /// rank) can reach the owner; the default policy would `bail!` and kill the
+    /// owner. The override swallows it (RMO-4) and does not mutate a held pending
+    /// entry, which still resolves normally afterwards. Delivered through the
+    /// owner's real delivery-failure dispatch, not a direct callback call.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn invalid_reference_does_not_kill_owner() -> anyhow::Result<()> {
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(crate::config::RDMA_ALLOW_TCP_FALLBACK, true);
+
+        let cx = context().await;
+        let client = cx.actor_instance;
+
+        let mut host_mesh = HostMesh::local_in_process().await?;
+        let proc_mesh = host_mesh
+            .spawn(
+                client,
+                "rdma_procs",
+                hyperactor_mesh::extent!(procs = 1),
+                None,
+                None,
+            )
+            .await?;
+        let key: ProcMeshRef = (*proc_mesh).clone();
+
+        let owner = RdmaManagerOwnerActor::new((), Flattrs::default()).await?;
+        let owner_handle = client.spawn(owner);
+        let owner_addr = owner_handle.actor_addr().clone();
+
+        // Hold a real entry pending so the swallow is proved non-mutating.
+        // Prequeue ensure + hold behind a pause so the entry is held before any
+        // real `ReadyAck` lands.
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            Pause {
+                entered: entered_tx,
+                release: release_rx,
+            },
+        );
+        entered_rx.await.expect("owner entered Pause");
+        let (r, rx) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, key.clone(), r.bind())
+            .await?;
+        let (ht, hrx) = oneshot::channel();
+        owner_handle.post(
+            client,
+            HoldPending {
+                key: key.clone(),
+                reply: ht,
+            },
+        );
+        let _ = release_tx.send(());
+        let (entry, _controller_id, _controller) = hrx.await?.expect("held pending");
+
+        // Build an invalid-reference return and deliver it through the owner's
+        // real delivery-failure dispatch (blanket `Handler<Undeliverable>`).
+        let mut env = MessageEnvelope::new(
+            owner_addr.clone(),
+            owner_addr.port_addr(0.into()),
+            wirevalue::Any::serialize(&0u64).unwrap(),
+            Flattrs::new(),
+        );
+        env.push_delivery_failure(DeliveryFailure::new(InvalidReference::new(
+            owner_addr.clone(),
+            InvalidReferenceReason::ActorNotExist,
+        )));
+        let undeliverable_port =
+            PortRef::<Undeliverable<MessageEnvelope>>::attest_handler_port(&owner_addr);
+        undeliverable_port.post(client, Undeliverable::Returned(env));
+
+        // The swallow did not mutate the held entry: it stays pending.
+        wait_for_remaining(&owner_handle, client, key.clone(), 1).await;
+        assert_eq!(
+            probe(&owner_handle, client, key.clone()).await.state,
+            EntryStateTag::Pending,
+            "an invalid-reference return must not resolve a pending entry",
+        );
+
+        // Release the sentinel; the entry resolves normally and the owner still
+        // serves a cached repeat ensure.
+        owner_handle.post(client, ReadyAck { entry });
+        assert_eq!(
+            rx.recv().await?,
+            Ok(()),
+            "held entry resolves normally after the swallow",
+        );
+        let (r2, rx2) = client.open_once_port::<Result<(), RdmaInitError>>();
+        owner_handle
+            .ensure_rdma_manager(client, key.clone(), r2.bind())
+            .await?;
+        assert_eq!(
+            rx2.recv().await?,
+            Ok(()),
+            "owner alive and caching after an invalid-reference return",
+        );
+
+        owner_handle.stop("test complete")?;
+        let _ = owner_handle.await;
+        host_mesh.shutdown(client).await?;
         Ok(())
     }
 }


### PR DESCRIPTION
Summary:

a `Handle` lets Python watch the result of a background Tokio task without driving it. right now the only way to get one is to first wrap the work in a `PythonTask` and call `spawn_handle` on it, so a Rust binding can't just run a Rust future and hand Python back a `Handle`. there's also no way, from Rust, to check whether a handle finished successfully or failed without also pulling out its Python result value.

this adds two small Rust-only methods on `PyHandle` (not exposed to Python, so Python still can't build a handle itself):

- `PyHandle::spawn(future)` runs a Rust future in the background right away and hands back a `Handle` to observe it. it reuses the same machinery the `PythonTask` producers already use to publish a result — just without the `PythonTask` wrapper.
- `PyHandle::wait_completion()` waits for the handle to finish and reports success or the failure, without copying the result value. it can be called any number of times, and every caller sees the same outcome.

it also shares one existing helper, `pytokio::send_result`, between both kinds of producer instead of duplicating it, and rewords that helper's log message so it reads sensibly for both.

the goal is to let a later binding expose a background Rust operation to Python as a plain `Handle`, with a cheap way to wait on just success-or-failure. the new behavior is documented as HDL-13 in the invariant list at the top of `handle.rs`, and the related HDL-1, HDL-9, and HDL-10 entries are updated to mention the new method.

Differential Revision: D113090418


