### PR TITLE
prove `Future._Tokio` is no longer produced

### DIFF
--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -206,10 +206,13 @@ class Future(Generic[R]):
         )
 
     def _take_inner(self) -> "PythonTask[R]":
-        """Surrender the underlying ``PythonTask`` to a caller that needs to drive
-        it directly (for example to await the raw Rust future without the GIL).
-        Only valid on a Future that has not yet been awaited or resolved; the
-        Future is spent afterward (a second take, or any get()/await, raises).
+        """Take the underlying one-shot ``PythonTask`` from this Future.
+
+        Awaiting the task drives its Rust future inline as part of the caller.
+        Calling ``spawn()`` and awaiting its ``Shared`` observes a separately
+        running producer that is not aborted when the observer is dropped. Only
+        valid on a Future that has not yet been awaited or resolved; the Future is
+        spent afterward (a second take, or any get()/await, raises).
         """
         match self._status:
             case _Unawaited(coro=coro):

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -367,7 +367,7 @@ class HostMesh(MeshTrait):
         for pm in self._proc_meshes:
             await pm._flush_pending_actor_spawns()
             try:
-                await pm._logging_manager.flush_async()
+                await pm._logging_manager._flush_from_tokio()
             except Exception:
                 pass
 

--- a/python/monarch/_src/actor/logging.py
+++ b/python/monarch/_src/actor/logging.py
@@ -14,8 +14,8 @@ from typing import Optional, TextIO, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.logging import LoggingMeshClient
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._src.actor.actor_mesh import context
-from monarch._src.actor.future import Future
 from monarch._src.actor.ipython_check import is_ipython
 
 IN_IPYTHON: bool = is_ipython()
@@ -84,8 +84,8 @@ class LoggingManager:
 
                     def _post_run_cell_flush(_: object) -> None:
                         # For async cells the loop is still running when the
-                        # callback fires; `flush()` would then call
-                        # `Future.get()` inside that loop, which is an error.
+                        # callback fires; `flush()` would then block that loop
+                        # in `Handle.get(timeout=3)`.
                         # Schedule the async flush on the loop instead.
                         try:
                             loop = asyncio.get_running_loop()
@@ -180,17 +180,16 @@ class LoggingManager:
         self.register_flusher_if_in_ipython()
         self.enable_fd_capture_if_in_ipython()
 
+    def _new_flush_task(self) -> PythonTask[None]:
+        """Return an unscheduled Rust logging-flush future wrapped as a PythonTask."""
+        assert self._logging_mesh_client is not None
+        return self._logging_mesh_client.flush(context().actor_instance._as_rust())
+
     def flush(self) -> None:
         assert self._logging_mesh_client is not None
         try:
-            # blocks for this proc mesh until 3 seconds timeout
-            Future(
-                coro=self._logging_mesh_client.flush(
-                    context().actor_instance._as_rust()
-                )
-                .spawn()
-                .task()
-            ).get(timeout=3)
+            # Schedule the Rust future and wait through a Handle for up to 3 seconds.
+            self._new_flush_task().spawn_handle().get(timeout=3)
         except Exception:
             # TODO: A harmless exception happens to come through due to coroutine
             # accessing shared resources via logging_mesh_client. Flush works fine
@@ -198,21 +197,24 @@ class LoggingManager:
             pass
 
     async def flush_async(self) -> None:
-        """Async version of flush for use in async contexts."""
+        """Flush by awaiting a Handle on the current asyncio event loop."""
         if self._logging_mesh_client is None:
             return
         try:
-            # Drive the flush through Future so it works on an asyncio loop too:
-            # a bare `await` of the PythonTask hits the pytokio gate there and is
-            # swallowed below (a silent no-op). Future.__await__ bridges to an
-            # asyncio.Future on a loop and awaits the spawned Shared on a tokio
-            # thread. Mirrors the sync flush().
-            await Future(
-                coro=self._logging_mesh_client.flush(
-                    context().actor_instance._as_rust()
-                )
-                .spawn()
-                .task()
-            )
+            # Schedule the Rust future and await its Handle on the asyncio loop.
+            await self._new_flush_task().spawn_handle()
+        except Exception:
+            pass
+
+    async def _flush_from_tokio(self) -> None:
+        """Flush while Rust's pytokio driver steps this coroutine on Tokio."""
+        if self._logging_mesh_client is None:
+            return
+        try:
+            # Despite being `async def`, this is not an asyncio task. Rust's
+            # pytokio driver advances it on Tokio. `spawn()` starts the Rust
+            # future, and this `await` yields its `Shared` back to pytokio; the
+            # Rust pytokio driver resumes this coroutine when the flush completes.
+            await self._new_flush_task().spawn()
         except Exception:
             pass

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -675,7 +675,7 @@ class ProcMesh(MeshTrait):
         async def _stop_nonblocking(instance: HyInstance) -> None:
             await self._flush_pending_actor_spawns()
             pm = await self._proc_mesh
