### PR TITLE
Keep execution id in process config (#4550)

### DIFF
--- a/hyperactor_config/src/attrs.rs
+++ b/hyperactor_config/src/attrs.rs
@@ -39,6 +39,16 @@
 //! assert_eq!(attrs.get(MAX_RETRIES), Some(&3));
 //! ```
 //!
+//! Declared default expressions are evaluated lazily at most once per process.
+//! This permits defaults that require runtime construction while preserving a
+//! stable value for the lifetime of the process.
+//! Default expressions must be inexpensive, infallible, free of externally
+//! visible side effects, and independent of global configuration. In particular,
+//! reading global configuration from a default expression can deadlock while the
+//! global configuration is being materialized. Registry consumers such as
+//! configuration diagnostics may initialize a default even when an explicit value
+//! ultimately wins.
+//!
 //! # Serialization
 //!
 //! `Attrs` can be serialized to and deserialized automatically:
@@ -141,8 +151,8 @@ pub struct AttrKeyInfo {
     pub display: fn(&dyn SerializableValue) -> String,
     /// Parse an attribute value using AttrValue::parse.
     pub parse: fn(&str) -> Result<Box<dyn SerializableValue>, anyhow::Error>,
-    /// Default value for the attribute, if any.
-    pub default: Option<&'static dyn SerializableValue>,
+    /// Accessor for the lazily initialized default value, if any.
+    pub default: Option<fn() -> &'static dyn SerializableValue>,
     /// A reference to the relevant key object with the associated
     /// type parameter erased. Can be downcast to a concrete Key<T>.
     pub erased: &'static dyn ErasedKey,
@@ -279,7 +289,7 @@ pub fn marked_attr_names(marker: Key<bool>) -> std::collections::HashSet<&'stati
 /// static lifetime and automatically registers them for serialization.
 pub struct Key<T: 'static> {
     name: &'static str,
-    default_value: Option<&'static T>,
+    default_value: Option<&'static LazyLock<T>>,
     attrs: &'static LazyLock<Attrs>,
 }
 
@@ -320,7 +330,7 @@ impl<T: Named + 'static> Key<T> {
     /// Creates a new key with the given name.
     pub const fn new(
         name: &'static str,
-        default_value: Option<&'static T>,
+        default_value: Option<&'static LazyLock<T>>,
         attrs: &'static LazyLock<Attrs>,
     ) -> Self {
         Self {
@@ -332,7 +342,7 @@ impl<T: Named + 'static> Key<T> {
 
     /// Returns a reference to the default value for this key, if one exists.
     pub fn default(&self) -> Option<&'static T> {
-        self.default_value
+        self.default_value.map(LazyLock::force)
     }
 
     /// Returns whether this key has a default value.
@@ -1015,9 +1025,17 @@ macro_rules! assert_impl {
 ///
 /// * Optional visibility modifier (`pub`, `pub(crate)`, etc.)
 /// * `attr` keyword (required)
+/// * Optional default expression, evaluated lazily at most once per process
 /// * Key name (identifier)
 /// * Type of values this key can store
 /// * Optional default value
+///
+/// Default expressions must be inexpensive, infallible, free of externally
+/// visible side effects, and must not access global configuration. A default
+/// can be initialized while global configuration is being materialized, so
+/// re-entering global configuration from the expression can deadlock. Registry
+/// consumers such as configuration diagnostics may initialize a default even
+/// when an explicit value ultimately wins.
 ///
 /// # Example
 ///
@@ -1061,9 +1079,10 @@ macro_rules! declare_attrs {
     (@single $(@meta($($meta_key:ident = $meta_value:expr),* $(,)?))* $(#[$attr:meta])* ; $vis:vis attr $name:ident: $type:ty = $default:expr;) => {
         $crate::assert_impl!($type, $crate::attrs::AttrValue);
 
-        // Create a static default value
+        // Evaluate each declared default at most once, on first use.
         $crate::paste! {
-            static [<$name _DEFAULT>]: $type = $default;
+            static [<$name _DEFAULT>]: std::sync::LazyLock<$type> =
+                std::sync::LazyLock::new(|| $default);
             static [<$name _META_ATTRS>]: std::sync::LazyLock<$crate::attrs::Attrs> =
                 std::sync::LazyLock::new(|| {
                     #[allow(unused_mut)]
@@ -1120,7 +1139,11 @@ macro_rules! declare_attrs {
                     let value: $type = $crate::attrs::AttrValue::parse(value)?;
                     Ok(Box::new(value) as Box<dyn $crate::attrs::SerializableValue>)
                 },
-                default: Some($crate::paste! { &[<$name _DEFAULT>] }),
+                default: Some(|| {
+                    $crate::paste! {
+                        &*[<$name _DEFAULT>] as &'static dyn $crate::attrs::SerializableValue
+                    }
+                }),
                 erased: &$name,
             }
         }
@@ -1193,6 +1216,8 @@ pub use declare_attrs;
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     use super::*;
@@ -1455,8 +1480,17 @@ mod tests {
         /// With default...
         attr TIMEOUT_WITH_DEFAULT: Duration = Duration::from_secs(10);
 
+        attr STRING_WITH_LAZY_DEFAULT: String = make_lazy_default();
+
         /// Just to ensure visibilty is parsed.
         pub(crate) attr CRATE_LOCAL_ATTR: String;
+    }
+
+    static LAZY_DEFAULT_CALLS: AtomicUsize = AtomicUsize::new(0);
+
+    fn make_lazy_default() -> String {
+        let call = LAZY_DEFAULT_CALLS.fetch_add(1, Ordering::Relaxed);
+        format!("lazy-default-{call}")
     }
 
     #[test]
@@ -1468,6 +1502,27 @@ mod tests {
             Attrs::new().get(TIMEOUT_WITH_DEFAULT),
             Some(&Duration::from_secs(10))
         );
+    }
+
+    #[test]
+    fn test_default_expression_is_initialized_once() {
+        let handles = (0..8)
+            .map(|_| {
+                std::thread::spawn(|| {
+                    STRING_WITH_LAZY_DEFAULT
+                        .default()
+                        .expect("key should have a default")
+                        .clone()
+                })
+            })
+            .collect::<Vec<_>>();
+        let values = handles
+            .into_iter()
+            .map(|handle| handle.join().expect("default reader should complete"))
+            .collect::<Vec<_>>();
+
+        assert!(values.iter().all(|value| value == "lazy-default-0"));
+        assert_eq!(LAZY_DEFAULT_CALLS.load(Ordering::Relaxed), 1);
     }
 
     #[test]

--- a/hyperactor_config/src/global.rs
+++ b/hyperactor_config/src/global.rs
@@ -379,7 +379,7 @@ impl Layers {
                 Some(b) => b,
                 None => {
                     if let Some(default) = info.default {
-                        default.cloned()
+                        default().cloned()
                     } else {
                         continue;
                     }
@@ -417,7 +417,7 @@ impl Layers {
                 Some(b) => b,
                 None => {
                     if let Some(default) = info.default {
-                        default.cloned()
+                        default().cloned()
                     } else {
                         continue;
                     }
@@ -838,7 +838,7 @@ pub fn config_entries() -> Vec<ConfigEntry> {
             Some(v) => ((info.display)(&*v), chosen_source.unwrap()),
             None => {
                 if let Some(default) = info.default {
-                    ((info.display)(default), Source::Default)
+                    ((info.display)(default()), Source::Default)
                 } else {
                     continue;
                 }
@@ -846,7 +846,7 @@ pub fn config_entries() -> Vec<ConfigEntry> {
         };
 
         // Compute default display string for changed_from_default comparison.
-        let default_str = info.default.map(|d| (info.display)(d));
+        let default_str = info.default.map(|default| (info.display)(default()));
         let changed_from_default = match &default_str {
             Some(ds) => value_str != *ds,
             None => true, // no declared default → always "changed"
@@ -1193,7 +1193,7 @@ mod tests {
         // other tests
         reset_to_defaults();
 
-        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), CODEC_MAX_FRAME_LENGTH_DEFAULT);
+        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), *CODEC_MAX_FRAME_LENGTH_DEFAULT);
         {
             let _guard = config.override_key(CODEC_MAX_FRAME_LENGTH, 1024);
             assert_eq!(get(CODEC_MAX_FRAME_LENGTH), 1024);
@@ -1201,7 +1201,7 @@ mod tests {
             // _guard goes out of scope
         }
 
-        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), CODEC_MAX_FRAME_LENGTH_DEFAULT);
+        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), *CODEC_MAX_FRAME_LENGTH_DEFAULT);
     }
 
     #[test]
@@ -1213,7 +1213,7 @@ mod tests {
         reset_to_defaults();
 
         // Test the new lock/override API for individual config values
-        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), CODEC_MAX_FRAME_LENGTH_DEFAULT);
+        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), *CODEC_MAX_FRAME_LENGTH_DEFAULT);
         assert_eq!(get(MESSAGE_DELIVERY_TIMEOUT), Duration::from_secs(30));
 
         // Test single value override
@@ -1224,7 +1224,7 @@ mod tests {
         }
 
         // Values should be restored after guard is dropped
-        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), CODEC_MAX_FRAME_LENGTH_DEFAULT);
+        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), *CODEC_MAX_FRAME_LENGTH_DEFAULT);
 
         // Test multiple overrides
         let orig_value = std::env::var("HYPERACTOR_MESSAGE_DELIVERY_TIMEOUT").ok();
