### PR TITLE
7/43 minimonarch: Implement actor monitoring across transports

### DIFF
--- a/monarch_mini/IMPLEMENTATION.md
+++ b/monarch_mini/IMPLEMENTATION.md
@@ -204,9 +204,46 @@ cost hierarchical.
 
 ## Monitoring
 
-Two mechanisms work together:
+### Single-gateway implementation *(current)*
 
-### Registration
+The multi-gateway design below is the eventual target. Until TCP gateways exist
+the whole job is a single tree rooted at the root actor, and monitoring is built
+directly on the routing table rather than on a dead-gateway set.
+
+- **Dead routes.** A routing entry is now `Connection`, `Unknown` (gateway
+  buffer), or `Dead`. `Dead` is carried up the ancestry inside the *same*
+  `PublishRoutes` command that carries live routes (one `live` list, one `dead`
+  list) — death is just another route state, never a separate channel and never
+  dropped on a republish (e.g. when an actor with a known-dead route gains a
+  parent). An actor that dies, or whose subtree becomes unreachable because a
+  connection failed, has its idents marked `Dead` and the newly-dead ones
+  published up so every ancestor learns it. Each established connection remembers
+  the idents routed through it, so a connection failure marks exactly those dead
+  in O(idents-handled) — never an O(route-table) scan. Messages to a `Dead` route
+  are dropped.
+
+- **Local monitor state.** The monitoring actor stores each monitor as
+  `(id, monitored_ident, failure_prefix)`. The `failure_prefix` never leaves this
+  actor; cancellation just removes the local record, so an in-flight firing is
+  dropped on arrival.
+
+- **Subscribe / fire.** `Subscribe` climbs from the monitoring actor until it
+  reaches the first actor that has the monitored ident in its routing table — the
+  common ancestor where a normal message to the target would turn downward (or
+  the root, for a target that does not exist yet). That ancestor records the
+  subscription. When the target's route there turns `Dead`, the ancestor routes a
+  `FireMonitor` back down to the monitor, which reconstructs
+  `[failure_prefix…, target, "actor died"]` from its local state. (The death
+  reason is not propagated for now; the monitor always reports a fixed reason.) If
+  the target is already `Dead` at the common ancestor, the monitor fires
+  immediately.
+
+This always fires a live monitor: a target's death always reaches the common
+ancestor as a `Dead` route (published up from the failure point), and the only
+way the ancestor misses it is if the ancestor itself dies — which also kills the
+monitoring actor (it is a descendant), so no firing is owed.
+
+### Registration *(multi-gateway design — implement later)*
 
 When `mm_actor_monitor` is called, a registration message is sent to the
 gateway of the actor being monitored. The gateway acknowledges with the full

--- a/monarch_mini/python/minimonarch.pyi
+++ b/monarch_mini/python/minimonarch.pyi
@@ -1,0 +1,114 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Type stubs for the minimonarch CPython extension (see minimonarch.c).
+
+Single small values (idents, reasons) are plain ``bytes`` and copied. Multipart
+message bodies are lists of ``minimonarch.bytearray`` and moved into / out of the
+message zero-copy.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Sequence
+from typing import Literal
+
+Role = Literal["parent", "child"]
+
+class bytearray:
+    """A writable, growable byte buffer whose storage can be *moved* into a
+    message part (after which the part owns it and the bytearray is left empty).
+
+    Exposed to Python as ``minimonarch.bytearray``. Supports the buffer protocol,
+    indexing, ``len()``, and equality against any bytes-like object.
+    """
+
+    def __init__(
+        self, source: int | bytes | bytearray | memoryview | None = ...
+    ) -> None:
+        """Construct empty (``None``), zero-filled of length ``source`` (``int``),
+        or copied from a bytes-like ``source``."""
+        ...
+
+    def append(self, byte: int) -> None: ...
+    def extend(self, data: bytes | bytearray | memoryview) -> None: ...
+    def tobytes(self) -> bytes: ...
+    def __len__(self) -> int: ...
+    def __getitem__(self, index: int) -> int: ...
+    def __setitem__(self, index: int, value: int) -> None: ...
+    def __eq__(self, other: object) -> bool: ...
+    def __ne__(self, other: object) -> bool: ...
+
+class Actor:
+    """An addressable messaging endpoint bound to the current context's poller.
+
+    Creating the first Actor in an asyncio context lazily creates the underlying
+    minimonarch runtime; see ``close()``.
+    """
+
+    def __init__(self, ident: bytes | None = ...) -> None:
+        """Create an actor. ``ident`` must be unique across the run; if ``None``,
+        a name must be assigned by the peer in a later ``serve``/``join``."""
+        ...
+
+    def send(self, receiver: bytes, parts: Sequence[bytearray]) -> None:
+        """Send a multipart message to ``receiver``. Each part is moved (left
+        empty) into the message."""
+        ...
+
+    def next(self) -> Awaitable[list[bytearray]]:
+        """Await the next delivered message as a list of received parts."""
+        ...
+
+    def serve(
+        self,
+        url: str,
+        role: Role,
+        name: bytes | None = ...,
+        hello: Sequence[bytearray] | None = ...,
+        failure: Sequence[bytearray] | None = ...,
+    ) -> None:
+        """Serve (listen) on ``url``. ``role`` is this actor's role in the pair:
+        ``"parent"`` or ``"child"``."""
+        ...
+
+    def join(
+        self,
+        url: str,
+        role: Role,
+        name: bytes | None = ...,
+        hello: Sequence[bytearray] | None = ...,
+        failure: Sequence[bytearray] | None = ...,
+    ) -> None:
+        """Join (connect to) ``url``. ``role`` is this actor's role in the pair:
+        ``"parent"`` or ``"child"``."""
+        ...
+
+    def die(self, reason: bytes) -> None:
+        """Signal that this actor is dead to its parent, children, and monitors."""
+        ...
+
+    def monitor(
+        self,
+        ident: bytes,
+        failure: Sequence[bytearray] | None = ...,
+    ) -> MonitorHandle:
+        """Monitor ``ident``. If it dies (or is already dead), this actor is sent
+        ``[*failure, ident, reason]``."""
+        ...
+
+class MonitorHandle:
+    """Handle for a registered monitor; call ``cancel()`` to deregister."""
+
+    def cancel(self) -> None:
+        """Stop delivering the monitor's failure message. Idempotent."""
+        ...
+
+def close() -> bool:
+    """Tear down the current context's minimonarch runtime, returning whether one
+    was installed. Actors survive as objects but error on further use; the next
+    Actor created in the context transparently makes a fresh runtime."""
+    ...

--- a/monarch_mini/python/test_smoke.py
+++ b/monarch_mini/python/test_smoke.py
@@ -365,10 +365,84 @@ async def test_unix_subprocess_kill_propagates_failure_and_cascades() -> None:
             await _kill_worker(proc)
 
 
-async def test_unimplemented_monitor_raises() -> None:
-    a = Actor(b"srv-actor")
-    with pytest.raises(RuntimeError, match="implement"):
-        a.monitor(b"other@root")
+async def test_monitor_fires_when_target_dies() -> None:
+    # watcher and target are siblings under root. watcher monitors target; when
+    # target dies, the failure climbs to their common ancestor (root) and fires
+    # back down to watcher as [failure_prefix..., target_ident, "actor died"].
+    root = Actor(b"root")
+    watcher = Actor(b"watcher")
+    target = Actor(b"target")
+    await _connect(root, b"root", watcher, b"watcher", "inproc://mon-watcher")
+    await _connect(root, b"root", target, b"target", "inproc://mon-target")
+
+    handle = watcher.monitor(b"target", failure=[ba(b"DOWN")])
+    assert isinstance(handle, minimonarch.MonitorHandle)
+
+    target.die(b"boom")
+    assert await watcher.next() == [b"DOWN", b"target", b"actor died"]
+
+
+async def test_monitor_fires_when_parent_of_target_dies() -> None:
+    # target dies indirectly: its parent `mid` dies, so target is unreachable.
+    # The death is reported up by root (mid's link carried both mid and target),
+    # so the monitor still fires even though target never reported its own death.
+    root = Actor(b"root")
+    watcher = Actor(b"watcher")
+    mid = Actor(b"mid")
+    target = Actor(b"target")
+    await _connect(root, b"root", watcher, b"watcher", "inproc://mon-pw")
+    await _connect(root, b"root", mid, b"mid", "inproc://mon-pm")
+    await _connect(mid, b"mid", target, b"target", "inproc://mon-mt")
+
+    watcher.monitor(b"target", failure=[ba(b"DOWN")])
+    mid.die(b"crash")
+    assert await watcher.next() == [b"DOWN", b"target", b"actor died"]
+
+
+async def test_cancelled_monitor_does_not_fire() -> None:
+    # A cancelled monitor must not deliver, even after the target dies.
+    root = Actor(b"root")
+    watcher = Actor(b"watcher")
+    target = Actor(b"target")
+    await _connect(root, b"root", watcher, b"watcher", "inproc://mon-cw")
+    await _connect(root, b"root", target, b"target", "inproc://mon-ct")
+
+    handle = watcher.monitor(b"target", failure=[ba(b"DOWN")])
+    handle.cancel()
+    target.die(b"boom")
+
+    # Prove nothing fired by sending watcher a sentinel: it must be the only,
+    # and first, message watcher receives.
+    watcher.send(b"watcher", [ba(b"sentinel")])
+    assert await watcher.next() == [b"sentinel"]
+
+
+async def test_monitor_on_already_dead_actor_fires_immediately() -> None:
+    # Monitoring an actor that is already known dead fires right away rather than
+    # waiting forever.
+    root = Actor(b"root")
+    watcher = Actor(b"watcher")
+    target = Actor(b"target")
+    await _connect(root, b"root", watcher, b"watcher", "inproc://mon-aw")
+    await _connect(root, b"root", target, b"target", "inproc://mon-at")
+
+    target.die(b"boom")
+    # root is target's parent, so it receives the connection-failure notification.
+    # Consuming it confirms root has processed (and recorded as dead) target's
+    # death before we subscribe.
+    assert await root.next() == [b"target", b"boom"]
+
+    watcher.monitor(b"target", failure=[ba(b"DOWN")])
+    assert await watcher.next() == [b"DOWN", b"target", b"actor died"]
+
+
+async def test_monitor_returns_cancellable_handle() -> None:
+    # cancel() is idempotent and returns None.
+    a = Actor(b"mon-handle")
+    handle = a.monitor(b"nonexistent@root", failure=[ba(b"DOWN")])
+    assert isinstance(handle, minimonarch.MonitorHandle)
+    assert handle.cancel() is None
+    assert handle.cancel() is None
 
 
 async def test_die_is_void() -> None:

--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -17,11 +17,22 @@ use crate::ctx::PollerKey;
 use crate::msg::MsgPart;
 
 pub(crate) struct ActorEntry {
-    pub(crate) ident: Option<Vec<u8>>,
+    pub(crate) name: ActorName,
     pub(crate) delivery: Delivery,
     pub(crate) parent: Option<Connection>,
     pub(crate) children: SlotMap<ChildConnectionKey, Connection>,
+    /// Routing table: per destination ident, where it lives (or that it is dead)
+    /// *and* the monitor subscriptions this actor is responsible for on it. Monitors
+    /// live on the route because they share its key and travel the same paths: a
+    /// monitor registered against an `Unknown` route is forwarded up exactly like a
+    /// buffered message when this actor gains a parent, and one on a `Connection`
+    /// route fires when that route transitions to `Dead`.
     pub(crate) routes: HashMap<Vec<u8>, Route>,
+    /// Monitors this actor *created* (it is the monitoring/`dest` side). Keyed by
+    /// monitor id so they can be fired locally and cancelled. The failure_prefix
+    /// stays here and never travels — the responsible ancestor only sends back
+    /// `id` and we reconstruct the full failure message from this.
+    pub(crate) monitors: HashMap<u64, LocalMonitor>,
     pub(crate) gateway: bool,
     pub(crate) alive: bool,
 }
