### PR TITLE
RLE optimized ValueMesh slicing (#4571)

### DIFF
--- a/hyperactor/Cargo.toml
+++ b/hyperactor/Cargo.toml
@@ -59,6 +59,7 @@ opentelemetry = "0.31"
 paste = "1.0.14"
 quinn = "0.11.11"
 rand = "0.10.2"
+rustc-hash = "2.1.3"
 rustls = { version = "0.23.37", features = ["ring"] }
 rustls-pemfile = "2.2.0"
 serde = { version = "1.0.219", features = ["derive", "rc"] }

--- a/hyperactor/benches/main.rs
+++ b/hyperactor/benches/main.rs
@@ -6,6 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::hint::black_box;
+use std::sync::Arc;
+use std::sync::Barrier;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread;
 use std::time::Duration;
 use std::time::Instant;
 
@@ -15,6 +21,8 @@ use criterion::Throughput;
 use criterion::criterion_group;
 use criterion::criterion_main;
 use futures::future::join_all;
+use hyperactor::PortAddr;
+use hyperactor::Proc;
 use hyperactor::channel;
 use hyperactor::channel::ChannelAddr;
 use hyperactor::channel::ChannelTransport;
@@ -26,6 +34,9 @@ use hyperactor::channel::serve;
 use hyperactor::mailbox::Mailbox;
 use hyperactor::mailbox::PortSender;
 use hyperactor::mailbox::monitored_return_handle;
+use hyperactor::ordering::SeqKey;
+use hyperactor::ordering::Sequencer;
+use hyperactor::port::Port;
 use hyperactor::testing::ids::test_actor_id;
 use serde::Deserialize;
 use serde::Serialize;
@@ -40,6 +51,18 @@ fn new_runtime() -> Runtime {
         .enable_all()
         .build()
         .unwrap()
+}
+
+fn new_benchmark_sequencer() -> Sequencer {
+    let runtime = new_runtime();
+    let _guard = runtime.enter();
+    let proc = Proc::direct(
+        ChannelAddr::any(ChannelTransport::Local),
+        "sequencer_bench".to_string(),
+    )
+    .unwrap();
+
+    proc.client("sequencer_bench").sequencer().clone()
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Named, PartialEq)]
@@ -343,6 +366,225 @@ fn bench_mailbox_message_rates(c: &mut Criterion) {
     group.finish();
 }
 
