### PR TITLE
short-circuit Send/Sync recursion to speed compiles

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,6 +2,11 @@
 rustflags = [
     "--cfg",
     "tracing_unstable",
+    # Declare the opt-in verification cfg used by hyperactor's Send/Sync
+    # shortcuts (see hyperactor/src/proc.rs) so it is not flagged as an
+    # unexpected cfg in ordinary builds.
+    "--check-cfg",
+    "cfg(hyperactor_verify_auto_traits)",
     # Mirror fbsource-common.bcfg [rust] allow_lints so `cargo clippy`
     # surfaces the same lint set as `arc rust-clippy`. Lints re-enabled
     # in monarch's PACKAGE via `-W` are intentionally omitted from this

--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -76,7 +76,10 @@ jobs:
             setup_cuda_toolkit
         fi
 
-        cargo install --path monarch_hyperactor
+        # CI disables the Send/Sync shortcut impls so rustc verifies the
+        # underlying auto-trait bounds structurally.
+        RUSTFLAGS="${RUSTFLAGS:-} --cfg hyperactor_verify_auto_traits" \
+          cargo install --path monarch_hyperactor
 
         # Build dashboard frontend (if Node.js is available)
         FRONTEND_DIR="python/monarch/monarch_dashboard/frontend"

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -80,7 +80,11 @@ jobs:
         uv run --frozen --python 3.11 --no-sync --project . bash ./scripts/build_monarch_for_docs.sh
 
         # Generate documentation for all workspace crates
-        uv run --frozen --python 3.11 --no-sync --project . cargo doc --workspace --no-deps
+        # CI disables the Send/Sync shortcut impls so rustc verifies the
+        # underlying auto-trait bounds structurally.
+        uv run --frozen --python 3.11 --no-sync --project . \
+          cargo --config 'build.rustflags=["--cfg", "hyperactor_verify_auto_traits"]' \
+          doc --workspace --no-deps
 
         # Prepare documentation structure for Sphinx and final output
         mkdir -p docs/source/target

--- a/.github/workflows/test-cpu-rust-macos.yml
+++ b/.github/workflows/test-cpu-rust-macos.yml
@@ -52,7 +52,9 @@ jobs:
       - name: Run macOS CPU Rust tests
         shell: bash
         env:
-          RUSTFLAGS: --cfg tracing_unstable
+          # CI disables the Send/Sync shortcut impls so rustc verifies the
+          # underlying auto-trait bounds structurally.
+          RUSTFLAGS: --cfg tracing_unstable --cfg hyperactor_verify_auto_traits
         run: |
           set -eux
           cargo nextest run --workspace --profile ci \

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -62,7 +62,11 @@ jobs:
         # uploaded). Exclude crates that require GPU hardware, CUDA libraries,
         # or torch C++ headers (libtorch) not available on CPU-only runners.
         rc=0
-        CARGO_BUILD_JOBS=${{ matrix.cargo-jobs }} cargo nextest run --workspace --profile ci \
+        # CI disables the Send/Sync shortcut impls so rustc verifies the
+        # underlying auto-trait bounds structurally.
+        CARGO_BUILD_JOBS=${{ matrix.cargo-jobs }} \
+          RUSTFLAGS="${RUSTFLAGS:-} --cfg hyperactor_verify_auto_traits" \
+          cargo nextest run --workspace --profile ci \
           -E "$(cat .config/nextest-filter.txt)" \
           --exclude monarch_messages \
           --exclude monarch_tensor_worker \

--- a/.github/workflows/test-gpu-rust.yml
+++ b/.github/workflows/test-gpu-rust.yml
@@ -70,7 +70,10 @@ jobs:
         # failure (otherwise set -e would exit before any artifacts are
         # uploaded).
         rc=0
-        cargo nextest run --workspace --profile ci \
+        # CI disables the Send/Sync shortcut impls so rustc verifies the
+        # underlying auto-trait bounds structurally.
+        RUSTFLAGS="${RUSTFLAGS:-} --cfg hyperactor_verify_auto_traits" \
+          cargo nextest run --workspace --profile ci \
           -E "$(cat .config/nextest-filter.txt)" \
           --exclude monarch_messages \
           --exclude monarch_tensor_worker \

--- a/hyperactor/src/gateway.rs
+++ b/hyperactor/src/gateway.rs
@@ -249,6 +249,23 @@ pub struct Gateway {
     inner: Arc<GatewayState>,
 }
 
+// This explicit impl is only a compiler performance optimization. It is safe
+// to delete this module and cfg and let Rust derive the auto traits; see proc.rs.
+#[cfg(not(hyperactor_verify_auto_traits))]
+mod _send_sync_shortcut {
+    use super::*;
+
+    // SAFETY: the verification build structurally checks this bound.
+    unsafe impl Send for GatewayState {}
+    // SAFETY: the verification build structurally checks this bound.
+    unsafe impl Sync for GatewayState {}
+}
+
+const _: fn() = || {
+    fn assert<T: Send + Sync + ?Sized>() {}
+    assert::<GatewayState>();
+};
+
 /// Handle returned by [`Gateway::attach_proc`] that detaches the proc
 /// (removing its local-delivery registration) when dropped. This is the
 /// sole remover of the entry; it runs from `ProcState::drop`, so by the

--- a/hyperactor/src/mailbox.rs
+++ b/hyperactor/src/mailbox.rs
@@ -1730,6 +1730,23 @@ pub struct Mailbox {
     inner: Arc<State>,
 }
 
+// This explicit impl is only a compiler performance optimization. It is safe
+// to delete this module and cfg and let Rust derive the auto traits; see proc.rs.
+#[cfg(not(hyperactor_verify_auto_traits))]
+mod _send_sync_shortcut {
+    use super::*;
+
+    // SAFETY: the verification build structurally checks this bound.
+    unsafe impl Send for Mailbox {}
+    // SAFETY: the verification build structurally checks this bound.
+    unsafe impl Sync for Mailbox {}
+}
+
+const _: fn() = || {
+    fn assert<T: Send + Sync + ?Sized>() {}
+    assert::<Mailbox>();
+};
+
 impl Mailbox {
     /// Create a mailbox associated with the provided actor ID.
     pub fn new(actor_id: impl Into<ActorAddr>) -> Self {

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -398,6 +398,38 @@ pub struct Proc {
     inner: Arc<ProcState>,
 }
 
+// Pre-assert `Send`/`Sync` on the concrete state types that own the deep
+// `dashmap`/`RwLock` towers. This makes rustc's auto-trait checker match a
+// one-step impl instead of structurally recursing those towers at every
+// monomorphization, which dominates downstream compile time (cuts
+// hyperactor_mesh's `evaluate_obligation` by ~88%).
+// This is only a compiler performance optimization. It is safe to delete the
+// explicit impls and cfg and let Rust derive the auto traits structurally.
+//
+// SAFETY: these types hold only `Send + Sync` data; the auto-derived bound
+// already held before these impls were added. The `hyperactor_verify_auto_traits`
+// cfg build used by CI drops these impls and forces the compiler to re-derive the
+// bound structurally, so any future non-`Send`/`Sync` field is caught there.
+#[cfg(not(hyperactor_verify_auto_traits))]
+mod _send_sync_shortcut {
+    use super::*;
+
+    // SAFETY: the verification build structurally checks this bound.
+    unsafe impl Send for ProcState {}
+    // SAFETY: the verification build structurally checks this bound.
+    unsafe impl Sync for ProcState {}
+    // SAFETY: the verification build structurally checks this bound.
+    unsafe impl Send for InstanceCellState {}
+    // SAFETY: the verification build structurally checks this bound.
+    unsafe impl Sync for InstanceCellState {}
+}
+
+const _: fn() = || {
+    fn assert<T: Send + Sync + ?Sized>() {}
+    assert::<ProcState>();
+    assert::<InstanceCellState>();
+};
+
 impl fmt::Debug for Proc {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Proc")

--- a/scripts/profile_compile_obligations.sh
+++ b/scripts/profile_compile_obligations.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# profile_compile_obligations.sh — profile and reduce rustc trait-solving
+# (`evaluate_obligation`) compile cost for crates in the monarch workspace.
+#
+# WHY THIS EXISTS
+# ---------------
+# For actor-heavy crates, `evaluate_obligation` (the rustc query that proves
+# trait bounds, dominated here by `Send`/`Sync` auto-trait checking) can be the
+# single largest slice of compile time. The standard trait solver proves
+# `Send`/`Sync` *structurally*: to show `T: Send` it recurses through every
+# field of `T`. For the actor/proc/gateway state — built on deep
+# `DashMap`/`RwLock`/`Arc` towers — that recursion is deep and is redone for
+# every monomorphization and every async-fn future that captures the state.
+#
+# Two independent fixes, both validated on hyperactor_mesh (2m34s -> ~1m00s):
+#   1. `-Z next-solver=globally` — the next-gen trait solver caches the
+#      structural proofs; drives evaluate_obligation to ~0. One flag, no unsafe.
+#   2. `unsafe impl Send/Sync` on the few concrete types that own the deep
+#      towers (ProcState, GatewayState, InstanceCellState, Mailbox) — makes the
+#      checker match a one-step impl instead of recursing. Same win on the
+#      standard solver; pair with a cfg-gated auto-verify guard (see VERIFY).
+#
+# METHODOLOGY NOTE (important): incremental compilation caches query results,
+# so a no-op rebuild reports ~0 for evaluate_obligation and hides the work.
+# Every run here sets CARGO_INCREMENTAL=0 so trait solving runs from scratch.
+#
+# USAGE
+#   scripts/profile_compile_obligations.sh profile  <crate> [extra rustc flags…]
+#   scripts/profile_compile_obligations.sh nextsolver <crate>   # A/B vs baseline
+#   scripts/profile_compile_obligations.sh attribute <crate>    # self-time by trait
+#   scripts/profile_compile_obligations.sh diff <profА> <profB>
+# Examples
+#   scripts/profile_compile_obligations.sh profile hyperactor_mesh
+#   scripts/profile_compile_obligations.sh attribute hyperactor
+#
+# ENV
+#   PROFILES_DIR   where *.mm_profdata land (default: $TMPDIR/monarch_compile_profiles)
+#   MEASUREME_DIR  path to a measureme checkout for the attribution tool's
+#                  `analyzeme` (default: fetch `analyzeme` from git). Needed only
+#                  for `attribute`; pin this if the profile format mismatches.
+set -euo pipefail
+
+MONARCH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROFILES_DIR="${PROFILES_DIR:-${TMPDIR:-/tmp}/monarch_compile_profiles}"
+mkdir -p "$PROFILES_DIR"
+cd "$MONARCH"
+
+# Rust builds here link against Python (PyO3); activate the venv if present.
+# shellcheck disable=SC1091
+if [ -f .venv/bin/activate ]; then
+  source .venv/bin/activate 2>/dev/null || true
+fi
+
+crate_root() { # echo the lib.rs path for a workspace crate (dir usually == name)
+  local c="$1"
+  if [ -f "$c/src/lib.rs" ]; then echo "$c/src/lib.rs"; else echo ""; fi
+}
+
+# Force a clean, NON-incremental reprofile of one crate's lib into the profiles
+# dir, then print the summarize table. Extra args after the crate are passed
+# verbatim to rustc (e.g. `-Z next-solver=globally`).
+reprofile() {
+  local crate="$1" name="$2"; shift 2
+  local root; root="$(crate_root "$crate")"
+  [ -n "$root" ] || { echo "no $crate/src/lib.rs" >&2; return 1; }
+  CARGO_INCREMENTAL=0 cargo build -p "$crate" --lib >/dev/null    # warm deps
+  touch "$root"                                                   # force recompile of just this crate
+  CARGO_INCREMENTAL=0 RUSTC_BOOTSTRAP=1 cargo rustc -p "$crate" --lib -- \
+    -Z self-profile -Z self-profile-events="${SELF_PROFILE_EVENTS:-default}" "$@"
+  local pf="" candidate
+  for candidate in "$crate"-*.mm_profdata; do
+    [ -e "$candidate" ] || continue
+    if [ -z "$pf" ] || [ "$candidate" -nt "$pf" ]; then
+      pf="$candidate"
+    fi
+  done
+  [ -n "$pf" ] || { echo "no profdata produced" >&2; return 1; }
+  mv "$pf" "$PROFILES_DIR/$name.mm_profdata"
+  echo "== summarize $name =="
+  summarize summarize "$PROFILES_DIR/$name.mm_profdata" | head -16
+  echo "saved: $PROFILES_DIR/$name.mm_profdata"
+}
+
+# Build the per-predicate attribution helper (self-time bucketed by trait).
+build_attrib_tool() {
+  local dir="$PROFILES_DIR/attrib_tool"
+  mkdir -p "$dir"
+  if [ -n "${MEASUREME_DIR:-}" ]; then
+    local dep="analyzeme = { path = \"$MEASUREME_DIR/analyzeme\" }"
+  else
+    local dep="analyzeme = { git = \"https://github.com/rust-lang/measureme\" }"
+  fi
+  cat > "$dir/Cargo.toml" <<TOML
+[package]
+name = "obl_attrib"
+version = "0.0.0"
+edition = "2021"
+[dependencies]
+$dep
+[[bin]]
+name = "obl_attrib"
+path = "main.rs"
+TOML
+  cat > "$dir/main.rs" <<'RUST'
+// Replicates summarize's stack-based self-time algorithm but buckets
+// evaluate_obligation self-time by the trait being proven (parsed from the
+// query key recorded with `-Z self-profile-events=default,query-keys`).
+use std::collections::HashMap;
+use analyzeme::{ProfilingData, EventPayload, Timestamp};
+struct Frame { start: u64, end: u64, bucket: Option<String> }
+fn main() {
+    let path = std::env::args().nth(1).expect("profdata path");
+    let data = ProfilingData::new(std::path::Path::new(&path)).expect("open profdata");
+    let mut by_trait: HashMap<String,(u128,u64)> = HashMap::new();
+    let mut threads: HashMap<u32, Vec<Frame>> = HashMap::new();
+    let mut total: u128 = 0;
+    for ev in data.iter_full().rev() {
+        let (s,e) = match ev.payload {
+            EventPayload::Timestamp(Timestamp::Interval{start,end}) => (
+                start.duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos() as u64,
+                end.duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos() as u64),
+            _ => continue,
+        };
+        let dur = (e - s) as i128;
+        let st = threads.entry(ev.thread_id).or_default();
+        while let Some(t) = st.last() { if t.start<=s && e<=t.end { break } st.pop(); }
+        if let Some(t) = st.last() { if let Some(k)=&t.bucket {
+            let x=by_trait.entry(k.clone()).or_insert((0,0)); x.0=(x.0 as i128-dur).max(0) as u128; } }
+        let bucket = if ev.label.as_ref()=="evaluate_obligation" && !ev.additional_data.is_empty() {
+            let k = ev.additional_data.iter().map(|c|c.as_ref()).collect::<Vec<_>>().join(" ");
+            let tr = last_trait(&k);
+            let x=by_trait.entry(tr.clone()).or_insert((0,0)); x.0+=dur as u128; x.1+=1;
+            total += dur as u128; Some(tr)
+        } else { None };
+        st.push(Frame{start:s,end:e,bucket});
+    }
+    println!("evaluate_obligation self-time {}ms", total/1_000_000);
+    let mut v: Vec<_> = by_trait.into_iter().collect();
+    v.sort_by(|a,b| b.1.0.cmp(&a.1.0));
+    println!("{:>9} {:>9} {:>6}  TRAIT", "self_ms","count","%");
+    for (k,(ns,c)) in v.iter().take(25) {
+        println!("{:>9} {:>9} {:>5.1}%  {}", ns/1_000_000, c, 100.0*(*ns as f64)/(total.max(1) as f64), k);
+    }
+}
+fn last_trait(k:&str)->String{ if let Some(p)=k.rfind(" as "){ let a=&k[p+4..];
+    let e=a.find(|c|c=='<'||c=='>'||c==','||c==' ').unwrap_or(a.len());
+    let pre = if k.contains("ProjectionPredicate") {"Projection:"} else {""};
+    format!("{pre}{}", a[..e].rsplit("::").next().unwrap_or(&a[..e])) } else { "<noas>".into() } }
+RUST
+  ( cd "$dir" && cargo build --release >/dev/null 2>&1 ) || {
+    echo "attribution tool build failed; set MEASUREME_DIR to a measureme checkout" >&2; return 1; }
+  echo "$dir/target/release/obl_attrib"
+}
+
+cmd="${1:-profile}"; shift || true
+case "$cmd" in
+  profile)
+    crate="${1:-hyperactor_mesh}"; shift || true
+    reprofile "$crate" "${crate}_baseline" "$@"
+    ;;
+  nextsolver)
+    crate="${1:-hyperactor_mesh}"
+    reprofile "$crate" "${crate}_baseline"
+    reprofile "$crate" "${crate}_nextsolver" -Z next-solver=globally
+    echo "== diff baseline -> next-solver =="
+    summarize diff "$PROFILES_DIR/${crate}_baseline.mm_profdata" \
+                   "$PROFILES_DIR/${crate}_nextsolver.mm_profdata" | head -12
+    ;;
+  attribute)
+    crate="${1:-hyperactor_mesh}"
+    SELF_PROFILE_EVENTS="default,query-keys" reprofile "$crate" "${crate}_keys" >/dev/null
+    tool="$(build_attrib_tool)"
+    "$tool" "$PROFILES_DIR/${crate}_keys.mm_profdata"
+    ;;
+  diff)
+    summarize diff "$1" "$2"
+    ;;
+  *)
+    echo "usage: $0 {profile|nextsolver|attribute <crate>|diff <a> <b>}" >&2; exit 2
+    ;;
+esac

