### PR TITLE
Make mesh-admin fixture readiness API-backed (#4539)

### DIFF
--- a/hyperactor_mesh/test/mesh_admin_integration/execution.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/execution.rs
@@ -75,40 +75,10 @@ const DECREMENT_POLL_INTERVAL: Duration = Duration::from_millis(100);
 /// snapshot must stay wedged and the release ACK must never arrive.
 const DEADLOCK_NEGATIVE_TIMEOUT: Duration = Duration::from_secs(5);
 const DEADLOCK_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const ACTOR_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(30);
 
 fn enc(s: &str) -> String {
     urlencoding::encode(s).into_owned()
-}
-
-/// Walk root -> hosts -> procs -> actors and return the ref of the first
-/// actor whose label equals `label`. ActorAddr.to_string() is
-/// `{actor_uid}.{proc_id}@{location}` where actor_uid is `label<base58>`;
-/// match the label exactly so we don't pick up the controller actor
-/// (`actor_mesh_controller_<label><...>`).
-async fn find_actor_by_label(fixture: &WorkloadFixture, label: &str) -> String {
-    let root: NodePayload = fixture
-        .get_node_payload("/v1/root")
-        .await
-        .expect("execution: GET /v1/root failed");
-    for host_ref in &root.children {
-        let host: NodePayload = fixture
-            .get_node_payload(&format!("/v1/{}", enc(&host_ref.to_string())))
-            .await
-            .unwrap_or_else(|e| panic!("execution: GET /v1/{host_ref} failed: {e:#}"));
-        for proc_ref in &host.children {
-            let proc: NodePayload = fixture
-                .get_node_payload(&format!("/v1/{}", enc(&proc_ref.to_string())))
-                .await
-                .unwrap_or_else(|e| panic!("execution: GET /v1/{proc_ref} failed: {e:#}"));
-            for actor_ref in &proc.children {
-                let s = actor_ref.to_string();
-                if s.split('<').next().unwrap_or("") == label {
-                    return s;
-                }
-            }
-        }
-    }
-    panic!("execution: actor with label {label:?} not found in topology");
 }
 
 /// Fetch the typed `Execution` for `actor_ref`. A live Python actor
@@ -216,11 +186,26 @@ fn assert_idle_shape(exec: &Execution, ctx: &str) {
 }
 
 async fn run_inner(fixture: &WorkloadFixture) {
-    let busy = find_actor_by_label(fixture, "busy_actor").await;
-    let idle = find_actor_by_label(fixture, "idle_actor").await;
-    let queue = find_actor_by_label(fixture, "queue_actor").await;
-    let concurrent = find_actor_by_label(fixture, "concurrent_actor").await;
-    let deadlock = find_actor_by_label(fixture, "deadlock_actor").await;
+    let busy = fixture
+        .wait_for_actor_by_label("busy_actor", ACTOR_DISCOVERY_TIMEOUT)
+        .await
+        .expect("execution: busy actor was not initialized");
+    let idle = fixture
+        .wait_for_actor_by_label("idle_actor", ACTOR_DISCOVERY_TIMEOUT)
+        .await
+        .expect("execution: idle actor was not initialized");
+    let queue = fixture
+        .wait_for_actor_by_label("queue_actor", ACTOR_DISCOVERY_TIMEOUT)
+        .await
+        .expect("execution: queue actor was not initialized");
+    let concurrent = fixture
+        .wait_for_actor_by_label("concurrent_actor", ACTOR_DISCOVERY_TIMEOUT)
+        .await
+        .expect("execution: concurrent actor was not initialized");
+    let deadlock = fixture
+        .wait_for_actor_by_label("deadlock_actor", ACTOR_DISCOVERY_TIMEOUT)
+        .await
+        .expect("execution: deadlock actor was not initialized");
 
     // --- Direct dispatch: one held invocation -> count 1. ---
     fixture

--- a/hyperactor_mesh/test/mesh_admin_integration/harness.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/harness.rs
@@ -27,6 +27,8 @@ use anyhow::Result;
 use anyhow::anyhow;
 use anyhow::bail;
 use hyperactor_mesh::introspect::NodePayload;
+use hyperactor_mesh::introspect::NodeProperties;
+use hyperactor_mesh::introspect::NodeRef;
 use hyperactor_mesh::introspect::dto::NodePayloadDto;
 use hyperactor_mesh::mesh_id::ResourceId;
 use reqwest::Client;
@@ -45,6 +47,8 @@ use tokio::sync::mpsc;
 
 pub(crate) const QUERY_RETRY_ATTEMPTS: usize = 5;
 pub(crate) const QUERY_RETRY_DELAY: Duration = Duration::from_secs(10);
+const ADMIN_READY_POLL_INTERVAL: Duration = Duration::from_millis(100);
+const ACTOR_DISCOVERY_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// Classified service and worker proc references. See MIT-7
 /// (proc-classification).
@@ -191,6 +195,87 @@ impl WorkloadFixture {
     pub(crate) async fn get_node_payload(&self, path: &str) -> Result<NodePayload> {
         let dto: NodePayloadDto = self.get_json(path).await?;
         NodePayload::try_from(dto).context("DTO → NodePayload conversion")
+    }
+
+    /// Wait until the authenticated admin API serves a typed root node.
+    async fn wait_until_admin_ready(&self, timeout: Duration) -> Result<()> {
+        let mut last_observation = "no request attempted".to_string();
+        let ready = tokio::time::timeout(timeout, async {
+            loop {
+                match self.get_node_payload("/v1/root").await {
+                    Ok(root) if matches!(root.properties, NodeProperties::Root { .. }) => return,
+                    Ok(root) => {
+                        last_observation = format!(
+                            "GET /v1/root returned unexpected properties: {:?}",
+                            root.properties
+                        );
+                    }
+                    Err(error) => last_observation = format!("{error:#}"),
+                }
+                tokio::time::sleep(ADMIN_READY_POLL_INTERVAL).await;
+            }
+        })
+        .await;
+
+        if ready.is_err() {
+            bail!(
+                "MIT-1: authenticated GET /v1/root was not ready within {}s; last observation: {}",
+                timeout.as_secs(),
+                last_observation
+            );
+        }
+        Ok(())
+    }
+
+    async fn find_actor_by_label(&self, label: &str) -> Result<Option<String>> {
+        let root = self.get_node_payload("/v1/root").await?;
+        for host_ref in &root.children {
+            let host_ref = host_ref.to_string();
+            let host = self
+                .get_node_payload(&format!("/v1/{}", urlencoding::encode(&host_ref)))
+                .await?;
+            for proc_ref in &host.children {
+                let proc_ref = proc_ref.to_string();
+                let proc = self
+                    .get_node_payload(&format!("/v1/{}", urlencoding::encode(&proc_ref)))
+                    .await?;
+                for actor_ref in &proc.children {
+                    if let NodeRef::Actor(actor) = actor_ref
+                        && actor.label().map(|value| value.as_str()) == Some(label)
+                    {
+                        return Ok(Some(actor_ref.to_string()));
+                    }
+                }
+            }
+        }
+        Ok(None)
+    }
+
+    /// Wait for a workload actor to become visible through mesh-admin.
+    pub(crate) async fn wait_for_actor_by_label(
+        &self,
+        label: &str,
+        timeout: Duration,
+    ) -> Result<String> {
+        let mut last_observation = "actor not present".to_string();
+        let actor_ref = tokio::time::timeout(timeout, async {
+            loop {
+                match self.find_actor_by_label(label).await {
+                    Ok(Some(actor_ref)) => return actor_ref,
+                    Ok(None) => last_observation = "actor not present".to_string(),
+                    Err(error) => last_observation = format!("{error:#}"),
+                }
+                tokio::time::sleep(ACTOR_DISCOVERY_POLL_INTERVAL).await;
+            }
+        })
+        .await;
+
+        actor_ref.with_context(|| {
+            format!(
+                "actor {label:?} was not visible through mesh-admin within {}s; last observation: {last_observation}",
+                timeout.as_secs()
+            )
+        })
     }
 
     /// POST a path with a JSON body relative to the admin URL.
@@ -448,7 +533,8 @@ pub(crate) async fn start_workload(
         .take()
         .ok_or_else(|| anyhow!("child stdin not captured"))?;
 
-    // MIT-1: Wait for the admin URL sentinel on stdout.
+    // The listening line discovers the ephemeral admin URL. MIT-1 is
+    // established below by querying the authenticated API.
     let stdout = child
         .stdout
         .take()
@@ -526,13 +612,10 @@ pub(crate) async fn start_workload(
             let _ = stdout_tx.send(line);
         }
     });
-    // Drop the stderr collector — we only need it on failure.
-    stderr_handle.abort();
-
     // MIT-5: Build reqwest client with test CA and client cert.
     let client = build_client(&pki.ca_pem, &pki.cert_pem, &pki.key_pem)?;
 
-    Ok(WorkloadFixture {
+    let fixture = WorkloadFixture {
         child: Mutex::new(Some(child)),
         admin_url,
         client,
@@ -540,7 +623,27 @@ pub(crate) async fn start_workload(
         _cert_dir: cert_dir,
         stdin: AsyncMutex::new(Some(stdin)),
         stdout_rx: AsyncMutex::new(stdout_rx),
-    })
+    };
+
+    if let Err(error) = fixture.wait_until_admin_ready(timeout).await {
+        fixture.shutdown().await;
+        let captured = stderr_handle.await.unwrap_or_default();
+        let tail = captured
+            .lines()
+            .rev()
+            .take(50)
+            .collect::<Vec<_>>()
+            .into_iter()
+            .rev()
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(error.context(format!("stderr (last 50 lines):\n{tail}")));
+    }
+
+    // Detach the collector so stderr remains drained for the fixture's
+    // lifetime. The task exits when the child closes the pipe.
+    drop(stderr_handle);
+    Ok(fixture)
 }
 
 /// Py-spy install. Attempted exactly once per process via `Once`.

--- a/hyperactor_mesh/test/mesh_admin_integration/inbound_ordering_workload.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/inbound_ordering_workload.rs
@@ -8,8 +8,8 @@
 
 //! Exercises MIT-78 (deterministic stalled inbound ordering over the
 //! mesh-admin API) by spawning the `inbound_ordering_workload` Python
-//! binary, waiting for it to print its admin URL, then polling
-//! `/v1/{stalled_receiver}` until the expected `InboundOrdering`
+//! binary, discovering its receiver through the authenticated admin
+//! API, then polling `/v1/{stalled_receiver}` until the expected `InboundOrdering`
 //! shape appears (bounded retry — fire-and-forget `.broadcast()`
 //! returning is not proof the receiver's snapshot has caught up).
 //!
@@ -44,41 +44,6 @@ const EXPECTED_TOTAL_BUFFERED: usize = 8;
 
 fn enc(s: &str) -> String {
     urlencoding::encode(s).into_owned()
-}
-
-/// Walk the topology (root -> hosts -> procs -> actors) and return
-/// the ref of the first actor whose label is `stalled_receiver`.
-async fn find_stalled_receiver(fixture: &WorkloadFixture) -> String {
-    let root: NodePayload = fixture
-        .get_node_payload("/v1/root")
-        .await
-        .expect("MIT-78: GET /v1/root failed");
-    for host_ref in &root.children {
-        let host: NodePayload = fixture
-            .get_node_payload(&format!("/v1/{}", enc(&host_ref.to_string())))
-            .await
-            .unwrap_or_else(|e| panic!("MIT-78: GET /v1/{host_ref} failed: {e:#}"));
-        for proc_ref in &host.children {
-            let proc: NodePayload = fixture
-                .get_node_payload(&format!("/v1/{}", enc(&proc_ref.to_string())))
-                .await
-                .unwrap_or_else(|e| panic!("MIT-78: GET /v1/{proc_ref} failed: {e:#}"));
-            for actor_ref in &proc.children {
-                let s = actor_ref.to_string();
-                // ActorAddr.to_string() is `{actor_uid}.{proc_id}@{location}`
-                // where actor_uid is `label<base58>`. Match the label
-                // exactly -- substring would also match the controller
-                // (`actor_mesh_controller_stalled_receiver<...>`),
-                // which is a different actor with a different session
-                // table.
-                let label = s.split('<').next().unwrap_or("");
-                if label == "stalled_receiver" {
-                    return s;
-                }
-            }
-        }
-    }
-    panic!("MIT-78: stalled_receiver actor not found in topology");
 }
 
 fn matches_expected(io: &InboundOrdering) -> bool {
@@ -121,7 +86,10 @@ async fn poll_until_stalled(
 }
 
 async fn run_inner(fixture: &WorkloadFixture) {
-    let receiver_ref = find_stalled_receiver(fixture).await;
+    let receiver_ref = fixture
+        .wait_for_actor_by_label("stalled_receiver", POLL_TIMEOUT)
+        .await
+        .expect("MIT-78: stalled receiver was not initialized");
     let (actor, last_io) = poll_until_stalled(fixture, &receiver_ref).await;
 
     let NodeProperties::Actor {

--- a/hyperactor_mesh/test/mesh_admin_integration/main.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/main.rs
@@ -15,9 +15,11 @@
 //! ### Fixture lifecycle
 //!
 //! - **MIT-1 (fixture-readiness):** A fixture is not considered live
-//!   until the admin URL sentinel (`"Mesh admin server listening on
-//!   "`) is observed from workload stdout within a timeout.
-//!   `start_workload` fails if the sentinel does not appear.
+//!   until its admin URL is discovered from workload stdout and an
+//!   authenticated `GET /v1/root` returns a typed root node within a
+//!   timeout. The listening line is URL discovery, not proof that the
+//!   HTTP API or workload actors are ready. Scenarios establish their
+//!   own workload-specific readiness through mesh-admin discovery.
 //! - **MIT-2 (scoped-cleanup):** Scenarios own their fixture
 //!   lifetime. `WorkloadFixture::shutdown()` takes the `Child` from
 //!   its `Mutex`, calls `start_kill()`, and `wait().await`s for reap.

--- a/hyperactor_mesh/test/mesh_admin_integration/supervision.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/supervision.rs
@@ -21,14 +21,8 @@ use std::time::Duration;
 use crate::harness;
 use crate::harness::WorkloadFixture;
 
-/// How long to wait for the admin URL sentinel after starting the
-/// sieve binary.
+/// How long to wait for mesh-admin readiness after starting the sieve binary.
 const SIEVE_START_TIMEOUT: Duration = Duration::from_secs(60);
-
-/// Settle time after admin-URL readiness for the sieve actor chain
-/// to build (the sieve starts 5s after the sentinel, then needs
-/// time to discover primes and spawn child actors).
-const SIEVE_CHAIN_READY_SLEEP: Duration = Duration::from_secs(10);
 
 /// Maximum number of discovery attempts before failing.
 const DISCOVERY_ATTEMPTS: usize = 30;
@@ -44,15 +38,11 @@ struct SieveScenario {
 impl SieveScenario {
     async fn start() -> Self {
         let bin = harness::sieve_rust_binary();
-        // The sieve prints "Starts in 5 seconds." then spawns actors.
-        // Give it enough time to find some primes and build the chain.
         // --num-primes 10: enough to build a chain of ~10 actors,
         // small enough to converge quickly.
         let fixture = harness::start_workload(&bin, &["--num-primes", "10"], SIEVE_START_TIMEOUT)
             .await
             .expect("failed to start sieve workload");
-        // Wait for sieve actors to spawn.
-        tokio::time::sleep(SIEVE_CHAIN_READY_SLEEP).await;
         SieveScenario { fixture }
     }
 


### PR DESCRIPTION
Summary:

Treat `Mesh admin server listening on` as URL discovery rather than readiness. `start_workload` now waits until an authenticated `GET /v1/root` deserializes to a typed root node before returning a live fixture, and preserves stderr diagnostics when that readiness probe fails.

Move workload-specific readiness to bounded mesh-admin topology discovery. Execution and inbound-ordering tests wait for their actors by exact label through the API, while the sieve scenario relies on its existing topology poll instead of a fixed sleep.

Reviewed By: shayne-fletcher

Differential Revision: D114130843


