### PR TITLE
[monarch] Fix macOS process and delivery cleanup

### DIFF
--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -156,10 +156,11 @@ declare_attrs! {
     ))
     pub attr MESH_TAIL_LOG_LINES: usize = 0;
 
-    /// If enabled (default), bootstrap child processes install
-    /// `PR_SET_PDEATHSIG(SIGKILL)` so the kernel reaps them if the
-    /// parent dies unexpectedly. This is a **production safety net**
-    /// against leaked children; tests usually disable it via
+    /// If enabled (default), bootstrap child processes arrange to exit when
+    /// their parent dies unexpectedly. Linux uses
+    /// `PR_SET_PDEATHSIG(SIGKILL)` and macOS monitors the parent process. This
+    /// is a **production safety net** against leaked children; tests usually
+    /// disable it via
     /// `std::env::set_var("HYPERACTOR_MESH_BOOTSTRAP_ENABLE_PDEATHSIG",
     /// "false")`.
     @meta(CONFIG = ConfigAttr::new(
@@ -196,6 +197,7 @@ pub const CLIENT_TRACE_ID_ENV: &str = "MONARCH_CLIENT_TRACE_ID";
 pub(crate) const BOOTSTRAP_LOG_CHANNEL: &str = "BOOTSTRAP_LOG_CHANNEL";
 
 pub(crate) const BOOTSTRAP_MODE_ENV: &str = "HYPERACTOR_MESH_BOOTSTRAP_MODE";
+pub(crate) const BOOTSTRAP_PARENT_PID_ENV: &str = "HYPERACTOR_MESH_BOOTSTRAP_PARENT_PID";
 pub(crate) const PROCESS_NAME_ENV: &str = "HYPERACTOR_PROCESS_NAME";
 
 #[macro_export]
@@ -582,6 +584,7 @@ impl Bootstrap {
                     // is a last-resort guard against leaks if that
                     // protocol is bypassed.
                     let _ = install_pdeathsig_kill();
+                    install_parent_death_monitor();
                 } else {
                     eprintln!("(bootstrap) PDEATHSIG disabled via config");
                 }
@@ -700,6 +703,49 @@ pub fn install_pdeathsig_kill() -> io::Result<()> {
     }
     Ok(())
 }
+
+/// Install the macOS fallback for Linux's `PR_SET_PDEATHSIG`.
+///
+/// macOS has no parent-death signal, so bootstrap procs periodically compare
+/// their current parent with the PID recorded by the native launcher. The
+/// initial comparison closes the race where the parent exits before this task
+/// starts.
+#[cfg(target_os = "macos")]
+fn install_parent_death_monitor() {
+    let expected_parent = std::env::var(BOOTSTRAP_PARENT_PID_ENV)
+        .ok()
+        .and_then(|value| value.parse::<libc::pid_t>().ok())
+        // SAFETY: `getppid()` is a side-effect-free libc syscall.
+        .unwrap_or_else(|| unsafe { libc::getppid() });
+
+    let parent_is_alive = move || {
+        // SAFETY: `getppid()` is a side-effect-free libc syscall.
+        unsafe { libc::getppid() == expected_parent }
+    };
+
+    if !parent_is_alive() {
+        // Match the uncatchable Linux `SIGKILL` behavior.
+        // SAFETY: both libc calls operate on the current process only.
+        unsafe { libc::kill(libc::getpid(), libc::SIGKILL) };
+        return;
+    }
+
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(1));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            if !parent_is_alive() {
+                // SAFETY: both libc calls operate on the current process only.
+                unsafe { libc::kill(libc::getpid(), libc::SIGKILL) };
+                return;
+            }
+        }
+    });
+}
+
+#[cfg(not(target_os = "macos"))]
+fn install_parent_death_monitor() {}
 
 /// Represents the lifecycle state of a **proc as hosted in an OS
 /// process** managed by `BootstrapProcManager`.