-            await self._logging_manager.flush_async()
+            await self._logging_manager._flush_from_tokio()
             await pm.stop_nonblocking(instance, reason)
             self._stopped = True
 

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -494,7 +494,7 @@ class ProcMesh(MeshTrait):
             # it here before any of the other python actors are spawned so
             # that the environment variables are set up before cuda init.
             if setup_actor is not None:
-                await setup_actor.setup.call()
+                await setup_actor.setup.call()._take_inner().spawn()
 
             return hy_proc_mesh
 
@@ -659,7 +659,7 @@ class ProcMesh(MeshTrait):
     async def _flush_pending_actor_spawns(self) -> None:
         for mesh in self._pending_actor_spawns:
             try:
-                await mesh.initialized
+                await mesh.initialized._take_inner().spawn()
             except Exception:
                 pass
         self._pending_actor_spawns.clear()

--- a/python/tests/_monarch/test_logging.py
+++ b/python/tests/_monarch/test_logging.py
@@ -14,7 +14,22 @@ from unittest.mock import Mock, patch
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.logging import flush_all_proc_mesh_logs, LoggingManager
+
+
+class _AwaitTracker:
+    def __init__(self, awaitable: Any) -> None:
+        self._awaitable = awaitable
+        self.awaited = False
+        self.get_called = False
+
+    def __await__(self) -> Any:
+        self.awaited = True
+        return self._awaitable.__await__()
+
+    def get(self, *args: object, **kwargs: object) -> None:
+        self.get_called = True
 
 
 class LoggingManagerTest(TestCase):
@@ -125,50 +140,97 @@ class LoggingManagerTest(TestCase):
         # Assert: None is returned
         self.assertIsNone(result)
 
-    @patch("monarch._src.actor.logging.Future")
     @patch("monarch._src.actor.logging.context")
-    def test_flush_calls_mesh_client_flush(
-        self, mock_context: Mock, mock_future: Mock
-    ) -> None:
-        # Setup: mock context, client, and Future
+    def test_flush_calls_mesh_client_flush(self, mock_context: Mock) -> None:
+        # Setup: mock context, client, task, and handle
         mock_instance = Mock()
         mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
         mock_client = Mock()
         mock_task = Mock()
-        mock_client.flush.return_value.spawn.return_value.task.return_value = mock_task
+        mock_handle = Mock()
+        mock_client.flush.return_value = mock_task
+        mock_task.spawn_handle.return_value = mock_handle
         self.logging_manager._logging_mesh_client = mock_client
 
-        mock_future_instance = Mock()
-        mock_future.return_value = mock_future_instance
-
         # Execute: flush logs
-        self.logging_manager.flush()
+        result = self.logging_manager.flush()
 
-        # Assert: mesh client flush was called
+        # Assert: the native task was observed through a Handle with the timeout.
+        self.assertIsNone(result)
         mock_client.flush.assert_called_once_with(mock_instance)
-        # Assert: Future was created and get was called with timeout
-        mock_future.assert_called_once_with(coro=mock_task)
-        mock_future_instance.get.assert_called_once_with(timeout=3)
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_task.spawn.assert_not_called()
+        mock_handle.get.assert_called_once_with(timeout=3)
 
-    @patch("monarch._src.actor.logging.Future")
     @patch("monarch._src.actor.logging.context")
-    def test_flush_handles_exception_gracefully(
-        self, mock_context: Mock, mock_future: Mock
-    ) -> None:
-        # Setup: mock context, client, and Future that raises exception
+    def test_flush_handles_exception_gracefully(self, mock_context: Mock) -> None:
+        # Setup: make Handle observation raise an ordinary exception.
         mock_instance = Mock()
         mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
         mock_client = Mock()
