### PR TITLE
Expose and test user-defined metrics (#4559)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,6 +3688,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "dashmap",
+ "datafusion",
  "erased-serde",
  "hdrhistogram",
  "hyperactor_config",

--- a/docs/DOCS_INDEX.md
+++ b/docs/DOCS_INDEX.md
@@ -26,6 +26,7 @@
 | Document | Location |
 |----------|----------|
 | **Observability Overview** | `docs/source/observability.md` |
+| **Metrics** | `docs/source/metrics.md` |
 | **Distributed Telemetry** | `docs/source/distributed-telemetry.md` |
 | **Mesh Admin TUI** | `docs/source/admin-tui.md` |
 | **Monarch Dashboard** | `docs/source/monarch-dashboard.md` |

--- a/docs/source/distributed-telemetry.md
+++ b/docs/source/distributed-telemetry.md
@@ -183,6 +183,7 @@ and event telemetry describe different views of the same job:
 
 ## Related documentation
 
+- [Metrics](metrics)
 - [Observability overview](observability)
 - [Monarch Dashboard](monarch-dashboard)
 - [Mesh Admin TUI](admin-tui)

--- a/docs/source/distributed-telemetry.md
+++ b/docs/source/distributed-telemetry.md
@@ -1,7 +1,7 @@
 # Distributed Telemetry
 
-Monarch distributed telemetry collects actor-system events on each host and
-makes them queryable as one logical database. It uses
+Monarch distributed telemetry collects actor-system events and OpenTelemetry
+metrics on each host and makes them queryable as one logical database. It uses
 [Apache DataFusion](https://github.com/apache/datafusion), an extensible SQL
 query engine built on [Apache Arrow](https://arrow.apache.org/). Distributed
 telemetry is the query layer behind the [Monarch Dashboard](monarch-dashboard)
@@ -52,6 +52,9 @@ meaning from their numeric values.
 | `actors` | Actor identity, rank, mesh, and creation time |
 | `events` | Structured tracing events and log fields |
 | `meshes` | Mesh creation, shape, class, name, and parent view |
+| `metric_gauges` | Gauge points with typed `value_f64`, `value_i64`, or `value_u64` values |
+| `metric_histograms` | Explicit histogram counts, typed summaries, bounds, and bucket counts |
+| `metric_sums` | Counter and up-down-counter points with typed sums and sum semantics |
 | `message_status_events` | Message delivery status transitions |
 | `messages` | Individual sender-to-receiver message deliveries |
 | `sent_messages` | One-to-many send operations and destination views |
@@ -71,6 +74,19 @@ SELECT table_name
 FROM information_schema.tables
 ORDER BY table_name
 ```
+
+### Metric tables
+
+Metrics are split by OTel aggregation rather than numeric type. Query
+`metric_gauges`, `metric_sums`, or `metric_histograms` based on the instrument
+aggregation. Each table preserves `f64`, `i64`, and `u64` in separate nullable
+columns so large integers do not lose precision.
+
+All metric rows include the instrument name, scope, unit, timestamps, point
+attributes, and resource attributes. Sum rows also include temporality and
+monotonicity. Histogram rows retain the count, typed sum, optional typed minimum
+and maximum, explicit bounds, and bucket counts. Bounds and bucket counts are
+JSON arrays in `bounds_json` and `bucket_counts_json`.
 
 ## Query examples
 
@@ -103,9 +119,23 @@ GROUP BY status
 ORDER BY count DESC
 ```
 
+Sum delta counter points within the retention window:
+
+```sql
+SELECT scope_name, SUM(sum_u64) AS mailbox_posts
+FROM metric_sums
+WHERE name = 'mailbox.posts'
+  AND temporality = 'delta'
+  AND sum_u64 IS NOT NULL
+GROUP BY scope_name
+ORDER BY mailbox_posts DESC
+```
+
 ## Architecture
 
-Each producer writes framed Arrow IPC batches to a host-local Unix socket. A
+Each producer writes framed Arrow IPC batches to a host-local Unix socket.
+Trace and entity dispatchers write their corresponding tables, while an OTel
+UDS metric exporter writes one frame for each non-empty aggregation buffer. A
 host-local `TelemetryActor` owns the socket, a Rust `DatabaseScanner`, and the
 in-memory tables. The root query engine plans SQL with DataFusion, pushes table
 scans to active collectors, and merges their Arrow results.
@@ -122,7 +152,8 @@ continue operating.
 ## Retention and snapshots
 
 `TelemetryConfig.retention_secs` applies to `sent_messages`, `messages`,
-`message_status_events`, `spans`, `span_events`, and `events`. Trace tables are
+`message_status_events`, `metric_gauges`, `metric_sums`, and
+`metric_histograms`, `spans`, `span_events`, and `events`. Trace tables are
 filtered independently by row timestamp, with spans filtered before dependent
 trace rows. A recent trace row is not displayed by span-joined views if its span
 has already expired. The default is 600 seconds. Set it to `0` to disable

--- a/docs/source/examples/otel_collector.py
+++ b/docs/source/examples/otel_collector.py
@@ -23,6 +23,12 @@ by default and wires up the OTLP log sink.
 Built-in actor system metrics (mailbox posts, messages sent/received, queue
 sizes, etc.) and log events are exported with no code changes.
 
+External OTLP export is independent of distributed telemetry. When a job also
+enables distributed telemetry, the same OTel metric provider feeds a job-local
+Unix-socket exporter and exposes points through the ``metric_gauges``,
+``metric_sums``, and ``metric_histograms`` SQL tables. Metric instrumentation
+does not need to know which readers or exporters are active.
+
 Architecture
 ------------
 

--- a/docs/source/metrics.md
+++ b/docs/source/metrics.md
@@ -1,0 +1,142 @@
+# Metrics
+
+Monarch records built-in counters, gauges, and histograms with OpenTelemetry
+(OTel). The same instruments can feed job-local distributed telemetry, an
+external OpenTelemetry Protocol (OTLP) endpoint, or both. Start with the
+[observability overview](observability) if you are choosing among Monarch's
+diagnostic surfaces.
+
+## Recording model
+
+One process-global OTel meter provider owns metric instruments and their
+readers. Libraries request a meter and record values without knowing which
+backends are active. Threads and libraries in the same Rust process share this
+provider. A different process, binary, or language runtime has its own provider
+and exports independently.
+
+Each instrument has a name, scope, unit, and type. The instrumentation code
+that records a point also selects its attribute set. OTel aggregates points by
+their complete identity, including attributes, so high-cardinality attributes
+create more time series and more rows at each collection interval.
+
+Independent periodic readers collect the same instruments for each enabled
+export path. `OTEL_METRIC_EXPORT_INTERVAL` controls their interval and defaults
+to one second. This provides low-latency visibility for short-lived jobs but
+produces more export traffic than typical monitoring intervals. Increase the
+interval for long-running jobs or high-cardinality instruments to reduce
+application and backend load. A slow or unavailable destination does not
+require different instrumentation for the other destinations.
+
+## Metric identity and context
+
+An exported metric point combines context from several levels. Distributed
+telemetry preserves those levels separately:
+
+| OTel concept | Set by | Meaning | Distributed telemetry representation |
+|--------------|--------|---------|--------------------------------------|
+| Resource attributes | Meter-provider initialization | Process-wide service and runtime identity shared by every metric, such as `service.name` | `resource_attributes_json` |
+| Instrumentation scope | The library requesting a meter | The library or module that owns the instrument | `scope_name` |
+| Instrument | The instrument builder | The metric name, unit, and aggregation type | `name`, `unit`, and the selected metric table |
+| Point attributes | Each record operation | Dimensions for one measurement, such as operation or outcome | `attributes_json` |
+
+Point attributes are part of a metric series identity. Monarch's built-in
+instrumentation selects these attributes. If instrumentation code records
+the same instrument with `{"outcome": "success"}` and `{"outcome": "failure"}`,
+OTel creates two independently aggregated series and therefore up to two rows
+per collection interval. Instrumentation authors should use attributes for
+bounded dimensions, not request IDs, timestamps, or other values that grow
+without limit.
+
+Resource attributes describe the process rather than an individual
+measurement. Startup configuration selects supported values such as
+`service.name` before the process-global provider is built. These attributes
+are then copied into every distributed metric row and cannot change per
+measurement. Instrumentation scope is also separate from point attributes: it
+identifies the library that created the instrument and disambiguates
+same-named instruments from different libraries. When grouping or joining
+metric rows, treat resource attributes, scope, instrument metadata, and point
+attributes as the complete context.
+
+Distributed telemetry currently stores only the instrumentation scope name.
+OTel scope version, schema URL, and scope attributes are not included in the
+metric tables.
+
+## Choose an export path
+
+| Path | Enablement | Destination | Primary use |
+|------|------------|-------------|-------------|
+| Distributed telemetry | `job.enable_telemetry(...)` | Job-local SQL tables | Debugging and analysis within the current job |
+| OTLP | `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry Collector over OTLP/HTTP | External aggregation, monitoring, and visualization |
+
+You can enable both paths. They share instruments and resource attributes but
+collect and export independently.
+
+## Distributed telemetry path
+
+```text
+OTel instruments
+    └─> periodic reader
+          └─> Unix Domain Socket (UDS) metric exporter
+                └─> host-local telemetry sidecar
+                      └─> DataFusion SQL tables
+```
+
+Calling `job.enable_telemetry(...)` activates the process-global Unix-socket
+sink. On each collection, the UDS exporter encodes non-empty aggregation
+buffers as Arrow batches and sends them to the host-local telemetry sidecar.
+The sidecar exposes three physical tables:
+
+| Table | Aggregation |
+|-------|-------------|
+| `metric_gauges` | Gauge points |
+| `metric_sums` | Counter and up-down-counter points |
+| `metric_histograms` | Explicit histogram points and buckets |
+
+The UDS exporter uses delta temporality, so each row describes one collection
+interval. Each unique metric name, scope, and attribute set produces its own
+row. Numeric values remain in separate `f64`, `i64`, and `u64` columns rather
+than being converted to one common type.
+
+This path is job-local, in memory, and best-effort. Empty aggregation buffers
+produce no frame. A full producer queue, serialization failure, oversized
+frame, or socket failure drops the affected frame rather than blocking the
+application. Activating the socket starts delivery for future intervals; it
+does not replay metrics collected while the sink was inactive. Metric tables
+follow `TelemetryConfig.retention_secs`.
+
+See [Distributed Telemetry](distributed-telemetry) for complete table contents
+and SQL examples.
+
+## OTLP path
+
+```text
+OTel instruments
+    └─> periodic reader
+          └─> OTLP metric exporter
+                └─> OpenTelemetry Collector
+                      └─> external metrics backend
+```
+
+In a build with OTLP support, setting `OTEL_EXPORTER_OTLP_ENDPOINT` enables an
+independent metric reader. It sends collections to the configured OpenTelemetry
+Collector over OTLP/HTTP. The collector controls routing, processing, and
+delivery to external metrics systems.
+
+See [OpenTelemetry and Grafana](./generated/examples/otel_collector) for a
+Kubernetes collector, Prometheus, and Grafana example.
+
+## Configuration
+
+| Setting | Default | Effect |
+|---------|---------|--------|
+| `ENABLE_OTEL_METRICS` | `true` | Enables Monarch OTel metric collection |
+| `OTEL_METRIC_EXPORT_INTERVAL` | `1s` | Sets the periodic reader interval |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Unset | Enables OTLP metric export when configured |
+| `OTEL_SERVICE_NAME` | `unknown_service` | Sets the service name resource attribute |
+| `TelemetryConfig.retention_secs` | `600` | Retains distributed metric rows for this many seconds; `0` disables retention |
+
+## Related documentation
+
+- [Observability overview](observability)
+- [Distributed Telemetry](distributed-telemetry)
+- [OpenTelemetry and Grafana](./generated/examples/otel_collector)

--- a/docs/source/metrics.md
+++ b/docs/source/metrics.md
@@ -27,6 +27,22 @@ interval for long-running jobs or high-cardinality instruments to reduce
 application and backend load. A slow or unavailable destination does not
 require different instrumentation for the other destinations.
 
+## Record custom metrics
+
+Use Monarch's process-global meter to create OpenTelemetry instruments. The
+same instrument feeds every enabled export path:
+
+```python
+from monarch.actor import get_meter
+
+requests = get_meter().create_counter("example.requests")
+requests.add(1, {"operation": "predict", "outcome": "success"})
+```
+
+Create instruments once and reuse them. Use attributes only for bounded
+dimensions such as operation and outcome; request IDs and other unbounded
+values create a new time series for each value.
+
 ## Metric identity and context
 
 An exported metric point combines context from several levels. Distributed

--- a/docs/source/observability.md
+++ b/docs/source/observability.md
@@ -21,10 +21,7 @@ Periodic mesh-admin snapshots also flow into telemetry so the dashboard can
 show the live administrative topology.
 
 Distributed telemetry is a job-scoped, in-memory query system. OpenTelemetry
-instruments metrics once, and independent readers deliver them to enabled
-backends. The distributed telemetry exporter sends metrics to the job-local
-SQL tables over a Unix socket, while external export can run alongside it. You
-can use both on the same job.
+export to an external backend can run alongside it on the same job.
 
 ## Enable observability
 
@@ -68,6 +65,21 @@ print(result["rows"])
 Use `state.dashboard_url` in a browser. Pass `state.admin_url` to
 `monarch-tui --addr`.
 
+## Metrics
+
+Monarch records its built-in metrics through one process-global OpenTelemetry
+meter provider. Libraries record counters, gauges, and histograms without
+choosing a destination. Independent readers can send the same instruments to
+job-local distributed telemetry, an external OTLP endpoint, or both.
+
+| Path | Enablement | Destination | Primary use |
+|------|------------|-------------|-------------|
+| Distributed telemetry | `job.enable_telemetry(...)` | Job-local SQL tables | Debugging and analysis within the current job |
+| OTLP | `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry Collector over OTLP/HTTP | External aggregation, monitoring, and visualization |
+
+See [Metrics](metrics) for provider scope, collection and flushing behavior,
+configuration, and both export paths.
+
 ## Data flow
 
 ```text
@@ -102,6 +114,7 @@ That supports the TUI, but it does not provide the dashboard or SQL history.
 
 ## Next steps
 
+- [Understand metric collection and export](metrics)
 - [Query distributed telemetry](distributed-telemetry)
 - [Use the Monarch Dashboard](monarch-dashboard)
 - [Diagnose a mesh with the Admin TUI](admin-tui)
@@ -111,6 +124,7 @@ That supports the TUI, but it does not provide the dashboard or SQL history.
 :maxdepth: 1
 :hidden:
 distributed-telemetry
+metrics
 admin-tui
 monarch-dashboard
 ```

--- a/docs/source/observability.md
+++ b/docs/source/observability.md
@@ -4,13 +4,14 @@ Monarch provides one observability setup with three complementary job-local
 surfaces: distributed telemetry for SQL analysis, the Monarch Dashboard for
 visual monitoring, and the Mesh Admin TUI for live diagnostics. Enable
 telemetry on a job to start all three data paths consistently. OpenTelemetry
-provides a separate export path for external backends.
+supplies metrics to distributed telemetry and can independently export metrics
+and logs to external backends.
 
 ## Choose a surface
 
 | Use case | Surface | What it provides |
 |----------|---------|------------------|
-| Query actor, mesh, message, and trace history | [Distributed telemetry](distributed-telemetry) | DataFusion SQL across host-local collectors |
+| Query actor, mesh, message, trace, and metric history | [Distributed telemetry](distributed-telemetry) | DataFusion SQL across host-local collectors |
 | Monitor topology, status, failures, and traffic in a browser | [Monarch Dashboard](monarch-dashboard) | Live summaries, hierarchy views, and a job DAG |
 | Diagnose a running mesh from a terminal | [Mesh Admin TUI](admin-tui) | Live topology, health checks, and py-spy stack traces |
 | Export metrics and logs to an external backend | [OpenTelemetry and Grafana](./generated/examples/otel_collector) | OTLP export to systems such as Prometheus and Loki |
@@ -20,8 +21,10 @@ Periodic mesh-admin snapshots also flow into telemetry so the dashboard can
 show the live administrative topology.
 
 Distributed telemetry is a job-scoped, in-memory query system. OpenTelemetry
-export is the external aggregation path for metrics and logs. You can use both
-on the same job.
+instruments metrics once, and independent readers deliver them to enabled
+backends. The distributed telemetry exporter sends metrics to the job-local
+SQL tables over a Unix socket, while external export can run alongside it. You
+can use both on the same job.
 
 ## Enable observability
 
@@ -72,6 +75,10 @@ actor and proc events ──> host-local collectors ──> distributed query en
                                                         ├─> SQL query client
                                                         └─> Monarch Dashboard
 
+OTel instruments ──> process-global meter provider ──┬─> UDS metric exporter
+                                                      │        └─> host-local collectors
+                                                      └─> external metric exporter
+
 live mesh ──> Mesh Admin API ──────────────────────────────> Mesh Admin TUI
      └──────> periodic snapshots ──> distributed telemetry ─> Dashboard DAG
 ```
@@ -85,7 +92,7 @@ are not a durable event archive.
 
 | `TelemetryConfig` field | Default | Effect |
 |-------------------------|---------|--------|
-| `retention_secs` | `600` | Retention window for message and trace tables; `0` disables retention |
+| `retention_secs` | `600` | Retention window for message, trace, and metric tables; `0` disables retention |
 | `include_dashboard` | `False` | Advertise the browser dashboard |
 | `dashboard_port` | `8265` | Preferred dashboard port; use `0` for an ephemeral port |
 | `snapshot_interval_secs` | `30` | Mesh-introspection snapshot interval; `0` disables periodic snapshots |

--- a/hyperactor_telemetry/Cargo.toml
+++ b/hyperactor_telemetry/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version = "0.3.23", features = ["chrono", "env-filter", "
 whoami = "1.5"
 
 [dev-dependencies]
+datafusion = "52.5.0"
 quickcheck = "1.1"
 quickcheck_macros = "1.2.0"
 tracing-test = { version = "0.2.6", features = ["no-env-filter"] }

--- a/hyperactor_telemetry/src/lib.rs
+++ b/hyperactor_telemetry/src/lib.rs
@@ -57,6 +57,7 @@ mod config;
 pub mod in_memory_reader;
 #[cfg(all(fbcode_build, target_os = "linux"))]
 mod meta;
+mod metrics_table;
 mod otel;
 pub(crate) mod otlp;
 mod pool;

--- a/hyperactor_telemetry/src/metrics_table.rs
+++ b/hyperactor_telemetry/src/metrics_table.rs
@@ -1,0 +1,501 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! OpenTelemetry metric export to the distributed telemetry table.
+
+use std::time::Duration;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use monarch_telemetry_schema::metric_tables::MetricGauge;
+use monarch_telemetry_schema::metric_tables::MetricGaugeBuffer;
+use monarch_telemetry_schema::metric_tables::MetricHistogram;
+use monarch_telemetry_schema::metric_tables::MetricHistogramBuffer;
+use monarch_telemetry_schema::metric_tables::MetricSum;
+use monarch_telemetry_schema::metric_tables::MetricSumBuffer;
+use opentelemetry::Array;
+use opentelemetry::Value;
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::metrics::Temporality;
+use opentelemetry_sdk::metrics::data::AggregatedMetrics;
+use opentelemetry_sdk::metrics::data::Gauge;
+use opentelemetry_sdk::metrics::data::Histogram;
+use opentelemetry_sdk::metrics::data::MetricData;
+use opentelemetry_sdk::metrics::data::ResourceMetrics;
+use opentelemetry_sdk::metrics::data::Sum;
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+
+#[derive(Debug)]
+pub(crate) struct UdsMetricExporter;
+
+pub(crate) fn uds_metric_exporter() -> UdsMetricExporter {
+    UdsMetricExporter
+}
+
+impl PushMetricExporter for UdsMetricExporter {
+    async fn export(&self, metrics: &ResourceMetrics) -> OTelSdkResult {
+        if crate::unix_sink::unix_socket_sink_is_active() {
+            let buffers = encode_metrics(metrics);
+            crate::unix_sink::send_metric_buffers(buffers.gauges, buffers.sums, buffers.histograms);
+        }
+        Ok(())
+    }
+
+    fn force_flush(&self) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn shutdown_with_timeout(&self, _timeout: Duration) -> OTelSdkResult {
+        Ok(())
+    }
+
+    fn temporality(&self) -> Temporality {
+        Temporality::Delta
+    }
+}
+
+#[derive(Default)]
+struct MetricBuffers {
+    gauges: MetricGaugeBuffer,
+    sums: MetricSumBuffer,
+    histograms: MetricHistogramBuffer,
+}
+
+#[derive(Clone, Copy)]
+struct InstrumentMetadata<'a> {
+    name: &'a str,
+    scope_name: &'a str,
+    unit: &'a str,
+}
+
+trait TableMetricNumber: Copy {
+    fn into_columns(self) -> (Option<f64>, Option<i64>, Option<u64>);
+}
+
+impl TableMetricNumber for f64 {
+    fn into_columns(self) -> (Option<f64>, Option<i64>, Option<u64>) {
+        (Some(self), None, None)
+    }
+}
+
+impl TableMetricNumber for i64 {
+    fn into_columns(self) -> (Option<f64>, Option<i64>, Option<u64>) {
+        (None, Some(self), None)
+    }
+}
+
+impl TableMetricNumber for u64 {
+    fn into_columns(self) -> (Option<f64>, Option<i64>, Option<u64>) {
+        (None, None, Some(self))
+    }
+}
+
+fn encode_metrics(metrics: &ResourceMetrics) -> MetricBuffers {
+    let mut buffers = MetricBuffers::default();
+    let resource_attributes_json = resource_attributes_to_json(metrics.resource());
+    for scope in metrics.scope_metrics() {
+        for metric in scope.metrics() {
+            let metadata = InstrumentMetadata {
+                name: metric.name(),
+                scope_name: scope.scope().name(),
+                unit: metric.unit(),
+            };
+            match metric.data() {
+                AggregatedMetrics::F64(data) => {
+                    buffer_metric(&mut buffers, &resource_attributes_json, metadata, data)
+                }
+                AggregatedMetrics::I64(data) => {
+                    buffer_metric(&mut buffers, &resource_attributes_json, metadata, data)
+                }
+                AggregatedMetrics::U64(data) => {
+                    buffer_metric(&mut buffers, &resource_attributes_json, metadata, data)
+                }
+            }
+        }
+    }
+    buffers
+}
+
+fn buffer_metric<T: TableMetricNumber>(
+    buffers: &mut MetricBuffers,
+    resource_attributes_json: &str,
+    metadata: InstrumentMetadata<'_>,
+    data: &MetricData<T>,
+) {
+    match data {
+        MetricData::Gauge(gauge) => buffer_gauge(
+            &mut buffers.gauges,
+            resource_attributes_json,
+            metadata,
+            gauge,
+        ),
+        MetricData::Sum(sum) => {
+            buffer_sum(&mut buffers.sums, resource_attributes_json, metadata, sum)
+        }
+        MetricData::Histogram(histogram) => buffer_histogram(
+            &mut buffers.histograms,
+            resource_attributes_json,
+            metadata,
+            histogram,
+        ),
+        MetricData::ExponentialHistogram(_) => tracing::warn!(
+            metric = metadata.name,
+            "distributed metrics table does not support exponential histograms"
+        ),
+    }
+}
+
+fn buffer_gauge<T: TableMetricNumber>(
+    buffer: &mut MetricGaugeBuffer,
+    resource_attributes_json: &str,
+    metadata: InstrumentMetadata<'_>,
+    gauge: &Gauge<T>,
+) {
+    for point in gauge.data_points() {
+        let (value_f64, value_i64, value_u64) = point.value().into_columns();
+        buffer.insert(MetricGauge {
+            name: metadata.name.to_string(),
+            timestamp_us: timestamp_to_micros(gauge.time()),
+            start_timestamp_us: gauge.start_time().map(timestamp_to_micros),
+            scope_name: metadata.scope_name.to_string(),
+            unit: metadata.unit.to_string(),
+            attributes_json: key_values_to_json(point.attributes()),
+            resource_attributes_json: resource_attributes_json.to_string(),
+            value_f64,
+            value_i64,
+            value_u64,
+        });
+    }
+}
+
+fn buffer_sum<T: TableMetricNumber>(
+    buffer: &mut MetricSumBuffer,
+    resource_attributes_json: &str,
+    metadata: InstrumentMetadata<'_>,
+    sum: &Sum<T>,
+) {
+    for point in sum.data_points() {
+        let (sum_f64, sum_i64, sum_u64) = point.value().into_columns();
+        buffer.insert(MetricSum {
+            name: metadata.name.to_string(),
+            timestamp_us: timestamp_to_micros(sum.time()),
+            start_timestamp_us: timestamp_to_micros(sum.start_time()),
+            scope_name: metadata.scope_name.to_string(),
+            unit: metadata.unit.to_string(),
+            temporality: temporality_name(sum.temporality()).to_string(),
+            is_monotonic: sum.is_monotonic(),
+            attributes_json: key_values_to_json(point.attributes()),
+            resource_attributes_json: resource_attributes_json.to_string(),
+            sum_f64,
+            sum_i64,
+            sum_u64,
+        });
+    }
+}
+
+fn buffer_histogram<T: TableMetricNumber>(
+    buffer: &mut MetricHistogramBuffer,
+    resource_attributes_json: &str,
+    metadata: InstrumentMetadata<'_>,
+    histogram: &Histogram<T>,
+) {
+    for point in histogram.data_points() {
+        let (sum_f64, sum_i64, sum_u64) = point.sum().into_columns();
+        let (min_f64, min_i64, min_u64) = point
+            .min()
+            .map(TableMetricNumber::into_columns)
+            .unwrap_or_default();
+        let (max_f64, max_i64, max_u64) = point
+            .max()
+            .map(TableMetricNumber::into_columns)
+            .unwrap_or_default();
+        buffer.insert(MetricHistogram {
+            name: metadata.name.to_string(),
+            timestamp_us: timestamp_to_micros(histogram.time()),
+            start_timestamp_us: timestamp_to_micros(histogram.start_time()),
+            scope_name: metadata.scope_name.to_string(),
+            unit: metadata.unit.to_string(),
+            temporality: temporality_name(histogram.temporality()).to_string(),
+            attributes_json: key_values_to_json(point.attributes()),
+            resource_attributes_json: resource_attributes_json.to_string(),
+            count: point.count(),
+            sum_f64,
+            sum_i64,
+            sum_u64,
+            min_f64,
+            min_i64,
+            min_u64,
+            max_f64,
+            max_i64,
+            max_u64,
+            bounds_json: serde_json::to_string(&point.bounds().collect::<Vec<_>>())
+                .expect("metric bounds should serialize"),
+            bucket_counts_json: serde_json::to_string(&point.bucket_counts().collect::<Vec<_>>())
+                .expect("metric bucket counts should serialize"),
+        });
+    }
+}
+
+fn temporality_name(temporality: Temporality) -> &'static str {
+    match temporality {
+        Temporality::Cumulative => "cumulative",
+        Temporality::Delta => "delta",
+        _ => "unknown",
+    }
+}
+
+fn key_values_to_json<'a>(
+    attributes: impl IntoIterator<Item = &'a opentelemetry::KeyValue>,
+) -> String {
+    monarch_telemetry_schema::fields_to_json(
+        attributes
+            .into_iter()
+            .map(|kv| (kv.key.as_str(), otel_value_to_json(&kv.value))),
+    )
+}
+
+fn resource_attributes_to_json(resource: &opentelemetry_sdk::Resource) -> String {
+    monarch_telemetry_schema::fields_to_json(
+        resource
+            .iter()
+            .map(|(key, value)| (key.as_str(), otel_value_to_json(value))),
+    )
+}
+
+fn otel_value_to_json(value: &Value) -> serde_json::Value {
+    match value {
+        Value::Bool(value) => serde_json::Value::Bool(*value),
+        Value::I64(value) => serde_json::Value::Number((*value).into()),
+        Value::F64(value) => serde_json::Number::from_f64(*value)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        Value::String(value) => serde_json::Value::String(value.as_str().to_string()),
+        Value::Array(array) => match array {
+            Array::Bool(values) => serde_json::Value::Array(
+                values
+                    .iter()
+                    .copied()
+                    .map(serde_json::Value::Bool)
+                    .collect(),
+            ),
+            Array::I64(values) => serde_json::Value::Array(
+                values
+                    .iter()
+                    .copied()
+                    .map(|value| serde_json::Value::Number(value.into()))
+                    .collect(),
+            ),
+            Array::F64(values) => serde_json::Value::Array(
+                values
+                    .iter()
+                    .map(|value| {
+                        serde_json::Number::from_f64(*value)
+                            .map(serde_json::Value::Number)
+                            .unwrap_or(serde_json::Value::Null)
+                    })
+                    .collect(),
+            ),
+            Array::String(values) => serde_json::Value::Array(
+                values
+                    .iter()
+                    .map(|value| serde_json::Value::String(value.as_str().to_string()))
+                    .collect(),
+            ),
+            _ => serde_json::Value::String(value.as_str().into_owned()),
+        },
+        _ => serde_json::Value::String(value.as_str().into_owned()),
+    }
+}
+
+fn timestamp_to_micros(timestamp: SystemTime) -> i64 {
+    timestamp
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_micros() as i64
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use datafusion::arrow::array::Array as _;
+    use datafusion::arrow::array::BooleanArray;
+    use datafusion::arrow::array::Float64Array;
+    use datafusion::arrow::array::Int64Array;
+    use datafusion::arrow::array::StringArray;
+    use datafusion::arrow::array::UInt64Array;
+    use datafusion::arrow::record_batch::RecordBatch;
+    use monarch_record_batch::RecordBatchBuffer;
+    use opentelemetry::KeyValue;
+    use opentelemetry::metrics::MeterProvider as _;
+    use opentelemetry_sdk::Resource;
+    use opentelemetry_sdk::metrics::ManualReader;
+    use opentelemetry_sdk::metrics::SdkMeterProvider;
+    use opentelemetry_sdk::metrics::reader::MetricReader;
+    use serde_json::json;
+
+    use super::*;
+    use crate::in_memory_reader::InMemoryReader;
+
+    fn column<'a, T: 'static>(batch: &'a RecordBatch, name: &str) -> &'a T {
+        batch
+            .column_by_name(name)
+            .unwrap_or_else(|| panic!("missing {name} column"))
+            .as_any()
+            .downcast_ref::<T>()
+            .unwrap_or_else(|| panic!("unexpected {name} column type"))
+    }
+
+    #[test]
+    fn encodes_typed_points_and_sum_semantics() {
+        const EXACT_I64: i64 = -9_007_199_254_740_993;
+
+        let reader = Arc::new(
+            ManualReader::builder()
+                .with_temporality(Temporality::Delta)
+                .build(),
+        );
+        let resource = Resource::builder_empty()
+            .with_attribute(KeyValue::new("service.name", "test-service"))
+            .build();
+        let provider = SdkMeterProvider::builder()
+            .with_resource(resource)
+            .with_reader(InMemoryReader::new(Arc::clone(&reader)))
+            .build();
+        let meter = provider.meter("test.scope");
+        meter
+            .u64_counter("requests")
+            .build()
+            .add(u64::MAX, &[KeyValue::new("route", "a")]);
+        meter
+            .i64_up_down_counter("queue.depth")
+            .build()
+            .add(EXACT_I64, &[]);
+        meter.f64_gauge("load").build().record(1.5, &[]);
+        meter
+            .u64_histogram("batch.size")
+            .with_boundaries(vec![1.0, 10.0])
+            .build()
+            .record(9_007_199_254_740_993, &[]);
+
+        let mut metrics = ResourceMetrics::default();
+        reader.collect(&mut metrics).unwrap();
+        let MetricBuffers {
+            mut gauges,
+            mut sums,
+            mut histograms,
+        } = encode_metrics(&metrics);
+        let gauge_batch = gauges.drain_to_record_batch().unwrap();
+        let sum_batch = sums.drain_to_record_batch().unwrap();
+        let histogram_batch = histograms.drain_to_record_batch().unwrap();
+
+        assert_eq!(gauge_batch.num_rows(), 1);
+        assert_eq!(sum_batch.num_rows(), 2);
+        assert_eq!(histogram_batch.num_rows(), 1);
+        let names = column::<StringArray>(&sum_batch, "name");
+        let row_for = |name: &str| {
+            (0..sum_batch.num_rows())
+                .find(|row| names.value(*row) == name)
+                .unwrap_or_else(|| panic!("missing {name} row"))
+        };
+
+        let requests = row_for("requests");
+        assert_eq!(
+            column::<UInt64Array>(&sum_batch, "sum_u64").value(requests),
+            u64::MAX
+        );
+        assert!(column::<Float64Array>(&sum_batch, "sum_f64").is_null(requests));
+        assert!(column::<Int64Array>(&sum_batch, "sum_i64").is_null(requests));
+        assert_eq!(
+            column::<StringArray>(&sum_batch, "temporality").value(requests),
+            "delta"
+        );
+        assert!(column::<BooleanArray>(&sum_batch, "is_monotonic").value(requests));
+
+        let queue = row_for("queue.depth");
+        assert_eq!(
+            column::<Int64Array>(&sum_batch, "sum_i64").value(queue),
+            EXACT_I64
+        );
+        assert!(!column::<BooleanArray>(&sum_batch, "is_monotonic").value(queue));
+
+        assert_eq!(column::<StringArray>(&gauge_batch, "name").value(0), "load");
+        assert_eq!(
+            column::<Float64Array>(&gauge_batch, "value_f64").value(0),
+            1.5
+        );
+
+        assert_eq!(
+            column::<StringArray>(&histogram_batch, "name").value(0),
+            "batch.size"
+        );
+        assert_eq!(
+            column::<UInt64Array>(&histogram_batch, "sum_u64").value(0),
+            9_007_199_254_740_993
+        );
+        assert_eq!(
+            column::<UInt64Array>(&histogram_batch, "min_u64").value(0),
+            9_007_199_254_740_993
+        );
+        assert_eq!(
+            column::<UInt64Array>(&histogram_batch, "max_u64").value(0),
+            9_007_199_254_740_993
+        );
+        assert_eq!(column::<UInt64Array>(&histogram_batch, "count").value(0), 1);
+        let bounds: Vec<f64> =
+            serde_json::from_str(column::<StringArray>(&histogram_batch, "bounds_json").value(0))
+                .unwrap();
+        let bucket_counts: Vec<u64> = serde_json::from_str(
+            column::<StringArray>(&histogram_batch, "bucket_counts_json").value(0),
+        )
+        .unwrap();
+        assert_eq!(bounds, vec![1.0, 10.0]);
+        assert_eq!(bucket_counts.len(), bounds.len() + 1);
+        assert_eq!(bucket_counts.iter().sum::<u64>(), 1);
+
+        let attributes: serde_json::Value = serde_json::from_str(
+            column::<StringArray>(&sum_batch, "attributes_json").value(requests),
+        )
+        .unwrap();
+        assert_eq!(attributes["route"], json!("a"));
+        let resources: serde_json::Value = serde_json::from_str(
+            column::<StringArray>(&sum_batch, "resource_attributes_json").value(requests),
+        )
+        .unwrap();
+        assert_eq!(resources["service.name"], json!("test-service"));
+    }
+
+    #[test]
+    fn attributes_json_preserves_value_types() {
+        let attributes = [
+            KeyValue::new("name", "worker"),
+            KeyValue::new("pid", 42_i64),
+            KeyValue::new("enabled", true),
+            KeyValue::new("ratio", 1.5_f64),
+            KeyValue::new("flags", Value::Array(Array::Bool(vec![true, false]))),
+            KeyValue::new("ranks", Value::Array(Array::I64(vec![1, 2]))),
+            KeyValue::new("weights", Value::Array(Array::F64(vec![1.5, 2.5]))),
+            KeyValue::new(
+                "names",
+                Value::Array(Array::String(vec!["first".into(), "second".into()])),
+            ),
+        ];
+
+        let attributes: serde_json::Value =
+            serde_json::from_str(&key_values_to_json(attributes.iter())).unwrap();
+
+        assert_eq!(attributes["name"], json!("worker"));
+        assert_eq!(attributes["pid"], json!(42));
+        assert_eq!(attributes["enabled"], json!(true));
+        assert_eq!(attributes["ratio"], json!(1.5));
+        assert_eq!(attributes["flags"], json!([true, false]));
+        assert_eq!(attributes["ranks"], json!([1, 2]));
+        assert_eq!(attributes["weights"], json!([1.5, 2.5]));
+        assert_eq!(attributes["names"], json!(["first", "second"]));
+    }
+}

--- a/hyperactor_telemetry/src/otel.rs
+++ b/hyperactor_telemetry/src/otel.rs
@@ -76,21 +76,28 @@ pub fn init_metrics() {
     {
         let resource = crate::meta::metrics_resource();
         let exporter = crate::meta::scuba_metric_exporter(&resource);
+        let uds = crate::metrics_table::uds_metric_exporter();
         install_metric_provider(|| {
             SdkMeterProvider::builder()
                 .with_reader(periodic_reader(exporter))
+                .with_reader(periodic_reader(uds))
                 .with_resource(resource)
                 .build()
         });
     }
     #[cfg(not(all(fbcode_build, target_os = "linux")))]
-    if let Some(exporter) = crate::otlp::otlp_metric_exporter() {
+    {
+        let otlp = crate::otlp::otlp_metric_exporter();
+        let uds = crate::metrics_table::uds_metric_exporter();
         let resource = Resource::builder().build();
         install_metric_provider(|| {
-            SdkMeterProvider::builder()
-                .with_reader(periodic_reader(exporter))
-                .with_resource(resource)
-                .build()
+            let mut builder = SdkMeterProvider::builder()
+                .with_reader(periodic_reader(uds))
+                .with_resource(resource);
+            if let Some(exporter) = otlp {
+                builder = builder.with_reader(periodic_reader(exporter));
+            }
+            builder.build()
         });
     }
 }

--- a/hyperactor_telemetry/src/otel.rs
+++ b/hyperactor_telemetry/src/otel.rs
@@ -6,6 +6,52 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::sync::OnceLock;
+
+#[cfg(not(all(fbcode_build, target_os = "linux")))]
+use opentelemetry_sdk::Resource;
+use opentelemetry_sdk::metrics::PeriodicReader;
+use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
+
+static METER_PROVIDER: OnceLock<SdkMeterProvider> = OnceLock::new();
+
+fn periodic_reader<E>(exporter: E) -> PeriodicReader<E>
+where
+    E: PushMetricExporter,
+{
+    let interval = hyperactor_config::global::get(crate::config::OTEL_METRIC_EXPORT_INTERVAL);
+    PeriodicReader::builder(exporter)
+        .with_interval(interval)
+        .build()
+}
+
+fn install_metric_provider<B>(build_provider: B)
+where
+    B: FnOnce() -> SdkMeterProvider,
+{
+    install_metric_provider_with(
+        &METER_PROVIDER,
+        build_provider,
+        opentelemetry::global::set_meter_provider,
+    );
+}
+
+fn install_metric_provider_with<B, F>(
+    provider_cell: &OnceLock<SdkMeterProvider>,
+    build_provider: B,
+    set_global_provider: F,
+) where
+    B: FnOnce() -> SdkMeterProvider,
+    F: FnOnce(SdkMeterProvider),
+{
+    provider_cell.get_or_init(|| {
+        let provider = build_provider();
+        set_global_provider(provider.clone());
+        provider
+    });
+}
+
 #[allow(dead_code)]
 pub fn tracing_layer<
     S: tracing::Subscriber + for<'span> tracing_subscriber::registry::LookupSpan<'span>,
@@ -22,14 +68,91 @@ pub fn tracing_layer<
 
 #[allow(dead_code)]
 pub fn init_metrics() {
+    if METER_PROVIDER.get().is_some() {
+        return;
+    }
+
     #[cfg(all(fbcode_build, target_os = "linux"))]
     {
-        opentelemetry::global::set_meter_provider(crate::meta::meter_provider());
+        let resource = crate::meta::metrics_resource();
+        let exporter = crate::meta::scuba_metric_exporter(&resource);
+        install_metric_provider(|| {
+            SdkMeterProvider::builder()
+                .with_reader(periodic_reader(exporter))
+                .with_resource(resource)
+                .build()
+        });
     }
     #[cfg(not(all(fbcode_build, target_os = "linux")))]
-    {
-        if let Some(provider) = crate::otlp::otlp_meter_provider() {
-            opentelemetry::global::set_meter_provider(provider);
+    if let Some(exporter) = crate::otlp::otlp_metric_exporter() {
+        let resource = Resource::builder().build();
+        install_metric_provider(|| {
+            SdkMeterProvider::builder()
+                .with_reader(periodic_reader(exporter))
+                .with_resource(resource)
+                .build()
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    use super::*;
+
+    #[test]
+    fn installs_metric_provider_once() {
+        let provider_cell = OnceLock::new();
+        let installations = AtomicUsize::new(0);
+
+        for _ in 0..2 {
+            install_metric_provider_with(
+                &provider_cell,
+                || SdkMeterProvider::builder().build(),
+                |_| {
+                    installations.fetch_add(1, Ordering::Relaxed);
+                },
+            );
         }
+
+        assert_eq!(installations.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn installs_metric_provider_once_concurrently() {
+        let provider_cell = Arc::new(OnceLock::new());
+        let constructions = Arc::new(AtomicUsize::new(0));
+        let installations = Arc::new(AtomicUsize::new(0));
+        let handles = (0..8)
+            .map(|_| {
+                let provider_cell = Arc::clone(&provider_cell);
+                let constructions = Arc::clone(&constructions);
+                let installations = Arc::clone(&installations);
+                std::thread::spawn(move || {
+                    install_metric_provider_with(
+                        &provider_cell,
+                        || {
+                            constructions.fetch_add(1, Ordering::Relaxed);
+                            SdkMeterProvider::builder().build()
+                        },
+                        |_| {
+                            installations.fetch_add(1, Ordering::Relaxed);
+                        },
+                    );
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle
+                .join()
+                .expect("provider installation should not panic");
+        }
+
+        assert_eq!(constructions.load(Ordering::Relaxed), 1);
+        assert_eq!(installations.load(Ordering::Relaxed), 1);
     }
 }

--- a/hyperactor_telemetry/src/otlp.rs
+++ b/hyperactor_telemetry/src/otlp.rs
@@ -9,11 +9,10 @@
 //! OTLP export for OSS observability.
 //!
 //! When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, this module provides:
-//! - A `SdkMeterProvider` that exports metrics via OTLP/HTTP+protobuf
+//! - A metric exporter that sends metrics via OTLP/HTTP+protobuf
 //! - An `OtlpLogSink` that exports log events via OTLP/HTTP+protobuf
 //!
-//! When the env var is unset, both functions return `None`, preserving
-//! the current no-op behavior for OSS builds.
+//! When the env var is unset, the OTLP functions return `None`.
 
 use opentelemetry::logs::AnyValue;
 use opentelemetry::logs::LogRecord;
@@ -23,10 +22,9 @@ use opentelemetry::logs::Severity;
 use opentelemetry_sdk::logs::BatchLogProcessor;
 use opentelemetry_sdk::logs::SdkLogger;
 use opentelemetry_sdk::logs::SdkLoggerProvider;
-use opentelemetry_sdk::metrics::SdkMeterProvider;
+use opentelemetry_sdk::metrics::exporter::PushMetricExporter;
 use tracing_subscriber::filter::Targets;
 
-use crate::config::OTEL_METRIC_EXPORT_INTERVAL;
 use crate::trace_dispatcher::FieldValue;
 use crate::trace_dispatcher::TraceEvent;
 use crate::trace_dispatcher::TraceEventSink;
@@ -34,16 +32,15 @@ use crate::trace_dispatcher::TraceEventSink;
 #[allow(dead_code)]
 const OTLP_ENDPOINT_ENV: &str = "OTEL_EXPORTER_OTLP_ENDPOINT";
 
-/// Build an OTLP-backed `SdkMeterProvider` if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
+/// Build an OTLP metric exporter if `OTEL_EXPORTER_OTLP_ENDPOINT` is set.
 ///
 /// The `opentelemetry-otlp` crate automatically reads standard OTel env vars
 /// (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`,
 /// `OTEL_EXPORTER_OTLP_TIMEOUT`, etc.), so callers only need to set those.
 ///
-/// Returns `None` if the endpoint is not configured, leaving the global
-/// meter provider as the default no-op.
+/// Returns `None` if the endpoint is not configured.
 #[allow(dead_code)]
-pub fn otlp_meter_provider() -> Option<SdkMeterProvider> {
+pub fn otlp_metric_exporter() -> Option<impl PushMetricExporter> {
     if std::env::var(OTLP_ENDPOINT_ENV).is_err() {
         return None;
     }
@@ -59,15 +56,7 @@ pub fn otlp_meter_provider() -> Option<SdkMeterProvider> {
         }
     };
 
-    let interval = hyperactor_config::global::get(OTEL_METRIC_EXPORT_INTERVAL);
-
-    let reader = opentelemetry_sdk::metrics::PeriodicReader::builder(exporter)
-        .with_interval(interval)
-        .build();
-
-    let provider = SdkMeterProvider::builder().with_reader(reader).build();
-
-    Some(provider)
+    Some(exporter)
 }
 
 #[allow(dead_code)]
@@ -243,10 +232,10 @@ mod tests {
     use crate::trace_dispatcher::TraceEvent;
 
     #[test]
-    fn test_otlp_meter_provider_returns_none_without_endpoint() {
+    fn test_otlp_metric_exporter_returns_none_without_endpoint() {
         // Safety: test-only; no other threads read this env var concurrently.
         unsafe { std::env::remove_var(OTLP_ENDPOINT_ENV) };
-        assert!(otlp_meter_provider().is_none());
+        assert!(otlp_metric_exporter().is_none());
     }
 
     fn make_test_log_sink() -> OtlpLogSink {

--- a/hyperactor_telemetry/src/unix_sink.rs
+++ b/hyperactor_telemetry/src/unix_sink.rs
@@ -8,10 +8,11 @@
 
 //! Producer-side Unix-socket sink for telemetry sidecars.
 //!
-//! This module is the producer-side transport for telemetry. It installs
-//! an inactive process-global `UnixSocketSink`, buffers trace and entity events into
-//! schema-specific `RecordBatchBuffer`s, and, once activated with a socket
-//! path, forwards flushed batches to the sidecar over a Unix socket.
+//! This module is the producer-side transport for telemetry. It shares one
+//! process-global `UnixSocketSink` across traces, entities, and metrics. It buffers
+//! trace and entity events into schema-specific `RecordBatchBuffer`s and, once
+//! activated with a socket path, forwards flushed batches to the sidecar over a
+//! Unix socket. Metrics are sent only while the sink is active.
 //!
 //! The dispatcher thread only does cheap row buffering and bounded channel
 //! sends. Arrow IPC serialization and socket I/O run on a dedicated writer
@@ -53,6 +54,12 @@ use monarch_telemetry_schema::entity_tables::MessageStatusEventBuffer;
 use monarch_telemetry_schema::entity_tables::SENT_MESSAGES;
 use monarch_telemetry_schema::entity_tables::SentMessage;
 use monarch_telemetry_schema::entity_tables::SentMessageBuffer;
+use monarch_telemetry_schema::metric_tables::METRIC_GAUGES;
+use monarch_telemetry_schema::metric_tables::METRIC_HISTOGRAMS;
+use monarch_telemetry_schema::metric_tables::METRIC_SUMS;
+use monarch_telemetry_schema::metric_tables::MetricGaugeBuffer;
+use monarch_telemetry_schema::metric_tables::MetricHistogramBuffer;
+use monarch_telemetry_schema::metric_tables::MetricSumBuffer;
 use monarch_telemetry_schema::trace_tables::EVENTS;
 use monarch_telemetry_schema::trace_tables::Event;
 use monarch_telemetry_schema::trace_tables::EventBuffer;
@@ -77,6 +84,10 @@ const WORKER_QUEUE_CAPACITY: usize = 10_000;
 
 /// Process-global sink installed with the tracing subscriber and activated later.
 static UNIX_SOCKET_SINK: OnceLock<Arc<UnixSocketSink>> = OnceLock::new();
+
+fn unix_socket_sink() -> &'static Arc<UnixSocketSink> {
+    UNIX_SOCKET_SINK.get_or_init(|| Arc::new(UnixSocketSink::new()))
+}
 
 /// Producer-side sink that forwards telemetry batches to a sidecar socket.
 pub struct UnixSocketSink {
@@ -117,6 +128,9 @@ enum TelemetryTableBuffer {
     SentMessages(SentMessageBuffer),
     Messages(MessageBuffer),
     MessageStatusEvents(MessageStatusEventBuffer),
+    MetricGauges(MetricGaugeBuffer),
+    MetricSums(MetricSumBuffer),
+    MetricHistograms(MetricHistogramBuffer),
 }
 
 struct UnixSocketSinkAdapter {
@@ -197,6 +211,51 @@ impl UnixSocketSink {
     /// Return the cumulative number of dropped socket frames.
     pub fn dropped_frames(&self) -> u64 {
         self.dropped.load(Ordering::Relaxed)
+    }
+
+    fn send_metric_buffers(
+        &self,
+        gauges: MetricGaugeBuffer,
+        sums: MetricSumBuffer,
+        histograms: MetricHistogramBuffer,
+    ) {
+        let sender = match self.inner.lock() {
+            Ok(inner) => inner.worker.as_ref().map(|worker| worker.sender.clone()),
+            Err(_) => {
+                let dropped = [gauges.is_empty(), sums.is_empty(), histograms.is_empty()]
+                    .into_iter()
+                    .filter(|empty| !empty)
+                    .count() as u64;
+                self.dropped.fetch_add(dropped, Ordering::Relaxed);
+                return;
+            }
+        };
+
+        let Some(sender) = sender else {
+            return;
+        };
+
+        if !gauges.is_empty() {
+            try_send_table_buffer(
+                TelemetryTableBuffer::MetricGauges(gauges),
+                &sender,
+                &self.dropped,
+            );
+        }
+        if !sums.is_empty() {
+            try_send_table_buffer(
+                TelemetryTableBuffer::MetricSums(sums),
+                &sender,
+                &self.dropped,
+            );
+        }
+        if !histograms.is_empty() {
+            try_send_table_buffer(
+                TelemetryTableBuffer::MetricHistograms(histograms),
+                &sender,
+                &self.dropped,
+            );
+        }
     }
 
     /// Convert one dispatcher event into its table row and buffer it locally.
@@ -394,8 +453,7 @@ impl TraceEventSink for UnixSocketSinkAdapter {
 
 /// Install the inactive process-global Unix socket sink.
 pub(crate) fn install_unix_socket_sink_inactive() -> Box<dyn TraceEventSink> {
-    let sink = Arc::new(UnixSocketSink::new());
-    let _ = UNIX_SOCKET_SINK.set(Arc::clone(&sink));
+    let sink = Arc::clone(unix_socket_sink());
     Box::new(UnixSocketSinkAdapter {
         sink,
         target_filter: get_tracing_targets(),
@@ -404,10 +462,7 @@ pub(crate) fn install_unix_socket_sink_inactive() -> Box<dyn TraceEventSink> {
 
 /// Activate the process-global Unix socket sink against a socket path.
 pub fn set_unix_socket_sink_path(path: impl Into<PathBuf>) -> anyhow::Result<()> {
-    let sink = UNIX_SOCKET_SINK
-        .get()
-        .ok_or_else(|| anyhow::anyhow!("unix socket sink is not installed"))?;
-    sink.set_path(path.into())
+    unix_socket_sink().set_path(path.into())
 }
 
 /// Return whether the process-global Unix socket sink is active.
@@ -423,6 +478,18 @@ pub fn unix_socket_sink_dropped_frames() -> Option<u64> {
     UNIX_SOCKET_SINK.get().map(|sink| sink.dropped_frames())
 }
 
+/// Send encoded metric table buffers through the active sidecar transport.
+pub(crate) fn send_metric_buffers(
+    gauges: MetricGaugeBuffer,
+    sums: MetricSumBuffer,
+    histograms: MetricHistogramBuffer,
+) {
+    let Some(sink) = UNIX_SOCKET_SINK.get() else {
+        return;
+    };
+    sink.send_metric_buffers(gauges, sums, histograms);
+}
+
 fn flush_buffer<B>(
     buffer: &mut B,
     table_buffer: impl FnOnce(B) -> TelemetryTableBuffer,
@@ -436,7 +503,15 @@ fn flush_buffer<B>(
     }
 
     let batch = table_buffer(std::mem::take(buffer));
-    match sender.try_send(batch) {
+    try_send_table_buffer(batch, sender, dropped);
+}
+
+fn try_send_table_buffer(
+    buffer: TelemetryTableBuffer,
+    sender: &mpsc::SyncSender<TelemetryTableBuffer>,
+    dropped: &AtomicU64,
+) {
+    match sender.try_send(buffer) {
         Ok(()) => {}
         Err(mpsc::TrySendError::Full(_)) | Err(mpsc::TrySendError::Disconnected(_)) => {
             // Socket delivery must never backpressure the tracing dispatcher.
@@ -547,6 +622,15 @@ fn writer_loop(
             TelemetryTableBuffer::MessageStatusEvents(buffer) => {
                 (MESSAGE_STATUS_EVENTS, buffer.drain_to_record_batch())
             }
+            TelemetryTableBuffer::MetricGauges(buffer) => {
+                (METRIC_GAUGES, buffer.drain_to_record_batch())
+            }
+            TelemetryTableBuffer::MetricSums(buffer) => {
+                (METRIC_SUMS, buffer.drain_to_record_batch())
+            }
+            TelemetryTableBuffer::MetricHistograms(buffer) => {
+                (METRIC_HISTOGRAMS, buffer.drain_to_record_batch())
+            }
         };
         let Ok(batch) = batch else {
             dropped.fetch_add(1, Ordering::Relaxed);
@@ -650,6 +734,9 @@ mod tests {
     use std::time::SystemTime;
 
     use monarch_record_batch::RecordBatchBuffer;
+    use monarch_telemetry_schema::metric_tables::MetricGauge;
+    use monarch_telemetry_schema::metric_tables::MetricHistogram;
+    use monarch_telemetry_schema::metric_tables::MetricSum;
 
     use super::*;
     use crate::ActorEvent;
@@ -775,6 +862,69 @@ mod tests {
                 status: "complete".to_string(),
             })),
         ]
+    }
+
+    fn metric_gauge_buffer() -> MetricGaugeBuffer {
+        let mut buffer = MetricGaugeBuffer::default();
+        buffer.insert(MetricGauge {
+            name: "load".to_string(),
+            timestamp_us: 123,
+            start_timestamp_us: None,
+            scope_name: "test".to_string(),
+            unit: "1".to_string(),
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            value_f64: Some(1.5),
+            value_i64: None,
+            value_u64: None,
+        });
+        buffer
+    }
+
+    fn metric_sum_buffer() -> MetricSumBuffer {
+        let mut buffer = MetricSumBuffer::default();
+        buffer.insert(MetricSum {
+            name: "mailbox.posts".to_string(),
+            timestamp_us: 123,
+            start_timestamp_us: 100,
+            scope_name: "hyperactor::mailbox".to_string(),
+            unit: "1".to_string(),
+            temporality: "delta".to_string(),
+            is_monotonic: true,
+            attributes_json: r#"{"actor_id":"actor"}"#.to_string(),
+            resource_attributes_json: r#"{"execution_id":"test"}"#.to_string(),
+            sum_f64: None,
+            sum_i64: None,
+            sum_u64: Some(3),
+        });
+        buffer
+    }
+
+    fn metric_histogram_buffer() -> MetricHistogramBuffer {
+        let mut buffer = MetricHistogramBuffer::default();
+        buffer.insert(MetricHistogram {
+            name: "latency".to_string(),
+            timestamp_us: 123,
+            start_timestamp_us: 100,
+            scope_name: "test".to_string(),
+            unit: "ms".to_string(),
+            temporality: "delta".to_string(),
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            count: 1,
+            sum_f64: Some(5.0),
+            sum_i64: None,
+            sum_u64: None,
+            min_f64: Some(5.0),
+            min_i64: None,
+            min_u64: None,
+            max_f64: Some(5.0),
+            max_i64: None,
+            max_u64: None,
+            bounds_json: "[10.0]".to_string(),
+            bucket_counts_json: "[1,0]".to_string(),
+        });
+        buffer
     }
 
     fn read_frame(stream: &mut UnixStream) -> Frame {
@@ -987,6 +1137,57 @@ mod tests {
         );
         frames.iter().for_each(assert_entity_frame_schema);
         assert_eq!(sink.dropped_frames(), 0);
+    }
+
+    #[test]
+    fn active_sink_sends_metric_frames() {
+        let path = socket_path("metrics.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        let (sender, receiver) = mpsc::channel();
+        let read_handle = std::thread::spawn(move || {
+            let (stream, _addr) = listener.accept().unwrap();
+            sender.send(read_frames(stream, 3)).unwrap();
+        });
+
+        let sink = UnixSocketSink::new();
+        sink.set_path(path).unwrap();
+        sink.send_metric_buffers(
+            metric_gauge_buffer(),
+            metric_sum_buffer(),
+            metric_histogram_buffer(),
+        );
+
+        let frames = receiver.recv_timeout(Duration::from_secs(5)).unwrap();
+        read_handle.join().unwrap();
+        assert_eq!(frames[0].table_name, METRIC_GAUGES);
+        assert_frame_batch::<MetricGaugeBuffer>(&frames[0]);
+        assert_eq!(frames[1].table_name, METRIC_SUMS);
+        assert_frame_batch::<MetricSumBuffer>(&frames[1]);
+        assert_eq!(frames[2].table_name, METRIC_HISTOGRAMS);
+        assert_frame_batch::<MetricHistogramBuffer>(&frames[2]);
+        assert_eq!(sink.dropped_frames(), 0);
+    }
+
+    #[test]
+    fn poisoned_sink_counts_dropped_metric_frames() {
+        let sink = Arc::new(UnixSocketSink::new());
+        let poison_sink = Arc::clone(&sink);
+        assert!(
+            std::thread::spawn(move || {
+                let _guard = poison_sink.inner.lock().unwrap();
+                panic!("poison metric sink lock");
+            })
+            .join()
+            .is_err()
+        );
+
+        sink.send_metric_buffers(
+            metric_gauge_buffer(),
+            metric_sum_buffer(),
+            metric_histogram_buffer(),
+        );
+
+        assert_eq!(sink.dropped_frames(), 3);
     }
 
     #[test]

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -40,6 +40,9 @@ use monarch_telemetry_schema::deserialize_one_batch;
 use monarch_telemetry_schema::entity_tables::MESSAGE_STATUS_EVENTS;
 use monarch_telemetry_schema::entity_tables::MESSAGES;
 use monarch_telemetry_schema::entity_tables::SENT_MESSAGES;
+use monarch_telemetry_schema::metric_tables::METRIC_GAUGES;
+use monarch_telemetry_schema::metric_tables::METRIC_HISTOGRAMS;
+use monarch_telemetry_schema::metric_tables::METRIC_SUMS;
 use monarch_telemetry_schema::trace_tables::EVENTS;
 use monarch_telemetry_schema::trace_tables::SPAN_EVENTS;
 use monarch_telemetry_schema::trace_tables::SPANS;
@@ -332,6 +335,9 @@ const RETENTION_TABLES: &[&str] = &[
     SENT_MESSAGES,
     MESSAGES,
     MESSAGE_STATUS_EVENTS,
+    METRIC_GAUGES,
+    METRIC_SUMS,
+    METRIC_HISTOGRAMS,
 ];
 
 /// Interval between routine retention sweeps.
@@ -1063,6 +1069,12 @@ mod tests {
     use monarch_telemetry_schema::entity_tables::SENT_MESSAGES;
     use monarch_telemetry_schema::entity_tables::SentMessage;
     use monarch_telemetry_schema::entity_tables::SentMessageBuffer;
+    use monarch_telemetry_schema::metric_tables::MetricGauge;
+    use monarch_telemetry_schema::metric_tables::MetricGaugeBuffer;
+    use monarch_telemetry_schema::metric_tables::MetricHistogram;
+    use monarch_telemetry_schema::metric_tables::MetricHistogramBuffer;
+    use monarch_telemetry_schema::metric_tables::MetricSum;
+    use monarch_telemetry_schema::metric_tables::MetricSumBuffer;
     use monarch_telemetry_schema::trace_tables::Event;
     use monarch_telemetry_schema::trace_tables::EventBuffer;
     use monarch_telemetry_schema::trace_tables::Span;
@@ -1258,6 +1270,121 @@ mod tests {
             });
         }
         ingest_batch(scanner, EVENTS, events.drain_to_record_batch().unwrap()).await;
+
+        let mut gauges = MetricGaugeBuffer::default();
+        gauges.insert(MetricGauge {
+            name: "old_gauge".to_string(),
+            timestamp_us: old_us,
+            start_timestamp_us: None,
+            scope_name: "test".to_string(),
+            unit: "1".to_string(),
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            value_f64: Some(1.0),
+            value_i64: None,
+            value_u64: None,
+        });
+        gauges.insert(MetricGauge {
+            name: "fresh_gauge".to_string(),
+            timestamp_us: fresh_us,
+            start_timestamp_us: None,
+            scope_name: "test".to_string(),
+            unit: "1".to_string(),
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            value_f64: Some(2.0),
+            value_i64: None,
+            value_u64: None,
+        });
+        ingest_batch(
+            scanner,
+            METRIC_GAUGES,
+            gauges.drain_to_record_batch().unwrap(),
+        )
+        .await;
+
+        let mut sums = MetricSumBuffer::default();
+        sums.insert(MetricSum {
+            name: "old_sum".to_string(),
+            timestamp_us: old_us,
+            start_timestamp_us: old_us - 1,
+            scope_name: "test".to_string(),
+            unit: "1".to_string(),
+            temporality: "delta".to_string(),
+            is_monotonic: true,
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            sum_f64: None,
+            sum_i64: None,
+            sum_u64: Some(1),
+        });
+        sums.insert(MetricSum {
+            name: "fresh_sum".to_string(),
+            timestamp_us: fresh_us,
+            start_timestamp_us: fresh_us - 1,
+            scope_name: "test".to_string(),
+            unit: "1".to_string(),
+            temporality: "delta".to_string(),
+            is_monotonic: true,
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            sum_f64: None,
+            sum_i64: None,
+            sum_u64: Some(2),
+        });
+        ingest_batch(scanner, METRIC_SUMS, sums.drain_to_record_batch().unwrap()).await;
+
+        let mut histograms = MetricHistogramBuffer::default();
+        histograms.insert(MetricHistogram {
+            name: "old_histogram".to_string(),
+            timestamp_us: old_us,
+            start_timestamp_us: old_us - 1,
+            scope_name: "test".to_string(),
+            unit: "ms".to_string(),
+            temporality: "delta".to_string(),
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            count: 1,
+            sum_f64: Some(1.0),
+            sum_i64: None,
+            sum_u64: None,
+            min_f64: Some(1.0),
+            min_i64: None,
+            min_u64: None,
+            max_f64: Some(1.0),
+            max_i64: None,
+            max_u64: None,
+            bounds_json: "[]".to_string(),
+            bucket_counts_json: "[1]".to_string(),
+        });
+        histograms.insert(MetricHistogram {
+            name: "fresh_histogram".to_string(),
+            timestamp_us: fresh_us,
+            start_timestamp_us: fresh_us - 1,
+            scope_name: "test".to_string(),
+            unit: "ms".to_string(),
+            temporality: "delta".to_string(),
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            count: 1,
+            sum_f64: Some(2.0),
+            sum_i64: None,
+            sum_u64: None,
+            min_f64: None,
+            min_i64: None,
+            min_u64: None,
+            max_f64: None,
+            max_i64: None,
+            max_u64: None,
+            bounds_json: "[]".to_string(),
+            bucket_counts_json: "[1]".to_string(),
+        });
+        ingest_batch(
+            scanner,
+            METRIC_HISTOGRAMS,
+            histograms.drain_to_record_batch().unwrap(),
+        )
+        .await;
     }
 
     async fn table_row_count_async(scanner: &DatabaseScanner, table_name: &str) -> usize {
@@ -1561,6 +1688,9 @@ mod tests {
             table_i64_values_async(&scanner, EVENTS, "timestamp_us").await,
             vec![fresh_us]
         );
+        assert_eq!(table_row_count_async(&scanner, METRIC_GAUGES).await, 1);
+        assert_eq!(table_row_count_async(&scanner, METRIC_SUMS).await, 1);
+        assert_eq!(table_row_count_async(&scanner, METRIC_HISTOGRAMS).await, 1);
         assert_eq!(table_row_count_async(&scanner, ACTORS).await, 2);
     }
 

--- a/monarch_distributed_telemetry/src/lib.rs
+++ b/monarch_distributed_telemetry/src/lib.rs
@@ -38,6 +38,12 @@ use monarch_telemetry_schema::entity_tables::MessageBuffer;
 use monarch_telemetry_schema::entity_tables::MessageStatusEventBuffer;
 use monarch_telemetry_schema::entity_tables::SENT_MESSAGES;
 use monarch_telemetry_schema::entity_tables::SentMessageBuffer;
+use monarch_telemetry_schema::metric_tables::METRIC_GAUGES;
+use monarch_telemetry_schema::metric_tables::METRIC_HISTOGRAMS;
+use monarch_telemetry_schema::metric_tables::METRIC_SUMS;
+use monarch_telemetry_schema::metric_tables::MetricGaugeBuffer;
+use monarch_telemetry_schema::metric_tables::MetricHistogramBuffer;
+use monarch_telemetry_schema::metric_tables::MetricSumBuffer;
 pub use monarch_telemetry_schema::serialize_batch;
 use monarch_telemetry_schema::trace_tables::EVENTS;
 use monarch_telemetry_schema::trace_tables::EventBuffer;
@@ -99,9 +105,9 @@ fn _start_socket_ingest(scanner: PyRef<'_, DatabaseScanner>, socket_path: &str) 
         .map_err(|error| pyo3::exceptions::PyRuntimeError::new_err(error.to_string()))
 }
 
-/// Register trace and entity schemas with a database scanner.
+/// Register trace, entity, and metric schemas with a database scanner.
 #[pyfunction]
-fn _register_trace_entity_schemas(scanner: PyRef<'_, DatabaseScanner>) -> PyResult<()> {
+fn _register_telemetry_schemas(scanner: PyRef<'_, DatabaseScanner>) -> PyResult<()> {
     register_table_schema::<SpanBuffer>(&scanner, SPANS)?;
     register_table_schema::<SpanEventBuffer>(&scanner, SPAN_EVENTS)?;
     register_table_schema::<EventBuffer>(&scanner, EVENTS)?;
@@ -111,6 +117,9 @@ fn _register_trace_entity_schemas(scanner: PyRef<'_, DatabaseScanner>) -> PyResu
     register_table_schema::<SentMessageBuffer>(&scanner, SENT_MESSAGES)?;
     register_table_schema::<MessageBuffer>(&scanner, MESSAGES)?;
     register_table_schema::<MessageStatusEventBuffer>(&scanner, MESSAGE_STATUS_EVENTS)?;
+    register_table_schema::<MetricGaugeBuffer>(&scanner, METRIC_GAUGES)?;
+    register_table_schema::<MetricSumBuffer>(&scanner, METRIC_SUMS)?;
+    register_table_schema::<MetricHistogramBuffer>(&scanner, METRIC_HISTOGRAMS)?;
     Ok(())
 }
 
@@ -138,7 +147,7 @@ fn _set_unix_socket_sink_path(socket_path: &str) -> PyResult<()> {
 
 pub fn register_python_bindings(module: &Bound<'_, PyModule>) -> PyResult<()> {
     module.add_function(wrap_pyfunction!(_start_socket_ingest, module)?)?;
-    module.add_function(wrap_pyfunction!(_register_trace_entity_schemas, module)?)?;
+    module.add_function(wrap_pyfunction!(_register_telemetry_schemas, module)?)?;
     module.add_function(wrap_pyfunction!(_set_unix_socket_sink_path, module)?)?;
     Ok(())
 }

--- a/monarch_telemetry_schema/src/lib.rs
+++ b/monarch_telemetry_schema/src/lib.rs
@@ -213,14 +213,90 @@ pub mod entity_tables {
     }
 }
 
+/// Metric table row schemas.
+pub mod metric_tables {
+    use super::*;
+
+    /// Table containing OpenTelemetry gauge data points.
+    pub const METRIC_GAUGES: &str = "metric_gauges";
+    /// Table containing OpenTelemetry sum data points.
+    pub const METRIC_SUMS: &str = "metric_sums";
+    /// Table containing OpenTelemetry explicit-histogram data points.
+    pub const METRIC_HISTOGRAMS: &str = "metric_histograms";
+
+    /// Row data for the metric gauges table.
+    #[derive(RecordBatchRow)]
+    pub struct MetricGauge {
+        pub name: String,
+        pub timestamp_us: i64,
+        pub start_timestamp_us: Option<i64>,
+        pub scope_name: String,
+        pub unit: String,
+        pub attributes_json: String,
+        pub resource_attributes_json: String,
+        pub value_f64: Option<f64>,
+        pub value_i64: Option<i64>,
+        pub value_u64: Option<u64>,
+    }
+
+    /// Row data for the metric sums table.
+    #[derive(RecordBatchRow)]
+    pub struct MetricSum {
+        pub name: String,
+        pub timestamp_us: i64,
+        pub start_timestamp_us: i64,
+        pub scope_name: String,
+        pub unit: String,
+        pub temporality: String,
+        pub is_monotonic: bool,
+        pub attributes_json: String,
+        pub resource_attributes_json: String,
+        pub sum_f64: Option<f64>,
+        pub sum_i64: Option<i64>,
+        pub sum_u64: Option<u64>,
+    }
+
+    /// Row data for the metric histograms table.
+    #[derive(RecordBatchRow)]
+    pub struct MetricHistogram {
+        pub name: String,
+        pub timestamp_us: i64,
+        pub start_timestamp_us: i64,
+        pub scope_name: String,
+        pub unit: String,
+        pub temporality: String,
+        pub attributes_json: String,
+        pub resource_attributes_json: String,
+        pub count: u64,
+        pub sum_f64: Option<f64>,
+        pub sum_i64: Option<i64>,
+        pub sum_u64: Option<u64>,
+        pub min_f64: Option<f64>,
+        pub min_i64: Option<i64>,
+        pub min_u64: Option<u64>,
+        pub max_f64: Option<f64>,
+        pub max_i64: Option<i64>,
+        pub max_u64: Option<u64>,
+        pub bounds_json: String,
+        pub bucket_counts_json: String,
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use datafusion::arrow::array::Float64Array;
     use datafusion::arrow::array::StringArray;
     use datafusion::arrow::array::UInt64Array;
     use monarch_record_batch::RecordBatchBuffer;
     use serde_json::json;
 
     use super::*;
+    use crate::metric_tables::MetricGauge;
+    use crate::metric_tables::MetricGaugeBuffer;
+    use crate::metric_tables::MetricHistogram;
+    use crate::metric_tables::MetricHistogramBuffer;
+    use crate::metric_tables::MetricSum;
+    use crate::metric_tables::MetricSumBuffer;
     use crate::trace_tables::Span;
     use crate::trace_tables::SpanBuffer;
 
@@ -308,5 +384,121 @@ mod tests {
             .downcast_ref::<StringArray>()
             .unwrap();
         assert_eq!(names.value(0), "span");
+    }
+
+    #[test]
+    fn metric_table_schemas_round_trip() {
+        let mut gauges = MetricGaugeBuffer::default();
+        gauges.insert(MetricGauge {
+            name: "load".to_string(),
+            timestamp_us: 123,
+            start_timestamp_us: None,
+            scope_name: "test".to_string(),
+            unit: "1".to_string(),
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: r#"{"execution_id":"test"}"#.to_string(),
+            value_f64: Some(1.5),
+            value_i64: None,
+            value_u64: None,
+        });
+        let gauge_batch = deserialize_one_batch(
+            &serialize_batch(&gauges.drain_to_record_batch().unwrap()).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(gauge_batch.num_rows(), 1);
+        assert_eq!(
+            gauge_batch
+                .column_by_name("value_f64")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<Float64Array>()
+                .unwrap()
+                .value(0),
+            1.5
+        );
+
+        let mut sums = MetricSumBuffer::default();
+        sums.insert(MetricSum {
+            name: "mailbox.posts".to_string(),
+            timestamp_us: 123,
+            start_timestamp_us: 100,
+            scope_name: "hyperactor::mailbox".to_string(),
+            unit: "1".to_string(),
+            temporality: "delta".to_string(),
+            is_monotonic: true,
+            attributes_json: r#"{"actor_id":"actor"}"#.to_string(),
+            resource_attributes_json: r#"{"execution_id":"test"}"#.to_string(),
+            sum_f64: None,
+            sum_i64: None,
+            sum_u64: Some(u64::MAX),
+        });
+        let sum_batch = deserialize_one_batch(
+            &serialize_batch(&sums.drain_to_record_batch().unwrap()).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(sum_batch.num_rows(), 1);
+        let names = sum_batch
+            .column_by_name("name")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(names.value(0), "mailbox.posts");
+        let resource_attributes = sum_batch
+            .column_by_name("resource_attributes_json")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        assert_eq!(resource_attributes.value(0), r#"{"execution_id":"test"}"#);
+        let values = sum_batch
+            .column_by_name("sum_u64")
+            .unwrap()
+            .as_any()
+            .downcast_ref::<UInt64Array>()
+            .unwrap();
+        assert_eq!(values.value(0), u64::MAX);
+
+        let mut histograms = MetricHistogramBuffer::default();
+        histograms.insert(MetricHistogram {
+            name: "latency".to_string(),
+            timestamp_us: 123,
+            start_timestamp_us: 100,
+            scope_name: "test".to_string(),
+            unit: "ms".to_string(),
+            temporality: "delta".to_string(),
+            attributes_json: "{}".to_string(),
+            resource_attributes_json: "{}".to_string(),
+            count: 1,
+            sum_f64: Some(5.0),
+            sum_i64: None,
+            sum_u64: None,
+            min_f64: Some(5.0),
+            min_i64: None,
+            min_u64: None,
+            max_f64: Some(5.0),
+            max_i64: None,
+            max_u64: None,
+            bounds_json: "[1.0,10.0]".to_string(),
+            bucket_counts_json: "[0,1,0]".to_string(),
+        });
+        let histogram_batch = deserialize_one_batch(
+            &serialize_batch(&histograms.drain_to_record_batch().unwrap()).unwrap(),
+        )
+        .unwrap();
+
+        assert_eq!(histogram_batch.num_rows(), 1);
+        assert_eq!(
+            histogram_batch
+                .column_by_name("count")
+                .unwrap()
+                .as_any()
+                .downcast_ref::<UInt64Array>()
+                .unwrap()
+                .value(0),
+            1
+        );
     }
 }

--- a/python/monarch/_rust_bindings/monarch_distributed_telemetry/__init__.pyi
+++ b/python/monarch/_rust_bindings/monarch_distributed_telemetry/__init__.pyi
@@ -15,10 +15,10 @@ def _start_socket_ingest(
     """Start Unix-socket ingest for a database scanner."""
     ...
 
-def _register_trace_entity_schemas(
+def _register_telemetry_schemas(
     scanner: database_scanner.DatabaseScanner,
 ) -> None:
-    """Register trace and entity schemas for a database scanner."""
+    """Register trace, entity, and metric schemas for a database scanner."""
     ...
 
 def _set_unix_socket_sink_path(socket_path: str) -> None:

--- a/python/monarch/_src/actor/telemetry/__init__.py
+++ b/python/monarch/_src/actor/telemetry/__init__.py
@@ -310,6 +310,12 @@ _INSTALLED = False
 METER: metrics.Meter = Meter("monarch")
 
 
+def get_meter() -> metrics.Meter:
+    """Return Monarch's process-global OpenTelemetry meter."""
+
+    return METER
+
+
 def install() -> None:
     global _INSTALLED
     if _INSTALLED:

--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -28,7 +28,7 @@ import os
 from typing import Any, List, Optional
 
 from monarch._rust_bindings.monarch_distributed_telemetry import (
-    _register_trace_entity_schemas,
+    _register_telemetry_schemas,
     _start_socket_ingest,
 )
 from monarch._rust_bindings.monarch_distributed_telemetry.database_scanner import (
@@ -107,7 +107,7 @@ class TelemetryActor(Actor):
             retention_secs=self._retention_secs,
         )
         try:
-            _register_trace_entity_schemas(scanner)
+            _register_telemetry_schemas(scanner)
             _pre_register_snapshot_schemas(scanner)
             _start_socket_ingest(scanner, telemetry_socket_path(self._apply_id))
             self._scanner = scanner

--- a/python/monarch/actor/__init__.py
+++ b/python/monarch/actor/__init__.py
@@ -47,7 +47,7 @@ from monarch._src.actor.host_mesh import (
 )
 from monarch._src.actor.proc_mesh import get_or_spawn_controller, ProcMesh
 from monarch._src.actor.supervision import unhandled_fault_hook
-from monarch._src.actor.telemetry import span, traced
+from monarch._src.actor.telemetry import get_meter, span, traced
 from monarch.actor.concurrent import concurrent_endpoint
 
 __all__ = [
@@ -88,6 +88,7 @@ __all__ = [
     "unhandled_fault_hook",
     "MeshFailure",
     "config",
+    "get_meter",
     "span",
     "traced",
 ]

--- a/python/monarch/distributed_telemetry/__init__.py
+++ b/python/monarch/distributed_telemetry/__init__.py
@@ -21,5 +21,5 @@ Usage:
     client = state.query_engine_client
     assert client is not None
     # ... spawn procs, they're automatically tracked ...
-    result = client.query("SELECT * FROM metrics")
+    result = client.query("SELECT * FROM metric_sums")
 """

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -1619,6 +1619,35 @@ def test_metrics_table() -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
+def test_custom_metric() -> None:
+    """Test that a user-defined metric retains its scope and attributes."""
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+
+        requests = monarch.actor.get_meter().create_counter("example.requests")
+        requests.add(1, {"operation": "predict", "outcome": "success"})
+
+        metric_rows = _query(
+            state,
+            "SELECT scope_name, attributes_json, sum_u64 AS metric_sum "
+            "FROM metric_sums "
+            "WHERE name = 'example.requests'",
+            timeout_secs=40.0,
+        )
+
+        assert metric_rows["scope_name"] == ["monarch"], metric_rows
+        assert metric_rows["metric_sum"] == [1], metric_rows
+        assert json.loads(metric_rows["attributes_json"][0]) == {
+            "operation": "predict",
+            "outcome": "success",
+        }
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
 def test_sent_messages_with_sliced_mesh() -> None:
     """Test that sent_messages view_json/shape_json reflect sliced vs full actor mesh casts."""
     with scoped_state(

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -1571,6 +1571,54 @@ def test_message_status_events_failed_handler() -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
+def test_metrics_table() -> None:
+    """Test that OpenTelemetry metrics are queryable through distributed SQL."""
+    with scoped_state(
+        ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
+        cached_path=None,
+    ) as state:
+        _assert_sidecar(state)
+        hosts = state.hosts
+        worker_procs = hosts.spawn_procs(
+            per_host={"workers": 1}, name="metrics_workers_procs"
+        )
+        workers = worker_procs.spawn("metrics_test_worker", WorkerActor)
+        workers.initialized.get()
+        workers.ping.call().get()
+
+        metric_rows = _query(
+            state,
+            "SELECT name, attributes_json, resource_attributes_json, "
+            "sum_u64 AS metric_sum, temporality, is_monotonic "
+            "FROM metric_sums "
+            "WHERE name = 'mailbox.posts' "
+            "AND sum_u64 > 0",
+            timeout_secs=40.0,
+        )
+
+        assert metric_rows.get("name"), "Expected mailbox.posts metric rows"
+        assert all(name == "mailbox.posts" for name in metric_rows["name"]), metric_rows
+        assert all(metric_sum > 0 for metric_sum in metric_rows["metric_sum"]), (
+            metric_rows
+        )
+        assert all(value == "delta" for value in metric_rows["temporality"]), (
+            metric_rows
+        )
+        assert all(metric_rows["is_monotonic"]), metric_rows
+
+        attributes = [json.loads(raw) for raw in metric_rows["attributes_json"]]
+        assert any("actor_id" in attrs for attrs in attributes), attributes
+        assert any("dest_actor_id" in attrs for attrs in attributes), attributes
+        resources = [json.loads(raw) for raw in metric_rows["resource_attributes_json"]]
+        assert all(resource.get("service.name") for resource in resources), resources
+        assert all(
+            resource.get("telemetry.sdk.name") == "opentelemetry"
+            for resource in resources
+        ), resources
+
+
+@pytest.mark.timeout(120)
+@isolate_in_subprocess
 def test_sent_messages_with_sliced_mesh() -> None:
     """Test that sent_messages view_json/shape_json reflect sliced vs full actor mesh casts."""
     with scoped_state(


### PR DESCRIPTION
Summary:

Expose `get_meter()` through `monarch.actor` as the public entry point for custom OpenTelemetry instruments. Document bounded-cardinality counter usage and verify that a public custom counter retains its scope, delta value, and attributes in the distributed `metric_sums` table.

Differential Revision: D114282422
