### PR TITLE
let actors use services owned by the client root (#4493)

### DIFF
--- a/docs/source/books/hyperactor-book/src/actors/remote.md
+++ b/docs/source/books/hyperactor-book/src/actors/remote.md
@@ -170,6 +170,7 @@ impl ProcMeshRef {
               spec: mesh_agent::ActorSpec {
                   actor_type: actor_type.clone(),      // ← string name sent over the wire
                   params_data: serialized_params.clone(),
+                  actor_environment: cx.instance().actor_environment().clone(),
               },
           },
       )?;
@@ -201,7 +202,8 @@ impl Remote {
 
 In a typical setup, higher-level code in a separate crate starts from a generic `A: RemoteSpawn`, uses `Remote::name_of::<A>()` to obtain the global type name, serializes `A::Params`, and sends a request containing:
 - `actor_type`: that global type name, and
-- `params_data`: serialized `A::Params`.
+- `params_data`: serialized `A::Params`, and
+- `actor_environment`: the spawning actor's persistent environment.
 
 On the receiving side, a control-plane or management actor calls:
 ```rust
@@ -213,7 +215,7 @@ to look up the corresponding `SpawnableActor` by `actor_type` and invoke its `gs
 
 Remote spawning in hyperactor involves two complementary pieces:
 1. **Type-level registration** Each `A: RemoteSpawn` contributes a `SpawnableActor` record when the user writes `#[spawnable]` on a concrete actor declaration or `register_spawnable!(A)` for a concrete instantiation. These records are collected at runtime by `Remote::collect()`.
-2. **Data-level spawn requests** Higher-level code starts from a concrete actor type (e.g. `A: RemoteSpawn`), uses `Remote::name_of::<A>()` to obtain it's global type name, serializes `A::Params`, and sends a request containing those two pieces of data.
+2. **Data-level spawn requests** Higher-level code starts from a concrete actor type (e.g. `A: RemoteSpawn`), uses `Remote::name_of::<A>()` to obtain it's global type name, serializes `A::Params`, and sends those values together with the spawning actor's persistent environment.
 
 On the receiving side, a management component reconstructs the actor by calling:
 ```rust

--- a/docs/source/books/hyperactor-mesh-book/src/meshes/proc-mesh-and-agent.md
+++ b/docs/source/books/hyperactor-mesh-book/src/meshes/proc-mesh-and-agent.md
@@ -89,6 +89,7 @@ impl ProcMeshRef {
               spec: mesh_agent::ActorSpec {
                   actor_type: actor_type.clone(),
                   params_data: serialized_params.clone(),
+                  actor_environment: cx.instance().actor_environment().clone(),
               },
           },
       )?;
@@ -131,6 +132,7 @@ What this does, step by step:
            spec: mesh_agent::ActorSpec {
                actor_type: actor_type.clone(),
                params_data: serialized_params.clone(),
+               actor_environment: cx.instance().actor_environment().clone(),
            },
        },
    )?;
@@ -140,9 +142,10 @@ What this does, step by step:
    - `cast` sends the same `CreateOrUpdate<ActorSpec>` to **every** `ProcAgent`,
    - the `name` field is the *mesh-level* actor name ("this actor, on this mesh"),
    - `actor_type` is the *global* type name resolved via `Remote`,
-   - `params_data` is the serialized `A::Params`.
+   - `params_data` is the serialized `A::Params`,
+   - `actor_environment` is the spawning actor's persistent environment.
 
-At this point the proc mesh has done its part: it has told every proc in the mesh: "For mesh actor name, please ensure you have one local actor of type `actor_type`, constructed from `params_data`."
+At this point the proc mesh has done its part: it has told every proc in the mesh: "For this mesh actor, please ensure you have one local actor of type `actor_type`, constructed from `params_data`, and carrying this persistent environment."
 
 ### How `ProcAgent` handles `CreateOrUpdate<ActorSpec>`
 

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -34,6 +34,7 @@ use typeuri::Named;
 
 use crate as hyperactor; // for macros
 use crate::ActorAddr;
+use crate::ActorEnvironment;
 use crate::ActorRef;
 use crate::Addr;
 #[cfg(test)]
@@ -533,14 +534,18 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
         parent: InstanceCell,
         uid: crate::id::Uid,
         serialized_params: Data,
-        environment: Flattrs,
+        environment: ActorEnvironment,
+        transient: Flattrs,
     ) -> Pin<Box<dyn Future<Output = Result<AnyActorHandle, anyhow::Error>> + Send>> {
         let proc = proc.clone();
         Box::pin(async move {
             let params =
                 bincode::serde::decode_from_slice(&serialized_params, bincode::config::legacy())
                     .map(|(v, _)| v)?;
-            let actor = Self::new(params, environment).await?;
+            // The constructor sees persistent + transient headers (transient
+            // wins on collision); only the persistent environment is stored on
+            // the instance (AENV-2, AENV-4).
+            let actor = Self::new(params, environment.constructor_view(transient)?).await?;
             let handle = proc.spawn_child_with_uid(parent, uid, actor)?;
             handle.bind::<Self>();
             Ok(handle.into_any())

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -501,15 +501,19 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
         proc: &Proc,
         uid: crate::id::Uid,
         serialized_params: Data,
-        environment: Flattrs,
+        environment: ActorEnvironment,
+        transient: Flattrs,
     ) -> Pin<Box<dyn Future<Output = Result<ActorAddr, anyhow::Error>> + Send>> {
         let proc = proc.clone();
         Box::pin(async move {
             let params =
                 bincode::serde::decode_from_slice(&serialized_params, bincode::config::legacy())
                     .map(|(v, _)| v)?;
-            let actor = Self::new(params, environment).await?;
-            let handle = proc.spawn_with_uid(uid, actor)?;
+            // The constructor sees persistent + transient headers (transient
+            // wins on collision); only the persistent environment is stored on
+            // the instance (AENV-3, AENV-4).
+            let actor = Self::new(params, environment.constructor_view(transient)?).await?;
+            let handle = proc.spawn_with_uid_in_environment(uid, actor, environment)?;
             // We return only the ActorAddr, not a typed ActorRef.
             // Callers that hold this ID can interact with the actor
             // only via the serialized/opaque messaging path, which

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -510,8 +510,10 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
                 bincode::serde::decode_from_slice(&serialized_params, bincode::config::legacy())
                     .map(|(v, _)| v)?;
             // The constructor sees persistent + transient headers (transient
-            // wins on collision); only the persistent environment is stored on
-            // the instance (AENV-3, AENV-4).
+            // wins); the instance stores only `environment`. Local callers
+            // derive it from the parent (AENV-2); remote callers transport the
+            // spawning actor's value (AENV-3). Transient headers are never
+            // stored (AENV-4).
             let actor = Self::new(params, environment.constructor_view(transient)?).await?;
             let handle = proc.spawn_with_uid_in_environment(uid, actor, environment)?;
             // We return only the ActorAddr, not a typed ActorRef.
@@ -548,9 +550,10 @@ pub trait RemoteSpawn: Actor + Referable + Binds<Self> {
                     .map(|(v, _)| v)?;
             // The constructor sees persistent + transient headers (transient
             // wins on collision); only the persistent environment is stored on
-            // the instance (AENV-2, AENV-4).
+            // the instance (AENV-3, AENV-4).
             let actor = Self::new(params, environment.constructor_view(transient)?).await?;
-            let handle = proc.spawn_child_with_uid(parent, uid, actor)?;
+            let handle =
+                proc.spawn_child_with_uid_in_environment(parent, uid, actor, environment)?;
             handle.bind::<Self>();
             Ok(handle.into_any())
         })

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -179,6 +179,30 @@ impl Remote {
         transient: Flattrs,
     ) -> Result<AnyActorHandle, anyhow::Error> {
         let environment = parent.actor_environment().clone();
+        self.gspawn_child_in_environment(
+            proc,
+            parent,
+            actor_type,
+            actor_uid,
+            params,
+            environment,
+            transient,
+        )
+        .await
+    }
+
+    /// Spawn a child with an explicit environment instead of inheriting from
+    /// its physical parent.
+    pub(crate) async fn gspawn_child_in_environment(
+        &self,
+        proc: &Proc,
+        parent: InstanceCell,
+        actor_type: &str,
+        actor_uid: Uid,
+        params: Data,
+        environment: ActorEnvironment,
+        transient: Flattrs,
+    ) -> Result<AnyActorHandle, anyhow::Error> {
         let entry = self
             .by_name
             .get(actor_type)

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -17,6 +17,7 @@ use std::sync::LazyLock;
 use hyperactor_config::Flattrs;
 
 use crate::Actor;
+use crate::ActorEnvironment;
 use crate::AnyActorHandle;
 use crate::Data;
 use crate::id::Uid;
@@ -80,13 +81,16 @@ pub struct SpawnableActor {
     >,
 
     /// Type-erased child spawn function. This is the type's
-    /// [`RemoteSpawn::gspawn_child`].
+    /// [`RemoteSpawn::gspawn_child`]. The `ActorEnvironment` is the persistent
+    /// environment stored on the new instance; the `Flattrs` are the transient
+    /// constructor headers overlaid only for `RemoteSpawn::new`.
     pub gspawn_child:
         fn(
             &Proc,
             InstanceCell,
             Uid,
             Data,
+            ActorEnvironment,
             Flattrs,
         ) -> Pin<Box<dyn Future<Output = Result<AnyActorHandle, anyhow::Error>> + Send>>,
 
@@ -168,13 +172,14 @@ impl Remote {
         actor_type: &str,
         actor_uid: Uid,
         params: Data,
-        environment: Flattrs,
+        transient: Flattrs,
     ) -> Result<AnyActorHandle, anyhow::Error> {
+        let environment = parent.actor_environment().clone();
         let entry = self
             .by_name
             .get(actor_type)
             .ok_or_else(|| anyhow::anyhow!("actor type {} not registered", actor_type))?;
-        (entry.gspawn_child)(proc, parent, actor_uid, params, environment).await
+        (entry.gspawn_child)(proc, parent, actor_uid, params, environment, transient).await
     }
 }
 

--- a/hyperactor/src/actor/remote.rs
+++ b/hyperactor/src/actor/remote.rs
@@ -70,11 +70,14 @@ pub struct SpawnableActor {
     pub name: &'static LazyLock<&'static str>,
 
     /// Type-erased root spawn function. This is the type's
-    /// [`RemoteSpawn::gspawn_root_bind`].
+    /// [`RemoteSpawn::gspawn_root_bind`]. The `ActorEnvironment` is the
+    /// persistent environment stored on the new instance; the `Flattrs` are the
+    /// transient constructor headers overlaid only for `RemoteSpawn::new`.
     pub gspawn_root_bind: fn(
         &Proc,
         Uid,
         Data,
+        ActorEnvironment,
         Flattrs,
     ) -> Pin<
         Box<dyn Future<Output = Result<crate::ActorAddr, anyhow::Error>> + Send>,
@@ -154,13 +157,14 @@ impl Remote {
         actor_type: &str,
         actor_uid: Uid,
         params: Data,
-        environment: Flattrs,
+        environment: ActorEnvironment,
+        transient: Flattrs,
     ) -> Result<crate::ActorAddr, anyhow::Error> {
         let entry = self
             .by_name
             .get(actor_type)
             .ok_or_else(|| anyhow::anyhow!("actor type {} not registered", actor_type))?;
-        (entry.gspawn_root_bind)(proc, actor_uid, params, environment).await
+        (entry.gspawn_root_bind)(proc, actor_uid, params, environment, transient).await
     }
 
     /// Spawns the actor as a child of the provided parent. Returns an
@@ -269,6 +273,7 @@ mod tests {
                 "hyperactor::actor::remote::tests::MyActor",
                 Uid::instance(Label::new("actor").unwrap()),
                 bincode::serde::encode_to_vec(true, bincode::config::legacy()).unwrap(),
+                ActorEnvironment::default(),
                 Flattrs::default(),
             )
             .await
@@ -280,6 +285,7 @@ mod tests {
                 "hyperactor::actor::remote::tests::MyActor",
                 Uid::instance(Label::new("actor").unwrap()),
                 bincode::serde::encode_to_vec(false, bincode::config::legacy()).unwrap(),
+                ActorEnvironment::default(),
                 Flattrs::default(),
             )
             .await

--- a/hyperactor/src/environment.rs
+++ b/hyperactor/src/environment.rs
@@ -6,10 +6,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! A bounded, typed environment for persistent actor context.
+//! The persistent, language-independent environment carried by an actor
+//! [`Instance`](crate::proc::Instance).
 //!
-//! An [`ActorEnvironment`] is a small set of typed attributes with a stable,
-//! language-independent wire representation.
+//! An [`ActorEnvironment`] is a small, immutable set of typed attributes fixed
+//! when the instance is constructed. Local children inherit the exact value.
 //!
 //! `hyperactor` owns how this environment is carried through actor creation,
 //! while higher-level crates own the values it contains. Those crates declare
@@ -23,6 +24,15 @@
 //!
 //! - **AENV-0 (value integrity):** every `ActorEnvironment` is structurally
 //!   valid, bounded, unique-keyed, and updated atomically.
+//! - **AENV-1 (instance ownership):** every [`Instance`](crate::proc::Instance)
+//!   stores exactly one immutable environment in its type-erased instance cell,
+//!   fixed at construction and exposed read-only.
+//! - **AENV-2 (local inheritance):** ordinary local child/client construction
+//!   derives its parent's exact environment from that cell.
+//! - **AENV-4 (transient separation):** message/cast constructor headers may
+//!   override the merged view passed to [`RemoteSpawn::new`](crate::actor::RemoteSpawn)
+//!   but never enter the stored/inherited environment; persistent capability
+//!   consumers read only the stored instance environment.
 
 use std::collections::HashMap;
 use std::collections::HashSet;
@@ -90,10 +100,12 @@ pub enum ActorEnvironmentError {
     InvalidEncoding(#[from] FlattrsValidationError),
 }
 
-/// A bounded collection of typed actor-context attributes.
+/// The persistent environment owned by an actor instance.
 ///
 /// The inner buffer is never exposed. Clones share the immutable buffer; a
-/// subsequent builder mutation creates a bounded private copy.
+/// subsequent builder mutation creates a bounded private copy. Once placed on
+/// an [`Instance`](crate::proc::Instance), only a shared view is exposed
+/// (AENV-1).
 #[derive(Clone)]
 pub struct ActorEnvironment(Arc<Flattrs>);
 
@@ -107,8 +119,8 @@ impl ActorEnvironment {
     /// Store `value` under `key` while enforcing the environment's entry and
     /// serialized-size bounds.
     ///
-    /// This is a construction API; successful updates replace the underlying
-    /// immutable buffer atomically.
+    /// This is a construction API. The environment stored on an `Instance` is
+    /// immutable because the runtime exposes no mutable instance accessor.
     pub fn set<T: Serialize>(
         &mut self,
         key: Key<T>,
@@ -141,6 +153,27 @@ impl ActorEnvironment {
     /// The number of entries in the environment.
     pub fn len(&self) -> usize {
         self.0.len()
+    }
+
+    /// Build the constructor view handed to
+    /// [`RemoteSpawn::new`](crate::actor::RemoteSpawn). Persistent entries are
+    /// included only when the transient headers do not define the same key, so
+    /// transient values win on collision (AENV-4). The transient buffer's
+    /// ordering and duplicate-key behavior are preserved, and the stored
+    /// environment is unchanged.
+    pub(crate) fn constructor_view(
+        &self,
+        mut transient: Flattrs,
+    ) -> Result<Flattrs, ActorEnvironmentError> {
+        transient.validate_wire()?;
+        let transient_keys: HashSet<_> = transient.iter().map(|(key_hash, _)| key_hash).collect();
+        for (key_hash, value) in self.0.iter() {
+            if !transient_keys.contains(&key_hash) {
+                transient.set_serialized(key_hash, value);
+            }
+        }
+        transient.validate_wire()?;
+        Ok(transient)
     }
 }
 
@@ -418,5 +451,53 @@ mod tests {
                 .map(|(value, _)| value)
                 .expect("deserialize boundary environment");
         assert_eq!(restored, boundary);
+    }
+
+    #[test]
+    fn constructor_view_overlays_transient() {
+        let mut env = ActorEnvironment::default();
+        env.set(TEST_TAG, 100u64).expect("insert tag");
+        env.set(TEST_LABEL, "persistent".to_string())
+            .expect("insert label");
+
+        let mut transient = Flattrs::new();
+        transient.set(TEST_TAG, 999u64);
+
+        let view = env
+            .constructor_view(transient)
+            .expect("merge valid constructor headers");
+        assert_eq!(view.get(TEST_TAG), Some(999u64));
+        assert_eq!(view.get(TEST_LABEL), Some("persistent".to_string()));
+        assert_eq!(env.get(TEST_TAG), Some(100u64));
+    }
+
+    #[test]
+    fn constructor_view_preserves_transient_duplicates_and_rejects_overflow() {
+        let first = bincode::serde::encode_to_vec(1u64, bincode::config::legacy())
+            .expect("serialize first value");
+        let second = bincode::serde::encode_to_vec(2u64, bincode::config::legacy())
+            .expect("serialize second value");
+        let mut raw = 2u16.to_le_bytes().to_vec();
+        append_entry(&mut raw, TEST_TAG.key_hash(), &first);
+        append_entry(&mut raw, TEST_TAG.key_hash(), &second);
+        let transient = Flattrs::from_part(Part::from(raw));
+
+        let mut env = ActorEnvironment::default();
+        env.set(TEST_TAG, 100u64).expect("insert persistent tag");
+        let view = env
+            .constructor_view(transient)
+            .expect("merge duplicate transient headers");
+        assert_eq!(view.get(TEST_TAG), Some(1u64));
+        assert_eq!(view.len(), 2, "transient duplicates must remain intact");
+
+        let mut raw = u16::MAX.to_le_bytes().to_vec();
+        for _ in 0..u16::MAX {
+            append_entry(&mut raw, TEST_TAG.key_hash().wrapping_add(1), &[]);
+        }
+        let full = Flattrs::from_part(Part::from(raw));
+        assert!(
+            env.constructor_view(full).is_err(),
+            "adding a persistent key must not wrap the Flattrs entry count"
+        );
     }
 }

--- a/hyperactor/src/environment.rs
+++ b/hyperactor/src/environment.rs
@@ -1,0 +1,422 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! A bounded, typed environment for persistent actor context.
+//!
+//! An [`ActorEnvironment`] is a small set of typed attributes with a stable,
+//! language-independent wire representation.
+//!
+//! `hyperactor` owns how this environment is carried through actor creation,
+//! while higher-level crates own the values it contains. Those crates declare
+//! typed [`Key`] attributes. Putting those values in a fixed struct would move
+//! higher-level concepts into `hyperactor` and require core runtime and wire
+//! changes for each new kind of inherited context. This is not an untyped
+//! general-purpose map: the API preserves each value's type, enforces fixed
+//! bounds, and requires mutable ownership for construction updates.
+//!
+//! # AENV invariant registry
+//!
+//! - **AENV-0 (value integrity):** every `ActorEnvironment` is structurally
+//!   valid, bounded, unique-keyed, and updated atomically.
+
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use hyperactor_config::AttrValue;
+use hyperactor_config::Flattrs;
+use hyperactor_config::FlattrsValidationError;
+use hyperactor_config::Key;
+use serde::Deserialize;
+use serde::Deserializer;
+use serde::Serialize;
+use serde::Serializer;
+use serde::de::DeserializeOwned;
+use serde::de::Error as _;
+use serde_multipart::Part;
+
+const MAX_ACTOR_ENVIRONMENT_ENTRIES: usize = 32;
+const MAX_ACTOR_ENVIRONMENT_BYTES: usize = 16 * 1024;
+
+/// An error constructing or decoding an [`ActorEnvironment`].
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum ActorEnvironmentError {
+    /// One serialized value cannot fit within the environment's byte bound.
+    #[error("serialized actor environment value is {bytes} bytes; maximum is {maximum}")]
+    ValueTooLarge {
+        /// The serialized value size in bytes.
+        bytes: usize,
+        /// The maximum accepted serialized value size.
+        maximum: usize,
+    },
+
+    /// The encoded entry count exceeds the environment's fixed bound.
+    #[error("actor environment has {entries} entries; maximum is {maximum}")]
+    TooManyEntries {
+        /// The number of encoded entries.
+        entries: usize,
+        /// The maximum accepted number of entries.
+        maximum: usize,
+    },
+
+    /// The encoded environment exceeds its fixed byte bound.
+    #[error("actor environment is {bytes} bytes; maximum is {maximum}")]
+    TooLarge {
+        /// The encoded size in bytes.
+        bytes: usize,
+        /// The maximum accepted encoded size.
+        maximum: usize,
+    },
+
+    /// A key occurs more than once in the encoded environment.
+    #[error("actor environment contains duplicate key hash {key_hash:#x}")]
+    DuplicateKey {
+        /// The repeated key hash.
+        key_hash: u64,
+    },
+
+    /// A typed value could not be serialized into the environment.
+    #[error("failed to serialize actor environment value: {0}")]
+    ValueSerialization(#[from] bincode::error::EncodeError),
+
+    /// The underlying `Flattrs` wire structure is malformed.
+    #[error("invalid actor environment encoding: {0}")]
+    InvalidEncoding(#[from] FlattrsValidationError),
+}
+
+/// A bounded collection of typed actor-context attributes.
+///
+/// The inner buffer is never exposed. Clones share the immutable buffer; a
+/// subsequent builder mutation creates a bounded private copy.
+#[derive(Clone)]
+pub struct ActorEnvironment(Arc<Flattrs>);
+
+impl Default for ActorEnvironment {
+    fn default() -> Self {
+        Self(Arc::new(Flattrs::new()))
+    }
+}
+
+impl ActorEnvironment {
+    /// Store `value` under `key` while enforcing the environment's entry and
+    /// serialized-size bounds.
+    ///
+    /// This is a construction API; successful updates replace the underlying
+    /// immutable buffer atomically.
+    pub fn set<T: Serialize>(
+        &mut self,
+        key: Key<T>,
+        value: T,
+    ) -> Result<(), ActorEnvironmentError> {
+        let serialized = bincode::serde::encode_to_vec(value, bincode::config::legacy())?;
+        if serialized.len() > MAX_ACTOR_ENVIRONMENT_BYTES {
+            return Err(ActorEnvironmentError::ValueTooLarge {
+                bytes: serialized.len(),
+                maximum: MAX_ACTOR_ENVIRONMENT_BYTES,
+            });
+        }
+        let mut candidate = self.0.as_ref().clone();
+        candidate.set_serialized(key.key_hash(), &serialized);
+        validate(&candidate)?;
+        self.0 = Arc::new(candidate);
+        Ok(())
+    }
+
+    /// Read the value stored under `key`, if present.
+    pub fn get<T: AttrValue + DeserializeOwned>(&self, key: Key<T>) -> Option<T> {
+        self.0.get(key)
+    }
+
+    /// Whether the environment holds no entries.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// The number of entries in the environment.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+fn validate(attrs: &Flattrs) -> Result<(), ActorEnvironmentError> {
+    attrs.validate_wire()?;
+    let encoded_bytes = attrs.encoded_len();
+    if encoded_bytes > MAX_ACTOR_ENVIRONMENT_BYTES {
+        return Err(ActorEnvironmentError::TooLarge {
+            bytes: encoded_bytes,
+            maximum: MAX_ACTOR_ENVIRONMENT_BYTES,
+        });
+    }
+
+    let declared = attrs.len();
+    if declared > MAX_ACTOR_ENVIRONMENT_ENTRIES {
+        return Err(ActorEnvironmentError::TooManyEntries {
+            entries: declared,
+            maximum: MAX_ACTOR_ENVIRONMENT_ENTRIES,
+        });
+    }
+
+    let mut seen = HashSet::with_capacity(declared);
+    for (key_hash, _) in attrs.iter() {
+        if !seen.insert(key_hash) {
+            return Err(ActorEnvironmentError::DuplicateKey { key_hash });
+        }
+    }
+    Ok(())
+}
+
+impl Serialize for ActorEnvironment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for ActorEnvironment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // This bound controls accepted instance state. The transport frame
+        // limit is responsible for bounding allocation before field decoding.
+        let part = Part::deserialize(deserializer)?;
+        let encoded_bytes = part.len();
+        if encoded_bytes > MAX_ACTOR_ENVIRONMENT_BYTES {
+            return Err(D::Error::custom(ActorEnvironmentError::TooLarge {
+                bytes: encoded_bytes,
+                maximum: MAX_ACTOR_ENVIRONMENT_BYTES,
+            }));
+        }
+        let attrs = Flattrs::from_part(part);
+        validate(&attrs).map_err(D::Error::custom)?;
+        Ok(Self(Arc::new(attrs)))
+    }
+}
+
+impl std::fmt::Debug for ActorEnvironment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ActorEnvironment")
+            .field("len", &self.0.len())
+            .finish()
+    }
+}
+
+/// Equality over the `(key hash, serialized bytes)` set, independent of
+/// insertion order. Construction and deserialization enforce one entry per key
+/// hash.
+impl PartialEq for ActorEnvironment {
+    fn eq(&self, other: &Self) -> bool {
+        if Arc::ptr_eq(&self.0, &other.0) {
+            return true;
+        }
+        if self.0.len() != other.0.len() {
+            return false;
+        }
+        let mine: HashMap<u64, &[u8]> = self.0.iter().collect();
+        other
+            .0
+            .iter()
+            .all(|(key_hash, value)| mine.get(&key_hash) == Some(&value))
+    }
+}
+
+impl Eq for ActorEnvironment {}
+
+#[cfg(test)]
+mod tests {
+    use hyperactor_config::declare_attrs;
+
+    use super::*;
+
+    declare_attrs! {
+        attr TEST_TAG: u64;
+        attr TEST_LABEL: String;
+        attr TEST_BYTES: Vec<u8>;
+    }
+
+    fn decode_raw(raw: Vec<u8>) -> Result<ActorEnvironment, bincode::error::DecodeError> {
+        let attrs = Flattrs::from_part(Part::from(raw));
+        let encoded = bincode::serde::encode_to_vec(attrs, bincode::config::legacy())
+            .expect("serialize raw Flattrs");
+        bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+            .map(|(value, _)| value)
+    }
+
+    // Malformed-buffer tests must encode the private layout directly because
+    // the public Flattrs builders cannot construct invalid wire shapes.
+    fn append_entry(raw: &mut Vec<u8>, key_hash: u64, value: &[u8]) {
+        raw.extend_from_slice(&key_hash.to_le_bytes());
+        raw.extend_from_slice(&(value.len() as u32).to_le_bytes());
+        raw.extend_from_slice(value);
+    }
+
+    #[test]
+    fn default_accepts_first_insertion() {
+        let mut env = ActorEnvironment::default();
+        assert!(env.is_empty());
+        env.set(TEST_TAG, 7u64).expect("insert first value");
+        assert_eq!(env.get(TEST_TAG), Some(7u64));
+        assert_eq!(env.len(), 1);
+    }
+
+    #[test]
+    fn serde_roundtrips() {
+        let mut env = ActorEnvironment::default();
+        env.set(TEST_TAG, 42u64).expect("insert tag");
+        env.set(TEST_LABEL, "root".to_string())
+            .expect("insert label");
+
+        let bytes =
+            bincode::serde::encode_to_vec(&env, bincode::config::legacy()).expect("serialize");
+        let restored: ActorEnvironment =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::legacy())
+                .map(|(value, _)| value)
+                .expect("deserialize");
+
+        assert_eq!(restored.get(TEST_TAG), Some(42u64));
+        assert_eq!(restored.get(TEST_LABEL), Some("root".to_string()));
+        assert_eq!(restored, env);
+    }
+
+    #[test]
+    fn equality_is_order_independent() {
+        let mut a = ActorEnvironment::default();
+        a.set(TEST_TAG, 1u64).expect("insert tag");
+        a.set(TEST_LABEL, "x".to_string()).expect("insert label");
+
+        let mut b = ActorEnvironment::default();
+        b.set(TEST_LABEL, "x".to_string()).expect("insert label");
+        b.set(TEST_TAG, 1u64).expect("insert tag");
+
+        assert_eq!(a, b);
+
+        let mut c = ActorEnvironment::default();
+        c.set(TEST_TAG, 2u64).expect("insert tag");
+        c.set(TEST_LABEL, "x".to_string()).expect("insert label");
+        assert_ne!(a, c);
+    }
+
+    #[test]
+    fn serde_rejects_duplicate_keys() {
+        let value = bincode::serde::encode_to_vec(1u64, bincode::config::legacy())
+            .expect("serialize value");
+        let mut raw = 2u16.to_le_bytes().to_vec();
+        append_entry(&mut raw, TEST_TAG.key_hash(), &value);
+        append_entry(&mut raw, TEST_TAG.key_hash(), &value);
+
+        assert!(decode_raw(raw).is_err(), "duplicate keys must be rejected");
+    }
+
+    #[test]
+    fn serde_rejects_truncated_and_trailing_buffers() {
+        assert!(
+            decode_raw(vec![1]).is_err(),
+            "a partial count header must be rejected"
+        );
+        assert!(
+            decode_raw(1u16.to_le_bytes().to_vec()).is_err(),
+            "a declared entry without entry bytes must be rejected"
+        );
+        assert!(
+            decode_raw(vec![0, 0, 1]).is_err(),
+            "bytes after the declared entries must be rejected"
+        );
+    }
+
+    #[test]
+    fn set_rejects_oversized_values_without_mutating() {
+        let mut env = ActorEnvironment::default();
+        let err = env
+            .set(TEST_BYTES, vec![0; MAX_ACTOR_ENVIRONMENT_BYTES])
+            .expect_err("oversized value must be rejected");
+        assert!(matches!(err, ActorEnvironmentError::ValueTooLarge { .. }));
+        assert!(env.is_empty(), "a rejected insertion must be atomic");
+    }
+
+    #[test]
+    fn set_rejects_entry_and_aggregate_bounds_atomically() {
+        let mut raw = (MAX_ACTOR_ENVIRONMENT_ENTRIES as u16)
+            .to_le_bytes()
+            .to_vec();
+        for offset in 1..=MAX_ACTOR_ENVIRONMENT_ENTRIES {
+            append_entry(
+                &mut raw,
+                TEST_TAG.key_hash().wrapping_add(offset as u64),
+                &[],
+            );
+        }
+        let mut full = decode_raw(raw).expect("decode environment at the entry bound");
+        let before = full.clone();
+        let err = full
+            .set(TEST_TAG, 1u64)
+            .expect_err("a 33rd entry must be rejected");
+        assert!(matches!(err, ActorEnvironmentError::TooManyEntries { .. }));
+        assert_eq!(full, before, "a rejected insertion must be atomic");
+
+        let mut large = ActorEnvironment::default();
+        large
+            .set(TEST_BYTES, vec![0; MAX_ACTOR_ENVIRONMENT_BYTES - 64])
+            .expect("the first value fits within the aggregate bound");
+        let before = large.clone();
+        let err = large
+            .set(TEST_LABEL, "x".repeat(128))
+            .expect_err("aggregate encoded size must be enforced");
+        assert!(matches!(err, ActorEnvironmentError::TooLarge { .. }));
+        assert_eq!(large, before, "a rejected insertion must be atomic");
+    }
+
+    #[test]
+    fn serde_rejects_policy_bounds() {
+        let mut too_many = ((MAX_ACTOR_ENVIRONMENT_ENTRIES + 1) as u16)
+            .to_le_bytes()
+            .to_vec();
+        for offset in 1..=MAX_ACTOR_ENVIRONMENT_ENTRIES + 1 {
+            append_entry(
+                &mut too_many,
+                TEST_TAG.key_hash().wrapping_add(offset as u64),
+                &[],
+            );
+        }
+        assert!(
+            decode_raw(too_many).is_err(),
+            "an oversized entry set must be rejected"
+        );
+
+        let mut too_large = 1u16.to_le_bytes().to_vec();
+        append_entry(
+            &mut too_large,
+            TEST_BYTES.key_hash(),
+            &vec![0; MAX_ACTOR_ENVIRONMENT_BYTES],
+        );
+        let err = decode_raw(too_large).expect_err("oversized environment must fail");
+        assert!(
+            err.to_string().contains("maximum"),
+            "a structurally valid oversized environment must hit the byte bound: {err}"
+        );
+
+        let mut boundary = ActorEnvironment::default();
+        boundary
+            .set(TEST_BYTES, Vec::<u8>::new())
+            .expect("measure one-entry encoding overhead");
+        let payload_len = MAX_ACTOR_ENVIRONMENT_BYTES - boundary.0.encoded_len();
+        boundary
+            .set(TEST_BYTES, vec![0; payload_len])
+            .expect("the exact byte boundary must be accepted");
+        assert_eq!(boundary.0.encoded_len(), MAX_ACTOR_ENVIRONMENT_BYTES);
+        let encoded = bincode::serde::encode_to_vec(&boundary, bincode::config::legacy())
+            .expect("serialize boundary environment");
+        let restored: ActorEnvironment =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(value, _)| value)
+                .expect("deserialize boundary environment");
+        assert_eq!(restored, boundary);
+    }
+}

--- a/hyperactor/src/environment.rs
+++ b/hyperactor/src/environment.rs
@@ -10,7 +10,8 @@
 //! [`Instance`](crate::proc::Instance).
 //!
 //! An [`ActorEnvironment`] is a small, immutable set of typed attributes fixed
-//! when the instance is constructed. Local children inherit the exact value.
+//! when the instance is constructed. Local children inherit the exact value,
+//! and `ProcMesh` root spawns serialize it across the proc boundary.
 //!
 //! `hyperactor` owns how this environment is carried through actor creation,
 //! while higher-level crates own the values it contains. Those crates declare
@@ -29,6 +30,8 @@
 //!   fixed at construction and exposed read-only.
 //! - **AENV-2 (local inheritance):** ordinary local child/client construction
 //!   derives its parent's exact environment from that cell.
+//! - **AENV-3 (remote inheritance):** `ProcMesh` root spawn serializes the
+//!   spawning instance's exact environment through `ActorSpec`.
 //! - **AENV-4 (transient separation):** message/cast constructor headers may
 //!   override the merged view passed to [`RemoteSpawn::new`](crate::actor::RemoteSpawn)
 //!   but never enter the stored/inherited environment; persistent capability

--- a/hyperactor/src/environment.rs
+++ b/hyperactor/src/environment.rs
@@ -10,8 +10,9 @@
 //! [`Instance`](crate::proc::Instance).
 //!
 //! An [`ActorEnvironment`] is a small, immutable set of typed attributes fixed
-//! when the instance is constructed. Local children inherit the exact value,
-//! and `ProcMesh` root spawns serialize it across the proc boundary.
+//! when the instance is constructed. It is inherited by local children and
+//! serialized to remote children, giving stable actor context a native home
+//! that does not depend on the actor's implementation language.
 //!
 //! `hyperactor` owns how this environment is carried through actor creation,
 //! while higher-level crates own the values it contains. Those crates declare
@@ -30,12 +31,16 @@
 //!   fixed at construction and exposed read-only.
 //! - **AENV-2 (local inheritance):** ordinary local child/client construction
 //!   derives its parent's exact environment from that cell.
-//! - **AENV-3 (remote inheritance):** `ProcMesh` root spawn serializes the
-//!   spawning instance's exact environment through `ActorSpec`.
+//! - **AENV-3 (remote inheritance):** native remote-spawn adapters serialize the
+//!   spawning instance's exact environment; nested remote spawn repeats that
+//!   operation independently.
 //! - **AENV-4 (transient separation):** message/cast constructor headers may
 //!   override the merged view passed to [`RemoteSpawn::new`](crate::actor::RemoteSpawn)
 //!   but never enter the stored/inherited environment; persistent capability
 //!   consumers read only the stored instance environment.
+//! - **AENV-5 (runtime neutrality):** inheritance is implemented by native
+//!   `Instance`/spawn plumbing and does not depend on the actor implementation
+//!   language.
 
 use std::collections::HashMap;
 use std::collections::HashSet;

--- a/hyperactor/src/lib.rs
+++ b/hyperactor/src/lib.rs
@@ -68,6 +68,7 @@ pub mod client;
 pub mod config;
 pub mod context;
 pub mod endpoint;
+pub mod environment;
 /// Gateway management for proc connectivity.
 pub mod gateway;
 pub mod id;
@@ -132,6 +133,8 @@ pub use client::Client;
 pub use endpoint::Endpoint;
 pub use endpoint::EndpointLocation;
 pub use endpoint::RemoteEndpoint;
+pub use environment::ActorEnvironment;
+pub use environment::ActorEnvironmentError;
 pub use gateway::Gateway;
 #[doc(inline)]
 pub use hyperactor_macros::HandleClient;

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -185,6 +185,7 @@ use crate::config;
 use crate::context;
 use crate::context::Mailbox as _;
 use crate::endpoint::Endpoint as _;
+use crate::environment::ActorEnvironment;
 use crate::gateway::Gateway;
 use crate::id::ActorId;
 use crate::id::Label;
@@ -1101,7 +1102,7 @@ impl Proc {
     /// Spawn a root actor with a fresh uid labeled from the actor type.
     pub fn spawn<A: Actor>(&self, actor: A) -> ActorHandle<A> {
         let actor_id: ActorAddr = self.allocate_root_type::<A>();
-        self.spawn_inner(actor_id, actor, None)
+        self.spawn_inner(actor_id, actor, None, ActorEnvironment::default())
     }
 
     /// Spawn a root actor with a fresh uid carrying a display label.
@@ -1110,7 +1111,7 @@ impl Proc {
     /// identity.
     pub fn spawn_with_label<A: Actor>(&self, label: &str, actor: A) -> ActorHandle<A> {
         let actor_id: ActorAddr = self.allocate_root_label(label);
-        self.spawn_inner(actor_id, actor, None)
+        self.spawn_inner(actor_id, actor, None, ActorEnvironment::default())
     }
 
     /// Spawn a root actor on this proc using an explicit uid.
@@ -1125,17 +1126,20 @@ impl Proc {
         actor: A,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
         let actor_id: ActorAddr = self.allocate_root_uid(uid)?;
-        Ok(self.spawn_inner(actor_id, actor, None))
+        Ok(self.spawn_inner(actor_id, actor, None, ActorEnvironment::default()))
     }
 
-    /// Common spawn logic for both root and child actors.
+    /// Common spawn logic for both root and child actors. `environment` is
+    /// required so no private path can silently default it (AENV-1).
     fn spawn_inner<A: Actor>(
         &self,
         actor_id: ActorAddr,
         actor: A,
         parent: Option<InstanceCell>,
+        environment: ActorEnvironment,
     ) -> ActorHandle<A> {
-        let (instance, receivers) = Instance::new(self.clone(), actor_id, false, parent);
+        let (instance, receivers) =
+            Instance::new(self.clone(), actor_id, false, parent, environment);
         instance.start(actor, receivers)
     }
 
@@ -1145,8 +1149,13 @@ impl Proc {
     /// `tokio::spawn`.
     pub fn client(&self, label: &str) -> Client {
         let actor_id = self.allocate_client_id(label);
-        let (instance, _receivers) =
-            Instance::<ClientActor>::new(self.clone(), actor_id, false, None);
+        let (instance, _receivers) = Instance::<ClientActor>::new(
+            self.clone(),
+            actor_id,
+            false,
+            None,
+            ActorEnvironment::default(),
+        );
         instance.change_status(ActorStatus::Client);
         Client::new(instance)
     }
@@ -1168,7 +1177,13 @@ impl Proc {
         name: &str,
     ) -> Result<(Instance<()>, ActorHandle<()>), anyhow::Error> {
         let actor_id: ActorAddr = self.allocate_root_id(name)?;
-        let (instance, receivers) = Instance::new(self.clone(), actor_id, false, None);
+        let (instance, receivers) = Instance::new(
+            self.clone(),
+            actor_id,
+            false,
+            None,
+            ActorEnvironment::default(),
+        );
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
         instance.spawn_detached_introspect(receivers.introspect);
@@ -1181,13 +1196,27 @@ impl Proc {
     /// launch child actors, etc. The actor itself does not handle any
     /// messages unless driven by the caller.
     pub fn actor_instance<A: Actor>(&self, name: &str) -> Result<ActorInstance<A>, anyhow::Error> {
+        self.actor_instance_in_environment(name, ActorEnvironment::default())
+    }
+
+    /// Create an inverted actor instance with an explicit environment.
+    ///
+    /// This is the root-construction boundary used by runtimes that seed stable
+    /// context before driving the returned instance. The environment is fixed
+    /// before the instance becomes observable (AENV-1).
+    pub fn actor_instance_in_environment<A: Actor>(
+        &self,
+        name: &str,
+        environment: ActorEnvironment,
+    ) -> Result<ActorInstance<A>, anyhow::Error> {
         let actor_id: ActorAddr = self.allocate_root_id(name)?;
         let span = tracing::debug_span!(
             "actor_instance",
             subject = %actor_id.subject(),
         );
         let _guard = span.enter();
-        let (instance, receivers) = Instance::new(self.clone(), actor_id.clone(), false, None);
+        let (instance, receivers) =
+            Instance::new(self.clone(), actor_id.clone(), false, None, environment);
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
         instance.change_status(ActorStatus::Client);
 
@@ -1320,7 +1349,9 @@ impl Proc {
             subject = %actor_id.subject(),
         );
 
-        let (instance, _receivers) = Instance::new(self.clone(), actor_id, false, Some(parent));
+        let environment = parent.actor_environment().clone();
+        let (instance, _receivers) =
+            Instance::new(self.clone(), actor_id, false, Some(parent), environment);
         // Client-mode instance: no actor loop, no introspect task.
         // Receivers are intentionally dropped.
         let handle = ActorHandle::new(instance.inner.cell.clone(), instance.inner.ports.clone());
@@ -1335,7 +1366,8 @@ impl Proc {
     /// with its parent.
     pub(crate) fn spawn_child<A: Actor>(&self, parent: InstanceCell, actor: A) -> ActorHandle<A> {
         let actor_id = self.allocate_child_id::<A>(parent.actor_addr());
-        self.spawn_inner(actor_id, actor, Some(parent))
+        let environment = parent.actor_environment().clone();
+        self.spawn_inner(actor_id, actor, Some(parent), environment)
     }
 
     /// Spawn a child actor from the provided parent using an explicit uid.
@@ -1345,8 +1377,9 @@ impl Proc {
         uid: Uid,
         actor: A,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
+        let environment = parent.actor_environment().clone();
         let actor_id = self.ensure_child_uid(parent.actor_addr(), uid)?;
-        Ok(self.spawn_inner(actor_id, actor, Some(parent)))
+        Ok(self.spawn_inner(actor_id, actor, Some(parent), environment))
     }
 
     /// Spawn a named child actor. Same as `spawn_child` but the child
@@ -1359,7 +1392,8 @@ impl Proc {
         actor: A,
     ) -> ActorHandle<A> {
         let actor_id = self.allocate_named_child_id(parent.actor_addr(), name);
-        self.spawn_inner(actor_id, actor, Some(parent))
+        let environment = parent.actor_environment().clone();
+        self.spawn_inner(actor_id, actor, Some(parent), environment)
     }
 
     /// Call `abort` on the `JoinHandle` associated with the given
@@ -2323,11 +2357,16 @@ pub struct InstanceReceivers<A: Actor> {
 
 impl<A: Actor> Instance<A> {
     /// Create a new actor instance in Created state.
+    ///
+    /// `actor_environment` is required and always stored. Ordinary child
+    /// helpers derive it from the parent cell before calling this constructor;
+    /// root and remote-override paths supply it explicitly (AENV-1, AENV-2).
     fn new(
         proc: Proc,
         actor_id: ActorAddr,
         detached: bool,
         parent: Option<InstanceCell>,
+        actor_environment: ActorEnvironment,
     ) -> (Self, InstanceReceivers<A>) {
         // Set up messaging
         let mailbox = Mailbox::new(actor_id.clone());
@@ -2387,6 +2426,7 @@ impl<A: Actor> Instance<A> {
             actor_id,
             instance_id,
             actor_type,
+            actor_environment,
             proc.clone(),
             actor_loop,
             status_tx,
@@ -3476,7 +3516,7 @@ impl<A: Actor> Instance<A> {
     /// Spawn a registered actor as this instance's child.
     ///
     /// The actor type is resolved through the remote spawn registry. The child
-    /// receives an empty environment.
+    /// inherits this instance's environment (AENV-2).
     pub async fn gspawn(&self, actor_type: &str, params: Data) -> anyhow::Result<AnyActorHandle> {
         self.gspawn_uid(actor_type, crate::id::Uid::anonymous(), params)
             .await
@@ -3485,7 +3525,8 @@ impl<A: Actor> Instance<A> {
     /// Spawn a registered actor as this instance's child using an explicit uid.
     ///
     /// The actor type is resolved through the remote spawn registry. The child
-    /// receives an empty environment.
+    /// inherits this instance's environment (AENV-2). No transient constructor
+    /// headers are supplied on this local path.
     pub async fn gspawn_uid(
         &self,
         actor_type: &str,
@@ -3499,7 +3540,7 @@ impl<A: Actor> Instance<A> {
                 actor_type,
                 uid,
                 params,
-                Flattrs::default(),
+                Flattrs::new(),
             )
             .await
     }
@@ -3532,6 +3573,15 @@ impl<A: Actor> Instance<A> {
     /// The owning proc.
     pub fn proc(&self) -> &Proc {
         &self.inner.proc
+    }
+
+    /// This instance's persistent environment.
+    ///
+    /// The environment is fixed at construction and inherited by local children
+    /// (AENV-1, AENV-2). Only a shared, read-only view is returned; there is no
+    /// mutable accessor.
+    pub fn actor_environment(&self) -> &ActorEnvironment {
+        self.inner.cell.actor_environment()
     }
 
     /// Clone this Instance to get an owned struct that can be
@@ -3598,6 +3648,7 @@ impl Instance<ClientActor> {
             actor_id,
             false,
             Some(self.inner.cell.clone()),
+            self.inner.cell.actor_environment().clone(),
         );
         instance.change_status(ActorStatus::Client);
         Client::new(instance)
@@ -3764,6 +3815,9 @@ impl fmt::Debug for InstanceCell {
 struct InstanceCellState {
     /// The actor's id.
     actor_id: ActorAddr,
+
+    /// Persistent, type-erased context fixed when the instance is created.
+    actor_environment: ActorEnvironment,
 
     /// The actor instance's `Uuid::now_v7()` identity. Stable for the
     /// lifetime of this instance; surfaced via `InstanceCell::instance_id`
@@ -3991,6 +4045,7 @@ impl InstanceCell {
         actor_id: ActorAddr,
         instance_id: Uuid,
         actor_type: ActorType,
+        actor_environment: ActorEnvironment,
         proc: Proc,
         actor_loop: Option<(
             mpsc::UnboundedSender<Signal>,
@@ -4012,6 +4067,7 @@ impl InstanceCell {
                 actor_id: actor_id.clone(),
                 instance_id,
                 actor_type,
+                actor_environment,
                 proc: proc.clone(),
                 actor_loop,
                 status_tx,
@@ -4054,6 +4110,11 @@ impl InstanceCell {
     /// The actor's address.
     pub fn actor_addr(&self) -> &ActorAddr {
         &self.inner.actor_id
+    }
+
+    /// The persistent environment fixed when this instance was created.
+    pub(crate) fn actor_environment(&self) -> &ActorEnvironment {
+        &self.inner.actor_environment
     }
 
     /// The proc in which this actor is running.
@@ -8159,5 +8220,125 @@ mod tests {
             ChildTeardown::from_run_result(&failed),
             ChildTeardown::Cooperative(StopMode::Stop)
         );
+    }
+
+    hyperactor_config::attrs::declare_attrs! {
+        attr AENV_TEST_TAG: u64;
+    }
+
+    /// Sentinel stored under `AENV_TEST_TAG` by a seeded environment. Non-zero
+    /// so it is distinguishable from the empty-environment reading of `0`.
+    const AENV_SENTINEL: u64 = 0xA0FE;
+
+    /// A registered probe that, at construction (`Actor::init`), reports the
+    /// value stored under `AENV_TEST_TAG` in its own instance environment to a
+    /// reply port. Used to observe inherited environments across every local
+    /// child path (AENV-2).
+    #[derive(Debug)]
+    #[hyperactor::export(())]
+    struct EnvProbe {
+        reply: PortRef<u64>,
+    }
+
+    #[async_trait]
+    impl Actor for EnvProbe {
+        async fn init(&mut self, this: &Instance<Self>) -> Result<(), anyhow::Error> {
+            let observed = this.actor_environment().get(AENV_TEST_TAG).unwrap_or(0);
+            self.reply.post(this, observed);
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<()> for EnvProbe {
+        async fn handle(&mut self, _cx: &Context<Self>, _message: ()) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl crate::RemoteSpawn for EnvProbe {
+        type Params = PortRef<u64>;
+
+        async fn new(reply: PortRef<u64>, _environment: Flattrs) -> anyhow::Result<Self> {
+            Ok(Self { reply })
+        }
+    }
+
+    crate::register_spawnable!(EnvProbe);
+
+    // AENV-1: ordinary root/client instances start with an empty environment.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn aenv_ordinary_instances_start_empty() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        assert!(
+            context::Actor::instance(&client)
+                .actor_environment()
+                .is_empty()
+        );
+
+        // A root actor observes an empty environment (reads back the `0`
+        // fallback for the absent tag).
+        let (tx, mut rx) = client.open_port::<u64>();
+        let _root = proc.spawn(EnvProbe { reply: tx.bind() });
+        assert_eq!(rx.recv().await.unwrap(), 0);
+    }
+
+    // AENV-1, AENV-2: a seeded parent's environment is inherited exactly by
+    // every local child construction path.
+    #[async_timed_test(timeout_secs = 30)]
+    async fn aenv_local_children_inherit_environment() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+
+        let mut seed = ActorEnvironment::default();
+        seed.set(AENV_TEST_TAG, AENV_SENTINEL)
+            .expect("seed actor environment");
+        let parent = proc
+            .actor_instance_in_environment::<EnvProbe>("seeded", seed.clone())
+            .expect("create seeded root instance");
+        assert_eq!(parent.instance.actor_environment(), &seed);
+
+        // Direct child/client: inspected synchronously.
+        assert_eq!(parent.instance.child().0.actor_environment(), &seed);
+
+        let client_parent = proc
+            .actor_instance_in_environment::<ClientActor>("seeded_client", seed.clone())
+            .expect("create seeded client instance");
+        let child_client = client_parent.instance.child_client();
+        assert_eq!(
+            context::Actor::instance(&child_client).actor_environment(),
+            &seed,
+        );
+
+        // Ordinary child.
+        let (tx, mut rx) = client.open_port::<u64>();
+        let _ordinary = parent.instance.spawn(EnvProbe { reply: tx.bind() });
+        assert_eq!(rx.recv().await.unwrap(), AENV_SENTINEL);
+
+        // Named child.
+        let (tx, mut rx) = client.open_port::<u64>();
+        let _named = parent
+            .instance
+            .spawn_with_label("named", EnvProbe { reply: tx.bind() });
+        assert_eq!(rx.recv().await.unwrap(), AENV_SENTINEL);
+
+        // Explicit-uid child.
+        let (tx, mut rx) = client.open_port::<u64>();
+        let _uid = parent
+            .instance
+            .spawn_with_uid(crate::id::Uid::anonymous(), EnvProbe { reply: tx.bind() })
+            .unwrap();
+        assert_eq!(rx.recv().await.unwrap(), AENV_SENTINEL);
+
+        // Registered gspawn child.
+        let (tx, mut rx) = client.open_port::<u64>();
+        let params = bincode::serde::encode_to_vec(tx.bind(), bincode::config::legacy()).unwrap();
+        let type_name = crate::actor::remote::Remote::global()
+            .name_of::<EnvProbe>()
+            .expect("EnvProbe is registered");
+        let _gspawned = parent.instance.gspawn(type_name, params).await.unwrap();
+        assert_eq!(rx.recv().await.unwrap(), AENV_SENTINEL);
     }
 }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1394,6 +1394,18 @@ impl Proc {
         actor: A,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
         let environment = parent.actor_environment().clone();
+        self.spawn_child_with_uid_in_environment(parent, uid, actor, environment)
+    }
+
+    /// Spawn a child actor with an explicit environment instead of inheriting
+    /// from its physical parent.
+    pub(crate) fn spawn_child_with_uid_in_environment<A: Actor>(
+        &self,
+        parent: InstanceCell,
+        uid: Uid,
+        actor: A,
+        environment: ActorEnvironment,
+    ) -> Result<ActorHandle<A>, anyhow::Error> {
         let actor_id = self.ensure_child_uid(parent.actor_addr(), uid)?;
         Ok(self.spawn_inner(actor_id, actor, Some(parent), environment))
     }
@@ -3556,6 +3568,32 @@ impl<A: Actor> Instance<A> {
                 actor_type,
                 uid,
                 params,
+                Flattrs::new(),
+            )
+            .await
+    }
+
+    /// Spawn a registered child with an explicitly transported environment.
+    ///
+    /// Native remote-spawn protocols use this after decoding the spawning
+    /// actor's environment (AENV-3). Ordinary local callers should use
+    /// [`gspawn_uid`], which inherits this instance's environment (AENV-2).
+    #[doc(hidden)]
+    pub async fn gspawn_uid_in_environment(
+        &self,
+        actor_type: &str,
+        uid: crate::id::Uid,
+        params: Data,
+        environment: ActorEnvironment,
+    ) -> anyhow::Result<AnyActorHandle> {
+        crate::actor::remote::Remote::global()
+            .gspawn_child_in_environment(
+                &self.inner.proc,
+                self.inner.cell.clone(),
+                actor_type,
+                uid,
+                params,
+                environment,
                 Flattrs::new(),
             )
             .await

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -1125,8 +1125,24 @@ impl Proc {
         uid: Uid,
         actor: A,
     ) -> Result<ActorHandle<A>, anyhow::Error> {
+        self.spawn_with_uid_in_environment(uid, actor, ActorEnvironment::default())
+    }
+
+    /// Spawn a root actor on this proc using an explicit uid and an explicit
+    /// environment.
+    ///
+    /// The environment-carrying counterpart to
+    /// [`spawn_with_uid`](Self::spawn_with_uid), used by the type-erased remote
+    /// root-spawn path to store the environment transported in `ActorSpec`
+    /// (AENV-3).
+    pub(crate) fn spawn_with_uid_in_environment<A: Actor>(
+        &self,
+        uid: Uid,
+        actor: A,
+        environment: ActorEnvironment,
+    ) -> Result<ActorHandle<A>, anyhow::Error> {
         let actor_id: ActorAddr = self.allocate_root_uid(uid)?;
-        Ok(self.spawn_inner(actor_id, actor, None, ActorEnvironment::default()))
+        Ok(self.spawn_inner(actor_id, actor, None, environment))
     }
 
     /// Common spawn logic for both root and child actors. `environment` is

--- a/hyperactor_mesh/src/client_root.rs
+++ b/hyperactor_mesh/src/client_root.rs
@@ -1,0 +1,282 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! A native, language-independent client-root capability.
+//!
+//! A Hyperactor mesh program has exactly one root client. Rust and Python are
+//! alternative bootstrap implementations of that one root, not separate root
+//! namespaces; worker ProcAgents host actors but never become client roots.
+//!
+//! [`ClientRootRef`] is an opaque bearer capability to the root, carried in an
+//! actor's [`ActorEnvironment`](hyperactor::ActorEnvironment) and inherited by
+//! descendants. Its sole authority is to create or reuse a statically declared,
+//! root-owned service through the root ProcAgent's [`EnsureClientRootService`]
+//! handler.
+//!
+//! # CROOT invariant registry
+//!
+//! - **CROOT-1 (singleton binding):** the active client bootstrap binds
+//!   [`ClientRootApi`] on the program's one root ProcAgent and stores that exact
+//!   reference; worker ProcAgents never bind it.
+//! - **CROOT-2 (typed API attenuation):** [`ClientRootRef`] exposes only typed
+//!   ensure-service authority and no root administration.
+//! - **CROOT-3 (single identity):** exact name/type/parameter equality returns
+//!   one cached spawn result; a type or parameter-byte difference for the same
+//!   name conflicts. The service actor is created under a fresh random instance
+//!   id, which avoids the predictable collision a name-derived id would create;
+//!   the create path re-draws the id if it collides with one already present in
+//!   `actor_states`.
+//! - **CROOT-4 (worker rejection):** a worker ProcAgent has no bound client-root
+//!   handler, so a retyped worker reference reaches an unbound port and cannot
+//!   create a service.
+//! - **CROOT-5 (root ownership):** service lifetime belongs to the root
+//!   ProcAgent, never the requester; a reused reference to a service that has
+//!   reached a terminal state fails closed rather than returning a dead actor.
+//! - **CROOT-6 (validation):** a capability absent from the actor environment
+//!   fails closed — [`ClientRootRef::from_env`] returns an error rather than a
+//!   silent `None`, before any request is sent.
+//! - **CROOT-7 (continuity):** each created service receives the same
+//!   [`ClientRootRef`] in its native environment.
+//! - **CROOT-8 (runtime neutrality):** Rust and Python roots store the same
+//!   native capability under the same environment key.
+//! - **CROOT-9 (map layering):** a service's spawn result and lifecycle live
+//!   solely in the ProcAgent `actor_states` registry; the service-identity table
+//!   records only the (actor type, exact parameter bytes, instance id) a repeat
+//!   ensure must match. Only ensure writes that table, and only alongside the
+//!   `actor_states` entry, so the two never disagree.
+//! - **CROOT-10 (attestation boundary):** the only explicit attestation restores
+//!   `ActorRef<A>` immediately after the erased spawn reply whose requested and
+//!   recorded actor type was derived from that same `A`; every other reference is
+//!   bound or deserialized.
+//! - **CROOT-11 (handler resilience):** the `EnsureClientRootService` handler
+//!   disables undeliverable-return on its reply and always returns `Ok(())`,
+//!   reporting every expected failure through the typed reply; a malformed,
+//!   conflicting, or reply-undeliverable request never faults the root ProcAgent.
+//! - **CROOT-12 (crate layering):** every client-root type and policy stays in
+//!   `hyperactor_mesh` (or a higher composition crate); `hyperactor` remains a
+//!   generic attribute carrier with no static mesh dependency.
+
+use std::marker::PhantomData;
+
+use hyperactor::ActorAddr;
+use hyperactor::ActorEnvironment;
+use hyperactor::ActorHandle;
+use hyperactor::ActorRef;
+use hyperactor::Data;
+use hyperactor::Endpoint;
+use hyperactor::OncePortRef;
+use hyperactor::RemoteSpawn;
+use hyperactor::actor::remote::Remote;
+use hyperactor::context;
+use hyperactor::id::Label;
+use hyperactor_config::AttrValue;
+use hyperactor_config::declare_attrs;
+use serde::Deserialize;
+use serde::Serialize;
+use typeuri::Named;
+
+use crate::CodecError;
+use crate::Error;
+use crate::proc_agent::ProcAgent;
+
+/// A typed failure from a client-root ensure request.
+#[derive(Clone, Debug, Serialize, Deserialize, thiserror::Error)]
+pub enum ClientRootError {
+    /// The same service name was already created with a different actor type or
+    /// different serialized parameters.
+    #[error("conflicting client-root service specification for `{name}`")]
+    ConflictingSpec {
+        /// The service name that conflicted.
+        name: String,
+    },
+
+    /// The service actor failed to spawn (the failure is cached and not retried
+    /// implicitly).
+    #[error("client-root service `{name}` failed to spawn: {message}")]
+    Spawn {
+        /// The service name.
+        name: String,
+        /// The spawn failure, rendered as text (the underlying error is not
+        /// serializable).
+        message: String,
+    },
+
+    /// The service exists but is not usable: it has stopped, failed, or is
+    /// stopping after spawning, or the root is shutting down. The caller must not
+    /// treat it as a live actor.
+    #[error("client-root service `{name}` is not available: {reason}")]
+    Unavailable {
+        /// The service name.
+        name: String,
+        /// Why the service is unavailable.
+        reason: String,
+    },
+}
+
+/// Ensure a statically declared, root-owned service exists, returning its
+/// address. Posted to the root ProcAgent through [`ClientRootApi`].
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub(crate) struct EnsureClientRootService {
+    /// The validated static service name.
+    pub(crate) service_name: Label,
+    /// The registered remote actor type name resolved from the descriptor.
+    pub(crate) actor_type: String,
+    /// The exact serialized `RemoteSpawn` parameters.
+    pub(crate) params: Data,
+    /// Typed reply channel.
+    pub(crate) reply: OncePortRef<EnsureClientRootServiceReply>,
+}
+
+/// The typed reply to [`EnsureClientRootService`]. A `Named` newtype so it can
+/// travel through a `OncePortRef`.
+#[derive(Debug, Serialize, Deserialize, Named)]
+pub(crate) struct EnsureClientRootServiceReply(pub(crate) Result<ActorAddr, ClientRootError>);
+
+// The narrow, restricted behavior a `ClientRootRef` can drive on the root
+// ProcAgent: exactly one message, no root administration. The behavior lives in
+// a private module because the macro emits a `pub` type; only a crate-visible
+// alias is re-exported, so the protocol never leaks past the crate.
+mod protocol {
+    use super::EnsureClientRootService;
+
+    hyperactor::behavior!(ClientRootApi, EnsureClientRootService);
+}
+pub(crate) use protocol::ClientRootApi;
+
+/// An opaque bearer capability to the program's one client root.
+///
+/// The inner behavior reference is never exposed. Possession of an inherited
+/// `ClientRootRef` is the authority under Hyperactor's trusted-actor model
+/// (CROOT-2); it is API attenuation, not actor authentication.
+#[derive(Clone, Serialize, Deserialize, Named, PartialEq, Eq, Hash)]
+pub struct ClientRootRef {
+    root: ActorRef<ClientRootApi>,
+}
+
+impl ClientRootRef {
+    /// Bind [`ClientRootApi`] on the program's root ProcAgent handle and wrap
+    /// the resulting reference (CROOT-1). Only the active root bootstrap calls
+    /// this; worker ProcAgents never bind the API.
+    pub fn bind(root: &ActorHandle<ProcAgent>) -> Self {
+        Self {
+            root: root.bind::<ClientRootApi>(),
+        }
+    }
+
+    /// Read the client-root capability from the supplied actor environment,
+    /// failing closed when it is absent (CROOT-6). Every consumer (starting
+    /// with RDMA) obtains the root here rather than re-deriving it, so the
+    /// missing-capability path is enforced in one place.
+    pub fn from_env(environment: &ActorEnvironment) -> crate::Result<ClientRootRef> {
+        environment.get(CLIENT_ROOT).ok_or(Error::MissingClientRoot)
+    }
+
+    /// Construct a reference from an already-bound behavior reference. Used by
+    /// the root ProcAgent to seed a created service's environment with the same
+    /// capability (CROOT-7).
+    pub(crate) fn from_ref(root: ActorRef<ClientRootApi>) -> Self {
+        Self { root }
+    }
+
+    /// The root behavior address, for typed-error attribution only.
+    pub(crate) fn addr(&self) -> &ActorAddr {
+        self.root.actor_addr()
+    }
+}
+
+// A bearer capability must not be copied out of config or diagnostics as a
+// reconstructible string. `AttrValue` imposes no display/parse round-trip law,
+// so display/`Debug` are redacted and textual parse always fails; serde still
+// carries the real bytes, which is how `ActorEnvironment` stores and retrieves
+// the value.
+impl std::fmt::Debug for ClientRootRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ClientRootRef(<redacted>)")
+    }
+}
+
+impl AttrValue for ClientRootRef {
+    fn display(&self) -> String {
+        "<redacted>".to_string()
+    }
+
+    fn parse(_value: &str) -> Result<Self, anyhow::Error> {
+        anyhow::bail!("ClientRootRef is a bearer capability and cannot be parsed from text")
+    }
+}
+
+declare_attrs! {
+    /// The client-root capability carried in an actor's environment.
+    pub attr CLIENT_ROOT: ClientRootRef;
+}
+
+/// A statically declared, root-owned service: a fixed service name plus a
+/// registered actor type `A`. Callers supply `A::Params`; there is no
+/// caller-supplied runtime actor type or untyped address.
+pub struct ClientRootService<A: RemoteSpawn> {
+    name: &'static str,
+    _actor: PhantomData<fn() -> A>,
+}
+
+impl<A: RemoteSpawn> ClientRootService<A> {
+    /// Declare a statically named root-owned service.
+    ///
+    /// This constructs only the local typed descriptor. [`Self::ensure`] is
+    /// the operation that asks the root ProcAgent to create or reuse the actor.
+    pub const fn declare(name: &'static str) -> Self {
+        Self {
+            name,
+            _actor: PhantomData,
+        }
+    }
+
+    /// Ensure this service exists under `client_root`, returning a typed
+    /// reference to it. Concurrent identical ensures collapse on the serial root
+    /// ProcAgent; a different actor type or parameter bytes for the same name
+    /// returns [`ClientRootError::ConflictingSpec`].
+    pub async fn ensure(
+        &self,
+        cx: &impl context::Actor,
+        client_root: &ClientRootRef,
+        params: A::Params,
+    ) -> crate::Result<ActorRef<A>> {
+        let service_name = Label::new(self.name).map_err(|e| Error::Other(e.into()))?;
+        let actor_type = Remote::collect()
+            .name_of::<A>()
+            .ok_or_else(|| Error::ActorTypeNotRegistered(std::any::type_name::<A>().to_string()))?
+            .to_string();
+        let params = bincode::serde::encode_to_vec(&params, bincode::config::legacy())
+            .map_err(|e| Error::CodecError(CodecError::BincodeEncodeError(Box::new(e))))?;
+
+        let (reply_handle, reply_receiver) = cx
+            .mailbox()
+            .open_once_port::<EnsureClientRootServiceReply>();
+        client_root.root.post(
+            cx,
+            EnsureClientRootService {
+                service_name,
+                actor_type,
+                params,
+                reply: reply_handle.bind(),
+            },
+        );
+        // A failed reply delivery is a genuine call failure against the root; a
+        // typed `ClientRootError` carried in the reply surfaces transparently.
+        let EnsureClientRootServiceReply(result) = reply_receiver
+            .recv()
+            .await
+            .map_err(|e| Error::CallError(client_root.addr().clone(), e.into()))?;
+        let addr = result?;
+
+        // CROOT-10: `RemoteSpawn` erased `A` to `ActorAddr` after binding the
+        // actor. This request's registered actor type came from `A`, and the
+        // root ProcAgent returned only the matching service entry, so restore
+        // that discarded phantom type here. This is the module's sole `attest`.
+        Ok(ActorRef::<A>::attest(addr))
+    }
+}

--- a/hyperactor_mesh/src/global_context.rs
+++ b/hyperactor_mesh/src/global_context.rs
@@ -488,8 +488,16 @@ async fn bootstrap_host() -> GlobalState {
         ),
     )
     .expect("failed to create proc mesh ref");
+    // Bind the client-root API on this program's one root ProcAgent and seed the
+    // root client's environment with the resulting capability. Descendants
+    // inherit it through the actor-environment propagation paths (CROOT-1).
+    let client_root = crate::client_root::ClientRootRef::bind(&local_proc_agent);
+    let mut root_env = hyperactor::ActorEnvironment::default();
+    root_env
+        .set(crate::client_root::CLIENT_ROOT, client_root)
+        .expect("failed to seed client-root capability");
     let actor_instance = local_proc
-        .actor_instance::<GlobalClientActor>("client")
+        .actor_instance_in_environment::<GlobalClientActor>("client", root_env)
         .expect("failed to create root client instance");
 
     let hyperactor::proc::ActorInstance {
@@ -646,6 +654,18 @@ mod tests {
         assert!(
             try_registered_client_proc().is_none(),
             "registered-client-proc lookup must not fall back to Rust GLOBAL_CONTEXT",
+        );
+    }
+
+    /// CROOT-1 / CROOT-8: the Rust root bootstrap seeds the client-root
+    /// capability on the root client's environment, so `from_env` finds it.
+    #[tokio::test]
+    async fn test_bootstrap_seeds_client_root() {
+        let cx = context().await;
+        let environment = cx.actor_instance.actor_environment();
+        assert!(
+            crate::client_root::ClientRootRef::from_env(environment).is_ok(),
+            "bootstrap must seed the client-root capability on the root client",
         );
     }
 

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -23,6 +23,7 @@ pub mod actor_mesh;
 mod assign;
 pub mod bootstrap;
 pub mod casting;
+pub mod client_root;
 pub mod config;
 pub mod config_dump;
 pub mod connect;
@@ -165,6 +166,12 @@ pub enum Error {
 
     #[error("actor not registered for type {0}")]
     ActorTypeNotRegistered(String),
+
+    #[error(transparent)]
+    ClientRootError(#[from] crate::client_root::ClientRootError),
+
+    #[error("client-root capability is absent from this actor's environment")]
+    MissingClientRoot,
 
     // TODO: this should be a valuemesh of statuses
     #[error("error while spawning actor {0}: {1}")]

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use hyperactor::Actor;
 use hyperactor::ActorAddr;
+use hyperactor::ActorEnvironment;
 use hyperactor::ActorHandle;
 use hyperactor::Addr;
 use hyperactor::Client;
@@ -882,6 +883,10 @@ pub struct ActorSpec {
     pub actor_type: String,
     /// serialized parameters
     pub params_data: Data,
+    /// The persistent environment to store on the spawned actor's instance.
+    /// Copied from the spawning context's instance and serialized per spawn
+    /// (AENV-3).
+    pub actor_environment: ActorEnvironment,
 }
 wirevalue::register_type!(ActorSpec);
 
@@ -936,6 +941,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
         let ActorSpec {
             actor_type,
             params_data,
+            actor_environment,
         } = create_or_update.spec;
         self.actor_states.insert(
             create_or_update.id.clone(),
@@ -948,6 +954,7 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
                         &actor_type,
                         create_or_update.id.uid().clone(),
                         params_data,
+                        actor_environment,
                         cx.headers().clone(),
                     )
                     .await,
@@ -1580,6 +1587,7 @@ mod tests {
                 ActorSpec {
                     actor_type: actor_type.clone(),
                     params_data: actor_params.clone(),
+                    actor_environment: ActorEnvironment::default(),
                 },
             )
             .await
@@ -1630,6 +1638,7 @@ mod tests {
                 ActorSpec {
                     actor_type: actor_type.clone(),
                     params_data: actor_params.clone(),
+                    actor_environment: ActorEnvironment::default(),
                 },
             )
             .await
@@ -1829,5 +1838,44 @@ mod tests {
 
         // Unblock the actor.
         gate.notify_one();
+    }
+
+    hyperactor_config::attrs::declare_attrs! {
+        attr AENV_SPEC_TAG: u64;
+        attr AENV_SPEC_LABEL: String;
+    }
+
+    // AENV-3: the actor environment travels with `ActorSpec` through the same
+    // positional codec used for every remote spawn, and `ActorSpec` equality
+    // composes the environment's semantic (order-independent) equality rather
+    // than a raw-buffer comparison.
+    #[test]
+    fn actor_environment_serializes_in_actor_spec() {
+        let mut env = ActorEnvironment::default();
+        env.set(AENV_SPEC_TAG, 7u64).expect("insert tag");
+        env.set(AENV_SPEC_LABEL, "root".to_string())
+            .expect("insert label");
+
+        let spec = ActorSpec {
+            actor_type: "probe".to_string(),
+            params_data: vec![1, 2, 3],
+            actor_environment: env.clone(),
+        };
+
+        let bytes = bincode::serde::encode_to_vec(&spec, bincode::config::legacy()).unwrap();
+        let restored: ActorSpec =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
+
+        assert_eq!(restored.actor_environment.get(AENV_SPEC_TAG), Some(7u64));
+        assert_eq!(
+            restored.actor_environment.get(AENV_SPEC_LABEL),
+            Some("root".to_string())
+        );
+        assert_eq!(restored.actor_environment, env);
+        // Derived `ActorSpec` equality composes the semantic environment
+        // equality.
+        assert_eq!(restored, spec);
     }
 }

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -51,6 +51,12 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
+use crate::client_root::CLIENT_ROOT;
+use crate::client_root::ClientRootApi;
+use crate::client_root::ClientRootError;
+use crate::client_root::ClientRootRef;
+use crate::client_root::EnsureClientRootService;
+use crate::client_root::EnsureClientRootServiceReply;
 use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
 use crate::introspect::ProcessMemoryStats;
@@ -172,6 +178,20 @@ struct ActorInstanceState {
     /// threshold, the delivered view rank at which to position the reply
     /// overlay, and the reply port to send once the threshold is met.
     pending_wait_status: Vec<(resource::Status, usize, PortRef<crate::StatusOverlay>)>,
+}
+
+/// Identity of a root-owned client-root service. `actor_states` (keyed by the
+/// service's instance `ResourceId`) remains the sole lifecycle registry; this
+/// records only what a repeat ensure must match exactly (CROOT-3, CROOT-9).
+#[derive(Debug)]
+struct ServiceEntry {
+    /// The registered remote actor type name.
+    actor_type: String,
+    /// The exact serialized `RemoteSpawn` parameter bytes.
+    params: Data,
+    /// The service actor's fresh instance id, whose `actor_states` entry stores
+    /// the spawn result.
+    id: ResourceId,
 }
 
 impl ActorInstanceState {
@@ -324,6 +344,10 @@ pub struct ProcAgent {
     stopping_all: bool,
     /// If set, check for expired actors whose keepalive has lapsed.
     mesh_orphan_timeout: Option<Duration>,
+    /// Root-owned client-root services keyed by validated static service name.
+    /// Populated only on the one root ProcAgent that binds `ClientRootApi`;
+    /// empty (and unreachable) on worker ProcAgents (CROOT-1, CROOT-4).
+    client_root_services: HashMap<Label, ServiceEntry>,
 }
 
 impl ProcAgent {
@@ -347,6 +371,7 @@ impl ProcAgent {
             shutdown_tx,
             stopping_all: false,
             mesh_orphan_timeout: orphan_timeout,
+            client_root_services: HashMap::new(),
         };
         proc.spawn_with_uid::<Self>(
             Uid::singleton(Label::new(PROC_AGENT_ACTOR_NAME).unwrap()),
@@ -904,6 +929,179 @@ pub struct ActorState {
 }
 wirevalue::register_type!(ActorState);
 
+impl ProcAgent {
+    /// Create a root-tracked actor and record its state under `id`, returning
+    /// whether a spawn was attempted.
+    ///
+    /// On a poisoned proc (an actor with an error supervision event) it records a
+    /// failed state without spawning and returns `false`. Otherwise it attempts
+    /// the spawn — merging the spec's persistent environment with `headers` (the
+    /// transient constructor headers) only for `RemoteSpawn::new` — and returns
+    /// `true` whether or not `gspawn` itself succeeded; a spawn failure is cached
+    /// in `actor_states`, which remains the sole lifecycle authority. Callers that
+    /// need the actual spawn result read it back from `actor_states` (see
+    /// `service_result`). Shared by the mesh `CreateOrUpdate` path and the
+    /// client-root ensure path.
+    async fn create_actor(
+        &mut self,
+        id: ResourceId,
+        create_rank: usize,
+        spec: ActorSpec,
+        headers: Flattrs,
+    ) -> bool {
+        let poisoned = self.actor_states.values().any(|s| s.has_errors());
+        let spawn = if poisoned {
+            Err(anyhow::anyhow!(
+                "Cannot spawn new actors on mesh with supervision events"
+            ))
+        } else {
+            let ActorSpec {
+                actor_type,
+                params_data,
+                actor_environment,
+            } = spec;
+            self.remote
+                .gspawn(
+                    &self.proc,
+                    &actor_type,
+                    id.uid().clone(),
+                    params_data,
+                    actor_environment,
+                    headers,
+                )
+                .await
+        };
+        self.actor_states.insert(
+            id,
+            ActorInstanceState {
+                create_rank,
+                spawn,
+                stop_initiated: false,
+                supervision_event: None,
+                subscribers: Vec::new(),
+                expiry_time: None,
+                generation: 1,
+                pending_wait_status: Vec::new(),
+            },
+        );
+        !poisoned
+    }
+
+    /// Create or reuse the statically named, root-owned service and return its
+    /// address. Runs entirely inside the serial ProcAgent handler, so concurrent
+    /// identical ensures collapse: the first records the entry and the rest
+    /// observe it (CROOT-3, CROOT-5).
+    async fn ensure_client_root_service(
+        &mut self,
+        cx: &Context<'_, Self>,
+        service_name: Label,
+        actor_type: String,
+        params: Data,
+    ) -> Result<ActorAddr, ClientRootError> {
+        let conflict = || ClientRootError::ConflictingSpec {
+            name: service_name.as_str().to_string(),
+        };
+
+        // Reuse an existing service only on an exact (type, params) match; a
+        // service that has since gone terminal fails closed in `service_result`.
+        if let Some(entry) = self.client_root_services.get(&service_name) {
+            if entry.actor_type != actor_type || entry.params != params {
+                return Err(conflict());
+            }
+            return Self::service_result(&self.actor_states, &entry.id, &service_name);
+        }
+
+        // Refuse to create a new service once shutdown has begun: a StopAll has
+        // already snapshotted and stopped the live actors, so a service created
+        // afterwards would never be stopped and would strand shutdown.
+        if self.stopping_all {
+            return Err(ClientRootError::Unavailable {
+                name: service_name.as_str().to_string(),
+                reason: "the client root is shutting down".to_string(),
+            });
+        }
+
+        // A fresh random instance id (CROOT-3): this avoids the predictable
+        // collision a name-derived id would create with a mesh actor or a
+        // preoccupying actor. The loop guards the negligible random-uid collision
+        // against the ids already present in `actor_states`.
+        let id = loop {
+            let candidate = ResourceId::instance(service_name.clone());
+            if !self.actor_states.contains_key(&candidate) {
+                break candidate;
+            }
+        };
+
+        // The created service inherits the same client-root capability so its own
+        // descendants stay in this root (CROOT-7).
+        let self_root = ClientRootRef::from_ref(
+            hyperactor::context::Actor::instance(cx).bind::<ClientRootApi>(),
+        );
+        let mut service_env = hyperactor::ActorEnvironment::default();
+        service_env
+            .set(CLIENT_ROOT, self_root)
+            .map_err(|e| ClientRootError::Spawn {
+                name: service_name.as_str().to_string(),
+                message: e.to_string(),
+            })?;
+        let spec = ActorSpec {
+            actor_type: actor_type.clone(),
+            params_data: params.clone(),
+            actor_environment: service_env,
+        };
+        // Root-owned construction uses empty transient headers: the requester's
+        // message headers are request-scoped and must not leak into a long-lived,
+        // root-owned service that outlives the requester (AENV-4).
+        let spawn_attempted = self.create_actor(id.clone(), 0, spec, Flattrs::new()).await;
+
+        // Record the identity so later ensures reuse it; the spawn result
+        // (including a cached failure) lives in `actor_states`.
+        self.client_root_services.insert(
+            service_name.clone(),
+            ServiceEntry {
+                actor_type,
+                params,
+                id: id.clone(),
+            },
+        );
+        // Reflect the new service in the root's introspect view, matching the
+        // mesh create path (whenever a spawn was attempted).
+        if spawn_attempted {
+            let _ = self.publish_introspect_properties(cx);
+        }
+        Self::service_result(&self.actor_states, &id, &service_name)
+    }
+
+    /// Read the recorded spawn result for a service's reserved id.
+    fn service_result(
+        actor_states: &HashMap<ResourceId, ActorInstanceState>,
+        id: &ResourceId,
+        service_name: &Label,
+    ) -> Result<ActorAddr, ClientRootError> {
+        let Some(state) = actor_states.get(id) else {
+            return Err(ClientRootError::Spawn {
+                name: service_name.as_str().to_string(),
+                message: "service actor state is missing".to_string(),
+            });
+        };
+        // A cached spawn failure (including a poisoned-proc failure) is returned
+        // as-is; proc poisoning is latched, so it is never retried.
+        let addr = state.spawn.as_ref().map_err(|e| ClientRootError::Spawn {
+            name: service_name.as_str().to_string(),
+            message: e.to_string(),
+        })?;
+        // Fail closed if the service spawned but has since gone terminal
+        // (stopped, failed, or stopping): reuse must never hand back a dead ref.
+        match state.status() {
+            resource::Status::Running => Ok(addr.clone()),
+            other => Err(ClientRootError::Unavailable {
+                name: service_name.as_str().to_string(),
+                reason: format!("service is {}", other),
+            }),
+        }
+    }
+}
+
 #[async_trait]
 impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
     async fn handle(
@@ -915,59 +1113,51 @@ impl Handler<resource::CreateOrUpdate<ActorSpec>> for ProcAgent {
             // There is no update.
             return Ok(());
         }
-        let create_rank = create_or_update.rank.unwrap();
-        // If any actor on this proc has error supervision events,
-        // we disallow spawning new actors on it, as this proc may be in an
-        // invalid state.
-        if self.actor_states.values().any(|s| s.has_errors()) {
-            self.actor_states.insert(
-                create_or_update.id.clone(),
-                ActorInstanceState {
-                    spawn: Err(anyhow::anyhow!(
-                        "Cannot spawn new actors on mesh with supervision events"
-                    )),
-                    create_rank,
-                    stop_initiated: false,
-                    supervision_event: None,
-                    subscribers: Vec::new(),
-                    expiry_time: None,
-                    generation: 1,
-                    pending_wait_status: Vec::new(),
-                },
-            );
+        // Once shutdown has begun, a new actor would escape the StopAll snapshot
+        // and strand shutdown; do not create it.
+        if self.stopping_all {
             return Ok(());
         }
-
-        let ActorSpec {
-            actor_type,
-            params_data,
-            actor_environment,
-        } = create_or_update.spec;
-        self.actor_states.insert(
-            create_or_update.id.clone(),
-            ActorInstanceState {
+        let create_rank = create_or_update.rank.unwrap();
+        // Publish introspect whenever a spawn was attempted (non-poisoned proc),
+        // matching the prior behavior; on a poisoned proc the helper records a
+        // failed state without spawning and does not publish.
+        let spawn_attempted = self
+            .create_actor(
+                create_or_update.id.clone(),
                 create_rank,
-                spawn: self
-                    .remote
-                    .gspawn(
-                        &self.proc,
-                        &actor_type,
-                        create_or_update.id.uid().clone(),
-                        params_data,
-                        actor_environment,
-                        cx.headers().clone(),
-                    )
-                    .await,
-                stop_initiated: false,
-                supervision_event: None,
-                subscribers: Vec::new(),
-                expiry_time: None,
-                generation: 1,
-                pending_wait_status: Vec::new(),
-            },
-        );
+                create_or_update.spec,
+                cx.headers().clone(),
+            )
+            .await;
+        if spawn_attempted {
+            let _ = self.publish_introspect_properties(cx);
+        }
+        Ok(())
+    }
+}
 
-        let _ = self.publish_introspect_properties(cx);
+#[async_trait]
+impl Handler<EnsureClientRootService> for ProcAgent {
+    async fn handle(
+        &mut self,
+        cx: &Context<Self>,
+        message: EnsureClientRootService,
+    ) -> anyhow::Result<()> {
+        let EnsureClientRootService {
+            service_name,
+            actor_type,
+            params,
+            mut reply,
+        } = message;
+        // A departed requester must not fault the root: an undeliverable reply is
+        // dropped rather than returned to this ProcAgent (CROOT-11). Expected
+        // failures travel in the typed reply, and the handler always returns Ok.
+        reply.return_undeliverable(false);
+        let result = self
+            .ensure_client_root_service(cx, service_name, actor_type, params)
+            .await;
+        reply.post(cx, EnsureClientRootServiceReply(result));
         Ok(())
     }
 }
@@ -1877,5 +2067,550 @@ mod tests {
         // Derived `ActorSpec` equality composes the semantic environment
         // equality.
         assert_eq!(restored, spec);
+    }
+
+    // ----- client-root capability proofs -----
+
+    // Boot a root ProcAgent and bind the client-root API on it.
+    async fn boot_client_root() -> (
+        hyperactor::Proc,
+        ActorHandle<ProcAgent>,
+        crate::client_root::ClientRootRef,
+    ) {
+        use hyperactor::Proc;
+        use hyperactor::actor::ActorStatus;
+        use hyperactor::channel::ChannelTransport;
+
+        let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string()).unwrap();
+        let agent = ProcAgent::boot_v1(proc.clone(), None).unwrap();
+        agent
+            .status()
+            .wait_for(|s| matches!(s, ActorStatus::Idle))
+            .await
+            .unwrap();
+        let client_root = crate::client_root::ClientRootRef::bind(&agent);
+        (proc, agent, client_root)
+    }
+
+    // Proof 1: the capability serde-round-trips its bound reference, while its
+    // display/Debug are redacted and textual parse is rejected (CROOT-2).
+    #[tokio::test]
+    async fn client_root_ref_redacts_and_round_trips() {
+        use hyperactor_config::AttrValue;
+
+        use crate::client_root::ClientRootRef;
+
+        let (_proc, _agent, client_root) = boot_client_root().await;
+
+        let bytes = bincode::serde::encode_to_vec(&client_root, bincode::config::legacy()).unwrap();
+        let restored: ClientRootRef =
+            bincode::serde::decode_from_slice(&bytes, bincode::config::legacy())
+                .map(|(v, _)| v)
+                .unwrap();
+        assert_eq!(
+            restored, client_root,
+            "capability must round-trip via serde"
+        );
+
+        assert_eq!(client_root.display(), "<redacted>");
+        assert_eq!(format!("{:?}", client_root), "ClientRootRef(<redacted>)");
+        assert!(
+            ClientRootRef::parse("anything").is_err(),
+            "a bearer capability must not be reconstructible from text"
+        );
+    }
+
+    // Proof 10: binding the API twice on the same root returns the same
+    // reference and adds no registration/activation state (CROOT-1).
+    #[tokio::test]
+    async fn client_root_bind_is_idempotent() {
+        use crate::client_root::ClientRootRef;
+
+        let (_proc, agent, first) = boot_client_root().await;
+        let second = ClientRootRef::bind(&agent);
+        assert_eq!(first, second);
+    }
+
+    // Proofs 3/5: ensuring the same service returns one root-owned actor, and a
+    // requester exiting does not stop it — a later requester observes the same
+    // address.
+    #[tokio::test]
+    async fn client_root_ensure_is_root_owned_and_single_identity() {
+        use crate::client_root::ClientRootService;
+
+        let (proc, _agent, client_root) = boot_client_root().await;
+        let service = ClientRootService::<ExtraActor>::declare("probe-service");
+
+        let caller_a = proc.client("caller-a");
+        let first = service
+            .ensure(&caller_a, &client_root, ())
+            .await
+            .expect("first ensure creates the service");
+        // The first requester context is gone; a later ensure still reuses the
+        // one service (CROOT-3). Departed-requester survival and the in-flight
+        // drop are covered by `client_root_departed_requester_does_not_fault_root`.
+        drop(caller_a);
+
+        let caller_b = proc.client("caller-b");
+        let second = service
+            .ensure(&caller_b, &client_root, ())
+            .await
+            .expect("second ensure reuses the service after requester exit");
+        assert_eq!(
+            first.actor_addr(),
+            second.actor_addr(),
+            "identical ensures must resolve to the one root-owned service (CROOT-3)"
+        );
+    }
+
+    // A second registered actor type, distinct from `ExtraActor`, so a repeat
+    // ensure under the same name with a different type conflicts.
+    #[derive(Debug, Default, Serialize, Deserialize)]
+    #[hyperactor::export(handlers = [])]
+    struct OtherActor;
+    impl hyperactor::Actor for OtherActor {}
+    hyperactor::register_spawnable!(OtherActor);
+
+    // CROOT-3: the same service name with a different actor type conflicts and
+    // surfaces as a transparent `Error::ClientRootError(ConflictingSpec)`.
+    #[tokio::test]
+    async fn client_root_conflicting_type_is_rejected() {
+        use crate::client_root::ClientRootError;
+        use crate::client_root::ClientRootService;
+
+        let (proc, _agent, client_root) = boot_client_root().await;
+        let caller = proc.client("caller");
+
+        ClientRootService::<ExtraActor>::declare("shared")
+            .ensure(&caller, &client_root, ())
+            .await
+            .expect("first ensure creates the service");
+
+        let err = ClientRootService::<OtherActor>::declare("shared")
+            .ensure(&caller, &client_root, ())
+            .await
+            .expect_err("a different actor type for the same name must conflict");
+        assert!(
+            matches!(
+                err,
+                crate::Error::ClientRootError(ClientRootError::ConflictingSpec { .. })
+            ),
+            "expected ClientRootError::ConflictingSpec, got {err:?}"
+        );
+    }
+
+    // H5 / CROOT-3: the service actor uses a fresh instance id, not a
+    // deterministic `client-root-<name>` singleton, avoiding the predictable
+    // collision a name-derived id would create with a mesh actor.
+    #[tokio::test]
+    async fn client_root_service_uses_instance_id() {
+        use crate::client_root::ClientRootService;
+
+        let (proc, _agent, client_root) = boot_client_root().await;
+        let caller = proc.client("caller");
+        let svc = ClientRootService::<ExtraActor>::declare("probe")
+            .ensure(&caller, &client_root, ())
+            .await
+            .expect("ensure creates the service");
+        assert!(
+            !svc.actor_addr().is_root(),
+            "a client-root service must use a fresh instance uid, not a singleton id"
+        );
+    }
+
+    // A spawnable actor whose remote constructor increments a global counter, so
+    // a test can prove single-flight *construction*, not just a single identity.
+    static COUNTING_ACTOR_BUILDS: std::sync::atomic::AtomicUsize =
+        std::sync::atomic::AtomicUsize::new(0);
+
+    #[derive(Debug)]
+    #[hyperactor::export(handlers = [])]
+    #[hyperactor::spawnable]
+    struct CountingActor;
+    impl hyperactor::Actor for CountingActor {}
+
+    #[async_trait::async_trait]
+    impl hyperactor::RemoteSpawn for CountingActor {
+        type Params = ();
+        async fn new(_params: (), _environment: Flattrs) -> anyhow::Result<Self> {
+            COUNTING_ACTOR_BUILDS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Ok(Self)
+        }
+    }
+
+    // Proof 2: concurrent identical ensures collapse through the serial root
+    // ProcAgent to a single service identity AND a single construction.
+    #[tokio::test]
+    async fn client_root_concurrent_ensures_collapse() {
+        use std::sync::atomic::Ordering;
+
+        use crate::client_root::ClientRootService;
+
+        COUNTING_ACTOR_BUILDS.store(0, Ordering::SeqCst);
+        let (proc, _agent, client_root) = boot_client_root().await;
+        let ensure = |name: &'static str| {
+            let caller = proc.client(name);
+            let client_root = &client_root;
+            async move {
+                ClientRootService::<CountingActor>::declare("concurrent")
+                    .ensure(&caller, client_root, ())
+                    .await
+                    .expect("ensure succeeds")
+                    .actor_addr()
+                    .clone()
+            }
+        };
+
+        let (a, b, c, d) = tokio::join!(
+            ensure("caller-0"),
+            ensure("caller-1"),
+            ensure("caller-2"),
+            ensure("caller-3"),
+        );
+        assert_eq!(a, b, "concurrent ensures must resolve to one service");
+        assert_eq!(a, c, "concurrent ensures must resolve to one service");
+        assert_eq!(a, d, "concurrent ensures must resolve to one service");
+        assert_eq!(
+            COUNTING_ACTOR_BUILDS.load(Ordering::SeqCst),
+            1,
+            "single-flight: identical concurrent ensures must construct once"
+        );
+    }
+
+    // H3: `service_result` fails closed for a service that has gone terminal or
+    // never spawned; only a running service returns its address.
+    #[tokio::test]
+    async fn client_root_service_result_fails_closed_on_terminal() {
+        use hyperactor::actor::ActorStatus;
+
+        use crate::client_root::ClientRootError;
+
+        let (_proc, agent, _client_root) = boot_client_root().await;
+        let addr = agent.bind::<ProcAgent>().actor_addr().clone();
+        let name = Label::new("svc").unwrap();
+        let id = ResourceId::instance(name.clone());
+
+        let mk = |spawn: Result<ActorAddr, anyhow::Error>,
+                  stop_initiated: bool,
+                  supervision_event: Option<ActorSupervisionEvent>| {
+            ActorInstanceState {
+                create_rank: 0,
+                spawn,
+                stop_initiated,
+                supervision_event,
+                subscribers: Vec::new(),
+                expiry_time: None,
+                generation: 1,
+                pending_wait_status: Vec::new(),
+            }
+        };
+
+        // Running -> Ok(addr).
+        let mut states = HashMap::new();
+        states.insert(id.clone(), mk(Ok(addr.clone()), false, None));
+        assert_eq!(
+            ProcAgent::service_result(&states, &id, &name).expect("running service resolves"),
+            addr
+        );
+
+        // Stopping (stop initiated, no event yet) -> Unavailable.
+        let mut states = HashMap::new();
+        states.insert(id.clone(), mk(Ok(addr.clone()), true, None));
+        assert!(matches!(
+            ProcAgent::service_result(&states, &id, &name),
+            Err(ClientRootError::Unavailable { .. })
+        ));
+
+        // Terminal via a supervision event -> Unavailable.
+        let mut states = HashMap::new();
+        let event = ActorSupervisionEvent::new(
+            addr.clone(),
+            None,
+            ActorStatus::Stopped("done".into()),
+            None,
+        );
+        states.insert(id.clone(), mk(Ok(addr.clone()), false, Some(event)));
+        assert!(matches!(
+            ProcAgent::service_result(&states, &id, &name),
+            Err(ClientRootError::Unavailable { .. })
+        ));
+
+        // Cached spawn failure -> Spawn.
+        let mut states = HashMap::new();
+        states.insert(id.clone(), mk(Err(anyhow::anyhow!("boom")), false, None));
+        assert!(matches!(
+            ProcAgent::service_result(&states, &id, &name),
+            Err(ClientRootError::Spawn { .. })
+        ));
+
+        // Missing state -> Spawn.
+        let states: HashMap<ResourceId, ActorInstanceState> = HashMap::new();
+        assert!(matches!(
+            ProcAgent::service_result(&states, &id, &name),
+            Err(ClientRootError::Spawn { .. })
+        ));
+    }
+
+    // CROOT-6: reading the capability from an environment that lacks it fails
+    // closed with the typed `MissingClientRoot`, not a silent absence.
+    #[tokio::test]
+    async fn client_root_from_env_absent_fails_closed() {
+        use crate::client_root::ClientRootRef;
+
+        let (proc, _agent, _client_root) = boot_client_root().await;
+        let caller = proc.client("no-capability");
+        let environment = hyperactor::context::Actor::instance(&caller).actor_environment();
+        assert!(
+            matches!(
+                ClientRootRef::from_env(environment),
+                Err(crate::Error::MissingClientRoot)
+            ),
+            "a caller without the capability must fail closed with MissingClientRoot"
+        );
+    }
+
+    // Boot a root ProcAgent with a shutdown channel so a StopAll signals the
+    // exit code instead of calling `process::exit`.
+    async fn boot_client_root_with_shutdown() -> (
+        hyperactor::Proc,
+        ActorHandle<ProcAgent>,
+        crate::client_root::ClientRootRef,
+        tokio::sync::oneshot::Receiver<i32>,
+    ) {
+        use hyperactor::Proc;
+        use hyperactor::actor::ActorStatus;
+        use hyperactor::channel::ChannelTransport;
+
+        let proc = Proc::direct(ChannelTransport::Unix.any(), "root".to_string()).unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        let agent = ProcAgent::boot_v1(proc.clone(), Some(tx)).unwrap();
+        agent
+            .status()
+            .wait_for(|s| matches!(s, ActorStatus::Idle))
+            .await
+            .unwrap();
+        let client_root = crate::client_root::ClientRootRef::bind(&agent);
+        (proc, agent, client_root, rx)
+    }
+
+    // A root-owned service that reports the client-root capability it reads back
+    // from its own environment, so a test can compare its exact identity.
+    #[derive(Debug, Serialize, Deserialize, Named)]
+    struct ClientRootObservation(Option<crate::client_root::ClientRootRef>);
+    wirevalue::register_type!(ClientRootObservation);
+
+    #[derive(Debug, Serialize, Deserialize, Named)]
+    struct ObserveClientRoot {
+        reply: hyperactor::OncePortRef<ClientRootObservation>,
+    }
+    wirevalue::register_type!(ObserveClientRoot);
+
+    #[derive(Debug, Default, Serialize, Deserialize)]
+    #[hyperactor::export(handlers = [ObserveClientRoot])]
+    struct EnvProbeActor;
+    impl hyperactor::Actor for EnvProbeActor {}
+    hyperactor::register_spawnable!(EnvProbeActor);
+
+    #[async_trait::async_trait]
+    impl Handler<ObserveClientRoot> for EnvProbeActor {
+        async fn handle(
+            &mut self,
+            cx: &Context<Self>,
+            msg: ObserveClientRoot,
+        ) -> anyhow::Result<()> {
+            let environment = hyperactor::context::Actor::instance(cx).actor_environment();
+            let observed = crate::client_root::ClientRootRef::from_env(environment).ok();
+            msg.reply.post(cx, ClientRootObservation(observed));
+            Ok(())
+        }
+    }
+
+    // H1 / CROOT-11: a requester that departs before the reply lands must not
+    // fault the root. The reply is posted to a dropped once-port, which without
+    // `return_undeliverable(false)` would return to the root's fatal
+    // `handle_invalid_reference`. The root must still serve a later request.
+    #[tokio::test]
+    async fn client_root_departed_requester_does_not_fault_root() {
+        use std::time::Duration;
+
+        use hyperactor::ActorRef;
+        use hyperactor::Endpoint;
+
+        use crate::client_root::ClientRootApi;
+        use crate::client_root::ClientRootService;
+
+        let (proc, _agent, client_root) = boot_client_root().await;
+
+        {
+            let caller = proc.client("ephemeral");
+            let (reply_handle, reply_receiver) =
+                caller.open_once_port::<EnsureClientRootServiceReply>();
+            let reply = reply_handle.bind();
+            // Drop the receiver BEFORE posting so the reply is guaranteed
+            // undeliverable; otherwise the root could answer before the port is
+            // gone and the fatal-return path would never be exercised.
+            drop(reply_receiver);
+            let actor_type = Remote::collect()
+                .name_of::<ExtraActor>()
+                .unwrap()
+                .to_string();
+            let params = bincode::serde::encode_to_vec((), bincode::config::legacy()).unwrap();
+            let api = ActorRef::<ClientRootApi>::attest(client_root.addr().clone());
+            api.post(
+                &caller,
+                EnsureClientRootService {
+                    service_name: Label::new("ephemeral-svc").unwrap(),
+                    actor_type,
+                    params,
+                    reply,
+                },
+            );
+            drop(caller);
+        }
+
+        // Two sequential survivor ensures. The undeliverable reply-return is
+        // enqueued to the root while it handles the request above, so by the time
+        // the second ensure completes the root has processed it; a fatal return
+        // would fail (or hang) one of these rather than slip past a single fast
+        // reply.
+        let survivor = proc.client("survivor");
+        for name in ["after-departure-1", "after-departure-2"] {
+            tokio::time::timeout(
+                Duration::from_secs(15),
+                ClientRootService::<ExtraActor>::declare(name).ensure(&survivor, &client_root, ()),
+            )
+            .await
+            .expect("root must stay responsive after a departed requester")
+            .expect("root must serve a new ensure after a departed requester");
+        }
+    }
+
+    // A stop-gated service: its handler blocks until released, so a test can hold
+    // a proc open across a StopAll and then observe shutdown run to completion.
+    // The gate is process-global (statics) because a remote-spawned actor cannot
+    // carry a non-serializable field.
+    static GATE_ENTERED: tokio::sync::Notify = tokio::sync::Notify::const_new();
+    static GATE_RELEASE: tokio::sync::Notify = tokio::sync::Notify::const_new();
+
+    #[derive(
+        Debug,
+        Clone,
+        Serialize,
+        Deserialize,
+        Named,
+        hyperactor::Handler,
+        hyperactor::HandleClient
+    )]
+    enum GateMsg {
+        Block(),
+    }
+    wirevalue::register_type!(GateMsg);
+
+    #[derive(Debug, Default, Serialize, Deserialize)]
+    #[hyperactor::export(handlers = [GateMsg])]
+    struct GateActor;
+    impl hyperactor::Actor for GateActor {}
+    hyperactor::register_spawnable!(GateActor);
+
+    #[async_trait::async_trait]
+    #[hyperactor::handle(GateMsg)]
+    impl GateMsgHandler for GateActor {
+        async fn block(&mut self, _cx: &Context<Self>) -> anyhow::Result<()> {
+            GATE_ENTERED.notify_one();
+            GATE_RELEASE.notified().await;
+            Ok(())
+        }
+    }
+
+    // H2: once shutdown has begun a NEW ensure is refused, so a service cannot
+    // escape the StopAll snapshot and strand shutdown. A gated keeper holds the
+    // proc open across StopAll; releasing it lets shutdown run to completion.
+    #[tokio::test]
+    async fn client_root_ensure_rejected_during_shutdown() {
+        use std::time::Duration;
+
+        use hyperactor::Endpoint;
+
+        use crate::client_root::ClientRootError;
+        use crate::client_root::ClientRootService;
+
+        let (proc, agent, client_root, shutdown_rx) = boot_client_root_with_shutdown().await;
+
+        // A gated keeper never reaches terminal state while blocked, so StopAll
+        // defers shutdown until we release it.
+        let keeper = ClientRootService::<GateActor>::declare("keeper")
+            .ensure(&proc.client("keeper-caller"), &client_root, ())
+            .await
+            .expect("keeper service is created before shutdown");
+        keeper.post(&proc.client("gate-driver"), GateMsg::Block());
+        GATE_ENTERED.notified().await;
+
+        // Begin shutdown; the blocked keeper defers it. A new ensure is refused.
+        let control = proc.client("control");
+        agent.bind::<ProcAgent>().post(
+            &control,
+            resource::StopAll {
+                reason: "test shutdown".to_string(),
+            },
+        );
+        let err = tokio::time::timeout(
+            Duration::from_secs(15),
+            ClientRootService::<ExtraActor>::declare("too-late").ensure(&control, &client_root, ()),
+        )
+        .await
+        .expect("agent must answer while the keeper defers shutdown")
+        .expect_err("a new ensure during shutdown must be rejected");
+        assert!(
+            matches!(
+                err,
+                crate::Error::ClientRootError(ClientRootError::Unavailable { .. })
+            ),
+            "ensure during shutdown must be Unavailable, got {err:?}"
+        );
+
+        // Release the keeper; it terminates and shutdown completes, delivering a
+        // clean exit code through `shutdown_rx`.
+        GATE_RELEASE.notify_one();
+        let code = tokio::time::timeout(Duration::from_secs(30), shutdown_rx)
+            .await
+            .expect("shutdown must complete once the last actor terminates")
+            .expect("shutdown channel delivered an exit code");
+        assert_eq!(code, 0, "clean shutdown exit code");
+    }
+
+    // CROOT-7: a service spawned through ensure inherits the client-root
+    // capability in its environment and reads it back with `from_env`.
+    #[tokio::test]
+    async fn client_root_service_observes_inherited_capability() {
+        use std::time::Duration;
+
+        use hyperactor::Endpoint;
+
+        use crate::client_root::ClientRootService;
+
+        let (proc, _agent, client_root) = boot_client_root().await;
+        let caller = proc.client("caller");
+        let probe = ClientRootService::<EnvProbeActor>::declare("env-probe")
+            .ensure(&caller, &client_root, ())
+            .await
+            .expect("ensure creates the probe service");
+
+        let (reply_handle, reply_receiver) = caller.open_once_port::<ClientRootObservation>();
+        probe.post(
+            &caller,
+            ObserveClientRoot {
+                reply: reply_handle.bind(),
+            },
+        );
+        let ClientRootObservation(observed) =
+            tokio::time::timeout(Duration::from_secs(15), reply_receiver.recv())
+                .await
+                .expect("probe must reply")
+                .expect("reply channel is open");
+        assert_eq!(
+            observed,
+            Some(client_root.clone()),
+            "a service must inherit the exact client-root capability, not merely some capability"
+        );
     }
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -914,6 +914,7 @@ impl ProcMeshRef {
                 spec: proc_agent::ActorSpec {
                     actor_type: actor_type.clone(),
                     params_data: serialized_params.clone(),
+                    actor_environment: cx.instance().actor_environment().clone(),
                 },
             },
         )?;
@@ -1253,12 +1254,16 @@ fn python_class_from_supervision_name(sdn: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     #[cfg(fbcode_build)]
+    use std::collections::HashMap;
+    #[cfg(fbcode_build)]
     use std::collections::HashSet;
     #[cfg(fbcode_build)]
     use std::ops::Deref;
     #[cfg(fbcode_build)]
     use std::time::Duration;
 
+    #[cfg(fbcode_build)]
+    use hyperactor::ActorEnvironment;
     #[cfg(fbcode_build)]
     use hyperactor::Instance;
     #[cfg(fbcode_build)]
@@ -1282,6 +1287,8 @@ mod tests {
     use super::ACTOR_SPAWN_MAX_IDLE;
     #[cfg(fbcode_build)]
     use crate::ActorMesh;
+    #[cfg(fbcode_build)]
+    use crate::casting::CAST_POINT;
     #[cfg(fbcode_build)]
     use crate::host_mesh::PROC_SPAWN_MAX_IDLE;
     #[cfg(fbcode_build)]
@@ -1308,6 +1315,158 @@ mod tests {
         testactor::assert_mesh_shape(actor_mesh).await;
 
         let _ = hm.shutdown(instance).await;
+    }
+
+    #[async_timed_test(timeout_secs = 300)]
+    #[cfg(fbcode_build)]
+    async fn actor_environment_survives_two_remote_hops_and_excludes_cast_point() {
+        const SENTINEL: u64 = 0xA0FE;
+        let operation_timeout = Duration::from_secs(120);
+
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(PROC_SPAWN_MAX_IDLE, operation_timeout);
+        let _guard2 = config.override_key(
+            hyperactor::config::HOST_SPAWN_READY_TIMEOUT,
+            operation_timeout,
+        );
+
+        let base = testing::instance();
+        let persistent_point = extent!(persistent = 3).point_of_rank(2).unwrap();
+        let mut environment = ActorEnvironment::default();
+        environment
+            .set(testactor::ACTOR_ENVIRONMENT_TEST_TAG, SENTINEL)
+            .expect("seed persistent tag");
+        environment
+            .set(CAST_POINT, persistent_point.clone())
+            .expect("seed persistent cast-point collision");
+        let root = base
+            .proc()
+            .actor_instance_in_environment::<testing::TestRootClient>(
+                &format!("actor_environment_root_{}", Uuid::now_v7()),
+                environment,
+            )
+            .expect("create seeded root instance");
+
+        let mut hm = testing::host_mesh(1).await;
+        let proc_mesh = hm
+            .spawn(
+                &root.instance,
+                "actor_environment",
+                extent!(gpus = 2),
+                None,
+                None,
+            )
+            .await
+            .expect("spawn proc mesh");
+        let first_hop = proc_mesh
+            .range("gpus", 0..1)
+            .expect("first proc-mesh slice");
+        let second_hop = proc_mesh
+            .range("gpus", 1..2)
+            .expect("second proc-mesh slice");
+        let first_point = first_hop
+            .region()
+            .extent()
+            .point_of_rank(0)
+            .expect("first slice has rank zero");
+        let second_point = second_hop
+            .region()
+            .extent()
+            .point_of_rank(0)
+            .expect("second slice has rank zero");
+        let first_proc_addr = first_hop
+            .get(0)
+            .expect("first proc")
+            .proc_addr()
+            .to_string();
+        let second_proc_addr = second_hop
+            .get(0)
+            .expect("second proc")
+            .proc_addr()
+            .to_string();
+        assert_ne!(
+            first_proc_addr, second_proc_addr,
+            "the two hops must target distinct proc addresses",
+        );
+        assert!(
+            persistent_point != first_point && persistent_point != second_point,
+            "persistent and transient cast points must be distinct",
+        );
+
+        let (reply, mut replies) = root
+            .instance
+            .open_port::<testactor::ActorEnvironmentObservation>();
+        first_hop
+            .spawn_controllerless_service::<testactor::ActorEnvironmentProbe, _>(
+                &root.instance,
+                "actor_environment_hop_1",
+                &testactor::ActorEnvironmentProbeParams {
+                    label: "hop_1".to_string(),
+                    reply: reply.bind(),
+                    nested: Some((
+                        second_hop,
+                        "actor_environment_hop_2".to_string(),
+                        "hop_2".to_string(),
+                    )),
+                },
+            )
+            .await
+            .expect("spawn first environment probe");
+
+        let expected = HashMap::from([
+            ("hop_1".to_string(), (first_point, first_proc_addr)),
+            ("hop_2".to_string(), (second_point, second_proc_addr)),
+        ]);
+        let mut seen = HashSet::new();
+        let reply_deadline = tokio::time::Instant::now() + operation_timeout;
+        for _ in 0..2 {
+            let observed = tokio::time::timeout_at(reply_deadline, replies.recv())
+                .await
+                .expect("environment probe reply timed out")
+                .expect("environment probe reply port closed");
+            let (expected_point, expected_proc_addr) = expected
+                .get(&observed.label)
+                .unwrap_or_else(|| panic!("unexpected probe label {}", observed.label));
+            assert!(
+                seen.insert(observed.label.clone()),
+                "received duplicate observation from {}",
+                observed.label,
+            );
+            assert_eq!(
+                observed.persistent_tag,
+                Some(SENTINEL),
+                "{} must inherit the persistent tag",
+                observed.label,
+            );
+            assert_eq!(
+                observed.constructor_tag,
+                Some(SENTINEL),
+                "{} constructor must see the persistent tag",
+                observed.label,
+            );
+            assert_eq!(
+                observed.stored_point,
+                Some(persistent_point.clone()),
+                "{} must store only the persistent point",
+                observed.label,
+            );
+            assert_eq!(
+                observed.constructor_point,
+                Some(expected_point.clone()),
+                "{} constructor must see its real rank-local cast point",
+                observed.label,
+            );
+            assert_eq!(
+                &observed.proc_addr, expected_proc_addr,
+                "{} must run on its requested proc",
+                observed.label,
+            );
+        }
+        assert_eq!(seen.len(), expected.len(), "both hops must report");
+
+        hm.shutdown(&root.instance)
+            .await
+            .expect("host mesh shutdown should complete");
     }
 
     /// Reuse a per-proc singleton service across two overlapping proc-mesh views

--- a/hyperactor_mesh/src/testactor.rs
+++ b/hyperactor_mesh/src/testactor.rs
@@ -32,6 +32,7 @@ use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::Flattrs;
+use hyperactor_config::attrs::declare_attrs;
 use hyperactor_config::global::Source;
 use ndslice::Point;
 #[cfg(test)]
@@ -46,6 +47,7 @@ use crate::ActorMesh;
 #[cfg(test)]
 use crate::ActorMeshRef;
 use crate::ProcMeshRef;
+use crate::casting::CAST_POINT;
 use crate::casting::CastInfo;
 use crate::mesh_id::ActorMeshId;
 use crate::supervision::MeshFailure;
@@ -281,6 +283,93 @@ impl hyperactor::RemoteSpawn for FailingCreateTestActor {
         Err(anyhow::anyhow!("test failure"))
     }
 }
+
+declare_attrs! {
+    /// Persistent sentinel used by actor-environment transport tests.
+    pub attr ACTOR_ENVIRONMENT_TEST_TAG: u64;
+}
+
+/// What an [`ActorEnvironmentProbe`] observed at construction and after its
+/// native instance was installed.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Named)]
+pub struct ActorEnvironmentObservation {
+    pub label: String,
+    pub persistent_tag: Option<u64>,
+    pub constructor_tag: Option<u64>,
+    pub constructor_point: Option<Point>,
+    pub stored_point: Option<Point>,
+    pub proc_addr: String,
+}
+wirevalue::register_type!(ActorEnvironmentObservation);
+
+/// Construction parameters for [`ActorEnvironmentProbe`].
+#[derive(Clone, Debug, Serialize, Deserialize, Named)]
+pub struct ActorEnvironmentProbeParams {
+    pub label: String,
+    pub reply: hyperactor::PortRef<ActorEnvironmentObservation>,
+    pub nested: Option<(ProcMeshRef, String, String)>,
+}
+wirevalue::register_type!(ActorEnvironmentProbeParams);
+
+/// A remote-spawn probe that optionally performs one nested ProcMesh spawn.
+#[derive(Debug)]
+#[hyperactor::export(handlers = [])]
+pub struct ActorEnvironmentProbe {
+    label: String,
+    reply: hyperactor::PortRef<ActorEnvironmentObservation>,
+    nested: Option<(ProcMeshRef, String, String)>,
+    constructor_tag: Option<u64>,
+    constructor_point: Option<Point>,
+}
+
+#[async_trait]
+impl Actor for ActorEnvironmentProbe {
+    async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+        self.reply.post(
+            this,
+            ActorEnvironmentObservation {
+                label: self.label.clone(),
+                persistent_tag: this.actor_environment().get(ACTOR_ENVIRONMENT_TEST_TAG),
+                constructor_tag: self.constructor_tag,
+                constructor_point: self.constructor_point.clone(),
+                stored_point: this.actor_environment().get(CAST_POINT),
+                proc_addr: this.proc().proc_addr().to_string(),
+            },
+        );
+
+        if let Some((proc_mesh, name, label)) = self.nested.take() {
+            proc_mesh
+                .spawn_controllerless_service::<Self, _>(
+                    this,
+                    &name,
+                    &ActorEnvironmentProbeParams {
+                        label,
+                        reply: self.reply.clone(),
+                        nested: None,
+                    },
+                )
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl hyperactor::RemoteSpawn for ActorEnvironmentProbe {
+    type Params = ActorEnvironmentProbeParams;
+
+    async fn new(params: Self::Params, environment: Flattrs) -> anyhow::Result<Self> {
+        Ok(Self {
+            label: params.label,
+            reply: params.reply,
+            nested: params.nested,
+            constructor_tag: environment.get(ACTOR_ENVIRONMENT_TEST_TAG),
+            constructor_point: environment.get(CAST_POINT),
+        })
+    }
+}
+
+hyperactor::register_spawnable!(ActorEnvironmentProbe);
 
 #[derive(Clone, Debug, Serialize, Deserialize, Named)]
 pub struct SetConfigAttrs(pub Vec<u8>);

--- a/hyperactor_remote/src/actor_spawner.rs
+++ b/hyperactor_remote/src/actor_spawner.rs
@@ -260,7 +260,7 @@ pub trait ActorSpawnerEndpoint {
                 .actor_addr_uid(uid.clone()),
         );
         let actor_spawner = self.clone();
-        let gspawn = Gspawn::for_actor_uid::<A>(uid, params)?;
+        let gspawn = Gspawn::for_actor_uid::<A>(cx, uid, params)?;
         cx.instance().spawn(Supervisor::bootstrap_uid(
             liveness,
             SupervisionOptions::default(),
@@ -285,6 +285,7 @@ mod tests {
     use async_trait::async_trait;
     use hyperactor::Actor;
     use hyperactor::ActorAddr;
+    use hyperactor::ActorEnvironment;
     use hyperactor::ActorHandle;
     use hyperactor::Context;
     use hyperactor::Endpoint as _;
@@ -298,6 +299,7 @@ mod tests {
     use hyperactor::Uid;
     use hyperactor::supervision::ActorSupervisionEvent;
     use hyperactor_config::Flattrs;
+    use hyperactor_config::attrs::declare_attrs;
     use serde::Deserialize;
     use serde::Serialize;
     use typeuri::Named;
@@ -360,6 +362,54 @@ mod tests {
     }
 
     hyperactor::register_spawnable!(FailingChild);
+
+    declare_attrs! {
+        attr REMOTE_ENVIRONMENT_TAG: u64;
+        attr REMOTE_SERVER_ONLY_TAG: u64;
+    }
+
+    #[derive(Debug)]
+    #[hyperactor::export(handlers = [])]
+    struct EnvironmentChild {
+        reply: PortRef<(u64, u64, Option<u64>, Option<u64>)>,
+        constructor_value: u64,
+        constructor_server_only: Option<u64>,
+    }
+
+    #[async_trait]
+    impl Actor for EnvironmentChild {
+        async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+            let stored_value = this
+                .actor_environment()
+                .get(REMOTE_ENVIRONMENT_TAG)
+                .unwrap_or_default();
+            self.reply.post(
+                this,
+                (
+                    self.constructor_value,
+                    stored_value,
+                    self.constructor_server_only,
+                    this.actor_environment().get(REMOTE_SERVER_ONLY_TAG),
+                ),
+            );
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl RemoteSpawn for EnvironmentChild {
+        type Params = PortRef<(u64, u64, Option<u64>, Option<u64>)>;
+
+        async fn new(reply: Self::Params, environment: Flattrs) -> anyhow::Result<Self> {
+            Ok(Self {
+                reply,
+                constructor_value: environment.get(REMOTE_ENVIRONMENT_TAG).unwrap_or_default(),
+                constructor_server_only: environment.get(REMOTE_SERVER_ONLY_TAG),
+            })
+        }
+    }
+
+    hyperactor::register_spawnable!(EnvironmentChild);
 
     #[derive(Debug)]
     struct PlainSpawner {
@@ -440,6 +490,7 @@ mod tests {
             client,
             SpawnActorMessage {
                 gspawn: Gspawn::for_actor_uid::<TestChild>(
+                    client,
                     Uid::instance(Label::new("test_child").unwrap()),
                     (),
                 )
@@ -524,6 +575,88 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn actor_spawner_carries_callers_actor_environment() {
+        const SENTINEL: u64 = 0xA0FE;
+
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let mut server_environment = ActorEnvironment::default();
+        server_environment
+            .set(REMOTE_ENVIRONMENT_TAG, SENTINEL + 1)
+            .expect("seed conflicting server environment");
+        server_environment
+            .set(REMOTE_SERVER_ONLY_TAG, 99)
+            .expect("seed server-only environment");
+        let server = proc
+            .actor_instance_in_environment::<TestChild>("seeded_server", server_environment)
+            .expect("create seeded server instance");
+        let actor_spawner = server.instance.spawn(ActorSpawner);
+        let (reply, mut reply_rx) = client.open_port::<(u64, u64, Option<u64>, Option<u64>)>();
+        let (ready, ready_rx) = client.open_once_port::<()>();
+
+        let mut environment = ActorEnvironment::default();
+        environment
+            .set(REMOTE_ENVIRONMENT_TAG, SENTINEL)
+            .expect("seed caller environment");
+        let caller = proc
+            .actor_instance_in_environment::<TestChild>("seeded_caller", environment)
+            .expect("create seeded caller instance");
+
+        actor_spawner
+            .spawn_uid_with_ready::<EnvironmentChild>(
+                &caller.instance,
+                Uid::instance(Label::new("environment_child").unwrap()),
+                reply.bind(),
+                ready,
+            )
+            .expect("request remote child");
+        tokio::time::timeout(Duration::from_secs(5), ready_rx.recv())
+            .await
+            .expect("remote child readiness timed out")
+            .expect("remote child readiness port closed");
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(5), reply_rx.recv())
+                .await
+                .expect("environment reply timed out")
+                .expect("environment reply port closed"),
+            (SENTINEL, SENTINEL, None, None),
+            "constructor and stored instance must receive only the caller's environment",
+        );
+
+        actor_spawner.stop("test").expect("stop actor spawner");
+        tokio::time::timeout(Duration::from_secs(5), actor_spawner)
+            .await
+            .expect("actor spawner stop timed out");
+    }
+
+    #[test]
+    fn gspawn_serializes_actor_environment() {
+        let mut environment = ActorEnvironment::default();
+        environment
+            .set(REMOTE_ENVIRONMENT_TAG, 17)
+            .expect("seed actor environment");
+        let gspawn = Gspawn::with_uid(
+            TestChild::typename(),
+            Uid::instance(Label::new("serialized_child").unwrap()),
+            encoded_unit(),
+            environment,
+        );
+
+        let encoded = bincode::serde::encode_to_vec(&gspawn, bincode::config::legacy())
+            .expect("serialize gspawn");
+        let restored: Gspawn =
+            bincode::serde::decode_from_slice(&encoded, bincode::config::legacy())
+                .map(|(value, _)| value)
+                .expect("deserialize gspawn");
+
+        assert_eq!(restored, gspawn);
+        assert_eq!(
+            restored.actor_environment().get(REMOTE_ENVIRONMENT_TAG),
+            Some(17),
+        );
+    }
+
+    #[tokio::test]
     async fn test_actor_spawner_worker_reports_child_failure() {
         let proc = Proc::isolated();
         let client = proc.client("client");
@@ -584,7 +717,12 @@ mod tests {
         actor_spawner.post(
             &client,
             SpawnActorMessage {
-                gspawn: Gspawn::with_uid("unknown::Actor", Uid::anonymous(), encoded_unit()),
+                gspawn: Gspawn::with_uid(
+                    "unknown::Actor",
+                    Uid::anonymous(),
+                    encoded_unit(),
+                    ActorEnvironment::default(),
+                ),
                 supervise: Supervise {
                     session_id: session_id.clone(),
                     supervisor: supervisor.bind(),

--- a/hyperactor_remote/src/proto.rs
+++ b/hyperactor_remote/src/proto.rs
@@ -19,6 +19,7 @@
 //! worker accepts only the active session.
 
 use hyperactor::ActorAddr;
+use hyperactor::ActorEnvironment;
 use hyperactor::Data;
 use hyperactor::HandleClient;
 use hyperactor::Handler;
@@ -26,6 +27,7 @@ use hyperactor::PortRef;
 use hyperactor::RefClient;
 use hyperactor::RemoteSpawn;
 use hyperactor::actor::StopMode;
+use hyperactor::context;
 use hyperactor::id::Uid;
 use hyperactor::supervision::ActorSupervisionEvent;
 use serde::Deserialize;
@@ -40,20 +42,27 @@ pub struct Gspawn {
     actor_type: String,
     uid: Uid,
     params: Data,
+    environment: ActorEnvironment,
 }
 wirevalue::register_type!(Gspawn);
 
 impl Gspawn {
-    /// Create a spawn specification for the registered actor type with a fresh uid.
-    pub fn for_actor<A>(params: A::Params) -> anyhow::Result<Self>
+    /// Create a spawn specification for the registered actor type with a fresh
+    /// uid and the caller's persistent environment.
+    pub fn for_actor<A>(cx: &impl context::Actor, params: A::Params) -> anyhow::Result<Self>
     where
         A: RemoteSpawn + Named,
     {
-        Self::for_actor_uid::<A>(Uid::anonymous(), params)
+        Self::for_actor_uid::<A>(cx, Uid::anonymous(), params)
     }
 
-    /// Create a spawn specification for the registered actor type with an explicit uid.
-    pub fn for_actor_uid<A>(uid: Uid, params: A::Params) -> anyhow::Result<Self>
+    /// Create a spawn specification for the registered actor type with an
+    /// explicit uid and the caller's persistent environment.
+    pub fn for_actor_uid<A>(
+        cx: &impl context::Actor,
+        uid: Uid,
+        params: A::Params,
+    ) -> anyhow::Result<Self>
     where
         A: RemoteSpawn + Named,
     {
@@ -61,14 +70,21 @@ impl Gspawn {
             A::typename(),
             uid,
             bincode::serde::encode_to_vec(params, bincode::config::legacy())?,
+            cx.instance().actor_environment().clone(),
         ))
     }
 
-    pub(crate) fn with_uid(actor_type: impl Into<String>, uid: Uid, params: Data) -> Self {
+    pub(crate) fn with_uid(
+        actor_type: impl Into<String>,
+        uid: Uid,
+        params: Data,
+        environment: ActorEnvironment,
+    ) -> Self {
         Self {
             actor_type: actor_type.into(),
             uid,
             params,
+            environment,
         }
     }
 
@@ -87,14 +103,25 @@ impl Gspawn {
         &self.params
     }
 
+    /// The persistent environment to install on the spawned actor.
+    pub fn actor_environment(&self) -> &ActorEnvironment {
+        &self.environment
+    }
+
     /// Spawn the actor as a supervised child of `parent`.
     pub async fn spawn_child<C: hyperactor::context::Actor>(
         self,
         parent: &C,
     ) -> anyhow::Result<hyperactor::AnyActorHandle> {
+        let Self {
+            actor_type,
+            uid,
+            params,
+            environment,
+        } = self;
         parent
             .instance()
-            .gspawn_uid(&self.actor_type, self.uid, self.params)
+            .gspawn_uid_in_environment(&actor_type, uid, params, environment)
             .await
     }
 }


### PR DESCRIPTION
Summary:

Python actors can already find shared, client-owned services because `_ControllerController` is passed to every actor. Rust actors have no equivalent. native code therefore has to reach back through Python, or let a requesting actor own work that should survive that actor.

this gives every actor a narrow reference back to the program's one client root. the reference travels through `ActorEnvironment`, so descendants keep it wherever they run. an actor can ask the root to start a named service or return the one already running. the root owns that service, so it survives individual callers and shuts down with the root.

the upcoming RDMA change uses this to keep one `RdmaManagerOwnerActor` at the client root without consulting Python globals. the mechanism itself is generic: actors written in any language use the same path.

Reviewed By: zdevito

Differential Revision: D113349924


