### PR TITLE
telemetry: log per-batch scan progress at trace, not info

### DIFF
--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -900,7 +900,7 @@ impl DatabaseScanner {
                     };
 
                     if let Ok(data) = serialize_batch(&batch) {
-                        tracing::info!("Scanner {}: sending batch {}", rank, count);
+                        tracing::trace!("Scanner {}: sending batch {}", rank, count);
                         let msg = QueryResponse {
                             data: Part::from(data),
                         };


### PR DESCRIPTION
Summary:
`DatabaseScanner` logged `Scanner N: sending batch M` at `info!` for every Arrow batch it streams to the query engine (`database_scanner.rs:903`, inside the per-batch result loop), so a scan of a large table emits one INFO line per batch.

Observed on a dev dashboard run: a full scan of the in-memory messages table streamed ~28k batches, and with the dashboard polling the query engine every few seconds it emitted thousands of INFO lines/sec — that run's `monarch_log.log` grew to ~50GB. Downgrade the per-batch line to `trace!`. The per-scan summary (`Scanner N: local scan complete, sent M batches`, line 912) stays at `info!` for the useful aggregate, and per-batch progress remains available under `RUST_LOG=trace` for debugging a stuck scan.

Reviewed By: thedavekwon

Differential Revision: D113951207


