### PR TITLE
Add generic observability doc

### DIFF
--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -25,7 +25,11 @@
 
 | Document | Location |
 |----------|----------|
+| **Observability Overview** | `docs/source/observability.md` |
+| **Distributed Telemetry** | `docs/source/distributed-telemetry.md` |
 | **Mesh Admin TUI** | `docs/source/admin-tui.md` |
+| **Monarch Dashboard** | `docs/source/monarch-dashboard.md` |
+| **OpenTelemetry and Grafana** | `docs/source/examples/otel_collector.py` |
 
 ## Examples
 

--- a/docs/source/admin-tui.md
+++ b/docs/source/admin-tui.md
@@ -5,6 +5,10 @@ inspecting live Monarch meshes. It connects to the mesh admin HTTP API and
 renders the full topology — hosts, processes, and actors — as a navigable tree
 with a contextual detail pane.
 
+See the [observability overview](observability) for how the TUI complements
+[distributed telemetry](distributed-telemetry) and the
+[Monarch Dashboard](monarch-dashboard).
+
 The TUI is included in the `torchmonarch` PyPI package. After
 `pip install torchmonarch`, the `monarch-tui` command is available on PATH.
 
@@ -124,10 +128,29 @@ monarch-tui --addr 127.0.0.1:1729 --diagnose
 # Exits 0 if healthy, 1 if any check failed.
 ```
 
+## Telemetry Query Proxy
+
+When the admin server starts with distributed telemetry, it also exposes:
+
+| Endpoint | Purpose |
+|----------|---------|
+| `POST /v1/query` | Run DataFusion SQL and return `{"rows": [...]}` |
+| `POST /v1/pyspy_dump/{proc_reference}` | Capture and persist a py-spy dump in telemetry tables |
+
+For example, post `{"sql": "SELECT * FROM actors LIMIT 10"}` to
+`/v1/query`. Discover available tables with
+`SELECT table_name FROM information_schema.tables`.
+
+The TUI's `p` key and `GET /v1/pyspy/{proc_reference}` perform a one-shot
+capture. Use the `pyspy_dump` endpoint when the capture must remain queryable
+in `pyspy_dumps`, `pyspy_stack_traces`, `pyspy_frames`, and
+`pyspy_local_variables`.
+
 ## Source Code
 
 | Component | Location |
 |-----------|----------|
-| TUI binary | `hyperactor_mesh/bin/admin_tui/` |
+| TUI binary | `hyperactor_mesh_admin_tui/bin/admin_tui.rs` |
+| TUI library | `hyperactor_mesh_admin_tui/src/` |
 | Admin HTTP API | `hyperactor_mesh/src/mesh_admin.rs` |
 | Dining philosophers example | `python/examples/dining_philosophers.py` |

--- a/docs/source/api/monarch.job.rst
+++ b/docs/source/api/monarch.job.rst
@@ -57,6 +57,21 @@ interface for job lifecycle management.
    :exclude-members: __init__
 
 
+Observability
+=============
+
+See the :doc:`../observability` guide for the relationship between distributed
+telemetry, the Monarch Dashboard, and the Mesh Admin TUI.
+
+.. autoclass:: TelemetryConfig
+   :members:
+   :undoc-members:
+
+.. autoclass:: MeshAdminConfig
+   :members:
+   :undoc-members:
+
+
 Job Implementations
 ===================
 

--- a/docs/source/distributed-telemetry.md
+++ b/docs/source/distributed-telemetry.md
@@ -1,0 +1,156 @@
+# Distributed Telemetry
+
+Monarch distributed telemetry collects actor-system events on each host and
+makes them queryable as one logical database. It uses
+[Apache DataFusion](https://github.com/apache/datafusion), an extensible SQL
+query engine built on [Apache Arrow](https://arrow.apache.org/). Distributed
+telemetry is the query layer behind the [Monarch Dashboard](monarch-dashboard)
+and complements the live [Mesh Admin TUI](admin-tui).
+
+Start with the [observability overview](observability) if you are choosing a
+diagnostic surface or configuring a job for the first time.
+
+## Quick start
+
+Enable telemetry before obtaining job state:
+
+```python
+from monarch.job import ProcessJob, TelemetryConfig
+
+job = ProcessJob({"workers": 2}).enable_telemetry(
+    TelemetryConfig(retention_secs=600)
+)
+state = job.state(cached_path=None)
+
+client = state.query_engine_client
+if client is None:
+    raise RuntimeError("telemetry did not start")
+
+result = client.query(
+    """
+    SELECT a.full_name, s.new_status, s.reason, s.timestamp_us
+    FROM actor_status_events AS s
+    JOIN actors AS a ON a.id = s.actor_id
+    ORDER BY s.timestamp_us DESC
+    LIMIT 50
+    """
+)
+for row in result["rows"]:
+    print(row)
+```
+
+`QueryEngineClient.query()` accepts DataFusion SQL and returns a dictionary
+whose `rows` value is a list of dictionaries. Timestamps ending in `_us` are
+microseconds since the Unix epoch. IDs are opaque join keys; do not infer
+meaning from their numeric values.
+
+## Core tables
+
+| Table | Contents |
+|-------|----------|
+| `actor_status_events` | Actor status transitions and reasons |
+| `actors` | Actor identity, rank, mesh, and creation time |
+| `events` | Structured tracing events and log fields |
+| `meshes` | Mesh creation, shape, class, name, and parent view |
+| `message_status_events` | Message delivery status transitions |
+| `messages` | Individual sender-to-receiver message deliveries |
+| `sent_messages` | One-to-many send operations and destination views |
+| `span_events` | Span enter, exit, and close events |
+| `spans` | Trace span metadata and parent relationships |
+
+Mesh-introspection snapshots add `actor_failures`, `actor_inbound_orderings`,
+`actor_nodes`, `children`, `host_nodes`, `nodes`, `ordering_sessions`,
+`proc_nodes`, `resolution_errors`, `root_nodes`, and `snapshots`. Persisted
+py-spy captures add `pyspy_dumps`, `pyspy_frames`, `pyspy_local_variables`, and
+`pyspy_stack_traces`.
+
+Discover the current table catalog with:
+
+```sql
+SELECT table_name
+FROM information_schema.tables
+ORDER BY table_name
+```
+
+## Query examples
+
+Count actor status transitions:
+
+```sql
+SELECT new_status, COUNT(*) AS count
+FROM actor_status_events
+GROUP BY new_status
+ORDER BY count DESC
+```
+
+Find recent actor failure events:
+
+```sql
+SELECT a.full_name, s.reason, s.timestamp_us
+FROM actor_status_events AS s
+JOIN actors AS a ON a.id = s.actor_id
+WHERE s.new_status = 'Failed'
+ORDER BY s.timestamp_us DESC
+LIMIT 100
+```
+
+Summarize message delivery transitions:
+
+```sql
+SELECT status, COUNT(*) AS count
+FROM message_status_events
+GROUP BY status
+ORDER BY count DESC
+```
+
+## Architecture
+
+Each producer writes framed Arrow IPC batches to a host-local Unix socket. A
+host-local `TelemetryActor` owns the socket, a Rust `DatabaseScanner`, and the
+in-memory tables. The root query engine plans SQL with DataFusion, pushes table
+scans to active collectors, and merges their Arrow results.
+
+The telemetry job sidecar owns the root collector and query service. Its
+in-memory state survives repeated `state()` calls and parent-process refreshes
+for the same job allocation. Calling `job.kill()` stops the sidecar and removes
+that state.
+
+Distributed scans are best-effort. If a worker collector fails or times out,
+the query can return reduced coverage while the job and healthy collectors
+continue operating.
+
+## Retention and snapshots
+
+`TelemetryConfig.retention_secs` applies to `sent_messages`, `messages`, and
+`message_status_events`. The default is 600 seconds. Set it to `0` to disable
+automatic retention. Retention runs every 30 seconds, so expired rows can
+remain visible until the next sweep. Other core tables have no automatic
+retention window.
+
+`TelemetryConfig.snapshot_interval_secs` controls periodic Mesh Admin topology
+snapshots. The default is 30 seconds; set it to `0` to disable them. Snapshots
+and event telemetry describe different views of the same job:
+
+- Event tables record changes such as actor creation, status transitions, and
+  message delivery.
+- Snapshot tables capture the administrative topology and actor diagnostics at
+  a point in time.
+
+## Troubleshooting
+
+- If `state.query_engine_client` is `None`, telemetry bootstrap failed. Check
+  the parent-process logs for `job sidecar telemetry bootstrap failed`.
+- If a query is empty immediately after work runs, retry briefly; ingestion and
+  collector flushes are asynchronous.
+- If rows from one host are missing, inspect collector warnings and use the
+  [Mesh Admin TUI diagnostics](admin-tui) to check that host.
+- If a SQL request fails, the raised HTTP error includes the DataFusion parse or
+  planning detail returned by the query service.
+
+## Related documentation
+
+- [Observability overview](observability)
+- [Monarch Dashboard](monarch-dashboard)
+- [Mesh Admin TUI](admin-tui)
+- [OpenTelemetry and Grafana](./generated/examples/otel_collector)
+- [Jobs API](api/monarch.job)

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -43,13 +43,13 @@ Here are some suggested steps to get started with Monarch:
 
 1. **Installation**: Check out the [Install guide](installation) for getting monarch installed.
 2. **Getting Started**: The [getting started](./generated/examples/getting_started) provides an introduction to Monarch's core API
-3. **Explore Examples**: Review the [Examples](./generated/examples/index) to see Monarch in action
-4. **Cookbook**: Browse the [Cookbook](cookbook) for short, task-oriented recipes.
-5. **Dive Deeper**: Explore the API Documentation for more detailed information:
+3. **Observe and Diagnose**: Start with the [Observability guide](observability), then query [Distributed Telemetry](distributed-telemetry), open the [Monarch Dashboard](monarch-dashboard), or diagnose a live mesh with the [Admin TUI](admin-tui).
+4. **Explore Examples**: Review the [Examples](./generated/examples/index) to see Monarch in action
+5. **Cookbook**: Browse the [Cookbook](cookbook) for short, task-oriented recipes.
+6. **Dive Deeper**: Explore the API Documentation for more detailed information:
     - [Python API](api/index)
     - [Rust API](rust-api)
-6. **Deep Understanding of Actors**: Gain comprehensive knowledge of [Actors](actors), the foundational building blocks of Monarch.
-7. **Monitoring Tools**: Inspect running meshes with the [Admin TUI](admin-tui) (terminal) or the [Monarch Dashboard](monarch-dashboard) (web GUI).
+7. **Deep Understanding of Actors**: Gain comprehensive knowledge of [Actors](actors), the foundational building blocks of Monarch.
 
 ```{toctree}
 :maxdepth: 2
