### PR TITLE
14/43 minimonarch: Give the UNIX transport its own wire framing

### DIFF
--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -16,6 +16,7 @@ mod msg;
 mod poller;
 mod quic_transport;
 mod transport;
+mod unix_framing;
 mod unix_transport;
 
 use std::cell::RefCell;

--- a/monarch_mini/src/unix_framing.rs
+++ b/monarch_mini/src/unix_framing.rs
@@ -6,22 +6,24 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Wire framing for the QUIC transport (and, later, tcp). The UNIX transport has
-//! its own framing (see [`crate::unix_framing`]) so machine-local shared-memory
-//! and fd-passing concerns never leak into the cross-machine wire format.
+//! Wire framing for the UNIX-socket transport.
+//!
+//! Deliberately **separate** from the generic [`crate::framing`] used by quic
+//! (and, later, tcp): the UNIX transport is where machine-local shared-memory
+//! handling lives, so its wire format grows fd-passing and shared-memory part
+//! descriptors that have no business leaking into the cross-machine framing.
+//! Keeping a private copy of the small set of frame types is cheaper than a
+//! shared abstraction that both sides have to bend around.
 //!
 //! Each frame is `[u64 header_len][header][raw part bytes...]`. The header is a
-//! bincode-encoded [`WireFrame`] holding only small metadata; for a message it
+//! bincode-encoded [`UnixFrame`] holding only small metadata; for a message it
 //! carries the *lengths* of the parts, never their bytes. Message-part bytes are
 //! written straight from the owning `MsgPart` and read straight into a freshly
 //! allocated per-part buffer — no copies of payload beyond the socket read/write.
 //!
-//! The reader/writer are generic over tokio's [`AsyncRead`]/[`AsyncWrite`], so the
-//! same code drives a QUIC stream's `RecvStream`/`SendStream`. Liveness policy
-//! (heartbeats, timeouts, EOF) lives in each
-//! transport; this module only serializes frames — with the one exception of the
-//! [`WireFrame::Heartbeat`] probe, which a transport may emit/consume but which is
-//! never a [`ConnectionCommand`].
+//! Unlike quic, the UNIX transport relies on socket EOF for liveness and never
+//! emits heartbeats, so there is no heartbeat frame and a decoded frame maps
+//! straight to a [`ConnectionCommand`].
 
 use serde::Deserialize;
 use serde::Serialize;
@@ -36,12 +38,11 @@ use crate::connection::ConnectionCommand;
 use crate::connection::SendPayload;
 use crate::msg::MsgPart;
 
-/// One frame on the wire. There is a variant per [`ConnectionCommand`] that
+/// One frame on the UNIX wire. There is a variant per [`ConnectionCommand`] that
 /// crosses the pipe (including `Establish`, which is how the two ends exchange
-/// identity), plus a transport-internal `Heartbeat`. Message-part *bytes* are
-/// never carried here — only their lengths.
+/// identity). Message-part *bytes* are never carried here — only their lengths.
 #[derive(Serialize, Deserialize)]
