### PR TITLE
Fix clippy::empty_line_after_doc_comments lint in fbcode/monarch/ndslice (#4546)

### DIFF
--- a/ndslice/src/selection.rs
+++ b/ndslice/src/selection.rs
@@ -90,8 +90,6 @@ pub mod pretty;
 /// examples.
 pub mod token_parser;
 
-/// Shape navigation guided by [`Selection`] expressions.
-
 /// Normalization logic for `Selection`.
 pub mod normal;
 


### PR DESCRIPTION
Summary: Pull Request resolved: https://github.com/meta-pytorch/monarch/pull/4546

Differential Revision: D114187337


