### PR TITLE
keep rdmaxcel-sys out of the build graph (#4512)

### DIFF
--- a/.github/workflows/test-cpu-rust-macos.yml
+++ b/.github/workflows/test-cpu-rust-macos.yml
@@ -63,6 +63,7 @@ jobs:
             --exclude monarch_tensor_worker \
             --exclude torch-sys-cuda \
             --exclude monarch_rdma \
+            --exclude monarch_rdma_extension \
             --exclude torch-sys \
             --exclude nccl-sys \
             --exclude rdmaxcel-sys \

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -72,6 +72,7 @@ jobs:
           --exclude monarch_tensor_worker \
           --exclude torch-sys-cuda \
           --exclude monarch_rdma \
+          --exclude monarch_rdma_extension \
           --exclude torch-sys \
           --exclude nccl-sys \
           --exclude rdmaxcel-sys \


### PR DESCRIPTION
Summary:

after D113473502: `test = false` is gone → default `test = true` → the crate now has a unit-test binary, so `cargo test --workspace` compiles `monarch_rdma_extension` → `monarch_rdma` → `rdmaxcel-sys` → its build script runs on the CPU-only runner → `panic!("Neither CUDA nor ROCm installation found")`.

fix #1 - both CPU Rust workflows (`test-cpu-rust.yml` x86_64 and `test-cpu-rust-macos.yml`) now exclude `monarch_rdma_extension`, so `cargo nextest/cargo test --no-run` won't  try to build the extension's unit-test binary → `rdmaxcel-sys` stays out of the CPU build graph → no more GPU-detection panic.

Differential Revision: D113671048


