### PR TITLE
characterize mesh lifecycle behavior before removing `_Tokio` (#4509)

### DIFF
--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -17,6 +17,7 @@ import tempfile
 import textwrap
 import threading
 import time
+from contextlib import ExitStack
 from typing import Dict, List, Optional, Set
 from unittest.mock import patch
 
@@ -151,6 +152,28 @@ def test_shutdown_host_mesh() -> None:
         am = pm.spawn("actor", RankActor)
         am.get_rank.choose().get()
         hm.shutdown().get()
+        assert hm._inner_host_mesh is None
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_shutdown_immediately_after_proc_spawn_without_actor() -> None:
+    with ExitStack() as cleanup:
+        job = ProcessJob({"hosts": 1})
+        cleanup.callback(job.kill)
+        hm = job.state(cached_path=None).hosts
+        hm.spawn_procs(name="pending_proc")
+
+        shutdown_result = hm.shutdown().get(timeout=10.0)
+        cleanup.pop_all()
+        assert shutdown_result is None
+
+        assert hm._inner_host_mesh is None
+        with pytest.raises(
+            RuntimeError,
+            match="HostMesh has already been shut down",
+        ):
+            hm.spawn_procs()
 
 
 @pytest.mark.timeout(60)
@@ -281,8 +304,16 @@ def test_shutdown_sliced_host_mesh_throws_exception() -> None:
     with scoped_state(ProcessJob({"hosts": 2}), cached_path=None) as state:
         hm = state.hosts
         hm_sliced = hm.slice(hosts=1)
-        with pytest.raises(RuntimeError):
+        sliced_inner = hm_sliced._inner_host_mesh
+        assert sliced_inner is not None
+
+        with pytest.raises(
+            RuntimeError,
+            match="cannot shut down `HostMesh` that is a reference instead of owned",
+        ):
             hm_sliced.shutdown().get()
+
+        assert hm_sliced._inner_host_mesh is sliced_inner
 
 
 @pytest.mark.timeout(60)

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import threading
 import time
+from contextlib import ExitStack
 from typing import cast
 from unittest.mock import patch
 
@@ -29,6 +30,7 @@ from monarch._src.actor.actor_mesh import (
     ValueMesh,
 )
 from monarch._src.actor.endpoint import endpoint
+from monarch._src.actor.future import tokio_oracle, TokioOracleRecord
 from monarch._src.actor.host_mesh import this_host, this_proc
 from monarch._src.actor.proc_mesh import (
     get_or_spawn_controller,
@@ -41,6 +43,31 @@ from scoped_state import scoped_state
 
 
 _proc_rank = -1
+_BOOTSTRAP_FAILURE = "stage 3.4 bootstrap failure"
+
+
+def _successful_bootstrap() -> None:
+    return None
+
+
+def _fail_bootstrap() -> None:
+    raise RuntimeError(_BOOTSTRAP_FAILURE)
+
+
+def _tokio_records_for(
+    records: list[TokioOracleRecord],
+    *,
+    module: str,
+    filename: str,
+    function: str | None = None,
+) -> list[TokioOracleRecord]:
+    return [
+        record
+        for record in records
+        if record.module == module
+        and os.path.basename(record.filename) == filename
+        and (function is None or record.function == function)
+    ]
 
 
 class TestActor(Actor):
@@ -90,9 +117,49 @@ class TestActor(Actor):
 async def test_proc_mesh_initialization() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         host = state.hosts
-        proc_mesh = host.spawn_procs(name="test_proc")
-        # Test that initialization completes successfully
-        assert await proc_mesh.initialized
+        with tokio_oracle() as records:
+            proc_mesh = host.spawn_procs(
+                name="test_proc",
+                bootstrap=_successful_bootstrap,
+            )
+            assert await proc_mesh.initialized
+
+            setup_records = _tokio_records_for(
+                records,
+                module="monarch._src.actor.proc_mesh",
+                filename="proc_mesh.py",
+                function="task",
+            )
+            assert len(setup_records) == 1
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
+
+        with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
+            await proc_mesh.initialized
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+async def test_stop_state_tracks_native_stop_result() -> None:
+    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
+        owner = state.hosts.spawn_procs(per_host={"gpus": 2})
+        await owner.initialized
+        proc_ref = owner.slice(gpus=0)
+
+        with pytest.raises(
+            ValueError,
+            match="ProcMesh is not owned; must be stopped by an owner",
+        ):
+            await proc_ref.stop()
+
+        assert not proc_ref._stopped
+        assert await owner.stop() is None
+        assert owner._stopped
 
 
 @pytest.mark.timeout(60)
@@ -317,11 +384,46 @@ def test_raw_proc_mesh_pickle_blocks_on_proc_mesh_init() -> None:
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 async def test_actor_spawn_then_immediate_shutdown() -> None:
-    with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
-        proc_mesh = state.hosts.spawn_procs(name="test")
+    with ExitStack() as cleanup:
+        job = ProcessJob({"hosts": 1})
+        cleanup.callback(job.kill)
+        host = job.state(cached_path=None).hosts
+        proc_mesh = host.spawn_procs(name="test")
         await proc_mesh.initialized
+        assert proc_mesh._logging_manager._logging_mesh_client is not None
+
         # spawn actor but do NOT await initialized — immediately shutdown
-        proc_mesh.spawn("test_actor", TestActor, 42)
+        actor_mesh = proc_mesh.spawn("test_actor", TestActor, 42)
+
+        with tokio_oracle() as records:
+            shutdown_result = await host.shutdown()
+            cleanup.pop_all()
+            assert shutdown_result is None
+
+            proc_drain_records = _tokio_records_for(
+                records,
+                module="monarch._src.actor.proc_mesh",
+                filename="proc_mesh.py",
+                function="_flush_pending_actor_spawns",
+            )
+            logging_records = _tokio_records_for(
+                records,
+                module="monarch._src.actor.logging",
+                filename="logging.py",
+                function="flush_async",
+            )
+            host_records = _tokio_records_for(
+                records,
+                module="monarch._src.actor.host_mesh",
+                filename="host_mesh.py",
+            )
+
+            assert len(proc_drain_records) == 1
+            assert len(logging_records) == 1
+            assert host_records == []
+
+        assert await actor_mesh.initialized is None
+        assert proc_mesh._pending_actor_spawns == []
 
 
 @pytest.mark.timeout(60)


### PR DESCRIPTION
Summary:

monarch is removing the legacy `_Tokio` state from its python `Future` wrapper and moving ownership of asynchronous work into rust-owned `Handle`s. the next cutover covers proc-mesh startup, draining pending actors during shutdown, and flushing logs. before changing those paths, this tests-only diff records the three `_Tokio` producers that still exist and pins the lifecycle behavior that must remain unchanged.

the tests cover successful and failed proc startup, stop behavior for owned and borrowed proc meshes, shutdown while an actor or proc is still pending, and host-mesh state after successful or rejected shutdown. later diffs can remove each producer and change the recorded counts to zero without weakening those behavior checks.

Differential Revision: D113601207


