### PR TITLE
13/43 minimonarch: Make gateway an explicit creation argument

### DIFF
--- a/monarch_mini/examples/bench.c
+++ b/monarch_mini/examples/bench.c
@@ -46,7 +46,7 @@ int main(int argc, char** argv) {
       .deleter = NULL,
       .deleter_ctx = NULL};
   mm_actor_t actor = NULL;
-  CHECK(mm_actor_create(ctx, &ident, &actor));
+  CHECK(mm_actor_create(ctx, &ident, /*gateway=*/true, &actor));
   int fd = -1;
   mm_poller_t poller = NULL;
   CHECK(mm_poller_create(ctx, &fd, &poller));

--- a/monarch_mini/examples/hello.c
+++ b/monarch_mini/examples/hello.c
@@ -84,7 +84,7 @@ int main(void) {
       .deleter_ctx = NULL,
   };
   mm_actor_t actor = NULL;
-  CHECK(mm_actor_create(ctx, &ident, &actor));
+  CHECK(mm_actor_create(ctx, &ident, /*gateway=*/true, &actor));
 
   /* Send a message before subscribing to show that the actor buffers it. */
   const char* payload = "hello, self";
@@ -142,7 +142,7 @@ int main(void) {
       .deleter_ctx = NULL,
   };
   mm_actor_t child = NULL;
-  CHECK(mm_actor_create(ctx, &child_ident, &child));
+  CHECK(mm_actor_create(ctx, &child_ident, /*gateway=*/false, &child));
 
   mm_poller_t child_poller = NULL;
   int child_fd = -1;
@@ -225,7 +225,7 @@ int main(void) {
       .deleter_ctx = NULL,
   };
   mm_actor_t child2 = NULL;
