### PR TITLE
Export telemetry queries through Arrow C Stream (#4507)

### DIFF
--- a/monarch_distributed_telemetry/Cargo.toml
+++ b/monarch_distributed_telemetry/Cargo.toml
@@ -9,6 +9,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.103"
+arrow = { version = "57.3.1", features = ["ffi", "json", "prettyprint", "pyarrow"] }
 async-trait = "0.1.86"
 datafusion = "52.5.0"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -19,8 +19,11 @@ use std::time::UNIX_EPOCH;
 use anyhow::Context;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::dataframe::DataFrame;
 use datafusion::datasource::MemTable;
 use datafusion::datasource::TableProvider;
+use datafusion::error::Result as DFResult;
+use datafusion::logical_expr::col;
 use datafusion::prelude::SessionContext;
 use hyperactor as reference;
 use hyperactor::Endpoint as _;
@@ -260,6 +263,45 @@ const RETENTION_TABLES: &[&str] = &["sent_messages", "messages", "message_status
 /// Interval between routine retention sweeps.
 const RETENTION_INTERVAL: Duration = Duration::from_secs(30);
 
+fn build_scan_dataframe(
+    ctx: &SessionContext,
+    table: Arc<dyn TableProvider>,
+    projection: Option<&[usize]>,
+    where_clause: Option<&str>,
+    limit: Option<usize>,
+) -> DFResult<DataFrame> {
+    let schema = table.schema();
+    let mut dataframe = ctx.read_table(table)?;
+    if let Some(where_clause) = where_clause {
+        let filter = dataframe.parse_sql_expr(where_clause)?;
+        dataframe = dataframe.filter(filter)?;
+    }
+
+    dataframe = match projection {
+        Some([]) => dataframe.select_exprs(&["NULL as fake_column"])?,
+        Some(projection) => {
+            let columns = projection
+                .iter()
+                .map(|&index| {
+                    schema
+                        .fields()
+                        .get(index)
+                        .map(|field| col(field.name()))
+                        .ok_or_else(|| {
+                            datafusion::error::DataFusionError::Plan(format!(
+                                "projection index {index} out of range"
+                            ))
+                        })
+                })
+                .collect::<DFResult<Vec<_>>>()?;
+            dataframe.select(columns)?
+        }
+        None => dataframe,
+    };
+
+    dataframe.limit(0, limit)
+}
+
 #[pyclass(
     name = "DatabaseScanner",
     module = "monarch._rust_bindings.monarch_distributed_telemetry.database_scanner"
@@ -267,6 +309,7 @@ const RETENTION_INTERVAL: Duration = Duration::from_secs(30);
 pub struct DatabaseScanner {
     /// Tables stored by name - each holds the schema and shared PartitionData
     table_data: Arc<StdMutex<HashMap<String, Arc<LiveTableData>>>>,
+    scan_session: SessionContext,
     rank: usize,
     /// Retention window in microseconds.
     retention_us: i64,
@@ -290,6 +333,7 @@ impl DatabaseScanner {
     fn new(rank: usize, retention_secs: u64) -> PyResult<Self> {
         let scanner = Self {
             table_data: Arc::new(StdMutex::new(HashMap::new())),
+            scan_session: SessionContext::new(),
             rank,
             retention_us: retention_secs as i64 * 1_000_000,
             socket_ingest_handles: StdMutex::new(Vec::new()),
@@ -833,7 +877,7 @@ impl DatabaseScanner {
         let rank = self.rank;
 
         // Get the LiveTableData's MemTable
-        let (schema, mem_table) = {
+        let mem_table = {
             let guard = self
                 .table_data
                 .lock()
@@ -841,51 +885,25 @@ impl DatabaseScanner {
             let table_data = guard
                 .get(table_name)
                 .ok_or_else(|| PyException::new_err(format!("table '{}' not found", table_name)))?;
-            (table_data.schema(), table_data.mem_table())
+            table_data.mem_table()
         };
 
         // Handle empty projection (e.g., for COUNT(*) queries)
         // DataFusion may request 0 columns but we still need row counts
         let is_empty_projection = matches!(&projection, Some(proj) if proj.is_empty());
 
-        // Build a query using DataFusion
-        let ctx = SessionContext::new();
-        ctx.register_table(table_name, mem_table)
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-
-        // Build SELECT clause - for empty projection, use NULL as fake_column
-        let columns = match &projection {
-            Some(proj) if !proj.is_empty() => {
-                let selected: Vec<_> = proj
-                    .iter()
-                    .filter_map(|&i| schema.fields().get(i).map(|f| f.name().clone()))
-                    .collect();
-                if selected.is_empty() {
-                    "*".into()
-                } else {
-                    selected.join(", ")
-                }
-            }
-            Some(_) => "NULL as fake_column".into(),
-            _ => "*".into(),
-        };
-
-        let query = format!(
-            "SELECT {} FROM {}{}{}",
-            columns,
-            table_name,
-            where_clause
-                .map(|c| format!(" WHERE {}", c))
-                .unwrap_or_default(),
-            limit.map(|n| format!(" LIMIT {}", n)).unwrap_or_default()
-        );
-
         // Execute and stream batches directly to destination
         let batch_count = get_tokio_runtime()
             .block_on(async {
                 use futures::StreamExt;
 
-                let df = ctx.sql(&query).await?;
+                let df = build_scan_dataframe(
+                    &self.scan_session,
+                    mem_table,
+                    projection.as_deref(),
+                    where_clause.as_deref(),
+                    limit,
+                )?;
                 let mut stream = df.execute_stream().await?;
                 let mut count: usize = 0;
 
@@ -954,6 +972,7 @@ mod tests {
     use datafusion::arrow::array::Int64Array;
     use datafusion::arrow::array::StringArray;
     use datafusion::arrow::array::UInt64Array;
+    use datafusion::arrow::compute::concat_batches;
     use datafusion::arrow::datatypes::DataType;
     use datafusion::arrow::datatypes::Field;
     use datafusion::arrow::datatypes::Schema;
@@ -1008,6 +1027,7 @@ mod tests {
     fn test_scanner(retention_us: i64) -> DatabaseScanner {
         DatabaseScanner {
             table_data: Arc::new(StdMutex::new(HashMap::new())),
+            scan_session: SessionContext::new(),
             rank: 0,
             retention_us,
             socket_ingest_handles: StdMutex::new(Vec::new()),
@@ -1143,6 +1163,45 @@ mod tests {
         table.apply_retention("t", "1=1").await.unwrap();
 
         assert_eq!(row_count(&table).await, 3);
+    }
+
+    #[tokio::test]
+    async fn test_build_scan_dataframe_applies_filter_projection_and_limit() {
+        let table = LiveTableData::new(make_batch(&[]).schema());
+        table.push(make_batch(&[1, 2, 3, 4])).await;
+        let schema = table.schema();
+        let ctx = SessionContext::new();
+
+        let dataframe =
+            build_scan_dataframe(&ctx, table.mem_table(), Some(&[0]), Some("x >= 2"), Some(2))
+                .unwrap();
+        let batches = dataframe.collect().await.unwrap();
+        let batch = concat_batches(&schema, &batches).unwrap();
+        let values = batch
+            .column(0)
+            .as_any()
+            .downcast_ref::<Int64Array>()
+            .unwrap();
+
+        assert_eq!(values.values(), &[2, 3]);
+    }
+
+    #[test]
+    fn test_build_scan_dataframe_rejects_out_of_range_projection() {
+        let table = LiveTableData::new(make_batch(&[]).schema());
+        let ctx = SessionContext::new();
+
+        let error = build_scan_dataframe(&ctx, table.mem_table(), Some(&[1]), None, None)
+            .expect_err("out-of-range projection should fail");
+
+        assert!(
+            matches!(
+                &error,
+                datafusion::error::DataFusionError::Plan(message)
+                    if message == "projection index 1 out of range"
+            ),
+            "unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/monarch_distributed_telemetry/src/query_engine.rs
+++ b/monarch_distributed_telemetry/src/query_engine.rs
@@ -10,10 +10,12 @@
 
 use std::sync::Arc;
 
+use arrow::pyarrow::PyArrowType;
 use datafusion::arrow::datatypes::SchemaRef;
 use datafusion::arrow::ipc::reader::StreamReader;
-use datafusion::arrow::ipc::writer::StreamWriter;
 use datafusion::arrow::record_batch::RecordBatch;
+use datafusion::arrow::record_batch::RecordBatchIterator;
+use datafusion::arrow::record_batch::RecordBatchReader;
 use datafusion::catalog::Session;
 use datafusion::datasource::TableProvider;
 use datafusion::error::Result as DFResult;
@@ -45,7 +47,6 @@ use monarch_hyperactor::pytokio::PyPythonTask;
 use monarch_hyperactor::runtime::get_tokio_runtime;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
-use pyo3::types::PyBytes;
 use pyo3::types::PyModule;
 use tokio::sync::mpsc;
 
@@ -278,7 +279,7 @@ impl TableProvider for DistributedTableProvider {
             properties: PlanProperties::new(
                 EquivalenceProperties::new(output_schema),
                 Partitioning::UnknownPartitioning(1),
-                EmissionType::Final,
+                EmissionType::Incremental,
                 Boundedness::Bounded,
             ),
         }))
@@ -411,38 +412,26 @@ impl QueryEngine {
         "<QueryEngine>".into()
     }
 
-    /// Execute a SQL query and return results as Arrow IPC bytes.
-    fn query<'py>(&self, py: Python<'py>, sql: String) -> PyResult<Bound<'py, PyBytes>> {
+    /// Execute a SQL query and return an Arrow record batch reader.
+    fn query(
+        &self,
+        py: Python<'_>,
+        sql: String,
+    ) -> PyResult<PyArrowType<Box<dyn RecordBatchReader + Send>>> {
         let session_ctx = self.session.clone();
-
-        // Release the GIL and run the async query on the shared monarch runtime.
-        let results: Vec<RecordBatch> = py
-            .detach(|| {
+        let (schema, results) = py
+            .detach(|| -> DFResult<(SchemaRef, Vec<RecordBatch>)> {
                 get_tokio_runtime().block_on(async {
                     let df = session_ctx.sql(&sql).await?;
-                    df.collect().await
+                    let schema = Arc::clone(df.schema().inner());
+                    let results = df.collect().await?;
+                    Ok((schema, results))
                 })
             })
             .map_err(|e| PyException::new_err(e.to_string()))?;
 
-        // Serialize all results as a single Arrow IPC stream
-        let schema = results
-            .first()
-            .map(|b| b.schema())
-            .unwrap_or_else(|| Arc::new(datafusion::arrow::datatypes::Schema::empty()));
-        let mut buf = Vec::new();
-        let mut writer = StreamWriter::try_new(&mut buf, &schema)
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-        for batch in &results {
-            writer
-                .write(batch)
-                .map_err(|e| PyException::new_err(e.to_string()))?;
-        }
-        writer
-            .finish()
-            .map_err(|e| PyException::new_err(e.to_string()))?;
-
-        Ok(PyBytes::new(py, &buf))
+        let reader = RecordBatchIterator::new(results.into_iter().map(Ok), schema);
+        Ok(PyArrowType(Box::new(reader)))
     }
 }
 

--- a/monarch_distributed_telemetry/src/query_engine.rs
+++ b/monarch_distributed_telemetry/src/query_engine.rs
@@ -461,7 +461,11 @@ impl QueryEngine {
             .call_method0(py, "item")?
             .extract(py)?;
 
-        let config = SessionConfig::new().with_information_schema(true);
+        // Each distributed scan exposes one partition; extra local partitions
+        // add repartitioning overhead at representative telemetry sizes.
+        let config = SessionConfig::new()
+            .with_information_schema(true)
+            .with_target_partitions(1);
         let ctx = SessionContext::new_with_config(config);
 
         for table_name in &tables {

--- a/python/monarch/_rust_bindings/monarch_distributed_telemetry/query_engine.pyi
+++ b/python/monarch/_rust_bindings/monarch_distributed_telemetry/query_engine.pyi
@@ -4,11 +4,13 @@
 # This source code is licensed under the BSD-style license found in the
 # LICENSE file in the root directory of this source tree.
 
+import pyarrow as pa
+
 class QueryEngine:
     """DataFusion query execution, creates ports, collects results."""
 
     def __new__(cls, actor: object) -> "QueryEngine": ...
     def __repr__(self) -> str: ...
-    def query(self, sql: str) -> bytes:
-        """Execute a SQL query and return results as Arrow IPC bytes."""
+    def query(self, sql: str) -> pa.RecordBatchReader:
+        """Execute a SQL query and return an Arrow record batch reader."""
         ...

--- a/python/monarch/_rust_bindings/monarch_extension/distributed_telemetry.pyi
+++ b/python/monarch/_rust_bindings/monarch_extension/distributed_telemetry.pyi
@@ -8,6 +8,7 @@
 
 from typing import final, List, Optional
 
+import pyarrow as pa
 from monarch._rust_bindings.monarch_hyperactor.mailbox import PortId
 
 @final
@@ -97,7 +98,7 @@ class QueryEngine:
         """
         ...
 
-    def query(self, sql: str) -> bytes:
+    def query(self, sql: str) -> pa.RecordBatchReader:
         """
         Execute a SQL query.
 
@@ -105,6 +106,6 @@ class QueryEngine:
             sql: SQL query string
 
         Returns:
-            Arrow IPC serialized stream containing all record batches
+            Arrow record batch reader
         """
         ...

--- a/python/monarch/distributed_telemetry/engine.py
+++ b/python/monarch/distributed_telemetry/engine.py
@@ -63,18 +63,5 @@ class QueryEngine:
         Returns:
             PyArrow Table containing query results
         """
-        data: bytes = self._ensure_engine().query(sql)
-        reader = pa.ipc.open_stream(data)
+        reader: pa.RecordBatchReader = self._ensure_engine().query(sql)
         return reader.read_all()
-
-    def query_raw(self, sql: str) -> bytes:
-        """
-        Execute a SQL query and return raw Arrow IPC stream.
-
-        Args:
-            sql: SQL query string
-
-        Returns:
-            Arrow IPC serialized stream containing all record batches
-        """
-        return self._ensure_engine().query(sql)


### PR DESCRIPTION
Summary:

- Export collected DataFusion batches as a PyArrow `RecordBatchReader`, removing Arrow IPC encoding, byte allocation, and reparsing.
- Preserve planned schemas for empty results, describe distributed scans as incremental, and cover empty and repeated readers.
- Investigation suffix; reported cells are a one-invocation rerun on `devvm20156.pnb0.facebook.com`; deltas use the immediately preceding fresh-parent run. Each cell is the median of 100 executions. Negative is faster.

| Backend | `frame_count` | `filtered_count` | `group_by_filename` | `four_table_join` | `ordered_projection` |
|---|---:|---:|---:|---:|---:|
| `query-engine` | 1.887 (+11.1%) | 4.441 (+2.0%) | 2.536 (+0.4%) | 18.396 (-1.0%) | 2.524 (-9.1%) |
| `sidecar-http` | 4.426 (+24.5%) | 7.026 (+9.2%) | 4.129 (+3.5%) | 20.685 (+0.3%) | 10.477 (+5.3%) |

Differential Revision: D113595368