--- a/setup.py
+++ b/setup.py
@@ -213,6 +213,8 @@ if "PYO3_PYTHON" not in os.environ:
 
 # Set Rust and C++ flags
 rustflags = ["-Zthreads=16", "--cfg=tracing_unstable"]
+if os.environ.get("CI") == "true":
+    rustflags.append("--cfg=hyperactor_verify_auto_traits")
 if os.environ.get("ENABLE_MESSAGE_LOGGING"):
     rustflags.append("--cfg=enable_hyperactor_message_logging")
 


### PR DESCRIPTION
Summary:
For actor-heavy crates the rustc `evaluate_obligation` query (proving trait bounds) dominates compile time. Measured on `hyperactor_mesh` (cold, `CARGO_INCREMENTAL=0`): `evaluate_obligation` was 71.6s = 37% of compile across 355k calls. Per-trait attribution (replicating summarize's self-time algorithm, keyed by the recorded query predicate) shows 96% of that is `Send`/`Sync` auto-trait checking; serde `Serialize`/`Deserialize` is ~0% and `Copy` is 74k cheap shallow checks.

The mechanism: the standard trait solver proves `Send`/`Sync` structurally — to show `T: Send` it recurses through every field of `T`. The actor/proc/gateway state is built on deep `DashMap`/`RwLock`/`Arc` towers (`ProcState` alone has six distinct `DashMap`/`DashSet` fields, and each `DashMap<K, V>` expands to `Box<[CachePadded<RwLock<RawRwLock, RawTable<(K, SharedValue<V>)>>>]>`). That recursion is deep and is redone for every monomorphization and every `async fn` future that captures the state, producing ~49k distinct `Send`/`Sync` self-types.

Fix: pre-assert `Send`/`Sync` via `unsafe impl` on the four concrete leaf types that own the deep towers — `ProcState`, `GatewayState`, `InstanceCellState`, and `Mailbox`. rustc then matches a one-step impl (shallow subgoal) instead of recursing the towers. These types are already `Send + Sync` by auto-derivation (the runtime moves them across tokio threads); the impls only make the proof cheap.

Because the towers live in hyperactor core, the win propagates to every downstream crate. Measured on `hyperactor_mesh`: `evaluate_obligation` 71.6s -> 8.4s (-88%), wall clock 2m34s -> 1m01s (-61%), with codegen output unchanged. A cross-crate survey confirms hyperactor core is the leverage point: after this change `monarch_hyperactor`'s `evaluate_obligation` is 2.7s and every other workspace crate is under 2s, so no other crate needs its own impls.

Narrowest impactful subset: `ProcState` alone recovers ~75% of the saving; the four concrete leaf types reach wall-clock parity with the next-gen solver; adding the generic wrappers (`Instance<A>`, `Context<'_, A>`, `InstanceState<A>`) only moves 8.4s -> 6.2s and is not worth the extra `unsafe` surface.

Safety: `unsafe impl Send`/`Sync` is an unverified assertion, so each is paired with a `hyperactor_verify_auto_traits` cfg build that drops the impls and forces the compiler to re-derive the bound structurally via `_verify_send_sync` assertion functions. A non-`Send` field then fails that build. This was verified: adding a `PhantomData<*const u8>` field to `ProcState` makes the verify build fail (`*const u8 cannot be sent between threads safely, within ProcState`), while an ordinary build silently accepts it — which is exactly why the guard exists.

The next-gen trait solver (`-Z next-solver=globally`) eliminates this cost entirely without any `unsafe` (it caches the structural proofs); see the companion commit. This commit is the standard-solver fix and is independent of it.

Follow-ups for a Buck land: declare `cfg(hyperactor_verify_auto_traits)` in the Buck `rust_library` (then `arc autocargo`) so the cfg is known under Buck as it now is under cargo, and add a CI job that runs the verify build.

Reviewed By: shayne-fletcher

Differential Revision: D109774975