@@ -57,13 +57,12 @@ Here are some suggested steps to get started with Monarch:
 :hidden:
 installation
 ./generated/examples/getting_started
+observability
 ./generated/examples/index
 cookbook
 api/index
 rust-api
 actors
-admin-tui
-monarch-dashboard
 ```
 
 ## License

--- a/docs/source/monarch-dashboard.md
+++ b/docs/source/monarch-dashboard.md
@@ -6,12 +6,17 @@ full mesh topology — hosts, processes, actor meshes, and individual actors —
 interactive views with live-updating metrics, message traffic analysis, and a
 full DAG visualization.
 
+See the [observability overview](observability) for how the dashboard uses
+[distributed telemetry](distributed-telemetry) and complements the
+[Mesh Admin TUI](admin-tui).
+
 > **Note** — The Monarch Dashboard is in early development and may change
 > significantly between releases.
 
-The dashboard is included in the `torchmonarch` PyPI package. When a job enables
-`TelemetryConfig(include_dashboard=True)`, Monarch starts a local web server that
-serves the dashboard UI.
+The dashboard is included in the `torchmonarch` PyPI package. The telemetry
+sidecar hosts its query service. Set
+`TelemetryConfig(include_dashboard=True)` to advertise the browser UI and print
+its URL.
 
 ## Quick Start
 
@@ -118,14 +123,15 @@ Host → Proc → Actor
 Here is an example of how to enable the dashboard on your job via the [Jobs API](api/monarch.job).
 
 ```python
