### PR TITLE
9/43 minimonarch: Add Python round-trip benchmarks

### DIFF
--- a/monarch_mini/python/bench/bench_common.py
+++ b/monarch_mini/python/bench/bench_common.py
@@ -1,0 +1,130 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Shared configuration for the minimonarch round-trip benchmarks.
+
+This module is imported by both the orchestrator (``run_bench.py``) and the
+subprocess workers (``bench_worker.py``) so that they agree on the set of
+metrics, topologies, message sizes, and the protocol idents.
+
+Nothing here touches minimonarch — it is pure metadata so it is cheap to import
+in either process.
+"""
+
+from __future__ import annotations
+
+# --- Protocol idents -------------------------------------------------------
+# The sender, receiver, and the topology's structural actors use these fixed
+# idents. Idents must be unique across a single minimonarch run; since each
+# benchmark run is a fresh set of processes, fixed names are fine.
+SENDER = b"s"
+RECEIVER = b"r"
+
+# Marker the sender prints (on its own stdout line) wrapping the JSON results
+# blob, so the orchestrator can pick the results out of the worker's stdout.
+RESULT_MARKER = "MM_BENCH_RESULT "
+
+
+# --- Metrics ---------------------------------------------------------------
+# Each metric is one "number" the user asked for. ``unit``/``higher_better``
+# drive the plot axes and labels.
+METRICS: list[dict[str, object]] = [
+    {
+        "key": "latency",
+        "title": "Round-trip latency",
+        "unit": "us",
+        "monitor": False,
+        "throughput": False,
+        "higher_better": False,
+    },
+    {
+        "key": "throughput",
+        "title": "Round-trip throughput",
+        "unit": "GB/s",
+        "monitor": False,
+        "throughput": True,
+        "higher_better": True,
+    },
+    {
+        "key": "monitor_latency",
+        "title": "Round-trip latency w/ subscribe+unsubscribe",
+        "unit": "us",
+        "monitor": True,
+        "throughput": False,
+        "higher_better": False,
+    },
+    {
+        "key": "monitor_throughput",
+        "title": "Round-trip throughput w/ subscribe+unsubscribe",
+        "unit": "GB/s",
+        "monitor": True,
+        "throughput": True,
+        "higher_better": True,
+    },
+]
+
+
+# --- Topologies ------------------------------------------------------------
+# Each topology describes how sender ``s`` and receiver ``r`` are wired up and
+# which worker roles must be spawned. The orchestrator launches the helper
+# roles, then runs the sender role and reads its JSON.
+TOPOLOGIES: list[dict[str, object]] = [
+    {
+        "key": "inproc",
+        "title": "(a) in-process, common inproc parent",
+        "blurb": "s and r live in one process/context, both inproc children of a common parent p.",
+        # One process does everything: it hosts p, s, and r and runs r's echo
+        # loop as a background task while s measures.
+        "sender_role": "sender",
+        "helper_roles": [],
+        "n_procs": 1,
+    },
+    {
+        "key": "unix",
+        "title": "(b) two processes, common unix parent",
+        "blurb": "s and r are in separate processes, each an inproc-free child of a common parent p (third process) over unix://.",
+        "sender_role": "sender",
+        "helper_roles": ["parent", "receiver"],
+        "n_procs": 3,
+    },
+    {
+        "key": "manager",
+        "title": "(c) process/host manager",
+        "blurb": "s -inproc-> p0 -unix-> h <-unix- p1 <-inproc- r. h is a host manager; p0/p1 are process managers.",
+        "sender_role": "pm_sender",
+        "helper_roles": ["host", "pm_receiver"],
+        "n_procs": 3,
+    },
+]
+
+
+# --- Default workload ------------------------------------------------------
+# 64 B .. 16 MiB. Cross-process topologies copy real bytes over unix sockets,
+# so the top end is kept to 16 MiB to bound per-run cost; override on the CLI.
+DEFAULT_SIZES: list[int] = [64, 1 << 10, 1 << 14, 1 << 18, 1 << 20, 1 << 24]
+
+DEFAULT_LATENCY_ITERS = 50
+DEFAULT_THROUGHPUT_REPS = 10
+DEFAULT_THROUGHPUT_N = 100
+# Cap the bytes in flight per throughput rep so large sizes don't allocate
+# gigabytes: n is reduced to keep n*size under this.
+DEFAULT_THROUGHPUT_CAP_BYTES = 64 << 20
+
+
+def size_label(size: int) -> str:
+    """Human-readable size label, e.g. 1024 -> '1 KiB'."""
+    units = [(1 << 30, "GiB"), (1 << 20, "MiB"), (1 << 10, "KiB")]
+    for scale, name in units:
+        if size >= scale and size % scale == 0:
+            return f"{size // scale} {name}"
+    return f"{size} B"
+
+
+def metric_by_key(key: str) -> dict[str, object]:
+    for m in METRICS:
+        if m["key"] == key:
+            return m
+    raise KeyError(key)

--- a/monarch_mini/python/bench/bench_worker.py
+++ b/monarch_mini/python/bench/bench_worker.py
@@ -1,0 +1,310 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Subprocess worker for the minimonarch round-trip benchmarks.
+
+The orchestrator (``run_bench.py``) launches one or more of these per topology.
+Exactly one of them plays the *sender* role: it builds its slice of the
+topology, warms the path up, then measures all four metrics across every
+message size and prints the results as a single JSON line on stdout. The other
+roles (parent / host / receiver / process managers) just stand up their part of
+the tree and either echo (receiver) or idle (structural actors) until the
+orchestrator kills them.
+
+Usage:
+    python bench_worker.py <config-json>
+
+where ``<config-json>`` is the JSON produced by the orchestrator describing the
+topology, this process's role, the urls to use, and the workload parameters.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import time
+
+import minimonarch
+from minimonarch import Actor
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bench_common import RECEIVER, RESULT_MARKER, SENDER  # noqa: E402
+
+ba = minimonarch.bytearray
+
+# A small, fixed payload used only to warm the path up before timing.
+_WARMUP_SIZE = 64
+
+
+# ---------------------------------------------------------------------------
+# Receiver: echo every data message straight back to its return id.
+# ---------------------------------------------------------------------------
+async def _echo_forever(actor: Actor) -> None:
+    """Echo loop: each data message is ``[return_id, payload...]``; send the
+    payload parts straight back to ``return_id``. The payload bytearrays are
+    *moved* back into the reply, so no payload bytes are copied here."""
+    while True:
+        parts = await actor.next()
+        return_id = parts[0].tobytes()
+        actor.send(return_id, parts[1:])
+
+
+async def _consume_hellos(actor: Actor, n: int) -> None:
+    """Drain the ``n`` connection-established (``[self, other]``) messages that
+    a freshly connected actor receives, so later ``next()`` calls only ever see
+    data messages."""
+    for _ in range(n):
+        await actor.next()
+
+
+# ---------------------------------------------------------------------------
+# Sender: warm up, then measure.
+# ---------------------------------------------------------------------------
+async def _warmup(sender: Actor, deadline_s: float) -> None:
+    """Resend a probe to the receiver until it echoes back, establishing that
+    the full s -> r -> s path is live, then drain any duplicate echoes that the
+    retries may have produced so timed iterations start from a clean queue."""
+    loop = asyncio.get_running_loop()
+    start = loop.time()
+    while True:
+        sender.send(RECEIVER, [ba(SENDER), ba(_WARMUP_SIZE)])
+        try:
+            await asyncio.wait_for(sender.next(), 0.5)
+            break
+        except asyncio.TimeoutError:
+            if loop.time() - start > deadline_s:
+                raise TimeoutError("benchmark path never became reachable")
+    while True:  # drain duplicates
+        try:
+            await asyncio.wait_for(sender.next(), 0.1)
+        except asyncio.TimeoutError:
+            break
+
+
+async def _measure_latency(
+    sender: Actor, size: int, iters: int, monitor: bool
+) -> list[float]:
+    """Return ``iters`` samples of round-trip latency in microseconds. One
+    payload buffer ping-pongs so there is no per-iteration payload allocation.
+    When ``monitor`` is set, each round trip is wrapped in a
+    ``monitor(r)`` / ``cancel()`` pair and that cost is included in the sample."""
+    payload = ba(size)
+    # Prime: one untimed round trip to settle the buffer reuse.
+    sender.send(RECEIVER, [ba(SENDER), payload])
+    payload = (await sender.next())[0]
+
+    samples: list[float] = []
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        handle = sender.monitor(RECEIVER, failure=[ba(b"F")]) if monitor else None
+        sender.send(RECEIVER, [ba(SENDER), payload])
+        msg = await sender.next()
+        if handle is not None:
+            handle.cancel()
+        t1 = time.perf_counter()
+        payload = msg[0]
+        samples.append((t1 - t0) * 1e6)
+    return samples
+
+
+async def _measure_throughput(
+    sender: Actor, size: int, reps: int, n: int, cap_bytes: int, monitor: bool
+) -> list[dict[str, float]]:
+    """Return ``reps`` throughput samples. Each rep fires ``n`` messages
+    back-to-back, then awaits ``n`` replies; ``n`` is capped so n*size stays
+    under ``cap_bytes``. When ``monitor`` is set, every message gets its own
+    ``monitor(r)`` before send and its handle is cancelled after the replies."""
+    n = max(1, min(n, cap_bytes // max(size, 1)))
+    bufs = [ba(size) for _ in range(n)]
+
+    samples: list[dict[str, float]] = []
+    for _ in range(reps):
+        handles = []
+        t0 = time.perf_counter()
+        for i in range(n):
+            if monitor:
+                handles.append(sender.monitor(RECEIVER, failure=[ba(b"F")]))
+            sender.send(RECEIVER, [ba(SENDER), bufs[i]])
+        replies = [await sender.next() for _ in range(n)]
+        for handle in handles:
+            handle.cancel()
+        t1 = time.perf_counter()
+
+        bufs = [r[0] for r in replies]  # reuse echoed buffers next rep
+        elapsed = t1 - t0
+        samples.append(
+            {
+                "n": float(n),
+                "elapsed_s": elapsed,
+                "msgs_per_s": n / elapsed if elapsed else 0.0,
+                "gb_per_s": (n * size / elapsed) / 1e9 if elapsed else 0.0,
+            }
+        )
+    return samples
+
+
+async def _run_sender(sender: Actor, cfg: dict) -> dict:
+    """Run all four metrics across all sizes and return the results dict."""
+    await _warmup(sender, deadline_s=60.0)
+
+    sizes: list[int] = cfg["sizes"]
+    results: dict[str, dict] = {}
+
+    for size in sizes:
+        results.setdefault("latency", {})[size] = await _measure_latency(
+            sender, size, cfg["latency_iters"], monitor=False
+        )
+        results.setdefault("monitor_latency", {})[size] = await _measure_latency(
+            sender, size, cfg["latency_iters"], monitor=True
+        )
+        results.setdefault("throughput", {})[size] = await _measure_throughput(
+            sender,
+            size,
+            cfg["throughput_reps"],
+            cfg["throughput_n"],
+            cfg["throughput_cap_bytes"],
+            monitor=False,
+        )
+        results.setdefault("monitor_throughput", {})[size] = await _measure_throughput(
+            sender,
+            size,
+            cfg["throughput_reps"],
+            cfg["throughput_n"],
+            cfg["throughput_cap_bytes"],
+            monitor=True,
+        )
+    return {"topology": cfg["topology"], "results": results}
+
+
+# ---------------------------------------------------------------------------
+# Topology setup. Each role builds its actors and either measures (sender),
+# echoes (receiver), or idles (structural actors) until killed.
+# ---------------------------------------------------------------------------
+async def _idle_forever() -> None:
+    while True:
+        await asyncio.sleep(3600)
+
+
+async def role_sender_inproc(cfg: dict) -> dict:
+    """Topology (a): one process hosts parent p plus inproc children s and r.
+    r's echo loop runs as a background task while s measures."""
+    parent = Actor(b"p")
+    sender = Actor(SENDER)
+    receiver = Actor(RECEIVER)
+
+    parent.serve("inproc://bench-p-s", "parent")
+    sender.join("inproc://bench-p-s", "child")
+    parent.serve("inproc://bench-p-r", "parent")
+    receiver.join("inproc://bench-p-r", "child")
+
+    await _consume_hellos(parent, 2)
+    await _consume_hellos(sender, 1)
+    await _consume_hellos(receiver, 1)
+
+    echo = asyncio.ensure_future(_echo_forever(receiver))
+    try:
+        return await _run_sender(sender, cfg)
+    finally:
+        echo.cancel()
+
+
+async def role_parent(cfg: dict) -> None:
+    """Topology (b): the common parent p, serving both children over unix."""
+    parent = Actor(b"p")
+    parent.serve(cfg["urls"]["sender"], "parent")
+    parent.serve(cfg["urls"]["receiver"], "parent")
+    await _idle_forever()
+
+
+async def role_receiver(cfg: dict) -> None:
+    """Topology (b): receiver r, a unix child of p, echoing forever."""
+    receiver = Actor(RECEIVER)
+    receiver.join(cfg["urls"]["receiver"], "child")
+    await _consume_hellos(receiver, 1)
+    await _echo_forever(receiver)
+
+
+async def role_sender(cfg: dict) -> dict:
+    """Topology (b): sender s, a unix child of p."""
+    sender = Actor(SENDER)
+    sender.join(cfg["urls"]["sender"], "child")
+    await _consume_hellos(sender, 1)
+    return await _run_sender(sender, cfg)
+
+
+async def role_host(cfg: dict) -> None:
+    """Topology (c): host manager h (root), serving both process managers."""
+    host = Actor(b"h")
+    host.serve(cfg["urls"]["p0"], "parent")
+    host.serve(cfg["urls"]["p1"], "parent")
+    await _idle_forever()
+
+
+async def role_pm_receiver(cfg: dict) -> None:
+    """Topology (c): process manager p1 (unix child of h) plus its inproc
+    child receiver r, which echoes forever."""
+    pm = Actor(b"p1")
+    pm.join(cfg["urls"]["p1"], "child")
+    await _consume_hellos(pm, 1)
+
+    receiver = Actor(RECEIVER)
+    pm.serve("inproc://bench-p1-r", "parent")
+    receiver.join("inproc://bench-p1-r", "child")
+    await _consume_hellos(pm, 1)
+    await _consume_hellos(receiver, 1)
+
+    await _echo_forever(receiver)
+
+
+async def role_pm_sender(cfg: dict) -> dict:
+    """Topology (c): process manager p0 (unix child of h) plus its inproc child
+    sender s, which measures."""
+    pm = Actor(b"p0")
+    pm.join(cfg["urls"]["p0"], "child")
+    await _consume_hellos(pm, 1)
+
+    sender = Actor(SENDER)
+    pm.serve("inproc://bench-p0-s", "parent")
+    sender.join("inproc://bench-p0-s", "child")
+    await _consume_hellos(pm, 1)
+    await _consume_hellos(sender, 1)
+
+    return await _run_sender(sender, cfg)
+
+
+_ROLES = {
+    "sender": role_sender_inproc,  # remapped below per topology
+    "parent": role_parent,
+    "receiver": role_receiver,
+    "host": role_host,
+    "pm_receiver": role_pm_receiver,
+    "pm_sender": role_pm_sender,
+}
+
+
+def _resolve_role(cfg: dict):
+    """``sender`` means the inproc all-in-one role for topology (a) but the
+    unix-child role for topology (b); disambiguate on the topology key."""
+    role = cfg["role"]
+    if role == "sender":
+        return role_sender_inproc if cfg["topology"] == "inproc" else role_sender
+    return _ROLES[role]
+
+
+async def _main(cfg: dict) -> None:
+    coro = _resolve_role(cfg)(cfg)
+    out = await coro
+    if out is not None:  # a sender role produced results
+        sys.stdout.write(RESULT_MARKER + json.dumps(out) + "\n")
+        sys.stdout.flush()
+    minimonarch.close()
+
+
+if __name__ == "__main__":
+    config = json.loads(sys.argv[1])
+    asyncio.run(_main(config))

