### PR TITLE
Print resolved observability access details (#4540)

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -49,7 +49,7 @@ pub(crate) mod net;
 // implementation lives in `net` but we re-export here to keep `net`'s
 // internal types out of the public API surface.
 pub use net::ServerError;
-pub use net::try_tls_acceptor;
+pub use net::try_tls_acceptor_with_pem_bundle;
 pub use net::try_tls_connector;
 pub use net::try_tls_pem_bundle;
 

--- a/hyperactor/src/channel/net.rs
+++ b/hyperactor/src/channel/net.rs
@@ -2400,7 +2400,7 @@ fn oss_pem_bundle() -> crate::config::PemBundle {
 }
 
 /// Try to find a usable TLS [`PemBundle`](crate::config::PemBundle)
-/// by probing the same sources as [`try_tls_acceptor`] /
+/// by probing the same sources as [`try_tls_acceptor_with_pem_bundle`] /
 /// [`try_tls_connector`].
 ///
 /// Returns the first bundle whose CA certificate is readable.
@@ -2424,8 +2424,8 @@ pub fn try_tls_pem_bundle() -> Option<crate::config::PemBundle> {
     None
 }
 
-/// Try to build a [`TlsAcceptor`](tokio_rustls::TlsAcceptor) for an
-/// HTTP server by probing for available TLS certificates.
+/// Try to build a [`TlsAcceptor`](tokio_rustls::TlsAcceptor) and retain the
+/// exact [`PemBundle`](crate::config::PemBundle) selected for it.
 ///
 /// Detection order:
 /// 1. **OSS / explicit config** — `HYPERACTOR_TLS_CERT`,
@@ -2443,16 +2443,18 @@ pub fn try_tls_pem_bundle() -> Option<crate::config::PemBundle> {
 /// configured CA (mutual TLS via `WebPkiClientVerifier`). When
 /// `false`, the acceptor authenticates itself but does not demand
 /// client certificates.
-pub fn try_tls_acceptor(enforce_client_tls: bool) -> Option<tokio_rustls::TlsAcceptor> {
+pub fn try_tls_acceptor_with_pem_bundle(
+    enforce_client_tls: bool,
+) -> Option<(tokio_rustls::TlsAcceptor, crate::config::PemBundle)> {
     let oss_bundle = oss_pem_bundle();
     if let Ok(acceptor) = tls::tls_acceptor_from_bundle(&oss_bundle, enforce_client_tls) {
-        return Some(acceptor);
+        return Some((acceptor, oss_bundle));
     }
     tracing::debug!("OSS TLS acceptor failed, trying Meta paths");
 
     let meta_bundle = meta::get_server_pem_bundle();
     if let Ok(acceptor) = tls::tls_acceptor_from_bundle(&meta_bundle, enforce_client_tls) {
-        return Some(acceptor);
+        return Some((acceptor, meta_bundle));
     }
     tracing::debug!("Meta TLS acceptor failed, no TLS available");
 
@@ -2462,7 +2464,7 @@ pub fn try_tls_acceptor(enforce_client_tls: bool) -> Option<tokio_rustls::TlsAcc
 /// Try to build a [`TlsConnector`](tokio_rustls::TlsConnector) for an
 /// HTTP client that needs to connect to a TLS-enabled server.
 ///
-/// Detection mirrors [`try_tls_acceptor`]:
+/// Detection mirrors [`try_tls_acceptor_with_pem_bundle`]:
 /// 1. **OSS** — `HYPERACTOR_TLS_CA` (and optionally
 ///    `HYPERACTOR_TLS_CERT` + `HYPERACTOR_TLS_KEY` for mutual TLS).
 /// 2. **Meta** — root CA at `/var/facebook/rootcanal/ca.pem`,

--- a/hyperactor_mesh/examples/dining_philosophers.rs
+++ b/hyperactor_mesh/examples/dining_philosophers.rs
@@ -270,30 +270,6 @@ async fn main() -> Result<ExitCode> {
         .await?
         .addr
         .ok_or_else(|| anyhow::anyhow!("mesh admin did not report an address"))?;
-    let mtls_flags = if mesh_admin_url.starts_with("https") {
-        "--cacert /var/facebook/rootcanal/ca.pem \
-         --cert /var/facebook/x509_identities/server.pem \
-         --key /var/facebook/x509_identities/server.pem "
-    } else {
-        ""
-    };
-    println!("Mesh admin server listening on {}", mesh_admin_url);
-    println!(
-        "  - Root node:     curl {}{}/v1/root",
-        mtls_flags, mesh_admin_url
-    );
-    println!(
-        "  - Mesh tree:     curl {}{}/v1/tree",
-        mtls_flags, mesh_admin_url
-    );
-    println!(
-        "  - API docs:      curl {}{}/SKILL.md",
-        mtls_flags, mesh_admin_url
-    );
-    println!(
-        "  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {}\n                   cargo run -p hyperactor_mesh_admin_tui_lib --bin hyperactor_mesh_admin_tui -- --addr {}",
-        mesh_admin_url, mesh_admin_url
-    );
     println!(
         "  - Diagnose:      cargo run -p hyperactor_mesh_admin_tui_lib --bin hyperactor_mesh_admin_tui -- --addr {} --diagnose",
         mesh_admin_url

--- a/hyperactor_mesh/examples/sieve.rs
+++ b/hyperactor_mesh/examples/sieve.rs
@@ -28,7 +28,6 @@ use hyperactor::RemoteSpawn;
 use hyperactor_config::Flattrs;
 use hyperactor_mesh::context;
 use hyperactor_mesh::host_mesh::spawn_admin;
-use hyperactor_mesh::mesh_admin::MeshAdminMessageClient;
 use hyperactor_mesh::this_host;
 use hyperactor_mesh::this_proc;
 use ndslice::View;
@@ -137,36 +136,7 @@ async fn main() -> Result<ExitCode> {
 
     // Start the mesh admin agent.
     let h = this_host().await;
-    let admin_ref = spawn_admin([&h], instance, None, None).await?;
-    let mesh_admin_url = admin_ref
-        .get_admin_addr(instance)
-        .await?
-        .addr
-        .ok_or_else(|| anyhow::anyhow!("mesh admin did not report an address"))?;
-    let mtls_flags = if mesh_admin_url.starts_with("https") {
-        "--cacert /var/facebook/rootcanal/ca.pem \
-         --cert /var/facebook/x509_identities/server.pem \
-         --key /var/facebook/x509_identities/server.pem "
-    } else {
-        ""
-    };
-    println!("Mesh admin server listening on {}", mesh_admin_url);
-    println!(
-        "  - Root node:     curl {}{}/v1/root",
-        mtls_flags, mesh_admin_url
-    );
-    println!(
-        "  - Mesh tree:     curl {}{}/v1/tree",
-        mtls_flags, mesh_admin_url
-    );
-    println!(
-        "  - API docs:      curl {}{}/SKILL.md",
-        mtls_flags, mesh_admin_url
-    );
-    println!(
-        "  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {}\n                   cargo run -p hyperactor_mesh_admin_tui_lib --bin hyperactor_mesh_admin_tui -- --addr {}",
-        mesh_admin_url, mesh_admin_url
-    );
+    spawn_admin([&h], instance, None, None).await?;
     println!();
 
     // TODO: put an indicatif spinner here

--- a/hyperactor_mesh/src/mesh_admin.rs
+++ b/hyperactor_mesh/src/mesh_admin.rs
@@ -230,19 +230,28 @@
 //!   etc.) rather than propagating panics or unwinding. Failed reply
 //!   sends (the caller went away) are silently swallowed.
 //!
-//! ## TLS transport invariant (MA-T1)
+//! ## TLS transport invariants (MA-T*)
 //!
 //! - **MA-T1 (tls):** At Meta (`fbcode_build`), the admin HTTP
-//!   server **requires** mutual TLS. At startup it probes for
-//!   certificates via `try_tls_acceptor` with client cert
-//!   enforcement enabled. If no usable certificate bundle is found,
-//!   `init()` returns an error — no plain HTTP fallback. In OSS,
-//!   TLS is best-effort with plain HTTP fallback.
+//!   server **requires** mutual TLS. At startup it resolves a paired
+//!   acceptor and credential bundle via
+//!   `try_tls_acceptor_with_pem_bundle` with client cert enforcement
+//!   enabled. If no usable certificate bundle is found, `init()`
+//!   returns an error — no plain HTTP fallback. In OSS, TLS is
+//!   best-effort with plain HTTP fallback.
 //!
 //! - **MA-T2 (scheme-in-url):** The URL returned by `GetAdminAddr`
 //!   is always `https://host:port` or `http://host:port`, never a
 //!   bare `host:port`. All callers receive and use this full URL
 //!   directly.
+//!
+//! - **MA-T3 (access-instructions):** `MeshAdminAgent::init` emits one
+//!   startup access block. For HTTPS, runnable `curl` flags come from
+//!   the exact `PemBundle` paired with the selected acceptor and are
+//!   rendered only when the CA, certificate, and key are `Pem::File`
+//!   or `Pem::StaticPath`. If any credential is `Pem::Value`, the
+//!   block shows endpoint URLs without claiming a runnable `curl`
+//!   command. Plain HTTP endpoints retain runnable `curl` commands.
 //!
 //! ## Client host invariants (CH-*)
 //!
@@ -336,6 +345,7 @@
 
 use std::collections::HashMap;
 use std::io;
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -359,7 +369,9 @@ use hyperactor::Instance;
 use hyperactor::OncePortRef;
 use hyperactor::ProcAddr;
 use hyperactor::RefClient;
-use hyperactor::channel::try_tls_acceptor;
+use hyperactor::channel::try_tls_acceptor_with_pem_bundle;
+use hyperactor::config::Pem;
+use hyperactor::config::PemBundle;
 use hyperactor::introspect::IntrospectMessage;
 use hyperactor::introspect::IntrospectResult;
 use hyperactor::introspect::IntrospectView;
@@ -389,6 +401,52 @@ use crate::pyspy::PySpyProfileOpts;
 use crate::pyspy::PySpyProfileResult;
 use crate::pyspy::PySpyResult;
 use crate::pyspy::ValidatedProfileRequest;
+
+/// Builds user-facing commands for accessing a mesh admin server.
+fn mesh_admin_access_instructions(admin_url: &str, tls_bundle: Option<&PemBundle>) -> String {
+    fn path(pem: &Pem) -> Option<&Path> {
+        match pem {
+            Pem::File(path) => Some(path),
+            Pem::StaticPath(path) => Some(Path::new(*path)),
+            Pem::Value(_) => None,
+        }
+    }
+
+    let curl_prefix = if admin_url.starts_with("https://") {
+        tls_bundle.and_then(|bundle| {
+            Some(format!(
+                "curl --cacert {} --cert {} --key {} ",
+                path(&bundle.ca)?.display(),
+                path(&bundle.cert)?.display(),
+                path(&bundle.key)?.display(),
+            ))
+        })
+    } else {
+        Some("curl ".to_string())
+    };
+    let access = |path: &str| match &curl_prefix {
+        Some(prefix) => format!("{prefix}{admin_url}{path}"),
+        None => format!("{admin_url}{path}"),
+    };
+
+    format!(
+        concat!(
+            "Mesh admin server listening on {admin_url}\n",
+            "  - Root node:     {root_access}\n",
+            "  - Mesh tree:     {tree_access}\n",
+            "  - API docs:      {docs_access}\n",
+            "  - TUI:           buck2 run ",
+            "fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui ",
+            "-- --addr {admin_url}\n",
+            "                   cargo run -p hyperactor_mesh_admin_tui_lib ",
+            "--bin hyperactor_mesh_admin_tui -- --addr {admin_url}",
+        ),
+        admin_url = admin_url,
+        root_access = access("/v1/root"),
+        tree_access = access("/v1/tree"),
+        docs_access = access("/SKILL.md"),
+    )
+}
 
 /// Send an `IntrospectMessage` to an actor and receive the reply.
 /// Encapsulates open_once_port + send + timeout + error handling.
@@ -909,15 +967,16 @@ impl Actor for MeshAdminAgent {
     ///    call `bind()` — unlike `gspawn` — so the actor must do it
     ///    itself before becoming reachable).
     /// 2. Binds a TCP listener (ephemeral or fixed port).
-    /// 3. Builds a TLS acceptor (explicit env vars, then Meta default
-    ///    paths). At Meta (`fbcode_build`), mTLS is mandatory and
-    ///    init fails if no certs are found. In OSS, falls back to
-    ///    plain HTTP.
+    /// 3. Builds a TLS acceptor and retains its selected credential
+    ///    bundle (explicit env vars, then Meta default paths). At Meta
+    ///    (`fbcode_build`), mTLS is mandatory and init fails if no certs
+    ///    are found. In OSS, falls back to plain HTTP.
     /// 4. Creates a dedicated `Instance<()>` client mailbox on
     ///    system_proc for the HTTP bridge's reply ports, keeping
     ///    bridge traffic off the actor's own mailbox.
     /// 5. Spawns the axum server in a background task (HTTPS with
     ///    mTLS at Meta, HTTPS or HTTP in OSS depending on step 3).
+    /// 6. Prints one access block derived from the selected bundle.
     ///
     /// The hostname-based listen address is stored in `admin_host` so
     /// it can be returned via `GetAdminAddr`. The scheme (`https://`
@@ -945,9 +1004,9 @@ impl Actor for MeshAdminAgent {
         // In OSS: TLS is best-effort with plain HTTP fallback.
         // See MA-T1 in module doc.
         let enforce_mtls = cfg!(fbcode_build);
-        let tls_acceptor = try_tls_acceptor(enforce_mtls);
+        let tls = try_tls_acceptor_with_pem_bundle(enforce_mtls);
 
-        if enforce_mtls && tls_acceptor.is_none() {
+        if enforce_mtls && tls.is_none() {
             return Err(anyhow::anyhow!(
                 "mesh admin requires mTLS but no TLS certificates found; \
                  set HYPERACTOR_TLS_CERT/KEY/CA or ensure Meta cert paths exist \
@@ -955,11 +1014,7 @@ impl Actor for MeshAdminAgent {
             ));
         }
 
-        let scheme = if tls_acceptor.is_some() {
-            "https"
-        } else {
-            "http"
-        };
+        let scheme = if tls.is_some() { "https" } else { "http" };
 
         // Build the host portion of the admin URL.
         //
@@ -995,6 +1050,8 @@ impl Actor for MeshAdminAgent {
             .admin_host
             .clone()
             .unwrap_or_else(|| "unknown".to_string());
+        let access_instructions =
+            mesh_admin_access_instructions(&admin_url, tls.as_ref().map(|(_, bundle)| bundle));
         let bridge_state = Arc::new(BridgeState {
             admin_ref: ActorRef::attest(this.self_addr().clone()),
             bridge_cx,
@@ -1012,7 +1069,7 @@ impl Actor for MeshAdminAgent {
         });
         let router = create_mesh_admin_router(bridge_state);
 
-        if let Some(acceptor) = tls_acceptor {
+        if let Some((acceptor, _)) = tls {
             let tls_listener = TlsListener {
                 tcp: listener,
                 acceptor,
@@ -1031,6 +1088,7 @@ impl Actor for MeshAdminAgent {
             });
         }
 
+        println!("{access_instructions}");
         tracing::info!(
             "mesh admin server listening on {}",
             self.admin_host.as_deref().unwrap_or("unknown")
@@ -3057,10 +3115,10 @@ mod advertised_host {
 
     /// Extract SAN entries from the server cert PEM bundle.
     ///
-    /// Loads the same cert bundle that `try_tls_acceptor` uses,
-    /// parses the leaf cert with `x509_parser`, and returns SAN
-    /// DNS names and IP addresses. Returns empty if no cert is
-    /// available or parsing fails.
+    /// Probes cert bundles in the same source order as
+    /// `try_tls_acceptor_with_pem_bundle`, parses the leaf cert with
+    /// `x509_parser`, and returns SAN DNS names and IP addresses.
+    /// Returns empty if no cert is available or parsing fails.
     fn load_cert_sans() -> Vec<SanIdentity> {
         use std::io::BufReader;
 
@@ -3218,6 +3276,60 @@ mod tests {
     // ephemeral port. The default (`None`) reads MESH_ADMIN_ADDR
     // config which is `[::]:1729` — a fixed port that causes bind
     // conflicts when tests run concurrently.
+
+    #[test]
+    fn mesh_admin_access_instructions_print_file_tls_paths() {
+        let bundle = PemBundle {
+            ca: Pem::File("/tmp/custom-ca.pem".into()),
+            cert: Pem::File("/tmp/custom-cert.pem".into()),
+            key: Pem::File("/tmp/custom-key.pem".into()),
+        };
+
+        let instructions =
+            mesh_admin_access_instructions("https://admin.example.com", Some(&bundle));
+
+        assert!(instructions.contains(
+            "Root node:     curl --cacert /tmp/custom-ca.pem --cert /tmp/custom-cert.pem --key /tmp/custom-key.pem https://admin.example.com/v1/root"
+        ));
+    }
+
+    #[test]
+    fn mesh_admin_access_instructions_print_static_tls_paths() {
+        let bundle = PemBundle {
+            ca: Pem::StaticPath("/etc/hyperactor/tls/ca.crt"),
+            cert: Pem::StaticPath("/etc/hyperactor/tls/tls.crt"),
+            key: Pem::StaticPath("/etc/hyperactor/tls/tls.key"),
+        };
+
+        let instructions =
+            mesh_admin_access_instructions("https://admin.example.com", Some(&bundle));
+
+        assert!(instructions.contains(
+            "Root node:     curl --cacert /etc/hyperactor/tls/ca.crt --cert /etc/hyperactor/tls/tls.crt --key /etc/hyperactor/tls/tls.key https://admin.example.com/v1/root"
+        ));
+    }
+
+    #[test]
+    fn mesh_admin_access_instructions_do_not_render_pem_values_as_curl() {
+        let bundle = PemBundle {
+            ca: Pem::Value(b"ca".to_vec()),
+            cert: Pem::File("/tmp/custom-cert.pem".into()),
+            key: Pem::File("/tmp/custom-key.pem".into()),
+        };
+
+        let instructions =
+            mesh_admin_access_instructions("https://admin.example.com", Some(&bundle));
+
+        assert!(instructions.contains("Root node:     https://admin.example.com/v1/root"));
+        assert!(!instructions.contains("Root node:     curl"));
+    }
+
+    #[test]
+    fn mesh_admin_access_instructions_print_plain_http_curl() {
+        let instructions = mesh_admin_access_instructions("http://localhost:1729", None);
+
+        assert!(instructions.contains("Root node:     curl http://localhost:1729/v1/root"));
+    }
 
     /// Minimal introspectable actor for tests. The `#[export]`
     /// attribute generates `Named + Referable + Binds` so that

--- a/hyperactor_mesh/test/mesh_admin_integration/dining.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/dining.rs
@@ -100,6 +100,7 @@ impl Drop for ShutdownGuard<'_> {
 async fn check_dining_endpoints(bin: &Path) {
     DiningScenario::run(bin, |s| {
         Box::pin(async move {
+            s.fixture.assert_custom_tls_access_instructions().await;
             crate::admin::assert_admin_info(s).await;
             crate::admin::assert_admin_schema(s).await;
             crate::config::check(s).await;
@@ -110,14 +111,14 @@ async fn check_dining_endpoints(bin: &Path) {
     .await;
 }
 
-/// MIT-13, MIT-14, MIT-15, MIT-75, MIT-76, MIT-77: dining-based
+/// MIT-13, MIT-14, MIT-15, MIT-75, MIT-76, MIT-77, MIT-79: dining-based
 /// endpoint assertions — Rust binary.
 pub async fn run_dining_endpoints_rust() {
     let bin = harness::dining_philosophers_rust_binary();
     check_dining_endpoints(&bin).await;
 }
 
-/// MIT-13, MIT-14, MIT-15, MIT-75, MIT-76, MIT-77: dining-based
+/// MIT-13, MIT-14, MIT-15, MIT-75, MIT-76, MIT-77, MIT-79: dining-based
 /// endpoint assertions — Python binary.
 pub async fn run_dining_endpoints_python() {
     let bin = harness::dining_philosophers_python_binary();

--- a/hyperactor_mesh/test/mesh_admin_integration/harness.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/harness.rs
@@ -69,6 +69,8 @@ pub(crate) struct WorkloadFixture {
     pub(crate) admin_url: String,
     pub(crate) client: Client,
     ca_pem: Vec<u8>,
+    ca_path: PathBuf,
+    combined_path: PathBuf,
     _cert_dir: TempDir,
     /// Child stdin, for workloads driven by the stdin-command /
     /// stdout-sentinel handshake (`execution_workload`). `None` for
@@ -132,6 +134,25 @@ impl WorkloadFixture {
                 timeout.as_secs()
             )
         })?
+    }
+
+    /// Assert MIT-79: startup output advertises this fixture's TLS paths.
+    pub(crate) async fn assert_custom_tls_access_instructions(&self) {
+        let line = self
+            .wait_for_stdout("  - Root node:", Duration::from_secs(10))
+            .await
+            .expect("mesh admin must print root access instructions");
+        assert_eq!(
+            line,
+            format!(
+                "  - Root node:     curl --cacert {} --cert {} --key {} {}/v1/root",
+                self.ca_path.display(),
+                self.combined_path.display(),
+                self.combined_path.display(),
+                self.admin_url,
+            ),
+            "root access instructions must use the server's selected TLS paths"
+        );
     }
 
     /// Build a client that trusts the test CA but presents no client
@@ -620,6 +641,8 @@ pub(crate) async fn start_workload(
         admin_url,
         client,
         ca_pem: pki.ca_pem,
+        ca_path,
+        combined_path,
         _cert_dir: cert_dir,
         stdin: AsyncMutex::new(Some(stdin)),
         stdout_rx: AsyncMutex::new(stdout_rx),

--- a/hyperactor_mesh/test/mesh_admin_integration/main.rs
+++ b/hyperactor_mesh/test/mesh_admin_integration/main.rs
@@ -47,6 +47,13 @@
 //!   cert) are rejected by the mesh admin server. This is tested
 //!   explicitly, not assumed.
 //!
+//! ### Access instructions
+//!
+//! - **MIT-79 (tls-access-instruction-fidelity):** Rust and Python
+//!   dining fixtures start mesh admin with ephemeral
+//!   `HYPERACTOR_TLS_{CA,CERT,KEY}` paths and assert that the startup
+//!   root `curl` command advertises those exact paths.
+//!
 //! ### Discovery
 //!
 //! - **MIT-7 (proc-classification):** Service proc (contains
@@ -355,14 +362,14 @@ mod tree;
 
 // --- dining family ---
 
-/// MIT-13, MIT-14, MIT-15, MIT-75, MIT-76, MIT-77: dining-based
+/// MIT-13, MIT-14, MIT-15, MIT-75, MIT-76, MIT-77, MIT-79: dining-based
 /// endpoint assertions — Rust binary.
 #[tokio::test]
 async fn test_dining_endpoints_rust() {
     dining::run_dining_endpoints_rust().await;
 }
 
-/// MIT-13, MIT-14, MIT-15, MIT-75, MIT-76, MIT-77: dining-based
+/// MIT-13, MIT-14, MIT-15, MIT-75, MIT-76, MIT-77, MIT-79: dining-based
 /// endpoint assertions — Python binary.
 #[tokio::test]
 async fn test_dining_endpoints_python() {

--- a/python/examples/airport_turnaround_demo.py
+++ b/python/examples/airport_turnaround_demo.py
@@ -306,21 +306,6 @@ async def async_main(args: argparse.Namespace) -> None:
     gate_ref = await gates.whoami.call_one()
     flight0_ref = await flights.slice(replica=0).whoami.call_one()
 
-    admin_url = state.admin_url
-    assert admin_url is not None
-    mtls_flags = (
-        "--cacert /var/facebook/rootcanal/ca.pem "
-        "--cert /var/facebook/x509_identities/server.pem "
-        "--key /var/facebook/x509_identities/server.pem "
-        if admin_url.startswith("https")
-        else ""
-    )
-    tui = (
-        "buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui"
-    )
-    print(f"\nMesh admin server listening on {admin_url}")
-    print(f"  - Mesh tree:  curl {mtls_flags}{admin_url}/v1/tree")
-    print(f"  - TUI:        {tui} -- --addr {admin_url}")
     print("\nOpen these nodes in the TUI tree (by label):")
     print(f"  - flight (replicas 0..{args.flights - 1}) -> Execution: phase turnover")
     print("  - gate_manager        -> Execution: assign_gate xK when gates are full")

--- a/python/examples/dining_philosophers.py
+++ b/python/examples/dining_philosophers.py
@@ -189,22 +189,6 @@ async def async_main(
         state = job.state(cached_path=None)
         host = state.hosts
 
-        admin_url = state.admin_url
-        assert admin_url is not None
-        mtls_flags = (
-            "--cacert /var/facebook/rootcanal/ca.pem "
-            "--cert /var/facebook/x509_identities/server.pem "
-            "--key /var/facebook/x509_identities/server.pem "
-            if admin_url.startswith("https")
-            else ""
-        )
-        print(f"\nMesh admin server listening on {admin_url}")
-        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-        print(
-            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-        )
         print("\nPress Ctrl+C to stop.\n", flush=True)
 
         # Spawn philosopher processes and actors.

--- a/python/examples/execution_demo.py
+++ b/python/examples/execution_demo.py
@@ -146,19 +146,6 @@ async def async_main(args: argparse.Namespace) -> None:
         fork_ref = await fork_manager.whoami.call_one()
         phil0_ref = await philosophers.slice(replica=0).whoami.call_one()
 
-        admin_url = state.admin_url
-        assert admin_url is not None
-        mtls_flags = (
-            "--cacert /var/facebook/rootcanal/ca.pem "
-            "--cert /var/facebook/x509_identities/server.pem "
-            "--key /var/facebook/x509_identities/server.pem "
-            if admin_url.startswith("https")
-            else ""
-        )
-        tui = "buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui"
-        print(f"\nMesh admin server listening on {admin_url}")
-        print(f"  - Mesh tree:  curl {mtls_flags}{admin_url}/v1/tree")
-        print(f"  - TUI:        {tui} -- --addr {admin_url}")
         print("\nWatch list (find these in the TUI tree by label):")
         print(
             "  - actor `fork_manager`  -> Execution: `acquire xK` (live contention) + flight recorder"

--- a/python/examples/execution_workload.py
+++ b/python/examples/execution_workload.py
@@ -294,7 +294,6 @@ async def async_main() -> None:
 
         drainer = asyncio.create_task(drain_entered())
 
-        print(f"Mesh admin server listening on {state.admin_url}", flush=True)
         print(f"  - Busy actor:  {busy_ref}", flush=True)
         print(f"  - Idle actor:  {idle_ref}", flush=True)
         print(f"  - Queue actor: {queue_ref}", flush=True)

--- a/python/examples/inbound_ordering_workload.py
+++ b/python/examples/inbound_ordering_workload.py
@@ -150,16 +150,9 @@ async def async_main(args: argparse.Namespace) -> None:
         receiver_ref = str(receiver_addr)
         receiver_ref_encoded = urllib.parse.quote(receiver_ref, safe="")
 
-        print(f"Mesh admin server listening on {state.admin_url}", flush=True)
         print(f"  - Stalled receiver: {receiver_ref}", flush=True)
         print(
             f"  - curl: curl{mtls_flags} {state.admin_url}/v1/{receiver_ref_encoded}",
-            flush=True,
-        )
-        print(
-            "  - TUI:   "
-            f"buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui "
-            f"-- --addr {state.admin_url}",
             flush=True,
         )
         print(

--- a/python/examples/poisoned_mesh.py
+++ b/python/examples/poisoned_mesh.py
@@ -88,24 +88,6 @@ async def async_main(num_procs: int) -> None:
         state = job.state(cached_path=None)
         host = state.hosts
 
-        admin_url = state.admin_url
-        assert admin_url is not None
-        mtls_flags = (
-            "--cacert /var/facebook/rootcanal/ca.pem "
-            "--cert /var/facebook/x509_identities/server.pem "
-            "--key /var/facebook/x509_identities/server.pem "
-            if admin_url.startswith("https")
-            else ""
-        )
-        print(f"\nMesh admin server listening on {admin_url}")
-        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-        print(
-            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-        )
-        print(flush=True)
-
         procs = host.spawn_procs(per_host={"replica": num_procs})
         workers = procs.spawn("worker", Worker)
 

--- a/python/examples/pyspy_workload.py
+++ b/python/examples/pyspy_workload.py
@@ -154,9 +154,6 @@ async def async_main() -> None:
             f"\npy-spy workload: mode={args.mode}, "
             f"work_ms={args.work_ms}, concurrency={args.concurrency}"
         )
-        print(f"\nMesh admin server listening on {admin_url}")
-        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
         print("\nVerify with:")
         print("  buck2 run fbcode//monarch/python/examples:verify_pyspy -- \\")
         if mtls_flags:

--- a/python/examples/rapid_spawn_exit_stress.py
+++ b/python/examples/rapid_spawn_exit_stress.py
@@ -68,22 +68,6 @@ async def main():
         job_state = job.state(cached_path=None)
         proc_mesh = job_state.hosts.spawn_procs(per_host={"gpus": 1})
 
-        admin_url = job_state.admin_url
-        assert admin_url is not None
-        mtls_flags = (
-            "--cacert /var/facebook/rootcanal/ca.pem "
-            "--cert /var/facebook/x509_identities/server.pem "
-            "--key /var/facebook/x509_identities/server.pem "
-            if admin_url.startswith("https")
-            else ""
-        )
-        print(f"\nMesh admin server listening on {admin_url}")
-        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-        print(
-            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-        )
         print("\nPress Ctrl+C to stop.\n", flush=True)
 
         for i in range(args.iterations):

--- a/python/examples/sleep_actors.py
+++ b/python/examples/sleep_actors.py
@@ -62,22 +62,6 @@ async def async_main(num_procs: int) -> None:
         state = job.state(cached_path=None)
         host = state.hosts
 
-        admin_url = state.admin_url
-        assert admin_url is not None
-        mtls_flags = (
-            "--cacert /var/facebook/rootcanal/ca.pem "
-            "--cert /var/facebook/x509_identities/server.pem "
-            "--key /var/facebook/x509_identities/server.pem "
-            if admin_url.startswith("https")
-            else ""
-        )
-        print(f"\nMesh admin server listening on {admin_url}")
-        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-        print(
-            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-        )
         print(f"\nSpawning batches of sleepers across {num_procs} procs.")
         print("Press Ctrl+C to stop.\n", flush=True)
 

--- a/python/examples/stop_mesh.py
+++ b/python/examples/stop_mesh.py
@@ -49,24 +49,6 @@ async def async_main(num_procs: int) -> None:
         state = job.state(cached_path=None)
         host = state.hosts
 
-        admin_url = state.admin_url
-        assert admin_url is not None
-        mtls_flags = (
-            "--cacert /var/facebook/rootcanal/ca.pem "
-            "--cert /var/facebook/x509_identities/server.pem "
-            "--key /var/facebook/x509_identities/server.pem "
-            if admin_url.startswith("https")
-            else ""
-        )
-        print(f"\nMesh admin server listening on {admin_url}")
-        print(f"  - Root node:     curl {mtls_flags}{admin_url}/v1/root")
-        print(f"  - Mesh tree:     curl {mtls_flags}{admin_url}/v1/tree")
-        print(f"  - API docs:      curl {mtls_flags}{admin_url}/SKILL.md")
-        print(
-            f"  - TUI:           buck2 run fbcode//monarch/hyperactor_mesh_admin_tui:hyperactor_mesh_admin_tui -- --addr {admin_url}"
-        )
-        print(flush=True)
-
         procs = host.spawn_procs(per_host={"replica": num_procs})
         workers = procs.spawn("worker", Worker)
 

--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -217,10 +217,10 @@ class TelemetryComponent(JobComponent):
             self._telemetry_url = telemetry_url
             if isinstance(dashboard_url, str):
                 self._dashboard_url = dashboard_url
-                if self._config.include_dashboard:
-                    print(f"Monarch Dashboard: {dashboard_url}", flush=True)
             self._query_engine_client = QueryEngineClient(telemetry_url)
             install_sidecar_socket_sink(socket_path)
+            if self._dashboard_url is not None and self._config.include_dashboard:
+                print(f"Monarch Dashboard: {self._dashboard_url}", flush=True)
         except Exception:
             # Reset so a partial bootstrap leaves a clean "disabled" state:
             # fan-out no-ops and `state` exposes no query client.

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -1197,6 +1197,18 @@ def test_telemetry_uses_sidecar():
     m.install_sink.assert_called_once_with("/tmp/telemetry.sock")
 
 
+def test_telemetry_dashboard_url_printed_only_once(capsys):
+    with _patched_sidecar():
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(include_dashboard=True)
+        )
+        job.state(cached_path=None)
+        job.state(cached_path=None)
+
+    output = capsys.readouterr().out
+    assert output.count("Monarch Dashboard: http://dashboard\n") == 1
+
+
 def test_sidecar_bootstrap_then_fanout_carry_host_meshes():
     """state() bootstraps the sidecar with empty host_meshes, then fans out
     workers with the materialized host meshes."""
@@ -1271,15 +1283,18 @@ def test_sidecar_worker_fanout_uses_configured_host_meshes():
     assert state.hosts.python_executable == python_exe
 
 
-def test_sidecar_bootstrap_failure_is_isolated():
+def test_sidecar_bootstrap_failure_is_isolated(capsys):
     """A sidecar bootstrap failure disables telemetry and never fails state()."""
     with _patched_sidecar(ensure_open_side_effect=RuntimeError("boom")) as m:
-        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(TelemetryConfig())
+        job = MockJobTrait(host_names=["hosts"]).enable_telemetry(
+            TelemetryConfig(include_dashboard=True)
+        )
         state = job.state(cached_path=None)  # must not raise
 
     assert state.query_engine_client is None
     assert state.query_engine is None
     m.query_engine_client_cls.assert_not_called()
+    assert "Monarch Dashboard:" not in capsys.readouterr().out
 
 
 def test_sidecar_worker_fanout_failure_is_isolated():


### PR DESCRIPTION
Summary:

Print user-facing observability connection details from the components that own their initialized state. `TelemetryComponent` prints the dashboard URL only after successful setup and once per component runtime. `MeshAdminAgent` prints the mesh-admin URL, root, tree, API documentation, and TUI commands once the server starts, so Python and Rust callers share one output path.

Resolve mesh-admin TLS once and retain the exact `PemBundle` alongside the `TlsAcceptor`. Render runnable `curl` commands for HTTP, or for HTTPS when the selected CA, certificate, and key are all `Pem::File` or `Pem::StaticPath`. When any selected credential is `Pem::Value`, show endpoint URLs without advertising an unusable command.

Remove the duplicate fixed-path Python provider and per-example renderers. Cover file, static-path, and in-memory PEM representations with unit tests, and assert that the existing Rust and Python custom-TLS integration fixtures print their exact temporary credential paths.

Reviewed By: johnwhumphreys

Differential Revision: D114130844


