### PR TITLE
Bump nightly wheel version to 0.7.0

### DIFF
--- a/.github/workflows/build-dist.yml
+++ b/.github/workflows/build-dist.yml
@@ -96,7 +96,7 @@ jobs:
         if [ -n "${{ inputs.version }}" ]; then
           export MONARCH_VERSION="${{ inputs.version }}"
         else
-          export MONARCH_VERSION=0.6.0.dev$(date +'%Y%m%d')
+          export MONARCH_VERSION=0.7.0.dev$(date +'%Y%m%d')
         fi
         python -m build --wheel --no-isolation
 

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -69,7 +69,7 @@ jobs:
           if [ -n "${{ inputs.version }}" ]; then
             export MONARCH_VERSION="${{ inputs.version }}"
           else
-            export MONARCH_VERSION=0.6.0.dev$(date +'%Y%m%d')
+            export MONARCH_VERSION=0.7.0.dev$(date +'%Y%m%d')
           fi
 
           python -m build --wheel --no-isolation


### PR DESCRIPTION
Summary: Align the Linux and macOS nightly wheel fallbacks with the existing `0.7.0` package, internal wheel, and container versions. This prevents scheduled builds from continuing to publish `0.6.0.dev<date>` wheels.

Differential Revision: D114275382


