### PR TITLE
16/43 minimonarch: Read large QUIC payloads directly into shared memory

### DIFF
--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -174,11 +174,11 @@ struct Ctx {
     unix: UnixTransport,
     quic: QuicTransport,
     // The context-global shared-memory address-space manager. Always present
-    // (idle if shm is unused); handed to the unix transport, and unmaps everything
-    // when the context — and thus this last reference — is dropped.
+    // (idle if shm is unused); handed to the unix and quic transports, and unmaps
+    // everything when the context — and thus this last reference — is dropped.
     #[expect(
         dead_code,
-        reason = "held so the mapper outlives the context; used via the unix transport"
+        reason = "held so the mapper outlives the context; used via the unix and quic transports"
     )]
     mapper: MapperHandle,
     // A clone of the loop sender, used to schedule debounced monitor unsubscribes
@@ -196,7 +196,7 @@ impl Ctx {
             pollers: SlotMap::with_key(),
             inproc: InprocTransport::new(tx.clone()),
             unix: UnixTransport::new(tx.clone(), mapper.clone()),
-            quic: QuicTransport::new(tx.clone()),
+            quic: QuicTransport::new(tx.clone(), mapper.clone()),
             mapper,
             loop_tx: tx,
             thread: None,

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -13,8 +13,18 @@
 //! Each frame is `[u64 header_len][header][raw part bytes...]`. The header is a
 //! bincode-encoded [`WireFrame`] holding only small metadata; for a message it
 //! carries the *lengths* of the parts, never their bytes. Message-part bytes are
-//! written straight from the owning `MsgPart` and read straight into a freshly
-//! allocated per-part buffer — no copies of payload beyond the socket read/write.
+//! written straight from the owning `MsgPart`.
+//!
+//! On the read side a small part is read into a freshly allocated owned buffer.
+//! A *large* part, when the receiving actor has learned its gateway's
+//! [`ShmClient`] (every actor on a quic link is a gateway, so it has one), is read
+//! **straight into a freshly allocated shared-memory slab block** instead: the
+//! reader allocates the block, maps it, and reads the stream bytes directly into
+//! the mapping, yielding a [`MsgPart::Shm`]. The payload then never touches an
+//! owned heap buffer — and if the message is later forwarded across a machine-local
+//! unix hop, that hop relays the slab descriptor by reference rather than copying
+//! the bytes into shared memory a second time. Either way the only copy is the
+//! unavoidable kernel-to-userspace one.
 //!
 //! The reader/writer are generic over tokio's [`AsyncRead`]/[`AsyncWrite`], so the
 //! same code drives a QUIC stream's `RecvStream`/`SendStream`. Liveness policy
@@ -35,6 +45,9 @@ use crate::connection::AncestorPayload;
 use crate::connection::ConnectionCommand;
 use crate::connection::SendPayload;
 use crate::msg::MsgPart;
+use crate::shm::MapperHandle;
+use crate::shm::SHM_THRESHOLD;
+use crate::shm::ShmClient;
 
 /// One frame on the wire. There is a variant per [`ConnectionCommand`] that
 /// crosses the pipe (including `Establish`, which is how the two ends exchange
@@ -170,11 +183,18 @@ async fn write_frame<W: AsyncWrite + Unpin>(
     writer.flush().await
 }
 
-/// Read one frame. For a message the part bytes are read directly into the
-/// command's own buffers — the only copy is the unavoidable kernel-to-userspace
-/// one. A `Heartbeat` frame returns [`Incoming::Heartbeat`]; everything else maps
-/// straight back to a [`ConnectionCommand`].
-pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io::Result<Incoming> {
+/// Read one frame. For a message each part is read directly into its destination
+/// buffer — an owned heap buffer for a small part, or (when `client` is present
+/// and the part is large) a freshly allocated shared-memory slab block, so the
+/// only copy is the unavoidable kernel-to-userspace one. `mapper`/`client` are the
+/// receiving actor's shared-memory context (see [`read_part`]). A `Heartbeat`
+/// frame returns [`Incoming::Heartbeat`]; everything else maps straight back to a
+/// [`ConnectionCommand`].
+pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    mapper: &MapperHandle,
+    client: Option<ShmClient>,
+) -> std::io::Result<Incoming> {
     let mut len_buf = [0u8; 8];
     reader.read_exact(&mut len_buf).await?;
     let header_len = u64::from_le_bytes(len_buf) as usize;
@@ -194,9 +214,7 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io:
                 WirePayload::ActorMessage { part_lens } => {
                     let mut parts = Vec::with_capacity(part_lens.len());
                     for len in part_lens {
-                        let mut buf = vec![0u8; len as usize];
-                        reader.read_exact(&mut buf).await?;
-                        parts.push(MsgPart::from_bytes(buf));
+                        parts.push(read_part(reader, len, mapper, client).await?);
                     }
                     SendPayload::ActorMessage(parts)
                 }
@@ -230,4 +248,47 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(reader: &mut R) -> std::io:
         }),
         WireFrame::Severed { reason } => Incoming::Command(ConnectionCommand::Severed { reason }),
     })
