### PR TITLE
Add fixed-data telemetry query benchmark

### DIFF
--- a/python/benches/telemetry_query_benchmark/README.md
+++ b/python/benches/telemetry_query_benchmark/README.md
@@ -1,0 +1,60 @@
+# Telemetry Query Benchmark
+
+This benchmark isolates telemetry SQL performance from concurrent writes to its
+target tables. It synchronously preloads deterministic queried columns before
+issuing the first SQL query. Query traffic does not modify the four `pyspy_*`
+tables. The benchmark verifies every query result.
+
+`benchmark.py` defines the query matrix, execution protocol, and reporting.
+`pyspy_fixture.py` contains the workload-specific payload generation and
+expected rows. `query_backend.py` owns the direct and sidecar execution
+boundaries.
+
+Run the representative shape with:
+
+```bash
+buck run @mode/opt fbcode//monarch/python/benches/telemetry_query_benchmark:telemetry_query_benchmark
+```
+
+The default `query-engine` backend measures the direct DataFusion-to-PyArrow
+path. Run the end-to-end sidecar integration backend with:
+
+```bash
+buck run @mode/opt fbcode//monarch/python/benches/telemetry_query_benchmark:telemetry_query_benchmark -- \
+  --backend sidecar-http
+```
+
+The fixed fixture contains 20 dump rows, 80 stack-trace rows, 100,000 frame
+rows, and 100,000 local-variable rows. Each run preloads rows before running
+each case 100 times. The ingestion timestamp in `pyspy_dumps` varies by run and
+is intentionally excluded from every query.
+
+## Backends
+
+| Backend | Timed boundary |
+|---|---|
+| `query-engine` | Direct `QueryEngine.query()` through DataFusion and PyArrow table creation |
+| `sidecar-http` | Loopback HTTP, `QueryEngine`, JSON, and Python-row materialization |
+
+Both backends use the same fixture, SQL, and validators, but their actor and
+process topology differs. The direct backend materializes Python rows for
+validation only after the timed query call. Backend results have separate
+baselines and must not be compared to each other.
+
+## Query Matrix
+
+| Case | Work measured |
+|---|---|
+| `frame_count` | Full one-table scan and scalar aggregation |
+| `filtered_count` | Selective one-table filter and aggregation |
+| `group_by_filename` | Grouping, aggregation, and ordering |
+| `four_table_join` | Locals joined to frames, traces, and dumps |
+| `ordered_projection` | Sorted, bounded multi-column result serialization |
+
+## Scope
+
+The direct backend exercises DataFusion, the local telemetry actor and scanner,
+and PyArrow result construction. The sidecar backend additionally exercises
+`ProcessJob`, HTTP, JSON, and Python-row materialization. Neither backend
+measures concurrent ingestion, remote collector fan-out, peak memory, or
+production query mixes.

