### PR TITLE
5/43 minimonarch: Implement in-process actor transport

### DIFF
--- a/monarch_mini/examples/hello.c
+++ b/monarch_mini/examples/hello.c
@@ -114,14 +114,14 @@ int main(void) {
   /* The send is asynchronous, so the message may already be buffered or may
    * arrive after the poller is subscribed. */
   size_t index = 0;
-  mm_msg_part_t parts[1];
+  mm_msg_part_t parts[3];
   size_t n = 0;
-  sleep_next(poller, &index, parts, 1, &n);
+  sleep_next(poller, &index, parts, 3, &n);
   printf("received: %.*s\n", (int)parts[0].len, (const char*)parts[0].data);
   fflush(stdout);
 
   /* Arm the wakeup fd by draining to MM_ENOMSG, then wait for a later send. */
-  mm_err_t empty = mm_poller_next(poller, &index, parts, 1, &n);
+  mm_err_t empty = mm_poller_next(poller, &index, parts, 3, &n);
   if (empty != MM_ENOMSG) {
     fprintf(stderr, "expected MM_ENOMSG from drained poller\n");
     exit(1);
@@ -131,7 +131,7 @@ int main(void) {
   printf("sent message to self again\n");
   fflush(stdout);
 
-  poll_next(poller, fd, &index, parts, 1, &n);
+  poll_next(poller, fd, &index, parts, 3, &n);
   printf("received: %.*s\n", (int)parts[0].len, (const char*)parts[0].data);
 
   const char* child_ident_bytes = "child-actor";
@@ -164,6 +164,20 @@ int main(void) {
   };
   CHECK(mm_actor_serve(actor, url, &parent_args));
   CHECK(mm_actor_join(child, url, &child_args));
+  poll_next(poller, fd, &index, parts, 3, &n);
+  printf(
+      "parent joined: %.*s -> %.*s\n",
+      (int)parts[0].len,
+      (const char*)parts[0].data,
+      (int)parts[1].len,
+      (const char*)parts[1].data);
+  poll_next(child_poller, child_fd, &index, parts, 3, &n);
+  printf(
+      "child joined: %.*s -> %.*s\n",
+      (int)parts[0].len,
+      (const char*)parts[0].data,
+      (int)parts[1].len,
+      (const char*)parts[1].data);
 
   const char* parent_to_child = "hello, child";
   mm_msg_part_t parent_to_child_part = {
@@ -180,7 +194,7 @@ int main(void) {
       .deleter_ctx = NULL,
   };
   CHECK(mm_actor_send(actor, child_receiver, &parent_to_child_msg));
-  poll_next(child_poller, child_fd, &index, parts, 1, &n);
+  poll_next(child_poller, child_fd, &index, parts, 3, &n);
   printf(
       "child received: %.*s\n", (int)parts[0].len, (const char*)parts[0].data);
 
@@ -199,7 +213,7 @@ int main(void) {
       .deleter_ctx = NULL,
   };
   CHECK(mm_actor_send(child, parent_receiver, &child_to_parent_msg));
-  poll_next(poller, fd, &index, parts, 1, &n);
+  poll_next(poller, fd, &index, parts, 3, &n);
   printf(
       "parent received: %.*s\n", (int)parts[0].len, (const char*)parts[0].data);
 
@@ -243,7 +257,7 @@ int main(void) {
       .n_parts = 1,
   };
   CHECK(mm_actor_send(grandchild2, child_receiver, &grandchild2_to_child_msg));
-  poll_next(child_poller, child_fd, &index, parts, 1, &n);
+  poll_next(child_poller, child_fd, &index, parts, 3, &n);
   printf(
       "child received from grandchild2: %.*s\n",
       (int)parts[0].len,

--- a/monarch_mini/python/test_smoke.py
+++ b/monarch_mini/python/test_smoke.py
@@ -87,19 +87,21 @@ async def test_next_blocks_until_message() -> None:
     assert parts == [b"late"]
 
 
-@pytest.mark.parametrize(
-    "name,call",
-    [
-        ("serve", lambda a: a.serve("inproc://a", "parent")),
-        ("join", lambda a: a.join("inproc://a", "child")),
-        ("monitor", lambda a: a.monitor(b"other@root")),
-    ],
-)
-async def test_unimplemented_bindings_raise(name, call) -> None:
-    # serve/join/monitor are bound but the underlying Rust is not implemented.
+async def test_serve_join_inproc() -> None:
+    parent = Actor(b"py-parent")
+    child = Actor(b"py-child")
+
+    parent.serve("inproc://py-smoke", "parent")
+    child.join("inproc://py-smoke", "child")
+
+    assert await parent.next() == [b"py-parent", b"py-child"]
+    assert await child.next() == [b"py-child", b"py-parent"]
+
+
+async def test_unimplemented_monitor_raises() -> None:
     a = Actor(b"srv-actor")
     with pytest.raises(RuntimeError, match="implement"):
-        call(a)
+        a.monitor(b"other@root")
 
 
 async def test_die_is_void() -> None:

--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::HashMap;
+use std::collections::VecDeque;
+
+use slotmap::SlotMap;
+
+use crate::connection::Connection;
+use crate::ctx::ChildConnectionKey;
+use crate::ctx::PollerKey;
+use crate::msg::MsgPart;
+
+pub(crate) struct ActorEntry {
+    pub(crate) ident: Option<Vec<u8>>,
+    pub(crate) delivery: Delivery,
+    pub(crate) parent: Option<Connection>,
+    pub(crate) children: SlotMap<ChildConnectionKey, Connection>,
+    pub(crate) routes: HashMap<Vec<u8>, Route>,
+    pub(crate) gateway: bool,
+    pub(crate) alive: bool,
+}
+
+impl ActorEntry {
+    pub(crate) fn new(ident: Option<Vec<u8>>) -> Self {
+        Self {
+            ident,
+            delivery: Delivery::NoPoller {
+                buffered: VecDeque::new(),
+            },
+            parent: None,
+            children: SlotMap::with_key(),
+            routes: HashMap::new(),
+            gateway: true,
+            alive: true,
+        }
+    }
+
+    pub(crate) fn subscribe(
+        &mut self,
+        poller_key: PollerKey,
+        index: usize,
+    ) -> anyhow::Result<VecDeque<Vec<MsgPart>>> {
+        let old = std::mem::replace(&mut self.delivery, Delivery::Poller { poller_key, index });
+
+        let Delivery::NoPoller { buffered } = old else {
+            self.delivery = old;
+            anyhow::bail!("actor is already subscribed to a poller");
+        };
+
+        Ok(buffered)
+    }
+
+    pub(crate) fn unsubscribe(&mut self) {
+        self.delivery = Delivery::NoPoller {
+            buffered: VecDeque::new(),
+        };
+    }
+
+    pub(crate) fn poller_subscription(&self) -> Option<(PollerKey, usize)> {
+        match &self.delivery {
+            Delivery::NoPoller { .. } => None,
+            Delivery::Poller {
+                poller_key, index, ..
+            } => Some((*poller_key, *index)),
+        }
+    }
+
+    /// Buffer a message addressed to a destination whose route is not yet known
+    /// here, so it can be flushed once the route becomes known or this actor gains
+    /// a parent. This is the only place messages enter a [`Route::Unknown`] buffer.
+    pub(crate) fn buffer_unrouted(&mut self, destination: Vec<u8>, parts: Vec<MsgPart>) {
+        let Route::Unknown(buffered) = self
+            .routes
+            .entry(destination)
+            .or_insert_with(|| Route::Unknown(Vec::new()))
+        else {
+            unreachable!("a known route would have been used to send instead of buffering");
+        };
+        buffered.push(parts);
+    }
+
+    /// Remove every buffered (unrouted) destination, returning each with its pending
+    /// messages and leaving only concrete routes behind. Used when the actor gains a
+    /// parent: the messages are re-routed up to the parent and no longer buffered here.
+    pub(crate) fn drain_buffered_routes(&mut self) -> Vec<(Vec<u8>, Vec<Vec<MsgPart>>)> {
+        let mut buffered = Vec::new();
+        let mut kept = HashMap::new();
+        for (ident, route) in std::mem::take(&mut self.routes) {
+            match route {
+                Route::Unknown(messages) => buffered.push((ident, messages)),
+                Route::Connection(_) => {
+                    kept.insert(ident, route);
+                }
+            }
+        }
+        self.routes = kept;
+        buffered
+    }
+}
+
+/// A destination ident's entry in an actor's routing table.
+pub(crate) enum Route {
+    /// The destination is not (yet) known here — it may not have been created.
+    /// Messages for it are buffered until a route is published, then flushed.
+    Unknown(Vec<Vec<MsgPart>>),
+    /// The destination is reachable through this child connection.
+    Connection(ChildConnectionKey),
+}
+
+pub(crate) enum Delivery {
+    NoPoller { buffered: VecDeque<Vec<MsgPart>> },
+    Poller { poller_key: PollerKey, index: usize },
+}

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::VecDeque;
+
+use tokio::sync::mpsc;
+
+use crate::Role;
+use crate::ctx::ChildConnectionKey;
+use crate::ctx::Command;
+use crate::ctx::Key;
+use crate::msg::MsgPart;
+
+pub(crate) struct ConnectRequest {
+    pub(crate) role: Role,
+    pub(crate) name_for_other: Option<MsgPart>,
+    pub(crate) hello_prefix: Vec<MsgPart>,
+    pub(crate) failure_prefix: Vec<MsgPart>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum ConnectionRef {
+    ParentConnection {
+        ofactor: Key,
+    },
+    ChildConnection {
+        ofactor: Key,
+        slot: ChildConnectionKey,
+    },
+}
+
+impl ConnectionRef {
+    pub(crate) fn owning_actor(self) -> Key {
+        match self {
+            Self::ParentConnection { ofactor } | Self::ChildConnection { ofactor, .. } => ofactor,
+        }
+    }
+
+    pub(crate) fn role(self) -> Role {
+        match self {
+            Self::ParentConnection { .. } => Role::Child,
+            Self::ChildConnection { .. } => Role::Parent,
+        }
+    }
+}
+
+pub(crate) enum Connection {
+    Unestablished {
+        name_for_other: Option<Vec<u8>>,
+        hello_prefix: Vec<MsgPart>,
+        failure_prefix: Vec<MsgPart>,
+        queued_commands: VecDeque<ConnectionCommand>,
+    },
+    Established {
+        transport: Box<dyn ConnectionTransport>,
+        failure_prefix: Vec<MsgPart>,
+        peer_ident: Vec<u8>,
+    },
+    Failed,
+}
+
+pub(crate) trait ConnectionTransport: Send {
+    fn send(&self, action: ConnectionCommand) -> bool;
+}
+
+pub(crate) struct InprocConnectionTransport {
+    pub(crate) tx: mpsc::UnboundedSender<Command>,
+    pub(crate) peer: ConnectionRef,
+}
+
+impl ConnectionTransport for InprocConnectionTransport {
+    fn send(&self, action: ConnectionCommand) -> bool {
+        self.tx
+            .send(Command::ConnectionSentCommand {
+                connection: self.peer,
+                action,
+            })
+            .is_ok()
+    }
+}
+
+pub(crate) enum ConnectionCommand {
+    SendMessage {
+        destination_ident: Vec<u8>,
+        parts: Vec<MsgPart>,
+    },
+    Establish {
+        peer_alive: bool,
+        peer_role: Role,
+        peer_name: Option<Vec<u8>>,
+        requested_name: Option<Vec<u8>>,
+        transport: Box<dyn ConnectionTransport>,
+    },
+    Severed {
+        reason: Vec<u8>,
+    },
+    PublishRoutes {
+        actor_idents: Vec<Vec<u8>>,
+    },
+}
+
+impl Connection {
+    pub(crate) fn new_inproc(request: ConnectRequest) -> Self {
+        let name_for_other = request
+            .name_for_other
+            .as_ref()
+            .map(|name| name.as_bytes().to_vec());
+        Self::Unestablished {
+            name_for_other,
+            hello_prefix: request.hello_prefix,
+            failure_prefix: request.failure_prefix,
+            queued_commands: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn send(&mut self, command: ConnectionCommand) -> bool {
+        match self {
+            Self::Established { transport, .. } => transport.send(command),
+            Self::Unestablished {
+                queued_commands, ..
+            } => {
+                queued_commands.push_back(command);
+                true
+            }
+            Self::Failed => false,
+        }
+    }
+
+    /// Consume a connection that is being torn down, yielding the failure-message
+    /// prefix and the peer ident to report. `None` if it had already failed.
+    pub(crate) fn into_failure_report(self) -> Option<(Vec<MsgPart>, Vec<u8>)> {
+        match self {
+            Self::Established {
+                failure_prefix,
+                peer_ident,
+                ..
+            } => Some((failure_prefix, peer_ident)),
+            Self::Unestablished {
+                name_for_other,
+                failure_prefix,
+                ..
+            } => Some((failure_prefix, name_for_other.unwrap_or_default())),
+            Self::Failed => None,
+        }
+    }
+}
+
+/// Why a connection failed to establish, carrying everything needed to notify
+/// the owning actor: the failure-message prefix, the peer ident, and the reason.
+pub(crate) struct EstablishFailure {
+    pub(crate) failure_prefix: Vec<MsgPart>,
+    pub(crate) peer_ident: Vec<u8>,
+    pub(crate) reason: Vec<u8>,
+}

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -6,10 +6,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::collections::VecDeque;
+use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
-use std::rc::Rc;
 use std::thread;
 use std::thread::JoinHandle;
 
@@ -19,155 +18,27 @@ use tokio::runtime;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
 
+use crate::Role;
+use crate::actor::ActorEntry;
+use crate::actor::Delivery;
+use crate::actor::Route;
+use crate::connection::ConnectRequest;
+use crate::connection::Connection;
+use crate::connection::ConnectionCommand;
+use crate::connection::ConnectionRef;
+use crate::connection::ConnectionTransport;
+use crate::connection::EstablishFailure;
+use crate::connection::InprocConnectionTransport;
+use crate::matcher::InprocMatcher;
+use crate::matcher::Matcher;
 use crate::msg::MsgPart;
+use crate::poller::Delivered;
+use crate::poller::PollerEntry;
 
 new_key_type! {
     pub(crate) struct Key;
     pub(crate) struct PollerKey;
-}
-
-pub(crate) struct Delivered {
-    pub(crate) index: usize,
-    pub(crate) msg: Vec<MsgPart>,
-}
-
-struct ActorEntry {
-    ident: Option<Vec<u8>>,
-    delivery: Delivery,
-}
-
-struct PollerEntry {
-    tx: mpsc::UnboundedSender<Delivered>,
-    subscriptions: Vec<PollerSubscription>,
-    event_fd: OwnedFd,
-    delivered_count: u64,
-    wake_after: Option<u64>,
-}
-
-struct PollerSubscription {
-    index: usize,
-    actor: Key,
-}
-
-impl PollerEntry {
-    fn new(tx: mpsc::UnboundedSender<Delivered>, event_fd: OwnedFd) -> Self {
-        Self {
-            tx,
-            subscriptions: Vec::new(),
-            event_fd,
-            delivered_count: 0,
-            wake_after: Some(0),
-        }
-    }
-
-    fn has_index(&self, index: usize) -> bool {
-        self.subscriptions
-            .iter()
-            .any(|subscription| subscription.index == index)
-    }
-
-    fn insert(&mut self, index: usize, actor: Key) {
-        self.subscriptions.push(PollerSubscription { index, actor });
-    }
-
-    fn remove(&mut self, index: usize) -> Option<Key> {
-        let position = self
-            .subscriptions
-            .iter()
-            .position(|subscription| subscription.index == index)?;
-        Some(self.subscriptions.swap_remove(position).actor)
-    }
-
-    fn deliver(&mut self, index: usize, msg: Vec<MsgPart>) {
-        if self.tx.send(Delivered { index, msg }).is_err() {
-            return;
-        }
-
-        self.delivered_count += 1;
-        let Some(wake_after) = self.wake_after else {
-            return;
-        };
-
-        if self.delivered_count > wake_after {
-            write_eventfd(&self.event_fd);
-            self.wake_after = None;
-        }
-    }
-
-    fn arm(&mut self, wake_after: u64) {
-        if self.delivered_count > wake_after {
-            write_eventfd(&self.event_fd);
-            self.wake_after = None;
-        } else {
-            self.wake_after = Some(wake_after);
-        }
-    }
-}
-
-struct PollerDelivery {
-    poller_key: PollerKey,
-    index: usize,
-    msg: Vec<MsgPart>,
-}
-
-enum Delivery {
-    NoPoller { buffered: VecDeque<Vec<MsgPart>> },
-    Poller { poller_key: PollerKey, index: usize },
-}
-
-impl ActorEntry {
-    fn new(ident: Option<Vec<u8>>) -> Self {
-        Self {
-            ident,
-            delivery: Delivery::NoPoller {
-                buffered: VecDeque::new(),
-            },
-        }
-    }
-
-    fn deliver(&mut self, msg: Vec<MsgPart>) -> Option<PollerDelivery> {
-        match &mut self.delivery {
-            Delivery::NoPoller { buffered } => {
-                buffered.push_back(msg);
-                None
-            }
-            Delivery::Poller { poller_key, index } => Some(PollerDelivery {
-                poller_key: *poller_key,
-                index: *index,
-                msg,
-            }),
-        }
-    }
-
-    fn subscribe(
-        &mut self,
-        poller_key: PollerKey,
-        index: usize,
-    ) -> anyhow::Result<VecDeque<Vec<MsgPart>>> {
-        let old = std::mem::replace(&mut self.delivery, Delivery::Poller { poller_key, index });
-
-        let Delivery::NoPoller { buffered } = old else {
-            self.delivery = old;
-            anyhow::bail!("actor is already subscribed to a poller");
-        };
-
-        Ok(buffered)
-    }
-
-    fn unsubscribe(&mut self) {
-        self.delivery = Delivery::NoPoller {
-            buffered: VecDeque::new(),
-        };
-    }
-
-    fn poller_subscription(&self) -> Option<(PollerKey, usize)> {
-        match &self.delivery {
-            Delivery::NoPoller { .. } => None,
-            Delivery::Poller {
-                poller_key, index, ..
-            } => Some((*poller_key, *index)),
-        }
-    }
+    pub(crate) struct ChildConnectionKey;
 }
 
 pub(crate) enum Command {
@@ -205,8 +76,26 @@ pub(crate) enum Command {
     },
     Send {
         sender: Key,
-        receiver_ident: MsgPart,
+        destination_ident: MsgPart,
         parts: Vec<MsgPart>,
+    },
+    Serve {
+        actor: Key,
+        url: String,
+        request: ConnectRequest,
+    },
+    Join {
+        actor: Key,
+        url: String,
+        request: ConnectRequest,
+    },
+    ConnectionSentCommand {
+        connection: ConnectionRef,
+        action: ConnectionCommand,
+    },
+    Die {
+        actor: Key,
+        reason: MsgPart,
     },
     Shutdown {
         done: oneshot::Sender<JoinHandle<()>>,
@@ -216,127 +105,655 @@ pub(crate) enum Command {
 struct Ctx {
     actors: SlotMap<Key, ActorEntry>,
     pollers: SlotMap<PollerKey, PollerEntry>,
+    tx: mpsc::UnboundedSender<Command>,
+    inproc: HashMap<String, InprocMatcher>,
     thread: Option<JoinHandle<()>>,
-    _not_send: PhantomData<Rc<()>>,
+    _not_send: PhantomData<*const ()>,
 }
 
 impl Ctx {
-    fn new() -> Self {
+    fn new(tx: mpsc::UnboundedSender<Command>) -> Self {
         Self {
             actors: SlotMap::with_key(),
             pollers: SlotMap::with_key(),
+            tx,
+            inproc: HashMap::new(),
             thread: None,
             _not_send: PhantomData,
         }
     }
 
-    async fn run(mut self, mut rx: mpsc::UnboundedReceiver<Command>) {
-        while let Some(command) = rx.recv().await {
-            match command {
-                Command::Init { thread } => {
-                    self.thread = Some(thread);
+    fn run_command(&mut self, command: Command) -> bool {
+        match command {
+            Command::Init { thread } => {
+                self.thread = Some(thread);
+            }
+            Command::CreateActor { ident, done } => {
+                let key = self.actors.insert(ActorEntry::new(
+                    ident.as_ref().map(|part| part.as_bytes().to_vec()),
+                ));
+                drop(ident);
+                let _ = done.send(key);
+            }
+            Command::DestroyActor { key } => {
+                let subscription = self.actor(key).poller_subscription();
+                self.die_actor(key, b"actor destroyed".to_vec());
+                if let Some((poller, index)) = subscription {
+                    if let Some(poller) = self.pollers.get_mut(poller) {
+                        let _ = poller.remove(index);
+                    }
+                    self.actor_mut(key).unsubscribe();
                 }
-                Command::CreateActor { ident, done } => {
-                    let key = self.actors.insert(ActorEntry::new(
-                        ident.as_ref().map(|part| part.as_bytes().to_vec()),
-                    ));
-                    drop(ident);
-                    let _ = done.send(key);
-                }
-                Command::DestroyActor { key } => {
-                    if let Some(actor) = self.actors.remove(key) {
-                        if let Some((poller, index)) = actor.poller_subscription() {
-                            if let Some(poller) = self.pollers.get_mut(poller) {
-                                let _ = poller.remove(index);
-                            }
-                        }
+            }
+            Command::CreatePoller { tx, event_fd, done } => {
+                let key = self.pollers.insert(PollerEntry::new(tx, event_fd));
+                let _ = done.send(key);
+            }
+            Command::DestroyPoller { poller } => {
+                if let Some(poller) = self.pollers.remove(poller) {
+                    for subscription in poller.subscriptions {
+                        self.actor_mut(subscription.actor).unsubscribe();
                     }
                 }
-                Command::CreatePoller { tx, event_fd, done } => {
-                    let key = self.pollers.insert(PollerEntry::new(tx, event_fd));
-                    let _ = done.send(key);
-                }
-                Command::DestroyPoller { poller } => {
-                    if let Some(poller) = self.pollers.remove(poller) {
-                        for subscription in poller.subscriptions {
-                            if let Some(actor) = self.actors.get_mut(subscription.actor) {
-                                actor.unsubscribe();
-                            }
+            }
+            Command::Subscribe {
+                poller,
+                index,
+                actor,
+                done,
+            } => {
+                if !self.pollers.contains_key(poller) {
+                    let _ = done.send(Err(anyhow::anyhow!("poller does not exist")));
+                } else if self.pollers[poller].has_index(index) {
+                    let _ = done.send(Err(anyhow::anyhow!("poller index is already subscribed")));
+                } else {
+                    // Move the actor onto the poller and flush any messages that were
+                    // buffered while it had no poller attached.
+                    let result = (|| -> anyhow::Result<()> {
+                        let buffered = self.actor_mut(actor).subscribe(poller, index)?;
+                        let poller_entry =
+                            self.pollers.get_mut(poller).expect("poller should exist");
+                        poller_entry.insert(index, actor);
+                        for msg in buffered {
+                            poller_entry.deliver(index, msg);
                         }
-                    }
-                }
-                Command::Subscribe {
-                    poller,
-                    index,
-                    actor,
-                    done,
-                } => {
-                    let result = self.subscribe(poller, index, actor);
+                        Ok(())
+                    })();
                     let _ = done.send(result);
                 }
-                Command::Unsubscribe { poller, index } => {
-                    if let Some(poller) = self.pollers.get_mut(poller) {
-                        if let Some(actor) = poller.remove(index) {
-                            if let Some(actor) = self.actors.get_mut(actor) {
-                                actor.unsubscribe();
-                            }
-                        }
+            }
+            Command::Unsubscribe { poller, index } => {
+                if let Some(poller) = self.pollers.get_mut(poller) {
+                    if let Some(actor) = poller.remove(index) {
+                        self.actor_mut(actor).unsubscribe();
                     }
                 }
-                Command::ArmPoller { poller, wake_after } => {
-                    if let Some(poller) = self.pollers.get_mut(poller) {
-                        poller.arm(wake_after);
+            }
+            Command::ArmPoller { poller, wake_after } => {
+                if let Some(poller) = self.pollers.get_mut(poller) {
+                    poller.arm(wake_after);
+                }
+            }
+            Command::Send {
+                sender,
+                destination_ident,
+                parts,
+            } => {
+                self.route_message(sender, destination_ident.as_bytes().to_vec(), parts);
+            }
+            Command::Serve {
+                actor,
+                url,
+                request,
+            } => {
+                self.serve(actor, url, request);
+            }
+            Command::Join {
+                actor,
+                url,
+                request,
+            } => {
+                self.join(actor, url, request);
+            }
+            Command::ConnectionSentCommand { connection, action } => {
+                if !matches!(self.connection(connection), Connection::Failed) {
+                    self.run_connection_command(connection, action);
+                }
+            }
+            Command::Die { actor, reason } => {
+                let reason = reason.as_bytes().to_vec();
+                self.die_actor(actor, reason);
+            }
+            Command::Shutdown { done } => {
+                let thread = self
+                    .thread
+                    .take()
+                    .expect("context should have thread handle");
+                let _ = done.send(thread);
+                return true;
+            }
+        }
+        false
+    }
+
+    fn actor(&self, actor: Key) -> &ActorEntry {
+        self.actors.get(actor).expect("actor should exist")
+    }
+
+    fn actor_mut(&mut self, actor: Key) -> &mut ActorEntry {
+        self.actors.get_mut(actor).expect("actor should exist")
+    }
+
+    fn connection(&self, connection: ConnectionRef) -> &Connection {
+        let actor = self.actor(connection.owning_actor());
+        match connection {
+            ConnectionRef::ParentConnection { .. } => actor
+                .parent
+                .as_ref()
+                .expect("parent connection should exist"),
+            ConnectionRef::ChildConnection { slot, .. } => actor
+                .children
+                .get(slot)
+                .expect("child connection should exist"),
+        }
+    }
+
+    fn connection_mut(&mut self, connection: ConnectionRef) -> &mut Connection {
+        let actor = self.actor_mut(connection.owning_actor());
+        match connection {
+            ConnectionRef::ParentConnection { .. } => actor
+                .parent
+                .as_mut()
+                .expect("parent connection should exist"),
+            ConnectionRef::ChildConnection { slot, .. } => actor
+                .children
+                .get_mut(slot)
+                .expect("child connection should exist"),
+        }
+    }
+
+    fn connection_set(&mut self, connection: ConnectionRef, value: Connection) -> Connection {
+        std::mem::replace(self.connection_mut(connection), value)
+    }
+
+    fn route_message(&mut self, sender: Key, destination_ident: Vec<u8>, parts: Vec<MsgPart>) {
+        let entry = self.actor(sender);
+        if !entry.alive {
+            return;
+        }
+        if entry.ident.as_deref() == Some(destination_ident.as_slice()) {
+            self.deliver_to_actor(sender, parts);
+            return;
+        }
+
+        // A known child route: hand the message down toward the destination.
+        if let Some(Route::Connection(child_key)) = entry.routes.get(destination_ident.as_slice()) {
+            let child_key = *child_key;
+            let connection = self
+                .actor_mut(sender)
+                .children
+                .get_mut(child_key)
+                .expect("route child connection should exist");
+            let _ = connection.send(ConnectionCommand::SendMessage {
+                destination_ident,
+                parts,
+            });
+            return;
+        }
+
+        // No known route here. Forward toward the gateway; the gateway itself (no
+        // parent) buffers the message until the destination's route is published —
+        // the destination may not even have been created yet. A `Route::Unknown`
+        // entry only exists at a gateway, so it also lands in the buffer branch.
+        if let Some(parent_connection) = self.actor_mut(sender).parent.as_mut() {
+            let _ = parent_connection.send(ConnectionCommand::SendMessage {
+                destination_ident,
+                parts,
+            });
+        } else {
+            self.actor_mut(sender)
+                .buffer_unrouted(destination_ident, parts);
+        }
+    }
+
+    fn serve(&mut self, actor: Key, url: String, request: ConnectRequest) {
+        if !url.starts_with("inproc://") {
+            self.deliver_connect_failure(actor, request, b"unsupported url scheme".to_vec());
+            return;
+        }
+
+        let Some(pending) = self.attach_inproc_connection(actor, request) else {
+            return;
+        };
+        let mut matcher = self.inproc.remove(&url).unwrap_or_else(Matcher::new);
+        let _ = matcher.push_left(pending, |serve, join| {
+            self.establish_inproc(serve, join);
+        });
+        self.inproc.insert(url, matcher);
+    }
+
+    fn join(&mut self, actor: Key, url: String, request: ConnectRequest) {
+        if !url.starts_with("inproc://") {
+            self.deliver_connect_failure(actor, request, b"unsupported url scheme".to_vec());
+            return;
+        }
+
+        let Some(pending) = self.attach_inproc_connection(actor, request) else {
+            return;
+        };
+        let mut matcher = self.inproc.remove(&url).unwrap_or_else(Matcher::new);
+        let _ = matcher.push_right(pending, |serve, join| {
+            self.establish_inproc(serve, join);
+        });
+        self.inproc.insert(url, matcher);
+    }
+
+    fn attach_inproc_connection(
+        &mut self,
+        actor: Key,
+        request: ConnectRequest,
+    ) -> Option<ConnectionRef> {
+        let role = request.role;
+        let connection = Connection::new_inproc(request);
+
+        let connection = match role {
+            Role::Parent => {
+                let actor_entry = self.actor(actor);
+                if !actor_entry.gateway && actor_entry.parent.is_none() {
+                    let Connection::Unestablished {
+                        mut failure_prefix, ..
+                    } = connection
+                    else {
+                        unreachable!("new connection should be unestablished");
+                    };
+                    failure_prefix.push(MsgPart::from_bytes(Vec::new()));
+                    failure_prefix.push(MsgPart::from_bytes(
+                        b"invalid parent-child topology".to_vec(),
+                    ));
+                    self.deliver_to_actor(actor, failure_prefix);
+                    return None;
+                }
+                let slot = self.actor_mut(actor).children.insert(connection);
+                ConnectionRef::ChildConnection {
+                    ofactor: actor,
+                    slot,
+                }
+            }
+            Role::Child => {
+                let actor_entry = self.actor_mut(actor);
+                // An actor may have at most one parent. It is free to have already
+                // served children or buffered messages as a gateway; gaining a parent
+                // hands all of that upward (see publish_routes_after_established).
+                if actor_entry.parent.is_some() {
+                    let Connection::Unestablished {
+                        mut failure_prefix, ..
+                    } = connection
+                    else {
+                        unreachable!("new connection should be unestablished");
+                    };
+                    failure_prefix.push(MsgPart::from_bytes(Vec::new()));
+                    failure_prefix.push(MsgPart::from_bytes(
+                        b"invalid parent-child topology".to_vec(),
+                    ));
+                    self.deliver_to_actor(actor, failure_prefix);
+                    return None;
+                }
+                actor_entry.parent = Some(connection);
+                actor_entry.gateway = false;
+                ConnectionRef::ParentConnection { ofactor: actor }
+            }
+        };
+
+        Some(connection)
+    }
+
+    fn establish_inproc(&mut self, serve: ConnectionRef, join: ConnectionRef) {
+        self.send_inproc_established(serve, join);
+        self.send_inproc_established(join, serve);
+    }
+
+    fn send_inproc_established(&mut self, connection: ConnectionRef, peer: ConnectionRef) {
+        let tx = self.tx.clone();
+
+        // Peer liveness is not something the receiver can observe locally (a real
+        // transport's peer may be remote), so report it in the Establish message and
+        // let establish treat a dead peer as a sever reason. The peer's own name and
+        // the name it wants to give us are only known while its connection is still
+        // pending, so a torn-down peer is reported as nameless.
+        let peer_alive = self.actor(peer.owning_actor()).alive;
+        let (peer_name, requested_name) = match self.connection(peer) {
+            Connection::Unestablished { name_for_other, .. } => (
+                self.actor(peer.owning_actor()).ident.clone(),
+                name_for_other.clone(),
+            ),
+            _ => (None, None),
+        };
+
+        self.send_connection_command(
+            connection,
+            ConnectionCommand::Establish {
+                peer_alive,
+                peer_role: peer.role(),
+                peer_name,
+                requested_name,
+                transport: Box::new(InprocConnectionTransport { tx, peer }),
+            },
+        );
+    }
+
+    fn connection_topology_is_valid(&self, connection: ConnectionRef) -> bool {
+        let actor = self.actor(connection.owning_actor());
+        match connection.role() {
+            Role::Parent => actor.alive && (actor.gateway || actor.parent.is_some()),
+            Role::Child => actor.alive,
+        }
+    }
+
+    fn populate_routes(
+        &mut self,
+        parent: Key,
+        child_connection: ChildConnectionKey,
+        idents: Vec<Vec<u8>>,
+    ) {
+        for ident in &idents {
+            let previous = self
+                .actor_mut(parent)
+                .routes
+                .insert(ident.clone(), Route::Connection(child_connection));
+
+            // If we had been buffering messages for this destination because its route
+            // was unknown, re-route them now that it is known; route_message sends them
+            // down the child connection we just recorded.
+            if let Some(Route::Unknown(buffered)) = previous {
+                for parts in buffered {
+                    self.route_message(parent, ident.clone(), parts);
+                }
+            }
+        }
+        self.publish_routes_to_parent(parent, idents);
+    }
+
+    fn publish_routes_to_parent(&mut self, actor: Key, actor_idents: Vec<Vec<u8>>) {
+        let actor = self.actor_mut(actor);
+        let Some(parent) = actor.parent.as_mut() else {
+            return;
+        };
+        let _ = parent.send(ConnectionCommand::PublishRoutes { actor_idents });
+    }
+
+    fn publish_routes_after_established(
+        &mut self,
+        connection: ConnectionRef,
+        local_ident: Vec<u8>,
+        peer_ident: Vec<u8>,
+    ) {
+        match connection {
+            ConnectionRef::ChildConnection { ofactor, slot } => {
+                self.populate_routes(ofactor, slot, vec![peer_ident]);
+            }
+            ConnectionRef::ParentConnection { ofactor } => {
+                // We just gained a parent. Stop buffering for destinations we couldn't
+                // place while parentless: drop those entries and re-route their held
+                // messages, which now flow up to the parent (route_message forwards
+                // them, since their local routes are gone).
+                let buffered = self.actor_mut(ofactor).drain_buffered_routes();
+
+                // Advertise the destinations we can already reach (concrete child
+                // routes) plus our own ident.
+                let mut actor_idents = self
+                    .actor(ofactor)
+                    .routes
+                    .keys()
+                    .cloned()
+                    .collect::<Vec<_>>();
+                actor_idents.push(local_ident);
+                self.publish_routes_to_parent(ofactor, actor_idents);
+
+                for (destination, messages) in buffered {
+                    for parts in messages {
+                        self.route_message(ofactor, destination.clone(), parts);
                     }
-                }
-                Command::Send {
-                    sender,
-                    receiver_ident,
-                    parts,
-                } => {
-                    self.send(sender, receiver_ident, parts);
-                }
-                Command::Shutdown { done } => {
-                    let thread = self
-                        .thread
-                        .take()
-                        .expect("context should have thread handle");
-                    let _ = done.send(thread);
-                    break;
                 }
             }
         }
     }
 
-    fn subscribe(&mut self, poller: PollerKey, index: usize, actor: Key) -> anyhow::Result<()> {
-        let Some(poller_entry) = self.pollers.get_mut(poller) else {
-            anyhow::bail!("poller does not exist");
-        };
-        if poller_entry.has_index(index) {
-            anyhow::bail!("poller index is already subscribed");
-        }
-
-        let Some(actor_entry) = self.actors.get_mut(actor) else {
-            anyhow::bail!("actor does not exist");
-        };
-
-        let buffered = actor_entry.subscribe(poller, index)?;
-        poller_entry.insert(index, actor);
-        for msg in buffered {
-            poller_entry.deliver(index, msg);
-        }
-        Ok(())
+    fn send_connection_command(&mut self, connection: ConnectionRef, action: ConnectionCommand) {
+        let _ = self
+            .tx
+            .send(Command::ConnectionSentCommand { connection, action });
     }
 
-    fn send(&mut self, sender: Key, receiver_ident: MsgPart, parts: Vec<MsgPart>) {
-        let Some(actor) = self.actors.get_mut(sender) else {
-            return;
+    fn run_connection_command(&mut self, connection: ConnectionRef, action: ConnectionCommand) {
+        match action {
+            ConnectionCommand::SendMessage {
+                destination_ident,
+                parts,
+            } => self.route_message(connection.owning_actor(), destination_ident, parts),
+            ConnectionCommand::Establish {
+                peer_alive,
+                peer_role,
+                peer_name,
+                requested_name,
+                transport,
+            } => {
+                if let Err(EstablishFailure {
+                    failure_prefix,
+                    peer_ident,
+                    reason,
+                }) = self.establish_connection(
+                    connection,
+                    peer_alive,
+                    peer_role,
+                    peer_name,
+                    requested_name,
+                    transport,
+                ) {
+                    // Establishment failed (roles disagree, name conflict, dead peer,
+                    // ...): sever the connection and notify the actor.
+                    let _ = self.connection_set(connection, Connection::Failed);
+                    self.fail_connection(connection, failure_prefix, peer_ident, reason);
+                }
+            }
+            ConnectionCommand::Severed { reason } => {
+                // The peer (or our own death cascade) tore this connection down. Mark
+                // it failed and pull out what we need to notify the owning actor.
+                let Some((failure_prefix, peer_ident)) = self
+                    .connection_set(connection, Connection::Failed)
+                    .into_failure_report()
+                else {
+                    return;
+                };
+                self.fail_connection(connection, failure_prefix, peer_ident, reason);
+            }
+            ConnectionCommand::PublishRoutes { actor_idents } => {
+                assert!(
+                    matches!(self.connection(connection), Connection::Established { .. }),
+                    "published routes should arrive on an established connection"
+                );
+                // Published routes always arrive over a child connection: record them
+                // as routes to that child (which also forwards them on toward the root).
+                let ConnectionRef::ChildConnection { ofactor, slot } = connection else {
+                    panic!("published routes should arrive on a child connection");
+                };
+                self.populate_routes(ofactor, slot, actor_idents);
+            }
+        }
+    }
+
+    /// Notify an actor that one of its connections failed: deliver the failure
+    /// prefix (followed by the peer ident and the reason), and — since a child
+    /// cannot exist without its parent — tear the actor down if this was its
+    /// parent connection. `deliver_to_actor`/`die_actor` are no-ops on a dead
+    /// actor, so this is safe to call regardless of the actor's liveness.
+    fn fail_connection(
+        &mut self,
+        connection: ConnectionRef,
+        mut failure_prefix: Vec<MsgPart>,
+        peer_ident: Vec<u8>,
+        reason: Vec<u8>,
+    ) {
+        let actor = connection.owning_actor();
+        failure_prefix.push(MsgPart::from_bytes(peer_ident));
+        failure_prefix.push(MsgPart::from_bytes(reason.clone()));
+        self.deliver_to_actor(actor, failure_prefix);
+        if connection.role() == Role::Child {
+            self.die_actor(actor, reason);
+        }
+    }
+
+    fn establish_connection(
+        &mut self,
+        connection: ConnectionRef,
+        peer_alive: bool,
+        peer_role: Role,
+        peer_name: Option<Vec<u8>>,
+        requested_name: Option<Vec<u8>>,
+        transport: Box<dyn ConnectionTransport>,
+    ) -> Result<(), EstablishFailure> {
+        // Take the unestablished connection apart; establishing it consumes the
+        // hello/failure prefixes and any commands queued before it was ready.
+        let local_connection = self.connection_mut(connection);
+        let local_status = std::mem::replace(local_connection, Connection::Failed);
+
+        let Connection::Unestablished {
+            name_for_other,
+            hello_prefix,
+            failure_prefix,
+            queued_commands,
+        } = local_status
+        else {
+            unreachable!("local status should be unestablished");
         };
 
-        if actor.ident.as_deref() == Some(receiver_ident.as_bytes()) {
-            let delivery = actor.deliver(parts);
-            if let Some(delivery) = delivery {
-                if let Some(poller) = self.pollers.get_mut(delivery.poller_key) {
-                    poller.deliver(delivery.index, delivery.msg);
+        let failure_peer_ident = peer_name
+            .clone()
+            .or_else(|| name_for_other.clone())
+            .unwrap_or_default();
+
+        let mut failure_prefix = Some(failure_prefix);
+        let result = (|| -> Result<(), Vec<u8>> {
+            if !peer_alive {
+                return Err(b"peer actor died".to_vec());
+            }
+            if connection.role() == peer_role {
+                return Err(b"connection roles do not agree".to_vec());
+            }
+            if !self.connection_topology_is_valid(connection) {
+                return Err(b"invalid parent-child topology".to_vec());
+            }
+
+            let actor = connection.owning_actor();
+            let local_ident = {
+                let actor_entry = self.actor_mut(actor);
+                if let Some(requested_name) = requested_name {
+                    match &actor_entry.ident {
+                        Some(existing) if existing != &requested_name => {
+                            return Err(b"actor name conflict".to_vec());
+                        }
+                        Some(_) => {}
+                        None => actor_entry.ident = Some(requested_name),
+                    }
+                }
+                actor_entry
+                    .ident
+                    .clone()
+                    .ok_or_else(|| b"actor has no ident".to_vec())?
+            };
+            let peer_ident = peer_name
+                .or(name_for_other)
+                .ok_or_else(|| b"peer actor has no ident".to_vec())?;
+
+            self.connection_set(
+                connection,
+                Connection::Established {
+                    transport,
+                    failure_prefix: failure_prefix
+                        .take()
+                        .expect("failure prefix should be available"),
+                    peer_ident: peer_ident.clone(),
+                },
+            );
+            let connection_entry = self.connection_mut(connection);
+            let mut queued_commands = queued_commands;
+            while let Some(command) = queued_commands.pop_front() {
+                let _ = connection_entry.send(command);
+            }
+
+            self.publish_routes_after_established(
+                connection,
+                local_ident.clone(),
+                peer_ident.clone(),
+            );
+
+            let mut msg = hello_prefix;
+            msg.push(MsgPart::from_bytes(local_ident));
+            msg.push(MsgPart::from_bytes(peer_ident));
+            self.deliver_to_actor(actor, msg);
+            Ok(())
+        })();
+
+        result.map_err(|reason| EstablishFailure {
+            failure_prefix: failure_prefix
+                .take()
+                .expect("failure prefix should be available"),
+            peer_ident: failure_peer_ident,
+            reason,
+        })
+    }
+
+    fn deliver_connect_failure(
+        &mut self,
+        actor: Key,
+        mut request: ConnectRequest,
+        reason: Vec<u8>,
+    ) {
+        let other_ident = request
+            .name_for_other
+            .as_ref()
+            .map(|part| part.as_bytes().to_vec())
+            .unwrap_or_default();
+        request
+            .failure_prefix
+            .push(MsgPart::from_bytes(other_ident));
+        request.failure_prefix.push(MsgPart::from_bytes(reason));
+        self.deliver_to_actor(actor, request.failure_prefix);
+    }
+
+    fn die_actor(&mut self, actor: Key, reason: Vec<u8>) {
+        let entry = self.actor_mut(actor);
+        if !entry.alive {
+            return;
+        }
+        entry.alive = false;
+
+        for (_, connection) in &mut entry.children {
+            connection.send(ConnectionCommand::Severed {
+                reason: reason.clone(),
+            });
+            *connection = Connection::Failed;
+        }
+        if let Some(connection) = entry.parent.as_mut() {
+            connection.send(ConnectionCommand::Severed { reason });
+            *connection = Connection::Failed;
+        }
+    }
+
+    fn deliver_to_actor(&mut self, actor: Key, msg: Vec<MsgPart>) {
+        let actor = self.actor_mut(actor);
+        if !actor.alive {
+            return;
+        }
+        match &mut actor.delivery {
+            Delivery::NoPoller { buffered } => {
+                buffered.push_back(msg);
+            }
+            Delivery::Poller { poller_key, index } => {
+                let poller_key = *poller_key;
+                let index = *index;
+                let _ = actor;
+                if let Some(poller) = self.pollers.get_mut(poller_key) {
+                    poller.deliver(index, msg);
                 }
             }
         }
@@ -348,18 +765,10 @@ pub struct CtxHandle {
     tx: mpsc::UnboundedSender<Command>,
 }
 
-fn write_eventfd(event_fd: &OwnedFd) {
-    use std::os::fd::AsRawFd;
-
-    let value = 1_u64.to_ne_bytes();
-    unsafe {
-        let _ = crate::write(event_fd.as_raw_fd(), value.as_ptr().cast(), value.len());
-    }
-}
-
 impl CtxHandle {
     pub fn new() -> anyhow::Result<Self> {
-        let (tx, rx) = mpsc::unbounded_channel();
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let runtime_tx = tx.clone();
         let thread = thread::Builder::new()
             .name("monarch-mini".to_owned())
             .spawn(move || {
@@ -367,7 +776,15 @@ impl CtxHandle {
                     .build()
                     .expect("tokio runtime should build");
                 let local = tokio::task::LocalSet::new();
-                local.block_on(&rt, Ctx::new().run(rx));
+                // Event loop: dispatch commands until a Shutdown command is handled.
+                local.block_on(&rt, async move {
+                    let mut ctx = Ctx::new(runtime_tx);
+                    while let Some(command) = rx.recv().await {
+                        if ctx.run_command(command) {
+                            break;
+                        }
+                    }
+                });
             })?;
 
         let handle = Self { tx };
@@ -382,24 +799,9 @@ impl CtxHandle {
     }
 }
 
+// Tests live in a separate file but are declared here as a submodule of `ctx`
+// (rather than a crate-level module) so they can reach `Ctx`'s private internals
+// without widening its visibility.
 #[cfg(test)]
-mod tests {
-    use tokio::sync::oneshot;
-
-    use super::Command;
-    use super::CtxHandle;
-
-    #[test]
-    fn context_starts_and_stops_runtime_thread() {
-        let ctx = CtxHandle::new().expect("context should start");
-        let (done_tx, done_rx) = oneshot::channel();
-        ctx.send_command(Command::Shutdown { done: done_tx })
-            .expect("shutdown should send");
-        done_rx
-            .blocking_recv()
-            .expect("shutdown should return thread")
-            .join()
-            .expect("thread should join");
-        drop(ctx);
-    }
-}
+#[path = "tests.rs"]
+mod tests;

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -6,12 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//
-// C FFI layer. CCtx/CActor/CPoller/CMonitorHandle are thin wrappers that exist
-// solely to cross the C boundary. All real logic lives in the inner types.
-
+mod actor;
+mod connection;
 mod ctx;
+mod matcher;
 mod msg;
+mod poller;
 
 use std::cell::RefCell;
 use std::ffi::CString;
@@ -23,14 +23,15 @@ use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
 
+use connection::ConnectRequest;
 use ctx::Command;
 use ctx::CtxHandle;
-use ctx::Delivered;
 use ctx::Key;
 use ctx::PollerKey;
 use msg::CMsg;
 use msg::CMsgPart;
 use msg::MsgPart;
+use poller::Delivered;
 
 const EFD_CLOEXEC: c_int = 0o2000000;
 const EFD_NONBLOCK: c_int = 0o4000;
@@ -80,7 +81,7 @@ pub struct CMonitorHandle {
 // ---------------------------------------------------------------------------
 
 #[repr(i32)]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Role {
     Child = 0,
     Parent = 1,
@@ -292,7 +293,7 @@ pub unsafe extern "C" fn mm_actor_send(
     a.ctx
         .send_command(Command::Send {
             sender: a.key,
-            receiver_ident: MsgPart::from_c(receiver_ident),
+            destination_ident: MsgPart::from_c(receiver_ident),
             parts: parts_from_cmsg(msg),
         })
         .into()
@@ -304,14 +305,24 @@ pub unsafe extern "C" fn mm_actor_serve(
     url: *const c_char,
     args: *const CConnectArgs,
 ) -> Error {
-    let url = std::ffi::CStr::from_ptr(url).to_str().unwrap_or("");
+    let url = std::ffi::CStr::from_ptr(url)
+        .to_str()
+        .unwrap_or("")
+        .to_owned();
     let a = &*actor;
     let args = &*args;
-    let _ = (&a.ctx, a.key, url, args.role == Role::Parent);
-    let _name_for_joiner = opt_name(args.name_for_other);
-    let _hello_prefix = parts_from_cmsg(args.hello_prefix);
-    let _failure_prefix = parts_from_cmsg(args.failure_prefix);
-    not_implemented()
+    a.ctx
+        .send_command(Command::Serve {
+            actor: a.key,
+            url,
+            request: ConnectRequest {
+                role: args.role,
+                name_for_other: opt_name(args.name_for_other),
+                hello_prefix: parts_from_cmsg(args.hello_prefix),
+                failure_prefix: parts_from_cmsg(args.failure_prefix),
+            },
+        })
+        .into()
 }
 
 #[no_mangle]
@@ -320,20 +331,33 @@ pub unsafe extern "C" fn mm_actor_join(
     url: *const c_char,
     args: *const CConnectArgs,
 ) -> Error {
-    let url = std::ffi::CStr::from_ptr(url).to_str().unwrap_or("");
+    let url = std::ffi::CStr::from_ptr(url)
+        .to_str()
+        .unwrap_or("")
+        .to_owned();
     let a = &*actor;
     let args = &*args;
-    let _ = (&a.ctx, a.key, url, args.role == Role::Parent);
-    let _name_for_server = opt_name(args.name_for_other);
-    let _hello_prefix = parts_from_cmsg(args.hello_prefix);
-    let _failure_prefix = parts_from_cmsg(args.failure_prefix);
-    not_implemented()
+    a.ctx
+        .send_command(Command::Join {
+            actor: a.key,
+            url,
+            request: ConnectRequest {
+                role: args.role,
+                name_for_other: opt_name(args.name_for_other),
+                hello_prefix: parts_from_cmsg(args.hello_prefix),
+                failure_prefix: parts_from_cmsg(args.failure_prefix),
+            },
+        })
+        .into()
 }
 
 #[no_mangle]
 pub unsafe extern "C" fn mm_actor_die(actor: *mut CActor, reason: CMsgPart) {
     let a = &*actor;
-    let _ = (&a.ctx, a.key, MsgPart::from_c(reason));
+    let _ = a.ctx.send_command(Command::Die {
+        actor: a.key,
+        reason: MsgPart::from_c(reason),
+    });
 }
 
 #[no_mangle]

--- a/monarch_mini/src/matcher.rs
+++ b/monarch_mini/src/matcher.rs
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::collections::VecDeque;
+
+use crate::connection::ConnectionRef;
+
+pub(crate) struct Matcher<Left, Right> {
+    left: VecDeque<Left>,
+    right: VecDeque<Right>,
+}
+
+impl<Left, Right> Matcher<Left, Right> {
+    pub(crate) fn new() -> Self {
+        Self {
+            left: VecDeque::new(),
+            right: VecDeque::new(),
+        }
+    }
+
+    pub(crate) fn push_left<Output>(
+        &mut self,
+        left: Left,
+        on_match: impl FnOnce(Left, Right) -> Output,
+    ) -> Option<Output> {
+        let Some(right) = self.right.pop_front() else {
+            self.left.push_back(left);
+            return None;
+        };
+        Some(on_match(left, right))
+    }
+
+    pub(crate) fn push_right<Output>(
+        &mut self,
+        right: Right,
+        on_match: impl FnOnce(Left, Right) -> Output,
+    ) -> Option<Output> {
+        let Some(left) = self.left.pop_front() else {
+            self.right.push_back(right);
+            return None;
+        };
+        Some(on_match(left, right))
+    }
+}
+
+pub(crate) type InprocMatcher = Matcher<ConnectionRef, ConnectionRef>;

--- a/monarch_mini/src/msg.rs
+++ b/monarch_mini/src/msg.rs
@@ -8,6 +8,8 @@
 
 use std::ffi::c_void;
 
+struct OwnedBytes(Vec<u8>);
+
 /// Owning Rust message part. Calls the C deleter on drop.
 /// The C caller must not free or use the data after passing it in.
 pub struct MsgPart {
@@ -34,6 +36,18 @@ pub struct CMsg {
 }
 
 impl MsgPart {
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        let owned = Box::new(OwnedBytes(bytes));
+        let data = owned.0.as_ptr().cast();
+        let len = owned.0.len();
+        MsgPart {
+            data,
+            len,
+            deleter: Some(drop_owned_bytes),
+            deleter_ctx: Box::into_raw(owned).cast(),
+        }
+    }
+
     /// Take ownership of a CMsgPart passed in from C.
     pub unsafe fn from_c(part: CMsgPart) -> Self {
         MsgPart {
@@ -66,6 +80,15 @@ impl MsgPart {
     }
 }
 
+unsafe extern "C" fn drop_owned_bytes(ctx: *mut c_void) {
+    // SAFETY: `ctx` was created by `MsgPart::from_bytes` with
+    // `Box::into_raw(Box<OwnedBytes>)`, and this deleter is installed exactly
+    // once on the owning `MsgPart`.
+    unsafe {
+        drop(Box::from_raw(ctx.cast::<OwnedBytes>()));
+    }
+}
+
 impl Drop for MsgPart {
     fn drop(&mut self) {
         if let Some(deleter) = self.deleter {
@@ -74,5 +97,10 @@ impl Drop for MsgPart {
     }
 }
 
+// SAFETY: `MsgPart` transfers opaque C-owned memory between threads without
+// dereferencing it except to read immutable bytes. Ownership remains unique,
+// and the deleter runs only from `Drop`.
 unsafe impl Send for MsgPart {}
+// SAFETY: shared references to `MsgPart` expose only immutable byte slices.
+// Mutation and destruction require ownership of the `MsgPart`.
 unsafe impl Sync for MsgPart {}

--- a/monarch_mini/src/poller.rs
+++ b/monarch_mini/src/poller.rs
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::os::fd::OwnedFd;
+
+use tokio::sync::mpsc;
+
+use crate::ctx::Key;
+use crate::msg::MsgPart;
+
+pub(crate) struct Delivered {
+    pub(crate) index: usize,
+    pub(crate) msg: Vec<MsgPart>,
+}
+
+pub(crate) struct PollerEntry {
+    tx: mpsc::UnboundedSender<Delivered>,
+    pub(crate) subscriptions: Vec<PollerSubscription>,
+    event_fd: OwnedFd,
+    delivered_count: u64,
+    wake_after: Option<u64>,
+}
+
+pub(crate) struct PollerSubscription {
+    index: usize,
+    pub(crate) actor: Key,
+}
+
+impl PollerEntry {
+    pub(crate) fn new(tx: mpsc::UnboundedSender<Delivered>, event_fd: OwnedFd) -> Self {
+        Self {
+            tx,
+            subscriptions: Vec::new(),
+            event_fd,
+            delivered_count: 0,
+            wake_after: Some(0),
+        }
+    }
+
+    pub(crate) fn has_index(&self, index: usize) -> bool {
+        self.subscriptions
+            .iter()
+            .any(|subscription| subscription.index == index)
+    }
+
+    pub(crate) fn insert(&mut self, index: usize, actor: Key) {
+        self.subscriptions.push(PollerSubscription { index, actor });
+    }
+
+    pub(crate) fn remove(&mut self, index: usize) -> Option<Key> {
+        let position = self
+            .subscriptions
+            .iter()
+            .position(|subscription| subscription.index == index)?;
+        Some(self.subscriptions.swap_remove(position).actor)
+    }
+
+    pub(crate) fn deliver(&mut self, index: usize, msg: Vec<MsgPart>) {
+        if self.tx.send(Delivered { index, msg }).is_err() {
+            return;
+        }
+
+        self.delivered_count += 1;
+        let Some(wake_after) = self.wake_after else {
+            return;
+        };
+
+        if self.delivered_count > wake_after {
+            write_eventfd(&self.event_fd);
+            self.wake_after = None;
+        }
+    }
+
+    pub(crate) fn arm(&mut self, wake_after: u64) {
+        if self.delivered_count > wake_after {
+            write_eventfd(&self.event_fd);
+            self.wake_after = None;
+        } else {
+            self.wake_after = Some(wake_after);
+        }
+    }
+}
+
+fn write_eventfd(event_fd: &OwnedFd) {
+    use std::os::fd::AsRawFd;
+
+    let value = 1_u64.to_ne_bytes();
+    unsafe {
+        let _ = crate::write(event_fd.as_raw_fd(), value.as_ptr().cast(), value.len());
+    }
+}

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -1,0 +1,389 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use std::fs::File;
+use std::os::fd::OwnedFd;
+
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+use crate::Role;
+use crate::actor::ActorEntry;
+use crate::actor::Delivery;
+use crate::actor::Route;
+use crate::connection::ConnectRequest;
+use crate::connection::Connection;
+use crate::ctx::Command;
+use crate::ctx::Ctx;
+use crate::ctx::CtxHandle;
+use crate::ctx::Key;
+use crate::ctx::PollerKey;
+use crate::msg::MsgPart;
+use crate::poller::Delivered;
+
+#[test]
+fn context_starts_and_stops_runtime_thread() {
+    let ctx = CtxHandle::new().expect("context should start");
+    let (done_tx, done_rx) = oneshot::channel();
+    ctx.send_command(Command::Shutdown { done: done_tx })
+        .expect("shutdown should send");
+    done_rx
+        .blocking_recv()
+        .expect("shutdown should return thread")
+        .join()
+        .expect("thread should join");
+    drop(ctx);
+}
+
+#[test]
+fn inproc_matches_join_before_serve() {
+    let (mut ctx, mut rx) = test_ctx();
+    let parent = actor(&mut ctx, "parent");
+    let child = actor(&mut ctx, "child");
+
+    ctx.join(child, "inproc://queue".to_owned(), request(Role::Child));
+    assert!(ctx.actors[parent].children.is_empty());
+
+    ctx.serve(parent, "inproc://queue".to_owned(), request(Role::Parent));
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(ctx.actors[child].parent.is_some());
+    assert_eq!(buffered_strings(&ctx, parent), vec!["parent", "child"]);
+    assert_eq!(buffered_strings(&ctx, child), vec!["child", "parent"]);
+}
+
+#[test]
+fn inproc_send_queues_until_connection_establishes() {
+    let (mut ctx, mut rx) = test_ctx();
+    let parent = actor(&mut ctx, "parent");
+    let child = actor(&mut ctx, "child");
+
+    ctx.join(child, "inproc://queue".to_owned(), request(Role::Child));
+    ctx.route_message(
+        child,
+        b"parent".to_vec(),
+        vec![MsgPart::from_bytes(b"queued".to_vec())],
+    );
+    ctx.serve(parent, "inproc://queue".to_owned(), request(Role::Parent));
+    drain_commands(&mut ctx, &mut rx);
+
+    assert_eq!(
+        buffered_strings(&ctx, parent),
+        vec!["parent", "child", "queued"]
+    );
+}
+
+#[test]
+fn inproc_routes_through_ancestors_without_sibling_pollution() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let child = actor(&mut ctx, "child");
+    let sibling = actor(&mut ctx, "sibling");
+    let grandchild = actor(&mut ctx, "grandchild");
+
+    connect(&mut ctx, root, child, "inproc://child");
+    connect(&mut ctx, root, sibling, "inproc://sibling");
+    connect(&mut ctx, child, grandchild, "inproc://grandchild");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(ctx.actors[sibling].routes.is_empty());
+    assert!(
+        ctx.actors[child]
+            .routes
+            .contains_key(b"grandchild".as_slice())
+    );
+    assert!(
+        ctx.actors[root]
+            .routes
+            .contains_key(b"grandchild".as_slice())
+    );
+}
+
+#[test]
+fn inproc_receive_loops_route_messages() {
+    let ctx = CtxHandle::new().expect("context should start");
+    let root = runtime_actor(&ctx, "root");
+    let child = runtime_actor(&ctx, "child");
+    let sibling = runtime_actor(&ctx, "sibling");
+    let grandchild = runtime_actor(&ctx, "grandchild");
+    let (poller, mut rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, poller, 0, grandchild);
+
+    runtime_connect(&ctx, root, child, "inproc://child");
+    runtime_connect(&ctx, root, sibling, "inproc://sibling");
+    runtime_connect(&ctx, child, grandchild, "inproc://grandchild");
+    assert_eq!(recv_strings(&mut rx), vec!["grandchild", "child"]);
+
+    ctx.send_command(Command::Send {
+        sender: sibling,
+        destination_ident: MsgPart::from_bytes(b"grandchild".to_vec()),
+        parts: vec![MsgPart::from_bytes(b"from sibling".to_vec())],
+    })
+    .expect("send should enqueue");
+
+    assert_eq!(recv_strings(&mut rx), vec!["from sibling"]);
+    shutdown(ctx);
+}
+
+#[test]
+fn die_breaks_inproc_connection_and_delivers_failure() {
+    let ctx = CtxHandle::new().expect("context should start");
+    let parent = runtime_actor(&ctx, "parent");
+    let child = runtime_actor(&ctx, "child");
+    let (poller, mut rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, poller, 0, parent);
+
+    ctx.send_command(Command::Serve {
+        actor: parent,
+        url: "inproc://child".to_owned(),
+        request: request_with_failure(Role::Parent, "parent-failed"),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: child,
+        url: "inproc://child".to_owned(),
+        request: request_with_failure(Role::Child, "child-failed"),
+    })
+    .expect("join should enqueue");
+    assert_eq!(recv_strings(&mut rx), vec!["parent", "child"]);
+
+    ctx.send_command(Command::Die {
+        actor: child,
+        reason: MsgPart::from_bytes(b"done".to_vec()),
+    })
+    .expect("die should enqueue");
+
+    assert_eq!(
+        recv_strings(&mut rx),
+        vec!["parent-failed", "child", "done"]
+    );
+    shutdown(ctx);
+}
+
+#[test]
+fn dead_pending_connect_fails_when_matched() {
+    let (mut ctx, mut rx) = test_ctx();
+    let server = actor(&mut ctx, "server");
+    let joiner = actor(&mut ctx, "joiner");
+
+    ctx.serve(
+        server,
+        "inproc://late".to_owned(),
+        request_with_failure(Role::Parent, "server-failed"),
+    );
+    ctx.die_actor(server, b"gone".to_vec());
+    ctx.join(
+        joiner,
+        "inproc://late".to_owned(),
+        request_with_failure(Role::Child, "joiner-failed"),
+    );
+    drain_commands(&mut ctx, &mut rx);
+
+    assert_eq!(
+        buffered_strings(&ctx, joiner),
+        vec!["joiner-failed", "", "peer actor died"]
+    );
+    assert!(matches!(
+        ctx.actors[joiner].parent,
+        Some(Connection::Failed)
+    ));
+    assert!(!ctx.actors[joiner].gateway);
+}
+
+#[test]
+fn message_to_unrouted_actor_buffers_at_gateway_then_flushes() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let child = actor(&mut ctx, "child");
+    connect(&mut ctx, root, child, "inproc://child");
+    drain_commands(&mut ctx, &mut rx);
+
+    // "grandchild" has no route yet, so the message routes up to the gateway
+    // (root) and is buffered there instead of being dropped.
+    ctx.route_message(
+        child,
+        b"grandchild".to_vec(),
+        vec![MsgPart::from_bytes(b"early".to_vec())],
+    );
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[root].routes.get(b"grandchild".as_slice()),
+        Some(Route::Unknown(_))
+    ));
+
+    // The grandchild now appears under the child; publishing its route up to the
+    // gateway flushes the buffered message down to it (after the hello message).
+    let grandchild = actor(&mut ctx, "grandchild");
+    connect(&mut ctx, child, grandchild, "inproc://grandchild");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert_eq!(
+        buffered_strings(&ctx, grandchild),
+        vec!["grandchild", "child", "early"]
+    );
+}
+
+#[test]
+fn buffered_messages_flush_upward_when_actor_gains_a_parent() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let target = actor(&mut ctx, "target");
+    let mover = actor(&mut ctx, "mover");
+
+    connect(&mut ctx, root, target, "inproc://target");
+    drain_commands(&mut ctx, &mut rx);
+
+    // `mover` sends to "target" before it has a parent, so it buffers the message
+    // locally — it has no idea where "target" lives.
+    ctx.run_command(Command::Send {
+        sender: mover,
+        destination_ident: MsgPart::from_bytes(b"target".to_vec()),
+        parts: vec![MsgPart::from_bytes(b"hello-target".to_vec())],
+    });
+    assert!(matches!(
+        ctx.actors[mover].routes.get(b"target".as_slice()),
+        Some(Route::Unknown(_))
+    ));
+
+    // `mover` now joins `root`. Gaining a parent drops the buffer and re-routes the
+    // held message up to root, which delivers it down to `target`.
+    connect(&mut ctx, root, mover, "inproc://mover");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(ctx.actors[mover].routes.get(b"target".as_slice()).is_none());
+    assert_eq!(
+        buffered_strings(&ctx, target),
+        vec!["target", "root", "hello-target"]
+    );
+}
+
+fn test_ctx() -> (Ctx, mpsc::UnboundedReceiver<Command>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    (Ctx::new(tx), rx)
+}
+
+fn drain_commands(ctx: &mut Ctx, rx: &mut mpsc::UnboundedReceiver<Command>) {
+    while let Ok(command) = rx.try_recv() {
+        ctx.run_command(command);
+    }
+}
+
+fn actor(ctx: &mut Ctx, ident: &str) -> Key {
+    ctx.actors
+        .insert(ActorEntry::new(Some(ident.as_bytes().to_vec())))
+}
+
+fn connect(ctx: &mut Ctx, parent: Key, child: Key, url: &str) {
+    ctx.serve(parent, url.to_owned(), request(Role::Parent));
+    ctx.join(child, url.to_owned(), request(Role::Child));
+}
+
+fn runtime_connect(ctx: &CtxHandle, parent: Key, child: Key, url: &str) {
+    ctx.send_command(Command::Serve {
+        actor: parent,
+        url: url.to_owned(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: child,
+        url: url.to_owned(),
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+}
+
+fn runtime_actor(ctx: &CtxHandle, ident: &str) -> Key {
+    let (done_tx, done_rx) = oneshot::channel();
+    ctx.send_command(Command::CreateActor {
+        ident: Some(MsgPart::from_bytes(ident.as_bytes().to_vec())),
+        done: done_tx,
+    })
+    .expect("create actor should enqueue");
+    done_rx.blocking_recv().expect("actor should be created")
+}
+
+fn runtime_poller(ctx: &CtxHandle) -> (PollerKey, mpsc::UnboundedReceiver<Delivered>) {
+    let (tx, rx) = mpsc::unbounded_channel();
+    let (done_tx, done_rx) = oneshot::channel();
+    let event_fd = OwnedFd::from(File::open("/dev/null").expect("dev null should open"));
+    ctx.send_command(Command::CreatePoller {
+        tx,
+        event_fd,
+        done: done_tx,
+    })
+    .expect("create poller should enqueue");
+    (
+        done_rx.blocking_recv().expect("poller should be created"),
+        rx,
+    )
+}
+
+fn runtime_subscribe(ctx: &CtxHandle, poller: PollerKey, index: usize, actor: Key) {
+    let (done_tx, done_rx) = oneshot::channel();
+    ctx.send_command(Command::Subscribe {
+        poller,
+        index,
+        actor,
+        done: done_tx,
+    })
+    .expect("subscribe should enqueue");
+    done_rx
+        .blocking_recv()
+        .expect("subscribe should return")
+        .expect("subscribe should succeed");
+}
+
+fn recv_strings(rx: &mut mpsc::UnboundedReceiver<Delivered>) -> Vec<String> {
+    rx.blocking_recv()
+        .expect("message should be delivered")
+        .msg
+        .iter()
+        .map(|part| String::from_utf8(part.as_bytes().to_vec()).unwrap())
+        .collect()
+}
+
+fn shutdown(ctx: CtxHandle) {
+    let (done_tx, done_rx) = oneshot::channel();
+    ctx.send_command(Command::Shutdown { done: done_tx })
+        .expect("shutdown should enqueue");
+    done_rx
+        .blocking_recv()
+        .expect("shutdown should return thread")
+        .join()
+        .expect("thread should join");
+}
+
+fn request(role: Role) -> ConnectRequest {
+    ConnectRequest {
+        role,
+        name_for_other: None,
+        hello_prefix: Vec::new(),
+        failure_prefix: Vec::new(),
+    }
+}
+
+fn request_with_failure(role: Role, failure: &str) -> ConnectRequest {
+    ConnectRequest {
+        role,
+        name_for_other: None,
+        hello_prefix: Vec::new(),
+        failure_prefix: vec![MsgPart::from_bytes(failure.as_bytes().to_vec())],
+    }
+}
+
+fn buffered_strings(ctx: &Ctx, actor: Key) -> Vec<String> {
+    let Delivery::NoPoller { buffered } = &ctx.actors[actor].delivery else {
+        panic!("actor should not be subscribed");
+    };
+    buffered
+        .iter()
+        .flat_map(|msg| msg.iter())
+        .map(|part| String::from_utf8(part.as_bytes().to_vec()).unwrap())
+        .collect()
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* __->__ #4580
* #4579
* #4578
* #4577
* #4576

Implement `inproc://` serve/join matching, connection establishment, routed delivery, buffering, and failure propagation across actor hierarchies. Split actor, connection, matcher, poller, and message ownership logic into focused modules and cover the behavior with Rust unit tests and an asyncio smoke test.

Differential Revision: [D108378819](https://our.internmc.facebook.com/intern/diff/D108378819/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D108378819/)!