### PR TITLE
pyspy: thread the real mesh-admin URL into the telemetry sidecar (#4561)

### DIFF
--- a/python/monarch/_src/job/job_components.py
+++ b/python/monarch/_src/job/job_components.py
@@ -306,6 +306,24 @@ class AdminComponent(JobComponent):
                     admin_addr=self._config.admin_addr,
                     telemetry_url=telemetry_url,
                 ).get()
+        # Push the resolved admin URL into the telemetry sidecar (a separate
+        # process) so the dashboard's pyspy client targets the real admin
+        # endpoint rather than the default https://<fqdn>:1729. Best-effort and
+        # only when telemetry is live; never fatal to job startup.
+        if (
+            self._telemetry is not None
+            and self._telemetry._telemetry_url is not None
+            and self._admin_url is not None
+            and job.apply_id is not None
+        ):
+            try:
+                Telemetry(self._telemetry._config).set_admin_url(
+                    job.apply_id, self._admin_url
+                )
+            except Exception:
+                logger.warning(
+                    "failed to push admin URL to telemetry sidecar", exc_info=True
+                )
         job_state.admin_url = self._admin_url
 
 

--- a/python/monarch/_src/job/job_sidecar.py
+++ b/python/monarch/_src/job/job_sidecar.py
@@ -123,6 +123,14 @@ class TelemetryRequest:
     spawn_worker_collectors: bool = True
 
 
+@dataclass
+class AdminUrlRequest:
+    """Set the mesh-admin URL in the job sidecar process."""
+
+    apply_id: str
+    admin_url: str
+
+
 class _JobSidecarState:
     """State owned by the background job sidecar process."""
 
@@ -131,6 +139,12 @@ class _JobSidecarState:
         self._mounts_key: bytes | None = None
         self._telemetry_handle: Any | None = None
         self._apply_id: str | None = None
+
+    def _ensure_apply_id(self, apply_id: str) -> None:
+        if self._apply_id is None:
+            self._apply_id = apply_id
+        elif self._apply_id != apply_id:
+            raise RuntimeError(f"job sidecar already owns apply id {self._apply_id}")
 
     def handle_mounts(self, request: MountsRequest) -> str:
         # The request carries declarative mount config. Compare that serialized
@@ -170,11 +184,9 @@ class _JobSidecarState:
     def handle_telemetry(self, request: TelemetryRequest) -> object:
         from monarch._src.job.telemetry_config import _TelemetryHandle
 
+        self._ensure_apply_id(request.apply_id)
         if self._telemetry_handle is None:
             self._telemetry_handle = _TelemetryHandle(request.apply_id)
-            self._apply_id = request.apply_id
-        elif self._apply_id != request.apply_id:
-            raise RuntimeError(f"job sidecar already owns apply id {self._apply_id}")
 
         return self._telemetry_handle.open_or_refresh(
             request.host_meshes,
@@ -182,12 +194,17 @@ class _JobSidecarState:
             spawn_worker_collectors=request.spawn_worker_collectors,
         )
 
+    def handle_admin_url(self, request: AdminUrlRequest) -> str:
+        self._ensure_apply_id(request.apply_id)
+        os.environ["MONARCH_ADMIN_URL"] = request.admin_url
+        return "ok"
+
     def shutdown(self) -> None:
         self.clear_mounts()
         if self._telemetry_handle is not None:
             self._telemetry_handle.shutdown()
             self._telemetry_handle = None
-            self._apply_id = None
+        self._apply_id = None
 
 
 def _dbg(msg: str) -> None:
@@ -246,6 +263,12 @@ def _run_job_sidecar(socket_path: str, runtime_transport: str | None = None) -> 
                     elif isinstance(msg, TelemetryRequest):
                         try:
                             response = state.handle_telemetry(msg)
+                        except Exception:
+                            # TODO: Centralize sidecar error.
+                            response = {"error": traceback.format_exc()}
+                    elif isinstance(msg, AdminUrlRequest):
+                        try:
+                            response = state.handle_admin_url(msg)
                         except Exception:
                             # TODO: Centralize sidecar error.
                             response = {"error": traceback.format_exc()}

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -29,15 +29,16 @@ The parent talks to telemetry via two channels:
   framed Arrow IPC from producers, decoded by Rust socket ingest into the
   collector's scanner.
 