--- a/python/benches/telemetry_query_benchmark/benchmark.py
+++ b/python/benches/telemetry_query_benchmark/benchmark.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Benchmark fixed-data queries through telemetry query backends."""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import socket
+import statistics
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from typing import Callable, cast
+
+from monarch.python.benches.telemetry_query_benchmark import (
+    pyspy_fixture,
+    query_backend,
+)
+
+_QueryRows = query_backend.QueryRows
+_Validator = Callable[[_QueryRows], None]
+_QUERY_ITERATIONS = 100
+
+
+@dataclass(frozen=True)
+class _QueryCase:
+    name: str
+    sql: str
+    validate: _Validator
+
+
+def _expect_scalar(
+    rows: _QueryRows,
+    *,
+    column: str,
+    expected: int,
+) -> None:
+    if len(rows) != 1:
+        raise RuntimeError(f"expected one row for {column}; got {len(rows)}")
+    value = rows[0].get(column)
+    if type(value) is not int:
+        raise RuntimeError(f"expected integer {column}; got {value!r}")
+    if value != expected:
+        raise RuntimeError(f"expected {column}={expected}; got {value!r}")
+
+
+def _expect_rows(
+    rows: _QueryRows,
+    *,
+    expected: _QueryRows,
+) -> None:
+    if rows != expected:
+        raise RuntimeError("query rows differ from the deterministic fixture")
+    for row, expected_row in zip(rows, expected):
+        if any(
+            type(value) is not type(expected_row[column])
+            for column, value in row.items()
+        ):
+            raise RuntimeError("query row types differ from the deterministic fixture")
+
+
+def _scalar_case(
+    name: str,
+    sql: str,
+    column: str,
+    expected: int,
+) -> _QueryCase:
+    return _QueryCase(
+        name,
+        sql,
+        functools.partial(_expect_scalar, column=column, expected=expected),
+    )
+
+
+def _query_cases(
+    shape: pyspy_fixture.DatasetShape,
+) -> tuple[_QueryCase, ...]:
+    return (
+        _scalar_case(
+            "frame_count",
+            "SELECT COUNT(*) AS frame_count FROM pyspy_frames",
+            "frame_count",
+            shape.frames,
+        ),
+        _scalar_case(
+            "filtered_count",
+            "SELECT COUNT(*) AS frame_count FROM pyspy_frames "
+            "WHERE filename = 'module_0.py'",
+            "frame_count",
+            shape.filename_zero_frames,
+        ),
+        _QueryCase(
+            "group_by_filename",
+            "SELECT filename, COUNT(*) AS frame_count FROM pyspy_frames "
+            "GROUP BY filename ORDER BY filename",
+            functools.partial(
+                _expect_rows,
+                expected=pyspy_fixture.expected_filename_group_rows(shape),
+            ),
+        ),
+        _scalar_case(
+            "four_table_join",
+            "SELECT COUNT(*) AS local_count FROM pyspy_local_variables l "
+            "JOIN pyspy_frames f ON l.dump_id = f.dump_id "
+            "AND l.thread_id = f.thread_id AND l.frame_depth = f.frame_depth "
+            "JOIN pyspy_stack_traces s ON f.dump_id = s.dump_id "
+            "AND f.thread_id = s.thread_id "
+            "JOIN pyspy_dumps d ON f.dump_id = d.dump_id WHERE l.arg = TRUE",
+            "local_count",
+            shape.frames,
+        ),
+        _QueryCase(
+            "ordered_projection",
+            "SELECT dump_id, thread_id, frame_depth, name, filename, line "
+            "FROM pyspy_frames ORDER BY dump_id, thread_id, frame_depth "
+            "LIMIT 1000",
+            functools.partial(
+                _expect_rows,
+                expected=pyspy_fixture.expected_projection_rows(
+                    shape,
+                    1_000,
+                ),
+            ),
+        ),
+    )
+
+
+def _execute_query(
+    backend: query_backend.QueryBackend,
+    case: _QueryCase,
+) -> float:
+    start = time.monotonic()
+    data = backend.query(case.sql)
+    elapsed = time.monotonic() - start
+    case.validate(backend.rows(data))
+    return elapsed
+
+
+def _benchmark_case(
+    backend: query_backend.QueryBackend,
+    case: _QueryCase,
+) -> float:
+    return statistics.median(
+        _execute_query(backend, case) for _ in range(_QUERY_ITERATIONS)
+    )
+
+
+def _run_benchmark(
+    shape: pyspy_fixture.DatasetShape,
+    backend_name: query_backend.BackendName,
+) -> dict[str, float]:
+    cases = _query_cases(shape)
+    backend = query_backend.create_backend(backend_name)
+    try:
+        backend.preload(shape)
+
+        query_medians = {}
+        for case in cases:
+            query_medians[case.name] = _benchmark_case(
+                backend,
+                case,
+            )
+    except BaseException:
+        with suppress(Exception):
+            backend.close()
+        raise
+    else:
+        backend.close()
+        return query_medians
+
+
+def _print_summary(query_medians: dict[str, float]) -> None:
+    print("| Query | Median (ms) |")
+    print("|---|---:|")
+    for name, median in query_medians.items():
+        print(f"| `{name}` | {median * 1000.0:.3f} |")
+
+
+def _parse_backend() -> query_backend.BackendName:
+    parser = argparse.ArgumentParser(
+        description="benchmark fixed-data telemetry SQL queries",
+    )
+    parser.add_argument(
+        "--backend",
+        choices=("query-engine", "sidecar-http"),
+        default="query-engine",
+        help="Execution boundary to measure; use sidecar-http for end-to-end integration coverage.",
+    )
+    return cast(query_backend.BackendName, parser.parse_args().backend)
+
+
+def main() -> None:
+    backend = _parse_backend()
+    shape = pyspy_fixture.DatasetShape(
+        dumps=20,
+        threads_per_dump=4,
+        frames_per_thread=1_250,
+    )
+    print(f"hostname={socket.gethostname()}")
+    print(f"backend={backend}")
+    _print_summary(_run_benchmark(shape, backend))
+
+
+if __name__ == "__main__":
+    main()

--- a/python/benches/telemetry_query_benchmark/pyspy_fixture.py
+++ b/python/benches/telemetry_query_benchmark/pyspy_fixture.py
@@ -1,0 +1,125 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Deterministic PySpy data for telemetry query benchmarks."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+
+_FILENAME_GROUPS = 16
+
+
+@dataclass(frozen=True)
+class DatasetShape:
+    """Cardinalities for a normalized PySpy fixture."""
+
+    dumps: int
+    threads_per_dump: int
+    frames_per_thread: int
+
+    @property
+    def traces(self) -> int:
+        return self.dumps * self.threads_per_dump
+
+    @property
+    def frames(self) -> int:
+        return self.traces * self.frames_per_thread
+
+    @property
+    def filename_zero_frames(self) -> int:
+        frames_per_trace = (
+            self.frames_per_thread + _FILENAME_GROUPS - 1
+        ) // _FILENAME_GROUPS
+        return self.traces * frames_per_trace
+
+
+def dump_id(index: int) -> str:
+    """Return the stable identifier for one fixture dump."""
+    return f"dump-{index:06d}"
+
+
+def make_dump(shape: DatasetShape) -> str:
+    """Build one compact PySpy JSON payload."""
+    payload = {
+        "Ok": {
+            "stack_traces": [
+                _make_trace(shape, thread_index)
+                for thread_index in range(shape.threads_per_dump)
+            ],
+        }
+    }
+    return json.dumps(payload, separators=(",", ":"))
+
+
+def expected_projection_rows(
+    shape: DatasetShape,
+    row_count: int,
+) -> list[dict[str, object]]:
+    """Return the rows expected from the ordered frame projection."""
+    return [_frame_identity(shape, index) for index in range(row_count)]
+
+
+def expected_filename_group_rows(
+    shape: DatasetShape,
+) -> list[dict[str, object]]:
+    """Return the ordered frame count for each generated filename."""
+    counts = _expected_filename_counts(shape)
+    return [
+        {"filename": filename, "frame_count": counts[filename]}
+        for filename in sorted(counts)
+    ]
+
+
+def _make_frame(
+    frame_index: int,
+) -> dict[str, object]:
+    filename = f"module_{frame_index % _FILENAME_GROUPS}.py"
+    return {
+        "name": f"function_{frame_index % 64}",
+        "filename": filename,
+        "line": frame_index + 1,
+        "locals": [{"arg": True}],
+    }
+
+
+def _make_trace(
+    shape: DatasetShape,
+    thread_index: int,
+) -> dict[str, object]:
+    return {
+        "thread_id": thread_index,
+        "frames": [
+            _make_frame(frame_index) for frame_index in range(shape.frames_per_thread)
+        ],
+    }
+
+
+def _frame_identity(shape: DatasetShape, index: int) -> dict[str, object]:
+    frames_per_dump = shape.threads_per_dump * shape.frames_per_thread
+    dump_index, dump_offset = divmod(index, frames_per_dump)
+    thread_index, frame_index = divmod(dump_offset, shape.frames_per_thread)
+    return {
+        "dump_id": dump_id(dump_index),
+        "thread_id": thread_index,
+        "frame_depth": frame_index,
+        "name": f"function_{frame_index % 64}",
+        "filename": f"module_{frame_index % _FILENAME_GROUPS}.py",
+        "line": frame_index + 1,
+    }
+
+
+def _expected_filename_counts(shape: DatasetShape) -> dict[str, int]:
+    counts = {}
+    for filename_index in range(min(_FILENAME_GROUPS, shape.frames_per_thread)):
+        per_trace = (
+            shape.frames_per_thread - 1 - filename_index
+        ) // _FILENAME_GROUPS + 1
+        counts[f"module_{filename_index}.py"] = shape.traces * per_trace
+    return counts

--- a/python/benches/telemetry_query_benchmark/query_backend.py
+++ b/python/benches/telemetry_query_benchmark/query_backend.py
@@ -1,0 +1,155 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""Execution backends for the telemetry query benchmark."""
+
+from __future__ import annotations
+
+import shutil
+import uuid
+from contextlib import suppress
+from typing import Any, cast, Literal, Protocol
+
+import pyarrow as pa
+from monarch._src.job._telemetry_query_client import QueryEngineClient
+from monarch._src.job.telemetry_actor import telemetry_socket_dir, TelemetryActor
+from monarch.actor import context, shutdown_context
+from monarch.distributed_telemetry.engine import QueryEngine
+from monarch.job import ProcessJob, TelemetryConfig
+from monarch.python.benches.telemetry_query_benchmark import pyspy_fixture
+
+BackendName = Literal["query-engine", "sidecar-http"]
+QueryRows = list[dict[str, object]]
+QueryData = dict[str, object] | pa.Table
+_QUERY_TIMEOUT_SEC = 60.0
+
+
+class QueryBackend(Protocol):
+    """A fixture store and query execution boundary."""
+
+    def preload(self, shape: pyspy_fixture.DatasetShape) -> None:
+        """Load the deterministic fixture."""
+        ...
+
+    def query(self, sql: str) -> QueryData:
+        """Execute SQL and return the backend-native result."""
+        ...
+
+    def rows(self, data: QueryData) -> QueryRows:
+        """Materialize rows outside the timed query interval."""
+        ...
+
+    def close(self) -> None:
+        """Release resources owned by this backend."""
+        ...
+
+
+class _SidecarHttpBackend:
+    def __init__(self) -> None:
+        job = ProcessJob({"hosts": 1}).enable_telemetry(
+            TelemetryConfig(
+                retention_secs=0,
+                include_dashboard=False,
+                dashboard_port=0,
+            )
+        )
+        try:
+            state = job.state(cached_path=None)
+            if state.telemetry_url is None:
+                raise RuntimeError("telemetry query URL is unavailable")
+            self._client = QueryEngineClient(
+                state.telemetry_url,
+                _QUERY_TIMEOUT_SEC,
+            )
+        except Exception:
+            with suppress(Exception):
+                job.kill()
+            raise
+        self._job = job
+
+    def preload(self, shape: pyspy_fixture.DatasetShape) -> None:
+        payload = pyspy_fixture.make_dump(shape)
+        for dump_index in range(shape.dumps):
+            response = self._client.store_pyspy_dump(
+                pyspy_fixture.dump_id(dump_index),
+                f"proc[{dump_index}]",
+                payload,
+            )
+            if response.get("status") != "ok":
+                raise RuntimeError(f"py-spy preload failed: {response!r}")
+
+    def query(self, sql: str) -> QueryData:
+        return cast(dict[str, object], self._client.query(sql))
+
+    def rows(self, data: QueryData) -> QueryRows:
+        if isinstance(data, pa.Table):
+            raise RuntimeError("sidecar HTTP returned an Arrow table")
+        rows = data.get("rows")
+        if not isinstance(rows, list) or any(not isinstance(row, dict) for row in rows):
+            raise RuntimeError(f"query returned malformed rows: {rows!r}")
+        return cast(QueryRows, rows)
+
+    def close(self) -> None:
+        self._job.kill()
+
+
+class _QueryEngineBackend:
+    def __init__(self) -> None:
+        self._apply_id = f"query_benchmark_{uuid.uuid4().hex}"
+        socket_dir = telemetry_socket_dir(self._apply_id)
+        try:
+            proc_mesh = context().actor_instance.proc_mesh
+            actor: Any = proc_mesh.spawn(
+                "telemetry_query_benchmark",
+                TelemetryActor,
+                self._apply_id,
+                0,
+            )
+            if not actor.activate.call_one().get():
+                raise RuntimeError("telemetry collector activation failed")
+            engine = QueryEngine(actor)
+            self._actor = actor
+            self._engine = engine
+        except Exception:
+            with suppress(Exception):
+                shutdown_context().get(timeout=5.0)
+            shutil.rmtree(socket_dir, ignore_errors=True)
+            raise
+
+    def preload(self, shape: pyspy_fixture.DatasetShape) -> None:
+        payload = pyspy_fixture.make_dump(shape)
+        for dump_index in range(shape.dumps):
+            stored = self._actor.store_pyspy_dump.call_one(
+                pyspy_fixture.dump_id(dump_index),
+                f"proc[{dump_index}]",
+                payload,
+            ).get()
+            if not stored:
+                raise RuntimeError("py-spy preload failed")
+
+    def query(self, sql: str) -> QueryData:
+        return self._engine.query(sql)
+
+    def rows(self, data: QueryData) -> QueryRows:
+        if not isinstance(data, pa.Table):
+            raise RuntimeError("direct query engine returned JSON rows")
+        return cast(QueryRows, data.to_pylist())
+
+    def close(self) -> None:
+        try:
+            with suppress(TimeoutError):
+                shutdown_context().get(timeout=5.0)
+        finally:
+            shutil.rmtree(telemetry_socket_dir(self._apply_id), ignore_errors=True)
+
+
+def create_backend(name: BackendName) -> QueryBackend:
+    """Create a benchmark backend."""
+    if name == "query-engine":
+        return _QueryEngineBackend()
+    return _SidecarHttpBackend()


### PR DESCRIPTION
Summary:
- Add a deterministic 100,000-frame PySpy fixture with five correctness-checked SQL query characteristics.
- Benchmark direct `QueryEngine` and loopback `sidecar-http` without concurrent writes; each cell is the median of 100 executions.
- `mode/opt` on `devvm20156.pnb0.facebook.com`; one run per backend.

| Backend | `frame_count` | `filtered_count` | `group_by_filename` | `four_table_join` | `ordered_projection` |
|---|---:|---:|---:|---:|---:|
| `query-engine` | 4.401 | 6.541 | 9.199 | 40.222 | 3.676 |
| `sidecar-http` | 7.634 | 8.680 | 11.456 | 41.953 | 11.108 |

Differential Revision: D113595370


