### PR TITLE
remove proc-mesh setup and drain _Tokio producers

### DIFF
--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -206,10 +206,13 @@ class Future(Generic[R]):
         )
 
     def _take_inner(self) -> "PythonTask[R]":
-        """Surrender the underlying ``PythonTask`` to a caller that needs to drive
-        it directly (for example to await the raw Rust future without the GIL).
-        Only valid on a Future that has not yet been awaited or resolved; the
-        Future is spent afterward (a second take, or any get()/await, raises).
+        """Take the underlying one-shot ``PythonTask`` from this Future.
+
+        Awaiting the task drives its Rust future inline as part of the caller.
+        Calling ``spawn()`` and awaiting its ``Shared`` observes a separately
+        running producer that is not aborted when the observer is dropped. Only
+        valid on a Future that has not yet been awaited or resolved; the Future is
+        spent afterward (a second take, or any get()/await, raises).
         """
         match self._status:
             case _Unawaited(coro=coro):

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -367,7 +367,7 @@ class HostMesh(MeshTrait):
         for pm in self._proc_meshes:
             await pm._flush_pending_actor_spawns()
             try:
-                await pm._logging_manager.flush_async()
+                await pm._logging_manager._flush_from_tokio()
             except Exception:
                 pass
 

--- a/python/monarch/_src/actor/logging.py
+++ b/python/monarch/_src/actor/logging.py
@@ -14,8 +14,8 @@ from typing import Optional, TextIO, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.logging import LoggingMeshClient
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._src.actor.actor_mesh import context
-from monarch._src.actor.future import Future
 from monarch._src.actor.ipython_check import is_ipython
 
 IN_IPYTHON: bool = is_ipython()
@@ -84,8 +84,8 @@ class LoggingManager:
 
                     def _post_run_cell_flush(_: object) -> None:
                         # For async cells the loop is still running when the
-                        # callback fires; `flush()` would then call
-                        # `Future.get()` inside that loop, which is an error.
+                        # callback fires; `flush()` would then block that loop
+                        # in `Handle.get(timeout=3)`.
                         # Schedule the async flush on the loop instead.
                         try:
                             loop = asyncio.get_running_loop()
@@ -180,17 +180,16 @@ class LoggingManager:
         self.register_flusher_if_in_ipython()
         self.enable_fd_capture_if_in_ipython()
 
+    def _new_flush_task(self) -> PythonTask[None]:
+        """Return an unscheduled Rust logging-flush future wrapped as a PythonTask."""
+        assert self._logging_mesh_client is not None
+        return self._logging_mesh_client.flush(context().actor_instance._as_rust())
+
     def flush(self) -> None:
         assert self._logging_mesh_client is not None
         try:
-            # blocks for this proc mesh until 3 seconds timeout
-            Future(
-                coro=self._logging_mesh_client.flush(
-                    context().actor_instance._as_rust()
-                )
-                .spawn()
-                .task()
-            ).get(timeout=3)
+            # Schedule the Rust future and wait through a Handle for up to 3 seconds.
+            self._new_flush_task().spawn_handle().get(timeout=3)
         except Exception:
             # TODO: A harmless exception happens to come through due to coroutine
             # accessing shared resources via logging_mesh_client. Flush works fine
@@ -198,21 +197,24 @@ class LoggingManager:
             pass
 
     async def flush_async(self) -> None:
-        """Async version of flush for use in async contexts."""
+        """Flush by awaiting a Handle on the current asyncio event loop."""
         if self._logging_mesh_client is None:
             return
         try:
-            # Drive the flush through Future so it works on an asyncio loop too:
-            # a bare `await` of the PythonTask hits the pytokio gate there and is
-            # swallowed below (a silent no-op). Future.__await__ bridges to an
-            # asyncio.Future on a loop and awaits the spawned Shared on a tokio
-            # thread. Mirrors the sync flush().
-            await Future(
-                coro=self._logging_mesh_client.flush(
-                    context().actor_instance._as_rust()
-                )
-                .spawn()
-                .task()
-            )
+            # Schedule the Rust future and await its Handle on the asyncio loop.
+            await self._new_flush_task().spawn_handle()
+        except Exception:
+            pass
+
+    async def _flush_from_tokio(self) -> None:
+        """Flush while Rust's pytokio driver steps this coroutine on Tokio."""
+        if self._logging_mesh_client is None:
+            return
+        try:
+            # Despite being `async def`, this is not an asyncio task. Rust's
+            # pytokio driver advances it on Tokio. `spawn()` starts the Rust
+            # future, and this `await` yields its `Shared` back to pytokio; the
+            # Rust pytokio driver resumes this coroutine when the flush completes.
+            await self._new_flush_task().spawn()
         except Exception:
             pass

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -675,7 +675,7 @@ class ProcMesh(MeshTrait):
         async def _stop_nonblocking(instance: HyInstance) -> None:
             await self._flush_pending_actor_spawns()
             pm = await self._proc_mesh
