### PR TITLE
6/43 minimonarch: Unix transport implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4732,8 +4732,11 @@ name = "monarch_mini"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bincode 2.0.1",
+ "serde",
  "slotmap",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/monarch_mini/python/pyproject.toml
+++ b/monarch_mini/python/pyproject.toml
@@ -23,12 +23,16 @@ dev = ["pytest>=8", "pytest-asyncio>=0.23"]
 [tool.setuptools]
 py-modules = []
 
-# Rebuild the wheel when the extension or build inputs change.
+# Rebuild the wheel when the extension or build inputs change. The Rust sources
+# and Cargo manifest are inputs too (setup.py builds the staticlib), so changes
+# there must also invalidate the cached wheel.
 [tool.uv]
 cache-keys = [
     { file = "pyproject.toml" },
     { file = "setup.py" },
     { file = "minimonarch.c" },
+    { file = "../Cargo.toml" },
+    { file = "../src/**/*.rs" },
 ]
 
 [tool.pytest.ini_options]

--- a/monarch_mini/python/test_smoke.py
+++ b/monarch_mini/python/test_smoke.py
@@ -12,6 +12,10 @@ From this directory:
 """
 
 import asyncio
+import os
+import subprocess
+import sys
+import tempfile
 
 import minimonarch
 import pytest
@@ -96,6 +100,269 @@ async def test_serve_join_inproc() -> None:
 
     assert await parent.next() == [b"py-parent", b"py-child"]
     assert await child.next() == [b"py-child", b"py-parent"]
+
+
+async def _connect(
+    parent: Actor,
+    parent_ident: bytes,
+    child: Actor,
+    child_ident: bytes,
+    url: str,
+) -> None:
+    """Establish a parent/child inproc link and consume both hello messages.
+
+    Mirrors the serve/join handshake exercised by examples/hello.c: after the
+    pair matches, each side receives [self_ident, other_ident].
+    """
+    parent.serve(url, "parent")
+    child.join(url, "child")
+    assert await parent.next() == [parent_ident, child_ident]
+    assert await child.next() == [child_ident, parent_ident]
+
+
+async def test_parent_child_bidirectional_send() -> None:
+    # A directly-joined parent and child can message each other both ways.
+    parent = Actor(b"parent")
+    child = Actor(b"child")
+    await _connect(parent, b"parent", child, b"child", "inproc://pc")
+
+    parent.send(b"child", [ba(b"down")])
+    assert await child.next() == [b"down"]
+
+    child.send(b"parent", [ba(b"up")])
+    assert await parent.next() == [b"up"]
+
+
+async def test_grandchild_routes_up_to_grandparent() -> None:
+    # A message with no local route is forwarded up the ancestry until an actor
+    # that knows the destination is reached (here the root is the destination).
+    root = Actor(b"root")
+    child = Actor(b"child")
+    grandchild = Actor(b"grandchild")
+    await _connect(root, b"root", child, b"child", "inproc://root-child")
+    await _connect(
+        child, b"child", grandchild, b"grandchild", "inproc://child-grandchild"
+    )
+
+    grandchild.send(b"root", [ba(b"hi-grandparent")])
+    assert await root.next() == [b"hi-grandparent"]
+
+
+async def test_grandparent_routes_down_to_grandchild() -> None:
+    # The root's routing table is populated up the chain when grandchild joins,
+    # so a send from the root finds its way two hops down.
+    root = Actor(b"root")
+    child = Actor(b"child")
+    grandchild = Actor(b"grandchild")
+    await _connect(root, b"root", child, b"child", "inproc://root-child")
+    await _connect(
+        child, b"child", grandchild, b"grandchild", "inproc://child-grandchild"
+    )
+
+    root.send(b"grandchild", [ba(b"hi-grandchild")])
+    assert await grandchild.next() == [b"hi-grandchild"]
+
+
+async def test_message_routes_across_subtrees_via_common_ancestor() -> None:
+    # Mirrors the grandchild2 -> child hop in examples/hello.c: a message routes
+    # up from one subtree to the common ancestor (root) and back down another.
+    root = Actor(b"root")
+    child = Actor(b"child")
+    child2 = Actor(b"child2")
+    grandchild2 = Actor(b"grandchild2")
+    await _connect(root, b"root", child, b"child", "inproc://root-child")
+    await _connect(root, b"root", child2, b"child2", "inproc://root-child2")
+    await _connect(
+        child2, b"child2", grandchild2, b"grandchild2", "inproc://child2-grandchild2"
+    )
+
+    grandchild2.send(b"child", [ba(b"cousin-hello")])
+    assert await child.next() == [b"cousin-hello"]
+
+
+async def test_die_delivers_failure_to_parent() -> None:
+    # When a child dies, its parent's connection breaks and the parent receives
+    # [failure_prefix..., other_ident, reason].
+    parent = Actor(b"parent")
+    child = Actor(b"child")
+    parent.serve("inproc://dies", "parent", failure=[ba(b"parent-failed")])
+    child.join("inproc://dies", "child", failure=[ba(b"child-failed")])
+    assert await parent.next() == [b"parent", b"child"]
+    assert await child.next() == [b"child", b"parent"]
+
+    child.die(b"done")
+    assert await parent.next() == [b"parent-failed", b"child", b"done"]
+
+
+def _unix_url(name: str) -> str:
+    # A short path under a fresh temp dir keeps us under the sun_path limit and
+    # avoids collisions between tests (each uses its own socket file).
+    return f"unix://{tempfile.mkdtemp(prefix='mm-smoke-')}/{name}.sock"
+
+
+async def test_serve_join_unix() -> None:
+    # The unix:// transport establishes a parent/child pair over a real socket,
+    # here looping back within a single process/context.
+    url = _unix_url("hello")
+    parent = Actor(b"ux-parent")
+    child = Actor(b"ux-child")
+
+    parent.serve(url, "parent")
+    child.join(url, "child")
+
+    assert await parent.next() == [b"ux-parent", b"ux-child"]
+    assert await child.next() == [b"ux-child", b"ux-parent"]
+
+
+async def test_unix_join_before_serve() -> None:
+    # The joiner's connector polls until the server binds, so join may go first.
+    url = _unix_url("late")
+    child = Actor(b"ux-late-child")
+    parent = Actor(b"ux-late-parent")
+
+    child.join(url, "child")
+    await asyncio.sleep(0.05)  # let the connector spin with nothing to connect to
+    parent.serve(url, "parent")
+
+    assert await parent.next() == [b"ux-late-parent", b"ux-late-child"]
+    assert await child.next() == [b"ux-late-child", b"ux-late-parent"]
+
+
+async def test_unix_bidirectional_send() -> None:
+    # Messages flow both directions across the socket; payload bytes are framed
+    # without extra copies.
+    url = _unix_url("send")
+    parent = Actor(b"ux-send-parent")
+    child = Actor(b"ux-send-child")
+    parent.serve(url, "parent")
+    child.join(url, "child")
+    assert await parent.next() == [b"ux-send-parent", b"ux-send-child"]
+    assert await child.next() == [b"ux-send-child", b"ux-send-parent"]
+
+    parent.send(b"ux-send-child", [ba(b"down"), ba(b"stream")])
+    assert await child.next() == [b"down", b"stream"]
+
+    child.send(b"ux-send-parent", [ba(b"up")])
+    assert await parent.next() == [b"up"]
+
+
+async def test_unix_die_delivers_failure() -> None:
+    # Closing one end (here via die) severs the connection; the peer's reader
+    # sees the Severed frame / EOF and the failure message is delivered.
+    url = _unix_url("die")
+    parent = Actor(b"ux-die-parent")
+    child = Actor(b"ux-die-child")
+    parent.serve(url, "parent", failure=[ba(b"parent-failed")])
+    child.join(url, "child", failure=[ba(b"child-failed")])
+    assert await parent.next() == [b"ux-die-parent", b"ux-die-child"]
+    assert await child.next() == [b"ux-die-child", b"ux-die-parent"]
+
+    child.die(b"bye")
+    assert await parent.next() == [b"parent-failed", b"ux-die-child", b"bye"]
+
+
+def _spawn_worker(url: str, mode: str) -> "subprocess.Popen[bytes]":
+    # Run the worker on the same interpreter so it imports the built extension.
+    worker = os.path.join(os.path.dirname(__file__), "unix_worker.py")
+    return subprocess.Popen([sys.executable, worker, url, mode])
+
+
+async def _await_worker_exit(proc: "subprocess.Popen[bytes]") -> None:
+    # Wait off the event loop so the poller keeps draining while we join.
+    loop = asyncio.get_running_loop()
+    try:
+        rc = await loop.run_in_executor(None, lambda: proc.wait(timeout=30))
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        await loop.run_in_executor(None, proc.wait)
+        raise
+    assert rc == 0, f"worker subprocess exited with code {rc}"
+
+
+async def _kill_worker(proc: "subprocess.Popen[bytes]") -> None:
+    proc.kill()
+    await asyncio.get_running_loop().run_in_executor(None, proc.wait)
+
+
+async def test_unix_subprocess_parent_serves_routes_inproc_and_unix() -> None:
+    # Parent SERVES over unix; a real subprocess child JOINS. The main process
+    # also has an inproc child (`client`) and the subprocess has an inproc child
+    # (`worker`), so the `client` -> `worker` message crosses inproc -> unix ->
+    # inproc and is echoed back the same way.
+    url = _unix_url("bridge")
+    proc = _spawn_worker(url, "joiner")
+    try:
+        root = Actor(b"root")
+        client = Actor(b"client")
+        root.serve("inproc://client-link", "parent")
+        client.join("inproc://client-link", "child")
+        assert await client.next() == [b"client", b"root"]
+        assert await root.next() == [b"root", b"client"]
+
+        root.serve(url, "parent")
+        assert await asyncio.wait_for(root.next(), 30) == [b"root", b"bridge"]
+
+        client.send(b"worker", [ba(b"hi-worker")])  # inproc -> unix -> inproc
+        assert await asyncio.wait_for(client.next(), 30) == [b"hi-worker"]
+    finally:
+        await _await_worker_exit(proc)
+
+
+async def test_unix_subprocess_child_serves_join_before_serve() -> None:
+    # The roles are flipped: the subprocess actor is the CHILD and SERVES (binds),
+    # while the main actor is the PARENT and JOINS. The main joins immediately but
+    # the subprocess sleeps before serving, so the connector must retry until the
+    # socket appears (join-before-serve).
+    url = _unix_url("server")
+    proc = _spawn_worker(url, "server")
+    try:
+        boss = Actor(b"boss")
+        boss.join(url, "parent")
+        assert await asyncio.wait_for(boss.next(), 30) == [b"boss", b"server"]
+
+        boss.send(b"server", [ba(b"ping-data")])
+        assert await asyncio.wait_for(boss.next(), 30) == [b"ping-data"]
+    finally:
+        await _await_worker_exit(proc)
+
+
+async def test_unix_subprocess_kill_propagates_failure_and_cascades() -> None:
+    # The subprocess hosts the PARENT (`up`) and serves over unix; the main joins
+    # as its child `mid`, which in turn serves a local inproc child `leaf`. Hard-
+    # killing the subprocess drops the socket: `mid` (child of the now-dead parent)
+    # gets a failure and dies, and that death cascades locally to `leaf`.
+    url = _unix_url("up")
+    proc = _spawn_worker(url, "parent")
+    try:
+        mid = Actor(b"mid")
+        mid.join(url, "child", failure=[ba(b"mid-failed")])
+        assert await asyncio.wait_for(mid.next(), 30) == [b"mid", b"up"]
+
+        leaf = Actor(b"leaf")
+        mid.serve("inproc://leaf-link", "parent")
+        leaf.join("inproc://leaf-link", "child", failure=[ba(b"leaf-failed")])
+        assert await mid.next() == [b"mid", b"leaf"]
+        assert await leaf.next() == [b"leaf", b"mid"]
+
+        # Hard-kill the subprocess; the unix socket drops.
+        await _kill_worker(proc)
+
+        # The dead parent severs mid's parent link: mid gets the failure (naming the
+        # dead peer "up") and, being a child that lost its parent, dies — which
+        # delivers a die message to its local inproc child leaf.
+        assert await asyncio.wait_for(mid.next(), 30) == [
+            b"mid-failed",
+            b"up",
+            b"unix connection closed",
+        ]
+        assert await asyncio.wait_for(leaf.next(), 30) == [
+            b"leaf-failed",
+            b"mid",
+            b"unix connection closed",
+        ]
+    finally:
+        if proc.poll() is None:
+            await _kill_worker(proc)
 
 
 async def test_unimplemented_monitor_raises() -> None:

--- a/monarch_mini/python/unix_worker.py
+++ b/monarch_mini/python/unix_worker.py
@@ -1,0 +1,85 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Helper run as a subprocess by test_smoke.py's cross-process unix tests.
+
+Usage: ``python unix_worker.py <unix-url> <mode>``. Each mode connects to (or is
+connected to by) actors in the parent test process over a real unix socket,
+exchanges data, then closes its context — whose teardown flushes the socket — and
+exits 0. A failed assertion exits non-zero, failing the test.
+"""
+
+import asyncio
+import sys
+
+import minimonarch
+from minimonarch import Actor
+
+ba = minimonarch.bytearray
+
+
+async def _echo_once(actor: Actor, reply_to: bytes) -> None:
+    """Wait for one message and send it straight back to `reply_to` (the same
+    bytearrays are moved back, so the payload is never copied)."""
+    parts = await actor.next()
+    actor.send(reply_to, parts)
+
+
+async def run_joiner(url: str) -> None:
+    """This process is the CHILD and JOINS the parent the test serves over unix.
+
+    `bridge` then serves its own inproc child `worker`, so a message the test
+    sends to `worker` travels inproc -> unix -> inproc and is echoed straight
+    back. `bridge` itself only ever relays (it is never addressed directly), so
+    its queue holds just its two hellos.
+    """
+    bridge = Actor(b"bridge")
+    bridge.join(url, "child")
+    assert await bridge.next() == [b"bridge", b"root"]
+
+    worker = Actor(b"worker")
+    bridge.serve("inproc://worker-link", "parent")
+    worker.join("inproc://worker-link", "child")
+    assert await bridge.next() == [b"bridge", b"worker"]
+    assert await worker.next() == [b"worker", b"bridge"]
+
+    await _echo_once(worker, b"client")
+    minimonarch.close()
+
+
+async def run_server(url: str) -> None:
+    """This process is the CHILD and SERVES (binds) over unix; the test is the
+    PARENT and joins us.
+
+    We sleep before serving so the test's join is posted first, exercising the
+    connector's retry/backoff (join-before-serve).
+    """
+    await asyncio.sleep(0.2)
+    server = Actor(b"server")
+    server.serve(url, "child")
+    assert await server.next() == [b"server", b"boss"]
+    await _echo_once(server, b"boss")
+    minimonarch.close()
+
+
+async def run_parent(url: str) -> None:
+    """This process hosts the PARENT and serves over unix; the test joins as the
+    child. We then idle forever — the test hard-kills us to drop the socket and
+    observe the failure cascade in its own actors.
+    """
+    up = Actor(b"up")
+    up.serve(url, "parent")
+    assert await up.next() == [b"up", b"mid"]
+    while True:
+        await asyncio.sleep(3600)
+
+
+_MODES = {"joiner": run_joiner, "server": run_server, "parent": run_parent}
+
+
+if __name__ == "__main__":
+    url, mode = sys.argv[1], sys.argv[2]
+    asyncio.run(_MODES[mode](url))

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -8,11 +8,8 @@
 
 use std::collections::VecDeque;
 
