### PR TITLE
Use one local telemetry query partition (#4506)

### DIFF
--- a/monarch_distributed_telemetry/src/query_engine.rs
+++ b/monarch_distributed_telemetry/src/query_engine.rs
@@ -461,7 +461,11 @@ impl QueryEngine {
             .call_method0(py, "item")?
             .extract(py)?;
 
-        let config = SessionConfig::new().with_information_schema(true);
+        // Each distributed scan exposes one partition; extra local partitions
+        // add repartitioning overhead at representative telemetry sizes.
+        let config = SessionConfig::new()
+            .with_information_schema(true)
+            .with_target_partitions(1);
         let ctx = SessionContext::new_with_config(config);
 
         for table_name in &tables {


### PR DESCRIPTION
Summary:

- Configure telemetry query sessions with one target partition to match each distributed scan's single output partition.
- Avoid local repartitioning overhead for the fixed telemetry query topology.
- `mode/opt` on `devvm20156.pnb0.facebook.com`; cells are 100-execution median ms with parent delta. Negative is faster.

| Backend | `frame_count` | `filtered_count` | `group_by_filename` | `four_table_join` | `ordered_projection` |
|---|---:|---:|---:|---:|---:|
| `query-engine` | 2.576 (-41.5%) | 5.119 (-21.7%) | 3.378 (-63.3%) | 19.911 (-50.5%) | 3.781 (+2.9%) |
| `sidecar-http` | 4.886 (-36.0%) | 6.509 (-25.0%) | 4.671 (-59.2%) | 22.252 (-47.0%) | 10.773 (-3.0%) |

Differential Revision: D113595371


