### PR TITLE
3/43 minimonarch: Add a self-send benchmark and deduplicate poller arming

### DIFF
--- a/monarch_mini/examples/bench.c
+++ b/monarch_mini/examples/bench.c
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+ * bench.c — minimal in-process self send->receive round-trip latency.
+ * Sends a small message to self, waits for it on the poller fd, repeats.
+ */
+
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include "minimonarch.h"
+
+#define CHECK(call)                                               \
+  do {                                                            \
+    mm_err_t _e = (call);                                         \
+    if (_e != MM_OK) {                                            \
+      fprintf(stderr, "%s failed: %s\n", #call, mm_last_error()); \
+      exit(1);                                                    \
+    }                                                             \
+  } while (0)
+
+static const char IDENT[] = "bench@root";
+
+static double now_s(void) {
+  struct timespec ts;
+  clock_gettime(CLOCK_MONOTONIC, &ts);
+  return (double)ts.tv_sec + (double)ts.tv_nsec * 1e-9;
+}
+
+int main(int argc, char** argv) {
+  int iters = argc > 1 ? atoi(argv[1]) : 1000;
+
+  mm_ctx_t ctx = NULL;
+  CHECK(mm_ctx_create(&ctx));
+  mm_msg_part_t ident = {
+      .data = IDENT,
+      .len = strlen(IDENT),
+      .deleter = NULL,
+      .deleter_ctx = NULL};
+  mm_actor_t actor = NULL;
+  CHECK(mm_actor_create(ctx, &ident, &actor));
+  int fd = -1;
+  mm_poller_t poller = NULL;
+  CHECK(mm_poller_create(ctx, &fd, &poller));
+  CHECK(mm_poller_subscribe(poller, 0, actor));
+
+  char payload[64] = {0};
+  mm_msg_part_t part = {
+      .data = payload,
+      .len = sizeof(payload),
+      .deleter = NULL,
+      .deleter_ctx = NULL};
+  mm_msg_t msg = {.parts = &part, .n_parts = 1};
+  mm_msg_part_t receiver = {
+      .data = IDENT,
+      .len = strlen(IDENT),
+      .deleter = NULL,
+      .deleter_ctx = NULL};
+
+  size_t index = 0;
+  mm_msg_part_t parts[4];
+  size_t n = 0;
+
+  // (A) Latency, poll-based: ping-pong, blocking on the poller fd (eventfd).
+  double start = now_s();
+  for (int i = 0; i < iters; i++) {
+    CHECK(mm_actor_send(actor, receiver, &msg));
+    for (;;) {
+      mm_err_t e = mm_poller_next(poller, &index, parts, 4, &n);
+      if (e == MM_OK) {
+        break;
+      }
+      if (e != MM_ENOMSG) {
+        fprintf(stderr, "next failed: %s\n", mm_last_error());
+        exit(1);
+      }
+      struct pollfd pfd = {.fd = fd, .events = POLLIN};
+      poll(&pfd, 1, -1);
+    }
+  }
+  double lat_poll = (now_s() - start) / iters;
+
+  // (A') Latency, busy-poll: ping-pong, spinning on mm_poller_next, never
+  // touching the eventfd/poll. Relies on the arm-dedup so the spin doesn't
+  // flood ArmPoller commands.
+  start = now_s();
+  for (int i = 0; i < iters; i++) {
+    CHECK(mm_actor_send(actor, receiver, &msg));
+    while (mm_poller_next(poller, &index, parts, 4, &n) != MM_OK) {
+      /* spin */
+    }
+  }
+  double lat_busy = (now_s() - start) / iters;
+
+  // (B) Throughput: send all, then drain all. Amortizes the cross-thread
+  // wakeup / eventfd / poll cost over many messages.
+  start = now_s();
+  for (int i = 0; i < iters; i++) {
+    CHECK(mm_actor_send(actor, receiver, &msg));
+  }
+  for (int got = 0; got < iters;) {
+    mm_err_t e = mm_poller_next(poller, &index, parts, 4, &n);
+    if (e == MM_OK) {
+      got++;
+    } else if (e == MM_ENOMSG) {
+      struct pollfd pfd = {.fd = fd, .events = POLLIN};
+      poll(&pfd, 1, -1);
+    } else {
+      fprintf(stderr, "next failed: %s\n", mm_last_error());
+      exit(1);
+    }
+  }
+  double thr = (now_s() - start) / iters;
+
+  printf("%d iters, 64 B:\n", iters);
+  printf("  latency (poll/eventfd): %.3f us/round-trip\n", lat_poll * 1e6);
+  printf("  latency (busy-poll):    %.3f us/round-trip\n", lat_busy * 1e6);
+  printf("  throughput (batched):   %.3f us/msg\n", thr * 1e6);
+
+  mm_poller_unsubscribe(poller, 0);
+  mm_poller_destroy(poller);
+  mm_actor_destroy(actor);
+  mm_ctx_destroy(ctx);
+  return 0;
+}

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -60,6 +60,14 @@ pub struct CPoller {
     rx: tokio::sync::mpsc::UnboundedReceiver<Delivered>,
     pending: Option<Delivered>,
     consumed_count: u64,
+    // The consumed_count at which we last armed the poller, if still armed. The
+    // server side is one-shot: it fires (writes the eventfd) once and disarms,
+    // and firing always enqueues a message first. So while try_recv() keeps
+    // returning Empty at the same consumed_count, the arm we sent is still live
+    // and there is no need to drain the eventfd or re-send ArmPoller. This makes
+    // a busy poll loop (repeated mm_poller_next without waiting) cheap: it only
+    // arms once per consumed message instead of on every empty poll.
+    armed_at: Option<u64>,
 }
 
 pub struct CMonitorHandle {
@@ -392,6 +400,9 @@ pub unsafe extern "C" fn mm_poller_create(
                 rx,
                 pending: None,
                 consumed_count: 0,
+                // The poller is created armed at 0 (PollerEntry::new), so mirror
+                // that here to avoid a redundant first arm.
+                armed_at: Some(0),
             }));
             Error::Ok
         }
@@ -462,11 +473,17 @@ pub unsafe extern "C" fn mm_poller_next(
         Ok(delivered) => delivered,
         Err(tokio::sync::mpsc::error::TryRecvError::Disconnected) => return Error::NoMsg,
         Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {
-            drain_eventfd(&p.event_fd);
-            let _ = p.ctx.send_command(Command::ArmPoller {
-                poller: p.key,
-                wake_after: p.consumed_count,
-            });
+            // Only drain + arm if we are not already armed at this count. A
+            // repeated empty poll (busy loop, or a spurious fd wakeup) needs
+            // neither, since the prior arm is still live.
+            if p.armed_at != Some(p.consumed_count) {
+                drain_eventfd(&p.event_fd);
+                let _ = p.ctx.send_command(Command::ArmPoller {
+                    poller: p.key,
+                    wake_after: p.consumed_count,
+                });
+                p.armed_at = Some(p.consumed_count);
+            }
             return Error::NoMsg;
         }
     };


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* __->__ #4578
* #4577
* #4576

Adds a C benchmark that measures self-send round-trip latency for eventfd and busy polling, along with batched message throughput. Tracks the poller's armed consumption count so repeated empty reads avoid redundant eventfd drains and `ArmPoller` commands.

Differential Revision: [D114750235](https://our.internmc.facebook.com/intern/diff/D114750235/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750235/)!