+        mock_task = Mock()
+        mock_handle = Mock()
+        mock_client.flush.return_value = mock_task
+        mock_task.spawn_handle.return_value = mock_handle
+        mock_handle.get.side_effect = Exception("Test exception")
         self.logging_manager._logging_mesh_client = mock_client
 
-        mock_future_instance = Mock()
-        mock_future_instance.get.side_effect = Exception("Test exception")
-        mock_future.return_value = mock_future_instance
-
         # Execute: flush logs (should not raise exception)
-        self.logging_manager.flush()
+        result = self.logging_manager.flush()
 
-        # Assert: no exception is raised and method completes gracefully
+        # Assert: the operation was started and the observer error was suppressed.
+        self.assertIsNone(result)
+        mock_client.flush.assert_called_once_with(mock_instance)
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_handle.get.assert_called_once_with(timeout=3)
+
+    def test_flush_from_tokio_awaits_shared_not_handle(self) -> None:
+        mock_task = Mock()
+        shared = _AwaitTracker(Shared.from_value(None))
+        mock_task.spawn.return_value = shared
+        self.logging_manager._logging_mesh_client = Mock()
+
+        with patch.object(
+            self.logging_manager, "_new_flush_task", return_value=mock_task
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
+        mock_task.spawn.assert_called_once_with()
+        mock_task.spawn_handle.assert_not_called()
+        self.assertTrue(shared.awaited)
+        self.assertFalse(shared.get_called)
+
+    def test_flush_from_tokio_without_client_is_noop(self) -> None:
+        with patch.object(
+            self.logging_manager, "_new_flush_task"
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_not_called()
+
+    def test_flush_from_tokio_suppresses_ordinary_error(self) -> None:
+        async def fail() -> None:
+            raise RuntimeError("test error")
+
+        self.logging_manager._logging_mesh_client = Mock()
+        with patch.object(
+            self.logging_manager,
+            "_new_flush_task",
+            return_value=PythonTask.from_coroutine(fail()),
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
 
 
 class FlushAllProcMeshLogsTest(TestCase):
@@ -204,6 +266,26 @@ class FlushAllProcMeshLogsTest(TestCase):
 class LoggingManagerAsyncTest(IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.logging_manager = LoggingManager()
+
+    async def test_flush_async_awaits_handle_not_shared(self) -> None:
+        ready = asyncio.get_running_loop().create_future()
+        ready.set_result(None)
+        handle = _AwaitTracker(ready)
+        mock_task = Mock()
+        mock_task.spawn_handle.return_value = handle
+        self.logging_manager._logging_mesh_client = Mock()
+
+        with patch.object(
+            self.logging_manager, "_new_flush_task", return_value=mock_task
+        ) as mock_new_flush_task:
+            result = await self.logging_manager.flush_async()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_task.spawn.assert_not_called()
+        self.assertTrue(handle.awaited)
+        self.assertFalse(handle.get_called)
 
     @patch("monarch._src.actor.logging.LoggingMeshClient")
     @patch("monarch._src.actor.logging.context")

--- a/python/tests/test_actor_driver_characterization.py
+++ b/python/tests/test_actor_driver_characterization.py
@@ -58,10 +58,9 @@ class _DriverProbe(Actor):
             bare_await_raised = True
 
         # (3) Awaiting a monarch Future here takes the _Handle (asyncio) path,
-        # not _Tokio. Scope the oracle (so a process-wide oracle is left
-        # intact) and count only _Tokio attributed to this probe body, so
-        # unrelated concurrent activity on the loop can't perturb the count.
-        with tokio_oracle() as records:
+        # not _Tokio. Preserve a process-wide raise-mode oracle while this
+        # probe runs.
+        with tokio_oracle(raise_on_produce=True) as records:
             await Future(coro=PythonTask.sleep(0))
             tokio_count = sum(
                 1 for r in records if r.module == __name__ and r.function == "probe"

--- a/python/tests/test_client_shutdown.py
+++ b/python/tests/test_client_shutdown.py
@@ -40,7 +40,9 @@ def test_client_shutdown() -> None:
     # Now shutdown the client. Delete references to avoid accidental reuse.
     del procs
     del actors
-    shutdown_context().get()
+    assert shutdown_context().get() is None
+    # The already-complete shutdown path remains safe and idempotent.
+    assert shutdown_context().get() is None
     # After this, all the resources created by the client should be released,
     # including this_host and the procs. We check this by seeing if the pids are
     # still alive after a short wait period (procs are cleaned up with an async

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, attach, context
 from monarch._src.actor.bootstrap import attach_to_workers
@@ -63,9 +64,10 @@ def test_multi_host_mesh() -> None:
         assert hy_host.region.slice() == host.region.slice()
 
         # Hosts 5 and 7
-        sliced = host._new_with_shape(
-            Shape(labels=["hosts"], slice=Slice(offset=5, sizes=[2], strides=[2]))
+        slice_shape = Shape(
+            labels=["hosts"], slice=Slice(offset=5, sizes=[2], strides=[2])
         )
+        sliced = host._new_with_shape(slice_shape)
         assert sliced.extent.labels == ["hosts"]
         assert sliced.extent.sizes == [2]
         assert not sliced.stream_logs
@@ -74,6 +76,25 @@ def test_multi_host_mesh() -> None:
         hy_sliced = sliced._hy_host_mesh.block_on()
         assert hy_sliced.region.labels == sliced.region.labels
         assert hy_sliced.region.slice() == sliced.region.slice()
+
+        release_host_mesh = threading.Event()
+
+        async def resolve_host_mesh():
+            await PythonTask.spawn_blocking(release_host_mesh.wait)
+            return hy_host
+
+        # Keep the native mesh unresolved so slicing must take the pending path.
+        host._inner_host_mesh = PythonTask.from_coroutine(resolve_host_mesh()).spawn()
+        try:
+            assert host._hy_host_mesh.poll() is None
+            pending_sliced = host._new_with_shape(slice_shape)
+            assert pending_sliced._hy_host_mesh.poll() is None
+        finally:
+            release_host_mesh.set()
+
+        hy_pending_sliced = pending_sliced._hy_host_mesh.block_on()
+        assert hy_pending_sliced.region.labels == pending_sliced.region.labels
+        assert hy_pending_sliced.region.slice() == pending_sliced.region.slice()
 
 
 @pytest.mark.timeout(120)

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -1842,12 +1842,12 @@ def test_exec_command_output_dir_suppresses_printing(capsys):
 def test_exec_command_produces_no_tokio():
     """Gate A (job cluster): exec_command produces no `_Tokio` state.
 
-    Drives exec_command with the record-only `_Tokio` oracle enabled and asserts
+    Drives exec_command with the `_Tokio` oracle in raise mode and asserts
     job.py produced no `_Tokio` (no `await <Future>` on the tokio thread). Before
-    the `_take_inner()` migration this recorded the three job producers
+    the `_take_inner()` migration this found the three job producers
     (run_python.call, run.call, procs.stop); after it, zero.
     """
-    with tokio_oracle() as records:
+    with tokio_oracle(raise_on_produce=True) as records:
         # shell branch: exercises run.call + the procs.stop finally
         host_mesh, _procs, bash_actors, _markers = _exec_env()
         bash_actors.run.call.return_value = _results_future(

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -30,7 +30,7 @@ from monarch._src.actor.actor_mesh import (
     ValueMesh,
 )
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.future import tokio_oracle, TokioOracleRecord
+from monarch._src.actor.future import Future, tokio_oracle, TokioOracleRecord
 from monarch._src.actor.host_mesh import this_host, this_proc
 from monarch._src.actor.proc_mesh import (
     get_or_spawn_controller,
@@ -44,6 +44,11 @@ from scoped_state import scoped_state
 
 _proc_rank = -1
 _BOOTSTRAP_FAILURE = "stage 3.4 bootstrap failure"
+_STAGE_3_4_ORACLE_FILES = {
+    "monarch._src.actor.host_mesh": "host_mesh.py",
+    "monarch._src.actor.logging": "logging.py",
+    "monarch._src.actor.proc_mesh": "proc_mesh.py",
+}
 
 
 def _successful_bootstrap() -> None:
@@ -54,20 +59,30 @@ def _fail_bootstrap() -> None:
     raise RuntimeError(_BOOTSTRAP_FAILURE)
 
 
-def _tokio_records_for(
+def _stage_3_4_tokio_records(
     records: list[TokioOracleRecord],
-    *,
-    module: str,
-    filename: str,
-    function: str | None = None,
 ) -> list[TokioOracleRecord]:
     return [
         record
         for record in records
-        if record.module == module
-        and os.path.basename(record.filename) == filename
-        and (function is None or record.function == function)
+        if _STAGE_3_4_ORACLE_FILES.get(record.module)
+        == os.path.basename(record.filename)
     ]
+
+
+class _PendingActorProbe:
+    def __init__(
+        self,
+        name: str,
+        driven: list[str],
+        error: Exception | None = None,
+    ) -> None:
+        async def initialize() -> None:
+            driven.append(name)
+            if error is not None:
+                raise error
+
+        self.initialized = Future(coro=initialize())
 
 
 class TestActor(Actor):
@@ -123,24 +138,18 @@ async def test_proc_mesh_initialization() -> None:
                 bootstrap=_successful_bootstrap,
             )
             assert await proc_mesh.initialized
-
-            setup_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.proc_mesh",
-                filename="proc_mesh.py",
-                function="task",
-            )
-            assert len(setup_records) == 1
+            assert _stage_3_4_tokio_records(records) == []
 
 
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
-        proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
-
-        with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
-            await proc_mesh.initialized
+        with tokio_oracle() as records:
+            proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
+            with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
+                await proc_mesh.initialized
+            assert _stage_3_4_tokio_records(records) == []
 
 
 @pytest.mark.timeout(60)
@@ -191,13 +200,8 @@ async def test_stop_state_tracks_native_stop_result() -> None:
             with tokio_oracle() as records:
                 assert await owner.stop() is None
 
-                logging_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.logging",
-                    filename="logging.py",
-                )
                 assert proc_flush_called
-                assert logging_records == []
+                assert _stage_3_4_tokio_records(records) == []
         assert flush_started
         assert owner._stopped
 
@@ -455,6 +459,23 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
 
         # spawn actor but do NOT await initialized — immediately shutdown
         actor_mesh = proc_mesh.spawn("test_actor", TestActor, 42)
+        drain_order: list[str] = []
+        proc_mesh._pending_actor_spawns.extend(
+            [
+                cast(
+                    ActorMesh,
+                    _PendingActorProbe(
+                        "failed",
+                        drain_order,
+                        RuntimeError("pending actor initialization failed"),
+                    ),
+                ),
+                cast(
+                    ActorMesh,
+                    _PendingActorProbe("succeeded", drain_order),
+                ),
+            ]
+        )
 
         with (
             patch.object(logging_manager, "_new_flush_task", record_flush_start),
@@ -469,29 +490,11 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
                 cleanup.pop_all()
                 assert shutdown_result is None
 
-                proc_drain_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.proc_mesh",
-                    filename="proc_mesh.py",
-                    function="_flush_pending_actor_spawns",
-                )
-                logging_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.logging",
-                    filename="logging.py",
-                )
-                host_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.host_mesh",
-                    filename="host_mesh.py",
-                )
-
-                assert len(proc_drain_records) == 1
                 assert host_flush_called
-                assert logging_records == []
-                assert host_records == []
+                assert _stage_3_4_tokio_records(records) == []
 
         assert flush_started
+        assert drain_order == ["failed", "succeeded"]
         assert await actor_mesh.initialized is None
         assert proc_mesh._pending_actor_spawns == []
 

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -132,7 +132,7 @@ class TestActor(Actor):
 async def test_proc_mesh_initialization() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         host = state.hosts
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             proc_mesh = host.spawn_procs(
                 name="test_proc",
                 bootstrap=_successful_bootstrap,
@@ -145,7 +145,7 @@ async def test_proc_mesh_initialization() -> None:
 @isolate_in_subprocess
 async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
             with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
                 await proc_mesh.initialized
@@ -197,7 +197,7 @@ async def test_stop_state_tracks_native_stop_result() -> None:
                 record_flush_from_tokio,
             ),
         ):
-            with tokio_oracle() as records:
+            with tokio_oracle(raise_on_produce=True) as records:
                 assert await owner.stop() is None
 
                 assert proc_flush_called
@@ -243,13 +243,28 @@ def test_proc_mesh_sliced() -> None:
         # Initialize _proc_rank on each actor process
         actor = proc_mesh.spawn("test_actor", TestActor, 42)
         actor.get_proc_rank.call().get()
+        hy_proc_mesh = proc_mesh._proc_mesh.block_on()
+        release_proc_mesh = threading.Event()
+
+        async def resolve_proc_mesh() -> HyProcMesh:
+            await PythonTask.spawn_blocking(release_proc_mesh.wait)
+            return hy_proc_mesh
+
+        # Keep the native mesh unresolved so slicing must take the pending path.
+        proc_mesh._proc_mesh = PythonTask.from_coroutine(resolve_proc_mesh()).spawn()
+
         # Hosts 0 and 2, gpus 1 and 2
-        sliced = proc_mesh._new_with_shape(
-            Shape(
-                labels=["hosts", "gpus"],
-                slice=Slice(offset=1, sizes=[2, 2], strides=[6, 1]),
-            )
+        slice_shape = Shape(
+            labels=["hosts", "gpus"],
+            slice=Slice(offset=1, sizes=[2, 2], strides=[6, 1]),
         )
+        try:
+            assert proc_mesh._proc_mesh.poll() is None
+            sliced = proc_mesh._new_with_shape(slice_shape)
+            assert sliced._proc_mesh.poll() is None
+        finally:
+            release_proc_mesh.set()
+
         actor = sliced.spawn("test_actor_sliced", TestActor, 42)
         proc_ranks = actor.get_proc_rank.call().get()
         assert proc_ranks.extent.labels == ["hosts", "gpus"]
@@ -485,7 +500,7 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
                 record_flush_from_tokio,
             ),
         ):
-            with tokio_oracle() as records:
+            with tokio_oracle(raise_on_produce=True) as records:
                 shutdown_result = await host.shutdown()
                 cleanup.pop_all()
                 assert shutdown_result is None

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -149,6 +149,8 @@ async def test_stop_state_tracks_native_stop_result() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         owner = state.hosts.spawn_procs(per_host={"gpus": 2})
         await owner.initialized
+        logging_manager = owner._logging_manager
+        assert logging_manager._logging_mesh_client is not None
         proc_ref = owner.slice(gpus=0)
 
         with pytest.raises(
@@ -158,7 +160,45 @@ async def test_stop_state_tracks_native_stop_result() -> None:
             await proc_ref.stop()
 
         assert not proc_ref._stopped
-        assert await owner.stop() is None
+        flush_started = False
+        proc_flush_called = False
+        new_flush_task = logging_manager._new_flush_task
+        flush_from_tokio = logging_manager._flush_from_tokio
+
+        def record_flush_start() -> PythonTask[None]:
+            flush_task = new_flush_task()
+
+            async def task() -> None:
+                nonlocal flush_started
+                flush_started = True
+                await flush_task
+
+            return PythonTask.from_coroutine(task())
+
+        async def record_flush_from_tokio() -> None:
+            nonlocal proc_flush_called
+            proc_flush_called = True
+            await flush_from_tokio()
+
+        with (
+            patch.object(logging_manager, "_new_flush_task", record_flush_start),
+            patch.object(
+                logging_manager,
+                "_flush_from_tokio",
+                record_flush_from_tokio,
+            ),
+        ):
+            with tokio_oracle() as records:
+                assert await owner.stop() is None
+
+                logging_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.logging",
+                    filename="logging.py",
+                )
+                assert proc_flush_called
+                assert logging_records == []
+        assert flush_started
         assert owner._stopped
 
 
@@ -390,38 +430,68 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
         host = job.state(cached_path=None).hosts
         proc_mesh = host.spawn_procs(name="test")
         await proc_mesh.initialized
-        assert proc_mesh._logging_manager._logging_mesh_client is not None
+        logging_manager = proc_mesh._logging_manager
+        assert logging_manager._logging_mesh_client is not None
+
+        flush_started = False
+        host_flush_called = False
+        new_flush_task = logging_manager._new_flush_task
+        flush_from_tokio = logging_manager._flush_from_tokio
+
+        def record_flush_start() -> PythonTask[None]:
+            flush_task = new_flush_task()
+
+            async def task() -> None:
+                nonlocal flush_started
+                flush_started = True
+                await flush_task
+
+            return PythonTask.from_coroutine(task())
+
+        async def record_flush_from_tokio() -> None:
+            nonlocal host_flush_called
+            host_flush_called = True
+            await flush_from_tokio()
 
         # spawn actor but do NOT await initialized — immediately shutdown
         actor_mesh = proc_mesh.spawn("test_actor", TestActor, 42)
 
-        with tokio_oracle() as records:
-            shutdown_result = await host.shutdown()
-            cleanup.pop_all()
-            assert shutdown_result is None
+        with (
+            patch.object(logging_manager, "_new_flush_task", record_flush_start),
+            patch.object(
+                logging_manager,
+                "_flush_from_tokio",
+                record_flush_from_tokio,
+            ),
+        ):
+            with tokio_oracle() as records:
+                shutdown_result = await host.shutdown()
+                cleanup.pop_all()
+                assert shutdown_result is None
 
-            proc_drain_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.proc_mesh",
-                filename="proc_mesh.py",
-                function="_flush_pending_actor_spawns",
-            )
-            logging_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.logging",
-                filename="logging.py",
-                function="flush_async",
-            )
-            host_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.host_mesh",
-                filename="host_mesh.py",
-            )
+                proc_drain_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.proc_mesh",
+                    filename="proc_mesh.py",
+                    function="_flush_pending_actor_spawns",
+                )
+                logging_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.logging",
+                    filename="logging.py",
+                )
+                host_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.host_mesh",
+                    filename="host_mesh.py",
+                )
 
