### PR TITLE
Skip is_subset check

### DIFF
--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -76,6 +76,7 @@ use hyperactor_config::Flattrs;
 use ndslice::Point;
 use ndslice::Region;
 use ndslice::view::MapIntoExt;
+use ndslice::view::RankedSliceable;
 use ndslice::view::View;
 use serde::Deserialize;
 use serde::Serialize;
@@ -349,8 +350,8 @@ impl CastDomainRef {
         let subtree_seqs = self
             .subtrees
             .iter()
-            .map(|subtree| seqs.subset(subtree.served_region.clone()))
-            .collect::<Result<Vec<_>, _>>()?;
+            .map(|subtree| seqs.sliced(subtree.served_region.clone()))
+            .collect::<Vec<_>>();
         // Split even for one subtree: a direct route bypasses the leaf
         // CastActor that would otherwise create the one-peer reducer proxy.
         split_ports(cx, &mut data, self.subtrees.len(), false)?;


### PR DESCRIPTION
Summary:
`View::subset` performs an expensive `Region::is_subset` check that is unnecessary for each cast because the input in contructed once and proptests cover its correctness. After the check, it is just a call to `View::slice` so we can call `View::slice` directly instead
```
    fn subset(&self, region: Region) -> Result<Self, ViewError> {
        if !region.is_subset(self.region()) {
            return Err(ViewError::InvalidRange {
                base: Box::new(self.region().clone()),
                selected: Box::new(region.clone()),
            });
        }

        Ok(self.sliced(region))
    }
```

This check can become quite expensive at scale (pink slivers are `View::slice` and gaps in between are the check) {F1993291543}

Reviewed By: thedavekwon

Differential Revision: D114441904


