### PR TITLE
Move telemetry worker ownership to query root (#4475)

### DIFF
--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -38,7 +38,7 @@ from monarch._rust_bindings.monarch_extension.snapshot_integration import (
     _pre_register_snapshot_schemas,
 )
 from monarch._rust_bindings.monarch_hyperactor.mailbox import PortId
-from monarch.actor import Actor, current_rank, endpoint
+from monarch.actor import Actor, current_rank, endpoint, HostMesh, ProcMesh
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -70,9 +70,9 @@ class TelemetryActor(Actor):
         # the host-local socket namespace.
         self._scanner: DatabaseScanner | None = None
         # Worker actor meshes this collector fans queries out to. Empty for
-        # leaf collectors; the query-root collector receives its list via
-        # `set_worker_collector_meshes` once the worker meshes exist.
+        # leaf collectors; the query-root collector owns the worker meshes.
         self._worker_collector_meshes: list[Any] = []
+        self._worker_proc_meshes: list[ProcMesh] = []
 
     def _scanner_or_raise(self) -> DatabaseScanner:
         scanner = self._scanner
@@ -116,10 +116,71 @@ class TelemetryActor(Actor):
         return self._activate_impl()
 
     @endpoint
-    def set_worker_collector_meshes(self, worker_collector_meshes: List[Any]) -> None:
-        """Replace the client collector's worker mesh list."""
+    def start_worker_collector(
+        self,
+        host_mesh: HostMesh,
+        spawn_worker_collector: bool = True,
+    ) -> None:
+        """Start and register the telemetry collector for a worker host mesh."""
         self._scanner_or_raise()
-        self._worker_collector_meshes = list(worker_collector_meshes)
+        self._start_worker_collector(
+            host_mesh,
+            spawn_worker_collector,
+        )
+
+    def _start_worker_collector(
+        self,
+        host_mesh: HostMesh,
+        spawn_worker_collector: bool = True,
+    ) -> Any | None:
+        proc_mesh = host_mesh.spawn_procs(name="telemetry_hosts")
+        if not spawn_worker_collector:
+            self._worker_proc_meshes.append(proc_mesh)
+            return None
+
+        try:
+            worker_collector_mesh: Any = proc_mesh.spawn(
+                "TelemetryActor",
+                TelemetryActor,
+                self._apply_id,
+                self._retention_secs,
+            )
+            active = any(
+                active for _rank, active in worker_collector_mesh.activate.call().get()
+            )
+        except Exception:
+            self._stop_worker_mesh(
+                proc_mesh,
+                "telemetry collector startup failed",
+            )
+            raise
+
+        self._worker_proc_meshes.append(proc_mesh)
+        if active:
+            self._worker_collector_meshes.append(worker_collector_mesh)
+            return worker_collector_mesh
+
+        self._stop_worker_mesh(
+            worker_collector_mesh,
+            "telemetry collector inactive",
+        )
+        return None
+
+    @endpoint
+    def stop_worker_collectors(self) -> None:
+        for proc_mesh in self._worker_proc_meshes:
+            self._stop_worker_mesh(
+                proc_mesh,
+                "telemetry shutdown",
+            )
+        self._worker_proc_meshes.clear()
+        self._worker_collector_meshes.clear()
+
+    def _stop_worker_mesh(self, mesh: Any, reason: str) -> None:
+        try:
+            mesh.stop(reason).get(timeout=5.0)
+        except Exception:
+            logger.info("failed to stop telemetry mesh: %s", reason, exc_info=True)
 
     @endpoint
     def table_names(self) -> List[str]:
@@ -173,9 +234,9 @@ class TelemetryActor(Actor):
         child_futures = []
         for collector_mesh in self._worker_collector_meshes:
             try:
-                # Constructing the call can fail if the sidecar holds a stale
-                # actor ref. Treat that as reduced result coverage, matching
-                # the legacy best-effort query behavior.
+                # Constructing the call can fail if the actor ref is stale.
+                # Treat that as reduced result coverage, matching best-effort
+                # query behavior.
                 child_futures.append(
                     collector_mesh.scan.call(
                         dest, table_name, projection, limit, filter_expr

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -57,7 +57,7 @@ from monarch._src.job.telemetry_actor import (
     telemetry_socket_path,
     TelemetryActor,
 )
-from monarch.actor import context, HostMesh, ProcMesh, shutdown_context
+from monarch.actor import context, HostMesh, shutdown_context
 from monarch.distributed_telemetry.engine import QueryEngine
 from monarch.monarch_dashboard.server.app import start_dashboard
 from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
@@ -221,9 +221,7 @@ class _TelemetryHandle:
         self._client_actor: Any | None = None
         self._query_engine: QueryEngine | None = None
         self._dashboard_info: dict[str, object] | None = None
-        # None means worker fan-out has not run yet. An empty list means fan-out
-        # ran, but no worker collectors became active.
-        self._worker_proc_meshes: list[ProcMesh] | None = None
+        self._worker_collectors_started: bool = False
 
     @property
     def client_socket_path(self) -> str:
@@ -244,12 +242,12 @@ class _TelemetryHandle:
             # the in-memory telemetry store and re-bind the data socket.
             logger.warning("telemetry handle config drift ignored")
 
-        if host_meshes and self._worker_proc_meshes is None:
-            self._worker_proc_meshes = self._spawn_telemetry_actors(
+        if host_meshes and not self._worker_collectors_started:
+            self._spawn_telemetry_actors(
                 host_meshes,
-                parsed,
                 spawn_worker_collectors=spawn_worker_collectors,
             )
+            self._worker_collectors_started = True
 
         dashboard_info = self._dashboard_info
         if dashboard_info is None:
@@ -302,98 +300,33 @@ class _TelemetryHandle:
     def _spawn_telemetry_actors(
         self,
         host_meshes: Mapping[str, HostMesh],
-        config: TelemetryConfig,
         *,
         spawn_worker_collectors: bool = True,
-    ) -> list[ProcMesh]:
+    ) -> None:
         client_actor = self._client_actor
         if client_actor is None:
             raise RuntimeError("telemetry handle has no client actor")
 
-        worker_proc_meshes: list[ProcMesh] = []
-        worker_collector_meshes: list[Any] = []
         for host_mesh in host_meshes.values():
             try:
-                proc_mesh, worker_collector_mesh = (
-                    self._start_worker_telemetry_collector(
-                        host_mesh,
-                        config,
-                        spawn_worker_collector=spawn_worker_collectors,
-                    )
-                )
+                client_actor.start_worker_collector.call_one(
+                    host_mesh,
+                    spawn_worker_collectors,
+                ).get()
             except Exception:
                 logger.warning(
                     "failed to start worker telemetry collector",
                     exc_info=True,
                 )
-                continue
-            worker_proc_meshes.append(proc_mesh)
-            if worker_collector_mesh is not None:
-                worker_collector_meshes.append(worker_collector_mesh)
-
-        client_actor.set_worker_collector_meshes.call_one(worker_collector_meshes).get()
-        return worker_proc_meshes
-
-    def _start_worker_telemetry_collector(
-        self,
-        host_mesh: HostMesh,
-        config: TelemetryConfig,
-        *,
-        spawn_worker_collector: bool = True,
-    ) -> tuple[ProcMesh, Any | None]:
-        proc_mesh = host_mesh.spawn_procs(name="telemetry_hosts")
-        if not spawn_worker_collector:
-            return proc_mesh, None
-
-        try:
-            worker_collector_mesh = proc_mesh.spawn(
-                "TelemetryActor",
-                TelemetryActor,
-                self._apply_id,
-                config.retention_secs,
-            )
-            active = any(
-                active for _rank, active in worker_collector_mesh.activate.call().get()
-            )
-        except Exception:
-            self._stop_worker_mesh(
-                proc_mesh,
-                "telemetry collector startup failed",
-                "failed to stop failed telemetry worker proc mesh",
-            )
-            raise
-
-        if active:
-            return proc_mesh, worker_collector_mesh
-
-        # Only one live collector may own a host-local socket namespace. Keep
-        # the proc alive so mesh-admin snapshots can still resolve it, but stop
-        # the inactive actor so queries do not fan out to it.
-        self._stop_worker_mesh(
-            worker_collector_mesh,
-            "telemetry collector inactive",
-            "failed to stop inactive telemetry worker collector",
-        )
-        return proc_mesh, None
-
-    def _stop_worker_mesh(
-        self,
-        mesh: Any,
-        reason: str,
-        log_message: str,
-    ) -> None:
-        try:
-            mesh.stop(reason).get()
-        except Exception:
-            logger.info(log_message, exc_info=True)
 
     def shutdown(self) -> None:
-        for proc_mesh in self._worker_proc_meshes or []:
+        client_actor = self._client_actor
+        if client_actor is not None:
             try:
-                proc_mesh.stop("telemetry shutdown").get()
+                client_actor.stop_worker_collectors.call_one().get(timeout=5.0)
             except Exception:
                 logger.info(
-                    "failed to stop telemetry worker proc mesh",
+                    "failed to stop telemetry worker collectors",
                     exc_info=True,
                 )
         # Drain in-flight async work with a short cap. Beyond that, we

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -18,7 +18,7 @@ import urllib.error
 import urllib.request
 import uuid
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
 
 import monarch._src.job.job_sidecar as js
 import monarch._src.job.telemetry_config as tc
@@ -216,166 +216,133 @@ def test_open_or_refresh_raises_when_not_open() -> None:
             handle.open_or_refresh({}, _cfg_dict())
 
 
-def test_open_or_refresh_spawns_telemetry_actors_once_with_no_active_workers() -> None:
+@pytest.mark.parametrize("spawn_worker_collectors", [True, False])
+def test_open_or_refresh_starts_worker_collectors_once(
+    spawn_worker_collectors: bool,
+) -> None:
     handle = tc._TelemetryHandle("apply")
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
 
     def fake_bootstrap(config) -> None:
+        handle._client_actor = client_actor
         handle._dashboard_info = {
             "api_url": "http://api",
             "local_url": "http://local",
             "url": "http://ext",
         }
 
-    with (
-        patch.object(handle, "_bootstrap", side_effect=fake_bootstrap),
-        patch.object(handle, "_spawn_telemetry_actors", return_value=[]) as spawn,
-    ):
-        handle.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
-        handle.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
+    with patch.object(handle, "_bootstrap", side_effect=fake_bootstrap):
+        handle.open_or_refresh(
+            {"hosts": host_mesh},
+            _cfg_dict(),
+            spawn_worker_collectors,
+        )
+        handle.open_or_refresh(
+            {"hosts": host_mesh},
+            _cfg_dict(),
+            spawn_worker_collectors,
+        )
 
-    spawn.assert_called_once()
-    assert handle._worker_proc_meshes == []
+    client_actor.start_worker_collector.call_one.assert_called_once_with(
+        host_mesh,
+        spawn_worker_collectors,
+    )
+    client_actor.start_worker_collector.call_one.return_value.get.assert_called_once_with()
 
 
-def test_spawn_telemetry_actors_registers_workers_and_stops_on_shutdown() -> None:
-    """Spawning creates a collector mesh, registers it with the client
-    collector, retains it, and stops its proc mesh on shutdown."""
-    actor_mesh = MagicMock()
-    proc_mesh = MagicMock()
-    host_mesh = MagicMock()
+def test_shutdown_stops_worker_collectors() -> None:
     client_actor = MagicMock()
     handle = tc._TelemetryHandle("fanout_test")
     handle._client_actor = client_actor
 
-    proc_mesh.spawn.return_value = actor_mesh
-    host_mesh.spawn_procs.return_value = proc_mesh
-    actor_mesh.activate.call.return_value.get.return_value = [(0, True)]
-
-    worker_proc_meshes = handle._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
-    )
-
-    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
-    proc_mesh.spawn.assert_called_once_with(
-        "TelemetryActor",
-        tc.TelemetryActor,
-        "fanout_test",
-        0,
-    )
-    actor_mesh.activate.call.return_value.get.assert_called_once_with()
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with(
-        [actor_mesh]
-    )
-    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
-
-    assert worker_proc_meshes == [proc_mesh]
-    handle._worker_proc_meshes = worker_proc_meshes
     with patch.object(tc, "shutdown_context") as shutdown_context:
         handle.shutdown()
-    proc_mesh.stop.assert_called_once_with("telemetry shutdown")
-    proc_mesh.stop.return_value.get.assert_called_once_with()
+    client_actor.stop_worker_collectors.call_one.assert_called_once_with()
+    client_actor.stop_worker_collectors.call_one.return_value.get.assert_called_once_with(
+        timeout=5.0
+    )
     shutdown_context.return_value.get.assert_called_once_with(timeout=5.0)
 
 
-def test_spawn_telemetry_actors_can_skip_worker_collectors() -> None:
-    proc_mesh = MagicMock()
-    host_mesh = MagicMock()
-    client_actor = MagicMock()
-    handle = tc._TelemetryHandle("fanout_test")
-    handle._client_actor = client_actor
-
-    host_mesh.spawn_procs.return_value = proc_mesh
-
-    worker_proc_meshes = handle._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
-        spawn_worker_collectors=False,
-    )
-
-    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
-    proc_mesh.spawn.assert_not_called()
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
-    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
-    assert worker_proc_meshes == [proc_mesh]
-
-
-def test_spawn_telemetry_actors_drops_inactive_worker_collectors() -> None:
+def test_start_worker_collector_drops_inactive_actor() -> None:
     actor_mesh = MagicMock()
     proc_mesh = MagicMock()
     host_mesh = MagicMock()
-    client_actor = MagicMock()
-    handle = tc._TelemetryHandle("fanout_test")
-    handle._client_actor = client_actor
+    telemetry_actor = tc.TelemetryActor("fanout_test", 0)
 
     proc_mesh.spawn.return_value = actor_mesh
     host_mesh.spawn_procs.return_value = proc_mesh
     actor_mesh.activate.call.return_value.get.return_value = [(0, False)]
 
-    worker_proc_meshes = handle._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
+    worker_collector_mesh = telemetry_actor._start_worker_collector(
+        host_mesh,
     )
 
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
-    assert worker_proc_meshes == [proc_mesh]
+    assert worker_collector_mesh is None
+    assert telemetry_actor._worker_proc_meshes == [proc_mesh]
     actor_mesh.stop.assert_called_once_with("telemetry collector inactive")
-    actor_mesh.stop.return_value.get.assert_called_once_with()
+    actor_mesh.stop.return_value.get.assert_called_once_with(timeout=5.0)
 
 
-def test_spawn_telemetry_actors_noops_when_setup_raises() -> None:
+def test_start_worker_collector_retains_active_actor() -> None:
+    actor_mesh = MagicMock()
+    proc_mesh = MagicMock()
     host_mesh = MagicMock()
+    telemetry_actor = tc.TelemetryActor("fanout_test", 0)
+
+    proc_mesh.spawn.return_value = actor_mesh
+    host_mesh.spawn_procs.return_value = proc_mesh
+    actor_mesh.activate.call.return_value.get.return_value = [(0, True)]
+
+    assert telemetry_actor._start_worker_collector(host_mesh) is actor_mesh
+    assert telemetry_actor._worker_proc_meshes == [proc_mesh]
+    assert telemetry_actor._worker_collector_meshes == [actor_mesh]
+
+
+def test_open_or_refresh_continues_after_worker_setup_failure() -> None:
+    failed_host_mesh = MagicMock()
+    healthy_host_mesh = MagicMock()
     client_actor = MagicMock()
     handle = tc._TelemetryHandle("fanout_test")
-    handle._client_actor = client_actor
 
-    host_mesh.spawn_procs.side_effect = RuntimeError("boom")
+    def fake_bootstrap(config) -> None:
+        handle._client_actor = client_actor
+        handle._dashboard_info = {
+            "api_url": "http://api",
+            "local_url": "http://local",
+            "url": "http://ext",
+        }
 
-    worker_proc_meshes = handle._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
+    client_actor.start_worker_collector.call_one.return_value.get.side_effect = (
+        RuntimeError("boom"),
+        None,
     )
 
-    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
-    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
-    assert worker_proc_meshes == []
+    with patch.object(handle, "_bootstrap", side_effect=fake_bootstrap):
+        handle.open_or_refresh(
+            {
+                "failed": failed_host_mesh,
+                "healthy": healthy_host_mesh,
+            },
+            _cfg_dict(),
+        )
+
+    assert client_actor.start_worker_collector.call_one.call_args_list == [
+        call(failed_host_mesh, True),
+        call(healthy_host_mesh, True),
+    ]
+    assert client_actor.start_worker_collector.call_one.return_value.get.call_count == 2
 
 
 @pytest.mark.parametrize("failure_point", ["spawn", "activate"])
-def test_spawn_telemetry_actors_stops_partially_started_proc_mesh(
+def test_start_worker_collector_stops_partially_started_proc_mesh(
     failure_point: str,
 ) -> None:
     actor_mesh = MagicMock()
     proc_mesh = MagicMock()
     host_mesh = MagicMock()
-    client_actor = MagicMock()
-    sidecar = tc._TelemetryHandle("fanout_test")
-    sidecar._client_actor = client_actor
+    telemetry_actor = tc.TelemetryActor("fanout_test", 0)
 
     host_mesh.spawn_procs.return_value = proc_mesh
     if failure_point == "spawn":
@@ -386,23 +353,14 @@ def test_spawn_telemetry_actors_stops_partially_started_proc_mesh(
             "activate boom"
         )
 
-    worker_proc_meshes = sidecar._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
-    )
+    with pytest.raises(RuntimeError):
+        telemetry_actor._start_worker_collector(
+            host_mesh,
+        )
 
     host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
-    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
-    assert worker_proc_meshes == []
     proc_mesh.stop.assert_called_once_with("telemetry collector startup failed")
-    proc_mesh.stop.return_value.get.assert_called_once_with()
+    proc_mesh.stop.return_value.get.assert_called_once_with(timeout=5.0)
 
 
 def test_ensure_open_requires_apply_id() -> None:


### PR DESCRIPTION
Summary:

Move worker telemetry process and collector creation from `_TelemetryHandle` into the query-root `TelemetryActor`, making the actor the owner of the meshes it fans queries out to. Delegate worker startup and shutdown through actor endpoints while preserving the existing failure propagation and best-effort query behavior.

Reviewed By: zdevito

Differential Revision: D113092448


