### PR TITLE
12/43 minimonarch: Unify message and monitor payload routing

### DIFF
--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -12,6 +12,7 @@ use std::collections::VecDeque;
 use slotmap::SlotMap;
 
 use crate::connection::Connection;
+use crate::connection::SendPayload;
 use crate::ctx::ChildConnectionKey;
 use crate::ctx::PollerKey;
 use crate::msg::MsgPart;
@@ -121,16 +122,16 @@ impl ActorEntry {
         }
     }
 
-    /// Buffer a message addressed to a destination whose route is not yet known
+    /// Buffer a payload addressed to a destination whose route is not yet known
     /// here, so it can be flushed once the route becomes known or this actor gains
-    /// a parent. This is the only place messages enter a [`Route::Unknown`] buffer.
-    pub(crate) fn buffer_unrouted(&mut self, destination: Vec<u8>, parts: Vec<MsgPart>) {
+    /// a parent. This is the only place payloads enter a [`Route::Unknown`] buffer.
+    pub(crate) fn buffer_unrouted(&mut self, destination: Vec<u8>, payload: SendPayload) {
         match self
             .routes
             .entry(destination)
             .or_insert_with(Route::new_unknown)
         {
-            Route::Unknown { messages, .. } => messages.push(parts),
+            Route::Unknown { messages, .. } => messages.push(payload),
             _ => unreachable!("a known route would have been used to send instead of buffering"),
         }
     }
@@ -162,7 +163,7 @@ pub(crate) enum Route {
     /// published (then carried into [`Route::Connection`]) or this actor gains a
     /// parent (then forwarded up).
     Unknown {
-        messages: Vec<Vec<MsgPart>>,
+        messages: Vec<SendPayload>,
         monitors: Vec<MonitorSub>,
     },
     /// The destination is reachable through this child connection. Monitors here

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -9,6 +9,9 @@
 use std::collections::HashSet;
 use std::collections::VecDeque;
 
+use serde::Deserialize;
+use serde::Serialize;
+
 use crate::Role;
 use crate::ctx::ChildConnectionKey;
 use crate::ctx::Key;
@@ -100,10 +103,40 @@ pub(crate) trait ConnectionTransport: Send {
     fn send(&self, action: ConnectionCommand) -> bool;
 }
 
+/// What a [`ConnectionCommand::SendMessage`] delivers once it reaches the actor
+/// it is addressed to. Both kinds route identically (destination-driven, the same
+/// table walk); they differ only in what the destination does on arrival, so a
+/// single routing pathway carries them.
+pub(crate) enum SendPayload {
+    /// An ordinary actor message: opaque part bytes handed to the destination's
+    /// poller.
+    ActorMessage(Vec<MsgPart>),
+    /// A monitor firing: the dead target ident, from which the destination (the
+    /// monitoring actor) reconstructs each local monitor's failure message. A fire
+    /// is only ever armed at an ancestor that already has a route to the
+    /// monitoring actor, so it routes strictly *downward* and never buffers at a
+    /// gateway.
+    FireMonitor(Vec<u8>),
+}
+
+/// What a [`ConnectionCommand::ToAncestor`] does once it reaches the common
+/// ancestor of `to_monitor` (the first actor up the tree that holds it in its
+/// routing table, or the root). Both variants route up that same path, differing
+/// only in the action at the ancestor; `dest` is the monitoring actor a fire
+/// returns to.
+#[derive(Serialize, Deserialize)]
+pub(crate) enum AncestorPayload {
+    /// Register the subscription on the target's route (firing at once if it is
+    /// already dead).
+    Subscribe { dest: Vec<u8> },
+    /// Remove the matching subscription from the target's route.
+    Unsubscribe { dest: Vec<u8> },
+}
+
 pub(crate) enum ConnectionCommand {
     SendMessage {
         destination_ident: Vec<u8>,
-        parts: Vec<MsgPart>,
+        payload: SendPayload,
     },
     /// The sender announcing itself to the peer: its role, ident, the name it
     /// assigns the peer, and whether it is still alive. Flows over the transport
@@ -130,26 +163,13 @@ pub(crate) enum ConnectionCommand {
         live: Vec<Vec<u8>>,
         dead: Vec<Vec<u8>>,
     },
-    /// Register a monitor: travels up from the monitoring actor until it reaches
-    /// the common ancestor that has `to_monitor` in its routing table (or the
-    /// root). That ancestor records the subscription (one per monitoring actor per
-    /// target — no per-monitor id, since a fire is identified by the dead ident).
-    Subscribe {
-        dest: Vec<u8>,
+    /// Route a monitor operation up toward the common ancestor that has
+    /// `to_monitor` in its routing table (or the root): one per monitoring actor
+    /// per target — no per-monitor id, since a fire is identified by the dead
+    /// ident. The [`AncestorPayload`] selects register vs. cancel.
+    ToAncestor {
         to_monitor: Vec<u8>,
-    },
-    /// Cancel a previously-registered monitor; travels the same path as
-    /// [`ConnectionCommand::Subscribe`] and removes the subscription.
-    Unsubscribe {
-        dest: Vec<u8>,
-        to_monitor: Vec<u8>,
-    },
-    /// Deliver a monitor firing toward the monitoring actor `dest_ident`. Routed
-    /// like a normal message; carries the dead target ident so the owner can fan
-    /// the fire out to every local monitor on it (reason is a fixed "actor died").
-    FireMonitor {
-        dest_ident: Vec<u8>,
-        to_monitor: Vec<u8>,
+        payload: AncestorPayload,
     },
 }
 

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -27,11 +27,13 @@ use crate::actor::Delivery;
 use crate::actor::MonitorSub;
 use crate::actor::Route;
 use crate::actor::TargetMonitors;
+use crate::connection::AncestorPayload;
 use crate::connection::ConnectRequest;
 use crate::connection::Connection;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
+use crate::connection::SendPayload;
 use crate::inproc_transport::InprocTransport;
 use crate::msg::MsgPart;
 use crate::poller::Delivered;
@@ -253,7 +255,11 @@ impl Ctx {
                 destination_ident,
                 parts,
             } => {
-                self.route_message(sender, destination_ident.as_bytes().to_vec(), parts);
+                self.route_message(
+                    sender,
+                    destination_ident.as_bytes().to_vec(),
+                    SendPayload::ActorMessage(parts),
+                );
             }
             Command::Serve {
                 actor,
@@ -347,18 +353,24 @@ impl Ctx {
         std::mem::replace(self.connection_mut(connection), value)
     }
 
-    fn route_message(&mut self, sender: Key, destination_ident: Vec<u8>, parts: Vec<MsgPart>) {
+    /// The single destination-driven routing pathway. Both an ordinary actor
+    /// message and a monitor firing travel through here, differing only in what
+    /// `deliver_payload` does once the destination is reached. A monitor fire is
+    /// armed only at an ancestor that already routes to its destination, so it
+    /// always finds a concrete route down (or a dead one) and never reaches the
+    /// gateway-buffer branch.
+    fn route_message(&mut self, sender: Key, destination_ident: Vec<u8>, payload: SendPayload) {
         let entry = self.actor(sender);
         if !entry.alive {
             return;
         }
         if entry.name() == Some(destination_ident.as_slice()) {
-            self.deliver_to_actor(sender, parts);
+            self.deliver_payload(sender, payload);
             return;
         }
 
         match entry.routes.get(destination_ident.as_slice()) {
-            // A known child route: hand the message down toward the destination.
+            // A known child route: hand the payload down toward the destination.
             Some(Route::Connection { child, .. }) => {
                 let child_key = *child;
                 let connection = self
@@ -368,28 +380,38 @@ impl Ctx {
                     .expect("route child connection should exist");
                 let _ = connection.send(ConnectionCommand::SendMessage {
                     destination_ident,
-                    parts,
+                    payload,
                 });
                 return;
             }
-            // The destination is known to be dead: drop the message rather than
+            // The destination is known to be dead: drop the payload rather than
             // forwarding it up (where it would buffer forever at the gateway).
             Some(Route::Dead) => return,
             Some(Route::Unknown { .. }) | None => {}
         }
 
-        // No known route here. Forward toward the gateway; the gateway itself (no
-        // parent) buffers the message until the destination's route is published —
-        // the destination may not even have been created yet. A `Route::Unknown`
-        // entry only exists at a gateway, so it also lands in the buffer branch.
+        // No known route here. Forward the payload — intact — toward the gateway;
+        // the gateway itself (no parent) buffers it until the destination's route
+        // is published, since the destination may not even have been created yet. A
+        // `Route::Unknown` entry only exists at a gateway, so it also lands here.
         if let Some(parent_connection) = self.actor_mut(sender).parent.as_mut() {
             let _ = parent_connection.send(ConnectionCommand::SendMessage {
                 destination_ident,
-                parts,
+                payload,
             });
         } else {
             self.actor_mut(sender)
-                .buffer_unrouted(destination_ident, parts);
+                .buffer_unrouted(destination_ident, payload);
+        }
+    }
+
+    /// Hand a routed payload to the actor it is addressed to: an actor message
+    /// goes to the poller, a monitor fire fans out to every local monitor on the
+    /// dead target.
+    fn deliver_payload(&mut self, actor: Key, payload: SendPayload) {
+        match payload {
+            SendPayload::ActorMessage(parts) => self.deliver_to_actor(actor, parts),
+            SendPayload::FireMonitor(to_monitor) => self.deliver_monitor_failure(actor, to_monitor),
         }
     }
 
@@ -586,10 +608,10 @@ impl Ctx {
             self.actor_mut(parent)
                 .record_routed_via_child(child_connection, ident);
 
-            // Re-route any messages buffered while the route was unknown; route_message
+            // Re-route any payloads buffered while the route was unknown; route_message
             // sends them down the child connection we just recorded.
-            for parts in buffered {
-                self.route_message(parent, ident.clone(), parts);
+            for payload in buffered {
+                self.route_message(parent, ident.clone(), payload);
             }
         }
 
@@ -616,7 +638,7 @@ impl Ctx {
             newly_dead.push(ident);
         }
         for (dest, to_monitor) in to_fire {
-            self.route_fire_monitor(parent, dest, to_monitor);
+            self.route_message(parent, dest, SendPayload::FireMonitor(to_monitor));
         }
 
         // Forward both the live and the newly-dead idents up to the parent.
@@ -650,7 +672,7 @@ impl Ctx {
                 // must travel up *as dead*, else the parent treats a known-dead actor
                 // as alive), while buffered Unknown routes — which we could not place
                 // while parentless — are dropped and their held messages and monitor
-                // subscriptions re-routed up (route_message / route_subscribe now
+                // subscriptions re-routed up (route_message / route_ancestor now
                 // forward, since there is a parent and no local route).
                 let mut live = vec![local_ident];
                 let mut dead = Vec::new();
@@ -666,11 +688,15 @@ impl Ctx {
                             kept.insert(ident, route);
                         }
                         Route::Unknown { messages, monitors } => {
-                            for parts in messages {
-                                self.route_message(ofactor, ident.clone(), parts);
+                            for payload in messages {
+                                self.route_message(ofactor, ident.clone(), payload);
                             }
                             for sub in monitors {
-                                self.route_subscribe(ofactor, sub.dest, ident.clone());
+                                self.route_ancestor(
+                                    ofactor,
+                                    ident.clone(),
+                                    AncestorPayload::Subscribe { dest: sub.dest },
+                                );
                             }
                         }
                     }
@@ -685,8 +711,8 @@ impl Ctx {
         match action {
             ConnectionCommand::SendMessage {
                 destination_ident,
-                parts,
-            } => self.route_message(connection.owning_actor(), destination_ident, parts),
+                payload,
+            } => self.route_message(connection.owning_actor(), destination_ident, payload),
             ConnectionCommand::Establish {
                 role,
                 ident,
@@ -719,17 +745,11 @@ impl Ctx {
                 };
                 self.populate_routes(ofactor, slot, live, dead);
             }
-            ConnectionCommand::Subscribe { dest, to_monitor } => {
-                self.route_subscribe(connection.owning_actor(), dest, to_monitor);
-            }
-            ConnectionCommand::Unsubscribe { dest, to_monitor } => {
-                self.route_unsubscribe(connection.owning_actor(), dest, to_monitor);
-            }
-            ConnectionCommand::FireMonitor {
-                dest_ident,
+            ConnectionCommand::ToAncestor {
                 to_monitor,
+                payload,
             } => {
-                self.route_fire_monitor(connection.owning_actor(), dest_ident, to_monitor);
+                self.route_ancestor(connection.owning_actor(), to_monitor, payload);
             }
         }
     }
@@ -940,7 +960,11 @@ impl Ctx {
         // one needs exactly one upstream `Subscribe`.
         let deferred: Vec<Vec<u8>> = entry.monitored.keys().cloned().collect();
         for to_monitor in deferred {
-            self.route_subscribe(actor, name.clone(), to_monitor);
+            self.route_ancestor(
+                actor,
+                to_monitor,
+                AncestorPayload::Subscribe { dest: name.clone() },
+            );
         }
     }
 
@@ -989,7 +1013,7 @@ impl Ctx {
             ActorName::Named(name) => name.clone(),
             ActorName::Unknown { .. } => return,
         };
-        self.route_subscribe(actor, dest, to_monitor);
+        self.route_ancestor(actor, to_monitor, AncestorPayload::Subscribe { dest });
     }
 
     /// Remove local monitor `id` (found by scanning its target). Dropping the last
@@ -1077,62 +1101,54 @@ impl Ctx {
             ActorName::Named(name) => name.clone(),
             ActorName::Unknown { .. } => return,
         };
-        self.route_unsubscribe(actor, dest, to_monitor);
+        self.route_ancestor(actor, to_monitor, AncestorPayload::Unsubscribe { dest });
     }
 
-    /// Walk a subscription up from `at` until the actor that has `to_monitor` in
-    /// its routing table (the common ancestor) or the root. Fire immediately if
-    /// the monitored actor is already known dead.
-    fn route_subscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
-        enum Step {
-            FireDead,
-            Register,
-            Forward,
+    /// Route a monitor operation up to the *common ancestor* of `to_monitor`: the
+    /// first actor from `at` upward that holds `to_monitor` in its routing table
+    /// (or the root). That ancestor is where a normal message to the target turns
+    /// downward, so it is where a subscription is held and where a fire originates.
+    /// Both subscribe and cancel travel this one path, differing only in the
+    /// [`AncestorPayload`] handler that runs once the ancestor is reached.
+    fn route_ancestor(&mut self, at: Key, to_monitor: Vec<u8>, payload: AncestorPayload) {
+        // Forward up while this actor is not yet the common ancestor (it has no
+        // route to the target) and a parent exists. Otherwise we are the ancestor —
+        // or the root, where the target may not exist yet and the subscription is
+        // held until it does — so the payload acts here.
+        if !self.actor(at).routes.contains_key(to_monitor.as_slice()) {
+            if let Some(parent) = self.actor_mut(at).parent.as_mut() {
+                let _ = parent.send(ConnectionCommand::ToAncestor {
+                    to_monitor,
+                    payload,
+                });
+                return;
+            }
         }
-        let entry = self.actor(at);
-        let step = match entry.routes.get(to_monitor.as_slice()) {
-            Some(Route::Dead) => Step::FireDead,
-            // A live (or buffered-unknown) route means this is the common ancestor.
-            Some(_) => Step::Register,
-            // Not an ancestor of the target: forward up, or hold here if we are the
-            // root (the target may not exist yet — it will end up watched here).
-            None if entry.parent.is_some() => Step::Forward,
-            None => Step::Register,
-        };
-        match step {
-            Step::FireDead => {
-                self.route_fire_monitor(at, dest, to_monitor);
-            }
-            Step::Register => {
-                self.actor_mut(at)
-                    .buffer_monitor(to_monitor, MonitorSub { dest });
-            }
-            Step::Forward => {
-                let _ = self
-                    .actor_mut(at)
-                    .parent
-                    .as_mut()
-                    .expect("forward implies a parent")
-                    .send(ConnectionCommand::Subscribe { dest, to_monitor });
-            }
+        match payload {
+            AncestorPayload::Subscribe { dest } => self.subscribe(at, dest, to_monitor),
+            AncestorPayload::Unsubscribe { dest } => self.unsubscribe(at, dest, to_monitor),
         }
     }
 
-    /// Walk the same path as [`route_subscribe`] and remove the matching
-    /// subscription. Idempotent: a sub that already fired (and was removed) or was
+    /// Register a subscription at the common ancestor `at`: fire immediately if the
+    /// target is already known dead, otherwise hold the subscription on its route
+    /// (creating an `Unknown` buffer if the target is not yet known here).
+    fn subscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
+        if matches!(
+            self.actor(at).routes.get(to_monitor.as_slice()),
+            Some(Route::Dead)
+        ) {
+            self.route_message(at, dest, SendPayload::FireMonitor(to_monitor));
+        } else {
+            self.actor_mut(at)
+                .buffer_monitor(to_monitor, MonitorSub { dest });
+        }
+    }
+
+    /// Remove the matching subscription at the common ancestor `at`. Idempotent: a
+    /// sub that already fired (and was removed), targets a now-dead route, or was
     /// never registered is a no-op.
-    fn route_unsubscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
-        let entry = self.actor(at);
-        let forward = !entry.routes.contains_key(to_monitor.as_slice()) && entry.parent.is_some();
-        if forward {
-            let _ = self
-                .actor_mut(at)
-                .parent
-                .as_mut()
-                .expect("forward implies a parent")
-                .send(ConnectionCommand::Unsubscribe { dest, to_monitor });
-            return;
-        }
+    fn unsubscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
         if let Some(monitors) = self
             .actor_mut(at)
             .routes
@@ -1140,41 +1156,6 @@ impl Ctx {
             .and_then(Route::monitors_mut)
         {
             monitors.retain(|sub| sub.dest != dest);
-        }
-    }
-
-    /// Route a monitor fire for the dead `to_monitor` toward `dest`. The
-    /// subscription is held at the common ancestor of the monitoring actor
-    /// (`dest`) and the monitored actor, so `dest` is always this actor or one of
-    /// its descendants: the fire only ever travels *down*. It is delivered locally
-    /// if we own `dest`, forwarded down its child route otherwise, or dropped if
-    /// that route has since died. The route is never unknown here.
-    fn route_fire_monitor(&mut self, from: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
-        let entry = self.actor(from);
-        if entry.name() == Some(dest.as_slice()) {
-            self.deliver_monitor_failure(from, to_monitor);
-            return;
-        }
-        match entry.routes.get(dest.as_slice()) {
-            Some(Route::Connection { child, .. }) => {
-                let child = *child;
-                let _ = self
-                    .actor_mut(from)
-                    .children
-                    .get_mut(child)
-                    .expect("a live child route must have its connection")
-                    .send(ConnectionCommand::FireMonitor {
-                        dest_ident: dest,
-                        to_monitor,
-                    });
-            }
-            // The monitoring actor's branch died before the fire reached it.
-            Some(Route::Dead) => {}
-            Some(Route::Unknown { .. }) | None => {
-                unreachable!(
-                    "monitor fire target must be a known descendant of the subscription holder"
-                )
-            }
         }
     }
 

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -29,7 +29,9 @@ use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 
 use crate::Role;
+use crate::connection::AncestorPayload;
 use crate::connection::ConnectionCommand;
+use crate::connection::SendPayload;
 use crate::msg::MsgPart;
 
 /// One frame on the wire. There is a variant per [`ConnectionCommand`] that
@@ -46,23 +48,15 @@ enum WireFrame {
     },
     Message {
         destination_ident: Vec<u8>,
-        part_lens: Vec<u64>,
+        payload: WirePayload,
     },
     PublishRoutes {
         live: Vec<Vec<u8>>,
         dead: Vec<Vec<u8>>,
     },
-    Subscribe {
-        dest: Vec<u8>,
+    ToAncestor {
         to_monitor: Vec<u8>,
-    },
-    Unsubscribe {
-        dest: Vec<u8>,
-        to_monitor: Vec<u8>,
-    },
-    FireMonitor {
-        dest_ident: Vec<u8>,
-        to_monitor: Vec<u8>,
+        payload: AncestorPayload,
     },
     Severed {
         reason: Vec<u8>,
@@ -70,6 +64,16 @@ enum WireFrame {
     /// Transport-internal liveness probe; consumed by the reader to refresh its
     /// deadline and never surfaced as a [`ConnectionCommand`].
     Heartbeat,
+}
+
+/// Wire form of a [`SendMessage`](ConnectionCommand::SendMessage)'s payload. An
+/// actor message carries only its parts' *lengths* in the header (the bytes are
+/// streamed raw afterwards, zero-copy); a monitor fire carries the small dead
+/// target ident inline.
+#[derive(Serialize, Deserialize)]
+enum WirePayload {
+    ActorMessage { part_lens: Vec<u64> },
+    FireMonitor { to_monitor: Vec<u8> },
 }
 
 fn bincode_config() -> bincode::config::Configuration {
@@ -96,16 +100,22 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
     let frame = match command {
         ConnectionCommand::SendMessage {
             destination_ident,
-            parts: message_parts,
+            payload,
         } => {
-            let part_lens = message_parts
-                .iter()
-                .map(|part| part.as_bytes().len() as u64)
-                .collect();
-            parts = message_parts;
+            let payload = match payload {
+                SendPayload::ActorMessage(message_parts) => {
+                    let part_lens = message_parts
+                        .iter()
+                        .map(|part| part.as_bytes().len() as u64)
+                        .collect();
+                    parts = message_parts;
+                    WirePayload::ActorMessage { part_lens }
+                }
+                SendPayload::FireMonitor(to_monitor) => WirePayload::FireMonitor { to_monitor },
+            };
             WireFrame::Message {
                 destination_ident,
-                part_lens,
+                payload,
             }
         }
         ConnectionCommand::Establish {
@@ -120,18 +130,12 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
             alive,
         },
         ConnectionCommand::PublishRoutes { live, dead } => WireFrame::PublishRoutes { live, dead },
-        ConnectionCommand::Subscribe { dest, to_monitor } => {
-            WireFrame::Subscribe { dest, to_monitor }
-        }
-        ConnectionCommand::Unsubscribe { dest, to_monitor } => {
-            WireFrame::Unsubscribe { dest, to_monitor }
-        }
-        ConnectionCommand::FireMonitor {
-            dest_ident,
+        ConnectionCommand::ToAncestor {
             to_monitor,
-        } => WireFrame::FireMonitor {
-            dest_ident,
+            payload,
+        } => WireFrame::ToAncestor {
             to_monitor,
+            payload,
         },
         ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
     };
@@ -179,17 +183,23 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io:
         WireFrame::Heartbeat => Incoming::Heartbeat,
         WireFrame::Message {
             destination_ident,
-            part_lens,
+            payload,
         } => {
-            let mut parts = Vec::with_capacity(part_lens.len());
-            for len in part_lens {
-                let mut buf = vec![0u8; len as usize];
-                reader.read_exact(&mut buf).await?;
-                parts.push(MsgPart::from_bytes(buf));
-            }
+            let payload = match payload {
+                WirePayload::ActorMessage { part_lens } => {
+                    let mut parts = Vec::with_capacity(part_lens.len());
+                    for len in part_lens {
+                        let mut buf = vec![0u8; len as usize];
+                        reader.read_exact(&mut buf).await?;
+                        parts.push(MsgPart::from_bytes(buf));
+                    }
+                    SendPayload::ActorMessage(parts)
+                }
+                WirePayload::FireMonitor { to_monitor } => SendPayload::FireMonitor(to_monitor),
+            };
             Incoming::Command(ConnectionCommand::SendMessage {
                 destination_ident,
-                parts,
+                payload,
             })
         }
         WireFrame::Establish {
@@ -206,18 +216,12 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io:
         WireFrame::PublishRoutes { live, dead } => {
             Incoming::Command(ConnectionCommand::PublishRoutes { live, dead })
         }
-        WireFrame::Subscribe { dest, to_monitor } => {
-            Incoming::Command(ConnectionCommand::Subscribe { dest, to_monitor })
-        }
-        WireFrame::Unsubscribe { dest, to_monitor } => {
-            Incoming::Command(ConnectionCommand::Unsubscribe { dest, to_monitor })
-        }
-        WireFrame::FireMonitor {
-            dest_ident,
+        WireFrame::ToAncestor {
             to_monitor,
-        } => Incoming::Command(ConnectionCommand::FireMonitor {
-            dest_ident,
+            payload,
+        } => Incoming::Command(ConnectionCommand::ToAncestor {
             to_monitor,
+            payload,
         }),
         WireFrame::Severed { reason } => Incoming::Command(ConnectionCommand::Severed { reason }),
     })

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -20,6 +20,7 @@ use crate::actor::Delivery;
 use crate::actor::Route;
 use crate::connection::ConnectRequest;
 use crate::connection::Connection;
+use crate::connection::SendPayload;
 use crate::ctx::Command;
 use crate::ctx::Ctx;
 use crate::ctx::CtxHandle;
@@ -69,7 +70,7 @@ fn inproc_send_queues_until_connection_establishes() {
     ctx.route_message(
         child,
         b"parent".to_vec(),
-        vec![MsgPart::from_bytes(b"queued".to_vec())],
+        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"queued".to_vec())]),
     );
     ctx.serve(parent, "inproc://queue".to_owned(), request(Role::Parent));
     drain_commands(&mut ctx, &mut rx);
@@ -214,7 +215,7 @@ fn message_to_unrouted_actor_buffers_at_gateway_then_flushes() {
     ctx.route_message(
         child,
         b"grandchild".to_vec(),
-        vec![MsgPart::from_bytes(b"early".to_vec())],
+        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"early".to_vec())]),
     );
     drain_commands(&mut ctx, &mut rx);
     assert!(matches!(


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* __->__ #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Unify actor messages and monitor fires under a shared `SendPayload` routing path, including buffered routes and wire framing.
Model monitor subscribe and unsubscribe operations as `AncestorPayload` values that travel through one common-ancestor route before acting.

Differential Revision: [D114750236](https://our.internmc.facebook.com/intern/diff/D114750236/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750236/)!