-            await self._logging_manager.flush_async()
+            await self._logging_manager._flush_from_tokio()
             await pm.stop_nonblocking(instance, reason)
             self._stopped = True
 

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -494,7 +494,7 @@ class ProcMesh(MeshTrait):
             # it here before any of the other python actors are spawned so
             # that the environment variables are set up before cuda init.
             if setup_actor is not None:
-                await setup_actor.setup.call()
+                await setup_actor.setup.call()._take_inner().spawn()
 
             return hy_proc_mesh
 
@@ -659,7 +659,7 @@ class ProcMesh(MeshTrait):
     async def _flush_pending_actor_spawns(self) -> None:
         for mesh in self._pending_actor_spawns:
             try:
-                await mesh.initialized
+                await mesh.initialized._take_inner().spawn()
             except Exception:
                 pass
         self._pending_actor_spawns.clear()

--- a/python/tests/_monarch/test_logging.py
+++ b/python/tests/_monarch/test_logging.py
@@ -14,7 +14,22 @@ from unittest.mock import Mock, patch
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.logging import flush_all_proc_mesh_logs, LoggingManager
+
+
+class _AwaitTracker:
+    def __init__(self, awaitable: Any) -> None:
+        self._awaitable = awaitable
+        self.awaited = False
+        self.get_called = False
+
+    def __await__(self) -> Any:
+        self.awaited = True
+        return self._awaitable.__await__()
+
+    def get(self, *args: object, **kwargs: object) -> None:
+        self.get_called = True
 
 
 class LoggingManagerTest(TestCase):
@@ -125,50 +140,97 @@ class LoggingManagerTest(TestCase):
         # Assert: None is returned
         self.assertIsNone(result)
 
-    @patch("monarch._src.actor.logging.Future")
     @patch("monarch._src.actor.logging.context")
-    def test_flush_calls_mesh_client_flush(
-        self, mock_context: Mock, mock_future: Mock
-    ) -> None:
-        # Setup: mock context, client, and Future
+    def test_flush_calls_mesh_client_flush(self, mock_context: Mock) -> None:
+        # Setup: mock context, client, task, and handle
         mock_instance = Mock()
         mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
         mock_client = Mock()
         mock_task = Mock()
-        mock_client.flush.return_value.spawn.return_value.task.return_value = mock_task
+        mock_handle = Mock()
+        mock_client.flush.return_value = mock_task
+        mock_task.spawn_handle.return_value = mock_handle
         self.logging_manager._logging_mesh_client = mock_client
 
-        mock_future_instance = Mock()
-        mock_future.return_value = mock_future_instance
-
         # Execute: flush logs
-        self.logging_manager.flush()
+        result = self.logging_manager.flush()
 
-        # Assert: mesh client flush was called
+        # Assert: the native task was observed through a Handle with the timeout.
+        self.assertIsNone(result)
         mock_client.flush.assert_called_once_with(mock_instance)
-        # Assert: Future was created and get was called with timeout
-        mock_future.assert_called_once_with(coro=mock_task)
-        mock_future_instance.get.assert_called_once_with(timeout=3)
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_task.spawn.assert_not_called()
+        mock_handle.get.assert_called_once_with(timeout=3)
 
-    @patch("monarch._src.actor.logging.Future")
     @patch("monarch._src.actor.logging.context")
-    def test_flush_handles_exception_gracefully(
-        self, mock_context: Mock, mock_future: Mock
-    ) -> None:
-        # Setup: mock context, client, and Future that raises exception
+    def test_flush_handles_exception_gracefully(self, mock_context: Mock) -> None:
+        # Setup: make Handle observation raise an ordinary exception.
         mock_instance = Mock()
         mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
         mock_client = Mock()
+        mock_task = Mock()
+        mock_handle = Mock()
+        mock_client.flush.return_value = mock_task
+        mock_task.spawn_handle.return_value = mock_handle
+        mock_handle.get.side_effect = Exception("Test exception")
         self.logging_manager._logging_mesh_client = mock_client
 