-enum WireFrame {
+enum UnixFrame {
     Establish {
         role: Role,
         ident: Option<Vec<u8>>,
@@ -50,7 +51,7 @@ enum WireFrame {
     },
     Message {
         destination_ident: Vec<u8>,
-        payload: WirePayload,
+        payload: UnixPayload,
     },
     PublishRoutes {
         live: Vec<Vec<u8>>,
@@ -63,9 +64,6 @@ enum WireFrame {
     Severed {
         reason: Vec<u8>,
     },
-    /// Transport-internal liveness probe; consumed by the reader to refresh its
-    /// deadline and never surfaced as a [`ConnectionCommand`].
-    Heartbeat,
 }
 
 /// Wire form of a [`SendMessage`](ConnectionCommand::SendMessage)'s payload. An
@@ -73,7 +71,7 @@ enum WireFrame {
 /// streamed raw afterwards, zero-copy); a monitor fire carries the small dead
 /// target ident inline.
 #[derive(Serialize, Deserialize)]
-enum WirePayload {
+enum UnixPayload {
     ActorMessage { part_lens: Vec<u64> },
     FireMonitor { to_monitor: Vec<u8> },
 }
@@ -82,16 +80,9 @@ fn bincode_config() -> bincode::config::Configuration {
     bincode::config::standard()
 }
 
-/// A frame decoded off the wire: either a command for the loop, or a transport
-/// heartbeat (consumed internally to refresh the liveness deadline).
-pub(crate) enum Incoming {
-    Command(ConnectionCommand),
-    Heartbeat,
-}
-
 /// Serialize and write one command: a length-prefixed bincode header, then — for
-/// a message — each part's bytes streamed straight from its buffer. Flushes so the
-/// peer (and, for quic, its heartbeat deadline) sees it promptly.
+/// a message — each part's bytes streamed straight from its buffer. Flushes so
+/// the peer sees it promptly.
 pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
     writer: &mut W,
     command: ConnectionCommand,
@@ -111,11 +102,11 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
                         .map(|part| part.as_bytes().len() as u64)
                         .collect();
                     parts = message_parts;
-                    WirePayload::ActorMessage { part_lens }
+                    UnixPayload::ActorMessage { part_lens }
                 }
-                SendPayload::FireMonitor(to_monitor) => WirePayload::FireMonitor { to_monitor },
+                SendPayload::FireMonitor(to_monitor) => UnixPayload::FireMonitor { to_monitor },
             };
-            WireFrame::Message {
+            UnixFrame::Message {
                 destination_ident,
                 payload,
             }
@@ -125,33 +116,28 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
             ident,
             name_for_other,
             alive,
-        } => WireFrame::Establish {
+        } => UnixFrame::Establish {
             role,
             ident,
             name_for_other,
             alive,
         },
-        ConnectionCommand::PublishRoutes { live, dead } => WireFrame::PublishRoutes { live, dead },
+        ConnectionCommand::PublishRoutes { live, dead } => UnixFrame::PublishRoutes { live, dead },
         ConnectionCommand::ToAncestor {
             to_monitor,
             payload,
-        } => WireFrame::ToAncestor {
+        } => UnixFrame::ToAncestor {
             to_monitor,
             payload,
         },
-        ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
+        ConnectionCommand::Severed { reason } => UnixFrame::Severed { reason },
     };
     write_frame(writer, &frame, &parts).await
 }
 
-/// Write a transport heartbeat probe.
-pub(crate) async fn write_heartbeat<W: AsyncWrite + Unpin>(writer: &mut W) -> std::io::Result<()> {
-    write_frame(writer, &WireFrame::Heartbeat, &[]).await
-}
-
 async fn write_frame<W: AsyncWrite + Unpin>(
     writer: &mut W,
-    frame: &WireFrame,
+    frame: &UnixFrame,
     parts: &[MsgPart],
 ) -> std::io::Result<()> {
     let header = bincode::serde::encode_to_vec(frame, bincode_config())
@@ -167,28 +153,28 @@ async fn write_frame<W: AsyncWrite + Unpin>(
     writer.flush().await
 }
 
-/// Read one frame. For a message the part bytes are read directly into the
-/// command's own buffers — the only copy is the unavoidable kernel-to-userspace
-/// one. A `Heartbeat` frame returns [`Incoming::Heartbeat`]; everything else maps
-/// straight back to a [`ConnectionCommand`].
-pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<Incoming> {
+/// Read one frame and map it straight back to a [`ConnectionCommand`]. For a
+/// message the part bytes are read directly into the command's own buffers — the
+/// only copy is the unavoidable kernel-to-userspace one.
+pub(crate) async fn read_command<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<ConnectionCommand> {
     let mut len_buf = [0u8; 8];
     reader.read_exact(&mut len_buf).await?;
     let header_len = u64::from_le_bytes(len_buf) as usize;
 
     let mut header = vec![0u8; header_len];
     reader.read_exact(&mut header).await?;
-    let (frame, _) = bincode::serde::decode_from_slice::<WireFrame, _>(&header, bincode_config())
+    let (frame, _) = bincode::serde::decode_from_slice::<UnixFrame, _>(&header, bincode_config())
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
 
     Ok(match frame {
-        WireFrame::Heartbeat => Incoming::Heartbeat,
-        WireFrame::Message {
+        UnixFrame::Message {
             destination_ident,
             payload,
         } => {
             let payload = match payload {
-                WirePayload::ActorMessage { part_lens } => {
+                UnixPayload::ActorMessage { part_lens } => {
                     let mut parts = Vec::with_capacity(part_lens.len());
                     for len in part_lens {
                         let mut buf = vec![0u8; len as usize];
@@ -197,34 +183,32 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io:
                     }
                     SendPayload::ActorMessage(parts)
                 }
-                WirePayload::FireMonitor { to_monitor } => SendPayload::FireMonitor(to_monitor),
+                UnixPayload::FireMonitor { to_monitor } => SendPayload::FireMonitor(to_monitor),
             };
-            Incoming::Command(ConnectionCommand::SendMessage {
+            ConnectionCommand::SendMessage {
                 destination_ident,
                 payload,
-            })
+            }
         }
-        WireFrame::Establish {
+        UnixFrame::Establish {
             role,
             ident,
             name_for_other,
             alive,
-        } => Incoming::Command(ConnectionCommand::Establish {
+        } => ConnectionCommand::Establish {
             role,
             ident,
             name_for_other,
             alive,
-        }),
-        WireFrame::PublishRoutes { live, dead } => {
-            Incoming::Command(ConnectionCommand::PublishRoutes { live, dead })
-        }
-        WireFrame::ToAncestor {
+        },
+        UnixFrame::PublishRoutes { live, dead } => ConnectionCommand::PublishRoutes { live, dead },
+        UnixFrame::ToAncestor {
             to_monitor,
             payload,
-        } => Incoming::Command(ConnectionCommand::ToAncestor {
+        } => ConnectionCommand::ToAncestor {
             to_monitor,
             payload,
-        }),
-        WireFrame::Severed { reason } => Incoming::Command(ConnectionCommand::Severed { reason }),
+        },
+        UnixFrame::Severed { reason } => ConnectionCommand::Severed { reason },
     })
 }

--- a/monarch_mini/src/unix_transport.rs
+++ b/monarch_mini/src/unix_transport.rs
@@ -19,11 +19,12 @@
 //!
 //! ## Framing
 //!
-//! Each frame is `[u64 header_len][header][raw part bytes...]`. The header is a
-//! bincode-encoded [`WireFrame`] holding only small metadata; for a message it
-//! carries the *lengths* of the parts, never their bytes. Message-part bytes are
-//! written straight from the owning `MsgPart` and read straight into a freshly
-//! allocated per-part buffer — no copies of payload beyond the socket read/write.
+//! Framing lives in [`crate::unix_framing`]: each frame is
+//! `[u64 header_len][header][raw part bytes...]`, where the header is a bincode
+//! `UnixFrame` holding only small metadata; for a message it carries the
+//! *lengths* of the parts, never their bytes. Message-part bytes are written
+//! straight from the owning `MsgPart` and read straight into a freshly allocated
+//! per-part buffer — no copies of payload beyond the socket read/write.
 //!
 //! ## Liveness
 //!
@@ -51,10 +52,9 @@ use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
 use crate::ctx::Command;
-use crate::framing;
-use crate::framing::Incoming;
 use crate::matcher::Matcher;
 use crate::transport::Transport;
+use crate::unix_framing;
 
 /// Connect-retry backoff bounds. A join may be posted before its serve, so the
 /// connector polls; it starts fast and backs off (doubling) to a steady poll so a
@@ -313,7 +313,7 @@ async fn writer_task(
                 let Some(command) = command else {
                     break; // transport dropped
                 };
-                if framing::write_command(&mut write_half, command).await.is_err() {
+                if unix_framing::write_command(&mut write_half, command).await.is_err() {
                     return;
                 }
             }
@@ -321,7 +321,7 @@ async fn writer_task(
                 // Teardown: the command loop has stopped, so no further commands
                 // will be enqueued. Flush whatever is already queued, then stop.
                 while let Ok(command) = rx.try_recv() {
-                    if framing::write_command(&mut write_half, command).await.is_err() {
+                    if unix_framing::write_command(&mut write_half, command).await.is_err() {
                         return;
                     }
                 }
@@ -336,8 +336,7 @@ async fn writer_task(
 
 /// Decode each frame off the socket and forward it to the command loop. Any read
 /// error or EOF turns into a `Severed` so the command loop tears the connection
-/// down. UNIX never sends heartbeats, so a `Heartbeat` frame is not expected here;
-/// it is harmlessly ignored if one ever arrives.
+/// down. The UNIX wire has no heartbeat frame — liveness is socket EOF.
 async fn reader_task(
     mut read_half: OwnedReadHalf,
     fd: RawFd,
@@ -346,13 +345,13 @@ async fn reader_task(
     loop_tx: mpsc::UnboundedSender<Command>,
 ) {
     loop {
-        // Before parking in read_frame's await, cooperatively spin peeking the
+        // Before parking in read_command's await, cooperatively spin peeking the
         // socket so an imminent frame is picked up without a kernel read-wakeup.
         // yield_now (not a tight spin) keeps the loop processing other commands
         // — e.g. the reply this peer is about to send.
         spin_for_readable(fd, spin).await;
-        match framing::read_frame(&mut read_half).await {
-            Ok(Incoming::Command(action)) => {
+        match unix_framing::read_command(&mut read_half).await {
+            Ok(action) => {
                 if loop_tx
                     .send(Command::ConnectionAction { connection, action })
                     .is_err()
@@ -360,7 +359,6 @@ async fn reader_task(
                     return;
                 }
             }
-            Ok(Incoming::Heartbeat) => continue,
             Err(_) => {
                 sever(&loop_tx, connection, b"unix connection closed".to_vec());
                 return;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* __->__ #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Split UNIX-socket serialization into a dedicated `unix_framing` module so machine-local shared-memory and file-descriptor extensions can evolve independently of QUIC framing. The new framing maps UNIX frames directly to `ConnectionCommand` values without heartbeat handling, and the UNIX transport now uses it for reads and writes.

Differential Revision: [D114750218](https://our.internmc.facebook.com/intern/diff/D114750218/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750218/)!