### PR TITLE
Suppress type errors for Pyre upgrade - monarch

### DIFF
--- a/examples/rdma_pingpong/rdma_pingpong.py
+++ b/examples/rdma_pingpong/rdma_pingpong.py
@@ -56,6 +56,7 @@ class PingPongActor(Actor):
     @endpoint
     async def get_buffer(self) -> RDMABuffer:
         if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
+            # pyrefly: ignore [missing-attribute]
             return RDMABuffer(self.data.view(torch.uint8).flatten())
         else:
             # pyrefly: ignore [bad-argument-type]
@@ -65,7 +66,9 @@ class PingPongActor(Actor):
     async def read_from(self, peer_buf: RDMABuffer) -> float:
         """Read peer's data into recv_buf, return elapsed seconds."""
         if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
+            # pyrefly: ignore [missing-attribute]
             self.recv_buf.zero_()
+            # pyrefly: ignore [missing-attribute]
             local = self.recv_buf.view(torch.uint8).flatten()
         elif self.buffer_type == "bytearray":
             for i in range(len(self.recv_buf)):
@@ -89,6 +92,7 @@ class PingPongActor(Actor):
         if self.buffer_type in ("cpu_tensor", "cuda_tensor"):
             # .cpu() is a no-op on CPU tensors, required for cuda_tensor
             # since numpy doesn't accept CUDA storage.
+            # pyrefly: ignore [missing-attribute]
             raw = buf.cpu().numpy().tobytes()
         else:
             raw = bytes(buf)

--- a/python/benches/remotemount/bench_metadata_encoding.py
+++ b/python/benches/remotemount/bench_metadata_encoding.py
@@ -59,7 +59,9 @@ def make_synthetic_metadata(num_files: int, num_dirs: int = 0) -> dict[str, Any]
             # pyrefly: ignore [unsupported-operation]
             meta[f"/dir_{i}/sub_file_{j}.txt"] = {
                 "attr": file_attr,
+                # pyrefly: ignore [bad-assignment]
                 "global_offset": offset + j * 256,
+                # pyrefly: ignore [bad-assignment]
                 "file_len": 256,
             }
 
@@ -74,7 +76,9 @@ def make_synthetic_metadata(num_files: int, num_dirs: int = 0) -> dict[str, Any]
         # pyrefly: ignore [unsupported-operation]
         meta[f"/file_{i}.bin"] = {
             "attr": file_attr,
+            # pyrefly: ignore [bad-assignment]
             "global_offset": offset,
+            # pyrefly: ignore [bad-assignment]
             "file_len": file_size,
         }
         offset += file_size


### PR DESCRIPTION
Summary:
This diff was automatically generated by the Pyre per-target upgrade tool.

It adds `# pyre-fixme` or `pyrefly: ignore` comments to suppress type errors that will be introduced by an upcoming Pyre or Pyrefly release. These suppressions allow the upgrade to proceed without breaking existing code.

#pyreupgrade

Differential Revision: D113939098