--- a/hyperactor_mesh/src/mesh_controller.rs
+++ b/hyperactor_mesh/src/mesh_controller.rs
@@ -26,10 +26,12 @@ use hyperactor::actor::Referable;
 use hyperactor::actor::handle_undeliverable_message;
 use hyperactor::context;
 use hyperactor::kv_pairs;
+use hyperactor::mailbox::ExpiredDelivery;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::RemoteMessage;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableReason;
+use hyperactor::mailbox::headers::RUST_MESSAGE_TYPE;
 use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
@@ -660,6 +662,37 @@ impl<T: Controlled> ResourceController<T> {
             .unwrap_or_else(|| self.mesh.id().to_string())
     }
 
+    /// Remove the destination of a returned supervision message from the
+    /// subscriber set. Some transport failures, including TTL expiry, can
+    /// return the original `Option<MeshFailure>` without its marker header.
+    /// In that case the message type still identifies a subscription message,
+    /// even if an unsubscribe raced with the delivery failure.
+    fn remove_undeliverable_subscriber(
+        &mut self,
+        returned: &MessageEnvelope,
+    ) -> Option<hyperactor::PortRef<Option<MeshFailure>>> {
+        let marked = returned
+            .headers()
+            .get(ACTOR_MESH_SUBSCRIBER_MESSAGE)
+            .unwrap_or(false);
+        let message_type = returned
+            .data()
+            .typename()
+            .map(str::to_owned)
+            .or_else(|| returned.headers().get(RUST_MESSAGE_TYPE));
+        let has_subscriber_type =
+            message_type.as_deref() == Some(std::any::type_name::<Option<MeshFailure>>());
+        if !marked && !has_subscriber_type {
+            return None;
+        }
+
+        // PortRef equality uses the port address, so attesting the type here is
+        // sufficient for looking up the destination in the subscriber set.
+        let port = hyperactor::PortRef::<Option<MeshFailure>>::attest(returned.dest().clone());
+        self.health_state.subscribers.remove(&port);
+        Some(port)
+    }
+
     /// Schedule the next `CheckState` self-message if the monitor is active.
     ///
     /// `send_fn` bridges the type gap: the caller passes a closure that
@@ -854,22 +887,13 @@ where
         let Some(returned) = envelope.as_message() else {
             return handle_undeliverable_message(cx, reason, envelope);
         };
