### PR TITLE
remove the pytokio-backed `Future` state

### DIFF
--- a/docs/source/api/monarch.actor.rst
+++ b/docs/source/api/monarch.actor.rst
@@ -74,6 +74,7 @@ Messaging is done through the "adverbs" defined for each endpoint
    :undoc-members:
    :inherited-members:
    :show-inheritance:
+   :exclude-members: __init__
 
 .. autoclass:: ValueMesh
    :members:

--- a/monarch_hyperactor/src/endpoint.rs
+++ b/monarch_hyperactor/src/endpoint.rs
@@ -596,17 +596,13 @@ impl PyValueStream {
         })?
         .into();
 
-        let kwargs = PyDict::new(py);
-        kwargs.set_item("coro", task)?;
-        let future = self.future_class.call(py, (), Some(&kwargs))?;
+        let future = self.future_class.call_method1(py, "_from_coro", (task,))?;
         Ok(Some(future))
     }
 }
 
 fn wrap_in_future(py: Python<'_>, task: PyPythonTask) -> PyResult<Py<PyAny>> {
-    let kwargs = PyDict::new(py);
-    kwargs.set_item("coro", task)?;
-    let future = make_future(py).call((), Some(&kwargs))?;
+    let future = make_future(py).call_method1("_from_coro", (task,))?;
     Ok(future.unbind())
 }
 

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -75,8 +75,8 @@
 //! - **RDC-5** (public result contract): buffer creation returns the buffer;
 //!   successful submit and drop tasks return Python `None`, including the public
 //!   read and write methods that delegate to submit.
-//! - **RDC-6** (no RDMA `_Tokio` producer): production `rdma.py` has no Tokio-driven
-//!   coroutine that awaits a `Future` (enforced in `rdma.py`).
+//! - **RDC-6** (no Tokio-driven `Future` await): production `rdma.py` has no
+//!   Tokio-driven coroutine that awaits a `Future` (enforced in `rdma.py`).
 //! - **RDC-7** (validate before eager init): local backend, memory, zero-size, and
 //!   submit-timeout checks complete before the cached readiness helper is called
 //!   (enforced in `RDMABuffer.__init__` and `RDMAAction.submit`).

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -555,7 +555,7 @@ def shutdown_context() -> "Future[None]":
         async def _noop() -> None:
             pass
 
-        return Future(coro=_noop())
+        return Future._from_coro(_noop())
 
     c: Context | None = _context.get()
 
@@ -585,7 +585,7 @@ def shutdown_context() -> "Future[None]":
             await instance.stop_and_wait("shutdown")
             _context.set(None)
 
-    return Future(coro=_shutdown_sequence())
+    return Future._from_coro(_shutdown_sequence())
 
 
 def context() -> Context:
@@ -876,7 +876,7 @@ class Accumulator(Generic[P, R, A]):
                 value = self._combine(value, await x._take_inner())
             return value
 
-        return Future(coro=impl())
+        return Future._from_coro(impl())
 
 
 @rust_struct("monarch_hyperactor::value_mesh::ValueMesh")
@@ -1091,7 +1091,7 @@ class Port(Generic[R]):
         message = PendingMessage(kind, state)
         resolved = message.try_resolve_now()
         if resolved is None:
-            resolved = await Future(coro=cast(Any, message).resolve())
+            resolved = await Future._from_coro(cast(Any, message).resolve())
         self.send_message(resolved)
 
     def exception(self, obj: Exception) -> None: ...
@@ -1203,7 +1203,7 @@ class PortReceiver(Generic[R]):
                 raise ValueError(f"Unexpected message kind: {msg.kind}")
 
     def recv(self) -> "Future[R]":
-        return Future(coro=self._recv())
+        return Future._from_coro(self._recv())
 
     def ranked(self) -> "RankedPortReceiver[R]":
         return RankedPortReceiver[R](self._mailbox, self._receiver)
@@ -1456,7 +1456,7 @@ class _Actor:
 
             response = response_port.resolve_and_send(result)
             if isinstance(response, PythonTask):
-                await Future(coro=response)
+                await Future._from_coro(response)
             else:
                 await response
         except Exception as e:
@@ -1873,17 +1873,17 @@ class ActorMesh(MeshTrait, Generic[T]):
 
     def stop(self, reason: str = "stopped by client") -> "Future[None]":
         instance = context().actor_instance._as_rust()
-        return Future(coro=self._inner.stop(instance, reason))
+        return Future._from_coro(self._inner.stop(instance, reason))
 
     @property
     def initialized(self) -> Future[None]:
-        return Future(coro=self._inner.initialized())
+        return Future._from_coro(self._inner.initialized())
 
     @property
     def _name(self) -> Future[str]:
         """Retrieves the name stored in the ActorMesh internally."""
         # Not called "name" to avoid clashing with a common endpoint name.
-        return Future(coro=self._inner.name())
+        return Future._from_coro(self._inner.name())
 
 
 class ActorError(Exception):

--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -206,10 +206,13 @@ class Future(Generic[R]):
         )
 
     def _take_inner(self) -> "PythonTask[R]":
-        """Surrender the underlying ``PythonTask`` to a caller that needs to drive
-        it directly (for example to await the raw Rust future without the GIL).
-        Only valid on a Future that has not yet been awaited or resolved; the
-        Future is spent afterward (a second take, or any get()/await, raises).
+        """Take the underlying one-shot ``PythonTask`` from this Future.
+
+        Awaiting the task drives its Rust future inline as part of the caller.
+        Calling ``spawn()`` and awaiting its ``Shared`` observes a separately
+        running producer that is not aborted when the observer is dropped. Only
+        valid on a Future that has not yet been awaited or resolved; the Future is
+        spent afterward (a second take, or any get()/await, raises).
         """
         match self._status:
             case _Unawaited(coro=coro):

--- a/python/monarch/_src/actor/future.py
+++ b/python/monarch/_src/actor/future.py
@@ -7,11 +7,8 @@
 # pyre-strict
 
 import asyncio
-import contextlib
 import logging
 import math
-import os
-import sys
 import warnings
 from typing import (
     Any,
@@ -28,7 +25,6 @@ from monarch._rust_bindings.monarch_hyperactor.pytokio import (
     Handle,
     is_tokio_thread,
     PythonTask,
-    Shared,
     WouldBlockRuntime,
 )
 from monarch._src.actor.telemetry import log_with_tracing
@@ -42,34 +38,6 @@ async def _aincomplete(impl: Any, self: Any) -> Any:
     except Exception as e:
         self._set_exception(e)
         raise
-
-
-# Future is our generic mechanism for providing both a synchronous and asynchronous API for
-# Monarch Future objects.
-
-# We treat all code as running in one of two contexts: synchronous (asyncio._get_running_loop() is None)
-# or asynchronous.
-
-# Inside of asynchronous code, clients of our API must use `await` to wait for monarch Futures to prevent
-# blocking the surrounding event loop.
-
-# In synchronous code users must call get() because the call is comming from an non-async function so
-# await is not allowed.
-
-# [avoiding async code duplication]
-# Because we allow for two modes, it is tempting as developers of Monarch to start to write two copies of
-# of code for each mode. However, this results in a lot of confusing code duplication.
-# To avoid this, we utilize the fact that synchronous code is allowed to start/complete an asyncio event loop
-# via asyncio.run in order to complete the `get()` operation. So we can just write the async version and use
-# it to implement the synchronoous version.
-
-# However, starting and running an event loop is somewhat expensive. For simple messages, using an event loop
-# is about 4x slower than just directly waiting on the tokio result. To avoid this slow down we perform an
-# optimization. For any case where the `impl` coroutine of a future calls `await` only on PythonFuture
-# (a Tokio future returning a Python value) objects, we pass requires_loop=False to the Future. In this mode,
-# the future will just run the coroutine manually, and the PythonFuture object will recognize it is being awaited
-# without an event loop (search [avoiding code duplication]) and simply do a blocking wait. By avoiding the event
-# loop machinery, this gives it the same throughput as if we ran it synchronously.
 
 
 class _Unawaited(NamedTuple):
@@ -88,122 +56,35 @@ class _Handle(NamedTuple):
     handle: Handle[Any]
 
 
-class _Tokio(NamedTuple):
-    shared: Shared[Any]
-
-
 class _Taken(NamedTuple):
     pass
 
 
-_Status = _Unawaited | _Complete | _Exception | _Handle | _Tokio | _Taken
-
-
-# The `_Tokio` state means the task was bridged to a pytokio `Shared` on a
-# tokio-thread await; `get()` and `as_asyncio()` both refuse it because that
-# value is only awaitable from a PythonTask coroutine.
-_ALREADY_TOKIO_MSG = (
-    "already converted into a pytokio.Shared object, use 'await' from a "
-    "PythonTask coroutine to get the value."
-)
-
-
-# Record-only instrument for the pytokio-removal migration: it records the
-# callsite each time the `_Tokio` state is produced (the sole production site is
-# the tokio branch of `Future.__await__` below), so the migration can prove per
-# callsite that no production path still produces `_Tokio`. Off by default, so it
-# is a no-op with no behavior change; enable in a test with `enable_tokio_oracle()`
-# or process-wide with MONARCH_TOKIO_ORACLE=1 (record) / =raise. Raise mode is
-# opt-in and never on by default.
-class TokioOracleRecord(NamedTuple):
-    module: str
-    filename: str
-    lineno: int
-    function: str
-
-
-_tokio_oracle_mode: str = os.environ.get("MONARCH_TOKIO_ORACLE", "")
-_tokio_oracle_records: list[TokioOracleRecord] = []
-
-
-def enable_tokio_oracle(*, raise_on_produce: bool = False) -> None:
-    global _tokio_oracle_mode
-    _tokio_oracle_mode = "raise" if raise_on_produce else "record"
-
-
-def disable_tokio_oracle() -> None:
-    global _tokio_oracle_mode
-    _tokio_oracle_mode = ""
-
-
-def reset_tokio_oracle() -> None:
-    _tokio_oracle_records.clear()
-
-
-def tokio_oracle_records() -> list[TokioOracleRecord]:
-    return list(_tokio_oracle_records)
-
-
-@contextlib.contextmanager
-def tokio_oracle(
-    *, raise_on_produce: bool = False
-) -> Generator[list[TokioOracleRecord], None, None]:
-    """Scoped `_Tokio`-production oracle for tests: records (or, with
-    `raise_on_produce`, raises on) every `_Tokio` production for the duration
-    and yields the live records list, then restores the prior mode and records.
-    The save/restore keeps a process-wide oracle (e.g. `MONARCH_TOKIO_ORACLE`)
-    intact, and the scope guarantees cleanup so a caller cannot leak enabled
-    state by forgetting to disable it. Prefer this over the bare
-    `enable_tokio_oracle`/`reset_tokio_oracle`/`disable_tokio_oracle` trio.
-    """
-    global _tokio_oracle_mode
-    prev_mode = _tokio_oracle_mode
-    prev_records = _tokio_oracle_records.copy()
-    _tokio_oracle_mode = "raise" if raise_on_produce else "record"
-    _tokio_oracle_records.clear()
-    try:
-        yield _tokio_oracle_records
-    finally:
-        _tokio_oracle_mode = prev_mode
-        _tokio_oracle_records[:] = prev_records
-
-
-def _record_tokio_production() -> None:
-    # The callsite we want is the coroutine that awaited the Future: two frames
-    # up (this fn -> Future.__await__ -> awaiter).
-    if not _tokio_oracle_mode:
-        return
-    f = sys._getframe(2)
-    record = TokioOracleRecord(
-        module=str(f.f_globals.get("__name__", "<unknown>")),
-        filename=f.f_code.co_filename,
-        lineno=f.f_lineno,
-        function=f.f_code.co_name,
-    )
-    _tokio_oracle_records.append(record)
-    if _tokio_oracle_mode == "raise":
-        raise RuntimeError(
-            f"_Tokio produced at {record.filename}:{record.lineno} "
-            f"in {record.module}.{record.function}"
-        )
+_Status = _Unawaited | _Complete | _Exception | _Handle | _Taken
 
 
 class Future(Generic[R]):
-    """
-    The Future class wraps a PythonTask, which is a handle to a asyncio coroutine running on the Tokio event loop.
-    These coroutines do not use asyncio or asyncio.Future; instead, they are executed directly on the Tokio runtime.
-    The Future class provides both synchronous (.get()) and asynchronous APIs (await) for interacting with these tasks.
+    """A result returned by Monarch asynchronous operations.
 
-    Args:
-        coro (Coroutine[Any, Any, R] | PythonTask[R]): The coroutine or PythonTask representing
-            the asynchronous computation.
-
+    Use ``get()`` from synchronous code. On an asyncio loop, use ``await`` or
+    ``as_asyncio()``. Future objects cannot be constructed directly.
     """
 
