### PR TITLE
Reuse rustup from OSS build images

### DIFF
--- a/scripts/common-setup.sh
+++ b/scripts/common-setup.sh
@@ -67,8 +67,10 @@ install_node() {
 # Install and configure Rust nightly toolchain
 setup_rust_toolchain() {
     echo "Setting up Rust toolchain..."
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-    source "${HOME}"/.cargo/env
+    if ! command -v rustup &> /dev/null; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        export PATH="${CARGO_HOME:-$HOME/.cargo}/bin:$PATH"
+    fi
     rustup toolchain install nightly
     rustup default nightly
     # Explicitly install the pinned toolchain from rust-toolchain file.
@@ -81,6 +83,7 @@ setup_rust_toolchain() {
             rustup toolchain install "$PINNED_CHANNEL"
         fi
     fi
+    rustup show
     # We use cargo nextest to run tests in individual processes for similarity
     # to buck test.
     # Replace "cargo test" commands with "cargo nextest run".


### PR DESCRIPTION
Summary: The manylinux CUDA image now provides Rust and rustup under `/opt/rust`, while the setup script always reinstalled rustup and sourced `$HOME/.cargo/env`. Reuse rustup when it is already on `PATH`, and add Cargo’s bin directory directly after fresh installations. Log `rustup show` after installing the pinned toolchain so CI records the active toolchain and compiler version.

Differential Revision: D114083439