@@ -29,15 +40,34 @@ pub(crate) struct ActorEntry {
 impl ActorEntry {
     pub(crate) fn new(ident: Option<Vec<u8>>) -> Self {
         Self {
-            ident,
+            name: ActorName::new(ident),
             delivery: Delivery::NoPoller {
                 buffered: VecDeque::new(),
             },
             parent: None,
             children: SlotMap::with_key(),
             routes: HashMap::new(),
+            monitors: HashMap::new(),
             gateway: true,
             alive: true,
+        }
+    }
+
+    /// Record that `ident` is live through child connection `child`, so that if that
+    /// connection later fails we can mark exactly those idents dead in
+    /// O(idents-handled) instead of scanning the whole routing table. Only live
+    /// idents are tracked; ones already dead need no re-killing on failure.
+    pub(crate) fn record_routed_via_child(&mut self, child: ChildConnectionKey, ident: &[u8]) {
+        if let Some(Connection::Established { routed_idents, .. }) = self.children.get_mut(child) {
+            routed_idents.insert(ident.to_vec());
+        }
+    }
+
+    /// This actor's ident, or `None` if it has not been named yet.
+    pub(crate) fn name(&self) -> Option<&[u8]> {
+        match &self.name {
+            ActorName::Named(name) => Some(name),
+            ActorName::Unknown { .. } => None,
         }
     }
 
@@ -75,42 +105,117 @@ impl ActorEntry {
     /// here, so it can be flushed once the route becomes known or this actor gains
     /// a parent. This is the only place messages enter a [`Route::Unknown`] buffer.
     pub(crate) fn buffer_unrouted(&mut self, destination: Vec<u8>, parts: Vec<MsgPart>) {
-        let Route::Unknown(buffered) = self
+        match self
             .routes
             .entry(destination)
-            .or_insert_with(|| Route::Unknown(Vec::new()))
-        else {
-            unreachable!("a known route would have been used to send instead of buffering");
-        };
-        buffered.push(parts);
+            .or_insert_with(Route::new_unknown)
+        {
+            Route::Unknown { messages, .. } => messages.push(parts),
+            _ => unreachable!("a known route would have been used to send instead of buffering"),
+        }
     }
 
-    /// Remove every buffered (unrouted) destination, returning each with its pending
-    /// messages and leaving only concrete routes behind. Used when the actor gains a
-    /// parent: the messages are re-routed up to the parent and no longer buffered here.
-    pub(crate) fn drain_buffered_routes(&mut self) -> Vec<(Vec<u8>, Vec<Vec<MsgPart>>)> {
-        let mut buffered = Vec::new();
-        let mut kept = HashMap::new();
-        for (ident, route) in std::mem::take(&mut self.routes) {
-            match route {
-                Route::Unknown(messages) => buffered.push((ident, messages)),
-                Route::Connection(_) => {
-                    kept.insert(ident, route);
-                }
+    /// Register a monitor subscription on `to_monitor`'s route. Held on the route
+    /// (creating an `Unknown` buffer if there is none yet) until the route turns
+    /// `Dead` (fired) or this actor gains a parent (forwarded up, for `Unknown`).
+    /// The caller guarantees the route is not `Dead` (a dead route fires at once).
+    pub(crate) fn buffer_monitor(&mut self, to_monitor: Vec<u8>, sub: MonitorSub) {
+        match self
+            .routes
+            .entry(to_monitor)
+            .or_insert_with(Route::new_unknown)
+        {
+            Route::Unknown { monitors, .. } | Route::Connection { monitors, .. } => {
+                monitors.push(sub)
             }
+            Route::Dead => unreachable!("a dead route fires immediately and never registers"),
         }
-        self.routes = kept;
-        buffered
     }
 }
 
-/// A destination ident's entry in an actor's routing table.
+/// A destination ident's entry in an actor's routing table. Carries the monitor
+/// subscriptions this actor is responsible for on that destination alongside its
+/// reachability, so the two stay in lock-step (same key, same propagation path).
 pub(crate) enum Route {
     /// The destination is not (yet) known here — it may not have been created.
-    /// Messages for it are buffered until a route is published, then flushed.
-    Unknown(Vec<Vec<MsgPart>>),
-    /// The destination is reachable through this child connection.
-    Connection(ChildConnectionKey),
+    /// Messages and monitor subscriptions for it are buffered until a route is
+    /// published (then carried into [`Route::Connection`]) or this actor gains a
+    /// parent (then forwarded up).
+    Unknown {
+        messages: Vec<Vec<MsgPart>>,
+        monitors: Vec<MonitorSub>,
+    },
+    /// The destination is reachable through this child connection. Monitors here
+    /// fire when the route transitions to [`Route::Dead`].
+    Connection {
+        child: ChildConnectionKey,
+        monitors: Vec<MonitorSub>,
+    },
+    /// The destination was reachable but has since died (directly, or because a
+    /// connection on the path to it failed). Messages for it are dropped; its
+    /// monitors were fired and removed at the moment of transition.
+    Dead,
+}
+
+impl Route {
+    pub(crate) fn new_unknown() -> Self {
+        Route::Unknown {
+            messages: Vec::new(),
+            monitors: Vec::new(),
+        }
+    }
+
+    /// The monitor subscriptions held on this route, if it can hold any (i.e. it is
+    /// not `Dead`).
+    pub(crate) fn monitors_mut(&mut self) -> Option<&mut Vec<MonitorSub>> {
+        match self {
+            Route::Unknown { monitors, .. } | Route::Connection { monitors, .. } => Some(monitors),
+            Route::Dead => None,
+        }
+    }
+}
+
+/// A monitor created by this actor (the monitoring/`dest` side). Held until the
+/// monitored actor dies or the monitor is cancelled.
+pub(crate) struct LocalMonitor {
+    pub(crate) to_monitor: Vec<u8>,
+    pub(crate) failure_prefix: Vec<MsgPart>,
+}
+
+/// A subscription held at the responsible common ancestor `R`: when the watched
+/// ident dies, route a fire to `dest` carrying `id`.
+pub(crate) struct MonitorSub {
+    pub(crate) dest: Vec<u8>,
+    pub(crate) id: u64,
+}
+
+/// An actor's ident, which may not be known at creation (a child can be named by
+/// its parent when it joins).
+pub(crate) enum ActorName {
+    /// Not named yet. Monitors created in the meantime cannot address their
+    /// fire-backs (which route to this actor's own ident), so they wait here until
+    /// a name is assigned, then subscribe for real.
+    Unknown {
+        pending_monitors: Vec<PendingMonitor>,
+    },
+    Named(Vec<u8>),
+}
+
+impl ActorName {
+    pub(crate) fn new(ident: Option<Vec<u8>>) -> Self {
+        match ident {
+            Some(name) => ActorName::Named(name),
+            None => ActorName::Unknown {
+                pending_monitors: Vec::new(),
+            },
+        }
+    }
+}
+
+/// A monitor whose subscription was deferred until its creating actor is named.
+pub(crate) struct PendingMonitor {
+    pub(crate) id: u64,
+    pub(crate) to_monitor: Vec<u8>,
 }
 
 pub(crate) enum Delivery {

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -6,6 +6,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::collections::HashSet;
 use std::collections::VecDeque;
 
 use crate::Role;
@@ -80,6 +81,12 @@ pub(crate) enum Connection {
         transport: Box<dyn ConnectionTransport>,
         failure_prefix: Vec<MsgPart>,
         peer_ident: Vec<u8>,
+        /// Every ident that has been *live* through this connection (the peer and,
+        /// for a child connection, the live routes published up through it). On
+        /// failure these are exactly the idents to mark dead — no route-table scan
+        /// needed. Idents that arrived already dead are not tracked: they are dead
+        /// regardless of this connection's fate.
+        routed_idents: HashSet<Vec<u8>>,
     },
     Failed,
 }
@@ -113,8 +120,37 @@ pub(crate) enum ConnectionCommand {
     Severed {
         reason: Vec<u8>,
     },
+    /// Carry route state up the ancestry. `live` idents become
+    /// [`Route::Connection`](crate::actor::Route::Connection) toward this child;
+    /// `dead` idents become [`Route::Dead`](crate::actor::Route::Dead) and fire any
+    /// monitors watching them. Death travels in the *same* command as life so a
+    /// route's state is never lost on the way up (a dead actor is never mistaken
+    /// for one that does not exist yet). This is the only way dead routes propagate.
     PublishRoutes {
-        actor_idents: Vec<Vec<u8>>,
+        live: Vec<Vec<u8>>,
+        dead: Vec<Vec<u8>>,
+    },
+    /// Register a monitor: travels up from the monitoring actor until it reaches
+    /// the common ancestor that has `to_monitor` in its routing table (or the
+    /// root). That ancestor records the subscription.
+    Subscribe {
+        dest: Vec<u8>,
+        id: u64,
+        to_monitor: Vec<u8>,
+    },
+    /// Cancel a previously-registered monitor; travels the same path as
+    /// [`ConnectionCommand::Subscribe`] and removes the subscription.
+    Unsubscribe {
+        dest: Vec<u8>,
+        id: u64,
+        to_monitor: Vec<u8>,
+    },
+    /// Deliver a monitor firing toward the monitoring actor `dest_ident`. Routed
+    /// like a normal message; on arrival the owner reconstructs the failure
+    /// message from its local failure_prefix (the reason is a fixed "actor died").
+    FireMonitor {
+        dest_ident: Vec<u8>,
+        monitor_id: u64,
     },
 }
 
@@ -151,35 +187,41 @@ impl Connection {
     }
 
     /// Consume a connection that is being torn down, yielding the failure-message
-    /// prefix and the peer ident to report. `None` if it had already failed.
-    pub(crate) fn into_failure_report(self) -> Option<(Vec<MsgPart>, Vec<u8>)> {
+    /// prefix, the peer ident to report, and every ident that was reachable
+    /// through it (to mark dead). `None` if it had already failed.
+    pub(crate) fn into_failure_report(self) -> Option<FailureReport> {
         match self {
             Self::Established {
                 failure_prefix,
                 peer_ident,
+                routed_idents,
                 ..
-            } => Some((failure_prefix, peer_ident)),
+            } => Some((failure_prefix, peer_ident, routed_idents)),
             Self::Unestablished {
                 name_for_other,
                 failure_prefix,
                 ..
-            } => Some((failure_prefix, name_for_other.unwrap_or_default())),
+            } => Some((
+                failure_prefix,
+                name_for_other.unwrap_or_default(),
+                HashSet::new(),
+            )),
             // Connecting has not yet learned the peer's ident; fall back to the
             // name we assigned it, if any.
             Self::Connecting {
                 name_for_other,
                 failure_prefix,
                 ..
-            } => Some((failure_prefix, name_for_other.unwrap_or_default())),
+            } => Some((
+                failure_prefix,
+                name_for_other.unwrap_or_default(),
+                HashSet::new(),
+            )),
             Self::Failed => None,
         }
     }
 }
 
-/// Why a connection failed to establish, carrying everything needed to notify
-/// the owning actor: the failure-message prefix, the peer ident, and the reason.
-pub(crate) struct EstablishFailure {
-    pub(crate) failure_prefix: Vec<MsgPart>,
-    pub(crate) peer_ident: Vec<u8>,
-    pub(crate) reason: Vec<u8>,
-}
+/// What [`Connection::into_failure_report`] yields: the failure-message prefix,
+/// the peer ident to report, and every ident that routed through the connection.
+pub(crate) type FailureReport = (Vec<MsgPart>, Vec<u8>, HashSet<Vec<u8>>);

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -6,6 +6,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
 use std::thread;
@@ -19,14 +21,17 @@ use tokio::sync::oneshot;
 
 use crate::Role;
 use crate::actor::ActorEntry;
+use crate::actor::ActorName;
 use crate::actor::Delivery;
+use crate::actor::LocalMonitor;
+use crate::actor::MonitorSub;
+use crate::actor::PendingMonitor;
 use crate::actor::Route;
 use crate::connection::ConnectRequest;
 use crate::connection::Connection;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
-use crate::connection::EstablishFailure;
 use crate::inproc_transport::InprocTransport;
 use crate::msg::MsgPart;
 use crate::poller::Delivered;
@@ -96,7 +101,7 @@ pub(crate) enum Command {
         url: String,
         request: ConnectRequest,
     },
-    ConnectionSentCommand {
+    ConnectionAction {
         connection: ConnectionRef,
         action: ConnectionCommand,
     },
@@ -111,6 +116,16 @@ pub(crate) enum Command {
         actor: Key,
         reason: MsgPart,
     },
+    Monitor {
+        actor: Key,
+        id: u64,
+        to_monitor: MsgPart,
+        failure_prefix: Vec<MsgPart>,
+    },
+    CancelMonitor {
+        actor: Key,
+        id: u64,
+    },
     Shutdown {
         done: oneshot::Sender<JoinHandle<()>>,
     },
@@ -121,7 +136,7 @@ struct Ctx {
     pollers: SlotMap<PollerKey, PollerEntry>,
     // The transports. Each owns its own pairing/socket state and coroutines plus
     // a clone of the loop sender; the command loop only forwards serves/joins to
-    // them and handles the generic TransportConnected/ConnectionSentCommand they
+    // them and handles the generic TransportConnected/ConnectionAction they
     // emit.
     inproc: InprocTransport,
     unix: UnixTransport,
@@ -233,7 +248,7 @@ impl Ctx {
             } => {
                 self.join(actor, url, request);
             }
-            Command::ConnectionSentCommand { connection, action } => {
+            Command::ConnectionAction { connection, action } => {
                 if !matches!(self.connection(connection), Connection::Failed) {
                     self.run_connection_command(connection, action);
                 }
@@ -247,6 +262,48 @@ impl Ctx {
             Command::Die { actor, reason } => {
                 let reason = reason.as_bytes().to_vec();
                 self.die_actor(actor, reason);
+            }
+            Command::Monitor {
+                actor,
+                id,
+                to_monitor,
+                failure_prefix,
+            } => {
+                let to_monitor = to_monitor.as_bytes().to_vec();
+                self.actor_mut(actor).monitors.insert(
+                    id,
+                    LocalMonitor {
+                        to_monitor: to_monitor.clone(),
+                        failure_prefix,
+                    },
+                );
+                // The fire is addressed by our own ident. If we are not named yet,
+                // defer the subscription until a name is assigned (a join will); the
+                // local record above still lets us cancel it meanwhile.
+                let dest = match &mut self.actor_mut(actor).name {
+                    ActorName::Named(name) => name.clone(),
+                    ActorName::Unknown { pending_monitors } => {
+                        pending_monitors.push(PendingMonitor { id, to_monitor });
+                        return;
+                    }
+                };
+                self.route_subscribe(actor, dest, id, to_monitor);
+            }
+            Command::CancelMonitor { actor, id } => {
+                // Drop the local record (so an in-flight fire is dropped on arrival).
+                let Some(local) = self.actor_mut(actor).monitors.remove(&id) else {
+                    return;
+                };
+                // If we are named the subscription was propagated upstream, so walk an
+                // unsubscribe up; otherwise it is still in our deferred list, drop it.
+                let dest = match &mut self.actor_mut(actor).name {
+                    ActorName::Named(name) => name.clone(),
+                    ActorName::Unknown { pending_monitors } => {
+                        pending_monitors.retain(|pending| pending.id != id);
+                        return;
+                    }
+                };
+                self.route_unsubscribe(actor, dest, id, local.to_monitor);
             }
             Command::Shutdown { .. } => {
                 // Handled directly by the event loop (see CtxHandle::new) so it
@@ -301,24 +358,30 @@ impl Ctx {
         if !entry.alive {
             return;
         }
-        if entry.ident.as_deref() == Some(destination_ident.as_slice()) {
+        if entry.name() == Some(destination_ident.as_slice()) {
             self.deliver_to_actor(sender, parts);
             return;
         }
 
-        // A known child route: hand the message down toward the destination.
-        if let Some(Route::Connection(child_key)) = entry.routes.get(destination_ident.as_slice()) {
-            let child_key = *child_key;
-            let connection = self
-                .actor_mut(sender)
-                .children
-                .get_mut(child_key)
-                .expect("route child connection should exist");
-            let _ = connection.send(ConnectionCommand::SendMessage {
-                destination_ident,
-                parts,
-            });
-            return;
+        match entry.routes.get(destination_ident.as_slice()) {
+            // A known child route: hand the message down toward the destination.
+            Some(Route::Connection { child, .. }) => {
+                let child_key = *child;
+                let connection = self
+                    .actor_mut(sender)
+                    .children
+                    .get_mut(child_key)
+                    .expect("route child connection should exist");
+                let _ = connection.send(ConnectionCommand::SendMessage {
+                    destination_ident,
+                    parts,
+                });
+                return;
+            }
+            // The destination is known to be dead: drop the message rather than
+            // forwarding it up (where it would buffer forever at the gateway).
+            Some(Route::Dead) => return,
+            Some(Route::Unknown { .. }) | None => {}
         }
 
         // No known route here. Forward toward the gateway; the gateway itself (no
@@ -445,7 +508,10 @@ impl Ctx {
         transport: Box<dyn ConnectionTransport>,
     ) {
         let role = connection.role();
-        let ident = self.actor(connection.owning_actor()).ident.clone();
+        let ident = self
+            .actor(connection.owning_actor())
+            .name()
+            .map(|name| name.to_vec());
         let alive = matches!(
             self.connection(connection),
             Connection::Unestablished { .. }
@@ -491,36 +557,83 @@ impl Ctx {
         }
     }
 
+    /// Record routes arriving over `child_connection`: `live` idents become
+    /// concrete routes to that child (and are remembered against it, so they can be
+    /// marked dead if it later fails), `dead` idents are marked [`Route::Dead`].
+    /// Both kinds are carried further up.
     fn populate_routes(
         &mut self,
         parent: Key,
         child_connection: ChildConnectionKey,
-        idents: Vec<Vec<u8>>,
+        live: Vec<Vec<u8>>,
+        dead: Vec<Vec<u8>>,
     ) {
-        for ident in &idents {
-            let previous = self
-                .actor_mut(parent)
-                .routes
-                .insert(ident.clone(), Route::Connection(child_connection));
+        for ident in &live {
+            // Take any existing entry so we can carry its monitors onto the now-known
+            // route and flush its buffered messages. Monitors stay here: this actor is
+            // the responsible ancestor for the destination (it is reachable below it).
+            let previous = self.actor_mut(parent).routes.remove(ident.as_slice());
+            let (monitors, buffered) = match previous {
+                Some(Route::Unknown { messages, monitors }) => (monitors, messages),
+                Some(Route::Connection { monitors, .. }) => (monitors, Vec::new()),
+                _ => (Vec::new(), Vec::new()),
+            };
+            self.actor_mut(parent).routes.insert(
+                ident.clone(),
+                Route::Connection {
+                    child: child_connection,
+                    monitors,
+                },
+            );
+            // Remember the ident is carried by this child so we can mark exactly
+            // these dead (no table scan) if the connection later fails.
+            self.actor_mut(parent)
+                .record_routed_via_child(child_connection, ident);
 
-            // If we had been buffering messages for this destination because its route
-            // was unknown, re-route them now that it is known; route_message sends them
-            // down the child connection we just recorded.
-            if let Some(Route::Unknown(buffered)) = previous {
-                for parts in buffered {
-                    self.route_message(parent, ident.clone(), parts);
-                }
+            // Re-route any messages buffered while the route was unknown; route_message
+            // sends them down the child connection we just recorded.
+            for parts in buffered {
+                self.route_message(parent, ident.clone(), parts);
             }
         }
-        self.publish_routes_to_parent(parent, idents);
+
+        // Mark the dead idents dead (they are not tracked against the child — they
+        // are already dead, so a later failure of this connection has nothing to
+        // re-kill there). Keep only those that newly transitioned so propagation
+        // can't loop, firing the monitors that were waiting on each.
+        let mut newly_dead = Vec::new();
+        let mut to_fire: Vec<MonitorSub> = Vec::new();
+        for ident in dead {
+            let routes = &mut self.actor_mut(parent).routes;
+            match routes.get_mut(&ident) {
+                Some(Route::Dead) => continue, // already dead
+                Some(route) => {
+                    to_fire.extend(route.monitors_mut().map(std::mem::take).unwrap_or_default());
+                    *route = Route::Dead;
+                }
+                None => {
+                    routes.insert(ident.clone(), Route::Dead);
+                }
+            }
+            newly_dead.push(ident);
+        }
+        for sub in to_fire {
+            self.route_fire_monitor(parent, sub.dest, sub.id);
+        }
+
+        // Forward both the live and the newly-dead idents up to the parent.
+        self.publish_routes_to_parent(parent, live, newly_dead);
     }
 
-    fn publish_routes_to_parent(&mut self, actor: Key, actor_idents: Vec<Vec<u8>>) {
+    fn publish_routes_to_parent(&mut self, actor: Key, live: Vec<Vec<u8>>, dead: Vec<Vec<u8>>) {
+        if live.is_empty() && dead.is_empty() {
+            return;
+        }
         let actor = self.actor_mut(actor);
         let Some(parent) = actor.parent.as_mut() else {
             return;
         };
-        let _ = parent.send(ConnectionCommand::PublishRoutes { actor_idents });
+        let _ = parent.send(ConnectionCommand::PublishRoutes { live, dead });
     }
 
     fn publish_routes_after_established(
@@ -531,31 +644,41 @@ impl Ctx {
     ) {
         match connection {
             ConnectionRef::ChildConnection { ofactor, slot } => {
-                self.populate_routes(ofactor, slot, vec![peer_ident]);
+                self.populate_routes(ofactor, slot, vec![peer_ident], Vec::new());
             }
             ConnectionRef::ParentConnection { ofactor } => {
-                // We just gained a parent. Stop buffering for destinations we couldn't
-                // place while parentless: drop those entries and re-route their held
-                // messages, which now flow up to the parent (route_message forwards
-                // them, since their local routes are gone).
-                let buffered = self.actor_mut(ofactor).drain_buffered_routes();
-
-                // Advertise the destinations we can already reach (concrete child
-                // routes) plus our own ident.
-                let mut actor_idents = self
-                    .actor(ofactor)
-                    .routes
-                    .keys()
-                    .cloned()
-                    .collect::<Vec<_>>();
-                actor_idents.push(local_ident);
-                self.publish_routes_to_parent(ofactor, actor_idents);
-
-                for (destination, messages) in buffered {
-                    for parts in messages {
-                        self.route_message(ofactor, destination.clone(), parts);
+                // We just gained a parent. Walk the whole routing table once: concrete
+                // routes are advertised up (live as live, dead as dead — a dead route
+                // must travel up *as dead*, else the parent treats a known-dead actor
+                // as alive), while buffered Unknown routes — which we could not place
+                // while parentless — are dropped and their held messages and monitor
+                // subscriptions re-routed up (route_message / route_subscribe now
+                // forward, since there is a parent and no local route).
+                let mut live = vec![local_ident];
+                let mut dead = Vec::new();
+                let mut kept = HashMap::new();
+                for (ident, route) in std::mem::take(&mut self.actor_mut(ofactor).routes) {
+                    match route {
+                        Route::Connection { .. } => {
+                            live.push(ident.clone());
+                            kept.insert(ident, route);
+                        }
+                        Route::Dead => {
+                            dead.push(ident.clone());
+                            kept.insert(ident, route);
+                        }
+                        Route::Unknown { messages, monitors } => {
+                            for parts in messages {
+                                self.route_message(ofactor, ident.clone(), parts);
+                            }
+                            for sub in monitors {
+                                self.route_subscribe(ofactor, sub.dest, sub.id, ident.clone());
+                            }
+                        }
                     }
                 }
+                self.actor_mut(ofactor).routes = kept;
+                self.publish_routes_to_parent(ofactor, live, dead);
             }
         }
     }
@@ -572,67 +695,94 @@ impl Ctx {
                 name_for_other,
                 alive,
             } => {
-                // The peer announced itself; finalize our side using the transport
-                // we stashed when our pipe connected.
-                if let Err(EstablishFailure {
-                    failure_prefix,
-                    peer_ident,
-                    reason,
-                }) = self.establish_connection(connection, role, ident, name_for_other, alive)
+                // The peer announced itself; finalize our side using the transport we
+                // stashed when our pipe connected. On failure establish_connection
+                // parks the connection carrying its failure info, so fail_connection
+                // tears it down the same way a sever does.
+                if let Err(reason) =
+                    self.establish_connection(connection, role, ident, name_for_other, alive)
                 {
-                    // Establishment failed (peer announced dead, roles disagree,
-                    // name conflict, ...): sever the connection and notify the actor.
-                    let _ = self.connection_set(connection, Connection::Failed);
-                    self.fail_connection(connection, failure_prefix, peer_ident, reason);
+                    self.fail_connection(connection, reason);
                 }
             }
             ConnectionCommand::Severed { reason } => {
-                // The peer (or our own death cascade) tore this connection down. Mark
-                // it failed and pull out what we need to notify the owning actor.
-                let Some((failure_prefix, peer_ident)) = self
-                    .connection_set(connection, Connection::Failed)
-                    .into_failure_report()
-                else {
-                    return;
-                };
-                self.fail_connection(connection, failure_prefix, peer_ident, reason);
+                // The peer (or our own death cascade) tore this connection down.
+                self.fail_connection(connection, reason);
             }
-            ConnectionCommand::PublishRoutes { actor_idents } => {
+            ConnectionCommand::PublishRoutes { live, dead } => {
                 assert!(
                     matches!(self.connection(connection), Connection::Established { .. }),
                     "published routes should arrive on an established connection"
                 );
                 // Published routes always arrive over a child connection: record them
-                // as routes to that child (which also forwards them on toward the root).
+                // (live and dead) as routes to that child, forwarding both up the tree.
                 let ConnectionRef::ChildConnection { ofactor, slot } = connection else {
                     panic!("published routes should arrive on a child connection");
                 };
-                self.populate_routes(ofactor, slot, actor_idents);
+                self.populate_routes(ofactor, slot, live, dead);
+            }
+            ConnectionCommand::Subscribe {
+                dest,
+                id,
+                to_monitor,
+            } => {
+                self.route_subscribe(connection.owning_actor(), dest, id, to_monitor);
+            }
+            ConnectionCommand::Unsubscribe {
+                dest,
+                id,
+                to_monitor,
+            } => {
+                self.route_unsubscribe(connection.owning_actor(), dest, id, to_monitor);
+            }
+            ConnectionCommand::FireMonitor {
+                dest_ident,
+                monitor_id,
+            } => {
+                self.route_fire_monitor(connection.owning_actor(), dest_ident, monitor_id);
             }
         }
     }
 
-    /// Notify an actor that one of its connections failed: deliver the failure
-    /// prefix (followed by the peer ident and the reason), and — since a child
-    /// cannot exist without its parent — tear the actor down if this was its
-    /// parent connection. `deliver_to_actor`/`die_actor` are no-ops on a dead
-    /// actor, so this is safe to call regardless of the actor's liveness.
-    fn fail_connection(
-        &mut self,
-        connection: ConnectionRef,
-        mut failure_prefix: Vec<MsgPart>,
-        peer_ident: Vec<u8>,
-        reason: Vec<u8>,
-    ) {
+    /// Tear `connection` down: mark it [`Connection::Failed`] and derive everything
+    /// to report from the connection it replaced — the failure prefix, the peer
+    /// ident, and the idents it routed. Deliver the failure (prefix, peer ident,
+    /// reason), and — since a child cannot exist without its parent — tear the actor
+    /// down if this was its parent connection. An already-failed connection yields
+    /// nothing (a duplicate severance), so this is safe to call more than once.
+    fn fail_connection(&mut self, connection: ConnectionRef, reason: Vec<u8>) {
+        let Some((mut failure_prefix, peer_ident, routed_idents)) = self
+            .connection_set(connection, Connection::Failed)
+            .into_failure_report()
+        else {
+            return;
+        };
         let actor = connection.owning_actor();
         failure_prefix.push(MsgPart::from_bytes(peer_ident));
         failure_prefix.push(MsgPart::from_bytes(reason.clone()));
         self.deliver_to_actor(actor, failure_prefix);
-        if connection.role() == Role::Child {
-            self.die_actor(actor, reason);
+        match connection.role() {
+            // The failed connection was this actor's parent: the actor cannot
+            // outlive its parent, so it dies (which severs its own children).
+            Role::Child => self.die_actor(actor, reason),
+            // The failed connection was a child: everything that was live through it
+            // is now dead. Publish exactly that — as if those idents had arrived dead
+            // over the connection — which marks them dead, fires monitors, and
+            // propagates up. (`slot` goes unused: there are no live idents to record.)
+            Role::Parent => {
+                let ConnectionRef::ChildConnection { slot, .. } = connection else {
+                    unreachable!("a Role::Parent connection is a child connection");
+                };
+                self.populate_routes(actor, slot, Vec::new(), routed_idents.into_iter().collect());
+            }
         }
     }
 
+    /// Finalize a connecting connection from the peer's `Establish`. On any failure
+    /// (peer dead, roles disagree, name conflict, ...) the connection is parked as
+    /// `Established` carrying only its failure info — prefix and the peer ident to
+    /// blame — and `Err(reason)` is returned so the caller's `fail_connection` tears
+    /// it down uniformly. Routes are empty in that case (it never really came up).
     fn establish_connection(
         &mut self,
         connection: ConnectionRef,
@@ -640,13 +790,11 @@ impl Ctx {
         peer_name: Option<Vec<u8>>,
         requested_name: Option<Vec<u8>>,
         peer_alive: bool,
-    ) -> Result<(), EstablishFailure> {
+    ) -> Result<(), Vec<u8>> {
         // Take the connecting connection apart; establishing it consumes the
         // hello/failure prefixes, any commands queued before it was ready, and the
         // transport stashed when the pipe connected.
-        let local_connection = self.connection_mut(connection);
-        let local_status = std::mem::replace(local_connection, Connection::Failed);
-
+        let local_status = std::mem::replace(self.connection_mut(connection), Connection::Failed);
         let Connection::Connecting {
             transport,
             name_for_other,
@@ -658,83 +806,93 @@ impl Ctx {
             unreachable!("peer Establish should arrive only on a connecting connection");
         };
 
+        let actor = connection.owning_actor();
+        // Peer ident to blame in a failure: the peer's own ident, else whatever we
+        // named it. Resolved up front so it is available on the error path.
         let failure_peer_ident = peer_name
             .clone()
             .or_else(|| name_for_other.clone())
             .unwrap_or_default();
 
-        let mut failure_prefix = Some(failure_prefix);
-        let result = (|| -> Result<(), Vec<u8>> {
-            // The peer announced it had already died; sever instead of finalizing.
-            // `failure_peer_ident` (above) still carries the peer ident it sent, so
-            // the failure names which connection died.
+        // Validate and resolve the two idents we need, without mutating actor state.
+        let resolved = 'resolve: {
             if !peer_alive {
-                return Err(b"peer actor died".to_vec());
+                break 'resolve Err(b"peer actor died".to_vec());
             }
             if connection.role() == peer_role {
-                return Err(b"connection roles do not agree".to_vec());
+                break 'resolve Err(b"connection roles do not agree".to_vec());
             }
             if !self.connection_topology_is_valid(connection) {
-                return Err(b"invalid parent-child topology".to_vec());
+                break 'resolve Err(b"invalid parent-child topology".to_vec());
             }
-
-            let actor = connection.owning_actor();
-            let local_ident = {
-                let actor_entry = self.actor_mut(actor);
-                if let Some(requested_name) = requested_name {
-                    match &actor_entry.ident {
-                        Some(existing) if existing != &requested_name => {
-                            return Err(b"actor name conflict".to_vec());
-                        }
-                        Some(_) => {}
-                        None => actor_entry.ident = Some(requested_name),
+            // Resolve the name we will end up with (erroring on a conflict), without
+            // mutating yet — the actual adopt-and-flush happens via assign_name once
+            // the connection is established and deferred monitors can route.
+            let local_ident = if let Some(requested_name) = requested_name {
+                match self.actor(actor).name() {
+                    Some(existing) if existing != requested_name.as_slice() => {
+                        break 'resolve Err(b"actor name conflict".to_vec());
                     }
+                    Some(existing) => existing.to_vec(),
+                    None => requested_name,
                 }
-                actor_entry
-                    .ident
-                    .clone()
-                    .ok_or_else(|| b"actor has no ident".to_vec())?
+            } else {
+                match self.actor(actor).name() {
+                    Some(name) => name.to_vec(),
+                    None => break 'resolve Err(b"actor has no ident".to_vec()),
+                }
             };
-            let peer_ident = peer_name
-                .or(name_for_other)
-                .ok_or_else(|| b"peer actor has no ident".to_vec())?;
-
-            self.connection_set(
-                connection,
-                Connection::Established {
-                    transport,
-                    failure_prefix: failure_prefix
-                        .take()
-                        .expect("failure prefix should be available"),
-                    peer_ident: peer_ident.clone(),
-                },
-            );
-            let connection_entry = self.connection_mut(connection);
-            let mut queued_commands = queued_commands;
-            while let Some(command) = queued_commands.pop_front() {
-                let _ = connection_entry.send(command);
+            match peer_name.or(name_for_other) {
+                Some(peer_ident) => Ok((local_ident, peer_ident)),
+                None => Err(b"peer actor has no ident".to_vec()),
             }
+        };
 
-            self.publish_routes_after_established(
-                connection,
-                local_ident.clone(),
-                peer_ident.clone(),
-            );
+        let (local_ident, peer_ident) = match resolved {
+            Ok(idents) => idents,
+            Err(reason) => {
+                // Park the connection carrying just its failure info so
+                // fail_connection can report it from the connection like any sever.
+                self.connection_set(
+                    connection,
+                    Connection::Established {
+                        transport,
+                        failure_prefix,
+                        peer_ident: failure_peer_ident,
+                        routed_idents: HashSet::new(),
+                    },
+                );
+                return Err(reason);
+            }
+        };
 
-            let mut msg = hello_prefix;
-            msg.push(MsgPart::from_bytes(local_ident));
-            msg.push(MsgPart::from_bytes(peer_ident));
-            self.deliver_to_actor(actor, msg);
-            Ok(())
-        })();
+        self.connection_set(
+            connection,
+            Connection::Established {
+                transport,
+                failure_prefix,
+                peer_ident: peer_ident.clone(),
+                routed_idents: HashSet::new(),
+            },
+        );
+        let connection_entry = self.connection_mut(connection);
+        let mut queued_commands = queued_commands;
+        while let Some(command) = queued_commands.pop_front() {
+            let _ = connection_entry.send(command);
+        }
 
-        result.map_err(|reason| EstablishFailure {
-            failure_prefix: failure_prefix
-                .take()
-                .expect("failure prefix should be available"),
-            peer_ident: failure_peer_ident,
-            reason,
-        })
+        // Adopt the name now that the connection is established: this also replays
+        // any monitor subscriptions deferred while we were unnamed, which can now
+        // route up through this freshly-established link.
+        self.assign_name(actor, local_ident.clone());
+
+        self.publish_routes_after_established(connection, local_ident.clone(), peer_ident.clone());
+
+        let mut msg = hello_prefix;
+        msg.push(MsgPart::from_bytes(local_ident));
+        msg.push(MsgPart::from_bytes(peer_ident));
+        self.deliver_to_actor(actor, msg);
+        Ok(())
     }
 
     fn deliver_connect_failure(
@@ -772,6 +930,143 @@ impl Ctx {
             connection.send(ConnectionCommand::Severed { reason });
             *connection = Connection::Failed;
         }
+    }
+
+    // -- Monitors ---------------------------------------------------------------
+
+    /// Assign `name` to `actor` (a no-op if already named) and replay any monitor
+    /// subscriptions that were deferred while it was unnamed — now they have a
+    /// fire-back address. The connection that carried the name must already be
+    /// established so the replayed subscriptions can route up.
+    fn assign_name(&mut self, actor: Key, name: Vec<u8>) {
+        let entry = self.actor_mut(actor);
+        let pending = match &mut entry.name {
+            ActorName::Named(_) => return, // already named; nothing was deferred
+            ActorName::Unknown { pending_monitors } => std::mem::take(pending_monitors),
+        };
+        entry.name = ActorName::Named(name.clone());
+        for monitor in pending {
+            self.route_subscribe(actor, name.clone(), monitor.id, monitor.to_monitor);
+        }
+    }
+
+    /// Walk a subscription up from `at` until the actor that has `to_monitor` in
+    /// its routing table (the common ancestor) or the root. Fire immediately if
+    /// the monitored actor is already known dead.
+    fn route_subscribe(&mut self, at: Key, dest: Vec<u8>, id: u64, to_monitor: Vec<u8>) {
+        enum Step {
+            FireDead,
+            Register,
+            Forward,
+        }
+        let entry = self.actor(at);
+        let step = match entry.routes.get(to_monitor.as_slice()) {
+            Some(Route::Dead) => Step::FireDead,
+            // A live (or buffered-unknown) route means this is the common ancestor.
+            Some(_) => Step::Register,
+            // Not an ancestor of the target: forward up, or hold here if we are the
+            // root (the target may not exist yet — it will end up watched here).
+            None if entry.parent.is_some() => Step::Forward,
+            None => Step::Register,
+        };
+        match step {
+            Step::FireDead => {
+                self.route_fire_monitor(at, dest, id);
+            }
+            Step::Register => {
+                self.actor_mut(at)
+                    .buffer_monitor(to_monitor, MonitorSub { dest, id });
+            }
+            Step::Forward => {
+                let _ = self
+                    .actor_mut(at)
+                    .parent
+                    .as_mut()
+                    .expect("forward implies a parent")
+                    .send(ConnectionCommand::Subscribe {
+                        dest,
+                        id,
+                        to_monitor,
+                    });
+            }
+        }
+    }
+
+    /// Walk the same path as [`route_subscribe`] and remove the matching
+    /// subscription. Idempotent: a sub that already fired (and was removed) or was
+    /// never registered is a no-op.
+    fn route_unsubscribe(&mut self, at: Key, dest: Vec<u8>, id: u64, to_monitor: Vec<u8>) {
+        let entry = self.actor(at);
+        let forward = !entry.routes.contains_key(to_monitor.as_slice()) && entry.parent.is_some();
+        if forward {
+            let _ = self
+                .actor_mut(at)
+                .parent
+                .as_mut()
+                .expect("forward implies a parent")
+                .send(ConnectionCommand::Unsubscribe {
+                    dest,
+                    id,
+                    to_monitor,
+                });
+            return;
+        }
+        if let Some(monitors) = self
+            .actor_mut(at)
+            .routes
+            .get_mut(to_monitor.as_slice())
+            .and_then(Route::monitors_mut)
+        {
+            monitors.retain(|sub| !(sub.id == id && sub.dest == dest));
+        }
+    }
+
+    /// Route a monitor fire toward `dest`. The subscription is held at the common
+    /// ancestor of the monitoring actor (`dest`) and the monitored actor, so `dest`
+    /// is always this actor or one of its descendants: the fire only ever travels
+    /// *down*. It is delivered locally if we own `dest`, forwarded down its child
+    /// route otherwise, or dropped if that route has since died (the monitoring
+    /// actor is gone). The route is never unknown here and the fire never routes up.
+    fn route_fire_monitor(&mut self, from: Key, dest: Vec<u8>, id: u64) {
+        let entry = self.actor(from);
+        if entry.name() == Some(dest.as_slice()) {
+            self.deliver_monitor_failure(from, id);
+            return;
+        }
+        match entry.routes.get(dest.as_slice()) {
+            Some(Route::Connection { child, .. }) => {
+                let child = *child;
+                let _ = self
+                    .actor_mut(from)
+                    .children
+                    .get_mut(child)
+                    .expect("a live child route must have its connection")
+                    .send(ConnectionCommand::FireMonitor {
+                        dest_ident: dest,
+                        monitor_id: id,
+                    });
+            }
+            // The monitoring actor's branch died before the fire reached it.
+            Some(Route::Dead) => {}
+            Some(Route::Unknown { .. }) | None => {
+                unreachable!(
+                    "monitor fire target must be a known descendant of the subscription holder"
+                )
+            }
+        }
+    }
+
+    /// A monitor fired and reached the monitoring actor. Reconstruct the failure
+    /// message from the local failure_prefix and deliver it with a fixed reason. A
+    /// cancelled monitor (no local record) drops the fire.
+    fn deliver_monitor_failure(&mut self, actor: Key, id: u64) {
+        let Some(local) = self.actor_mut(actor).monitors.remove(&id) else {
+            return;
+        };
+        let mut msg = local.failure_prefix;
+        msg.push(MsgPart::from_bytes(local.to_monitor));
+        msg.push(MsgPart::from_bytes(b"actor died".to_vec()));
+        self.deliver_to_actor(actor, msg);
     }
 
     fn deliver_to_actor(&mut self, actor: Key, msg: Vec<MsgPart>) {

--- a/monarch_mini/src/inproc_transport.rs
+++ b/monarch_mini/src/inproc_transport.rs
@@ -88,7 +88,7 @@ struct InprocConnectionTransport {
 impl ConnectionTransport for InprocConnectionTransport {
     fn send(&self, action: ConnectionCommand) -> bool {
         self.tx
-            .send(Command::ConnectionSentCommand {
+            .send(Command::ConnectionAction {
                 connection: self.peer,
                 action,
             })
@@ -101,7 +101,7 @@ impl Drop for InprocConnectionTransport {
         // Dropping the send half is the in-process analogue of a socket closing:
         // tell the peer its side of the pipe is gone. (A no-op if the peer is
         // already failed.)
-        let _ = self.tx.send(Command::ConnectionSentCommand {
+        let _ = self.tx.send(Command::ConnectionAction {
             connection: self.peer,
             action: ConnectionCommand::Severed {
                 reason: b"peer connection closed".to_vec(),

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -25,6 +25,8 @@ use std::ffi::c_void;
 use std::os::fd::AsRawFd;
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
 use connection::ConnectRequest;
 use ctx::Command;
@@ -55,6 +57,10 @@ pub struct CCtx(CtxHandle);
 pub struct CActor {
     ctx: CtxHandle,
     key: Key,
+    // Monitor ids are allocated here, on the caller's side, so mm_actor_monitor
+    // never has to round-trip the event loop for one. Ids only need to be unique
+    // among this actor's own monitors (they key its per-actor `monitors` map).
+    next_monitor_id: AtomicU64,
 }
 
 pub struct CPoller {
@@ -76,7 +82,8 @@ pub struct CPoller {
 
 pub struct CMonitorHandle {
     ctx: CtxHandle,
-    key: Key,
+    actor: Key,
+    id: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -146,12 +153,12 @@ impl From<anyhow::Result<()>> for Error {
     }
 }
 
-fn not_implemented() -> Error {
-    anyhow::anyhow!("Not yet implemented").into()
-}
-
 fn actor_from_create(ctx: CtxHandle, key: Key) -> CActor {
-    CActor { ctx, key }
+    CActor {
+        ctx,
+        key,
+        next_monitor_id: AtomicU64::new(0),
+    }
 }
 
 fn create_eventfd() -> anyhow::Result<OwnedFd> {
@@ -379,10 +386,25 @@ pub unsafe extern "C" fn mm_actor_monitor(
     out: *mut *mut CMonitorHandle,
 ) -> Error {
     let a = &*actor;
-    let _ = (&a.ctx, a.key, out);
-    let _to_monitor_ident = MsgPart::from_c(to_monitor_ident);
-    let _failure_prefix = parts_from_cmsg(failure_prefix);
-    not_implemented()
+    // Allocate the id locally and fire the command without waiting: this runs in
+    // messaging loops and must never block on the event loop thread.
+    let id = a.next_monitor_id.fetch_add(1, Ordering::Relaxed);
+    match a.ctx.send_command(Command::Monitor {
+        actor: a.key,
+        id,
+        to_monitor: MsgPart::from_c(to_monitor_ident),
+        failure_prefix: parts_from_cmsg(failure_prefix),
+    }) {
+        Ok(()) => {
+            *out = Box::into_raw(Box::new(CMonitorHandle {
+                ctx: a.ctx.clone(),
+                actor: a.key,
+                id,
+            }));
+            Error::Ok
+        }
+        Err(e) => e.into(),
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -391,8 +413,11 @@ pub unsafe extern "C" fn mm_actor_monitor(
 
 #[no_mangle]
 pub unsafe extern "C" fn mm_monitor_handle_cancel(handle: *mut CMonitorHandle) {
-    let h = &*handle;
-    let _ = (&h.ctx, h.key);
+    let handle = Box::from_raw(handle);
+    let _ = handle.ctx.send_command(Command::CancelMonitor {
+        actor: handle.actor,
+        id: handle.id,
+    });
 }
 
 // ---------------------------------------------------------------------------

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -14,6 +14,7 @@ use tokio::sync::oneshot;
 
 use crate::Role;
 use crate::actor::ActorEntry;
+use crate::actor::ActorName;
 use crate::actor::Delivery;
 use crate::actor::Route;
 use crate::connection::ConnectRequest;
@@ -217,7 +218,7 @@ fn message_to_unrouted_actor_buffers_at_gateway_then_flushes() {
     drain_commands(&mut ctx, &mut rx);
     assert!(matches!(
         ctx.actors[root].routes.get(b"grandchild".as_slice()),
-        Some(Route::Unknown(_))
+        Some(Route::Unknown { .. })
     ));
 
     // The grandchild now appears under the child; publishing its route up to the
@@ -251,7 +252,7 @@ fn buffered_messages_flush_upward_when_actor_gains_a_parent() {
     });
     assert!(matches!(
         ctx.actors[mover].routes.get(b"target".as_slice()),
-        Some(Route::Unknown(_))
+        Some(Route::Unknown { .. })
     ));
 
     // `mover` now joins `root`. Gaining a parent drops the buffer and re-routes the
@@ -259,10 +260,252 @@ fn buffered_messages_flush_upward_when_actor_gains_a_parent() {
     connect(&mut ctx, root, mover, "inproc://mover");
     drain_commands(&mut ctx, &mut rx);
 
-    assert!(ctx.actors[mover].routes.get(b"target".as_slice()).is_none());
+    assert!(!ctx.actors[mover].routes.contains_key(b"target".as_slice()));
     assert_eq!(
         buffered_strings(&ctx, target),
         vec!["target", "root", "hello-target"]
+    );
+}
+
+#[test]
+fn monitor_fires_when_sibling_dies() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = actor(&mut ctx, "watcher");
+    let target = actor(&mut ctx, "target");
+    connect(&mut ctx, root, watcher, "inproc://watcher");
+    connect(&mut ctx, root, target, "inproc://target");
+    drain_commands(&mut ctx, &mut rx);
+
+    // `watcher` monitors its sibling `target`. The subscription has no route to
+    // `target` locally, so it climbs to their common ancestor `root`, which holds
+    // `target` in its routing table.
+    monitor(&mut ctx, watcher, 0, "target", "DOWN");
+    drain_commands(&mut ctx, &mut rx);
+    // The subscription is held on target's route at the common ancestor.
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 1);
+
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+
+    // root sees target's connection drop, marks it dead, and fires the monitor
+    // back down to watcher, which reconstructs [failure_prefix, target, reason].
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor died"]
+    );
+}
+
+#[test]
+fn monitor_fires_when_parent_of_target_dies() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = actor(&mut ctx, "watcher");
+    let mid = actor(&mut ctx, "mid");
+    let target = actor(&mut ctx, "target");
+    connect(&mut ctx, root, watcher, "inproc://watcher");
+    connect(&mut ctx, root, mid, "inproc://mid");
+    connect(&mut ctx, mid, target, "inproc://target");
+    drain_commands(&mut ctx, &mut rx);
+
+    monitor(&mut ctx, watcher, 0, "target", "DOWN");
+    drain_commands(&mut ctx, &mut rx);
+
+    // `mid` dies, not `target` directly. `target` is unreachable, but the death is
+    // reported by root (mid's connection carried both "mid" and "target"), so the
+    // monitor still fires. `target` itself cascades dead but never reports it.
+    ctx.die_actor(mid, b"crash".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor died"]
+    );
+}
+
+#[test]
+fn cancelled_monitor_does_not_fire() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = actor(&mut ctx, "watcher");
+    let target = actor(&mut ctx, "target");
+    connect(&mut ctx, root, watcher, "inproc://watcher");
+    connect(&mut ctx, root, target, "inproc://target");
+    drain_commands(&mut ctx, &mut rx);
+
+    monitor(&mut ctx, watcher, 0, "target", "DOWN");
+    drain_commands(&mut ctx, &mut rx);
+    ctx.run_command(Command::CancelMonitor {
+        actor: watcher,
+        id: 0,
+    });
+    drain_commands(&mut ctx, &mut rx);
+    // The subscription was walked back off target's route on cancel.
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 0);
+
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+
+    // Only the establishment hello — no monitor failure was delivered.
+    assert_eq!(buffered_strings(&ctx, watcher), vec!["watcher", "root"]);
+}
+
+#[test]
+fn monitor_on_already_dead_actor_fires_immediately() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = actor(&mut ctx, "watcher");
+    let target = actor(&mut ctx, "target");
+    connect(&mut ctx, root, watcher, "inproc://watcher");
+    connect(&mut ctx, root, target, "inproc://target");
+    drain_commands(&mut ctx, &mut rx);
+
+    // Target dies first; root now records it as a dead route.
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[root].routes.get(b"target".as_slice()),
+        Some(Route::Dead)
+    ));
+
+    // Monitoring it now must fire right away rather than waiting forever.
+    monitor(&mut ctx, watcher, 0, "target", "DOWN");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor died"]
+    );
+}
+
+#[test]
+fn buffered_subscription_forwards_up_when_actor_gains_a_parent() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let mid = actor(&mut ctx, "mid");
+    let watcher = actor(&mut ctx, "watcher");
+    let target = actor(&mut ctx, "target");
+
+    // `watcher` joins `mid` while `mid` is still parentless (its own gateway).
+    connect(&mut ctx, mid, watcher, "inproc://buf-w");
+    drain_commands(&mut ctx, &mut rx);
+
+    // `watcher` monitors `target`, unknown anywhere yet. The subscription climbs to
+    // `mid` (parentless) and is buffered there on an Unknown route — exactly like a
+    // message to an unknown destination.
+    monitor(&mut ctx, watcher, 0, "target", "DOWN");
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[mid].routes.get(b"target".as_slice()),
+        Some(Route::Unknown { .. })
+    ));
+    assert_eq!(route_monitor_count(&ctx, mid, "target"), 1);
+
+    // `mid` now joins `root`. The buffered subscription must forward up to `root`
+    // (the bug: previously it was stranded at `mid`).
+    connect(&mut ctx, root, mid, "inproc://buf-m");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(route_monitor_count(&ctx, mid, "target"), 0);
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 1);
+
+    // `target` finally appears under `root`; its route flips Unknown -> Connection,
+    // carrying the subscription. When it dies, the monitor fires down to `watcher`.
+    connect(&mut ctx, root, target, "inproc://buf-t");
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[root].routes.get(b"target".as_slice()),
+        Some(Route::Connection { .. })
+    ));
+
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "mid", "DOWN", "target", "actor died"]
+    );
+}
+
+#[test]
+fn monitor_on_unnamed_actor_waits_for_its_name() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let target = actor(&mut ctx, "target");
+    // `watcher` is created without a name; root will name it when it joins.
+    let watcher = ctx.actors.insert(ActorEntry::new(None));
+    connect(&mut ctx, root, target, "inproc://un-target");
+    drain_commands(&mut ctx, &mut rx);
+
+    // Monitoring while unnamed can't address a fire-back yet, so it is deferred:
+    // nothing is registered upstream at root.
+    monitor(&mut ctx, watcher, 0, "target", "DOWN");
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[watcher].name,
+        ActorName::Unknown { .. }
+    ));
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 0);
+
+    // root adopts and names `watcher` on join; that releases the deferred monitor,
+    // which now subscribes up to root.
+    ctx.serve(
+        root,
+        "inproc://un-watcher".to_owned(),
+        request_named(Role::Parent, "watcher"),
+    );
+    ctx.join(
+        watcher,
+        "inproc://un-watcher".to_owned(),
+        request(Role::Child),
+    );
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 1);
+
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor died"]
+    );
+}
+
+#[test]
+fn dead_route_is_carried_up_as_dead_when_gaining_a_parent() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let mid = actor(&mut ctx, "mid");
+    let target = actor(&mut ctx, "target");
+
+    // `mid` adopts `target` while still parentless (a gateway of its own subtree).
+    connect(&mut ctx, mid, target, "inproc://target");
+    drain_commands(&mut ctx, &mut rx);
+
+    // `target` dies; `mid` records the dead route but has no parent to publish to.
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[mid].routes.get(b"target".as_slice()),
+        Some(Route::Dead)
+    ));
+
+    // `mid` now joins `root`. Republishing its table on gaining a parent must carry
+    // the dead route up *as dead* — not as a live route, and not dropped (which
+    // would make `target` look like it never existed).
+    connect(&mut ctx, root, mid, "inproc://mid");
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[root].routes.get(b"target".as_slice()),
+        Some(Route::Dead)
+    ));
+
+    // And a monitor reaching root therefore fires rather than waiting forever.
+    let watcher = actor(&mut ctx, "watcher");
+    connect(&mut ctx, root, watcher, "inproc://watcher");
+    drain_commands(&mut ctx, &mut rx);
+    monitor(&mut ctx, watcher, 0, "target", "DOWN");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor died"]
     );
 }
 
@@ -353,6 +596,98 @@ fn unix_writer_flushes_pending_sends_before_teardown() {
     shutdown(server_ctx);
 }
 
+#[test]
+fn unix_monitor_fires_across_processes() {
+    // Two processes joined by a socket. `target` lives with the server `srv`;
+    // `watcher` is in the client process, joined to `srv` as a child. Monitoring
+    // `target` makes a Subscribe climb the socket to `srv` (their common
+    // ancestor), and `target`'s death sends a FireMonitor back down the socket —
+    // exercising both control frames on the wire.
+    let server_ctx = CtxHandle::new().expect("server context should start");
+    let client_ctx = CtxHandle::new().expect("client context should start");
+    let srv = runtime_actor(&server_ctx, "srv");
+    let target = runtime_actor(&server_ctx, "target");
+    let watcher = runtime_actor(&client_ctx, "watcher");
+    let (srv_poller, mut srv_rx) = runtime_poller(&server_ctx);
+    let (target_poller, mut target_rx) = runtime_poller(&server_ctx);
+    let (watcher_poller, mut watcher_rx) = runtime_poller(&client_ctx);
+    runtime_subscribe(&server_ctx, srv_poller, 0, srv);
+    runtime_subscribe(&server_ctx, target_poller, 1, target);
+    runtime_subscribe(&client_ctx, watcher_poller, 0, watcher);
+
+    // srv adopts target locally (inproc) and serves the socket for the client.
+    server_ctx
+        .send_command(Command::Serve {
+            actor: srv,
+            url: "inproc://target".to_owned(),
+            request: request(Role::Parent),
+        })
+        .expect("serve should enqueue");
+    server_ctx
+        .send_command(Command::Join {
+            actor: target,
+            url: "inproc://target".to_owned(),
+            request: request(Role::Child),
+        })
+        .expect("join should enqueue");
+    let url = unix_test_url("monitor");
+    server_ctx
+        .send_command(Command::Serve {
+            actor: srv,
+            url: url.clone(),
+            request: request(Role::Parent),
+        })
+        .expect("serve should enqueue");
+    client_ctx
+        .send_command(Command::Join {
+            actor: watcher,
+            url,
+            request: request(Role::Child),
+        })
+        .expect("join should enqueue");
+
+    // Drain both hellos at srv so we know it holds routes to target and watcher
+    // before the subscription arrives.
+    let first = recv_strings(&mut srv_rx);
+    let second = recv_strings(&mut srv_rx);
+    let mut srv_peers = vec![first[1].clone(), second[1].clone()];
+    srv_peers.sort();
+    assert_eq!(srv_peers, vec!["target", "watcher"]);
+    // The hello also carries target's route up to srv (inproc), so target is a
+    // live route there before we monitor.
+    assert_eq!(recv_strings(&mut target_rx), vec!["target", "srv"]);
+    assert_eq!(recv_strings(&mut watcher_rx), vec!["watcher", "srv"]);
+
+    runtime_monitor(&client_ctx, watcher, 0, "target", "DOWN");
+
+    // The Subscribe and this probe both travel watcher→srv on the same socket in
+    // order. Seeing the probe arrive at target proves srv already registered the
+    // subscription, so the kill below races nothing.
+    client_ctx
+        .send_command(Command::Send {
+            sender: watcher,
+            destination_ident: MsgPart::from_bytes(b"target".to_vec()),
+            parts: vec![MsgPart::from_bytes(b"probe".to_vec())],
+        })
+        .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut target_rx), vec!["probe"]);
+
+    server_ctx
+        .send_command(Command::Die {
+            actor: target,
+            reason: MsgPart::from_bytes(b"boom".to_vec()),
+        })
+        .expect("die should enqueue");
+
+    assert_eq!(
+        recv_strings(&mut watcher_rx),
+        vec!["DOWN", "target", "actor died"]
+    );
+
+    shutdown(client_ctx);
+    shutdown(server_ctx);
+}
+
 fn unix_test_url(name: &str) -> String {
     // The listener unlinks any stale socket before binding, so reusing a stable
     // per-process path across runs is safe.
@@ -383,6 +718,26 @@ fn actor(ctx: &mut Ctx, ident: &str) -> Key {
 fn connect(ctx: &mut Ctx, parent: Key, child: Key, url: &str) {
     ctx.serve(parent, url.to_owned(), request(Role::Parent));
     ctx.join(child, url.to_owned(), request(Role::Child));
+}
+
+/// Number of monitor subscriptions held on `ident`'s route at `actor` (0 if the
+/// route is absent or dead).
+fn route_monitor_count(ctx: &Ctx, actor: Key, ident: &str) -> usize {
+    match ctx.actors[actor].routes.get(ident.as_bytes()) {
+        Some(Route::Connection { monitors, .. }) | Some(Route::Unknown { monitors, .. }) => {
+            monitors.len()
+        }
+        _ => 0,
+    }
+}
+
+fn monitor(ctx: &mut Ctx, actor: Key, id: u64, to_monitor: &str, failure: &str) {
+    ctx.run_command(Command::Monitor {
+        actor,
+        id,
+        to_monitor: MsgPart::from_bytes(to_monitor.as_bytes().to_vec()),
+        failure_prefix: vec![MsgPart::from_bytes(failure.as_bytes().to_vec())],
+    });
 }
 
 fn runtime_connect(ctx: &CtxHandle, parent: Key, child: Key, url: &str) {
@@ -424,6 +779,16 @@ fn runtime_poller(ctx: &CtxHandle) -> (PollerKey, mpsc::UnboundedReceiver<Delive
         done_rx.blocking_recv().expect("poller should be created"),
         rx,
     )
+}
+
+fn runtime_monitor(ctx: &CtxHandle, actor: Key, id: u64, to_monitor: &str, failure: &str) {
+    ctx.send_command(Command::Monitor {
+        actor,
+        id,
+        to_monitor: MsgPart::from_bytes(to_monitor.as_bytes().to_vec()),
+        failure_prefix: vec![MsgPart::from_bytes(failure.as_bytes().to_vec())],
+    })
+    .expect("monitor should enqueue");
 }
 
 fn runtime_subscribe(ctx: &CtxHandle, poller: PollerKey, index: usize, actor: Key) {
@@ -476,6 +841,15 @@ fn request_with_failure(role: Role, failure: &str) -> ConnectRequest {
         name_for_other: None,
         hello_prefix: Vec::new(),
         failure_prefix: vec![MsgPart::from_bytes(failure.as_bytes().to_vec())],
+    }
+}
+
+fn request_named(role: Role, name_for_other: &str) -> ConnectRequest {
+    ConnectRequest {
+        role,
+        name_for_other: Some(MsgPart::from_bytes(name_for_other.as_bytes().to_vec())),
+        hello_prefix: Vec::new(),
+        failure_prefix: Vec::new(),
     }
 }
 

--- a/monarch_mini/src/unix_transport.rs
+++ b/monarch_mini/src/unix_transport.rs
@@ -12,7 +12,7 @@
 //! This is pure plumbing. A connection's coroutines bring up the socket, produce
 //! a [`ConnectionTransport`] for it, and hand it to the command loop via
 //! `Command::TransportConnected`; the reader forwards every frame it decodes back
-//! as a `ConnectionSentCommand`. All establishment policy (announcing our
+//! as a `ConnectionAction`. All establishment policy (announcing our
 //! identity, learning the peer's, hello, liveness) lives in the command loop and
 //! is identical to inproc — this file never reads actor state or builds an
 //! `Establish`. An `Establish` is just another frame on the wire.
@@ -78,7 +78,22 @@ enum WireFrame {
         part_lens: Vec<u64>,
     },
     PublishRoutes {
-        actor_idents: Vec<Vec<u8>>,
+        live: Vec<Vec<u8>>,
+        dead: Vec<Vec<u8>>,
+    },
+    Subscribe {
+        dest: Vec<u8>,
+        id: u64,
+        to_monitor: Vec<u8>,
+    },
+    Unsubscribe {
+        dest: Vec<u8>,
+        id: u64,
+        to_monitor: Vec<u8>,
+    },
+    FireMonitor {
+        dest_ident: Vec<u8>,
+        monitor_id: u64,
     },
     Severed {
         reason: Vec<u8>,
@@ -278,7 +293,7 @@ async fn connector_task(
 
 /// Wire up a connected socket: build its [`UnixConnectionTransport`], announce it
 /// to the command loop, and spawn the writer (drains commands → frames) and
-/// reader (frames → `ConnectionSentCommand`). `TransportConnected` is enqueued
+/// reader (frames → `ConnectionAction`). `TransportConnected` is enqueued
 /// before the reader can forward anything, so the command loop installs the
 /// transport before any frame (including the peer's `Establish`) arrives.
 fn spawn_connection(
@@ -363,7 +378,7 @@ async fn reader_task(
         match read_command(&mut read_half).await {
             Ok(action) => {
                 if loop_tx
-                    .send(Command::ConnectionSentCommand { connection, action })
+                    .send(Command::ConnectionAction { connection, action })
                     .is_err()
                 {
                     return;
@@ -378,7 +393,7 @@ async fn reader_task(
 }
 
 fn sever(loop_tx: &mpsc::UnboundedSender<Command>, connection: ConnectionRef, reason: Vec<u8>) {
-    let _ = loop_tx.send(Command::ConnectionSentCommand {
+    let _ = loop_tx.send(Command::ConnectionAction {
         connection,
         action: ConnectionCommand::Severed { reason },
     });
@@ -420,9 +435,32 @@ async fn write_command(
             name_for_other,
             alive,
         },
-        ConnectionCommand::PublishRoutes { actor_idents } => {
-            WireFrame::PublishRoutes { actor_idents }
-        }
+        ConnectionCommand::PublishRoutes { live, dead } => WireFrame::PublishRoutes { live, dead },
+        ConnectionCommand::Subscribe {
+            dest,
+            id,
+            to_monitor,
+        } => WireFrame::Subscribe {
+            dest,
+            id,
+            to_monitor,
+        },
+        ConnectionCommand::Unsubscribe {
+            dest,
+            id,
+            to_monitor,
+        } => WireFrame::Unsubscribe {
+            dest,
+            id,
+            to_monitor,
+        },
+        ConnectionCommand::FireMonitor {
+            dest_ident,
+            monitor_id,
+        } => WireFrame::FireMonitor {
+            dest_ident,
+            monitor_id,
+        },
         ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
     };
 
@@ -480,9 +518,32 @@ async fn read_command(read_half: &mut OwnedReadHalf) -> std::io::Result<Connecti
             name_for_other,
             alive,
         },
-        WireFrame::PublishRoutes { actor_idents } => {
-            ConnectionCommand::PublishRoutes { actor_idents }
-        }
+        WireFrame::PublishRoutes { live, dead } => ConnectionCommand::PublishRoutes { live, dead },
+        WireFrame::Subscribe {
+            dest,
+            id,
+            to_monitor,
+        } => ConnectionCommand::Subscribe {
+            dest,
+            id,
+            to_monitor,
+        },
+        WireFrame::Unsubscribe {
+            dest,
+            id,
+            to_monitor,
+        } => ConnectionCommand::Unsubscribe {
+            dest,
+            id,
+            to_monitor,
+        },
+        WireFrame::FireMonitor {
+            dest_ident,
+            monitor_id,
+        } => ConnectionCommand::FireMonitor {
+            dest_ident,
+            monitor_id,
+        },
         WireFrame::Severed { reason } => ConnectionCommand::Severed { reason },
     })
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* __->__ #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Implement cancellable monitor subscriptions that follow actor routes, fire on direct or inherited death, and preserve dead-route state during topology changes. Expose monitoring through the C and Python APIs, encode subscriptions over Unix transport, and add Python and Rust coverage for cancellation, already-dead targets, unnamed actors, and cross-process delivery.

Differential Revision: [D114750227](https://our.internmc.facebook.com/intern/diff/D114750227/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750227/)!