### PR TITLE
4/43 minimonarch: Add asyncio Python bindings

### DIFF
--- a/monarch_mini/python/.gitignore
+++ b/monarch_mini/python/.gitignore
@@ -1,0 +1,9 @@
+# Build intermediates and local environments for the minimonarch extension.
+build/
+*.so
+*.o
+*.egg-info/
+__pycache__/
+.pytest_cache/
+.venv/
+uv.lock

--- a/monarch_mini/python/minimonarch.c
+++ b/monarch_mini/python/minimonarch.c
@@ -1,0 +1,1254 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//
+// minimonarch.c — a small CPython extension that binds the minimonarch C API
+// (minimonarch.h) into asyncio-friendly Python objects, to make writing tests
+// against minimonarch easier.
+//
+// Surface. Single small values (idents, reasons) are bytes and copied;
+// multipart message bodies are lists of minimonarch.bytearray and moved.
+//
+//     ba = minimonarch.bytearray
+//     a = Actor(b'ident@root')            # creates (or reuses) a context
+//     a.send(b'ident@root', [ba(b'a'), ba(b'b')])
+//     parts = await a.next()              # -> list[minimonarch.bytearray]
+//     a.join('inproc://a', 'child')
+//     b = Actor(b'other@root')
+//     b.serve('inproc://b', 'parent')
+//     h = a.monitor(b'ident@root')        # -> MonitorHandle (unimplemented)
+//     h.cancel()
+//     a.die(b'reason')
+//
+// Design notes:
+//
+//   * Contexts live in a contextvars.ContextVar. The first Actor created in a
+//     given context lazily creates an mm_ctx_t + a single mm_poller_t and
+//     installs that poller's wakeup fd on the running asyncio loop. Every actor
+//     in the context subscribes to that one poller.
+//
+//   * The poller's fd reader drains mm_poller_next() and routes each delivered
+//     message onto the owning Actor's asyncio.Queue. next() is simply that
+//     queue's get(): it returns a buffered message immediately or suspends
+//     until one arrives. A message is a list of minimonarch.bytearray, each
+//     adopting a received buffer zero-copy; it can be moved straight back into
+//     another send(), so a buffer can ping-pong without ever being copied.
+//
+//   * No message part ever holds a Python reference, so no deleter ever needs
+//     the GIL — on any thread. Single-value args (a bytes ident/reason) are
+//     copied into a C buffer; multipart bodies are lists of bytearray whose
+//     storage is moved into the parts. Either way the part owns C memory and
+//     frees it with a plain free().
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+#include <stddef.h>
+#include <time.h>
+
+#include "minimonarch.h"
+
+// ---------------------------------------------------------------------------
+// Module-level cached objects
+// ---------------------------------------------------------------------------
+
+static PyObject* g_ctx_var; // ContextVar holding the current Context
+static PyObject* g_get_running_loop; // asyncio.get_running_loop
+static PyObject* g_queue_type; // asyncio.Queue
+static PyObject* g_pump_func; // C reader callback registered with add_reader
+
+// Actor.next() busy-pumps the poller for this long before falling back to the
+// fd/queue wait. This catches an imminent message directly off the poller and
+// skips the eventfd/epoll wakeup — and, by staying busy across the routing
+// thread's own park-wakeup, absorbs that latency too, roughly halving
+// round-trip time (~18 us -> ~8 us locally). 10 us is about the routing
+// thread's wakeup, which is the floor the message waits on; spinning longer
+// buys nothing, and it only spins while a message is pending (then sleeps on
+// the fd), so an idle consumer doesn't burn a core.
+//
+// This is safe only because the routing thread never blocks on the GIL: every
+// message part is a moved minimonarch.bytearray whose deleter is a plain free()
+// (no Python refcounting), so the runtime never needs the GIL the spinning
+// consumer holds. Otherwise the spin would starve the routing thread.
+#define NEXT_SPIN_NS 10000L
+
+static PyTypeObject ContextType;
+static PyTypeObject ActorType;
+static PyTypeObject MonitorHandleType;
+
+// ---------------------------------------------------------------------------
+// Object layouts
+// ---------------------------------------------------------------------------
+
+typedef struct {
+  PyObject_HEAD mm_ctx_t ctx;
+  mm_poller_t poller;
+  int fd;
+  PyObject* loop; // strong ref to the asyncio loop
+  PyObject* queues; // dict: index(int) -> asyncio.Queue
+  PyObject* token; // ContextVar token from the Set that installed us
+  size_t next_index;
+  int reader_installed;
+  int closed; // resources released; shutdown is idempotent
+  PyObject* weakreflist; // so the loop's reader can hold us weakly
+} Context;
+
+typedef struct {
+  PyObject_HEAD mm_actor_t actor;
+  Context* ctx; // strong ref
+  size_t index; // poller subscription index
+  PyObject* queue; // this actor's asyncio.Queue (also held in ctx->queues)
+} Actor;
+
+typedef struct {
+  PyObject_HEAD mm_monitor_handle_t handle;
+} MonitorHandle;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+static int set_mm_error(void) {
+  PyErr_SetString(PyExc_RuntimeError, mm_last_error());
+  return -1;
+}
+
+// ---------------------------------------------------------------------------
+// bytearray — a writable, growable byte buffer (like Python's bytearray) whose
+// C-owned storage can be *moved* into a message part. After a move the part
+// owns the allocation and frees it with a plain free() — no GIL on the runtime
+// thread — and the bytearray is left empty.
+//
+// The C type is named ByteArray; it is exposed to Python as
+// minimonarch.bytearray.
+// ---------------------------------------------------------------------------
+
+typedef struct {
+  PyObject_HEAD char* data; // malloc'd; NULL when empty/moved
+  Py_ssize_t len;
+  Py_ssize_t cap;
+  Py_ssize_t exports; // outstanding buffer-protocol views; block resize/move
+} ByteArray;
+
+static PyTypeObject ByteArrayType;
+
+static void free_deleter(void* ctx) {
+  free(ctx);
+}
+
+static int bytearray_reserve(ByteArray* b, Py_ssize_t need) {
+  if (need <= b->cap) {
+    return 0;
+  }
+  Py_ssize_t cap = b->cap ? b->cap : 8;
+  while (cap < need) {
+    cap *= 2;
+  }
+  char* grown = realloc(b->data, (size_t)cap);
+  if (!grown) {
+    PyErr_NoMemory();
+    return -1;
+  }
+  b->data = grown;
+  b->cap = cap;
+  return 0;
+}
+
+// Resizing or moving while a memoryview is exported would dangle that view.
+static int bytearray_check_mutable(ByteArray* b) {
+  if (b->exports > 0) {
+    PyErr_SetString(
+        PyExc_BufferError,
+        "bytearray has exported views; cannot resize or move");
+    return -1;
+  }
+  return 0;
+}
+
+// Move the storage into `out` (free deleter) and reset the ByteArray to empty.
+// Returns -1 (exception set) if views are outstanding.
+static int bytearray_move_to_part(ByteArray* b, mm_msg_part_t* out) {
+  if (bytearray_check_mutable(b) < 0) {
+    return -1;
+  }
+  out->data = b->data;
+  out->len = (size_t)b->len;
+  out->deleter = b->data ? free_deleter : NULL;
+  out->deleter_ctx = b->data;
+  b->data = NULL;
+  b->len = 0;
+  b->cap = 0;
+  return 0;
+}
+
+static int ByteArray_init(ByteArray* self, PyObject* args, PyObject* kwds) {
+  static char* kw[] = {"source", NULL};
+  PyObject* source = NULL;
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kw, &source)) {
+    return -1;
+  }
+  if (source == NULL || source == Py_None) {
+    return 0; // empty
+  }
+  if (PyLong_Check(source)) {
+    Py_ssize_t count = PyLong_AsSsize_t(source);
+    if (count < 0) {
+      if (!PyErr_Occurred()) {
+        PyErr_SetString(
+            PyExc_ValueError, "bytearray count must be non-negative");
+      }
+      return -1;
+    }
+    if (bytearray_reserve(self, count) < 0) {
+      return -1;
+    }
+    memset(self->data, 0, (size_t)count);
+    self->len = count;
+    return 0;
+  }
+  // Any bytes-like: copy its contents in.
+  Py_buffer view;
+  if (PyObject_GetBuffer(source, &view, PyBUF_SIMPLE) < 0) {
+    return -1;
+  }
+  if (bytearray_reserve(self, view.len) < 0) {
+    PyBuffer_Release(&view);
+    return -1;
+  }
+  memcpy(self->data, view.buf, (size_t)view.len);
+  self->len = view.len;
+  PyBuffer_Release(&view);
+  return 0;
+}
+
+static void ByteArray_dealloc(ByteArray* self) {
+  free(self->data);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static Py_ssize_t ByteArray_length(ByteArray* self) {
+  return self->len;
+}
+
+static PyObject* ByteArray_item(ByteArray* self, Py_ssize_t i) {
+  if (i < 0) {
+    i += self->len;
+  }
+  if (i < 0 || i >= self->len) {
+    PyErr_SetString(PyExc_IndexError, "bytearray index out of range");
+    return NULL;
+  }
+  return PyLong_FromLong((unsigned char)self->data[i]);
+}
+
+static int ByteArray_ass_item(ByteArray* self, Py_ssize_t i, PyObject* value) {
+  if (i < 0) {
+    i += self->len;
+  }
+  if (i < 0 || i >= self->len) {
+    PyErr_SetString(PyExc_IndexError, "bytearray index out of range");
+    return -1;
+  }
+  if (!value) {
+    PyErr_SetString(PyExc_TypeError, "cannot delete bytearray items");
+    return -1;
+  }
+  long byte = PyLong_AsLong(value);
+  if (byte == -1 && PyErr_Occurred()) {
+    return -1;
+  }
+  if (byte < 0 || byte > 255) {
+    PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
+    return -1;
+  }
+  self->data[i] = (char)byte;
+  return 0;
+}
+
+static PyObject* ByteArray_append(ByteArray* self, PyObject* arg) {
+  if (bytearray_check_mutable(self) < 0) {
+    return NULL;
+  }
+  long byte = PyLong_AsLong(arg);
+  if (byte == -1 && PyErr_Occurred()) {
+    return NULL;
+  }
+  if (byte < 0 || byte > 255) {
+    PyErr_SetString(PyExc_ValueError, "byte must be in range(0, 256)");
+    return NULL;
+  }
+  if (bytearray_reserve(self, self->len + 1) < 0) {
+    return NULL;
+  }
+  self->data[self->len++] = (char)byte;
+  Py_RETURN_NONE;
+}
+
+static PyObject* ByteArray_extend(ByteArray* self, PyObject* arg) {
+  if (bytearray_check_mutable(self) < 0) {
+    return NULL;
+  }
+  Py_buffer view;
+  if (PyObject_GetBuffer(arg, &view, PyBUF_SIMPLE) < 0) {
+    return NULL;
+  }
+  if (bytearray_reserve(self, self->len + view.len) < 0) {
+    PyBuffer_Release(&view);
+    return NULL;
+  }
+  memcpy(self->data + self->len, view.buf, (size_t)view.len);
+  self->len += view.len;
+  PyBuffer_Release(&view);
+  Py_RETURN_NONE;
+}
+
+static PyObject* ByteArray_tobytes(
+    ByteArray* self,
+    PyObject* Py_UNUSED(ignored)) {
+  return PyBytes_FromStringAndSize(self->data, self->len);
+}
+
+static int ByteArray_getbuffer(PyObject* self, Py_buffer* view, int flags) {
+  ByteArray* b = (ByteArray*)self;
+  if (PyBuffer_FillInfo(view, self, b->data, b->len, /*readonly=*/0, flags) <
+      0) {
+    return -1;
+  }
+  b->exports++;
+  return 0;
+}
+
+static void ByteArray_releasebuffer(PyObject* self, Py_buffer* view) {
+  (void)view;
+  ((ByteArray*)self)->exports--;
+}
+
+// Content equality against any bytes-like (so a received bytearray compares
+// equal to the bytes that were sent). Only == / != are defined.
+static PyObject*
+ByteArray_richcompare(PyObject* self, PyObject* other, int op) {
+  if (op != Py_EQ && op != Py_NE) {
+    Py_RETURN_NOTIMPLEMENTED;
+  }
+  Py_buffer a;
+  Py_buffer b;
+  if (PyObject_GetBuffer(self, &a, PyBUF_SIMPLE) < 0) {
+    PyErr_Clear();
+    Py_RETURN_NOTIMPLEMENTED;
+  }
+  if (PyObject_GetBuffer(other, &b, PyBUF_SIMPLE) < 0) {
+    PyErr_Clear();
+    PyBuffer_Release(&a);
+    Py_RETURN_NOTIMPLEMENTED;
+  }
+  int equal = a.len == b.len &&
+      (a.len == 0 || memcmp(a.buf, b.buf, (size_t)a.len) == 0);
+  PyBuffer_Release(&a);
+  PyBuffer_Release(&b);
+  if ((op == Py_EQ) == (equal != 0)) {
+    Py_RETURN_TRUE;
+  }
+  Py_RETURN_FALSE;
+}
+
+static PySequenceMethods ByteArray_as_sequence = {
+    .sq_length = (lenfunc)ByteArray_length,
+    .sq_item = (ssizeargfunc)ByteArray_item,
+    .sq_ass_item = (ssizeobjargproc)ByteArray_ass_item,
+};
+
+static PyBufferProcs ByteArray_as_buffer = {
+    .bf_getbuffer = ByteArray_getbuffer,
+    .bf_releasebuffer = ByteArray_releasebuffer,
+};
+
+static PyMethodDef ByteArray_methods[] = {
+    {"append", (PyCFunction)ByteArray_append, METH_O, "append(byte) -> None"},
+    {"extend",
+     (PyCFunction)ByteArray_extend,
+     METH_O,
+     "extend(bytes-like) -> None"},
+    {"tobytes",
+     (PyCFunction)ByteArray_tobytes,
+     METH_NOARGS,
+     "tobytes() -> bytes"},
+    {NULL, NULL, 0, NULL},
+};
+
+static PyTypeObject ByteArrayType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "minimonarch.bytearray",
+    .tp_basicsize = sizeof(ByteArray),
+    .tp_dealloc = (destructor)ByteArray_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc =
+        "A writable, growable byte buffer; send() moves it into the message.",
+    .tp_richcompare = ByteArray_richcompare,
+    .tp_as_sequence = &ByteArray_as_sequence,
+    .tp_as_buffer = &ByteArray_as_buffer,
+    .tp_methods = ByteArray_methods,
+    .tp_init = (initproc)ByteArray_init,
+    .tp_new = PyType_GenericNew,
+};
+
+// Move a single minimonarch.bytearray argument into `out`. Type-checks and, on
+// success, leaves the bytearray empty. Returns -1 (exception set) otherwise.
+static int arg_move(PyObject* obj, mm_msg_part_t* out) {
+  if (!PyObject_TypeCheck(obj, &ByteArrayType)) {
+    PyErr_SetString(PyExc_TypeError, "expected a minimonarch.bytearray");
+    return -1;
+  }
+  return bytearray_move_to_part((ByteArray*)obj, out);
+}
+
+// Copy a single small bytes value (an ident, a reason) into a C-owned part with
+// a plain free() deleter. Single-value arguments are bytes (and copied) rather
+// than bytearray; only multipart message bodies are moved bytearrays. Returns
+// -1 (exception set) on a non-bytes value or allocation failure.
+static int bytes_to_part(PyObject* obj, mm_msg_part_t* out) {
+  if (!PyBytes_Check(obj)) {
+    PyErr_SetString(PyExc_TypeError, "expected bytes");
+    return -1;
+  }
+  Py_ssize_t len = PyBytes_GET_SIZE(obj);
+  void* buf = malloc((size_t)(len ? len : 1));
+  if (!buf) {
+    PyErr_NoMemory();
+    return -1;
+  }
+  if (len) {
+    memcpy(buf, PyBytes_AS_STRING(obj), (size_t)len);
+  }
+  out->data = buf;
+  out->len = (size_t)len;
+  out->deleter = free_deleter;
+  out->deleter_ctx = buf;
+  return 0;
+}
+
+// Build a message-part array by moving each minimonarch.bytearray in `seq`
+// (storage taken over, each bytearray left empty). On error, releases parts
+// already taken via their free() deleters and returns NULL.
+static mm_msg_part_t* build_parts(PyObject* seq, size_t* out_n) {
+  Py_ssize_t n = PySequence_Size(seq);
+  if (n < 0) {
+    return NULL;
+  }
+  mm_msg_part_t* arr = PyMem_Malloc((size_t)n * sizeof(mm_msg_part_t));
+  if (!arr) {
+    PyErr_NoMemory();
+    return NULL;
+  }
+  for (Py_ssize_t i = 0; i < n; i++) {
+    PyObject* item = PySequence_GetItem(seq, i);
+    int ok = item && arg_move(item, &arr[i]) == 0;
+    Py_XDECREF(item);
+    if (!ok) {
+      for (Py_ssize_t j = 0; j < i; j++) {
+        if (arr[j].deleter) {
+          arr[j].deleter(arr[j].deleter_ctx);
+        }
+      }
+      PyMem_Free(arr);
+      return NULL;
+    }
+  }
+  *out_n = (size_t)n;
+  return arr;
+}
+
+// Adopt a received part's buffer into a new minimonarch.bytearray, zero-copy:
+// the bytearray takes over the malloc'd storage and will free()/realloc() it
+// like any other bytearray. (Every part this binding produces is malloc-owned
+// with a free() deleter, so adopting the pointer is equivalent to its deleter.)
+// Returns a new reference, or NULL (with the buffer freed) on failure. Because
+// the result is itself a bytearray, a received message can be moved straight
+// back into another send() — the buffer is reused, never copied.
+static PyObject* bytearray_adopt(mm_msg_part_t* part) {
+  ByteArray* b = PyObject_New(ByteArray, &ByteArrayType);
+  if (!b) {
+    if (part->deleter) {
+      part->deleter(part->deleter_ctx);
+    }
+    return NULL;
+  }
+  b->data = (char*)part->data;
+  b->len = (Py_ssize_t)part->len;
+  b->cap = (Py_ssize_t)part->len;
+  b->exports = 0;
+  return (PyObject*)b;
+}
+
+// ---------------------------------------------------------------------------
+// Message delivery (runs on the asyncio loop thread, via the fd reader)
+// ---------------------------------------------------------------------------
+
+static void deliver_to_queue(Context* c, size_t index, PyObject* msg) {
+  PyObject* key = PyLong_FromSize_t(index);
+  if (!key) {
+    PyErr_Clear();
+    return;
+  }
+  PyObject* queue = PyDict_GetItemWithError(c->queues, key); // borrowed
+  Py_DECREF(key);
+  if (!queue) {
+    return; // no actor subscribed at this index (already destroyed)
+  }
+
+  // The queue is unbounded, so put_nowait never blocks. A pending get() (i.e.
+  // a coroutine awaiting next()) is woken; otherwise the message is buffered.
+  PyObject* r = PyObject_CallMethod(queue, "put_nowait", "O", msg);
+  Py_XDECREF(r);
+  if (!r) {
+    PyErr_Clear();
+  }
+}
+
+// Build a list of minimonarch.bytearray from `parts` (each adopting its buffer
+// zero-copy) and route it to `index`'s queue. Must hold the GIL.
+static void
+route_one(Context* c, size_t index, mm_msg_part_t* parts, size_t n) {
+  PyObject* msg = PyList_New((Py_ssize_t)n);
+  for (size_t i = 0; i < n; i++) {
+    PyObject* part = bytearray_adopt(&parts[i]);
+    if (msg && part) {
+      PyList_SET_ITEM(msg, (Py_ssize_t)i, part); // steals part
+    } else {
+      Py_XDECREF(part);
+    }
+  }
+  if (msg) {
+    deliver_to_queue(c, index, msg);
+    Py_DECREF(msg);
+  } else {
+    PyErr_Clear();
+  }
+}
+
+// Drain every currently-available message from the poller, routing each to its
+// queue. Returns 1 if a message destined for `want_index` was delivered, else
+// 0. Pass (size_t)-1 for want_index to ignore the result. Must hold the GIL.
+static int pump_drain(Context* c, size_t want_index) {
+  mm_msg_part_t stack_parts[16];
+  mm_msg_part_t* parts = stack_parts;
+  size_t cap = 16;
+  int got_want = 0;
+
+  for (;;) {
+    size_t index = 0;
+    size_t n = 0;
+    mm_err_t err = mm_poller_next(c->poller, &index, parts, cap, &n);
+    if (err == MM_ENOMSG) {
+      break;
+    }
+    if (err == MM_EBUFSZ) {
+      if (parts != stack_parts) {
+        PyMem_Free(parts);
+      }
+      parts = PyMem_Malloc(n * sizeof(mm_msg_part_t));
+      if (!parts) {
+        PyErr_NoMemory();
+        PyErr_WriteUnraisable(NULL);
+        return got_want;
+      }
+      cap = n;
+      continue; // message not consumed; retry with a bigger buffer
+    }
+    if (err != MM_OK) {
+      break;
+    }
+
+    route_one(c, index, parts, n);
+    if (index == want_index) {
+      got_want = 1;
+    }
+  }
+
+  if (parts != stack_parts) {
+    PyMem_Free(parts);
+  }
+  return got_want;
+}
+
+// asyncio fd reader: drains the poller and routes each message to the queue
+// registered for its index. Receives the Context as a weakref so the loop
+// never keeps the Context alive (which would form an uncollectable cycle).
+
+static PyObject* mm_pump(PyObject* self, PyObject* wref) {
+  (void)self;
+  PyObject* obj = PyWeakref_GetObject(wref); // borrowed
+  if (obj != Py_None) {
+    pump_drain((Context*)obj, (size_t)-1);
+  }
+  Py_RETURN_NONE;
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+static Context* context_new(void) {
+  PyObject* loop = PyObject_CallNoArgs(g_get_running_loop);
+  if (!loop) {
+    return NULL;
+  }
+  Context* c = PyObject_New(Context, &ContextType);
+  if (!c) {
+    Py_DECREF(loop);
+    return NULL;
+  }
+  c->ctx = NULL;
+  c->poller = NULL;
+  c->fd = -1;
+  c->loop = loop;
+  c->queues = NULL;
+  c->token = NULL;
+  c->next_index = 0;
+  c->reader_installed = 0;
+  c->closed = 0;
+  c->weakreflist = NULL;
+
+  if (mm_ctx_create(&c->ctx) != MM_OK) {
+    set_mm_error();
+    Py_DECREF(c);
+    return NULL;
+  }
+  if (mm_poller_create(c->ctx, &c->fd, &c->poller) != MM_OK) {
+    set_mm_error();
+    Py_DECREF(c);
+    return NULL;
+  }
+  c->queues = PyDict_New();
+  if (!c->queues) {
+    Py_DECREF(c);
+    return NULL;
+  }
+
+  // Register the reader with a *weak* reference to the Context. A strong ref
+  // here would make the loop pin the Context, forming an uncollectable cycle
+  // (loop -> reader -> ctx -> queues -> Queue -> loop). With a weakref the loop
+  // never keeps the Context alive; the contextvar and live Actors do.
+  PyObject* wref = PyWeakref_NewRef((PyObject*)c, NULL);
+  if (!wref) {
+    Py_DECREF(c);
+    return NULL;
+  }
+  PyObject* res = PyObject_CallMethod(
+      c->loop, "add_reader", "iOO", c->fd, g_pump_func, wref);
+  Py_DECREF(wref);
+  if (!res) {
+    Py_DECREF(c);
+    return NULL;
+  }
+  Py_DECREF(res);
+  c->reader_installed = 1;
+  return c;
+}
+
+// Return the Context for the current contextvars context, creating and
+// installing one if absent. Returns a new reference.
+static Context* context_current(void) {
+  PyObject* cur = NULL;
+  if (PyContextVar_Get(g_ctx_var, NULL, &cur) < 0) {
+    return NULL;
+  }
+  if (cur != NULL) {
+    return (Context*)cur; // new ref from PyContextVar_Get
+  }
+  Context* c = context_new();
+  if (!c) {
+    return NULL;
+  }
+  PyObject* token = PyContextVar_Set(g_ctx_var, (PyObject*)c);
+  if (!token) {
+    Py_DECREF(c);
+    return NULL;
+  }
+  c->token = token; // kept so close() can reset the var in this context
+  return c; // we still own the creation reference
+}
+
+// Tear down the minimonarch runtime for this context: detach the fd reader,
+// destroy the poller, then the context itself (mm_ctx_destroy flushes pending
+// messages and joins the runtime thread). Idempotent. Actor objects are NOT
+// touched here — they survive as Python objects, and the `closed` flag makes
+// their methods raise instead of dereferencing the destroyed runtime.
+static void context_shutdown(Context* self) {
+  if (self->closed) {
+    return;
+  }
+  self->closed = 1;
+
+  if (self->reader_installed && self->loop) {
+    PyObject* r =
+        PyObject_CallMethod(self->loop, "remove_reader", "i", self->fd);
+    Py_XDECREF(r);
+    if (!r) {
+      PyErr_Clear();
+    }
+    self->reader_installed = 0;
+  }
+
+  if (self->poller) {
+    mm_poller_destroy(self->poller);
+    self->poller = NULL;
+  }
+  if (self->ctx) {
+    // ctx_destroy flushes and joins the runtime thread; its part deleters are
+    // plain free()s now, so no GIL coordination is needed. Release the GIL
+    // anyway so we don't hold it across the join.
+    mm_ctx_t ctx = self->ctx;
+    self->ctx = NULL;
+    Py_BEGIN_ALLOW_THREADS mm_ctx_destroy(ctx);
+    Py_END_ALLOW_THREADS
+  }
+}
+
+static void Context_dealloc(Context* self) {
+  if (self->weakreflist) {
+    PyObject_ClearWeakRefs((PyObject*)self);
+  }
+  context_shutdown(self);
+  Py_CLEAR(self->loop);
+  Py_CLEAR(self->queues);
+  Py_CLEAR(self->token);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyTypeObject ContextType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "minimonarch._Context",
+    .tp_basicsize = sizeof(Context),
+    .tp_dealloc = (destructor)Context_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Internal minimonarch context (one per contextvars context).",
+    .tp_weaklistoffset = offsetof(Context, weakreflist),
+};
+
+// ---------------------------------------------------------------------------
+// Actor
+// ---------------------------------------------------------------------------
+
+static int Actor_init(Actor* self, PyObject* args, PyObject* kwds) {
+  static char* kw[] = {"ident", NULL};
+  PyObject* ident = Py_None;
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kw, &ident)) {
+    return -1;
+  }
+
+  Context* c = context_current(); // new ref
+  if (!c) {
+    return -1;
+  }
+  self->ctx = c; // steal the reference
+  self->actor = NULL;
+  self->index = 0;
+  self->queue = NULL;
+
+  mm_actor_t actor = NULL;
+  mm_err_t err;
+  if (ident == Py_None) {
+    Py_BEGIN_ALLOW_THREADS err = mm_actor_create(c->ctx, NULL, &actor);
+    Py_END_ALLOW_THREADS
+  } else {
+    mm_msg_part_t p;
+    if (bytes_to_part(ident, &p) < 0) {
+      return -1;
+    }
+    Py_BEGIN_ALLOW_THREADS err = mm_actor_create(c->ctx, &p, &actor);
+    Py_END_ALLOW_THREADS
+  }
+  if (err != MM_OK) {
+    set_mm_error();
+    return -1;
+  }
+  self->actor = actor;
+  self->index = c->next_index++;
+
+  if (mm_poller_subscribe(c->poller, self->index, actor) != MM_OK) {
+    return set_mm_error();
+  }
+
+  self->queue = PyObject_CallNoArgs(g_queue_type);
+  if (!self->queue) {
+    return -1;
+  }
+
+  // Register the queue under our index so the pump can route to it. The context
+  // and the actor both hold a strong reference to the same Queue object.
+  PyObject* key = PyLong_FromSize_t(self->index);
+  if (!key) {
+    return -1;
+  }
+  int rc = PyDict_SetItem(c->queues, key, self->queue);
+  Py_DECREF(key);
+  return rc;
+}
+
+static void Actor_dealloc(Actor* self) {
+  if (self->ctx) {
+    int closed = self->ctx->closed;
+    if (self->actor) {
+      // Destroying the actor is still valid after the context is closed (it
+      // just no-ops against the torn-down runtime). The poller, however, has
+      // been freed, so only unsubscribe while the context is still open.
+      if (!closed) {
+        mm_poller_unsubscribe(self->ctx->poller, self->index);
+      }
+      mm_actor_destroy(self->actor);
+    }
+    if (!closed) {
+      PyObject* key = PyLong_FromSize_t(self->index);
+      if (key) {
+        if (PyDict_DelItem(self->ctx->queues, key) < 0) {
+          PyErr_Clear();
+        }
+        Py_DECREF(key);
+      }
+    }
+  }
+  Py_XDECREF(self->queue);
+  Py_XDECREF((PyObject*)self->ctx);
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+// Returns -1 (with an exception set) if the actor's context has been closed.
+// Note: actor destruction is intentionally exempt and handled in Actor_dealloc.
+static int actor_ensure_open(Actor* self) {
+  if (!self->ctx || self->ctx->closed) {
+    PyErr_SetString(PyExc_RuntimeError, "actor's context has been closed");
+    return -1;
+  }
+  return 0;
+}
+
+static PyObject* Actor_send(Actor* self, PyObject* args) {
+  PyObject* receiver;
+  PyObject* parts_seq;
+  if (actor_ensure_open(self) < 0) {
+    return NULL;
+  }
+  if (!PyArg_ParseTuple(args, "OO", &receiver, &parts_seq)) {
+    return NULL;
+  }
+
+  // Copy the receiver ident (bytes) first so a bad receiver fails before we
+  // consume any payload bytearrays.
+  mm_msg_part_t recv;
+  if (bytes_to_part(receiver, &recv) < 0) {
+    return NULL;
+  }
+
+  size_t n = 0;
+  mm_msg_part_t* arr = build_parts(parts_seq, &n);
+  if (!arr && PyErr_Occurred()) {
+    if (recv.deleter) {
+      recv.deleter(recv.deleter_ctx); // free the already-moved receiver
+    }
+    return NULL;
+  }
+
+  mm_msg_t msg = {.parts = arr, .n_parts = n};
+  mm_err_t err = mm_actor_send(self->actor, recv, &msg);
+  PyMem_Free(arr);
+  if (err != MM_OK) {
+    return set_mm_error(), NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+static PyObject* Actor_next(Actor* self, PyObject* Py_UNUSED(ignored)) {
+  if (actor_ensure_open(self) < 0) {
+    return NULL;
+  }
+
+  // If nothing is already queued, busy-pump the poller for NEXT_SPIN_NS before
+  // giving up and awaiting the fd. This catches a message that's about to
+  // arrive on the cheap path and skips the eventfd round trip. Pumping also
+  // routes messages for other actors into their queues. If the budget expires,
+  // the final pump_drain has armed the poller, so the fd reader will still
+  // deliver and wake the queue.get() below.
+  //
+  // asyncio.Queue has no __len__, so check emptiness via qsize().
+  int empty = 1;
+  PyObject* qs = PyObject_CallMethod(self->queue, "qsize", NULL);
+  if (qs) {
+    empty = (PyLong_AsLong(qs) == 0);
+    Py_DECREF(qs);
+  } else {
+    PyErr_Clear();
+  }
+  if (empty) {
+    struct timespec start;
+    clock_gettime(CLOCK_MONOTONIC, &start);
+    for (;;) {
+      if (pump_drain(self->ctx, self->index)) {
+        break; // a message for us was delivered
+      }
+      struct timespec now;
+      clock_gettime(CLOCK_MONOTONIC, &now);
+      long elapsed = (now.tv_sec - start.tv_sec) * 1000000000L +
+          (now.tv_nsec - start.tv_nsec);
+      if (elapsed >= NEXT_SPIN_NS) {
+        break;
+      }
+    }
+  }
+
+  // queue.get() returns an awaitable that resolves to the next message —
+  // immediately if one is queued, otherwise when the fd reader delivers one.
+  return PyObject_CallMethod(self->queue, "get", NULL);
+}
+
+// Parse a role string ("parent" or "child") into mm_role_t. Returns -1 and
+// sets an exception on an unknown value.
+static int parse_role(const char* role, mm_role_t* out) {
+  if (strcmp(role, "parent") == 0) {
+    *out = MM_PARENT;
+    return 0;
+  }
+  if (strcmp(role, "child") == 0) {
+    *out = MM_CHILD;
+    return 0;
+  }
+  PyErr_Format(
+      PyExc_ValueError, "role must be 'parent' or 'child', not '%s'", role);
+  return -1;
+}
+
+// Shared implementation for serve()/join().
+static PyObject* actor_connect(
+    Actor* self,
+    const char* url,
+    mm_role_t role,
+    PyObject* name,
+    PyObject* hello,
+    PyObject* failure,
+    int is_serve) {
+  if (actor_ensure_open(self) < 0) {
+    return NULL;
+  }
+  mm_connect_args_t args = {
+      .role = role,
+      .name_for_other = NULL,
+      .hello_prefix = NULL,
+      .failure_prefix = NULL,
+  };
+  mm_msg_part_t name_part;
+  mm_msg_t hello_msg;
+  mm_msg_t failure_msg;
+  mm_msg_part_t* hello_arr = NULL;
+  mm_msg_part_t* failure_arr = NULL;
+  size_t hn = 0;
+  size_t fn = 0;
+  PyObject* result = NULL;
+
+  if (name && name != Py_None) {
+    if (bytes_to_part(name, &name_part) < 0) {
+      return NULL;
+    }
+    args.name_for_other = &name_part;
+  }
+  if (hello && hello != Py_None) {
+    hello_arr = build_parts(hello, &hn);
+    if (!hello_arr && PyErr_Occurred()) {
+      goto done;
+    }
+    hello_msg.parts = hello_arr;
+    hello_msg.n_parts = hn;
+    args.hello_prefix = &hello_msg;
+  }
+  if (failure && failure != Py_None) {
+    failure_arr = build_parts(failure, &fn);
+    if (!failure_arr && PyErr_Occurred()) {
+      goto done;
+    }
+    failure_msg.parts = failure_arr;
+    failure_msg.n_parts = fn;
+    args.failure_prefix = &failure_msg;
+  }
+
+  mm_err_t err = is_serve ? mm_actor_serve(self->actor, url, &args)
+                          : mm_actor_join(self->actor, url, &args);
+  if (err != MM_OK) {
+    set_mm_error();
+    goto done;
+  }
+  Py_INCREF(Py_None);
+  result = Py_None;
+
+done:
+  PyMem_Free(hello_arr);
+  PyMem_Free(failure_arr);
+  return result;
+}
+
+static PyObject* actor_connect_method(
+    Actor* self,
+    PyObject* args,
+    PyObject* kwds,
+    int is_serve) {
+  static char* kw[] = {"url", "role", "name", "hello", "failure", NULL};
+  const char* url;
+  const char* role_str;
+  PyObject* name = NULL;
+  PyObject* hello = NULL;
+  PyObject* failure = NULL;
+  if (!PyArg_ParseTupleAndKeywords(
+          args, kwds, "ss|OOO", kw, &url, &role_str, &name, &hello, &failure)) {
+    return NULL;
+  }
+  mm_role_t role;
+  if (parse_role(role_str, &role) < 0) {
+    return NULL;
+  }
+  return actor_connect(self, url, role, name, hello, failure, is_serve);
+}
+
+static PyObject* Actor_serve(Actor* self, PyObject* args, PyObject* kwds) {
+  return actor_connect_method(self, args, kwds, 1);
+}
+
+static PyObject* Actor_join(Actor* self, PyObject* args, PyObject* kwds) {
+  return actor_connect_method(self, args, kwds, 0);
+}
+
+static PyObject* Actor_die(Actor* self, PyObject* args) {
+  PyObject* reason;
+  if (actor_ensure_open(self) < 0) {
+    return NULL;
+  }
+  if (!PyArg_ParseTuple(args, "O", &reason)) {
+    return NULL;
+  }
+  mm_msg_part_t p;
+  if (bytes_to_part(reason, &p) < 0) {
+    return NULL;
+  }
+  mm_actor_die(self->actor, p);
+  Py_RETURN_NONE;
+}
+
+static PyObject* Actor_monitor(Actor* self, PyObject* args, PyObject* kwds) {
+  static char* kw[] = {"ident", "failure", NULL};
+  PyObject* ident;
+  PyObject* failure = NULL;
+  if (actor_ensure_open(self) < 0) {
+    return NULL;
+  }
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kw, &ident, &failure)) {
+    return NULL;
+  }
+
+  mm_msg_part_t to_monitor;
+  if (bytes_to_part(ident, &to_monitor) < 0) {
+    return NULL;
+  }
+  mm_msg_part_t* arr = NULL;
+  size_t n = 0;
+  mm_msg_t failure_msg;
+  mm_msg_t* failure_ptr = NULL;
+  if (failure && failure != Py_None) {
+    arr = build_parts(failure, &n);
+    if (!arr && PyErr_Occurred()) {
+      if (to_monitor.deleter) {
+        to_monitor.deleter(to_monitor.deleter_ctx); // free the moved ident
+      }
+      return NULL;
+    }
+    failure_msg.parts = arr;
+    failure_msg.n_parts = n;
+    failure_ptr = &failure_msg;
+  }
+
+  mm_monitor_handle_t handle = NULL;
+  mm_err_t err =
+      mm_actor_monitor(self->actor, to_monitor, failure_ptr, &handle);
+  PyMem_Free(arr);
+  if (err != MM_OK) {
+    return set_mm_error(), NULL;
+  }
+
+  MonitorHandle* mh = PyObject_New(MonitorHandle, &MonitorHandleType);
+  if (!mh) {
+    return NULL;
+  }
+  mh->handle = handle;
+  return (PyObject*)mh;
+}
+
+static PyMethodDef Actor_methods[] = {
+    {"send",
+     (PyCFunction)Actor_send,
+     METH_VARARGS,
+     "send(receiver: bytes, parts: list[bytes]) -> None"},
+    {"next",
+     (PyCFunction)Actor_next,
+     METH_NOARGS,
+     "next() -> awaitable[list[bytes]]: next delivered message"},
+    {"serve",
+     (PyCFunction)Actor_serve,
+     METH_VARARGS | METH_KEYWORDS,
+     "serve(url, role, name=None, hello=None, failure=None) -> None; "
+     "role is 'parent' or 'child'"},
+    {"join",
+     (PyCFunction)Actor_join,
+     METH_VARARGS | METH_KEYWORDS,
+     "join(url, role, name=None, hello=None, failure=None) -> None; "
+     "role is 'parent' or 'child'"},
+    {"die", (PyCFunction)Actor_die, METH_VARARGS, "die(reason: bytes) -> None"},
+    {"monitor",
+     (PyCFunction)Actor_monitor,
+     METH_VARARGS | METH_KEYWORDS,
+     "monitor(ident: bytes, failure=None) -> MonitorHandle"},
+    {NULL, NULL, 0, NULL},
+};
+
+static PyTypeObject ActorType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "minimonarch.Actor",
+    .tp_basicsize = sizeof(Actor),
+    .tp_dealloc = (destructor)Actor_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "A minimonarch actor bound to the current context's poller.",
+    .tp_methods = Actor_methods,
+    .tp_init = (initproc)Actor_init,
+    .tp_new = PyType_GenericNew,
+};
+
+// ---------------------------------------------------------------------------
+// MonitorHandle
+// ---------------------------------------------------------------------------
+
+static PyObject* MonitorHandle_cancel(
+    MonitorHandle* self,
+    PyObject* Py_UNUSED(ignored)) {
+  if (self->handle) {
+    mm_monitor_handle_cancel(self->handle);
+    self->handle = NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+static void MonitorHandle_dealloc(MonitorHandle* self) {
+  Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+static PyMethodDef MonitorHandle_methods[] = {
+    {"cancel",
+     (PyCFunction)MonitorHandle_cancel,
+     METH_NOARGS,
+     "cancel() -> None: stop delivering the failure message"},
+    {NULL, NULL, 0, NULL},
+};
+
+static PyTypeObject MonitorHandleType = {
+    PyVarObject_HEAD_INIT(NULL, 0).tp_name = "minimonarch.MonitorHandle",
+    .tp_basicsize = sizeof(MonitorHandle),
+    .tp_dealloc = (destructor)MonitorHandle_dealloc,
+    .tp_flags = Py_TPFLAGS_DEFAULT,
+    .tp_doc = "Handle for a registered monitor; call cancel() to deregister.",
+    .tp_methods = MonitorHandle_methods,
+};
+
+// ---------------------------------------------------------------------------
+// Module
+// ---------------------------------------------------------------------------
+
+static PyMethodDef pump_def = {"_mm_pump", (PyCFunction)mm_pump, METH_O, NULL};
+
+// close() -> bool: tear down the minimonarch context installed in the current
+// contextvars context, if any. Destroys its actors, poller, and the underlying
+// runtime (mm_ctx_destroy), and resets the contextvar so the next Actor()
+// creates a fresh context. Returns True if a context was closed, else False.
+static PyObject* mm_close(PyObject* self, PyObject* Py_UNUSED(ignored)) {
+  PyObject* cur = NULL;
+  if (PyContextVar_Get(g_ctx_var, NULL, &cur) < 0) {
+    return NULL;
+  }
+  if (cur == NULL) {
+    Py_RETURN_FALSE; // no context in this contextvars context
+  }
+  Context* c = (Context*)cur; // new ref
+
+  context_shutdown(c);
+
+  if (c->token) {
+    int rc = PyContextVar_Reset(g_ctx_var, c->token);
+    Py_CLEAR(c->token);
+    if (rc < 0) {
+      Py_DECREF(c);
+      return NULL;
+    }
+  }
+  Py_DECREF(c);
+  Py_RETURN_TRUE;
+}
+
+static PyMethodDef module_methods[] = {
+    {"close",
+     (PyCFunction)mm_close,
+     METH_NOARGS,
+     "close() -> bool: destroy the current context's minimonarch runtime"},
+    {NULL, NULL, 0, NULL},
+};
+
+static struct PyModuleDef minimonarch_module = {
+    PyModuleDef_HEAD_INIT,
+    .m_name = "minimonarch",
+    .m_doc = "asyncio bindings for the minimonarch C API",
+    .m_size = -1,
+    .m_methods = module_methods,
+};
+
+static int import_callable(const char* mod, const char* attr, PyObject** out) {
+  PyObject* m = PyImport_ImportModule(mod);
+  if (!m) {
+    return -1;
+  }
+  *out = PyObject_GetAttrString(m, attr);
+  Py_DECREF(m);
+  return *out ? 0 : -1;
+}
+
+PyMODINIT_FUNC PyInit_minimonarch(void) {
+  if (PyType_Ready(&ContextType) < 0 || PyType_Ready(&ActorType) < 0 ||
+      PyType_Ready(&MonitorHandleType) < 0 ||
+      PyType_Ready(&ByteArrayType) < 0) {
+    return NULL;
+  }
+
+  if (import_callable("asyncio", "get_running_loop", &g_get_running_loop) < 0) {
+    return NULL;
+  }
+  if (import_callable("asyncio", "Queue", &g_queue_type) < 0) {
+    return NULL;
+  }
+
+  g_ctx_var = PyContextVar_New("minimonarch.context", NULL);
+  if (!g_ctx_var) {
+    return NULL;
+  }
+  g_pump_func = PyCFunction_New(&pump_def, NULL);
+  if (!g_pump_func) {
+    return NULL;
+  }
+
+  PyObject* m = PyModule_Create(&minimonarch_module);
+  if (!m) {
+    return NULL;
+  }
+
+  Py_INCREF(&ActorType);
+  Py_INCREF(&MonitorHandleType);
+  Py_INCREF(&ByteArrayType);
+  if (PyModule_AddObject(m, "Actor", (PyObject*)&ActorType) < 0 ||
+      PyModule_AddObject(m, "MonitorHandle", (PyObject*)&MonitorHandleType) <
+          0 ||
+      PyModule_AddObject(m, "bytearray", (PyObject*)&ByteArrayType) < 0) {
+    Py_DECREF(m);
+    return NULL;
+  }
+  return m;
+}

--- a/monarch_mini/python/pyproject.toml
+++ b/monarch_mini/python/pyproject.toml
@@ -1,0 +1,35 @@
+# Standalone uv project for the minimonarch Python extension, so that
+# `uv run ...` inside this directory builds only minimonarch (and its Rust
+# staticlib) — independent of the parent torchmonarch project.
+#
+#   uv run pytest
+#
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "minimonarch"
+version = "0.1.0"
+description = "asyncio bindings for the minimonarch C API"
+requires-python = ">=3.10"
+
+[dependency-groups]
+dev = ["pytest>=8", "pytest-asyncio>=0.23"]
+
+# Pure-Python module discovery is disabled; the package is a single C extension
+# declared in setup.py (ext_modules). Without this, setuptools' flat-layout
+# auto-discovery trips over test_smoke.py / setup.py.
+[tool.setuptools]
+py-modules = []
+
+# Rebuild the wheel when the extension or build inputs change.
+[tool.uv]
+cache-keys = [
+    { file = "pyproject.toml" },
+    { file = "setup.py" },
+    { file = "minimonarch.c" },
+]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"

--- a/monarch_mini/python/setup.py
+++ b/monarch_mini/python/setup.py
@@ -1,0 +1,48 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+#
+# Build the minimonarch Python extension. Project metadata lives in
+# pyproject.toml; this file only declares the C extension (and builds the Rust
+# staticlib it links against) since setuptools needs ext_modules in setup.py.
+#
+#   uv run pytest        # builds + installs minimonarch, then runs the tests
+
+import os
+import subprocess
+
+from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+CRATE_DIR = os.path.dirname(HERE)  # monarch_mini/
+WORKSPACE_DIR = os.path.dirname(CRATE_DIR)  # monarch/
+STATIC_LIB = os.path.join(WORKSPACE_DIR, "target", "debug", "libmonarch_mini.a")
+
+
+class CargoBuildExt(build_ext):
+    """Build the Rust staticlib before compiling the C extension."""
+
+    def run(self):
+        subprocess.check_call(
+            ["cargo", "build", "-p", "monarch_mini"], cwd=WORKSPACE_DIR
+        )
+        super().run()
+
+
+ext = Extension(
+    name="minimonarch",
+    sources=["minimonarch.c"],
+    include_dirs=[CRATE_DIR],  # for minimonarch.h
+    extra_objects=[STATIC_LIB],
+    # System libraries the Rust standard library / tokio pull in.
+    libraries=["pthread", "dl", "m"],
+)
+
+setup(
+    ext_modules=[ext],
+    cmdclass={"build_ext": CargoBuildExt},
+)

--- a/monarch_mini/python/test_bench.py
+++ b/monarch_mini/python/test_bench.py
@@ -1,0 +1,103 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Benchmark: in-process self send -> receive round trips at various sizes.
+
+An actor sends a message to itself and awaits it back, for message sizes from
+64 B up to 1 GiB. The payload is a single minimonarch.bytearray, allocated once:
+send() *moves* its storage into the message, next() hands that same storage back
+as a bytearray, and the next iteration moves it again. The one buffer ping-pongs
+with zero copies and zero per-iteration allocation, so the round-trip time
+should be flat regardless of size.
+
+Run as a pytest test (use -s to see the report):
+
+    uv run pytest -s test_bench.py
+
+or standalone:
+
+    uv run python test_bench.py
+"""
+
+import asyncio
+import time
+
+import minimonarch
+from minimonarch import Actor
+
+ba = minimonarch.bytearray
+
+ITERS = 20
+
+# (label, size in bytes), 64 B .. 1 GiB.
+SIZES = [
+    ("64 B", 64),
+    ("1 KiB", 1 << 10),
+    ("64 KiB", 1 << 16),
+    ("1 MiB", 1 << 20),
+    ("16 MiB", 1 << 24),
+    ("256 MiB", 1 << 28),
+    ("1 GiB", 1 << 30),
+]
+
+
+async def roundtrip_per_iter(size: int, iters: int) -> float:
+    """Mean seconds for one send->receive round trip at `size`. A single buffer
+    is allocated once and reused: send moves it out, next() hands it back."""
+    a = Actor(b"bench")
+    buf = ba(size)  # allocated ONCE; reused every iteration
+
+    # Warm up (prime the poller/loop machinery).
+    a.send(b"bench", [buf])
+    buf = (await a.next())[0]
+
+    total = 0.0
+    for _ in range(iters):
+        start = time.perf_counter()
+        a.send(b"bench", [buf])  # moves buf's storage into the message
+        msg = await a.next()  # hands that same storage back as a bytearray
+        total += time.perf_counter() - start
+        buf = msg[0]  # reuse it next iteration — no allocation, no copy
+        assert len(buf) == size
+    return total / iters
+
+
+async def run_benchmark() -> list[tuple[str, int, float]]:
+    results = []
+    print(f"\nin-process self round-trip, {ITERS} iters/size (move, zero-copy)\n")
+    print(f"{'size':>10} {'per-iter':>14} {'throughput':>16}")
+    print("-" * 42)
+    for label, size in SIZES:
+        per_iter = await roundtrip_per_iter(size, ITERS)
+        gbps = (size / per_iter) / 1e9 if per_iter else float("inf")
+        results.append((label, size, per_iter))
+        print(f"{label:>10} {per_iter * 1e6:>11.2f} us {gbps:>12.2f} GB/s")
+    return results
+
+
+async def test_roundtrip_does_not_scale_with_size() -> None:
+    results = await run_benchmark()
+    per_iters = [p for _, _, p in results]
+    smallest = min(per_iters)
+    largest_size_per_iter = results[-1][2]  # 1 GiB
+
+    # If delivery copied the payload, 1 GiB would cost ~0.1 s/iter — orders of
+    # magnitude above the ~tens-of-microseconds round trip. The move keeps it
+    # flat; allow generous slack for scheduling noise but still catch O(size).
+    budget = smallest * 30 + 2e-3
+    print(
+        f"\n1 GiB per-iter {largest_size_per_iter * 1e6:.2f} us vs "
+        f"min {smallest * 1e6:.2f} us (budget {budget * 1e6:.2f} us)"
+    )
+    assert largest_size_per_iter <= budget, (
+        "in-process round-trip time scales with message size — delivery is "
+        "not zero-copy"
+    )
+    print("OK: in-process delivery does not scale with message size")
+
+
+if __name__ == "__main__":
+    asyncio.run(test_roundtrip_does_not_scale_with_size())

--- a/monarch_mini/python/test_smoke.py
+++ b/monarch_mini/python/test_smoke.py
@@ -1,0 +1,193 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""pytest smoke tests for the minimonarch asyncio bindings.
+
+From this directory:
+
+    uv run pytest
+"""
+
+import asyncio
+
+import minimonarch
+import pytest
+from minimonarch import Actor
+
+# Single-value arguments (idents, reasons) are plain bytes and copied. Multipart
+# message bodies are lists of minimonarch.bytearray, moved into the message.
+ba = minimonarch.bytearray
+
+
+def test_bytearray_behaves_like_bytearray() -> None:
+    b = ba()
+    assert len(b) == 0
+    b.append(0x61)  # 'a'
+    b.extend(b"bc")
+    assert len(b) == 3
+    assert bytes(memoryview(b)) == b"abc"
+    assert b.tobytes() == b"abc"
+    assert b[0] == 0x61
+    b[0] = 0x7A  # 'z'
+    assert b.tobytes() == b"zbc"
+    # range checks
+    with pytest.raises(IndexError):
+        _ = b[3]
+    with pytest.raises(IndexError):
+        b[3] = 0
+    with pytest.raises(ValueError):
+        b.append(256)
+    # construct from size (zero-filled) and from bytes
+    assert ba(3).tobytes() == b"\x00\x00\x00"
+    assert ba(b"hi").tobytes() == b"hi"
+
+
+def test_bytearray_cannot_resize_while_exported() -> None:
+    b = ba(b"abc")
+    mv = memoryview(b)
+    with pytest.raises(BufferError):
+        b.append(0)
+    mv.release()
+    b.append(0)  # fine once the view is gone
+    assert len(b) == 4
+
+
+async def test_self_send() -> None:
+    a = Actor(b"hello-actor")
+    a.send(b"hello-actor", [ba(b"hello, "), ba(b"self")])
+    parts = await a.next()
+    assert parts == [b"hello, ", b"self"]
+
+
+async def test_buffer_before_next() -> None:
+    # A message sent before next() is awaited must be buffered and delivered.
+    a = Actor(b"buf-actor")
+    a.send(b"buf-actor", [ba(b"one")])
+    a.send(b"buf-actor", [ba(b"two")])
+    # Give the poller a chance to drain into the queue.
+    await asyncio.sleep(0.05)
+    first = await a.next()
+    second = await a.next()
+    assert first == [b"one"]
+    assert second == [b"two"]
+
+
+async def test_next_blocks_until_message() -> None:
+    a = Actor(b"wait-actor")
+
+    async def delayed_send() -> None:
+        await asyncio.sleep(0.05)
+        a.send(b"wait-actor", [ba(b"late")])
+
+    asyncio.ensure_future(delayed_send())
+    parts = await a.next()
+    assert parts == [b"late"]
+
+
+@pytest.mark.parametrize(
+    "name,call",
+    [
+        ("serve", lambda a: a.serve("inproc://a", "parent")),
+        ("join", lambda a: a.join("inproc://a", "child")),
+        ("monitor", lambda a: a.monitor(b"other@root")),
+    ],
+)
+async def test_unimplemented_bindings_raise(name, call) -> None:
+    # serve/join/monitor are bound but the underlying Rust is not implemented.
+    a = Actor(b"srv-actor")
+    with pytest.raises(RuntimeError, match="implement"):
+        call(a)
+
+
+async def test_die_is_void() -> None:
+    # die is a void call; it should not raise even though unimplemented.
+    a = Actor(b"die-actor")
+    assert a.die(b"bye") is None
+
+
+async def test_ident_is_bytes_parts_are_bytearray() -> None:
+    a = Actor(b"strict")
+    # The receiver ident is bytes; a bytearray there is rejected.
+    with pytest.raises(TypeError, match="bytes"):
+        a.send(ba(b"strict"), [ba(b"x")])
+    # Message parts are bytearray; bytes there is rejected.
+    with pytest.raises(TypeError, match="minimonarch.bytearray"):
+        a.send(b"strict", [b"x"])
+
+
+async def test_send_moves_bytearray_parts() -> None:
+    a = Actor(b"mv")
+    payload = ba(b"payload")
+    a.send(b"mv", [payload])
+    # send() moved the bytearray part: it is now empty.
+    assert len(payload) == 0
+    assert payload.tobytes() == b""
+    parts = await a.next()
+    assert parts == [b"payload"]
+
+
+async def test_recv_returns_reusable_bytearray() -> None:
+    a = Actor(b"zc")
+    a.send(b"zc", [ba(b"zero-copy-payload")])
+    (part,) = await a.next()
+    # A received part is itself a minimonarch.bytearray (not a memoryview), so
+    # it can be moved straight back into another send.
+    assert isinstance(part, ba)
+    assert part == b"zero-copy-payload"
+    a.send(b"zc", [part])  # reuse: move the same buffer back
+    assert len(part) == 0  # moved out again
+    assert await a.next() == [b"zero-copy-payload"]
+
+
+async def test_send_rejects_exported_bytearray() -> None:
+    a = Actor(b"exp")
+    payload = ba(b"x")
+    mv = memoryview(payload)
+    with pytest.raises(BufferError):
+        a.send(b"exp", [payload])
+    mv.release()
+
+
+async def test_bad_role_rejected() -> None:
+    a = Actor(b"role-actor")
+    with pytest.raises(ValueError, match="'parent' or 'child'"):
+        a.serve("inproc://a", "boss")
+
+
+async def test_close_returns_false_without_context() -> None:
+    # Nothing has created a context in this (fresh per-test) event loop yet.
+    assert minimonarch.close() is False
+
+
+async def test_close_destroys_context_but_actors_survive() -> None:
+    a = Actor(b"closing-actor")
+    a.send(b"closing-actor", [ba(b"hi")])
+    assert await a.next() == [b"hi"]
+
+    # close() finds the context via the contextvar and tears it down.
+    assert minimonarch.close() is True
+    # A second close is a no-op now that the var has been reset.
+    assert minimonarch.close() is False
+
+    # The Actor object survives (it is not deallocated/invalidated), but the
+    # API errors on further use against the destroyed runtime.
+    assert isinstance(a, Actor)
+    with pytest.raises(RuntimeError, match="closed"):
+        a.send(b"closing-actor", [ba(b"again")])
+    with pytest.raises(RuntimeError, match="closed"):
+        a.next()
+
+    # Destroying the actor (dropping the last reference) is still fine.
+    del a
+
+
+async def test_actor_after_close_gets_fresh_context() -> None:
+    Actor(b"first")
+    assert minimonarch.close() is True
+    # A new Actor after close transparently creates a new context and works.
+    b = Actor(b"second")
+    b.send(b"second", [ba(b"fresh")])
+    assert await b.next() == [b"fresh"]

--- a/monarch_mini/python/uv.lock
+++ b/monarch_mini/python/uv.lock
@@ -1,0 +1,183 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "minimonarch"
+version = "0.1.0"
+source = { editable = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8" },
+    { name = "pytest-asyncio", specifier = ">=0.23" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* __->__ #4579
* #4578
* #4577
* #4576

Add a CPython extension that exposes minimonarch actors through asyncio, with per-context polling, lifecycle management, and actor messaging APIs.
Provide a movable bytearray type for zero-copy message reuse, standalone uv packaging, and smoke and benchmark coverage for binding behavior and transfer performance.

Differential Revision: [D114750223](https://our.internmc.facebook.com/intern/diff/D114750223/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750223/)!