-        mock_future_instance = Mock()
-        mock_future_instance.get.side_effect = Exception("Test exception")
-        mock_future.return_value = mock_future_instance
-
         # Execute: flush logs (should not raise exception)
-        self.logging_manager.flush()
+        result = self.logging_manager.flush()
 
-        # Assert: no exception is raised and method completes gracefully
+        # Assert: the operation was started and the observer error was suppressed.
+        self.assertIsNone(result)
+        mock_client.flush.assert_called_once_with(mock_instance)
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_handle.get.assert_called_once_with(timeout=3)
+
+    def test_flush_from_tokio_awaits_shared_not_handle(self) -> None:
+        mock_task = Mock()
+        shared = _AwaitTracker(Shared.from_value(None))
+        mock_task.spawn.return_value = shared
+        self.logging_manager._logging_mesh_client = Mock()
+
+        with patch.object(
+            self.logging_manager, "_new_flush_task", return_value=mock_task
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
+        mock_task.spawn.assert_called_once_with()
+        mock_task.spawn_handle.assert_not_called()
+        self.assertTrue(shared.awaited)
+        self.assertFalse(shared.get_called)
+
+    def test_flush_from_tokio_without_client_is_noop(self) -> None:
+        with patch.object(
+            self.logging_manager, "_new_flush_task"
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_not_called()
+
+    def test_flush_from_tokio_suppresses_ordinary_error(self) -> None:
+        async def fail() -> None:
+            raise RuntimeError("test error")
+
+        self.logging_manager._logging_mesh_client = Mock()
+        with patch.object(
+            self.logging_manager,
+            "_new_flush_task",
+            return_value=PythonTask.from_coroutine(fail()),
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
 
 
 class FlushAllProcMeshLogsTest(TestCase):
@@ -204,6 +266,26 @@ class FlushAllProcMeshLogsTest(TestCase):
 class LoggingManagerAsyncTest(IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.logging_manager = LoggingManager()
+
+    async def test_flush_async_awaits_handle_not_shared(self) -> None:
+        ready = asyncio.get_running_loop().create_future()
+        ready.set_result(None)
+        handle = _AwaitTracker(ready)
+        mock_task = Mock()
+        mock_task.spawn_handle.return_value = handle
+        self.logging_manager._logging_mesh_client = Mock()
+
+        with patch.object(
+            self.logging_manager, "_new_flush_task", return_value=mock_task
+        ) as mock_new_flush_task:
+            result = await self.logging_manager.flush_async()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_task.spawn.assert_not_called()
+        self.assertTrue(handle.awaited)
+        self.assertFalse(handle.get_called)
 
     @patch("monarch._src.actor.logging.LoggingMeshClient")
     @patch("monarch._src.actor.logging.context")

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -30,7 +30,7 @@ from monarch._src.actor.actor_mesh import (
     ValueMesh,
 )
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.future import tokio_oracle, TokioOracleRecord
+from monarch._src.actor.future import Future, tokio_oracle, TokioOracleRecord
 from monarch._src.actor.host_mesh import this_host, this_proc
 from monarch._src.actor.proc_mesh import (
     get_or_spawn_controller,
@@ -44,6 +44,11 @@ from scoped_state import scoped_state
 
 _proc_rank = -1
 _BOOTSTRAP_FAILURE = "stage 3.4 bootstrap failure"
+_STAGE_3_4_ORACLE_FILES = {
+    "monarch._src.actor.host_mesh": "host_mesh.py",
+    "monarch._src.actor.logging": "logging.py",
+    "monarch._src.actor.proc_mesh": "proc_mesh.py",
+}
 
 
 def _successful_bootstrap() -> None:
@@ -54,20 +59,30 @@ def _fail_bootstrap() -> None:
     raise RuntimeError(_BOOTSTRAP_FAILURE)
 
 
-def _tokio_records_for(
+def _stage_3_4_tokio_records(
     records: list[TokioOracleRecord],
-    *,
-    module: str,
-    filename: str,
-    function: str | None = None,
 ) -> list[TokioOracleRecord]:
     return [
         record
         for record in records
-        if record.module == module
-        and os.path.basename(record.filename) == filename
-        and (function is None or record.function == function)
+        if _STAGE_3_4_ORACLE_FILES.get(record.module)
+        == os.path.basename(record.filename)
     ]
+
+
+class _PendingActorProbe:
+    def __init__(
+        self,
+        name: str,
+        driven: list[str],
+        error: Exception | None = None,
+    ) -> None:
+        async def initialize() -> None:
+            driven.append(name)
+            if error is not None:
+                raise error
+
+        self.initialized = Future(coro=initialize())
 
 
 class TestActor(Actor):
@@ -123,24 +138,18 @@ async def test_proc_mesh_initialization() -> None:
                 bootstrap=_successful_bootstrap,
             )
             assert await proc_mesh.initialized
-
-            setup_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.proc_mesh",
-                filename="proc_mesh.py",
-                function="task",
-            )
-            assert len(setup_records) == 1
+            assert _stage_3_4_tokio_records(records) == []
 
 
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
-        proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
-
-        with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
-            await proc_mesh.initialized
+        with tokio_oracle() as records:
+            proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
+            with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
+                await proc_mesh.initialized
+            assert _stage_3_4_tokio_records(records) == []
 
 
 @pytest.mark.timeout(60)
@@ -191,13 +200,8 @@ async def test_stop_state_tracks_native_stop_result() -> None:
             with tokio_oracle() as records:
                 assert await owner.stop() is None
 
-                logging_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.logging",
-                    filename="logging.py",
-                )
                 assert proc_flush_called
-                assert logging_records == []
+                assert _stage_3_4_tokio_records(records) == []
         assert flush_started
         assert owner._stopped
 
@@ -455,6 +459,23 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
 
         # spawn actor but do NOT await initialized — immediately shutdown
         actor_mesh = proc_mesh.spawn("test_actor", TestActor, 42)
+        drain_order: list[str] = []
+        proc_mesh._pending_actor_spawns.extend(
+            [
+                cast(
+                    ActorMesh,
+                    _PendingActorProbe(
+                        "failed",
+                        drain_order,
+                        RuntimeError("pending actor initialization failed"),
+                    ),
+                ),
+                cast(
+                    ActorMesh,
+                    _PendingActorProbe("succeeded", drain_order),
+                ),
+            ]
+        )
 
         with (
             patch.object(logging_manager, "_new_flush_task", record_flush_start),
@@ -469,29 +490,11 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
                 cleanup.pop_all()
                 assert shutdown_result is None
 
-                proc_drain_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.proc_mesh",
-                    filename="proc_mesh.py",
-                    function="_flush_pending_actor_spawns",
-                )
-                logging_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.logging",
-                    filename="logging.py",
-                )
-                host_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.host_mesh",
-                    filename="host_mesh.py",
-                )
-
-                assert len(proc_drain_records) == 1
                 assert host_flush_called
-                assert logging_records == []
-                assert host_records == []
+                assert _stage_3_4_tokio_records(records) == []
 
         assert flush_started
+        assert drain_order == ["failed", "succeeded"]
         assert await actor_mesh.initialized is None
         assert proc_mesh._pending_actor_spawns == []
 

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -149,6 +149,8 @@ async def test_stop_state_tracks_native_stop_result() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         owner = state.hosts.spawn_procs(per_host={"gpus": 2})
         await owner.initialized
+        logging_manager = owner._logging_manager
+        assert logging_manager._logging_mesh_client is not None
         proc_ref = owner.slice(gpus=0)
 
         with pytest.raises(
@@ -158,7 +160,45 @@ async def test_stop_state_tracks_native_stop_result() -> None:
             await proc_ref.stop()
 
         assert not proc_ref._stopped
-        assert await owner.stop() is None
+        flush_started = False
+        proc_flush_called = False
+        new_flush_task = logging_manager._new_flush_task
+        flush_from_tokio = logging_manager._flush_from_tokio
+
+        def record_flush_start() -> PythonTask[None]:
+            flush_task = new_flush_task()
+
+            async def task() -> None:
+                nonlocal flush_started
+                flush_started = True
+                await flush_task
+
+            return PythonTask.from_coroutine(task())
+
+        async def record_flush_from_tokio() -> None:
+            nonlocal proc_flush_called
+            proc_flush_called = True
+            await flush_from_tokio()
+
+        with (
+            patch.object(logging_manager, "_new_flush_task", record_flush_start),
+            patch.object(
+                logging_manager,
+                "_flush_from_tokio",
+                record_flush_from_tokio,
+            ),
+        ):
+            with tokio_oracle() as records:
+                assert await owner.stop() is None
+
+                logging_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.logging",
+                    filename="logging.py",
+                )
+                assert proc_flush_called
+                assert logging_records == []
+        assert flush_started
         assert owner._stopped
 
 
@@ -390,38 +430,68 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
         host = job.state(cached_path=None).hosts
         proc_mesh = host.spawn_procs(name="test")
         await proc_mesh.initialized
-        assert proc_mesh._logging_manager._logging_mesh_client is not None
+        logging_manager = proc_mesh._logging_manager
+        assert logging_manager._logging_mesh_client is not None
+
+        flush_started = False
+        host_flush_called = False
+        new_flush_task = logging_manager._new_flush_task
+        flush_from_tokio = logging_manager._flush_from_tokio
+
+        def record_flush_start() -> PythonTask[None]:
+            flush_task = new_flush_task()
+
+            async def task() -> None:
+                nonlocal flush_started
+                flush_started = True
+                await flush_task
+
+            return PythonTask.from_coroutine(task())
+
+        async def record_flush_from_tokio() -> None:
+            nonlocal host_flush_called
+            host_flush_called = True
+            await flush_from_tokio()
 
         # spawn actor but do NOT await initialized — immediately shutdown
         actor_mesh = proc_mesh.spawn("test_actor", TestActor, 42)
 
-        with tokio_oracle() as records:
-            shutdown_result = await host.shutdown()
-            cleanup.pop_all()
-            assert shutdown_result is None
+        with (
+            patch.object(logging_manager, "_new_flush_task", record_flush_start),
+            patch.object(
+                logging_manager,
+                "_flush_from_tokio",
+                record_flush_from_tokio,
+            ),
+        ):
+            with tokio_oracle() as records:
+                shutdown_result = await host.shutdown()
+                cleanup.pop_all()
+                assert shutdown_result is None
 
-            proc_drain_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.proc_mesh",
-                filename="proc_mesh.py",
-                function="_flush_pending_actor_spawns",
-            )
-            logging_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.logging",
-                filename="logging.py",
-                function="flush_async",
-            )
-            host_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.host_mesh",
-                filename="host_mesh.py",
-            )
+                proc_drain_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.proc_mesh",
+                    filename="proc_mesh.py",
+                    function="_flush_pending_actor_spawns",
+                )
+                logging_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.logging",
+                    filename="logging.py",
+                )
+                host_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.host_mesh",
+                    filename="host_mesh.py",
+                )
 
