### PR TITLE
Migrate ROCm CI to MI350x meta-pytorch runners

### DIFF
--- a/.github/workflows/set-matrix.yaml
+++ b/.github/workflows/set-matrix.yaml
@@ -7,7 +7,8 @@ on:
         description: 'Override default ROCm runner label'
         required: false
         type: string
-        default: linux.rocm.gpu.gfx942.1.meta-pytorch
+        # Migrated to the DigitalOcean MI350x meta-pytorch runner fleet.
+        default: linux.rocm.gpu.meta-pytorch.mi350.1
       runner-cuda:
         description: 'Override default CUDA runner label'
         required: false


### PR DESCRIPTION
## Summary

Migrate the ROCm CI to the new MI350x meta-pytorch runner fleet.

- `.github/workflows/set-matrix.yaml`: change the `runner-rocm` input `default` from `linux.rocm.gpu.gfx942.1.meta-pytorch` to `linux.rocm.gpu.meta-pytorch.mi350.1`.

Draft until the DigitalOcean MI350x runners are confirmed online and picking up jobs.

## Test plan

- [ ] Confirm the MI350x meta-pytorch runners are online and registered with the label `linux.rocm.gpu.meta-pytorch.mi350.1`.
- [ ] Trigger the ROCm CI workflow and confirm jobs schedule onto the new runners and pass.

Made with Cursor