-    def __init__(self, *, coro: "Coroutine[Any, Any, R] | PythonTask[R]") -> None:
-        self._status: _Status = _Unawaited(
+    _status: _Status
+
+    def __init__(self) -> None:
+        raise TypeError(
+            "Future objects are returned by Monarch operations and cannot be "
+            "constructed directly."
+        )
+
+    @classmethod
+    def _from_coro(cls, coro: "Coroutine[Any, Any, R] | PythonTask[R]") -> "Future[R]":
+        future = cast("Future[R]", object.__new__(cls))
+        future._status = _Unawaited(
             coro if isinstance(coro, PythonTask) else PythonTask.from_coroutine(coro)
         )
+        return future
 
     def _take_inner(self) -> "PythonTask[R]":
         """Take the underlying one-shot ``PythonTask`` from this Future.
@@ -286,7 +167,7 @@ class Future(Generic[R]):
                     # the timeout path spawns a Handle then raises -- both mutate.)
                     raise WouldBlockRuntime(
                         "Future.get() cannot block from within a Tokio runtime; "
-                        "await the Future inside a PythonTask coroutine instead."
+                        "observe the Future from a synchronous or asyncio context."
                     )
                 if timeout is not None:
                     # Validate the timeout BEFORE spawning: an invalid value must
@@ -330,8 +211,6 @@ class Future(Generic[R]):
                 return cast("R", value)
             case _Exception(exe=exe):
                 raise exe
-            case _Tokio(_):
-                raise ValueError(_ALREADY_TOKIO_MSG)
             case _Taken():
                 raise ValueError("Future was consumed.")
             case _:
@@ -344,13 +223,11 @@ class Future(Generic[R]):
             return self.as_asyncio().__await__()
         elif is_tokio_thread():
             match self._status:
-                case _Unawaited(coro=coro):
-                    _record_tokio_production()
-                    shared = coro.spawn()
-                    self._status = _Tokio(shared)
-                    return shared.__await__()
-                case _Tokio(shared=shared):
-                    return shared.__await__()
+                case _Unawaited():
+                    raise RuntimeError(
+                        "Future cannot be awaited on a Tokio thread; observe it "
+                        "from an asyncio loop or synchronous context."
+                    )
                 case _Handle(_):
                     raise ValueError(
                         "Future is backed by a Handle and is not awaitable on a tokio thread; "
@@ -404,8 +281,6 @@ class Future(Generic[R]):
                     else exe
                 )
                 return cast("asyncio.Future[R]", failed)
-            case _Tokio(_):
-                raise ValueError(_ALREADY_TOKIO_MSG)
             case _Taken():
                 raise ValueError("Future was consumed.")
             case _:

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -367,7 +367,7 @@ class HostMesh(MeshTrait):
         for pm in self._proc_meshes:
             await pm._flush_pending_actor_spawns()
             try:
-                await pm._logging_manager.flush_async()
+                await pm._logging_manager._flush_from_tokio()
             except Exception:
                 pass
 

--- a/python/monarch/_src/actor/host_mesh.py
+++ b/python/monarch/_src/actor/host_mesh.py
@@ -395,7 +395,7 @@ class HostMesh(MeshTrait):
             # Remove the inner host mesh to clean up associated memory.
             self._inner_host_mesh = None
 
-        return Future(coro=task())
+        return Future._from_coro(task())
 
     def stop(self) -> Future[None]:
         """
@@ -415,7 +415,7 @@ class HostMesh(MeshTrait):
             hy_mesh = await self._hy_host_mesh
             await hy_mesh.stop(context().actor_instance._as_rust())
 
-        return Future(coro=task())
+        return Future._from_coro(task())
 
     async def __aenter__(self) -> "HostMesh":
         if self._inner_host_mesh is None:
@@ -466,7 +466,7 @@ class HostMesh(MeshTrait):
             await hm
             return True
 
-        return Future(coro=task())
+        return Future._from_coro(task())
 
     @property
     def _hy_host_mesh(self) -> Shared[HyHostMesh]:
@@ -510,7 +510,7 @@ def _spawn_admin(
         os.environ["MONARCH_ADMIN_URL"] = admin_url
         return admin_url, admin_ref
 
-    return Future(coro=task())
+    return Future._from_coro(task())
 
 
 def hosts_from_config(name: str) -> HostMesh:

--- a/python/monarch/_src/actor/logging.py
+++ b/python/monarch/_src/actor/logging.py
@@ -14,8 +14,8 @@ from typing import Optional, TextIO, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.logging import LoggingMeshClient
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._src.actor.actor_mesh import context
-from monarch._src.actor.future import Future
 from monarch._src.actor.ipython_check import is_ipython
 
 IN_IPYTHON: bool = is_ipython()
@@ -84,8 +84,8 @@ class LoggingManager:
 
                     def _post_run_cell_flush(_: object) -> None:
                         # For async cells the loop is still running when the
-                        # callback fires; `flush()` would then call
-                        # `Future.get()` inside that loop, which is an error.
+                        # callback fires; `flush()` would then block that loop
+                        # in `Handle.get(timeout=3)`.
                         # Schedule the async flush on the loop instead.
                         try:
                             loop = asyncio.get_running_loop()
@@ -180,17 +180,16 @@ class LoggingManager:
         self.register_flusher_if_in_ipython()
         self.enable_fd_capture_if_in_ipython()
 
+    def _new_flush_task(self) -> PythonTask[None]:
+        """Return an unscheduled Rust logging-flush future wrapped as a PythonTask."""
+        assert self._logging_mesh_client is not None
+        return self._logging_mesh_client.flush(context().actor_instance._as_rust())
+
     def flush(self) -> None:
         assert self._logging_mesh_client is not None
         try:
-            # blocks for this proc mesh until 3 seconds timeout
-            Future(
-                coro=self._logging_mesh_client.flush(
-                    context().actor_instance._as_rust()
-                )
-                .spawn()
-                .task()
-            ).get(timeout=3)
+            # Schedule the Rust future and wait through a Handle for up to 3 seconds.
+            self._new_flush_task().spawn_handle().get(timeout=3)
         except Exception:
             # TODO: A harmless exception happens to come through due to coroutine
             # accessing shared resources via logging_mesh_client. Flush works fine
@@ -198,21 +197,24 @@ class LoggingManager:
             pass
 
     async def flush_async(self) -> None:
-        """Async version of flush for use in async contexts."""
+        """Flush by awaiting a Handle on the current asyncio event loop."""
         if self._logging_mesh_client is None:
             return
         try:
-            # Drive the flush through Future so it works on an asyncio loop too:
-            # a bare `await` of the PythonTask hits the pytokio gate there and is
-            # swallowed below (a silent no-op). Future.__await__ bridges to an
-            # asyncio.Future on a loop and awaits the spawned Shared on a tokio
-            # thread. Mirrors the sync flush().
-            await Future(
-                coro=self._logging_mesh_client.flush(
-                    context().actor_instance._as_rust()
-                )
-                .spawn()
-                .task()
-            )
+            # Schedule the Rust future and await its Handle on the asyncio loop.
+            await self._new_flush_task().spawn_handle()
+        except Exception:
+            pass
+
+    async def _flush_from_tokio(self) -> None:
+        """Flush while Rust's pytokio driver steps this coroutine on Tokio."""
+        if self._logging_mesh_client is None:
+            return
+        try:
+            # Despite being `async def`, this is not an asyncio task. Rust's
+            # pytokio driver advances it on Tokio. `spawn()` starts the Rust
+            # future, and this `await` yields its `Shared` back to pytokio; the
+            # Rust pytokio driver resumes this coroutine when the flush completes.
+            await self._new_flush_task().spawn()
         except Exception:
             pass

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -675,7 +675,7 @@ class ProcMesh(MeshTrait):
         async def _stop_nonblocking(instance: HyInstance) -> None:
             await self._flush_pending_actor_spawns()
             pm = await self._proc_mesh
-            await self._logging_manager.flush_async()
+            await self._logging_manager._flush_from_tokio()
             await pm.stop_nonblocking(instance, reason)
             self._stopped = True
 

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -494,7 +494,7 @@ class ProcMesh(MeshTrait):
             # it here before any of the other python actors are spawned so
             # that the environment variables are set up before cuda init.
             if setup_actor is not None:
-                await setup_actor.setup.call()
+                await setup_actor.setup.call()._take_inner().spawn()
 
             return hy_proc_mesh
 
@@ -659,7 +659,7 @@ class ProcMesh(MeshTrait):
     async def _flush_pending_actor_spawns(self) -> None:
         for mesh in self._pending_actor_spawns:
             try:
-                await mesh.initialized
+                await mesh.initialized._take_inner().spawn()
             except Exception:
                 pass
         self._pending_actor_spawns.clear()

--- a/python/monarch/_src/actor/proc_mesh.py
+++ b/python/monarch/_src/actor/proc_mesh.py
@@ -372,7 +372,7 @@ class ProcMesh(MeshTrait):
             await pm
             return True
 
-        return Future(coro=task())
+        return Future._from_coro(task())
 
     @property
     def host_mesh(self) -> "HostMesh":
@@ -462,7 +462,7 @@ class ProcMesh(MeshTrait):
         This must be called on the asyncio stream.
         """
         assert asyncio.get_running_loop() is not None
-        return await Future(coro=self._proc_mesh.task())
+        return await Future._from_coro(self._proc_mesh.task())
 
     @classmethod
     def from_host_mesh(
@@ -679,7 +679,7 @@ class ProcMesh(MeshTrait):
             await pm.stop_nonblocking(instance, reason)
             self._stopped = True
 
-        return Future(coro=_stop_nonblocking(instance))
+        return Future._from_coro(_stop_nonblocking(instance))
 
     async def __aexit__(
         self, exc_type: object, exc_val: object, exc_tb: object

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -925,7 +925,7 @@ def exec_command(
         finally:
             await procs.stop()._take_inner()
 
-    return Future(coro=_impl())
+    return Future._from_coro(_impl())
 
 
 class LocalJob(JobTrait):

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -479,7 +479,9 @@ class RDMABuffer:
         # RDC-6: no Tokio-driven coroutine awaits the Handle; the native drop task
         # waits on it and we wrap that task directly (RDC-3).
         ready = _ensure_init_rdma_manager()
-        return Future(coro=self._buffer.drop(client=client, rdma_manager_init=ready))
+        return Future._from_coro(
+            self._buffer.drop(client=client, rdma_manager_init=ready)
+        )
 
     @property
     def owner(self) -> str:
@@ -544,8 +546,10 @@ class RDMAAction:
         # RDC-6: no Tokio-driven coroutine awaits the Handle; the native submit task
         # waits on it before taking the action lock, and we wrap that task directly.
         ready = _ensure_init_rdma_manager()
-        return Future(
-            coro=self._inner.submit(
-                client=client, timeout=timeout, rdma_manager_init=ready
+        return Future._from_coro(
+            self._inner.submit(
+                client=client,
+                timeout=timeout,
+                rdma_manager_init=ready,
             )
         )

--- a/python/tests/_monarch/test_logging.py
+++ b/python/tests/_monarch/test_logging.py
@@ -14,7 +14,22 @@ from unittest.mock import Mock, patch
 
 import pytest
 from monarch._rust_bindings.monarch_hyperactor.proc_mesh import ProcMesh as HyProcMesh
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.logging import flush_all_proc_mesh_logs, LoggingManager
+
+
+class _AwaitTracker:
+    def __init__(self, awaitable: Any) -> None:
+        self._awaitable = awaitable
+        self.awaited = False
+        self.get_called = False
+
+    def __await__(self) -> Any:
+        self.awaited = True
+        return self._awaitable.__await__()
+
+    def get(self, *args: object, **kwargs: object) -> None:
+        self.get_called = True
 
 
 class LoggingManagerTest(TestCase):
@@ -125,50 +140,97 @@ class LoggingManagerTest(TestCase):
         # Assert: None is returned
         self.assertIsNone(result)
 
-    @patch("monarch._src.actor.logging.Future")
     @patch("monarch._src.actor.logging.context")
-    def test_flush_calls_mesh_client_flush(
-        self, mock_context: Mock, mock_future: Mock
-    ) -> None:
-        # Setup: mock context, client, and Future
+    def test_flush_calls_mesh_client_flush(self, mock_context: Mock) -> None:
+        # Setup: mock context, client, task, and handle
         mock_instance = Mock()
         mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
         mock_client = Mock()
         mock_task = Mock()
-        mock_client.flush.return_value.spawn.return_value.task.return_value = mock_task
+        mock_handle = Mock()
+        mock_client.flush.return_value = mock_task
+        mock_task.spawn_handle.return_value = mock_handle
         self.logging_manager._logging_mesh_client = mock_client
 
-        mock_future_instance = Mock()
-        mock_future.return_value = mock_future_instance
-
         # Execute: flush logs
-        self.logging_manager.flush()
+        result = self.logging_manager.flush()
 
-        # Assert: mesh client flush was called
+        # Assert: the native task was observed through a Handle with the timeout.
+        self.assertIsNone(result)
         mock_client.flush.assert_called_once_with(mock_instance)
-        # Assert: Future was created and get was called with timeout
-        mock_future.assert_called_once_with(coro=mock_task)
-        mock_future_instance.get.assert_called_once_with(timeout=3)
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_task.spawn.assert_not_called()
+        mock_handle.get.assert_called_once_with(timeout=3)
 
-    @patch("monarch._src.actor.logging.Future")
     @patch("monarch._src.actor.logging.context")
-    def test_flush_handles_exception_gracefully(
-        self, mock_context: Mock, mock_future: Mock
-    ) -> None:
-        # Setup: mock context, client, and Future that raises exception
+    def test_flush_handles_exception_gracefully(self, mock_context: Mock) -> None:
+        # Setup: make Handle observation raise an ordinary exception.
         mock_instance = Mock()
         mock_context.return_value.actor_instance._as_rust.return_value = mock_instance
         mock_client = Mock()
+        mock_task = Mock()
+        mock_handle = Mock()
+        mock_client.flush.return_value = mock_task
+        mock_task.spawn_handle.return_value = mock_handle
+        mock_handle.get.side_effect = Exception("Test exception")
         self.logging_manager._logging_mesh_client = mock_client
 
-        mock_future_instance = Mock()
-        mock_future_instance.get.side_effect = Exception("Test exception")
-        mock_future.return_value = mock_future_instance
-
         # Execute: flush logs (should not raise exception)
-        self.logging_manager.flush()
+        result = self.logging_manager.flush()
 
-        # Assert: no exception is raised and method completes gracefully
+        # Assert: the operation was started and the observer error was suppressed.
+        self.assertIsNone(result)
+        mock_client.flush.assert_called_once_with(mock_instance)
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_handle.get.assert_called_once_with(timeout=3)
+
+    def test_flush_from_tokio_awaits_shared_not_handle(self) -> None:
+        mock_task = Mock()
+        shared = _AwaitTracker(Shared.from_value(None))
+        mock_task.spawn.return_value = shared
+        self.logging_manager._logging_mesh_client = Mock()
+
+        with patch.object(
+            self.logging_manager, "_new_flush_task", return_value=mock_task
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
+        mock_task.spawn.assert_called_once_with()
+        mock_task.spawn_handle.assert_not_called()
+        self.assertTrue(shared.awaited)
+        self.assertFalse(shared.get_called)
+
+    def test_flush_from_tokio_without_client_is_noop(self) -> None:
+        with patch.object(
+            self.logging_manager, "_new_flush_task"
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_not_called()
+
+    def test_flush_from_tokio_suppresses_ordinary_error(self) -> None:
+        async def fail() -> None:
+            raise RuntimeError("test error")
+
+        self.logging_manager._logging_mesh_client = Mock()
+        with patch.object(
+            self.logging_manager,
+            "_new_flush_task",
+            return_value=PythonTask.from_coroutine(fail()),
+        ) as mock_new_flush_task:
+            result = PythonTask.from_coroutine(
+                self.logging_manager._flush_from_tokio()
+            ).block_on()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
 
 
 class FlushAllProcMeshLogsTest(TestCase):
@@ -204,6 +266,26 @@ class FlushAllProcMeshLogsTest(TestCase):
 class LoggingManagerAsyncTest(IsolatedAsyncioTestCase):
     def setUp(self) -> None:
         self.logging_manager = LoggingManager()
+
+    async def test_flush_async_awaits_handle_not_shared(self) -> None:
+        ready = asyncio.get_running_loop().create_future()
+        ready.set_result(None)
+        handle = _AwaitTracker(ready)
+        mock_task = Mock()
+        mock_task.spawn_handle.return_value = handle
+        self.logging_manager._logging_mesh_client = Mock()
+
+        with patch.object(
+            self.logging_manager, "_new_flush_task", return_value=mock_task
+        ) as mock_new_flush_task:
+            result = await self.logging_manager.flush_async()
+
+        self.assertIsNone(result)
+        mock_new_flush_task.assert_called_once_with()
+        mock_task.spawn_handle.assert_called_once_with()
+        mock_task.spawn.assert_not_called()
+        self.assertTrue(handle.awaited)
+        self.assertFalse(handle.get_called)
 
     @patch("monarch._src.actor.logging.LoggingMeshClient")
     @patch("monarch._src.actor.logging.context")

--- a/python/tests/test_actor_driver_characterization.py
+++ b/python/tests/test_actor_driver_characterization.py
@@ -17,16 +17,14 @@ Concretely, inside an endpoint:
   - ``asyncio.get_running_loop()`` succeeds (a loop is running); and
   - a bare ``await PythonTask.sleep(0)`` raises (pytokio refuses to await a raw
     ``PythonTask`` while an asyncio loop is active); and
-  - awaiting a monarch ``Future`` takes the ``_Handle`` (asyncio) path, never
-    ``_Tokio`` -- the Step-3.0 ``_Tokio``-production oracle records zero entries
-    for the endpoint body.
+  - awaiting a monarch ``Future`` succeeds through the asyncio path.
 
-This is why the reverted "A1" reroute (replacing ``await Future(...)`` in the
-reply path with a bare ``await PythonTask``) was wrong: under the loop the bare
-await raises. If a future change switches the dispatcher to drive endpoints on
-the tokio runtime (``PythonTask.from_coroutine``), these assertions flip -- which
-is the exact signal that such reroutes become valid. Pinned for both dispatch
-modes (queue and direct).
+This is why the reverted "A1" reroute (replacing an await of a Monarch
+``Future`` in the reply path with a bare ``await PythonTask``) was wrong: under
+the loop the bare await raises. If a future change switches the dispatcher to
+drive endpoints on the tokio runtime (``PythonTask.from_coroutine``), these
+assertions flip -- which is the exact signal that such reroutes become valid.
+Pinned for both dispatch modes (queue and direct).
 """
 
 import asyncio
@@ -34,7 +32,7 @@ import asyncio
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-from monarch._src.actor.future import Future, tokio_oracle
+from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import this_host
 from monarch.actor import Actor, endpoint
 from monarch.config import parametrize_config
@@ -42,7 +40,7 @@ from monarch.config import parametrize_config
 
 class _DriverProbe(Actor):
     @endpoint
-    async def probe(self) -> tuple[bool, bool, int]:
+    async def probe(self) -> tuple[bool, bool]:
         # (1) The endpoint body runs under a real asyncio loop.
         try:
             asyncio.get_running_loop()
@@ -57,16 +55,10 @@ class _DriverProbe(Actor):
         except RuntimeError:
             bare_await_raised = True
 
-        # (3) Awaiting a monarch Future here takes the _Handle (asyncio) path,
-        # not _Tokio. Preserve a process-wide raise-mode oracle while this
-        # probe runs.
-        with tokio_oracle(raise_on_produce=True) as records:
-            await Future(coro=PythonTask.sleep(0))
-            tokio_count = sum(
-                1 for r in records if r.module == __name__ and r.function == "probe"
-            )
+        # (3) Awaiting a monarch Future succeeds on the endpoint's asyncio loop.
+        await Future._from_coro(PythonTask.sleep(0))
 
-        return (has_loop, bare_await_raised, tokio_count)
+        return (has_loop, bare_await_raised)
 
 
 @pytest.mark.timeout(120)
@@ -75,14 +67,10 @@ class _DriverProbe(Actor):
 async def test_actor_endpoint_is_asyncio_driven() -> None:
     proc = this_host().spawn_procs(per_host={"gpus": 1})
     probe = proc.spawn("driver_probe", _DriverProbe)
-    has_loop, bare_await_raised, tokio_count = await probe.probe.call_one()
+    has_loop, bare_await_raised = await probe.probe.call_one()
     assert has_loop, "an @endpoint body must run under a real asyncio loop"
     assert bare_await_raised, (
         "a bare `await PythonTask` inside an @endpoint must raise: pytokio "
         "refuses to await a raw PythonTask while an asyncio loop is active"
-    )
-    assert tokio_count == 0, (
-        "awaiting a monarch Future inside an @endpoint must take the _Handle "
-        f"(asyncio) path, not _Tokio; oracle recorded {tokio_count} _Tokio entries"
     )
     await proc.stop()

--- a/python/tests/test_actor_driver_characterization.py
+++ b/python/tests/test_actor_driver_characterization.py
@@ -58,10 +58,9 @@ class _DriverProbe(Actor):
             bare_await_raised = True
 
         # (3) Awaiting a monarch Future here takes the _Handle (asyncio) path,
-        # not _Tokio. Scope the oracle (so a process-wide oracle is left
-        # intact) and count only _Tokio attributed to this probe body, so
-        # unrelated concurrent activity on the loop can't perturb the count.
-        with tokio_oracle() as records:
+        # not _Tokio. Preserve a process-wide raise-mode oracle while this
+        # probe runs.
+        with tokio_oracle(raise_on_produce=True) as records:
             await Future(coro=PythonTask.sleep(0))
             tokio_count = sum(
                 1 for r in records if r.module == __name__ and r.function == "probe"

--- a/python/tests/test_client_shutdown.py
+++ b/python/tests/test_client_shutdown.py
@@ -40,7 +40,9 @@ def test_client_shutdown() -> None:
     # Now shutdown the client. Delete references to avoid accidental reuse.
     del procs
     del actors
-    shutdown_context().get()
+    assert shutdown_context().get() is None
+    # The already-complete shutdown path remains safe and idempotent.
+    assert shutdown_context().get() is None
     # After this, all the resources created by the client should be released,
     # including this_host and the procs. We check this by seeing if the pids are
     # still alive after a short wait period (procs are cleaned up with an async

--- a/python/tests/test_future_characterization.py
+++ b/python/tests/test_future_characterization.py
@@ -10,10 +10,9 @@
 
 Pins the behavior of ``monarch._src.actor.future.Future`` -- its internal
 states and the transitions between them, ``as_asyncio()`` and the ``__await__``
-shim over it, the residual ``_Tokio`` cross-world guards, the
-``get()``-inside-a-loop warning, and the ``_take_inner()`` accessor with its
-``_Taken`` terminal state -- so that any change to that behavior is caught here
-and made explicit.
+shim over it, rejection of Tokio-thread awaits, the ``get()``-inside-a-loop
+warning, and the ``_take_inner()`` accessor with its ``_Taken`` terminal state
+-- so that any change to that behavior is caught here and made explicit.
 """
 
 import asyncio
@@ -61,9 +60,19 @@ def _run_in_tokio(coro):
 # A fresh Future is _Unawaited; the first access drives the underlying task
 # exactly once. Sync get() caches into _Complete/_Exception; as_asyncio() and
 # the asyncio __await__ shim spawn a Handle and move to the observe-only
-# _Handle; a tokio-thread await still spawns a Shared and moves to _Tokio.
-# These pin that lifecycle and its idempotency.
+# _Handle. A Tokio-thread await is rejected without starting the task or
+# changing its state. These pin that lifecycle and its idempotency.
 # ---------------------------------------------------------------------------
+
+
+def test_direct_construction_is_rejected():
+    with pytest.raises(
+        TypeError,
+        match="Future objects are returned by Monarch operations",
+    ):
+        Future()
+    with pytest.raises(TypeError, match="unexpected keyword argument 'coro'"):
+        Future(coro=None)
 
 
 def test_get_success_transitions_to_complete_and_is_idempotent():
@@ -71,7 +80,7 @@ def test_get_success_transitions_to_complete_and_is_idempotent():
     and returns the value; a second get() returns the cached value without
     re-running the coroutine. The coroutine must run exactly once, so
     resolve-and-cache is the contract being pinned."""
-    fut: Future[int] = Future(coro=_value(42))
+    fut: Future[int] = Future._from_coro(_value(42))
     assert fut.get() == 42
     assert fut.get() == 42
 
@@ -84,7 +93,7 @@ def test_get_exception_transitions_to_exception_and_reraises_stored():
     the constructed ValueError) because the exception crosses the Rust/pyo3
     boundary -- the contract is that _Exception caches one object and re-raises
     it."""
-    fut: Future[int] = Future(coro=_raise(ValueError("boom")))
+    fut: Future[int] = Future._from_coro(_raise(ValueError("boom")))
     with pytest.raises(ValueError, match="boom") as first:
         fut.get()
     with pytest.raises(ValueError, match="boom") as second:
@@ -97,7 +106,7 @@ def test_get_timeout_raises_timeout_error():
     deadline, so an unfinished task surfaces a TimeoutError rather than hanging.
     The timeout is non-cancelling (state becomes _Handle); the sibling
     test_get_timeout_is_non_poisoning_and_reobservable pins re-observation."""
-    fut: Future[None] = Future(coro=PythonTask.sleep(3600))
+    fut: Future[None] = Future._from_coro(PythonTask.sleep(3600))
     with pytest.raises(TimeoutError):
         fut.get(timeout=0.1)
 
@@ -106,7 +115,7 @@ def test_get_timeout_is_non_poisoning_and_reobservable():
     """get(timeout=...) that times out routes through a Handle and does NOT
     poison the Future: it transitions to _Handle, and a later get() (no timeout)
     still resolves the same task (the timeout is non-cancelling)."""
-    fut: Future[int] = Future(coro=_sleep_then(0.2, 11))
+    fut: Future[int] = Future._from_coro(_sleep_then(0.2, 11))
     with pytest.raises(TimeoutError):
         fut.get(timeout=0.01)  # too short: task still running
     assert isinstance(fut._status, future_mod._Handle)
@@ -117,7 +126,7 @@ def test_get_timeout_success_returns_and_transitions_to_handle():
     """get(timeout=...) whose task finishes within the timeout returns the value
     and transitions to the observe-only _Handle (not _Complete): the timed get
     routes through a Handle, so a later no-timeout get() re-observes the result."""
-    fut: Future[int] = Future(coro=_sleep_then(0.01, 7))
+    fut: Future[int] = Future._from_coro(_sleep_then(0.01, 7))
     assert fut.get(timeout=5) == 7
     assert isinstance(fut._status, future_mod._Handle)
     assert fut.get() == 7
@@ -127,37 +136,46 @@ async def test_await_asyncio_transitions_to_handle_and_is_reobservable():
     """Awaiting under an asyncio loop bridges through as_asyncio(), transitions
     _Unawaited -> the observe-only _Handle, and yields the value; re-awaiting
     observes the same Handle (a fresh loop-local future each time)."""
-    fut: Future[int] = Future(coro=_value(7))
+    fut: Future[int] = Future._from_coro(_value(7))
     assert await fut == 7  # _Unawaited -> _Handle
     assert isinstance(fut._status, future_mod._Handle)
     assert await fut == 7  # re-observe the same Handle
 
 
-def test_await_tokio_transitions_to_tokio_and_is_idempotent():
-    """Awaiting on a tokio thread (inside from_coroutine, where
-    is_tokio_thread() is True) transitions _Unawaited -> _Tokio (spawning a
-    Shared) and yields the value; re-awaiting reuses it. The _Handle-vs-_Tokio
-    split is by which async world the await runs in (asyncio loop vs tokio
-    thread)."""
-    fut: Future[int] = Future(coro=_value(9))
+def test_nested_future_await_raises_without_consuming_inner_future():
+    """An outer Future drives its coroutine on Tokio, where awaiting an inner
+    Future is rejected without starting or consuming the inner task. A later
+    valid observer can still drive the inner task exactly once."""
+    started = []
+
+    async def value():
+        started.append("started")
+        return 9
+
+    fut: Future[int] = Future._from_coro(value())
 
     async def driver():
         assert is_tokio_thread()
-        first = await fut  # _Unawaited -> _Tokio
-        second = await fut  # idempotent re-await of the _Tokio state
-        return first, second
+        with pytest.raises(RuntimeError) as caught:
+            await fut
+        return str(caught.value)
 
-    assert _run_in_tokio(driver()) == (9, 9)
+    outer: Future[str] = Future._from_coro(driver())
+    assert outer.get() == (
+        "Future cannot be awaited on a Tokio thread; observe it from an "
+        "asyncio loop or synchronous context."
+    )
+    assert started == []
+    assert isinstance(fut._status, future_mod._Unawaited)
+    assert fut.get() == 9
+    assert started == ["started"]
 
 
 # ---------------------------------------------------------------------------
 # Observation is non-consuming now: get()/as_asyncio()/await mix freely on the
 # asyncio+sync side (get after await, await after get, repeated as_asyncio all
-# resolve). The only remaining "already converted" guards are the cross-world
-# ones involving the residual _Tokio state (and _Handle-awaited-on-a-tokio-
-# thread), which remain while the pytokio-driving from_coroutine path exists.
-# These pin that: the formerly-erroring same-world cases now resolve; the
-# cross-world ones still raise.
+# resolve). A _Handle awaited on a Tokio thread is still rejected. These pin
+# both the supported observations and the remaining cross-driver guard.
 # ---------------------------------------------------------------------------
 
 
@@ -165,7 +183,7 @@ def test_get_after_asyncio_await_returns():
     """get() after an asyncio await (_Handle) now returns the value instead of
     raising -- observation is non-consuming, so the sync get() observes the same
     Handle."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     asyncio.run(_await_once(fut))  # -> _Handle
     assert fut.get() == 1
 
@@ -174,7 +192,7 @@ def test_get_after_asyncio_await_error_reraises():
     """Failure mirror of the previous: get() on a _Handle whose live producer
     FAILED re-raises the stored exception through handle.get(). Drives the live
     spawn_handle producer (not a pre-resolved get())."""
-    fut: Future[int] = Future(coro=_raise(ValueError("boom")))
+    fut: Future[int] = Future._from_coro(_raise(ValueError("boom")))
 
     async def bridge():
         # Drive _Unawaited -> _Handle via the live producer; swallow the failure
@@ -188,37 +206,11 @@ def test_get_after_asyncio_await_error_reraises():
         fut.get()
 
 
-def test_get_after_tokio_conversion_raises():
-    """get() after a tokio await (_Tokio): once converted to a pytokio Shared,
-    get() refuses and points at awaiting inside a from_coroutine coroutine."""
-    fut: Future[int] = Future(coro=_value(1))
-    _run_in_tokio(_await_once(fut))  # -> _Tokio
-    with pytest.raises(
-        ValueError, match=r"already converted into a pytokio\.Shared object"
-    ):
-        fut.get()
-
-
-def test_await_asyncio_on_tokio_converted_raises():
-    """Cross-world: convert on tokio (_Tokio), then await under asyncio -- the
-    asyncio path (as_asyncio) refuses a tokio-converted Future."""
-    fut: Future[int] = Future(coro=_value(1))
-    _run_in_tokio(_await_once(fut))  # -> _Tokio
-
-    async def attempt():
-        with pytest.raises(
-            ValueError, match=r"already converted into a pytokio\.Shared object"
-        ):
-            await fut
-
-    asyncio.run(attempt())
-
-
 def test_await_asyncio_after_get_returns():
     """await under asyncio after a sync get() resolved it (_Complete) now returns
     the value -- as_asyncio() hands back a settled loop future instead of
     raising."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     assert fut.get() == 1  # -> _Complete
 
     async def attempt():
@@ -232,7 +224,7 @@ def test_await_asyncio_after_get_exception_reraises_stored():
     get() (_Exception) hands back a settled failed loop future that re-raises the
     *same* stored exception object."""
     boom = ValueError("boom")
-    fut: Future[int] = Future(coro=_raise(boom))
+    fut: Future[int] = Future._from_coro(_raise(boom))
     with pytest.raises(ValueError, match="boom"):
         fut.get()  # -> _Exception
 
@@ -249,7 +241,7 @@ def test_await_asyncio_live_handle_error_propagates():
     via as_asyncio, from _Unawaited -- not pre-resolved) surfaces the exception
     through the bridged asyncio future: exercises send_result(Err) -> observer ->
     set_exception, which the pre-resolved settled-future path does not."""
-    fut: Future[int] = Future(coro=_raise(ValueError("boom")))
+    fut: Future[int] = Future._from_coro(_raise(ValueError("boom")))
 
     async def attempt():
         with pytest.raises(ValueError, match="boom"):
@@ -261,7 +253,7 @@ def test_await_asyncio_live_handle_error_propagates():
 def test_await_tokio_on_handle_bridged_raises():
     """Convert on asyncio (_Handle), then await on a tokio thread: the tokio
     branch intentionally refuses a Future already bridged to asyncio."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     asyncio.run(_await_once(fut))  # -> _Handle
 
     async def attempt():
@@ -275,7 +267,7 @@ def test_await_tokio_after_get_raises_synchronous_future():
     """await on a tokio thread after a sync get() resolved it (_Complete): the
     tokio branch refuses with the 'already converted into a synchronous future'
     guard."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     assert fut.get() == 1  # -> _Complete
 
     async def attempt():
@@ -289,7 +281,7 @@ def test_await_tokio_after_get_exception_raises_synchronous_future():
     """Failure mirror of test_await_tokio_after_get_raises_synchronous_future:
     await on a tokio thread after a failed sync get() (_Exception) hits the same
     'synchronous future' guard as _Complete."""
-    fut: Future[int] = Future(coro=_raise(ValueError("boom")))
+    fut: Future[int] = Future._from_coro(_raise(ValueError("boom")))
     with pytest.raises(ValueError, match="boom"):
         fut.get()  # -> _Exception
 
@@ -303,7 +295,7 @@ def test_await_tokio_after_get_exception_raises_synchronous_future():
 def test_await_with_no_event_loop_raises():
     """await with neither an asyncio loop nor a tokio runtime active: there is no
     driver, so __await__ refuses outright."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     with pytest.raises(ValueError, match="no active event loop"):
         fut.__await__()
 
@@ -326,7 +318,7 @@ def test_get_in_asyncio_loop_warns_and_still_returns(monkeypatch):
     monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
 
     async def runner():
-        fut: Future[int] = Future(coro=_value(5))
+        fut: Future[int] = Future._from_coro(_value(5))
         with pytest.warns(UserWarning, match="active event loop") as record:
             value = fut.get()
         # the asyncio-context advice is as_asyncio()/await (both valid on a loop)
@@ -351,13 +343,16 @@ def test_get_in_tokio_thread_raises_would_block_and_is_non_consuming(monkeypatch
     monkeypatch.setattr(
         future_mod.warnings, "warn", lambda msg, *a, **k: warned.append(str(msg))
     )
-    fut: Future[int] = Future(coro=_value(5))
+    fut: Future[int] = Future._from_coro(_value(5))
 
     async def attempt():
         assert is_tokio_thread()
         return fut.get()
 
-    with pytest.raises(WouldBlockRuntime):
+    with pytest.raises(
+        WouldBlockRuntime,
+        match="observe the Future from a synchronous or asyncio context",
+    ):
         _run_in_tokio(attempt())
     assert len(calls) == 1
     assert calls[0]["extra"]["context"] == "tokio"
@@ -380,13 +375,16 @@ def test_get_timeout_in_tokio_thread_raises_would_block_and_is_non_consuming(
     monkeypatch.setattr(
         future_mod.warnings, "warn", lambda msg, *a, **k: warned.append(str(msg))
     )
-    fut: Future[int] = Future(coro=_value(5))
+    fut: Future[int] = Future._from_coro(_value(5))
 
     async def attempt():
         assert is_tokio_thread()
         return fut.get(timeout=0.1)
 
-    with pytest.raises(WouldBlockRuntime):
+    with pytest.raises(
+        WouldBlockRuntime,
+        match="observe the Future from a synchronous or asyncio context",
+    ):
         _run_in_tokio(attempt())
     assert len(calls) == 1
     assert calls[0]["extra"]["context"] == "tokio"
@@ -400,7 +398,7 @@ def test_get_invalid_timeout_does_not_spawn_or_mutate():
     BEFORE spawning a Handle, so a bad argument never starts work or flips state:
     the Future stays _Unawaited and a later valid get() still drives it."""
     for bad in (float("nan"), -1.0, float("inf")):
-        fut: Future[int] = Future(coro=_value(8))
+        fut: Future[int] = Future._from_coro(_value(8))
         with pytest.raises(ValueError, match="invalid timeout"):
             fut.get(timeout=bad)
         assert isinstance(fut._status, future_mod._Unawaited)
@@ -416,7 +414,7 @@ def test_get_on_handle_in_asyncio_loop_warns_and_forwards_once(monkeypatch):
     monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
 
     async def runner():
-        fut: Future[int] = Future(coro=_value(5))
+        fut: Future[int] = Future._from_coro(_value(5))
         fut.as_asyncio()  # -> _Handle
         with pytest.warns(UserWarning) as caught:
             value = fut.get()
@@ -438,9 +436,9 @@ def test_get_in_loop_on_cached_state_traces_without_warning(monkeypatch):
     calls = []
     monkeypatch.setattr(future_mod, "log_with_tracing", lambda *a, **k: calls.append(k))
 
-    done: Future[int] = Future(coro=_value(5))
+    done: Future[int] = Future._from_coro(_value(5))
     assert done.get() == 5  # off loop -> _Complete
-    failed: Future[int] = Future(coro=_raise(ValueError("boom")))
+    failed: Future[int] = Future._from_coro(_raise(ValueError("boom")))
     with pytest.raises(ValueError, match="boom"):
         failed.get()  # off loop -> _Exception
     calls.clear()
@@ -481,7 +479,7 @@ def test_take_inner_returns_task_and_marks_future_taken():
     """_take_inner() on an unawaited Future returns the underlying (still
     drivable) PythonTask and transitions the Future to the terminal _Taken
     state."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     task = fut._take_inner()
     assert isinstance(task, PythonTask)
     assert isinstance(fut._status, future_mod._Taken)
@@ -490,7 +488,7 @@ def test_take_inner_returns_task_and_marks_future_taken():
 
 def test_take_inner_twice_raises():
     """The Future is spent after the first _take_inner(); a second raises."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     fut._take_inner()
     with pytest.raises(ValueError, match="already been awaited"):
         fut._take_inner()
@@ -499,7 +497,7 @@ def test_take_inner_twice_raises():
 def test_get_after_take_inner_raises():
     """get() after _take_inner() fails at the Future instead of re-driving the
     surrendered task."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     fut._take_inner()
     with pytest.raises(ValueError, match="consumed"):
         fut.get()
@@ -507,7 +505,7 @@ def test_get_after_take_inner_raises():
 
 async def test_await_asyncio_after_take_inner_raises():
     """await under asyncio after _take_inner() fails instead of re-driving."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     fut._take_inner()
     with pytest.raises(ValueError, match="consumed"):
         await fut
@@ -515,7 +513,7 @@ async def test_await_asyncio_after_take_inner_raises():
 
 def test_await_tokio_after_take_inner_raises():
     """await on a tokio thread after _take_inner() fails instead of re-driving."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     fut._take_inner()
 
     async def attempt():
@@ -528,7 +526,7 @@ def test_await_tokio_after_take_inner_raises():
 def test_take_inner_after_get_raises():
     """_take_inner() requires an unawaited Future: once get() has resolved it
     (_Complete), taking the inner task is refused."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     assert fut.get() == 1  # -> _Complete
     with pytest.raises(ValueError, match="already been awaited"):
         fut._take_inner()
@@ -537,17 +535,8 @@ def test_take_inner_after_get_raises():
 def test_take_inner_after_asyncio_await_raises():
     """Once an asyncio await has bridged the Future (_Handle), _take_inner() is
     refused."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     asyncio.run(_await_once(fut))  # -> _Handle
-    with pytest.raises(ValueError, match="already been awaited"):
-        fut._take_inner()
-
-
-def test_take_inner_after_tokio_await_raises():
-    """Once a tokio await has converted the Future (_Tokio), _take_inner() is
-    refused."""
-    fut: Future[int] = Future(coro=_value(1))
-    _run_in_tokio(_await_once(fut))  # -> _Tokio
     with pytest.raises(ValueError, match="already been awaited"):
         fut._take_inner()
 
@@ -564,7 +553,7 @@ def test_take_inner_after_tokio_await_raises():
 def test_as_asyncio_off_loop_raises_and_is_non_consuming():
     """Off a running loop, as_asyncio() raises RuntimeError WITHOUT spawning: the
     Future stays _Unawaited, so a later get() still drives the task."""
-    fut: Future[int] = Future(coro=_value(3))
+    fut: Future[int] = Future._from_coro(_value(3))
     with pytest.raises(RuntimeError):
         fut.as_asyncio()
     assert isinstance(fut._status, future_mod._Unawaited)
@@ -575,7 +564,7 @@ async def test_as_asyncio_twice_same_loop_both_resolve():
     """Two as_asyncio() futures from one Future on the same loop both resolve to
     the value (ordinary multi-observer case); the Future is _Handle after the
     first."""
-    fut: Future[int] = Future(coro=_value(4))
+    fut: Future[int] = Future._from_coro(_value(4))
     f1 = fut.as_asyncio()
     assert isinstance(fut._status, future_mod._Handle)
     f2 = fut.as_asyncio()
@@ -586,7 +575,7 @@ async def test_as_asyncio_twice_same_loop_both_resolve():
 async def test_as_asyncio_cancel_one_then_await_again_resolves():
     """Cancelling one as_asyncio() observer does not poison the Future: a later
     await still resolves (each observer is a fresh loop-local future)."""
-    fut: Future[int] = Future(coro=_value(5))
+    fut: Future[int] = Future._from_coro(_value(5))
     f1 = fut.as_asyncio()
     f1.cancel()
     assert await fut == 5
@@ -595,7 +584,7 @@ async def test_as_asyncio_cancel_one_then_await_again_resolves():
 def test_as_asyncio_across_two_loops_both_resolve():
     """The same Future observed from two different event loops resolves in each
     (each as_asyncio() binds a fresh future to the current loop)."""
-    fut: Future[int] = Future(coro=_value(6))
+    fut: Future[int] = Future._from_coro(_value(6))
 
     async def observe():
         return await fut
@@ -611,7 +600,7 @@ async def test_as_asyncio_on_cached_stop_iteration_wraps_in_runtime_error():
     returned future. Mirrors the Handle observer path (HDL-7). A StopIteration
     can't reach _Exception via from_coroutine (it becomes a normal return), so
     the cached state is set directly."""
-    fut: Future[int] = Future(coro=_value(1))
+    fut: Future[int] = Future._from_coro(_value(1))
     fut._status = future_mod._Exception(StopIteration("done"))
     settled = fut.as_asyncio()
     with pytest.raises(RuntimeError, match="StopIteration"):

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -287,7 +287,7 @@ def test_attach_to_workers_accepts_future_addresses() -> None:
         )
         procs.append(proc)
         # Wrap the address in a Future[str] so attach goes through _take_inner.
-        fut: Future[str] = Future(coro=_resolve(addr))
+        fut: Future[str] = Future._from_coro(_resolve(addr))
         workers.append(fut)
 
     try:

--- a/python/tests/test_host_mesh.py
+++ b/python/tests/test_host_mesh.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 import cloudpickle
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
+from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
 from monarch._rust_bindings.monarch_hyperactor.shape import Point, Shape, Slice
 from monarch._src.actor.actor_mesh import _client_context, Actor, attach, context
 from monarch._src.actor.bootstrap import attach_to_workers
@@ -63,9 +64,10 @@ def test_multi_host_mesh() -> None:
         assert hy_host.region.slice() == host.region.slice()
 
         # Hosts 5 and 7
-        sliced = host._new_with_shape(
-            Shape(labels=["hosts"], slice=Slice(offset=5, sizes=[2], strides=[2]))
+        slice_shape = Shape(
+            labels=["hosts"], slice=Slice(offset=5, sizes=[2], strides=[2])
         )
+        sliced = host._new_with_shape(slice_shape)
         assert sliced.extent.labels == ["hosts"]
         assert sliced.extent.sizes == [2]
         assert not sliced.stream_logs
@@ -74,6 +76,25 @@ def test_multi_host_mesh() -> None:
         hy_sliced = sliced._hy_host_mesh.block_on()
         assert hy_sliced.region.labels == sliced.region.labels
         assert hy_sliced.region.slice() == sliced.region.slice()
+
+        release_host_mesh = threading.Event()
+
+        async def resolve_host_mesh():
+            await PythonTask.spawn_blocking(release_host_mesh.wait)
+            return hy_host
+
+        # Keep the native mesh unresolved so slicing must take the pending path.
+        host._inner_host_mesh = PythonTask.from_coroutine(resolve_host_mesh()).spawn()
+        try:
+            assert host._hy_host_mesh.poll() is None
+            pending_sliced = host._new_with_shape(slice_shape)
+            assert pending_sliced._hy_host_mesh.poll() is None
+        finally:
+            release_host_mesh.set()
+
+        hy_pending_sliced = pending_sliced._hy_host_mesh.block_on()
+        assert hy_pending_sliced.region.labels == pending_sliced.region.labels
+        assert hy_pending_sliced.region.slice() == pending_sliced.region.slice()
 
 
 @pytest.mark.timeout(120)

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -1842,12 +1842,12 @@ def test_exec_command_output_dir_suppresses_printing(capsys):
 def test_exec_command_produces_no_tokio():
     """Gate A (job cluster): exec_command produces no `_Tokio` state.
 
-    Drives exec_command with the record-only `_Tokio` oracle enabled and asserts
+    Drives exec_command with the `_Tokio` oracle in raise mode and asserts
     job.py produced no `_Tokio` (no `await <Future>` on the tokio thread). Before
-    the `_take_inner()` migration this recorded the three job producers
+    the `_take_inner()` migration this found the three job producers
     (run_python.call, run.call, procs.stop); after it, zero.
     """
-    with tokio_oracle() as records:
+    with tokio_oracle(raise_on_produce=True) as records:
         # shell branch: exercises run.call + the procs.stop finally
         host_mesh, _procs, bash_actors, _markers = _exec_env()
         bash_actors.run.call.return_value = _results_future(

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -25,7 +25,6 @@ from unittest.mock import MagicMock, patch
 import monarch._src.job._job_sidecar_worker as js_worker
 import monarch._src.job.job_sidecar as js
 import pytest
-from monarch._src.actor.future import tokio_oracle
 
 # Import directly from _src since job module isn't properly exposed
 from monarch._src.job.job import (
@@ -1711,7 +1710,7 @@ def _exec_env():
     bash_actors = MagicMock()
     procs = MagicMock()
     procs.spawn.return_value = bash_actors
-    procs.stop.return_value = Future(coro=_stop_impl())
+    procs.stop.return_value = Future._from_coro(_stop_impl())
     host_mesh = MagicMock()
     host_mesh.spawn_procs.return_value = procs
     return host_mesh, procs, bash_actors, markers
@@ -1723,7 +1722,7 @@ def _results_future(pairs):
     async def _impl():
         return pairs
 
-    return Future(coro=_impl())
+    return Future._from_coro(_impl())
 
 
 def test_exec_command_returns_max_returncode():
@@ -1837,30 +1836,3 @@ def test_exec_command_output_dir_suppresses_printing(capsys):
     )
     exec_command(host_mesh, ["echo", "hi"], output_dir="/tmp/out").get()
     assert "SHOULD_NOT_PRINT" not in capsys.readouterr().out
-
-
-def test_exec_command_produces_no_tokio():
-    """Gate A (job cluster): exec_command produces no `_Tokio` state.
-
-    Drives exec_command with the `_Tokio` oracle in raise mode and asserts
-    job.py produced no `_Tokio` (no `await <Future>` on the tokio thread). Before
-    the `_take_inner()` migration this found the three job producers
-    (run_python.call, run.call, procs.stop); after it, zero.
-    """
-    with tokio_oracle(raise_on_produce=True) as records:
-        # shell branch: exercises run.call + the procs.stop finally
-        host_mesh, _procs, bash_actors, _markers = _exec_env()
-        bash_actors.run.call.return_value = _results_future(
-            [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
-        )
-        exec_command(host_mesh, ["echo", "hi"]).get()
-
-        # python branch: exercises run_python.call + the procs.stop finally
-        host_mesh, _procs, bash_actors, _markers = _exec_env()
-        bash_actors.run_python.call.return_value = _results_future(
-            [("rank0", {"returncode": 0, "stdout": "", "stderr": ""})]
-        )
-        exec_command(host_mesh, ["train.py"]).get()
-
-        job_records = [r for r in records if r.filename.endswith("job.py")]
-        assert job_records == [], f"exec_command still produces _Tokio: {job_records}"

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -30,7 +30,7 @@ from monarch._src.actor.actor_mesh import (
     ValueMesh,
 )
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.future import Future, tokio_oracle, TokioOracleRecord
+from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import this_host, this_proc
 from monarch._src.actor.proc_mesh import (
     get_or_spawn_controller,
@@ -44,11 +44,6 @@ from scoped_state import scoped_state
 
 _proc_rank = -1
 _BOOTSTRAP_FAILURE = "stage 3.4 bootstrap failure"
-_STAGE_3_4_ORACLE_FILES = {
-    "monarch._src.actor.host_mesh": "host_mesh.py",
-    "monarch._src.actor.logging": "logging.py",
-    "monarch._src.actor.proc_mesh": "proc_mesh.py",
-}
 
 
 def _successful_bootstrap() -> None:
@@ -57,17 +52,6 @@ def _successful_bootstrap() -> None:
 
 def _fail_bootstrap() -> None:
     raise RuntimeError(_BOOTSTRAP_FAILURE)
-
-
-def _stage_3_4_tokio_records(
-    records: list[TokioOracleRecord],
-) -> list[TokioOracleRecord]:
-    return [
-        record
-        for record in records
-        if _STAGE_3_4_ORACLE_FILES.get(record.module)
-        == os.path.basename(record.filename)
-    ]
 
 
 class _PendingActorProbe:
@@ -82,7 +66,7 @@ class _PendingActorProbe:
             if error is not None:
                 raise error
 
-        self.initialized = Future(coro=initialize())
+        self.initialized = Future._from_coro(initialize())
 
 
 class TestActor(Actor):
@@ -132,24 +116,20 @@ class TestActor(Actor):
 async def test_proc_mesh_initialization() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         host = state.hosts
-        with tokio_oracle(raise_on_produce=True) as records:
-            proc_mesh = host.spawn_procs(
-                name="test_proc",
-                bootstrap=_successful_bootstrap,
-            )
-            assert await proc_mesh.initialized
-            assert _stage_3_4_tokio_records(records) == []
+        proc_mesh = host.spawn_procs(
+            name="test_proc",
+            bootstrap=_successful_bootstrap,
+        )
+        assert await proc_mesh.initialized
 
 
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
-        with tokio_oracle(raise_on_produce=True) as records:
-            proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
-            with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
-                await proc_mesh.initialized
-            assert _stage_3_4_tokio_records(records) == []
+        proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
+        with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
+            await proc_mesh.initialized
 
 
 @pytest.mark.timeout(60)
@@ -197,11 +177,9 @@ async def test_stop_state_tracks_native_stop_result() -> None:
                 record_flush_from_tokio,
             ),
         ):
-            with tokio_oracle(raise_on_produce=True) as records:
-                assert await owner.stop() is None
+            assert await owner.stop() is None
 
-                assert proc_flush_called
-                assert _stage_3_4_tokio_records(records) == []
+            assert proc_flush_called
         assert flush_started
         assert owner._stopped
 
@@ -500,13 +478,11 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
                 record_flush_from_tokio,
             ),
         ):
-            with tokio_oracle(raise_on_produce=True) as records:
-                shutdown_result = await host.shutdown()
-                cleanup.pop_all()
-                assert shutdown_result is None
+            shutdown_result = await host.shutdown()
+            cleanup.pop_all()
+            assert shutdown_result is None
 
-                assert host_flush_called
-                assert _stage_3_4_tokio_records(records) == []
+            assert host_flush_called
 
         assert flush_started
         assert drain_order == ["failed", "succeeded"]

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -30,7 +30,7 @@ from monarch._src.actor.actor_mesh import (
     ValueMesh,
 )
 from monarch._src.actor.endpoint import endpoint
-from monarch._src.actor.future import tokio_oracle, TokioOracleRecord
+from monarch._src.actor.future import Future, tokio_oracle, TokioOracleRecord
 from monarch._src.actor.host_mesh import this_host, this_proc
 from monarch._src.actor.proc_mesh import (
     get_or_spawn_controller,
@@ -44,6 +44,11 @@ from scoped_state import scoped_state
 
 _proc_rank = -1
 _BOOTSTRAP_FAILURE = "stage 3.4 bootstrap failure"
+_STAGE_3_4_ORACLE_FILES = {
+    "monarch._src.actor.host_mesh": "host_mesh.py",
+    "monarch._src.actor.logging": "logging.py",
+    "monarch._src.actor.proc_mesh": "proc_mesh.py",
+}
 
 
 def _successful_bootstrap() -> None:
@@ -54,20 +59,30 @@ def _fail_bootstrap() -> None:
     raise RuntimeError(_BOOTSTRAP_FAILURE)
 
 
-def _tokio_records_for(
+def _stage_3_4_tokio_records(
     records: list[TokioOracleRecord],
-    *,
-    module: str,
-    filename: str,
-    function: str | None = None,
 ) -> list[TokioOracleRecord]:
     return [
         record
         for record in records
-        if record.module == module
-        and os.path.basename(record.filename) == filename
-        and (function is None or record.function == function)
+        if _STAGE_3_4_ORACLE_FILES.get(record.module)
+        == os.path.basename(record.filename)
     ]
+
+
+class _PendingActorProbe:
+    def __init__(
+        self,
+        name: str,
+        driven: list[str],
+        error: Exception | None = None,
+    ) -> None:
+        async def initialize() -> None:
+            driven.append(name)
+            if error is not None:
+                raise error
+
+        self.initialized = Future(coro=initialize())
 
 
 class TestActor(Actor):
@@ -123,24 +138,18 @@ async def test_proc_mesh_initialization() -> None:
                 bootstrap=_successful_bootstrap,
             )
             assert await proc_mesh.initialized
-
-            setup_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.proc_mesh",
-                filename="proc_mesh.py",
-                function="task",
-            )
-            assert len(setup_records) == 1
+            assert _stage_3_4_tokio_records(records) == []
 
 
 @pytest.mark.timeout(60)
 @isolate_in_subprocess
 async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
-        proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
-
-        with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
-            await proc_mesh.initialized
+        with tokio_oracle() as records:
+            proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
+            with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
+                await proc_mesh.initialized
+            assert _stage_3_4_tokio_records(records) == []
 
 
 @pytest.mark.timeout(60)
@@ -191,13 +200,8 @@ async def test_stop_state_tracks_native_stop_result() -> None:
             with tokio_oracle() as records:
                 assert await owner.stop() is None
 
-                logging_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.logging",
-                    filename="logging.py",
-                )
                 assert proc_flush_called
