### PR TITLE
move `after_ready` so its tests build on CPU

### DIFF
--- a/monarch_hyperactor/src/handle.rs
+++ b/monarch_hyperactor/src/handle.rs
@@ -399,6 +399,99 @@ impl PyHandle {
     }
 }
 
+/// Run `operation` only after `ready` resolves `Ok`, returning the readiness
+/// error unchanged if it does not.
+///
+/// Generic over the result and error so the short-circuit law is unit-testable
+/// without pyo3; the RDMA bindings instantiate `E = PyErr` and this helper never
+/// inspects or remaps it. `operation` is a closure, not an already-started
+/// future, so no effect begins before readiness. The typical `ready` input is
+/// [`PyHandle::wait_completion`].
+pub async fn after_ready<T, E, RF, Op, OF>(ready: RF, operation: Op) -> Result<T, E>
+where
+    RF: Future<Output = Result<(), E>>,
+    Op: FnOnce() -> OF,
+    OF: Future<Output = Result<T, E>>,
+{
+    ready.await?;
+    operation().await
+}
+
+#[cfg(test)]
+mod after_ready_tests {
+    use std::future::Future;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+    use std::task::Context;
+    use std::task::Poll;
+    use std::task::Waker;
+
+    use super::after_ready;
+
+    #[derive(Debug, PartialEq)]
+    struct SentinelErr(&'static str);
+
+    /// After readiness resolves `Ok`, the operation closure runs exactly once
+    /// and its result is returned.
+    #[tokio::test]
+    async fn after_ready_runs_operation_once_on_success() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let out: Result<u8, SentinelErr> =
+            after_ready(async { Ok::<(), SentinelErr>(()) }, move || {
+                let c = c.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    Ok(7u8)
+                }
+            })
+            .await;
+        assert_eq!(out, Ok(7));
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    /// A readiness error is returned unchanged and the operation closure is
+    /// never invoked.
+    #[tokio::test]
+    async fn after_ready_short_circuits_on_readiness_error() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let out: Result<u8, SentinelErr> = after_ready(
+            async { Err::<(), SentinelErr>(SentinelErr("boom")) },
+            move || {
+                let c = c.clone();
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    Ok(7u8)
+                }
+            },
+        )
+        .await;
+        assert_eq!(out, Err(SentinelErr("boom")));
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+
+    /// While readiness is pending the composed future cannot complete and the
+    /// operation closure is never invoked.
+    #[test]
+    fn after_ready_does_not_run_operation_while_pending() {
+        let calls = Arc::new(AtomicUsize::new(0));
+        let c = calls.clone();
+        let pending_ready = std::future::pending::<Result<(), SentinelErr>>();
+        let mut fut = Box::pin(after_ready(pending_ready, move || {
+            let c = c.clone();
+            async move {
+                c.fetch_add(1, Ordering::SeqCst);
+                Ok(7u8)
+            }
+        }));
+        let mut cx = Context::from_waker(Waker::noop());
+        assert_eq!(fut.as_mut().poll(&mut cx), Poll::Pending);
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
+    }
+}
+
 #[cfg(test)]
 impl PyHandle {
     /// Construct a resolved `Handle` from `value`.

--- a/monarch_rdma/extension/Cargo.toml
+++ b/monarch_rdma/extension/Cargo.toml
@@ -9,6 +9,8 @@ license = "BSD-3-Clause"
 
 [lib]
 path = "lib.rs"
+test = false
+doctest = false
 
 [dependencies]
 hyperactor = { version = "0.0.0", path = "../../hyperactor" }

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -82,7 +82,6 @@
 //!   (enforced in `RDMABuffer.__init__` and `RDMAAction.submit`).
 
 #![allow(unsafe_op_in_unsafe_fn)]
-use std::future::Future;
 use std::ops::Deref;
 use std::sync::Arc;
 use std::time::Duration;
@@ -93,6 +92,7 @@ use hyperactor_mesh::client_root::ClientRootRef;
 use hyperactor_mesh::client_root::ClientRootService;
 use monarch_hyperactor::context::PyInstance;
 use monarch_hyperactor::handle::PyHandle;
+use monarch_hyperactor::handle::after_ready;
 use monarch_hyperactor::proc_mesh::PyProcMesh;
 use monarch_hyperactor::pytokio::PyPythonTask;
 use monarch_hyperactor::pytokio::PyShared;
@@ -684,22 +684,6 @@ impl PyRdmaAction {
     }
 }
 
