### PR TITLE
8/43 minimonarch: Add direct QUIC transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4733,6 +4733,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bincode 2.0.1",
+ "quinn",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "slotmap",
  "tokio",

--- a/monarch_mini/python/quic_worker.py
+++ b/monarch_mini/python/quic_worker.py
@@ -1,0 +1,64 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Helper run as a subprocess by test_smoke.py's cross-process quic tests.
+
+Usage: ``python quic_worker.py <quic-url> <mode>``. The QUIC TLS material is read
+from the ``MM_QUIC_CERT`` / ``MM_QUIC_KEY`` / ``MM_QUIC_CA`` environment variables,
+which the parent test process sets and the worker inherits.
+
+Modes:
+  * ``echo_child``  — join as a child, echo one message back, close cleanly, exit 0.
+  * ``parent``      — serve as the parent, then idle forever (the test hard-kills /
+                      freezes us so the survivor must detect the loss by heartbeat).
+  * ``child``       — join as a child, then idle forever (same, from the child end).
+"""
+
+import asyncio
+import sys
+
+import minimonarch
+from minimonarch import Actor
+
+ba = minimonarch.bytearray
+
+
+async def run_echo_child(url: str) -> None:
+    """Join as child `q-echo`, echo one message back to `q-srv`, then close."""
+    echo = Actor(b"q-echo")
+    echo.join(url, "child")
+    assert await echo.next() == [b"q-echo", b"q-srv"]
+    parts = await echo.next()
+    echo.send(b"q-srv", parts)
+    minimonarch.close()
+
+
+async def run_parent(url: str) -> None:
+    """Serve as parent `q-up`; the test joins as child `q-mid`, then idles so the
+    test can kill/freeze us and watch its child detect the loss via heartbeat."""
+    up = Actor(b"q-up")
+    up.serve(url, "parent")
+    assert await up.next() == [b"q-up", b"q-mid"]
+    while True:
+        await asyncio.sleep(3600)
+
+
+async def run_child(url: str) -> None:
+    """Join as child `q-down`; the test serves as parent `q-boss`, then idles so the
+    test can kill/freeze us and watch its parent detect the loss via heartbeat."""
+    down = Actor(b"q-down")
+    down.join(url, "child")
+    assert await down.next() == [b"q-down", b"q-boss"]
+    while True:
+        await asyncio.sleep(3600)
+
+
+_MODES = {"echo_child": run_echo_child, "parent": run_parent, "child": run_child}
+
+
+if __name__ == "__main__":
+    url, mode = sys.argv[1], sys.argv[2]
+    asyncio.run(_MODES[mode](url))

--- a/monarch_mini/python/test_smoke.py
+++ b/monarch_mini/python/test_smoke.py
@@ -365,6 +365,102 @@ async def test_unix_subprocess_kill_propagates_failure_and_cascades() -> None:
             await _kill_worker(proc)
 
 
+def _quic_certs_env() -> None:
+    # The quic transport reads its TLS material from these env vars; set them before
+    # any quic serve/join so both this process and the worker subprocess (which
+    # inherits the environment) can build their configs. Same values everywhere.
+    certs = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test_certs"))
+    os.environ["MM_QUIC_CERT"] = os.path.join(certs, "cert.pem")
+    os.environ["MM_QUIC_KEY"] = os.path.join(certs, "key.pem")
+    os.environ["MM_QUIC_CA"] = os.path.join(certs, "ca.pem")
+
+
+def _quic_url() -> str:
+    # Grab a free UDP port; join/serve retry, so the brief gap before it is rebound
+    # by quic is harmless.
+    import socket
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return f"quic://127.0.0.1:{port}"
+
+
+def _spawn_quic_worker(url: str, mode: str) -> "subprocess.Popen[bytes]":
+    worker = os.path.join(os.path.dirname(__file__), "quic_worker.py")
+    return subprocess.Popen([sys.executable, worker, url, mode])
+
+
+async def test_quic_subprocess_echo() -> None:
+    # End-to-end across two real processes over QUIC: this process is the parent
+    # `q-srv`; a subprocess child `q-echo` joins, echoes one message back, and exits
+    # cleanly. Exercises handshake + framed send/receive across the stream.
+    _quic_certs_env()
+    url = _quic_url()
+    srv = Actor(b"q-srv")
+    srv.serve(url, "parent")
+    proc = _spawn_quic_worker(url, "echo_child")
+    try:
+        assert await asyncio.wait_for(srv.next(), 30) == [b"q-srv", b"q-echo"]
+        srv.send(b"q-echo", [ba(b"ping")])
+        assert await asyncio.wait_for(srv.next(), 30) == [b"ping"]
+    finally:
+        await _await_worker_exit(proc)
+
+
+async def test_quic_kill_parent_end_caught_by_heartbeat() -> None:
+    # The subprocess hosts the PARENT (`q-up`) and serves over QUIC; this process
+    # joins as child `q-mid`. Hard-killing the subprocess sends no clean close (it's
+    # UDP — there is no FIN), so the only way `q-mid` learns its parent is gone is
+    # the bidirectional heartbeat lapsing. Losing its parent, the child also dies.
+    _quic_certs_env()
+    url = _quic_url()
+    proc = _spawn_quic_worker(url, "parent")
+    try:
+        mid = Actor(b"q-mid")
+        mid.join(url, "child", failure=[ba(b"mid-failed")])
+        assert await asyncio.wait_for(mid.next(), 30) == [b"q-mid", b"q-up"]
+
+        proc.kill()  # SIGKILL: no clean QUIC close, so the heartbeat must catch it
+        await asyncio.get_running_loop().run_in_executor(None, proc.wait)
+
+        assert await asyncio.wait_for(mid.next(), 30) == [
+            b"mid-failed",
+            b"q-up",
+            b"quic heartbeat timeout",
+        ]
+    finally:
+        if proc.poll() is None:
+            await _kill_worker(proc)
+
+
+async def test_quic_kill_child_end_caught_by_heartbeat() -> None:
+    # The mirror image: this process is the PARENT `q-boss` serving over QUIC; the
+    # subprocess child `q-down` joins, then is hard-killed. The parent's child
+    # connection produces no clean close, so the heartbeat timeout is what severs it
+    # and delivers the failure naming the dead child.
+    _quic_certs_env()
+    url = _quic_url()
+    boss = Actor(b"q-boss")
+    boss.serve(url, "parent", failure=[ba(b"boss-failed")])
+    proc = _spawn_quic_worker(url, "child")
+    try:
+        assert await asyncio.wait_for(boss.next(), 30) == [b"q-boss", b"q-down"]
+
+        proc.kill()  # SIGKILL: no clean QUIC close, so the heartbeat must catch it
+        await asyncio.get_running_loop().run_in_executor(None, proc.wait)
+
+        assert await asyncio.wait_for(boss.next(), 30) == [
+            b"boss-failed",
+            b"q-down",
+            b"quic heartbeat timeout",
+        ]
+    finally:
+        if proc.poll() is None:
+            await _kill_worker(proc)
+
+
 async def test_monitor_fires_when_target_dies() -> None:
     # watcher and target are siblings under root. watcher monitors target; when
     # target dies, the failure climbs to their common ancestor (root) and fires

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -36,6 +36,7 @@ use crate::inproc_transport::InprocTransport;
 use crate::msg::MsgPart;
 use crate::poller::Delivered;
 use crate::poller::PollerEntry;
+use crate::quic_transport::QuicTransport;
 use crate::transport::Transport;
 use crate::unix_transport::UnixTransport;
 
@@ -44,7 +45,7 @@ use crate::unix_transport::UnixTransport;
 /// is attached, while the request can still report failure — without a `&mut self`
 /// borrow.
 fn valid_scheme(url: &str) -> bool {
-    url.starts_with("inproc://") || url.starts_with("unix://")
+    url.starts_with("inproc://") || url.starts_with("unix://") || url.starts_with("quic://")
 }
 
 new_key_type! {
@@ -140,6 +141,7 @@ struct Ctx {
     // emit.
     inproc: InprocTransport,
     unix: UnixTransport,
+    quic: QuicTransport,
     thread: Option<JoinHandle<()>>,
     _not_send: PhantomData<*const ()>,
 }
@@ -150,7 +152,8 @@ impl Ctx {
             actors: SlotMap::with_key(),
             pollers: SlotMap::with_key(),
             inproc: InprocTransport::new(tx.clone()),
-            unix: UnixTransport::new(tx),
+            unix: UnixTransport::new(tx.clone()),
+            quic: QuicTransport::new(tx),
             thread: None,
             _not_send: PhantomData,
         }
@@ -406,6 +409,8 @@ impl Ctx {
             &mut self.inproc
         } else if url.starts_with("unix://") {
             &mut self.unix
+        } else if url.starts_with("quic://") {
+            &mut self.quic
         } else {
             unreachable!("scheme already validated by valid_scheme");
         }
@@ -1115,10 +1120,11 @@ impl CtxHandle {
                     let mut ctx = Ctx::new(runtime_tx);
                     while let Some(command) = rx.recv().await {
                         if let Command::Shutdown { done } = command {
-                            // Wait for the UNIX transport to flush every pending
-                            // write to the OS and stop its coroutines before the
-                            // runtime (and the coroutines) is torn down.
+                            // Wait for the socket transports to flush every pending
+                            // write and stop their coroutines before the runtime (and
+                            // the coroutines) is torn down.
                             ctx.unix.shutdown().await;
+                            ctx.quic.shutdown().await;
                             let thread = ctx
                                 .thread
                                 .take()

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Wire framing shared by the socket-style transports (unix, quic).
+//!
+//! Each frame is `[u64 header_len][header][raw part bytes...]`. The header is a
+//! bincode-encoded [`WireFrame`] holding only small metadata; for a message it
+//! carries the *lengths* of the parts, never their bytes. Message-part bytes are
+//! written straight from the owning `MsgPart` and read straight into a freshly
+//! allocated per-part buffer — no copies of payload beyond the socket read/write.
+//!
+//! The reader/writer are generic over tokio's [`AsyncRead`]/[`AsyncWrite`], so the
+//! same code drives a UNIX socket's halves and a QUIC stream's `RecvStream`/
+//! `SendStream`. Liveness policy (heartbeats, timeouts, EOF) lives in each
+//! transport; this module only serializes frames — with the one exception of the
+//! [`WireFrame::Heartbeat`] probe, which a transport may emit/consume but which is
+//! never a [`ConnectionCommand`].
+
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+
+use crate::Role;
+use crate::connection::ConnectionCommand;
+use crate::msg::MsgPart;
+
+/// One frame on the wire. There is a variant per [`ConnectionCommand`] that
+/// crosses the pipe (including `Establish`, which is how the two ends exchange
+/// identity), plus a transport-internal `Heartbeat`. Message-part *bytes* are
+/// never carried here — only their lengths.
+#[derive(Serialize, Deserialize)]
+enum WireFrame {
+    Establish {
+        role: Role,
+        ident: Option<Vec<u8>>,
+        name_for_other: Option<Vec<u8>>,
+        alive: bool,
+    },
+    Message {
+        destination_ident: Vec<u8>,
+        part_lens: Vec<u64>,
+    },
+    PublishRoutes {
+        live: Vec<Vec<u8>>,
+        dead: Vec<Vec<u8>>,
+    },
+    Subscribe {
+        dest: Vec<u8>,
+        id: u64,
+        to_monitor: Vec<u8>,
+    },
+    Unsubscribe {
+        dest: Vec<u8>,
+        id: u64,
+        to_monitor: Vec<u8>,
+    },
+    FireMonitor {
+        dest_ident: Vec<u8>,
+        monitor_id: u64,
+    },
+    Severed {
+        reason: Vec<u8>,
+    },
+    /// Transport-internal liveness probe; consumed by the reader to refresh its
+    /// deadline and never surfaced as a [`ConnectionCommand`].
+    Heartbeat,
+}
+
+fn bincode_config() -> bincode::config::Configuration {
+    bincode::config::standard()
+}
+
+/// A frame decoded off the wire: either a command for the loop, or a transport
+/// heartbeat (consumed internally to refresh the liveness deadline).
+pub(crate) enum Incoming {
+    Command(ConnectionCommand),
+    Heartbeat,
+}
+
+/// Serialize and write one command: a length-prefixed bincode header, then — for
+/// a message — each part's bytes streamed straight from its buffer. Flushes so the
+/// peer (and, for quic, its heartbeat deadline) sees it promptly.
+pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    command: ConnectionCommand,
+) -> std::io::Result<()> {
+    // A message additionally keeps a list of part bytes to stream raw after the
+    // header; every other command is header-only.
+    let mut parts: Vec<MsgPart> = Vec::new();
+    let frame = match command {
+        ConnectionCommand::SendMessage {
+            destination_ident,
+            parts: message_parts,
+        } => {
+            let part_lens = message_parts
+                .iter()
+                .map(|part| part.as_bytes().len() as u64)
+                .collect();
+            parts = message_parts;
+            WireFrame::Message {
+                destination_ident,
+                part_lens,
+            }
+        }
+        ConnectionCommand::Establish {
+            role,
+            ident,
+            name_for_other,
+            alive,
+        } => WireFrame::Establish {
+            role,
+            ident,
+            name_for_other,
+            alive,
+        },
+        ConnectionCommand::PublishRoutes { live, dead } => WireFrame::PublishRoutes { live, dead },
+        ConnectionCommand::Subscribe {
+            dest,
+            id,
+            to_monitor,
+        } => WireFrame::Subscribe {
+            dest,
+            id,
+            to_monitor,
+        },
+        ConnectionCommand::Unsubscribe {
+            dest,
+            id,
+            to_monitor,
+        } => WireFrame::Unsubscribe {
+            dest,
+            id,
+            to_monitor,
+        },
+        ConnectionCommand::FireMonitor {
+            dest_ident,
+            monitor_id,
+        } => WireFrame::FireMonitor {
+            dest_ident,
+            monitor_id,
+        },
+        ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
+    };
+    write_frame(writer, &frame, &parts).await
+}
+
+/// Write a transport heartbeat probe.
+pub(crate) async fn write_heartbeat<W: AsyncWrite + Unpin>(writer: &mut W) -> std::io::Result<()> {
+    write_frame(writer, &WireFrame::Heartbeat, &[]).await
+}
+
+async fn write_frame<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    frame: &WireFrame,
+    parts: &[MsgPart],
+) -> std::io::Result<()> {
+    let header = bincode::serde::encode_to_vec(frame, bincode_config())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    writer
+        .write_all(&(header.len() as u64).to_le_bytes())
+        .await?;
+    writer.write_all(&header).await?;
+    // Write each part's bytes straight from its owning buffer — no copy.
+    for part in parts {
+        writer.write_all(part.as_bytes()).await?;
+    }
+    writer.flush().await
+}
+
+/// Read one frame. For a message the part bytes are read directly into the
+/// command's own buffers — the only copy is the unavoidable kernel-to-userspace
+/// one. A `Heartbeat` frame returns [`Incoming::Heartbeat`]; everything else maps
+/// straight back to a [`ConnectionCommand`].
+pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<Incoming> {
+    let mut len_buf = [0u8; 8];
+    reader.read_exact(&mut len_buf).await?;
+    let header_len = u64::from_le_bytes(len_buf) as usize;
+
+    let mut header = vec![0u8; header_len];
+    reader.read_exact(&mut header).await?;
+    let (frame, _) = bincode::serde::decode_from_slice::<WireFrame, _>(&header, bincode_config())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+
+    Ok(match frame {
+        WireFrame::Heartbeat => Incoming::Heartbeat,
+        WireFrame::Message {
+            destination_ident,
+            part_lens,
+        } => {
+            let mut parts = Vec::with_capacity(part_lens.len());
+            for len in part_lens {
+                let mut buf = vec![0u8; len as usize];
+                reader.read_exact(&mut buf).await?;
+                parts.push(MsgPart::from_bytes(buf));
+            }
+            Incoming::Command(ConnectionCommand::SendMessage {
+                destination_ident,
+                parts,
+            })
+        }
+        WireFrame::Establish {
+            role,
+            ident,
+            name_for_other,
+            alive,
+        } => Incoming::Command(ConnectionCommand::Establish {
+            role,
+            ident,
+            name_for_other,
+            alive,
+        }),
+        WireFrame::PublishRoutes { live, dead } => {
+            Incoming::Command(ConnectionCommand::PublishRoutes { live, dead })
+        }
+        WireFrame::Subscribe {
+            dest,
+            id,
+            to_monitor,
+        } => Incoming::Command(ConnectionCommand::Subscribe {
+            dest,
+            id,
+            to_monitor,
+        }),
+        WireFrame::Unsubscribe {
+            dest,
+            id,
+            to_monitor,
+        } => Incoming::Command(ConnectionCommand::Unsubscribe {
+            dest,
+            id,
+            to_monitor,
+        }),
+        WireFrame::FireMonitor {
+            dest_ident,
+            monitor_id,
+        } => Incoming::Command(ConnectionCommand::FireMonitor {
+            dest_ident,
+            monitor_id,
+        }),
+        WireFrame::Severed { reason } => Incoming::Command(ConnectionCommand::Severed { reason }),
+    })
+}

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -9,10 +9,12 @@
 mod actor;
 mod connection;
 mod ctx;
+mod framing;
 mod inproc_transport;
 mod matcher;
 mod msg;
 mod poller;
+mod quic_transport;
 mod transport;
 mod unix_transport;
 

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -1,0 +1,551 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! QUIC transport for connecting actors across machines (or local processes).
+//!
+//! Structurally a sibling of the UNIX transport: a connection's coroutines bring
+//! up one bidirectional QUIC stream, produce a [`ConnectionTransport`] for it, and
+//! hand it to the command loop via `Command::TransportConnected`; the reader
+//! forwards every decoded frame back as a `ConnectionAction`. Establishment policy
+//! (identity exchange, hello, liveness reporting) lives in the command loop and is
+//! identical across transports. Wire framing is shared (see [`crate::framing`]).
+//!
+//! ## Why QUIC differs from UNIX
+//!
+//! QUIC runs over UDP in userspace, so there is no file-descriptor close to signal
+//! a lost peer: a crashed, frozen, or partitioned peer simply stops sending. So
+//! instead of relying on EOF we run an application-level **bidirectional
+//! heartbeat**: each side's writer emits a [`framing::write_heartbeat`] every
+//! [`HEARTBEAT_INTERVAL`], and each side's reader wraps every frame read in a
+//! [`HEARTBEAT_TIMEOUT`]; any frame (data or heartbeat) refreshes the deadline, and
+//! a timeout emits `Severed`. A clean drop still finishes the stream, so the peer
+//! also observes immediate EOF — the heartbeat is the backstop for the unclean
+//! cases.
+//!
+//! ## Security
+//!
+//! TLS material is taken from the environment (the "we will provide it" hook):
+//! `MM_QUIC_CERT` / `MM_QUIC_KEY` (the cert chain + key this endpoint serves) and
+//! `MM_QUIC_CA` (the authority a joiner trusts). The server presents its cert; the
+//! client verifies it against the CA for the fixed server name [`SERVER_NAME`].
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use quinn::ClientConfig;
+use quinn::Connection;
+use quinn::Endpoint;
+use quinn::RecvStream;
+use quinn::SendStream;
+use quinn::ServerConfig;
+use rustls::RootCertStore;
+use rustls_pki_types::CertificateDer;
+use rustls_pki_types::PrivateKeyDer;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tokio::time::Duration;
+use tokio::time::MissedTickBehavior;
+
+use crate::connection::ConnectionCommand;
+use crate::connection::ConnectionRef;
+use crate::connection::ConnectionTransport;
+use crate::ctx::Command;
+use crate::framing;
+use crate::framing::Incoming;
+use crate::matcher::Matcher;
+use crate::transport::Transport;
+
+/// Server name the client uses to verify the server's certificate (the cert's SAN
+/// must cover it). Fixed: routing/identity is handled above this layer.
+const SERVER_NAME: &str = "monarch-mini";
+
+/// Connect-retry backoff bounds. A join may precede its serve, and the QUIC
+/// handshake fails until the server is bound, so the connector polls — fast at
+/// first, backing off to a steady poll.
+const CONNECT_RETRY_MIN: Duration = Duration::from_millis(5);
+const CONNECT_RETRY_MAX: Duration = Duration::from_millis(1000);
+
+/// How often each side emits a heartbeat, and how long a side waits for any frame
+/// before declaring the connection broken. The timeout is several intervals so a
+/// stray scheduling delay doesn't trip it.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(250);
+const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Process-wide rustls crypto provider (ring), installed once before any config is
+/// built. Ignoring the result is intentional: a competing install is fine.
+fn ensure_crypto_provider() {
+    static INSTALLED: OnceLock<()> = OnceLock::new();
+    INSTALLED.get_or_init(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
+/// Server + client TLS configs, built once from the environment and shared by all
+/// quic serves/joins in this context.
+struct TlsConfig {
+    server: ServerConfig,
+    client: ClientConfig,
+}
+
+fn load_certs(path: &str) -> anyhow::Result<Vec<CertificateDer<'static>>> {
+    let data = std::fs::read(path).map_err(|err| anyhow::anyhow!("reading {path}: {err}"))?;
+    let certs = rustls_pemfile::certs(&mut &data[..]).collect::<Result<Vec<_>, _>>()?;
+    anyhow::ensure!(!certs.is_empty(), "no certificates in {path}");
+    Ok(certs)
+}
+
+fn load_key(path: &str) -> anyhow::Result<PrivateKeyDer<'static>> {
+    let data = std::fs::read(path).map_err(|err| anyhow::anyhow!("reading {path}: {err}"))?;
+    rustls_pemfile::private_key(&mut &data[..])?
+        .ok_or_else(|| anyhow::anyhow!("no private key in {path}"))
+}
+
+fn load_tls() -> anyhow::Result<TlsConfig> {
+    ensure_crypto_provider();
+    let cert_path =
+        std::env::var("MM_QUIC_CERT").map_err(|_| anyhow::anyhow!("MM_QUIC_CERT not set"))?;
+    let key_path =
+        std::env::var("MM_QUIC_KEY").map_err(|_| anyhow::anyhow!("MM_QUIC_KEY not set"))?;
+    let ca_path = std::env::var("MM_QUIC_CA").map_err(|_| anyhow::anyhow!("MM_QUIC_CA not set"))?;
+
+    let server = ServerConfig::with_single_cert(load_certs(&cert_path)?, load_key(&key_path)?)?;
+
+    let mut roots = RootCertStore::empty();
+    for ca in load_certs(&ca_path)? {
+        roots.add(ca)?;
+    }
+    let client = ClientConfig::with_root_certificates(Arc::new(roots))?;
+
+    Ok(TlsConfig { server, client })
+}
+
+fn parse_addr(url: &str) -> anyhow::Result<SocketAddr> {
+    let authority = url.strip_prefix("quic://").unwrap_or(url);
+    authority
+        .parse::<SocketAddr>()
+        .map_err(|err| anyhow::anyhow!("invalid quic address {authority:?}: {err}"))
+}
+
+/// Owns all QUIC transport state and coroutines. Mirrors `UnixTransport`: the
+/// command loop holds one and forwards serves/joins to it; it never sees streams
+/// or pairing state. TLS configs are built lazily on first use and cached.
+pub(crate) struct QuicTransport {
+    loop_tx: mpsc::UnboundedSender<Command>,
+    shutdown_tx: watch::Sender<bool>,
+    // One listener coroutine per url; serve connections are forwarded to it and it
+    // owns the serve/accept pairing.
+    listeners: HashMap<String, mpsc::UnboundedSender<ConnectionRef>>,
+    tls: Option<Arc<TlsConfig>>,
+    // Liveness-token issuer: each connection's writer holds a clone for its
+    // lifetime. Teardown drops this issuing copy and waits for `alive_rx` to close
+    // — i.e. for every writer to have flushed and exited.
+    alive_tx: Option<mpsc::UnboundedSender<()>>,
+    alive_rx: mpsc::UnboundedReceiver<()>,
+}
+
+impl QuicTransport {
+    pub(crate) fn new(loop_tx: mpsc::UnboundedSender<Command>) -> Self {
+        let (shutdown_tx, _) = watch::channel(false);
+        let (alive_tx, alive_rx) = mpsc::unbounded_channel();
+        Self {
+            loop_tx,
+            shutdown_tx,
+            listeners: HashMap::new(),
+            tls: None,
+            alive_tx: Some(alive_tx),
+            alive_rx,
+        }
+    }
+
+    fn alive_token(&self) -> mpsc::UnboundedSender<()> {
+        self.alive_tx
+            .as_ref()
+            .expect("alive-token issuer present before shutdown")
+            .clone()
+    }
+
+    /// Build (or return the cached) TLS configs from the environment.
+    fn tls(&mut self) -> anyhow::Result<Arc<TlsConfig>> {
+        if let Some(tls) = &self.tls {
+            return Ok(tls.clone());
+        }
+        let tls = Arc::new(load_tls()?);
+        self.tls = Some(tls.clone());
+        Ok(tls)
+    }
+
+    /// Signal every writer to flush and exit, then wait until they all have — the
+    /// same teardown contract as the UNIX transport.
+    pub(crate) async fn shutdown(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+        self.alive_tx = None;
+        let _ = self.alive_rx.recv().await;
+    }
+}
+
+impl Transport for QuicTransport {
+    fn serve(&mut self, url: String, connection: ConnectionRef) {
+        let tls = match self.tls() {
+            Ok(tls) => tls,
+            Err(err) => {
+                sever(
+                    &self.loop_tx,
+                    connection,
+                    format!("quic tls: {err:#}").into_bytes(),
+                );
+                return;
+            }
+        };
+        // The first serve on a url spawns its listener coroutine; later serves just
+        // forward another connection to it.
+        if !self.listeners.contains_key(&url) {
+            let addr = match parse_addr(&url) {
+                Ok(addr) => addr,
+                Err(err) => {
+                    sever(&self.loop_tx, connection, format!("{err:#}").into_bytes());
+                    return;
+                }
+            };
+            let (tx, rx) = mpsc::unbounded_channel();
+            tokio::task::spawn_local(listener_task(
+                addr,
+                tls.server.clone(),
+                rx,
+                self.loop_tx.clone(),
+                self.shutdown_tx.subscribe(),
+                self.alive_token(),
+            ));
+            self.listeners.insert(url.clone(), tx);
+        }
+        let _ = self
+            .listeners
+            .get(&url)
+            .expect("listener just inserted")
+            .send(connection);
+    }
+
+    fn join(&mut self, url: String, connection: ConnectionRef) {
+        let tls = match self.tls() {
+            Ok(tls) => tls,
+            Err(err) => {
+                sever(
+                    &self.loop_tx,
+                    connection,
+                    format!("quic tls: {err:#}").into_bytes(),
+                );
+                return;
+            }
+        };
+        let addr = match parse_addr(&url) {
+            Ok(addr) => addr,
+            Err(err) => {
+                sever(&self.loop_tx, connection, format!("{err:#}").into_bytes());
+                return;
+            }
+        };
+        tokio::task::spawn_local(connector_task(
+            addr,
+            tls.client.clone(),
+            connection,
+            self.loop_tx.clone(),
+            self.shutdown_tx.subscribe(),
+            self.alive_token(),
+        ));
+    }
+}
+
+/// Bind a QUIC server endpoint on `addr` and pair each accepted connection's
+/// stream with the next queued serve (either may arrive first). On a bind failure
+/// the serves are severed instead. Stops on teardown or when the command loop
+/// drops the serve sender.
+async fn listener_task(
+    addr: SocketAddr,
+    server_config: ServerConfig,
+    mut serves: mpsc::UnboundedReceiver<ConnectionRef>,
+    loop_tx: mpsc::UnboundedSender<Command>,
+    mut shutdown: watch::Receiver<bool>,
+    alive: mpsc::UnboundedSender<()>,
+) {
+    let endpoint = match Endpoint::server(server_config, addr) {
+        Ok(endpoint) => endpoint,
+        Err(err) => {
+            // Bind failed (e.g. port in use). The url is dead for serving; stay alive
+            // and fail every serve on it until teardown rather than respawn-retrying.
+            let reason = format!("quic bind failed: {err}").into_bytes();
+            loop {
+                tokio::select! {
+                    serve = serves.recv() => match serve {
+                        Some(connection) => sever(&loop_tx, connection, reason.clone()),
+                        None => return,
+                    },
+                    _ = shutdown.changed() => return,
+                }
+            }
+        }
+    };
+
+    // Accepting a connection and its stream is a multi-step handshake; run it off
+    // the pairing loop so a slow handshake doesn't stall matching. Each accepted
+    // (connection, stream) lands on `accepted_rx`.
+    let (accepted_tx, mut accepted_rx) = mpsc::unbounded_channel();
+    tokio::task::spawn_local(acceptor_task(
+        endpoint.clone(),
+        accepted_tx,
+        shutdown.clone(),
+    ));
+
+    let mut matcher: Matcher<ConnectionRef, (Connection, SendStream, RecvStream)> = Matcher::new();
+    loop {
+        tokio::select! {
+            serve = serves.recv() => {
+                let Some(connection) = serve else { return; };
+                let _ = matcher.push_left(connection, |connection, (conn, send, recv)| {
+                    spawn_connection(
+                        send, recv, connection,
+                        loop_tx.clone(), shutdown.clone(), alive.clone(),
+                        KeepAlive { _endpoint: None, _connection: conn },
+                    )
+                });
+            }
+            accepted = accepted_rx.recv() => {
+                let Some(triple) = accepted else { return; };
+                let _ = matcher.push_right(triple, |connection, (conn, send, recv)| {
+                    spawn_connection(
+                        send, recv, connection,
+                        loop_tx.clone(), shutdown.clone(), alive.clone(),
+                        KeepAlive { _endpoint: None, _connection: conn },
+                    )
+                });
+            }
+            _ = shutdown.changed() => return,
+        }
+    }
+    // `endpoint` is held for the whole task, keeping the server socket (and every
+    // accepted connection's driver) alive until teardown.
+}
+
+/// Accept connections on `endpoint`, accept the one bi-stream each joiner opens,
+/// and forward the result. Each handshake runs in its own task so one slow peer
+/// doesn't block others.
+async fn acceptor_task(
+    endpoint: Endpoint,
+    accepted_tx: mpsc::UnboundedSender<(Connection, SendStream, RecvStream)>,
+    mut shutdown: watch::Receiver<bool>,
+) {
+    loop {
+        tokio::select! {
+            incoming = endpoint.accept() => {
+                let Some(incoming) = incoming else { return; }; // endpoint closed
+                let accepted_tx = accepted_tx.clone();
+                tokio::task::spawn_local(async move {
+                    let Ok(connecting) = incoming.accept() else { return; };
+                    let Ok(connection) = connecting.await else { return; };
+                    if let Ok((send, recv)) = connection.accept_bi().await {
+                        let _ = accepted_tx.send((connection, send, recv));
+                    }
+                });
+            }
+            _ = shutdown.changed() => return,
+        }
+    }
+}
+
+/// Connect to `addr`, retrying until the server binds and the handshake succeeds
+/// (so a join may precede its serve), then open one bi-stream and wire it up.
+async fn connector_task(
+    addr: SocketAddr,
+    client_config: ClientConfig,
+    connection: ConnectionRef,
+    loop_tx: mpsc::UnboundedSender<Command>,
+    mut shutdown: watch::Receiver<bool>,
+    alive: mpsc::UnboundedSender<()>,
+) {
+    let endpoint = match Endpoint::client("0.0.0.0:0".parse().expect("valid bind addr")) {
+        Ok(mut endpoint) => {
+            endpoint.set_default_client_config(client_config);
+            endpoint
+        }
+        Err(err) => {
+            sever(
+                &loop_tx,
+                connection,
+                format!("quic client bind failed: {err}").into_bytes(),
+            );
+            return;
+        }
+    };
+
+    let mut retry = CONNECT_RETRY_MIN;
+    loop {
+        if *shutdown.borrow() {
+            return;
+        }
+        // connect() fails synchronously on a bad config; the handshake (.await)
+        // fails until the server is up. Both just back off and retry.
+        let connected = match endpoint.connect(addr, SERVER_NAME) {
+            Ok(connecting) => connecting.await.ok(),
+            Err(_) => None,
+        };
+        if let Some(conn) = connected {
+            match conn.open_bi().await {
+                Ok((send, recv)) => {
+                    spawn_connection(
+                        send,
+                        recv,
+                        connection,
+                        loop_tx,
+                        shutdown,
+                        alive,
+                        KeepAlive {
+                            _endpoint: Some(endpoint),
+                            _connection: conn,
+                        },
+                    );
+                    return;
+                }
+                Err(_) => {
+                    sever(&loop_tx, connection, b"quic open stream failed".to_vec());
+                    return;
+                }
+            }
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(retry) => {}
+            _ = shutdown.changed() => return,
+        }
+        retry = (retry * 2).min(CONNECT_RETRY_MAX);
+    }
+}
+
+/// Wire up an established bi-stream: build its [`QuicConnectionTransport`], announce
+/// it to the command loop, and spawn the writer (drains commands → frames, plus a
+/// heartbeat tick) and reader (frames → `ConnectionAction`, with a heartbeat
+/// timeout). `keep` holds the QUIC connection (and, for a joiner, the client
+/// endpoint) alive for the duration of the writer.
+fn spawn_connection(
+    send: SendStream,
+    recv: RecvStream,
+    connection: ConnectionRef,
+    loop_tx: mpsc::UnboundedSender<Command>,
+    shutdown: watch::Receiver<bool>,
+    alive: mpsc::UnboundedSender<()>,
+    keep: KeepAlive,
+) {
+    let (writer_tx, writer_rx) = mpsc::unbounded_channel();
+    let transport = Box::new(QuicConnectionTransport { tx: writer_tx });
+    let _ = loop_tx.send(Command::TransportConnected {
+        connection,
+        transport,
+    });
+    tokio::task::spawn_local(writer_task(send, writer_rx, shutdown, alive, keep));
+    tokio::task::spawn_local(reader_task(recv, connection, loop_tx));
+}
+
+/// Keeps the QUIC connection (and a joiner's client endpoint) alive for as long as
+/// the writer runs; dropping it closes them, which the peer observes.
+struct KeepAlive {
+    _endpoint: Option<Endpoint>,
+    _connection: Connection,
+}
+
+/// Transport for one end of a QUIC stream: `send` hands a command to the writer
+/// task. Dropping it ends the writer, which finishes the stream — the peer's reader
+/// then sees EOF.
+struct QuicConnectionTransport {
+    tx: mpsc::UnboundedSender<ConnectionCommand>,
+}
+
+impl ConnectionTransport for QuicConnectionTransport {
+    fn send(&self, action: ConnectionCommand) -> bool {
+        self.tx.send(action).is_ok()
+    }
+}
+
+/// Write each queued command as a frame, and a heartbeat every
+/// [`HEARTBEAT_INTERVAL`] so the peer's reader keeps seeing traffic. On teardown,
+/// drains queued frames first, then finishes the stream.
+async fn writer_task(
+    mut send: SendStream,
+    mut rx: mpsc::UnboundedReceiver<ConnectionCommand>,
+    mut shutdown: watch::Receiver<bool>,
+    _alive: mpsc::UnboundedSender<()>,
+    _keep: KeepAlive,
+) {
+    let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
+    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    loop {
+        tokio::select! {
+            command = rx.recv() => {
+                let Some(command) = command else {
+                    break; // transport dropped
+                };
+                if framing::write_command(&mut send, command).await.is_err() {
+                    return;
+                }
+            }
+            _ = heartbeat.tick() => {
+                if framing::write_heartbeat(&mut send).await.is_err() {
+                    return;
+                }
+            }
+            _ = shutdown.changed() => {
+                // Teardown: no further commands will be enqueued. Flush whatever is
+                // already queued, then stop.
+                while let Ok(command) = rx.try_recv() {
+                    if framing::write_command(&mut send, command).await.is_err() {
+                        return;
+                    }
+                }
+                break;
+            }
+        }
+    }
+    // Finish the stream so the peer's reader sees EOF promptly (the fast path); the
+    // heartbeat timeout is the backstop when a peer dies without finishing.
+    let _ = send.finish();
+}
+
+/// Decode each frame off the stream and forward it to the command loop. A read
+/// that does not complete within [`HEARTBEAT_TIMEOUT`] — or an error/EOF — emits
+/// `Severed`. Heartbeat frames refresh the deadline and are not forwarded.
+async fn reader_task(
+    mut recv: RecvStream,
+    connection: ConnectionRef,
+    loop_tx: mpsc::UnboundedSender<Command>,
+) {
+    loop {
+        match tokio::time::timeout(HEARTBEAT_TIMEOUT, framing::read_frame(&mut recv)).await {
+            Err(_elapsed) => {
+                sever(&loop_tx, connection, b"quic heartbeat timeout".to_vec());
+                return;
+            }
+            Ok(Ok(Incoming::Command(action))) => {
+                if loop_tx
+                    .send(Command::ConnectionAction { connection, action })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Ok(Ok(Incoming::Heartbeat)) => continue,
+            Ok(Err(_)) => {
+                sever(&loop_tx, connection, b"quic connection closed".to_vec());
+                return;
+            }
+        }
+    }
+}
+
+fn sever(loop_tx: &mpsc::UnboundedSender<Command>, connection: ConnectionRef, reason: Vec<u8>) {
+    let _ = loop_tx.send(Command::ConnectionAction {
+        connection,
+        action: ConnectionCommand::Severed { reason },
+    });
+}

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -7,6 +7,7 @@
  */
 
 use std::fs::File;
+use std::net::SocketAddr;
 use std::os::fd::OwnedFd;
 
 use tokio::sync::mpsc;
@@ -686,6 +687,200 @@ fn unix_monitor_fires_across_processes() {
 
     shutdown(client_ctx);
     shutdown(server_ctx);
+}
+
+#[test]
+fn quic_serve_join_establishes_and_routes() {
+    set_quic_env();
+    let ctx = CtxHandle::new().expect("context should start");
+    let parent = runtime_actor(&ctx, "q-parent");
+    let child = runtime_actor(&ctx, "q-child");
+    let (parent_poller, mut parent_rx) = runtime_poller(&ctx);
+    let (child_poller, mut child_rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, parent_poller, 0, parent);
+    runtime_subscribe(&ctx, child_poller, 0, child);
+
+    let url = free_quic_url();
+    ctx.send_command(Command::Serve {
+        actor: parent,
+        url: url.clone(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: child,
+        url,
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+
+    // The QUIC handshake completes and both sides get their hello.
+    assert_eq!(recv_strings(&mut parent_rx), vec!["q-parent", "q-child"]);
+    assert_eq!(recv_strings(&mut child_rx), vec!["q-child", "q-parent"]);
+
+    // A message both directions is framed over the stream and delivered intact.
+    ctx.send_command(Command::Send {
+        sender: parent,
+        destination_ident: MsgPart::from_bytes(b"q-child".to_vec()),
+        parts: vec![
+            MsgPart::from_bytes(b"down".to_vec()),
+            MsgPart::from_bytes(b"stream".to_vec()),
+        ],
+    })
+    .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut child_rx), vec!["down", "stream"]);
+
+    ctx.send_command(Command::Send {
+        sender: child,
+        destination_ident: MsgPart::from_bytes(b"q-parent".to_vec()),
+        parts: vec![MsgPart::from_bytes(b"up".to_vec())],
+    })
+    .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut parent_rx), vec!["up"]);
+
+    shutdown(ctx);
+}
+
+#[test]
+fn quic_join_before_serve() {
+    // The joiner's QUIC handshake fails until the server binds, so the connector
+    // retries — join may go first.
+    set_quic_env();
+    let ctx = CtxHandle::new().expect("context should start");
+    let parent = runtime_actor(&ctx, "q-late-parent");
+    let child = runtime_actor(&ctx, "q-late-child");
+    let (parent_poller, mut parent_rx) = runtime_poller(&ctx);
+    let (child_poller, mut child_rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, parent_poller, 0, parent);
+    runtime_subscribe(&ctx, child_poller, 0, child);
+
+    let url = free_quic_url();
+    ctx.send_command(Command::Join {
+        actor: child,
+        url: url.clone(),
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+    std::thread::sleep(std::time::Duration::from_millis(50)); // let the connector spin
+    ctx.send_command(Command::Serve {
+        actor: parent,
+        url,
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+
+    assert_eq!(
+        recv_strings(&mut parent_rx),
+        vec!["q-late-parent", "q-late-child"]
+    );
+    assert_eq!(
+        recv_strings(&mut child_rx),
+        vec!["q-late-child", "q-late-parent"]
+    );
+
+    shutdown(ctx);
+}
+
+#[test]
+fn quic_heartbeat_timeout_severs_connection() {
+    // A peer that holds the QUIC connection open but never sends anything (no
+    // Establish, no heartbeats) can't be detected by EOF — only the heartbeat
+    // timeout catches it. A raw silent quinn server stands in for such a peer; the
+    // joining actor must receive its failure message once the heartbeat lapses.
+    set_quic_env();
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    // Bind the silent server first so we know its concrete port.
+    let port = spawn_silent_quic_server(addr);
+    let url = format!("quic://127.0.0.1:{port}");
+
+    let ctx = CtxHandle::new().expect("context should start");
+    let client = runtime_actor(&ctx, "q-silent-client");
+    let (poller, mut rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, poller, 0, client);
+
+    ctx.send_command(Command::Join {
+        actor: client,
+        url,
+        request: request_with_failure(Role::Child, "client-failed"),
+    })
+    .expect("join should enqueue");
+
+    // No Establish ever arrives, so the peer ident is empty; the heartbeat timeout
+    // is what severs the connection and delivers the failure.
+    assert_eq!(
+        recv_strings(&mut rx),
+        vec!["client-failed", "", "quic heartbeat timeout"]
+    );
+
+    shutdown(ctx);
+}
+
+/// Bind a raw quinn server on an ephemeral port using the test cert, accept one
+/// connection and hold it open (never sending a frame). Returns the bound port.
+/// The server thread is detached; it exits on its own after a grace period.
+fn spawn_silent_quic_server(addr: SocketAddr) -> u16 {
+    use std::io::BufReader;
+
+    let (port_tx, port_rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("silent server runtime");
+        rt.block_on(async move {
+            let _ = quinn::rustls::crypto::ring::default_provider().install_default();
+            let dir = cert_dir();
+            let cert_data = std::fs::read(dir.join("cert.pem")).expect("read cert");
+            let key_data = std::fs::read(dir.join("key.pem")).expect("read key");
+            let certs = rustls_pemfile::certs(&mut BufReader::new(&cert_data[..]))
+                .collect::<Result<Vec<_>, _>>()
+                .expect("parse cert");
+            let key = rustls_pemfile::private_key(&mut BufReader::new(&key_data[..]))
+                .expect("parse key")
+                .expect("a private key");
+            let server_config =
+                quinn::ServerConfig::with_single_cert(certs, key).expect("server config");
+            let endpoint = quinn::Endpoint::server(server_config, addr).expect("bind quic server");
+            port_tx
+                .send(endpoint.local_addr().expect("local addr").port())
+                .expect("report port");
+
+            // Accept one connection and hold it open without ever replying.
+            let mut held = Vec::new();
+            if let Some(incoming) = endpoint.accept().await {
+                if let Ok(connecting) = incoming.accept() {
+                    if let Ok(conn) = connecting.await {
+                        held.push(conn);
+                    }
+                }
+            }
+            tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+            drop(held);
+        });
+    });
+    port_rx
+        .recv()
+        .expect("silent server should report its port")
+}
+
+fn cert_dir() -> std::path::PathBuf {
+    std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("test_certs")
+}
+
+fn set_quic_env() {
+    // All quic tests use the same fixture certs, so setting the same values from
+    // multiple test threads is benign.
+    let dir = cert_dir();
+    std::env::set_var("MM_QUIC_CERT", dir.join("cert.pem"));
+    std::env::set_var("MM_QUIC_KEY", dir.join("key.pem"));
+    std::env::set_var("MM_QUIC_CA", dir.join("ca.pem"));
+}
+
+fn free_quic_url() -> String {
+    let socket = std::net::UdpSocket::bind("127.0.0.1:0").expect("bind ephemeral udp");
+    let port = socket.local_addr().expect("local addr").port();
+    drop(socket);
+    format!("quic://127.0.0.1:{port}")
 }
 
 fn unix_test_url(name: &str) -> String {

--- a/monarch_mini/src/unix_transport.rs
+++ b/monarch_mini/src/unix_transport.rs
@@ -35,9 +35,6 @@
 use std::collections::HashMap;
 use std::path::PathBuf;
 
-use serde::Deserialize;
-use serde::Serialize;
-use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 use tokio::net::UnixListener;
 use tokio::net::UnixStream;
@@ -47,13 +44,13 @@ use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::Duration;
 
-use crate::Role;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
 use crate::ctx::Command;
+use crate::framing;
+use crate::framing::Incoming;
 use crate::matcher::Matcher;
-use crate::msg::MsgPart;
 use crate::transport::Transport;
 
 /// Connect-retry backoff bounds. A join may be posted before its serve, so the
@@ -61,48 +58,6 @@ use crate::transport::Transport;
 /// serve that is slow — or never comes — doesn't spam the OS with connect()s.
 const CONNECT_RETRY_MIN: Duration = Duration::from_millis(5);
 const CONNECT_RETRY_MAX: Duration = Duration::from_millis(1000);
-
-/// One frame on the wire. There is a variant per [`ConnectionCommand`] that
-/// crosses the pipe (including `Establish`, which is how the two ends exchange
-/// identity). Message-part *bytes* are never carried here — only their lengths.
-#[derive(Serialize, Deserialize)]
-enum WireFrame {
-    Establish {
-        role: Role,
-        ident: Option<Vec<u8>>,
-        name_for_other: Option<Vec<u8>>,
-        alive: bool,
-    },
-    Message {
-        destination_ident: Vec<u8>,
-        part_lens: Vec<u64>,
-    },
-    PublishRoutes {
-        live: Vec<Vec<u8>>,
-        dead: Vec<Vec<u8>>,
-    },
-    Subscribe {
-        dest: Vec<u8>,
-        id: u64,
-        to_monitor: Vec<u8>,
-    },
-    Unsubscribe {
-        dest: Vec<u8>,
-        id: u64,
-        to_monitor: Vec<u8>,
-    },
-    FireMonitor {
-        dest_ident: Vec<u8>,
-        monitor_id: u64,
-    },
-    Severed {
-        reason: Vec<u8>,
-    },
-}
-
-fn bincode_config() -> bincode::config::Configuration {
-    bincode::config::standard()
-}
 
 /// Owns all UNIX transport state and coroutines. The command loop holds one of
 /// these and forwards serves/joins to it; it never sees sockets, urls, or pairing
@@ -345,7 +300,7 @@ async fn writer_task(
                 let Some(command) = command else {
                     break; // transport dropped
                 };
-                if write_command(&mut write_half, command).await.is_err() {
+                if framing::write_command(&mut write_half, command).await.is_err() {
                     return;
                 }
             }
@@ -353,7 +308,7 @@ async fn writer_task(
                 // Teardown: the command loop has stopped, so no further commands
                 // will be enqueued. Flush whatever is already queued, then stop.
                 while let Ok(command) = rx.try_recv() {
-                    if write_command(&mut write_half, command).await.is_err() {
+                    if framing::write_command(&mut write_half, command).await.is_err() {
                         return;
                     }
                 }
@@ -368,15 +323,16 @@ async fn writer_task(
 
 /// Decode each frame off the socket and forward it to the command loop. Any read
 /// error or EOF turns into a `Severed` so the command loop tears the connection
-/// down. The command loop's command handling is shared with inproc and unchanged.
+/// down. UNIX never sends heartbeats, so a `Heartbeat` frame is not expected here;
+/// it is harmlessly ignored if one ever arrives.
 async fn reader_task(
     mut read_half: OwnedReadHalf,
     connection: ConnectionRef,
     loop_tx: mpsc::UnboundedSender<Command>,
 ) {
     loop {
-        match read_command(&mut read_half).await {
-            Ok(action) => {
+        match framing::read_frame(&mut read_half).await {
+            Ok(Incoming::Command(action)) => {
                 if loop_tx
                     .send(Command::ConnectionAction { connection, action })
                     .is_err()
@@ -384,6 +340,7 @@ async fn reader_task(
                     return;
                 }
             }
+            Ok(Incoming::Heartbeat) => continue,
             Err(_) => {
                 sever(&loop_tx, connection, b"unix connection closed".to_vec());
                 return;
@@ -397,153 +354,4 @@ fn sever(loop_tx: &mpsc::UnboundedSender<Command>, connection: ConnectionRef, re
         connection,
         action: ConnectionCommand::Severed { reason },
     });
-}
-
-/// Serialize one command and write it: a length-prefixed bincode header, then —
-/// for a message — each part's bytes streamed straight from its buffer. Every
-/// command crosses the wire, `Establish` included.
-async fn write_command(
-    write_half: &mut OwnedWriteHalf,
-    command: ConnectionCommand,
-) -> std::io::Result<()> {
-    // Figure out the header frame to write; a message additionally keeps a list of
-    // part bytes to stream raw after the header.
-    let mut parts: Vec<MsgPart> = Vec::new();
-    let frame = match command {
-        ConnectionCommand::SendMessage {
-            destination_ident,
-            parts: message_parts,
-        } => {
-            let part_lens = message_parts
-                .iter()
-                .map(|part| part.as_bytes().len() as u64)
-                .collect();
-            parts = message_parts;
-            WireFrame::Message {
-                destination_ident,
-                part_lens,
-            }
-        }
-        ConnectionCommand::Establish {
-            role,
-            ident,
-            name_for_other,
-            alive,
-        } => WireFrame::Establish {
-            role,
-            ident,
-            name_for_other,
-            alive,
-        },
-        ConnectionCommand::PublishRoutes { live, dead } => WireFrame::PublishRoutes { live, dead },
-        ConnectionCommand::Subscribe {
-            dest,
-            id,
-            to_monitor,
-        } => WireFrame::Subscribe {
-            dest,
-            id,
-            to_monitor,
-        },
-        ConnectionCommand::Unsubscribe {
-            dest,
-            id,
-            to_monitor,
-        } => WireFrame::Unsubscribe {
-            dest,
-            id,
-            to_monitor,
-        },
-        ConnectionCommand::FireMonitor {
-            dest_ident,
-            monitor_id,
-        } => WireFrame::FireMonitor {
-            dest_ident,
-            monitor_id,
-        },
-        ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
-    };
-
-    let header = bincode::serde::encode_to_vec(&frame, bincode_config())
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    write_half
-        .write_all(&(header.len() as u64).to_le_bytes())
-        .await?;
-    write_half.write_all(&header).await?;
-    // Write each part's bytes straight from its owning buffer — no copy.
-    for part in parts {
-        write_half.write_all(part.as_bytes()).await?;
-    }
-    Ok(())
-}
-
-/// Read one frame and decode it straight into a [`ConnectionCommand`]. For a
-/// message the part bytes are read directly into the command's own buffers — the
-/// only copy is the unavoidable kernel-to-userspace one, and there is no
-/// intermediate `WireFrame`-plus-parts to re-match.
-async fn read_command(read_half: &mut OwnedReadHalf) -> std::io::Result<ConnectionCommand> {
-    let mut len_buf = [0u8; 8];
-    read_half.read_exact(&mut len_buf).await?;
-    let header_len = u64::from_le_bytes(len_buf) as usize;
-
-    let mut header = vec![0u8; header_len];
-    read_half.read_exact(&mut header).await?;
-    let (frame, _) = bincode::serde::decode_from_slice::<WireFrame, _>(&header, bincode_config())
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-
-    Ok(match frame {
-        WireFrame::Message {
-            destination_ident,
-            part_lens,
-        } => {
-            let mut parts = Vec::with_capacity(part_lens.len());
-            for len in part_lens {
-                let mut buf = vec![0u8; len as usize];
-                read_half.read_exact(&mut buf).await?;
-                parts.push(MsgPart::from_bytes(buf));
-            }
-            ConnectionCommand::SendMessage {
-                destination_ident,
-                parts,
-            }
-        }
-        WireFrame::Establish {
-            role,
-            ident,
-            name_for_other,
-            alive,
-        } => ConnectionCommand::Establish {
-            role,
-            ident,
-            name_for_other,
-            alive,
-        },
-        WireFrame::PublishRoutes { live, dead } => ConnectionCommand::PublishRoutes { live, dead },
-        WireFrame::Subscribe {
-            dest,
-            id,
-            to_monitor,
-        } => ConnectionCommand::Subscribe {
-            dest,
-            id,
-            to_monitor,
-        },
-        WireFrame::Unsubscribe {
-            dest,
-            id,
-            to_monitor,
-        } => ConnectionCommand::Unsubscribe {
-            dest,
-            id,
-            to_monitor,
-        },
-        WireFrame::FireMonitor {
-            dest_ident,
-            monitor_id,
-        } => ConnectionCommand::FireMonitor {
-            dest_ident,
-            monitor_id,
-        },
-        WireFrame::Severed { reason } => ConnectionCommand::Severed { reason },
-    })
 }

--- a/monarch_mini/test_certs/.gitignore
+++ b/monarch_mini/test_certs/.gitignore
@@ -1,0 +1,3 @@
+/ca.pem
+/cert.pem
+/key.pem

--- a/monarch_mini/test_certs/README.md
+++ b/monarch_mini/test_certs/README.md
@@ -1,0 +1,11 @@
+# Test certificates
+
+Generate the local TLS fixtures before running Rust or Python QUIC tests:
+
+```sh
+cd fbcode/monarch/monarch_mini
+./test_certs/generate.sh
+```
+
+The generated `ca.pem`, `cert.pem`, and `key.pem` files are ignored by source
+control. Run the script again whenever you need to replace them.

--- a/monarch_mini/test_certs/generate.sh
+++ b/monarch_mini/test_certs/generate.sh
@@ -1,0 +1,49 @@
+#!/bin/sh
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+set -eu
+
+cert_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+tmp_dir=$(mktemp -d)
+trap 'rm -rf "$tmp_dir"' EXIT HUP INT TERM
+umask 077
+
+openssl req \
+  -x509 \
+  -newkey rsa:2048 \
+  -nodes \
+  -keyout "$tmp_dir/ca-key.pem" \
+  -out "$cert_dir/ca.pem" \
+  -days 3650 \
+  -subj "/CN=Minimonarch Test CA"
+
+openssl req \
+  -new \
+  -newkey rsa:2048 \
+  -nodes \
+  -keyout "$cert_dir/key.pem" \
+  -out "$tmp_dir/server.csr" \
+  -subj "/CN=monarch-mini"
+
+printf '%s\n' \
+  'subjectAltName=DNS:monarch-mini,DNS:localhost,IP:127.0.0.1,IP:::1' \
+  'extendedKeyUsage=serverAuth' \
+  >"$tmp_dir/server.ext"
+
+openssl x509 \
+  -req \
+  -in "$tmp_dir/server.csr" \
+  -CA "$cert_dir/ca.pem" \
+  -CAkey "$tmp_dir/ca-key.pem" \
+  -CAserial "$tmp_dir/ca.srl" \
+  -CAcreateserial \
+  -out "$cert_dir/cert.pem" \
+  -days 3650 \
+  -extfile "$tmp_dir/server.ext"
+
+chmod 644 "$cert_dir/ca.pem" "$cert_dir/cert.pem"
+chmod 600 "$cert_dir/key.pem"


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* __->__ #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add a TLS-secured QUIC transport that supports actor serve and join operations, connection retries, clean shutdown, and heartbeat-based failure detection. Extract socket wire framing for reuse by UNIX and QUIC transports, and cover QUIC routing and peer-loss behavior in Rust and cross-process Python tests.

Differential Revision: [D114750234](https://our.internmc.facebook.com/intern/diff/D114750234/)