-                assert logging_records == []
+                assert _stage_3_4_tokio_records(records) == []
         assert flush_started
         assert owner._stopped
 
@@ -455,6 +459,23 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
 
         # spawn actor but do NOT await initialized — immediately shutdown
         actor_mesh = proc_mesh.spawn("test_actor", TestActor, 42)
+        drain_order: list[str] = []
+        proc_mesh._pending_actor_spawns.extend(
+            [
+                cast(
+                    ActorMesh,
+                    _PendingActorProbe(
+                        "failed",
+                        drain_order,
+                        RuntimeError("pending actor initialization failed"),
+                    ),
+                ),
+                cast(
+                    ActorMesh,
+                    _PendingActorProbe("succeeded", drain_order),
+                ),
+            ]
+        )
 
         with (
             patch.object(logging_manager, "_new_flush_task", record_flush_start),
@@ -469,29 +490,11 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
                 cleanup.pop_all()
                 assert shutdown_result is None
 
-                proc_drain_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.proc_mesh",
-                    filename="proc_mesh.py",
-                    function="_flush_pending_actor_spawns",
-                )
-                logging_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.logging",
-                    filename="logging.py",
-                )
-                host_records = _tokio_records_for(
-                    records,
-                    module="monarch._src.actor.host_mesh",
-                    filename="host_mesh.py",
-                )
-
-                assert len(proc_drain_records) == 1
                 assert host_flush_called