-use tokio::sync::mpsc;
-
 use crate::Role;
 use crate::ctx::ChildConnectionKey;
-use crate::ctx::Command;
 use crate::ctx::Key;
 use crate::msg::MsgPart;
 
@@ -49,8 +46,31 @@ impl ConnectionRef {
     }
 }
 
+/// A parent/child link. State only moves forward:
+///
+/// ```text
+/// Unestablished → Connecting → Established → Failed
+/// ```
+///
+/// - `Unestablished`: attached, but the transport has not come up yet. Outgoing
+///   commands are buffered.
+/// - `Connecting`: the transport is up (we can send), our own `Establish` has
+///   gone out over it, and we are waiting for the peer's `Establish` to learn the
+///   peer's identity. Outgoing commands are still buffered for hello-ordering.
+/// - `Established`: the peer's identity is known; buffered commands are flushed
+///   and routing/hello proceed.
 pub(crate) enum Connection {
     Unestablished {
+        name_for_other: Option<Vec<u8>>,
+        hello_prefix: Vec<MsgPart>,
+        failure_prefix: Vec<MsgPart>,
+        queued_commands: VecDeque<ConnectionCommand>,
+    },
+    Connecting {
+        transport: Box<dyn ConnectionTransport>,
+        // The name we assigned the peer (if any). Kept — even though we already
+        // sent it in our own Establish — so we can resolve the peer's ident from
+        // it should the peer still have been unnamed when it sent its Establish.
         name_for_other: Option<Vec<u8>>,
         hello_prefix: Vec<MsgPart>,
         failure_prefix: Vec<MsgPart>,
@@ -64,24 +84,13 @@ pub(crate) enum Connection {
     Failed,
 }
 
+/// The send half of a connection's pipe. Transports are pure plumbing: `send`
+/// ferries a [`ConnectionCommand`] to the peer, and **dropping** the transport is
+/// the universal "pipe closed" signal — the peer observes it and is severed.
+/// (For UNIX this falls out of closing the socket; the inproc transport pushes a
+/// `Severed` from its `Drop`.)
 pub(crate) trait ConnectionTransport: Send {
     fn send(&self, action: ConnectionCommand) -> bool;
-}
-
-pub(crate) struct InprocConnectionTransport {
-    pub(crate) tx: mpsc::UnboundedSender<Command>,
-    pub(crate) peer: ConnectionRef,
-}
-
-impl ConnectionTransport for InprocConnectionTransport {
-    fn send(&self, action: ConnectionCommand) -> bool {
-        self.tx
-            .send(Command::ConnectionSentCommand {
-                connection: self.peer,
-                action,
-            })
-            .is_ok()
-    }
 }
 
 pub(crate) enum ConnectionCommand {
@@ -89,12 +98,17 @@ pub(crate) enum ConnectionCommand {
         destination_ident: Vec<u8>,
         parts: Vec<MsgPart>,
     },
+    /// The sender announcing itself to the peer: its role, ident, the name it
+    /// assigns the peer, and whether it is still alive. Flows over the transport
+    /// like any other command. A live sender drives the receiver to `Established`;
+    /// a sender that announces `alive: false` (its actor died before the pipe came
+    /// up) drives the receiver to sever instead — but still carries the ident, so
+    /// the failure names the connection that died.
     Establish {
-        peer_alive: bool,
-        peer_role: Role,
-        peer_name: Option<Vec<u8>>,
-        requested_name: Option<Vec<u8>>,
-        transport: Box<dyn ConnectionTransport>,
+        role: Role,
+        ident: Option<Vec<u8>>,
+        name_for_other: Option<Vec<u8>>,
+        alive: bool,
     },
     Severed {
         reason: Vec<u8>,
@@ -105,7 +119,7 @@ pub(crate) enum ConnectionCommand {
 }
 
 impl Connection {
-    pub(crate) fn new_inproc(request: ConnectRequest) -> Self {
+    pub(crate) fn new_unestablished(request: ConnectRequest) -> Self {
         let name_for_other = request
             .name_for_other
             .as_ref()
@@ -121,7 +135,12 @@ impl Connection {
     pub(crate) fn send(&mut self, command: ConnectionCommand) -> bool {
         match self {
             Self::Established { transport, .. } => transport.send(command),
+            // Before establishment outgoing commands are buffered (even once the
+            // transport is up, so the peer's hello precedes any message).
             Self::Unestablished {
+                queued_commands, ..
+            }
+            | Self::Connecting {
                 queued_commands, ..
             } => {
                 queued_commands.push_back(command);
@@ -141,6 +160,13 @@ impl Connection {
                 ..
             } => Some((failure_prefix, peer_ident)),
             Self::Unestablished {
+                name_for_other,
+                failure_prefix,
+                ..
+            } => Some((failure_prefix, name_for_other.unwrap_or_default())),
+            // Connecting has not yet learned the peer's ident; fall back to the
+            // name we assigned it, if any.
+            Self::Connecting {
                 name_for_other,
                 failure_prefix,
                 ..

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -6,7 +6,6 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-use std::collections::HashMap;
 use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
 use std::thread;
@@ -28,12 +27,20 @@ use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
 use crate::connection::EstablishFailure;
-use crate::connection::InprocConnectionTransport;
-use crate::matcher::InprocMatcher;
-use crate::matcher::Matcher;
+use crate::inproc_transport::InprocTransport;
 use crate::msg::MsgPart;
 use crate::poller::Delivered;
 use crate::poller::PollerEntry;
+use crate::transport::Transport;
+use crate::unix_transport::UnixTransport;
+
+/// Whether `url`'s scheme is one we have a transport for. Kept separate from
+/// [`Ctx::transport_for`] so the scheme can be validated — before the connection
+/// is attached, while the request can still report failure — without a `&mut self`
+/// borrow.
+fn valid_scheme(url: &str) -> bool {
+    url.starts_with("inproc://") || url.starts_with("unix://")
+}
 
 new_key_type! {
     pub(crate) struct Key;
@@ -93,6 +100,13 @@ pub(crate) enum Command {
         connection: ConnectionRef,
         action: ConnectionCommand,
     },
+    // A transport's pipe is up; install it on the connection. Transport-agnostic:
+    // both inproc and unix emit it, and the command loop drives establishment
+    // from here (sends our Establish along the transport).
+    TransportConnected {
+        connection: ConnectionRef,
+        transport: Box<dyn ConnectionTransport>,
+    },
     Die {
         actor: Key,
         reason: MsgPart,
@@ -105,8 +119,12 @@ pub(crate) enum Command {
 struct Ctx {
     actors: SlotMap<Key, ActorEntry>,
     pollers: SlotMap<PollerKey, PollerEntry>,
-    tx: mpsc::UnboundedSender<Command>,
-    inproc: HashMap<String, InprocMatcher>,
+    // The transports. Each owns its own pairing/socket state and coroutines plus
+    // a clone of the loop sender; the command loop only forwards serves/joins to
+    // them and handles the generic TransportConnected/ConnectionSentCommand they
+    // emit.
+    inproc: InprocTransport,
+    unix: UnixTransport,
     thread: Option<JoinHandle<()>>,
     _not_send: PhantomData<*const ()>,
 }
@@ -116,14 +134,14 @@ impl Ctx {
         Self {
             actors: SlotMap::with_key(),
             pollers: SlotMap::with_key(),
-            tx,
-            inproc: HashMap::new(),
+            inproc: InprocTransport::new(tx.clone()),
+            unix: UnixTransport::new(tx),
             thread: None,
             _not_send: PhantomData,
         }
     }
 
-    fn run_command(&mut self, command: Command) -> bool {
+    fn run_command(&mut self, command: Command) {
         match command {
             Command::Init { thread } => {
                 self.thread = Some(thread);
@@ -220,20 +238,22 @@ impl Ctx {
                     self.run_connection_command(connection, action);
                 }
             }
+            Command::TransportConnected {
+                connection,
+                transport,
+            } => {
+                self.transport_connected(connection, transport);
+            }
             Command::Die { actor, reason } => {
                 let reason = reason.as_bytes().to_vec();
                 self.die_actor(actor, reason);
             }
-            Command::Shutdown { done } => {
-                let thread = self
-                    .thread
-                    .take()
-                    .expect("context should have thread handle");
-                let _ = done.send(thread);
-                return true;
+            Command::Shutdown { .. } => {
+                // Handled directly by the event loop (see CtxHandle::new) so it
+                // can await the UNIX writer flush before tearing the loop down.
+                unreachable!("Shutdown is intercepted by the event loop");
             }
         }
-        false
     }
 
     fn actor(&self, actor: Key) -> &ActorEntry {
@@ -316,45 +336,48 @@ impl Ctx {
         }
     }
 
+    /// Select the transport for a url's scheme. Only called once the scheme is
+    /// known valid (see [`valid_scheme`]), so a missing transport is a bug.
+    fn transport_for(&mut self, url: &str) -> &mut dyn Transport {
+        if url.starts_with("inproc://") {
+            &mut self.inproc
+        } else if url.starts_with("unix://") {
+            &mut self.unix
+        } else {
+            unreachable!("scheme already validated by valid_scheme");
+        }
+    }
+
     fn serve(&mut self, actor: Key, url: String, request: ConnectRequest) {
-        if !url.starts_with("inproc://") {
+        // Shared setup runs first regardless of transport: validate the scheme,
+        // then attach the unestablished connection. Only then do we hand the
+        // connection to the transport, which brings up its pipe and announces it
+        // back via TransportConnected. (The scheme is validated before attach so a
+        // bad scheme can still report failure with the as-yet-unconsumed request.)
+        if !valid_scheme(&url) {
             self.deliver_connect_failure(actor, request, b"unsupported url scheme".to_vec());
             return;
         }
-
-        let Some(pending) = self.attach_inproc_connection(actor, request) else {
+        let Some(connection) = self.attach_connection(actor, request) else {
             return;
         };
-        let mut matcher = self.inproc.remove(&url).unwrap_or_else(Matcher::new);
-        let _ = matcher.push_left(pending, |serve, join| {
-            self.establish_inproc(serve, join);
-        });
-        self.inproc.insert(url, matcher);
+        self.transport_for(&url).serve(url, connection);
     }
 
     fn join(&mut self, actor: Key, url: String, request: ConnectRequest) {
-        if !url.starts_with("inproc://") {
+        if !valid_scheme(&url) {
             self.deliver_connect_failure(actor, request, b"unsupported url scheme".to_vec());
             return;
         }
-
-        let Some(pending) = self.attach_inproc_connection(actor, request) else {
+        let Some(connection) = self.attach_connection(actor, request) else {
             return;
         };
-        let mut matcher = self.inproc.remove(&url).unwrap_or_else(Matcher::new);
-        let _ = matcher.push_right(pending, |serve, join| {
-            self.establish_inproc(serve, join);
-        });
-        self.inproc.insert(url, matcher);
+        self.transport_for(&url).join(url, connection);
     }
 
-    fn attach_inproc_connection(
-        &mut self,
-        actor: Key,
-        request: ConnectRequest,
-    ) -> Option<ConnectionRef> {
+    fn attach_connection(&mut self, actor: Key, request: ConnectRequest) -> Option<ConnectionRef> {
         let role = request.role;
-        let connection = Connection::new_inproc(request);
+        let connection = Connection::new_unestablished(request);
 
         let connection = match role {
             Role::Parent => {
@@ -407,38 +430,57 @@ impl Ctx {
         Some(connection)
     }
 
-    fn establish_inproc(&mut self, serve: ConnectionRef, join: ConnectionRef) {
-        self.send_inproc_established(serve, join);
-        self.send_inproc_established(join, serve);
-    }
-
-    fn send_inproc_established(&mut self, connection: ConnectionRef, peer: ConnectionRef) {
-        let tx = self.tx.clone();
-
-        // Peer liveness is not something the receiver can observe locally (a real
-        // transport's peer may be remote), so report it in the Establish message and
-        // let establish treat a dead peer as a sever reason. The peer's own name and
-        // the name it wants to give us are only known while its connection is still
-        // pending, so a torn-down peer is reported as nameless.
-        let peer_alive = self.actor(peer.owning_actor()).alive;
-        let (peer_name, requested_name) = match self.connection(peer) {
-            Connection::Unestablished { name_for_other, .. } => (
-                self.actor(peer.owning_actor()).ident.clone(),
-                name_for_other.clone(),
-            ),
-            _ => (None, None),
-        };
-
-        self.send_connection_command(
-            connection,
-            ConnectionCommand::Establish {
-                peer_alive,
-                peer_role: peer.role(),
-                peer_name,
-                requested_name,
-                transport: Box::new(InprocConnectionTransport { tx, peer }),
-            },
+    /// A transport's pipe is up. Announce ourselves to the peer along it via an
+    /// `Establish`, then hold the transport on the connection until the peer's
+    /// `Establish` lands (`Unestablished` → `Connecting`).
+    ///
+    /// If the owning actor already died, the connection is `Failed`: we still send
+    /// an `Establish`, carrying our (dead) ident but `alive: false`, so the peer
+    /// severs *and names us* in its failure. We then drop the transport without
+    /// transitioning (its drop-severance is the generic fallback, skipped once the
+    /// peer is already failing).
+    fn transport_connected(
+        &mut self,
+        connection: ConnectionRef,
+        transport: Box<dyn ConnectionTransport>,
+    ) {
+        let role = connection.role();
+        let ident = self.actor(connection.owning_actor()).ident.clone();
+        let alive = matches!(
+            self.connection(connection),
+            Connection::Unestablished { .. }
         );
+        let name_for_other = match self.connection(connection) {
+            Connection::Unestablished { name_for_other, .. } => name_for_other.clone(),
+            _ => None,
+        };
+        transport.send(ConnectionCommand::Establish {
+            role,
+            ident,
+            name_for_other: name_for_other.clone(),
+            alive,
+        });
+        if !alive {
+            return;
+        }
+
+        let conn = self.connection_mut(connection);
+        let Connection::Unestablished {
+            hello_prefix,
+            failure_prefix,
+            queued_commands,
+            ..
+        } = std::mem::replace(conn, Connection::Failed)
+        else {
+            unreachable!("alive implies Unestablished");
+        };
+        *conn = Connection::Connecting {
+            transport,
+            name_for_other,
+            hello_prefix,
+            failure_prefix,
+            queued_commands,
+        };
     }
 
     fn connection_topology_is_valid(&self, connection: ConnectionRef) -> bool {
@@ -518,12 +560,6 @@ impl Ctx {
         }
     }
 
-    fn send_connection_command(&mut self, connection: ConnectionRef, action: ConnectionCommand) {
-        let _ = self
-            .tx
-            .send(Command::ConnectionSentCommand { connection, action });
-    }
-
     fn run_connection_command(&mut self, connection: ConnectionRef, action: ConnectionCommand) {
         match action {
             ConnectionCommand::SendMessage {
@@ -531,26 +567,21 @@ impl Ctx {
                 parts,
             } => self.route_message(connection.owning_actor(), destination_ident, parts),
             ConnectionCommand::Establish {
-                peer_alive,
-                peer_role,
-                peer_name,
-                requested_name,
-                transport,
+                role,
+                ident,
+                name_for_other,
+                alive,
             } => {
+                // The peer announced itself; finalize our side using the transport
+                // we stashed when our pipe connected.
                 if let Err(EstablishFailure {
                     failure_prefix,
                     peer_ident,
                     reason,
-                }) = self.establish_connection(
-                    connection,
-                    peer_alive,
-                    peer_role,
-                    peer_name,
-                    requested_name,
-                    transport,
-                ) {
-                    // Establishment failed (roles disagree, name conflict, dead peer,
-                    // ...): sever the connection and notify the actor.
+                }) = self.establish_connection(connection, role, ident, name_for_other, alive)
+                {
+                    // Establishment failed (peer announced dead, roles disagree,
+                    // name conflict, ...): sever the connection and notify the actor.
                     let _ = self.connection_set(connection, Connection::Failed);
                     self.fail_connection(connection, failure_prefix, peer_ident, reason);
                 }
@@ -605,25 +636,26 @@ impl Ctx {
     fn establish_connection(
         &mut self,
         connection: ConnectionRef,
-        peer_alive: bool,
         peer_role: Role,
         peer_name: Option<Vec<u8>>,
         requested_name: Option<Vec<u8>>,
-        transport: Box<dyn ConnectionTransport>,
+        peer_alive: bool,
     ) -> Result<(), EstablishFailure> {
-        // Take the unestablished connection apart; establishing it consumes the
-        // hello/failure prefixes and any commands queued before it was ready.
+        // Take the connecting connection apart; establishing it consumes the
+        // hello/failure prefixes, any commands queued before it was ready, and the
+        // transport stashed when the pipe connected.
         let local_connection = self.connection_mut(connection);
         let local_status = std::mem::replace(local_connection, Connection::Failed);
 
-        let Connection::Unestablished {
+        let Connection::Connecting {
+            transport,
             name_for_other,
             hello_prefix,
             failure_prefix,
             queued_commands,
         } = local_status
         else {
-            unreachable!("local status should be unestablished");
+            unreachable!("peer Establish should arrive only on a connecting connection");
         };
 
         let failure_peer_ident = peer_name
@@ -633,6 +665,9 @@ impl Ctx {
 
         let mut failure_prefix = Some(failure_prefix);
         let result = (|| -> Result<(), Vec<u8>> {
+            // The peer announced it had already died; sever instead of finalizing.
+            // `failure_peer_ident` (above) still carries the peer ident it sent, so
+            // the failure names which connection died.
             if !peer_alive {
                 return Err(b"peer actor died".to_vec());
             }
@@ -773,16 +808,30 @@ impl CtxHandle {
             .name("monarch-mini".to_owned())
             .spawn(move || {
                 let rt = runtime::Builder::new_current_thread()
+                    .enable_io()
+                    .enable_time()
                     .build()
                     .expect("tokio runtime should build");
                 let local = tokio::task::LocalSet::new();
-                // Event loop: dispatch commands until a Shutdown command is handled.
+                // Event loop: dispatch commands until Shutdown. Shutdown is handled
+                // here (not in run_command) so it can await the UNIX writer flush
+                // before the runtime — and with it the writer tasks — is dropped.
                 local.block_on(&rt, async move {
                     let mut ctx = Ctx::new(runtime_tx);
                     while let Some(command) = rx.recv().await {
-                        if ctx.run_command(command) {
+                        if let Command::Shutdown { done } = command {
+                            // Wait for the UNIX transport to flush every pending
+                            // write to the OS and stop its coroutines before the
+                            // runtime (and the coroutines) is torn down.
+                            ctx.unix.shutdown().await;
+                            let thread = ctx
+                                .thread
+                                .take()
+                                .expect("context should have thread handle");
+                            let _ = done.send(thread);
                             break;
                         }
+                        ctx.run_command(command);
                     }
                 });
             })?;

--- a/monarch_mini/src/inproc_transport.rs
+++ b/monarch_mini/src/inproc_transport.rs
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! In-process transport: connects two actors living in the same context.
+//!
+//! The "pipe" is the context's own command channel. A serve and a join on the
+//! same url are paired by a [`Matcher`]; on a match each side gets an
+//! [`InprocConnectionTransport`] pointed at the other, announced to the command
+//! loop via `Command::TransportConnected`. From there establishment is the same
+//! generic flow the command loop runs for every transport — the command loop
+//! sends each side's `Establish` along its transport, and the peer receives it.
+//!
+//! There are no coroutines and no extra hops: `send` forwards a command straight
+//! to the peer connection through the command loop, and dropping the transport
+//! pushes a `Severed` to the peer (the in-process analogue of a socket closing).
+
+use std::collections::HashMap;
+
+use tokio::sync::mpsc;
+
+use crate::connection::ConnectionCommand;
+use crate::connection::ConnectionRef;
+use crate::connection::ConnectionTransport;
+use crate::ctx::Command;
+use crate::matcher::Matcher;
+use crate::transport::Transport;
+
+pub(crate) struct InprocTransport {
+    loop_tx: mpsc::UnboundedSender<Command>,
+    matchers: HashMap<String, Matcher<ConnectionRef, ConnectionRef>>,
+}
+
+impl InprocTransport {
+    pub(crate) fn new(loop_tx: mpsc::UnboundedSender<Command>) -> Self {
+        Self {
+            loop_tx,
+            matchers: HashMap::new(),
+        }
+    }
+}
+
+impl Transport for InprocTransport {
+    fn serve(&mut self, url: String, connection: ConnectionRef) {
+        let loop_tx = self.loop_tx.clone();
+        let mut matcher = self.matchers.remove(&url).unwrap_or_else(Matcher::new);
+        let _ = matcher.push_left(connection, |serve, join| pair(&loop_tx, serve, join));
+        self.matchers.insert(url, matcher);
+    }
+
+    fn join(&mut self, url: String, connection: ConnectionRef) {
+        let loop_tx = self.loop_tx.clone();
+        let mut matcher = self.matchers.remove(&url).unwrap_or_else(Matcher::new);
+        let _ = matcher.push_right(connection, |serve, join| pair(&loop_tx, serve, join));
+        self.matchers.insert(url, matcher);
+    }
+}
+
+/// A serve and a join matched: give each side a transport pointed at the other
+/// and announce both to the command loop.
+fn pair(loop_tx: &mpsc::UnboundedSender<Command>, serve: ConnectionRef, join: ConnectionRef) {
+    connect(loop_tx, serve, join);
+    connect(loop_tx, join, serve);
+}
+
+fn connect(loop_tx: &mpsc::UnboundedSender<Command>, local: ConnectionRef, peer: ConnectionRef) {
+    let transport = Box::new(InprocConnectionTransport {
+        tx: loop_tx.clone(),
+        peer,
+    });
+    let _ = loop_tx.send(Command::TransportConnected {
+        connection: local,
+        transport,
+    });
+}
+
+/// Transport for one end of an inproc connection. `send` delivers a command to
+/// the peer connection by re-entering the command loop.
+struct InprocConnectionTransport {
+    tx: mpsc::UnboundedSender<Command>,
+    peer: ConnectionRef,
+}
+
+impl ConnectionTransport for InprocConnectionTransport {
+    fn send(&self, action: ConnectionCommand) -> bool {
+        self.tx
+            .send(Command::ConnectionSentCommand {
+                connection: self.peer,
+                action,
+            })
+            .is_ok()
+    }
+}
+
+impl Drop for InprocConnectionTransport {
+    fn drop(&mut self) {
+        // Dropping the send half is the in-process analogue of a socket closing:
+        // tell the peer its side of the pipe is gone. (A no-op if the peer is
+        // already failed.)
+        let _ = self.tx.send(Command::ConnectionSentCommand {
+            connection: self.peer,
+            action: ConnectionCommand::Severed {
+                reason: b"peer connection closed".to_vec(),
+            },
+        });
+    }
+}

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -9,9 +9,12 @@
 mod actor;
 mod connection;
 mod ctx;
+mod inproc_transport;
 mod matcher;
 mod msg;
 mod poller;
+mod transport;
+mod unix_transport;
 
 use std::cell::RefCell;
 use std::ffi::CString;
@@ -81,7 +84,15 @@ pub struct CMonitorHandle {
 // ---------------------------------------------------------------------------
 
 #[repr(i32)]
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(
+    Debug,
+    PartialEq,
+    Eq,
+    Clone,
+    Copy,
+    serde::Serialize,
+    serde::Deserialize
+)]
 pub enum Role {
     Child = 0,
     Parent = 1,

--- a/monarch_mini/src/matcher.rs
+++ b/monarch_mini/src/matcher.rs
@@ -8,8 +8,6 @@
 
 use std::collections::VecDeque;
 
-use crate::connection::ConnectionRef;
-
 pub(crate) struct Matcher<Left, Right> {
     left: VecDeque<Left>,
     right: VecDeque<Right>,
@@ -47,5 +45,3 @@ impl<Left, Right> Matcher<Left, Right> {
         Some(on_match(left, right))
     }
 }
-
-pub(crate) type InprocMatcher = Matcher<ConnectionRef, ConnectionRef>;

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -184,9 +184,13 @@ fn dead_pending_connect_fails_when_matched() {
     );
     drain_commands(&mut ctx, &mut rx);
 
+    // The dead server still announces itself — its ident, but `alive: false` — so
+    // the joiner severs instead of establishing (no hello), and its failure both
+    // names the dead peer ("server") and says why ("peer actor died"). No peer
+    // state was inspected: the dead side reported its own ident and liveness.
     assert_eq!(
         buffered_strings(&ctx, joiner),
-        vec!["joiner-failed", "", "peer actor died"]
+        vec!["joiner-failed", "server", "peer actor died"]
     );
     assert!(matches!(
         ctx.actors[joiner].parent,
@@ -260,6 +264,104 @@ fn buffered_messages_flush_upward_when_actor_gains_a_parent() {
         buffered_strings(&ctx, target),
         vec!["target", "root", "hello-target"]
     );
+}
+
+#[test]
+fn unix_serve_join_establishes_and_routes() {
+    let ctx = CtxHandle::new().expect("context should start");
+    let parent = runtime_actor(&ctx, "ux-parent");
+    let child = runtime_actor(&ctx, "ux-child");
+    let (parent_poller, mut parent_rx) = runtime_poller(&ctx);
+    let (child_poller, mut child_rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, parent_poller, 0, parent);
+    runtime_subscribe(&ctx, child_poller, 0, child);
+
+    let url = unix_test_url("route");
+    ctx.send_command(Command::Serve {
+        actor: parent,
+        url: url.clone(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: child,
+        url,
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+
+    // The handshake completes over the socket and both sides get their hello.
+    assert_eq!(recv_strings(&mut parent_rx), vec!["ux-parent", "ux-child"]);
+    assert_eq!(recv_strings(&mut child_rx), vec!["ux-child", "ux-parent"]);
+
+    // A message addressed across the socket is framed and delivered intact.
+    ctx.send_command(Command::Send {
+        sender: parent,
+        destination_ident: MsgPart::from_bytes(b"ux-child".to_vec()),
+        parts: vec![MsgPart::from_bytes(b"hi-child".to_vec())],
+    })
+    .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut child_rx), vec!["hi-child"]);
+
+    shutdown(ctx);
+}
+
+#[test]
+fn unix_writer_flushes_pending_sends_before_teardown() {
+    // Two contexts = two runtimes connected by a real socket, standing in for two
+    // processes. A send issued just before the client tears down must reach the
+    // OS before teardown completes, so the (separate) server still receives it.
+    let server_ctx = CtxHandle::new().expect("server context should start");
+    let client_ctx = CtxHandle::new().expect("client context should start");
+    let server = runtime_actor(&server_ctx, "flush-server");
+    let client = runtime_actor(&client_ctx, "flush-client");
+    let (server_poller, mut server_rx) = runtime_poller(&server_ctx);
+    runtime_subscribe(&server_ctx, server_poller, 0, server);
+
+    let url = unix_test_url("flush");
+    server_ctx
+        .send_command(Command::Serve {
+            actor: server,
+            url: url.clone(),
+            request: request(Role::Parent),
+        })
+        .expect("serve should enqueue");
+    client_ctx
+        .send_command(Command::Join {
+            actor: client,
+            url,
+            request: request(Role::Child),
+        })
+        .expect("join should enqueue");
+    assert_eq!(
+        recv_strings(&mut server_rx),
+        vec!["flush-server", "flush-client"]
+    );
+
+    // Enqueue a send, then immediately shut the client down. The shutdown drains
+    // the writer before completing, so the message is not lost.
+    client_ctx
+        .send_command(Command::Send {
+            sender: client,
+            destination_ident: MsgPart::from_bytes(b"flush-server".to_vec()),
+            parts: vec![MsgPart::from_bytes(b"last-words".to_vec())],
+        })
+        .expect("send should enqueue");
+    shutdown(client_ctx);
+
+    assert_eq!(recv_strings(&mut server_rx), vec!["last-words"]);
+    shutdown(server_ctx);
+}
+
+fn unix_test_url(name: &str) -> String {
+    // The listener unlinks any stale socket before binding, so reusing a stable
+    // per-process path across runs is safe.
+    format!(
+        "unix://{}/mm-rs-test-{}-{}.sock",
+        std::env::temp_dir().display(),
+        std::process::id(),
+        name
+    )
 }
 
 fn test_ctx() -> (Ctx, mpsc::UnboundedReceiver<Command>) {

--- a/monarch_mini/src/transport.rs
+++ b/monarch_mini/src/transport.rs
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! The seam between the command loop and a transport implementation.
+//!
+//! A transport's whole job is to bring up a connection's pipe and produce a
+//! [`ConnectionTransport`](crate::connection::ConnectionTransport) for it, then
+//! hand that to the command loop via `Command::TransportConnected`. Everything
+//! about *establishment* — announcing our identity, learning the peer's,
+//! delivering the hello, detecting death — lives in the command loop and is
+//! identical across transports. A transport never reads actor state and never
+//! constructs an `Establish`.
+
+use crate::connection::ConnectionRef;
+
+pub(crate) trait Transport {
+    /// Begin serving `connection` on `url` (this actor is the parent/server).
+    fn serve(&mut self, url: String, connection: ConnectionRef);
+    /// Begin joining `connection` on `url` (this actor is the child/client).
+    fn join(&mut self, url: String, connection: ConnectionRef);
+}

--- a/monarch_mini/src/unix_transport.rs
+++ b/monarch_mini/src/unix_transport.rs
@@ -1,0 +1,488 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! UNIX-socket transport for connecting actors in two different local
+//! processes.
+//!
+//! This is pure plumbing. A connection's coroutines bring up the socket, produce
+//! a [`ConnectionTransport`] for it, and hand it to the command loop via
+//! `Command::TransportConnected`; the reader forwards every frame it decodes back
+//! as a `ConnectionSentCommand`. All establishment policy (announcing our
+//! identity, learning the peer's, hello, liveness) lives in the command loop and
+//! is identical to inproc — this file never reads actor state or builds an
+//! `Establish`. An `Establish` is just another frame on the wire.
+//!
+//! ## Framing
+//!
+//! Each frame is `[u64 header_len][header][raw part bytes...]`. The header is a
+//! bincode-encoded [`WireFrame`] holding only small metadata; for a message it
+//! carries the *lengths* of the parts, never their bytes. Message-part bytes are
+//! written straight from the owning `MsgPart` and read straight into a freshly
+//! allocated per-part buffer — no copies of payload beyond the socket read/write.
+//!
+//! ## Liveness
+//!
+//! Dropping a connection's [`UnixConnectionTransport`] drops its writer channel,
+//! which ends the writer task and closes the socket's write half; the peer's
+//! reader then sees EOF and emits `Severed`. That is the same "drop the transport
+//! ⇒ peer severed" contract the inproc transport implements explicitly.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::net::UnixListener;
+use tokio::net::UnixStream;
+use tokio::net::unix::OwnedReadHalf;
+use tokio::net::unix::OwnedWriteHalf;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::time::Duration;
+
+use crate::Role;
+use crate::connection::ConnectionCommand;
+use crate::connection::ConnectionRef;
+use crate::connection::ConnectionTransport;
+use crate::ctx::Command;
+use crate::matcher::Matcher;
+use crate::msg::MsgPart;
+use crate::transport::Transport;
+
+/// Connect-retry backoff bounds. A join may be posted before its serve, so the
+/// connector polls; it starts fast and backs off (doubling) to a steady poll so a
+/// serve that is slow — or never comes — doesn't spam the OS with connect()s.
+const CONNECT_RETRY_MIN: Duration = Duration::from_millis(5);
+const CONNECT_RETRY_MAX: Duration = Duration::from_millis(1000);
+
+/// One frame on the wire. There is a variant per [`ConnectionCommand`] that
+/// crosses the pipe (including `Establish`, which is how the two ends exchange
+/// identity). Message-part *bytes* are never carried here — only their lengths.
+#[derive(Serialize, Deserialize)]
+enum WireFrame {
+    Establish {
+        role: Role,
+        ident: Option<Vec<u8>>,
+        name_for_other: Option<Vec<u8>>,
+        alive: bool,
+    },
+    Message {
+        destination_ident: Vec<u8>,
+        part_lens: Vec<u64>,
+    },
+    PublishRoutes {
+        actor_idents: Vec<Vec<u8>>,
+    },
+    Severed {
+        reason: Vec<u8>,
+    },
+}
+
+fn bincode_config() -> bincode::config::Configuration {
+    bincode::config::standard()
+}
+
+/// Owns all UNIX transport state and coroutines. The command loop holds one of
+/// these and forwards serves/joins to it; it never sees sockets, urls, or pairing
+/// state. The loop sender and the teardown signal are captured here once.
+pub(crate) struct UnixTransport {
+    loop_tx: mpsc::UnboundedSender<Command>,
+    shutdown_tx: watch::Sender<bool>,
+    // One listener coroutine per url; serve connections are forwarded to it and
+    // it owns the serve/accept pairing.
+    listeners: HashMap<String, mpsc::UnboundedSender<ConnectionRef>>,
+    // Liveness-token issuer: each connection's writer holds a clone for its
+    // lifetime, as do the listener/connector coroutines. Teardown drops this
+    // issuing copy and waits for `alive_rx` to close — i.e. for every writer to
+    // have flushed and exited.
+    alive_tx: Option<mpsc::UnboundedSender<()>>,
+    alive_rx: mpsc::UnboundedReceiver<()>,
+}
+
+impl UnixTransport {
+    pub(crate) fn new(loop_tx: mpsc::UnboundedSender<Command>) -> Self {
+        let (shutdown_tx, _) = watch::channel(false);
+        let (alive_tx, alive_rx) = mpsc::unbounded_channel();
+        Self {
+            loop_tx,
+            shutdown_tx,
+            listeners: HashMap::new(),
+            alive_tx: Some(alive_tx),
+            alive_rx,
+        }
+    }
+
+    fn alive_token(&self) -> mpsc::UnboundedSender<()> {
+        self.alive_tx
+            .as_ref()
+            .expect("alive-token issuer present before shutdown")
+            .clone()
+    }
+
+    /// Signal every writer to flush and exit, then wait until they all have.
+    /// Reader/listener/connector coroutines observe the same signal and stop,
+    /// dropping their liveness tokens; once all tokens are gone `alive_rx`
+    /// closes. Called on context shutdown before the runtime is torn down, so no
+    /// queued frame is lost.
+    pub(crate) async fn shutdown(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+        self.alive_tx = None; // drop the issuing token; only coroutine clones remain
+        // We never send on this channel; recv resolves to None exactly when the
+        // last clone is dropped (every writer flushed and exited).
+        let _ = self.alive_rx.recv().await;
+    }
+}
+
+impl Transport for UnixTransport {
+    fn serve(&mut self, url: String, connection: ConnectionRef) {
+        // The first serve on a url spawns its listener coroutine; later serves
+        // just forward another connection to it.
+        if !self.listeners.contains_key(&url) {
+            let (tx, rx) = mpsc::unbounded_channel();
+            tokio::task::spawn_local(listener_task(
+                socket_path(&url),
+                rx,
+                self.loop_tx.clone(),
+                self.shutdown_tx.subscribe(),
+                self.alive_token(),
+            ));
+            self.listeners.insert(url.clone(), tx);
+        }
+        let _ = self
+            .listeners
+            .get(&url)
+            .expect("listener just inserted")
+            .send(connection);
+    }
+
+    fn join(&mut self, url: String, connection: ConnectionRef) {
+        tokio::task::spawn_local(connector_task(
+            socket_path(&url),
+            connection,
+            self.loop_tx.clone(),
+            self.shutdown_tx.subscribe(),
+            self.alive_token(),
+        ));
+    }
+}
+
+/// Strip the `unix://` prefix from a url, yielding the filesystem path.
+fn socket_path(url: &str) -> PathBuf {
+    PathBuf::from(url.strip_prefix("unix://").unwrap_or(url))
+}
+
+/// Bind `path` and pair each accepted socket with the next queued serve (either
+/// may arrive first, so both sides are buffered). On a bind failure the serves
+/// are severed instead. Stops on the teardown signal or when the command loop
+/// drops the serve sender.
+async fn listener_task(
+    path: PathBuf,
+    mut serves: mpsc::UnboundedReceiver<ConnectionRef>,
+    loop_tx: mpsc::UnboundedSender<Command>,
+    mut shutdown: watch::Receiver<bool>,
+    alive: mpsc::UnboundedSender<()>,
+) {
+    // A stale socket file from a previous run would make bind fail with
+    // EADDRINUSE; the server owns the path, so removing it is safe.
+    let _ = tokio::fs::remove_file(&path).await;
+    let listener = match UnixListener::bind(&path) {
+        Ok(listener) => listener,
+        Err(err) => {
+            // Bind failed. Do NOT retry — a later bind could race a real server on
+            // this path. The url is dead for serving, so stay alive and fail every
+            // serve on it (those already queued and any that arrive later) until
+            // teardown, rather than letting future serves respawn and retry.
+            let reason = format!("unix bind failed: {err}").into_bytes();
+            loop {
+                tokio::select! {
+                    serve = serves.recv() => match serve {
+                        Some(connection) => sever(&loop_tx, connection, reason.clone()),
+                        None => return, // command loop gone
+                    },
+                    _ = shutdown.changed() => return,
+                }
+            }
+        }
+    };
+
+    // Serves and accepted sockets arrive independently; the matcher pairs them up
+    // regardless of order and wires up each pair as it completes.
+    let mut matcher: Matcher<ConnectionRef, UnixStream> = Matcher::new();
+    loop {
+        tokio::select! {
+            serve = serves.recv() => {
+                let Some(connection) = serve else {
+                    return; // command loop gone
+                };
+                let _ = matcher.push_left(connection, |connection, stream| {
+                    spawn_connection(stream, connection, loop_tx.clone(), shutdown.clone(), alive.clone())
+                });
+            }
+            accepted = listener.accept() => {
+                let (stream, _addr) = match accepted {
+                    Ok(accepted) => accepted,
+                    Err(err) => {
+                        // Usually transient (e.g. EMFILE); keep accepting, but don't
+                        // swallow it silently.
+                        tracing::warn!("unix accept on {} failed: {err}", path.display());
+                        continue;
+                    }
+                };
+                let _ = matcher.push_right(stream, |connection, stream| {
+                    spawn_connection(stream, connection, loop_tx.clone(), shutdown.clone(), alive.clone())
+                });
+            }
+            _ = shutdown.changed() => return,
+        }
+    }
+}
+
+/// Connect to `path`, retrying until the server binds (so a join may precede its
+/// serve), then wire up the connection. Stops on the teardown signal.
+async fn connector_task(
+    path: PathBuf,
+    connection: ConnectionRef,
+    loop_tx: mpsc::UnboundedSender<Command>,
+    mut shutdown: watch::Receiver<bool>,
+    alive: mpsc::UnboundedSender<()>,
+) {
+    let mut retry = CONNECT_RETRY_MIN;
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        match UnixStream::connect(&path).await {
+            Ok(stream) => {
+                spawn_connection(stream, connection, loop_tx, shutdown, alive);
+                return;
+            }
+            Err(_) => {
+                tokio::select! {
+                    _ = tokio::time::sleep(retry) => {}
+                    _ = shutdown.changed() => return,
+                }
+                // Back off toward the cap so a slow or absent serve is polled at
+                // most once per CONNECT_RETRY_MAX.
+                retry = (retry * 2).min(CONNECT_RETRY_MAX);
+            }
+        }
+    }
+}
+
+/// Wire up a connected socket: build its [`UnixConnectionTransport`], announce it
+/// to the command loop, and spawn the writer (drains commands → frames) and
+/// reader (frames → `ConnectionSentCommand`). `TransportConnected` is enqueued
+/// before the reader can forward anything, so the command loop installs the
+/// transport before any frame (including the peer's `Establish`) arrives.
+fn spawn_connection(
+    stream: UnixStream,
+    connection: ConnectionRef,
+    loop_tx: mpsc::UnboundedSender<Command>,
+    shutdown: watch::Receiver<bool>,
+    alive: mpsc::UnboundedSender<()>,
+) {
+    let (read_half, write_half) = stream.into_split();
+    let (writer_tx, writer_rx) = mpsc::unbounded_channel();
+
+    let transport = Box::new(UnixConnectionTransport { tx: writer_tx });
+    let _ = loop_tx.send(Command::TransportConnected {
+        connection,
+        transport,
+    });
+    tokio::task::spawn_local(writer_task(write_half, writer_rx, shutdown, alive));
+    tokio::task::spawn_local(reader_task(read_half, connection, loop_tx));
+}
+
+/// Transport for one end of a UNIX connection: `send` hands a command to the
+/// writer task, which serializes it to the socket. Dropping it ends the writer
+/// (closing the socket), which the peer observes as EOF.
+struct UnixConnectionTransport {
+    tx: mpsc::UnboundedSender<ConnectionCommand>,
+}
+
+impl ConnectionTransport for UnixConnectionTransport {
+    fn send(&self, action: ConnectionCommand) -> bool {
+        self.tx.send(action).is_ok()
+    }
+}
+
+/// Write each queued command as a frame. Exits on a write error, when the
+/// channel closes (transport dropped), or on the teardown signal — and in that
+/// last case it first drains every command already queued so those writes reach
+/// the OS before teardown completes. Holds `_alive` for its whole lifetime:
+/// dropping it on exit is how teardown learns this writer has finished flushing.
+async fn writer_task(
+    mut write_half: OwnedWriteHalf,
+    mut rx: mpsc::UnboundedReceiver<ConnectionCommand>,
+    mut shutdown: watch::Receiver<bool>,
+    _alive: mpsc::UnboundedSender<()>,
+) {
+    loop {
+        tokio::select! {
+            command = rx.recv() => {
+                let Some(command) = command else {
+                    break; // transport dropped
+                };
+                if write_command(&mut write_half, command).await.is_err() {
+                    return;
+                }
+            }
+            _ = shutdown.changed() => {
+                // Teardown: the command loop has stopped, so no further commands
+                // will be enqueued. Flush whatever is already queued, then stop.
+                while let Ok(command) = rx.try_recv() {
+                    if write_command(&mut write_half, command).await.is_err() {
+                        return;
+                    }
+                }
+                break;
+            }
+        }
+    }
+    // Every queued frame has been handed to the OS; shut the write side down to
+    // flush and signal EOF to the peer.
+    let _ = write_half.shutdown().await;
+}
+
+/// Decode each frame off the socket and forward it to the command loop. Any read
+/// error or EOF turns into a `Severed` so the command loop tears the connection
+/// down. The command loop's command handling is shared with inproc and unchanged.
+async fn reader_task(
+    mut read_half: OwnedReadHalf,
+    connection: ConnectionRef,
+    loop_tx: mpsc::UnboundedSender<Command>,
+) {
+    loop {
+        match read_command(&mut read_half).await {
+            Ok(action) => {
+                if loop_tx
+                    .send(Command::ConnectionSentCommand { connection, action })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Err(_) => {
+                sever(&loop_tx, connection, b"unix connection closed".to_vec());
+                return;
+            }
+        }
+    }
+}
+
+fn sever(loop_tx: &mpsc::UnboundedSender<Command>, connection: ConnectionRef, reason: Vec<u8>) {
+    let _ = loop_tx.send(Command::ConnectionSentCommand {
+        connection,
+        action: ConnectionCommand::Severed { reason },
+    });
+}
+
+/// Serialize one command and write it: a length-prefixed bincode header, then —
+/// for a message — each part's bytes streamed straight from its buffer. Every
+/// command crosses the wire, `Establish` included.
+async fn write_command(
+    write_half: &mut OwnedWriteHalf,
+    command: ConnectionCommand,
+) -> std::io::Result<()> {
+    // Figure out the header frame to write; a message additionally keeps a list of
+    // part bytes to stream raw after the header.
+    let mut parts: Vec<MsgPart> = Vec::new();
+    let frame = match command {
+        ConnectionCommand::SendMessage {
+            destination_ident,
+            parts: message_parts,
+        } => {
+            let part_lens = message_parts
+                .iter()
+                .map(|part| part.as_bytes().len() as u64)
+                .collect();
+            parts = message_parts;
+            WireFrame::Message {
+                destination_ident,
+                part_lens,
+            }
+        }
+        ConnectionCommand::Establish {
+            role,
+            ident,
+            name_for_other,
+            alive,
+        } => WireFrame::Establish {
+            role,
+            ident,
+            name_for_other,
+            alive,
+        },
+        ConnectionCommand::PublishRoutes { actor_idents } => {
+            WireFrame::PublishRoutes { actor_idents }
+        }
+        ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
+    };
+
+    let header = bincode::serde::encode_to_vec(&frame, bincode_config())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    write_half
+        .write_all(&(header.len() as u64).to_le_bytes())
+        .await?;
+    write_half.write_all(&header).await?;
+    // Write each part's bytes straight from its owning buffer — no copy.
+    for part in parts {
+        write_half.write_all(part.as_bytes()).await?;
+    }
+    Ok(())
+}
+
+/// Read one frame and decode it straight into a [`ConnectionCommand`]. For a
+/// message the part bytes are read directly into the command's own buffers — the
+/// only copy is the unavoidable kernel-to-userspace one, and there is no
+/// intermediate `WireFrame`-plus-parts to re-match.
+async fn read_command(read_half: &mut OwnedReadHalf) -> std::io::Result<ConnectionCommand> {
+    let mut len_buf = [0u8; 8];
+    read_half.read_exact(&mut len_buf).await?;
+    let header_len = u64::from_le_bytes(len_buf) as usize;
+
+    let mut header = vec![0u8; header_len];
+    read_half.read_exact(&mut header).await?;
+    let (frame, _) = bincode::serde::decode_from_slice::<WireFrame, _>(&header, bincode_config())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+
+    Ok(match frame {
+        WireFrame::Message {
+            destination_ident,
+            part_lens,
+        } => {
+            let mut parts = Vec::with_capacity(part_lens.len());
+            for len in part_lens {
+                let mut buf = vec![0u8; len as usize];
+                read_half.read_exact(&mut buf).await?;
+                parts.push(MsgPart::from_bytes(buf));
+            }
+            ConnectionCommand::SendMessage {
+                destination_ident,
+                parts,
+            }
+        }
+        WireFrame::Establish {
+            role,
+            ident,
+            name_for_other,
+            alive,
+        } => ConnectionCommand::Establish {
+            role,
+            ident,
+            name_for_other,
+            alive,
+        },
+        WireFrame::PublishRoutes { actor_idents } => {
+            ConnectionCommand::PublishRoutes { actor_idents }
+        }
+        WireFrame::Severed { reason } => ConnectionCommand::Severed { reason },
+    })
+}


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* __->__ #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add a Unix-domain socket transport that frames connection commands and message parts, retries joins until a listener is available, and flushes queued writes during shutdown. Generalize connection establishment behind a shared transport interface so in-process and Unix links use the same handshake, routing, and failure semantics, with Rust and cross-process Python coverage.

Differential Revision: [D114750216](https://our.internmc.facebook.com/intern/diff/D114750216/)