### PR TITLE
Merge all telemetry to single entry point (#4477)

### DIFF
--- a/docs/source/monarch-dashboard.md
+++ b/docs/source/monarch-dashboard.md
@@ -124,8 +124,7 @@ from monarch.job import LocalJob, ProcessJob, KubernetesJob, SlurmJob, Telemetry
 # job = ...
 dashboard_port = 8265
 
-# Enable admin API and telemetry/dashboard as they work together.
-job.enable_admin()
+# Enable telemetry, mesh admin, snapshots, and the dashboard together.
 job.enable_telemetry(
     TelemetryConfig(include_dashboard=True, dashboard_port=dashboard_port)
 )

--- a/python/examples/airport_turnaround_demo.py
+++ b/python/examples/airport_turnaround_demo.py
@@ -260,7 +260,6 @@ class FlightActor(Actor):
 
 async def async_main(args: argparse.Namespace) -> None:
     job = ProcessJob({"hosts": 1})
-    job.enable_admin()
     if args.dashboard:
         job.enable_telemetry(
             TelemetryConfig(
@@ -268,6 +267,8 @@ async def async_main(args: argparse.Namespace) -> None:
                 dashboard_port=args.dashboard_port,
             )
         )
+    else:
+        job.enable_admin()
     state = job.state(cached_path=None)
     host = state.hosts
 

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -172,7 +172,6 @@ async def async_main(
     telemetry: bool = True,
 ) -> None:
     job = ProcessJob({"hosts": 1})
-    job.enable_admin()
     if telemetry:
         resolved_dashboard_port = dashboard_port
         if resolved_dashboard_port is None:
@@ -182,9 +181,10 @@ async def async_main(
             TelemetryConfig(
                 include_dashboard=dashboard,
                 dashboard_port=resolved_dashboard_port,
-                snapshot_interval_secs=30.0,
             )
         )
+    else:
+        job.enable_admin()
     try:
         state = job.state(cached_path=None)
         host = state.hosts

--- a/python/examples/execution_demo.py
+++ b/python/examples/execution_demo.py
@@ -127,7 +127,7 @@ async def async_main(args: argparse.Namespace) -> None:
     think_ms = (args.think_ms_min, args.think_ms_max)
     eat_ms = (args.eat_ms_min, args.eat_ms_max)
 
-    job = ProcessJob({"hosts": 1}).enable_admin()
+    job = ProcessJob({"hosts": 1}).enable_telemetry()
     loops = []
     try:
         state = job.state(cached_path=None)

--- a/python/examples/execution_workload.py
+++ b/python/examples/execution_workload.py
@@ -234,7 +234,7 @@ async def _hold_task(actor, id: str, entered_port: "Port[str]") -> None:
 
 
 async def async_main() -> None:
-    job = ProcessJob({"hosts": 1}).enable_admin()
+    job = ProcessJob({"hosts": 1}).enable_telemetry()
     # In-flight held invocations, tracked so they can be cancelled at
     # shutdown.
     holds: dict[str, asyncio.Task] = {}

--- a/python/examples/inbound_ordering_workload.py
+++ b/python/examples/inbound_ordering_workload.py
@@ -102,7 +102,7 @@ class Sender(Actor):
 
 
 async def async_main(args: argparse.Namespace) -> None:
-    job = ProcessJob({"hosts": 1}).enable_admin()
+    job = ProcessJob({"hosts": 1}).enable_telemetry()
     try:
         state = job.state(cached_path=None)
         host = state.hosts

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -83,13 +83,7 @@ class Worker(Actor):
 
 
 async def async_main(num_procs: int) -> None:
-    job = (
-        ProcessJob({"hosts": 1})
-        .enable_telemetry(
-            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
-        )
-        .enable_admin()
-    )
+    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(dashboard_port=0))
     try:
         state = job.state(cached_path=None)
         host = state.hosts

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -136,16 +136,7 @@ def parse_args() -> argparse.Namespace:
 async def async_main() -> None:
     args = parse_args()
 
