### PR TITLE
15/43 minimonarch: Use shared memory to transport large messages

### DIFF
--- a/monarch_mini/SHARED_MEMORY_PLAN_V2.md
+++ b/monarch_mini/SHARED_MEMORY_PLAN_V2.md
@@ -1,0 +1,290 @@
+We are making a change to monarch_mini (/home/zdevito/feature_mini/fbcode/monarch/monarch_mini/IMPLEMENTATION.md).
+# Shared-Memory Large-Message Transport — Plan v2
+
+Goal: when an actor sends a **large message part** to an actor in another process on
+the same machine, move that part's bytes through a shared-memory slab (one `memcpy`
+into the slab + a tiny descriptor) instead of streaming the bytes across each unix
+hop. Small parts stay inline. Death-safe via fd liveness.
+
+This document is self-contained — the concrete syscalls and constants are in the
+**Appendix** at the end. The design (slab + per-request-pipe liveness + two-hop
+relay) has been prototyped and measured: a *persistent* per-context mapping is
+mandatory (mapping/unmapping per message plateaus around 2.8 GB/s; a persistent
+mapping approaches single-core `memcpy` bandwidth), and the per-message fd-handle
+liveness adds only a fixed ~60 µs/msg that amortizes away for large payloads.
+
+---
+
+## Stages (after each stage, you will make a commit. DO NOT ATTEMPT TO LAND ANYTHING,  YOU ARE JUST MAKING THE STACK)
+
+1. **Gateway is an explicit argument.** Add a `gateway: bool` to actor creation
+   (`mm_actor_create` in `minimonarch.h` + `lib.rs`, `Command::CreateActor`,
+   `ActorEntry`, the Python binding + `.pyi`, the C examples). Replace the
+   auto-derived notion entirely: `ActorEntry.gateway` is set once at creation and
+   never flips. Enforce at `join`: **a gateway must have no parent or a network
+   (tcp/quic) parent** — reject joining a gateway to a unix/inproc parent. (The
+   existing topology checks that read `gateway` are effectively dead today; either
+   drop the `gateway` term from them or mark test roots as gateways — pick one and
+   keep all existing tests passing.)
+
+2. **Decouple `framing.rs` from the unix transport.**  The unix transport gets its **own** wire enums so
+   message + shared-memory handling is inlined there; no shm/fd concepts leak into
+   the generic framing which will be used for quic/tcp only. It is ok for these objects to have some duplicates, there is not many wire message types.
+
+3. **Slab allocator (no mapping).** A bump + per-size-freelist allocator that
+   **only** creates the slab file (`memfd_create`), grows it (`ftruncate`), and
+   hands out `(offset)` allocations. It never `mmap`s — mapping is the `ShmMapper`'s
+   job. The grant just needs the offset (the file has already been grown to cover
+   it).
+
+4. **The three objects** (below): `ShmServer`, `ShmClient`, `ShmMapper`.
+
+5. **Per-part send/receive over unix.** Per *part*: a part `>= SHM_THRESHOLD`
+   (~256 KiB) on a context that has a `ShmClient` → allocate, `memcpy` into the slab
+   (via the mapper), send a descriptor `{offset, len}` + the liveness token fd;
+   smaller parts stream inline. The receiver reconstructs the part as **unmapped
+   metadata** `(token, offset, len)`; it is mapped only when handed to the user.
+   Intermediates forward the descriptor (relay the token fd) with **no map, no
+   copy**. (So a message of small headers + one big payload only shm-ifies the
+   payload.)
+
+6. **GatewayState propagation.** When a child connection establishes, the parent
+   hands the child its gateway state (the `ShmClient`'s two fds). Propagates down
+   **both unix and inproc** edges (an inproc child shares the process but must still
+   forward to *its* unix children — `unix → inproc → unix`), never quic. Each actor
+   that receives it sets its own `ShmClient` and re-propagates to its children. When a new
+   child is actor is connected, and you have a ShmClient, you will also send this client down.
+   This handles the case where the child goins after the ShmClient has already been added.
+
+---
+
+## The three objects (distinct owners / lifetimes)
+
+### `ShmServer` — the allocation authority (owned by a gateway actor)
+
+Runs the unix dgram socket that answers allocation requests, owns the slab
+allocator and the slab `memfd`. An **optional** member of a gateway `ActorEntry`;
+dropping it (when the gateway actor is destroyed) stops the server and releases the
+slab. Spawns one task that loops over the dgram socket.
+
+```rust
+struct ShmServer {
+    server_task: JoinHandle<()>,   // Drop aborts it
+    client: ShmClient,             // hands out clones for this gateway's slab
+}
+
+struct Allocator {                 // owned by the server task
+    slab_fd: Arc<OwnedFd>,         // the memfd; ftruncate to grow
+    file_size: u64,
+    top: u64,                      // bump pointer
+    free: HashMap<u64, Vec<u64>>,  // per-(aligned)size freelist
+}
+// alloc(len) -> offset: reuse a freed same-size block, else bump + ftruncate. No mmap.
+```
+
+### `ShmClient` — a tiny, `Copy` handle (per connection that wants it)
+
+Just two **raw, non-owning** fds: the **dgram fd** (where to send alloc requests) and
+the **slab fd** (which slab to map / forward). Not the allocation authority and not
+the address-space owner — a plain pair of ints. Each actor *optionally* holds one
+(set once it learns its gateway). **Per actor, not per context: two actors in one
+context may belong to different gateways.** Passed to the transports when they do a
+read/write.
+
+```rust
+#[derive(Clone, Copy)]
+struct ShmClient {
+    dgram_fd: RawFd, // dgram to the ShmServer for alloc requests (NOT owned here)
+    slab_fd: RawFd,  // slab object, for the mapper + for forwarding (NOT owned here)
+}
+
+```
+> Ownership: the gateway side's fds are owned by its `ShmServer`. On a **child**, the
+> fds arriving in `GatewayState` are deliberately **not tracked** — extract the
+> `RawFd` and leave the fd open for the process lifetime (`into_raw_fd`). Closing them
+> in a child would be harmless anyway (the server keeps its own copies, so the
+> slab/socket stay alive), and a mapped region survives its fd closing — so this keeps
+> `ShmClient` a trivially-`Copy` pair of ints with no lifetime tracking.
+>
+> Async sends on `dgram_fd`: set it non-blocking once and drive the (small, rare)
+> request `sendmsg` under readiness via a transient `AsyncFd` over a `BorrowedFd`
+> (or have whoever owns the `OwnedFd` expose one). The grant is read from the
+> per-request pipe, which the `allocate` call owns.
+
+### `ShmMapper` — context-global address-space manager
+
+Takes a `(slab fd, range)` and returns a pointer, reserving once per slab object and
+growing the mapping in place (so pointers never move). Created for **every** context
+(passed to the transport traits at construction); sits idle if shm is unused. Keeps
+its ranges mapped and `munmap`s them all when the context is destroyed. Keyed by
+fd so registrations from the same ShmClient clones can share the same mapping. A single
+context may have actors that have a different gateway, so it is possible to see more than one fd in the ShmMapper.
+However, all actors sharing the same ShmClient are always going to have the same fd.
+
+```rust
+type MapperHandle = Arc<Mutex<ShmMapper>>;
+struct ShmMapper { reservations: HashMap<u64 /*inode*/, Reservation> }
+struct Reservation { fd: OwnedFd, base: *mut u8, mapped: u64 } // PROT_NONE reserve + MAP_FIXED grow
+impl ShmMapper {
+    // ensure [offset, offset+len) of slab `slab_fd` is mapped; return base+offset.
+    unsafe fn map(&mut self, slab_fd: RawFd, offset: u64, len: usize) -> Result<*mut u8>;
+}
+```
+> Takes the client's non-owning `RawFd`; We do not close client fds so it is fine to just keep the RawFd
+ so it can keep growing the mapping. Only grow the reservations, the only time we unmap entirely is when the context is destroyed.
+
+Wiring: `ShmMapper` is constructed in `Ctx::new` and passed to each transport at
+construction (only unix uses it). The `ShmClient` is per-actor, stored as Arc<Mutex<Option<ShmClient>>>. This way we can pass this slot to the transport recv/send coroutines and enable ShmClient as soon as we get the information about it.
+`ShmServer` lives on the gateway `ActorEntry`.
+
+---
+
+## Client → server request protocol (dgrams + fd tracking)
+
+The dgram request socket is **shared** (the server's `client_end` is duped to every
+child via GatewayState), so it is many-writers → one-reader and **cannot carry an
+addressed reply**. The grant therefore comes back down a **private per-request
+pipe**, and that same pipe doubles as the liveness token.
+
+Per allocation (in `ShmClient::allocate(len)`):
+
+1. `let (read_end, write_end) = pipe()`.
+2. Send on the dgram socket: `Alloc{len}` (8 bytes LE) **+ `write_end`** via
+   `SCM_RIGHTS`. Drop the local `write_end`.
+3. Server task `recvmsg`s `{len, write_end}`, `alloc(len) -> offset`, writes
+   `offset` (8 bytes) **into `write_end`**, and starts watching `write_end` for
+   hangup. Reply is read back from `read_end`.
+4. `read_end` is now the **liveness token**: it rides with the descriptor toward the
+   destination (SCM_RIGHTS per unix hop; a plain move over inproc). Each holder/hop
+   closes its copy when done.
+5. **Free signal:** the server holds `write_end`; when *every* copy of `read_end` is
+   closed (delivered-and-consumed, or any holder died → kernel closes its fds) the
+   `write_end` reports hangup → `free(offset, len)`. No explicit free message.
+
+> Liveness orientation matters: **server keeps the write end, the read end travels.**
+> The grant must go down this private pipe (the dgram is shared and can't address a
+> reply). Detecting the hangup on a write end in tokio: register
+> `Interest::WRITABLE`, ignore the initial "writable" wake, return on
+> `is_write_closed()` (a write end is always writable, so `readable()`/`writable()`
+> alone won't do it; closed read ends surface as `EPOLLERR`/`EPOLLHUP` = write-closed).
+
+Request message format (fixed): `[u64 len]` + 1 fd (write_end). Grant: `[u64 offset]`
+down the pipe.
+
+---
+
+## Unix wire format (its own enums; only touch fd syscalls when fds are present)
+
+A frame is `[u64 header_len][header][maybe fd-exchange][inline part bytes]`. The
+header is a bincode `UnixFrame`; **the header and inline bytes are read/written with
+plain `try_read`/`try_write`.** Only if the header says fds are present do we do one
+extra `sendmsg`/`recvmsg` step (a 1-byte payload carrying all the fds). No-fd frames
+never touch the fd-passing syscalls.
+
+```rust
+enum UnixFrame {
+    Establish { .. }, PublishRoutes { .. }, ToAncestor { .. }, Severed { .. },
+    Message { destination_ident: Vec<u8>, payload: WirePayload },
+    GatewayState,                       // carries 2 fds (slab, dgram)
+}
+enum WirePayload { ActorMessage { parts: Vec<PartDesc> }, FireMonitor { .. } }
+enum PartDesc { Inline { len: u64 }, Shm { offset: u64, len: u64 } } // Shm => 1 fd, in part order
+```
+
+Sender: write `[len][header]` (plain); if the header implies fds (count the `Shm`
+parts, or `GatewayState`), do one `sendmsg(1 byte, [fds...])`; then write inline part
+bytes (plain). Receiver: read `[len][header]` (plain); if the decoded header implies
+N fds, `recvmsg` once to collect them; then read inline bytes (plain), popping one fd
+per `Shm` part in order.
+
+`MsgPart` becomes an enum: `Owned{..}` (today's bytes+deleter) or
+`Shm{ mapper: MapperHandle, slab_fd: Arc<OwnedFd>, token: OwnedFd, offset, len }`.
+A `Shm` part is unmapped metadata in flight; `as_bytes`/`into_c` map it (source/dest)
+via `mapper.map(slab_fd, offset, len)`; `slab_meta()` exposes `(offset, len, token)`
+for relay without mapping. Dropping the part closes `token` (its liveness ref).
+
+---
+
+## Invariants
+
+1. A slab offset is freed **exactly once**, when its pipe write end hangs up.
+2. The hangup cannot fire while any holder (sender, any in-transit hop dup, the
+   destination's part) still holds a copy of the read-end token.
+3. Mapping happens **only** at the source (to `memcpy` in) and the destination (to
+   hand bytes to the user). Intermediates forward `(offset, len, token)` only.
+4. `ShmServer` lifetime = its gateway actor. `ShmClient` = per actor. `ShmMapper` =
+   per context (always present, idle if unused; unmaps everything on context drop).
+5. The slab is a `memfd` (no `/dev/shm` name); the kernel reclaims it when the last
+   fd (server's + all distributed dups) closes. No path leaks on any crash.
+
+## Test targets (OSS: `cargo test -p monarch_mini --lib`)
+
+- Allocator: alloc/grow/free-reuse (no mapping).
+- Request protocol: allocate → grant → write/read slab via mapper → drop token →
+  freed → reused (single process, `ShmServer` + `ShmClient` + `ShmMapper`).
+- Liveness: hangup fires only after the last token closes; an in-transit dup keeps it
+  alive.
+- Per-part: a `[small header, big payload]` message — header inline, payload via slab,
+  both intact in order.
+- End-to-end: gateway → child large message; two-hop relay (`p0 → h → p1`); deep
+  `gateway → P → Q` and `unix → inproc → unix` (state forwarded past an inproc hop).
+- Keep all existing inproc/unix/quic/monitor tests green.
+
+---
+
+## Appendix: the libc mechanisms (self-contained)
+
+All `unsafe`; wrap each in a checked helper that turns the syscall's `-1`/`EAGAIN`
+into `Result`/`io::ErrorKind::WouldBlock` so async callers compose with tokio
+`try_io`. Constants:
+
+```rust
+const RESERVE: usize = 1 << 37; // 128 GiB virtual reservation per slab (PROT_NONE)
+const INITIAL: u64   = 1 << 20; // 1 MiB initial slab file size
+const GROW:    u64   = 1 << 20; // ftruncate/map growth granularity
+const ALIGN:   u64   = 64;      // allocation alignment
+```
+
+**Slab object (allocator).** `memfd_create("monarch_mini_shm\0", MFD_CLOEXEC)` → an
+anonymous, *unnamed* file: nothing leaks in `/dev/shm`, and the kernel reclaims it
+when the last fd closes. `ftruncate(fd, new_size)` to size/grow. (Portable fallback:
+`shm_open` then immediate `shm_unlink`.)
+
+**Persistent mapping (`ShmMapper`, one `Reservation` per slab inode).** Reserve a
+large range once, then map the file `MAP_FIXED` over its front so `base` never moves
+as the file grows:
+- reserve: `mmap(NULL, RESERVE, PROT_NONE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_NORESERVE, -1, 0)` → `base`.
+- ensure mapped to `size`: `mmap(base + mapped, size - mapped, PROT_READ|PROT_WRITE, MAP_SHARED|MAP_FIXED, slab_fd, mapped)`, then `mapped = size`.
+- pointer: `base + offset` (after ensuring `mapped >= offset + len`).
+- dedup key / size: `fstat(slab_fd)` → `st_ino` (key), `st_size` (initial mapped extent).
+- drop: `munmap(base, RESERVE)`. (Existing mappings survive the slab fd closing —
+  `mmap` holds the inode — so only *growth* needs an owned dup of the fd.)
+
+**Liveness pipe.** `pipe2(fds, O_CLOEXEC)` → `(read_end = fds[0], write_end = fds[1])`.
+The server keeps `write_end` and watches it for hangup; the `read_end` travels.
+Hangup watch (tokio): set `write_end` `O_NONBLOCK`, wrap in
+`AsyncFd::with_interest(fd, Interest::WRITABLE)`, loop `ready(WRITABLE).await`, return
+when `guard.ready().is_write_closed()`, else `guard.clear_ready()` and re-wait.
+(`writable()`/`readable()` alone don't work: a write end is always writable, never
+readable; closed read ends surface as `EPOLLERR`/`EPOLLHUP` = write-closed.)
+
+**Request socket.** `socketpair(AF_UNIX, SOCK_DGRAM, 0)` → `(g_end, client_end)`. The
+server reads `g_end`; `client_end` is duped to children in `GatewayState`. Many
+writers, one reader — hence the reply rides the per-request pipe, not the socket.
+
+**Passing fds over a unix socket (one `sendmsg`, N fds via `SCM_RIGHTS`).** Keep a
+single-syscall send/recv pair (these are the only fd-touching calls):
+- send: `msghdr` with one `iovec` over the data bytes (≥1 byte is required to carry a
+  cmsg) and a control buffer holding one `cmsghdr` (`cmsg_level = SOL_SOCKET`,
+  `cmsg_type = SCM_RIGHTS`, `cmsg_len = CMSG_LEN(n * size_of::<RawFd>())`); copy the
+  `RawFd`s into `CMSG_DATA(cmsg)`; `sendmsg(sock, &mh, MSG_NOSIGNAL)`.
+- recv: `recvmsg(sock, &mh, MSG_CMSG_CLOEXEC)`; walk `CMSG_FIRSTHDR`/`CMSG_NXTHDR`,
+  and for each `SCM_RIGHTS` cmsg copy out the `RawFd`s (each is a fresh **owned** fd
+  the kernel installed). `recvmsg` returning `0` bytes is EOF.
+- size the control buffer for the max fds in one frame (e.g. `[u64; N]` via
+  `CMSG_SPACE`); cap N (~64) so it's fixed-size.
+
+In the unix transport these are used in exactly two places: the conditional
+fd-exchange step (1-byte payload + the frame's fds) and the `ShmClient` request send
+(the `Alloc` datagram + the `write_end`). The header/length-prefix and inline part
+bytes use plain `try_read`/`try_write` — never `recvmsg`/`sendmsg`.

--- a/monarch_mini/python/minimonarch.c
+++ b/monarch_mini/python/minimonarch.c
@@ -43,7 +43,9 @@
 //     the GIL — on any thread. Single-value args (a bytes ident/reason) are
 //     copied into a C buffer; multipart bodies are lists of bytearray whose
 //     storage is moved into the parts. Either way the part owns C memory and
-//     frees it with a plain free().
+//     releases it with its deleter — a plain free(), or (for a buffer adopted
+//     from a received part) that part's own deleter, such as dropping a
+//     shared-memory slab token. None of these touch Python.
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
@@ -70,10 +72,11 @@ static PyObject* g_pump_func; // C reader callback registered with add_reader
 // buys nothing, and it only spins while a message is pending (then sleeps on
 // the fd), so an idle consumer doesn't burn a core.
 //
-// This is safe only because the routing thread never blocks on the GIL: every
-// message part is a moved minimonarch.bytearray whose deleter is a plain free()
-// (no Python refcounting), so the runtime never needs the GIL the spinning
-// consumer holds. Otherwise the spin would starve the routing thread.
+// This is safe only because the routing thread never blocks on the GIL: a
+// message part's deleter never touches Python — a plain free(), or a Rust-side
+// release (freeing a buffer, dropping a shared-memory slab token) — so the
+// runtime never needs the GIL the spinning consumer holds. Otherwise the spin
+// would starve the routing thread.
 #define NEXT_SPIN_NS 10000L
 
 static PyTypeObject ContextType;
@@ -120,18 +123,28 @@ static int set_mm_error(void) {
 // ---------------------------------------------------------------------------
 // bytearray — a writable, growable byte buffer (like Python's bytearray) whose
 // C-owned storage can be *moved* into a message part. After a move the part
-// owns the allocation and frees it with a plain free() — no GIL on the runtime
-// thread — and the bytearray is left empty.
+// owns the storage and releases it with the bytearray's deleter — a plain
+// free(), or the deleter of a received part it adopted (no GIL on the runtime
+// thread) — and the bytearray is left empty.
 //
 // The C type is named ByteArray; it is exposed to Python as
 // minimonarch.bytearray.
 // ---------------------------------------------------------------------------
 
 typedef struct {
-  PyObject_HEAD char* data; // malloc'd; NULL when empty/moved
+  PyObject_HEAD char* data; // NULL when empty/moved
   Py_ssize_t len;
   Py_ssize_t cap;
   Py_ssize_t exports; // outstanding buffer-protocol views; block resize/move
+  // How `data` is released. For a buffer this object allocated, this is
+  // `free_deleter` (deleter_ctx == data) and the buffer is malloc'd, so it may
+  // be free()'d and grown in place. For a buffer adopted from a received
+  // message part, this is that part's own deleter (e.g. dropping a
+  // shared-memory slab token) and `data` must NOT be free()/realloc()'d — a
+  // mutation copies it into an owned buffer first (see bytearray_make_owned).
+  // NULL means nothing to release (empty, or borrowed data with no deleter).
+  void (*deleter)(void* ctx);
+  void* deleter_ctx;
 } ByteArray;
 
 static PyTypeObject ByteArrayType;
@@ -140,7 +153,39 @@ static void free_deleter(void* ctx) {
   free(ctx);
 }
 
+// Ensure `data` is a buffer this object owns and may free()/realloc() — i.e.
+// malloc'd with `free_deleter`. A buffer adopted from a message part (any other
+// deleter, including a shared-memory slab token) is copied into a fresh
+// malloc'd buffer and the original released via its own deleter. No-op for an
+// empty or already-owned buffer.
+static int bytearray_make_owned(ByteArray* b) {
+  if (b->data == NULL || b->deleter == free_deleter) {
+    return 0;
+  }
+  char* owned = malloc((size_t)(b->len ? b->len : 1));
+  if (!owned) {
+    PyErr_NoMemory();
+    return -1;
+  }
+  if (b->len) {
+    memcpy(owned, b->data, (size_t)b->len);
+  }
+  if (b->deleter) {
+    b->deleter(b->deleter_ctx);
+  }
+  b->data = owned;
+  b->cap = b->len;
+  b->deleter = free_deleter;
+  b->deleter_ctx = owned;
+  return 0;
+}
+
 static int bytearray_reserve(ByteArray* b, Py_ssize_t need) {
+  // Growing (or any reserve before a write) requires an owned, realloc-able
+  // buffer; materialize an adopted one first.
+  if (bytearray_make_owned(b) < 0) {
+    return -1;
+  }
   if (need <= b->cap) {
     return 0;
   }
@@ -155,6 +200,8 @@ static int bytearray_reserve(ByteArray* b, Py_ssize_t need) {
   }
   b->data = grown;
   b->cap = cap;
+  b->deleter = free_deleter;
+  b->deleter_ctx = grown;
   return 0;
 }
 
@@ -169,19 +216,23 @@ static int bytearray_check_mutable(ByteArray* b) {
   return 0;
 }
 
-// Move the storage into `out` (free deleter) and reset the ByteArray to empty.
-// Returns -1 (exception set) if views are outstanding.
+// Move the storage into `out`, carrying its deleter so the part releases the
+// buffer the same way this bytearray would have (a plain free() for an owned
+// buffer, or the original part's deleter for an adopted one). Resets the
+// ByteArray to empty. Returns -1 (exception set) if views are outstanding.
 static int bytearray_move_to_part(ByteArray* b, mm_msg_part_t* out) {
   if (bytearray_check_mutable(b) < 0) {
     return -1;
   }
   out->data = b->data;
   out->len = (size_t)b->len;
-  out->deleter = b->data ? free_deleter : NULL;
-  out->deleter_ctx = b->data;
+  out->deleter = b->deleter;
+  out->deleter_ctx = b->deleter_ctx;
   b->data = NULL;
   b->len = 0;
   b->cap = 0;
+  b->deleter = NULL;
+  b->deleter_ctx = NULL;
   return 0;
 }
 
@@ -226,7 +277,9 @@ static int ByteArray_init(ByteArray* self, PyObject* args, PyObject* kwds) {
 }
 
 static void ByteArray_dealloc(ByteArray* self) {
-  free(self->data);
+  if (self->deleter) {
+    self->deleter(self->deleter_ctx);
+  }
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
@@ -461,12 +514,15 @@ static mm_msg_part_t* build_parts(PyObject* seq, size_t* out_n) {
 }
 
 // Adopt a received part's buffer into a new minimonarch.bytearray, zero-copy:
-// the bytearray takes over the malloc'd storage and will free()/realloc() it
-// like any other bytearray. (Every part this binding produces is malloc-owned
-// with a free() deleter, so adopting the pointer is equivalent to its deleter.)
-// Returns a new reference, or NULL (with the buffer freed) on failure. Because
+// the bytearray takes over the part's storage *and its deleter*, so it is
+// released the part's way (a free() for a heap part, or e.g. dropping a
+// shared-memory slab token) rather than always free()'d. The buffer is treated
+// as read-only-in-place: a mutation copies it to an owned buffer first (see
+// bytearray_make_owned), so we never free()/realloc() foreign or slab memory.
+// Returns a new reference, or NULL (deleter still invoked) on failure. Because
 // the result is itself a bytearray, a received message can be moved straight
-// back into another send() — the buffer is reused, never copied.
+// back into another send() — the buffer (and its deleter) is reused, never
+// copied.
 static PyObject* bytearray_adopt(mm_msg_part_t* part) {
   ByteArray* b = PyObject_New(ByteArray, &ByteArrayType);
   if (!b) {
@@ -479,6 +535,8 @@ static PyObject* bytearray_adopt(mm_msg_part_t* part) {
   b->len = (Py_ssize_t)part->len;
   b->cap = (Py_ssize_t)part->len;
   b->exports = 0;
+  b->deleter = part->deleter;
+  b->deleter_ctx = part->deleter_ctx;
   return (PyObject*)b;
 }
 

--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -8,6 +8,8 @@
 
 use std::collections::HashMap;
 use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 use slotmap::SlotMap;
 
@@ -16,6 +18,8 @@ use crate::connection::SendPayload;
 use crate::ctx::ChildConnectionKey;
 use crate::ctx::PollerKey;
 use crate::msg::MsgPart;
+use crate::shm::ShmClientSlot;
+use crate::shm::ShmServer;
 
 pub(crate) struct ActorEntry {
     pub(crate) name: ActorName,
@@ -43,6 +47,15 @@ pub(crate) struct ActorEntry {
     /// route through it. Joining a gateway to a non-network parent is rejected.
     pub(crate) gateway: bool,
     pub(crate) alive: bool,
+    /// This actor's gateway shared-memory client, once it learns its gateway. The
+    /// value is `Option<ShmClient>`; it lives behind an `Arc<Mutex<_>>` only so the
+    /// actor's transport coroutines can read it and the reader can set it the
+    /// moment a gateway-state handoff arrives.
+    pub(crate) shm_client: ShmClientSlot,
+    /// The shared-memory allocation authority, present only on a gateway actor.
+    /// Dropping it (when the gateway is destroyed) stops the server and releases
+    /// the slab.
+    pub(crate) shm_server: Option<ShmServer>,
 }
 
 /// State of this actor's monitoring of one target ident. The variant *is* the
@@ -75,6 +88,8 @@ impl ActorEntry {
             monitored: HashMap::new(),
             gateway,
             alive: true,
+            shm_client: Arc::new(Mutex::new(None)),
+            shm_server: None,
         }
     }
 

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -16,6 +16,7 @@ use crate::Role;
 use crate::ctx::ChildConnectionKey;
 use crate::ctx::Key;
 use crate::msg::MsgPart;
+use crate::shm::ShmClient;
 
 pub(crate) struct ConnectRequest {
     pub(crate) role: Role,
@@ -100,6 +101,10 @@ pub(crate) enum Connection {
 /// (For UNIX this falls out of closing the socket; the inproc transport pushes a
 /// `Severed` from its `Drop`.)
 pub(crate) trait ConnectionTransport: Send {
+    /// Send a command to the peer. Each transport decides what to do with each
+    /// command — in particular, quic silently drops
+    /// [`ConnectionCommand::GatewayState`] (shared memory is machine-local), while
+    /// unix and inproc forward it.
     fn send(&self, action: ConnectionCommand) -> bool;
 }
 
@@ -170,6 +175,13 @@ pub(crate) enum ConnectionCommand {
     ToAncestor {
         to_monitor: Vec<u8>,
         payload: AncestorPayload,
+    },
+    /// The parent handing the child its gateway's [`ShmClient`] (the slab + dgram
+    /// request socket fds), so the child can move large parts through the same
+    /// slab and re-propagate the state to its own machine-local children. Flows
+    /// down unix and inproc edges only (never quic).
+    GatewayState {
+        client: ShmClient,
     },
 }
 

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::thread;
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -39,6 +41,10 @@ use crate::msg::MsgPart;
 use crate::poller::Delivered;
 use crate::poller::PollerEntry;
 use crate::quic_transport::QuicTransport;
+use crate::shm::MapperHandle;
+use crate::shm::ShmClient;
+use crate::shm::ShmMapper;
+use crate::shm::ShmServer;
 use crate::transport::Transport;
 use crate::unix_transport::UnixTransport;
 
@@ -167,6 +173,14 @@ struct Ctx {
     inproc: InprocTransport,
     unix: UnixTransport,
     quic: QuicTransport,
+    // The context-global shared-memory address-space manager. Always present
+    // (idle if shm is unused); handed to the unix transport, and unmaps everything
+    // when the context — and thus this last reference — is dropped.
+    #[expect(
+        dead_code,
+        reason = "held so the mapper outlives the context; used via the unix transport"
+    )]
+    mapper: MapperHandle,
     // A clone of the loop sender, used to schedule debounced monitor unsubscribes
     // back onto the event loop after a grace period.
     loop_tx: mpsc::UnboundedSender<Command>,
@@ -176,12 +190,14 @@ struct Ctx {
 
 impl Ctx {
     fn new(tx: mpsc::UnboundedSender<Command>) -> Self {
+        let mapper: MapperHandle = Arc::new(Mutex::new(ShmMapper::new()));
         Self {
             actors: SlotMap::with_key(),
             pollers: SlotMap::with_key(),
             inproc: InprocTransport::new(tx.clone()),
-            unix: UnixTransport::new(tx.clone()),
+            unix: UnixTransport::new(tx.clone(), mapper.clone()),
             quic: QuicTransport::new(tx.clone()),
+            mapper,
             loop_tx: tx,
             thread: None,
             _not_send: PhantomData,
@@ -203,6 +219,13 @@ impl Ctx {
                     gateway,
                 ));
                 drop(ident);
+                // A gateway owns the slab for its process group: stand up its
+                // shared-memory server now and seed its own client slot, so it can
+                // shm-ify large sends to its children and hand the state down to
+                // them. Best-effort — on failure the gateway just streams inline.
+                if gateway {
+                    self.init_gateway_shm(key);
+                }
                 let _ = done.send(key);
             }
             Command::DestroyActor { key } => {
@@ -464,7 +487,8 @@ impl Ctx {
         let Some(connection) = self.attach_connection(actor, request) else {
             return;
         };
-        self.transport_for(&url).serve(url, connection);
+        let shm_client = self.actor(actor).shm_client.clone();
+        self.transport_for(&url).serve(url, connection, shm_client);
     }
 
     fn join(&mut self, actor: Key, url: String, request: ConnectRequest) {
@@ -483,7 +507,8 @@ impl Ctx {
         let Some(connection) = self.attach_connection(actor, request) else {
             return;
         };
-        self.transport_for(&url).join(url, connection);
+        let shm_client = self.actor(actor).shm_client.clone();
+        self.transport_for(&url).join(url, connection, shm_client);
     }
 
     /// Whether attaching a parent over `url` to `actor` must be rejected because
@@ -506,6 +531,15 @@ impl Ctx {
                 // publish_routes_after_established). The gateway flag is fixed at
                 // creation and no longer gates this.
                 let slot = self.actor_mut(actor).children.insert(connection);
+                // A new child is where we (re)generate gateway state from what we
+                // already hold: send it down the fresh connection. It buffers until
+                // the connection establishes, and the transport decides whether to
+                // actually forward it (quic drops it).
+                if let Some(client) = self.shm_client_of(actor) {
+                    if let Some(connection) = self.actor_mut(actor).children.get_mut(slot) {
+                        let _ = connection.send(ConnectionCommand::GatewayState { client });
+                    }
+                }
                 ConnectionRef::ChildConnection {
                     ofactor: actor,
                     slot,
@@ -778,6 +812,11 @@ impl Ctx {
             } => {
                 self.route_ancestor(connection.owning_actor(), to_monitor, payload);
             }
+            ConnectionCommand::GatewayState { client } => {
+                // Our parent handed us its gateway's client: adopt it and pass it
+                // on to our own machine-local children.
+                self.receive_gateway_state(connection.owning_actor(), client);
+            }
         }
     }
 
@@ -966,6 +1005,58 @@ impl Ctx {
         if let Some(connection) = entry.parent.as_mut() {
             connection.send(ConnectionCommand::Severed { reason });
             *connection = Connection::Failed;
+        }
+    }
+
+    // -- Shared-memory gateway state --------------------------------------------
+
+    /// Stand up a gateway actor's shared-memory server and record its own client
+    /// in the registry. Best-effort: a failure leaves the actor without shm
+    /// (inline sends).
+    fn init_gateway_shm(&mut self, actor: Key) {
+        match ShmServer::new() {
+            Ok(server) => {
+                let client = server.client();
+                self.set_shm_client(actor, client);
+                self.actor_mut(actor).shm_server = Some(server);
+            }
+            Err(err) => tracing::warn!("failed to start gateway shm server: {err}"),
+        }
+    }
+
+    /// Record `actor`'s gateway client in its slot (which its transport coroutines
+    /// read).
+    fn set_shm_client(&self, actor: Key, client: ShmClient) {
+        *self
+            .actor(actor)
+            .shm_client
+            .lock()
+            .expect("shm client slot mutex poisoned") = Some(client);
+    }
+
+    /// This actor's current gateway client, if it has learned one.
+    fn shm_client_of(&self, actor: Key) -> Option<ShmClient> {
+        *self
+            .actor(actor)
+            .shm_client
+            .lock()
+            .expect("shm client slot mutex poisoned")
+    }
+
+    /// Adopt a gateway client received from our parent and pass it on to every
+    /// child connection — the transport decides whether to actually forward it
+    /// (quic drops it), and an as-yet-unestablished child buffers it until it
+    /// connects. This catches up children that connected before the client
+    /// arrived; children that connect afterwards are handled at attach time.
+    /// (Re-recording the client the unix reader already set is harmless and covers
+    /// the inproc path, which has no reader.)
+    fn receive_gateway_state(&mut self, actor: Key, client: ShmClient) {
+        self.set_shm_client(actor, client);
+        let child_keys: Vec<ChildConnectionKey> = self.actor(actor).children.keys().collect();
+        for slot in child_keys {
+            if let Some(connection) = self.actor_mut(actor).children.get_mut(slot) {
+                let _ = connection.send(ConnectionCommand::GatewayState { client });
+            }
         }
     }
 

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -140,6 +140,9 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
             payload,
         },
         ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
+        // Shared memory is machine-local, so quic drops gateway state rather than
+        // forwarding it: skip without writing anything to the wire.
+        ConnectionCommand::GatewayState { .. } => return Ok(()),
     };
     write_frame(writer, &frame, &parts).await
 }

--- a/monarch_mini/src/inproc_transport.rs
+++ b/monarch_mini/src/inproc_transport.rs
@@ -28,6 +28,7 @@ use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
 use crate::ctx::Command;
 use crate::matcher::Matcher;
+use crate::shm::ShmClientSlot;
 use crate::transport::Transport;
 
 pub(crate) struct InprocTransport {
@@ -45,14 +46,14 @@ impl InprocTransport {
 }
 
 impl Transport for InprocTransport {
-    fn serve(&mut self, url: String, connection: ConnectionRef) {
+    fn serve(&mut self, url: String, connection: ConnectionRef, _shm_client: ShmClientSlot) {
         let loop_tx = self.loop_tx.clone();
         let mut matcher = self.matchers.remove(&url).unwrap_or_else(Matcher::new);
         let _ = matcher.push_left(connection, |serve, join| pair(&loop_tx, serve, join));
         self.matchers.insert(url, matcher);
     }
 
-    fn join(&mut self, url: String, connection: ConnectionRef) {
+    fn join(&mut self, url: String, connection: ConnectionRef, _shm_client: ShmClientSlot) {
         let loop_tx = self.loop_tx.clone();
         let mut matcher = self.matchers.remove(&url).unwrap_or_else(Matcher::new);
         let _ = matcher.push_right(connection, |serve, join| pair(&loop_tx, serve, join));
@@ -87,6 +88,8 @@ struct InprocConnectionTransport {
 
 impl ConnectionTransport for InprocConnectionTransport {
     fn send(&self, action: ConnectionCommand) -> bool {
+        // Same process: every command — gateway state (raw fds and all) included —
+        // is delivered straight to the peer connection through the command loop.
         self.tx
             .send(Command::ConnectionAction {
                 connection: self.peer,

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -15,6 +15,7 @@ mod matcher;
 mod msg;
 mod poller;
 mod quic_transport;
+mod shm;
 mod transport;
 mod unix_framing;
 mod unix_transport;

--- a/monarch_mini/src/msg.rs
+++ b/monarch_mini/src/msg.rs
@@ -7,16 +7,131 @@
  */
 
 use std::ffi::c_void;
+use std::mem::ManuallyDrop;
+use std::os::fd::OwnedFd;
+use std::os::fd::RawFd;
+
+use crate::shm::MapperHandle;
 
 struct OwnedBytes(Vec<u8>);
 
-/// Owning Rust message part. Calls the C deleter on drop.
-/// The C caller must not free or use the data after passing it in.
-pub struct MsgPart {
+/// A message part that owns its bytes via a C-style deleter (the original,
+/// inline representation): either Rust-allocated bytes or a buffer handed in from
+/// C. Calls the deleter on drop.
+pub(crate) struct OwnedPart {
     data: *const c_void,
-    pub len: usize,
+    len: usize,
     deleter: Option<unsafe extern "C" fn(*mut c_void)>,
     deleter_ctx: *mut c_void,
+}
+
+impl OwnedPart {
+    fn as_bytes(&self) -> &[u8] {
+        if self.data.is_null() || self.len == 0 {
+            &[]
+        } else {
+            // SAFETY: `data`/`len` describe a valid immutable buffer owned by this
+            // part for its lifetime (from `from_bytes`/`from_c`); we only read it.
+            unsafe { std::slice::from_raw_parts(self.data as *const u8, self.len) }
+        }
+    }
+
+    /// Transfer ownership of the buffer back to C, suppressing this part's drop so
+    /// the deleter runs once, on the C side.
+    fn into_c(self) -> CMsgPart {
+        let me = ManuallyDrop::new(self);
+        CMsgPart {
+            data: me.data,
+            len: me.len,
+            deleter: me.deleter,
+            deleter_ctx: me.deleter_ctx,
+        }
+    }
+}
+
+impl Drop for OwnedPart {
+    fn drop(&mut self) {
+        if let Some(deleter) = self.deleter {
+            // SAFETY: `deleter_ctx` was paired with `deleter` at construction and
+            // this is the sole owner, so the deleter runs exactly once here.
+            unsafe { deleter(self.deleter_ctx) };
+        }
+    }
+}
+
+/// A message part living in a shared-memory slab: unmapped metadata in flight.
+/// It is mapped only when its bytes are actually needed — at the source (to
+/// `memcpy` in, before sending) and at the destination (to hand bytes to the
+/// user). Intermediate hops forward `(offset, len, token)` without mapping.
+pub(crate) struct ShmPart {
+    /// The context's mapper, used to turn `(slab_fd, offset, len)` into a pointer
+    /// on demand. Shared so every part that maps the same slab reuses one mapping.
+    mapper: MapperHandle,
+    /// The slab object this part lives in (kept open for the process lifetime).
+    slab_fd: RawFd,
+    /// The liveness token (a read end of the grant pipe). Holding it keeps the
+    /// slab block alive; dropping it releases this part's reference.
+    token: OwnedFd,
+    /// Offset and length of the part within the slab.
+    offset: u64,
+    len: u64,
+}
+
+impl ShmPart {
+    /// Map the slab range and return a pointer to its bytes. Panics only on a
+    /// mapping failure, which for an already-file-backed slab range is effectively
+    /// out-of-address-space — not reachable through the public interface.
+    fn map(&self) -> *mut u8 {
+        // SAFETY: `slab_fd` is the live slab this part was granted from, and
+        // `[offset, offset+len)` is within a region the allocator grew the file to
+        // cover, so mapping it is sound (see `ShmMapper::map`).
+        unsafe {
+            self.mapper
+                .lock()
+                .expect("shm mapper mutex should not be poisoned")
+                .map(self.slab_fd, self.offset, self.len as usize)
+                .expect("mapping a granted slab range should succeed")
+        }
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        if self.len == 0 {
+            return &[];
+        }
+        let ptr = self.map();
+        // SAFETY: `map` returned a pointer to `len` readable bytes valid for the
+        // mapper's (context's) lifetime, which outlives this part.
+        unsafe { std::slice::from_raw_parts(ptr, self.len as usize) }
+    }
+
+    /// Materialize into a C part: map the bytes and hand C a pointer into the slab
+    /// mapping, with a deleter that drops the liveness token (releasing this
+    /// part's reference) when C is done. The mapping itself stays (the mapper owns
+    /// it for the context's lifetime).
+    fn into_c(self) -> CMsgPart {
+        let data: *const c_void = if self.len == 0 {
+            std::ptr::null()
+        } else {
+            self.map() as *const c_void
+        };
+        let token = Box::new(self.token);
+        CMsgPart {
+            data,
+            len: self.len as usize,
+            deleter: Some(drop_owned_fd),
+            deleter_ctx: Box::into_raw(token).cast(),
+        }
+    }
+}
+
+/// A multipart-message part. `Owned` is the inline bytes+deleter representation;
+/// `Shm` is a reference to bytes in a shared-memory slab (used for large parts
+/// between processes on one machine). The enum itself has no `Drop` — each
+/// variant owns and releases its own resources — so it can be moved out of in a
+/// `match` (needed to relay an `Shm` part's token).
+pub(crate) enum MsgPart {
+    Owned(OwnedPart),
+    Shm(ShmPart),
 }
 
 /// C-layout struct mirroring mm_msg_part_t. Used only at the FFI boundary in lib.rs.
@@ -36,71 +151,115 @@ pub struct CMsg {
 }
 
 impl MsgPart {
-    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+    pub(crate) fn from_bytes(bytes: Vec<u8>) -> Self {
         let owned = Box::new(OwnedBytes(bytes));
         let data = owned.0.as_ptr().cast();
         let len = owned.0.len();
-        MsgPart {
+        MsgPart::Owned(OwnedPart {
             data,
             len,
             deleter: Some(drop_owned_bytes),
             deleter_ctx: Box::into_raw(owned).cast(),
-        }
+        })
     }
 
     /// Take ownership of a CMsgPart passed in from C.
-    pub unsafe fn from_c(part: CMsgPart) -> Self {
-        MsgPart {
+    pub(crate) unsafe fn from_c(part: CMsgPart) -> Self {
+        MsgPart::Owned(OwnedPart {
             data: part.data,
             len: part.len,
             deleter: part.deleter,
             deleter_ctx: part.deleter_ctx,
+        })
+    }
+
+    /// Construct a shared-memory part from a received descriptor (unmapped).
+    pub(crate) fn new_shm(
+        mapper: MapperHandle,
+        slab_fd: RawFd,
+        token: OwnedFd,
+        offset: u64,
+        len: u64,
+    ) -> Self {
+        MsgPart::Shm(ShmPart {
+            mapper,
+            slab_fd,
+            token,
+            offset,
+            len,
+        })
+    }
+
+    /// The part's byte length, without materializing a shared-memory part.
+    pub(crate) fn len(&self) -> usize {
+        match self {
+            MsgPart::Owned(o) => o.len,
+            MsgPart::Shm(s) => s.len as usize,
         }
     }
 
-    pub fn as_bytes(&self) -> &[u8] {
-        if self.data.is_null() || self.len == 0 {
-            &[]
-        } else {
-            unsafe { std::slice::from_raw_parts(self.data as *const u8, self.len) }
+    /// Whether this is already a shared-memory part (so it is relayed by
+    /// descriptor, never copied or mapped).
+    pub(crate) fn is_shm(&self) -> bool {
+        matches!(self, MsgPart::Shm(_))
+    }
+
+    /// Take this shared-memory part's `(offset, len, token)` for relay, moving the
+    /// liveness token out. Panics if called on an `Owned` part (guard with
+    /// [`is_shm`](Self::is_shm)).
+    pub(crate) fn into_shm(self) -> (u64, u64, OwnedFd) {
+        match self {
+            MsgPart::Shm(s) => (s.offset, s.len, s.token),
+            MsgPart::Owned(_) => panic!("into_shm called on an owned part"),
         }
     }
 
-    /// Transfer ownership back to C. self is consumed without calling drop;
-    /// the C caller becomes responsible for calling the deleter.
-    pub fn into_c(self) -> CMsgPart {
-        let part = CMsgPart {
-            data: self.data,
-            len: self.len,
-            deleter: self.deleter,
-            deleter_ctx: self.deleter_ctx,
-        };
-        std::mem::forget(self);
-        part
+    /// The bytes of the part. For a shared-memory part this maps the slab range
+    /// (source/destination use); intermediates relay without calling this.
+    pub(crate) fn as_bytes(&self) -> &[u8] {
+        match self {
+            MsgPart::Owned(o) => o.as_bytes(),
+            MsgPart::Shm(s) => s.as_bytes(),
+        }
+    }
+
+    /// Transfer ownership back to C. For a shared-memory part this maps the bytes
+    /// and hands C a pointer into the slab, with a deleter that releases the
+    /// liveness token when C is done.
+    pub(crate) fn into_c(self) -> CMsgPart {
+        match self {
+            MsgPart::Owned(o) => o.into_c(),
+            MsgPart::Shm(s) => s.into_c(),
+        }
     }
 }
 
 unsafe extern "C" fn drop_owned_bytes(ctx: *mut c_void) {
     // SAFETY: `ctx` was created by `MsgPart::from_bytes` with
     // `Box::into_raw(Box<OwnedBytes>)`, and this deleter is installed exactly
-    // once on the owning `MsgPart`.
+    // once on the owning `OwnedPart`.
     unsafe {
         drop(Box::from_raw(ctx.cast::<OwnedBytes>()));
     }
 }
 
-impl Drop for MsgPart {
-    fn drop(&mut self) {
-        if let Some(deleter) = self.deleter {
-            unsafe { deleter(self.deleter_ctx) };
-        }
+unsafe extern "C" fn drop_owned_fd(ctx: *mut c_void) {
+    // SAFETY: `ctx` was created by `ShmPart::into_c` with
+    // `Box::into_raw(Box<OwnedFd>)`, and this deleter is installed exactly once on
+    // the produced part; dropping the box closes the liveness token fd.
+    unsafe {
+        drop(Box::from_raw(ctx.cast::<OwnedFd>()));
     }
 }
 
-// SAFETY: `MsgPart` transfers opaque C-owned memory between threads without
-// dereferencing it except to read immutable bytes. Ownership remains unique,
-// and the deleter runs only from `Drop`.
+// SAFETY: `MsgPart` transfers opaque C-owned memory (Owned) and shared-memory
+// metadata (Shm) between threads. For Owned, ownership is unique and the bytes
+// are only read immutably; the deleter runs only from drop. For Shm, mapping may
+// happen on whichever thread consumes the part (e.g. the poller's caller thread),
+// which is sound: the mapper's state is behind a `Mutex` and the mapping it
+// returns is process-global, so the resulting pointer is valid from any thread.
 unsafe impl Send for MsgPart {}
-// SAFETY: shared references to `MsgPart` expose only immutable byte slices.
-// Mutation and destruction require ownership of the `MsgPart`.
+// SAFETY: shared references to `MsgPart` expose only immutable byte slices (and
+// mapping, which is serialized by the mapper's mutex). Mutation and destruction
+// require ownership of the `MsgPart`.
 unsafe impl Sync for MsgPart {}

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -60,6 +60,7 @@ use crate::ctx::Command;
 use crate::framing;
 use crate::framing::Incoming;
 use crate::matcher::Matcher;
+use crate::shm::ShmClientSlot;
 use crate::transport::Transport;
 
 /// Server name the client uses to verify the server's certificate (the cert's SAN
@@ -191,7 +192,7 @@ impl QuicTransport {
 }
 
 impl Transport for QuicTransport {
-    fn serve(&mut self, url: String, connection: ConnectionRef) {
+    fn serve(&mut self, url: String, connection: ConnectionRef, _shm_client: ShmClientSlot) {
         let tls = match self.tls() {
             Ok(tls) => tls,
             Err(err) => {
@@ -231,7 +232,7 @@ impl Transport for QuicTransport {
             .send(connection);
     }
 
-    fn join(&mut self, url: String, connection: ConnectionRef) {
+    fn join(&mut self, url: String, connection: ConnectionRef, _shm_client: ShmClientSlot) {
         let tls = match self.tls() {
             Ok(tls) => tls,
             Err(err) => {

--- a/monarch_mini/src/shm.rs
+++ b/monarch_mini/src/shm.rs
@@ -1,0 +1,1054 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Shared-memory slab machinery for the machine-local large-message transport.
+//!
+//! Three objects with distinct owners and lifetimes:
+//!
+//! - [`Allocator`] — the bump + per-size-freelist allocator over a single slab
+//!   `memfd`. It owns the slab file, grows it, and hands out offsets; it never
+//!   maps anything.
+//! - [`ShmServer`] — the allocation *authority* (one per gateway actor). It runs
+//!   a unix dgram server that answers allocation requests against an `Allocator`,
+//!   and per grant watches a liveness pipe so a slab block is freed exactly once,
+//!   when the last holder of its token closes.
+//! - [`ShmClient`] — a tiny `Copy` pair of raw fds (the dgram request socket and
+//!   the slab object). Per actor; not the authority, just a handle.
+//! - [`ShmMapper`] — the context-global address-space manager. It reserves a huge
+//!   `PROT_NONE` range per slab once and grows a `MAP_FIXED` mapping into it so
+//!   pointers never move, and unmaps everything when the context is destroyed.
+//!
+//! The bottom of the file holds the libc mechanisms (`memfd_create`, `ftruncate`,
+//! `mmap` reserve/grow, `pipe2`, `socketpair`, and the `SCM_RIGHTS`
+//! `sendmsg`/`recvmsg` pair), each wrapped in a checked helper that turns the
+//! syscall's `-1`/`EAGAIN` into a `Result`/[`io::ErrorKind::WouldBlock`].
+
+// The shared-memory machinery is wired into the transport across later stages, so
+// in a non-test library build these APIs are momentarily unused; the unit tests
+// exercise them directly. (Removed once non-test callers wire them in.)
+#![cfg_attr(
+    not(test),
+    expect(
+        dead_code,
+        reason = "wired into the unix transport in a later stage of the shared-memory plan"
+    )
+)]
+
+use std::collections::HashMap;
+use std::ffi::CStr;
+use std::io;
+use std::os::fd::AsRawFd;
+use std::os::fd::BorrowedFd;
+use std::os::fd::FromRawFd;
+use std::os::fd::OwnedFd;
+use std::os::fd::RawFd;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use tokio::io::Interest;
+use tokio::io::unix::AsyncFd;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+/// Virtual address space reserved (PROT_NONE) per slab object, once. The slab
+/// file's `MAP_FIXED` mapping grows into the front of this reservation so the
+/// base never moves as the file grows. 128 GiB is far more than any slab will
+/// reach but costs nothing until touched.
+const RESERVE: usize = 1 << 37; // 128 GiB
+/// Initial slab file size, and the granularity we grow it by. Both a power of two
+/// so growth is a handful of `ftruncate`s even for large slabs.
+const INITIAL: u64 = 1 << 20; // 1 MiB
+const GROW: u64 = 1 << 20; // 1 MiB
+/// Every allocation is rounded up to this alignment, which also keys the
+/// per-size freelist (so a freed block can only satisfy a same-size request).
+const ALIGN: u64 = 64;
+
+/// Parts at least this large are moved through the slab (one memcpy + a tiny
+/// descriptor) instead of streamed inline over the socket; smaller parts stay
+/// inline, where the per-message fd/liveness overhead would not pay off.
+pub(crate) const SHM_THRESHOLD: u64 = 256 * 1024;
+
+/// A per-actor slot holding its gateway's [`ShmClient`] once learned. Lives on
+/// the actor and is shared (cloned) with that actor's transport coroutines, so
+/// shared memory turns on as soon as the gateway state arrives.
+pub(crate) type ShmClientSlot = Arc<Mutex<Option<ShmClient>>>;
+
+/// The slab object's name. `memfd_create` names are purely informational (they
+/// appear in `/proc/<pid>/fd` link targets as `memfd:<name>`); nothing collides.
+const SLAB_NAME: &CStr = c"monarch_mini_shm";
+
+/// Round `value` up to the next multiple of `align` (a power of two).
+fn align_up(value: u64, align: u64) -> u64 {
+    (value + align - 1) & !(align - 1)
+}
+
+/// Checked end of a range that must fit inside one mapper reservation.
+fn checked_range_end(offset: u64, len: usize) -> io::Result<u64> {
+    let len = u64::try_from(len)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "shared-memory length overflow"))?;
+    offset
+        .checked_add(len)
+        .filter(|&end| end <= RESERVE as u64)
+        .ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "shared-memory range exceeds reservation",
+            )
+        })
+}
+
+/// Create an anonymous, *unnamed* in-memory file. Nothing leaks in `/dev/shm`,
+/// and the kernel reclaims it once the last fd (this one plus any distributed
+/// dups) closes — so no path leaks on any crash.
+fn create_slab() -> io::Result<OwnedFd> {
+    // SAFETY: `SLAB_NAME` is a valid NUL-terminated C string that outlives the
+    // call. `memfd_create` either returns a fresh owned fd or -1; on success we
+    // take sole ownership of that fd via `OwnedFd::from_raw_fd`.
+    let fd = unsafe { libc::memfd_create(SLAB_NAME.as_ptr(), libc::MFD_CLOEXEC) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `fd` is a fresh, owned, valid file descriptor returned by
+    // `memfd_create` above and not owned by anything else.
+    Ok(unsafe { OwnedFd::from_raw_fd(fd) })
+}
+
+/// Set the slab file's size to `size` bytes (only ever called to grow it).
+fn set_slab_size(fd: RawFd, size: u64) -> io::Result<()> {
+    // SAFETY: `fd` is the live slab memfd owned by the `Allocator`; `ftruncate`
+    // only changes the file's length and has no other effect on the process.
+    let r = unsafe { libc::ftruncate(fd, size as libc::off_t) };
+    if r < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// Bump + per-size-freelist allocator over a single slab `memfd`. Owned by the
+/// allocation-authority side (the future `ShmServer`). It only ever creates and
+/// grows the file and hands out offsets; it never maps anything.
+struct Allocator {
+    /// The slab memfd. `Arc` so the same object can be shared (e.g. handed to a
+    /// mapper) without re-opening; the allocator only needs it to `ftruncate`.
+    slab_fd: Arc<OwnedFd>,
+    /// Current on-disk size of the slab file. `top` never exceeds this.
+    file_size: u64,
+    /// Bump pointer: the next never-yet-allocated offset.
+    top: u64,
+    /// Freed blocks, keyed by their aligned size. A request reuses a same-size
+    /// freed block before bumping, so steady same-size traffic does not grow the
+    /// file unboundedly.
+    free: HashMap<u64, Vec<u64>>,
+}
+
+impl Allocator {
+    /// Create a fresh slab, grown to [`INITIAL`] so the first allocations need no
+    /// `ftruncate`.
+    fn new() -> io::Result<Self> {
+        let slab_fd = create_slab()?;
+        set_slab_size(slab_fd.as_raw_fd(), INITIAL)?;
+        Ok(Self {
+            slab_fd: Arc::new(slab_fd),
+            file_size: INITIAL,
+            top: 0,
+            free: HashMap::new(),
+        })
+    }
+
+    /// The slab object, for whoever maps or forwards it.
+    fn slab_fd(&self) -> &Arc<OwnedFd> {
+        &self.slab_fd
+    }
+
+    /// Allocate `len` bytes, returning the slab offset. Reuses a freed same-size
+    /// block if one exists; otherwise bumps and grows the file (rounded up to
+    /// [`GROW`]) so the returned range is backed before the caller maps it. No
+    /// `mmap` happens here.
+    fn alloc(&mut self, len: u64) -> io::Result<u64> {
+        let size = align_up(len.max(1), ALIGN);
+
+        if let Some(offset) = self.free.get_mut(&size).and_then(Vec::pop) {
+            return Ok(offset);
+        }
+
+        let offset = self.top;
+        let new_top = offset + size;
+        if new_top > self.file_size {
+            let new_size = align_up(new_top, GROW);
+            set_slab_size(self.slab_fd.as_raw_fd(), new_size)?;
+            self.file_size = new_size;
+        }
+        self.top = new_top;
+        Ok(offset)
+    }
+
+    /// Return a previously-allocated block to its size's freelist. `len` must be
+    /// the same length passed to the [`alloc`](Self::alloc) that produced
+    /// `offset` (it is re-aligned identically, so the freelist key matches).
+    fn free(&mut self, offset: u64, len: u64) {
+        let size = align_up(len.max(1), ALIGN);
+        self.free.entry(size).or_default().push(offset);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ShmClient — a tiny, Copy handle to a gateway's slab (per actor)
+// ---------------------------------------------------------------------------
+
+/// A non-owning pair of raw fds: where to send allocation requests (the dgram
+/// socket to the [`ShmServer`]) and which slab to map/forward. Deliberately
+/// `Copy` and lifetime-free — the owning `ShmServer` (or, on a child, the process
+/// itself) keeps the fds alive. An actor holds one once it learns its gateway.
+#[derive(Clone, Copy)]
+pub(crate) struct ShmClient {
+    /// Dgram socket to the `ShmServer` for `Alloc` requests. Set non-blocking by
+    /// its owner; shared by every actor under the same gateway (many writers, one
+    /// reader), so a reply cannot be addressed over it — see [`ShmClient::allocate`].
+    dgram_fd: RawFd,
+    /// The slab object, for the mapper and for forwarding to children.
+    slab_fd: RawFd,
+}
+
+impl ShmClient {
+    /// Reconstruct a client from fds learned via gateway-state propagation (the
+    /// dgram request socket and the slab object). The fds are non-owning and must
+    /// stay open for the process lifetime (the caller leaks the received owned fds
+    /// into raw fds before calling this).
+    pub(crate) fn from_raw(dgram_fd: RawFd, slab_fd: RawFd) -> Self {
+        Self { dgram_fd, slab_fd }
+    }
+
+    /// The slab object fd (for mapping or forwarding).
+    pub(crate) fn slab_fd(&self) -> RawFd {
+        self.slab_fd
+    }
+
+    /// The dgram request socket fd (for forwarding via gateway-state propagation).
+    pub(crate) fn dgram_fd(&self) -> RawFd {
+        self.dgram_fd
+    }
+
+    /// Request `len` bytes from the server, returning `(offset, token)`. Because
+    /// the dgram socket is shared (one reader, many writers) the grant cannot ride
+    /// back on it; instead we mint a private pipe, hand the server its `write_end`
+    /// alongside the request, and read the granted offset back from our `read_end`.
+    /// That `read_end` is then the **liveness token**: as long as any copy of it is
+    /// open the server holds the block; when the last copy closes (delivered and
+    /// consumed, or a holder died) the server frees it.
+    pub(crate) async fn allocate(&self, len: u64) -> io::Result<(u64, OwnedFd)> {
+        let (read_end, write_end) = make_pipe()?;
+        set_nonblocking(read_end.as_raw_fd())?;
+
+        // Send `Alloc{len}` + the pipe's write end; then drop our write end so the
+        // server holds the only copy (its hangup watch keys off that).
+        let len_bytes = len.to_le_bytes();
+        send_dgram_with_fd(self.dgram_fd, &len_bytes, write_end.as_raw_fd()).await?;
+        drop(write_end);
+
+        let offset = read_grant(read_end.as_raw_fd()).await?;
+        Ok((offset, read_end))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ShmServer — the allocation authority (one per gateway actor)
+// ---------------------------------------------------------------------------
+
+/// Owns the slab `memfd` and the `Allocator`, and runs a dgram server that
+/// answers allocation requests and frees each grant when its liveness pipe hangs
+/// up. Dropping it aborts the server task and releases the slab.
+pub(crate) struct ShmServer {
+    /// The server loop; aborted on drop, which drops the `Allocator` and the
+    /// server's end of the dgram socket, releasing the slab once all distributed
+    /// fds are gone.
+    server_task: JoinHandle<()>,
+    /// Clonable handle to this gateway's slab, handed to actors / children.
+    client: ShmClient,
+    /// Number of grants freed (a grant's liveness pipe hung up). Observability for
+    /// tests and diagnostics; never affects behavior.
+    freed: Arc<std::sync::atomic::AtomicU64>,
+    /// Owned client end of the dgram socket. Kept alive here so the raw `dgram_fd`
+    /// inside `client` stays valid for the server's lifetime.
+    _client_end: OwnedFd,
+    /// Owned slab fd. Kept alive here so the raw `slab_fd` inside `client` stays
+    /// valid (the allocator inside the task holds another `Arc` clone).
+    _slab_fd: Arc<OwnedFd>,
+}
+
+impl Drop for ShmServer {
+    fn drop(&mut self) {
+        self.server_task.abort();
+    }
+}
+
+impl ShmServer {
+    /// Build a slab + dgram server and spawn its loop. Must be called on the
+    /// context's tokio runtime (it uses `spawn_local` and the io driver).
+    pub(crate) fn new() -> io::Result<Self> {
+        let allocator = Allocator::new()?;
+        let slab_fd = Arc::clone(allocator.slab_fd());
+
+        let (server_end, client_end) = make_dgram_pair()?;
+        set_nonblocking(server_end.as_raw_fd())?;
+        set_nonblocking(client_end.as_raw_fd())?;
+
+        let client = ShmClient {
+            dgram_fd: client_end.as_raw_fd(),
+            slab_fd: slab_fd.as_raw_fd(),
+        };
+        let freed = Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        let server_task =
+            tokio::task::spawn_local(server_loop(server_end, allocator, Arc::clone(&freed)));
+
+        Ok(Self {
+            server_task,
+            client,
+            freed,
+            _client_end: client_end,
+            _slab_fd: slab_fd,
+        })
+    }
+
+    /// A `Copy` handle to this gateway's slab.
+    pub(crate) fn client(&self) -> ShmClient {
+        self.client
+    }
+
+    /// Number of grants freed so far (observability).
+    fn freed_count(&self) -> u64 {
+        self.freed.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+/// The server loop: read allocation requests off `server_end`, allocate, write the
+/// granted offset back down the request's pipe, and spawn a per-grant watcher that
+/// frees the block when the pipe hangs up. Frees are funneled back here over an
+/// mpsc so the single `Allocator` is only touched from this task.
+async fn server_loop(
+    server_end: OwnedFd,
+    mut allocator: Allocator,
+    freed: Arc<std::sync::atomic::AtomicU64>,
+) {
+    let server_fd = server_end.as_raw_fd();
+    let afd = match AsyncFd::with_interest(server_end, Interest::READABLE) {
+        Ok(afd) => afd,
+        Err(err) => {
+            tracing::error!("shm server: registering dgram socket failed: {err}");
+            return;
+        }
+    };
+    let (free_tx, mut free_rx) = mpsc::unbounded_channel::<(u64, u64)>();
+
+    loop {
+        tokio::select! {
+            request = recv_alloc_request(&afd, server_fd) => {
+                let Ok((len, write_end)) = request else {
+                    return; // socket error: the gateway is going away
+                };
+                let offset = match allocator.alloc(len) {
+                    Ok(offset) => offset,
+                    Err(err) => {
+                        tracing::error!("shm server: alloc({len}) failed: {err}");
+                        // Drop write_end: the client's read_grant sees EOF and errors.
+                        continue;
+                    }
+                };
+                // Grant the offset down the private pipe (8 bytes into a fresh pipe
+                // never blocks), then watch the write end for the all-tokens-closed
+                // hangup that frees the block.
+                if write_all(write_end.as_raw_fd(), &offset.to_le_bytes()).is_err() {
+                    allocator.free(offset, len);
+                    continue;
+                }
+                tokio::task::spawn_local(watch_grant(write_end, offset, len, free_tx.clone()));
+            }
+            freed_block = free_rx.recv() => {
+                // free_tx is held here too, so recv never returns None.
+                let Some((offset, len)) = freed_block else { return };
+                allocator.free(offset, len);
+                freed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+        }
+    }
+}
+
+/// Watch a grant's pipe `write_end` for hangup — i.e. every copy of the matching
+/// `read_end` token closing — then report the block free. A write end is always
+/// writable, so plain writability never fires; we wait for the edge-triggered
+/// readiness whose `is_write_closed()` flags the closed read ends
+/// (`EPOLLERR`/`EPOLLHUP`), ignoring the initial writable wake.
+async fn watch_grant(
+    write_end: OwnedFd,
+    offset: u64,
+    len: u64,
+    free_tx: mpsc::UnboundedSender<(u64, u64)>,
+) {
+    if set_nonblocking(write_end.as_raw_fd()).is_err() {
+        return;
+    }
+    let afd = match AsyncFd::with_interest(write_end, Interest::WRITABLE) {
+        Ok(afd) => afd,
+        Err(_) => return,
+    };
+    loop {
+        let mut guard = match afd.ready(Interest::WRITABLE).await {
+            Ok(guard) => guard,
+            Err(_) => return,
+        };
+        if guard.ready().is_write_closed() {
+            let _ = free_tx.send((offset, len));
+            return;
+        }
+        // The expected initial "writable" edge; clear it and park for the next
+        // edge, which (mio is edge-triggered) only comes on hangup.
+        guard.clear_ready();
+    }
+}
+
+/// Await one allocation request off the server dgram socket: `[u64 len]` + one fd
+/// (the grant pipe's write end). Loops past `WouldBlock`; returns `Err` on a real
+/// socket error or a malformed request.
+async fn recv_alloc_request(
+    afd: &AsyncFd<OwnedFd>,
+    server_fd: RawFd,
+) -> io::Result<(u64, OwnedFd)> {
+    loop {
+        let mut guard = afd.readable().await?;
+        let mut buf = [0u8; 8];
+        // An allocation request carries exactly one fd: the grant pipe's write end.
+        match guard.try_io(|_| recv_with_fds(server_fd, &mut buf, 1)) {
+            Ok(Ok((n, mut fds))) => {
+                if n != 8 || fds.len() != 1 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        "malformed shm alloc request",
+                    ));
+                }
+                let len = u64::from_le_bytes(buf);
+                let write_end = fds.pop().expect("exactly one fd checked above");
+                return Ok((len, write_end));
+            }
+            Ok(Err(err)) => return Err(err),
+            Err(_would_block) => continue,
+        }
+    }
+}
+
+/// Send `Alloc` request bytes + the grant pipe's write end over the (non-blocking)
+/// dgram socket, awaiting writability on `WouldBlock`. The socket is shared by
+/// many writers, so a transient borrowed `AsyncFd` is used only on backpressure.
+async fn send_dgram_with_fd(dgram_fd: RawFd, data: &[u8], fd: RawFd) -> io::Result<()> {
+    loop {
+        match send_with_fds(dgram_fd, data, &[fd]) {
+            Ok(_) => return Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                // SAFETY: `dgram_fd` is a live socket owned elsewhere for the whole
+                // call; the transient `BorrowedFd`/`AsyncFd` only watch readiness
+                // and never close it.
+                let borrowed = unsafe { BorrowedFd::borrow_raw(dgram_fd) };
+                let afd = AsyncFd::with_interest(borrowed, Interest::WRITABLE)?;
+                let _ = afd.writable().await?;
+            }
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+/// Read the 8-byte granted offset back from the request's private (non-blocking)
+/// pipe `read_fd`, awaiting readability as needed. EOF before 8 bytes means the
+/// server dropped the write end without granting (an allocation error).
+async fn read_grant(read_fd: RawFd) -> io::Result<u64> {
+    // SAFETY: `read_fd` is the live read end owned by the caller for the whole
+    // call; the `AsyncFd` watches readiness over a borrow and never closes it.
+    let borrowed = unsafe { BorrowedFd::borrow_raw(read_fd) };
+    let afd = AsyncFd::with_interest(borrowed, Interest::READABLE)?;
+    let mut buf = [0u8; 8];
+    let mut filled = 0;
+    while filled < buf.len() {
+        let mut guard = afd.readable().await?;
+        match guard.try_io(|_| read_fd_bytes(read_fd, &mut buf[filled..])) {
+            Ok(Ok(0)) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "shm grant pipe closed before reply",
+                ));
+            }
+            Ok(Ok(n)) => filled += n,
+            Ok(Err(err)) => return Err(err),
+            Err(_would_block) => continue,
+        }
+    }
+    Ok(u64::from_le_bytes(buf))
+}
+
+// ---------------------------------------------------------------------------
+// ShmMapper — context-global address-space manager
+// ---------------------------------------------------------------------------
+
+/// Shared handle to the per-context [`ShmMapper`].
+pub(crate) type MapperHandle = Arc<Mutex<ShmMapper>>;
+
+/// One slab's persistent mapping: a large `PROT_NONE` reservation whose front is
+/// progressively backed by the slab file via `MAP_FIXED`, so `base` never moves
+/// as the file grows.
+struct Reservation {
+    /// Owned dup of the slab fd, kept so the mapping can keep growing even after
+    /// the client's fd closes. (Existing mappings survive the fd closing; only
+    /// growth needs a live fd.)
+    _fd: OwnedFd,
+    /// Start of the reserved address range.
+    base: *mut u8,
+    /// How many bytes from `base` are currently backed by the file.
+    mapped: u64,
+}
+
+impl Drop for Reservation {
+    fn drop(&mut self) {
+        // SAFETY: `base` came from a `mmap` of `RESERVE` bytes in `ShmMapper::map`
+        // and is owned solely by this `Reservation`; unmapping it exactly once on
+        // drop is sound. Any pointers handed out from it must not outlive the
+        // context (and thus the mapper), which is the mapper's contract.
+        unsafe {
+            libc::munmap(self.base.cast(), RESERVE);
+        }
+    }
+}
+
+/// Maps slab ranges into this context's address space and keeps them mapped until
+/// the context is destroyed. One reservation per distinct slab (keyed by inode),
+/// so clones of the same `ShmClient` share a single mapping.
+pub(crate) struct ShmMapper {
+    reservations: HashMap<u64, Reservation>,
+}
+
+impl ShmMapper {
+    pub(crate) fn new() -> Self {
+        Self {
+            reservations: HashMap::new(),
+        }
+    }
+
+    /// Ensure `[offset, offset+len)` of the slab `slab_fd` is mapped and return a
+    /// pointer to `base + offset`. Reserves the slab's address range on first use
+    /// and grows the backed extent in place as needed; the base never moves.
+    ///
+    /// # Safety
+    /// `slab_fd` must be a valid fd referring to the slab whose allocator produced
+    /// `offset`, and `[offset, offset+len)` must lie within a region the allocator
+    /// has grown the file to cover. The returned pointer is valid only while this
+    /// mapper (i.e. the context) lives, and only `len` bytes are accessible.
+    pub(crate) unsafe fn map(
+        &mut self,
+        slab_fd: RawFd,
+        offset: u64,
+        len: usize,
+    ) -> io::Result<*mut u8> {
+        let need = checked_range_end(offset, len)?;
+        let (inode, _size) = fstat_ino_size(slab_fd)?;
+
+        let reservation = match self.reservations.entry(inode) {
+            std::collections::hash_map::Entry::Occupied(e) => e.into_mut(),
+            std::collections::hash_map::Entry::Vacant(e) => {
+                let base = mmap_reserve(RESERVE)?;
+                let fd = dup_fd(slab_fd)?;
+                e.insert(Reservation {
+                    _fd: fd,
+                    base,
+                    mapped: 0,
+                })
+            }
+        };
+
+        if need > reservation.mapped {
+            let target = align_up(need, page_size());
+            // SAFETY: `base` is the start of a `RESERVE`-byte reservation; `target`
+            // cannot exceed `RESERVE` because `checked_range_end` bounded `need` and
+            // `RESERVE` is page-aligned. `target` and `mapped` are page-aligned, so the
+            // `MAP_FIXED` overlay lands inside the reservation at a page boundary backed
+            // by the slab file (which the allocator has grown to cover `need`). `_fd` is
+            // a live slab fd.
+            unsafe {
+                mmap_fixed(
+                    reservation.base,
+                    reservation.mapped,
+                    target - reservation.mapped,
+                    reservation._fd.as_raw_fd(),
+                )?;
+            }
+            reservation.mapped = target;
+        }
+
+        // SAFETY: `base` is a valid mapping of at least `reservation.mapped >=
+        // offset + len` bytes (ensured just above), so `base + offset` points
+        // within it.
+        Ok(unsafe { reservation.base.add(offset as usize) })
+    }
+}
+
+// SAFETY: a `ShmMapper`'s only non-`Send` field is the raw `base` pointer in each
+// `Reservation`. The mapper lives behind `Arc<Mutex<_>>` and is only ever
+// dereferenced on the single-threaded context runtime; the `Mutex` serializes the
+// (rare) cross-thread access from the handle. The mapping is process-global, so
+// the pointer is meaningful from any thread.
+unsafe impl Send for ShmMapper {}
+
+// ---------------------------------------------------------------------------
+// libc mechanisms (each wrapped to return io::Result; -1/EAGAIN -> Err)
+// ---------------------------------------------------------------------------
+
+/// `O_NONBLOCK` the given fd (preserving its other flags).
+fn set_nonblocking(fd: RawFd) -> io::Result<()> {
+    // SAFETY: `fd` is a live fd owned by the caller; fcntl F_GETFL/F_SETFL only
+    // read and write its status flags.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let r = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    if r < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// `dup` an fd into an owned handle.
+fn dup_fd(fd: RawFd) -> io::Result<OwnedFd> {
+    // SAFETY: `fd` is live; `dup` returns a fresh owned fd or -1.
+    let dup = unsafe { libc::dup(fd) };
+    if dup < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: `dup` is a fresh, owned, valid fd not owned by anything else.
+    Ok(unsafe { OwnedFd::from_raw_fd(dup) })
+}
+
+/// `fstat` for the inode (mapping dedup key) and current size.
+fn fstat_ino_size(fd: RawFd) -> io::Result<(u64, u64)> {
+    // SAFETY: `st` is fully written by a successful fstat; `fd` is a live fd.
+    let mut st: libc::stat = unsafe { std::mem::zeroed() };
+    let r = unsafe { libc::fstat(fd, &mut st) };
+    if r < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok((st.st_ino as u64, st.st_size as u64))
+}
+
+/// System page size, for aligning `MAP_FIXED` growth.
+fn page_size() -> u64 {
+    // SAFETY: sysconf with a valid name has no preconditions and no side effects.
+    let v = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+    if v > 0 { v as u64 } else { 4096 }
+}
+
+/// Create a `(read_end, write_end)` pipe with `O_CLOEXEC`.
+fn make_pipe() -> io::Result<(OwnedFd, OwnedFd)> {
+    let mut fds = [0 as RawFd; 2];
+    // SAFETY: `fds` is a valid 2-element array; pipe2 fills it on success.
+    let r = unsafe { libc::pipe2(fds.as_mut_ptr(), libc::O_CLOEXEC) };
+    if r < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: both entries are fresh, owned, valid fds from a successful pipe2.
+    Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
+}
+
+/// Create a `(server_end, client_end)` `AF_UNIX`/`SOCK_DGRAM` socket pair.
+fn make_dgram_pair() -> io::Result<(OwnedFd, OwnedFd)> {
+    let mut fds = [0 as RawFd; 2];
+    // SAFETY: `fds` is a valid 2-element array; socketpair fills it on success.
+    let r = unsafe {
+        libc::socketpair(
+            libc::AF_UNIX,
+            libc::SOCK_DGRAM | libc::SOCK_CLOEXEC,
+            0,
+            fds.as_mut_ptr(),
+        )
+    };
+    if r < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: both entries are fresh, owned, valid fds from a successful socketpair.
+    Ok(unsafe { (OwnedFd::from_raw_fd(fds[0]), OwnedFd::from_raw_fd(fds[1])) })
+}
+
+/// Write all of `data` to `fd` (used only for the 8-byte grant into a fresh pipe,
+/// which never partials/blocks, but loop on short writes for correctness).
+fn write_all(fd: RawFd, data: &[u8]) -> io::Result<()> {
+    let mut written = 0;
+    while written < data.len() {
+        // SAFETY: `fd` is a live writable fd; we pass a valid pointer/length into
+        // the remaining slice and only read `len` bytes from it.
+        let n = unsafe { libc::write(fd, data[written..].as_ptr().cast(), data.len() - written) };
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        written += n as usize;
+    }
+    Ok(())
+}
+
+/// One non-blocking `read` into `buf`, mapping `EAGAIN` to `WouldBlock`.
+fn read_fd_bytes(fd: RawFd, buf: &mut [u8]) -> io::Result<usize> {
+    // SAFETY: `fd` is a live readable fd; `buf` is a valid mutable slice that read
+    // fills up to its length.
+    let n = unsafe { libc::read(fd, buf.as_mut_ptr().cast(), buf.len()) };
+    if n < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(n as usize)
+}
+
+/// Reserve `len` bytes of address space (`PROT_NONE`, anonymous, no commit).
+fn mmap_reserve(len: usize) -> io::Result<*mut u8> {
+    // SAFETY: a fresh anonymous PROT_NONE reservation has no preconditions; we
+    // check for MAP_FAILED before returning the pointer.
+    let p = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            len,
+            libc::PROT_NONE,
+            libc::MAP_PRIVATE | libc::MAP_ANONYMOUS | libc::MAP_NORESERVE,
+            -1,
+            0,
+        )
+    };
+    if p == libc::MAP_FAILED {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(p.cast())
+}
+
+/// Overlay `[at, at+len)` of the reservation at `base` with the slab file's bytes
+/// at file offset `at` (read/write, shared). `base+at` and `at` must be page
+/// aligned and the range must lie within the reservation.
+///
+/// # Safety
+/// `base` must be the start of a live `RESERVE`-byte reservation, `at + len <=
+/// RESERVE`, both `at` and `base` page-aligned, and `fd` a live slab fd whose file
+/// is at least `at + len` bytes.
+unsafe fn mmap_fixed(base: *mut u8, at: u64, len: u64, fd: RawFd) -> io::Result<()> {
+    // SAFETY: per this fn's contract `base.add(at)` is page-aligned and inside the
+    // reservation, so MAP_FIXED overlays a valid sub-range; the file is backed to
+    // `at + len`. We check MAP_FAILED before returning.
+    let p = unsafe {
+        libc::mmap(
+            base.add(at as usize).cast(),
+            len as usize,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED | libc::MAP_FIXED,
+            fd,
+            at as libc::off_t,
+        )
+    };
+    if p == libc::MAP_FAILED {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}
+
+/// `sendmsg` `data` plus `fds` (via one `SCM_RIGHTS` control message) on `sock`.
+/// `MSG_NOSIGNAL` so a dead peer yields `EPIPE` rather than a signal.
+pub(crate) fn send_with_fds(sock: RawFd, data: &[u8], fds: &[RawFd]) -> io::Result<usize> {
+    let fd_bytes = std::mem::size_of_val(fds);
+    // SAFETY: the whole block builds a single msghdr with one iovec over `data` and
+    // one SCM_RIGHTS cmsg holding `fds`, exactly as the cmsg macros require, then
+    // calls sendmsg. `data`/`fds` outlive the call; the control buffer is sized via
+    // CMSG_SPACE and zeroed; we copy the fds into CMSG_DATA bytewise (no alignment
+    // assumption). The result is checked before use.
+    unsafe {
+        let mut iov = libc::iovec {
+            iov_base: data.as_ptr() as *mut libc::c_void,
+            iov_len: data.len(),
+        };
+        let control_len = libc::CMSG_SPACE(fd_bytes as libc::c_uint) as usize;
+        let mut control = vec![0u8; control_len];
+
+        let mut msg: libc::msghdr = std::mem::zeroed();
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = control.as_mut_ptr().cast();
+        msg.msg_controllen = control_len as _;
+
+        let cmsg = libc::CMSG_FIRSTHDR(&msg);
+        (*cmsg).cmsg_level = libc::SOL_SOCKET;
+        (*cmsg).cmsg_type = libc::SCM_RIGHTS;
+        (*cmsg).cmsg_len = libc::CMSG_LEN(fd_bytes as libc::c_uint) as _;
+        std::ptr::copy_nonoverlapping(fds.as_ptr().cast::<u8>(), libc::CMSG_DATA(cmsg), fd_bytes);
+
+        let n = libc::sendmsg(sock, &msg, libc::MSG_NOSIGNAL);
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(n as usize)
+    }
+}
+
+/// `recvmsg` into `data`, collecting any `SCM_RIGHTS` fds as fresh owned fds
+/// (`MSG_CMSG_CLOEXEC`). Non-blocking (`MSG_DONTWAIT`); `EAGAIN` -> `WouldBlock`.
+/// Returns `(bytes_read, fds)`; `0` bytes means EOF. `max_fds` sizes the control
+/// buffer: the caller knows from the frame header exactly how many fds the sender
+/// attached, so there is no fixed cap — too small a buffer would truncate the
+/// ancillary data (`MSG_CTRUNC`) and the caller's count check would catch it.
+pub(crate) fn recv_with_fds(
+    sock: RawFd,
+    data: &mut [u8],
+    max_fds: usize,
+) -> io::Result<(usize, Vec<OwnedFd>)> {
+    let fd_size = std::mem::size_of::<RawFd>();
+    // SAFETY: the block builds a msghdr with one iovec over `data` and a control
+    // buffer sized for `max_fds` cmsg fds, calls recvmsg, then walks the returned
+    // cmsgs copying out each SCM_RIGHTS fd (installed by the kernel as a fresh fd we
+    // take ownership of). All pointers come from the just-filled msghdr.
+    unsafe {
+        let mut iov = libc::iovec {
+            iov_base: data.as_mut_ptr().cast(),
+            iov_len: data.len(),
+        };
+        let control_len = libc::CMSG_SPACE((max_fds * fd_size) as libc::c_uint) as usize;
+        let mut control = vec![0u8; control_len];
+
+        let mut msg: libc::msghdr = std::mem::zeroed();
+        msg.msg_iov = &mut iov;
+        msg.msg_iovlen = 1;
+        msg.msg_control = control.as_mut_ptr().cast();
+        msg.msg_controllen = control_len as _;
+
+        let n = libc::recvmsg(sock, &mut msg, libc::MSG_CMSG_CLOEXEC | libc::MSG_DONTWAIT);
+        if n < 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let mut fds = Vec::new();
+        let mut cmsg = libc::CMSG_FIRSTHDR(&msg);
+        while !cmsg.is_null() {
+            if (*cmsg).cmsg_level == libc::SOL_SOCKET && (*cmsg).cmsg_type == libc::SCM_RIGHTS {
+                let payload = (*cmsg).cmsg_len as usize - libc::CMSG_LEN(0) as usize;
+                let count = payload / fd_size;
+                let src = libc::CMSG_DATA(cmsg);
+                for i in 0..count {
+                    let mut raw: RawFd = 0;
+                    std::ptr::copy_nonoverlapping(
+                        src.add(i * fd_size),
+                        (&mut raw as *mut RawFd).cast::<u8>(),
+                        fd_size,
+                    );
+                    fds.push(OwnedFd::from_raw_fd(raw));
+                }
+            }
+            cmsg = libc::CMSG_NXTHDR(&msg, cmsg);
+        }
+        Ok((n as usize, fds))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mapper_range_must_fit_reservation() {
+        assert_eq!(
+            checked_range_end(RESERVE as u64 - 1, 1).expect("last byte should fit"),
+            RESERVE as u64
+        );
+        assert_eq!(
+            checked_range_end(RESERVE as u64, 1)
+                .expect_err("range past reservation should fail")
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+        assert_eq!(
+            checked_range_end(u64::MAX, 1)
+                .expect_err("overflowing range should fail")
+                .kind(),
+            io::ErrorKind::InvalidData
+        );
+    }
+
+    /// Bumping past the initial size grows the file; a smaller, then larger
+    /// request walk the bump pointer with correct alignment.
+    #[test]
+    fn alloc_bumps_and_grows() {
+        let mut alloc = Allocator::new().expect("create slab");
+        assert_eq!(alloc.file_size, INITIAL);
+
+        // First two allocations are sub-ALIGN, so each consumes exactly ALIGN and
+        // they sit back to back at 0 and ALIGN.
+        assert_eq!(alloc.alloc(10).expect("alloc a"), 0);
+        assert_eq!(alloc.alloc(1).expect("alloc b"), ALIGN);
+
+        // A request larger than the current file forces a grow. After the two
+        // 64-byte allocations the bump pointer is at 2*ALIGN = 128.
+        let big = INITIAL + 5;
+        let offset = alloc.alloc(big).expect("alloc big");
+        assert_eq!(offset, 2 * ALIGN);
+        // The file grew to cover offset + aligned(big), rounded up to GROW.
+        let expected = align_up(2 * ALIGN + align_up(big, ALIGN), GROW);
+        assert_eq!(alloc.file_size, expected);
+        assert!(alloc.file_size >= offset + big);
+    }
+
+    /// Freeing a block lets the next same-size request reuse its offset instead of
+    /// bumping; a different size still bumps.
+    #[test]
+    fn free_same_size_is_reused() {
+        let mut alloc = Allocator::new().expect("create slab");
+
+        let a = alloc.alloc(100).expect("alloc a"); // size = aligned(100) = 128
+        let b = alloc.alloc(100).expect("alloc b");
+        assert_ne!(a, b);
+
+        alloc.free(a, 100);
+        // Same size: reuses the just-freed offset rather than advancing the bump.
+        let reused = alloc.alloc(120).expect("alloc reused"); // aligned(120) == 128
+        assert_eq!(
+            reused, a,
+            "a same-size request should reuse the freed block"
+        );
+
+        // A different size class has no free block, so it bumps fresh (past b).
+        let other = alloc.alloc(500).expect("alloc other");
+        assert!(other >= b + align_up(100, ALIGN));
+    }
+
+    /// The freelist is keyed by aligned size, so freeing one size never satisfies
+    /// a request for another.
+    #[test]
+    fn free_is_size_classed() {
+        let mut alloc = Allocator::new().expect("create slab");
+        let small = alloc.alloc(10).expect("alloc small");
+        alloc.free(small, 10);
+
+        // A request in a larger size class must not reuse the small freed block.
+        let large = alloc.alloc(1000).expect("alloc large");
+        assert_ne!(large, small);
+    }
+
+    /// The slab fd is shareable and stays valid for growth across clones.
+    #[test]
+    fn slab_fd_is_shared() {
+        let mut alloc = Allocator::new().expect("create slab");
+        let shared = Arc::clone(alloc.slab_fd());
+        // Force a grow; the shared handle still refers to the same (now larger)
+        // file.
+        alloc.alloc(INITIAL + 1).expect("alloc forcing grow");
+        assert!(shared.as_raw_fd() >= 0);
+    }
+
+    /// Run an async body on a fresh current-thread runtime + LocalSet, matching how
+    /// the shm tasks run inside the context (spawn_local, io driver).
+    fn run_local<F: std::future::Future>(future: F) -> F::Output {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        tokio::task::LocalSet::new().block_on(&rt, future)
+    }
+
+    /// The mapper maps a slab range writable, keeps the base fixed across repeated
+    /// maps, and the bytes written through it persist (it is the same file).
+    #[test]
+    fn mapper_maps_slab_writable_and_keeps_base_fixed() {
+        let mut alloc = Allocator::new().expect("create slab");
+        let len = 4096usize;
+        let offset = alloc.alloc(len as u64).expect("alloc");
+        let slab = alloc.slab_fd().as_raw_fd();
+
+        let mut mapper = ShmMapper::new();
+        // SAFETY: `slab` is the live slab fd and `[offset, offset+len)` was just
+        // allocated, so the file is grown to cover it.
+        let ptr = unsafe { mapper.map(slab, offset, len).expect("map") };
+        // SAFETY: `ptr` is a writable mapping of `len` bytes for the mapper's life.
+        unsafe { std::slice::from_raw_parts_mut(ptr, len).fill(0xAB) };
+
+        // Mapping the same range again returns the same pointer (base never moves)
+        // and observes the bytes written above (same underlying file).
+        // SAFETY: same justification as the first map.
+        let ptr2 = unsafe { mapper.map(slab, offset, len).expect("remap") };
+        assert_eq!(ptr2, ptr, "the reservation base must not move");
+        // SAFETY: `ptr2` maps the same `len` bytes.
+        let seen = unsafe { std::slice::from_raw_parts(ptr2, len) };
+        assert!(
+            seen.iter().all(|&b| b == 0xAB),
+            "written bytes should persist"
+        );
+    }
+
+    /// Full request protocol: allocate a grant, write/read it through the mapper,
+    /// then drop the token so the server frees the block — after which a same-size
+    /// allocation reuses the freed offset.
+    #[test]
+    fn allocate_grants_slab_then_frees_and_reuses_on_token_drop() {
+        run_local(async {
+            let server = ShmServer::new().expect("server");
+            let client = server.client();
+            let mapper: MapperHandle = Arc::new(Mutex::new(ShmMapper::new()));
+
+            let len = 5000u64;
+            let (offset, token) = client.allocate(len).await.expect("allocate");
+
+            // SAFETY: `offset` was just granted against `client`'s slab for `len`
+            // bytes, so the file covers it; the pointer lives as long as `mapper`.
+            let ptr = unsafe {
+                mapper
+                    .lock()
+                    .expect("mapper lock")
+                    .map(client.slab_fd(), offset, len as usize)
+                    .expect("map grant")
+            };
+            // SAFETY: `ptr` is a writable mapping of `len` bytes.
+            unsafe { std::slice::from_raw_parts_mut(ptr, len as usize).fill(0x5A) };
+            // SAFETY: read back the same range.
+            let seen = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+            assert!(seen.iter().all(|&b| b == 0x5A), "slab grant is writable");
+
+            // Dropping the only token closes the read end; the server's hangup watch
+            // then frees the block. Wait until that free is processed.
+            drop(token);
+            for _ in 0..500 {
+                if server.freed_count() >= 1 {
+                    break;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(1)).await;
+            }
+            assert_eq!(server.freed_count(), 1, "the block should be freed once");
+
+            // A same-size request now reuses the just-freed offset.
+            let (offset2, _token2) = client.allocate(len).await.expect("re-allocate");
+            assert_eq!(offset2, offset, "a freed block should be reused");
+        });
+    }
+
+    /// The hangup that frees a block fires only after the *last* copy of its token
+    /// closes: an in-transit duplicate keeps the block alive.
+    #[test]
+    fn liveness_fires_only_after_last_token_closes() {
+        run_local(async {
+            let (read_end, write_end) = make_pipe().expect("pipe");
+            let (free_tx, mut free_rx) = mpsc::unbounded_channel();
+            tokio::task::spawn_local(watch_grant(write_end, 42, 100, free_tx));
+
+            // A second holder of the token (as if relayed to an in-transit hop).
+            let read_dup = dup_fd(read_end.as_raw_fd()).expect("dup token");
+
+            // Closing one copy must NOT free the block.
+            drop(read_end);
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            assert!(
+                free_rx.try_recv().is_err(),
+                "free must not fire while a duplicate token is open"
+            );
+
+            // Closing the last copy frees it, reporting the original (offset, len).
+            drop(read_dup);
+            let freed = free_rx.recv().await.expect("free reported");
+            assert_eq!(freed, (42, 100), "free reports the granted block");
+        });
+    }
+}

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -817,6 +817,134 @@ fn unix_monitor_fires_across_processes() {
 }
 
 #[test]
+fn unix_gateway_sends_large_message_through_shared_memory() {
+    // Two contexts (= two processes) joined by a unix socket. The gateway owns a
+    // slab; on establishment it hands its child the gateway state, then sends a
+    // large message that is moved through the slab (not streamed) and arrives
+    // intact. If the state had not propagated, the receiver could not reconstruct
+    // the slab part and the connection would sever instead.
+    let server_ctx = CtxHandle::new().expect("server context should start");
+    let client_ctx = CtxHandle::new().expect("client context should start");
+    let gw = runtime_gateway_actor(&server_ctx, "shm-gw");
+    let child = runtime_actor(&client_ctx, "shm-child");
+    let (child_poller, mut child_rx) = runtime_poller(&client_ctx);
+    runtime_subscribe(&client_ctx, child_poller, 0, child);
+
+    let url = unix_test_url("shm-gateway");
+    server_ctx
+        .send_command(Command::Serve {
+            actor: gw,
+            url: url.clone(),
+            request: request(Role::Parent),
+        })
+        .expect("serve should enqueue");
+    client_ctx
+        .send_command(Command::Join {
+            actor: child,
+            url,
+            request: request(Role::Child),
+        })
+        .expect("join should enqueue");
+
+    assert_eq!(recv_strings(&mut child_rx), vec!["shm-child", "shm-gw"]);
+
+    let len = crate::shm::SHM_THRESHOLD as usize + 1234;
+    let payload = vec![0x41u8; len];
+    server_ctx
+        .send_command(Command::Send {
+            sender: gw,
+            destination_ident: MsgPart::from_bytes(b"shm-child".to_vec()),
+            parts: vec![MsgPart::from_bytes(payload.clone())],
+        })
+        .expect("send should enqueue");
+
+    let parts = recv_parts(&mut child_rx);
+    assert_eq!(parts.len(), 1, "one part delivered");
+    assert_eq!(parts[0], payload, "large slab payload arrives intact");
+
+    shutdown(client_ctx);
+    shutdown(server_ctx);
+}
+
+#[test]
+fn unix_inproc_unix_forwards_gateway_state_past_inproc_hop() {
+    // gw --unix--> a --inproc--> b --unix--> c, across three contexts. The gateway
+    // state must travel down the unix edge, across the inproc edge, and out the
+    // next unix edge so that the final hop (b -> c) can move a large message
+    // through the slab. The message originates at gw and must arrive intact at c.
+    let ctx_a = CtxHandle::new().expect("ctx a");
+    let ctx_b = CtxHandle::new().expect("ctx b");
+    let ctx_c = CtxHandle::new().expect("ctx c");
+
+    let gw = runtime_gateway_actor(&ctx_a, "hop-gw");
+    let a = runtime_actor(&ctx_b, "hop-a");
+    let b = runtime_actor(&ctx_b, "hop-b");
+    let c = runtime_actor(&ctx_c, "hop-c");
+    let (c_poller, mut c_rx) = runtime_poller(&ctx_c);
+    runtime_subscribe(&ctx_c, c_poller, 0, c);
+
+    // gw --unix--> a
+    let gw_url = unix_test_url("hop-gw");
+    ctx_a
+        .send_command(Command::Serve {
+            actor: gw,
+            url: gw_url.clone(),
+            request: request(Role::Parent),
+        })
+        .expect("serve");
+    ctx_b
+        .send_command(Command::Join {
+            actor: a,
+            url: gw_url,
+            request: request(Role::Child),
+        })
+        .expect("join");
+
+    // a --inproc--> b (same context)
+    runtime_connect(&ctx_b, a, b, "inproc://hop-ab");
+
+    // b --unix--> c
+    let bc_url = unix_test_url("hop-bc");
+    ctx_b
+        .send_command(Command::Serve {
+            actor: b,
+            url: bc_url.clone(),
+            request: request(Role::Parent),
+        })
+        .expect("serve");
+    ctx_c
+        .send_command(Command::Join {
+            actor: c,
+            url: bc_url,
+            request: request(Role::Child),
+        })
+        .expect("join");
+
+    assert_eq!(recv_strings(&mut c_rx), vec!["hop-c", "hop-b"]);
+
+    let len = crate::shm::SHM_THRESHOLD as usize + 99;
+    let payload = vec![0x5Au8; len];
+    ctx_a
+        .send_command(Command::Send {
+            sender: gw,
+            destination_ident: MsgPart::from_bytes(b"hop-c".to_vec()),
+            parts: vec![MsgPart::from_bytes(payload.clone())],
+        })
+        .expect("send");
+
+    let parts = recv_parts(&mut c_rx);
+    assert_eq!(parts.len(), 1);
+    assert_eq!(
+        parts[0], payload,
+        "large payload survives unix->inproc->unix"
+    );
+
+    shutdown(ctx_c);
+    shutdown(ctx_b);
+    shutdown(ctx_a);
+}
+
+#[test]
 fn quic_serve_join_establishes_and_routes() {
     set_quic_env();
     let ctx = CtxHandle::new().expect("context should start");
@@ -1086,14 +1214,33 @@ fn runtime_connect(ctx: &CtxHandle, parent: Key, child: Key, url: &str) {
 }
 
 fn runtime_actor(ctx: &CtxHandle, ident: &str) -> Key {
+    runtime_actor_with_gateway(ctx, ident, false)
+}
+
+fn runtime_gateway_actor(ctx: &CtxHandle, ident: &str) -> Key {
+    runtime_actor_with_gateway(ctx, ident, true)
+}
+
+fn runtime_actor_with_gateway(ctx: &CtxHandle, ident: &str, gateway: bool) -> Key {
     let (done_tx, done_rx) = oneshot::channel();
     ctx.send_command(Command::CreateActor {
         ident: Some(MsgPart::from_bytes(ident.as_bytes().to_vec())),
-        gateway: false,
+        gateway,
         done: done_tx,
     })
     .expect("create actor should enqueue");
     done_rx.blocking_recv().expect("actor should be created")
+}
+
+/// Block for the next delivered message, returning each part's bytes (mapping any
+/// shared-memory parts in the process).
+fn recv_parts(rx: &mut mpsc::UnboundedReceiver<Delivered>) -> Vec<Vec<u8>> {
+    rx.blocking_recv()
+        .expect("message should be delivered")
+        .msg
+        .iter()
+        .map(|part| part.as_bytes().to_vec())
+        .collect()
 }
 
 fn runtime_poller(ctx: &CtxHandle) -> (PollerKey, mpsc::UnboundedReceiver<Delivered>) {

--- a/monarch_mini/src/transport.rs
+++ b/monarch_mini/src/transport.rs
@@ -17,10 +17,13 @@
 //! constructs an `Establish`.
 
 use crate::connection::ConnectionRef;
+use crate::shm::ShmClientSlot;
 
 pub(crate) trait Transport {
     /// Begin serving `connection` on `url` (this actor is the parent/server).
-    fn serve(&mut self, url: String, connection: ConnectionRef);
+    /// `shm_client` is the owning actor's shared-memory client slot; only the unix
+    /// transport uses it (to move large parts through the slab), others ignore it.
+    fn serve(&mut self, url: String, connection: ConnectionRef, shm_client: ShmClientSlot);
     /// Begin joining `connection` on `url` (this actor is the child/client).
-    fn join(&mut self, url: String, connection: ConnectionRef);
+    fn join(&mut self, url: String, connection: ConnectionRef, shm_client: ShmClientSlot);
 }

--- a/monarch_mini/src/unix_framing.rs
+++ b/monarch_mini/src/unix_framing.rs
@@ -6,41 +6,51 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-//! Wire framing for the UNIX-socket transport.
+//! Wire framing for the UNIX-socket transport, including shared-memory parts.
 //!
-//! Deliberately **separate** from the generic [`crate::framing`] used by quic
-//! (and, later, tcp): the UNIX transport is where machine-local shared-memory
-//! handling lives, so its wire format grows fd-passing and shared-memory part
-//! descriptors that have no business leaking into the cross-machine framing.
-//! Keeping a private copy of the small set of frame types is cheaper than a
-//! shared abstraction that both sides have to bend around.
+//! Deliberately **separate** from the generic [`crate::framing`] used by quic:
+//! the UNIX transport is where machine-local shared-memory handling lives, so its
+//! wire format carries fd-passing and slab part descriptors that have no business
+//! in the cross-machine framing.
 //!
-//! Each frame is `[u64 header_len][header][raw part bytes...]`. The header is a
-//! bincode-encoded [`UnixFrame`] holding only small metadata; for a message it
-//! carries the *lengths* of the parts, never their bytes. Message-part bytes are
-//! written straight from the owning `MsgPart` and read straight into a freshly
-//! allocated per-part buffer — no copies of payload beyond the socket read/write.
+//! A frame is `[u64 header_len][header][maybe fd-exchange][inline part bytes]`.
+//! The header is a bincode [`UnixFrame`]; the header and inline bytes are
+//! read/written with plain readiness-driven `try_read`/`try_write`. Only if the
+//! header says fds are present (one per [`PartDesc::Shm`] part) do we do one extra
+//! `sendmsg`/`recvmsg` step — a 1-byte payload carrying all the fds via
+//! `SCM_RIGHTS`. No-fd frames never touch the fd-passing syscalls.
 //!
-//! Unlike quic, the UNIX transport relies on socket EOF for liveness and never
-//! emits heartbeats, so there is no heartbeat frame and a decoded frame maps
-//! straight to a [`ConnectionCommand`].
+//! Per part on send: a part already in the slab is relayed by descriptor (no map,
+//! no copy); a large owned part on a connection that has a [`ShmClient`] is
+//! allocated, `memcpy`d into the slab, and sent as a descriptor + liveness token;
+//! everything else streams inline. On receive, an inline part is read into owned
+//! bytes and a slab part is reconstructed as *unmapped* metadata (mapped only when
+//! the user takes the bytes).
+
+use std::os::fd::AsRawFd;
+use std::os::fd::IntoRawFd;
+use std::os::fd::OwnedFd;
+use std::os::fd::RawFd;
 
 use serde::Deserialize;
 use serde::Serialize;
-use tokio::io::AsyncRead;
-use tokio::io::AsyncReadExt;
-use tokio::io::AsyncWrite;
-use tokio::io::AsyncWriteExt;
+use tokio::io::Interest;
+use tokio::net::UnixStream;
 
 use crate::Role;
 use crate::connection::AncestorPayload;
 use crate::connection::ConnectionCommand;
 use crate::connection::SendPayload;
 use crate::msg::MsgPart;
+use crate::shm::MapperHandle;
+use crate::shm::SHM_THRESHOLD;
+use crate::shm::ShmClient;
+use crate::shm::recv_with_fds;
+use crate::shm::send_with_fds;
 
-/// One frame on the UNIX wire. There is a variant per [`ConnectionCommand`] that
-/// crosses the pipe (including `Establish`, which is how the two ends exchange
-/// identity). Message-part *bytes* are never carried here — only their lengths.
+/// One frame on the UNIX wire. A variant per [`ConnectionCommand`] that crosses
+/// the pipe (including `Establish`). Message-part *bytes* are never carried here —
+/// only inline-part lengths and slab-part descriptors.
 #[derive(Serialize, Deserialize)]
 enum UnixFrame {
     Establish {
@@ -64,107 +74,196 @@ enum UnixFrame {
     Severed {
         reason: Vec<u8>,
     },
+    /// Gateway-state handoff: the header carries nothing; two fds (the slab object
+    /// then the dgram request socket) ride the fd-exchange step.
+    GatewayState,
 }
 
-/// Wire form of a [`SendMessage`](ConnectionCommand::SendMessage)'s payload. An
-/// actor message carries only its parts' *lengths* in the header (the bytes are
-/// streamed raw afterwards, zero-copy); a monitor fire carries the small dead
+/// Wire form of a message payload. An actor message carries a descriptor per part
+/// (inline length or slab offset/length); a monitor fire carries the small dead
 /// target ident inline.
 #[derive(Serialize, Deserialize)]
 enum UnixPayload {
-    ActorMessage { part_lens: Vec<u64> },
+    ActorMessage { parts: Vec<PartDesc> },
     FireMonitor { to_monitor: Vec<u8> },
+}
+
+/// How one message part is represented on the wire. `Inline` parts have their
+/// bytes streamed raw after the header; `Shm` parts carry only an offset+length
+/// into the slab and are accompanied (in part order) by one liveness-token fd in
+/// the fd-exchange step.
+#[derive(Serialize, Deserialize)]
+enum PartDesc {
+    Inline { len: u64 },
+    Shm { offset: u64, len: u64 },
 }
 
 fn bincode_config() -> bincode::config::Configuration {
     bincode::config::standard()
 }
 
-/// Serialize and write one command: a length-prefixed bincode header, then — for
-/// a message — each part's bytes streamed straight from its buffer. Flushes so
-/// the peer sees it promptly.
-pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
-    writer: &mut W,
+/// Serialize and write one command over `stream`. For a message, large owned
+/// parts are moved into the slab (allocate via `client`, `memcpy` via `mapper`)
+/// and sent as descriptors + token fds; slab parts are relayed by descriptor;
+/// small/owned parts stream inline. `client`/`mapper` are unused by non-message
+/// commands and by messages with no large parts.
+pub(crate) async fn write_command(
+    stream: &UnixStream,
     command: ConnectionCommand,
+    mapper: &MapperHandle,
+    client: Option<ShmClient>,
 ) -> std::io::Result<()> {
-    // A message additionally keeps a list of part bytes to stream raw after the
-    // header; every other command is header-only.
-    let mut parts: Vec<MsgPart> = Vec::new();
-    let frame = match command {
+    match command {
         ConnectionCommand::SendMessage {
             destination_ident,
-            payload,
+            payload: SendPayload::ActorMessage(parts),
+        } => write_actor_message(stream, destination_ident, parts, mapper, client).await,
+        ConnectionCommand::SendMessage {
+            destination_ident,
+            payload: SendPayload::FireMonitor(to_monitor),
         } => {
-            let payload = match payload {
-                SendPayload::ActorMessage(message_parts) => {
-                    let part_lens = message_parts
-                        .iter()
-                        .map(|part| part.as_bytes().len() as u64)
-                        .collect();
-                    parts = message_parts;
-                    UnixPayload::ActorMessage { part_lens }
-                }
-                SendPayload::FireMonitor(to_monitor) => UnixPayload::FireMonitor { to_monitor },
-            };
-            UnixFrame::Message {
+            let frame = UnixFrame::Message {
                 destination_ident,
-                payload,
-            }
+                payload: UnixPayload::FireMonitor { to_monitor },
+            };
+            write_header(stream, &frame).await
         }
         ConnectionCommand::Establish {
             role,
             ident,
             name_for_other,
             alive,
-        } => UnixFrame::Establish {
-            role,
-            ident,
-            name_for_other,
-            alive,
-        },
-        ConnectionCommand::PublishRoutes { live, dead } => UnixFrame::PublishRoutes { live, dead },
+        } => {
+            write_header(
+                stream,
+                &UnixFrame::Establish {
+                    role,
+                    ident,
+                    name_for_other,
+                    alive,
+                },
+            )
+            .await
+        }
+        ConnectionCommand::PublishRoutes { live, dead } => {
+            write_header(stream, &UnixFrame::PublishRoutes { live, dead }).await
+        }
         ConnectionCommand::ToAncestor {
             to_monitor,
             payload,
-        } => UnixFrame::ToAncestor {
-            to_monitor,
-            payload,
-        },
-        ConnectionCommand::Severed { reason } => UnixFrame::Severed { reason },
-    };
-    write_frame(writer, &frame, &parts).await
+        } => {
+            write_header(
+                stream,
+                &UnixFrame::ToAncestor {
+                    to_monitor,
+                    payload,
+                },
+            )
+            .await
+        }
+        ConnectionCommand::Severed { reason } => {
+            write_header(stream, &UnixFrame::Severed { reason }).await
+        }
+        ConnectionCommand::GatewayState { client } => {
+            write_header(stream, &UnixFrame::GatewayState).await?;
+            // Order matters: slab fd first, then the dgram request socket — the
+            // reader reconstructs in the same order.
+            send_fd_exchange(stream, &[client.slab_fd(), client.dgram_fd()]).await
+        }
+    }
 }
 
-async fn write_frame<W: AsyncWrite + Unpin>(
-    writer: &mut W,
-    frame: &UnixFrame,
-    parts: &[MsgPart],
+/// Build and write a `Message` frame: classify each part (relay slab / shm-ify
+/// large owned / inline), write the header, hand over the token fds in one
+/// fd-exchange step, then stream the inline bytes.
+async fn write_actor_message(
+    stream: &UnixStream,
+    destination_ident: Vec<u8>,
+    parts: Vec<MsgPart>,
+    mapper: &MapperHandle,
+    client: Option<ShmClient>,
 ) -> std::io::Result<()> {
+    let mut descs = Vec::with_capacity(parts.len());
+    let mut tokens: Vec<OwnedFd> = Vec::new();
+    let mut inline: Vec<MsgPart> = Vec::new();
+
+    for part in parts {
+        if part.is_shm() {
+            // Already in the slab: relay the descriptor and its token, no copy.
+            let (offset, len, token) = part.into_shm();
+            descs.push(PartDesc::Shm { offset, len });
+            tokens.push(token);
+            continue;
+        }
+        let len = part.len() as u64;
+        match client {
+            Some(client) if len >= SHM_THRESHOLD => {
+                let (offset, token) = client.allocate(len).await?;
+                let dst = {
+                    let mut mapper = mapper.lock().expect("shm mapper mutex poisoned");
+                    // SAFETY: `offset` was just granted for `len` bytes against
+                    // `client`'s slab, so the file covers it and the mapper can map it.
+                    unsafe { mapper.map(client.slab_fd(), offset, len as usize)? }
+                };
+                let src = part.as_bytes();
+                // SAFETY: `dst` is a writable mapping of `len` bytes (just mapped)
+                // and `src` is exactly `len` bytes; the regions do not overlap (one
+                // is the user buffer, the other the slab).
+                unsafe { std::ptr::copy_nonoverlapping(src.as_ptr(), dst, len as usize) };
+                descs.push(PartDesc::Shm { offset, len });
+                tokens.push(token);
+                // `part` (the owned bytes) drops here, freeing the user buffer.
+            }
+            _ => {
+                descs.push(PartDesc::Inline { len });
+                inline.push(part);
+            }
+        }
+    }
+
+    let frame = UnixFrame::Message {
+        destination_ident,
+        payload: UnixPayload::ActorMessage { parts: descs },
+    };
+    write_header(stream, &frame).await?;
+
+    if !tokens.is_empty() {
+        let raw: Vec<RawFd> = tokens.iter().map(AsRawFd::as_raw_fd).collect();
+        send_fd_exchange(stream, &raw).await?;
+        // The kernel has duplicated the tokens to the peer; drop our copies so the
+        // grant's liveness now rides with the peer (and any relay hop).
+        drop(tokens);
+    }
+
+    for part in &inline {
+        write_all(stream, part.as_bytes()).await?;
+    }
+    Ok(())
+}
+
+/// Serialize `frame` and write `[u64 len][header]`.
+async fn write_header(stream: &UnixStream, frame: &UnixFrame) -> std::io::Result<()> {
     let header = bincode::serde::encode_to_vec(frame, bincode_config())
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    writer
-        .write_all(&(header.len() as u64).to_le_bytes())
-        .await?;
-    writer.write_all(&header).await?;
-    // Write each part's bytes straight from its owning buffer — no copy.
-    for part in parts {
-        writer.write_all(part.as_bytes()).await?;
-    }
-    writer.flush().await
+    write_all(stream, &(header.len() as u64).to_le_bytes()).await?;
+    write_all(stream, &header).await
 }
 
-/// Read one frame and map it straight back to a [`ConnectionCommand`]. For a
-/// message the part bytes are read directly into the command's own buffers — the
-/// only copy is the unavoidable kernel-to-userspace one.
-pub(crate) async fn read_command<R: AsyncRead + Unpin>(
-    reader: &mut R,
+/// Read one frame and map it back to a [`ConnectionCommand`]. Inline parts are
+/// read into owned buffers; slab parts are reconstructed as unmapped metadata
+/// using this connection's `mapper` and `client` (for the slab fd) plus the token
+/// fds received in the fd-exchange step.
+pub(crate) async fn read_command(
+    stream: &UnixStream,
+    mapper: &MapperHandle,
+    client: Option<ShmClient>,
 ) -> std::io::Result<ConnectionCommand> {
     let mut len_buf = [0u8; 8];
-    reader.read_exact(&mut len_buf).await?;
+    read_exact(stream, &mut len_buf).await?;
     let header_len = u64::from_le_bytes(len_buf) as usize;
 
     let mut header = vec![0u8; header_len];
-    reader.read_exact(&mut header).await?;
+    read_exact(stream, &mut header).await?;
     let (frame, _) = bincode::serde::decode_from_slice::<UnixFrame, _>(&header, bincode_config())
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
 
@@ -173,18 +272,7 @@ pub(crate) async fn read_command<R: AsyncRead + Unpin>(
             destination_ident,
             payload,
         } => {
-            let payload = match payload {
-                UnixPayload::ActorMessage { part_lens } => {
-                    let mut parts = Vec::with_capacity(part_lens.len());
-                    for len in part_lens {
-                        let mut buf = vec![0u8; len as usize];
-                        reader.read_exact(&mut buf).await?;
-                        parts.push(MsgPart::from_bytes(buf));
-                    }
-                    SendPayload::ActorMessage(parts)
-                }
-                UnixPayload::FireMonitor { to_monitor } => SendPayload::FireMonitor(to_monitor),
-            };
+            let payload = read_message_payload(stream, payload, mapper, client).await?;
             ConnectionCommand::SendMessage {
                 destination_ident,
                 payload,
@@ -210,5 +298,270 @@ pub(crate) async fn read_command<R: AsyncRead + Unpin>(
             payload,
         },
         UnixFrame::Severed { reason } => ConnectionCommand::Severed { reason },
+        UnixFrame::GatewayState => {
+            // Two fds in the order they were sent: slab object, then dgram socket.
+            // They must stay open for the process lifetime, so leak the received
+            // owned fds into raw fds the (non-owning, `Copy`) ShmClient holds.
+            let mut fds = recv_fd_exchange(stream, 2).await?.into_iter();
+            let slab = fds.next().expect("two fds checked by recv_fd_exchange");
+            let dgram = fds.next().expect("two fds checked by recv_fd_exchange");
+            ConnectionCommand::GatewayState {
+                client: ShmClient::from_raw(dgram.into_raw_fd(), slab.into_raw_fd()),
+            }
+        }
     })
+}
+
+/// Reconstruct a message payload's parts: collect token fds (one per slab part)
+/// in the single fd-exchange step, then walk the descriptors in order, reading
+/// inline bytes and pairing each slab descriptor with the next token fd.
+async fn read_message_payload(
+    stream: &UnixStream,
+    payload: UnixPayload,
+    mapper: &MapperHandle,
+    client: Option<ShmClient>,
+) -> std::io::Result<SendPayload> {
+    let descs = match payload {
+        UnixPayload::ActorMessage { parts } => parts,
+        UnixPayload::FireMonitor { to_monitor } => return Ok(SendPayload::FireMonitor(to_monitor)),
+    };
+
+    let n_fds = descs
+        .iter()
+        .filter(|d| matches!(d, PartDesc::Shm { .. }))
+        .count();
+    let mut tokens = if n_fds > 0 {
+        recv_fd_exchange(stream, n_fds).await?.into_iter()
+    } else {
+        Vec::new().into_iter()
+    };
+
+    let mut parts = Vec::with_capacity(descs.len());
+    for desc in descs {
+        match desc {
+            PartDesc::Inline { len } => {
+                let mut buf = vec![0u8; len as usize];
+                read_exact(stream, &mut buf).await?;
+                parts.push(MsgPart::from_bytes(buf));
+            }
+            PartDesc::Shm { offset, len } => {
+                let token = tokens.next().ok_or_else(|| {
+                    std::io::Error::new(std::io::ErrorKind::InvalidData, "missing shm token fd")
+                })?;
+                let client = client.ok_or_else(|| {
+                    std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "received a slab part but have no shm client",
+                    )
+                })?;
+                parts.push(MsgPart::new_shm(
+                    mapper.clone(),
+                    client.slab_fd(),
+                    token,
+                    offset,
+                    len,
+                ));
+            }
+        }
+    }
+    Ok(SendPayload::ActorMessage(parts))
+}
+
+// ---------------------------------------------------------------------------
+// Readiness-driven byte and fd IO over the shared UnixStream
+// ---------------------------------------------------------------------------
+
+/// Fill `buf` exactly, awaiting readability between partial reads. EOF before the
+/// buffer is full is an error (a truncated frame).
+async fn read_exact(stream: &UnixStream, buf: &mut [u8]) -> std::io::Result<()> {
+    let mut filled = 0;
+    while filled < buf.len() {
+        stream.readable().await?;
+        match stream.try_read(&mut buf[filled..]) {
+            Ok(0) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "unix frame truncated",
+                ));
+            }
+            Ok(n) => filled += n,
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
+}
+
+/// Write all of `buf`, awaiting writability between partial writes.
+async fn write_all(stream: &UnixStream, buf: &[u8]) -> std::io::Result<()> {
+    let mut sent = 0;
+    while sent < buf.len() {
+        stream.writable().await?;
+        match stream.try_write(&buf[sent..]) {
+            Ok(n) => sent += n,
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(err) => return Err(err),
+        }
+    }
+    Ok(())
+}
+
+/// The fd-exchange step on send: one `sendmsg` of a single marker byte carrying
+/// all `fds` via `SCM_RIGHTS`, driven under write readiness.
+async fn send_fd_exchange(stream: &UnixStream, fds: &[RawFd]) -> std::io::Result<()> {
+    loop {
+        stream.writable().await?;
+        match stream.try_io(Interest::WRITABLE, || {
+            send_with_fds(stream.as_raw_fd(), &[0u8], fds)
+        }) {
+            Ok(_) => return Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+/// The fd-exchange step on receive: one `recvmsg` of the single marker byte,
+/// collecting the `expected` token fds. The 1-byte iovec bounds the read to the
+/// marker so following inline bytes stay in the stream.
+async fn recv_fd_exchange(stream: &UnixStream, expected: usize) -> std::io::Result<Vec<OwnedFd>> {
+    loop {
+        stream.readable().await?;
+        let mut marker = [0u8; 1];
+        match stream.try_io(Interest::READABLE, || {
+            recv_with_fds(stream.as_raw_fd(), &mut marker, expected)
+        }) {
+            Ok((0, _)) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::UnexpectedEof,
+                    "unix frame truncated before fd exchange",
+                ));
+            }
+            Ok((_, fds)) => {
+                if fds.len() != expected {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        "unexpected fd count in fd exchange",
+                    ));
+                }
+                return Ok(fds);
+            }
+            Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => continue,
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::sync::Mutex;
+
+    use super::*;
+    use crate::connection::ConnectionCommand;
+    use crate::connection::SendPayload;
+    use crate::msg::MsgPart;
+    use crate::shm::MapperHandle;
+    use crate::shm::SHM_THRESHOLD;
+    use crate::shm::ShmMapper;
+    use crate::shm::ShmServer;
+
+    fn run_local<F: std::future::Future>(future: F) -> F::Output {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .expect("build runtime");
+        tokio::task::LocalSet::new().block_on(&rt, future)
+    }
+
+    fn mapper() -> MapperHandle {
+        Arc::new(Mutex::new(ShmMapper::new()))
+    }
+
+    /// A `[small header, big payload]` message: the header stays inline and the
+    /// payload travels through the slab (a descriptor + token on the socket, not
+    /// the bytes), and both arrive intact and in order. The two mappers stand in
+    /// for the sender's and receiver's separate contexts mapping the one slab.
+    #[test]
+    fn large_part_goes_through_slab_small_part_inline() {
+        run_local(async {
+            let server = ShmServer::new().expect("shm server");
+            let client = server.client();
+            let send_mapper = mapper();
+            let recv_mapper = mapper();
+            let (a, b) = UnixStream::pair().expect("socketpair");
+
+            let header = b"header".to_vec();
+            let payload = vec![0x42u8; SHM_THRESHOLD as usize + 100];
+            let command = ConnectionCommand::SendMessage {
+                destination_ident: b"dest".to_vec(),
+                payload: SendPayload::ActorMessage(vec![
+                    MsgPart::from_bytes(header.clone()),
+                    MsgPart::from_bytes(payload.clone()),
+                ]),
+            };
+
+            let (write_res, read_res) = tokio::join!(
+                write_command(&a, command, &send_mapper, Some(client)),
+                read_command(&b, &recv_mapper, Some(client)),
+            );
+            write_res.expect("write");
+            let received = read_res.expect("read");
+
+            let ConnectionCommand::SendMessage {
+                destination_ident,
+                payload: SendPayload::ActorMessage(parts),
+            } = received
+            else {
+                panic!("expected an actor message");
+            };
+            assert_eq!(destination_ident, b"dest");
+            assert_eq!(parts.len(), 2, "both parts reconstructed");
+            assert_eq!(
+                parts[0].as_bytes(),
+                header.as_slice(),
+                "inline header intact"
+            );
+            assert_eq!(
+                parts[1].as_bytes(),
+                payload.as_slice(),
+                "slab payload intact and in order"
+            );
+        });
+    }
+
+    /// With no shm client, even a large part falls back to streaming inline.
+    #[test]
+    fn large_part_without_client_streams_inline() {
+        run_local(async {
+            let map = mapper();
+            let (a, b) = UnixStream::pair().expect("socketpair");
+            let payload = vec![0x7u8; SHM_THRESHOLD as usize + 100];
+            let command = ConnectionCommand::SendMessage {
+                destination_ident: b"d".to_vec(),
+                payload: SendPayload::ActorMessage(vec![MsgPart::from_bytes(payload.clone())]),
+            };
+
+            let (write_res, read_res) = tokio::join!(
+                write_command(&a, command, &map, None),
+                read_command(&b, &map, None),
+            );
+            write_res.expect("write");
+            let received = read_res.expect("read");
+
+            let ConnectionCommand::SendMessage {
+                payload: SendPayload::ActorMessage(parts),
+                ..
+            } = received
+            else {
+                panic!("expected an actor message");
+            };
+            assert_eq!(parts.len(), 1);
+            assert_eq!(
+                parts[0].as_bytes(),
+                payload.as_slice(),
+                "inline fallback intact"
+            );
+        });
+    }
 }

--- a/monarch_mini/src/unix_transport.rs
+++ b/monarch_mini/src/unix_transport.rs
@@ -12,38 +12,41 @@
 //! This is pure plumbing. A connection's coroutines bring up the socket, produce
 //! a [`ConnectionTransport`] for it, and hand it to the command loop via
 //! `Command::TransportConnected`; the reader forwards every frame it decodes back
-//! as a `ConnectionAction`. All establishment policy (announcing our
-//! identity, learning the peer's, hello, liveness) lives in the command loop and
-//! is identical to inproc — this file never reads actor state or builds an
+//! as a `ConnectionAction`. All establishment policy (announcing our identity,
+//! learning the peer's, hello, liveness) lives in the command loop and is
+//! identical to inproc — this file never reads actor state or builds an
 //! `Establish`. An `Establish` is just another frame on the wire.
 //!
-//! ## Framing
+//! ## Framing and shared memory
 //!
-//! Framing lives in [`crate::unix_framing`]: each frame is
-//! `[u64 header_len][header][raw part bytes...]`, where the header is a bincode
-//! `UnixFrame` holding only small metadata; for a message it carries the
-//! *lengths* of the parts, never their bytes. Message-part bytes are written
-//! straight from the owning `MsgPart` and read straight into a freshly allocated
-//! per-part buffer — no copies of payload beyond the socket read/write.
+//! Framing lives in [`crate::unix_framing`]. Because the UNIX transport carries
+//! shared-memory part descriptors and passes file descriptors (the slab grant
+//! tokens) over the socket via `SCM_RIGHTS`, the reader and writer share one
+//! [`UnixStream`] (via `Arc`) and drive it through the readiness API
+//! (`readable`/`writable` + `try_read`/`try_write`/`try_io`) rather than the
+//! split read/write halves — both directions and the fd-exchange step then use a
+//! single reactor registration. Each connection is handed the context's
+//! [`MapperHandle`] and its owning actor's [`ShmClientSlot`]; large parts move
+//! through the slab once that slot holds a gateway client, and stay inline
+//! otherwise.
 //!
 //! ## Liveness
 //!
 //! Dropping a connection's [`UnixConnectionTransport`] drops its writer channel,
-//! which ends the writer task and closes the socket's write half; the peer's
-//! reader then sees EOF and emits `Severed`. That is the same "drop the transport
-//! ⇒ peer severed" contract the inproc transport implements explicitly.
+//! which ends the writer task; the writer then shuts the socket's write half down,
+//! and the peer's reader sees EOF and emits `Severed`. That is the same "drop the
+//! transport ⇒ peer severed" contract the inproc transport implements explicitly.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::os::fd::AsRawFd;
 use std::os::fd::RawFd;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Instant;
 
-use tokio::io::AsyncWriteExt;
 use tokio::net::UnixListener;
 use tokio::net::UnixStream;
-use tokio::net::unix::OwnedReadHalf;
-use tokio::net::unix::OwnedWriteHalf;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::Duration;
@@ -53,6 +56,9 @@ use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
 use crate::ctx::Command;
 use crate::matcher::Matcher;
+use crate::shm::MapperHandle;
+use crate::shm::ShmClient;
+use crate::shm::ShmClientSlot;
 use crate::transport::Transport;
 use crate::unix_framing;
 
@@ -63,21 +69,46 @@ const CONNECT_RETRY_MIN: Duration = Duration::from_millis(5);
 const CONNECT_RETRY_MAX: Duration = Duration::from_millis(1000);
 
 /// A reader waiting for a frame spins this long peeking the socket before
-/// parking on `recv().await`, trading CPU for the elimination of the kernel
+/// parking on `readable().await`, trading CPU for the elimination of the kernel
 /// read-wakeup latency. Sized to comfortably exceed a small-message round trip
 /// so steady ping-pong traffic never parks; an idle reader spins this long once,
 /// then parks to zero CPU.
 const READ_SPIN: Duration = Duration::from_micros(200);
 
+/// What a connection's coroutines need for shared memory: the context-global
+/// mapper and the owning actor's client slot.
+#[derive(Clone)]
+struct ShmCtx {
+    mapper: MapperHandle,
+    client: ShmClientSlot,
+}
+
+impl ShmCtx {
+    /// Snapshot the owning actor's gateway client (`None` until it arrives).
+    fn client(&self) -> Option<ShmClient> {
+        *self.client.lock().expect("shm client slot mutex poisoned")
+    }
+
+    /// Record the owning actor's gateway client (called by the reader the instant
+    /// it decodes a gateway-state handoff, before the command loop re-propagates).
+    fn set_client(&self, client: ShmClient) {
+        *self.client.lock().expect("shm client slot mutex poisoned") = Some(client);
+    }
+}
+
 /// Owns all UNIX transport state and coroutines. The command loop holds one of
 /// these and forwards serves/joins to it; it never sees sockets, urls, or pairing
-/// state. The loop sender and the teardown signal are captured here once.
+/// state. The loop sender, teardown signal, and context mapper are captured here.
 pub(crate) struct UnixTransport {
     loop_tx: mpsc::UnboundedSender<Command>,
     shutdown_tx: watch::Sender<bool>,
+    // The context-global address-space mapper, captured once at construction and
+    // handed to every connection's coroutines (the per-actor client slot is passed
+    // in per serve/join).
+    mapper: MapperHandle,
     // One listener coroutine per url; serve connections are forwarded to it and
     // it owns the serve/accept pairing.
-    listeners: HashMap<String, mpsc::UnboundedSender<ConnectionRef>>,
+    listeners: HashMap<String, mpsc::UnboundedSender<(ConnectionRef, ShmClientSlot)>>,
     // Liveness-token issuer: each connection's writer holds a clone for its
     // lifetime, as do the listener/connector coroutines. Teardown drops this
     // issuing copy and waits for `alive_rx` to close — i.e. for every writer to
@@ -87,12 +118,13 @@ pub(crate) struct UnixTransport {
 }
 
 impl UnixTransport {
-    pub(crate) fn new(loop_tx: mpsc::UnboundedSender<Command>) -> Self {
+    pub(crate) fn new(loop_tx: mpsc::UnboundedSender<Command>, mapper: MapperHandle) -> Self {
         let (shutdown_tx, _) = watch::channel(false);
         let (alive_tx, alive_rx) = mpsc::unbounded_channel();
         Self {
             loop_tx,
             shutdown_tx,
+            mapper,
             listeners: HashMap::new(),
             alive_tx: Some(alive_tx),
             alive_rx,
@@ -104,6 +136,15 @@ impl UnixTransport {
             .as_ref()
             .expect("alive-token issuer present before shutdown")
             .clone()
+    }
+
+    /// Pair the context mapper with an actor's client slot into a connection's
+    /// shared-memory context.
+    fn shm_ctx(&self, client: ShmClientSlot) -> ShmCtx {
+        ShmCtx {
+            mapper: self.mapper.clone(),
+            client,
+        }
     }
 
     /// Signal every writer to flush and exit, then wait until they all have.
@@ -121,7 +162,7 @@ impl UnixTransport {
 }
 
 impl Transport for UnixTransport {
-    fn serve(&mut self, url: String, connection: ConnectionRef) {
+    fn serve(&mut self, url: String, connection: ConnectionRef, shm_client: ShmClientSlot) {
         // The first serve on a url spawns its listener coroutine; later serves
         // just forward another connection to it.
         if !self.listeners.contains_key(&url) {
@@ -132,6 +173,7 @@ impl Transport for UnixTransport {
                 self.loop_tx.clone(),
                 self.shutdown_tx.subscribe(),
                 self.alive_token(),
+                self.mapper.clone(),
             ));
             self.listeners.insert(url.clone(), tx);
         }
@@ -139,16 +181,17 @@ impl Transport for UnixTransport {
             .listeners
             .get(&url)
             .expect("listener just inserted")
-            .send(connection);
+            .send((connection, shm_client));
     }
 
-    fn join(&mut self, url: String, connection: ConnectionRef) {
+    fn join(&mut self, url: String, connection: ConnectionRef, shm_client: ShmClientSlot) {
         tokio::task::spawn_local(connector_task(
             socket_path(&url),
             connection,
             self.loop_tx.clone(),
             self.shutdown_tx.subscribe(),
             self.alive_token(),
+            self.shm_ctx(shm_client),
         ));
     }
 }
@@ -164,10 +207,11 @@ fn socket_path(url: &str) -> PathBuf {
 /// drops the serve sender.
 async fn listener_task(
     path: PathBuf,
-    mut serves: mpsc::UnboundedReceiver<ConnectionRef>,
+    mut serves: mpsc::UnboundedReceiver<(ConnectionRef, ShmClientSlot)>,
     loop_tx: mpsc::UnboundedSender<Command>,
     mut shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
+    mapper: MapperHandle,
 ) {
     // A stale socket file from a previous run would make bind fail with
     // EADDRINUSE; the server owns the path, so removing it is safe.
@@ -183,7 +227,7 @@ async fn listener_task(
             loop {
                 tokio::select! {
                     serve = serves.recv() => match serve {
-                        Some(connection) => sever(&loop_tx, connection, reason.clone()),
+                        Some((connection, _)) => sever(&loop_tx, connection, reason.clone()),
                         None => return, // command loop gone
                     },
                     _ = shutdown.changed() => return,
@@ -193,16 +237,19 @@ async fn listener_task(
     };
 
     // Serves and accepted sockets arrive independently; the matcher pairs them up
-    // regardless of order and wires up each pair as it completes.
-    let mut matcher: Matcher<ConnectionRef, UnixStream> = Matcher::new();
+    // regardless of order and wires up each pair as it completes. Each serve
+    // carries the owning actor's client slot, paired into the connection's shm
+    // context.
+    let mut matcher: Matcher<(ConnectionRef, ShmCtx), UnixStream> = Matcher::new();
     loop {
         tokio::select! {
             serve = serves.recv() => {
-                let Some(connection) = serve else {
+                let Some((connection, shm_client)) = serve else {
                     return; // command loop gone
                 };
-                let _ = matcher.push_left(connection, |connection, stream| {
-                    spawn_connection(stream, connection, loop_tx.clone(), shutdown.clone(), alive.clone())
+                let shm = ShmCtx { mapper: mapper.clone(), client: shm_client };
+                let _ = matcher.push_left((connection, shm), |(connection, shm), stream| {
+                    spawn_connection(stream, connection, loop_tx.clone(), shutdown.clone(), alive.clone(), shm)
                 });
             }
             accepted = listener.accept() => {
@@ -215,8 +262,8 @@ async fn listener_task(
                         continue;
                     }
                 };
-                let _ = matcher.push_right(stream, |connection, stream| {
-                    spawn_connection(stream, connection, loop_tx.clone(), shutdown.clone(), alive.clone())
+                let _ = matcher.push_right(stream, |(connection, shm), stream| {
+                    spawn_connection(stream, connection, loop_tx.clone(), shutdown.clone(), alive.clone(), shm)
                 });
             }
             _ = shutdown.changed() => return,
@@ -232,6 +279,7 @@ async fn connector_task(
     loop_tx: mpsc::UnboundedSender<Command>,
     mut shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
+    shm: ShmCtx,
 ) {
     let mut retry = CONNECT_RETRY_MIN;
     loop {
@@ -240,7 +288,7 @@ async fn connector_task(
         }
         match UnixStream::connect(&path).await {
             Ok(stream) => {
-                spawn_connection(stream, connection, loop_tx, shutdown, alive);
+                spawn_connection(stream, connection, loop_tx, shutdown, alive, shm);
                 return;
             }
             Err(_) => {
@@ -258,20 +306,21 @@ async fn connector_task(
 
 /// Wire up a connected socket: build its [`UnixConnectionTransport`], announce it
 /// to the command loop, and spawn the writer (drains commands → frames) and
-/// reader (frames → `ConnectionAction`). `TransportConnected` is enqueued
-/// before the reader can forward anything, so the command loop installs the
-/// transport before any frame (including the peer's `Establish`) arrives.
+/// reader (frames → `ConnectionAction`). Both share the `UnixStream` (via `Arc`)
+/// so the fd-exchange step and both byte directions use one registration.
+/// `TransportConnected` is enqueued before the reader can forward anything, so the
+/// command loop installs the transport before any frame (including the peer's
+/// `Establish`) arrives.
 fn spawn_connection(
     stream: UnixStream,
     connection: ConnectionRef,
     loop_tx: mpsc::UnboundedSender<Command>,
     shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
+    shm: ShmCtx,
 ) {
-    // Raw fd of the underlying socket (shared by both split halves); used only
-    // for the read-spin's MSG_PEEK readiness probe.
+    let stream = Arc::new(stream);
     let fd = stream.as_raw_fd();
-    let (read_half, write_half) = stream.into_split();
     let (writer_tx, writer_rx) = mpsc::unbounded_channel();
 
     let transport = Box::new(UnixConnectionTransport { tx: writer_tx });
@@ -279,19 +328,28 @@ fn spawn_connection(
         connection,
         transport,
     });
-    tokio::task::spawn_local(writer_task(write_half, writer_rx, shutdown, alive));
-    tokio::task::spawn_local(reader_task(read_half, fd, READ_SPIN, connection, loop_tx));
+    tokio::task::spawn_local(writer_task(
+        Arc::clone(&stream),
+        fd,
+        writer_rx,
+        shutdown,
+        alive,
+        shm.clone(),
+    ));
+    tokio::task::spawn_local(reader_task(stream, fd, READ_SPIN, connection, loop_tx, shm));
 }
 
 /// Transport for one end of a UNIX connection: `send` hands a command to the
 /// writer task, which serializes it to the socket. Dropping it ends the writer
-/// (closing the socket), which the peer observes as EOF.
+/// (closing the write half), which the peer observes as EOF.
 struct UnixConnectionTransport {
     tx: mpsc::UnboundedSender<ConnectionCommand>,
 }
 
 impl ConnectionTransport for UnixConnectionTransport {
     fn send(&self, action: ConnectionCommand) -> bool {
+        // The unix wire carries every command, including gateway state (the slab +
+        // dgram fds go via SCM_RIGHTS — see unix_framing).
         self.tx.send(action).is_ok()
     }
 }
@@ -302,27 +360,53 @@ impl ConnectionTransport for UnixConnectionTransport {
 /// the OS before teardown completes. Holds `_alive` for its whole lifetime:
 /// dropping it on exit is how teardown learns this writer has finished flushing.
 async fn writer_task(
-    mut write_half: OwnedWriteHalf,
+    stream: Arc<UnixStream>,
+    fd: RawFd,
+    rx: mpsc::UnboundedReceiver<ConnectionCommand>,
+    shutdown: watch::Receiver<bool>,
+    _alive: mpsc::UnboundedSender<()>,
+    shm: ShmCtx,
+) {
+    writer_task_with(
+        stream,
+        fd,
+        rx,
+        shutdown,
+        shm,
+        |stream, command, shm| async move {
+            unix_framing::write_command(&stream, command, &shm.mapper, shm.client()).await
+        },
+    )
+    .await;
+}
+
+async fn writer_task_with<Write, WriteFuture>(
+    stream: Arc<UnixStream>,
+    fd: RawFd,
     mut rx: mpsc::UnboundedReceiver<ConnectionCommand>,
     mut shutdown: watch::Receiver<bool>,
-    _alive: mpsc::UnboundedSender<()>,
-) {
-    loop {
+    shm: ShmCtx,
+    mut write: Write,
+) where
+    Write: FnMut(Arc<UnixStream>, ConnectionCommand, ShmCtx) -> WriteFuture,
+    WriteFuture: Future<Output = std::io::Result<()>>,
+{
+    'writer: loop {
         tokio::select! {
             command = rx.recv() => {
                 let Some(command) = command else {
                     break; // transport dropped
                 };
-                if unix_framing::write_command(&mut write_half, command).await.is_err() {
-                    return;
+                if write(Arc::clone(&stream), command, shm.clone()).await.is_err() {
+                    break 'writer;
                 }
             }
             _ = shutdown.changed() => {
                 // Teardown: the command loop has stopped, so no further commands
                 // will be enqueued. Flush whatever is already queued, then stop.
                 while let Ok(command) = rx.try_recv() {
-                    if unix_framing::write_command(&mut write_half, command).await.is_err() {
-                        return;
+                    if write(Arc::clone(&stream), command, shm.clone()).await.is_err() {
+                        break 'writer;
                     }
                 }
                 break;
@@ -330,19 +414,30 @@ async fn writer_task(
         }
     }
     // Every queued frame has been handed to the OS; shut the write side down to
-    // flush and signal EOF to the peer.
-    let _ = write_half.shutdown().await;
+    // flush and signal EOF to the peer. (The reader keeps its half open.)
+    shutdown_write(fd);
+}
+
+/// Half-close the write direction of the socket so the peer's reader sees EOF.
+fn shutdown_write(fd: RawFd) {
+    // SAFETY: `fd` is the live connection socket owned by this connection's tasks;
+    // shutting down only its write direction has no effect on the read half the
+    // reader task still uses.
+    unsafe {
+        libc::shutdown(fd, libc::SHUT_WR);
+    }
 }
 
 /// Decode each frame off the socket and forward it to the command loop. Any read
 /// error or EOF turns into a `Severed` so the command loop tears the connection
 /// down. The UNIX wire has no heartbeat frame — liveness is socket EOF.
 async fn reader_task(
-    mut read_half: OwnedReadHalf,
+    stream: Arc<UnixStream>,
     fd: RawFd,
     spin: Duration,
     connection: ConnectionRef,
     loop_tx: mpsc::UnboundedSender<Command>,
+    shm: ShmCtx,
 ) {
     loop {
         // Before parking in read_command's await, cooperatively spin peeking the
@@ -350,8 +445,15 @@ async fn reader_task(
         // yield_now (not a tight spin) keeps the loop processing other commands
         // — e.g. the reply this peer is about to send.
         spin_for_readable(fd, spin).await;
-        match unix_framing::read_command(&mut read_half).await {
+        match unix_framing::read_command(&stream, &shm.mapper, shm.client()).await {
             Ok(action) => {
+                // Record the gateway client immediately, before the command loop
+                // processes it: a large message can follow on this same connection
+                // and the reader needs the slab fd to reconstruct it. The forwarded
+                // action still drives the loop to re-propagate.
+                if let ConnectionCommand::GatewayState { client } = &action {
+                    shm.set_client(*client);
+                }
                 if loop_tx
                     .send(Command::ConnectionAction { connection, action })
                     .is_err()
@@ -369,7 +471,7 @@ async fn reader_task(
 
 /// Spin up to `spin` waiting for the socket to become readable, yielding between
 /// probes so the event loop keeps running. Returns as soon as data is available
-/// (or EOF / the window elapses); the following `read_frame` then proceeds
+/// (or EOF / the window elapses); the following `read_command` then proceeds
 /// without parking when a frame is already waiting. A no-op when `spin` is zero.
 async fn spin_for_readable(fd: RawFd, spin: Duration) {
     if spin.is_zero() {
@@ -378,9 +480,9 @@ async fn spin_for_readable(fd: RawFd, spin: Duration) {
     let start = Instant::now();
     let mut probe = 0u8;
     loop {
-        // MSG_PEEK so the byte is not consumed (read_frame still reads it);
+        // MSG_PEEK so the byte is not consumed (read_command still reads it);
         // MSG_DONTWAIT so the probe never blocks.
-        // SAFETY: `fd` is the live socket fd owned by this task's read half;
+        // SAFETY: `fd` is the live socket fd shared by this connection's tasks;
         // `probe` is a valid 1-byte buffer. recv only reads into it.
         let r = unsafe {
             libc::recv(
@@ -391,7 +493,7 @@ async fn spin_for_readable(fd: RawFd, spin: Duration) {
             )
         };
         // r >= 0 means data is ready (>0) or the peer closed (0) — either way let
-        // read_frame run now. r < 0 is almost always EAGAIN (nothing yet).
+        // read_command run now. r < 0 is almost always EAGAIN (nothing yet).
         if r >= 0 || start.elapsed() >= spin {
             return;
         }
@@ -404,4 +506,45 @@ fn sever(loop_tx: &mpsc::UnboundedSender<Command>, connection: ConnectionRef, re
         connection,
         action: ConnectionCommand::Severed { reason },
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+    use std::sync::Mutex;
+
+    use tokio::io::AsyncReadExt;
+
+    use super::*;
+    use crate::shm::ShmMapper;
+
+    #[tokio::test]
+    async fn writer_error_shuts_down_write_half() {
+        let (writer, mut peer) = UnixStream::pair().expect("socket pair should open");
+        let writer = Arc::new(writer);
+        let _reader_half = Arc::clone(&writer);
+        let fd = writer.as_raw_fd();
+        let (tx, rx) = mpsc::unbounded_channel();
+        let (_shutdown_tx, shutdown_rx) = watch::channel(false);
+        let shm = ShmCtx {
+            mapper: Arc::new(Mutex::new(ShmMapper::new())),
+            client: Arc::new(Mutex::new(None)),
+        };
+        tx.send(ConnectionCommand::Severed {
+            reason: b"test".to_vec(),
+        })
+        .expect("command should enqueue");
+
+        writer_task_with(writer, fd, rx, shutdown_rx, shm, |_, _, _| {
+            std::future::ready(Err(io::Error::other("injected write failure")))
+        })
+        .await;
+
+        let mut byte = [0u8; 1];
+        assert_eq!(
+            peer.read(&mut byte).await.expect("peer read should finish"),
+            0,
+            "peer should observe EOF after the writer fails"
+        );
+    }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* __->__ #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add a gateway-owned shared-memory allocator, stable slab mapper, liveness tokens, and SCM_RIGHTS framing so large message parts cross local UNIX connections without repeated socket copies. Propagate gateway state through UNIX and in-process hops, preserve shared-memory part deleters in the C/Python bytearray binding, and cover allocation, reclamation, and end-to-end routing.

Differential Revision: [D114750243](https://our.internmc.facebook.com/intern/diff/D114750243/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750243/)!