@@ -1246,7 +1246,7 @@ mod tests {
         );
 
         // All values should be restored
-        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), CODEC_MAX_FRAME_LENGTH_DEFAULT);
+        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), *CODEC_MAX_FRAME_LENGTH_DEFAULT);
         assert_eq!(get(MESSAGE_DELIVERY_TIMEOUT), Duration::from_secs(30));
     }
 
@@ -1862,7 +1862,7 @@ mod tests {
         drop(guard2); // Drop MESSAGE_TTL_DEFAULT first
 
         // MESSAGE_TTL_DEFAULT should restore, others should remain.
-        assert_eq!(get(MESSAGE_TTL_DEFAULT), MESSAGE_TTL_DEFAULT_DEFAULT);
+        assert_eq!(get(MESSAGE_TTL_DEFAULT), *MESSAGE_TTL_DEFAULT_DEFAULT);
         assert_eq!(get(CODEC_MAX_FRAME_LENGTH), 1111);
         assert!(!get(CHANNEL_MULTIPART));
 
@@ -1873,8 +1873,8 @@ mod tests {
         drop(guard3);
 
         // All should be restored.
-        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), CODEC_MAX_FRAME_LENGTH_DEFAULT);
-        assert_eq!(get(CHANNEL_MULTIPART), CHANNEL_MULTIPART_DEFAULT);
+        assert_eq!(get(CODEC_MAX_FRAME_LENGTH), *CODEC_MAX_FRAME_LENGTH_DEFAULT);
+        assert_eq!(get(CHANNEL_MULTIPART), *CHANNEL_MULTIPART_DEFAULT);
     }
 
     #[test]
