### PR TITLE
Fix CUDA expandable_segments RDMA failure (status=10) under a NIC pin

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -28,6 +28,7 @@ use std::sync::OnceLock;
 
 use anyhow::Context;
 
+use super::device_selection::IbvDeviceTarget;
 use super::device_selection::get_cuda_device_to_ibv_device;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
@@ -738,12 +739,27 @@ impl MlxDomain {
             return Ok(RegisteredSegment::view(seg, addr, size));
         }
 
-        // Pull live segments and keep only the ones on ordinals we serve.
+        // Pull live segments and keep only the ones on ordinals we serve --
+        // unless this NIC is an explicit pin (`config.target`). A pin forces
+        // *every* registration onto this NIC in `resolve_local_mr`, overriding
+        // the GPU-optimal-NIC selection that `cuda_ordinals` is derived from
+        // (`assigned_cuda_devices` -> `select_optimal_ibv_devices`). In that
+        // case the topology filter is wrong: it would drop segments on GPUs
+        // whose optimal NIC differs from the pin, sending them to the
+        // whole-allocation dmabuf fallback -- which mis-registers
+        // `expandable_segments` CUDA memory (it trusts `cuMemGetAddressRange`,
+        // which returns a single VMM mapping granule, not the whole segment) and
+        // faults remote writes with `REM_ACCESS_ERR`. When pinned here, bind
+        // whatever segments land on this NIC instead.
+        let pinned_here = matches!(
+            &self.config.target,
+            Some(IbvDeviceTarget::Nic(name)) if *name == self.ops.device_name()
+        );
         let scanned: Vec<ScannedSegment> = self
             .ops
             .scan_segments()
             .into_iter()
-            .filter(|s| self.cuda_ordinals.contains(&s.cuda_ordinal))
+            .filter(|s| pinned_here || self.cuda_ordinals.contains(&s.cuda_ordinal))
             .collect();
 
         let qp = self.loopback_qp_ptr(domain)?;