+/// Compare single-key and batch sequence assignment across cast fanout sizes.
+fn bench_cast_seq_assignment(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cast_seq_assignment");
+    for n in [1usize, 8, 64, 512, 4096, 8192, 16384, 32768] {
+        let ports: Vec<PortAddr> = (0..n)
+            .map(|i| {
+                test_actor_id(&format!("worker_{i}"), "worker").port_addr(Port::handler_id(0, None))
+            })
+            .collect();
+        let keys: Vec<SeqKey> = ports
+            .iter()
+            .map(|port| SeqKey::for_handler(&port.actor_addr()))
+            .collect();
+
+        group.throughput(Throughput::Elements(n as u64));
+
+        group.bench_with_input(
+            BenchmarkId::new("per_dest_assign_seq", n),
+            &ports,
+            |b, ports| {
+                let seq = new_benchmark_sequencer();
+                for p in ports {
+                    black_box(seq.assign_seq(p));
+                }
+                b.iter(|| {
+                    for p in ports {
+                        black_box(seq.assign_seq(black_box(p)));
+                    }
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("batch_assign_seqs", n),
+            &keys,
+            |b, keys| {
+                let seq = new_benchmark_sequencer();
+                black_box(seq.assign_seqs(keys));
+                b.iter(|| {
+                    black_box(seq.assign_seqs(black_box(keys)));
+                });
+            },
+        );
+
+        group.bench_with_input(
+            BenchmarkId::new("batch_assign_seqs_divergent", n),
+            &keys,
+            |b, keys| {
+                let seq = new_benchmark_sequencer();
+                let advanced_keys: Vec<_> = keys.iter().step_by(2).cloned().collect();
+                black_box(seq.assign_seqs(&advanced_keys));
+                b.iter(|| {
+                    black_box(seq.assign_seqs(black_box(keys)));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+const CONTENTION_FANOUT: usize = 4096;
+const CONTENTION_WORKERS: usize = 4;
+const MIXED_CONTENTION_FANOUTS: [usize; 5] = [1, 8, 64, 512, 4096];
+
+#[derive(Clone, Copy)]
+enum AssignmentMode {
+    PerDestination,
+    Batch,
+}
+
+impl AssignmentMode {
+    fn assign(self, sequencer: &Sequencer, ports: &[PortAddr], keys: &[SeqKey]) {
+        match self {
+            Self::PerDestination => {
+                for port in ports {
+                    black_box(sequencer.assign_seq(black_box(port)));
+                }
+            }
+            Self::Batch => {
+                black_box(sequencer.assign_seqs(black_box(keys)));
+            }
+        }
+    }
+}
+
+fn contention_inputs(worker_count: usize, fanout: usize) -> Vec<(Vec<PortAddr>, Vec<SeqKey>)> {
+    (0..worker_count)
+        .map(|worker| {
+            let ports: Vec<_> = (0..fanout)
+                .map(|rank| {
+                    test_actor_id(&format!("worker_{worker}_{rank}"), "worker")
+                        .port_addr(Port::handler_id(0, None))
+                })
+                .collect();
+            let keys = ports
+                .iter()
+                .map(|port| SeqKey::for_handler(&port.actor_addr()))
+                .collect();
+            (ports, keys)
+        })
+        .collect()
+}
+
+fn run_concurrent_assignments(
+    iterations: u64,
+    inputs: &[(Vec<PortAddr>, Vec<SeqKey>)],
+    mode: AssignmentMode,
+) -> Duration {
+    let sequencer = new_benchmark_sequencer();
+    for (_, keys) in inputs {
+        black_box(sequencer.assign_seqs(keys));
+    }
+
+    let barrier = Arc::new(Barrier::new(inputs.len() + 1));
+    let mut start = None;
+    thread::scope(|scope| {
+        for (ports, keys) in inputs {
+            let sequencer = sequencer.clone();
+            let barrier = barrier.clone();
+            scope.spawn(move || {
+                barrier.wait();
+                for _ in 0..iterations {
+                    mode.assign(&sequencer, ports, keys);
+                }
+            });
+        }
+
+        start = Some(Instant::now());
+        barrier.wait();
+    });
+    start
+        .expect("timer must start before workers run")
+        .elapsed()
+}
+
+fn run_mixed_assignments(
+    iterations: u64,
+    ports: &[PortAddr],
+    keys: &[SeqKey],
+    scalar_port: &PortAddr,
+    mode: AssignmentMode,
+) -> Duration {
+    let sequencer = new_benchmark_sequencer();
+    black_box(sequencer.assign_seqs(keys));
+    black_box(sequencer.assign_seq(scalar_port));
+
+    let started = AtomicBool::new(false);
+    let stop = AtomicBool::new(false);
+    let mut elapsed = None;
+    thread::scope(|scope| {
+        let background_sequencer = sequencer.clone();
+        let background_started = &started;
+        let background_stop = &stop;
+        scope.spawn(move || {
+            mode.assign(&background_sequencer, ports, keys);
+            background_started.store(true, Ordering::Release);
+            while !background_stop.load(Ordering::Acquire) {
+                mode.assign(&background_sequencer, ports, keys);
+            }
+        });
+
+        while !started.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+        }
+
+        let start = Instant::now();
+        for _ in 0..iterations {
+            black_box(sequencer.assign_seq(black_box(scalar_port)));
+        }
+        elapsed = Some(start.elapsed());
+        stop.store(true, Ordering::Release);
+    });
+    elapsed.expect("scalar assignments must complete")
+}
+
+/// Compare aggregate sequence-assignment throughput from concurrent casts.
+fn bench_cast_seq_concurrent_contention(c: &mut Criterion) {
+    let inputs = contention_inputs(CONTENTION_WORKERS, CONTENTION_FANOUT);
+    let mut group = c.benchmark_group("cast_seq_concurrent_contention");
+    group.throughput(Throughput::Elements(
+        (CONTENTION_WORKERS * CONTENTION_FANOUT) as u64,
+    ));
+
+    for (name, mode) in [
+        ("per_dest_assign_seq", AssignmentMode::PerDestination),
+        ("batch_assign_seqs", AssignmentMode::Batch),
+    ] {
+        group.bench_function(
+            BenchmarkId::new(name, format!("{CONTENTION_WORKERS}x{CONTENTION_FANOUT}")),
+            |b| b.iter_custom(|iterations| run_concurrent_assignments(iterations, &inputs, mode)),
+        );
+    }
+    group.finish();
+}
+
+/// Compare scalar assignment latency while a concurrent cast uses the sequencer.
+fn bench_cast_seq_mixed_contention(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cast_seq_mixed_contention");
+
+    for fanout in MIXED_CONTENTION_FANOUTS {
+        let mut inputs = contention_inputs(1, fanout);
+        let (ports, keys) = inputs.pop().expect("one contention input must exist");
+        let scalar_port =
+            test_actor_id("scalar_worker", "worker").port_addr(Port::handler_id(0, None));
+
+        for (name, mode) in [
+            ("per_dest_cast", AssignmentMode::PerDestination),
+            ("batch_cast", AssignmentMode::Batch),
+        ] {
+            group.bench_function(BenchmarkId::new(name, fanout), |b| {
+                b.iter_custom(|iterations| {
+                    run_mixed_assignments(iterations, &ports, &keys, &scalar_port, mode)
+                })
+            });
+        }
+    }
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default().without_plots();
@@ -351,6 +593,9 @@ criterion_group! {
     bench_mailbox_message_sizes,
     bench_mailbox_message_rates,
     bench_channel_ping_pong,
+    bench_cast_seq_assignment,
+    bench_cast_seq_concurrent_contention,
+    bench_cast_seq_mixed_contention,
 }
 
 criterion_main!(benches);

--- a/hyperactor/src/config.rs
+++ b/hyperactor/src/config.rs
@@ -18,6 +18,7 @@ use std::time::Duration;
 use hyperactor_config::AttrValue;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
+use hyperactor_config::NonZeroUsize;
 use hyperactor_config::attrs::declare_attrs;
 use serde::Deserialize;
 use serde::Serialize;
@@ -229,6 +230,15 @@ declare_attrs! {
     ))
     pub attr ENABLE_DEST_ACTOR_REORDERING_BUFFER: bool = true;
 
+    /// Maximum number of destination keys assigned while holding the
+    /// sequencer lock.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("HYPERACTOR_SEQUENCER_MAX_LOCKED_KEYS".to_string()),
+        Some("sequencer_max_locked_keys".to_string()),
+    ))
+    pub attr SEQUENCER_MAX_LOCKED_KEYS: NonZeroUsize =
+        NonZeroUsize::new(128).expect("128 is non-zero");
+
     /// Timeout for [`Host::spawn`] to await proc readiness.
     ///
     /// Default: 30 seconds. If set to zero, disables the timeout and
@@ -318,6 +328,7 @@ mod tests {
         );
         assert_eq!(config[MESSAGE_ACK_EVERY_N_MESSAGES], 1000);
         assert_eq!(config[SPLIT_MAX_BUFFER_SIZE], 5);
+        assert_eq!(config[SEQUENCER_MAX_LOCKED_KEYS].get(), 128);
     }
 
     #[tracing_test::traced_test]
@@ -405,6 +416,7 @@ mod tests {
         );
         assert_eq!(config[MESSAGE_ACK_EVERY_N_MESSAGES], 1000);
         assert_eq!(config[SPLIT_MAX_BUFFER_SIZE], 5);
+        assert_eq!(config[SEQUENCER_MAX_LOCKED_KEYS].get(), 128);
 
         // Verify the keys have defaults
         assert!(CODEC_MAX_FRAME_LENGTH.has_default());
@@ -412,6 +424,7 @@ mod tests {
         assert!(MESSAGE_ACK_TIME_INTERVAL.has_default());
         assert!(MESSAGE_ACK_EVERY_N_MESSAGES.has_default());
         assert!(SPLIT_MAX_BUFFER_SIZE.has_default());
+        assert!(SEQUENCER_MAX_LOCKED_KEYS.has_default());
 
         // Verify we can get defaults directly from keys
         assert_eq!(
@@ -428,6 +441,10 @@ mod tests {
         );
         assert_eq!(MESSAGE_ACK_EVERY_N_MESSAGES.default(), Some(&1000));
         assert_eq!(SPLIT_MAX_BUFFER_SIZE.default(), Some(&5));
+        assert_eq!(
+            SEQUENCER_MAX_LOCKED_KEYS.default().map(|v| v.get()),
+            Some(128)
+        );
     }
 
     #[test]

--- a/hyperactor/src/ordering.rs
+++ b/hyperactor/src/ordering.rs
@@ -10,13 +10,14 @@
 //! for any given sender and receiver actor pair.
 
 use std::any::TypeId;
-use std::collections::HashMap;
 use std::fmt;
+use std::ops::Range;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use hyperactor_config::AttrValue;
 use hyperactor_config::attrs::declare_attrs;
+use rustc_hash::FxHashMap;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -177,11 +178,26 @@ impl std::str::FromStr for OrderingSnapshot {
 /// Handler ports share a sequence per actor; ephemeral ports get individual
 /// sequences. Control ports are direct.
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
-enum SeqKey {
-    /// Shared sequence for all handler ports of an actor
+pub struct SeqKey(SeqKeyKind);
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+enum SeqKeyKind {
     Actor(ActorAddr),
-    /// Individual sequence for a specific ephemeral port.
     Port(PortAddr),
+}
+
+impl SeqKey {
+    /// Return the sequence key shared by an actor's handler ports.
+    pub fn for_handler(actor: &ActorAddr) -> Self {
+        Self(SeqKeyKind::Actor(actor.clone()))
+    }
+
+    /// Return the sequence key for an ephemeral port.
+    pub fn for_ephemeral_port(port: &PortAddr) -> Option<Self> {
+        port.port()
+            .is_ephemeral()
+            .then(|| Self(SeqKeyKind::Port(port.clone())))
+    }
 }
 
 /// A message's sequencer number infomation.
@@ -246,14 +262,14 @@ declare_attrs! {
 pub struct Sequencer {
     session_id: Uuid,
     // Map's key is the sequence key (actor or port), value is the last seq number.
-    last_seqs: Arc<Mutex<HashMap<SeqKey, u64>>>,
+    last_seqs: Arc<Mutex<FxHashMap<SeqKey, u64>>>,
 }
 
 impl Sequencer {
     pub(crate) fn new(session_id: Uuid) -> Self {
         Self {
             session_id,
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         }
     }
 
@@ -288,7 +304,7 @@ impl Sequencer {
         self.last_seqs
             .lock()
             .unwrap()
-            .get(&SeqKey::Actor(actor.clone()))
+            .get(&SeqKey::for_handler(actor))
             .copied()
             .unwrap_or_default()
     }
@@ -299,10 +315,52 @@ impl Sequencer {
         }
 
         if port_id.is_handler_port() {
-            Some(SeqKey::Actor(port_id.actor_addr().clone()))
+            Some(SeqKey::for_handler(&port_id.actor_addr()))
         } else {
-            Some(SeqKey::Port(port_id.clone()))
+            SeqKey::for_ephemeral_port(port_id)
         }
+    }
+
+    /// Assign the next sequence number to each key.
+    ///
+    /// This assigns the same sequence numbers, in the same order, as calling
+    /// [`Self::assign_seq`] for each equivalent destination. Each occurrence
+    /// of a repeated key advances its sequence number.
+    ///
+    /// The result is run-length encoded. Each `(range, seq)` assigns `seq` to
+    /// the input indexes in `range`. The ordered ranges cover `0..keys.len()`
+    /// without gaps. An empty input returns an empty result.
+    pub fn assign_seqs(&self, keys: &[SeqKey]) -> Vec<(Range<usize>, u64)> {
+        let mut runs: Vec<(Range<usize>, u64)> = Vec::new();
+        let mut run_start = 0usize;
+        let mut prev: Option<u64> = None;
+        let mut ordinal = 0;
+        for chunk in keys
+            .chunks(hyperactor_config::global::get(crate::config::SEQUENCER_MAX_LOCKED_KEYS).get())
+        {
+            let mut guard = self.last_seqs.lock().unwrap();
+            for key in chunk {
+                let seq = if let Some(last) = guard.get_mut(key) {
+                    *last += 1;
+                    *last
+                } else {
+                    guard.insert(key.clone(), 1);
+                    1
+                };
+                if let Some(prev_seq) = prev
+                    && prev_seq != seq
+                {
+                    runs.push((run_start..ordinal, prev_seq));
+                    run_start = ordinal;
+                }
+                prev = Some(seq);
+                ordinal += 1;
+            }
+        }
+        if let Some(prev_seq) = prev {
+            runs.push((run_start..keys.len(), prev_seq));
+        }
+        runs
     }
 
     /// Id of the session this sequencer belongs to.
@@ -313,6 +371,7 @@ impl Sequencer {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::collections::HashSet;
     use std::sync::Arc;
     use std::sync::atomic::AtomicUsize;
@@ -371,10 +430,159 @@ mod tests {
     }
 
     #[test]
+    fn assign_seqs_returns_no_runs_for_empty_input() {
+        // GIVEN a sequencer with no assigned keys.
+        let sequencer = Sequencer::new(Uuid::now_v7());
+
+        // WHEN sequence numbers are requested for no keys.
+        let runs = sequencer.assign_seqs(&[]);
+
+        // THEN there are no encoded runs.
+        assert!(runs.is_empty());
+    }
+
+    #[test]
+    fn seq_key_for_ephemeral_port_rejects_other_port_kinds() {
+        // GIVEN one ephemeral, handler, and control port on the same actor.
+        let actor = test_actor_id("worker_0", "worker");
+        let ephemeral = actor.port_addr(Port::from(1));
+        let handler = actor.port_addr(Port::handler::<TestMsg1>());
+        let control = actor.port_addr(Port::control(ControlPort::Status));
+
+        // WHEN each port is passed to the ephemeral-key constructor.
+        let ephemeral_key = SeqKey::for_ephemeral_port(&ephemeral);
+        let handler_key = SeqKey::for_ephemeral_port(&handler);
+        let control_key = SeqKey::for_ephemeral_port(&control);
+
+        // THEN only the ephemeral port produces a key.
+        assert!(ephemeral_key.is_some());
+        assert!(handler_key.is_none());
+        assert!(control_key.is_none());
+    }
+
+    #[test]
+    fn assign_seqs_coalesces_synchronized_keys() {
+        // GIVEN synchronized keys and a chunk size smaller than the input.
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(
+            crate::config::SEQUENCER_MAX_LOCKED_KEYS,
+            hyperactor_config::NonZeroUsize::MIN,
+        );
+        let sequencer = Sequencer::new(Uuid::now_v7());
+        let keys: Vec<_> = (0..3)
+            .map(|i| SeqKey::for_handler(&test_actor_id(&format!("worker_{i}"), "worker")))
+            .collect();
+
+        // WHEN the keys advance together.
+        let single = sequencer.assign_seqs(&keys[..1]);
+        let first = sequencer.assign_seqs(&keys[1..]);
+        let second = sequencer.assign_seqs(&keys[1..]);
+
+        // THEN each synchronized set is represented by one run.
+        assert_eq!(single, vec![(0..1, 1)]);
+        assert_eq!(first, vec![(0..2, 1)]);
+        assert_eq!(second, vec![(0..2, 2)]);
+    }
+
+    #[test]
+    fn assign_seqs_keeps_nonadjacent_equal_values_in_separate_runs() {
+        // GIVEN the first and third keys are one sequence ahead of the second.
+        let sequencer = Sequencer::new(Uuid::now_v7());
+        let keys: Vec<_> = (0..3)
+            .map(|i| SeqKey::for_handler(&test_actor_id(&format!("worker_{i}"), "worker")))
+            .collect();
+        sequencer.assign_seqs(&[keys[0].clone(), keys[2].clone()]);
+
+        // WHEN all three keys are assigned in input order.
+        let runs = sequencer.assign_seqs(&keys);
+
+        // THEN the values [2, 1, 2] remain three ordered runs.
+        assert_eq!(runs, vec![(0..1, 2), (1..2, 1), (2..3, 2)]);
+    }
+
+    #[test]
+    fn assign_seqs_advances_repeated_interleaved_keys() {
+        // GIVEN two new keys repeated in an interleaved input.
+        let sequencer = Sequencer::new(Uuid::now_v7());
+        let a = SeqKey::for_handler(&test_actor_id("worker_0", "worker"));
+        let b = SeqKey::for_handler(&test_actor_id("worker_1", "worker"));
+        let keys = [a.clone(), b.clone(), a.clone(), b, a];
+
+        // WHEN the batch is assigned.
+        let runs = sequencer.assign_seqs(&keys);
+
+        // THEN every occurrence advances its key and adjacent equal values coalesce.
+        assert_eq!(runs, vec![(0..2, 1), (2..4, 2), (4..5, 3)]);
+    }
+
+    #[test]
+    fn assign_seqs_matches_assign_seq_after_mixed_history() {
+        // GIVEN scalar and batch sequencers with the same mixed history and a
+        // batch chunk size smaller than the requested assignment.
+        let config = hyperactor_config::global::lock();
+        let _guard = config.override_key(
+            crate::config::SEQUENCER_MAX_LOCKED_KEYS,
+            hyperactor_config::NonZeroUsize::new(2).expect("2 is non-zero"),
+        );
+        let scalar = Sequencer::new(Uuid::now_v7());
+        let batch = Sequencer::new(Uuid::now_v7());
+
+        let actor_0 = test_actor_id("worker_0", "worker");
+        let actor_1 = test_actor_id("worker_1", "worker");
+        let ports = [
+            actor_0.port_addr(Port::handler::<TestMsg1>()),
+            actor_1.port_addr(Port::handler::<TestMsg1>()),
+            actor_0.port_addr(Port::from(1)),
+        ];
+        for index in [0, 2, 0] {
+            assert_eq!(
+                get_seq(scalar.assign_seq(&ports[index])),
+                get_seq(batch.assign_seq(&ports[index]))
+            );
+        }
+
+        // WHEN one sequencer assigns an interleaved batch and the other uses scalars.
+        let indexes = [0, 1, 0, 2, 1];
+        let expected: Vec<_> = indexes
+            .iter()
+            .map(|&index| get_seq(scalar.assign_seq(&ports[index])))
+            .collect();
+        // `[(0..2, 1), (2..5, 2)]` -> `[1, 1, 2, 2, 2]`.
+        let actual: Vec<_> = {
+            let keys: Vec<_> = indexes
+                .iter()
+                .map(|&index| {
+                    let port = &ports[index];
+                    if port.is_handler_port() {
+                        SeqKey::for_handler(&port.actor_addr())
+                    } else {
+                        SeqKey::for_ephemeral_port(port).expect("test port must be ephemeral")
+                    }
+                })
+                .collect();
+
+            batch
+                .assign_seqs(&keys)
+                .into_iter()
+                .flat_map(|(range, seq)| range.map(move |_| seq))
+                .collect()
+        };
+
+        // THEN both APIs assign the same values and leave the same subsequent state.
+        assert_eq!(actual, expected);
+        for port in &ports {
+            assert_eq!(
+                get_seq(scalar.assign_seq(port)),
+                get_seq(batch.assign_seq(port))
+            );
+        }
+    }
+
+    #[test]
     fn test_sequencer_clone() {
         let sequencer = Sequencer {
             session_id: Uuid::now_v7(),
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         };
 
         let actor_ref: ActorAddr = test_actor_id("test_0", "test");
@@ -394,7 +602,7 @@ mod tests {
     fn test_sequencer_handler_ports_share_sequence() {
         let sequencer = Sequencer {
             session_id: Uuid::now_v7(),
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         };
 
         let actor_ref: ActorAddr = test_actor_id("worker_0", "worker");
@@ -417,7 +625,7 @@ mod tests {
     fn test_sequencer_non_handler_ports_have_independent_sequences() {
         let sequencer = Sequencer {
             session_id: Uuid::now_v7(),
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         };
 
         let actor_ref_0: ActorAddr = test_actor_id("worker_0", "worker");
@@ -444,7 +652,7 @@ mod tests {
     fn test_sequencer_mixed_handler_and_non_handler_ports() {
         let sequencer = Sequencer {
             session_id: Uuid::now_v7(),
-            last_seqs: Arc::new(Mutex::new(HashMap::new())),
+            last_seqs: Arc::new(Mutex::new(FxHashMap::default())),
         };
 
         let actor_ref: ActorAddr = test_actor_id("worker_0", "worker");

--- a/hyperactor/src/value_mesh.rs
+++ b/hyperactor/src/value_mesh.rs
@@ -23,6 +23,7 @@ use std::ptr;
 use std::ptr::NonNull;
 
 use futures::Future;
+use ndslice::Slice;
 use ndslice::extent;
 use ndslice::view;
 use ndslice::view::Ranked;
@@ -562,6 +563,29 @@ impl<T: 'static> ValueMesh<T> {
 impl<T: Clone + 'static> view::RankedSliceable for ValueMesh<T> {
     fn sliced(&self, region: Region) -> Self {
         debug_assert!(region.is_subset(self.region()), "sliced: not a subset");
+
+        match &self.rep {
+            Rep::Dense { .. } => self.slice_dense(region),
+            Rep::Compressed { .. } if region.num_ranks() == 0 => Self {
+                region,
+                rep: Rep::Compressed {
+                    table: Vec::new(),
+                    runs: Vec::new(),
+                },
+            },
+            Rep::Compressed { table, runs } => {
+                let source_ordinal_slice = region
+                    .slice()
+                    .relative_ordinal_slice(self.region.slice())
+                    .expect("sliced region should preserve the parent dimensions");
+                self.slice_compressed(region, table, runs, source_ordinal_slice)
+            }
+        }
+    }
+}
+
+impl<T: Clone + 'static> ValueMesh<T> {
+    fn slice_dense(&self, region: Region) -> Self {
         let ranks: Vec<T> = self
             .region()
             .remap(&region)
@@ -574,6 +598,152 @@ impl<T: Clone + 'static> view::RankedSliceable for ValueMesh<T> {
             "sliced: cardinality mismatch"
         );
         Self::new_unchecked(region, ranks)
+    }
+
+    /// Slice an RLE mesh without visiting every selected rank.
+    ///
+    /// For each source run that intersects the slice, find the first selected
+    /// rank inside the run and the first selected rank after the run. These
+    /// slice-relative ranks become the start and end of an output run.
+    ///
+    /// `slice_ordinals` maps each ordinal in the result to an ordinal in the
+    /// source mesh. For each source run, walking the dimensions finds the last
+    /// selected rank inside the run without visiting each selected rank.
+    ///
+    /// ```text
+    /// slice_ordinals: sizes=[3, 3], strides=[8, 2], offset=9
+    ///
+    ///    9 _ 11 _ 13
+    ///   17 _ 19 _ 21
+    ///   25 _ 27 _ 29
+    ///
+    /// source runs:  A=[0,13)  B=[13,20)  C=[20,40)
+    /// selected:       A  A      B  B  B      C  C  C  C
+    /// output runs:  A=[0,2)   B=[2,5)     C=[5,9)
+    /// ```
+    ///
+    /// Work therefore scales with intersecting source runs rather than selected
+    /// ranks when the source compresses well.
+    fn slice_compressed(
+        &self,
+        slice_region: Region,
+        value_table: &[T],
+        source_runs: &[Run],
+        slice_ordinals: Slice,
+    ) -> Self {
+        // Find the last slice ordinal at or before a source ordinal by jumping
+        // as far as possible in each dimension.
+        //
+        // For example, use a dense 2 x 3 x 4 slice:
+        //
+        //   sizes:   [2, 3, 4]
+        //   strides: [12, 4, 1]
+        //   offset:  0
+        //
+        // The source contains these runs:
+        //
+        //   A=[0,3)  B=[3,19)  C=[19,24)
+        //
+        //   page 0                  page 1
+        //    0A  1A  2A  3B        12B 13B 14B 15B
+        //    4B  5B  6B  7B        16B 17B 18B 19C
+        //    8B  9B 10B 11B        20C 21C 22C 23C
+        //
+        // B ends at 19, so its last source ordinal is 18. Decompose 18 across
+        // the dimensions:
+        //
+        //   page:   18 / 12 = 1  -> slice ordinal 12, remainder 6
+        //   row:     6 /  4 = 1  -> slice ordinal 16, remainder 2
+        //   column:  2 /  1 = 2  -> slice ordinal 18, remainder 0
+        //
+        // The last slice ordinal in B is 18. The exclusive end of the output
+        // run is therefore 19. This takes one step per dimension and does not
+        // visit source ordinals 3 through 18 individually.
+        let last_slice_ordinal_at_or_before = |source_ordinal: usize| {
+            let mut distance = source_ordinal - slice_ordinals.offset();
+            let mut slice_stride = slice_region.num_ranks();
+            let mut slice_ordinal = 0;
+
+            for (&dim_size, &source_stride) in
+                slice_ordinals.sizes().iter().zip(slice_ordinals.strides())
+            {
+                slice_stride /= dim_size;
+                let coordinate = (distance / source_stride).min(dim_size - 1);
+                slice_ordinal += coordinate * slice_stride;
+                distance -= coordinate * source_stride;
+            }
+
+            slice_ordinal
+        };
+
+        let source_ordinal_at = |mut slice_ordinal: usize| {
+            let mut source_ordinal = slice_ordinals.offset();
+
+            for (&dim_size, &stride) in slice_ordinals
+                .sizes()
+                .iter()
+                .zip(slice_ordinals.strides())
+                .rev()
+            {
+                source_ordinal += slice_ordinal % dim_size * stride;
+                slice_ordinal /= dim_size;
+            }
+
+            source_ordinal
+        };
+
+        let mut slice_runs: Vec<Run> = Vec::new();
+        let mut slice_ordinal_cursor = 0usize;
+        let mut source_ordinal_cursor = slice_ordinals.offset();
+        let mut source_run_index = 0usize;
+
+        while slice_ordinal_cursor < slice_region.num_ranks() {
+            // Slice iteration and source runs are both ordered, so this cursor
+            // only moves forward. Strided selections can skip complete runs.
+            while source_runs
+                .get(source_run_index)
+                .is_some_and(|run| run.end as usize <= source_ordinal_cursor)
+            {
+                source_run_index += 1;
+            }
+
+            let source_run = &source_runs[source_run_index];
+            debug_assert!(source_run.start as usize <= source_ordinal_cursor);
+
+            let next_slice_ordinal =
+                last_slice_ordinal_at_or_before(source_run.end as usize - 1) + 1;
+
+            if let Some(previous_run) = slice_runs.last_mut()
+                && previous_run.id == source_run.id
+            {
+                // `Run` has same value as the previous `Run`, extend the previous `Run`:
+                //   source runs:    2A  2B  2A
+                //   selected ranks: 2A      2A
+                //   output:         4A
+                previous_run.end = next_slice_ordinal as u64;
+            } else {
+                // Append `Run` to end
+                slice_runs.push(Run::new(
+                    slice_ordinal_cursor,
+                    next_slice_ordinal,
+                    source_run.id,
+                ));
+            }
+
+            slice_ordinal_cursor = next_slice_ordinal;
+
+            if slice_ordinal_cursor < slice_region.num_ranks() {
+                source_ordinal_cursor = source_ordinal_at(slice_ordinal_cursor);
+            }
+        }
+
+        Self {
+            region: slice_region,
+            rep: Rep::Compressed {
+                table: value_table.to_vec(),
+                runs: slice_runs,
+            },
+        }
     }
 }
 
@@ -1097,6 +1267,93 @@ mod tests {
     use typeuri::Named;
 
     use super::*;
+
+    /// Generates supported rectangular slicing cases.
+    fn rectangular_slicing_case() -> impl Strategy<Value = (Region, Region, Vec<u8>)> {
+        // Generate one- to four-dimensional parents with small, sometimes
+        // singleton extents.
+        prop::collection::vec(1usize..=5, 1..=4)
+            // Bound the work performed by each property-test case.
+            .prop_filter("rank count must stay small", |sizes| {
+                sizes.iter().product::<usize>() <= 256
+            })
+            // Generate the affine layout, rectangular selection, and values
+            // after the parent shape determines their lengths.
+            .prop_flat_map(|sizes| {
+                let num_dims = sizes.len();
+                let num_ranks: usize = sizes.iter().product();
+                (
+                    Just(sizes),
+                    // Exercise arbitrary base-rank offsets.
+                    0usize..=16,
+                    // Exercise dense row-major layouts with scaled strides.
+                    1usize..=4,
+                    // Seed a nonempty contiguous or strided range per dimension.
+                    prop::collection::vec((0usize..=32, 0usize..=32, 0usize..=32), num_dims),
+                    // A small alphabet produces merged and fragmented RLE runs.
+                    prop::collection::vec(0u8..=3, num_ranks),
+                )
+            })
+            // Convert the generated parameters into a parent region and one
+            // rectangular subregion.
+            .prop_map(|(sizes, offset, scale, ranges, values)| {
+                let labels: Vec<_> = (0..sizes.len()).map(|dim| format!("d{dim}")).collect();
+                let mut strides = vec![0; sizes.len()];
+                let mut stride = scale;
+                for dim in (0..sizes.len()).rev() {
+                    strides[dim] = stride;
+                    stride *= sizes[dim];
+                }
+
+                let region = Region::new(
+                    labels.clone(),
+                    Slice::new(offset, sizes.clone(), strides)
+                        .expect("generated parent slice should be valid"),
+                );
+                let selected = ranges.into_iter().enumerate().fold(
+                    region.clone(),
+                    |selected, (dim, (begin_seed, end_seed, step_seed))| {
+                        let begin = begin_seed % sizes[dim];
+                        let end = begin + 1 + end_seed % (sizes[dim] - begin);
+                        let valid_steps: Vec<_> = (1..=sizes[dim])
+                            .filter(|step| sizes[dim].is_multiple_of(*step))
+                            .collect();
+                        let step = valid_steps[step_seed % valid_steps.len()];
+                        selected
+                            .range(&labels[dim], ndslice::Range(begin, Some(end), step))
+                            .expect("generated range should be valid")
+                    },
+                );
+
+                (region, selected, values)
+            })
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(512))]
+
+        #[test]
+        fn compressed_slicing_matches_dense_slicing(
+            (region, selected, values) in rectangular_slicing_case()
+        ) {
+            let dense = ValueMesh::new_unchecked(region, values);
+            let mut compressed = dense.clone();
+            compressed.compress_adjacent_in_place();
+
+            let expected = dense.sliced(selected.clone());
+            let actual = compressed.sliced(selected);
+
+            prop_assert_eq!(actual.region(), expected.region());
+            prop_assert_eq!(
+                actual.values().collect::<Vec<_>>(),
+                expected.values().collect::<Vec<_>>(),
+            );
+            prop_assert!(
+                matches!(actual.rep, Rep::Compressed { .. }),
+                "the supported rectangular selection should stay compressed",
+            );
+        }
+    }
 
     #[test]
     fn value_mesh_new_ok() {

--- a/hyperactor_cast/src/cast_actor.rs
+++ b/hyperactor_cast/src/cast_actor.rs
@@ -39,6 +39,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::sync::OnceLock;
 
 use anyhow::Result;
 use async_trait::async_trait;
@@ -70,14 +71,15 @@ use hyperactor::mailbox::UndeliverableReason;
 use hyperactor::mailbox::monitored_return_handle;
 use hyperactor::ordering::SEQ_INFO;
 use hyperactor::ordering::SeqInfo;
+use hyperactor::ordering::SeqKey;
 use hyperactor::port::Port;
 use hyperactor::value_mesh::ValueMesh;
 use hyperactor_config::Flattrs;
 use ndslice::Point;
 use ndslice::Region;
-use ndslice::view::MapIntoExt;
 use ndslice::view::RankedSliceable;
 use ndslice::view::View;
+use ndslice::view::ViewExt;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -275,6 +277,9 @@ pub struct CastDomainRef {
     subtrees: Vec<CastSubtree>,
     /// Destination actor addresses keyed by this domain's rank space.
     members: Arc<ValueMesh<ActorAddr>>,
+    /// Per-rank handler sequence keys derived lazily from `members`.
+    #[serde(skip)]
+    seq_keys: Arc<OnceLock<Arc<Vec<SeqKey>>>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -294,6 +299,7 @@ impl CastDomainRef {
             id,
             subtrees,
             members,
+            seq_keys: Arc::new(OnceLock::new()),
         }
     }
 
@@ -344,7 +350,7 @@ impl CastDomainRef {
         let mut data = wirevalue::Any::<wirevalue::encoding::Multipart>::serialize(&message)?;
         let sender = cx.mailbox().actor_addr().clone();
         let dest_port = M::port();
-        let (session_id, seqs) = self.seqs_for_cast(cx, dest_port)?;
+        let (session_id, seqs) = self.seqs_for_cast(cx)?;
 
         let cast_headers = headers.clone();
         let subtree_seqs = self
@@ -426,24 +432,24 @@ impl CastDomainRef {
     /// forwarding hops do not need route-local metadata to derive receiver
     /// ordering. `ValueMesh` preserves the domain rank space while allowing
     /// compact representations when seqs happen to be compressible.
-    fn seqs_for_cast(
-        &self,
-        cx: &impl context::Actor,
-        dest_port: u64,
-    ) -> Result<(Uuid, ValueMesh<u64>)> {
+    fn seqs_for_cast(&self, cx: &impl context::Actor) -> Result<(Uuid, ValueMesh<u64>)> {
         let sequencer = cx.instance().sequencer();
 
-        let mut seqs: ValueMesh<u64> = self.members.as_ref().map_into(|member| {
-            let port = member.port_addr(Port::handler_id(dest_port, None));
-            let SeqInfo::Session { session_id: _, seq } = sequencer.assign_seq(&port) else {
-                unreachable!("assign_seq always returns SeqInfo::Session");
-            };
-            seq
-        });
-
-        seqs.compress_adjacent_in_place();
-
-        Ok((sequencer.session_id(), seqs))
+        Ok((
+            sequencer.session_id(),
+            ValueMesh::from_ranges_with_default(
+                self.members.region().clone(),
+                0,
+                sequencer.assign_seqs(self.seq_keys.get_or_init(|| {
+                    Arc::new(
+                        self.members
+                            .values()
+                            .map(|member| SeqKey::for_handler(&member))
+                            .collect(),
+                    )
+                })),
+            )?,
+        ))
     }
 }
 

--- a/ndslice/src/slice.rs
+++ b/ndslice/src/slice.rs
@@ -48,6 +48,9 @@ pub enum SliceError {
 
     #[error("dimension {dim} out of range for {ndims}-dimensional slice")]
     DimensionOutOfRange { dim: usize, ndims: usize },
+
+    #[error("slice arithmetic overflow")]
+    ArithmeticOverflow,
 }
 
 /// Slice is a compact representation of indices into the flat
@@ -193,6 +196,86 @@ impl Slice {
     /// element at a given index in the underlying array.
     pub fn strides(&self) -> &[usize] {
         &self.strides
+    }
+
+    /// Express this slice in the ordinal space of `parent`.
+    ///
+    /// Returns an error if this slice does not select a valid, dimension-
+    /// preserving subregion of `parent`.
+    ///
+    /// ```text
+    /// parent ranks (offset=100, sizes=[4, 4], strides=[8, 2]):
+    /// 100  102   104  106
+    /// 108 [110] [112] 114
+    /// 116  118   120  122
+    /// 124 [126] [128] 130
+    ///
+    /// self:              offset=110, sizes=[2, 2], strides=[16, 2]
+    /// selected ranks:   [110, 112, 126, 128]
+    /// parent ordinals:  [  5,   6,  13,  14]
+    /// result: offset=5, sizes=[2, 2], strides=[8, 1]
+    /// ```
+    pub fn relative_ordinal_slice(&self, parent: &Self) -> Result<Self, SliceError> {
+        if parent.num_dim() != self.num_dim() {
+            return Err(SliceError::InvalidDims {
+                expected: parent.num_dim(),
+                got: self.num_dim(),
+            });
+        }
+
+        // parent_coordinates: [1, 1]
+        let parent_coordinates = parent.coordinates(self.offset())?;
+        // offset: 5
+        let offset = parent.index(self.offset())?;
+        // parent_ordinal_strides: [4, 1]
+        let parent_ordinal_strides = Slice::new_row_major(parent.sizes().to_vec());
+        let strides = self
+            .sizes()
+            .iter()
+            .enumerate()
+            .map(|(dimension, &extent)| -> Result<usize, SliceError> {
+                if extent == 1 {
+                    return Ok(parent_ordinal_strides.strides()[dimension]);
+                }
+
+                let parent_stride = parent.strides()[dimension];
+                let selected_stride = self.strides()[dimension];
+                if !selected_stride.is_multiple_of(parent_stride) {
+                    return Err(SliceError::IncompatibleView {
+                        reason: format!(
+                            "stride {selected_stride} in dimension {dimension} is not a multiple of parent stride {parent_stride}"
+                        ),
+                    });
+                }
+
+                let step = selected_stride / parent_stride;
+                {
+                    let last_coordinate = parent_coordinates[dimension]
+                        .checked_add(
+                            extent
+                                .checked_sub(1)
+                                .and_then(|extent| extent.checked_mul(step))
+                                .ok_or(SliceError::ArithmeticOverflow)?,
+                        )
+                        .ok_or(SliceError::ArithmeticOverflow)?;
+
+                    if last_coordinate >= parent.sizes()[dimension] {
+                        return Err(SliceError::IncompatibleView {
+                            reason: format!(
+                                "dimension {dimension} ends at coordinate {last_coordinate}, outside parent extent {}",
+                                parent.sizes()[dimension]
+                            ),
+                        });
+                    }
+                }
+
+                parent_ordinal_strides.strides()[dimension]
+                    .checked_mul(step)
+                    .ok_or(SliceError::ArithmeticOverflow)
+            })
+            .collect::<Result<_, _>>()?;
+
+        Self::new(offset, self.sizes().to_vec(), strides)
     }
 
     pub fn is_contiguous(&self) -> bool {
@@ -938,6 +1021,30 @@ mod tests {
 
         let s = Slice::new(0, vec![2, 2], vec![4, 2]).unwrap();
         assert_eq!(s.index(2).unwrap(), 1);
+    }
+
+    #[test]
+    fn relative_ordinal_slice_maps_selected_ranks_into_parent_ordinals() {
+        let parent = Slice::new(100, vec![4, 4], vec![8, 2]).expect("parent should be valid");
+        let selected = Slice::new(110, vec![2, 2], vec![16, 2]).expect("selection should be valid");
+
+        assert_eq!(
+            selected
+                .relative_ordinal_slice(&parent)
+                .expect("selection should map into parent ordinals"),
+            Slice::new(5, vec![2, 2], vec![8, 1]).expect("result should be valid")
+        );
+    }
+
+    #[test]
+    fn relative_ordinal_slice_rejects_selection_that_wraps_parent_dimension() {
+        let parent = Slice::new_row_major(vec![2, 4]);
+        let selected = Slice::new(1, vec![1, 4], vec![4, 1]).expect("selection should be valid");
+
+        assert!(matches!(
+            selected.relative_ordinal_slice(&parent),
+            Err(SliceError::IncompatibleView { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION
Summary:

https://www.internalfb.com/collab-files/view/paste%3A2448576763?view=focus
{F1993424637} 
{F1993424656} 

Currently we slice RLE'd `ValueMesh`es using the same algorithm as dense `ValueMesh`es, which is O(ranks), and also produces a dense `ValueMesh` losing the RLE. 

We should be exploiting the RLE to slice in a more computationally efficient way and also producing an RLE'd `ValueMesh`.

The trickiest part of this is computing what the `Run`s for the sliced `ValueMesh` would be.

A `Run` consists of a start, end, and value.

The algorithm for this is just: 

For each run that intersects with the `Slice`: 
1. Find the first `Slice` rank inside the run
2. Find the first`Slice` rank after the `Run`,
3. Emit output `Run` using `Slice` relative ranks as its start and end.

Within this, the hardest part is finding the first `Slice` rank after the `Run`. 

The way this is done efficiently is to start with the distance from the slice offset to the last source ordinal in the Run. 

We work from the highest dimension to the lowest dimension. 

For each dimension, we calculate how many units we can jump without passing the last source ordinal. We make that jump, subtract its distance, and continue with the next lower dimension.

This gives us the last Slice rank inside the Run. We add one to get the exclusive end of the output Run.

For example with a 3D slice with dimensions page, row, col, with sizes 2 x 3 x 4:
```
sizes:   [2, 3, 4]
strides: [12, 4, 1]
offset:  0
```
The source contains these runs:
```
A=[0,3)  B=[3,19)  C=[19,24)
page 0                  page 1
0A  1A  2A  3B        12B 13B 14B 15B
4B  5B  6B  7B        16B 17B 18B 19C
8B  9B 10B 11B        20C 21C 22C 23C
```
B ends at 19, so its last source ordinal is 18. Decompose 18 across
the dimensions:
```
page:   18 / 12 = 1  -> slice ordinal 12, remainder 6
row:     6 /  4 = 1  -> slice ordinal 16, remainder 2
column:  2 /  1 = 2  -> slice ordinal 18, remainder 0
```
The last slice ordinal in B is 18. The exclusive end of the output
run is therefore 19. This takes one step per dimension and does not
visit source ordinals 3 through 18 individually.

Differential Revision: D114441915