-    job = (
-        ProcessJob({"hosts": 1})
-        .enable_telemetry(
-            TelemetryConfig(
-                dashboard_port=0,
-                snapshot_interval_secs=30.0,
-            )
-        )
-        .enable_admin()
-    )
+    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(dashboard_port=0))
     try:
         state = job.state(cached_path=None)
         host = state.hosts

--- a/python/examples/rapid_spawn_exit_stress.py
+++ b/python/examples/rapid_spawn_exit_stress.py
@@ -63,13 +63,7 @@ async def main():
     )
     args = parser.parse_args()
 
-    job = (
-        ProcessJob({"hosts": 1})
-        .enable_telemetry(
-            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
-        )
-        .enable_admin()
-    )
+    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(dashboard_port=0))
     try:
         job_state = job.state(cached_path=None)
         proc_mesh = job_state.hosts.spawn_procs(per_host={"gpus": 1})

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -57,13 +57,7 @@ MAX_SLEEP = 5.0
 
 
 async def async_main(num_procs: int) -> None:
-    job = (
-        ProcessJob({"hosts": 1})
-        .enable_telemetry(
-            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
-        )
-        .enable_admin()
-    )
+    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(dashboard_port=0))
     try:
         state = job.state(cached_path=None)
         host = state.hosts

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -44,13 +44,7 @@ class Worker(Actor):
 
 
 async def async_main(num_procs: int) -> None:
-    job = (
-        ProcessJob({"hosts": 1})
-        .enable_telemetry(
-            TelemetryConfig(dashboard_port=0, snapshot_interval_secs=30.0)
-        )
-        .enable_admin()
-    )
+    job = ProcessJob({"hosts": 1}).enable_telemetry(TelemetryConfig(dashboard_port=0))
     try:
         state = job.state(cached_path=None)
         host = state.hosts

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -422,20 +422,25 @@ class JobTrait(ABC):
     def enable_telemetry(
         self,
         config: "Optional[TelemetryConfig]" = None,
+        *,
+        mesh_admin_config: "Optional[MeshAdminConfig]" = None,
         **kwargs,
         # pyrefly: ignore [not-a-type]
     ) -> Self:
-        """Configure automatic telemetry startup on the next :meth:`state` call.
+        """Configure telemetry services on the next :meth:`state` call.
 
         Args:
             config: A :class:`TelemetryConfig` instance.  If omitted, one is
                 constructed from *kwargs* (forwarded to ``TelemetryConfig``).
+            mesh_admin_config: A :class:`MeshAdminConfig` instance. If omitted,
+                the default is configured unless mesh admin was already configured.
 
         Returns:
             ``self``, for chaining.
         """
         self._components.configure_telemetry(
-            config if config is not None else TelemetryConfig(**kwargs)
+            config if config is not None else TelemetryConfig(**kwargs),
+            mesh_admin_config=mesh_admin_config,
         )
         return self
 

--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -56,14 +56,14 @@ logger: logging.Logger = logging.getLogger(__name__)
 class MeshAdminConfig:
     """Configuration for automatic mesh admin agent startup.
 
-    When configured via ``JobTrait.enable_admin``, a MeshAdminAgent HTTP
-    server is spawned when ``state()`` is called. The server aggregates
-    topology across all host meshes and exposes it via a REST API that the
-    admin TUI can attach to.
+    When passed to ``JobTrait.enable_telemetry``, a MeshAdminAgent HTTP server
+    is spawned when ``state()`` is called. The server aggregates topology
+    across all host meshes and exposes it via a REST API that the admin TUI
+    can attach to.
 
     Args:
-        admin_addr: Bind address for the admin HTTP server.  When
-            ``None`` the server picks an available address automatically.
+        admin_addr: Bind address for the admin HTTP server. When ``None``, the
+            server uses the configured ``MESH_ADMIN_ADDR``.
     """
 
     admin_addr: Optional[str] = None
@@ -412,35 +412,50 @@ class JobComponents:
         for component in reversed(self._ordered()):
             component.reset_runtime()
 
-    def configure_telemetry(self, config: TelemetryConfig) -> None:
-        if self.telemetry is None:
-            self.telemetry = TelemetryComponent(config)
+    def configure_telemetry(
+        self,
+        config: TelemetryConfig,
+        mesh_admin_config: Optional[MeshAdminConfig] = None,
+    ) -> None:
+        """Configure telemetry and its mesh admin and snapshot dependencies."""
+        telemetry = self.telemetry
+        if telemetry is None:
+            telemetry = TelemetryComponent(config)
+            self.telemetry = telemetry
             telemetry_changed = True
         else:
-            telemetry_changed = self.telemetry._config != config
+            telemetry_changed = telemetry._config != config
             if telemetry_changed:
-                self.telemetry.reset_runtime()
-            self.telemetry._config = config
+                telemetry.reset_runtime()
+            telemetry._config = config
         if telemetry_changed:
             self._warn_if_snapshot_stale()
-        if self.admin is not None:
-            if telemetry_changed:
-                self.admin.reset_runtime()
-            # Admin config is unchanged here; only rewire its telemetry handle.
-            self.admin._telemetry = self.telemetry
-        self._configure_snapshot()
-
-    def configure_admin(self, config: MeshAdminConfig) -> None:
-        if self.admin is None:
-            self.admin = AdminComponent(config, self.telemetry)
-        else:
-            self._set_admin_inputs(config)
-        self._configure_snapshot()
-
-    def _set_admin_inputs(self, config: MeshAdminConfig) -> None:
         admin = self.admin
         if admin is None:
-            return
+            admin = AdminComponent(
+                mesh_admin_config
+                if mesh_admin_config is not None
+                else MeshAdminConfig(),
+                telemetry,
+            )
+            self.admin = admin
+        else:
+            if telemetry_changed:
+                admin.reset_runtime()
+            admin._telemetry = telemetry
+            if mesh_admin_config is not None:
+                self._set_admin_inputs(admin, mesh_admin_config)
+        if self.snapshot is None:
+            self.snapshot = SnapshotComponent(telemetry, admin)
+
+    def configure_admin(self, config: MeshAdminConfig) -> None:
+        admin = self.admin
+        if admin is None:
+            self.admin = AdminComponent(config, self.telemetry)
+        else:
+            self._set_admin_inputs(admin, config)
+
+    def _set_admin_inputs(self, admin: AdminComponent, config: MeshAdminConfig) -> None:
         if admin._config != config:
             admin.reset_runtime()
             self._warn_if_snapshot_stale()
@@ -463,13 +478,3 @@ class JobComponents:
                 "telemetry or admin config changed while periodic snapshots are running: "
                 "snapshots stay bound to the original runtime until the job is killed and re-applied"
             )
-
-    def _configure_snapshot(self) -> None:
-        if self.telemetry is not None and self.admin is not None:
-            if self.snapshot is None:
-                self.snapshot = SnapshotComponent(self.telemetry, self.admin)
-            else:
-                self.snapshot._telemetry = self.telemetry
-                self.snapshot._admin = self.admin
-        elif self.snapshot is not None:
-            self.snapshot = None

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -70,10 +70,11 @@ _startup_provider_registered: bool = False
 
 @dataclass
 class TelemetryConfig:
-    """Configuration for automatic telemetry startup.
+    """Configuration for automatic telemetry and snapshot startup.
 
-    When configured via ``JobTrait.enable_telemetry``, telemetry
-    (and optionally a dashboard) is started when ``state()`` is called.
+    When configured via ``JobTrait.enable_telemetry``, telemetry, mesh admin,
+    and optionally snapshots and a dashboard are started when ``state()`` is
+    called.
 
     Args:
         retention_secs: Retention window in seconds for message tables.
@@ -82,20 +83,14 @@ class TelemetryConfig:
         dashboard_port: Preferred port for the dashboard.
         snapshot_interval_secs: Interval in seconds between periodic mesh
             introspection snapshots. Snapshots capture the mesh topology
-            into the telemetry query surface. 0 disables periodic capture
-            (default). When ``include_dashboard`` is True and this is 0,
-            it is automatically set to 30s because the dashboard requires
-            snapshot data for system actor filtering.
+            into the telemetry query surface. The default is 30 seconds;
+            0 disables periodic capture.
     """
 
     retention_secs: int = 600
     include_dashboard: bool = False
     dashboard_port: int = 8265