-                assert logging_records == []
-                assert host_records == []
+                assert _stage_3_4_tokio_records(records) == []
 
         assert flush_started
+        assert drain_order == ["failed", "succeeded"]
         assert await actor_mesh.initialized is None
         assert proc_mesh._pending_actor_spawns == []
 

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -132,7 +132,7 @@ class TestActor(Actor):
 async def test_proc_mesh_initialization() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         host = state.hosts
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             proc_mesh = host.spawn_procs(
                 name="test_proc",
                 bootstrap=_successful_bootstrap,
@@ -145,7 +145,7 @@ async def test_proc_mesh_initialization() -> None:
 @isolate_in_subprocess
 async def test_proc_mesh_initialized_fails_when_bootstrap_fails() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             proc_mesh = state.hosts.spawn_procs(bootstrap=_fail_bootstrap)
             with pytest.raises(monarch.actor.ActorError, match=_BOOTSTRAP_FAILURE):
                 await proc_mesh.initialized
@@ -197,7 +197,7 @@ async def test_stop_state_tracks_native_stop_result() -> None:
                 record_flush_from_tokio,
             ),
         ):
-            with tokio_oracle() as records:
+            with tokio_oracle(raise_on_produce=True) as records:
                 assert await owner.stop() is None
 
                 assert proc_flush_called