-            assert len(proc_drain_records) == 1
-            assert len(logging_records) == 1
-            assert host_records == []
+                assert len(proc_drain_records) == 1
+                assert host_flush_called
+                assert logging_records == []
+                assert host_records == []
 
+        assert flush_started
         assert await actor_mesh.initialized is None
         assert proc_mesh._pending_actor_spawns == []
 

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -49,6 +49,7 @@ from monarch._src.actor.future import (
     enable_tokio_oracle,
     Future,
     reset_tokio_oracle,
+    tokio_oracle,
     tokio_oracle_records,
 )
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
@@ -1091,7 +1092,16 @@ async def test_flush_async_drives_flush_on_asyncio_loop() -> None:
         await asyncio.sleep(1)
 
         # System under test: flush_async on the test's asyncio loop.
-        await pm._logging_manager.flush_async()
+        with tokio_oracle() as records:
+            await pm._logging_manager.flush_async()
+
+            logging_records = [
+                record
+                for record in records
+                if record.module == "monarch._src.actor.logging"
+                and os.path.basename(record.filename) == "logging.py"
+            ]
+            assert logging_records == []
 
         await asyncio.sleep(1)
         sys.stdout.flush()


### PR DESCRIPTION
Summary:
the pytokio-removal project has already moved logging flushes away from the Tokio await path in `Future`. the two remaining mesh-lifecycle producers are proc setup waiting for `SetupActor` and teardown waiting for pending actor initialization.

in both places, the old Tokio branch only spawned the fresh underlying `PythonTask` and awaited its `Shared`. this diff performs that sequence explicitly with `_take_inner().spawn()`, preserving setup gating, failure propagation, drain behavior, teardown ordering, and the non-aborting producer lifetime. public mesh APIs and storage are unchanged.

the existing lifecycle oracles now require module-wide zero `_Tokio` production from `proc_mesh.py`, `host_mesh.py`, and `logging.py`. deterministic drain probes ensure zero cannot pass by clearing pending actors without observing them, while the known-producing control proves the oracle remains active.

Differential Revision: D113952283


