### PR TITLE
11/43 minimonarch: Deduplicate and debounce monitor subscriptions

### DIFF
--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -28,13 +28,33 @@ pub(crate) struct ActorEntry {
     /// buffered message when this actor gains a parent, and one on a `Connection`
     /// route fires when that route transitions to `Dead`.
     pub(crate) routes: HashMap<Vec<u8>, Route>,
-    /// Monitors this actor *created* (it is the monitoring/`dest` side). Keyed by
-    /// monitor id so they can be fired locally and cancelled. The failure_prefix
-    /// stays here and never travels — the responsible ancestor only sends back
-    /// `id` and we reconstruct the full failure message from this.
-    pub(crate) monitors: HashMap<u64, LocalMonitor>,
+    /// Monitors this actor *created* (it is the monitoring/`dest` side), grouped by
+    /// the *monitored target* ident. All of an actor's monitors on one target share
+    /// a single upstream subscription: the first creates it, the rest just join,
+    /// and they all fire together when that target dies (a fire carries only the
+    /// dead ident — no per-monitor id is needed on the wire). The matching
+    /// `Unsubscribe` is debounced via [`TargetMonitors::unsub_timer`], so rapid
+    /// monitor/cancel churn on one target sends no per-cycle traffic.
+    pub(crate) monitored: HashMap<Vec<u8>, TargetMonitors>,
     pub(crate) gateway: bool,
     pub(crate) alive: bool,
+}
+
+/// State of this actor's monitoring of one target ident. The variant *is* the
+/// state — no generation bookkeeping — so a debounced unsubscribe is correct by
+/// construction: re-monitoring aborts the pending task and flips back to
+/// `Active`, and the timer's command only acts if the entry is still
+/// `PendingUnsubscribe` when it is processed.
+pub(crate) enum TargetMonitors {
+    /// Live local monitors: monitor id → its failure-message prefix. The prefix
+    /// never travels; the full message is reconstructed here when the target
+    /// dies. (For an unnamed actor these are recorded but the upstream `Subscribe`
+    /// is held until naming.)
+    Active(HashMap<u64, Vec<MsgPart>>),
+    /// Every monitor on this target was cancelled; the upstream subscription is
+    /// still live, but a debounced unsubscribe task is scheduled. Holds that
+    /// task's abort handle so re-monitoring (or a fire) cancels it.
+    PendingUnsubscribe(tokio::task::AbortHandle),
 }
 
 impl ActorEntry {
@@ -47,7 +67,7 @@ impl ActorEntry {
             parent: None,
             children: SlotMap::with_key(),
             routes: HashMap::new(),
-            monitors: HashMap::new(),
+            monitored: HashMap::new(),
             gateway: true,
             alive: true,
         }
@@ -175,29 +195,21 @@ impl Route {
     }
 }
 
-/// A monitor created by this actor (the monitoring/`dest` side). Held until the
-/// monitored actor dies or the monitor is cancelled.
-pub(crate) struct LocalMonitor {
-    pub(crate) to_monitor: Vec<u8>,
-    pub(crate) failure_prefix: Vec<MsgPart>,
-}
-
 /// A subscription held at the responsible common ancestor `R`: when the watched
-/// ident dies, route a fire to `dest` carrying `id`.
+/// ident dies, route a fire down to `dest` (the monitoring actor). One per
+/// monitoring actor per target — the dead ident itself identifies the fire, so
+/// no per-monitor id is carried.
 pub(crate) struct MonitorSub {
     pub(crate) dest: Vec<u8>,
-    pub(crate) id: u64,
 }
 
 /// An actor's ident, which may not be known at creation (a child can be named by
 /// its parent when it joins).
 pub(crate) enum ActorName {
     /// Not named yet. Monitors created in the meantime cannot address their
-    /// fire-backs (which route to this actor's own ident), so they wait here until
-    /// a name is assigned, then subscribe for real.
-    Unknown {
-        pending_monitors: Vec<PendingMonitor>,
-    },
+    /// fire-backs (which route to this actor's own ident), so their upstream
+    /// `Subscribe` is held (in `monitored`) until a name is assigned, then sent.
+    Unknown {},
     Named(Vec<u8>),
 }
 
