### PR TITLE
17/43 minimonarch: Gateway side-channel sends

### DIFF
--- a/monarch_mini/python/gateway_worker.py
+++ b/monarch_mini/python/gateway_worker.py
@@ -1,0 +1,57 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Helper run as a subprocess by test_smoke.py's multi-gateway QUIC tests.
+
+Usage: ``python gateway_worker.py <root-url> <b-url> <a-tag>``. The QUIC TLS
+material is read from the ``MM_QUIC_CERT`` / ``MM_QUIC_KEY`` / ``MM_QUIC_CA``
+environment variables, which the parent test process sets and the worker
+inherits.
+
+This worker is gateway ``gwB`` (specifier = the authority of ``<b-url>``): it
+joins the shared root, serves its own address so a sibling gateway can
+side-channel to it, hosts an inproc child ``b1@<b-tag>``, and — on receiving the
+cross-gateway ``ping`` — replies ``pong`` directly to ``a1@<a-tag>`` (a direct
+gateway-to-gateway reply). It then idles so the reply flushes while it stays
+alive; the parent test kills it when finished.
+"""
+
+import asyncio
+import sys
+
+import minimonarch
+from minimonarch import Actor
+
+ba = minimonarch.bytearray
+
+
+async def run_gwb(root_url: str, b_url: str, a_tag: str) -> None:
+    b_tag = b_url.split("://", 1)[1]
+    gwb = Actor(f"gwB@{b_tag}".encode(), gateway=True)
+    gwb.serve(b_url, "parent")  # listener so siblings can side-channel to us
+    gwb.join(root_url, "child")  # join the shared root
+    b1 = Actor(f"b1@{b_tag}".encode())
+    gwb.serve("inproc://b-b1", "parent")
+    b1.join("inproc://b-b1", "child")
+
+    # Drain the establishment hellos for gwB and b1.
+    await gwb.next()
+    await b1.next()
+
+    # Await the cross-gateway ping, then reply pong straight back to a1@<a-tag>
+    # (gwB opens its own direct side-channel to gateway A).
+    await b1.next()
+    b1.send(f"a1@{a_tag}".encode(), [ba(b"pong")])
+
+    # Idle so the reply side-channel connects and flushes while we stay alive; the
+    # parent test kills us once it has observed the reply.
+    while True:
+        await asyncio.sleep(3600)
+
+
+if __name__ == "__main__":
+    root_url, b_url, a_tag = sys.argv[1], sys.argv[2], sys.argv[3]
+    asyncio.run(run_gwb(root_url, b_url, a_tag))

--- a/monarch_mini/python/test_smoke.py
+++ b/monarch_mini/python/test_smoke.py
@@ -461,6 +461,88 @@ async def test_quic_kill_child_end_caught_by_heartbeat() -> None:
             await _kill_worker(proc)
 
 
+def _spawn_gateway_worker(
+    root_url: str, b_url: str, a_tag: str
+) -> "subprocess.Popen[bytes]":
+    worker = os.path.join(os.path.dirname(__file__), "gateway_worker.py")
+    return subprocess.Popen([sys.executable, worker, root_url, b_url, a_tag])
+
+
+async def test_quic_gateways_cross_gateway_bypasses_root_and_reaches_root() -> None:
+    # Two QUIC gateways joined to a shared root. gwA (and its inproc child a1) lives
+    # in this process; gwB (and its inproc child b1) is a subprocess. We verify:
+    #   * a1@A -> b1@B reaches b1 over a *direct* gateway-to-gateway side-channel
+    #     (b1 replies pong straight back to a1), and
+    #   * a1@A -> root and a1@A -> rootchild still climb gwA's parent link to the
+    #     root domain, and
+    #   * the root actor never sees the cross-gateway traffic (its only deliveries
+    #     are the join hellos and the message explicitly addressed to it).
+    _quic_certs_env()
+    root_url = _quic_url()
+    a_url = _quic_url()
+    b_url = _quic_url()
+    a_tag = a_url.split("://", 1)[1]
+    b_tag = b_url.split("://", 1)[1]
+
+    root = Actor(b"root", gateway=True)
+    rootchild = Actor(b"rootchild")
+    gwa = Actor(f"gwA@{a_tag}".encode(), gateway=True)
+    a1 = Actor(f"a1@{a_tag}".encode())
+
+    # root is the shared rendezvous: it serves once per joining gateway (gwA here,
+    # gwB in the worker).
+    root.serve(root_url, "parent")
+    root.serve(root_url, "parent")
+    gwa.join(root_url, "child")
+    gwa.serve(a_url, "parent")  # listener so gwB can side-channel its reply to us
+    root.serve("inproc://root-rc", "parent")
+    rootchild.join("inproc://root-rc", "child")
+    gwa.serve("inproc://a-a1", "parent")
+    a1.join("inproc://a-a1", "child")
+
+    proc = _spawn_gateway_worker(root_url, b_url, a_tag)
+    try:
+        # Local establishment hellos.
+        assert await asyncio.wait_for(a1.next(), 30) == [
+            f"a1@{a_tag}".encode(),
+            f"gwA@{a_tag}".encode(),
+        ]
+        assert await asyncio.wait_for(rootchild.next(), 30) == [b"rootchild", b"root"]
+
+        # root sees all three join hellos (gwA, gwB, rootchild) in any order; drain
+        # them so the only further delivery to root is the message addressed to it.
+        expected_peers = {
+            f"gwA@{a_tag}".encode(),
+            f"gwB@{b_tag}".encode(),
+            b"rootchild",
+        }
+        seen: set[bytes] = set()
+        while seen != expected_peers:
+            hello = await asyncio.wait_for(root.next(), 30)
+            assert bytes(hello[0]) == b"root"
+            seen.add(bytes(hello[1]))
+
+        # a1@A -> root: the empty (root-domain) specifier climbs gwA's parent link.
+        a1.send(b"root", [ba(b"hi-root")])
+        assert await asyncio.wait_for(root.next(), 30) == [b"hi-root"]
+
+        # a1@A -> rootchild: up to root, then down its inproc child link.
+        a1.send(b"rootchild", [ba(b"hi-rc")])
+        assert await asyncio.wait_for(rootchild.next(), 30) == [b"hi-rc"]
+
+        # a1@A -> b1@B crosses gateways directly; b1 replies pong straight back.
+        a1.send(f"b1@{b_tag}".encode(), [ba(b"ping")])
+        assert await asyncio.wait_for(a1.next(), 30) == [b"pong"]
+
+        # Bypass: the cross-gateway ping/pong and the hi-rc message never reached the
+        # root actor — its queue is empty now that the hellos and hi-root are drained.
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(root.next(), 0.5)
+    finally:
+        if proc.poll() is None:
+            await _kill_worker(proc)
+
+
 async def test_monitor_fires_when_target_dies() -> None:
     # watcher and target are siblings under root. watcher monitors target; when
     # target dies, the failure climbs to their common ancestor (root) and fires

--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -19,7 +19,6 @@ use crate::ctx::ChildConnectionKey;
 use crate::ctx::PollerKey;
 use crate::msg::MsgPart;
 use crate::shm::ShmClientSlot;
-use crate::shm::ShmServer;
 
 pub(crate) struct ActorEntry {
     pub(crate) name: ActorName,
@@ -47,15 +46,12 @@ pub(crate) struct ActorEntry {
     /// route through it. Joining a gateway to a non-network parent is rejected.
     pub(crate) gateway: bool,
     pub(crate) alive: bool,
-    /// This actor's gateway shared-memory client, once it learns its gateway. The
-    /// value is `Option<ShmClient>`; it lives behind an `Arc<Mutex<_>>` only so the
-    /// actor's transport coroutines can read it and the reader can set it the
-    /// moment a gateway-state handoff arrives.
+    /// This actor's gateway shared-memory client, once it learns its gateway (the
+    /// context's shared slab for a gateway, or a parent's slab received via
+    /// gateway-state handoff). The value is `Option<ShmClient>`; it lives behind an
+    /// `Arc<Mutex<_>>` only so the actor's transport coroutines can read it and the
+    /// reader can set it the moment a handoff arrives.
     pub(crate) shm_client: ShmClientSlot,
-    /// The shared-memory allocation authority, present only on a gateway actor.
-    /// Dropping it (when the gateway is destroyed) stops the server and releases
-    /// the slab.
-    pub(crate) shm_server: Option<ShmServer>,
 }
 
 /// State of this actor's monitoring of one target ident. The variant *is* the
@@ -89,7 +85,6 @@ impl ActorEntry {
             gateway,
             alive: true,
             shm_client: Arc::new(Mutex::new(None)),
-            shm_server: None,
         }
     }
 

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -43,6 +43,7 @@ use crate::poller::PollerEntry;
 use crate::quic_transport::QuicTransport;
 use crate::shm::MapperHandle;
 use crate::shm::ShmClient;
+use crate::shm::ShmClientSlot;
 use crate::shm::ShmMapper;
 use crate::shm::ShmServer;
 use crate::transport::Transport;
@@ -62,6 +63,18 @@ fn valid_scheme(url: &str) -> bool {
 /// for its process group. (Today only quic; tcp joins this set later.)
 fn is_network_scheme(url: &str) -> bool {
     url.starts_with("quic://")
+}
+
+/// The gateway specifier (the `@endpoint` suffix) of an ident, or an empty slice
+/// if it has none. Actor idents are formatted `name@gateway_specifier`; an ident
+/// with no `@` belongs to the root gateway (specifier-less). The specifier is the
+/// address a gateway dials to reach the ident's owning gateway directly, so it is
+/// also a gateway's own domain tag (parsed from its own ident).
+fn gateway_tag(ident: &[u8]) -> &[u8] {
+    match ident.iter().rposition(|&b| b == b'@') {
+        Some(pos) => &ident[pos + 1..],
+        None => &[],
+    }
 }
 
 new_key_type! {
@@ -129,6 +142,13 @@ pub(crate) enum Command {
         connection: ConnectionRef,
         action: ConnectionCommand,
     },
+    // A message arrived over a gateway side-channel (a direct gateway-to-gateway
+    // QUIC connection, not a parent/child link). The receiving gateway is resolved
+    // from the destination, since several gateways may share one endpoint url.
+    SideChannelDeliver {
+        destination_ident: Vec<u8>,
+        payload: SendPayload,
+    },
     // A transport's pipe is up; install it on the connection. Transport-agnostic:
     // both inproc and unix emit it, and the command loop drives establishment
     // from here (sends our Establish along the transport).
@@ -181,6 +201,28 @@ struct Ctx {
         reason = "held so the mapper outlives the context; used via the unix and quic transports"
     )]
     mapper: MapperHandle,
+    // The context-global shared-memory server, shared by every gateway in this
+    // context (created lazily when the first gateway appears). One slab + client
+    // per serving process — not per gateway actor — so multiple independent actor
+    // trees in the same process share it. Dropping it (with the context) releases
+    // the slab.
+    shm_server: Option<ShmServer>,
+    // The single shm client for this context: the slab handed to gateways and to
+    // the quic listener coroutines. Empty until the first gateway creates the
+    // server. A clone of this slot lives in the quic transport.
+    shm_client: ShmClientSlot,
+    // Side-channel messages whose destination no gateway in this context can route
+    // yet, keyed by destination ident. The destination's owning gateway is not
+    // known up front (several gateways may serve the same endpoint url), so these
+    // are held context-wide and flushed once a gateway learns a route to the
+    // destination — or the destination actor is created here.
+    pending_side_channel: HashMap<Vec<u8>, Vec<SendPayload>>,
+    // Every gateway actor ever created in this context, so resolving a side-channel
+    // destination scans only gateways (a handful) rather than every actor. A
+    // *dead* gateway is kept: its routing table still tells us whether a destination
+    // was reachable through it, so we can drop a side-channel message for a dead
+    // subtree rather than hold it forever.
+    gateways: Vec<Key>,
     // A clone of the loop sender, used to schedule debounced monitor unsubscribes
     // back onto the event loop after a grace period.
     loop_tx: mpsc::UnboundedSender<Command>,
@@ -191,17 +233,32 @@ struct Ctx {
 impl Ctx {
     fn new(tx: mpsc::UnboundedSender<Command>) -> Self {
         let mapper: MapperHandle = Arc::new(Mutex::new(ShmMapper::new()));
+        let shm_client: ShmClientSlot = Arc::new(Mutex::new(None));
         Self {
             actors: SlotMap::with_key(),
             pollers: SlotMap::with_key(),
             inproc: InprocTransport::new(tx.clone()),
             unix: UnixTransport::new(tx.clone(), mapper.clone()),
-            quic: QuicTransport::new(tx.clone(), mapper.clone()),
+            quic: QuicTransport::new(tx.clone(), mapper.clone(), shm_client.clone()),
             mapper,
+            shm_server: None,
+            shm_client,
+            pending_side_channel: HashMap::new(),
+            gateways: Vec::new(),
             loop_tx: tx,
             thread: None,
             _not_send: PhantomData,
         }
+    }
+
+    /// Insert a new actor, tracking it in `gateways` if it is one (so side-channel
+    /// delivery scans only gateways, never every actor).
+    fn insert_actor(&mut self, ident: Option<Vec<u8>>, gateway: bool) -> Key {
+        let key = self.actors.insert(ActorEntry::new(ident, gateway));
+        if gateway {
+            self.gateways.push(key);
+        }
+        key
     }
 
     fn run_command(&mut self, command: Command) {
@@ -214,15 +271,13 @@ impl Ctx {
                 gateway,
                 done,
             } => {
-                let key = self.actors.insert(ActorEntry::new(
-                    ident.as_ref().map(|part| part.as_bytes().to_vec()),
-                    gateway,
-                ));
+                let key =
+                    self.insert_actor(ident.as_ref().map(|part| part.as_bytes().to_vec()), gateway);
                 drop(ident);
-                // A gateway owns the slab for its process group: stand up its
-                // shared-memory server now and seed its own client slot, so it can
-                // shm-ify large sends to its children and hand the state down to
-                // them. Best-effort — on failure the gateway just streams inline.
+                // A gateway shares the context's slab (created lazily on the first
+                // gateway): seed its client slot from it, so it can shm-ify large
+                // sends to its children and hand the state down to them. Best-effort
+                // — on failure the gateway just streams inline.
                 if gateway {
                     self.init_gateway_shm(key);
                 }
@@ -322,6 +377,12 @@ impl Ctx {
                 transport,
             } => {
                 self.transport_connected(connection, transport);
+            }
+            Command::SideChannelDeliver {
+                destination_ident,
+                payload,
+            } => {
+                self.deliver_side_channel(destination_ident, payload);
             }
             Command::Die { actor, reason } => {
                 let reason = reason.as_bytes().to_vec();
@@ -425,6 +486,36 @@ impl Ctx {
             // forwarding it up (where it would buffer forever at the gateway).
             Some(Route::Dead) => return,
             Some(Route::Unknown { .. }) | None => {}
+        }
+
+        // No local route. A gateway is the boundary of its routing domain, so a
+        // destination on a *different* gateway is reached by a direct side-channel
+        // rather than by climbing toward the root. Destinations in the root domain
+        // (no specifier) still climb the parent chain; destinations in our own
+        // domain that we simply do not know yet are buffered locally — never sent
+        // up, which would only bounce them back to us.
+        if self.actor(sender).gateway {
+            let own_tag = gateway_tag(self.actor(sender).name().unwrap_or_default()).to_vec();
+            let dest_tag = gateway_tag(&destination_ident).to_vec();
+            if !dest_tag.is_empty() && dest_tag != own_tag {
+                match std::str::from_utf8(&dest_tag) {
+                    Ok(tag) => {
+                        self.quic
+                            .send_to_gateway(tag.to_owned(), destination_ident, payload)
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "gateway destination has non-utf8 specifier; dropping message"
+                        )
+                    }
+                }
+                return;
+            }
+            if !own_tag.is_empty() && dest_tag == own_tag {
+                self.actor_mut(sender)
+                    .buffer_unrouted(destination_ident, payload);
+                return;
+            }
         }
 
         // No known route here. Forward the payload — intact — toward the gateway;
@@ -652,11 +743,18 @@ impl Ctx {
             // route and flush its buffered messages. Monitors stay here: this actor is
             // the responsible ancestor for the destination (it is reachable below it).
             let previous = self.actor_mut(parent).routes.remove(ident.as_slice());
-            let (monitors, buffered) = match previous {
+            let (monitors, mut buffered) = match previous {
                 Some(Route::Unknown { messages, monitors }) => (monitors, messages),
                 Some(Route::Connection { monitors, .. }) => (monitors, Vec::new()),
                 _ => (Vec::new(), Vec::new()),
             };
+            // Side-channel messages held context-wide for this destination become
+            // routable at this same moment, so route them alongside the buffered
+            // ones — this is the one place a previously-unroutable side-channel
+            // destination gains a route.
+            if let Some(pending) = self.pending_side_channel.remove(ident.as_slice()) {
+                buffered.extend(pending);
+            }
             self.actor_mut(parent).routes.insert(
                 ident.clone(),
                 Route::Connection {
@@ -669,7 +767,8 @@ impl Ctx {
             self.actor_mut(parent)
                 .record_routed_via_child(child_connection, ident);
 
-            // Re-route any payloads buffered while the route was unknown; route_message
+            // Re-route every payload that was waiting on this route (buffered against
+            // the Unknown route, plus any pending side-channel messages); route_message
             // sends them down the child connection we just recorded.
             for payload in buffered {
                 self.route_message(parent, ident.clone(), payload);
@@ -708,6 +807,14 @@ impl Ctx {
 
     fn publish_routes_to_parent(&mut self, actor: Key, live: Vec<Vec<u8>>, dead: Vec<Vec<u8>>) {
         if live.is_empty() && dead.is_empty() {
+            return;
+        }
+        // A gateway is the top of its routing domain: it does not leak its
+        // subtree's routes up to its (network) parent. This is what keeps actors
+        // on one gateway out of another gateway's routing tables — cross-gateway
+        // delivery uses direct side-channels (see route_message) instead. (Message
+        // forwarding up the parent chain is unaffected; only route publication is.)
+        if self.actor(actor).gateway {
             return;
         }
         let actor = self.actor_mut(actor);
@@ -1010,18 +1117,35 @@ impl Ctx {
 
     // -- Shared-memory gateway state --------------------------------------------
 
-    /// Stand up a gateway actor's shared-memory server and record its own client
-    /// in the registry. Best-effort: a failure leaves the actor without shm
-    /// (inline sends).
+    /// Seed a gateway actor's client slot from the context's shared shm server,
+    /// creating that server on the first gateway. Best-effort: if the server can't
+    /// start, the gateway just streams inline.
     fn init_gateway_shm(&mut self, actor: Key) {
-        match ShmServer::new() {
-            Ok(server) => {
-                let client = server.client();
-                self.set_shm_client(actor, client);
-                self.actor_mut(actor).shm_server = Some(server);
-            }
-            Err(err) => tracing::warn!("failed to start gateway shm server: {err}"),
+        if let Some(client) = self.ensure_context_shm() {
+            self.set_shm_client(actor, client);
         }
+    }
+
+    /// The context's shared shm client, creating the single server on first use.
+    /// All gateways in the context share it, so the slab is per serving process
+    /// rather than per gateway actor. Returns `None` if the server can't start.
+    fn ensure_context_shm(&mut self) -> Option<ShmClient> {
+        if self.shm_server.is_none() {
+            match ShmServer::new() {
+                Ok(server) => {
+                    *self
+                        .shm_client
+                        .lock()
+                        .expect("shm client slot mutex poisoned") = Some(server.client());
+                    self.shm_server = Some(server);
+                }
+                Err(err) => tracing::warn!("failed to start context shm server: {err}"),
+            }
+        }
+        *self
+            .shm_client
+            .lock()
+            .expect("shm client slot mutex poisoned")
     }
 
     /// Record `actor`'s gateway client in its slot (which its transport coroutines
@@ -1057,6 +1181,33 @@ impl Ctx {
             if let Some(connection) = self.actor_mut(actor).children.get_mut(slot) {
                 let _ = connection.send(ConnectionCommand::GatewayState { client });
             }
+        }
+    }
+
+    // -- Side-channel delivery --------------------------------------------------
+
+    /// Route a message that arrived over a gateway side-channel. Because several
+    /// gateways may serve the same endpoint url, the destination's owning gateway is
+    /// not known up front, so find the first gateway that has the destination in its
+    /// routing table (or *is* it) and hand off to `route_message`, which delivers a
+    /// live route, drops a dead one, drops anything via a dead gateway, and buffers
+    /// an `Unknown` entry. An `Unknown` entry counts: it means an actor under that
+    /// gateway already addressed the destination, so it is expected to appear there.
+    /// If no gateway knows the destination at all, hold the message in
+    /// `pending_side_channel` until a route is recorded (see `populate_routes`).
+    fn deliver_side_channel(&mut self, destination_ident: Vec<u8>, payload: SendPayload) {
+        let routable = self.gateways.iter().copied().find(|&key| {
+            let actor = &self.actors[key];
+            actor.name() == Some(destination_ident.as_slice())
+                || actor.routes.contains_key(&destination_ident)
+        });
+        match routable {
+            Some(key) => self.route_message(key, destination_ident, payload),
+            None => self
+                .pending_side_channel
+                .entry(destination_ident)
+                .or_default()
+                .push(payload),
         }
     }
 

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -95,6 +95,55 @@ fn bincode_config() -> bincode::config::Configuration {
     bincode::config::standard()
 }
 
+/// The first frame a QUIC *joiner* (the connecting side) writes, declaring what
+/// the freshly opened bi-stream is for. The accepting side reads exactly one of
+/// these before deciding how to drive the stream:
+///
+/// - `Join` — an ordinary parent/child connection; the command loop takes over
+///   (identity exchange, hello, heartbeated liveness) exactly as before.
+/// - `SideChannel` — a gateway-to-gateway message channel: the accepting gateway
+///   just reads [`WireFrame::Message`] frames and routes them locally. It is
+///   never paired with a serve, never establishes a parent/child link, and is
+///   never heartbeated.
+///
+/// Only the joiner writes a preamble (one direction); the server never does, so
+/// the joiner's own reader keeps reading [`WireFrame`]s as before.
+#[derive(Serialize, Deserialize)]
+pub(crate) enum Preamble {
+    Join,
+    SideChannel,
+}
+
+/// Write the connection preamble (see [`Preamble`]). Length-prefixed bincode,
+/// the same scheme as [`write_frame`], so a reader can decode it with
+/// [`read_preamble`] before switching to the per-frame loop.
+pub(crate) async fn write_preamble<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    preamble: Preamble,
+) -> std::io::Result<()> {
+    let header = bincode::serde::encode_to_vec(&preamble, bincode_config())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    writer
+        .write_all(&(header.len() as u64).to_le_bytes())
+        .await?;
+    writer.write_all(&header).await?;
+    writer.flush().await
+}
+
+/// Read the connection preamble written by [`write_preamble`].
+pub(crate) async fn read_preamble<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<Preamble> {
+    let mut len_buf = [0u8; 8];
+    reader.read_exact(&mut len_buf).await?;
+    let header_len = u64::from_le_bytes(len_buf) as usize;
+    let mut header = vec![0u8; header_len];
+    reader.read_exact(&mut header).await?;
+    let (preamble, _) = bincode::serde::decode_from_slice::<Preamble, _>(&header, bincode_config())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    Ok(preamble)
+}
+
 /// A frame decoded off the wire: either a command for the loop, or a transport
 /// heartbeat (consumed internally to refresh the liveness deadline).
 pub(crate) enum Incoming {

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -56,9 +56,11 @@ use tokio::time::MissedTickBehavior;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
+use crate::connection::SendPayload;
 use crate::ctx::Command;
 use crate::framing;
 use crate::framing::Incoming;
+use crate::framing::Preamble;
 use crate::matcher::Matcher;
 use crate::shm::MapperHandle;
 use crate::shm::ShmClient;
@@ -165,9 +167,18 @@ pub(crate) struct QuicTransport {
     // handed to every connection's reader so a large incoming part can be read
     // straight into a slab block.
     mapper: MapperHandle,
-    // One listener coroutine per url; serve connections (with the owning actor's
-    // shm context) are forwarded to it and it owns the serve/accept pairing.
+    // The context's single shm client slot, used *only* by side-channel readers,
+    // which are not tied to any actor. A join/serve connection reads into its
+    // owning actor's own slot instead (passed through serve/join).
+    context_shm: ShmClientSlot,
+    // One listener coroutine per url; serve connections are forwarded to it and it
+    // owns the serve/accept pairing.
     listeners: HashMap<String, mpsc::UnboundedSender<(ConnectionRef, ShmCtx)>>,
+    // One side-channel writer per remote gateway, keyed by its dial address (the
+    // `@specifier` tag). Each owns a task that lazily connects (retrying until the
+    // gateway is live), streams message frames, and reconnects if the connection
+    // drops. Never heartbeated; cached across messages.
+    side_channels: HashMap<String, mpsc::UnboundedSender<ConnectionCommand>>,
     tls: Option<Arc<TlsConfig>>,
     // Liveness-token issuer: each connection's writer holds a clone for its
     // lifetime. Teardown drops this issuing copy and waits for `alive_rx` to close
@@ -177,22 +188,29 @@ pub(crate) struct QuicTransport {
 }
 
 impl QuicTransport {
-    pub(crate) fn new(loop_tx: mpsc::UnboundedSender<Command>, mapper: MapperHandle) -> Self {
+    pub(crate) fn new(
+        loop_tx: mpsc::UnboundedSender<Command>,
+        mapper: MapperHandle,
+        context_shm: ShmClientSlot,
+    ) -> Self {
         let (shutdown_tx, _) = watch::channel(false);
         let (alive_tx, alive_rx) = mpsc::unbounded_channel();
         Self {
             loop_tx,
             shutdown_tx,
             mapper,
+            context_shm,
             listeners: HashMap::new(),
+            side_channels: HashMap::new(),
             tls: None,
             alive_tx: Some(alive_tx),
             alive_rx,
         }
     }
 
-    /// Pair the context mapper with an actor's client slot into a connection's
-    /// shared-memory context.
+    /// A connection's shared-memory context: the context mapper paired with the
+    /// given client slot. A join/serve connection passes its owning actor's slot; a
+    /// side-channel passes [`Self::context_shm`].
     fn shm_ctx(&self, client: ShmClientSlot) -> ShmCtx {
         ShmCtx {
             mapper: self.mapper.clone(),
@@ -215,6 +233,52 @@ impl QuicTransport {
         let tls = Arc::new(load_tls()?);
         self.tls = Some(tls.clone());
         Ok(tls)
+    }
+
+    /// Send a message to a remote gateway over a direct side-channel, opening (and
+    /// caching) the connection on first use. The caller (the command loop) has
+    /// already determined `tag` is a different gateway than the sender's own. The
+    /// side-channel is best-effort and not heartbeated; a message enqueued while
+    /// the remote gateway is not yet live waits for the connection to come up.
+    pub(crate) fn send_to_gateway(
+        &mut self,
+        tag: String,
+        destination_ident: Vec<u8>,
+        payload: SendPayload,
+    ) {
+        if !self.side_channels.contains_key(&tag) {
+            let client = match self.tls() {
+                Ok(tls) => tls.client.clone(),
+                Err(err) => {
+                    tracing::warn!("side channel tls: {err:#}");
+                    return;
+                }
+            };
+            let addr = match parse_addr(&tag) {
+                Ok(addr) => addr,
+                Err(err) => {
+                    tracing::warn!("side channel address: {err:#}");
+                    return;
+                }
+            };
+            let (tx, rx) = mpsc::unbounded_channel();
+            tokio::task::spawn_local(side_channel_writer_task(
+                addr,
+                client,
+                rx,
+                self.shutdown_tx.subscribe(),
+                self.alive_token(),
+            ));
+            self.side_channels.insert(tag.clone(), tx);
+        }
+        let _ = self
+            .side_channels
+            .get(&tag)
+            .expect("side channel just inserted")
+            .send(ConnectionCommand::SendMessage {
+                destination_ident,
+                payload,
+            });
     }
 
     /// Signal every writer to flush and exit, then wait until they all have — the
@@ -240,7 +304,9 @@ impl Transport for QuicTransport {
             }
         };
         // The first serve on a url spawns its listener coroutine; later serves just
-        // forward another connection to it.
+        // forward another connection to it. The listener carries the *context* shm
+        // context for side-channel readers (which have no owning actor); each Join
+        // connection instead uses the owning actor's slot, forwarded alongside it.
         if !self.listeners.contains_key(&url) {
             let addr = match parse_addr(&url) {
                 Ok(addr) => addr,
@@ -250,6 +316,7 @@ impl Transport for QuicTransport {
                 }
             };
             let (tx, rx) = mpsc::unbounded_channel();
+            let context_shm = self.shm_ctx(self.context_shm.clone());
             tokio::task::spawn_local(listener_task(
                 addr,
                 tls.server.clone(),
@@ -257,6 +324,7 @@ impl Transport for QuicTransport {
                 self.loop_tx.clone(),
                 self.shutdown_tx.subscribe(),
                 self.alive_token(),
+                context_shm,
             ));
             self.listeners.insert(url.clone(), tx);
         }
@@ -299,10 +367,22 @@ impl Transport for QuicTransport {
     }
 }
 
-/// Bind a QUIC server endpoint on `addr` and pair each accepted connection's
-/// stream with the next queued serve (either may arrive first). On a bind failure
-/// the serves are severed instead. Stops on teardown or when the command loop
-/// drops the serve sender.
+/// A connection accepted by the listener, classified by the joiner's preamble.
+/// A `Join` is paired with a serve and driven by the command loop as before; a
+/// `SideChannel` is a gateway-to-gateway message stream read directly into the
+/// home gateway's routing.
+enum Accepted {
+    Join(Connection, SendStream, RecvStream),
+    SideChannel(Connection, RecvStream),
+}
+
+/// Bind a QUIC server endpoint on `addr` and dispatch each accepted connection by
+/// its preamble: a `Join` is paired with the next queued serve (either may arrive
+/// first); a `SideChannel` is read straight into the context's gateway routing. On
+/// a bind failure the serves are severed instead. Stops on teardown or when the
+/// command loop drops the serve sender. `side_channel_shm` is the *context* shm
+/// context, used only for side-channel readers (which have no owning actor); each
+/// Join connection instead uses the per-serve shm forwarded with it.
 async fn listener_task(
     addr: SocketAddr,
     server_config: ServerConfig,
@@ -310,6 +390,7 @@ async fn listener_task(
     loop_tx: mpsc::UnboundedSender<Command>,
     mut shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
+    side_channel_shm: ShmCtx,
 ) {
     let endpoint = match Endpoint::server(server_config, addr) {
         Ok(endpoint) => endpoint,
@@ -329,9 +410,9 @@ async fn listener_task(
         }
     };
 
-    // Accepting a connection and its stream is a multi-step handshake; run it off
-    // the pairing loop so a slow handshake doesn't stall matching. Each accepted
-    // (connection, stream) lands on `accepted_rx`.
+    // Accepting a connection, its stream, and its preamble is a multi-step
+    // handshake; run it off the pairing loop so a slow handshake doesn't stall
+    // matching. Each classified connection lands on `accepted_rx`.
     let (accepted_tx, mut accepted_rx) = mpsc::unbounded_channel();
     tokio::task::spawn_local(acceptor_task(
         endpoint.clone(),
@@ -355,15 +436,24 @@ async fn listener_task(
                 });
             }
             accepted = accepted_rx.recv() => {
-                let Some(triple) = accepted else { return; };
-                let _ = matcher.push_right(triple, |(connection, shm), (conn, send, recv)| {
-                    spawn_connection(
-                        send, recv, connection,
-                        loop_tx.clone(), shutdown.clone(), alive.clone(),
-                        KeepAlive { _endpoint: None, _connection: conn },
-                        shm,
-                    )
-                });
+                match accepted {
+                    None => return,
+                    Some(Accepted::Join(conn, send, recv)) => {
+                        let _ = matcher.push_right((conn, send, recv), |(connection, shm), (conn, send, recv)| {
+                            spawn_connection(
+                                send, recv, connection,
+                                loop_tx.clone(), shutdown.clone(), alive.clone(),
+                                KeepAlive { _endpoint: None, _connection: conn },
+                                shm,
+                            )
+                        });
+                    }
+                    Some(Accepted::SideChannel(conn, recv)) => {
+                        tokio::task::spawn_local(side_channel_reader_task(
+                            conn, recv, loop_tx.clone(), side_channel_shm.clone(),
+                        ));
+                    }
+                }
             }
             _ = shutdown.changed() => return,
         }
@@ -373,11 +463,11 @@ async fn listener_task(
 }
 
 /// Accept connections on `endpoint`, accept the one bi-stream each joiner opens,
-/// and forward the result. Each handshake runs in its own task so one slow peer
-/// doesn't block others.
+/// read its preamble, and forward the classified result. Each handshake runs in
+/// its own task so one slow peer doesn't block others.
 async fn acceptor_task(
     endpoint: Endpoint,
-    accepted_tx: mpsc::UnboundedSender<(Connection, SendStream, RecvStream)>,
+    accepted_tx: mpsc::UnboundedSender<Accepted>,
     mut shutdown: watch::Receiver<bool>,
 ) {
     loop {
@@ -388,12 +478,51 @@ async fn acceptor_task(
                 tokio::task::spawn_local(async move {
                     let Ok(connecting) = incoming.accept() else { return; };
                     let Ok(connection) = connecting.await else { return; };
-                    if let Ok((send, recv)) = connection.accept_bi().await {
-                        let _ = accepted_tx.send((connection, send, recv));
-                    }
+                    let Ok((send, mut recv)) = connection.accept_bi().await else { return; };
+                    // The joiner's first frame says what this stream is for.
+                    let accepted = match framing::read_preamble(&mut recv).await {
+                        Ok(Preamble::Join) => Accepted::Join(connection, send, recv),
+                        Ok(Preamble::SideChannel) => Accepted::SideChannel(connection, recv),
+                        Err(_) => return,
+                    };
+                    let _ = accepted_tx.send(accepted);
                 });
             }
             _ = shutdown.changed() => return,
+        }
+    }
+}
+
+/// Read message frames off a gateway side-channel and forward each to the command
+/// loop, which resolves the owning gateway from the destination. There is no
+/// heartbeat and no establishment: an EOF or error just ends the reader (the
+/// sending gateway reconnects when it next has something to send). `_conn` is held
+/// only to keep the QUIC connection (and thus `recv`) alive.
+async fn side_channel_reader_task(
+    _conn: Connection,
+    mut recv: RecvStream,
+    loop_tx: mpsc::UnboundedSender<Command>,
+    shm: ShmCtx,
+) {
+    loop {
+        match framing::read_frame(&mut recv, &shm.mapper, shm.client()).await {
+            Ok(Incoming::Command(ConnectionCommand::SendMessage {
+                destination_ident,
+                payload,
+            })) => {
+                if loop_tx
+                    .send(Command::SideChannelDeliver {
+                        destination_ident,
+                        payload,
+                    })
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            // A side-channel carries only messages; ignore anything else.
+            Ok(_) => {}
+            Err(_) => return,
         }
     }
 }
@@ -437,7 +566,16 @@ async fn connector_task(
         };
         if let Some(conn) = connected {
             match conn.open_bi().await {
-                Ok((send, recv)) => {
+                Ok((mut send, recv)) => {
+                    // Tell the acceptor this is an ordinary join (not a side-channel)
+                    // before the command loop drives establishment over the stream.
+                    if framing::write_preamble(&mut send, Preamble::Join)
+                        .await
+                        .is_err()
+                    {
+                        sever(&loop_tx, connection, b"quic open stream failed".to_vec());
+                        return;
+                    }
                     spawn_connection(
                         send,
                         recv,
@@ -462,6 +600,103 @@ async fn connector_task(
         tokio::select! {
             _ = tokio::time::sleep(retry) => {}
             _ = shutdown.changed() => return,
+        }
+        retry = (retry * 2).min(CONNECT_RETRY_MAX);
+    }
+}
+
+/// Drive a gateway side-channel writer: drain queued message commands, writing
+/// each as a frame to the remote gateway. The connection is established lazily on
+/// the first message (retrying until the gateway is live) and reconnected if it
+/// drops — there is no heartbeat, so a dropped connection is noticed on the next
+/// write. A message in flight when the connection drops may be lost; the channel
+/// is best-effort by design (any gateway may drop a side-channel to reclaim state).
+async fn side_channel_writer_task(
+    addr: SocketAddr,
+    client_config: ClientConfig,
+    mut rx: mpsc::UnboundedReceiver<ConnectionCommand>,
+    mut shutdown: watch::Receiver<bool>,
+    _alive: mpsc::UnboundedSender<()>,
+) {
+    let endpoint = match Endpoint::client("0.0.0.0:0".parse().expect("valid bind addr")) {
+        Ok(mut endpoint) => {
+            endpoint.set_default_client_config(client_config);
+            endpoint
+        }
+        Err(err) => {
+            tracing::warn!("side channel client bind failed: {err}");
+            return;
+        }
+    };
+
+    // The current connection, if up: its send stream plus a keep-alive holding the
+    // QUIC connection open. `None` means we must (re)connect before the next write.
+    let mut stream: Option<(SendStream, KeepAlive)> = None;
+    loop {
+        let command = tokio::select! {
+            command = rx.recv() => match command {
+                Some(command) => command,
+                None => break, // sender dropped (gateway gone)
+            },
+            _ = shutdown.changed() => break,
+        };
+        if stream.is_none() {
+            let Some((mut send, keep)) = connect_side_channel(&endpoint, addr, &mut shutdown).await
+            else {
+                break; // shutting down before the gateway came up
+            };
+            // Announce the stream as a side-channel so the peer reads messages
+            // rather than driving a join handshake.
+            if framing::write_preamble(&mut send, Preamble::SideChannel)
+                .await
+                .is_err()
+            {
+                continue; // reconnect on the next message (this one is dropped)
+            }
+            stream = Some((send, keep));
+        }
+        let (send, _keep) = stream.as_mut().expect("stream is connected");
+        if framing::write_command(send, command).await.is_err() {
+            stream = None; // dropped; reconnect on the next message
+        }
+    }
+    if let Some((mut send, _keep)) = stream {
+        let _ = send.finish();
+    }
+}
+
+/// Connect a side-channel to `addr`, retrying with backoff until the gateway binds
+/// and a bi-stream opens, or until teardown (then `None`). Mirrors the join
+/// connector's retry so a side-channel may be opened before its target gateway is
+/// live.
+async fn connect_side_channel(
+    endpoint: &Endpoint,
+    addr: SocketAddr,
+    shutdown: &mut watch::Receiver<bool>,
+) -> Option<(SendStream, KeepAlive)> {
+    let mut retry = CONNECT_RETRY_MIN;
+    loop {
+        if *shutdown.borrow() {
+            return None;
+        }
+        let connected = match endpoint.connect(addr, SERVER_NAME) {
+            Ok(connecting) => connecting.await.ok(),
+            Err(_) => None,
+        };
+        if let Some(conn) = connected {
+            if let Ok((send, _recv)) = conn.open_bi().await {
+                return Some((
+                    send,
+                    KeepAlive {
+                        _endpoint: None,
+                        _connection: conn,
+                    },
+                ));
+            }
+        }
+        tokio::select! {
+            _ = tokio::time::sleep(retry) => {}
+            _ = shutdown.changed() => return None,
         }
         retry = (retry * 2).min(CONNECT_RETRY_MAX);
     }

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -279,6 +279,89 @@ fn message_to_unrouted_actor_buffers_at_gateway_then_flushes() {
 }
 
 #[test]
+fn side_channel_routes_to_owning_gateway_among_several_on_one_endpoint() {
+    // Two gateways with the same endpoint tag `X` (e.g. two independent trees in
+    // one serving process) share the listener. A side-channel arrival is routed by
+    // its destination, so a message for c2@X reaches c2 (under gw2), not gw1.
+    let (mut ctx, mut rx) = test_ctx();
+    let gw1 = gateway_actor(&mut ctx, "gw1@X");
+    let c1 = actor(&mut ctx, "c1@X");
+    let gw2 = gateway_actor(&mut ctx, "gw2@X");
+    let c2 = actor(&mut ctx, "c2@X");
+    connect(&mut ctx, gw1, c1, "inproc://gw1-c1");
+    connect(&mut ctx, gw2, c2, "inproc://gw2-c2");
+    drain_commands(&mut ctx, &mut rx);
+
+    ctx.deliver_side_channel(
+        b"c2@X".to_vec(),
+        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"two".to_vec())]),
+    );
+    ctx.deliver_side_channel(
+        b"c1@X".to_vec(),
+        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"one".to_vec())]),
+    );
+    drain_commands(&mut ctx, &mut rx);
+
+    assert_eq!(buffered_strings(&ctx, c2), vec!["c2@X", "gw2@X", "two"]);
+    assert_eq!(buffered_strings(&ctx, c1), vec!["c1@X", "gw1@X", "one"]);
+}
+
+#[test]
+fn side_channel_message_pends_until_a_gateway_route_is_known() {
+    // A side-channel message for a destination no gateway can route yet is held in
+    // the context-wide pending table, then flushed once a gateway learns the route.
+    let (mut ctx, mut rx) = test_ctx();
+    let gw = gateway_actor(&mut ctx, "gw@X");
+    let child = actor(&mut ctx, "c@X");
+
+    ctx.deliver_side_channel(
+        b"c@X".to_vec(),
+        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"held".to_vec())]),
+    );
+    assert!(
+        ctx.pending_side_channel.contains_key(b"c@X".as_slice()),
+        "unroutable side-channel message should pend"
+    );
+
+    // The destination joins the gateway; its route propagates up and the pending
+    // message flushes down to it.
+    connect(&mut ctx, gw, child, "inproc://gw-c");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(
+        !ctx.pending_side_channel.contains_key(b"c@X".as_slice()),
+        "pending entry should be released once the route is known"
+    );
+    assert_eq!(buffered_strings(&ctx, child), vec!["c@X", "gw@X", "held"]);
+}
+
+#[test]
+fn side_channel_message_dropped_when_owning_gateway_is_dead() {
+    // A dead gateway is kept in the lookup set: its routing table still shows the
+    // destination was reachable through it, so a side-channel message for that
+    // (now-gone) subtree is dropped rather than held pending forever.
+    let (mut ctx, mut rx) = test_ctx();
+    let gw = gateway_actor(&mut ctx, "gw@X");
+    let child = actor(&mut ctx, "c@X");
+    connect(&mut ctx, gw, child, "inproc://gw-c");
+    drain_commands(&mut ctx, &mut rx);
+
+    ctx.run_command(Command::Die {
+        actor: gw,
+        reason: MsgPart::from_bytes(b"gone".to_vec()),
+    });
+
+    ctx.deliver_side_channel(
+        b"c@X".to_vec(),
+        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"x".to_vec())]),
+    );
+    assert!(
+        !ctx.pending_side_channel.contains_key(b"c@X".as_slice()),
+        "a message for a dead gateway's subtree should be dropped, not pended"
+    );
+}
+
+#[test]
 fn buffered_messages_flush_upward_when_actor_gains_a_parent() {
     let (mut ctx, mut rx) = test_ctx();
     let root = actor(&mut ctx, "root");
@@ -1093,6 +1176,171 @@ fn quic_join_before_serve() {
 }
 
 #[test]
+fn quic_gateway_to_gateway_bypasses_root() {
+    // Two QUIC gateways (gwA, gwB), each its own process/context, both joined to a
+    // shared root gateway. A message from a1@A to b1@B must reach b1 by a *direct*
+    // gateway-to-gateway side-channel (A dials B), bypassing root entirely — proven
+    // by root receiving only the join hellos and never the cross-gateway traffic.
+    set_quic_env();
+    let root_ctx = CtxHandle::new().expect("root ctx");
+    let a_ctx = CtxHandle::new().expect("a ctx");
+    let b_ctx = CtxHandle::new().expect("b ctx");
+
+    let root_url = free_quic_url();
+    let a_url = free_quic_url();
+    let b_url = free_quic_url();
+    let a_tag = quic_authority(&a_url);
+    let b_tag = quic_authority(&b_url);
+
+    let root = runtime_gateway_actor(&root_ctx, "root");
+    let gw_a = runtime_gateway_actor(&a_ctx, &format!("gwA@{a_tag}"));
+    let a1 = runtime_actor(&a_ctx, &format!("a1@{a_tag}"));
+    let gw_b = runtime_gateway_actor(&b_ctx, &format!("gwB@{b_tag}"));
+    let b1 = runtime_actor(&b_ctx, &format!("b1@{b_tag}"));
+
+    let (root_poller, mut root_rx) = runtime_poller(&root_ctx);
+    let (a1_poller, mut a1_rx) = runtime_poller(&a_ctx);
+    let (b1_poller, mut b1_rx) = runtime_poller(&b_ctx);
+    runtime_subscribe(&root_ctx, root_poller, 0, root);
+    runtime_subscribe(&a_ctx, a1_poller, 0, a1);
+    runtime_subscribe(&b_ctx, b1_poller, 0, b1);
+
+    // root is the shared rendezvous: each gateway joins it as a child, so root
+    // serves once per gateway.
+    runtime_serve(&root_ctx, root, &root_url);
+    runtime_serve(&root_ctx, root, &root_url);
+    runtime_join(&a_ctx, gw_a, &root_url);
+    runtime_join(&b_ctx, gw_b, &root_url);
+
+    // Each gateway serves its own address so a sibling gateway can side-channel to
+    // it; local children join their gateway over inproc.
+    runtime_serve(&a_ctx, gw_a, &a_url);
+    runtime_serve(&b_ctx, gw_b, &b_url);
+    runtime_connect(&a_ctx, gw_a, a1, "inproc://bypass-a");
+    runtime_connect(&b_ctx, gw_b, b1, "inproc://bypass-b");
+
+    // Drain the local-child hellos (so b1 is routable before we send).
+    assert_eq!(
+        recv_strings(&mut a1_rx),
+        vec![format!("a1@{a_tag}"), format!("gwA@{a_tag}")]
+    );
+    assert_eq!(
+        recv_strings(&mut b1_rx),
+        vec![format!("b1@{b_tag}"), format!("gwB@{b_tag}")]
+    );
+
+    // root's only deliveries are the two gateway-join hellos (in either order).
+    let mut peers: Vec<String> = (0..2)
+        .map(|_| {
+            let hello = recv_strings(&mut root_rx);
+            assert_eq!(hello[0], "root");
+            hello[1].clone()
+        })
+        .collect();
+    peers.sort();
+    assert_eq!(peers, vec![format!("gwA@{a_tag}"), format!("gwB@{b_tag}")]);
+
+    // a1@A -> b1@B: gwA opens a direct side-channel to gwB, bypassing root.
+    a_ctx
+        .send_command(Command::Send {
+            sender: a1,
+            destination_ident: MsgPart::from_bytes(format!("b1@{b_tag}").into_bytes()),
+            parts: vec![MsgPart::from_bytes(b"cross-gateway".to_vec())],
+        })
+        .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut b1_rx), vec!["cross-gateway"]);
+
+    // The reply path b1@B -> a1@A side-channels back the other way.
+    b_ctx
+        .send_command(Command::Send {
+            sender: b1,
+            destination_ident: MsgPart::from_bytes(format!("a1@{a_tag}").into_bytes()),
+            parts: vec![MsgPart::from_bytes(b"reply".to_vec())],
+        })
+        .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut a1_rx), vec!["reply"]);
+
+    // Neither message touched root: after both arrived, root has nothing pending.
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert!(
+        root_rx.try_recv().is_err(),
+        "root must not receive cross-gateway traffic"
+    );
+
+    shutdown(a_ctx);
+    shutdown(b_ctx);
+    shutdown(root_ctx);
+}
+
+#[test]
+fn quic_gateway_reaches_root_actor_and_its_inproc_child() {
+    // From a child of gateway A, a message to the root domain (an empty specifier)
+    // climbs A's parent link to root rather than side-channelling: it reaches both
+    // the root actor itself and an inproc child of root.
+    set_quic_env();
+    let root_ctx = CtxHandle::new().expect("root ctx");
+    let a_ctx = CtxHandle::new().expect("a ctx");
+
+    let root_url = free_quic_url();
+    // gwA's domain tag; gwA need not serve it here (no side-channels are used).
+    let a_tag = quic_authority(&free_quic_url());
+
+    let root = runtime_gateway_actor(&root_ctx, "root");
+    let rootchild = runtime_actor(&root_ctx, "rootchild");
+    let gw_a = runtime_gateway_actor(&a_ctx, &format!("gwA@{a_tag}"));
+    let a1 = runtime_actor(&a_ctx, &format!("a1@{a_tag}"));
+
+    let (root_poller, mut root_rx) = runtime_poller(&root_ctx);
+    let (rc_poller, mut rc_rx) = runtime_poller(&root_ctx);
+    let (a1_poller, mut a1_rx) = runtime_poller(&a_ctx);
+    runtime_subscribe(&root_ctx, root_poller, 0, root);
+    runtime_subscribe(&root_ctx, rc_poller, 1, rootchild);
+    runtime_subscribe(&a_ctx, a1_poller, 0, a1);
+
+    runtime_serve(&root_ctx, root, &root_url);
+    runtime_join(&a_ctx, gw_a, &root_url);
+    runtime_connect(&root_ctx, root, rootchild, "inproc://reach-rc");
+    runtime_connect(&a_ctx, gw_a, a1, "inproc://reach-a");
+
+    // Drain establishment hellos.
+    assert_eq!(recv_strings(&mut rc_rx), vec!["rootchild", "root"]);
+    assert_eq!(
+        recv_strings(&mut a1_rx),
+        vec![format!("a1@{a_tag}"), format!("gwA@{a_tag}")]
+    );
+    let h1 = recv_strings(&mut root_rx);
+    let h2 = recv_strings(&mut root_rx);
+    assert_eq!(h1[0], "root");
+    assert_eq!(h2[0], "root");
+    let mut peers = vec![h1[1].clone(), h2[1].clone()];
+    peers.sort();
+    assert_eq!(peers, vec![format!("gwA@{a_tag}"), "rootchild".to_string()]);
+
+    // a1@A -> root: empty specifier climbs gwA's parent link to the root actor.
+    a_ctx
+        .send_command(Command::Send {
+            sender: a1,
+            destination_ident: MsgPart::from_bytes(b"root".to_vec()),
+            parts: vec![MsgPart::from_bytes(b"hi-root".to_vec())],
+        })
+        .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut root_rx), vec!["hi-root"]);
+
+    // a1@A -> rootchild: up to root, then down its inproc child link.
+    a_ctx
+        .send_command(Command::Send {
+            sender: a1,
+            destination_ident: MsgPart::from_bytes(b"rootchild".to_vec()),
+            parts: vec![MsgPart::from_bytes(b"hi-rc".to_vec())],
+        })
+        .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut rc_rx), vec!["hi-rc"]);
+
+    shutdown(a_ctx);
+    shutdown(root_ctx);
+}
+
+#[test]
 fn quic_heartbeat_timeout_severs_connection() {
     // A peer that holds the QUIC connection open but never sends anything (no
     // Establish, no heartbeats) can't be detected by EOF — only the heartbeat
@@ -1220,13 +1468,11 @@ fn actor(ctx: &mut Ctx, ident: &str) -> Key {
     // Test actors default to non-gateways: most join a local parent, which a
     // gateway is forbidden from doing. Tests that need a gateway construct it
     // explicitly with `gateway_actor`.
-    ctx.actors
-        .insert(ActorEntry::new(Some(ident.as_bytes().to_vec()), false))
+    ctx.insert_actor(Some(ident.as_bytes().to_vec()), false)
 }
 
 fn gateway_actor(ctx: &mut Ctx, ident: &str) -> Key {
-    ctx.actors
-        .insert(ActorEntry::new(Some(ident.as_bytes().to_vec()), true))
+    ctx.insert_actor(Some(ident.as_bytes().to_vec()), true)
 }
 
 fn connect(ctx: &mut Ctx, parent: Key, child: Key, url: &str) {
@@ -1267,6 +1513,33 @@ fn runtime_connect(ctx: &CtxHandle, parent: Key, child: Key, url: &str) {
         request: request(Role::Child),
     })
     .expect("join should enqueue");
+}
+
+/// Serve `url` from `actor` as a parent (the listening side). Used to set up a
+/// gateway's own QUIC endpoint or a shared rendezvous across contexts.
+fn runtime_serve(ctx: &CtxHandle, actor: Key, url: &str) {
+    ctx.send_command(Command::Serve {
+        actor,
+        url: url.to_owned(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+}
+
+/// Join `url` from `actor` as a child (the connecting side).
+fn runtime_join(ctx: &CtxHandle, actor: Key, url: &str) {
+    ctx.send_command(Command::Join {
+        actor,
+        url: url.to_owned(),
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+}
+
+/// The authority of a `quic://host:port` url — the gateway specifier tag that goes
+/// in the `@suffix` of idents owned by the gateway serving that url.
+fn quic_authority(url: &str) -> String {
+    url.strip_prefix("quic://").unwrap_or(url).to_owned()
 }
 
 fn runtime_actor(ctx: &CtxHandle, ident: &str) -> Key {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* __->__ #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Route cross-gateway messages over lazily connected direct QUIC side channels while preserving parent routing for root-domain destinations. Resolve incoming side-channel destinations across colocated gateways, centralize gateway shared memory per context, and cover routing behavior with Rust and Python integration tests.

Differential Revision: [D114750239](https://our.internmc.facebook.com/intern/diff/D114750239/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750239/)!