-from monarch.job import LocalJob, ProcessJob, KubernetesJob, SlurmJob, TelemetryConfig
+from monarch.job import ProcessJob, TelemetryConfig
 
-# Provision job - LocalJob, ProcessJob, KubernetesJob, SlurmJob, etc.
-# job = ...
-dashboard_port = 8265
-
-# Enable telemetry, mesh admin, snapshots, and the dashboard together.
-job.enable_telemetry(
-    TelemetryConfig(include_dashboard=True, dashboard_port=dashboard_port)
+job = ProcessJob({"workers": 2}).enable_telemetry(
+    TelemetryConfig(include_dashboard=True, dashboard_port=8265)
 )
+state = job.state(cached_path=None)
+print(state.dashboard_url)
 ```
+
+`enable_telemetry()` also starts mesh admin and periodic introspection
+snapshots. Use `state.query_engine_client` to query the same data directly; see
+[Distributed Telemetry](distributed-telemetry).

--- a/docs/source/observability.md
+++ b/docs/source/observability.md
@@ -1,0 +1,109 @@
+# Observability
+
+Monarch provides one observability setup with three complementary job-local
+surfaces: distributed telemetry for SQL analysis, the Monarch Dashboard for
+visual monitoring, and the Mesh Admin TUI for live diagnostics. Enable
+telemetry on a job to start all three data paths consistently. OpenTelemetry
+provides a separate export path for external backends.
+
+## Choose a surface
+
+| Use case | Surface | What it provides |
+|----------|---------|------------------|
+| Query actor, mesh, message, and trace history | [Distributed telemetry](distributed-telemetry) | DataFusion SQL across host-local collectors |
+| Monitor topology, status, failures, and traffic in a browser | [Monarch Dashboard](monarch-dashboard) | Live summaries, hierarchy views, and a job DAG |
+| Diagnose a running mesh from a terminal | [Mesh Admin TUI](admin-tui) | Live topology, health checks, and py-spy stack traces |
+| Export metrics and logs to an external backend | [OpenTelemetry and Grafana](./generated/examples/otel_collector) | OTLP export to systems such as Prometheus and Loki |
+
+The dashboard reads distributed telemetry. The TUI reads the Mesh Admin API.
+Periodic mesh-admin snapshots also flow into telemetry so the dashboard can
+show the live administrative topology.
+
+Distributed telemetry is a job-scoped, in-memory query system. OpenTelemetry
+export is the external aggregation path for metrics and logs. You can use both
+on the same job.
+
+## Enable observability
+
+Configure observability before calling `state()`:
+
+```python
+from monarch.job import ProcessJob, TelemetryConfig
+
+job = ProcessJob({"workers": 2}).enable_telemetry(
+    TelemetryConfig(
+        retention_secs=600,
+        include_dashboard=True,
+        dashboard_port=8265,
+        snapshot_interval_secs=30,
+    )
+)
+state = job.state(cached_path=None)
+```
+
+`enable_telemetry()` also enables mesh admin and periodic introspection
+snapshots. Adapt the example to your existing `LocalJob`, `ProcessJob`,
+`SlurmJob`, or `KubernetesJob` rather than creating a second job.
+
+The returned state exposes each surface:
+
+```python
+print(state.dashboard_url)
+print(state.admin_url)
+
+client = state.query_engine_client
+if client is None:
+    raise RuntimeError("telemetry did not start")
+
+result = client.query(
+    "SELECT new_status, COUNT(*) AS count "
+    "FROM actor_status_events GROUP BY new_status"
+)
+print(result["rows"])
+```
+
+Use `state.dashboard_url` in a browser. Pass `state.admin_url` to
+`monarch-tui --addr`.
+
+## Data flow
+
+```text
+actor and proc events ──> host-local collectors ──> distributed query engine
+                                                        ├─> SQL query client
+                                                        └─> Monarch Dashboard
+
+live mesh ──> Mesh Admin API ──────────────────────────────> Mesh Admin TUI
+     └──────> periodic snapshots ──> distributed telemetry ─> Dashboard DAG
+```
+
+Telemetry collection and distributed query fan-out are best-effort. A failed
+or slow worker collector can reduce query coverage without failing the job.
+Telemetry tables are in memory and belong to the current job allocation; they
+are not a durable event archive.
+
+## Configuration
+
+| `TelemetryConfig` field | Default | Effect |
+|-------------------------|---------|--------|
+| `retention_secs` | `600` | Retention window for message tables; `0` disables retention |
+| `include_dashboard` | `False` | Advertise the browser dashboard |
+| `dashboard_port` | `8265` | Preferred dashboard port; use `0` for an ephemeral port |
+| `snapshot_interval_secs` | `30` | Mesh-introspection snapshot interval; `0` disables periodic snapshots |
+
+For an admin server without distributed telemetry, call `job.enable_admin()`.
+That supports the TUI, but it does not provide the dashboard or SQL history.
+
+## Next steps
+
+- [Query distributed telemetry](distributed-telemetry)
+- [Use the Monarch Dashboard](monarch-dashboard)
+- [Diagnose a mesh with the Admin TUI](admin-tui)
+- [Export metrics and logs with OpenTelemetry](./generated/examples/otel_collector)
+
+```{toctree}
+:maxdepth: 1
+:hidden:
+distributed-telemetry
+admin-tui
+monarch-dashboard
+```


### PR DESCRIPTION
Summary:
Add umbrella section Monarch Observability that encompass all the existing surfaces. This is the first attempt to make it more uniform:
* Add Monarch Observability section
* Add Monarch Observability overview
* Add distributed telemetry documentation
* Update documents to mention about new features regarding Monarch observability

We still should add more sinks in the future like file logs

Reviewed By: johnwhumphreys

Differential Revision: D113949154


