### PR TITLE
Upgrade PyO3 from 0.26 to 0.27 (#4543)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,8 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd47f2a6ddc39244bd722a27ee5da66c03369d087b9e024eafdb03e98b98ea7"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-arith",
  "arrow-array",
@@ -197,9 +196,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-arith"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c7bbd679c5418b8639b92be01f361d60013c4906574b578b77b63c78356594c"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -211,9 +209,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8a4ab47b3f3eac60f7fd31b81e9028fda018607bcc63451aca4f2b755269862"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -230,9 +227,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d18b89b4c4f4811d0858175e79541fe98e33e18db3b011708bc287b1240593f"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "bytes",
  "half",
@@ -242,9 +238,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "722b5c41dd1d14d0a879a1bce92c6fe33f546101bb2acce57a209825edd075b3"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -264,9 +259,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-csv"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ddb80a4848e03b1655af496d5ac2563a779e5742fcb48f2ca2e089c9cd2197"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-cast",
@@ -279,9 +273,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1683705c63dcf0d18972759eda48489028cbbff67af7d6bef2c6b7b74ab778a"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -292,9 +285,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cf72d04c07229fbf4dbebe7145cac37d7cf7ec582fe705c6b92cb314af096ab"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -308,9 +300,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-json"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84a905f41fedfcd7679813c89a61dc369c0f932b27aa8dcc6aa051cc781a97d"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -332,9 +323,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-ord"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "082342947d4e5a2bcccf029a0a0397e21cb3bb8421edd9571d34fb5dd2670256"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -345,9 +335,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-pyarrow"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "699e04d51e2ac87efc52faa0a1bb9742b11b7f75c2abd2842de50c41cc630a47"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-data",
@@ -357,9 +346,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-row"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3a931b520a2a5e22033e01a6f2486b4cdc26f9106b759abeebc320f125e94d7"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -370,9 +358,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4cf0d4a6609679e03002167a61074a21d7b1ad9ea65e462b2c0a97f8a3b2bc6"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "bitflags 2.13.1",
  "serde_core",
@@ -381,9 +368,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-select"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b320d86a9806923663bb0fd9baa65ecaba81cb0cd77ff8c1768b9716b4ef891"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -395,9 +381,8 @@ dependencies = [
 
 [[package]]
 name = "arrow-string"
-version = "57.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b493e99162e5764077e7823e50ba284858d365922631c7aaefe9487b1abd02c2"
+version = "57.3.0"
+source = "git+https://github.com/apache/arrow-rs?rev=fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867#fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -2665,7 +2650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3436,7 +3421,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -3987,7 +3972,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4576,6 +4561,14 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
  "async-trait",
  "build_utils",
  "datafusion",
@@ -4586,6 +4579,7 @@ dependencies = [
  "monarch_hyperactor",
  "monarch_record_batch",
  "monarch_telemetry_schema",
+ "parquet",
  "pyo3",
  "serde",
  "serde_json",
@@ -5003,7 +4997,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5347,9 +5341,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "57.3.1"
+version = "57.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e832c6aa20310fc6de7ea5a3f4e20d34fd83e3b43229d32b81ffe5c14d74692"
+checksum = "6ee96b29972a257b855ff2341b37e61af5f12d6af1158b6dcdb5b31ea07bb3cb"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -5725,7 +5719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph",
@@ -5744,7 +5738,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -5802,9 +5796,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "anyhow",
  "indoc",
@@ -5821,9 +5815,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
+checksum = "57ddb5b570751e93cc6777e81fee8087e59cd53b5043292f2a6d59d5bd80fdfd"
 dependencies = [
  "futures 0.3.33",
  "once_cell",
@@ -5835,9 +5829,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes-macros"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29bc5c673e36a8102d0b9179149c1bb59990d8db4f3ae58bd7dceccab90b951"
+checksum = "bcd7d70ee0ca1661c40407e6f84e4463ef2658c90a9e2fbbd4515b2bcdfcaeca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5846,18 +5840,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -5865,9 +5859,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -5877,9 +5871,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -5929,7 +5923,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -5970,9 +5964,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6618,7 +6612,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6686,7 +6680,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7486,7 +7480,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7518,7 +7512,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8652,7 +8646,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,3 +90,22 @@ default-members = [
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fbcode_build)'] }
+
+[patch.crates-io]
+# Match fbsource's Arrow rev for OSS Cargo builds. The crates.io 57.3.x
+# arrow-pyarrow releases still pull pyo3 0.26, which conflicts with PyO3 0.27.
+arrow = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-arith = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-array = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-buffer = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-cast = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-csv = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-data = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-ipc = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-json = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-ord = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-pyarrow = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-row = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-schema = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-select = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }
+arrow-string = { git = "https://github.com/apache/arrow-rs", rev = "fcfe2b4160f6c99107dc89edecdfcd3ff9a4c867" }

--- a/build_utils/Cargo.toml
+++ b/build_utils/Cargo.toml
@@ -14,7 +14,7 @@ doctest = false
 [dependencies]
 cc = "1.2.67"
 glob = "0.3.2"
-pyo3-build-config = { version = "0.26", features = ["resolve-config"] }
+pyo3-build-config = { version = "0.27", features = ["resolve-config"] }
 which = "8.0.5"
 
 [lints]

--- a/monarch_distributed_telemetry/Cargo.toml
+++ b/monarch_distributed_telemetry/Cargo.toml
@@ -9,7 +9,15 @@ license = "BSD-3-Clause"
 
 [dependencies]
 anyhow = "1.0.103"
-arrow = { version = "57.3.1", features = ["ffi", "json", "prettyprint", "pyarrow"] }
+arrow = { version = "=57.3.0", features = ["ffi", "json", "prettyprint", "pyarrow"] }
+arrow-array = "=57.3.0"
+arrow-buffer = "=57.3.0"
+arrow-cast = "=57.3.0"
+arrow-data = "=57.3.0"
+arrow-ipc = "=57.3.0"
+arrow-ord = "=57.3.0"
+arrow-schema = "=57.3.0"
+arrow-select = "=57.3.0"
 async-trait = "0.1.86"
 datafusion = "52.5.0"
 futures = { version = "0.3.31", features = ["async-await", "compat"] }
@@ -19,7 +27,8 @@ monarch_gil = { version = "0.0.0", path = "../monarch_gil" }
 monarch_hyperactor = { version = "0.0.0", path = "../monarch_hyperactor" }
 monarch_record_batch = { version = "0.0.0", path = "../monarch_record_batch" }
 monarch_telemetry_schema = { version = "0.0.0", path = "../monarch_telemetry_schema" }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+parquet = "=57.3.0"
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }

--- a/monarch_distributed_telemetry/src/query_engine.rs
+++ b/monarch_distributed_telemetry/src/query_engine.rs
@@ -369,7 +369,8 @@ impl ExecutionPlan for DistributedExec {
                 // Surrender the underlying PythonTask via Future._take_inner(),
                 // then consume it to get the raw completion future.
                 let python_task_obj = future_obj.call_method0(py, "_take_inner")?;
-                let mut python_task: PyRefMut<'_, PyPythonTask> = python_task_obj.extract(py)?;
+                let mut python_task: PyRefMut<'_, PyPythonTask> =
+                    python_task_obj.extract(py).map_err(Into::<PyErr>::into)?;
                 let completion_future = python_task.take_task()?;
 
                 Ok(completion_future)

--- a/monarch_extension/Cargo.toml
+++ b/monarch_extension/Cargo.toml
@@ -34,8 +34,8 @@ monarch_rdma_extension = { version = "0.0.0", path = "../monarch_rdma/extension"
 monarch_tensor_worker = { version = "0.0.0", path = "../monarch_tensor_worker", optional = true, default-features = false }
 nccl-sys = { path = "../nccl-sys", optional = true }
 ndslice = { version = "0.0.0", path = "../ndslice" }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
-pyo3-async-runtimes = { version = "0.26", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3-async-runtimes = { version = "0.27", features = ["attributes", "tokio-runtime"] }
 rdmaxcel-sys = { path = "../rdmaxcel-sys", optional = true }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 tokio = { version = "1.52.4", features = ["full", "test-util", "tracing"] }

--- a/monarch_extension/src/chunked_fuse.rs
+++ b/monarch_extension/src/chunked_fuse.rs
@@ -284,13 +284,14 @@ fn f64_to_system_time(ts: f64) -> SystemTime {
     }
 }
 
-fn required_key<'py, T: pyo3::FromPyObject<'py>>(
+fn required_key<'py, T: for<'a> pyo3::FromPyObject<'a, 'py>>(
     dict: &Bound<'py, PyDict>,
     key: &str,
 ) -> PyResult<T> {
     dict.get_item(key)?
         .ok_or_else(|| PyRuntimeError::new_err(format!("missing required attr key: {key}")))?
         .extract()
+        .map_err(Into::into)
 }
 
 fn extract_attr(dict: &Bound<'_, PyDict>, kind: FileType) -> PyResult<FileAttr> {
@@ -319,11 +320,11 @@ fn extract_metadata(dict: &Bound<'_, PyDict>) -> PyResult<HashMap<OsString, FsEn
     let mut entries = HashMap::with_capacity(dict.len());
     for (key, value) in dict.iter() {
         let path: String = key.extract()?;
-        let entry_dict: &Bound<'_, PyDict> = value.downcast()?;
+        let entry_dict: &Bound<'_, PyDict> = value.cast()?;
         let attr_obj = entry_dict.get_item("attr")?.ok_or_else(|| {
             PyRuntimeError::new_err(format!("missing 'attr' key for path: {path}"))
         })?;
-        let attr_dict: &Bound<'_, PyDict> = attr_obj.downcast()?;
+        let attr_dict: &Bound<'_, PyDict> = attr_obj.cast()?;
 
         let fs_entry = if let Some(link_target) = entry_dict.get_item("link_target")? {
             let target: String = link_target.extract()?;

--- a/monarch_extension/src/convert.rs
+++ b/monarch_extension/src/convert.rs
@@ -131,8 +131,8 @@ impl<'a> MessageParser<'a> {
         }
     }
 
-    fn parse<T: pyo3::conversion::FromPyObject<'a>>(&self, name: &str) -> PyResult<T> {
-        self.attr(name)?.extract()
+    fn parse<T: for<'b> pyo3::conversion::FromPyObject<'b, 'a>>(&self, name: &str) -> PyResult<T> {
+        self.attr(name)?.extract().map_err(Into::into)
     }
 
     #[allow(non_snake_case)]

--- a/monarch_extension/src/readonly_fuse.rs
+++ b/monarch_extension/src/readonly_fuse.rs
@@ -107,7 +107,7 @@ type ActorFuture = Pin<Box<dyn Future<Output = PyResult<Py<PyAny>>> + Send + 'st
 /// `Future._take_inner()` surrenders the underlying `PythonTask`, whose
 /// `take_task()` then consumes it and returns the raw future.
 fn take_actor_future(py_future: Bound<'_, PyAny>) -> PyResult<ActorFuture> {
-    let task: Bound<'_, PyPythonTask> = py_future.call_method0("_take_inner")?.downcast_into()?;
+    let task: Bound<'_, PyPythonTask> = py_future.call_method0("_take_inner")?.cast_into()?;
     task.borrow_mut().take_task()
 }
 
@@ -147,10 +147,14 @@ fn file_type_from_mode(mode: u32) -> FileType {
 }
 
 fn extract_stat_attr(dict: &Bound<'_, PyDict>) -> PyResult<FileAttr> {
-    fn get<'py, T: FromPyObject<'py>>(dict: &Bound<'py, PyDict>, key: &str) -> PyResult<T> {
+    fn get<'py, T: for<'a> FromPyObject<'a, 'py>>(
+        dict: &Bound<'py, PyDict>,
+        key: &str,
+    ) -> PyResult<T> {
         dict.get_item(key)?
             .ok_or_else(|| PyRuntimeError::new_err(format!("missing stat key: {key}")))?
             .extract()
+            .map_err(Into::into)
     }
     let mode: u32 = get(dict, "st_mode")?;
     let size: u64 = get(dict, "st_size")?;
@@ -180,7 +184,7 @@ fn decode_getattr(result: Bound<'_, PyAny>) -> PyResult<FuseResult<FileAttr>> {
     if let Ok(errno) = result.extract::<libc::c_int>() {
         return Ok(Err(Errno::from(errno)));
     }
-    Ok(Ok(extract_stat_attr(result.downcast::<PyDict>()?)?))
+    Ok(Ok(extract_stat_attr(result.cast::<PyDict>()?)?))
 }
 
 fn decode_readdir(result: Bound<'_, PyAny>) -> PyResult<FuseResult<Vec<String>>> {

--- a/monarch_gil/Cargo.toml
+++ b/monarch_gil/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 hyperactor = { version = "0.0.0", path = "../hyperactor" }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 tokio = { version = "1.52.4", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }
 

--- a/monarch_hyperactor/Cargo.toml
+++ b/monarch_hyperactor/Cargo.toml
@@ -37,8 +37,8 @@ monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 nix = { version = "0.30.1", features = ["dir", "event", "hostname", "inotify", "ioctl", "mman", "mount", "net", "poll", "ptrace", "reboot", "resource", "sched", "signal", "term", "time", "user", "zerocopy"] }
 opentelemetry = "0.31"
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
-pyo3-async-runtimes = { version = "0.26", features = ["attributes", "tokio-runtime"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3-async-runtimes = { version = "0.27", features = ["attributes", "tokio-runtime"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -320,15 +320,15 @@ impl<'py> IntoPyObject<'py> for MeshRef {
 /// Extract the serializable [`MeshRef`] from a resolved mesh wrapper (the
 /// inverse of [`MeshRef::reconstruct`]), for the sender-side pending fill.
 pub(crate) fn mesh_ref_from_pyobject(value: &Bound<'_, PyAny>) -> PyResult<MeshRef> {
-    if let Ok(m) = value.downcast::<crate::proc_mesh::PyProcMesh>() {
+    if let Ok(m) = value.cast::<crate::proc_mesh::PyProcMesh>() {
         return Ok(MeshRef::Proc(Box::new(m.borrow().mesh_ref()?)));
     }
-    if let Ok(m) = value.downcast::<crate::host_mesh::PyHostMesh>() {
+    if let Ok(m) = value.cast::<crate::host_mesh::PyHostMesh>() {
         return Ok(MeshRef::Host(Box::new(m.borrow().mesh_ref().map_err(
             |e| pyo3::exceptions::PyValueError::new_err(e.to_string()),
         )?)));
     }
-    if let Ok(m) = value.downcast::<crate::actor_mesh::PythonActorMesh>() {
+    if let Ok(m) = value.cast::<crate::actor_mesh::PythonActorMesh>() {
         return Ok(MeshRef::Actor(Box::new(m.borrow().get_inner().mesh_ref()?)));
     }
     Err(pyo3::exceptions::PyRuntimeError::new_err(
@@ -649,7 +649,7 @@ impl PythonMessage {
     ) -> PyResult<Self> {
         let mesh_refs: Vec<MeshRef> = refs
             .iter()
-            .map(|item| Ok(item.downcast::<PyMeshRef>()?.borrow().inner.clone()))
+            .map(|item| Ok(item.cast::<PyMeshRef>()?.borrow().inner.clone()))
             .collect::<PyResult<_>>()?;
         Ok(PythonMessage::new_from_buf_with_refs(
             kind,
@@ -1056,7 +1056,7 @@ impl PythonActor {
             GilSite::ActorConstruct,
             |py| -> Result<Self, SerializablePyErr> {
                 let unpickled = actor_type.unpickle(py)?;
-                let class_type: &Bound<'_, PyType> = unpickled.downcast()?;
+                let class_type: &Bound<'_, PyType> = unpickled.cast()?;
                 let actor: Py<PyAny> = class_type.call0()?.into_py_any(py)?;
 
                 let task_locals = Python::detach(py, create_task_locals);
@@ -1490,7 +1490,7 @@ impl Actor for PythonActor {
                         &cx,
                         py_instance
                             .into_py_any(py)?
-                            .downcast_bound(py)
+                            .cast_bound(py)
                             .map_err(PyErr::from)?
                             .clone()
                             .unbind(),
@@ -1581,7 +1581,7 @@ impl Actor for PythonActor {
                         &cx,
                         py_instance
                             .into_py_any(py)?
-                            .downcast_bound(py)
+                            .cast_bound(py)
                             .map_err(PyErr::from)?
                             .clone()
                             .unbind(),
@@ -1605,7 +1605,7 @@ impl Actor for PythonActor {
                 .extract::<bool>(py)?;
             Ok::<_, anyhow::Error>((
                 py_envelope
-                    .downcast::<PythonUndeliverableMessageEnvelope>()
+                    .cast::<PythonUndeliverableMessageEnvelope>()
                     .map_err(PyErr::from)?
                     .try_borrow_mut()
                     .map_err(PyErr::from)?
@@ -2076,7 +2076,7 @@ async fn handle_async_endpoint_panic(
             Ok(value) => {
                 monarch_with_gil(GilSite::AwaitDrive, |py| -> Option<SerializablePyErr> {
                     let err: PyErr = value
-                        .downcast_bound::<PyBaseException>(py)
+                        .cast_bound::<PyBaseException>(py)
                         .unwrap()
                         .clone()
                         .into();

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -97,10 +97,13 @@ impl From<std::ops::Range<u16>> for PyPortRange {
     }
 }
 
-impl<'py> FromPyObject<'py> for PyPortRange {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for PyPortRange {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+        let obj = &*obj;
         // Extract slice(start, stop, step)
-        let slice = ob.downcast::<pyo3::types::PySlice>().map_err(|_| {
+        let slice = obj.cast::<pyo3::types::PySlice>().map_err(|_| {
             PyTypeError::new_err("Port range must be a slice object: slice(start, stop)")
         })?;
 
@@ -182,9 +185,12 @@ impl From<Duration> for PyDuration {
     }
 }
 
-impl<'py> FromPyObject<'py> for PyDuration {
-    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        let s: String = ob.extract()?;
+impl FromPyObject<'_, '_> for PyDuration {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+        let obj = &*obj;
+        let s: String = obj.extract()?;
         let duration = humantime::parse_duration(&s).map_err(|e| {
             PyValueError::new_err(format!("Invalid duration format '{}': {}", s, e))
         })?;
@@ -834,7 +840,7 @@ mod tests {
         monarch_with_gil_blocking(GilSite::Test, |_py| {
             // Strings ought not to work
             let s = PyString::new(_py, "bincode");
-            let result: PyResult<PyEncoding> = s.extract();
+            let result = s.extract::<PyEncoding>();
             assert!(result.is_err());
         });
     }
@@ -1010,7 +1016,7 @@ mod tests {
             let py_obj = py_range.into_pyobject(py).unwrap();
 
             // Should be a slice object
-            assert!(py_obj.downcast::<pyo3::types::PySlice>().is_ok());
+            assert!(py_obj.cast::<pyo3::types::PySlice>().is_ok());
 
             // Parse back
             let back: PyPortRange = py_obj.extract().unwrap();

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -1072,6 +1072,7 @@ impl ActorEndpoint {
         do_propagate
             .call1((&propagator, args, kwargs, fake_args, fake_kwargs, cache))?
             .extract()
+            .map_err(Into::into)
     }
 
     /// Propagation for fetch operations.

--- a/monarch_hyperactor/src/handle.rs
+++ b/monarch_hyperactor/src/handle.rs
@@ -1146,7 +1146,7 @@ def run_two(h):
                 let h = Py::new(py, handle).unwrap();
                 let helper = loop_helper(py);
                 let res = helper.getattr("run_cancel").unwrap().call1((h,)).unwrap();
-                let tup = res.downcast::<PyTuple>().unwrap();
+                let tup = res.cast::<PyTuple>().unwrap();
                 let cancelled = tup.get_item(0).unwrap().extract::<bool>().unwrap();
                 let poll_val = tup.get_item(1).unwrap();
                 (cancelled, !poll_val.is_none())
@@ -1183,7 +1183,7 @@ def run_two(h):
                     .unwrap()
                     .call1((h,))
                     .unwrap();
-                let tup = res.downcast::<PyTuple>().unwrap();
+                let tup = res.cast::<PyTuple>().unwrap();
                 (
                     tup.get_item(0).unwrap().extract::<bool>().unwrap(),
                     tup.get_item(1).unwrap().extract::<i64>().unwrap(),
@@ -1212,7 +1212,7 @@ def run_two(h):
             let h = Py::new(py, handle).unwrap();
             let helper = loop_helper(py);
             let res = helper.getattr("run_two").unwrap().call1((h,)).unwrap();
-            let tup = res.downcast::<PyTuple>().unwrap();
+            let tup = res.cast::<PyTuple>().unwrap();
             (
                 tup.get_item(0).unwrap().extract::<i64>().unwrap(),
                 tup.get_item(1).unwrap().extract::<i64>().unwrap(),
@@ -1276,7 +1276,7 @@ def run_two(h):
                 .unwrap()
                 .call1((h,))
                 .unwrap();
-            let tup = res.downcast::<PyTuple>().unwrap();
+            let tup = res.cast::<PyTuple>().unwrap();
             (
                 tup.get_item(0).unwrap().extract::<i64>().unwrap(),
                 tup.get_item(1).unwrap().extract::<bool>().unwrap(),

--- a/monarch_hyperactor/src/mailbox.rs
+++ b/monarch_hyperactor/src/mailbox.rs
@@ -658,7 +658,7 @@ impl CommReducer for PythonReducer {
             GilSite::Reducer,
             |py: Python<'_>| -> PyResult<PythonMessage> {
                 let result = self.0.call(py, (left, right), None)?;
-                result.extract::<PythonMessage>(py)
+                result.extract::<PythonMessage>(py).map_err(Into::into)
             },
         )
         .map_err(Into::into)

--- a/monarch_hyperactor/src/pytokio.rs
+++ b/monarch_hyperactor/src/pytokio.rs
@@ -606,6 +606,7 @@ impl PyPythonTask {
                     match result {
                         Ok(task) => Ok(Action::Wait(
                             task.extract::<Py<PyPythonTask>>()
+                                .map_err(Into::<PyErr>::into)
                                 .and_then(|t| t.borrow_mut(py).take_task())
                                 .unwrap_or_else(|pyerr| Box::pin(async move { Err(pyerr) })),
                         )),

--- a/monarch_hyperactor/src/runtime.rs
+++ b/monarch_hyperactor/src/runtime.rs
@@ -301,6 +301,13 @@ impl pyo3_async_runtimes::generic::Runtime for SimpleRuntime {
             fut.await;
         })
     }
+
+    fn spawn_blocking<F>(f: F) -> Self::JoinHandle
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        get_tokio_runtime().spawn_blocking(f)
+    }
 }
 
 tokio::task_local! {
@@ -320,11 +327,7 @@ impl pyo3_async_runtimes::generic::ContextExt for SimpleRuntime {
 
     fn get_task_locals() -> Option<TaskLocals> {
         TASK_LOCALS
-            .try_with(|c| {
-                c.get().map(|locals| {
-                    monarch_with_gil_blocking(GilSite::TaskLocals, |py| locals.clone_ref(py))
-                })
-            })
+            .try_with(|c| c.get().cloned())
             .unwrap_or_default()
     }
 }
@@ -332,7 +335,7 @@ impl pyo3_async_runtimes::generic::ContextExt for SimpleRuntime {
 pub fn future_into_py<F, T>(py: Python, fut: F) -> PyResult<Bound<PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: for<'py> IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py> + Send + 'static,
 {
     pyo3_async_runtimes::generic::future_into_py::<SimpleRuntime, F, T>(py, fut)
 }

--- a/monarch_messages/Cargo.toml
+++ b/monarch_messages/Cargo.toml
@@ -15,7 +15,7 @@ hyperactor = { version = "0.0.0", path = "../hyperactor" }
 monarch_gil = { version = "0.0.0", path = "../monarch_gil" }
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 thiserror = "2.0.18"

--- a/monarch_messages/src/controller.rs
+++ b/monarch_messages/src/controller.rs
@@ -14,7 +14,6 @@ use hyperactor::RefClient;
 use pyo3::FromPyObject;
 use pyo3::IntoPyObject;
 use pyo3::IntoPyObjectExt;
-use pyo3::types::PyAnyMethods;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -31,7 +30,7 @@ pub enum Ranks {
 }
 
 impl Ranks {
-    pub fn iter_slices<'a>(&'a self) -> std::slice::Iter<'a, ndslice::Slice> {
+    pub fn iter_slices(&self) -> std::slice::Iter<'_, ndslice::Slice> {
         match self {
             Self::Slice(slice) => std::slice::from_ref(slice).iter(),
             Self::SliceList(slices) => slices.iter(),
@@ -102,9 +101,11 @@ impl From<&Seq> for u64 {
     }
 }
 
-impl FromPyObject<'_> for Seq {
-    fn extract_bound(ob: &pyo3::Bound<'_, pyo3::PyAny>) -> pyo3::PyResult<Self> {
-        Ok(Self(ob.extract::<u64>()?))
+impl FromPyObject<'_, '_> for Seq {
+    type Error = pyo3::PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, pyo3::PyAny>) -> pyo3::PyResult<Self> {
+        Ok(Self(obj.extract::<u64>()?))
     }
 }
 

--- a/monarch_messages/src/wire_value.rs
+++ b/monarch_messages/src/wire_value.rs
@@ -51,9 +51,11 @@ pub enum WireValue {
 }
 wirevalue::register_type!(WireValue);
 
-impl FromPyObject<'_> for WireValue {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
-        Ok(WireValue::PyObject(PickledPyObject::pickle(obj)?))
+impl FromPyObject<'_, '_> for WireValue {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+        Ok(WireValue::PyObject(PickledPyObject::pickle(&obj)?))
     }
 }
 

--- a/monarch_messages/src/worker.rs
+++ b/monarch_messages/src/worker.rs
@@ -261,7 +261,7 @@ impl FunctionPath {
             if function.hasattr("_remote_impl")? {
                 function = function.getattr("_remote_impl")?;
             }
-            Ok(function.downcast_into()?)
+            Ok(function.cast_into()?)
         }
     }
 }
@@ -311,7 +311,7 @@ impl Cloudpickle {
         let py = obj.py();
         let dumps = cloudpickle_dumps(py);
         let bytes_obj = dumps.call1((obj,))?;
-        let bytes = bytes_obj.downcast::<PyBytes>()?.as_bytes().to_vec();
+        let bytes = bytes_obj.cast::<PyBytes>()?.as_bytes().to_vec();
         Ok(Self { bytes })
     }
 }
@@ -375,15 +375,15 @@ impl ArgsKwargs {
         py: Python<'py>,
     ) -> PyResult<(Bound<'py, PyTuple>, Bound<'py, PyDict>)> {
         let tuple = self.payload.resolve(py)?;
-        let tuple = tuple.downcast::<PyTuple>()?;
+        let tuple = tuple.cast::<PyTuple>()?;
 
         // Extract args (first element)
         let args = tuple.get_item(0)?;
-        let args_tuple = args.downcast::<PyTuple>()?;
+        let args_tuple = args.cast::<PyTuple>()?;
 
         // Extract kwargs (second element)
         let kwargs = tuple.get_item(1)?;
-        let kwargs_dict = kwargs.downcast::<PyDict>()?;
+        let kwargs_dict = kwargs.cast::<PyDict>()?;
 
         Ok((args_tuple.clone(), kwargs_dict.clone()))
     }

--- a/monarch_rdma/extension/Cargo.toml
+++ b/monarch_rdma/extension/Cargo.toml
@@ -18,7 +18,7 @@ hyperactor_mesh = { version = "0.0.0", path = "../../hyperactor_mesh" }
 monarch_hyperactor = { version = "0.0.0", path = "../../monarch_hyperactor" }
 monarch_rdma = { version = "0.0.0", path = ".." }
 monarch_types = { version = "0.0.0", path = "../../monarch_types" }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde_json = { version = "1.0.140", features = ["alloc", "float_roundtrip", "raw_value", "unbounded_depth"] }
 tokio = { version = "1.52.4", features = ["full", "test-util", "tracing"] }
 tracing = { version = "0.1.41", features = ["attributes", "valuable"] }

--- a/monarch_tensor_worker/Cargo.toml
+++ b/monarch_tensor_worker/Cargo.toml
@@ -22,7 +22,7 @@ monarch_messages = { version = "0.0.0", path = "../monarch_messages", default-fe
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 ndslice = { version = "0.0.0", path = "../ndslice" }
 parking_lot = { version = "0.12.1", features = ["arc_lock", "send_guard"] }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 sorted-vec = "0.8.10"
 tokio = { version = "1.52.4", features = ["full", "test-util", "tracing"] }

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -879,7 +879,8 @@ impl StreamActor {
                 device_meshes,
                 remote_process_groups,
             )?;
-            Ok(PyTree::<Py<PyAny>>::extract_bound(&result)
+            Ok(result
+                .extract::<PyTree<Py<PyAny>>>()
                 .map_err(SerializablePyErr::from_fn(py))?)
         })
     }
@@ -1601,7 +1602,9 @@ impl StreamMessageHandler for StreamActor {
         self.try_define(cx, seq, params.results, &mutates, async |self| {
             let result = self.call_actor(cx, params.call).await?;
             let result = monarch_with_gil_blocking(GilSite::StreamCompute, |py| {
-                PyTree::<Py<PyAny>>::extract_bound(&result.into_bound(py))
+                result
+                    .into_bound(py)
+                    .extract::<PyTree<Py<PyAny>>>()
                     .map_err(SerializablePyErr::from_fn(py))
             })?;
             Ok(result.into_leaves())

--- a/monarch_types/Cargo.toml
+++ b/monarch_types/Cargo.toml
@@ -10,7 +10,7 @@ license = "BSD-3-Clause"
 [dependencies]
 derive_more = { version = "1.0.0", features = ["full"] }
 monarch_gil = { version = "0.0.0", path = "../monarch_gil" }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 serde_bytes = "0.11"
 typeuri = { version = "0.0.0", path = "../typeuri" }

--- a/monarch_types/src/pyobject.rs
+++ b/monarch_types/src/pyobject.rs
@@ -20,11 +20,11 @@ pub struct PickledPyObject {
 }
 
 impl PickledPyObject {
-    pub fn pickle<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    pub fn pickle(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Self::pickle_impl(obj, false)
     }
 
-    pub fn cloudpickle<'py>(obj: &Bound<'py, PyAny>) -> PyResult<Self> {
+    pub fn cloudpickle(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
         Self::pickle_impl(obj, true)
     }
 
@@ -32,13 +32,13 @@ impl PickledPyObject {
         if cloudpickle { "cloudpickle" } else { "pickle" }
     }
 
-    fn pickle_impl<'py>(obj: &Bound<'py, PyAny>, cloudpickle: bool) -> PyResult<Self> {
+    fn pickle_impl(obj: &Bound<'_, PyAny>, cloudpickle: bool) -> PyResult<Self> {
         let module = Self::module(cloudpickle);
         let bytes = obj
             .py()
             .import(module)?
             .call_method1("dumps", (obj,))?
-            .downcast_into::<PyBytes>()?
+            .cast_into::<PyBytes>()?
             .as_bytes()
             .to_vec();
         Ok(Self { bytes, cloudpickle })
@@ -64,9 +64,11 @@ impl TryFrom<Bound<'_, PyAny>> for PickledPyObject {
     }
 }
 
-impl FromPyObject<'_> for PickledPyObject {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
-        PickledPyObject::pickle(obj)
+impl FromPyObject<'_, '_> for PickledPyObject {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+        PickledPyObject::pickle(&obj)
     }
 }
 

--- a/monarch_types/src/pytree.rs
+++ b/monarch_types/src/pytree.rs
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use pyo3::Borrowed;
 use pyo3::Bound;
 use pyo3::FromPyObject;
 use pyo3::IntoPyObject;
@@ -215,8 +216,8 @@ where
     }
 }
 
-impl<'a, T: FromPyObject<'a>> PyTree<T> {
-    pub fn flatten(tree: &Bound<'a, PyAny>) -> PyResult<Self> {
+impl<'py, T: for<'a> FromPyObject<'a, 'py>> PyTree<T> {
+    pub fn flatten(tree: &Bound<'py, PyAny>) -> PyResult<Self> {
         let py = tree.py();
 
         // Call into pytorch's flatten.
@@ -225,11 +226,11 @@ impl<'a, T: FromPyObject<'a>> PyTree<T> {
         let res = tree_flatten.call1((tree,))?;
 
         // Convert leaves to Rust objects.
-        let (leaves, treespec) = match res.downcast::<PyTuple>()?.as_slice() {
+        let (leaves, treespec) = match res.cast::<PyTuple>()?.as_slice() {
             [leaves, treespec] => {
                 let mut out = vec![];
                 for leaf in leaves.try_iter()? {
-                    out.push(T::extract_bound(&leaf?)?);
+                    out.push(leaf?.extract::<T>().map_err(Into::into)?);
                 }
                 (out, treespec)
             }
@@ -238,7 +239,7 @@ impl<'a, T: FromPyObject<'a>> PyTree<T> {
 
         if treespec
             .call_method0("is_leaf")?
-            .downcast::<PyBool>()?
+            .cast::<PyBool>()?
             .is_true()
         {
             Ok(Self {
@@ -255,9 +256,11 @@ impl<'a, T: FromPyObject<'a>> PyTree<T> {
 }
 
 /// Deserialize from a `PyObject`.
-impl<'a, T: FromPyObject<'a>> FromPyObject<'a> for PyTree<T> {
-    fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
-        Self::flatten(ob)
+impl<'a, 'py, T: for<'b> FromPyObject<'b, 'py>> FromPyObject<'a, 'py> for PyTree<T> {
+    type Error = PyErr;
+
+    fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> {
+        Self::flatten(&obj)
     }
 }
 

--- a/torch-sys-cuda/Cargo.toml
+++ b/torch-sys-cuda/Cargo.toml
@@ -13,7 +13,7 @@ derive_more = { version = "1.0.0", features = ["full"] }
 fxhash = "0.2.1"
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
 nccl-sys = { path = "../nccl-sys", optional = true }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 thiserror = "2.0.18"
 torch-sys2 = { version = "0.0.0", path = "../torch-sys2" }
 

--- a/torch-sys2/Cargo.toml
+++ b/torch-sys2/Cargo.toml
@@ -9,7 +9,7 @@ license = "BSD-3-Clause"
 
 [dependencies]
 monarch_types = { version = "0.0.0", path = "../monarch_types" }
-pyo3 = { version = "0.26", features = ["anyhow", "multiple-pymethods", "py-clone"] }
+pyo3 = { version = "0.27", features = ["anyhow", "multiple-pymethods", "py-clone"] }
 serde = { version = "1.0.219", features = ["derive", "rc"] }
 thiserror = "2.0.18"
 

--- a/torch-sys2/src/lib.rs
+++ b/torch-sys2/src/lib.rs
@@ -89,8 +89,11 @@ impl Device {
     }
 }
 
-impl FromPyObject<'_> for Device {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for Device {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+        let obj = &*obj;
         let device_str: String = obj.str()?.extract()?;
         // Parse the device string
         device_str.parse().map_err(|e: DeviceParseError| {
@@ -205,8 +208,11 @@ pub enum LayoutDef {
     Mkldnn,
 }
 
-impl FromPyObject<'_> for Layout {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for Layout {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+        let obj = &*obj;
         Python::attach(|py| {
             let strided = torch_strided(py);
             let sparse_coo = torch_sparse_coo(py);
@@ -349,8 +355,11 @@ pub enum ScalarTypeDef {
     Float8_e4m3fnuz,
 }
 
-impl FromPyObject<'_> for ScalarType {
-    fn extract_bound(obj: &Bound<'_, PyAny>) -> PyResult<Self> {
+impl FromPyObject<'_, '_> for ScalarType {
+    type Error = PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, PyAny>) -> PyResult<Self> {
+        let obj = &*obj;
         Python::attach(|py| {
             // Map of PyTorch dtype getters to ScalarType
             let dtype_map = [
@@ -464,7 +473,7 @@ impl Tensor {
         Python::attach(|py| {
             let tensor = self.inner.bind(py);
             let dtype = tensor.getattr("dtype").unwrap();
-            ScalarType::extract_bound(&dtype).unwrap()
+            dtype.extract::<ScalarType>().unwrap()
         })
     }
 
@@ -472,7 +481,7 @@ impl Tensor {
         Python::attach(|py| {
             let tensor = self.inner.bind(py);
             let device = tensor.getattr("device").unwrap();
-            Device::extract_bound(&device).unwrap()
+            device.extract::<Device>().unwrap()
         })
     }
 
@@ -547,10 +556,12 @@ impl Tensor {
     }
 }
 
-impl pyo3::FromPyObject<'_> for Tensor {
-    fn extract_bound(ob: &pyo3::Bound<'_, pyo3::PyAny>) -> pyo3::PyResult<Self> {
+impl pyo3::FromPyObject<'_, '_> for Tensor {
+    type Error = pyo3::PyErr;
+
+    fn extract(obj: pyo3::Borrowed<'_, '_, pyo3::PyAny>) -> pyo3::PyResult<Self> {
         Ok(Tensor {
-            inner: ob.clone().unbind(),
+            inner: pyo3::Bound::clone(&obj).unbind(),
         })
     }
 }


### PR DESCRIPTION
Summary:
X-link: https://github.com/mslsrc/prod_inference/pull/5794


Upgrade PyO3 to 0.27 and fix upgrade-time API breakages:
  - FromPyObject trait shape changed:
      - FromPyObject<'py> / extract_bound(&Bound<'py, PyAny>)
      - becomes FromPyObject<'a, 'py> with type Error and extract(Borrowed<'a, 'py, PyAny>)
  - extract() error typing is stricter:
      - extraction no longer always type-infers as PyErr cleanly in nested PyResult contexts.
      - Stack adds explicit closure return types and .map_err(Into::into) where needed.
  - Downcast APIs are replaced/deprecated:
      - downcast, downcast_bound, downcast_into, downcast_unchecked, DowncastError become cast, cast_bound, cast_into, cast_unchecked, CastError
  - PyCapsule pointer access changed:
      - old code used reference() or raw pointer() plus manual checks.
      - stack moves callsites toward pointer_checked(Some(c"...")), is_valid_checked, and CStr capsule names.

Also aligns required crates with pins and overlays:
   - bumps pyo3, pyo3-async-runtimes, pyo3-build-config, pythonize, and numpy to 0.27.
   - updates pyo3-python-tracing-subscriber to a compatible rev.
   - pins/patches Arrow crates to the git rev with arrow-pyarrow PyO3 0.27 support
   - adds a pyo3-build-config 0.27 overlay/fixup so the vendored crate works with our disabled-buildscript/cross-compile setup.

Reviewed By: dtolnay, yinghai

Differential Revision: D109086625