@@ -205,17 +217,9 @@ impl ActorName {
     pub(crate) fn new(ident: Option<Vec<u8>>) -> Self {
         match ident {
             Some(name) => ActorName::Named(name),
-            None => ActorName::Unknown {
-                pending_monitors: Vec::new(),
-            },
+            None => ActorName::Unknown {},
         }
     }
-}
-
-/// A monitor whose subscription was deferred until its creating actor is named.
-pub(crate) struct PendingMonitor {
-    pub(crate) id: u64,
-    pub(crate) to_monitor: Vec<u8>,
 }
 
 pub(crate) enum Delivery {

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -132,25 +132,24 @@ pub(crate) enum ConnectionCommand {
     },
     /// Register a monitor: travels up from the monitoring actor until it reaches
     /// the common ancestor that has `to_monitor` in its routing table (or the
-    /// root). That ancestor records the subscription.
+    /// root). That ancestor records the subscription (one per monitoring actor per
+    /// target — no per-monitor id, since a fire is identified by the dead ident).
     Subscribe {
         dest: Vec<u8>,
-        id: u64,
         to_monitor: Vec<u8>,
     },
     /// Cancel a previously-registered monitor; travels the same path as
     /// [`ConnectionCommand::Subscribe`] and removes the subscription.
     Unsubscribe {
         dest: Vec<u8>,
-        id: u64,
         to_monitor: Vec<u8>,
     },
     /// Deliver a monitor firing toward the monitoring actor `dest_ident`. Routed
-    /// like a normal message; on arrival the owner reconstructs the failure
-    /// message from its local failure_prefix (the reason is a fixed "actor died").
+    /// like a normal message; carries the dead target ident so the owner can fan
+    /// the fire out to every local monitor on it (reason is a fixed "actor died").
     FireMonitor {
         dest_ident: Vec<u8>,
-        monitor_id: u64,
+        to_monitor: Vec<u8>,
     },
 }
 

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -12,6 +12,7 @@ use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
 use std::thread;
 use std::thread::JoinHandle;
+use std::time::Duration;
 
 use slotmap::SlotMap;
 use slotmap::new_key_type;
@@ -23,10 +24,9 @@ use crate::Role;
 use crate::actor::ActorEntry;
 use crate::actor::ActorName;
 use crate::actor::Delivery;
-use crate::actor::LocalMonitor;
 use crate::actor::MonitorSub;
-use crate::actor::PendingMonitor;
 use crate::actor::Route;
+use crate::actor::TargetMonitors;
 use crate::connection::ConnectRequest;
 use crate::connection::Connection;
 use crate::connection::ConnectionCommand;
@@ -53,6 +53,12 @@ new_key_type! {
     pub(crate) struct PollerKey;
     pub(crate) struct ChildConnectionKey;
 }
