### PR TITLE
Migrate ROCm CI to the new MI350x meta-pytorch runner fleet

### DIFF
--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -7,7 +7,8 @@ on:
         description: 'Override default ROCm runner label'
         required: false
         type: string
-        default: linux.rocm.gpu.gfx942.1.meta-pytorch
+        # Migrated to the new MI350x meta-pytorch runner fleet.
+        default: linux.rocm.gpu.meta-pytorch.mi350.1
       runner-cuda:
         description: 'Override default CUDA runner label'
         required: false


### PR DESCRIPTION
## Summary

- Points the default ROCm runner label in `set-matrix.yaml` at the new MI350x meta-pytorch runner fleet: `linux.rocm.gpu.meta-pytorch.mi350.1` (was `linux.rocm.gpu.gfx942.1.meta-pytorch`).
- Part of migrating the meta-pytorch ecosystem ROCm CI onto the new MI350x cluster. The runner scale sets for these labels are provisioned by our infra.

**Draft** because the MI350x runners for the `meta-pytorch` org are not fully registered yet (pending the GitHub App / secret provisioning). Merging this before the runners are online would strand ROCm jobs with no runner to pick them up. ROCm CI here is also currently opt-in via a `ciflow/rocm` tag (see set-matrix.yaml), so this changes only which runner that opt-in path targets.

Note: single-GPU (`.mi350.1`) mirrors the prior single-GPU gfx942 label. The fleet also exposes `.mi350.{2,4,8}` if multi-GPU ROCm jobs are added later.

## Test plan

- [ ] After the new MI350x meta-pytorch runners are online, push a `ciflow/rocm/*` tag (or apply the `ciflow/rocm` label) and confirm the ROCm build/test matrix lands on `linux.rocm.gpu.meta-pytorch.mi350.1` and goes green.

Made with Cursor