### PR TITLE
Preserve client flush ordering during shutdown

### DIFF
--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2844,7 +2844,8 @@ impl<A: Actor> Instance<A> {
         self.inner.mailbox.drain();
     }
 
-    pub(crate) fn status(&self) -> watch::Receiver<ActorStatus> {
+    /// Subscribe to this actor's status changes.
+    pub fn status(&self) -> watch::Receiver<ActorStatus> {
         self.inner.cell.status().clone()
     }
 

--- a/hyperactor_mesh/src/bootstrap.rs
+++ b/hyperactor_mesh/src/bootstrap.rs
@@ -53,7 +53,6 @@ use hyperactor::context;
 use hyperactor::id::Uid;
 use hyperactor::mailbox::IntoBoxedMailboxSender;
 use hyperactor::mailbox::MailboxClient;
-use hyperactor::mailbox::MailboxServer;
 use hyperactor::proc::Proc;
 use hyperactor_cast::cast_actor::CAST_ACTOR_NAME;
 use hyperactor_config::CONFIG;
@@ -74,6 +73,7 @@ use crate::config::MESH_PROC_LAUNCHER_KIND;
 use crate::host::BulkTerminate;
 use crate::host::Host;
 use crate::host::HostError;
+use crate::host::HostShutdownHandles;
 use crate::host::ProcHandle;
 use crate::host::ProcManager;
 use crate::host::ReadyError as HostReadyError;
@@ -215,31 +215,63 @@ pub async fn halt<R>() -> R {
 
 /// A handle that waits for a host to finish shutting down.
 ///
-/// Obtained from [`host`]. Awaiting [`HostShutdownHandle::join`] blocks until
-/// the [`ShutdownHost`] handler sends back the mailbox server handle, drains
-/// it, and (if `exit_on_shutdown`) calls `process::exit`.
+/// Obtained from [`host`]. Awaiting [`HostShutdownHandle::stop_and_join`]
+/// blocks until the [`ShutdownHost`] handler sends back the client transport
+/// handles, stops and joins them, and (if `exit_on_shutdown`) calls
+/// `process::exit`.
 ///
 /// Note: [`DrainHost`] does **not** trigger this handle — a drained host
 /// keeps its mailbox server (and Unix socket) alive so new clients can
 /// reconnect to the same address.
 pub struct HostShutdownHandle {
-    rx: tokio::sync::oneshot::Receiver<hyperactor::gateway::GatewayServeHandle>,
+    rx: tokio::sync::oneshot::Receiver<HostShutdownHandles>,
+    exit_on_shutdown: bool,
+}
+
+/// A host whose children have drained but whose client transports are still serving.
+///
+/// Call [`stop_and_join`](Self::stop_and_join) after any final client-side
+/// flushes to stop and join the transport servers.
+pub struct DrainedHostShutdown {
+    handles: Option<HostShutdownHandles>,
     exit_on_shutdown: bool,
 }
 
 impl HostShutdownHandle {
-    /// Wait for the host to finish shutting down, drain its mailbox server,
-    /// and optionally exit the process.
-    pub async fn join(self) {
-        match self.rx.await {
-            Ok(mut serve_handle) => {
-                // Stop signals the frontend server and unwinds its
-                // bookkeeping; join then awaits teardown so pending
-                // messages drain before we return.
-                serve_handle.stop("host shutdown: draining frontend mailbox server");
-                let _ = serve_handle.join().await;
-            }
-            Err(_) => {} // sender dropped without sending — nothing to drain
+    /// Wait for the host to drain its children and release its client transports.
+    ///
+    /// The returned transports remain live until
+    /// [`DrainedHostShutdown::stop_and_join`], so callers can perform final
+    /// client-side flushes before teardown.
+    pub async fn wait_for_drain(self) -> DrainedHostShutdown {
+        DrainedHostShutdown {
+            handles: self.rx.await.ok(),
+            exit_on_shutdown: self.exit_on_shutdown,
+        }
+    }
+
+    /// Wait for the host to drain, run `before_join` while its transports are
+    /// still serving, and then stop and join the transport servers.
+    pub async fn stop_and_join_after_drain(self, before_join: impl future::Future<Output = ()>) {
+        let drained = self.wait_for_drain().await;
+        before_join.await;
+        drained.stop_and_join().await;
+    }
+
+    /// Wait for the host to finish shutting down, stop and join its transport
+    /// servers, and optionally exit the process.
+    pub async fn stop_and_join(self) {
+        self.stop_and_join_after_drain(future::ready(())).await;
+    }
+}
+
+impl DrainedHostShutdown {
+    /// Stop and join the transport servers, then optionally exit the process.
+    pub async fn stop_and_join(mut self) {
+        if let Some(handles) = self.handles.take() {
+            handles
+                .stop_and_join("host shutdown: draining transport servers")
+                .await;
         }
         if self.exit_on_shutdown {
             std::process::exit(0);
@@ -303,11 +335,10 @@ pub async fn host(
     let host = Host::new_with_gateway(manager, addr, listener, gateway, via).await?;
     let addr = host.addr().clone();
 
-    // The ShutdownHost handler will send the gateway serve handle back here
+    // The ShutdownHost handler sends the active client transports back here
     // for draining. The frontend starts before HostAgent is spawned, and the
     // host address is published only after HostAgent binds its handler.
-    let (shutdown_tx, shutdown_rx) =
-        tokio::sync::oneshot::channel::<hyperactor::gateway::GatewayServeHandle>();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel::<HostShutdownHandles>();
 
     let system_proc = host.system_proc().clone();
     let host_mesh_agent = system_proc.spawn_with_uid(
@@ -579,7 +610,8 @@ impl Bootstrap {
                 // Finally serve the proc on the same transport as the backend address,
                 // and call back.
                 let (proc_addr, proc_rx) = channel::serve(serve_addr)?;
-                let mailbox_handle = proc.clone().serve(proc_rx);
+                let mailbox_handle =
+                    hyperactor::mailbox::MailboxServer::serve(proc.clone(), proc_rx);
                 channel::dial(callback_addr)?
                     .send((proc_addr, agent_handle.bind::<ProcAgent>()))
                     .instrument(span)
@@ -617,7 +649,7 @@ impl Bootstrap {
                     .send(())
                     .await
                     .map_err(ChannelError::from)?;
-                shutdown.join().await;
+                shutdown.stop_and_join().await;
                 halt().await
             }
         }
@@ -2417,16 +2449,180 @@ fn runtime_dir() -> io::Result<TempDir> {
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
+    use std::sync::Arc;
+    use std::sync::atomic::AtomicBool;
+    use std::sync::atomic::Ordering;
 
+    use async_trait::async_trait;
+    use hyperactor::Location;
+    use hyperactor::PortHandle;
+    use hyperactor::ProcId;
     use hyperactor::RemoteSpawn;
     use hyperactor::channel::ChannelAddr;
     use hyperactor::channel::ChannelTransport;
     use hyperactor::channel::TcpMode;
+    use hyperactor::mailbox::MailboxSender;
+    use hyperactor::mailbox::MessageEnvelope;
+    use hyperactor::mailbox::Undeliverable;
     use hyperactor::testing::ids::test_proc_id;
     use hyperactor::testing::ids::test_proc_id_with_addr;
     use hyperactor_config::Flattrs;
 
     use super::*;
+
+    struct ShutdownFlushProbe {
+        gateway: Gateway,
+        expected_location: Location,
+        flushed: Arc<AtomicBool>,
+    }
+
+    #[async_trait]
+    impl MailboxSender for ShutdownFlushProbe {
+        fn post_unchecked(
+            &self,
+            _envelope: MessageEnvelope,
+            _return_handle: PortHandle<Undeliverable<MessageEnvelope>>,
+        ) {
+        }
+
+        async fn flush(&self) -> Result<(), anyhow::Error> {
+            assert_eq!(
+                self.gateway.default_location(),
+                self.expected_location,
+                "shutdown transports must remain live while the root proc flushes"
+            );
+            self.flushed.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_host_shutdown_flushes_before_joining_frontend() {
+        let relay_gateway = Gateway::new();
+        let mut relay = relay_gateway
+            .serve_duplex(ChannelAddr::any(ChannelTransport::Unix))
+            .unwrap();
+        let relay_addr = relay_gateway.default_location().addr().clone();
+
+        let gateway = Gateway::isolated();
+        let mut first = gateway
+            .serve(ChannelAddr::any(ChannelTransport::Local))
+            .unwrap();
+        let first_location = gateway.default_location();
+        let frontend = gateway
+            .serve(ChannelAddr::any(ChannelTransport::Local))
+            .unwrap();
+        let frontend_location = gateway.default_location();
+        assert_ne!(first_location, frontend_location);
+        let via = gateway.serve_via(relay_addr).await.unwrap();
+        let via_location = gateway.default_location();
+        assert!(via_location.as_via().is_some());
+
+        let proc = Proc::builder()
+            .proc_id(ProcId::instance(Label::strip("shutdown_flush_probe")))
+            .shared_gateway(gateway.clone())
+            .build()
+            .unwrap();
+        let flushed = Arc::new(AtomicBool::new(false));
+        let probe_id = proc
+            .proc_addr()
+            .actor_addr("shutdown_flush_probe")
+            .id()
+            .clone();
+        assert!(proc.muxer().bind(
+            probe_id,
+            ShutdownFlushProbe {
+                gateway: gateway.clone(),
+                expected_location: via_location,
+                flushed: flushed.clone(),
+            }
+        ));
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tx.send(HostShutdownHandles::new(frontend, Some(via)))
+            .unwrap();
+        let shutdown = HostShutdownHandle {
+            rx,
+            exit_on_shutdown: false,
+        };
+
+        shutdown
+            .stop_and_join_after_drain(async {
+                proc.flush().await.expect("flush probe should succeed");
+            })
+            .await;
+
+        assert!(flushed.load(Ordering::SeqCst));
+        assert_eq!(gateway.default_location(), first_location);
+
+        first.stop("test complete");
+        first.join().await.unwrap();
+        relay.stop("test complete");
+        relay.join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_cancelled_pre_join_stops_frontend() {
+        let gateway = Gateway::isolated();
+        let mut first = gateway
+            .serve(ChannelAddr::any(ChannelTransport::Local))
+            .unwrap();
+        let first_location = gateway.default_location();
+        let frontend = gateway
+            .serve(ChannelAddr::any(ChannelTransport::Local))
+            .unwrap();
+        assert_ne!(gateway.default_location(), first_location);
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tx.send(HostShutdownHandles::new(frontend, None)).unwrap();
+        let shutdown = HostShutdownHandle {
+            rx,
+            exit_on_shutdown: false,
+        };
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let shutdown_task = tokio::spawn(shutdown.stop_and_join_after_drain(async move {
+            entered_tx
+                .send(())
+                .expect("pre-join notification receiver must remain live");
+            future::pending::<()>().await;
+        }));
+
+        entered_rx
+            .await
+            .expect("pre-join future must signal before cancellation");
+        shutdown_task.abort();
+        assert!(
+            shutdown_task
+                .await
+                .expect_err("aborted join task must report cancellation")
+                .is_cancelled()
+        );
+        assert_eq!(gateway.default_location(), first_location);
+
+        first.stop("test complete");
+        first.join().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_dropped_shutdown_receiver_stops_frontend() {
+        let gateway = Gateway::isolated();
+        let mut first = gateway
+            .serve(ChannelAddr::any(ChannelTransport::Local))
+            .unwrap();
+        let first_location = gateway.default_location();
+        let frontend = gateway
+            .serve(ChannelAddr::any(ChannelTransport::Local))
+            .unwrap();
+        assert_ne!(gateway.default_location(), first_location);
+
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tx.send(HostShutdownHandles::new(frontend, None)).unwrap();
+        drop(rx);
+        assert_eq!(gateway.default_location(), first_location);
+
+        first.stop("test complete");
+        first.join().await.unwrap();
+    }
 
     #[tokio::test]
     async fn test_host_bootstrap_ready_callback() {
@@ -3121,7 +3317,7 @@ mod tests {
         // Route messages arriving on backend_addr into this test
         // proc's mailbox so the bootstrap child can reach the host
         // router.
-        instance.proc().clone().serve(rx);
+        hyperactor::mailbox::MailboxServer::serve(instance.proc().clone(), rx);
 
         // We return an arbitrary (but unbound!) unix direct proc id here;
         // it is okay, as we're not testing connectivity.

--- a/hyperactor_mesh/src/host.rs
+++ b/hyperactor_mesh/src/host.rs
@@ -150,6 +150,51 @@ pub enum HostError {
     ViaAttachFailure(#[source] anyhow::Error),
 }
 
+/// Client transport handles transferred to the bootstrap shutdown task.
+///
+/// Dropping this value stops any handles that have not already been joined,
+/// so cancellation cannot detach a live frontend or via transport.
+#[derive(Debug)]
+pub(crate) struct HostShutdownHandles {
+    frontend: Option<GatewayServeHandle>,
+    via: Option<GatewayServeHandle>,
+}
+
+impl HostShutdownHandles {
+    pub(crate) fn new(frontend: GatewayServeHandle, via: Option<GatewayServeHandle>) -> Self {
+        Self {
+            frontend: Some(frontend),
+            via,
+        }
+    }
+
+    pub(crate) async fn stop_and_join(mut self, reason: &str) {
+        if let Some(mut frontend) = self.frontend.take() {
+            frontend.stop(reason);
+            if let Err(error) = frontend.join().await {
+                tracing::warn!(%error, "failed to join host shutdown frontend");
+            }
+        }
+        if let Some(mut via) = self.via.take() {
+            via.stop(reason);
+            if let Err(error) = via.join().await {
+                tracing::warn!(%error, "failed to join host shutdown via transport");
+            }
+        }
+    }
+}
+
+impl Drop for HostShutdownHandles {
+    fn drop(&mut self) {
+        if let Some(frontend) = &mut self.frontend {
+            frontend.stop("host shutdown handles dropped");
+        }
+        if let Some(via) = &mut self.via {
+            via.stop("host shutdown handles dropped");
+        }
+    }
+}
+
 /// Lifecycle manager for the procs on one machine.
 ///
 /// The host delegates all connectivity to its [`Gateway`]. It creates
@@ -426,6 +471,14 @@ impl<M: ProcManager> Host<M> {
     /// frontend server explicitly.
     pub(crate) fn take_frontend_handle(&mut self) -> Option<GatewayServeHandle> {
         self.frontend_handle.take()
+    }
+
+    /// Take the transport handles that must remain live through final client flushes.
+    pub(crate) fn take_shutdown_handles(&mut self) -> HostShutdownHandles {
+        let frontend = self
+            .take_frontend_handle()
+            .expect("host shutdown must own its frontend handle");
+        HostShutdownHandles::new(frontend, self.via_handle.take())
     }
 
     /// Stop and join every gateway server owned by this host.
@@ -2301,11 +2354,13 @@ mod tests {
             Ok(proc.spawn_with_label::<()>("host_agent", ()))
         });
 
-        let host = Host::new_with_gateway(
+        let gateway = Gateway::new();
+        let fallback_location = gateway.default_location();
+        let mut host = Host::new_with_gateway(
             proc_manager,
             ChannelAddr::any(ChannelTransport::Unix),
             None,
-            Gateway::new(),
+            gateway.clone(),
             Some(remote_addr.clone()),
         )
         .await
@@ -2330,6 +2385,17 @@ mod tests {
             .expect("service proc must carry the via prefix");
         assert_eq!(svc_inner.addr(), &remote_addr);
 
+        let shutdown_handles = host.take_shutdown_handles();
+        drop(host);
+        assert_eq!(
+            gateway.default_location(),
+            default_location,
+            "shutdown handles must retain the via location after the host drops"
+        );
+        shutdown_handles.stop_and_join("test cleanup").await;
+        assert_eq!(gateway.default_location(), fallback_location);
+
         remote_accept.stop("test cleanup");
+        remote_accept.join().await.unwrap();
     }
 }

--- a/hyperactor_mesh/src/host_mesh/host_agent.rs
+++ b/hyperactor_mesh/src/host_mesh/host_agent.rs
@@ -44,7 +44,6 @@ use hyperactor::Uid;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::ActorStoppingReason;
 use hyperactor::context;
-use hyperactor::gateway::GatewayServeHandle;
 use hyperactor::id::Label;
 use hyperactor::mailbox::MailboxSender as _;
 use hyperactor::value_mesh::ValueOverlay;
@@ -66,6 +65,7 @@ use crate::config_dump::ConfigDump;
 use crate::config_dump::ConfigDumpResult;
 use crate::host::Host;
 use crate::host::HostError;
+use crate::host::HostShutdownHandles;
 use crate::host::LOCAL_PROC_NAME;
 use crate::host::LocalProcManager;
 use crate::host::SERVICE_PROC_NAME;
@@ -97,13 +97,13 @@ pub(crate) type ProcManagerSpawnFn = Box<dyn Fn(Proc) -> ProcManagerSpawnFuture 
 /// This abstraction lets the same `HostAgent` work across both
 /// out-of-process and in-process execution modes.
 #[derive(EnumAsInner)]
-pub enum HostAgentMode {
+pub(crate) enum HostAgentMode {
     Process {
         host: Host<BootstrapProcManager>,
-        /// If set, the ShutdownHost handler sends the frontend mailbox server
-        /// handle back to the bootstrap loop via this channel once shutdown is
-        /// complete, so the caller can drain it and exit.
-        shutdown_tx: Option<tokio::sync::oneshot::Sender<GatewayServeHandle>>,
+        /// If set, the ShutdownHost handler sends the active transport handles
+        /// back to the bootstrap loop once shutdown is complete, so the caller
+        /// can drain them and exit.
+        shutdown_tx: Option<tokio::sync::oneshot::Sender<HostShutdownHandles>>,
     },
     Local(Host<LocalProcManager<ProcManagerSpawnFn>>),
 }
@@ -382,9 +382,9 @@ pub struct HostAgent {
 
 impl HostAgent {
     /// Create a host mesh agent for a process-backed host.
-    pub fn new_process(
+    pub(crate) fn new_process(
         host: Host<BootstrapProcManager>,
-        shutdown_tx: Option<tokio::sync::oneshot::Sender<GatewayServeHandle>>,
+        shutdown_tx: Option<tokio::sync::oneshot::Sender<HostShutdownHandles>>,
     ) -> Self {
         Self::new(HostAgentMode::Process { host, shutdown_tx })
     }
@@ -1430,12 +1430,11 @@ impl Handler<ShutdownHost> for HostAgent {
                 tracing::info!(
                     proc_id = %cx.self_addr().proc_addr(),
                     actor_id = %cx.self_addr(),
-                    "host is shut down, sending mailbox handle to bootstrap for draining"
+                    "host is shut down, sending transport handles to bootstrap for draining"
                 );
-                if let Some(handle) = host.take_frontend_handle()
-                    && let Err(mut handle) = tx.send(handle)
-                {
-                    handle.stop("bootstrap shutdown receiver dropped");
+                let handles = host.take_shutdown_handles();
+                if let Err(handles) = tx.send(handles) {
+                    drop(handles);
                 }
             }
             HostAgentState::Detached(HostAgentMode::Local(mut host))

--- a/monarch_hyperactor/src/bootstrap.rs
+++ b/monarch_hyperactor/src/bootstrap.rs
@@ -111,7 +111,7 @@ pub fn run_worker_loop_forever(_py: Python<'_>, address: &str) -> PyResult<PyPyt
             host(addr, command, None, true, listener, Gateway::new(), None)
                 .await
                 .map_pyerr()?;
-        shutdown.join().await;
+        shutdown.stop_and_join().await;
         halt::<()>().await;
         Ok(())
     })

--- a/monarch_hyperactor/src/context.rs
+++ b/monarch_hyperactor/src/context.rs
@@ -120,16 +120,9 @@ impl PyInstance {
     #[pyo3(signature = (reason = None))]
     fn stop_and_wait(&self, reason: Option<&str>) -> PyResult<crate::pytokio::PyPythonTask> {
         let reason = reason.unwrap_or("shutdown").to_string();
-        let actor_id = self.inner.self_addr().clone();
-        let proc = self.inner.proc().clone();
+        let instance = self.inner.clone_for_py();
         crate::pytokio::PyPythonTask::new(async move {
-            let status_rx = proc.stop_actor(actor_id.id(), reason);
-            if let Some(mut rx) = status_rx {
-                let _ = rx.wait_for(|s| s.is_terminal()).await;
-            }
-            if let Err(e) = proc.flush().await {
-                tracing::warn!(%actor_id, "stop_and_wait: flush failed: {}", e);
-            }
+            stop_instance_and_wait(&instance, reason).await;
             Ok(())
         })
     }
@@ -179,6 +172,28 @@ impl PyInstance {
         if let Some(tracker) = &self.execution_tracker {
             tracker.finish(token);
         }
+    }
+}
+
+/// Stop an actor, wait for terminal status, and flush its proc's gateway.
+pub(crate) async fn stop_instance_and_wait(instance: &Instance<PythonActor>, reason: String) {
+    let actor_id = instance.self_addr().clone();
+    let proc = instance.proc().clone();
+    let mut status = instance.status();
+    if let Err(error) = instance.stop(&reason) {
+        tracing::warn!(%actor_id, %error, "stop_and_wait: stop failed");
+    } else {
+        let _ = status.wait_for(|s| s.is_terminal()).await;
+    }
+    let flush_timeout = hyperactor_config::global::get(hyperactor::config::FORWARDER_FLUSH_TIMEOUT);
+    match tokio::time::timeout(flush_timeout, proc.flush()).await {
+        Ok(Err(error)) => {
+            tracing::warn!(%actor_id, %error, "stop_and_wait: flush failed");
+        }
+        Err(_elapsed) => {
+            tracing::warn!(%actor_id, "stop_and_wait: flush timed out");
+        }
+        Ok(Ok(())) => {}
     }
 }
 

--- a/monarch_hyperactor/src/host_mesh.rs
+++ b/monarch_hyperactor/src/host_mesh.rs
@@ -52,6 +52,7 @@ use pyo3::types::PyBytes;
 use crate::actor::PythonActor;
 use crate::actor::to_py_error;
 use crate::context::PyInstance;
+use crate::context::stop_instance_and_wait;
 use crate::proc_mesh::PyProcMesh;
 use crate::pytokio::PyPythonTask;
 use crate::runtime::GilSite;
@@ -662,7 +663,7 @@ fn py_host_mesh_from_bytes(bytes: &Bound<'_, PyBytes>) -> PyResult<PyHostMesh> {
 fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
     let agent = HOST_MESH_AGENT_FOR_HOST
         .get()
-        .ok_or_else(|| PyException::new_err("No local host mesh to shutdown"))?
+        .ok_or_else(|| PyRuntimeError::new_err("No local host mesh to shutdown"))?
         .clone();
 
     PyPythonTask::new(async move {
@@ -693,12 +694,22 @@ fn shutdown_local_host_mesh() -> PyResult<PyPythonTask> {
             },
         );
 
-        // Join the host's mailbox server to flush receive-side acks
-        // before the process exits.
-        if let Some(lock) = HOST_SHUTDOWN_HANDLE.get()
-            && let Some(handle) = lock.lock().await.take()
-        {
-            handle.join().await;
+        let shutdown = if let Some(lock) = HOST_SHUTDOWN_HANDLE.get() {
+            lock.lock().await.take()
+        } else {
+            None
+        };
+        if let Some(shutdown) = shutdown {
+            if let Some(root) = ROOT_CLIENT_INSTANCE_FOR_HOST.get() {
+                shutdown
+                    .stop_and_join_after_drain(stop_instance_and_wait(root, "shutdown".to_string()))
+                    .await;
+            } else {
+                tracing::warn!("shutting down partially bootstrapped host without root client");
+                shutdown.stop_and_join().await;
+            }
+        } else if let Some(root) = ROOT_CLIENT_INSTANCE_FOR_HOST.get() {
+            stop_instance_and_wait(root, "shutdown".to_string()).await;
         }
 
         Ok(())

--- a/monarch_hyperactor/tests/client_root.rs
+++ b/monarch_hyperactor/tests/client_root.rs
@@ -56,6 +56,7 @@ use pyo3::types::PyTuple;
 fn python_bootstrap_seeds_client_root_on_local_proc_agent() -> Result<()> {
     pyo3::Python::initialize();
 
+    assert_shutdown_without_host_is_runtime_error()?;
     let test_result = exercise_python_bootstrap_contract();
     let shutdown_result = shutdown_python_host();
 
@@ -67,6 +68,23 @@ fn python_bootstrap_seeds_client_root_on_local_proc_agent() -> Result<()> {
             "client-root contract failed: {test_error:#}; host shutdown also failed: {shutdown_error:#}"
         ),
     }
+}
+
+fn assert_shutdown_without_host_is_runtime_error() -> Result<()> {
+    monarch_with_gil_blocking(GilSite::Test, |py| -> PyResult<()> {
+        py.run(c_str!("import monarch._rust_bindings"), None, None)?;
+        let host_mesh_mod = py.import("monarch._rust_bindings.monarch_hyperactor.host_mesh")?;
+        let error = host_mesh_mod
+            .getattr("shutdown_local_host_mesh")?
+            .call0()
+            .expect_err("shutdown without a host must fail");
+        assert!(
+            error.is_instance_of::<PyRuntimeError>(py),
+            "shutdown without a host must raise RuntimeError, got {error}"
+        );
+        Ok(())
+    })?;
+    Ok(())
 }
 
 fn exercise_python_bootstrap_contract() -> Result<()> {

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -570,19 +570,16 @@ def shutdown_context() -> "Future[None]":
                 shutdown_local_host_mesh,
             )
 
-            # Shutdown the host mesh first, while the client actor is still
-            # alive to route messages. This drains children and joins the
-            # mailbox server, flushing receive-side acks.
+            # With a local host, Rust stops and flushes the root client after
+            # child drain but before transport teardown. Repeating that here
+            # would flush after teardown; Python owns only the no-host fallback.
             await shutdown_local_host_mesh()
         except RuntimeError:
-            # No local host mesh to shutdown
-            pass
-        # Stop the client actor and wait for it to reach terminal status.
-        # This ensures pending messages are drained and send-side acks
-        # are flushed before the tokio runtime is torn down.
+            # A client created without a local host still needs to be stopped.
+            if c is not None:
+                instance = c.actor_instance._as_rust()
+                await instance.stop_and_wait("shutdown")
         if c is not None:
-            instance = c.actor_instance._as_rust()
-            await instance.stop_and_wait("shutdown")
             _context.set(None)
 
     return Future._from_coro(_shutdown_sequence())


### PR DESCRIPTION
Summary:
Calling `shutdown_context()` shortly after initializing Monarch's local client could intermittently time out because shutdown tore down transport state while the root client was still flushing acknowledgments.

Host shutdown now preserves this order:

```lang=text
children drain
  -> host gateway flush
  -> root client stop
  -> root client gateway flush (bounded)
  -> frontend stop/join
  -> via transport stop/join
```

`HostShutdownHandle` separates child drain from transport teardown so the root finalizer runs while the client transports are still live. `ShutdownHost` transfers both the frontend and optional `serve_via` handle into an RAII owner; dropping that owner stops any remaining transports, including when shutdown is cancelled, panics, or loses its receiver. This preserves attached-client routing through the root flush without leaking detached serve tasks.

Clients without a local host still use the Python stop-and-wait fallback. The Rust binding reports that case as `RuntimeError`, and a partially bootstrapped host without a root client drains and joins without panicking. The root gateway flush remains bounded by `FORWARDER_FLUSH_TIMEOUT`; this change does not impose one end-to-end deadline on every shutdown phase.

Reviewed By: mariusae

Differential Revision: D113919495