-Lifecycle: `Telemetry.ensure_open(apply_id, host_meshes, spawn_worker_collectors)`
-is called during `JobTrait._connect`. The first call (`host_meshes={}`) opens
-the job sidecar's telemetry handle and activates the client process's
-`UnixSocketSink` before raw host meshes are materialized, so host-mesh creation
-events are captured. Jobs call it again with materialised `host_meshes`; that
-second call creates telemetry host proc meshes for proc discovery. Remote jobs
-also activate one live `TelemetryActor` collector per host-local socket
-namespace and hand only those live worker refs to the client collector for
-query fan-out.
+Lifecycle: `Telemetry.ensure_open(...)` is called during `JobTrait._connect`.
+The first call (`host_meshes={}`) opens the job sidecar's telemetry handle and
+activates the client process's `UnixSocketSink` before raw host meshes are
+materialized, so host-mesh creation events are captured. Jobs call it again with
+materialised `host_meshes`; that second call creates telemetry host proc meshes
+for proc discovery. Remote jobs also activate one live `TelemetryActor`
+collector per host-local socket namespace and hand only those live worker refs
+to the client collector for query fan-out. Once mesh admin has spawned,
+`AdminComponent` calls `Telemetry.set_admin_url(...)`, which updates the sidecar
+process environment for dashboard requests such as pyspy dumps.
 """
 
 from __future__ import annotations
@@ -51,7 +52,11 @@ from typing import Any, Callable, cast, Mapping, TypedDict
 from monarch._rust_bindings.monarch_distributed_telemetry import (
     _set_unix_socket_sink_path,
 )
-from monarch._src.job.job_sidecar import create_job_sidecar, TelemetryRequest
+from monarch._src.job.job_sidecar import (
+    AdminUrlRequest,
+    create_job_sidecar,
+    TelemetryRequest,
+)
 from monarch._src.job.telemetry_actor import (
     telemetry_socket_dir,
     telemetry_socket_path,
@@ -153,9 +158,8 @@ class Telemetry:
 
     Uses `create_job_sidecar` so the job sidecar gets launched on first call
     and reused on subsequent calls (keyed on `apply_id`, not on config —
-    config edits do not restart the sidecar). `ensure_open` is the single
-    interaction point: it opens or refreshes the telemetry handle and forwards
-    the host meshes for worker fan-out.
+    config edits do not restart the sidecar). `ensure_open` opens or refreshes
+    the telemetry handle and forwards the host meshes for worker fan-out.
     """
 
     def __init__(self, config: TelemetryConfig) -> None:
@@ -200,6 +204,24 @@ class Telemetry:
         if isinstance(error, str):
             raise RuntimeError(error)
         return cast(_TelemetryResponse, response)
+
+    def set_admin_url(self, apply_id: str, admin_url: str) -> None:
+        """Set the mesh-admin URL in the job sidecar process."""
+        if not isinstance(apply_id, str):
+            raise RuntimeError("telemetry requires an active apply_id")
+
+        response = (
+            create_job_sidecar(apply_id)
+            .send(AdminUrlRequest(apply_id=apply_id, admin_url=admin_url))
+            .get()
+        )
+        if isinstance(response, dict):
+            error = response.get("error")
+            if isinstance(error, str):
+                raise RuntimeError(error)
+            raise RuntimeError(f"unexpected admin URL response: {response!r}")
+        if response != "ok":
+            raise RuntimeError(f"unexpected admin URL response: {response!r}")
 
 
 class _TelemetryHandle:

--- a/python/tests/test_job.py
+++ b/python/tests/test_job.py
@@ -1114,7 +1114,11 @@ def test_batch_job_shares_component_runtime_with_wrapped_job():
 
 
 @contextlib.contextmanager
