### PR TITLE
Apply time retention to trace tables (#4573)

### DIFF
--- a/docs/source/distributed-telemetry.md
+++ b/docs/source/distributed-telemetry.md
@@ -121,11 +121,14 @@ continue operating.
 
 ## Retention and snapshots
 
-`TelemetryConfig.retention_secs` applies to `sent_messages`, `messages`, and
-`message_status_events`. The default is 600 seconds. Set it to `0` to disable
-automatic retention. Retention runs every 30 seconds, so expired rows can
-remain visible until the next sweep. Other core tables have no automatic
-retention window.
+`TelemetryConfig.retention_secs` applies to `sent_messages`, `messages`,
+`message_status_events`, `spans`, `span_events`, and `events`. Trace tables are
+filtered independently by row timestamp, with spans filtered before dependent
+trace rows. A recent trace row is not displayed by span-joined views if its span
+has already expired. The default is 600 seconds. Set it to `0` to disable
+automatic retention. Retention runs every 30 seconds, so expired rows can remain
+visible until the next sweep. Other core tables have no automatic retention
+window.
 
 `TelemetryConfig.snapshot_interval_secs` controls periodic Mesh Admin topology
 snapshots. The default is 30 seconds; set it to `0` to disable them. Snapshots

--- a/docs/source/observability.md
+++ b/docs/source/observability.md
@@ -85,7 +85,7 @@ are not a durable event archive.
 
 | `TelemetryConfig` field | Default | Effect |
 |-------------------------|---------|--------|
-| `retention_secs` | `600` | Retention window for message tables; `0` disables retention |
+| `retention_secs` | `600` | Retention window for message and trace tables; `0` disables retention |
 | `include_dashboard` | `False` | Advertise the browser dashboard |
 | `dashboard_port` | `8265` | Preferred dashboard port; use `0` for an ephemeral port |
 | `snapshot_interval_secs` | `30` | Mesh-introspection snapshot interval; `0` disables periodic snapshots |

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -4349,8 +4349,16 @@ impl InstanceCell {
             return;
         }
         let old = old_status.expect("status change should capture previous status");
-        let actor_id = hash_to_u64(self.actor_addr().id());
+        // Idle/Processing transitions are omitted because they occur for every
+        // message. Duplicate status updates are omitted as well.
+        if (old.is_idle() && new.is_processing())
+            || (old.is_processing() && new.is_idle())
+            || old == new
+        {
+            return;
+        }
 
+        let actor_id = hash_to_u64(self.actor_addr().id());
         let new_status = new.arm().unwrap_or("unknown");
         let change_reason = match &new {
             ActorStatus::Failed(reason) => Some(reason.to_string()),
@@ -4359,22 +4367,15 @@ impl InstanceCell {
             _ => None,
         };
 
-        // Idle/Processing transitions are persisted but omitted from logs because
-        // they occur for every message.
-        if !((old.is_idle() && new.is_processing())
-            || (old.is_processing() && new.is_idle())
-            || old == new)
-        {
-            tracing::info!(
-                name = "ActorStatus",
-                actor_id = %self.actor_addr(),
-                actor_name = self.actor_addr().log_name(),
-                status = new_status,
-                prev_status = old.arm().unwrap_or("unknown"),
-                caller = %PanicLocation::caller(),
-                change_reason = change_reason.as_deref().unwrap_or(""),
-            );
-        }
+        tracing::info!(
+            name = "ActorStatus",
+            actor_id = %self.actor_addr(),
+            actor_name = self.actor_addr().log_name(),
+            status = new_status,
+            prev_status = old.arm().unwrap_or("unknown"),
+            caller = %PanicLocation::caller(),
+            change_reason = change_reason.as_deref().unwrap_or(""),
+        );
         notify_actor_status_changed(ActorStatusEvent {
             id: generate_actor_status_event_id(actor_id),
             timestamp: std::time::SystemTime::now(),

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -37,6 +37,12 @@ use monarch_hyperactor::mailbox::PyPortId;
 use monarch_hyperactor::runtime::get_tokio_runtime;
 use monarch_record_batch::RecordBatchBuffer;
 use monarch_telemetry_schema::deserialize_one_batch;
+use monarch_telemetry_schema::entity_tables::MESSAGE_STATUS_EVENTS;
+use monarch_telemetry_schema::entity_tables::MESSAGES;
+use monarch_telemetry_schema::entity_tables::SENT_MESSAGES;
+use monarch_telemetry_schema::trace_tables::EVENTS;
+use monarch_telemetry_schema::trace_tables::SPAN_EVENTS;
+use monarch_telemetry_schema::trace_tables::SPANS;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
@@ -318,8 +324,15 @@ impl TableStore {
 /// Default retention duration: 10 minutes in seconds.
 const DEFAULT_RETENTION_SECS: u64 = 10 * 60;
 
-/// Tables that keep only recent data; all others have unlimited retention.
-const RETENTION_TABLES: &[&str] = &["sent_messages", "messages", "message_status_events"];
+/// Ordered tables that keep only recent data; trace definitions are filtered first.
+const RETENTION_TABLES: &[&str] = &[
+    SPANS,
+    SPAN_EVENTS,
+    EVENTS,
+    SENT_MESSAGES,
+    MESSAGES,
+    MESSAGE_STATUS_EVENTS,
+];
 
 /// Interval between routine retention sweeps.
 const RETENTION_INTERVAL: Duration = Duration::from_secs(30);
@@ -1050,6 +1063,12 @@ mod tests {
     use monarch_telemetry_schema::entity_tables::SENT_MESSAGES;
     use monarch_telemetry_schema::entity_tables::SentMessage;
     use monarch_telemetry_schema::entity_tables::SentMessageBuffer;
+    use monarch_telemetry_schema::trace_tables::Event;
+    use monarch_telemetry_schema::trace_tables::EventBuffer;
+    use monarch_telemetry_schema::trace_tables::Span;
+    use monarch_telemetry_schema::trace_tables::SpanBuffer;
+    use monarch_telemetry_schema::trace_tables::SpanEvent;
+    use monarch_telemetry_schema::trace_tables::SpanEventBuffer;
 
     use super::*;
 
@@ -1189,6 +1208,56 @@ mod tests {
             display_name: Some("fresh".to_string()),
         });
         ingest_batch(scanner, ACTORS, actors.drain_to_record_batch().unwrap()).await;
+
+        let mut spans = SpanBuffer::default();
+        for (id, timestamp_us, parent_id) in [(9, old_us, None), (10, fresh_us, Some(9))] {
+            spans.insert(Span {
+                id,
+                name: format!("span-{id}"),
+                target: "test".to_string(),
+                level: "INFO".to_string(),
+                fields_json: "{}".to_string(),
+                timestamp_us,
+                parent_id,
+                thread_name: "test".to_string(),
+                file: None,
+                line: None,
+            });
+        }
+        ingest_batch(scanner, SPANS, spans.drain_to_record_batch().unwrap()).await;
+
+        let mut span_events = SpanEventBuffer::default();
+        for (timestamp_us, event_type) in [(old_us, "enter"), (fresh_us, "close")] {
+            span_events.insert(SpanEvent {
+                id: 9,
+                timestamp_us,
+                event_type: event_type.to_string(),
+            });
+        }
+        ingest_batch(
+            scanner,
+            SPAN_EVENTS,
+            span_events.drain_to_record_batch().unwrap(),
+        )
+        .await;
+
+        let mut events = EventBuffer::default();
+        for (name, timestamp_us) in [("old", old_us), ("fresh", fresh_us)] {
+            events.insert(Event {
+                name: name.to_string(),
+                target: "test".to_string(),
+                level: "INFO".to_string(),
+                fields_json: "{}".to_string(),
+                timestamp_us,
+                parent_span: Some(9),
+                thread_id: "1".to_string(),
+                thread_name: "test".to_string(),
+                module_path: None,
+                file: None,
+                line: None,
+            });
+        }
+        ingest_batch(scanner, EVENTS, events.drain_to_record_batch().unwrap()).await;
     }
 
     async fn table_row_count_async(scanner: &DatabaseScanner, table_name: &str) -> usize {
@@ -1197,6 +1266,64 @@ mod tests {
             Some(table) => row_count(&table).await,
             None => 0,
         }
+    }
+
+    async fn table_u64_values_async(
+        scanner: &DatabaseScanner,
+        table_name: &str,
+        column_name: &str,
+    ) -> Vec<u64> {
+        let table = scanner
+            .table_data
+            .lock()
+            .expect("table map should be available")
+            .get(table_name)
+            .expect("table should exist")
+            .clone();
+        let batches = table.mem_table.batches[0].read().await;
+        batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name(column_name)
+                    .expect("column should exist")
+                    .as_any()
+                    .downcast_ref::<UInt64Array>()
+                    .expect("column should be UInt64")
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect()
+    }
+
+    async fn table_i64_values_async(
+        scanner: &DatabaseScanner,
+        table_name: &str,
+        column_name: &str,
+    ) -> Vec<i64> {
+        let table = scanner
+            .table_data
+            .lock()
+            .expect("table map should be available")
+            .get(table_name)
+            .expect("table should exist")
+            .clone();
+        let batches = table.mem_table.batches[0].read().await;
+        batches
+            .iter()
+            .flat_map(|batch| {
+                batch
+                    .column_by_name(column_name)
+                    .expect("column should exist")
+                    .as_any()
+                    .downcast_ref::<Int64Array>()
+                    .expect("column should be Int64")
+                    .values()
+                    .iter()
+                    .copied()
+            })
+            .collect()
     }
 
     #[tokio::test]
@@ -1422,7 +1549,28 @@ mod tests {
             table_row_count_async(&scanner, MESSAGE_STATUS_EVENTS).await,
             1
         );
+        assert_eq!(
+            table_u64_values_async(&scanner, SPANS, "id").await,
+            vec![10]
+        );
+        assert_eq!(
+            table_u64_values_async(&scanner, SPAN_EVENTS, "id").await,
+            vec![9]
+        );
+        assert_eq!(
+            table_i64_values_async(&scanner, EVENTS, "timestamp_us").await,
+            vec![fresh_us]
+        );
         assert_eq!(table_row_count_async(&scanner, ACTORS).await, 2);
+    }
+
+    #[test]
+    fn test_trace_retention_runs_spans_first() {
+        assert_eq!(
+            &RETENTION_TABLES[..3],
+            &[SPANS, SPAN_EVENTS, EVENTS],
+            "span definitions must be filtered before dependent trace rows"
+        );
     }
 
     #[test]

--- a/python/monarch/_src/job/telemetry_actor.py
+++ b/python/monarch/_src/job/telemetry_actor.py
@@ -66,8 +66,8 @@ class TelemetryActor(Actor):
         # Job-instance identifier; namespaces the per-host socket path under
         # /tmp so concurrent jobs on the same host do not collide.
         self._apply_id: str = apply_id
-        # Collector-side retention window in seconds for message tables; 0
-        # disables retention. Passed to DataFusion's periodic retention task.
+        # Collector-side retention window in seconds for message and trace
+        # tables; 0 disables retention. Passed to the periodic retention task.
         self._retention_secs: int = retention_secs
         # The DataFusion store + socket-ingest pair this actor owns. `None`
         # means this actor has not activated as the single live collector for

--- a/python/monarch/_src/job/telemetry_config.py
+++ b/python/monarch/_src/job/telemetry_config.py
@@ -82,7 +82,8 @@ class TelemetryConfig:
     called.
 
     Args:
-        retention_secs: Retention window in seconds for message tables.
+        retention_secs: Retention window in seconds for message and trace
+            history. Trace tables are filtered independently by row timestamp.
             0 disables retention.
         include_dashboard: Whether to start the monarch dashboard web server.
         dashboard_port: Preferred port for the dashboard.

--- a/python/tests/test_distributed_telemetry.py
+++ b/python/tests/test_distributed_telemetry.py
@@ -985,8 +985,7 @@ def test_actor_status_events_table() -> None:
 
 @pytest.mark.timeout(120)
 @isolate_in_subprocess
-@pytest.mark.parametrize("required_status", ["Created", "Processing"])
-def test_user_actor_status_lifecycle(required_status: str) -> None:
+def test_user_actor_status_lifecycle() -> None:
     with scoped_state(
         ProcessJob({"hosts": 1}).enable_telemetry(_sidecar_telemetry_config()),
         cached_path=None,
@@ -1012,32 +1011,13 @@ def test_user_actor_status_lifecycle(required_status: str) -> None:
             min_rows=3,
         )["id"]
         actor_ids = ", ".join(str(actor_id) for actor_id in actors)
-        required_count = 3 if required_status == "Created" else 6
-        _query(
-            state,
-            "SELECT ase.id FROM actor_status_events ase "
-            "JOIN actors a ON ase.actor_id = a.id "
-            "JOIN meshes m ON a.mesh_id = m.id "
-            f"WHERE m.given_name IN ('{_TELEMETRY_WORKER_MESH}', "
-            f"'{_TELEMETRY_COORDINATOR_MESH}') "
-            f"AND ase.new_status = '{required_status}'",
-            min_rows=required_count,
-        )
-        if required_status == "Processing":
-            _query(
-                state,
-                "SELECT ase.id FROM actor_status_events ase "
-                "WHERE ase.new_status = 'Idle' "
-                f"AND ase.actor_id IN ({actor_ids})",
-                min_rows=9,
-            )
         status_rows = _pydict_to_rows(
             _query(
                 state,
-                "SELECT actor_id, timestamp_us, new_status, reason "
+                "SELECT actor_id, new_status, reason "
                 "FROM actor_status_events "
                 f"WHERE actor_id IN ({actor_ids})",
-                min_rows=9,
+                min_rows=3 * len(actors),
             )
         )
 
@@ -1047,25 +1027,10 @@ def test_user_actor_status_lifecycle(required_status: str) -> None:
             }
             for actor_id in actors
         }
-        missing = {
-            actor_id: statuses
-            for actor_id, statuses in statuses_by_actor.items()
-            if required_status not in statuses
-        }
-        assert not missing, missing
-        if required_status == "Processing":
-            for actor_id in actors:
-                processing_at = max(
-                    row["timestamp_us"]
-                    for row in status_rows
-                    if row["actor_id"] == actor_id and row["new_status"] == "Processing"
-                )
-                idle_at = max(
-                    row["timestamp_us"]
-                    for row in status_rows
-                    if row["actor_id"] == actor_id and row["new_status"] == "Idle"
-                )
-                assert idle_at >= processing_at
+        assert all(
+            statuses == {"Created", "Initializing", "Idle"}
+            for statuses in statuses_by_actor.values()
+        ), statuses_by_actor
 
 
 @pytest.mark.timeout(120)
@@ -1083,14 +1048,13 @@ def test_actor_status_events_failed_actor() -> None:
                 state,
                 "SELECT new_status, reason FROM actor_status_events "
                 f"WHERE actor_id = {actor_id}",
-                min_rows=7,
+                min_rows=5,
             )
         )
         assert {row["new_status"] for row in rows} == {
             "Created",
             "Initializing",
             "Idle",
-            "Processing",
             "Stopping",
             "Failed",
         }, rows
@@ -1990,7 +1954,7 @@ def test_query_after_stopping_actor_mesh() -> None:
                 "JOIN actors a ON ase.actor_id = a.id "
                 "JOIN meshes m ON a.mesh_id = m.id "
                 "WHERE m.given_name = 'actor_stop_worker'",
-                min_rows=14,
+                min_rows=10,
             )
         )
         statuses_by_actor = {
@@ -2000,8 +1964,7 @@ def test_query_after_stopping_actor_mesh() -> None:
             for actor_id in {row["actor_id"] for row in status_rows}
         }
         assert all(
-            statuses
-            == {"Created", "Initializing", "Idle", "Processing", "Stopping", "Stopped"}
+            statuses == {"Created", "Initializing", "Idle", "Stopping", "Stopped"}
             for statuses in statuses_by_actor.values()
         ), statuses_by_actor
         assert all(


### PR DESCRIPTION
Summary:

- Apply `TelemetryConfig.retention_secs` independently to `spans`, `span_events`, and `events`.
- Filter spans before dependent trace rows in every sequential retention sweep.

from MITRA runs 4+ days, I was able to get:
1.05B span_events, 170M actor_status_events, and 117M spans

Reviewed By: johnwhumphreys

Differential Revision: D114778018


