### PR TITLE
retain actor environment across local child creation (#4490)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -34,6 +34,7 @@ use typeuri::Named;
 
 use crate as hyperactor; // for macros
 use crate::ActorAddr;
+use crate::ActorEnvironment;
 use crate::ActorRef;
 use crate::Addr;
 #[cfg(test)]
@@ -533,14 +534,18 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
         parent: InstanceCell,
         uid: crate::id::Uid,
         serialized_params: Data,
-        environment: Flattrs,
+        environment: ActorEnvironment,
+        transient: Flattrs,
     ) -> Pin<Box<dyn Future<Output = Result<AnyActorHandle, anyhow::Error>> + Send>> {
         let proc = proc.clone();
         Box::pin(async move {
             let params =
                 bincode::serde::decode_from_slice(&serialized_params, bincode::config::legacy())
                     .map(|(v, _)| v)?;
-            let actor = Self::new(params, environment).await?;
+            // The constructor sees persistent + transient headers (transient
+            // wins on collision); only the persistent environment is stored on
+            // the instance (AENV-2, AENV-4).
+            let actor = Self::new(params, environment.constructor_view(transient)?).await?;
             let handle = proc.spawn_child_with_uid(parent, uid, actor)?;
             handle.bind::<Self>();
             Ok(handle.into_any())

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -17,6 +17,7 @@ use std::sync::LazyLock;
 use hyperactor_config::Flattrs;
 
 use crate::Actor;
+use crate::ActorEnvironment;
 use crate::AnyActorHandle;
 use crate::Data;
 use crate::id::Uid;
@@ -80,13 +81,16 @@ pub struct SpawnableActor {
     >,
 
     /// Type-erased child spawn function. This is the type's
-    /// [`RemoteSpawn::gspawn_child`].
+    /// [`RemoteSpawn::gspawn_child`]. The `ActorEnvironment` is the persistent
+    /// environment stored on the new instance; the `Flattrs` are the transient
+    /// constructor headers overlaid only for `RemoteSpawn::new`.
     pub gspawn_child:
         fn(
             &Proc,
             InstanceCell,
             Uid,
             Data,
+            ActorEnvironment,
             Flattrs,
         ) -> Pin<Box<dyn Future<Output = Result<AnyActorHandle, anyhow::Error>> + Send>>,
 
@@ -168,13 +172,14 @@ impl Remote {
         actor_type: &str,
         actor_uid: Uid,
         params: Data,
-        environment: Flattrs,
+        transient: Flattrs,
     ) -> Result<AnyActorHandle, anyhow::Error> {
+        let environment = parent.actor_environment().clone();
         let entry = self
             .by_name
             .get(actor_type)
             .ok_or_else(|| anyhow::anyhow!("actor type {} not registered", actor_type))?;
-        (entry.gspawn_child)(proc, parent, actor_uid, params, environment).await
+        (entry.gspawn_child)(proc, parent, actor_uid, params, environment, transient).await
     }
 }
 

--- a/hyperactor/src/environment.rs
+++ b/hyperactor/src/environment.rs
@@ -6,10 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! A bounded, typed environment for persistent actor context.
+//! The persistent, language-independent environment carried by an actor
+//! [`Instance`](crate::proc::Instance).
 //!
-//! An [`ActorEnvironment`] is a small set of typed attributes with a stable,
-//! language-independent wire representation.
+//! An [`ActorEnvironment`] is a small, immutable set of typed attributes fixed
+//! when the instance is constructed. Local children inherit the exact value.
 //!
 //! `hyperactor` owns how this environment is carried through actor creation,
 //! while higher-level crates own the values it contains. Those crates declare
@@ -23,6 +24,15 @@
 //!
 //! - **AENV-0 (value integrity):** every `ActorEnvironment` is structurally
 //!   valid, bounded, unique-keyed, and updated atomically.
+//! - **AENV-1 (instance ownership):** every [`Instance`](crate::proc::Instance)
+//!   stores exactly one immutable environment in its type-erased instance cell,
+//!   fixed at construction and exposed read-only.
+//! - **AENV-2 (local inheritance):** ordinary local child/client construction
+//!   derives its parent's exact environment from that cell.
+//! - **AENV-4 (transient separation):** message/cast constructor headers may
+//!   override the merged view passed to [`RemoteSpawn::new`](crate::actor::RemoteSpawn)
+//!   but never enter the stored/inherited environment; persistent capability
+//!   consumers read only the stored instance environment.
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -90,10 +100,12 @@ pub enum ActorEnvironmentError {
     InvalidEncoding(#[from] FlattrsValidationError),
 }
 
-/// A bounded collection of typed actor-context attributes.
+/// The persistent environment owned by an actor instance.
 ///
 /// The inner buffer is never exposed. Clones share the immutable buffer; a
-/// subsequent builder mutation creates a bounded private copy.
+/// subsequent builder mutation creates a bounded private copy. Once placed on
+/// an [`Instance`](crate::proc::Instance), only a shared view is exposed
+/// (AENV-1).
 #[derive(Clone)]
 pub struct ActorEnvironment(Arc<Flattrs>);
 
@@ -107,8 +119,8 @@ impl ActorEnvironment {
     /// Store `value` under `key` while enforcing the environment's entry and
     /// serialized-size bounds.
     ///
-    /// This is a construction API; successful updates replace the underlying
-    /// immutable buffer atomically.
+    /// This is a construction API. The environment stored on an `Instance` is
+    /// immutable because the runtime exposes no mutable instance accessor.
     pub fn set<T: Serialize>(
         &mut self,
         key: Key<T>,
@@ -141,6 +153,27 @@ impl ActorEnvironment {
     /// The number of entries in the environment.
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    /// Build the constructor view handed to
+    /// [`RemoteSpawn::new`](crate::actor::RemoteSpawn). Persistent entries are
+    /// included only when the transient headers do not define the same key, so
+    /// transient values win on collision (AENV-4). The transient buffer's
+    /// ordering and duplicate-key behavior are preserved, and the stored
+    /// environment is unchanged.
+    pub(crate) fn constructor_view(
+        &self,
+        mut transient: Flattrs,
+    ) -> Result<Flattrs, ActorEnvironmentError> {
+        transient.validate_wire()?;
+        let transient_keys: HashSet<_> = transient.iter().map(|(key_hash, _)| key_hash).collect();
+        for (key_hash, value) in self.0.iter() {
+            if !transient_keys.contains(&key_hash) {
+                transient.set_serialized(key_hash, value);
+            }
+        }
+        transient.validate_wire()?;
+        Ok(transient)
     }
 }
 
@@ -418,5 +451,53 @@ mod tests {
                 .map(|(value, _)| value)
                 .expect("deserialize boundary environment");
         assert_eq!(restored, boundary);
+    }
+
+    #[test]
+    fn constructor_view_overlays_transient() {
+        let mut env = ActorEnvironment::default();
+        env.set(TEST_TAG, 100u64).expect("insert tag");
+        env.set(TEST_LABEL, "persistent".to_string())
+            .expect("insert label");
+
+        let mut transient = Flattrs::new();
+        transient.set(TEST_TAG, 999u64);
+
+        let view = env
+            .constructor_view(transient)
+            .expect("merge valid constructor headers");
+        assert_eq!(view.get(TEST_TAG), Some(999u64));
+        assert_eq!(view.get(TEST_LABEL), Some("persistent".to_string()));
+        assert_eq!(env.get(TEST_TAG), Some(100u64));
+    }
+
+    #[test]
+    fn constructor_view_preserves_transient_duplicates_and_rejects_overflow() {
+        let first = bincode::serde::encode_to_vec(1u64, bincode::config::legacy())
+            .expect("serialize first value");
+        let second = bincode::serde::encode_to_vec(2u64, bincode::config::legacy())
+            .expect("serialize second value");
+        let mut raw = 2u16.to_le_bytes().to_vec();
+        append_entry(&mut raw, TEST_TAG.key_hash(), &first);
+        append_entry(&mut raw, TEST_TAG.key_hash(), &second);
+        let transient = Flattrs::from_part(Part::from(raw));
+
+        let mut env = ActorEnvironment::default();
+        env.set(TEST_TAG, 100u64).expect("insert persistent tag");
+        let view = env
+            .constructor_view(transient)
+            .expect("merge duplicate transient headers");
+        assert_eq!(view.get(TEST_TAG), Some(1u64));
+        assert_eq!(view.len(), 2, "transient duplicates must remain intact");
+
+        let mut raw = u16::MAX.to_le_bytes().to_vec();
+        for _ in 0..u16::MAX {
+            append_entry(&mut raw, TEST_TAG.key_hash().wrapping_add(1), &[]);
+        }
+        let full = Flattrs::from_part(Part::from(raw));
+        assert!(
+            env.constructor_view(full).is_err(),
+            "adding a persistent key must not wrap the Flattrs entry count"
+        );
     }
 }

--- a/hyperactor/src/environment.rs
+++ b/hyperactor/src/environment.rs
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! A bounded, typed environment for persistent actor context.
+//!
+//! An [`ActorEnvironment`] is a small set of typed attributes with a stable,
+//! language-independent wire representation.
+//!
+//! `hyperactor` owns how this environment is carried through actor creation,
+//! while higher-level crates own the values it contains. Those crates declare
+//! typed [`Key`] attributes. Putting those values in a fixed struct would move
+//! higher-level concepts into `hyperactor` and require core runtime and wire
+//! changes for each new kind of inherited context. This is not an untyped
+//! general-purpose map: the API preserves each value's type, enforces fixed
+//! bounds, and requires mutable ownership for construction updates.
+//!
+//! # AENV invariant registry
+//!
+//! - **AENV-0 (value integrity):** every `ActorEnvironment` is structurally
+//!   valid, bounded, unique-keyed, and updated atomically.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use hyperactor_config::AttrValue;
+use hyperactor_config::Flattrs;
+use hyperactor_config::FlattrsValidationError;
+use hyperactor_config::Key;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use serde::de::DeserializeOwned;
+use serde::de::Error as _;
+use serde_multipart::Part;
+
+const MAX_ACTOR_ENVIRONMENT_ENTRIES: usize = 32;
+const MAX_ACTOR_ENVIRONMENT_BYTES: usize = 16 * 1024;
+
+/// An error constructing or decoding an [`ActorEnvironment`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ActorEnvironmentError {
+    /// One serialized value cannot fit within the environment's byte bound.
+    #[error("serialized actor environment value is {bytes} bytes; maximum is {maximum}")]
+    ValueTooLarge {
+        /// The serialized value size in bytes.
+        bytes: usize,
+        /// The maximum accepted serialized value size.
+        maximum: usize,
+    },
+
+    /// The encoded entry count exceeds the environment's fixed bound.
+    #[error("actor environment has {entries} entries; maximum is {maximum}")]
+    TooManyEntries {
+        /// The number of encoded entries.
+        entries: usize,
+        /// The maximum accepted number of entries.
+        maximum: usize,
+    },
+
+    /// The encoded environment exceeds its fixed byte bound.
+    #[error("actor environment is {bytes} bytes; maximum is {maximum}")]
+    TooLarge {
+        /// The encoded size in bytes.
+        bytes: usize,
+        /// The maximum accepted encoded size.
+        maximum: usize,
+    },
+
+    /// A key occurs more than once in the encoded environment.
+    #[error("actor environment contains duplicate key hash {key_hash:#x}")]
+    DuplicateKey {
+        /// The repeated key hash.
+        key_hash: u64,
+    },
+
+    /// A typed value could not be serialized into the environment.
+    #[error("failed to serialize actor environment value: {0}")]
+    ValueSerialization(#[from] bincode::error::EncodeError),
+
+    /// The underlying `Flattrs` wire structure is malformed.
+    #[error("invalid actor environment encoding: {0}")]
+    InvalidEncoding(#[from] FlattrsValidationError),
+}
+
+/// A bounded collection of typed actor-context attributes.
+///
+/// The inner buffer is never exposed. Clones share the immutable buffer; a
+/// subsequent builder mutation creates a bounded private copy.
+#[derive(Clone)]
+pub struct ActorEnvironment(Arc<Flattrs>);
+
+impl Default for ActorEnvironment {
+    fn default() -> Self {
+        Self(Arc::new(Flattrs::new()))
+    }
+}
+
+impl ActorEnvironment {
+    /// Store `value` under `key` while enforcing the environment's entry and
+    /// serialized-size bounds.
+    ///
+    /// This is a construction API; successful updates replace the underlying
+    /// immutable buffer atomically.
+    pub fn set<T: Serialize>(
+        &mut self,
+        key: Key<T>,
+        value: T,
+    ) -> Result<(), ActorEnvironmentError> {
+        let serialized = bincode::serde::encode_to_vec(value, bincode::config::legacy())?;
+        if serialized.len() > MAX_ACTOR_ENVIRONMENT_BYTES {
+            return Err(ActorEnvironmentError::ValueTooLarge {
+                bytes: serialized.len(),
+                maximum: MAX_ACTOR_ENVIRONMENT_BYTES,
+            });
+        }
+        let mut candidate = self.0.as_ref().clone();
+        candidate.set_serialized(key.key_hash(), &serialized);
+        validate(&candidate)?;
+        self.0 = Arc::new(candidate);
+        Ok(())
+    }
+
+    /// Read the value stored under `key`, if present.
+    pub fn get<T: AttrValue + DeserializeOwned>(&self, key: Key<T>) -> Option<T> {
+        self.0.get(key)
+    }
+
+    /// Whether the environment holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The number of entries in the environment.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+fn validate(attrs: &Flattrs) -> Result<(), ActorEnvironmentError> {
+    attrs.validate_wire()?;
+    let encoded_bytes = attrs.encoded_len();
+    if encoded_bytes > MAX_ACTOR_ENVIRONMENT_BYTES {
+        return Err(ActorEnvironmentError::TooLarge {
+            bytes: encoded_bytes,
+            maximum: MAX_ACTOR_ENVIRONMENT_BYTES,
+        });
+    }
+
+    let declared = attrs.len();
+    if declared > MAX_ACTOR_ENVIRONMENT_ENTRIES {
+        return Err(ActorEnvironmentError::TooManyEntries {
+            entries: declared,
+            maximum: MAX_ACTOR_ENVIRONMENT_ENTRIES,
+        });
+    }
+
+    let mut seen = HashSet::with_capacity(declared);
+    for (key_hash, _) in attrs.iter() {
+        if !seen.insert(key_hash) {
+            return Err(ActorEnvironmentError::DuplicateKey { key_hash });
+        }
+    }
+    Ok(())
+}
+
+impl Serialize for ActorEnvironment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ActorEnvironment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // This bound controls accepted instance state. The transport frame
+        // limit is responsible for bounding allocation before field decoding.
+        let part = Part::deserialize(deserializer)?;
+        let encoded_bytes = part.len();
+        if encoded_bytes > MAX_ACTOR_ENVIRONMENT_BYTES {
+            return Err(D::Error::custom(ActorEnvironmentError::TooLarge {
+                bytes: encoded_bytes,
+                maximum: MAX_ACTOR_ENVIRONMENT_BYTES,
+            }));
+        }
+        let attrs = Flattrs::from_part(part);
+        validate(&attrs).map_err(D::Error::custom)?;
+        Ok(Self(Arc::new(attrs)))
+    }
+}
+
+impl std::fmt::Debug for ActorEnvironment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ActorEnvironment")
+            .field("len", &self.0.len())
+            .finish()
+    }
+}
+
+/// Equality over the `(key hash, serialized bytes)` set, independent of
+/// insertion order. Construction and deserialization enforce one entry per key
+/// hash.
+impl PartialEq for ActorEnvironment {
+    fn eq(&self, other: &Self) -> bool {
+        if Arc::ptr_eq(&self.0, &other.0) {
+            return true;
+        }
+        if self.0.len() != other.0.len() {
+            return false;
+        }
+        let mine: HashMap<u64, &[u8]> = self.0.iter().collect();
+        other
+            .0
+            .iter()
+            .all(|(key_hash, value)| mine.get(&key_hash) == Some(&value))
+    }
+}
+
+impl Eq for ActorEnvironment {}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor_config::declare_attrs;
+
+    use super::*;
+
+    declare_attrs! {
+        attr TEST_TAG: u64;
+        attr TEST_LABEL: String;
+        attr TEST_BYTES: Vec<u8>;
+    }
+
+    fn decode_raw(raw: Vec<u8>) -> Result<ActorEnvironment, bincode::error::DecodeError> {
+        let attrs = Flattrs::from_part(Part::from(raw));
+        let encoded = bincode::serde::encode_to_vec(attrs, bincode::config::legacy())
+            .expect("serialize raw Flattrs");
+        bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+            .map(|(value, _)| value)
+    }
+
+    // Malformed-buffer tests must encode the private layout directly because
+    // the public Flattrs builders cannot construct invalid wire shapes.
+    fn append_entry(raw: &mut Vec<u8>, key_hash: u64, value: &[u8]) {
+        raw.extend_from_slice(&key_hash.to_le_bytes());
+        raw.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        raw.extend_from_slice(value);
+    }
+
+    #[test]
+    fn default_accepts_first_insertion() {
+        let mut env = ActorEnvironment::default();
+        assert!(env.is_empty());
+        env.set(TEST_TAG, 7u64).expect("insert first value");
+        assert_eq!(env.get(TEST_TAG), Some(7u64));
+        assert_eq!(env.len(), 1);
+    }
+
+    #[test]
+    fn serde_roundtrips() {
+        let mut env = ActorEnvironment::default();
+        env.set(TEST_TAG, 42u64).expect("insert tag");
+        env.set(TEST_LABEL, "root".to_string())
+            .expect("insert label");
+
+        let bytes =
+            bincode::serde::encode_to_vec(&env, bincode::config::legacy()).expect("serialize");
+        let restored: ActorEnvironment =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::legacy())
+                .map(|(value, _)| value)
+                .expect("deserialize");
+
+        assert_eq!(restored.get(TEST_TAG), Some(42u64));
+        assert_eq!(restored.get(TEST_LABEL), Some("root".to_string()));
+        assert_eq!(restored, env);
+    }
+
+    #[test]
+    fn equality_is_order_independent() {
+        let mut a = ActorEnvironment::default();
+        a.set(TEST_TAG, 1u64).expect("insert tag");
+        a.set(TEST_LABEL, "x".to_string()).expect("insert label");
+
+        let mut b = ActorEnvironment::default();
+        b.set(TEST_LABEL, "x".to_string()).expect("insert label");
+        b.set(TEST_TAG, 1u64).expect("insert tag");
+
+        assert_eq!(a, b);
+
+        let mut c = ActorEnvironment::default();
+        c.set(TEST_TAG, 2u64).expect("insert tag");
+        c.set(TEST_LABEL, "x".to_string()).expect("insert label");
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn serde_rejects_duplicate_keys() {
+        let value = bincode::serde::encode_to_vec(1u64, bincode::config::legacy())
+            .expect("serialize value");
+        let mut raw = 2u16.to_le_bytes().to_vec();
+        append_entry(&mut raw, TEST_TAG.key_hash(), &value);
+        append_entry(&mut raw, TEST_TAG.key_hash(), &value);
+
+        assert!(decode_raw(raw).is_err(), "duplicate keys must be rejected");
+    }
+
+    #[test]
+    fn serde_rejects_truncated_and_trailing_buffers() {
+        assert!(
+            decode_raw(vec![1]).is_err(),
+            "a partial count header must be rejected"
+        );
+        assert!(
+            decode_raw(1u16.to_le_bytes().to_vec()).is_err(),
+            "a declared entry without entry bytes must be rejected"
+        );
+        assert!(
+            decode_raw(vec![0, 0, 1]).is_err(),
+            "bytes after the declared entries must be rejected"
+        );
+    }
+
+    #[test]
+    fn set_rejects_oversized_values_without_mutating() {
+        let mut env = ActorEnvironment::default();
+        let err = env
+            .set(TEST_BYTES, vec![0; MAX_ACTOR_ENVIRONMENT_BYTES])
+            .expect_err("oversized value must be rejected");
+        assert!(matches!(err, ActorEnvironmentError::ValueTooLarge { .. }));
+        assert!(env.is_empty(), "a rejected insertion must be atomic");
+    }
+
+    #[test]
+    fn set_rejects_entry_and_aggregate_bounds_atomically() {
+        let mut raw = (MAX_ACTOR_ENVIRONMENT_ENTRIES as u16)
+            .to_le_bytes()
+            .to_vec();
+        for offset in 1..=MAX_ACTOR_ENVIRONMENT_ENTRIES {
+            append_entry(
+                &mut raw,
+                TEST_TAG.key_hash().wrapping_add(offset as u64),
+                &[],
+            );
+        }
+        let mut full = decode_raw(raw).expect("decode environment at the entry bound");
+        let before = full.clone();
+        let err = full
+            .set(TEST_TAG, 1u64)
+            .expect_err("a 33rd entry must be rejected");
+        assert!(matches!(err, ActorEnvironmentError::TooManyEntries { .. }));
+        assert_eq!(full, before, "a rejected insertion must be atomic");
+
+        let mut large = ActorEnvironment::default();
+        large
+            .set(TEST_BYTES, vec![0; MAX_ACTOR_ENVIRONMENT_BYTES - 64])
+            .expect("the first value fits within the aggregate bound");
+        let before = large.clone();
+        let err = large
+            .set(TEST_LABEL, "x".repeat(128))
+            .expect_err("aggregate encoded size must be enforced");
+        assert!(matches!(err, ActorEnvironmentError::TooLarge { .. }));
+        assert_eq!(large, before, "a rejected insertion must be atomic");
+    }
+
+    #[test]
+    fn serde_rejects_policy_bounds() {
+        let mut too_many = ((MAX_ACTOR_ENVIRONMENT_ENTRIES + 1) as u16)
+            .to_le_bytes()
+            .to_vec();
+        for offset in 1..=MAX_ACTOR_ENVIRONMENT_ENTRIES + 1 {
+            append_entry(
+                &mut too_many,
+                TEST_TAG.key_hash().wrapping_add(offset as u64),
+                &[],
+            );
+        }
+        assert!(
+            decode_raw(too_many).is_err(),
+            "an oversized entry set must be rejected"
+        );
+
+        let mut too_large = 1u16.to_le_bytes().to_vec();
+        append_entry(
+            &mut too_large,
+            TEST_BYTES.key_hash(),
+            &vec![0; MAX_ACTOR_ENVIRONMENT_BYTES],
+        );
+        let err = decode_raw(too_large).expect_err("oversized environment must fail");
+        assert!(
+            err.to_string().contains("maximum"),
+            "a structurally valid oversized environment must hit the byte bound: {err}"
+        );
+
+        let mut boundary = ActorEnvironment::default();
+        boundary
+            .set(TEST_BYTES, Vec::<u8>::new())
+            .expect("measure one-entry encoding overhead");
+        let payload_len = MAX_ACTOR_ENVIRONMENT_BYTES - boundary.0.encoded_len();
+        boundary
+            .set(TEST_BYTES, vec![0; payload_len])
+            .expect("the exact byte boundary must be accepted");
+        assert_eq!(boundary.0.encoded_len(), MAX_ACTOR_ENVIRONMENT_BYTES);
+        let encoded = bincode::serde::encode_to_vec(&boundary, bincode::config::legacy())
+            .expect("serialize boundary environment");
+        let restored: ActorEnvironment =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(value, _)| value)
+                .expect("deserialize boundary environment");
+        assert_eq!(restored, boundary);
+    }
+}

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -68,6 +68,7 @@ pub mod client;
 pub mod config;
 pub mod context;
 pub mod endpoint;