-        if let Some(true) = returned.headers().get(ACTOR_MESH_SUBSCRIBER_MESSAGE) {
-            // Remove from the subscriber list (if it existed) so we don't
-            // send to this subscriber again.
-            // NOTE: The only part of the port that is used for equality checks is
-            // the port id, so create a new one just for the comparison.
-            let dest_port_id = returned.dest().clone();
-            let port = hyperactor::PortRef::<Option<MeshFailure>>::attest(dest_port_id);
-            let did_exist = self.health_state.subscribers.remove(&port);
-            if did_exist {
-                tracing::debug!(
-                    actor_id = %cx.self_addr(),
-                    num_subscribers = self.health_state.subscribers.len(),
-                    "ResourceController: removed subscriber {} from mesh controller",
-                    port.port_addr()
-                );
-            }
+        if let Some(port) = self.remove_undeliverable_subscriber(returned) {
+            tracing::debug!(
+                actor_id = %cx.self_addr(),
+                num_subscribers = self.health_state.subscribers.len(),
+                "ResourceController: removed subscriber {} from mesh controller",
+                port.port_addr()
+            );
             Ok(())
         } else if returned.headers().get(CAST_ACTOR_MESH_ID).is_some() {
             // A cast message we sent (e.g. StreamState or KeepaliveGetState)
@@ -897,18 +921,13 @@ where
         let Some(returned) = envelope.as_message() else {
             return hyperactor::actor::handle_invalid_reference(cx, invalid, envelope);
         };
-        if let Some(true) = returned.headers().get(ACTOR_MESH_SUBSCRIBER_MESSAGE) {
-            let dest_port_id = returned.dest().clone();
-            let port = hyperactor::PortRef::<Option<MeshFailure>>::attest(dest_port_id);
-            let did_exist = self.health_state.subscribers.remove(&port);
-            if did_exist {
-                tracing::debug!(
-                    actor_id = %cx.self_addr(),
-                    num_subscribers = self.health_state.subscribers.len(),
-                    "ResourceController: removed subscriber {} from mesh controller",
-                    port.port_addr()
-                );
-            }
+        if let Some(port) = self.remove_undeliverable_subscriber(returned) {
+            tracing::debug!(
+                actor_id = %cx.self_addr(),
+                num_subscribers = self.health_state.subscribers.len(),
+                "ResourceController: removed subscriber {} from mesh controller",
+                port.port_addr()
+            );
             Ok(())
         } else if returned.headers().get(CAST_ACTOR_MESH_ID).is_some() {
             tracing::warn!(
@@ -919,6 +938,36 @@ where
             Ok(())
         } else {
             hyperactor::actor::handle_invalid_reference(cx, invalid, envelope)
+        }
+    }
+
+    async fn handle_expired_delivery(
+        &mut self,
+        cx: &Instance<Self>,
+        expired: ExpiredDelivery,
+        envelope: Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        let envelope = update_undeliverable_envelope_for_casting(envelope);
+        let Some(returned) = envelope.as_message() else {
+            return hyperactor::actor::handle_expired_delivery(cx, expired, envelope);
+        };
+        if let Some(port) = self.remove_undeliverable_subscriber(returned) {
+            tracing::debug!(
+                actor_id = %cx.self_addr(),
+                num_subscribers = self.health_state.subscribers.len(),
+                "ResourceController: removed subscriber {} from mesh controller",
+                port.port_addr()
+            );
+            Ok(())
+        } else if returned.headers().get(CAST_ACTOR_MESH_ID).is_some() {
+            tracing::warn!(
+                actor_id = %cx.self_addr(),
+                dest = %returned.dest(),
+                "ResourceController: ignoring expired cast message",
+            );
+            Ok(())
+        } else {
+            hyperactor::actor::handle_expired_delivery(cx, expired, envelope)
         }
     }
 }

--- a/hyperactor_mesh/src/proc_launcher/native.rs
+++ b/hyperactor_mesh/src/proc_launcher/native.rs
@@ -87,6 +87,7 @@ use tracing::Instrument;
 
 use crate::bootstrap::BOOTSTRAP_LOG_CHANNEL;
 use crate::bootstrap::BOOTSTRAP_MODE_ENV;
+use crate::bootstrap::BOOTSTRAP_PARENT_PID_ENV;
 use crate::bootstrap::Bootstrap;
 use crate::bootstrap::BootstrapCommand;
 use crate::bootstrap::BootstrapProcConfig;
@@ -327,6 +328,10 @@ impl ProcLauncher for NativeProcLauncher {
 
         // Bootstrap payload
         cmd.env(BOOTSTRAP_MODE_ENV, opts.bootstrap_payload);
+
+        // macOS has no PR_SET_PDEATHSIG, so the bootstrap process uses this
+        // value to detect when its native launcher has died.
+        cmd.env(BOOTSTRAP_PARENT_PID_ENV, std::process::id().to_string());
 
         // Diagnostics name
         cmd.env(PROCESS_NAME_ENV, opts.process_name);

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -36,6 +36,8 @@ use hyperactor::actor::ActorErrorKind;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::Signal;
 use hyperactor::context::Actor as ContextActor;
+use hyperactor::mailbox::ExpiredDelivery;
+use hyperactor::mailbox::InvalidReference;
 use hyperactor::mailbox::MessageEnvelope;
 use hyperactor::mailbox::Undeliverable;
 use hyperactor::mailbox::UndeliverableMessageError;
@@ -1124,6 +1126,89 @@ impl PythonActor {
         })
     }
 
+    /// Offer a returned delivery failure to Python's
+    /// `_handle_undeliverable_message` hook.
+    ///
+    /// Hyperactor dispatches ordinary undeliverable messages, invalid
+    /// references, and TTL expiry through separate `Actor` callbacks. The
+    /// Python API intentionally presents all three as a message that could not
+    /// be delivered, so every callback must pass through this common bridge.
+    async fn dispatch_delivery_failure_to_python(
+        &mut self,
+        ins: &Instance<Self>,
+        mut envelope: Undeliverable<MessageEnvelope>,
+    ) -> Result<(Undeliverable<MessageEnvelope>, bool), anyhow::Error> {
+        if envelope
+            .as_message()
+            .is_some_and(|envelope| envelope.sender() != ins.self_addr())
+        {
+            // This can happen if the sender is comm. Update the envelope.
+            envelope = update_undeliverable_envelope_for_casting(envelope);
+        }
+        let envelope = match envelope {
+            Undeliverable::Returned(envelope) => envelope,
+            Undeliverable::Report(report) => {
+                return Err(UndeliverableMessageError::Report { report }.into());
+            }
+        };
+        assert_eq!(
+            envelope.sender(),
+            ins.self_addr(),
+            "undeliverable message was returned to the wrong actor. \
+            Return address = {}, src actor = {}, dest handler port = {}, message type = {}, envelope headers = {}",
+            envelope.sender(),
+            ins.self_addr(),
+            envelope.dest(),
+            envelope.data().typename().unwrap_or("unknown"),
+            envelope.headers()
+        );
+
+        let cx = Context::new(ins, envelope.headers().clone());
+
+        monarch_with_gil(GilSite::EndpointDispatch, |py| {
+            let py_cx = match &self.instance {
+                Some(instance) => crate::context::PyContext::new(&cx, instance.clone_ref(py)),
+                None => {
+                    let py_instance: crate::context::PyInstance = ins.into();
+                    crate::context::PyContext::new(
+                        &cx,
+                        py_instance
+                            .into_py_any(py)?
+                            .cast_bound(py)
+                            .map_err(PyErr::from)?
+                            .clone()
+                            .unbind(),
+                    )
+                }
+            }
+            .into_bound_py_any(py)?;
+            let py_envelope = PythonUndeliverableMessageEnvelope {
+                inner: Some(Undeliverable::Returned(envelope)),
+            }
+            .into_bound_py_any(py)?;
+            let handled = self
+                .actor
+                .call_method(
+                    py,
+                    "_handle_undeliverable_message",
+                    (&py_cx, &py_envelope),
+                    None,
+                )
+                .map_err(|err| anyhow::Error::from(SerializablePyErr::from(py, &err)))?
+                .extract::<bool>(py)?;
+            Ok::<_, anyhow::Error>((
+                py_envelope
+                    .cast::<PythonUndeliverableMessageEnvelope>()
+                    .map_err(PyErr::from)?
+                    .try_borrow_mut()
+                    .map_err(PyErr::from)?
+                    .take()?,
+                handled,
+            ))
+        })
+        .await
+    }
+
     /// Get-or-create the actor's cached `PyInstance`, injecting a clone of
     /// the execution tracker (PE-1) so `_Actor.handle` can bracket each
     /// invocation. All four `self.instance` creation sites route through
@@ -1543,80 +1628,48 @@ impl Actor for PythonActor {
         &mut self,
         ins: &Instance<Self>,
         reason: UndeliverableReason,
-        mut envelope: Undeliverable<MessageEnvelope>,
+        envelope: Undeliverable<MessageEnvelope>,
     ) -> Result<(), anyhow::Error> {
-        if envelope
-            .as_message()
-            .is_some_and(|envelope| envelope.sender() != ins.self_addr())
-        {
-            // This can happen if the sender is comm. Update the envelope.
-            envelope = update_undeliverable_envelope_for_casting(envelope);
-        }
-        let envelope = match envelope {
-            Undeliverable::Returned(envelope) => envelope,
-            Undeliverable::Report(report) => {
-                return Err(UndeliverableMessageError::Report { report }.into());
-            }
-        };
-        assert_eq!(
-            envelope.sender(),
-            ins.self_addr(),
-            "undeliverable message was returned to the wrong actor. \
-            Return address = {}, src actor = {}, dest handler port = {}, message type = {}, envelope headers = {}",
-            envelope.sender(),
-            ins.self_addr(),
-            envelope.dest(),
-            envelope.data().typename().unwrap_or("unknown"),
-            envelope.headers()
-        );
-
-        let cx = Context::new(ins, envelope.headers().clone());
-
-        let (envelope, handled) = monarch_with_gil(GilSite::EndpointDispatch, |py| {
-            let py_cx = match &self.instance {
-                Some(instance) => crate::context::PyContext::new(&cx, instance.clone_ref(py)),
-                None => {
-                    let py_instance: crate::context::PyInstance = ins.into();
-                    crate::context::PyContext::new(
-                        &cx,
-                        py_instance
-                            .into_py_any(py)?
-                            .cast_bound(py)
-                            .map_err(PyErr::from)?
-                            .clone()
-                            .unbind(),
-                    )
-                }
-            }
-            .into_bound_py_any(py)?;
-            let py_envelope = PythonUndeliverableMessageEnvelope {
-                inner: Some(Undeliverable::Returned(envelope)),
-            }
-            .into_bound_py_any(py)?;
-            let handled = self
-                .actor
-                .call_method(
-                    py,
-                    "_handle_undeliverable_message",
-                    (&py_cx, &py_envelope),
-                    None,
-                )
-                .map_err(|err| anyhow::Error::from(SerializablePyErr::from(py, &err)))?
-                .extract::<bool>(py)?;
-            Ok::<_, anyhow::Error>((
-                py_envelope
-                    .cast::<PythonUndeliverableMessageEnvelope>()
-                    .map_err(PyErr::from)?
-                    .try_borrow_mut()
-                    .map_err(PyErr::from)?
-                    .take()?,
-                handled,
-            ))
-        })
-        .await?;
+        let (envelope, handled) = self
+            .dispatch_delivery_failure_to_python(ins, envelope)
+            .await?;
 
         if !handled {
             hyperactor::actor::handle_undeliverable_message(ins, reason, envelope)
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn handle_invalid_reference(
+        &mut self,
+        ins: &Instance<Self>,
+        invalid: InvalidReference,
+        envelope: Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        let (envelope, handled) = self
+            .dispatch_delivery_failure_to_python(ins, envelope)
+            .await?;
+
+        if !handled {
+            hyperactor::actor::handle_invalid_reference(ins, invalid, envelope)
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn handle_expired_delivery(
+        &mut self,
+        ins: &Instance<Self>,
+        expired: ExpiredDelivery,
+        envelope: Undeliverable<MessageEnvelope>,
+    ) -> Result<(), anyhow::Error> {
+        let (envelope, handled) = self
+            .dispatch_delivery_failure_to_python(ins, envelope)
+            .await?;
+
+        if !handled {
+            hyperactor::actor::handle_expired_delivery(ins, expired, envelope)
         } else {
             Ok(())
         }

--- a/monarch_introspection_snapshot/test/snapshot_integration_test.rs
+++ b/monarch_introspection_snapshot/test/snapshot_integration_test.rs
@@ -172,6 +172,9 @@ fn spawn_snapshot_http_counter() -> (String, Arc<AtomicUsize>, Arc<AtomicBool>, 
                 }
                 Err(error) => panic!("snapshot HTTP test server failed: {error}"),
             };
+            // macOS can propagate the listener's nonblocking mode to accepted
+            // sockets, so make request reads blocking before applying a timeout.
+            stream.set_nonblocking(false).unwrap();
             stream
                 .set_read_timeout(Some(Duration::from_secs(5)))
                 .unwrap();

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -108,14 +108,31 @@ _NO_TENSOR_ENGINE_SKIP_PREFIXES = (
     "python/tests/simulator/test_communication_model.py::",
     "python/tests/simulator/test_ir.py::",
 )
+# Keep temporary macOS CI quarantines here instead of adding per-test skipif
+# markers, so the test definitions continue to describe supported behavior.
 _MACOS_ARM64_SKIP_NODEIDS = frozenset(
     {
+        "python/tests/test_actor_error.py::test_client_hard_exit_cleanup",
+        "python/tests/test_actor_error.py::test_supervise_callback_without_await_handled[actor_queue_dispatch=True]",
         "python/tests/test_config.py::test_codec_max_frame_length_with_increased_limit",
+        "python/tests/test_config.py::test_rdma_ibverbs_target_round_trip_and_propagation",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_cleanup_torch_distributed",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_lambda_sets_env_vars_before_cuda_init",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_proc_mesh_with_dictionary_env",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_proc_mesh_with_lambda_env",
+        "python/tests/test_debugger.py::test_debug",
+        "python/tests/test_debugger.py::test_debug_cli",
+        "python/tests/test_debugger.py::test_debug_multi_actor",
+        "python/tests/test_debugger.py::test_debug_nested",
         "python/tests/test_debugger.py::test_debug_with_pickle_by_value",
+        "python/tests/test_distributed_telemetry.py::test_all_actors_in_host_mesh",
+        "python/tests/test_distributed_telemetry.py::test_all_actors_in_proc_mesh",
+        "python/tests/test_distributed_telemetry.py::test_public_custom_trace_is_queryable",
+        "python/tests/test_distributed_telemetry.py::test_pyspy_tables_in_information_schema",
+        "python/tests/test_distributed_telemetry.py::test_query_after_stopping_actor_mesh",
+        "python/tests/test_distributed_telemetry.py::test_scan_timeout_on_dead_child",
+        "python/tests/test_distributed_telemetry.py::test_snapshot_schemas_pre_registered",
+        "python/tests/test_distributed_telemetry.py::test_store_pyspy_dump_and_query",
         "python/tests/test_host_mesh.py::test_host_mesh_context_manager",
         "python/tests/test_host_mesh.py::test_spawn_procs_with_taskset_bind",
         "python/tests/test_host_mesh.py::test_stop_and_reconnect",

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -120,7 +120,6 @@ _MACOS_ARM64_SKIP_NODEIDS = frozenset(
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_proc_mesh_with_dictionary_env",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_proc_mesh_with_lambda_env",
         "python/tests/test_debugger.py::test_debug_with_pickle_by_value",
-        "python/tests/test_distributed_telemetry.py::test_query_after_stopping_actor_mesh",
         "python/tests/test_host_mesh.py::test_host_mesh_context_manager",
         "python/tests/test_host_mesh.py::test_spawn_procs_with_taskset_bind",
         "python/tests/test_host_mesh.py::test_stop_and_reconnect",

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -112,7 +112,6 @@ _NO_TENSOR_ENGINE_SKIP_PREFIXES = (
 # markers, so the test definitions continue to describe supported behavior.
 _MACOS_ARM64_SKIP_NODEIDS = frozenset(
     {
-        "python/tests/test_actor_error.py::test_client_hard_exit_cleanup",
         "python/tests/test_actor_error.py::test_supervise_callback_without_await_handled[actor_queue_dispatch=True]",
         "python/tests/test_config.py::test_codec_max_frame_length_with_increased_limit",
         "python/tests/test_config.py::test_rdma_ibverbs_target_round_trip_and_propagation",
@@ -120,19 +119,8 @@ _MACOS_ARM64_SKIP_NODEIDS = frozenset(
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_lambda_sets_env_vars_before_cuda_init",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_proc_mesh_with_dictionary_env",
         "python/tests/test_cuda.py::TestEnvBeforeCuda::test_proc_mesh_with_lambda_env",
-        "python/tests/test_debugger.py::test_debug",
-        "python/tests/test_debugger.py::test_debug_cli",
-        "python/tests/test_debugger.py::test_debug_multi_actor",
-        "python/tests/test_debugger.py::test_debug_nested",
         "python/tests/test_debugger.py::test_debug_with_pickle_by_value",
-        "python/tests/test_distributed_telemetry.py::test_all_actors_in_host_mesh",
-        "python/tests/test_distributed_telemetry.py::test_all_actors_in_proc_mesh",
-        "python/tests/test_distributed_telemetry.py::test_public_custom_trace_is_queryable",
-        "python/tests/test_distributed_telemetry.py::test_pyspy_tables_in_information_schema",
         "python/tests/test_distributed_telemetry.py::test_query_after_stopping_actor_mesh",
-        "python/tests/test_distributed_telemetry.py::test_scan_timeout_on_dead_child",
-        "python/tests/test_distributed_telemetry.py::test_snapshot_schemas_pre_registered",
-        "python/tests/test_distributed_telemetry.py::test_store_pyspy_dump_and_query",
         "python/tests/test_host_mesh.py::test_host_mesh_context_manager",
         "python/tests/test_host_mesh.py::test_spawn_procs_with_taskset_bind",
         "python/tests/test_host_mesh.py::test_stop_and_reconnect",

--- a/python/tests/test_actor_error.py
+++ b/python/tests/test_actor_error.py
@@ -2097,9 +2097,13 @@ def test_client_hard_exit_cleanup() -> None:
             # These pids should be gone because that client spawned the procs.
             pids = q.get()
             pids_on_ref = q.get()
+            q.close()
+            q.join_thread()
             # Make sure to terminate abnormally (SIGTERM), so we can test that this
             # works even without any involvement from the user.
             p.terminate()
+            p.join(timeout=10)
+            assert not p.is_alive()
             # Ensure the processes exit after waiting for the timeout specified.
             time.sleep(15)
             processes_exist = [pid for pid in pids if is_process_running(pid)]
@@ -2112,3 +2116,9 @@ def test_client_hard_exit_cleanup() -> None:
 
             # There is currently no Python API to determine if the actors spawned
             # by the subprocess are gone other than an undeliverable message.
+
+            # The referenced mesh should survive the subprocess, but it must be
+            # stopped before this test exits. Its bootstrap inherits Python's
+            # multiprocessing resource-tracker pipe and otherwise prevents the
+            # isolated test process from shutting down on macOS.
+            procs.stop().get()

--- a/python/tests/test_rdma_action.py
+++ b/python/tests/test_rdma_action.py
@@ -8,11 +8,18 @@
 """End-to-end tests for ``monarch.rdma.RDMAAction``."""
 
 import os
+import sys
 
 # Required to enable RDMA support for CUDA tensors.
 os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
 
 import pytest  # noqa: E402
+
+# Use an early module-level skip instead of skipif because the RDMA native
+# bindings imported below are not built on non-Linux platforms.
+if sys.platform != "linux":
+    pytest.skip("RDMA tests require Linux", allow_module_level=True)
+
 import torch  # noqa: E402
 from monarch.actor import Actor, endpoint, this_host  # noqa: E402
 from monarch.rdma import RDMAAction, RDMABuffer  # noqa: E402

--- a/python/tests/test_rdma_local_memory_cache.py
+++ b/python/tests/test_rdma_local_memory_cache.py
@@ -23,9 +23,16 @@ Neither layer requires an RDMA backend, an ``RdmaManager``, or an actor
 mesh."""
 
 import gc
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+# Use an early module-level skip instead of skipif because the RDMA native
+# bindings imported below are not built on non-Linux platforms.
+if sys.platform != "linux":
+    pytest.skip("RDMA tests require Linux", allow_module_level=True)
+
 import torch
 from monarch._src.rdma import rdma as rdma_mod
 

--- a/python/tests/test_telemetry_config.py
+++ b/python/tests/test_telemetry_config.py
@@ -116,10 +116,12 @@ class _FakeTelemetryHandle:
 
 
 @pytest.mark.timeout(30)
-def test_run_job_sidecar_survives_broken_connection(tmp_path) -> None:
+def test_run_job_sidecar_survives_broken_connection() -> None:
     """A connection that sends garbage (or breaks mid-request) must drop only
     that connection, not tear down the job sidecar."""
-    socket_path = str(tmp_path / "cmd.sock")
+    # Darwin limits AF_UNIX paths to 104 bytes. pytest's per-test temporary
+    # directory exceeds that on GitHub's macOS runners, so use a short path.
+    socket_path = f"/tmp/monarch_{uuid.uuid4().hex[:8]}.sock"
     fake = _FakeTelemetryHandle()
 
     with patch.object(tc, "_TelemetryHandle", return_value=fake):


### PR DESCRIPTION
Stacked on #4563. Until that PR lands, the new changes in this stack are commits `8caa4f6e3` and `c68f8ddd3`.

## Summary

There were three lifecycle bugs behind the macOS actor, debugger, and telemetry failures.

macOS has no equivalent to Linux `PR_SET_PDEATHSIG`, so native bootstrap processes survived when their launcher exited unexpectedly. Sequential pytest splits accumulated those processes and eventually timed out.

The debugger also exposed a supervision race: teardown could unsubscribe an actor while an `Option<MeshFailure>` notification was still in flight. If that notification later expired, `ResourceController` treated the expected return as fatal because TTL-expired messages use the separate `handle_expired_delivery()` callback.

A later run of #4563 exposed the same callback split in `PythonActor`. `TelemetryActor._handle_undeliverable_message()` explicitly handles stale worker messages, but the Rust bridge invoked that hook only for ordinary undeliverable reasons. A TTL-expired `CreateOrUpdate<ActorSpec>` therefore bypassed Python and killed the telemetry query root.

This change:

- Records the native launcher PID and monitors it from macOS bootstrap processes.
- Recognizes returned supervision notifications across undeliverable, invalid-reference, and expired-delivery paths.
- Routes all three `PythonActor` delivery-failure categories through `_handle_undeliverable_message`, preserving category-specific default escalation when the hook returns `False`.
- Cleans up the hard-exit test resources and re-enables the tests covered by these fixes.

The branch is now rebased on #4569. The previous #4568 run showed a separate global shutdown problem: successful distributed-telemetry tests consistently took about 107 seconds, then later debugger and telemetry tests timed out. #4569 preserves root-client flush ordering during shutdown, so the new CI run includes that landed fix before exercising this branch. The newly observed un-awaited supervision timeout from #4563 remains quarantined because these changes do not address that callback path.

## Test plan

Inspected the failing jobs and downloaded their JUnit XML with `gh`.

The previous #4568 Python artifact reported 11 timeout failures. Successful distributed-telemetry tests in the same split took about 107 seconds each, which matches the shutdown path fixed by #4569. The Rust artifact reported only the two snapshot test-server `WouldBlock` failures now fixed in #4563.

Earlier local macOS arm64 results using a wheel built with:

```lang=sh
uv build --no-build-isolation --wheel
```

- `test_client_hard_exit_cleanup`: 5/5 isolated runs passed, plus both combined runs.
- `test_debug_cli`: 10/10 isolated runs passed. Before the fix, 3/5 isolated runs failed.
- The 12 initially re-enabled actor, debugger, and distributed-telemetry tests passed together twice: 12/12 in 124.44s and 12/12 in 121.49s.
- `test_query_after_stopping_actor_mesh` passed locally in 5.31s, confirming that the original CI failure was timing-sensitive.
- No Monarch bootstrap or telemetry-sidecar processes remained after either combined run.
- `rustfmt --edition 2024 --check`, `git diff --check`, and the exact Python skip-selection check passed after rebasing onto current `main`.

I could not complete a fresh native rebuild on this Mac because swap is disabled and the kernel killed even the single-job `proc-macro2` build script with `SIGKILL`. The pushed macOS CI run performs the final native build and full-suite verification.

Fresh macOS CI result after the rebase: the Rust job passed all 2,192 tests with zero failures. The JUnit XML reports PT-3 passing in 2.491s and PT-5 passing in 5.544s. The wheel build and Python job are still in progress.