### PR TITLE
Fix Monarch formatting borrows

### DIFF
--- a/hyperactor/src/channel.rs
+++ b/hyperactor/src/channel.rs
@@ -1926,7 +1926,7 @@ mod tests {
 
         for (raw, error) in cases_err {
             let Err(err) = raw.parse::<ChannelAddr>() else {
-                panic!("expected error parsing: {}", &raw)
+                panic!("expected error parsing: {}", raw)
             };
             assert_eq!(format!("{}", err), error);
         }

--- a/monarch_tensor_worker/src/stream.rs
+++ b/monarch_tensor_worker/src/stream.rs
@@ -1832,7 +1832,7 @@ impl StreamMessageHandler for StreamActor {
                             cx,
                             seq,
                             WorkerError {
-                                backtrace: format!("recording failed: {}", &seq_err),
+                                backtrace: format!("recording failed: {}", seq_err),
                                 worker_actor_id: cx.self_addr().clone(),
                             },
                         )


### PR DESCRIPTION
Summary: Remove redundant references in formatting macro arguments reported by `clippy::useless_borrows_in_formatting` under `fbcode/monarch`.

Reviewed By: dtolnay

Differential Revision: D113840267