-def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
+def _patched_sidecar(
+    ensure_open_side_effect=None,
+    ensure_open_return=None,
+    set_admin_url_side_effect=None,
+):
     with (
         patch("monarch._src.job.job_components.Telemetry") as telemetry_cls,
         patch(
@@ -1128,6 +1132,7 @@ def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
         ) as start_snapshots,
     ):
         ensure_open = telemetry_cls.return_value.ensure_open
+        set_admin_url = telemetry_cls.return_value.set_admin_url
         if ensure_open_side_effect is not None:
             ensure_open.side_effect = ensure_open_side_effect
         else:
@@ -1136,6 +1141,8 @@ def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
                 "dashboard_url": "http://dashboard",
                 "socket_path": "/tmp/telemetry.sock",
             }
+        if set_admin_url_side_effect is not None:
+            set_admin_url.side_effect = set_admin_url_side_effect
         admin_ref = MagicMock()
         admin_future = MagicMock()
         admin_future.get.return_value = ("http://localhost:1729", admin_ref)
@@ -1146,6 +1153,7 @@ def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
         )
         yield types.SimpleNamespace(
             ensure_open=ensure_open,
+            set_admin_url=set_admin_url,
             install_sink=install_sink,
             query_engine_client_cls=qec_cls,
             telemetry_cls=telemetry_cls,
@@ -1154,6 +1162,13 @@ def _patched_sidecar(ensure_open_side_effect=None, ensure_open_return=None):
             start_snapshots=start_snapshots,
             snapshot_instance=snapshot_instance,
         )
+
+
+def _assert_admin_url_update(set_admin_url):
+    set_admin_url.assert_called_once()
+    apply_id, admin_url = set_admin_url.call_args.args
+    assert isinstance(apply_id, str)
+    assert admin_url == "http://localhost:1729"
 
 
 def test_mesh_admin_receives_sidecar_telemetry_url():
@@ -1196,6 +1211,7 @@ def test_sidecar_bootstrap_then_fanout_carry_host_meshes():
     assert "spawn_worker_collectors" not in bootstrap_kwargs
     assert set(fanout_kwargs["host_meshes"].keys()) == {"hosts"}
     assert fanout_kwargs["spawn_worker_collectors"] is True
+    _assert_admin_url_update(m.set_admin_url)
 
 
 def test_local_job_sidecar_skips_worker_collector_actors():
@@ -1211,6 +1227,7 @@ def test_local_job_sidecar_skips_worker_collector_actors():
     assert "spawn_worker_collectors" not in bootstrap_kwargs
     assert set(fanout_kwargs["host_meshes"].keys()) == {"hosts"}
     assert fanout_kwargs["spawn_worker_collectors"] is False
+    _assert_admin_url_update(m.set_admin_url)
     assert state.query_engine_client is m.query_engine_client_cls.return_value
 
 
@@ -1236,6 +1253,7 @@ def test_process_job_sidecar_skips_worker_collector_actors():
     assert "spawn_worker_collectors" not in bootstrap_kwargs
     assert set(fanout_kwargs["host_meshes"].keys()) == {"hosts"}
     assert fanout_kwargs["spawn_worker_collectors"] is False
+    _assert_admin_url_update(m.set_admin_url)
     assert state.query_engine_client is m.query_engine_client_cls.return_value
 
 
@@ -1279,6 +1297,7 @@ def test_sidecar_worker_fanout_failure_is_isolated():
         state = job.state(cached_path=None)  # must not raise
 
     assert m.ensure_open.call_count == 2
+    _assert_admin_url_update(m.set_admin_url)
     assert state.query_engine_client is m.query_engine_client_cls.return_value
 
 
@@ -1289,6 +1308,7 @@ def test_telemetry_bootstraps_sidecar_by_default():
         state = job.state(cached_path=None)
 
     assert m.ensure_open.call_count == 2
+    _assert_admin_url_update(m.set_admin_url)
     assert state.query_engine is None
     assert state.query_engine_client is m.query_engine_client_cls.return_value
 

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -170,6 +170,35 @@ def test_run_job_sidecar_survives_broken_connection(tmp_path) -> None:
     assert fake.shutdown_called
 
 