+}
+
+/// Read one message part of `len` bytes off the stream.
+///
+/// A part `>= SHM_THRESHOLD` on a connection whose actor has learned its gateway
+/// [`ShmClient`] is read straight into a freshly allocated slab block: allocate the
+/// block, map it through the context `mapper`, and read the stream bytes directly
+/// into the mapping — yielding a [`MsgPart::Shm`] that a later unix hop forwards by
+/// descriptor without copying into shared memory again. Everything else (no client,
+/// or a small part) is read into an owned heap buffer as before.
+async fn read_part<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    len: u64,
+    mapper: &MapperHandle,
+    client: Option<ShmClient>,
+) -> std::io::Result<MsgPart> {
+    let Some(client) = client.filter(|_| len >= SHM_THRESHOLD) else {
+        let mut buf = vec![0u8; len as usize];
+        reader.read_exact(&mut buf).await?;
+        return Ok(MsgPart::from_bytes(buf));
+    };
+
+    let (offset, token) = client.allocate(len).await?;
+    let dst = {
+        let mut mapper = mapper.lock().expect("shm mapper mutex poisoned");
+        // SAFETY: `offset` was just granted for `len` bytes against `client`'s slab,
+        // so the file is grown to cover it and the mapper can map the range.
+        unsafe { mapper.map(client.slab_fd(), offset, len as usize)? }
+    };
+    // SAFETY: `dst` points at a writable mapping of exactly `len` bytes that stays
+    // valid for the mapper's (context's) lifetime — well past this read — so the
+    // slice is sound to fill across the await. The mapper lock was released above,
+    // so it is not held across IO. `len >= SHM_THRESHOLD > 0`, so this is non-empty.
+    let buf = unsafe { std::slice::from_raw_parts_mut(dst, len as usize) };
+    reader.read_exact(buf).await?;
+
+    Ok(MsgPart::new_shm(
+        mapper.clone(),
+        client.slab_fd(),
+        token,
+        offset,
+        len,
+    ))
 }

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -60,6 +60,8 @@ use crate::ctx::Command;
 use crate::framing;
 use crate::framing::Incoming;
 use crate::matcher::Matcher;
+use crate::shm::MapperHandle;
+use crate::shm::ShmClient;
 use crate::shm::ShmClientSlot;
 use crate::transport::Transport;
 
@@ -78,6 +80,25 @@ const CONNECT_RETRY_MAX: Duration = Duration::from_millis(1000);
 /// stray scheduling delay doesn't trip it.
 const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(250);
 const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// What a connection's reader needs for shared memory: the context-global mapper