+pub mod environment;
 /// Gateway management for proc connectivity.
 pub mod gateway;
 pub mod id;
@@ -132,6 +133,8 @@ pub use client::Client;
 pub use endpoint::Endpoint;
 pub use endpoint::EndpointLocation;
 pub use endpoint::RemoteEndpoint;
+pub use environment::ActorEnvironment;
+pub use environment::ActorEnvironmentError;
 pub use gateway::Gateway;
 #[doc(inline)]
 pub use hyperactor_macros::HandleClient;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -185,6 +185,7 @@ use crate::config;
 use crate::context;
 use crate::context::Mailbox as _;
 use crate::endpoint::Endpoint as _;
+use crate::environment::ActorEnvironment;
 use crate::gateway::Gateway;
 use crate::id::ActorId;
 use crate::id::Label;
@@ -1101,7 +1102,7 @@ impl Proc {
     /// Spawn a root actor with a fresh uid labeled from the actor type.
     pub fn spawn<A: Actor>(&self, actor: A) -> ActorHandle<A> {
         let actor_id: ActorAddr = self.allocate_root_type::<A>();
-        self.spawn_inner(actor_id, actor, None)
+        self.spawn_inner(actor_id, actor, None, ActorEnvironment::default())
     }
 
     /// Spawn a root actor with a fresh uid carrying a display label.
@@ -1110,7 +1111,7 @@ impl Proc {
     /// identity.
     pub fn spawn_with_label<A: Actor>(&self, label: &str, actor: A) -> ActorHandle<A> {
         let actor_id: ActorAddr = self.allocate_root_label(label);
-        self.spawn_inner(actor_id, actor, None)
+        self.spawn_inner(actor_id, actor, None, ActorEnvironment::default())
     }
 
     /// Spawn a root actor on this proc using an explicit uid.
@@ -1125,17 +1126,20 @@ impl Proc {
         actor: A,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
         let actor_id: ActorAddr = self.allocate_root_uid(uid)?;
-        Ok(self.spawn_inner(actor_id, actor, None))
+        Ok(self.spawn_inner(actor_id, actor, None, ActorEnvironment::default()))
     }
 
-    /// Common spawn logic for both root and child actors.
+    /// Common spawn logic for both root and child actors. `environment` is
+    /// required so no private path can silently default it (AENV-1).
     fn spawn_inner<A: Actor>(
         &self,
         actor_id: ActorAddr,
         actor: A,
         parent: Option<InstanceCell>,
+        environment: ActorEnvironment,
     ) -> ActorHandle<A> {
-        let (instance, receivers) = Instance::new(self.clone(), actor_id, false, parent);
+        let (instance, receivers) =
+            Instance::new(self.clone(), actor_id, false, parent, environment);
         instance.start(actor, receivers)
     }
 
@@ -1145,8 +1149,13 @@ impl Proc {
     /// `tokio::spawn`.
     pub fn client(&self, label: &str) -> Client {
         let actor_id = self.allocate_client_id(label);
-        let (instance, _receivers) =
-            Instance::<ClientActor>::new(self.clone(), actor_id, false, None);
+        let (instance, _receivers) = Instance::<ClientActor>::new(
+            self.clone(),
+            actor_id,
+            false,
+            None,
+            ActorEnvironment::default(),
+        );
         instance.change_status(ActorStatus::Client);
         Client::new(instance)
     }
@@ -1168,7 +1177,13 @@ impl Proc {
         name: &str,
     ) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
         let actor_id: ActorAddr = self.allocate_root_id(name)?;
-        let (instance, receivers) = Instance::new(self.clone(), actor_id, false, None);
+        let (instance, receivers) = Instance::new(
+            self.clone(),
+            actor_id,
+            false,
+            None,
+            ActorEnvironment::default(),
+        );
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
         instance.spawn_detached_introspect(receivers.introspect);
@@ -1181,13 +1196,27 @@ impl Proc {
     /// launch child actors, etc. The actor itself does not handle any
     /// messages unless driven by the caller.
     pub fn actor_instance<A: Actor>(&self, name: &str) -> Result<ActorInstance<A>, anyhow::Error> {
+        self.actor_instance_in_environment(name, ActorEnvironment::default())
+    }
+
+    /// Create an inverted actor instance with an explicit environment.
+    ///
+    /// This is the root-construction boundary used by runtimes that seed stable
+    /// context before driving the returned instance. The environment is fixed
+    /// before the instance becomes observable (AENV-1).
+    pub fn actor_instance_in_environment<A: Actor>(
+        &self,
+        name: &str,
+        environment: ActorEnvironment,
+    ) -> Result<ActorInstance<A>, anyhow::Error> {
         let actor_id: ActorAddr = self.allocate_root_id(name)?;
         let span = tracing::debug_span!(
             "actor_instance",
             subject = %actor_id.subject(),
         );
         let _guard = span.enter();
-        let (instance, receivers) = Instance::new(self.clone(), actor_id.clone(), false, None);
+        let (instance, receivers) =
+            Instance::new(self.clone(), actor_id.clone(), false, None, environment);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
 
@@ -1320,7 +1349,9 @@ impl Proc {
             subject = %actor_id.subject(),
         );
 
-        let (instance, _receivers) = Instance::new(self.clone(), actor_id, false, Some(parent));
+        let environment = parent.actor_environment().clone();
+        let (instance, _receivers) =
+            Instance::new(self.clone(), actor_id, false, Some(parent), environment);
         // Client-mode instance: no actor loop, no introspect task.
         // Receivers are intentionally dropped.
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
@@ -1335,7 +1366,8 @@ impl Proc {
     /// with its parent.
     pub(crate) fn spawn_child<A: Actor>(&self, parent: InstanceCell, actor: A) -> ActorHandle<A> {
         let actor_id = self.allocate_child_id::<A>(parent.actor_addr());
-        self.spawn_inner(actor_id, actor, Some(parent))
+        let environment = parent.actor_environment().clone();
+        self.spawn_inner(actor_id, actor, Some(parent), environment)
     }
 
     /// Spawn a child actor from the provided parent using an explicit uid.
@@ -1345,8 +1377,9 @@ impl Proc {
         uid: Uid,
         actor: A,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
+        let environment = parent.actor_environment().clone();
         let actor_id = self.ensure_child_uid(parent.actor_addr(), uid)?;
-        Ok(self.spawn_inner(actor_id, actor, Some(parent)))
+        Ok(self.spawn_inner(actor_id, actor, Some(parent), environment))
     }
 
     /// Spawn a named child actor. Same as `spawn_child` but the child
@@ -1359,7 +1392,8 @@ impl Proc {
         actor: A,
     ) -> ActorHandle<A> {
         let actor_id = self.allocate_named_child_id(parent.actor_addr(), name);
-        self.spawn_inner(actor_id, actor, Some(parent))
+        let environment = parent.actor_environment().clone();
+        self.spawn_inner(actor_id, actor, Some(parent), environment)
     }
 
     /// Call `abort` on the `JoinHandle` associated with the given
@@ -2323,11 +2357,16 @@ pub struct InstanceReceivers<A: Actor> {
 
 impl<A: Actor> Instance<A> {
     /// Create a new actor instance in Created state.
+    ///
+    /// `actor_environment` is required and always stored. Ordinary child
+    /// helpers derive it from the parent cell before calling this constructor;
+    /// root and remote-override paths supply it explicitly (AENV-1, AENV-2).
     fn new(
         proc: Proc,
         actor_id: ActorAddr,
         detached: bool,
         parent: Option<InstanceCell>,
+        actor_environment: ActorEnvironment,
     ) -> (Self, InstanceReceivers<A>) {
         // Set up messaging
         let mailbox = Mailbox::new(actor_id.clone());
@@ -2387,6 +2426,7 @@ impl<A: Actor> Instance<A> {
             actor_id,
             instance_id,
             actor_type,
+            actor_environment,
             proc.clone(),
             actor_loop,
             status_tx,
@@ -3476,7 +3516,7 @@ impl<A: Actor> Instance<A> {
     /// Spawn a registered actor as this instance's child.
     ///
     /// The actor type is resolved through the remote spawn registry. The child
-    /// receives an empty environment.
+    /// inherits this instance's environment (AENV-2).
     pub async fn gspawn(&self, actor_type: &str, params: Data) -> anyhow::Result<AnyActorHandle> {
         self.gspawn_uid(actor_type, crate::id::Uid::anonymous(), params)
             .await
@@ -3485,7 +3525,8 @@ impl<A: Actor> Instance<A> {
     /// Spawn a registered actor as this instance's child using an explicit uid.
     ///
     /// The actor type is resolved through the remote spawn registry. The child
-    /// receives an empty environment.
+    /// inherits this instance's environment (AENV-2). No transient constructor
+    /// headers are supplied on this local path.
     pub async fn gspawn_uid(
         &self,
         actor_type: &str,
@@ -3499,7 +3540,7 @@ impl<A: Actor> Instance<A> {
                 actor_type,
                 uid,
                 params,
-                Flattrs::default(),
+                Flattrs::new(),
             )
             .await
     }
@@ -3532,6 +3573,15 @@ impl<A: Actor> Instance<A> {
     /// The owning proc.
     pub fn proc(&self) -> &Proc {
         &self.inner.proc
+    }
+
+    /// This instance's persistent environment.
+    ///
+    /// The environment is fixed at construction and inherited by local children
+    /// (AENV-1, AENV-2). Only a shared, read-only view is returned; there is no
+    /// mutable accessor.
+    pub fn actor_environment(&self) -> &ActorEnvironment {
+        self.inner.cell.actor_environment()
     }
 
     /// Clone this Instance to get an owned struct that can be
@@ -3598,6 +3648,7 @@ impl Instance<ClientActor> {
             actor_id,
             false,
             Some(self.inner.cell.clone()),
+            self.inner.cell.actor_environment().clone(),
         );
         instance.change_status(ActorStatus::Client);
         Client::new(instance)
@@ -3764,6 +3815,9 @@ impl fmt::Debug for InstanceCell {
 struct InstanceCellState {
     /// The actor's id.
     actor_id: ActorAddr,
+
+    /// Persistent, type-erased context fixed when the instance is created.
+    actor_environment: ActorEnvironment,
 
     /// The actor instance's `Uuid::now_v7()` identity. Stable for the
     /// lifetime of this instance; surfaced via `InstanceCell::instance_id`
@@ -3991,6 +4045,7 @@ impl InstanceCell {
         actor_id: ActorAddr,
         instance_id: Uuid,
         actor_type: ActorType,
+        actor_environment: ActorEnvironment,
         proc: Proc,
         actor_loop: Option<(
             mpsc::UnboundedSender<Signal>,
@@ -4012,6 +4067,7 @@ impl InstanceCell {
                 actor_id: actor_id.clone(),
                 instance_id,
                 actor_type,
+                actor_environment,
                 proc: proc.clone(),
                 actor_loop,
                 status_tx,
@@ -4054,6 +4110,11 @@ impl InstanceCell {
     /// The actor's address.
     pub fn actor_addr(&self) -> &ActorAddr {
         &self.inner.actor_id
+    }
+
+    /// The persistent environment fixed when this instance was created.
+    pub(crate) fn actor_environment(&self) -> &ActorEnvironment {
+        &self.inner.actor_environment
     }
 
     /// The proc in which this actor is running.
@@ -8159,5 +8220,125 @@ mod tests {
             ChildTeardown::from_run_result(&failed),
             ChildTeardown::Cooperative(StopMode::Stop)
         );
+    }
+
+    hyperactor_config::attrs::declare_attrs! {
+        attr AENV_TEST_TAG: u64;
+    }
+
+    /// Sentinel stored under `AENV_TEST_TAG` by a seeded environment. Non-zero
+    /// so it is distinguishable from the empty-environment reading of `0`.
+    const AENV_SENTINEL: u64 = 0xA0FE;
+
+    /// A registered probe that, at construction (`Actor::init`), reports the
+    /// value stored under `AENV_TEST_TAG` in its own instance environment to a
+    /// reply port. Used to observe inherited environments across every local
+    /// child path (AENV-2).
+    #[derive(Debug)]
+    #[hyperactor::export(())]
+    struct EnvProbe {
+        reply: PortRef<u64>,
+    }
+
+    #[async_trait]
+    impl Actor for EnvProbe {
+        async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+            let observed = this.actor_environment().get(AENV_TEST_TAG).unwrap_or(0);
+            self.reply.post(this, observed);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<()> for EnvProbe {
+        async fn handle(&mut self, _cx: &Context<Self>, _message: ()) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl crate::RemoteSpawn for EnvProbe {
+        type Params = PortRef<u64>;
+
+        async fn new(reply: PortRef<u64>, _environment: Flattrs) -> anyhow::Result<Self> {
+            Ok(Self { reply })
+        }
+    }
+
+    crate::register_spawnable!(EnvProbe);
+
+    // AENV-1: ordinary root/client instances start with an empty environment.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn aenv_ordinary_instances_start_empty() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        assert!(
+            context::Actor::instance(&client)
+                .actor_environment()
+                .is_empty()
+        );
+
+        // A root actor observes an empty environment (reads back the `0`
+        // fallback for the absent tag).
+        let (tx, mut rx) = client.open_port::<u64>();
+        let _root = proc.spawn(EnvProbe { reply: tx.bind() });
+        assert_eq!(rx.recv().await.unwrap(), 0);
+    }
+
+    // AENV-1, AENV-2: a seeded parent's environment is inherited exactly by
+    // every local child construction path.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn aenv_local_children_inherit_environment() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+
+        let mut seed = ActorEnvironment::default();
+        seed.set(AENV_TEST_TAG, AENV_SENTINEL)
+            .expect("seed actor environment");
+        let parent = proc
+            .actor_instance_in_environment::<EnvProbe>("seeded", seed.clone())
+            .expect("create seeded root instance");
+        assert_eq!(parent.instance.actor_environment(), &seed);
+
+        // Direct child/client: inspected synchronously.
+        assert_eq!(parent.instance.child().0.actor_environment(), &seed);
+
+        let client_parent = proc
+            .actor_instance_in_environment::<ClientActor>("seeded_client", seed.clone())
+            .expect("create seeded client instance");
+        let child_client = client_parent.instance.child_client();
+        assert_eq!(
+            context::Actor::instance(&child_client).actor_environment(),
+            &seed,
+        );
+
+        // Ordinary child.
+        let (tx, mut rx) = client.open_port::<u64>();
+        let _ordinary = parent.instance.spawn(EnvProbe { reply: tx.bind() });
+        assert_eq!(rx.recv().await.unwrap(), AENV_SENTINEL);
+
+        // Named child.
+        let (tx, mut rx) = client.open_port::<u64>();
+        let _named = parent
+            .instance
+            .spawn_with_label("named", EnvProbe { reply: tx.bind() });
+        assert_eq!(rx.recv().await.unwrap(), AENV_SENTINEL);
+
+        // Explicit-uid child.
+        let (tx, mut rx) = client.open_port::<u64>();
+        let _uid = parent
+            .instance
+            .spawn_with_uid(crate::id::Uid::anonymous(), EnvProbe { reply: tx.bind() })
+            .unwrap();
+        assert_eq!(rx.recv().await.unwrap(), AENV_SENTINEL);
+
+        // Registered gspawn child.
+        let (tx, mut rx) = client.open_port::<u64>();
+        let params = bincode::serde::encode_to_vec(tx.bind(), bincode::config::legacy()).unwrap();
+        let type_name = crate::actor::remote::Remote::global()
+            .name_of::<EnvProbe>()
+            .expect("EnvProbe is registered");
+        let _gspawned = parent.instance.gspawn(type_name, params).await.unwrap();
+        assert_eq!(rx.recv().await.unwrap(), AENV_SENTINEL);
     }
 }


### PR DESCRIPTION
Summary:

once an actor has a reference to its client root, every local child must keep it. otherwise the child can no longer ask the same root-owned services as its parent, and correct behavior depends on which spawn API or implementation language created it.

this stores each actor's immutable environment with its native instance and gives local children the parent's value automatically. roots remain empty unless explicitly seeded, and transient constructor metadata is not retained or inherited. no remote protocol or wire format changes in this diff.

Reviewed By: zdevito

Differential Revision: D113320850