@@ -243,13 +243,28 @@ def test_proc_mesh_sliced() -> None:
         # Initialize _proc_rank on each actor process
         actor = proc_mesh.spawn("test_actor", TestActor, 42)
         actor.get_proc_rank.call().get()
+        hy_proc_mesh = proc_mesh._proc_mesh.block_on()
+        release_proc_mesh = threading.Event()
+
+        async def resolve_proc_mesh() -> HyProcMesh:
+            await PythonTask.spawn_blocking(release_proc_mesh.wait)
+            return hy_proc_mesh
+
+        # Keep the native mesh unresolved so slicing must take the pending path.
+        proc_mesh._proc_mesh = PythonTask.from_coroutine(resolve_proc_mesh()).spawn()
+
         # Hosts 0 and 2, gpus 1 and 2
-        sliced = proc_mesh._new_with_shape(
-            Shape(
-                labels=["hosts", "gpus"],
-                slice=Slice(offset=1, sizes=[2, 2], strides=[6, 1]),
-            )
+        slice_shape = Shape(
+            labels=["hosts", "gpus"],
+            slice=Slice(offset=1, sizes=[2, 2], strides=[6, 1]),
         )
+        try:
+            assert proc_mesh._proc_mesh.poll() is None
+            sliced = proc_mesh._new_with_shape(slice_shape)
+            assert sliced._proc_mesh.poll() is None
+        finally:
+            release_proc_mesh.set()
+
         actor = sliced.spawn("test_actor_sliced", TestActor, 42)
         proc_ranks = actor.get_proc_rank.call().get()
         assert proc_ranks.extent.labels == ["hosts", "gpus"]
@@ -485,7 +500,7 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
                 record_flush_from_tokio,
             ),
         ):
