### PR TITLE
Expand the topology graph by default

### DIFF
--- a/python/monarch/monarch_dashboard/frontend/src/components/topology/TopologyView.tsx
+++ b/python/monarch/monarch_dashboard/frontend/src/components/topology/TopologyView.tsx
@@ -183,11 +183,18 @@ function Flow() {
     );
   }, [msgStats]);
 
+  // Open the whole hierarchy on first load, so actors (or actor meshes in mesh
+  // view) are visible without a click. Collapsing afterwards is up to the user;
+  // Expand All re-opens whatever they closed. Skipped until the DAG actually has
+  // nodes — the snapshot is empty for the first interval after startup, and
+  // initializing off that empty tree would consume this one-shot and leave
+  // everything collapsed once the real topology arrived.
   useEffect(() => {
-    if (tree && !initExpanded.current) {
-      initExpanded.current = true;
-      setExpanded(new Set(tree.roots));
-    }
+    if (!tree || tree.roots.length === 0 || initExpanded.current) return;
+    initExpanded.current = true;
+    setExpanded(
+      new Set(Object.keys(tree.children).filter((id) => tree.children[id].length > 0))
+    );
   }, [tree]);
 
   useEffect(() => {


### PR DESCRIPTION
Summary:
The Topology tab seeded its expansion set with just the DAG roots, so it opened
with the actors (or actor meshes) collapsed behind a click.  This just changes it to expand by default.  The Expand All` and `Collapse` buttons keep their current semantics.

Also gate the one-shot initializer on the tree having roots: `/api/dag` is empty
until the first introspection snapshot lands, and initializing off that empty
tree would leave the graph collapsed once the real topology arrived.

Differential Revision: D114654059