-            assert len(proc_drain_records) == 1
-            assert len(logging_records) == 1
-            assert host_records == []
+                assert len(proc_drain_records) == 1
+                assert host_flush_called
+                assert logging_records == []
+                assert host_records == []
 
+        assert flush_started
         assert await actor_mesh.initialized is None
         assert proc_mesh._pending_actor_spawns == []
 

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -49,6 +49,7 @@ from monarch._src.actor.future import (
     enable_tokio_oracle,
     Future,
     reset_tokio_oracle,
+    tokio_oracle,
     tokio_oracle_records,
 )
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
@@ -1091,7 +1092,16 @@ async def test_flush_async_drives_flush_on_asyncio_loop() -> None:
         await asyncio.sleep(1)
 
         # System under test: flush_async on the test's asyncio loop.
-        await pm._logging_manager.flush_async()
+        with tokio_oracle() as records:
+            await pm._logging_manager.flush_async()
+
+            logging_records = [
+                record
+                for record in records
+                if record.module == "monarch._src.actor.logging"
+                and os.path.basename(record.filename) == "logging.py"
+            ]
+            assert logging_records == []
 
         await asyncio.sleep(1)
         sys.stdout.flush()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -44,14 +44,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
-from monarch._src.actor.future import (
-    disable_tokio_oracle,
-    enable_tokio_oracle,
-    Future,
-    reset_tokio_oracle,
-    tokio_oracle,
-    tokio_oracle_records,
-)
+from monarch._src.actor.future import Future, tokio_oracle
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
 from monarch._src.actor.logging import _pending_flush_tasks
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
@@ -1092,7 +1085,7 @@ async def test_flush_async_drives_flush_on_asyncio_loop() -> None:
         await asyncio.sleep(1)
 
         # System under test: flush_async on the test's asyncio loop.
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             await pm._logging_manager.flush_async()
 
             logging_records = [
@@ -2318,21 +2311,13 @@ def test_accumulate_forwards_args_to_stream():
 def test_accumulate_produces_no_tokio():
     """Gate A (accumulate cluster): accumulate produces no `_Tokio` state.
 
-    Drives accumulate with the record-only `_Tokio` oracle enabled and asserts
+    Drives accumulate with the `_Tokio` oracle in raise mode and asserts
     actor_mesh.py produced no `_Tokio` (no `await <Future>` on the tokio thread).
     Before the `_take_inner()` migration this recorded the impl producer at 876;
     after it, zero.
     """
-    disable_tokio_oracle()
-    reset_tokio_oracle()
-    enable_tokio_oracle()
-    try:
+    with tokio_oracle(raise_on_produce=True) as oracle_records:
         acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
         assert acc.accumulate().get() == 6
-        records = [
-            r for r in tokio_oracle_records() if r.filename.endswith("actor_mesh.py")
-        ]
+        records = [r for r in oracle_records if r.filename.endswith("actor_mesh.py")]
         assert records == [], f"accumulate still produces _Tokio: {records}"
-    finally:
-        disable_tokio_oracle()
-        reset_tokio_oracle()

--- a/python/tests/test_rdma_initialization.py
+++ b/python/tests/test_rdma_initialization.py
@@ -102,7 +102,7 @@ class _RdmaTokioOracleProbe(Actor):
 
     @endpoint
     async def create_buffer(self) -> tuple[RDMABuffer, list[tuple[str, int, str]]]:
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             self.buffer = RDMABuffer(memoryview(self.data))
             sites = _rdma_tokio_sites(records)
         return self.buffer, sites
@@ -112,7 +112,7 @@ class _RdmaTokioOracleProbe(Actor):
         self,
         buffer: RDMABuffer,
     ) -> tuple[bytes, list[tuple[str, int, str]]]:
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             readback = bytearray(len(_ORACLE_INITIAL))
             assert await buffer.read_into(memoryview(readback)) is None
             assert await buffer.write_from(memoryview(_ORACLE_UPDATED)) is None