--- a/monarch_mini/python/bench/report/index.md
+++ b/monarch_mini/python/bench/report/index.md
@@ -1,0 +1,61 @@
+# minimonarch round-trip benchmarks
+
+Each cell is the median over all samples for that message size.
+
+## Topologies
+
+- **(a) in-process, common inproc parent** — s and r live in one process/context, both inproc children of a common parent p.
+- **(b) two processes, common unix parent** — s and r are in separate processes, each an inproc-free child of a common parent p (third process) over unix://.
+- **(c) process/host manager** — s -inproc-> p0 -unix-> h <-unix- p1 <-inproc- r. h is a host manager; p0/p1 are process managers.
+
+## Round-trip latency (us)
+
+_median us per size_
+
+| size | inproc | unix | manager |
+| --- | --- | --- | --- |
+| 64 B | 37 | 228 | 203 |
+| 1 KiB | 36 | 205 | 233 |
+| 16 KiB | 32.2 | 227 | 204 |
+| 256 KiB | 31.5 | 498 | 502 |
+| 1 MiB | 35.4 | 1.33e+03 | 1.3e+03 |
+| 16 MiB | 32.2 | 1.6e+04 | 1.64e+04 |
+
+## Round-trip throughput (GB/s)
+
+_median GB/s per size_
+
+| size | inproc | unix | manager |
+| --- | --- | --- | --- |
+| 64 B | 0.00643 | 0.00204 | 0.00137 |
+| 1 KiB | 0.0963 | 0.0308 | 0.0288 |
+| 16 KiB | 2.3 | 0.33 | 0.318 |
+| 256 KiB | 36.8 | 0.749 | 0.733 |
+| 1 MiB | 141 | 0.981 | 0.871 |
+| 16 MiB | 1.01e+03 | 0.56 | 0.594 |
+
+## Round-trip latency w/ subscribe+unsubscribe (us)
+
+_median us per size_
+
+| size | inproc | unix | manager |
+| --- | --- | --- | --- |
+| 64 B | 43 | 226 | 215 |
+| 1 KiB | 41.1 | 200 | 249 |
+| 16 KiB | 36.1 | 208 | 213 |
+| 256 KiB | 34.1 | 510 | 524 |
+| 1 MiB | 45.1 | 1.28e+03 | 1.3e+03 |
+| 16 MiB | 35.3 | 1.68e+04 | 1.51e+04 |
+
+## Round-trip throughput w/ subscribe+unsubscribe (GB/s)
+
+_median GB/s per size_
+
+| size | inproc | unix | manager |
+| --- | --- | --- | --- |
+| 64 B | 0.00401 | 0.00144 | 0.00102 |
+| 1 KiB | 0.0779 | 0.0213 | 0.0159 |
+| 16 KiB | 1.32 | 0.266 | 0.255 |
+| 256 KiB | 14.5 | 0.83 | 0.782 |
+| 1 MiB | 78.6 | 0.918 | 0.906 |
+| 16 MiB | 634 | 0.52 | 0.577 |