-/// Run `operation` only after `ready` resolves `Ok` (RDC-3).
-///
-/// Generic over the result and error so the short-circuit law is unit-testable
-/// without pyo3; production instantiates `E = PyErr` and this helper never
-/// inspects or remaps it. `operation` is a closure, not an already-started
-/// future, so no effect begins before readiness.
-async fn after_ready<T, E, RF, Op, OF>(ready: RF, operation: Op) -> Result<T, E>
-where
-    RF: Future<Output = Result<(), E>>,
-    Op: FnOnce() -> OF,
-    OF: Future<Output = Result<T, E>>,
-{
-    ready.await?;
-    operation().await
-}
-
 async fn create_rdma_buffer(
     local: PyLocalMemoryHandle,
     client: PyInstance,
@@ -961,79 +945,4 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
         _get_memoryview_addr_and_size
     );
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use std::future::Future;
-    use std::sync::Arc;
-    use std::sync::atomic::AtomicUsize;
-    use std::sync::atomic::Ordering;
-    use std::task::Context;
-    use std::task::Poll;
-    use std::task::Waker;
-
-    use super::after_ready;
-
-    #[derive(Debug, PartialEq)]
-    struct SentinelErr(&'static str);
-
-    /// RDC-3: after readiness resolves `Ok`, the operation closure runs
-    /// exactly once and its result is returned.
-    #[tokio::test]
-    async fn after_ready_runs_operation_once_on_success() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let c = calls.clone();
-        let out: Result<u8, SentinelErr> =
-            after_ready(async { Ok::<(), SentinelErr>(()) }, move || {
-                let c = c.clone();
-                async move {
-                    c.fetch_add(1, Ordering::SeqCst);
-                    Ok(7u8)
-                }
-            })
-            .await;
-        assert_eq!(out, Ok(7));
-        assert_eq!(calls.load(Ordering::SeqCst), 1);
-    }
-
-    /// RDC-3: a readiness error is returned unchanged and the operation
-    /// closure is never invoked.
-    #[tokio::test]
-    async fn after_ready_short_circuits_on_readiness_error() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let c = calls.clone();
-        let out: Result<u8, SentinelErr> = after_ready(
-            async { Err::<(), SentinelErr>(SentinelErr("boom")) },
-            move || {
-                let c = c.clone();
-                async move {
-                    c.fetch_add(1, Ordering::SeqCst);
-                    Ok(7u8)
-                }
-            },
-        )
-        .await;
-        assert_eq!(out, Err(SentinelErr("boom")));
-        assert_eq!(calls.load(Ordering::SeqCst), 0);
-    }
-
-    /// RDC-3: while readiness is pending the composed future cannot complete
-    /// and the operation closure is never invoked.
-    #[test]
-    fn after_ready_does_not_run_operation_while_pending() {
-        let calls = Arc::new(AtomicUsize::new(0));
-        let c = calls.clone();
-        let pending_ready = std::future::pending::<Result<(), SentinelErr>>();
-        let mut fut = Box::pin(after_ready(pending_ready, move || {
-            let c = c.clone();
-            async move {
-                c.fetch_add(1, Ordering::SeqCst);
-                Ok(7u8)
-            }
-        }));
-        let mut cx = Context::from_waker(Waker::noop());
-        assert_eq!(fut.as_mut().poll(&mut cx), Poll::Pending);
-        assert_eq!(calls.load(Ordering::SeqCst), 0);
-    }
 }


### PR DESCRIPTION
Summary:
the CPU-only Rust CI started failing. the RDMA extension's tests were switched on, but building that extension needs GPU libraries (CUDA or ROCm) that the CPU CI machines don't have, so the build died before any test could run.

the only tests in that extension covered `after_ready` — a small helper that waits for setup to finish before running the next step, with nothing RDMA- or GPU-specific about it. this moves `after_ready` and its tests into `monarch_hyperactor`, which builds fine on CPU, and switches the extension's tests back off. the tests keep running, now on CPU, and the CPU build no longer drags in the GPU-only code.

nothing about how RDMA works changes.

Differential Revision: D113671896