-  CHECK(mm_actor_create(ctx, &child2_ident, &child2));
+  CHECK(mm_actor_create(ctx, &child2_ident, /*gateway=*/false, &child2));
 
   const char* grandchild2_ident_bytes = "grandchild2-actor";
   mm_msg_part_t grandchild2_ident = {
@@ -235,7 +235,8 @@ int main(void) {
       .deleter_ctx = NULL,
   };
   mm_actor_t grandchild2 = NULL;
-  CHECK(mm_actor_create(ctx, &grandchild2_ident, &grandchild2));
+  CHECK(mm_actor_create(
+      ctx, &grandchild2_ident, /*gateway=*/false, &grandchild2));
 
   const char* child2_url = "inproc://hello-child2";
   CHECK(mm_actor_serve(actor, child2_url, &parent_args));

--- a/monarch_mini/minimonarch.h
+++ b/monarch_mini/minimonarch.h
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stddef.h>
 
 /* ---------------------------------------------------------------------------
@@ -82,7 +83,11 @@ typedef enum mm_err {
 const char* mm_last_error(void);
 mm_err_t mm_ctx_create(mm_ctx_t* out);
 void mm_ctx_destroy(mm_ctx_t ctx);
-mm_err_t mm_actor_create(mm_ctx_t ctx, mm_msg_part_t* ident, mm_actor_t* out);
+mm_err_t mm_actor_create(
+    mm_ctx_t ctx,
+    mm_msg_part_t* ident,
+    bool gateway,
+    mm_actor_t* out);
 void mm_actor_destroy(mm_actor_t actor);
 mm_err_t mm_actor_send(
     mm_actor_t actor,
@@ -166,8 +171,19 @@ void mm_ctx_destroy(mm_ctx_t ctx);
  * omitted if the actor is a parent of the sending actor. Naming the actor on
  * creation is optional. If the name is not specified, it must be provided in
  * the join call. The caller must eventually call mm_actor_destroy().
+ *
+ * `gateway` declares whether this actor is a gateway: the entry point for its
+ * process group. A gateway must have no parent or a network (tcp/quic) parent;
+ * joining a gateway to a unix:// or inproc:// parent is rejected (delivered as
+ * a failure message). The flag is fixed at creation and never changes. Pass
+ * true for a root/endpoint actor that owns a machine-local subtree, false for
+ * an ordinary actor that will join a local parent.
  */
-mm_err_t mm_actor_create(mm_ctx_t ctx, mm_msg_part_t* ident, mm_actor_t* out);
+mm_err_t mm_actor_create(
+    mm_ctx_t ctx,
+    mm_msg_part_t* ident,
+    bool gateway,
+    mm_actor_t* out);
 
 /*
  * Destroy an actor and release all associated resources.

--- a/monarch_mini/python/minimonarch.c
+++ b/monarch_mini/python/minimonarch.c
@@ -732,9 +732,10 @@ static PyTypeObject ContextType = {
 // ---------------------------------------------------------------------------
 
 static int Actor_init(Actor* self, PyObject* args, PyObject* kwds) {
-  static char* kw[] = {"ident", NULL};
+  static char* kw[] = {"ident", "gateway", NULL};
   PyObject* ident = Py_None;
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O", kw, &ident)) {
+  int gateway = 0; // 'p' parses any truthy value into 0/1
+  if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Op", kw, &ident, &gateway)) {
     return -1;
   }
 
@@ -750,14 +751,16 @@ static int Actor_init(Actor* self, PyObject* args, PyObject* kwds) {
   mm_actor_t actor = NULL;
   mm_err_t err;
   if (ident == Py_None) {
-    Py_BEGIN_ALLOW_THREADS err = mm_actor_create(c->ctx, NULL, &actor);
+    Py_BEGIN_ALLOW_THREADS err =
+        mm_actor_create(c->ctx, NULL, (bool)gateway, &actor);
     Py_END_ALLOW_THREADS
   } else {
     mm_msg_part_t p;
     if (bytes_to_part(ident, &p) < 0) {
       return -1;
     }
-    Py_BEGIN_ALLOW_THREADS err = mm_actor_create(c->ctx, &p, &actor);
+    Py_BEGIN_ALLOW_THREADS err =
+        mm_actor_create(c->ctx, &p, (bool)gateway, &actor);
     Py_END_ALLOW_THREADS
   }
   if (err != MM_OK) {

--- a/monarch_mini/python/minimonarch.pyi
+++ b/monarch_mini/python/minimonarch.pyi
@@ -49,9 +49,13 @@ class Actor:
     minimonarch runtime; see ``close()``.
     """
 
-    def __init__(self, ident: bytes | None = ...) -> None:
+    def __init__(self, ident: bytes | None = ..., gateway: bool = ...) -> None:
         """Create an actor. ``ident`` must be unique across the run; if ``None``,
-        a name must be assigned by the peer in a later ``serve``/``join``."""
+        a name must be assigned by the peer in a later ``serve``/``join``.
+
+        ``gateway`` declares this actor as the entry point for its process group:
+        it must have no parent or a network (tcp/quic) parent, and joining it to a
+        ``unix://``/``inproc://`` parent is rejected. Fixed at creation."""
         ...
 
     def send(self, receiver: bytes, parts: Sequence[bytearray]) -> None:

--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -37,6 +37,10 @@ pub(crate) struct ActorEntry {
     /// `Unsubscribe` is debounced via [`TargetMonitors::unsub_timer`], so rapid
     /// monitor/cancel churn on one target sends no per-cycle traffic.
     pub(crate) monitored: HashMap<Vec<u8>, TargetMonitors>,
+    /// Whether this actor is a gateway: the entry point for its process group,
+    /// with no parent or a network (quic/tcp) parent. Set once at creation and
+    /// never flipped — a gateway owns the shared-memory slab for the actors that
+    /// route through it. Joining a gateway to a non-network parent is rejected.
     pub(crate) gateway: bool,
     pub(crate) alive: bool,
 }
@@ -59,7 +63,7 @@ pub(crate) enum TargetMonitors {
 }
 
 impl ActorEntry {
-    pub(crate) fn new(ident: Option<Vec<u8>>) -> Self {
+    pub(crate) fn new(ident: Option<Vec<u8>>, gateway: bool) -> Self {
         Self {
             name: ActorName::new(ident),
             delivery: Delivery::NoPoller {
@@ -69,7 +73,7 @@ impl ActorEntry {
             children: SlotMap::with_key(),
             routes: HashMap::new(),
             monitored: HashMap::new(),
-            gateway: true,
+            gateway,
             alive: true,
         }
     }

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -50,6 +50,14 @@ fn valid_scheme(url: &str) -> bool {
     url.starts_with("inproc://") || url.starts_with("unix://") || url.starts_with("quic://")
 }
 
+/// Whether `url`'s scheme connects across machines (a network transport). A
+/// gateway may only gain a parent over such a link — a gateway joined to a
+/// unix/inproc parent is rejected, since it would no longer be the entry point
+/// for its process group. (Today only quic; tcp joins this set later.)
+fn is_network_scheme(url: &str) -> bool {
+    url.starts_with("quic://")
+}
+
 new_key_type! {
     pub(crate) struct Key;
     pub(crate) struct PollerKey;
@@ -68,6 +76,7 @@ pub(crate) enum Command {
     },
     CreateActor {
         ident: Option<MsgPart>,
+        gateway: bool,
         done: oneshot::Sender<Key>,
     },
     DestroyActor {
@@ -184,9 +193,14 @@ impl Ctx {
             Command::Init { thread } => {
                 self.thread = Some(thread);
             }
-            Command::CreateActor { ident, done } => {
+            Command::CreateActor {
+                ident,
+                gateway,
+                done,
+            } => {
                 let key = self.actors.insert(ActorEntry::new(
                     ident.as_ref().map(|part| part.as_bytes().to_vec()),
+                    gateway,
                 ));
                 drop(ident);
                 let _ = done.send(key);
@@ -439,6 +453,14 @@ impl Ctx {
             self.deliver_connect_failure(actor, request, b"unsupported url scheme".to_vec());
             return;
         }
+        if self.gateway_parent_rejected(actor, request.role, &url) {
+            self.deliver_connect_failure(
+                actor,
+                request,
+                b"gateway must have no parent or a network parent".to_vec(),
+            );
+            return;
+        }
         let Some(connection) = self.attach_connection(actor, request) else {
             return;
         };
@@ -450,10 +472,27 @@ impl Ctx {
             self.deliver_connect_failure(actor, request, b"unsupported url scheme".to_vec());
             return;
         }
+        if self.gateway_parent_rejected(actor, request.role, &url) {
+            self.deliver_connect_failure(
+                actor,
+                request,
+                b"gateway must have no parent or a network parent".to_vec(),
+            );
+            return;
+        }
         let Some(connection) = self.attach_connection(actor, request) else {
             return;
         };
         self.transport_for(&url).join(url, connection);
+    }
+
+    /// Whether attaching a parent over `url` to `actor` must be rejected because
+    /// `actor` is a gateway gaining a non-network parent. A gateway is the entry
+    /// point for its process group, so it may only have no parent or a network
+    /// (quic/tcp) parent; a unix/inproc parent would demote it. Only a `Child`
+    /// role gains a parent, so a `Parent` role never trips this.
+    fn gateway_parent_rejected(&self, actor: Key, role: Role, url: &str) -> bool {
+        role == Role::Child && self.actor(actor).gateway && !is_network_scheme(url)
     }
 
     fn attach_connection(&mut self, actor: Key, request: ConnectRequest) -> Option<ConnectionRef> {
@@ -462,21 +501,10 @@ impl Ctx {
 
         let connection = match role {
             Role::Parent => {
-                let actor_entry = self.actor(actor);
-                if !actor_entry.gateway && actor_entry.parent.is_none() {
-                    let Connection::Unestablished {
-                        mut failure_prefix, ..
-                    } = connection
-                    else {
-                        unreachable!("new connection should be unestablished");
-                    };
-                    failure_prefix.push(MsgPart::from_bytes(Vec::new()));
-                    failure_prefix.push(MsgPart::from_bytes(
-                        b"invalid parent-child topology".to_vec(),
-                    ));
-                    self.deliver_to_actor(actor, failure_prefix);
-                    return None;
-                }
+                // An actor may adopt children before it has a parent (it buffers
+                // routes and hands them upward once it gains one — see
+                // publish_routes_after_established). The gateway flag is fixed at
+                // creation and no longer gates this.
                 let slot = self.actor_mut(actor).children.insert(connection);
                 ConnectionRef::ChildConnection {
                     ofactor: actor,
@@ -486,8 +514,8 @@ impl Ctx {
             Role::Child => {
                 let actor_entry = self.actor_mut(actor);
                 // An actor may have at most one parent. It is free to have already
-                // served children or buffered messages as a gateway; gaining a parent
-                // hands all of that upward (see publish_routes_after_established).
+                // served children or buffered messages; gaining a parent hands all
+                // of that upward (see publish_routes_after_established).
                 if actor_entry.parent.is_some() {
                     let Connection::Unestablished {
                         mut failure_prefix, ..
@@ -503,7 +531,6 @@ impl Ctx {
                     return None;
                 }
                 actor_entry.parent = Some(connection);
-                actor_entry.gateway = false;
                 ConnectionRef::ParentConnection { ofactor: actor }
             }
         };
@@ -568,11 +595,11 @@ impl Ctx {
     }
 
     fn connection_topology_is_valid(&self, connection: ConnectionRef) -> bool {
-        let actor = self.actor(connection.owning_actor());
-        match connection.role() {
-            Role::Parent => actor.alive && (actor.gateway || actor.parent.is_some()),
-            Role::Child => actor.alive,
-        }
+        // The gateway/parent topology is enforced up front at serve/join time (a
+        // gateway only gains a network parent; an actor has at most one parent),
+        // so by establishment the only thing that can have changed is the actor
+        // dying. Both roles are valid as long as the owning actor is still alive.
+        self.actor(connection.owning_actor()).alive
     }
 
     /// Record routes arriving over `child_connection`: `live` idents become

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -276,6 +276,7 @@ pub unsafe extern "C" fn mm_ctx_destroy(ctx: *mut CCtx) {
 pub unsafe extern "C" fn mm_actor_create(
     ctx: *mut CCtx,
     ident: *mut CMsgPart,
+    gateway: bool,
     out: *mut *mut CActor,
 ) -> Error {
     let handle = (*ctx).0.clone();
@@ -283,6 +284,7 @@ pub unsafe extern "C" fn mm_actor_create(
     match handle
         .send_command(Command::CreateActor {
             ident: opt_name(ident),
+            gateway,
             done: done_tx,
         })
         .and_then(|()| done_rx.blocking_recv().map_err(anyhow::Error::from))

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -203,6 +203,49 @@ fn dead_pending_connect_fails_when_matched() {
 }
 
 #[test]
+fn gateway_rejected_joining_local_parent() {
+    let (mut ctx, mut rx) = test_ctx();
+    let gw = gateway_actor(&mut ctx, "gw");
+
+    // A gateway must be the entry point for its process group, so it may not
+    // gain a unix/inproc parent. The join is rejected up front with a failure
+    // message and no parent connection is ever attached.
+    ctx.join(
+        gw,
+        "inproc://nope".to_owned(),
+        request_with_failure(Role::Child, "gw-failed"),
+    );
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(ctx.actors[gw].parent.is_none());
+    assert_eq!(
+        buffered_strings(&ctx, gw),
+        vec![
+            "gw-failed",
+            "",
+            "gateway must have no parent or a network parent"
+        ]
+    );
+}
+
+#[test]
+fn gateway_serves_local_children() {
+    let (mut ctx, mut rx) = test_ctx();
+    let gw = gateway_actor(&mut ctx, "gw");
+    let child = actor(&mut ctx, "child");
+
+    // Serving children (Role::Parent) is unaffected by the gateway rule — only
+    // *gaining a parent* over a local link is rejected. A gateway adopts local
+    // children normally.
+    connect(&mut ctx, gw, child, "inproc://gw-child");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(ctx.actors[child].parent.is_some());
+    assert_eq!(buffered_strings(&ctx, gw), vec!["gw", "child"]);
+    assert_eq!(buffered_strings(&ctx, child), vec!["child", "gw"]);
+}
+
+#[test]
 fn message_to_unrouted_actor_buffers_at_gateway_then_flushes() {
     let (mut ctx, mut rx) = test_ctx();
     let root = actor(&mut ctx, "root");
@@ -433,7 +476,7 @@ fn monitor_on_unnamed_actor_waits_for_its_name() {
     let root = actor(&mut ctx, "root");
     let target = actor(&mut ctx, "target");
     // `watcher` is created without a name; root will name it when it joins.
-    let watcher = ctx.actors.insert(ActorEntry::new(None));
+    let watcher = ctx.actors.insert(ActorEntry::new(None, false));
     connect(&mut ctx, root, target, "inproc://un-target");
     drain_commands(&mut ctx, &mut rx);
 
@@ -478,7 +521,7 @@ fn deferred_monitor_cancelled_after_naming_unsubscribes() {
     let (mut ctx, mut rx) = test_ctx();
     let root = actor(&mut ctx, "root");
     let target = actor(&mut ctx, "target");
-    let watcher = ctx.actors.insert(ActorEntry::new(None));
+    let watcher = ctx.actors.insert(ActorEntry::new(None, false));
     connect(&mut ctx, root, target, "inproc://an-target");
     drain_commands(&mut ctx, &mut rx);
 
@@ -522,7 +565,7 @@ fn deferred_monitor_cancelled_before_naming_never_subscribes() {
     let (mut ctx, mut rx) = test_ctx();
     let root = actor(&mut ctx, "root");
     let target = actor(&mut ctx, "target");
-    let watcher = ctx.actors.insert(ActorEntry::new(None));
+    let watcher = ctx.actors.insert(ActorEntry::new(None, false));
     connect(&mut ctx, root, target, "inproc://bn-target");
     drain_commands(&mut ctx, &mut rx);
 
@@ -990,8 +1033,16 @@ fn drain_commands(ctx: &mut Ctx, rx: &mut mpsc::UnboundedReceiver<Command>) {
 }
 
 fn actor(ctx: &mut Ctx, ident: &str) -> Key {
+    // Test actors default to non-gateways: most join a local parent, which a
+    // gateway is forbidden from doing. Tests that need a gateway construct it
+    // explicitly with `gateway_actor`.
     ctx.actors
-        .insert(ActorEntry::new(Some(ident.as_bytes().to_vec())))
+        .insert(ActorEntry::new(Some(ident.as_bytes().to_vec()), false))
+}
+
+fn gateway_actor(ctx: &mut Ctx, ident: &str) -> Key {
+    ctx.actors
+        .insert(ActorEntry::new(Some(ident.as_bytes().to_vec()), true))
 }
 
 fn connect(ctx: &mut Ctx, parent: Key, child: Key, url: &str) {
@@ -1038,6 +1089,7 @@ fn runtime_actor(ctx: &CtxHandle, ident: &str) -> Key {
     let (done_tx, done_rx) = oneshot::channel();
     ctx.send_command(Command::CreateActor {
         ident: Some(MsgPart::from_bytes(ident.as_bytes().to_vec())),
+        gateway: false,
         done: done_tx,
     })
     .expect("create actor should enqueue");


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* __->__ #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Makes gateway status an explicit, immutable actor-creation argument throughout the Rust core, C API, Python binding, type stub, and C examples. Rejects gateways that try to gain local in-process or Unix parents while preserving their ability to serve local children, with focused Rust coverage.

Differential Revision: [D114750220](https://our.internmc.facebook.com/intern/diff/D114750220/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750220/)!