### PR TITLE
[monarch] Fix macOS CPU CI

### DIFF
--- a/monarch_introspection_snapshot/test/snapshot_integration_test.rs
+++ b/monarch_introspection_snapshot/test/snapshot_integration_test.rs
@@ -172,6 +172,9 @@ fn spawn_snapshot_http_counter() -> (String, Arc<AtomicUsize>, Arc<AtomicBool>, 
                 }
                 Err(error) => panic!("snapshot HTTP test server failed: {error}"),
             };
+            // macOS can propagate the listener's nonblocking mode to accepted
+            // sockets, so make request reads blocking before applying a timeout.
+            stream.set_nonblocking(false).unwrap();
             stream
                 .set_read_timeout(Some(Duration::from_secs(5)))
                 .unwrap();

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -108,14 +108,31 @@ _NO_TENSOR_ENGINE_SKIP_PREFIXES = (
     "python/tests/simulator/test_communication_model.py::",
     "python/tests/simulator/test_ir.py::",
 )
+# Keep temporary macOS CI quarantines here instead of adding per-test skipif
+# markers, so the test definitions continue to describe supported behavior.
 _MACOS_ARM64_SKIP_NODEIDS = frozenset(
     {
+        "python/tests/test_actor_error.py::test_client_hard_exit_cleanup",
+        "python/tests/test_actor_error.py::test_supervise_callback_without_await_handled[actor_queue_dispatch=True]",
         "python/tests/test_config.py::test_codec_max_frame_length_with_increased_limit",
+        "python/tests/test_config.py::test_rdma_ibverbs_target_round_trip_and_propagation",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_cleanup_torch_distributed",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_lambda_sets_env_vars_before_cuda_init",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_proc_mesh_with_dictionary_env",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_proc_mesh_with_lambda_env",
+        "python/tests/test_debugger.py::test_debug",
+        "python/tests/test_debugger.py::test_debug_cli",
+        "python/tests/test_debugger.py::test_debug_multi_actor",
+        "python/tests/test_debugger.py::test_debug_nested",
         "python/tests/test_debugger.py::test_debug_with_pickle_by_value",
+        "python/tests/test_distributed_telemetry.py::test_all_actors_in_host_mesh",
+        "python/tests/test_distributed_telemetry.py::test_all_actors_in_proc_mesh",
+        "python/tests/test_distributed_telemetry.py::test_public_custom_trace_is_queryable",
+        "python/tests/test_distributed_telemetry.py::test_pyspy_tables_in_information_schema",
+        "python/tests/test_distributed_telemetry.py::test_query_after_stopping_actor_mesh",
+        "python/tests/test_distributed_telemetry.py::test_scan_timeout_on_dead_child",
+        "python/tests/test_distributed_telemetry.py::test_snapshot_schemas_pre_registered",
+        "python/tests/test_distributed_telemetry.py::test_store_pyspy_dump_and_query",
         "python/tests/test_host_mesh.py::test_host_mesh_context_manager",
         "python/tests/test_host_mesh.py::test_spawn_procs_with_taskset_bind",
         "python/tests/test_host_mesh.py::test_stop_and_reconnect",

--- a/python/tests/test_rdma_action.py
+++ b/python/tests/test_rdma_action.py
@@ -8,11 +8,18 @@
 """End-to-end tests for ``monarch.rdma.RDMAAction``."""
 
 import os
+import sys
 
 # Required to enable RDMA support for CUDA tensors.
 os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
 import pytest  # noqa: E402
+
+# Use an early module-level skip instead of skipif because the RDMA native
+# bindings imported below are not built on non-Linux platforms.
+if sys.platform != "linux":
+    pytest.skip("RDMA tests require Linux", allow_module_level=True)
+
 import torch  # noqa: E402
 from monarch.actor import Actor, endpoint, this_host  # noqa: E402
 from monarch.rdma import RDMAAction, RDMABuffer  # noqa: E402

--- a/python/tests/test_rdma_local_memory_cache.py
+++ b/python/tests/test_rdma_local_memory_cache.py
@@ -23,9 +23,16 @@ Neither layer requires an RDMA backend, an ``RdmaManager``, or an actor
 mesh."""
 
 import gc
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# Use an early module-level skip instead of skipif because the RDMA native
+# bindings imported below are not built on non-Linux platforms.
+if sys.platform != "linux":
+    pytest.skip("RDMA tests require Linux", allow_module_level=True)
+
 import torch
 from monarch._src.rdma import rdma as rdma_mod
 

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -116,10 +116,12 @@ class _FakeTelemetryHandle:
 
 
 @pytest.mark.timeout(30)
-def test_run_job_sidecar_survives_broken_connection(tmp_path) -> None:
+def test_run_job_sidecar_survives_broken_connection() -> None:
     """A connection that sends garbage (or breaks mid-request) must drop only
     that connection, not tear down the job sidecar."""
-    socket_path = str(tmp_path / "cmd.sock")
+    # Darwin limits AF_UNIX paths to 104 bytes. pytest's per-test temporary
+    # directory exceeds that on GitHub's macOS runners, so use a short path.
+    socket_path = f"/tmp/monarch_{uuid.uuid4().hex[:8]}.sock"
     fake = _FakeTelemetryHandle()
 
     with patch.object(tc, "_TelemetryHandle", return_value=fake):


### PR DESCRIPTION
## Summary

The macOS CPU jobs on `main` have repeatable platform-specific failures. These failures keep CI red and hide new regressions in code that macOS does support, so the goal of this change is to restore useful macOS CI signal.

The failures have five causes:

- **RDMA is Linux-only today**: the macOS wheel does not build the native RDMA bindings, but the RDMA tests are still collected. These modules use an early module-level skip because their native imports happen during collection, before a `skipif` marker could skip the tests.
- **Process-heavy tests time out on macOS arm64**: actor, debugger, and distributed-telemetry tests repeatedly hit their timeouts on GitHub macOS arm64 runners. For now, this change keeps exact node-ID quarantines centralized in `conftest.py`; per-test `skipif` markers would incorrectly make temporary CI exclusions part of the test definitions. Their subprocess and shutdown behavior is being investigated separately in #4568.
- **An un-awaited supervision callback is timing-sensitive**: `test_supervise_callback_without_await_handled` waited 30 seconds without receiving `__supervise__` in Python group 3. This exact parameterization is quarantined with the other macOS arm64 lifecycle failures.
- **A telemetry delivery race kills the query root**: `test_query_after_stopping_actor_mesh` can return a TTL-expired `CreateOrUpdate<ActorSpec>` message to `TelemetryActor`. This remains quarantined here while #4568 investigates the delivery bridge.
- **Darwin socket behavior differs**: one Python test exceeded the 104-byte `AF_UNIX` path limit. Separately, the Rust snapshot HTTP helper made its listener nonblocking; accepted streams on macOS then returned `WouldBlock`, the server thread panicked, and both periodic-capture tests observed zero requests. The Python test now uses a short path, and the Rust helper explicitly makes accepted sockets blocking before reading.

The end result is that supported macOS tests continue to run while known platform and lifecycle failures no longer hide new regressions.

## Test plan

Inspected both failing jobs and downloaded their JUnit XML artifacts with `gh`:

- Python group 3 had exactly one failure: `test_supervise_callback_without_await_handled[actor_queue_dispatch=True]` timed out waiting for its supervision event.
- Rust ran 2,184 tests with two failures: `test_pt3_immediate_first_capture` and `test_pt5_drain_halts_future_captures`. Both included the same background panic at `snapshot_integration_test.rs:181`: `WouldBlock` while reading the accepted socket.

Run:

```lang=sh
cargo fmt --check -- monarch_introspection_snapshot/test/snapshot_integration_test.rs
git diff --check
uv run --no-sync pytest "python/tests/test_actor_error.py::test_supervise_callback_without_await_handled[actor_queue_dispatch=True]" -q -rs
```

Example output:

```lang=text
1 skipped
```

I also attempted the two exact Rust tests with:

```lang=sh
CARGO_BUILD_JOBS=1 cargo nextest run --locked -p monarch_introspection_snapshot --test snapshot_integration_test -E "test(test_pt3_immediate_first_capture) | test(test_pt5_drain_halts_future_captures)" --no-capture
```

This Mac is still under severe memory pressure and the kernel killed the `proc-macro2` build script with `SIGKILL`. The pushed macOS CI run performs the native build and exact test coverage.

Fresh macOS CI result after this update: the Rust job passed all 2,192 tests with zero failures. The JUnit XML reports `test_pt3_immediate_first_capture` passing in 2.529s and `test_pt5_drain_halts_future_captures` passing in 5.425s. The Python job is still in progress.