-            with tokio_oracle() as records:
+            with tokio_oracle(raise_on_produce=True) as records:
                 shutdown_result = await host.shutdown()
                 cleanup.pop_all()
                 assert shutdown_result is None

--- a/python/tests/test_proc_mesh.py
+++ b/python/tests/test_proc_mesh.py
@@ -149,6 +149,8 @@ async def test_stop_state_tracks_native_stop_result() -> None:
     with scoped_state(ProcessJob({"hosts": 1}), cached_path=None) as state:
         owner = state.hosts.spawn_procs(per_host={"gpus": 2})
         await owner.initialized
+        logging_manager = owner._logging_manager
+        assert logging_manager._logging_mesh_client is not None
         proc_ref = owner.slice(gpus=0)
 
         with pytest.raises(
@@ -158,7 +160,45 @@ async def test_stop_state_tracks_native_stop_result() -> None:
             await proc_ref.stop()
 
         assert not proc_ref._stopped
-        assert await owner.stop() is None
+        flush_started = False
+        proc_flush_called = False
+        new_flush_task = logging_manager._new_flush_task
+        flush_from_tokio = logging_manager._flush_from_tokio
+
+        def record_flush_start() -> PythonTask[None]:
+            flush_task = new_flush_task()
+
+            async def task() -> None:
+                nonlocal flush_started
+                flush_started = True
+                await flush_task
+
+            return PythonTask.from_coroutine(task())
+
+        async def record_flush_from_tokio() -> None:
+            nonlocal proc_flush_called
+            proc_flush_called = True
+            await flush_from_tokio()
+
+        with (
+            patch.object(logging_manager, "_new_flush_task", record_flush_start),
+            patch.object(
+                logging_manager,
+                "_flush_from_tokio",
+                record_flush_from_tokio,
+            ),
+        ):
+            with tokio_oracle() as records:
+                assert await owner.stop() is None
+
+                logging_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.logging",
+                    filename="logging.py",
+                )
+                assert proc_flush_called
+                assert logging_records == []
+        assert flush_started
         assert owner._stopped
 
 