+/// and the owning actor's gateway-client slot. Mirrors the unix transport's
+/// `ShmCtx`. Only the quic *reader* uses it — to read a large incoming part
+/// straight into a slab block (every actor on a quic link is a gateway, so it has
+/// a client). The writer needs nothing: a `Shm` part carries its own mapper.
+#[derive(Clone)]
+struct ShmCtx {
+    mapper: MapperHandle,
+    client: ShmClientSlot,
+}
+
+impl ShmCtx {
+    /// Snapshot the owning actor's gateway client (`None` until it is learned; a
+    /// gateway seeds its own at creation, before any quic frame can arrive).
+    fn client(&self) -> Option<ShmClient> {
+        *self.client.lock().expect("shm client slot mutex poisoned")
+    }
+}
 
 /// Process-wide rustls crypto provider (ring), installed once before any config is
 /// built. Ignoring the result is intentional: a competing install is fine.
@@ -140,9 +161,13 @@ fn parse_addr(url: &str) -> anyhow::Result<SocketAddr> {
 pub(crate) struct QuicTransport {
     loop_tx: mpsc::UnboundedSender<Command>,
     shutdown_tx: watch::Sender<bool>,
-    // One listener coroutine per url; serve connections are forwarded to it and it
-    // owns the serve/accept pairing.
-    listeners: HashMap<String, mpsc::UnboundedSender<ConnectionRef>>,
+    // The context-global address-space mapper, captured once at construction and
+    // handed to every connection's reader so a large incoming part can be read
+    // straight into a slab block.
+    mapper: MapperHandle,
+    // One listener coroutine per url; serve connections (with the owning actor's
+    // shm context) are forwarded to it and it owns the serve/accept pairing.
+    listeners: HashMap<String, mpsc::UnboundedSender<(ConnectionRef, ShmCtx)>>,
     tls: Option<Arc<TlsConfig>>,
     // Liveness-token issuer: each connection's writer holds a clone for its
     // lifetime. Teardown drops this issuing copy and waits for `alive_rx` to close
@@ -152,16 +177,26 @@ pub(crate) struct QuicTransport {
 }
 
 impl QuicTransport {
-    pub(crate) fn new(loop_tx: mpsc::UnboundedSender<Command>) -> Self {
+    pub(crate) fn new(loop_tx: mpsc::UnboundedSender<Command>, mapper: MapperHandle) -> Self {
         let (shutdown_tx, _) = watch::channel(false);
         let (alive_tx, alive_rx) = mpsc::unbounded_channel();
         Self {
             loop_tx,
             shutdown_tx,
+            mapper,
             listeners: HashMap::new(),
             tls: None,
             alive_tx: Some(alive_tx),
             alive_rx,
+        }
+    }
+
+    /// Pair the context mapper with an actor's client slot into a connection's
+    /// shared-memory context.
+    fn shm_ctx(&self, client: ShmClientSlot) -> ShmCtx {
+        ShmCtx {
+            mapper: self.mapper.clone(),
+            client,
         }
     }
 
@@ -192,7 +227,7 @@ impl QuicTransport {
 }
 
 impl Transport for QuicTransport {
-    fn serve(&mut self, url: String, connection: ConnectionRef, _shm_client: ShmClientSlot) {
+    fn serve(&mut self, url: String, connection: ConnectionRef, shm_client: ShmClientSlot) {
         let tls = match self.tls() {
             Ok(tls) => tls,
             Err(err) => {
@@ -225,14 +260,15 @@ impl Transport for QuicTransport {
             ));
             self.listeners.insert(url.clone(), tx);
         }
+        let shm = self.shm_ctx(shm_client);
         let _ = self
             .listeners
             .get(&url)
             .expect("listener just inserted")
-            .send(connection);
+            .send((connection, shm));
     }
 
-    fn join(&mut self, url: String, connection: ConnectionRef, _shm_client: ShmClientSlot) {
+    fn join(&mut self, url: String, connection: ConnectionRef, shm_client: ShmClientSlot) {
         let tls = match self.tls() {
             Ok(tls) => tls,
             Err(err) => {
@@ -258,6 +294,7 @@ impl Transport for QuicTransport {
             self.loop_tx.clone(),
             self.shutdown_tx.subscribe(),
             self.alive_token(),
+            self.shm_ctx(shm_client),
         ));
     }
 }
@@ -269,7 +306,7 @@ impl Transport for QuicTransport {
 async fn listener_task(
     addr: SocketAddr,
     server_config: ServerConfig,
-    mut serves: mpsc::UnboundedReceiver<ConnectionRef>,
+    mut serves: mpsc::UnboundedReceiver<(ConnectionRef, ShmCtx)>,
     loop_tx: mpsc::UnboundedSender<Command>,
     mut shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
@@ -283,7 +320,7 @@ async fn listener_task(
             loop {
                 tokio::select! {
                     serve = serves.recv() => match serve {
-                        Some(connection) => sever(&loop_tx, connection, reason.clone()),
+                        Some((connection, _shm)) => sever(&loop_tx, connection, reason.clone()),
                         None => return,
                     },
                     _ = shutdown.changed() => return,
@@ -302,26 +339,29 @@ async fn listener_task(
         shutdown.clone(),
     ));
 
-    let mut matcher: Matcher<ConnectionRef, (Connection, SendStream, RecvStream)> = Matcher::new();
+    let mut matcher: Matcher<(ConnectionRef, ShmCtx), (Connection, SendStream, RecvStream)> =
+        Matcher::new();
     loop {
         tokio::select! {
             serve = serves.recv() => {
-                let Some(connection) = serve else { return; };
-                let _ = matcher.push_left(connection, |connection, (conn, send, recv)| {
+                let Some((connection, shm)) = serve else { return; };
+                let _ = matcher.push_left((connection, shm), |(connection, shm), (conn, send, recv)| {
                     spawn_connection(
                         send, recv, connection,
                         loop_tx.clone(), shutdown.clone(), alive.clone(),
                         KeepAlive { _endpoint: None, _connection: conn },
+                        shm,
                     )
                 });
             }
             accepted = accepted_rx.recv() => {
                 let Some(triple) = accepted else { return; };
-                let _ = matcher.push_right(triple, |connection, (conn, send, recv)| {
+                let _ = matcher.push_right(triple, |(connection, shm), (conn, send, recv)| {
                     spawn_connection(
                         send, recv, connection,
                         loop_tx.clone(), shutdown.clone(), alive.clone(),
                         KeepAlive { _endpoint: None, _connection: conn },
+                        shm,
                     )
                 });
             }
@@ -367,6 +407,7 @@ async fn connector_task(
     loop_tx: mpsc::UnboundedSender<Command>,
     mut shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
+    shm: ShmCtx,
 ) {
     let endpoint = match Endpoint::client("0.0.0.0:0".parse().expect("valid bind addr")) {
         Ok(mut endpoint) => {
@@ -408,6 +449,7 @@ async fn connector_task(
                             _endpoint: Some(endpoint),
                             _connection: conn,
                         },
+                        shm,
                     );
                     return;
                 }
@@ -430,6 +472,10 @@ async fn connector_task(
 /// heartbeat tick) and reader (frames → `ConnectionAction`, with a heartbeat
 /// timeout). `keep` holds the QUIC connection (and, for a joiner, the client
 /// endpoint) alive for the duration of the writer.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each argument is a distinct piece of per-connection state handed off to the writer or reader; bundling them adds indirection without clarifying anything"
+)]
 fn spawn_connection(
     send: SendStream,
     recv: RecvStream,
@@ -438,6 +484,7 @@ fn spawn_connection(
     shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
     keep: KeepAlive,
+    shm: ShmCtx,
 ) {
     let (writer_tx, writer_rx) = mpsc::unbounded_channel();
     let transport = Box::new(QuicConnectionTransport { tx: writer_tx });
@@ -446,7 +493,7 @@ fn spawn_connection(
         transport,
     });
     tokio::task::spawn_local(writer_task(send, writer_rx, shutdown, alive, keep));
-    tokio::task::spawn_local(reader_task(recv, connection, loop_tx));
+    tokio::task::spawn_local(reader_task(recv, connection, loop_tx, shm));
 }
 
 /// Keeps the QUIC connection (and a joiner's client endpoint) alive for as long as
@@ -520,9 +567,14 @@ async fn reader_task(
     mut recv: RecvStream,
     connection: ConnectionRef,
     loop_tx: mpsc::UnboundedSender<Command>,
+    shm: ShmCtx,
 ) {
     loop {
-        match tokio::time::timeout(HEARTBEAT_TIMEOUT, framing::read_frame(&mut recv)).await {
+        // The owning actor's gateway client is snapshot per frame so a large part
+        // is read straight into the slab once the client is known (a gateway seeds
+        // its own at creation, before any frame arrives).
+        let read = framing::read_frame(&mut recv, &shm.mapper, shm.client());
+        match tokio::time::timeout(HEARTBEAT_TIMEOUT, read).await {
             Err(_elapsed) => {
                 sever(&loop_tx, connection, b"quic heartbeat timeout".to_vec());
                 return;

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -997,6 +997,62 @@ fn quic_serve_join_establishes_and_routes() {
 }
 
 #[test]
+fn quic_gateway_reads_large_message_into_shared_memory() {
+    // A large message arriving over quic at a gateway is read straight into the
+    // gateway's shared-memory slab (a gateway seeds its own client at creation,
+    // before any frame can arrive), so the delivered part is a slab part — ready to
+    // relay across a later unix hop by descriptor without copying into shared memory
+    // again — and its bytes arrive intact. The non-gateway sender has no slab, so it
+    // just streams the bytes; the receiving gateway is what lands them in the slab.
+    set_quic_env();
+    let ctx = CtxHandle::new().expect("context should start");
+    let gw = runtime_gateway_actor(&ctx, "q-shm-gw");
+    let sender = runtime_actor(&ctx, "q-shm-sender");
+    let (gw_poller, mut gw_rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, gw_poller, 0, gw);
+
+    let url = free_quic_url();
+    ctx.send_command(Command::Serve {
+        actor: gw,
+        url: url.clone(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: sender,
+        url,
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+
+    // Drain the establishment hellos so the next delivery is the large message.
+    assert_eq!(recv_strings(&mut gw_rx), vec!["q-shm-gw", "q-shm-sender"]);
+
+    let len = crate::shm::SHM_THRESHOLD as usize + 4321;
+    let payload = vec![0x6Cu8; len];
+    ctx.send_command(Command::Send {
+        sender,
+        destination_ident: MsgPart::from_bytes(b"q-shm-gw".to_vec()),
+        parts: vec![MsgPart::from_bytes(payload.clone())],
+    })
+    .expect("send should enqueue");
+
+    let delivered = gw_rx.blocking_recv().expect("large message delivered");
+    assert_eq!(delivered.msg.len(), 1, "one part delivered");
+    assert!(
+        delivered.msg[0].is_shm(),
+        "a large part read off quic at a gateway lands in the slab"
+    );
+    assert_eq!(
+        delivered.msg[0].as_bytes(),
+        payload.as_slice(),
+        "slab payload read off quic arrives intact"
+    );
+
+    shutdown(ctx);
+}
+
+#[test]
 fn quic_join_before_serve() {
     // The joiner's QUIC handshake fails until the server binds, so the connector
     // retries — join may go first.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* __->__ #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Large message parts received over QUIC are allocated and read directly into the receiving gateway's shared-memory slab, avoiding an extra heap-to-shared-memory copy before a local Unix relay. The QUIC transport now propagates each actor's shared-memory context to frame readers, with a regression test that verifies the slab-backed payload and bytes.

Differential Revision: [D114750229](https://our.internmc.facebook.com/intern/diff/D114750229/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750229/)!