--- a/monarch_mini/python/bench/run_bench.py
+++ b/monarch_mini/python/bench/run_bench.py
@@ -1,0 +1,296 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Orchestrate the minimonarch round-trip benchmarks and build a Markdown report.
+
+For each topology this launches the required helper processes (parent / host /
+receiver / process managers) and then the sender process, which measures all
+four metrics across every message size and prints its results as JSON. The
+collected numbers are written to ``results.json`` and summarized as one median
+table per metric in an ``index.md`` report.
+
+Run it under uv so the worker subprocesses inherit an interpreter that can
+import the built minimonarch extension:
+
+    uv run python bench/run_bench.py
+    uv run python bench/run_bench.py --quick           # tiny, fast smoke run
+    uv run python bench/run_bench.py --report-only      # rebuild report from results.json
+
+The four metrics:
+  1. latency             - round-trip latency, one message in flight.
+  2. throughput          - round-trip throughput, many messages in flight.
+  3. monitor_latency     - latency with subscribe(r) before / unsubscribe after each round trip.
+  4. monitor_throughput  - throughput with a per-message subscribe / unsubscribe.
+
+The three topologies are described in bench_common.TOPOLOGIES.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bench_common import (  # noqa: E402
+    DEFAULT_LATENCY_ITERS,
+    DEFAULT_SIZES,
+    DEFAULT_THROUGHPUT_CAP_BYTES,
+    DEFAULT_THROUGHPUT_N,
+    DEFAULT_THROUGHPUT_REPS,
+    metric_by_key,
+    METRICS,
+    RESULT_MARKER,
+    size_label,
+    TOPOLOGIES,
+)
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_WORKER = os.path.join(_HERE, "bench_worker.py")
+
+
+# ---------------------------------------------------------------------------
+# Running one topology.
+# ---------------------------------------------------------------------------
+def _topology_urls(topology: str, sockdir: str) -> dict[str, str]:
+    """The unix socket urls each role uses. inproc needs none."""
+    if topology == "unix":
+        return {
+            "sender": f"unix://{sockdir}/s.sock",
+            "receiver": f"unix://{sockdir}/r.sock",
+        }
+    if topology == "manager":
+        return {
+            "p0": f"unix://{sockdir}/p0.sock",
+            "p1": f"unix://{sockdir}/p1.sock",
+        }
+    return {}
+
+
+def _spawn(cfg: dict, capture: bool) -> subprocess.Popen:
+    """Launch one worker process with its JSON config."""
+    return subprocess.Popen(
+        [sys.executable, _WORKER, json.dumps(cfg)],
+        stdout=subprocess.PIPE if capture else None,
+        stderr=subprocess.PIPE if capture else None,
+        text=True,
+    )
+
+
+def _kill(proc: subprocess.Popen) -> None:
+    if proc.poll() is None:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+
+def run_topology(topology: dict, base_cfg: dict, timeout_s: float) -> dict:
+    """Spawn the helpers and the sender for one topology; return the sender's
+    parsed results dict."""
+    key = topology["key"]
+    sockdir = tempfile.mkdtemp(prefix=f"mm-bench-{key}-")
+    try:
+        urls = _topology_urls(key, sockdir)
+        cfg = {**base_cfg, "topology": key, "urls": urls}
+
+        helpers = [
+            _spawn({**cfg, "role": r}, capture=False) for r in topology["helper_roles"]
+        ]
+        time.sleep(0.2)  # let helpers bind before the sender warms up
+        sender = _spawn({**cfg, "role": topology["sender_role"]}, capture=True)
+        try:
+            out, err = sender.communicate(timeout=timeout_s)
+        except subprocess.TimeoutExpired:
+            sender.kill()
+            out, err = sender.communicate()
+            raise RuntimeError(f"[{key}] sender timed out after {timeout_s}s\n{err}")
+        finally:
+            for h in helpers:
+                _kill(h)
+
+        if sender.returncode != 0:
+            raise RuntimeError(f"[{key}] sender exited {sender.returncode}\n{err}")
+
+        for line in out.splitlines():
+            if line.startswith(RESULT_MARKER):
+                return json.loads(line[len(RESULT_MARKER) :])
+        raise RuntimeError(f"[{key}] no results line in sender stdout\n{out}\n{err}")
+    finally:
+        shutil.rmtree(sockdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Extracting samples.
+# ---------------------------------------------------------------------------
+def _samples_for(metric_key: str, size_results: list) -> list[float]:
+    """Pull the samples for one size out of the worker's records. For latency
+    metrics the records are already the per-iter microsecond samples; for
+    throughput metrics each record is a dict and we report GB/s."""
+    if metric_by_key(metric_key)["throughput"]:
+        return [rec["gb_per_s"] for rec in size_results]
+    return list(size_results)
+
+
+def _median(values: list[float]) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    mid = len(s) // 2
+    return s[mid] if len(s) % 2 else (s[mid - 1] + s[mid]) / 2
+
+
+# ---------------------------------------------------------------------------
+# Report.
+# ---------------------------------------------------------------------------
+def _medians_per_size(
+    metric_key: str, topology_key: str, collected: dict
+) -> dict[int, float]:
+    """Median value per message size for one (metric, topology), or {} if the
+    topology was not run / has no data."""
+    blob = collected.get(topology_key)
+    if not blob:
+        return {}
+    per_size = blob["results"].get(metric_key, {})
+    medians: dict[int, float] = {}
+    for size_key, samples in per_size.items():
+        ys = _samples_for(metric_key, samples)
+        if ys:
+            medians[int(size_key)] = _median(ys)
+    return medians
+
+
+def build_report(collected: dict, out_dir: str) -> None:
+    """Render the median summary tables (one per metric) into index.md."""
+    md = _render_markdown(collected)
+    with open(os.path.join(out_dir, "index.md"), "w") as f:
+        f.write(md)
+    print(f"report: {os.path.join(out_dir, 'index.md')}")
+
+
+def _render_markdown(collected: dict) -> str:
+    lines: list[str] = [
+        "# minimonarch round-trip benchmarks",
+        "",
+        "Each cell is the median over all samples for that message size.",
+        "",
+        "## Topologies",
+        "",
+    ]
+    for topo in TOPOLOGIES:
+        suffix = "" if topo["key"] in collected else " _(not run)_"
+        lines.append(f"- **{topo['title']}** — {topo['blurb']}{suffix}")
+    lines.append("")
+
+    for metric in METRICS:
+        lines.append(f"## {metric['title']} ({metric['unit']})")
+        lines.append("")
+        lines.append(_median_table(metric, collected))
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def _median_table(metric: dict, collected: dict) -> str:
+    per_topo = {
+        topo["key"]: _medians_per_size(metric["key"], topo["key"], collected)
+        for topo in TOPOLOGIES
+    }
+    sizes: set[int] = set()
+    for medians in per_topo.values():
+        sizes |= set(medians)
+    if not sizes:
+        return "_no data_"
+
+    header = "| size | " + " | ".join(t["key"] for t in TOPOLOGIES) + " |"
+    sep = "| --- | " + " | ".join("---" for _ in TOPOLOGIES) + " |"
+    rows = [f"_median {metric['unit']} per size_", "", header, sep]
+    for size in sorted(sizes):
+        cols = []
+        for topo in TOPOLOGIES:
+            med = per_topo[topo["key"]].get(size)
+            cols.append(f"{med:.3g}" if med is not None else "—")
+        rows.append(f"| {size_label(size)} | " + " | ".join(cols) + " |")
+    return "\n".join(rows)
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--out", default=os.path.join(_HERE, "report"), help="output dir")
+    ap.add_argument(
+        "--sizes",
+        type=int,
+        nargs="+",
+        default=DEFAULT_SIZES,
+        help="message sizes in bytes",
+    )
+    ap.add_argument("--latency-iters", type=int, default=DEFAULT_LATENCY_ITERS)
+    ap.add_argument("--throughput-reps", type=int, default=DEFAULT_THROUGHPUT_REPS)
+    ap.add_argument("--throughput-n", type=int, default=DEFAULT_THROUGHPUT_N)
+    ap.add_argument(
+        "--throughput-cap-bytes", type=int, default=DEFAULT_THROUGHPUT_CAP_BYTES
+    )
+    ap.add_argument("--topologies", nargs="+", default=[t["key"] for t in TOPOLOGIES])
+    ap.add_argument(
+        "--timeout", type=float, default=900.0, help="per-topology sender timeout (s)"
+    )
+    ap.add_argument("--quick", action="store_true", help="tiny fast run (smoke test)")
+    ap.add_argument(
+        "--report-only",
+        action="store_true",
+        help="rebuild report from existing results.json",
+    )
+    args = ap.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+    results_path = os.path.join(args.out, "results.json")
+
+    if args.report_only:
+        with open(results_path) as f:
+            collected = json.load(f)
+        build_report(collected, args.out)
+        return
+
+    if args.quick:
+        args.sizes = [64, 1 << 12, 1 << 16]
+        args.latency_iters = 10
+        args.throughput_reps = 3
+        args.throughput_n = 20
+
+    base_cfg = {
+        "sizes": args.sizes,
+        "latency_iters": args.latency_iters,
+        "throughput_reps": args.throughput_reps,
+        "throughput_n": args.throughput_n,
+        "throughput_cap_bytes": args.throughput_cap_bytes,
+    }
+
+    collected: dict[str, dict] = {}
+    for topo in TOPOLOGIES:
+        if topo["key"] not in args.topologies:
+            continue
+        print(f"==> {topo['key']}: {topo['title']}")
+        t0 = time.perf_counter()
+        collected[topo["key"]] = run_topology(topo, base_cfg, args.timeout)
+        print(f"    done in {time.perf_counter() - t0:.1f}s")
+        with open(results_path, "w") as f:  # checkpoint after each topology
+            json.dump(collected, f, indent=2)
+
+    build_report(collected, args.out)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* __->__ #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add a Python benchmark harness that measures minimonarch round-trip latency and throughput, with and without monitoring, across in-process, Unix-socket, and manager topologies. Record raw results and generate a Markdown report of median measurements by topology and message size.

Differential Revision: [D114750240](https://our.internmc.facebook.com/intern/diff/D114750240/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750240/)!