@@ -390,38 +430,68 @@ async def test_actor_spawn_then_immediate_shutdown() -> None:
         host = job.state(cached_path=None).hosts
         proc_mesh = host.spawn_procs(name="test")
         await proc_mesh.initialized
-        assert proc_mesh._logging_manager._logging_mesh_client is not None
+        logging_manager = proc_mesh._logging_manager
+        assert logging_manager._logging_mesh_client is not None
+
+        flush_started = False
+        host_flush_called = False
+        new_flush_task = logging_manager._new_flush_task
+        flush_from_tokio = logging_manager._flush_from_tokio
+
+        def record_flush_start() -> PythonTask[None]:
+            flush_task = new_flush_task()
+
+            async def task() -> None:
+                nonlocal flush_started
+                flush_started = True
+                await flush_task
+
+            return PythonTask.from_coroutine(task())
+
+        async def record_flush_from_tokio() -> None:
+            nonlocal host_flush_called
+            host_flush_called = True
+            await flush_from_tokio()
 
         # spawn actor but do NOT await initialized — immediately shutdown
         actor_mesh = proc_mesh.spawn("test_actor", TestActor, 42)
 
-        with tokio_oracle() as records:
-            shutdown_result = await host.shutdown()
-            cleanup.pop_all()
-            assert shutdown_result is None
+        with (
+            patch.object(logging_manager, "_new_flush_task", record_flush_start),
+            patch.object(
+                logging_manager,
+                "_flush_from_tokio",
+                record_flush_from_tokio,
+            ),
+        ):
+            with tokio_oracle() as records:
+                shutdown_result = await host.shutdown()
+                cleanup.pop_all()
+                assert shutdown_result is None
 
-            proc_drain_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.proc_mesh",
-                filename="proc_mesh.py",
-                function="_flush_pending_actor_spawns",
-            )
-            logging_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.logging",
-                filename="logging.py",
-                function="flush_async",
-            )
-            host_records = _tokio_records_for(
-                records,
-                module="monarch._src.actor.host_mesh",
-                filename="host_mesh.py",
-            )
+                proc_drain_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.proc_mesh",
+                    filename="proc_mesh.py",
+                    function="_flush_pending_actor_spawns",
+                )
+                logging_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.logging",
+                    filename="logging.py",
+                )
+                host_records = _tokio_records_for(
+                    records,
+                    module="monarch._src.actor.host_mesh",
+                    filename="host_mesh.py",
+                )
 
-            assert len(proc_drain_records) == 1
-            assert len(logging_records) == 1
-            assert host_records == []
+                assert len(proc_drain_records) == 1
+                assert host_flush_called
+                assert logging_records == []
+                assert host_records == []
 
+        assert flush_started
         assert await actor_mesh.initialized is None
         assert proc_mesh._pending_actor_spawns == []
 

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -49,6 +49,7 @@ from monarch._src.actor.future import (
     enable_tokio_oracle,
     Future,
     reset_tokio_oracle,
+    tokio_oracle,
     tokio_oracle_records,
 )
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
@@ -1091,7 +1092,16 @@ async def test_flush_async_drives_flush_on_asyncio_loop() -> None:
         await asyncio.sleep(1)
 
         # System under test: flush_async on the test's asyncio loop.
-        await pm._logging_manager.flush_async()
+        with tokio_oracle() as records:
+            await pm._logging_manager.flush_async()
+
+            logging_records = [
+                record
+                for record in records
+                if record.module == "monarch._src.actor.logging"
+                and os.path.basename(record.filename) == "logging.py"
+            ]
+            assert logging_records == []
 
         await asyncio.sleep(1)
         sys.stdout.flush()

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -44,7 +44,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
-from monarch._src.actor.future import Future, tokio_oracle
+from monarch._src.actor.future import Future
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
 from monarch._src.actor.logging import _pending_flush_tasks
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
@@ -1085,16 +1085,7 @@ async def test_flush_async_drives_flush_on_asyncio_loop() -> None:
         await asyncio.sleep(1)
 
         # System under test: flush_async on the test's asyncio loop.
-        with tokio_oracle(raise_on_produce=True) as records:
-            await pm._logging_manager.flush_async()
-
-            logging_records = [
-                record
-                for record in records
-                if record.module == "monarch._src.actor.logging"
-                and os.path.basename(record.filename) == "logging.py"
-            ]
-            assert logging_records == []
+        await pm._logging_manager.flush_async()
 
         await asyncio.sleep(1)
         sys.stdout.flush()