+def test_handle_telemetry_refreshes_telemetry_handle() -> None:
+    fake = _FakeTelemetryHandle()
+    state = js._JobSidecarState()
+    with patch.object(tc, "_TelemetryHandle", return_value=fake):
+        state.handle_telemetry(
+            js.TelemetryRequest(
+                apply_id="apply",
+                config={},
+                host_meshes={},
+            )
+        )
+    assert fake.calls == [({}, {}, True)]
+
+
+def test_handle_admin_url_sets_sidecar_env(monkeypatch) -> None:
+    state = js._JobSidecarState()
+
+    monkeypatch.delenv("MONARCH_ADMIN_URL", raising=False)
+    response = state.handle_admin_url(
+        js.AdminUrlRequest(
+            apply_id="apply",
+            admin_url="https://host.example:1731",
+        )
+    )
+
+    assert response == "ok"
+    assert os.environ["MONARCH_ADMIN_URL"] == "https://host.example:1731"
+
+
 # ── _TelemetryHandle.open_or_refresh (bootstrap-once + drift) ─────────────────
 
 
@@ -422,6 +451,36 @@ def test_ensure_open_reraises_sidecar_error() -> None:
             }
             with pytest.raises(RuntimeError, match="boom"):
                 tel.ensure_open(apply_id)
+    finally:
+        _remove_socket_dir(apply_id)
+
+
+def test_set_admin_url_sends_admin_url_request() -> None:
+    apply_id = _new_apply_id()
+    tel = tc.Telemetry(TelemetryConfig())
+    try:
+        with patch.object(tc, "create_job_sidecar") as create_sidecar:
+            send = create_sidecar.return_value.send
+            send.return_value.get.return_value = "ok"
+            tel.set_admin_url(apply_id, "https://host.example:1731")
+        sent_request = send.call_args[0][0]
+        assert isinstance(sent_request, js.AdminUrlRequest)
+        assert sent_request.apply_id == apply_id
+        assert sent_request.admin_url == "https://host.example:1731"
+    finally:
+        _remove_socket_dir(apply_id)
+
+
+def test_set_admin_url_reraises_sidecar_error() -> None:
+    apply_id = _new_apply_id()
+    tel = tc.Telemetry(TelemetryConfig())
+    try:
+        with patch.object(tc, "create_job_sidecar") as create_sidecar:
+            create_sidecar.return_value.send.return_value.get.return_value = {
+                "error": "boom"
+            }
+            with pytest.raises(RuntimeError, match="boom"):
+                tel.set_admin_url(apply_id, "https://host.example:1731")
     finally:
         _remove_socket_dir(apply_id)
 


### PR DESCRIPTION
Summary:

The dashboard pyspy client resolves the mesh-admin base URL from `MONARCH_ADMIN_URL`, falling back to `https://<fqdn>:1729`. The dashboard runs inside the telemetry sidecar process, but `_spawn_admin` sets `MONARCH_ADMIN_URL` only in the parent/driver process. As a result, pyspy dumps targeted `:1729` over HTTPS, which is correct only for the default Meta configuration and wrong for custom or ephemeral admin ports and the OSS HTTP fallback.

Thread the real admin URL from the parent into the sidecar over the existing job-sidecar command socket, but keep it separate from telemetry bootstrap/fan-out:
- `TelemetryRequest` stays focused on opening/refreshing telemetry state and forwarding host meshes.
- `AdminUrlRequest` carries the resolved admin URL to the sidecar. The sidecar applies the same `apply_id` ownership guard and sets `os.environ["MONARCH_ADMIN_URL"]` in the sidecar process.
- `Telemetry.set_admin_url(apply_id, admin_url)` sends that explicit sidecar request and surfaces sidecar error envelopes to the parent.
- `AdminComponent.state` calls `set_admin_url` after `_spawn_admin` yields the real URL, best-effort and only when telemetry is live.

No change to `pyspy_client.py` or `start_dashboard`: the pyspy client reads `MONARCH_ADMIN_URL` lazily per request, so setting the env in the sidecar is sufficient. This also addresses Dave Klan review feedback that using `ensure_open(..., admin_url=...)` as a config side channel was awkward.

Follow-up to T282694823 (Shayne review comment on the original dashboard diff).

Differential Revision: D114299626


