### PR TITLE
Bulk sequencing: batch assign_seqs with RLE ranges (#4520)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,7 @@ dependencies = [
  "proptest",
  "quinn",
  "rand 0.10.2",
+ "rustc-hash",
  "rustls",
  "rustls-pemfile",
  "serde",

--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -59,6 +59,7 @@ opentelemetry = "0.31"
 paste = "1.0.14"
 quinn = "0.11.11"
 rand = "0.10.2"
+rustc-hash = "2.1.3"
 rustls = { version = "0.23.37", features = ["ring"] }
 rustls-pemfile = "2.2.0"
 serde = { version = "1.0.229", features = ["derive", "rc"] }

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -6,6 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::Barrier;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -15,6 +21,8 @@ use criterion::Throughput;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use futures::future::join_all;
+use hyperactor::PortAddr;
+use hyperactor::Proc;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
@@ -26,6 +34,9 @@ use hyperactor::channel::serve;
 use hyperactor::mailbox::Mailbox;
 use hyperactor::mailbox::PortSender;
 use hyperactor::mailbox::monitored_return_handle;
+use hyperactor::ordering::SeqKey;
+use hyperactor::ordering::Sequencer;
+use hyperactor::port::Port;
 use hyperactor::testing::ids::test_actor_id;
 use serde::Deserialize;
 use serde::Serialize;
@@ -40,6 +51,18 @@ fn new_runtime() -> Runtime {
         .enable_all()
         .build()
         .unwrap()
+}
+
+fn new_benchmark_sequencer() -> Sequencer {
+    let runtime = new_runtime();
+    let _guard = runtime.enter();
+    let proc = Proc::direct(
+        ChannelAddr::any(ChannelTransport::Local),
+        "sequencer_bench".to_string(),
+    )
+    .unwrap();
+
+    proc.client("sequencer_bench").sequencer().clone()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Named, PartialEq)]
@@ -343,6 +366,225 @@ fn bench_mailbox_message_rates(c: &mut Criterion) {
     group.finish();
 }
 