@@ -1135,10 +1126,8 @@ async def test_multiple_ongoing_flushes_no_deadlock() -> None:
             # FIXME: the order of futures doesn't necessarily mean the order of flushes due to the async nature.
             await asyncio.sleep(0.1)
             futures.append(
-                Future(
-                    coro=log_mesh.flush(context().actor_instance._as_rust())
-                    .spawn()
-                    .task()
+                Future._from_coro(
+                    log_mesh.flush(context().actor_instance._as_rust()).spawn().task()
                 )
             )
 
@@ -2273,7 +2262,7 @@ def _future_of(value):
     async def _v():
         return value
 
-    return Future(coro=_v())
+    return Future._from_coro(_v())
 
 
 def _stream_endpoint(values):
@@ -2306,18 +2295,3 @@ def test_accumulate_forwards_args_to_stream():
     ep = _stream_endpoint([1])
     Accumulator(ep, 0, operator.add).accumulate("a", k=1).get()
     ep.stream.assert_called_once_with("a", k=1)
-
-
-def test_accumulate_produces_no_tokio():
-    """Gate A (accumulate cluster): accumulate produces no `_Tokio` state.
-
-    Drives accumulate with the `_Tokio` oracle in raise mode and asserts
-    actor_mesh.py produced no `_Tokio` (no `await <Future>` on the tokio thread).
-    Before the `_take_inner()` migration this recorded the impl producer at 876;
-    after it, zero.
-    """
-    with tokio_oracle(raise_on_produce=True) as oracle_records:
-        acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
-        assert acc.accumulate().get() == 6
-        records = [r for r in oracle_records if r.filename.endswith("actor_mesh.py")]
-        assert records == [], f"accumulate still produces _Tokio: {records}"

--- a/python/tests/test_python_actors.py
+++ b/python/tests/test_python_actors.py
@@ -44,14 +44,7 @@ from monarch._rust_bindings.monarch_hyperactor.mailbox import (
 from monarch._rust_bindings.monarch_hyperactor.proc import ActorAddr
 from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask, Shared
 from monarch._src.actor.actor_mesh import ActorMesh, Channel, context, Port
-from monarch._src.actor.future import (
-    disable_tokio_oracle,
-    enable_tokio_oracle,
-    Future,
-    reset_tokio_oracle,
-    tokio_oracle,
-    tokio_oracle_records,
-)
+from monarch._src.actor.future import Future, tokio_oracle
 from monarch._src.actor.host_mesh import _spawn_admin, HostMesh, this_host, this_proc
 from monarch._src.actor.logging import _pending_flush_tasks
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, HyProcMesh
@@ -1092,7 +1085,7 @@ async def test_flush_async_drives_flush_on_asyncio_loop() -> None:
         await asyncio.sleep(1)
 
         # System under test: flush_async on the test's asyncio loop.
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             await pm._logging_manager.flush_async()
 
             logging_records = [
@@ -2318,21 +2311,13 @@ def test_accumulate_forwards_args_to_stream():
 def test_accumulate_produces_no_tokio():
     """Gate A (accumulate cluster): accumulate produces no `_Tokio` state.
 
-    Drives accumulate with the record-only `_Tokio` oracle enabled and asserts
+    Drives accumulate with the `_Tokio` oracle in raise mode and asserts
     actor_mesh.py produced no `_Tokio` (no `await <Future>` on the tokio thread).
     Before the `_take_inner()` migration this recorded the impl producer at 876;
     after it, zero.
     """
-    disable_tokio_oracle()
-    reset_tokio_oracle()
-    enable_tokio_oracle()
-    try:
+    with tokio_oracle(raise_on_produce=True) as oracle_records:
         acc = Accumulator(_stream_endpoint([1, 2, 3]), 0, operator.add)
         assert acc.accumulate().get() == 6
-        records = [
-            r for r in tokio_oracle_records() if r.filename.endswith("actor_mesh.py")
-        ]
+        records = [r for r in oracle_records if r.filename.endswith("actor_mesh.py")]
         assert records == [], f"accumulate still produces _Tokio: {records}"
-    finally:
-        disable_tokio_oracle()
-        reset_tokio_oracle()

--- a/python/tests/test_rdma_initialization.py
+++ b/python/tests/test_rdma_initialization.py
@@ -102,7 +102,7 @@ class _RdmaTokioOracleProbe(Actor):
 
     @endpoint
     async def create_buffer(self) -> tuple[RDMABuffer, list[tuple[str, int, str]]]:
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             self.buffer = RDMABuffer(memoryview(self.data))
             sites = _rdma_tokio_sites(records)
         return self.buffer, sites
@@ -112,7 +112,7 @@ class _RdmaTokioOracleProbe(Actor):
         self,
         buffer: RDMABuffer,
     ) -> tuple[bytes, list[tuple[str, int, str]]]:
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             readback = bytearray(len(_ORACLE_INITIAL))
             assert await buffer.read_into(memoryview(readback)) is None
             assert await buffer.write_from(memoryview(_ORACLE_UPDATED)) is None
@@ -122,7 +122,7 @@ class _RdmaTokioOracleProbe(Actor):
     @endpoint
     async def verify_and_drop(self) -> list[tuple[str, int, str]]:
         assert self.buffer is not None
-        with tokio_oracle() as records:
+        with tokio_oracle(raise_on_produce=True) as records:
             assert bytes(self.data) == _ORACLE_UPDATED
             assert await self.buffer.drop() is None
             sites = _rdma_tokio_sites(records)
@@ -143,9 +143,25 @@ def test_tokio_oracle_records_known_tokio_production() -> None:
             for record in records
             if record.module == __name__ and record.function == "produce"
         ]
+        assert records == control_sites
         assert len(control_sites) == 1, (
             f"expected one known _Tokio production, got {control_sites}"
         )
+
+
+def test_tokio_oracle_scoped_record_restores_outer_raise_mode() -> None:
+    from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
+    from monarch._src.actor.future import Future
+
+    async def produce() -> None:
+        await Future(coro=PythonTask.sleep(0))
+
+    with tokio_oracle(raise_on_produce=True):
+        with tokio_oracle() as records:
+            PythonTask.from_coroutine(produce()).block_on()
+            assert len(records) == 1
+        with pytest.raises(RuntimeError, match="_Tokio produced"):
+            PythonTask.from_coroutine(produce()).block_on()
 
 
 def test_manager_init_cache_reuses_handle_without_retaining_mesh(monkeypatch) -> None:

--- a/python/tests/test_rdma_initialization.py
+++ b/python/tests/test_rdma_initialization.py
@@ -9,8 +9,8 @@
 Tests for RDMA manager initialization and its failure surfaces.
 
 These tests cover the owner-backed binding from local and remote actors,
-production readiness caching and validation, the RDMA-local `_Tokio` gate,
-and backend configuration errors.
+production readiness caching and validation, public buffer operations, and
+backend configuration errors.
 """
 
 import gc
@@ -26,25 +26,14 @@ if sys.platform != "linux":
     pytest.skip("linux-only", allow_module_level=True)
 
 from isolate_in_subprocess import isolate_in_subprocess
-from monarch._src.actor.future import tokio_oracle, TokioOracleRecord
 from monarch._src.actor.proc_mesh import ProcMesh
 from monarch.actor import Actor, endpoint
 from monarch.config import configured
 from monarch.rdma import RDMABuffer
 
 
-_ORACLE_INITIAL = b"rdma-oracle-a"
-_ORACLE_UPDATED = b"rdma-oracle-b"
-
-
-def _rdma_tokio_sites(
-    records: list[TokioOracleRecord],
-) -> list[tuple[str, int, str]]:
-    return [
-        (record.filename, record.lineno, record.function)
-        for record in records
-        if record.module == RDMABuffer.__module__
-    ]
+_PUBLIC_PATH_INITIAL = b"rdma-public-path-a"
+_PUBLIC_PATH_UPDATED = b"rdma-public-path-b"
 
 
 class _RdmaInitProbe(Actor):
@@ -95,73 +84,31 @@ class _RdmaInitProbe(Actor):
         return buffer_error, submit_error
 
 
-class _RdmaTokioOracleProbe(Actor):
+class _RdmaPublicPathProbe(Actor):
     def __init__(self) -> None:
-        self.data = bytearray(_ORACLE_INITIAL)
+        self.data = bytearray(_PUBLIC_PATH_INITIAL)
         self.buffer: RDMABuffer | None = None
 
     @endpoint
-    async def create_buffer(self) -> tuple[RDMABuffer, list[tuple[str, int, str]]]:
-        with tokio_oracle(raise_on_produce=True) as records:
-            self.buffer = RDMABuffer(memoryview(self.data))
-            sites = _rdma_tokio_sites(records)
-        return self.buffer, sites
+    async def create_buffer(self) -> RDMABuffer:
+        self.buffer = RDMABuffer(memoryview(self.data))
+        return self.buffer
 
     @endpoint
     async def read_and_write(
         self,
         buffer: RDMABuffer,
-    ) -> tuple[bytes, list[tuple[str, int, str]]]:
-        with tokio_oracle(raise_on_produce=True) as records:
-            readback = bytearray(len(_ORACLE_INITIAL))
-            assert await buffer.read_into(memoryview(readback)) is None
-            assert await buffer.write_from(memoryview(_ORACLE_UPDATED)) is None
-            sites = _rdma_tokio_sites(records)
-        return bytes(readback), sites
+    ) -> bytes:
+        readback = bytearray(len(_PUBLIC_PATH_INITIAL))
+        assert await buffer.read_into(memoryview(readback)) is None
+        assert await buffer.write_from(memoryview(_PUBLIC_PATH_UPDATED)) is None
+        return bytes(readback)
 
     @endpoint
-    async def verify_and_drop(self) -> list[tuple[str, int, str]]:
+    async def verify_and_drop(self) -> None:
         assert self.buffer is not None
-        with tokio_oracle(raise_on_produce=True) as records:
-            assert bytes(self.data) == _ORACLE_UPDATED
-            assert await self.buffer.drop() is None
-            sites = _rdma_tokio_sites(records)
-        return sites
-
-
-def test_tokio_oracle_records_known_tokio_production() -> None:
-    from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-    from monarch._src.actor.future import Future
-
-    async def produce() -> None:
-        await Future(coro=PythonTask.sleep(0))
-
-    with tokio_oracle() as records:
-        PythonTask.from_coroutine(produce()).block_on()
-        control_sites = [
-            record
-            for record in records
-            if record.module == __name__ and record.function == "produce"
-        ]
-        assert records == control_sites
-        assert len(control_sites) == 1, (
-            f"expected one known _Tokio production, got {control_sites}"
-        )
-
-
-def test_tokio_oracle_scoped_record_restores_outer_raise_mode() -> None:
-    from monarch._rust_bindings.monarch_hyperactor.pytokio import PythonTask
-    from monarch._src.actor.future import Future
-
-    async def produce() -> None:
-        await Future(coro=PythonTask.sleep(0))
-
-    with tokio_oracle(raise_on_produce=True):
-        with tokio_oracle() as records:
-            PythonTask.from_coroutine(produce()).block_on()
-            assert len(records) == 1
-        with pytest.raises(RuntimeError, match="_Tokio produced"):
-            PythonTask.from_coroutine(produce()).block_on()
+        assert bytes(self.data) == _PUBLIC_PATH_UPDATED
+        assert await self.buffer.drop() is None
 
 
 def test_manager_init_cache_reuses_handle_without_retaining_mesh(monkeypatch) -> None:
@@ -349,7 +296,7 @@ async def test_public_paths_propagate_readiness_failure() -> None:
 
 @pytest.mark.timeout(90)
 @isolate_in_subprocess
-async def test_public_rdma_paths_produce_no_tokio() -> None:
+async def test_public_rdma_paths() -> None:
     from monarch.actor import this_host
 
     with configured(
@@ -362,26 +309,17 @@ async def test_public_rdma_paths_produce_no_tokio() -> None:
             consumer_proc = this_host().spawn_procs(per_host={"cpus": 1})
             try:
                 producer = producer_proc.spawn(
-                    "rdma_oracle_producer", _RdmaTokioOracleProbe
+                    "rdma_public_path_producer", _RdmaPublicPathProbe
                 )
                 consumer = consumer_proc.spawn(
-                    "rdma_oracle_consumer", _RdmaTokioOracleProbe
+                    "rdma_public_path_consumer", _RdmaPublicPathProbe
                 )
 
-                buffer, create_sites = await producer.create_buffer.call_one()
-                readback, transfer_sites = await consumer.read_and_write.call_one(
-                    buffer
-                )
-                drop_sites = await producer.verify_and_drop.call_one()
+                buffer = await producer.create_buffer.call_one()
+                readback = await consumer.read_and_write.call_one(buffer)
+                assert await producer.verify_and_drop.call_one() is None
 
-                assert readback == _ORACLE_INITIAL
-                assert create_sites == [], (
-                    f"RDMA buffer creation produced _Tokio: {create_sites}"
-                )
-                assert transfer_sites == [], (
-                    f"RDMA read/write produced _Tokio: {transfer_sites}"
-                )
-                assert drop_sites == [], f"RDMA drop produced _Tokio: {drop_sites}"
+                assert readback == _PUBLIC_PATH_INITIAL
             finally:
                 await consumer_proc.stop()
         finally:


### PR DESCRIPTION
Summary:
`Future.__await__` is retained permanently as a thin shim delegating to `as_asyncio()`; the pytokio-driving await path, the `_Tokio` branch and its guard, is removed. this implements the decision in [RFC: Retiring pytokio (toward unifying Rust/Python actors)](https://fburl.com/gdoc/8g895lcv).

concretely, awaiting a Monarch `Future` from a Python coroutine driven by Tokio is now an explicit error, while asyncio `await` and synchronous `get()` are unchanged. where a Tokio-driven coroutine still waits for a Monarch operation, two proc-mesh paths explicitly take and spawn the underlying task with `await future._take_inner().spawn()`.

the diff also removes `_Tokio` and the migration oracle used by `D114138892` to prove that no production path still enters this branch. direct `Future(coro=...)` construction is no longer public; Monarch builds the futures it returns through a private factory.

this leaves the remaining pytokio dependency explicit and bounded. a follow-up will move proc and host lifecycle orchestration into Rust and replace private `_from_coro()` construction with Rust-produced `Handle` values, allowing `_take_inner().spawn()`, `PythonTask`, and `Shared` to be deleted.

Differential Revision: D114161976