@@ -1004,6 +1020,22 @@ mod tests {
         let mlx = MlxDomain::new_with_ops(mock, IbvConfig::default(), TEST_MKEY_MAX_ENTRIES);
         // SAFETY: `IbvPd::null()` holds a null PD (and, through it, a null
         // context) whose `Drop`s are no-ops.
+        unsafe {
+            Arc::new(IbvDomain::for_test(
+                Arc::new(IbvPd::null()),
+                IbvDeviceInfo::for_test_named("test"),
+                mlx,
+            ))
+        }
+    }
+
+    /// Like [`domain`] but with an explicit NIC pin (`config.target`), so
+    /// `register_cuda_mlx5dv_mr` treats this domain as the pinned target when
+    /// `nic` matches the mock's device name.
+    fn domain_pinned_to(mock: Arc<MockOps>, nic: &str) -> Arc<IbvDomain<MlxDomain>> {
+        let config = IbvConfig::targeting(IbvDeviceTarget::nic(nic));
+        let mlx = MlxDomain::new_with_ops(mock, config, TEST_MKEY_MAX_ENTRIES);
+        // SAFETY: as in [`domain`].
         unsafe {
             Arc::new(IbvDomain::for_test(
                 Arc::new(IbvPd::null()),
@@ -1425,6 +1457,48 @@ mod tests {
             mock.lock().bind_calls.is_empty(),
             "no bind attempted for an unserved ordinal"
         );
+    }
+
+    #[test]
+    fn test_pinned_nic_binds_unserved_ordinal() {
+        // When this NIC is the explicit pin (`config.target`), every
+        // registration is routed here regardless of the GPU's optimal NIC, so
+        // the mlx5dv path must bind a segment on an ordinal this NIC's topology
+        // filter would otherwise exclude -- rather than dropping it onto the
+        // expandable-segments-unsafe dmabuf fallback.
+        let base = 0x10_0000_0000;
+        let mock = MockOps::new(SERVED_NIC, true, &[0]);
+        // Segment is on ordinal 5, which the topology filter (served: [0])
+        // excludes.
+        mock.lock().scan = vec![seg(base, MIB2, 5)];
+        let domain = domain_pinned_to(mock.clone(), SERVED_NIC);
+
+        let view =
+            register_cuda(&domain, base, 4096).expect("a pinned NIC binds segments on any ordinal");
+        assert_eq!(view.rdma_addr, 0, "view is anchored at the segment base");
+        assert_eq!(view.device_name, SERVED_NIC);
+        assert_eq!(
+            mock.lock().bind_calls.len(),
+            1,
+            "the unserved-ordinal segment is bound under the pin"
+        );
+    }
+
+    #[test]
+    fn test_pin_to_other_nic_keeps_ordinal_filter() {
+        // A pin naming a *different* NIC must not relax this NIC's ordinal
+        // filter: this domain is not the pinned target, so an unserved ordinal
+        // stays excluded.
+        let base = 0x10_0000_0000;
+        let mock = MockOps::new(SERVED_NIC, true, &[0]);
+        mock.lock().scan = vec![seg(base, MIB2, 5)];
+        let domain = domain_pinned_to(mock.clone(), "mlx5_other");
+
+        assert!(
+            register_cuda(&domain, base, 4096).is_err(),
+            "a pin naming a different NIC does not bypass this NIC's ordinal filter"
+        );
+        assert!(mock.lock().bind_calls.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

On a GB300 / MLNX-OFED 2410 cluster, torchstore over monarch RDMA fails writing into **CUDA** `RDMABuffer`s backed by a PyTorch `expandable_segments` pool: `status=10` (`IBV_WC_REM_ACCESS_ERR`, `vendor_err=136`). Default CUDA allocator and CPU destinations always succeed. The failure only appears when registrations are **pinned to one NIC** via `MONARCH_RDMA_IBVERBS_TARGET` (e.g. `nic:ibp0p0`) - the standard workaround for the cross-rail `status=12` (`RETRY_EXC_ERR`) on this fabric.

## Root cause

Two mechanisms interact:

1. **A NIC pin routes *every* registration onto the pinned NIC's domain.** `resolve_local_mr` (`manager_actor.rs:344-348`) resolves `config.target` and uses that NIC for both host and device memory, bypassing the GPU-co-located NIC selection.

2. **But the pinned domain's `cuda_ordinals` is derived from topology only.** `assigned_cuda_devices` -> `get_cuda_device_to_ibv_device` -> `select_optimal_ibv_devices(Gpu(ordinal))` (`device_selection.rs:215-240`) keeps only ordinals whose *optimal* NIC equals this device; the pin never enters that computation.

So when the pinned NIC is not the GPU's optimal rail, the scanned-segment filter in `register_cuda_mlx5dv_mr` (`mlx_domain.rs`) drops the GPU's segment:

```
mlx5dv CUDA registration failed, falling back to dmabuf:
  CUDA address 0x... + size ... is not covered by any scanned segment
  on the CUDA ordinals []
```

Registration then falls through to `register_host_or_dmabuf_mr` -> `register_dmabuf_mr` (`domain.rs:370`), whose docstring assumes *"The MR covers the entire allocation"*. It calls `cuMemGetAddressRange` and registers one dmabuf MR over the returned range. For `expandable_segments` that assumption is **false**: the torch segment is one VA reservation backed by piecewise VMM mappings, and `cuMemGetAddressRange` returns only the single ~20 MiB VMM mapping **granule** containing the pointer. The MR covers just that granule, so a write to a target that straddles the granule end overruns the MR -> `REM_ACCESS_ERR`.

Deterministic, arithmetic-exact predictor (verified by a single-write repro sweeping the target's offset within the segment):

```
FAIL  <=>  mr_offset + target_size > granule_size (~20 MiB)
```

The `status=12` workaround thus deterministically forces CUDA registration onto the buggy fallback.

Disproven along the way (kept for reviewers): indirect-mkey/UMR truncation (that path is inactive here), `iova=0` (self-consistent: `rdma_addr = mr_addr + mr_offset`), the rdma-core KLM int32 overflow (already fixed in this OFED), and the `[RdmaXcel] Failed to get current CUDA context.` log (prints identically on pass and fail).

## Fix

When this NIC is the explicit pin (`config.target == Nic(self)`), bypass the topology-based `cuda_ordinals` filter in `register_cuda_mlx5dv_mr` and bind whatever segments land here. The pin has already overridden NIC selection, so the topology filter is simply wrong in that mode.

This keeps the **whole-segment mlx5dv indirect-mkey path** - which registers the full `ScannedSegment` extent via `grow`/`register_range` and is already validated on this hardware - active under a pin, so the expandable-segments-unsafe dmabuf fallback is never reached. Cross-rail *registration* on the pinned NIC is exactly what the pin already does for host buffers (CPU self-test passes); `status=12` was a QP *connection* issue, not registration.

Behavior with no pin, and with a pin naming a *different* NIC, is unchanged.

## Tests

Added two unit tests (mock-ops harness, no hardware):
- `test_pinned_nic_binds_unserved_ordinal` - a pinned NIC binds a segment on an ordinal its topology filter would exclude.
- `test_pin_to_other_nic_keeps_ordinal_filter` - a pin naming a different NIC leaves this NIC's filter intact.

## Notes / follow-up

- Authored and reviewed against source; I could not compile locally (the repo pins `nightly-2026-05-22` / rustc 1.97 and this host only has cargo 1.82, no rustup). Relying on CI to build/test.
- **Defense-in-depth follow-up (not in this PR):** `register_dmabuf_mr` should also stop trusting `cuMemGetAddressRange` for VMM memory - look up the containing scanned segment and register its full extent (bounded by `MAX_MR_SIZE`, else route back through the stitching path), and fix the misleading docstring. With this PR the fallback is no longer reached in the pinned scenario, but hardening it would prevent a future silent truncation.

## Repro

Single `RDMABuffer` + single `write_from`, monarch + torch only, rail-pinned, `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`, 12 MiB CUDA target:
- offset 16/32 MiB into the segment -> **FAIL** (`status=10, vendor_err=136`)
- offset 0/64/128 MiB, or `expandable_segments:False`, or CPU dst -> **SUCCESS**