@@ -122,7 +122,7 @@ class _RdmaTokioOracleProbe(Actor):
     @endpoint
     async def verify_and_drop(self) -> list[tuple[str, int, str]]:
         assert self.buffer is not None
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             assert bytes(self.data) == _ORACLE_UPDATED
             assert await self.buffer.drop() is None
             sites = _rdma_tokio_sites(records)
@@ -143,9 +143,25 @@ def test_tokio_oracle_records_known_tokio_production() -> None:
             for record in records
             if record.module == __name__ and record.function == "produce"
         ]
+        assert records == control_sites
         assert len(control_sites) == 1, (
             f"expected one known _Tokio production, got {control_sites}"
         )
+
+
+def test_tokio_oracle_scoped_record_restores_outer_raise_mode() -> None:
+    from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+    from monarch._src.actor.future import Future
+
+    async def produce() -> None:
+        await Future(coro=PythonTask.sleep(0))
+
+    with tokio_oracle(raise_on_produce=True):
+        with tokio_oracle() as records:
+            PythonTask.from_coroutine(produce()).block_on()
+            assert len(records) == 1
+        with pytest.raises(RuntimeError, match="_Tokio produced"):
+            PythonTask.from_coroutine(produce()).block_on()
 
 
 def test_manager_init_cache_reuses_handle_without_retaining_mesh(monkeypatch) -> None:


### PR DESCRIPTION
Summary:
the pytokio-removal stack ending at D113952283 removed the known RDMA, mesh-lifecycle, job, accumulate, and logging producers of `Future._Tokio`. before deleting `_Tokio`, this tests-only diff proves that no remaining production coroutine awaits a Monarch `Future` while driven directly by Tokio.

the runtime gate now fails immediately on any `_Tokio` production. existing zero-oracle tests use scoped raise mode, the positive control requires exactly one known production, and a nesting test proves that a temporary record scope restores the outer raise mode. pending host-mesh and proc-mesh slicing are forced deterministically so those Tokio-driven branches cannot escape coverage.

the static audit closes over 6 direct `PythonTask.from_coroutine` roots and 19 `Future(coro=...)` sites:

- bootstrap, host-mesh, and proc-mesh drivers await only `Shared`, `PythonTask`, or native awaitables;
- shutdown, accumulation, port receive, mesh lifecycle, admin, and job coroutines either await native tasks or explicitly take the underlying task from a `Future`;
- pending-message, actor-response, sync-workspace, and RDMA wrappers contain an existing native `PythonTask`, not a Python coroutine that can await another `Future`.

the root-to-test crosswalk maps bootstrap and host lifecycle to `test_host_mesh`, `test_client_shutdown`, and `test_failure_introspection`; proc construction and lifecycle to `test_proc_mesh`; actor dispatch, accumulation, ports, and responses to `test_actor_driver_characterization`, `test_python_actors`, `test_controller_dedup`, `test_deferred_pickle_characterization`, and `test_cookbook`; job, RDMA, and sync observation to `test_job`, `test_rdma_initialization`, and `test_sync_workspace`; and the remaining raw Tokio drivers to the actor-mesh, hyperactor, logging, mailbox, and proc-launcher tests.

the three cookbook examples also run under raise mode as an inventory-independent smoke test. the removal decision rests on the closed static inventory and the raise-mode cases mapped to every root, not on broad coverage from those examples.

this diff does not change production behavior. the following diff can remove `_Tokio` from `Future` and replace Tokio-thread `await Future` with an explicit, non-consuming error.

Differential Revision: D114138892