+
+/// Grace period before a target's debounced `Unsubscribe` actually goes out. A
+/// monitor recreated on the same target within this window reuses the still-live
+/// upstream subscription, so churn (e.g. per-message monitor/cancel) sends no
+/// subscribe/unsubscribe traffic.
+const MONITOR_DEBOUNCE: Duration = Duration::from_millis(25);
 
 pub(crate) enum Command {
     Init {
@@ -127,6 +133,14 @@ pub(crate) enum Command {
         actor: Key,
         id: u64,
     },
+    // Fired by a debounce timer: if `to_monitor` is still `PendingUnsubscribe`
+    // (i.e. it was not re-monitored in the grace window), send the upstream
+    // `Unsubscribe` now and drop the entry. Otherwise it is `Active` again (or
+    // gone) and we keep the subscription.
+    UnsubscribeMonitor {
+        actor: Key,
+        to_monitor: Vec<u8>,
+    },
     Shutdown {
         done: oneshot::Sender<JoinHandle<()>>,
     },
@@ -142,6 +156,9 @@ struct Ctx {
     inproc: InprocTransport,
     unix: UnixTransport,
     quic: QuicTransport,
+    // A clone of the loop sender, used to schedule debounced monitor unsubscribes
+    // back onto the event loop after a grace period.
+    loop_tx: mpsc::UnboundedSender<Command>,
     thread: Option<JoinHandle<()>>,
     _not_send: PhantomData<*const ()>,
 }
@@ -153,7 +170,8 @@ impl Ctx {
             pollers: SlotMap::with_key(),
             inproc: InprocTransport::new(tx.clone()),
             unix: UnixTransport::new(tx.clone()),
-            quic: QuicTransport::new(tx),
+            quic: QuicTransport::new(tx.clone()),
+            loop_tx: tx,
             thread: None,
             _not_send: PhantomData,
         }
@@ -273,40 +291,13 @@ impl Ctx {
                 failure_prefix,
             } => {
                 let to_monitor = to_monitor.as_bytes().to_vec();
-                self.actor_mut(actor).monitors.insert(
-                    id,
-                    LocalMonitor {
-                        to_monitor: to_monitor.clone(),
-                        failure_prefix,
-                    },
-                );
-                // The fire is addressed by our own ident. If we are not named yet,
-                // defer the subscription until a name is assigned (a join will); the
-                // local record above still lets us cancel it meanwhile.
-                let dest = match &mut self.actor_mut(actor).name {
-                    ActorName::Named(name) => name.clone(),
-                    ActorName::Unknown { pending_monitors } => {
-                        pending_monitors.push(PendingMonitor { id, to_monitor });
-                        return;
-                    }
-                };
-                self.route_subscribe(actor, dest, id, to_monitor);
+                self.monitor_add(actor, id, to_monitor, failure_prefix);
             }
             Command::CancelMonitor { actor, id } => {
-                // Drop the local record (so an in-flight fire is dropped on arrival).
-                let Some(local) = self.actor_mut(actor).monitors.remove(&id) else {
-                    return;
-                };
-                // If we are named the subscription was propagated upstream, so walk an
-                // unsubscribe up; otherwise it is still in our deferred list, drop it.
-                let dest = match &mut self.actor_mut(actor).name {
-                    ActorName::Named(name) => name.clone(),
-                    ActorName::Unknown { pending_monitors } => {
-                        pending_monitors.retain(|pending| pending.id != id);
-                        return;
-                    }
-                };
-                self.route_unsubscribe(actor, dest, id, local.to_monitor);
+                self.monitor_remove(actor, id);
+            }
+            Command::UnsubscribeMonitor { actor, to_monitor } => {
+                self.unsubscribe_monitor(actor, to_monitor);
             }
             Command::Shutdown { .. } => {
                 // Handled directly by the event loop (see CtxHandle::new) so it
@@ -607,13 +598,15 @@ impl Ctx {
         // re-kill there). Keep only those that newly transitioned so propagation
         // can't loop, firing the monitors that were waiting on each.
         let mut newly_dead = Vec::new();
-        let mut to_fire: Vec<MonitorSub> = Vec::new();
+        // Each fire is the dead ident paired with a subscriber's `dest`.
+        let mut to_fire: Vec<(Vec<u8>, Vec<u8>)> = Vec::new();
         for ident in dead {
             let routes = &mut self.actor_mut(parent).routes;
             match routes.get_mut(&ident) {
                 Some(Route::Dead) => continue, // already dead
                 Some(route) => {
-                    to_fire.extend(route.monitors_mut().map(std::mem::take).unwrap_or_default());
+                    let subs = route.monitors_mut().map(std::mem::take).unwrap_or_default();
+                    to_fire.extend(subs.into_iter().map(|sub| (sub.dest, ident.clone())));
                     *route = Route::Dead;
                 }
                 None => {
@@ -622,8 +615,8 @@ impl Ctx {
             }
             newly_dead.push(ident);
         }
-        for sub in to_fire {
-            self.route_fire_monitor(parent, sub.dest, sub.id);
+        for (dest, to_monitor) in to_fire {
+            self.route_fire_monitor(parent, dest, to_monitor);
         }
 
         // Forward both the live and the newly-dead idents up to the parent.
@@ -677,7 +670,7 @@ impl Ctx {
                                 self.route_message(ofactor, ident.clone(), parts);
                             }
                             for sub in monitors {
-                                self.route_subscribe(ofactor, sub.dest, sub.id, ident.clone());
+                                self.route_subscribe(ofactor, sub.dest, ident.clone());
                             }
                         }
                     }
@@ -726,25 +719,17 @@ impl Ctx {
                 };
                 self.populate_routes(ofactor, slot, live, dead);
             }
-            ConnectionCommand::Subscribe {
-                dest,
-                id,
-                to_monitor,
-            } => {
-                self.route_subscribe(connection.owning_actor(), dest, id, to_monitor);
+            ConnectionCommand::Subscribe { dest, to_monitor } => {
+                self.route_subscribe(connection.owning_actor(), dest, to_monitor);
             }
-            ConnectionCommand::Unsubscribe {
-                dest,
-                id,
-                to_monitor,
-            } => {
-                self.route_unsubscribe(connection.owning_actor(), dest, id, to_monitor);
+            ConnectionCommand::Unsubscribe { dest, to_monitor } => {
+                self.route_unsubscribe(connection.owning_actor(), dest, to_monitor);
             }
             ConnectionCommand::FireMonitor {
                 dest_ident,
-                monitor_id,
+                to_monitor,
             } => {
-                self.route_fire_monitor(connection.owning_actor(), dest_ident, monitor_id);
+                self.route_fire_monitor(connection.owning_actor(), dest_ident, to_monitor);
             }
         }
     }
@@ -939,26 +924,166 @@ impl Ctx {
 
     // -- Monitors ---------------------------------------------------------------
 
-    /// Assign `name` to `actor` (a no-op if already named) and replay any monitor
+    /// Assign `name` to `actor` (a no-op if already named) and send any target
     /// subscriptions that were deferred while it was unnamed — now they have a
     /// fire-back address. The connection that carried the name must already be
-    /// established so the replayed subscriptions can route up.
+    /// established so the deferred subscriptions can route up.
     fn assign_name(&mut self, actor: Key, name: Vec<u8>) {
         let entry = self.actor_mut(actor);
-        let pending = match &mut entry.name {
-            ActorName::Named(_) => return, // already named; nothing was deferred
-            ActorName::Unknown { pending_monitors } => std::mem::take(pending_monitors),
-        };
-        entry.name = ActorName::Named(name.clone());
-        for monitor in pending {
-            self.route_subscribe(actor, name.clone(), monitor.id, monitor.to_monitor);
+        if matches!(entry.name, ActorName::Named(_)) {
+            return; // already named; nothing was deferred
         }
+        entry.name = ActorName::Named(name.clone());
+        // Everything watched while unnamed has its subscription held back; send
+        // them all now. An unnamed actor only ever holds `Active` entries (an
+        // emptied target is removed, never left `PendingUnsubscribe`), so every
+        // one needs exactly one upstream `Subscribe`.
+        let deferred: Vec<Vec<u8>> = entry.monitored.keys().cloned().collect();
+        for to_monitor in deferred {
+            self.route_subscribe(actor, name.clone(), to_monitor);
+        }
+    }
+
+    /// Add a local monitor (`id`, `failure_prefix`) on `to_monitor`. The first
+    /// monitor for a target sends one upstream `Subscribe` (deferred until named).
+    /// Joining an `Active` target, or re-monitoring a `PendingUnsubscribe` one
+    /// (whose subscription is still live — we abort its pending unsubscribe),
+    /// reuses the existing subscription, so churn sends no extra traffic.
+    fn monitor_add(
+        &mut self,
+        actor: Key,
+        id: u64,
+        to_monitor: Vec<u8>,
+        failure_prefix: Vec<MsgPart>,
+    ) {
+        let entry = self.actor_mut(actor);
+        match entry.monitored.get_mut(&to_monitor) {
+            Some(TargetMonitors::Active(entries)) => {
+                entries.insert(id, failure_prefix);
+                return; // subscription already live (or deferred); nothing to send
+            }
+            Some(TargetMonitors::PendingUnsubscribe(_)) => {
+                // Re-monitor within the grace window: cancel the pending unsubscribe
+                // and reactivate. The upstream subscription was never torn down, so
+                // we do not re-subscribe.
+                if let Some(TargetMonitors::PendingUnsubscribe(timer)) =
+                    entry.monitored.remove(&to_monitor)
+                {
+                    timer.abort();
+                }
+                entry.monitored.insert(
+                    to_monitor,
+                    TargetMonitors::Active(HashMap::from([(id, failure_prefix)])),
+                );
+                return;
+            }
+            None => {}
+        }
+        // Brand-new target: record it, then subscribe now if named, else defer to
+        // `assign_name` (the local record still allows cancel meanwhile).
+        entry.monitored.insert(
+            to_monitor.clone(),
+            TargetMonitors::Active(HashMap::from([(id, failure_prefix)])),
+        );
+        let dest = match &entry.name {
+            ActorName::Named(name) => name.clone(),
+            ActorName::Unknown { .. } => return,
+        };
+        self.route_subscribe(actor, dest, to_monitor);
+    }
+
+    /// Remove local monitor `id` (found by scanning its target). Dropping the last
+    /// monitor on a target does *not* unsubscribe immediately: it flips the target
+    /// to `PendingUnsubscribe` and schedules a debounced unsubscribe, so churn does
+    /// not hammer the hierarchy. An in-flight fire is dropped because no local
+    /// monitors remain.
+    fn monitor_remove(&mut self, actor: Key, id: u64) {
+        // Cloned up front so the spawned timer can own it without conflicting with
+        // the `entry` borrow below.
+        let loop_tx = self.loop_tx.clone();
+        let entry = self.actor_mut(actor);
+        let Some(to_monitor) = entry
+            .monitored
+            .iter()
+            .find(|(_, tm)| match tm {
+                TargetMonitors::Active(entries) => entries.contains_key(&id),
+                TargetMonitors::PendingUnsubscribe(_) => false,
+            })
+            .map(|(target, _)| target.clone())
+        else {
+            return;
+        };
+        let now_empty = match entry.monitored.get_mut(&to_monitor) {
+            Some(TargetMonitors::Active(entries)) => {
+                entries.remove(&id);
+                entries.is_empty()
+            }
+            _ => return,
+        };
+        if !now_empty {
+            return; // other monitors still watch this target
+        }
+        if !matches!(entry.name, ActorName::Named(_)) {
+            // Never sent upstream (deferred while unnamed); just drop it locally.
+            entry.monitored.remove(&to_monitor);
+            return;
+        }
+        match tokio::runtime::Handle::try_current() {
+            Ok(_) => {
+                // Schedule the debounced unsubscribe and park its abort handle in
+                // the entry, which now becomes `PendingUnsubscribe`.
+                let target = to_monitor.clone();
+                let timer = tokio::task::spawn_local(async move {
+                    tokio::time::sleep(MONITOR_DEBOUNCE).await;
+                    let _ = loop_tx.send(Command::UnsubscribeMonitor {
+                        actor,
+                        to_monitor: target,
+                    });
+                });
+                entry.monitored.insert(
+                    to_monitor,
+                    TargetMonitors::PendingUnsubscribe(timer.abort_handle()),
+                );
+            }
+            Err(_) => {
+                // No runtime (unit-test harness): unsubscribe synchronously.
+                entry.monitored.remove(&to_monitor);
+                self.unsubscribe_now(actor, to_monitor);
+            }
+        }
+    }
+
+    /// Debounce timer fired. Act only if the target is still `PendingUnsubscribe`
+    /// — i.e. it was not re-monitored (which would have flipped it back to
+    /// `Active` and aborted this task) nor torn down by a fire. The variant itself
+    /// is the truth, so there is no generation to check.
+    fn unsubscribe_monitor(&mut self, actor: Key, to_monitor: Vec<u8>) {
+        let Some(entry) = self.actors.get_mut(actor) else {
+            return;
+        };
+        if !matches!(
+            entry.monitored.get(&to_monitor),
+            Some(TargetMonitors::PendingUnsubscribe(_))
+        ) {
+            return; // re-monitored (Active) or already gone
+        }
+        entry.monitored.remove(&to_monitor);
+        self.unsubscribe_now(actor, to_monitor);
+    }
+
+    /// Send the upstream `Unsubscribe` for `to_monitor` from `actor` (named).
+    fn unsubscribe_now(&mut self, actor: Key, to_monitor: Vec<u8>) {
+        let dest = match &self.actor(actor).name {
+            ActorName::Named(name) => name.clone(),
+            ActorName::Unknown { .. } => return,
+        };
+        self.route_unsubscribe(actor, dest, to_monitor);
     }
 
     /// Walk a subscription up from `at` until the actor that has `to_monitor` in
     /// its routing table (the common ancestor) or the root. Fire immediately if
     /// the monitored actor is already known dead.
-    fn route_subscribe(&mut self, at: Key, dest: Vec<u8>, id: u64, to_monitor: Vec<u8>) {
+    fn route_subscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
         enum Step {
             FireDead,
             Register,
@@ -976,11 +1101,11 @@ impl Ctx {
         };
         match step {
             Step::FireDead => {
-                self.route_fire_monitor(at, dest, id);
+                self.route_fire_monitor(at, dest, to_monitor);
             }
             Step::Register => {
                 self.actor_mut(at)
-                    .buffer_monitor(to_monitor, MonitorSub { dest, id });
+                    .buffer_monitor(to_monitor, MonitorSub { dest });
             }
             Step::Forward => {
                 let _ = self
@@ -988,11 +1113,7 @@ impl Ctx {
                     .parent
                     .as_mut()
                     .expect("forward implies a parent")
-                    .send(ConnectionCommand::Subscribe {
-                        dest,
-                        id,
-                        to_monitor,
-                    });
+                    .send(ConnectionCommand::Subscribe { dest, to_monitor });
             }
         }
     }
@@ -1000,7 +1121,7 @@ impl Ctx {
     /// Walk the same path as [`route_subscribe`] and remove the matching
     /// subscription. Idempotent: a sub that already fired (and was removed) or was
     /// never registered is a no-op.
-    fn route_unsubscribe(&mut self, at: Key, dest: Vec<u8>, id: u64, to_monitor: Vec<u8>) {
+    fn route_unsubscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
         let entry = self.actor(at);
         let forward = !entry.routes.contains_key(to_monitor.as_slice()) && entry.parent.is_some();
         if forward {
@@ -1009,11 +1130,7 @@ impl Ctx {
                 .parent
                 .as_mut()
                 .expect("forward implies a parent")
-                .send(ConnectionCommand::Unsubscribe {
-                    dest,
-                    id,
-                    to_monitor,
-                });
+                .send(ConnectionCommand::Unsubscribe { dest, to_monitor });
             return;
         }
         if let Some(monitors) = self
@@ -1022,20 +1139,20 @@ impl Ctx {
             .get_mut(to_monitor.as_slice())
             .and_then(Route::monitors_mut)
         {
-            monitors.retain(|sub| !(sub.id == id && sub.dest == dest));
+            monitors.retain(|sub| sub.dest != dest);
         }
     }
 
-    /// Route a monitor fire toward `dest`. The subscription is held at the common
-    /// ancestor of the monitoring actor (`dest`) and the monitored actor, so `dest`
-    /// is always this actor or one of its descendants: the fire only ever travels
-    /// *down*. It is delivered locally if we own `dest`, forwarded down its child
-    /// route otherwise, or dropped if that route has since died (the monitoring
-    /// actor is gone). The route is never unknown here and the fire never routes up.
-    fn route_fire_monitor(&mut self, from: Key, dest: Vec<u8>, id: u64) {
+    /// Route a monitor fire for the dead `to_monitor` toward `dest`. The
+    /// subscription is held at the common ancestor of the monitoring actor
+    /// (`dest`) and the monitored actor, so `dest` is always this actor or one of
+    /// its descendants: the fire only ever travels *down*. It is delivered locally
+    /// if we own `dest`, forwarded down its child route otherwise, or dropped if
+    /// that route has since died. The route is never unknown here.
+    fn route_fire_monitor(&mut self, from: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
         let entry = self.actor(from);
         if entry.name() == Some(dest.as_slice()) {
-            self.deliver_monitor_failure(from, id);
+            self.deliver_monitor_failure(from, to_monitor);
             return;
         }
         match entry.routes.get(dest.as_slice()) {
@@ -1048,7 +1165,7 @@ impl Ctx {
                     .expect("a live child route must have its connection")
                     .send(ConnectionCommand::FireMonitor {
                         dest_ident: dest,
-                        monitor_id: id,
+                        to_monitor,
                     });
             }
             // The monitoring actor's branch died before the fire reached it.
@@ -1061,17 +1178,28 @@ impl Ctx {
         }
     }
 
-    /// A monitor fired and reached the monitoring actor. Reconstruct the failure
-    /// message from the local failure_prefix and deliver it with a fixed reason. A
-    /// cancelled monitor (no local record) drops the fire.
-    fn deliver_monitor_failure(&mut self, actor: Key, id: u64) {
-        let Some(local) = self.actor_mut(actor).monitors.remove(&id) else {
-            return;
+    /// A subscription fired and reached the monitoring actor. The target died, so
+    /// fan the fire out to *every* local monitor on that target, reconstructing
+    /// each one's failure message from its own prefix, then drop the whole entry
+    /// (the target is gone). A fire for a target with no entries — already
+    /// cancelled-and-debounced-away, or already fired — is dropped.
+    fn deliver_monitor_failure(&mut self, actor: Key, to_monitor: Vec<u8>) {
+        let entries = match self.actor_mut(actor).monitored.remove(&to_monitor) {
+            Some(TargetMonitors::Active(entries)) => entries,
+            // All monitors were cancelled (sub still live during the grace); the
+            // pending unsubscribe task is now moot — drop it and fire nothing.
+            Some(TargetMonitors::PendingUnsubscribe(timer)) => {
+                timer.abort();
+                return;
+            }
+            None => return,
         };
-        let mut msg = local.failure_prefix;
-        msg.push(MsgPart::from_bytes(local.to_monitor));
-        msg.push(MsgPart::from_bytes(b"actor died".to_vec()));
-        self.deliver_to_actor(actor, msg);
+        for failure_prefix in entries.into_values() {
+            let mut msg = failure_prefix;
+            msg.push(MsgPart::from_bytes(to_monitor.clone()));
+            msg.push(MsgPart::from_bytes(b"actor died".to_vec()));
+            self.deliver_to_actor(actor, msg);
+        }
     }
 
     fn deliver_to_actor(&mut self, actor: Key, msg: Vec<MsgPart>) {

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -54,17 +54,15 @@ enum WireFrame {
     },
     Subscribe {
         dest: Vec<u8>,
-        id: u64,
         to_monitor: Vec<u8>,
     },
     Unsubscribe {
         dest: Vec<u8>,
-        id: u64,
         to_monitor: Vec<u8>,
     },
     FireMonitor {
         dest_ident: Vec<u8>,
-        monitor_id: u64,
+        to_monitor: Vec<u8>,
     },
     Severed {
         reason: Vec<u8>,
@@ -122,30 +120,18 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
             alive,
         },
         ConnectionCommand::PublishRoutes { live, dead } => WireFrame::PublishRoutes { live, dead },
-        ConnectionCommand::Subscribe {
-            dest,
-            id,
-            to_monitor,
-        } => WireFrame::Subscribe {
-            dest,
-            id,
-            to_monitor,
-        },
-        ConnectionCommand::Unsubscribe {
-            dest,
-            id,
-            to_monitor,
-        } => WireFrame::Unsubscribe {
-            dest,
-            id,
-            to_monitor,
-        },
+        ConnectionCommand::Subscribe { dest, to_monitor } => {
+            WireFrame::Subscribe { dest, to_monitor }
+        }
+        ConnectionCommand::Unsubscribe { dest, to_monitor } => {
+            WireFrame::Unsubscribe { dest, to_monitor }
+        }
         ConnectionCommand::FireMonitor {
             dest_ident,
-            monitor_id,
+            to_monitor,
         } => WireFrame::FireMonitor {
             dest_ident,
-            monitor_id,
+            to_monitor,
         },
         ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
     };
@@ -220,30 +206,18 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io:
         WireFrame::PublishRoutes { live, dead } => {
             Incoming::Command(ConnectionCommand::PublishRoutes { live, dead })
         }
-        WireFrame::Subscribe {
-            dest,
-            id,
-            to_monitor,
-        } => Incoming::Command(ConnectionCommand::Subscribe {
-            dest,
-            id,
-            to_monitor,
-        }),
-        WireFrame::Unsubscribe {
-            dest,
-            id,
-            to_monitor,
-        } => Incoming::Command(ConnectionCommand::Unsubscribe {
-            dest,
-            id,
-            to_monitor,
-        }),
+        WireFrame::Subscribe { dest, to_monitor } => {
+            Incoming::Command(ConnectionCommand::Subscribe { dest, to_monitor })
+        }
+        WireFrame::Unsubscribe { dest, to_monitor } => {
+            Incoming::Command(ConnectionCommand::Unsubscribe { dest, to_monitor })
+        }
         WireFrame::FireMonitor {
             dest_ident,
-            monitor_id,
+            to_monitor,
         } => Incoming::Command(ConnectionCommand::FireMonitor {
             dest_ident,
-            monitor_id,
+            to_monitor,
         }),
         WireFrame::Severed { reason } => Incoming::Command(ConnectionCommand::Severed { reason }),
     })

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -469,6 +469,89 @@ fn monitor_on_unnamed_actor_waits_for_its_name() {
     );
 }
 
+// A monitor created while unnamed, then cancelled *after* the actor is named:
+// naming subscribes the deferred monitor upstream, and the later cancel must
+// tear that subscription back down (no orphan).
+#[test]
+fn deferred_monitor_cancelled_after_naming_unsubscribes() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let target = actor(&mut ctx, "target");
+    let watcher = ctx.actors.insert(ActorEntry::new(None));
+    connect(&mut ctx, root, target, "inproc://an-target");
+    drain_commands(&mut ctx, &mut rx);
+
+    monitor(&mut ctx, watcher, 0, "target", "DOWN"); // deferred while unnamed
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 0);
+
+    // Name it: the deferred monitor subscribes up to root.
+    ctx.serve(
+        root,
+        "inproc://an-watcher".to_owned(),
+        request_named(Role::Parent, "watcher"),
+    );
+    ctx.join(
+        watcher,
+        "inproc://an-watcher".to_owned(),
+        request(Role::Child),
+    );
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 1);
+
+    // Cancel after naming: with no runtime the debounced unsubscribe runs
+    // synchronously, so the upstream subscription is gone.
+    ctx.run_command(Command::CancelMonitor {
+        actor: watcher,
+        id: 0,
+    });
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 0);
+
+    // The target dying now delivers nothing but the establishment hello.
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(buffered_strings(&ctx, watcher), vec!["watcher", "root"]);
+}
+
+// A monitor created while unnamed, then cancelled *before* the actor is named:
+// the deferred record is dropped, so naming subscribes nothing upstream.
+#[test]
+fn deferred_monitor_cancelled_before_naming_never_subscribes() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let target = actor(&mut ctx, "target");
+    let watcher = ctx.actors.insert(ActorEntry::new(None));
+    connect(&mut ctx, root, target, "inproc://bn-target");
+    drain_commands(&mut ctx, &mut rx);
+
+    monitor(&mut ctx, watcher, 0, "target", "DOWN"); // deferred
+    ctx.run_command(Command::CancelMonitor {
+        actor: watcher,
+        id: 0,
+    }); // cancel while still unnamed
+    drain_commands(&mut ctx, &mut rx);
+
+    // Name it: nothing was left to subscribe.
+    ctx.serve(
+        root,
+        "inproc://bn-watcher".to_owned(),
+        request_named(Role::Parent, "watcher"),
+    );
+    ctx.join(
+        watcher,
+        "inproc://bn-watcher".to_owned(),
+        request(Role::Child),
+    );
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 0);
+
+    // And the target dying delivers no failure.
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(buffered_strings(&ctx, watcher), vec!["watcher", "root"]);
+}
+
 #[test]
 fn dead_route_is_carried_up_as_dead_when_gaining_a_parent() {
     let (mut ctx, mut rx) = test_ctx();


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* __->__ #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Group a watcher's local monitors by target so they share one upstream subscription and fan out a target failure locally. Debounce the final unsubscribe to reuse live subscriptions during churn, while preserving correct cancellation for watchers that are named after creating a monitor.

Differential Revision: [D114750224](https://our.internmc.facebook.com/intern/diff/D114750224/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750224/)!