@@ -1961,7 +1961,7 @@ mod tests {
         reset_to_defaults();
 
         // Override to the same value as the declared default.
-        let _guard = lock.override_key(CODEC_MAX_FRAME_LENGTH, CODEC_MAX_FRAME_LENGTH_DEFAULT);
+        let _guard = lock.override_key(CODEC_MAX_FRAME_LENGTH, *CODEC_MAX_FRAME_LENGTH_DEFAULT);
         let entries = config_entries();
         let codec = entries
             .iter()

--- a/hyperactor_config/src/global.rs
+++ b/hyperactor_config/src/global.rs
@@ -62,6 +62,7 @@ use crate::attrs::AttrKeyInfo;
 use crate::attrs::AttrValue;
 use crate::attrs::Attrs;
 use crate::attrs::Key;
+use crate::client_config_from_env;
 use crate::from_env;
 use crate::from_yaml;
 
@@ -524,9 +525,13 @@ struct GlobalConfig {
 /// which has the lowest precedence among explicit layers.
 static GLOBAL: LazyLock<GlobalConfig> = LazyLock::new(|| {
     let env = from_env();
-    let layers = Layers {
-        ordered: vec![Layer::Env(env)],
-    };
+    let mut ordered = vec![Layer::Env(env)];
+    if let Some(attrs) = client_config_from_env()
+        .unwrap_or_else(|error| panic!("invalid client config bootstrap environment: {error}"))
+    {
+        ordered.push(Layer::ClientOverride(attrs));
+    }
+    let layers = Layers { ordered };
     let materialized = ArcSwap::new(Arc::new(layers.materialize()));
     GlobalConfig {
         layers: RwLock::new(layers),
@@ -695,6 +700,15 @@ pub fn set(source: Source, attrs: Attrs) {
     let mut g = GLOBAL.layers.write().unwrap();
     g.set(source, attrs);
     rematerialize(&g);
+}
+
+/// Install a complete client configuration snapshot.
+///
+/// The snapshot replaces the existing [`Source::ClientOverride`] layer, making
+/// repeated installation idempotent while preserving higher-priority local
+/// configuration sources.
+pub fn install_client_config(attrs: Attrs) {
+    set(Source::ClientOverride, attrs);
 }
 
 /// Insert or update a configuration layer for the given [`Source`].

--- a/hyperactor_config/src/lib.rs
+++ b/hyperactor_config/src/lib.rs
@@ -300,7 +300,7 @@ pub fn from_env() -> Attrs {
         let Ok(val) = env::var(env_var) else {
             // Default value
             output.push_str("# ");
-            output.push_str(&export(env_var, key.default));
+            output.push_str(&export(env_var, key.default.map(|default| default())));
             continue;
         };
 
@@ -314,11 +314,11 @@ pub fn from_env() -> Attrs {
                     e
                 );
                 output.push_str("# ");
-                output.push_str(&export(env_var, key.default));
+                output.push_str(&export(env_var, key.default.map(|default| default())));
             }
             Ok(parsed) => {
                 output.push_str("# ");
-                output.push_str(&export(env_var, key.default));
+                output.push_str(&export(env_var, key.default.map(|default| default())));
                 output.push_str(&export(env_var, Some(parsed.as_ref())));
                 config.insert_value_by_name_unchecked(key.name, parsed);
             }

--- a/hyperactor_config/src/lib.rs
+++ b/hyperactor_config/src/lib.rs
@@ -58,6 +58,22 @@ pub use typeuri;
 
 // declare_attrs is already exported via #[macro_export] in attrs.rs
 
+const CLIENT_CONFIG_ENV: &str = "HYPERACTOR_CLIENT_CONFIG";
+
+/// Return the reserved environment entry carrying a client config snapshot.
+pub fn client_config_bootstrap_env(attrs: &Attrs) -> anyhow::Result<(&'static str, String)> {
+    Ok((CLIENT_CONFIG_ENV, serde_json::to_string(attrs)?))
+}
+
+/// Read the client config snapshot supplied to this process, if any.
+pub(crate) fn client_config_from_env() -> anyhow::Result<Option<Attrs>> {
+    match env::var(CLIENT_CONFIG_ENV) {
+        Ok(value) => Ok(Some(serde_json::from_str(&value)?)),
+        Err(env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(error.into()),
+    }
+}
+
 /// Metadata describing how a configuration key is exposed across
 /// environments.
 ///
@@ -344,6 +360,7 @@ mod tests {
     use crate::ConfigAttr;
     use crate::NonZeroUsize;
     use crate::attrs::declare_attrs;
+    use crate::client_config_bootstrap_env;
     use crate::from_env;
     use crate::from_yaml;
     use crate::to_yaml;
@@ -481,6 +498,22 @@ mod tests {
             Some("test_no_env_key".to_string()),
         ))
         pub attr NO_ENV_KEY: usize = 999;
+    }
+
+    #[test]
+    fn test_client_config_snapshot_round_trip() {
+        let mut attrs = crate::Attrs::new();
+        attrs.set(USIZE_KEY, 42);
+        attrs.set(STRING_KEY, "worker".to_string());
+
+        let (name, encoded) =
+            client_config_bootstrap_env(&attrs).expect("snapshot should serialize");
+        let decoded: crate::Attrs =
+            serde_json::from_str(&encoded).expect("snapshot should deserialize");
+
+        assert_eq!(name, "HYPERACTOR_CLIENT_CONFIG");
+        assert_eq!(decoded.get(USIZE_KEY), Some(&42));
+        assert_eq!(decoded.get(STRING_KEY).map(String::as_str), Some("worker"));
     }
 
     #[tracing_test::traced_test]

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -288,8 +288,8 @@ pub async fn host(
     via: Option<ChannelAddr>,
 ) -> anyhow::Result<(ActorHandle<HostAgent>, HostShutdownHandle)> {
     if let Some(attrs) = config {
-        hyperactor_config::global::set(hyperactor_config::global::Source::Runtime, attrs);
-        tracing::debug!("bootstrap: installed Runtime config snapshot (Host)");
+        hyperactor_config::global::install_client_config(attrs);
+        tracing::debug!("bootstrap: installed ClientOverride config snapshot (Host)");
     } else {
         tracing::debug!("bootstrap: no config snapshot provided (Host)");
     }
@@ -435,6 +435,12 @@ impl HostBootstrapReady {
 }
 
 impl Bootstrap {
+    fn config(&self) -> Option<&Attrs> {
+        match self {
+            Self::Proc { config, .. } | Self::Host { config, .. } => config.as_ref(),
+        }
+    }
+
     /// Serialize the mode into a environment-variable-safe string by
     /// base64-encoding its JSON representation.
     #[allow(clippy::result_large_err)]
@@ -471,6 +477,11 @@ impl Bootstrap {
             "HYPERACTOR_MESH_BOOTSTRAP_MODE",
             self.to_env_safe_string().unwrap(),
         );
+        if let Some(config) = self.config() {
+            let (name, value) = hyperactor_config::client_config_bootstrap_env(config)
+                .expect("client config snapshot should serialize");
+            cmd.env(name, value);
+        }
     }
 
     /// Bootstrap this binary according to this configuration.
@@ -536,10 +547,7 @@ impl Bootstrap {
                 )
                 .entered();
                 if let Some(attrs) = config {
-                    hyperactor_config::global::set(
-                        hyperactor_config::global::Source::ClientOverride,
-                        attrs,
-                    );
+                    hyperactor_config::global::install_client_config(attrs);
                     tracing::debug!("bootstrap: installed ClientOverride config snapshot (Proc)");
                 } else {
                     tracing::debug!("bootstrap: no config snapshot provided (Proc)");
@@ -2036,14 +2044,21 @@ impl ProcManager for BootstrapProcManager {
             .to_env_safe_string()
             .map_err(|e| HostError::ProcessConfigurationFailure(proc_id.clone(), e.into()))?;
 
+        let mut command = config
+            .bootstrap_command
+            .as_ref()
+            .unwrap_or(&self.command)
+            .clone();
+        let (config_env_name, config_env_value) =
+            hyperactor_config::client_config_bootstrap_env(&config.client_config_override)
+                .map_err(|error| HostError::ProcessConfigurationFailure(proc_id.clone(), error))?;
+        command
+            .env
+            .insert(config_env_name.to_string(), config_env_value);
         let opts = LaunchOptions {
             bootstrap_payload,
             process_name: format_process_name(&proc_id.clone()),
-            command: config
-                .bootstrap_command
-                .as_ref()
-                .unwrap_or(&self.command)
-                .clone(),
+            command,
             want_stdio: need_stdio,
             tail_lines: tail_size,
             log_channel: if enable_forwarding {

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -1822,13 +1822,7 @@ wirevalue::register_type!(SetClientConfig);
 impl Handler<SetClientConfig> for HostAgent {
     async fn handle(&mut self, cx: &Context<Self>, msg: SetClientConfig) -> anyhow::Result<()> {
         let rank = msg.rank.0.expect("rank should be stamped before delivery");
-        // Use `set` (not `create_or_merge`) because `push_config` always
-        // sends a complete `propagatable_attrs()` snapshot. Replacing the
-        // layer wholesale is intentional and idempotent.
-        hyperactor_config::global::set(
-            hyperactor_config::global::Source::ClientOverride,
-            msg.attrs,
-        );
+        hyperactor_config::global::install_client_config(msg.attrs);
         tracing::debug!("installed client config override on host agent");
         // Ack as a single-rank overlay at this host's ordinal. `StatusMesh` is
         // reused here purely as a per-rank presence/ack barrier, not as a

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -1152,30 +1152,37 @@ macro_rules! context_span {
 }
 
 pub mod env {
-    /// Env var name set when monarch launches subprocesses to forward the execution context
+    use hyperactor_config::CONFIG;
+    use hyperactor_config::ConfigAttr;
+    use hyperactor_config::attrs::declare_attrs;
+
     pub const HYPERACTOR_EXECUTION_ID_ENV: &str = "HYPERACTOR_EXECUTION_ID";
     pub const OTEL_EXPORTER: &str = "HYPERACTOR_OTEL_EXPORTER";
     pub const MAST_ENVIRONMENT: &str = "MAST_ENVIRONMENT";
 
-    /// Forward or generate a uuid for this execution. When running in production on mast, this is provided to
-    /// us via the MAST_HPC_JOB_NAME env var. Subprocesses should either forward the MAST_HPC_JOB_NAME
-    /// variable, or set the "MONARCH_EXECUTION_ID" var for subprocesses launched by this process.
-    /// We keep these env vars separate so that other applications that depend on the MAST_HPC_JOB_NAME existing
-    /// to understand their environment do not get confused and think they are running on mast when we are doing
-    ///  local testing.
+    fn generate_execution_id() -> String {
+        let username = crate::username();
+        let now = {
+            let now = std::time::SystemTime::now();
+            let datetime: chrono::DateTime<chrono::Local> = now.into();
+            datetime.format("%b-%d_%H:%M").to_string()
+        };
+        let random_number: u16 = (rand::random::<u32>() % 1000) as u16;
+        format!("{}_{}_{}", username, now, random_number)
+    }
+
+    declare_attrs! {
+        /// Identifier shared by all processes in one Monarch execution.
+        @meta(CONFIG = ConfigAttr::new(
+            Some(HYPERACTOR_EXECUTION_ID_ENV.to_string()),
+            None,
+        ))
+        pub attr EXECUTION_ID: String = generate_execution_id();
+    }
+
+    /// Return the inherited execution ID, generating a process-lifetime fallback.
     pub fn execution_id() -> String {
-        let id = std::env::var(HYPERACTOR_EXECUTION_ID_ENV).unwrap_or_else(|_| {
-            // not able to find an existing id so generate a unique one: username + current_time + random number.
-            let username = crate::username();
-            let now = {
-                let now = std::time::SystemTime::now();
-                let datetime: chrono::DateTime<chrono::Local> = now.into();
-                datetime.format("%b-%d_%H:%M").to_string()
-            };
-            let random_number: u16 = (rand::random::<u32>() % 1000) as u16;
-            let execution_id = format!("{}_{}_{}", username, now, random_number);
-            execution_id
-        });
+        let id = hyperactor_config::global::get_cloned(EXECUTION_ID);
         // Safety: Can be unsound if there are multiple threads
         // reading and writing the environment.
         unsafe {

--- a/monarch_hyperactor/src/config.rs
+++ b/monarch_hyperactor/src/config.rs
@@ -237,6 +237,15 @@ pub fn reset_config_to_defaults() -> PyResult<()> {
     Ok(())
 }
 
+/// Return the serialized client config snapshot to install in launched processes.
+#[pyfunction]
+fn get_client_config_bootstrap_env() -> PyResult<(String, String)> {
+    let snapshot = hyperactor_config::global::propagatable_attrs();
+    let (name, encoded) = hyperactor_config::client_config_bootstrap_env(&snapshot)
+        .map_err(|error| PyValueError::new_err(error.to_string()))?;
+    Ok((name.to_string(), encoded))
+}
+
 /// Map from the kwarg name passed to `monarch.configure(...)` to the
 /// `Key<T>` associated with that kwarg. This contains all attribute
 /// keys whose `@meta(CONFIG = ConfigAttr { py_name: Some(...), .. })`
@@ -707,6 +716,14 @@ pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     )?;
     module.add_function(reset)?;
 
+    let get_client_config_bootstrap_env =
+        wrap_pyfunction!(get_client_config_bootstrap_env, module)?;
+    get_client_config_bootstrap_env.setattr(
+        "__module__",
+        "monarch._rust_bindings.monarch_hyperactor.config",
+    )?;
+    module.add_function(get_client_config_bootstrap_env)?;
+
     let configure = wrap_pyfunction!(configure, module)?;
     configure.setattr(
         "__module__",
@@ -762,6 +779,36 @@ mod tests {
         ))
         attr TEST_NONZERO_USIZE: hyperactor_config::NonZeroUsize =
             hyperactor_config::NonZeroUsize::MIN;
+
+        @meta(CONFIG = ConfigAttr::new(
+            None,
+            Some("test_process_local_config".to_string()),
+        ).process_local())
+        attr TEST_PROCESS_LOCAL_CONFIG: bool = false;
+    }
+
+    #[test]
+    fn test_client_config_bootstrap_env_contains_typed_snapshot() {
+        let _lock = hyperactor_config::global::lock();
+        hyperactor_config::global::reset_to_defaults();
+
+        let mut runtime = Attrs::new();
+        runtime[TOKIO_WORKER_THREADS] = Some(
+            hyperactor_config::NonZeroUsize::try_from(4).expect("test value should be non-zero"),
+        );
+        runtime[TEST_PROCESS_LOCAL_CONFIG] = true;
+        hyperactor_config::global::set(Source::Runtime, runtime);
+
+        let (name, encoded) = get_client_config_bootstrap_env().expect("snapshot should serialize");
+        assert_eq!(name, "HYPERACTOR_CLIENT_CONFIG");
+        let snapshot: Attrs = serde_json::from_str(&encoded).expect("snapshot should decode");
+        assert_eq!(
+            snapshot.get(TOKIO_WORKER_THREADS).copied().flatten(),
+            hyperactor_config::NonZeroUsize::try_from(4).ok()
+        );
+        assert!(!snapshot.contains_key(TEST_PROCESS_LOCAL_CONFIG));
+
+        hyperactor_config::global::reset_to_defaults();
     }
 
     #[test]

--- a/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
+++ b/python/monarch/_rust_bindings/monarch_hyperactor/config.pyi
@@ -39,6 +39,10 @@ def reset_config_to_defaults() -> None:
     """
     ...
 
+def get_client_config_bootstrap_env() -> tuple[str, str]:
+    """Return the reserved environment entry carrying the client config snapshot."""
+    ...
+
 def configure(
     default_transport: ChannelTransport | str = ...,
     enable_log_forwarding: bool = ...,

--- a/python/monarch/_src/job/job.py
+++ b/python/monarch/_src/job/job.py
@@ -21,6 +21,9 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Dict, List, Literal, NamedTuple, Optional, Sequence
 
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    get_client_config_bootstrap_env,
+)
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job, MONARCH_BATCH_JOB_ENV
 from monarch._src.job._telemetry_query_client import QueryEngineClient
@@ -1006,7 +1009,9 @@ class LocalJob(JobTrait):
         stderr_log = os.path.join(log_dir, "stderr.log")
 
         # Create environment with the batch-mode marker set.
+        config_env_name, config_env_value = get_client_config_bootstrap_env()
         env = os.environ.copy()
+        env[config_env_name] = config_env_value
         env[MONARCH_BATCH_JOB_ENV] = "1"
 
         # Open log files
@@ -1193,7 +1198,11 @@ class SSHJob(LoginJob):
         addr = f"{self._scheme}://{host}:{self._port}"
         startup = f'from monarch.actor import run_worker_loop_forever; run_worker_loop_forever(address={repr(addr)}, ca="trust_all_connections")'
 
-        command = f"{shlex.quote(self._python_exe)} -c {shlex.quote(startup)}"
+        config_env_name, config_env_value = get_client_config_bootstrap_env()
+        env_prefix = f"{config_env_name}={shlex.quote(config_env_value)}"
+        command = (
+            f"{env_prefix} {shlex.quote(self._python_exe)} -c {shlex.quote(startup)}"
+        )
         proc = subprocess.Popen(
             ["ssh", *self._ssh_args, host, "-n", command],
             start_new_session=True,

--- a/python/monarch/_src/job/kubernetes.py
+++ b/python/monarch/_src/job/kubernetes.py
@@ -27,7 +27,10 @@ except ImportError:
     )
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    configure,
+    get_client_config_bootstrap_env,
+)
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job.job import JobState, JobTrait
 from monarch.actor import attach
@@ -41,6 +44,17 @@ logger.propagate = False
 # Default monarch port for worker communication
 _DEFAULT_MONARCH_PORT: int = 26600
 _RFC_1123_MAX_LEN = 63
+
+
+def _inject_client_config_env(
+    pod_template: dict[str, Any], config_env: tuple[str, str]
+) -> None:
+    name, value = config_env
+    container = pod_template["spec"]["containers"][0]
+    env_by_name = {entry["name"]: entry for entry in container.get("env", [])}
+    env_by_name[name] = {"name": name, "value": value}
+    container["env"] = list(env_by_name.values())
+
 
 # Seconds to wait for `kubectl port-forward` to report it is ready before giving
 # up, so a silently hung forward cannot stall job initialization indefinitely.
@@ -367,11 +381,13 @@ class KubernetesJob(JobTrait):
 
         api_client = client.ApiClient()
         api = client.CustomObjectsApi(api_client)
+        config_env = get_client_config_bootstrap_env()
 
         for mesh_name, mesh_config in provisioned.items():
             pod_template_dict = api_client.sanitize_for_serialization(
                 mesh_config["pod_template"]
             )
+            _inject_client_config_env(pod_template_dict, config_env)
             metadata: dict[str, Any] = {
                 "name": mesh_name,
                 "namespace": self._namespace,

--- a/python/monarch/_src/job/process.py
+++ b/python/monarch/_src/job/process.py
@@ -18,6 +18,9 @@ import threading
 import time
 from typing import Callable, Dict, List, Optional, Union
 
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    get_client_config_bootstrap_env,
+)
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.future import Future
 from monarch._src.job.job import JobState, JobTrait, ProcessState
@@ -138,6 +141,7 @@ class ProcessJob(JobTrait):
         self._tmpdir = tempfile.mkdtemp(prefix="monarch_process_job_")
 
         try:
+            config_env_name, config_env_value = get_client_config_bootstrap_env()
             for mesh_name, count in self._meshes.items():
                 for i in range(count):
                     host_key = f"{mesh_name}_{i}"
@@ -145,6 +149,7 @@ class ProcessJob(JobTrait):
                     env = {**os.environ, "HYPERACTOR_PROCESS_NAME": host_key}
                     if self._env is not None:
                         env.update(self._env)
+                    env[config_env_name] = config_env_value
                     if _IN_PAR:
                         # In PAR/XAR mode, sys.executable is the bare
                         # Python interpreter which cannot import modules

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -15,7 +15,10 @@ import sys
 from typing import Any, Dict, FrozenSet, List, Optional, Sequence
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    configure,
+    get_client_config_bootstrap_env,
+)
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job
 from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP
@@ -215,6 +218,8 @@ class SlurmJob(JobTrait):
                 sbatch_directives.append(f"#SBATCH {arg}")
 
         batch_script = "\n".join(sbatch_directives)
+        config_env_name, config_env_value = get_client_config_bootstrap_env()
+        batch_script += f"\nexport {config_env_name}={shlex.quote(config_env_value)}"
         if client_script is None:
             # Workers only; an external controller attaches and manages the
             # lifetime. Shares _WORKER_BOOTSTRAP with the batch runner.
@@ -357,10 +362,9 @@ class SlurmJob(JobTrait):
         hostname_idx = 0
 
         for mesh_name, num_nodes in self._meshes.items():
-            mesh_hostnames = self._all_hostnames[
-                hostname_idx : hostname_idx + num_nodes
-            ]
-            hostname_idx += num_nodes
+            next_hostname_idx = hostname_idx + num_nodes
+            mesh_hostnames = self._all_hostnames[hostname_idx:next_hostname_idx]
+            hostname_idx = next_hostname_idx
 
             workers = [f"tcp://{hostname}:{self._port}" for hostname in mesh_hostnames]
             host_mesh = attach_to_workers(

--- a/python/monarch/_src/job/spmd.py
+++ b/python/monarch/_src/job/spmd.py
@@ -20,7 +20,10 @@ from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
 from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
-from monarch._rust_bindings.monarch_hyperactor.config import configure
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    configure,
+    get_client_config_bootstrap_env,
+)
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.actor.host_mesh import this_host
 from monarch._src.job.job import JobState, JobTrait
@@ -319,6 +322,7 @@ def serve(
 
     # Cache original entrypoints before modifying
     original_roles = []
+    config_env_name, config_env_value = get_client_config_bootstrap_env()
     scheme = "metatls" if scheduler.startswith("mast") else "tcp"
     for role in appdef.roles:
         original_roles.append(
@@ -328,6 +332,8 @@ def serve(
             }
         )
 
+        role.env = dict(role.env or {})
+        role.env[config_env_name] = config_env_value
         role.args = [
             "python",
             "-X",

--- a/python/tests/_src/job/test_kubernetes.py
+++ b/python/tests/_src/job/test_kubernetes.py
@@ -488,14 +488,29 @@ class TestCreate(unittest.TestCase):
                 labels={"pod-label": "pod-value"},
                 annotations={"pod-annotation": "ann-value"},
             ),
-            spec=V1PodSpec(containers=[V1Container(name="worker", image="img")]),
+            spec=V1PodSpec(
+                containers=[
+                    V1Container(
+                        name="worker",
+                        image="img",
+                        env=[
+                            V1EnvVar(name="USER_ENV", value="user"),
+                            V1EnvVar(name="HYPERACTOR_CLIENT_CONFIG", value="stale"),
+                        ],
+                    )
+                ]
+            ),
         )
         job.add_mesh("workers", num_replicas=1, pod_template=pod_template)
 
         mock_api = MagicMock()
         mock_custom_api_cls.return_value = mock_api
 
-        job._create(None)
+        with patch(
+            "monarch._src.job.kubernetes.get_client_config_bootstrap_env",
+            return_value=("HYPERACTOR_CLIENT_CONFIG", "launch-snapshot"),
+        ) as mock_config_env:
+            job._create(None)
 
         body = mock_api.create_namespaced_custom_object.call_args.kwargs["body"]
         template_metadata = body["spec"]["podTemplate"]["metadata"]
@@ -503,6 +518,13 @@ class TestCreate(unittest.TestCase):
         self.assertEqual(
             template_metadata["annotations"], {"pod-annotation": "ann-value"}
         )
+        container_env = {
+            entry["name"]: entry["value"]
+            for entry in body["spec"]["podTemplate"]["spec"]["containers"][0]["env"]
+        }
+        self.assertEqual(container_env["USER_ENV"], "user")
+        self.assertEqual(container_env["HYPERACTOR_CLIENT_CONFIG"], "launch-snapshot")
+        mock_config_env.assert_called_once_with()
 
     def test_create_noop_when_all_attach_only(self) -> None:
         """No K8s API calls when no meshes are provisioned."""

--- a/python/tests/_src/job/test_slurm.py
+++ b/python/tests/_src/job/test_slurm.py
@@ -65,8 +65,9 @@ def test_batch_mode_invokes_in_allocation_runner(tmp_path, monkeypatch):
     assert shlex.quote(client) in script
     assert "--nodes=2" in script
     # the shell stays dumb: worker srun + teardown now live in the runner
-    assert "srun" not in script
-    assert "trap" not in script
+    script_lines = [line.lstrip() for line in script.splitlines()]
+    assert not any(line.startswith("srun ") for line in script_lines)
+    assert not any(line.startswith("trap ") for line in script_lines)
     assert "scancel" not in script
     assert "sleep" not in script
     # a BatchJob wrapper is cached so the in-allocation client reconnects
@@ -94,6 +95,24 @@ def test_external_controller_mode_has_no_client(tmp_path, monkeypatch):
     assert "_slurm_batch" not in script
     assert "MONARCH_BATCH_JOB" not in script
     assert not (tmp_path / ".monarch" / "job_state.pkl").exists()
+
+
+def test_submit_exports_quoted_client_config_snapshot(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    snapshot = '{"value":"contains spaces and \'quotes\'"}'
+    with (
+        patch(
+            "monarch._src.job.slurm.get_client_config_bootstrap_env",
+            return_value=("HYPERACTOR_CLIENT_CONFIG", snapshot),
+        ),
+        patch(
+            "monarch._src.job.slurm.subprocess.run", side_effect=_fake_sbatch
+        ) as mock,
+    ):
+        _make_job().apply()
+
+    script = _submitted_script(mock)
+    assert f"export HYPERACTOR_CLIENT_CONFIG={shlex.quote(snapshot)}" in script
 
 
 def test_submit_raises_when_job_id_unparseable(tmp_path, monkeypatch):

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -16,6 +16,7 @@ from monarch._rust_bindings.monarch_hyperactor.config import (
     get_client_config_bootstrap_env,
 )
 from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
+from monarch._rust_bindings.monarch_hyperactor.telemetry import get_execution_id
 from monarch.actor import Actor, endpoint, this_host
 from monarch.config import configure, configured, get_global_config
 
@@ -117,12 +118,14 @@ def test_rdma_ibverbs_target_round_trip_and_propagation() -> None:
 
 @isolate_in_subprocess
 def test_configure_is_reflected_in_client_config_bootstrap() -> None:
+    execution_id = get_execution_id()
     configure(tail_log_lines=67)
     env_name, encoded = get_client_config_bootstrap_env()
     snapshot = json.loads(encoded)
 
     assert env_name == "HYPERACTOR_CLIENT_CONFIG"
     assert snapshot["hyperactor_mesh::bootstrap::mesh_tail_log_lines"] == 67
+    assert snapshot["hyperactor_telemetry::env::execution_id"] == execution_id
 
 
 @isolate_in_subprocess

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -6,13 +6,18 @@
 
 # pyre-unsafe
 
+import json
+
 import monarch
 import pytest
 from isolate_in_subprocess import isolate_in_subprocess
 from monarch._rust_bindings.monarch_hyperactor.channel import BindSpec, ChannelTransport
+from monarch._rust_bindings.monarch_hyperactor.config import (
+    get_client_config_bootstrap_env,
+)
 from monarch._rust_bindings.monarch_hyperactor.supervision import SupervisionError
 from monarch.actor import Actor, endpoint, this_host
-from monarch.config import configured, get_global_config
+from monarch.config import configure, configured, get_global_config
 
 
 class Chunker(Actor):
@@ -108,6 +113,16 @@ def test_rdma_ibverbs_target_round_trip_and_propagation() -> None:
         assert probe.rdma_ibverbs_target.call_one().get() == target
 
     assert get_global_config()["rdma_ibverbs_target"] == ""
+
+
+@isolate_in_subprocess
+def test_configure_is_reflected_in_client_config_bootstrap() -> None:
+    configure(tail_log_lines=67)
+    env_name, encoded = get_client_config_bootstrap_env()
+    snapshot = json.loads(encoded)
+
+    assert env_name == "HYPERACTOR_CLIENT_CONFIG"
+    assert snapshot["hyperactor_mesh::bootstrap::mesh_tail_log_lines"] == 67
 
 
 @isolate_in_subprocess


### PR DESCRIPTION
Summary:

Declare execution ID as typed config and store generated fallbacks in a process-lifetime `Generated` source below every explicit source and above defaults. The generated identity survives Python Runtime cleanup, inherited bootstrap snapshots win before telemetry initialization, and ordinary subprocess environment inheritance remains intact.

Differential Revision: D113294621