-    snapshot_interval_secs: float = 0  # 0 = disabled
-
-    def __post_init__(self) -> None:
-        if self.include_dashboard and self.snapshot_interval_secs <= 0:
-            self.snapshot_interval_secs = 30.0
+    snapshot_interval_secs: float = 30.0
 
 
 # Successful response from the telemetry handle's `open_or_refresh` control message,

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -29,6 +29,7 @@ from monarch._src.actor.proc_mesh import (
     unregister_proc_mesh_spawn_callback,
 )
 from monarch.actor import span
+from monarch.config import configured
 from monarch.job import MeshAdminConfig, ProcessJob, TelemetryConfig
 from scoped_state import scoped_state
 
@@ -112,6 +113,12 @@ def _remove_socket_dir(apply_id: str) -> None:
     shutil.rmtree(
         job_telemetry_actor.telemetry_socket_dir(apply_id), ignore_errors=True
     )
+
+
+@pytest.fixture(autouse=True)
+def _ephemeral_mesh_admin_addr():
+    with configured(mesh_admin_addr="[::]:0"):
+        yield
 
 
 @pytest.mark.timeout(30)
@@ -1946,15 +1953,14 @@ def test_snapshot_periodic_capture_populates_tables(cleanup_callbacks) -> None:
     invariants in monarch_introspection_snapshot::integration.
     """
     with scoped_state(
-        ProcessJob({"hosts": 1})
-        .enable_telemetry(_sidecar_telemetry_config(snapshot_interval_secs=5))
-        .enable_admin(
-            MeshAdminConfig(
+        ProcessJob({"hosts": 1}).enable_telemetry(
+            _sidecar_telemetry_config(snapshot_interval_secs=5),
+            mesh_admin_config=MeshAdminConfig(
                 # Use an ephemeral admin port so concurrent --stress-runs
                 # replicas do not contend on the default fixed mesh-admin
                 # port.
                 admin_addr="[::]:0",
-            )
+            ),
         ),
         cached_path=None,
     ) as state:

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -658,7 +658,7 @@ def test_state_query_engine_none_without_telemetry():
 
 
 def test_state_query_client_set_with_telemetry():
-    """Test that the sidecar query client is set when telemetry is configured."""
+    """Test that telemetry configures the sidecar and mesh admin."""
     with _patched_sidecar() as m:
         job = MockJobTrait().enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)
@@ -666,6 +666,16 @@ def test_state_query_client_set_with_telemetry():
     assert state.query_engine is None
     assert state.query_engine_client is m.query_engine_client_cls.return_value
     assert state.telemetry_url == "http://sidecar"
+    assert state.admin_url == "http://localhost:1729"
+    assert job._components.snapshot is not None
+    _, kwargs = m.spawn_admin.call_args
+    assert kwargs["admin_addr"] is None
+    m.start_snapshots.assert_called_once_with(
+        base_url="http://sidecar",
+        admin_ref=m.admin_ref,
+        instance=m.snapshot_instance,
+        interval_secs=30.0,
+    )
 
 
 def test_component_configuration_after_apply_adds_telemetry():
@@ -924,104 +934,105 @@ def test_state_admin_url_none_without_mesh_admin():
     assert state.admin_url is None
 
 
-@patch("monarch._src.job.job_components._spawn_admin")
-def test_state_admin_url_set_with_mesh_admin(mock_spawn):
+def test_state_admin_url_set_with_telemetry():
     """Test that admin_url is available on the first state() call."""
-    mock_future = MagicMock()
-    mock_admin_ref = MagicMock()
-    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
-    mock_spawn.return_value = mock_future
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(TelemetryConfig())
+        state = job.state(cached_path=None)
 
-    job = MockJobTrait().enable_admin(MeshAdminConfig())
-    state = job.state(cached_path=None)
-
-    mock_spawn.assert_called_once()
+    m.spawn_admin.assert_called_once()
     assert state.admin_url == "http://localhost:1729"
 
 
-@patch("monarch._src.job.job_components._spawn_admin")
-def test_mesh_admin_started_only_once(mock_spawn):
+def test_mesh_admin_started_only_once():
     """Test that mesh admin is not restarted on subsequent state() calls."""
-    mock_future = MagicMock()
-    mock_admin_ref = MagicMock()
-    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
-    mock_spawn.return_value = mock_future
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(TelemetryConfig())
+        job.state(cached_path=None)
+        job.state(cached_path=None)
 
-    job = MockJobTrait().enable_admin(MeshAdminConfig())
-    job.state(cached_path=None)
-    job.state(cached_path=None)
-
-    mock_spawn.assert_called_once()
+    m.spawn_admin.assert_called_once()
 
 
-@patch("monarch._src.job.job_components._spawn_admin")
-def test_mesh_admin_dropped_on_pickle(mock_spawn):
+def test_mesh_admin_dropped_on_pickle():
     """Test that admin_url is dropped during pickling and restored after."""
-    mock_future = MagicMock()
-    mock_admin_ref = MagicMock()
-    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
-    mock_spawn.return_value = mock_future
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(TelemetryConfig())
+        job.state(cached_path=None)
+        assert m.spawn_admin.call_count == 1
 
-    job = MockJobTrait().enable_admin(MeshAdminConfig())
-    job.state(cached_path=None)
-    assert mock_spawn.call_count == 1
+        # Serialize and deserialize — live handles should be dropped
+        loaded_job = job_loads(job.dumps())
+        assert loaded_job._components.admin is not None
 
-    # Serialize and deserialize — live handles should be dropped
-    loaded_job = job_loads(job.dumps())
-    assert loaded_job._components.admin is not None
+        # Getting state again should re-spawn admin
+        state = loaded_job.state(cached_path=None)
 
-    # Getting state again should re-spawn admin
-    state = loaded_job.state(cached_path=None)
-    assert mock_spawn.call_count == 2
+    assert m.spawn_admin.call_count == 2
     assert state.admin_url is not None
 
 
-@patch("monarch._src.job.job_components._spawn_admin")
-def test_mesh_admin_receives_custom_addr(mock_spawn):
+def test_mesh_admin_receives_custom_addr():
     """Test that MeshAdminConfig.admin_addr is forwarded to _spawn_admin."""
-    mock_future = MagicMock()
-    mock_admin_ref = MagicMock()
-    mock_future.get.return_value = ("http://myhost:9999", mock_admin_ref)
-    mock_spawn.return_value = mock_future
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(
+            TelemetryConfig(),
+            mesh_admin_config=MeshAdminConfig(admin_addr="myhost:9999"),
+        )
+        job.state(cached_path=None)
 
-    job = MockJobTrait().enable_admin(MeshAdminConfig(admin_addr="myhost:9999"))
-    job.state(cached_path=None)
-
-    _, kwargs = mock_spawn.call_args
+    _, kwargs = m.spawn_admin.call_args
     assert kwargs.get("admin_addr") == "myhost:9999"
 
 
-@patch("monarch._src.job.job_components._spawn_admin")
-def test_mesh_admin_receives_telemetry_url(mock_spawn):
-    """Test that admin links to telemetry when both are configured."""
-    mock_future = MagicMock()
-    mock_admin_ref = MagicMock()
-    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
-    mock_spawn.return_value = mock_future
+def test_enable_admin_remains_independent_of_telemetry():
+    config = MeshAdminConfig(admin_addr="myhost:9999")
+    job = MockJobTrait()
 
-    with _patched_sidecar():
-        job = (
-            MockJobTrait()
-            .enable_telemetry(TelemetryConfig())
-            .enable_admin(MeshAdminConfig())
-        )
+    result = job.enable_admin(config)
+
+    assert result is job
+    assert job._components.telemetry is None
+    assert job._components.snapshot is None
+    assert job._components.admin is not None
+    assert job._components.admin._config is config
+
+
+def test_enable_telemetry_reuses_existing_mesh_admin():
+    config = MeshAdminConfig(admin_addr="myhost:9999")
+    job = MockJobTrait().enable_admin(config)
+    admin = job._components.admin
+
+    job.enable_telemetry(TelemetryConfig())
+
+    assert admin is not None
+    assert job._components.admin is admin
+    assert admin._config is config
+    assert admin._telemetry is job._components.telemetry
+    assert job._components.snapshot is not None
+    assert job._components.snapshot._admin is admin
+    assert job._components.snapshot._telemetry is job._components.telemetry
+
+
+def test_mesh_admin_receives_telemetry_url():
+    """Test that admin links to telemetry when both are configured."""
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)
 
-    _, kwargs = mock_spawn.call_args
+    _, kwargs = m.spawn_admin.call_args
     assert kwargs.get("telemetry_url") == "http://sidecar"
     assert state.telemetry_url == "http://sidecar"
     assert state.admin_url == "http://localhost:1729"
 
 
-@patch("monarch._src.job.job_components._spawn_admin")
-def test_mesh_admin_restarts_when_telemetry_config_changes(mock_spawn):
+def test_mesh_admin_restarts_when_telemetry_config_changes():
     mock_future = MagicMock()
     mock_admin_ref = MagicMock()
     mock_future.get.side_effect = [
         ("http://admin-one", mock_admin_ref),
         ("http://admin-two", mock_admin_ref),
     ]
-    mock_spawn.return_value = mock_future
     telemetry_one = {
         "telemetry_url": "http://telemetry-one",
         "dashboard_url": "http://dashboard-one",
@@ -1040,12 +1051,9 @@ def test_mesh_admin_restarts_when_telemetry_config_changes(mock_spawn):
             telemetry_two,
             telemetry_two,
         ]
-    ):
-        job = (
-            MockJobTrait()
-            .enable_telemetry(TelemetryConfig(retention_secs=1))
-            .enable_admin(MeshAdminConfig())
-        )
+    ) as m:
+        m.spawn_admin.return_value = mock_future
+        job = MockJobTrait().enable_telemetry(TelemetryConfig(retention_secs=1))
         state = job.state(cached_path=None)
         assert state.telemetry_url == "http://telemetry-one"
         assert state.admin_url == "http://admin-one"
@@ -1055,60 +1063,42 @@ def test_mesh_admin_restarts_when_telemetry_config_changes(mock_spawn):
 
     assert state.telemetry_url == "http://telemetry-two"
     assert state.admin_url == "http://admin-two"
-    assert mock_spawn.call_count == 2
-    assert [call.kwargs["telemetry_url"] for call in mock_spawn.call_args_list] == [
+    assert m.spawn_admin.call_count == 2
+    assert [call.kwargs["telemetry_url"] for call in m.spawn_admin.call_args_list] == [
         "http://telemetry-one",
         "http://telemetry-two",
     ]
 
 
-@patch(
-    "monarch._rust_bindings.monarch_extension.snapshot_integration._start_periodic_snapshots_http"
-)
-@patch("monarch.actor.context")
-@patch("monarch._src.job.job_components._spawn_admin")
-def test_snapshot_component_starts_once_after_telemetry_and_admin(
-    mock_spawn,
-    mock_context,
-    mock_start_snapshots,
-):
-    mock_admin_ref = MagicMock()
-    mock_instance = MagicMock()
-    mock_future = MagicMock()
-    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
-    mock_spawn.return_value = mock_future
-    mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
-
-    with _patched_sidecar():
-        job = (
-            MockJobTrait()
-            .enable_telemetry(TelemetryConfig(snapshot_interval_secs=5.0))
-            .enable_admin(MeshAdminConfig())
+def test_snapshot_component_starts_once_after_telemetry_and_admin():
+    with _patched_sidecar() as m:
+        job = MockJobTrait().enable_telemetry(
+            TelemetryConfig(snapshot_interval_secs=5.0)
         )
         job.state(cached_path=None)
         job.state(cached_path=None)
 
-    mock_start_snapshots.assert_called_once_with(
+    m.start_snapshots.assert_called_once_with(
         base_url="http://sidecar",
-        admin_ref=mock_admin_ref,
-        instance=mock_instance,
+        admin_ref=m.admin_ref,
+        instance=m.snapshot_instance,
         interval_secs=5.0,
     )
 
 
-@patch("monarch._src.job.job_components._spawn_admin")
-def test_batch_job_shares_component_runtime_with_wrapped_job(mock_spawn):
-    mock_future = MagicMock()
-    mock_admin_ref = MagicMock()
-    mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
-    mock_spawn.return_value = mock_future
-
+def test_snapshot_component_can_be_disabled():
     with _patched_sidecar() as m:
-        job = (
-            MockJobTrait(host_names=["hosts"])
-            .enable_telemetry(TelemetryConfig())
-            .enable_admin(MeshAdminConfig())
+        job = MockJobTrait().enable_telemetry(
+            TelemetryConfig(include_dashboard=True, snapshot_interval_secs=0)
         )
+        job.state(cached_path=None)
+
+    m.start_snapshots.assert_not_called()
+
+
+def test_batch_job_shares_component_runtime_with_wrapped_job():
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         batch = BatchJob(job)
         batch_state = batch.state(cached_path=None)
         job_state = job.state(cached_path=None)
@@ -1121,7 +1111,7 @@ def test_batch_job_shares_component_runtime_with_wrapped_job(mock_spawn):
     assert job_state.query_engine_client is m.query_engine_client_cls.return_value
     assert job_state.telemetry_url == "http://sidecar"
     assert job_state.admin_url == "http://localhost:1729"
-    mock_spawn.assert_called_once()
+    m.spawn_admin.assert_called_once()
 
 
 @contextlib.contextmanager
@@ -1132,6 +1122,11 @@ def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
             "monarch._src.job.job_components.install_sidecar_socket_sink"
         ) as install_sink,
         patch("monarch._src.job.job_components.QueryEngineClient") as qec_cls,
+        patch("monarch._src.job.job_components._spawn_admin") as spawn_admin,
+        patch("monarch.actor.context") as actor_context,
+        patch(
+            "monarch._rust_bindings.monarch_extension.snapshot_integration._start_periodic_snapshots_http"
+        ) as start_snapshots,
     ):
         ensure_open = telemetry_cls.return_value.ensure_open
         if ensure_open_side_effect is not None:
@@ -1142,33 +1137,33 @@ def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
                 "dashboard_url": "http://dashboard",
                 "socket_path": "/tmp/telemetry.sock",
             }
+        admin_ref = MagicMock()
+        admin_future = MagicMock()
+        admin_future.get.return_value = ("http://localhost:1729", admin_ref)
+        spawn_admin.return_value = admin_future
+        snapshot_instance = MagicMock()
+        actor_context.return_value.actor_instance._as_rust.return_value = (
+            snapshot_instance
+        )
         yield types.SimpleNamespace(
             ensure_open=ensure_open,
             install_sink=install_sink,
             query_engine_client_cls=qec_cls,
             telemetry_cls=telemetry_cls,
+            spawn_admin=spawn_admin,
+            admin_ref=admin_ref,
+            start_snapshots=start_snapshots,
+            snapshot_instance=snapshot_instance,
         )
 
 
 def test_mesh_admin_receives_sidecar_telemetry_url():
     """Admin links to sidecar telemetry when the sidecar path is configured."""
-    with (
-        _patched_sidecar(),
-        patch("monarch._src.job.job_components._spawn_admin") as mock_spawn,
-    ):
-        mock_future = MagicMock()
-        mock_admin_ref = MagicMock()
-        mock_future.get.return_value = ("http://localhost:1729", mock_admin_ref)
-        mock_spawn.return_value = mock_future
-
-        job = (
-            MockJobTrait(host_names=["hosts"])
-            .enable_telemetry(TelemetryConfig())
-            .enable_admin(MeshAdminConfig())
-        )
+    with _patched_sidecar() as m:
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
         state = job.state(cached_path=None)
 
-    _, kwargs = mock_spawn.call_args
+    _, kwargs = m.spawn_admin.call_args
     assert kwargs.get("telemetry_url") == "http://sidecar"
     assert state.telemetry_url == "http://sidecar"
     assert state.admin_url == "http://localhost:1729"


### PR DESCRIPTION
Summary:

Telemetry is most useful when all telemetry, mesh-admin, and snapshot are enabled. Make `enable_telemetry` single entry point and mark the others as deprecated. This will be one step closer to always-on telemetry.

Reviewed By: shayne-fletcher

Differential Revision: D113113549


