### PR TITLE
Keep telemetry query root alive after worker failures (#4476)

### DIFF
--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -38,7 +38,7 @@ from monarch._rust_bindings.monarch_extension.snapshot_integration import (
     _pre_register_snapshot_schemas,
 )
 from monarch._rust_bindings.monarch_hyperactor.mailbox import PortId
-from monarch.actor import Actor, current_rank, endpoint
+from monarch.actor import Actor, current_rank, endpoint, HostMesh, ProcMesh
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -70,9 +70,9 @@ class TelemetryActor(Actor):
         # the host-local socket namespace.
         self._scanner: DatabaseScanner | None = None
         # Worker actor meshes this collector fans queries out to. Empty for
-        # leaf collectors; the query-root collector receives its list via
-        # `set_worker_collector_meshes` once the worker meshes exist.
+        # leaf collectors; the query-root collector owns the worker meshes.
         self._worker_collector_meshes: list[Any] = []
+        self._worker_proc_meshes: list[ProcMesh] = []
 
     def _scanner_or_raise(self) -> DatabaseScanner:
         scanner = self._scanner
@@ -116,10 +116,71 @@ class TelemetryActor(Actor):
         return self._activate_impl()
 
     @endpoint
-    def set_worker_collector_meshes(self, worker_collector_meshes: List[Any]) -> None:
-        """Replace the client collector's worker mesh list."""
+    def start_worker_collector(
+        self,
+        host_mesh: HostMesh,
+        spawn_worker_collector: bool = True,
+    ) -> None:
+        """Start and register the telemetry collector for a worker host mesh."""
         self._scanner_or_raise()
-        self._worker_collector_meshes = list(worker_collector_meshes)
+        self._start_worker_collector(
+            host_mesh,
+            spawn_worker_collector,
+        )
+
+    def _start_worker_collector(
+        self,
+        host_mesh: HostMesh,
+        spawn_worker_collector: bool = True,
+    ) -> Any | None:
+        proc_mesh = host_mesh.spawn_procs(name="telemetry_hosts")
+        if not spawn_worker_collector:
+            self._worker_proc_meshes.append(proc_mesh)
+            return None
+
+        try:
+            worker_collector_mesh: Any = proc_mesh.spawn(
+                "TelemetryActor",
+                TelemetryActor,
+                self._apply_id,
+                self._retention_secs,
+            )
+            active = any(
+                active for _rank, active in worker_collector_mesh.activate.call().get()
+            )
+        except Exception:
+            self._stop_worker_mesh(
+                proc_mesh,
+                "telemetry collector startup failed",
+            )
+            raise
+
+        self._worker_proc_meshes.append(proc_mesh)
+        if active:
+            self._worker_collector_meshes.append(worker_collector_mesh)
+            return worker_collector_mesh
+
+        self._stop_worker_mesh(
+            worker_collector_mesh,
+            "telemetry collector inactive",
+        )
+        return None
+
+    @endpoint
+    def stop_worker_collectors(self) -> None:
+        for proc_mesh in self._worker_proc_meshes:
+            self._stop_worker_mesh(
+                proc_mesh,
+                "telemetry shutdown",
+            )
+        self._worker_proc_meshes.clear()
+        self._worker_collector_meshes.clear()
+
+    def _stop_worker_mesh(self, mesh: Any, reason: str) -> None:
+        try:
+            mesh.stop(reason).get(timeout=5.0)
+        except Exception:
+            logger.info("failed to stop telemetry mesh: %s", reason, exc_info=True)
 
     @endpoint
     def table_names(self) -> List[str]:
@@ -173,9 +234,9 @@ class TelemetryActor(Actor):
         child_futures = []
         for collector_mesh in self._worker_collector_meshes:
             try:
-                # Constructing the call can fail if the sidecar holds a stale
-                # actor ref. Treat that as reduced result coverage, matching
-                # the legacy best-effort query behavior.
+                # Constructing the call can fail if the actor ref is stale.
+                # Treat that as reduced result coverage, matching best-effort
+                # query behavior.
                 child_futures.append(
                     collector_mesh.scan.call(
                         dest, table_name, projection, limit, filter_expr

--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -37,7 +37,11 @@ from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner impor
 from monarch._rust_bindings.monarch_extension.snapshot_integration import (
     _pre_register_snapshot_schemas,
 )
-from monarch._rust_bindings.monarch_hyperactor.mailbox import PortId
+from monarch._rust_bindings.monarch_hyperactor.mailbox import (
+    PortId,
+    UndeliverableMessageEnvelope,
+)
+from monarch._rust_bindings.monarch_hyperactor.supervision import MeshFailure
 from monarch.actor import Actor, current_rank, endpoint, HostMesh, ProcMesh
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -69,9 +73,11 @@ class TelemetryActor(Actor):
         # means this actor has not activated as the single live collector for
         # the host-local socket namespace.
         self._scanner: DatabaseScanner | None = None
-        # Worker actor meshes this collector fans queries out to. Empty for
-        # leaf collectors; the query-root collector owns the worker meshes.
-        self._worker_collector_meshes: list[Any] = []
+        # Worker actor meshes this collector fans queries out to, keyed by
+        # mesh name (matching `MeshFailure.mesh_name`). Empty for leaf
+        # collectors; the query-root collector owns and tracks the worker
+        # meshes so their failures can be removed before later scans.
+        self._worker_collectors: dict[str, Any] = {}
         self._worker_proc_meshes: list[ProcMesh] = []
 
     def _scanner_or_raise(self) -> DatabaseScanner:
@@ -125,15 +131,21 @@ class TelemetryActor(Actor):
         self._scanner_or_raise()
         self._start_worker_collector(
             host_mesh,
+            TelemetryActor,
+            self._apply_id,
+            "telemetry_hosts",
             spawn_worker_collector,
         )
 
     def _start_worker_collector(
         self,
         host_mesh: HostMesh,
+        actor_class: type[TelemetryActor],
+        apply_id: str,
+        proc_name: str,
         spawn_worker_collector: bool = True,
     ) -> Any | None:
-        proc_mesh = host_mesh.spawn_procs(name="telemetry_hosts")
+        proc_mesh = host_mesh.spawn_procs(name=proc_name)
         if not spawn_worker_collector:
             self._worker_proc_meshes.append(proc_mesh)
             return None
@@ -141,8 +153,8 @@ class TelemetryActor(Actor):
         try:
             worker_collector_mesh: Any = proc_mesh.spawn(
                 "TelemetryActor",
-                TelemetryActor,
-                self._apply_id,
+                actor_class,
+                apply_id,
                 self._retention_secs,
             )
             active = any(
@@ -157,7 +169,8 @@ class TelemetryActor(Actor):
 
         self._worker_proc_meshes.append(proc_mesh)
         if active:
-            self._worker_collector_meshes.append(worker_collector_mesh)
+            mesh_name = worker_collector_mesh._name.get()
+            self._worker_collectors[mesh_name] = worker_collector_mesh
             return worker_collector_mesh
 
         self._stop_worker_mesh(
@@ -174,13 +187,24 @@ class TelemetryActor(Actor):
                 "telemetry shutdown",
             )
         self._worker_proc_meshes.clear()
-        self._worker_collector_meshes.clear()
+        self._worker_collectors.clear()
 
     def _stop_worker_mesh(self, mesh: Any, reason: str) -> None:
         try:
             mesh.stop(reason).get(timeout=5.0)
         except Exception:
             logger.info("failed to stop telemetry mesh: %s", reason, exc_info=True)
+
+    def _handle_undeliverable_message(
+        self, message: UndeliverableMessageEnvelope
+    ) -> bool:
+        logger.info("worker telemetry message was undeliverable, skipping: %s", message)
+        return True
+
+    def __supervise__(self, failure: MeshFailure) -> bool:
+        self._worker_collectors.pop(failure.mesh_name, None)
+        logger.warning("worker telemetry failure, skipping: %s", failure)
+        return True
 
     @endpoint
     def table_names(self) -> List[str]:
@@ -225,28 +249,32 @@ class TelemetryActor(Actor):
         """Scan the local store and configured worker collector meshes."""
         # The client collector is the singleton query root: scan its local store
         # first, then fan out flat to active worker collector meshes. Worker
-        # collectors have an empty `_worker_collector_meshes` list, so the same
+        # collectors have an empty `_worker_collectors` registry, so the same
         # endpoint is leaf-only when invoked on a worker.
         local_count: int = self._scanner_or_raise().scan(
             dest, table_name, projection, limit, filter_expr
         )
 
         child_futures = []
-        for collector_mesh in self._worker_collector_meshes:
+        for mesh_name, collector_mesh in tuple(self._worker_collectors.items()):
             try:
                 # Constructing the call can fail if the actor ref is stale.
                 # Treat that as reduced result coverage, matching best-effort
                 # query behavior.
                 child_futures.append(
-                    collector_mesh.scan.call(
-                        dest, table_name, projection, limit, filter_expr
+                    (
+                        mesh_name,
+                        collector_mesh.scan.call(
+                            dest, table_name, projection, limit, filter_expr
+                        ),
                     )
                 )
             except Exception:
                 logger.info("worker telemetry scan call failed, skipping")
+                self._worker_collectors.pop(mesh_name, None)
 
         total_count = local_count
-        for future in child_futures:
+        for mesh_name, future in child_futures:
             try:
                 # Worker collectors are independent leaves. A slow or failed
                 # worker should reduce query coverage, not fail the root query.
@@ -260,5 +288,6 @@ class TelemetryActor(Actor):
                 )
             except Exception:
                 logger.info("worker telemetry scan failed, skipping")
+                self._worker_collectors.pop(mesh_name, None)
 
         return total_count

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -57,7 +57,7 @@ from monarch._src.job.telemetry_actor import (
     telemetry_socket_path,
     TelemetryActor,
 )
-from monarch.actor import context, HostMesh, ProcMesh, shutdown_context
+from monarch.actor import context, HostMesh, shutdown_context
 from monarch.distributed_telemetry.engine import QueryEngine
 from monarch.monarch_dashboard.server.app import start_dashboard
 from monarch.monarch_dashboard.server.query_engine_adapter import QueryEngineAdapter
@@ -221,9 +221,7 @@ class _TelemetryHandle:
         self._client_actor: Any | None = None
         self._query_engine: QueryEngine | None = None
         self._dashboard_info: dict[str, object] | None = None
-        # None means worker fan-out has not run yet. An empty list means fan-out
-        # ran, but no worker collectors became active.
-        self._worker_proc_meshes: list[ProcMesh] | None = None
+        self._worker_collectors_started: bool = False
 
     @property
     def client_socket_path(self) -> str:
@@ -244,12 +242,12 @@ class _TelemetryHandle:
             # the in-memory telemetry store and re-bind the data socket.
             logger.warning("telemetry handle config drift ignored")
 
-        if host_meshes and self._worker_proc_meshes is None:
-            self._worker_proc_meshes = self._spawn_telemetry_actors(
+        if host_meshes and not self._worker_collectors_started:
+            self._spawn_telemetry_actors(
                 host_meshes,
-                parsed,
                 spawn_worker_collectors=spawn_worker_collectors,
             )
+            self._worker_collectors_started = True
 
         dashboard_info = self._dashboard_info
         if dashboard_info is None:
@@ -302,98 +300,33 @@ class _TelemetryHandle:
     def _spawn_telemetry_actors(
         self,
         host_meshes: Mapping[str, HostMesh],
-        config: TelemetryConfig,
         *,
         spawn_worker_collectors: bool = True,
-    ) -> list[ProcMesh]:
+    ) -> None:
         client_actor = self._client_actor
         if client_actor is None:
             raise RuntimeError("telemetry handle has no client actor")
 
-        worker_proc_meshes: list[ProcMesh] = []
-        worker_collector_meshes: list[Any] = []
         for host_mesh in host_meshes.values():
             try:
-                proc_mesh, worker_collector_mesh = (
-                    self._start_worker_telemetry_collector(
-                        host_mesh,
-                        config,
-                        spawn_worker_collector=spawn_worker_collectors,
-                    )
-                )
+                client_actor.start_worker_collector.call_one(
+                    host_mesh,
+                    spawn_worker_collectors,
+                ).get()
             except Exception:
                 logger.warning(
                     "failed to start worker telemetry collector",
                     exc_info=True,
                 )
-                continue
-            worker_proc_meshes.append(proc_mesh)
-            if worker_collector_mesh is not None:
-                worker_collector_meshes.append(worker_collector_mesh)
-
-        client_actor.set_worker_collector_meshes.call_one(worker_collector_meshes).get()
-        return worker_proc_meshes
-
-    def _start_worker_telemetry_collector(
-        self,
-        host_mesh: HostMesh,
-        config: TelemetryConfig,
-        *,
-        spawn_worker_collector: bool = True,
-    ) -> tuple[ProcMesh, Any | None]:
-        proc_mesh = host_mesh.spawn_procs(name="telemetry_hosts")
-        if not spawn_worker_collector:
-            return proc_mesh, None
-
-        try:
-            worker_collector_mesh = proc_mesh.spawn(
-                "TelemetryActor",
-                TelemetryActor,
-                self._apply_id,
-                config.retention_secs,
-            )
-            active = any(
-                active for _rank, active in worker_collector_mesh.activate.call().get()
-            )
-        except Exception:
-            self._stop_worker_mesh(
-                proc_mesh,
-                "telemetry collector startup failed",
-                "failed to stop failed telemetry worker proc mesh",
-            )
-            raise
-
-        if active:
-            return proc_mesh, worker_collector_mesh
-
-        # Only one live collector may own a host-local socket namespace. Keep
-        # the proc alive so mesh-admin snapshots can still resolve it, but stop
-        # the inactive actor so queries do not fan out to it.
-        self._stop_worker_mesh(
-            worker_collector_mesh,
-            "telemetry collector inactive",
-            "failed to stop inactive telemetry worker collector",
-        )
-        return proc_mesh, None
-
-    def _stop_worker_mesh(
-        self,
-        mesh: Any,
-        reason: str,
-        log_message: str,
-    ) -> None:
-        try:
-            mesh.stop(reason).get()
-        except Exception:
-            logger.info(log_message, exc_info=True)
 
     def shutdown(self) -> None:
-        for proc_mesh in self._worker_proc_meshes or []:
+        client_actor = self._client_actor
+        if client_actor is not None:
             try:
-                proc_mesh.stop("telemetry shutdown").get()
+                client_actor.stop_worker_collectors.call_one().get(timeout=5.0)
             except Exception:
                 logger.info(
-                    "failed to stop telemetry worker proc mesh",
+                    "failed to stop telemetry worker collectors",
                     exc_info=True,
                 )
         # Drain in-flight async work with a short cap. Beyond that, we

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -18,9 +18,11 @@ import uuid
 from typing import Any, cast
 
 import monarch._src.job.telemetry_actor as job_telemetry_actor
+import monarch.actor
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
+from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
 from monarch._src.actor.actor_mesh import Actor, ActorMesh
 from monarch._src.actor.endpoint import endpoint
 from monarch._src.actor.proc_mesh import (
@@ -30,6 +32,7 @@ from monarch._src.actor.proc_mesh import (
 )
 from monarch.actor import span
 from monarch.config import configured
+from monarch.distributed_telemetry.engine import QueryEngine
 from monarch.job import MeshAdminConfig, ProcessJob, TelemetryConfig
 from scoped_state import scoped_state
 
@@ -55,6 +58,46 @@ class SenderActor(Actor):
     def send_ping(self, target: WorkerActor) -> None:
         """Cast to the target actor mesh from within this actor."""
         target.ping.call().get()
+
+
+class _TelemetryActorFailure(BaseException):
+    pass
+
+
+class _CrashingTelemetryActor(job_telemetry_actor.TelemetryActor):
+    @endpoint
+    def crash(self) -> None:
+        raise _TelemetryActorFailure("intentional telemetry actor failure")
+
+
+class _FailureTestTelemetryRoot(job_telemetry_actor.TelemetryActor):
+    @endpoint
+    def start_failing_collector(self, host_mesh: Any, apply_id: str) -> Any:
+        failing = self._start_worker_collector(
+            host_mesh,
+            _CrashingTelemetryActor,
+            apply_id,
+            "telemetry_failure_procs",
+        )
+        if failing is None:
+            raise RuntimeError("failure test collector did not activate")
+        return failing
+
+    @endpoint
+    def start_healthy_collector(self, host_mesh: Any, apply_id: str) -> Any:
+        healthy = self._start_worker_collector(
+            host_mesh,
+            job_telemetry_actor.TelemetryActor,
+            apply_id,
+            "telemetry_healthy_procs",
+        )
+        if healthy is None:
+            raise RuntimeError("healthy test collector did not activate")
+        return healthy
+
+    @endpoint
+    def worker_collector_count(self) -> int:
+        return len(self._worker_collectors)
 
 
 def _telemetry_config(**kwargs: Any) -> TelemetryConfig:
@@ -119,6 +162,39 @@ def _remove_socket_dir(apply_id: str) -> None:
 def _ephemeral_mesh_admin_addr():
     with configured(mesh_admin_addr="[::]:0"):
         yield
+
+
+def _sample_pyspy_dump_json() -> str:
+    return json.dumps(
+        {
+            "Ok": {
+                "pid": 1234,
+                "binary": "python3",
+                "stack_traces": [
+                    {
+                        "pid": 1234,
+                        "thread_id": 1,
+                        "thread_name": "MainThread",
+                        "os_thread_id": 100,
+                        "active": True,
+                        "owns_gil": True,
+                        "frames": [
+                            {
+                                "name": "main",
+                                "filename": "app.py",
+                                "module": "app",
+                                "short_filename": "app.py",
+                                "line": 5,
+                                "locals": [],
+                                "is_entry": True,
+                            }
+                        ],
+                    }
+                ],
+                "warnings": [],
+            }
+        }
+    )
 
 
 @pytest.mark.timeout(30)
@@ -1260,6 +1336,107 @@ def test_sent_messages_sender_actor_id(cleanup_callbacks) -> None:
             assert sender_id not in target_actor_ids, (
                 f"sender_actor_id {sender_id} should NOT be a target actor"
             )
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_worker_telemetry_actor_failure_preserves_query_root() -> None:
+    apply_ids = {
+        "root": _new_apply_id(),
+        "failing": _new_apply_id(),
+    }
+    for apply_id in apply_ids.values():
+        _remove_socket_dir(apply_id)
+
+    try:
+        with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+            root = monarch.actor.context().actor_instance.proc_mesh.spawn(
+                "root_telemetry",
+                _FailureTestTelemetryRoot,
+                apply_ids["root"],
+                0,
+            )
+            assert root.activate.call_one().get()
+            failing = root.start_failing_collector.call_one(
+                state.hosts, apply_ids["failing"]
+            ).get()
+            assert root.worker_collector_count.call_one().get() == 1
+            query_engine = QueryEngine(root)
+            sql = "SELECT dump_id FROM pyspy_dumps"
+            assert query_engine.query(sql).num_rows == 0
+
+            with pytest.raises(SupervisionError):
+                failing.crash.call_one().get(timeout=30)
+
+            deadline = time.monotonic() + 30
+            worker_count = 1
+            while worker_count != 0 and time.monotonic() < deadline:
+                worker_count = root.worker_collector_count.call_one().get()
+                time.sleep(0.1)
+            assert worker_count == 0
+
+            assert query_engine.query(sql).num_rows == 0
+            assert "pyspy_dumps" in root.table_names.call_one().get(timeout=30)
+    finally:
+        for apply_id in apply_ids.values():
+            _remove_socket_dir(apply_id)
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
+def test_worker_telemetry_failure_preserves_other_workers() -> None:
+    apply_ids = {
+        "root": _new_apply_id(),
+        "healthy": _new_apply_id(),
+        "failing": _new_apply_id(),
+    }
+    for apply_id in apply_ids.values():
+        _remove_socket_dir(apply_id)
+
+    try:
+        with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+            root = monarch.actor.context().actor_instance.proc_mesh.spawn(
+                "root_telemetry",
+                _FailureTestTelemetryRoot,
+                apply_ids["root"],
+                0,
+            )
+            assert root.activate.call_one().get()
+
+            healthy = root.start_healthy_collector.call_one(
+                state.hosts, apply_ids["healthy"]
+            ).get()
+            failing = root.start_failing_collector.call_one(
+                state.hosts, apply_ids["failing"]
+            ).get()
+            assert root.worker_collector_count.call_one().get() == 2
+
+            # Seed a row in the healthy worker only, so a non-zero result proves
+            # the root actually fanned the scan out to it.
+            healthy.store_pyspy_dump.call_one(
+                "healthy-dump", "proc[0]", _sample_pyspy_dump_json()
+            ).get()
+
+            query_engine = QueryEngine(root)
+            sql = "SELECT dump_id FROM pyspy_dumps"
+            assert query_engine.query(sql).num_rows == 1
+
+            with pytest.raises(SupervisionError):
+                failing.crash.call_one().get(timeout=30)
+
+            deadline = time.monotonic() + 30
+            worker_count = 2
+            while worker_count != 1 and time.monotonic() < deadline:
+                worker_count = root.worker_collector_count.call_one().get()
+                time.sleep(0.1)
+            assert worker_count == 1
+
+            # Only the failed collector was pruned: the surviving healthy worker
+            # is still scanned and still contributes its row.
+            assert query_engine.query(sql).num_rows == 1
+    finally:
+        for apply_id in apply_ids.values():
+            _remove_socket_dir(apply_id)
 
 
 @pytest.mark.timeout(120)

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -18,7 +18,7 @@ import urllib.error
 import urllib.request
 import uuid
 from typing import cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import call, MagicMock, patch
 
 import monarch._src.job.job_sidecar as js
 import monarch._src.job.telemetry_config as tc
@@ -216,166 +216,133 @@ def test_open_or_refresh_raises_when_not_open() -> None:
             handle.open_or_refresh({}, _cfg_dict())
 
 
-def test_open_or_refresh_spawns_telemetry_actors_once_with_no_active_workers() -> None:
+@pytest.mark.parametrize("spawn_worker_collectors", [True, False])
+def test_open_or_refresh_starts_worker_collectors_once(
+    spawn_worker_collectors: bool,
+) -> None:
     handle = tc._TelemetryHandle("apply")
+    host_mesh = MagicMock()
+    client_actor = MagicMock()
 
     def fake_bootstrap(config) -> None:
+        handle._client_actor = client_actor
         handle._dashboard_info = {
             "api_url": "http://api",
             "local_url": "http://local",
             "url": "http://ext",
         }
 
-    with (
-        patch.object(handle, "_bootstrap", side_effect=fake_bootstrap),
-        patch.object(handle, "_spawn_telemetry_actors", return_value=[]) as spawn,
-    ):
-        handle.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
-        handle.open_or_refresh({"hosts": MagicMock()}, _cfg_dict())
+    with patch.object(handle, "_bootstrap", side_effect=fake_bootstrap):
+        handle.open_or_refresh(
+            {"hosts": host_mesh},
+            _cfg_dict(),
+            spawn_worker_collectors,
+        )
+        handle.open_or_refresh(
+            {"hosts": host_mesh},
+            _cfg_dict(),
+            spawn_worker_collectors,
+        )
 
-    spawn.assert_called_once()
-    assert handle._worker_proc_meshes == []
+    client_actor.start_worker_collector.call_one.assert_called_once_with(
+        host_mesh,
+        spawn_worker_collectors,
+    )
+    client_actor.start_worker_collector.call_one.return_value.get.assert_called_once_with()
 
 
-def test_spawn_telemetry_actors_registers_workers_and_stops_on_shutdown() -> None:
-    """Spawning creates a collector mesh, registers it with the client
-    collector, retains it, and stops its proc mesh on shutdown."""
-    actor_mesh = MagicMock()
-    proc_mesh = MagicMock()
-    host_mesh = MagicMock()
+def test_shutdown_stops_worker_collectors() -> None:
     client_actor = MagicMock()
     handle = tc._TelemetryHandle("fanout_test")
     handle._client_actor = client_actor
 
-    proc_mesh.spawn.return_value = actor_mesh
-    host_mesh.spawn_procs.return_value = proc_mesh
-    actor_mesh.activate.call.return_value.get.return_value = [(0, True)]
-
-    worker_proc_meshes = handle._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
-    )
-
-    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
-    proc_mesh.spawn.assert_called_once_with(
-        "TelemetryActor",
-        tc.TelemetryActor,
-        "fanout_test",
-        0,
-    )
-    actor_mesh.activate.call.return_value.get.assert_called_once_with()
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with(
-        [actor_mesh]
-    )
-    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
-
-    assert worker_proc_meshes == [proc_mesh]
-    handle._worker_proc_meshes = worker_proc_meshes
     with patch.object(tc, "shutdown_context") as shutdown_context:
         handle.shutdown()
-    proc_mesh.stop.assert_called_once_with("telemetry shutdown")
-    proc_mesh.stop.return_value.get.assert_called_once_with()
+    client_actor.stop_worker_collectors.call_one.assert_called_once_with()
+    client_actor.stop_worker_collectors.call_one.return_value.get.assert_called_once_with(
+        timeout=5.0
+    )
     shutdown_context.return_value.get.assert_called_once_with(timeout=5.0)
 
 
-def test_spawn_telemetry_actors_can_skip_worker_collectors() -> None:
-    proc_mesh = MagicMock()
-    host_mesh = MagicMock()
-    client_actor = MagicMock()
-    handle = tc._TelemetryHandle("fanout_test")
-    handle._client_actor = client_actor
-
-    host_mesh.spawn_procs.return_value = proc_mesh
-
-    worker_proc_meshes = handle._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
-        spawn_worker_collectors=False,
-    )
-
-    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
-    proc_mesh.spawn.assert_not_called()
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
-    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
-    assert worker_proc_meshes == [proc_mesh]
-
-
-def test_spawn_telemetry_actors_drops_inactive_worker_collectors() -> None:
+def test_start_worker_collector_drops_inactive_actor() -> None:
     actor_mesh = MagicMock()
     proc_mesh = MagicMock()
     host_mesh = MagicMock()
-    client_actor = MagicMock()
-    handle = tc._TelemetryHandle("fanout_test")
-    handle._client_actor = client_actor
+    telemetry_actor = tc.TelemetryActor("fanout_test", 0)
 
     proc_mesh.spawn.return_value = actor_mesh
     host_mesh.spawn_procs.return_value = proc_mesh
     actor_mesh.activate.call.return_value.get.return_value = [(0, False)]
 
-    worker_proc_meshes = handle._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
+    worker_collector_mesh = telemetry_actor._start_worker_collector(
+        host_mesh,
     )
 
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
-    assert worker_proc_meshes == [proc_mesh]
+    assert worker_collector_mesh is None
+    assert telemetry_actor._worker_proc_meshes == [proc_mesh]
     actor_mesh.stop.assert_called_once_with("telemetry collector inactive")
-    actor_mesh.stop.return_value.get.assert_called_once_with()
+    actor_mesh.stop.return_value.get.assert_called_once_with(timeout=5.0)
 
 
-def test_spawn_telemetry_actors_noops_when_setup_raises() -> None:
+def test_start_worker_collector_retains_active_actor() -> None:
+    actor_mesh = MagicMock()
+    proc_mesh = MagicMock()
     host_mesh = MagicMock()
+    telemetry_actor = tc.TelemetryActor("fanout_test", 0)
+
+    proc_mesh.spawn.return_value = actor_mesh
+    host_mesh.spawn_procs.return_value = proc_mesh
+    actor_mesh.activate.call.return_value.get.return_value = [(0, True)]
+
+    assert telemetry_actor._start_worker_collector(host_mesh) is actor_mesh
+    assert telemetry_actor._worker_proc_meshes == [proc_mesh]
+    assert telemetry_actor._worker_collector_meshes == [actor_mesh]
+
+
+def test_open_or_refresh_continues_after_worker_setup_failure() -> None:
+    failed_host_mesh = MagicMock()
+    healthy_host_mesh = MagicMock()
     client_actor = MagicMock()
     handle = tc._TelemetryHandle("fanout_test")
-    handle._client_actor = client_actor
 
-    host_mesh.spawn_procs.side_effect = RuntimeError("boom")
+    def fake_bootstrap(config) -> None:
+        handle._client_actor = client_actor
+        handle._dashboard_info = {
+            "api_url": "http://api",
+            "local_url": "http://local",
+            "url": "http://ext",
+        }
 
-    worker_proc_meshes = handle._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
+    client_actor.start_worker_collector.call_one.return_value.get.side_effect = (
+        RuntimeError("boom"),
+        None,
     )
 
-    host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
-    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
-    assert worker_proc_meshes == []
+    with patch.object(handle, "_bootstrap", side_effect=fake_bootstrap):
+        handle.open_or_refresh(
+            {
+                "failed": failed_host_mesh,
+                "healthy": healthy_host_mesh,
+            },
+            _cfg_dict(),
+        )
+
+    assert client_actor.start_worker_collector.call_one.call_args_list == [
+        call(failed_host_mesh, True),
+        call(healthy_host_mesh, True),
+    ]
+    assert client_actor.start_worker_collector.call_one.return_value.get.call_count == 2
 
 
 @pytest.mark.parametrize("failure_point", ["spawn", "activate"])
-def test_spawn_telemetry_actors_stops_partially_started_proc_mesh(
+def test_start_worker_collector_stops_partially_started_proc_mesh(
     failure_point: str,
 ) -> None:
     actor_mesh = MagicMock()
     proc_mesh = MagicMock()
     host_mesh = MagicMock()
-    client_actor = MagicMock()
-    sidecar = tc._TelemetryHandle("fanout_test")
-    sidecar._client_actor = client_actor
+    telemetry_actor = tc.TelemetryActor("fanout_test", 0)
 
     host_mesh.spawn_procs.return_value = proc_mesh
     if failure_point == "spawn":
@@ -386,23 +353,14 @@ def test_spawn_telemetry_actors_stops_partially_started_proc_mesh(
             "activate boom"
         )
 
-    worker_proc_meshes = sidecar._spawn_telemetry_actors(
-        {
-            "hosts": host_mesh,
-        },
-        TelemetryConfig(
-            retention_secs=0,
-            include_dashboard=False,
-            dashboard_port=0,
-        ),
-    )
+    with pytest.raises(RuntimeError):
+        telemetry_actor._start_worker_collector(
+            host_mesh,
+        )
 
     host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")
-    client_actor.set_worker_collector_meshes.call_one.assert_called_once_with([])
-    client_actor.set_worker_collector_meshes.call_one.return_value.get.assert_called_once_with()
-    assert worker_proc_meshes == []
     proc_mesh.stop.assert_called_once_with("telemetry collector startup failed")
-    proc_mesh.stop.return_value.get.assert_called_once_with()
+    proc_mesh.stop.return_value.get.assert_called_once_with(timeout=5.0)
 
 
 def test_ensure_open_requires_apply_id() -> None:

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -277,6 +277,9 @@ def test_start_worker_collector_drops_inactive_actor() -> None:
 
     worker_collector_mesh = telemetry_actor._start_worker_collector(
         host_mesh,
+        tc.TelemetryActor,
+        "fanout_test",
+        "telemetry_hosts",
     )
 
     assert worker_collector_mesh is None
@@ -294,10 +297,47 @@ def test_start_worker_collector_retains_active_actor() -> None:
     proc_mesh.spawn.return_value = actor_mesh
     host_mesh.spawn_procs.return_value = proc_mesh
     actor_mesh.activate.call.return_value.get.return_value = [(0, True)]
+    actor_mesh._name.get.return_value = "active"
 
-    assert telemetry_actor._start_worker_collector(host_mesh) is actor_mesh
+    assert (
+        telemetry_actor._start_worker_collector(
+            host_mesh,
+            tc.TelemetryActor,
+            "fanout_test",
+            "telemetry_hosts",
+        )
+        is actor_mesh
+    )
     assert telemetry_actor._worker_proc_meshes == [proc_mesh]
-    assert telemetry_actor._worker_collector_meshes == [actor_mesh]
+    assert telemetry_actor._worker_collectors == {"active": actor_mesh}
+    actor_mesh._name.get.assert_called_once_with()
+
+
+def test_telemetry_actor_supervision_prunes_only_matching_worker() -> None:
+    telemetry_actor = tc.TelemetryActor("fanout_test", 0)
+    failed = MagicMock()
+    healthy = MagicMock()
+    telemetry_actor._worker_collectors = {
+        "failed": failed,
+        "healthy": healthy,
+    }
+
+    failure = MagicMock(mesh_name="failed")
+    assert telemetry_actor.__supervise__(failure)
+    assert telemetry_actor._worker_collectors == {"healthy": healthy}
+
+    assert telemetry_actor.__supervise__(failure)
+    assert telemetry_actor.__supervise__(MagicMock(mesh_name="unknown"))
+    assert telemetry_actor._worker_collectors == {"healthy": healthy}
+
+
+def test_telemetry_actor_suppresses_undeliverable_worker_message() -> None:
+    telemetry_actor = tc.TelemetryActor("fanout_test", 0)
+
+    # A message the query root sent to a now-dead worker collector bounces back
+    # as undeliverable. Returning True suppresses escalation so the query root
+    # is not torn down.
+    assert telemetry_actor._handle_undeliverable_message(MagicMock())
 
 
 def test_open_or_refresh_continues_after_worker_setup_failure() -> None:
@@ -356,6 +396,9 @@ def test_start_worker_collector_stops_partially_started_proc_mesh(
     with pytest.raises(RuntimeError):
         telemetry_actor._start_worker_collector(
             host_mesh,
+            tc.TelemetryActor,
+            "fanout_test",
+            "telemetry_hosts",
         )
 
     host_mesh.spawn_procs.assert_called_once_with(name="telemetry_hosts")


### PR DESCRIPTION
Summary:

Handle failures from worker telemetry collectors inside the query-root `TelemetryActor` so one failed worker reduces query coverage instead of taking down telemetry queries. Track active collectors by stable mesh id, suppress undeliverable worker messages, and prune failed or unreachable collectors from future query fan-out.

Reviewed By: dulinriley

Differential Revision: D113092449