+/// Compare single-key and batch sequence assignment across cast fanout sizes.
+fn bench_cast_seq_assignment(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cast_seq_assignment");
+    for n in [1usize, 8, 64, 512, 4096, 8192, 16384, 32768] {
+        let ports: Vec<PortAddr> = (0..n)
+            .map(|i| {
+                test_actor_id(&format!("worker_{i}"), "worker").port_addr(Port::handler_id(0, None))
+            })
+            .collect();
+        let keys: Vec<SeqKey> = ports
+            .iter()
+            .map(|port| SeqKey::for_handler(&port.actor_addr()))
+            .collect();
+
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("per_dest_assign_seq", n),
+            &ports,
+            |b, ports| {
+                let seq = new_benchmark_sequencer();
+                for p in ports {
+                    black_box(seq.assign_seq(p));
+                }
+                b.iter(|| {
+                    for p in ports {
+                        black_box(seq.assign_seq(black_box(p)));
+                    }
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("batch_assign_seqs", n),
+            &keys,
+            |b, keys| {
+                let seq = new_benchmark_sequencer();
+                black_box(seq.assign_seqs(keys));
+                b.iter(|| {
+                    black_box(seq.assign_seqs(black_box(keys)));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("batch_assign_seqs_divergent", n),
+            &keys,
+            |b, keys| {
+                let seq = new_benchmark_sequencer();
+                let advanced_keys: Vec<_> = keys.iter().step_by(2).cloned().collect();
+                black_box(seq.assign_seqs(&advanced_keys));
+                b.iter(|| {
+                    black_box(seq.assign_seqs(black_box(keys)));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+const CONTENTION_FANOUT: usize = 4096;
+const CONTENTION_WORKERS: usize = 4;
+const MIXED_CONTENTION_FANOUTS: [usize; 5] = [1, 8, 64, 512, 4096];
+
+#[derive(Clone, Copy)]
+enum AssignmentMode {
+    PerDestination,
+    Batch,
+}
+
+impl AssignmentMode {
+    fn assign(self, sequencer: &Sequencer, ports: &[PortAddr], keys: &[SeqKey]) {
+        match self {
+            Self::PerDestination => {
+                for port in ports {
+                    black_box(sequencer.assign_seq(black_box(port)));
+                }
+            }
+            Self::Batch => {
+                black_box(sequencer.assign_seqs(black_box(keys)));
+            }
+        }
+    }
+}
+
+fn contention_inputs(worker_count: usize, fanout: usize) -> Vec<(Vec<PortAddr>, Vec<SeqKey>)> {
+    (0..worker_count)
+        .map(|worker| {
+            let ports: Vec<_> = (0..fanout)
+                .map(|rank| {
+                    test_actor_id(&format!("worker_{worker}_{rank}"), "worker")
+                        .port_addr(Port::handler_id(0, None))
+                })
+                .collect();
+            let keys = ports
+                .iter()
+                .map(|port| SeqKey::for_handler(&port.actor_addr()))
+                .collect();
+            (ports, keys)
+        })
+        .collect()
+}
+
+fn run_concurrent_assignments(
+    iterations: u64,
+    inputs: &[(Vec<PortAddr>, Vec<SeqKey>)],
+    mode: AssignmentMode,
+) -> Duration {
+    let sequencer = new_benchmark_sequencer();
+    for (_, keys) in inputs {
+        black_box(sequencer.assign_seqs(keys));
+    }
+
+    let barrier = Arc::new(Barrier::new(inputs.len() + 1));
+    let mut start = None;
+    thread::scope(|scope| {
+        for (ports, keys) in inputs {
+            let sequencer = sequencer.clone();
+            let barrier = barrier.clone();
+            scope.spawn(move || {
+                barrier.wait();
+                for _ in 0..iterations {
+                    mode.assign(&sequencer, ports, keys);
+                }
+            });
+        }
+
+        start = Some(Instant::now());
+        barrier.wait();
+    });
+    start
+        .expect("timer must start before workers run")
+        .elapsed()
+}
+
+fn run_mixed_assignments(
+    iterations: u64,
+    ports: &[PortAddr],
+    keys: &[SeqKey],
+    scalar_port: &PortAddr,
+    mode: AssignmentMode,
+) -> Duration {
+    let sequencer = new_benchmark_sequencer();
+    black_box(sequencer.assign_seqs(keys));
+    black_box(sequencer.assign_seq(scalar_port));
+
+    let started = AtomicBool::new(false);
+    let stop = AtomicBool::new(false);
+    let mut elapsed = None;
+    thread::scope(|scope| {
+        let background_sequencer = sequencer.clone();
+        let background_started = &started;
+        let background_stop = &stop;
+        scope.spawn(move || {
+            mode.assign(&background_sequencer, ports, keys);
+            background_started.store(true, Ordering::Release);
+            while !background_stop.load(Ordering::Acquire) {
+                mode.assign(&background_sequencer, ports, keys);
+            }
+        });
+
+        while !started.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+        }
+
+        let start = Instant::now();
+        for _ in 0..iterations {
+            black_box(sequencer.assign_seq(black_box(scalar_port)));
+        }
+        elapsed = Some(start.elapsed());
+        stop.store(true, Ordering::Release);
+    });
+    elapsed.expect("scalar assignments must complete")
+}
+
+/// Compare aggregate sequence-assignment throughput from concurrent casts.
+fn bench_cast_seq_concurrent_contention(c: &mut Criterion) {
+    let inputs = contention_inputs(CONTENTION_WORKERS, CONTENTION_FANOUT);
+    let mut group = c.benchmark_group("cast_seq_concurrent_contention");
+    group.throughput(Throughput::Elements(
+        (CONTENTION_WORKERS * CONTENTION_FANOUT) as u64,
+    ));
+
+    for (name, mode) in [
+        ("per_dest_assign_seq", AssignmentMode::PerDestination),
+        ("batch_assign_seqs", AssignmentMode::Batch),
+    ] {
+        group.bench_function(
+            BenchmarkId::new(name, format!("{CONTENTION_WORKERS}x{CONTENTION_FANOUT}")),
+            |b| b.iter_custom(|iterations| run_concurrent_assignments(iterations, &inputs, mode)),
+        );
+    }
+    group.finish();
+}
+
+/// Compare scalar assignment latency while a concurrent cast uses the sequencer.
+fn bench_cast_seq_mixed_contention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cast_seq_mixed_contention");
+
+    for fanout in MIXED_CONTENTION_FANOUTS {
+        let mut inputs = contention_inputs(1, fanout);
+        let (ports, keys) = inputs.pop().expect("one contention input must exist");
+        let scalar_port =
+            test_actor_id("scalar_worker", "worker").port_addr(Port::handler_id(0, None));
+
+        for (name, mode) in [
+            ("per_dest_cast", AssignmentMode::PerDestination),
+            ("batch_cast", AssignmentMode::Batch),
+        ] {
+            group.bench_function(BenchmarkId::new(name, fanout), |b| {
+                b.iter_custom(|iterations| {
+                    run_mixed_assignments(iterations, &ports, &keys, &scalar_port, mode)
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().without_plots();
@@ -351,6 +593,9 @@ criterion_group! {
     bench_mailbox_message_sizes,
     bench_mailbox_message_rates,
     bench_channel_ping_pong,
+    bench_cast_seq_assignment,
+    bench_cast_seq_concurrent_contention,
+    bench_cast_seq_mixed_contention,
 }
 
 criterion_main!(benches);

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use hyperactor_config::AttrValue;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
+use hyperactor_config::NonZeroUsize;
 use hyperactor_config::attrs::declare_attrs;
 use serde::Deserialize;
 use serde::Serialize;
@@ -229,6 +230,15 @@ declare_attrs! {
     ))
     pub attr ENABLE_DEST_ACTOR_REORDERING_BUFFER: bool = true;
 
+    /// Maximum number of destination keys assigned while holding the
+    /// sequencer lock.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_SEQUENCER_MAX_LOCKED_KEYS".to_string()),
+        Some("sequencer_max_locked_keys".to_string()),
+    ))
+    pub attr SEQUENCER_MAX_LOCKED_KEYS: NonZeroUsize =
+        NonZeroUsize::new(128).expect("128 is non-zero");
+
     /// Timeout for [`Host::spawn`] to await proc readiness.
     ///
     /// Default: 30 seconds. If set to zero, disables the timeout and
@@ -318,6 +328,7 @@ mod tests {
         );
         assert_eq!(config[MESSAGE_ACK_EVERY_N_MESSAGES], 1000);
         assert_eq!(config[SPLIT_MAX_BUFFER_SIZE], 5);
+        assert_eq!(config[SEQUENCER_MAX_LOCKED_KEYS].get(), 128);
     }
 
     #[tracing_test::traced_test]
@@ -405,6 +416,7 @@ mod tests {
         );
         assert_eq!(config[MESSAGE_ACK_EVERY_N_MESSAGES], 1000);
         assert_eq!(config[SPLIT_MAX_BUFFER_SIZE], 5);
+        assert_eq!(config[SEQUENCER_MAX_LOCKED_KEYS].get(), 128);
 
         // Verify the keys have defaults
         assert!(CODEC_MAX_FRAME_LENGTH.has_default());
@@ -412,6 +424,7 @@ mod tests {
         assert!(MESSAGE_ACK_TIME_INTERVAL.has_default());
         assert!(MESSAGE_ACK_EVERY_N_MESSAGES.has_default());
         assert!(SPLIT_MAX_BUFFER_SIZE.has_default());
+        assert!(SEQUENCER_MAX_LOCKED_KEYS.has_default());
 
         // Verify we can get defaults directly from keys
         assert_eq!(
@@ -428,6 +441,10 @@ mod tests {
         );
         assert_eq!(MESSAGE_ACK_EVERY_N_MESSAGES.default(), Some(&1000));
         assert_eq!(SPLIT_MAX_BUFFER_SIZE.default(), Some(&5));
+        assert_eq!(
+            SEQUENCER_MAX_LOCKED_KEYS.default().map(|v| v.get()),
+            Some(128)
+        );
     }
 
     #[test]

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -10,13 +10,14 @@
 //! for any given sender and receiver actor pair.
 
 use std::any::TypeId;
-use std::collections::HashMap;
 use std::fmt;
+use std::ops::Range;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use hyperactor_config::AttrValue;
 use hyperactor_config::attrs::declare_attrs;
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -177,11 +178,26 @@ impl std::str::FromStr for OrderingSnapshot {
 /// Handler ports share a sequence per actor; ephemeral ports get individual
 /// sequences. Control ports are direct.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-enum SeqKey {
-    /// Shared sequence for all handler ports of an actor
+pub struct SeqKey(SeqKeyKind);
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+enum SeqKeyKind {
     Actor(ActorAddr),
-    /// Individual sequence for a specific ephemeral port.
     Port(PortAddr),
+}
+
+impl SeqKey {
+    /// Return the sequence key shared by an actor's handler ports.
+    pub fn for_handler(actor: &ActorAddr) -> Self {
+        Self(SeqKeyKind::Actor(actor.clone()))
+    }
+
+    /// Return the sequence key for an ephemeral port.
+    pub fn for_ephemeral_port(port: &PortAddr) -> Option<Self> {
+        port.port()
+            .is_ephemeral()
+            .then(|| Self(SeqKeyKind::Port(port.clone())))
+    }
 }
 
 /// A message's sequencer number infomation.
@@ -246,14 +262,14 @@ declare_attrs! {
 pub struct Sequencer {
     session_id: Uuid,
     // Map's key is the sequence key (actor or port), value is the last seq number.
-    last_seqs: Arc<Mutex<HashMap<SeqKey, u64>>>,
+    last_seqs: Arc<Mutex<FxHashMap<SeqKey, u64>>>,
 }
 
 impl Sequencer {
     pub(crate) fn new(session_id: Uuid) -> Self {
         Self {
             session_id,
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         }
     }
 
@@ -288,7 +304,7 @@ impl Sequencer {
         self.last_seqs
             .lock()
             .unwrap()
-            .get(&SeqKey::Actor(actor.clone()))
+            .get(&SeqKey::for_handler(actor))
             .copied()
             .unwrap_or_default()
     }
@@ -299,10 +315,52 @@ impl Sequencer {
         }
 
         if port_id.is_handler_port() {
-            Some(SeqKey::Actor(port_id.actor_addr().clone()))
+            Some(SeqKey::for_handler(&port_id.actor_addr()))
         } else {
-            Some(SeqKey::Port(port_id.clone()))
+            SeqKey::for_ephemeral_port(port_id)
         }
+    }
+
+    /// Assign the next sequence number to each key.
+    ///
+    /// This assigns the same sequence numbers, in the same order, as calling
+    /// [`Self::assign_seq`] for each equivalent destination. Each occurrence
+    /// of a repeated key advances its sequence number.
+    ///
+    /// The result is run-length encoded. Each `(range, seq)` assigns `seq` to
+    /// the input indexes in `range`. The ordered ranges cover `0..keys.len()`
+    /// without gaps. An empty input returns an empty result.
+    pub fn assign_seqs(&self, keys: &[SeqKey]) -> Vec<(Range<usize>, u64)> {
+        let mut runs: Vec<(Range<usize>, u64)> = Vec::new();
+        let mut run_start = 0usize;
+        let mut prev: Option<u64> = None;
+        let mut ordinal = 0;
+        for chunk in keys
+            .chunks(hyperactor_config::global::get(crate::config::SEQUENCER_MAX_LOCKED_KEYS).get())
+        {
+            let mut guard = self.last_seqs.lock().unwrap();
+            for key in chunk {
+                let seq = if let Some(last) = guard.get_mut(key) {
+                    *last += 1;
+                    *last
+                } else {
+                    guard.insert(key.clone(), 1);
+                    1
+                };
+                if let Some(prev_seq) = prev
+                    && prev_seq != seq
+                {
+                    runs.push((run_start..ordinal, prev_seq));
+                    run_start = ordinal;
+                }
+                prev = Some(seq);
+                ordinal += 1;
+            }
+        }
+        if let Some(prev_seq) = prev {
+            runs.push((run_start..keys.len(), prev_seq));
+        }
+        runs
     }
 
     /// Id of the session this sequencer belongs to.
@@ -313,6 +371,7 @@ impl Sequencer {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::collections::HashSet;
     use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
@@ -371,10 +430,159 @@ mod tests {
     }
 
     #[test]
+    fn assign_seqs_returns_no_runs_for_empty_input() {
+        // GIVEN a sequencer with no assigned keys.
+        let sequencer = Sequencer::new(Uuid::now_v7());
+
+        // WHEN sequence numbers are requested for no keys.
+        let runs = sequencer.assign_seqs(&[]);
+
+        // THEN there are no encoded runs.
+        assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn seq_key_for_ephemeral_port_rejects_other_port_kinds() {
+        // GIVEN one ephemeral, handler, and control port on the same actor.
+        let actor = test_actor_id("worker_0", "worker");
+        let ephemeral = actor.port_addr(Port::from(1));
+        let handler = actor.port_addr(Port::handler::<TestMsg1>());
+        let control = actor.port_addr(Port::control(ControlPort::Status));
+
+        // WHEN each port is passed to the ephemeral-key constructor.
+        let ephemeral_key = SeqKey::for_ephemeral_port(&ephemeral);
+        let handler_key = SeqKey::for_ephemeral_port(&handler);
+        let control_key = SeqKey::for_ephemeral_port(&control);
+
+        // THEN only the ephemeral port produces a key.
+        assert!(ephemeral_key.is_some());
+        assert!(handler_key.is_none());
+        assert!(control_key.is_none());
+    }
+
+    #[test]
+    fn assign_seqs_coalesces_synchronized_keys() {
+        // GIVEN synchronized keys and a chunk size smaller than the input.
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(
+            crate::config::SEQUENCER_MAX_LOCKED_KEYS,
+            hyperactor_config::NonZeroUsize::MIN,
+        );
+        let sequencer = Sequencer::new(Uuid::now_v7());
+        let keys: Vec<_> = (0..3)
+            .map(|i| SeqKey::for_handler(&test_actor_id(&format!("worker_{i}"), "worker")))
+            .collect();
+
+        // WHEN the keys advance together.
+        let single = sequencer.assign_seqs(&keys[..1]);
+        let first = sequencer.assign_seqs(&keys[1..]);
+        let second = sequencer.assign_seqs(&keys[1..]);
+
+        // THEN each synchronized set is represented by one run.
+        assert_eq!(single, vec![(0..1, 1)]);
+        assert_eq!(first, vec![(0..2, 1)]);
+        assert_eq!(second, vec![(0..2, 2)]);
+    }
+
+    #[test]
+    fn assign_seqs_keeps_nonadjacent_equal_values_in_separate_runs() {
+        // GIVEN the first and third keys are one sequence ahead of the second.
+        let sequencer = Sequencer::new(Uuid::now_v7());
+        let keys: Vec<_> = (0..3)
+            .map(|i| SeqKey::for_handler(&test_actor_id(&format!("worker_{i}"), "worker")))
+            .collect();
+        sequencer.assign_seqs(&[keys[0].clone(), keys[2].clone()]);
+
+        // WHEN all three keys are assigned in input order.
+        let runs = sequencer.assign_seqs(&keys);
+
+        // THEN the values [2, 1, 2] remain three ordered runs.
+        assert_eq!(runs, vec![(0..1, 2), (1..2, 1), (2..3, 2)]);
+    }
+
+    #[test]
+    fn assign_seqs_advances_repeated_interleaved_keys() {
+        // GIVEN two new keys repeated in an interleaved input.
+        let sequencer = Sequencer::new(Uuid::now_v7());
+        let a = SeqKey::for_handler(&test_actor_id("worker_0", "worker"));
+        let b = SeqKey::for_handler(&test_actor_id("worker_1", "worker"));
+        let keys = [a.clone(), b.clone(), a.clone(), b, a];
+
+        // WHEN the batch is assigned.
+        let runs = sequencer.assign_seqs(&keys);
+
+        // THEN every occurrence advances its key and adjacent equal values coalesce.
+        assert_eq!(runs, vec![(0..2, 1), (2..4, 2), (4..5, 3)]);
+    }
+
+    #[test]
+    fn assign_seqs_matches_assign_seq_after_mixed_history() {
+        // GIVEN scalar and batch sequencers with the same mixed history and a
+        // batch chunk size smaller than the requested assignment.
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(
+            crate::config::SEQUENCER_MAX_LOCKED_KEYS,
+            hyperactor_config::NonZeroUsize::new(2).expect("2 is non-zero"),
+        );
+        let scalar = Sequencer::new(Uuid::now_v7());
+        let batch = Sequencer::new(Uuid::now_v7());
+
+        let actor_0 = test_actor_id("worker_0", "worker");
+        let actor_1 = test_actor_id("worker_1", "worker");
+        let ports = [
+            actor_0.port_addr(Port::handler::<TestMsg1>()),
+            actor_1.port_addr(Port::handler::<TestMsg1>()),
+            actor_0.port_addr(Port::from(1)),
+        ];
+        for index in [0, 2, 0] {
+            assert_eq!(
+                get_seq(scalar.assign_seq(&ports[index])),
+                get_seq(batch.assign_seq(&ports[index]))
+            );
+        }
+
+        // WHEN one sequencer assigns an interleaved batch and the other uses scalars.
+        let indexes = [0, 1, 0, 2, 1];
+        let expected: Vec<_> = indexes
+            .iter()
+            .map(|&index| get_seq(scalar.assign_seq(&ports[index])))
+            .collect();
+        // `[(0..2, 1), (2..5, 2)]` -> `[1, 1, 2, 2, 2]`.
+        let actual: Vec<_> = {
+            let keys: Vec<_> = indexes
+                .iter()
+                .map(|&index| {
+                    let port = &ports[index];
+                    if port.is_handler_port() {
+                        SeqKey::for_handler(&port.actor_addr())
+                    } else {
+                        SeqKey::for_ephemeral_port(port).expect("test port must be ephemeral")
+                    }
+                })
+                .collect();
+
+            batch
+                .assign_seqs(&keys)
+                .into_iter()
+                .flat_map(|(range, seq)| range.map(move |_| seq))
+                .collect()
+        };
+
+        // THEN both APIs assign the same values and leave the same subsequent state.
+        assert_eq!(actual, expected);
+        for port in &ports {
+            assert_eq!(
+                get_seq(scalar.assign_seq(port)),
+                get_seq(batch.assign_seq(port))
+            );
+        }
+    }
+
+    #[test]
     fn test_sequencer_clone() {
         let sequencer = Sequencer {
             session_id: Uuid::now_v7(),
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         };
 
         let actor_ref: ActorAddr = test_actor_id("test_0", "test");
@@ -394,7 +602,7 @@ mod tests {
     fn test_sequencer_handler_ports_share_sequence() {
         let sequencer = Sequencer {
             session_id: Uuid::now_v7(),
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         };
 
         let actor_ref: ActorAddr = test_actor_id("worker_0", "worker");
@@ -417,7 +625,7 @@ mod tests {
     fn test_sequencer_non_handler_ports_have_independent_sequences() {
         let sequencer = Sequencer {
             session_id: Uuid::now_v7(),
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         };
 
         let actor_ref_0: ActorAddr = test_actor_id("worker_0", "worker");
@@ -444,7 +652,7 @@ mod tests {
     fn test_sequencer_mixed_handler_and_non_handler_ports() {
         let sequencer = Sequencer {
             session_id: Uuid::now_v7(),
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         };
 
         let actor_ref: ActorAddr = test_actor_id("worker_0", "worker");


### PR DESCRIPTION
Summary:

Adds `Sequencer::assign_seqs` which assigns the next sequence number for a batch of keys under a single lock acquisition (versus one `assign_seq` — and one mutex acquisition — per destination), returning the result run-length encoded as `(Range<usize>, u64)` runs that partition `0..keys.len()`. 

# Benchmarks

| N | per_dest_assign_seq | batch_assign_seqs | speedup |
| 1 | 119.35 ns | 44.05 ns | 2.7x |
| 8 | 937.98 ns | 228.92 ns | 4.1x |
| 64 | 7.58 us | 1.73 us | 4.4x |
| 512 | 62.29 us | 14.40 us | 4.3x |
| 4096 | 566.38 us | 144.76 us | 3.9x |
| 8192 | 1.167 ms | 309.52 us | 3.8x |
| 16384 | 2.459 ms | 668.84 us | 3.7x |
| 32768 | 6.304 ms | 1.899 ms | 3.3x |

Removing the per-destination mutex acquisition gives a consistent ~3.3-4.4x speedup on cast-time sequence assignment across all fan-out sizes.

## HashMap vs FxHashMap

Per-destination `assign_seq`

| Keys | HashMap (us) | FxHashMap (us) | Time reduction | Speedup |
| 1 | 0.1339 | 0.1030 | 23.1% | 1.30x |
| 8 | 1.080 | 0.7975 | 26.2% | 1.35x |
| 64 | 8.396 | 6.333 | 24.6% | 1.33x |
| 512 | 69.792 | 51.855 | 25.7% | 1.35x |
| 4096 | 589.7 | 462.9 | 21.5% | 1.27x |
| 8192 | 1244.8 | 1007.2 | 19.1% | 1.24x |
| 16384 | 2599.2 | 2036.8 | 21.6% | 1.28x |
| 32768 | 6155.9 | 4419.7 | 28.2% | 1.39x |

Synchronized `assign_seqs`

| Keys | HashMap (us) | FxHashMap (us) | Time reduction | Speedup |
| 1 | 0.0922 | 0.0393 | 57.4% | 2.35x |
| 8 | 0.5559 | 0.2049 | 63.1% | 2.71x |
| 64 | 4.143 | 1.376 | 66.8% | 3.01x |
| 512 | 33.724 | 12.062 | 64.2% | 2.80x |
| 4096 | 325.9 | 113.2 | 65.3% | 2.88x |
| 8192 | 677.8 | 256.5 | 62.2% | 2.64x |
| 16384 | 1343.0 | 542.6 | 59.6% | 2.48x |
| 32768 | 3564.1 | 1286.9 | 63.9% | 2.77x |

Divergent `assign_seqs`

| Keys | HashMap (us) | FxHashMap (us) | Time reduction | Speedup |
| 1 | 0.0947 | 0.0403 | 57.5% | 2.35x |
| 8 | 0.6146 | 0.2254 | 63.3% | 2.73x |
| 64 | 4.387 | 1.621 | 63.0% | 2.71x |
| 512 | 34.926 | 12.731 | 63.5% | 2.74x |
| 4096 | 310.5 | 128.8 | 58.5% | 2.41x |
| 8192 | 684.1 | 274.0 | 59.9% | 2.50x |
| 16384 | 1428.5 | 580.9 | 59.3% | 2.46x |
| 32768 | 3637.2 | 1246.3 | 65.7% | 2.92x |

Reviewed By: mariusae

Differential Revision: D110783220


