### PR TITLE
18/43 minimonarch: Monitor actor existence timeout

### DIFF
--- a/monarch_mini/minimonarch.h
+++ b/monarch_mini/minimonarch.h
@@ -24,6 +24,7 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 
 /* ---------------------------------------------------------------------------
  * Types
@@ -104,6 +105,7 @@ mm_err_t mm_actor_monitor(
     mm_actor_t actor,
     mm_msg_part_t to_monitor_ident,
     const mm_msg_t* failure_prefix,
+    uint64_t timeout_for_nonexistence,
     mm_monitor_handle_t* out);
 void mm_monitor_handle_cancel(mm_monitor_handle_t handle);
 mm_err_t mm_poller_create(mm_ctx_t ctx, int* fd_out, mm_poller_t* out);
@@ -282,8 +284,22 @@ void mm_actor_die(mm_actor_t actor, mm_msg_part_t reason);
  * If `to_monitor_ident` dies or is already dead, this actor will be sent:
  *   [failure_prefix[0], ..., failure_prefix[n_failure-1], to_monitor_ident,
  * reason]
+ * where reason is "actor died".
  *
  * On success, writes the new handle to `*out`.
+ *
+ * Non-existence timeout
+ * ---------------------
+ * If `timeout_for_nonexistence` is non-zero and `to_monitor_ident` is still not
+ * known anywhere in the system after that many milliseconds, the monitor fires
+ * with the same failure shape but reason "actor does not exist". This firing is
+ * treated exactly like a death firing: it fires the monitor once and consumes
+ * it — if the target later appears and dies, nothing more is delivered for this
+ * monitor. A value of 0 disables the timeout (the monitor then fires only on an
+ * actual death). The timer starts once the monitoring actor has its own ident.
+ * Only the first monitor an actor places on a given target arms a timeout;
+ * additional monitors of the same target reuse the existing subscription and
+ * ignore their `timeout_for_nonexistence`.
  *
  * Ports
  * -----
@@ -298,6 +314,7 @@ mm_err_t mm_actor_monitor(
     mm_actor_t actor,
     mm_msg_part_t to_monitor_ident,
     const mm_msg_t* failure_prefix,
+    uint64_t timeout_for_nonexistence,
     mm_monitor_handle_t* out);
 
 /* ---------------------------------------------------------------------------

--- a/monarch_mini/python/minimonarch.c
+++ b/monarch_mini/python/minimonarch.c
@@ -1093,13 +1093,21 @@ static PyObject* Actor_die(Actor* self, PyObject* args) {
 }
 
 static PyObject* Actor_monitor(Actor* self, PyObject* args, PyObject* kwds) {
-  static char* kw[] = {"ident", "failure", NULL};
+  static char* kw[] = {"ident", "failure", "timeout_for_nonexistence", NULL};
   PyObject* ident;
   PyObject* failure = NULL;
+  unsigned long long timeout_for_nonexistence = 0;
   if (actor_ensure_open(self) < 0) {
     return NULL;
   }
-  if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O", kw, &ident, &failure)) {
+  if (!PyArg_ParseTupleAndKeywords(
+          args,
+          kwds,
+          "O|OK",
+          kw,
+          &ident,
+          &failure,
+          &timeout_for_nonexistence)) {
     return NULL;
   }
 
@@ -1125,8 +1133,12 @@ static PyObject* Actor_monitor(Actor* self, PyObject* args, PyObject* kwds) {
   }
 
   mm_monitor_handle_t handle = NULL;
-  mm_err_t err =
-      mm_actor_monitor(self->actor, to_monitor, failure_ptr, &handle);
+  mm_err_t err = mm_actor_monitor(
+      self->actor,
+      to_monitor,
+      failure_ptr,
+      (uint64_t)timeout_for_nonexistence,
+      &handle);
   PyMem_Free(arr);
   if (err != MM_OK) {
     return set_mm_error(), NULL;

--- a/monarch_mini/python/minimonarch.pyi
+++ b/monarch_mini/python/minimonarch.pyi
@@ -99,9 +99,17 @@ class Actor:
         self,
         ident: bytes,
         failure: Sequence[bytearray] | None = ...,
+        timeout_for_nonexistence: int = ...,
     ) -> MonitorHandle:
         """Monitor ``ident``. If it dies (or is already dead), this actor is sent
-        ``[*failure, ident, reason]``."""
+        ``[*failure, ident, b"actor died"]``.
+
+        If ``timeout_for_nonexistence`` is non-zero and ``ident`` is still not
+        known anywhere in the system after that many milliseconds, the monitor
+        fires once with reason ``b"actor does not exist"`` and is consumed (a
+        later appearance-then-death delivers nothing more). ``0`` (the default)
+        disables the timeout. Only the first monitor on a given target arms a
+        timeout; later monitors of the same target ignore it."""
         ...
 
 class MonitorHandle:

--- a/monarch_mini/python/test_smoke.py
+++ b/monarch_mini/python/test_smoke.py
@@ -614,6 +614,29 @@ async def test_monitor_on_already_dead_actor_fires_immediately() -> None:
     assert await watcher.next() == [b"DOWN", b"target", b"actor died"]
 
 
+async def test_monitor_timeout_fires_when_target_never_exists() -> None:
+    # With a non-existence timeout, monitoring a target that never appears fires
+    # once with reason "actor does not exist" after the timeout elapses.
+    root = Actor(b"root")
+    watcher = Actor(b"watcher")
+    await _connect(root, b"root", watcher, b"watcher", "inproc://mon-to")
+
+    watcher.monitor(b"target", failure=[ba(b"DOWN")], timeout_for_nonexistence=30)
+    assert await watcher.next() == [b"DOWN", b"target", b"actor does not exist"]
+
+
+async def test_monitor_timeout_disabled_by_default() -> None:
+    # The default timeout of 0 disables non-existence firing: an absent target
+    # produces nothing on its own.
+    root = Actor(b"root")
+    watcher = Actor(b"watcher")
+    await _connect(root, b"root", watcher, b"watcher", "inproc://mon-to-off")
+
+    watcher.monitor(b"target", failure=[ba(b"DOWN")])
+    with pytest.raises(asyncio.TimeoutError):
+        await asyncio.wait_for(watcher.next(), timeout=0.2)
+
+
 async def test_monitor_returns_cancellable_handle() -> None:
     # cancel() is idempotent and returns None.
     a = Actor(b"mon-handle")

--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -64,7 +64,13 @@ pub(crate) enum TargetMonitors {
     /// never travels; the full message is reconstructed here when the target
     /// dies. (For an unnamed actor these are recorded but the upstream `Subscribe`
     /// is held until naming.)
-    Active(HashMap<u64, Vec<MsgPart>>),
+    Active {
+        entries: HashMap<u64, Vec<MsgPart>>,
+        /// Effective non-existence timeout (ms; 0 = none) for this target, set by
+        /// the *first* monitor on it. Kept here so a `Subscribe` deferred while
+        /// the actor is unnamed can still carry the timeout once it is named.
+        timeout_ms: u64,
+    },
     /// Every monitor on this target was cancelled; the upstream subscription is
     /// still live, but a debounced unsubscribe task is scheduled. Holds that
     /// task's abort handle so re-monitoring (or a fire) cancels it.
@@ -216,6 +222,10 @@ impl Route {
 /// no per-monitor id is carried.
 pub(crate) struct MonitorSub {
     pub(crate) dest: Vec<u8>,
+    /// Non-existence timeout in ms; 0 = none. Travels with the subscription as it
+    /// is forwarded up the tree, so each ancestor that (re)installs it can arm a
+    /// fresh timer wherever the subscription currently lives.
+    pub(crate) timeout_ms: u64,
 }
 
 /// An actor's ident, which may not be known at creation (a child can be named by

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -116,12 +116,17 @@ pub(crate) enum SendPayload {
     /// An ordinary actor message: opaque part bytes handed to the destination's
     /// poller.
     ActorMessage(Vec<MsgPart>),
-    /// A monitor firing: the dead target ident, from which the destination (the
-    /// monitoring actor) reconstructs each local monitor's failure message. A fire
-    /// is only ever armed at an ancestor that already has a route to the
-    /// monitoring actor, so it routes strictly *downward* and never buffers at a
-    /// gateway.
-    FireMonitor(Vec<u8>),
+    /// A monitor firing: the dead-or-absent target ident, from which the
+    /// destination (the monitoring actor) reconstructs each local monitor's
+    /// failure message. `is_timeout` distinguishes a non-existence timeout (reason
+    /// `"actor does not exist"`) from an actual death (`"actor died"`); both route
+    /// identically. A fire is only ever armed at an ancestor that already has a
+    /// route to the monitoring actor, so it routes strictly *downward* and never
+    /// buffers at a gateway.
+    FireMonitor {
+        to_monitor: Vec<u8>,
+        is_timeout: bool,
+    },
 }
 
 /// What a [`ConnectionCommand::ToAncestor`] does once it reaches the common
@@ -132,8 +137,9 @@ pub(crate) enum SendPayload {
 #[derive(Serialize, Deserialize)]
 pub(crate) enum AncestorPayload {
     /// Register the subscription on the target's route (firing at once if it is
-    /// already dead).
-    Subscribe { dest: Vec<u8> },
+    /// already dead). `timeout_ms` (0 = none) arms a non-existence timer at the
+    /// ancestor that installs the subscription, and rides up with it on migration.
+    Subscribe { dest: Vec<u8>, timeout_ms: u64 },
     /// Remove the matching subscription from the target's route.
     Unsubscribe { dest: Vec<u8> },
 }

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -165,10 +165,20 @@ pub(crate) enum Command {
         id: u64,
         to_monitor: MsgPart,
         failure_prefix: Vec<MsgPart>,
+        timeout_ms: u64,
     },
     CancelMonitor {
         actor: Key,
         id: u64,
+    },
+    // Fired by a non-existence timeout timer armed at common ancestor `at`. A
+    // local check only: if `to_monitor`'s route at `at` is still `Unknown` the
+    // target never appeared, so fire the timeout; any other state (it exists, it
+    // died, or the subscription has migrated away leaving no route) is a no-op.
+    CheckMonitorTimeout {
+        at: Key,
+        dest: Vec<u8>,
+        to_monitor: Vec<u8>,
     },
     // Fired by a debounce timer: if `to_monitor` is still `PendingUnsubscribe`
     // (i.e. it was not re-monitored in the grace window), send the upstream
@@ -393,12 +403,42 @@ impl Ctx {
                 id,
                 to_monitor,
                 failure_prefix,
+                timeout_ms,
             } => {
                 let to_monitor = to_monitor.as_bytes().to_vec();
-                self.monitor_add(actor, id, to_monitor, failure_prefix);
+                self.monitor_add(actor, id, to_monitor, failure_prefix, timeout_ms);
             }
             Command::CancelMonitor { actor, id } => {
                 self.monitor_remove(actor, id);
+            }
+            Command::CheckMonitorTimeout {
+                at,
+                dest,
+                to_monitor,
+            } => {
+                // A non-existence timer armed at `at` expired. Inspect the target's
+                // route *here* only: `Unknown` means the subscription is still held
+                // here and the target never appeared → fire the timeout.
+                // `Connection` (target exists), `Dead` (already fired on the death
+                // path), and absent/`None` (the subscription migrated up, leaving
+                // this ancestor's route gone) are all no-ops. No wire traffic and no
+                // ancestry walk.
+                let still_unknown = matches!(
+                    self.actors
+                        .get(at)
+                        .map(|actor| actor.routes.get(to_monitor.as_slice())),
+                    Some(Some(Route::Unknown { .. }))
+                );
+                if still_unknown {
+                    self.route_message(
+                        at,
+                        dest,
+                        SendPayload::FireMonitor {
+                            to_monitor,
+                            is_timeout: true,
+                        },
+                    );
+                }
             }
             Command::UnsubscribeMonitor { actor, to_monitor } => {
                 self.unsubscribe_monitor(actor, to_monitor);
@@ -539,7 +579,17 @@ impl Ctx {
     fn deliver_payload(&mut self, actor: Key, payload: SendPayload) {
         match payload {
             SendPayload::ActorMessage(parts) => self.deliver_to_actor(actor, parts),
-            SendPayload::FireMonitor(to_monitor) => self.deliver_monitor_failure(actor, to_monitor),
+            SendPayload::FireMonitor {
+                to_monitor,
+                is_timeout,
+            } => {
+                let reason: &[u8] = if is_timeout {
+                    b"actor does not exist"
+                } else {
+                    b"actor died"
+                };
+                self.fire_local_monitors(actor, to_monitor, reason);
+            }
         }
     }
 
@@ -798,7 +848,14 @@ impl Ctx {
             newly_dead.push(ident);
         }
         for (dest, to_monitor) in to_fire {
-            self.route_message(parent, dest, SendPayload::FireMonitor(to_monitor));
+            self.route_message(
+                parent,
+                dest,
+                SendPayload::FireMonitor {
+                    to_monitor,
+                    is_timeout: false,
+                },
+            );
         }
 
         // Forward both the live and the newly-dead idents up to the parent.
@@ -860,10 +917,18 @@ impl Ctx {
                                 self.route_message(ofactor, ident.clone(), payload);
                             }
                             for sub in monitors {
+                                // Forward each subscription up *with its own
+                                // timeout*, so the new ancestor re-arms a fresh
+                                // timer where the subscription now lives. The old
+                                // ancestor's route for this target is now `None`,
+                                // so its still-pending timer no-ops when it fires.
                                 self.route_ancestor(
                                     ofactor,
                                     ident.clone(),
-                                    AncestorPayload::Subscribe { dest: sub.dest },
+                                    AncestorPayload::Subscribe {
+                                        dest: sub.dest,
+                                        timeout_ms: sub.timeout_ms,
+                                    },
                                 );
                             }
                         }
@@ -1224,15 +1289,26 @@ impl Ctx {
         }
         entry.name = ActorName::Named(name.clone());
         // Everything watched while unnamed has its subscription held back; send
-        // them all now. An unnamed actor only ever holds `Active` entries (an
-        // emptied target is removed, never left `PendingUnsubscribe`), so every
-        // one needs exactly one upstream `Subscribe`.
-        let deferred: Vec<Vec<u8>> = entry.monitored.keys().cloned().collect();
-        for to_monitor in deferred {
+        // them all now, each carrying the timeout stored on its record. An unnamed
+        // actor only ever holds `Active` entries (an emptied target is removed,
+        // never left `PendingUnsubscribe` — that path only exists for named
+        // actors), so every one needs exactly one upstream `Subscribe`.
+        let deferred: Vec<(Vec<u8>, u64)> = entry
+            .monitored
+            .iter()
+            .filter_map(|(target, tm)| match tm {
+                TargetMonitors::Active { timeout_ms, .. } => Some((target.clone(), *timeout_ms)),
+                TargetMonitors::PendingUnsubscribe(_) => None,
+            })
+            .collect();
+        for (to_monitor, timeout_ms) in deferred {
             self.route_ancestor(
                 actor,
                 to_monitor,
-                AncestorPayload::Subscribe { dest: name.clone() },
+                AncestorPayload::Subscribe {
+                    dest: name.clone(),
+                    timeout_ms,
+                },
             );
         }
     }
@@ -1248,17 +1324,20 @@ impl Ctx {
         id: u64,
         to_monitor: Vec<u8>,
         failure_prefix: Vec<MsgPart>,
+        timeout_ms: u64,
     ) {
         let entry = self.actor_mut(actor);
         match entry.monitored.get_mut(&to_monitor) {
-            Some(TargetMonitors::Active(entries)) => {
+            Some(TargetMonitors::Active { entries, .. }) => {
+                // Only the first monitor on a target arms a timeout; later ones
+                // join the existing subscription and ignore their `timeout_ms`.
                 entries.insert(id, failure_prefix);
                 return; // subscription already live (or deferred); nothing to send
             }
             Some(TargetMonitors::PendingUnsubscribe(_)) => {
                 // Re-monitor within the grace window: cancel the pending unsubscribe
                 // and reactivate. The upstream subscription was never torn down, so
-                // we do not re-subscribe.
+                // we do not re-subscribe (and do not re-arm a timeout).
                 if let Some(TargetMonitors::PendingUnsubscribe(timer)) =
                     entry.monitored.remove(&to_monitor)
                 {
@@ -1266,23 +1345,34 @@ impl Ctx {
                 }
                 entry.monitored.insert(
                     to_monitor,
-                    TargetMonitors::Active(HashMap::from([(id, failure_prefix)])),
+                    TargetMonitors::Active {
+                        entries: HashMap::from([(id, failure_prefix)]),
+                        timeout_ms: 0,
+                    },
                 );
                 return;
             }
             None => {}
         }
-        // Brand-new target: record it, then subscribe now if named, else defer to
-        // `assign_name` (the local record still allows cancel meanwhile).
+        // Brand-new target: record it (storing the timeout), then subscribe now if
+        // named, else defer to `assign_name` (the local record still allows cancel
+        // meanwhile and carries the timeout until naming).
         entry.monitored.insert(
             to_monitor.clone(),
-            TargetMonitors::Active(HashMap::from([(id, failure_prefix)])),
+            TargetMonitors::Active {
+                entries: HashMap::from([(id, failure_prefix)]),
+                timeout_ms,
+            },
         );
         let dest = match &entry.name {
             ActorName::Named(name) => name.clone(),
             ActorName::Unknown { .. } => return,
         };
-        self.route_ancestor(actor, to_monitor, AncestorPayload::Subscribe { dest });
+        self.route_ancestor(
+            actor,
+            to_monitor,
+            AncestorPayload::Subscribe { dest, timeout_ms },
+        );
     }
 
     /// Remove local monitor `id` (found by scanning its target). Dropping the last
@@ -1299,7 +1389,7 @@ impl Ctx {
             .monitored
             .iter()
             .find(|(_, tm)| match tm {
-                TargetMonitors::Active(entries) => entries.contains_key(&id),
+                TargetMonitors::Active { entries, .. } => entries.contains_key(&id),
                 TargetMonitors::PendingUnsubscribe(_) => false,
             })
             .map(|(target, _)| target.clone())
@@ -1307,7 +1397,7 @@ impl Ctx {
             return;
         };
         let now_empty = match entry.monitored.get_mut(&to_monitor) {
-            Some(TargetMonitors::Active(entries)) => {
+            Some(TargetMonitors::Active { entries, .. }) => {
                 entries.remove(&id);
                 entries.is_empty()
             }
@@ -1394,23 +1484,65 @@ impl Ctx {
             }
         }
         match payload {
-            AncestorPayload::Subscribe { dest } => self.subscribe(at, dest, to_monitor),
+            AncestorPayload::Subscribe { dest, timeout_ms } => {
+                self.subscribe(at, dest, to_monitor, timeout_ms)
+            }
             AncestorPayload::Unsubscribe { dest } => self.unsubscribe(at, dest, to_monitor),
         }
     }
 
     /// Register a subscription at the common ancestor `at`: fire immediately if the
     /// target is already known dead, otherwise hold the subscription on its route
-    /// (creating an `Unknown` buffer if the target is not yet known here).
-    fn subscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
+    /// (creating an `Unknown` buffer if the target is not yet known here). This is
+    /// the single place a non-existence timer is armed: if `timeout_ms != 0` and the
+    /// resulting route is `Unknown` (the target is not known here) a timer task is
+    /// spawned that, after the timeout, sends a [`Command::CheckMonitorTimeout`] to
+    /// recheck this same ancestor. The timer is never tracked or cancelled —
+    /// correctness comes from that fire-time route check, not from cancellation.
+    fn subscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>, timeout_ms: u64) {
         if matches!(
             self.actor(at).routes.get(to_monitor.as_slice()),
             Some(Route::Dead)
         ) {
-            self.route_message(at, dest, SendPayload::FireMonitor(to_monitor));
-        } else {
-            self.actor_mut(at)
-                .buffer_monitor(to_monitor, MonitorSub { dest });
+            self.route_message(
+                at,
+                dest,
+                SendPayload::FireMonitor {
+                    to_monitor,
+                    is_timeout: false,
+                },
+            );
+            return;
+        }
+        self.actor_mut(at).buffer_monitor(
+            to_monitor.clone(),
+            MonitorSub {
+                dest: dest.clone(),
+                timeout_ms,
+            },
+        );
+        // Arm a non-existence timer only when requested and the target is not
+        // currently known here (route is `Unknown`). On a `Connection` route the
+        // target exists, so a non-existence timeout is meaningless. Without a tokio
+        // runtime (unit-test harness) we skip arming; tests drive
+        // `CheckMonitorTimeout` directly.
+        if timeout_ms != 0
+            && matches!(
+                self.actor(at).routes.get(to_monitor.as_slice()),
+                Some(Route::Unknown { .. })
+            )
+            && tokio::runtime::Handle::try_current().is_ok()
+        {
+            let loop_tx = self.loop_tx.clone();
+            let timeout = Duration::from_millis(timeout_ms);
+            tokio::task::spawn_local(async move {
+                tokio::time::sleep(timeout).await;
+                let _ = loop_tx.send(Command::CheckMonitorTimeout {
+                    at,
+                    dest,
+                    to_monitor,
+                });
+            });
         }
     }
 
@@ -1428,14 +1560,17 @@ impl Ctx {
         }
     }
 
-    /// A subscription fired and reached the monitoring actor. The target died, so
-    /// fan the fire out to *every* local monitor on that target, reconstructing
-    /// each one's failure message from its own prefix, then drop the whole entry
-    /// (the target is gone). A fire for a target with no entries — already
-    /// cancelled-and-debounced-away, or already fired — is dropped.
-    fn deliver_monitor_failure(&mut self, actor: Key, to_monitor: Vec<u8>) {
+    /// A monitor firing (death or non-existence timeout) reached the monitoring
+    /// actor. Fan it out to *every* local monitor on that target, reconstructing
+    /// each one's failure message from its own prefix and the given `reason`, then
+    /// drop the whole entry (the monitors are consumed). Because the entry is
+    /// removed, the monitor cannot fire twice: a later real death routes a fire to
+    /// an actor that no longer has the entry → no-op. A fire for a target with no
+    /// entries — already cancelled-and-debounced-away, or already fired — is
+    /// dropped.
+    fn fire_local_monitors(&mut self, actor: Key, to_monitor: Vec<u8>, reason: &[u8]) {
         let entries = match self.actor_mut(actor).monitored.remove(&to_monitor) {
-            Some(TargetMonitors::Active(entries)) => entries,
+            Some(TargetMonitors::Active { entries, .. }) => entries,
             // All monitors were cancelled (sub still live during the grace); the
             // pending unsubscribe task is now moot — drop it and fire nothing.
             Some(TargetMonitors::PendingUnsubscribe(timer)) => {
@@ -1447,7 +1582,7 @@ impl Ctx {
         for failure_prefix in entries.into_values() {
             let mut msg = failure_prefix;
             msg.push(MsgPart::from_bytes(to_monitor.clone()));
-            msg.push(MsgPart::from_bytes(b"actor died".to_vec()));
+            msg.push(MsgPart::from_bytes(reason.to_vec()));
             self.deliver_to_actor(actor, msg);
         }
     }

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -87,8 +87,13 @@ enum WireFrame {
 /// target ident inline.
 #[derive(Serialize, Deserialize)]
 enum WirePayload {
-    ActorMessage { part_lens: Vec<u64> },
-    FireMonitor { to_monitor: Vec<u8> },
+    ActorMessage {
+        part_lens: Vec<u64>,
+    },
+    FireMonitor {
+        to_monitor: Vec<u8>,
+        is_timeout: bool,
+    },
 }
 
 fn bincode_config() -> bincode::config::Configuration {
@@ -175,7 +180,13 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
                     parts = message_parts;
                     WirePayload::ActorMessage { part_lens }
                 }
-                SendPayload::FireMonitor(to_monitor) => WirePayload::FireMonitor { to_monitor },
+                SendPayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                } => WirePayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                },
             };
             WireFrame::Message {
                 destination_ident,
@@ -267,7 +278,13 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
                     }
                     SendPayload::ActorMessage(parts)
                 }
-                WirePayload::FireMonitor { to_monitor } => SendPayload::FireMonitor(to_monitor),
+                WirePayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                } => SendPayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                },
             };
             Incoming::Command(ConnectionCommand::SendMessage {
                 destination_ident,

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -389,6 +389,7 @@ pub unsafe extern "C" fn mm_actor_monitor(
     actor: *mut CActor,
     to_monitor_ident: CMsgPart,
     failure_prefix: *const CMsg,
+    timeout_for_nonexistence: u64,
     out: *mut *mut CMonitorHandle,
 ) -> Error {
     let a = &*actor;
@@ -400,6 +401,7 @@ pub unsafe extern "C" fn mm_actor_monitor(
         id,
         to_monitor: MsgPart::from_c(to_monitor_ident),
         failure_prefix: parts_from_cmsg(failure_prefix),
+        timeout_ms: timeout_for_nonexistence,
     }) {
         Ok(()) => {
             *out = Box::into_raw(Box::new(CMonitorHandle {

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -679,6 +679,239 @@ fn deferred_monitor_cancelled_before_naming_never_subscribes() {
     assert_eq!(buffered_strings(&ctx, watcher), vec!["watcher", "root"]);
 }
 
+// --- Non-existence timeout (timeout_for_nonexistence) ----------------------
+
+// A timeout monitor on a target that never appears fires "actor does not exist"
+// when its timer (here driven directly) checks the still-`Unknown` route at the
+// common ancestor.
+#[test]
+fn timeout_fires_when_target_never_appears() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = actor(&mut ctx, "watcher");
+    connect(&mut ctx, root, watcher, "inproc://to-watcher");
+    drain_commands(&mut ctx, &mut rx);
+
+    // `target` is never created. The subscription climbs to `root` and buffers on
+    // an `Unknown` route there.
+    monitor_with_timeout(&mut ctx, watcher, 0, "target", "DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[root].routes.get(b"target".as_slice()),
+        Some(Route::Unknown { .. })
+    ));
+
+    // Drive the timer: the route is still `Unknown`, so the timeout fires.
+    check_monitor_timeout(&mut ctx, root, "watcher", "target");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor does not exist"]
+    );
+}
+
+// After a timeout fires, the local monitor is consumed: a later real death of the
+// (now-existing) target delivers nothing more for this monitor.
+#[test]
+fn timeout_fires_once_then_target_death_is_silent() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = actor(&mut ctx, "watcher");
+    connect(&mut ctx, root, watcher, "inproc://once-watcher");
+    drain_commands(&mut ctx, &mut rx);
+
+    monitor_with_timeout(&mut ctx, watcher, 0, "target", "DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    check_monitor_timeout(&mut ctx, root, "watcher", "target");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor does not exist"]
+    );
+
+    // The target now appears and later dies. The subscription still lingers at
+    // root, so a death fire is routed down — but `watcher`'s local entry is gone,
+    // so nothing new is delivered.
+    let target = actor(&mut ctx, "target");
+    connect(&mut ctx, root, target, "inproc://once-target");
+    drain_commands(&mut ctx, &mut rx);
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor does not exist"]
+    );
+}
+
+// When the target already exists (a `Connection` route at the ancestor), driving
+// the timeout is a no-op; a subsequent real death still fires "actor died".
+#[test]
+fn timeout_noop_when_target_exists() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = actor(&mut ctx, "watcher");
+    let target = actor(&mut ctx, "target");
+    connect(&mut ctx, root, watcher, "inproc://ex-watcher");
+    connect(&mut ctx, root, target, "inproc://ex-target");
+    drain_commands(&mut ctx, &mut rx);
+
+    monitor_with_timeout(&mut ctx, watcher, 0, "target", "DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[root].routes.get(b"target".as_slice()),
+        Some(Route::Connection { .. })
+    ));
+
+    // The route is `Connection`, so the timer fire delivers nothing.
+    check_monitor_timeout(&mut ctx, root, "watcher", "target");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(buffered_strings(&ctx, watcher), vec!["watcher", "root"]);
+
+    // A real death still fires the ordinary death reason.
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor died"]
+    );
+}
+
+// A timeout monitor created while the actor is unnamed retains its timeout on the
+// local record; once named, the deferred `Subscribe` carries the timeout and a
+// later timer fire reports "actor does not exist".
+#[test]
+fn timeout_deferred_until_named() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = ctx.actors.insert(ActorEntry::new(None, false));
+    drain_commands(&mut ctx, &mut rx);
+
+    monitor_with_timeout(&mut ctx, watcher, 0, "target", "DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    // Deferred: nothing upstream yet.
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 0);
+
+    // Naming releases the deferred subscription (carrying the timeout) up to root.
+    ctx.serve(
+        root,
+        "inproc://def-watcher".to_owned(),
+        request_named(Role::Parent, "watcher"),
+    );
+    ctx.join(
+        watcher,
+        "inproc://def-watcher".to_owned(),
+        request(Role::Child),
+    );
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 1);
+
+    check_monitor_timeout(&mut ctx, root, "watcher", "target");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "root", "DOWN", "target", "actor does not exist"]
+    );
+}
+
+// The regression that killed the previous attempt: a subscription armed at `mid`
+// migrates to `root` when `mid` gains a parent. The stale timer at `mid` must
+// no-op (its route is gone), and the migrated monitor must still fire on a real
+// death.
+#[test]
+fn timeout_migration_does_not_false_fire() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let mid = actor(&mut ctx, "mid");
+    let watcher = actor(&mut ctx, "watcher");
+    let target = actor(&mut ctx, "target");
+
+    // `watcher` joins parentless `mid` and monitors `target` with a timeout: the
+    // subscription buffers on an `Unknown` route at `mid` (the timer is armed here).
+    connect(&mut ctx, mid, watcher, "inproc://mig-w");
+    drain_commands(&mut ctx, &mut rx);
+    monitor_with_timeout(&mut ctx, watcher, 0, "target", "DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(route_monitor_count(&ctx, mid, "target"), 1);
+
+    // `mid` joins `root`: the subscription migrates up; `mid`'s route is dropped.
+    connect(&mut ctx, root, mid, "inproc://mig-m");
+    drain_commands(&mut ctx, &mut rx);
+    assert!(!ctx.actors[mid].routes.contains_key(b"target".as_slice()));
+    assert_eq!(route_monitor_count(&ctx, root, "target"), 1);
+
+    // `target` appears under `root`.
+    connect(&mut ctx, root, target, "inproc://mig-t");
+    drain_commands(&mut ctx, &mut rx);
+
+    // Driving the *old* timer at `mid` finds no route there: it must no-op.
+    check_monitor_timeout(&mut ctx, mid, "watcher", "target");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(buffered_strings(&ctx, watcher), vec!["watcher", "mid"]);
+
+    // A real death still fires "actor died" through the migrated subscription.
+    ctx.die_actor(target, b"boom".to_vec());
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "mid", "DOWN", "target", "actor died"]
+    );
+}
+
+// As above, but the target never appears: the timer re-armed at `root` after
+// migration still fires "actor does not exist".
+#[test]
+fn timeout_migration_still_fires_when_target_absent() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let mid = actor(&mut ctx, "mid");
+    let watcher = actor(&mut ctx, "watcher");
+
+    connect(&mut ctx, mid, watcher, "inproc://mab-w");
+    drain_commands(&mut ctx, &mut rx);
+    monitor_with_timeout(&mut ctx, watcher, 0, "target", "DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+
+    connect(&mut ctx, root, mid, "inproc://mab-m");
+    drain_commands(&mut ctx, &mut rx);
+    assert!(matches!(
+        ctx.actors[root].routes.get(b"target".as_slice()),
+        Some(Route::Unknown { .. })
+    ));
+
+    // The re-armed timer at `root` checks the still-`Unknown` route and fires.
+    check_monitor_timeout(&mut ctx, root, "watcher", "target");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        buffered_strings(&ctx, watcher),
+        vec!["watcher", "mid", "DOWN", "target", "actor does not exist"]
+    );
+}
+
+// Cancelling a timeout monitor removes the local entry, so even if a stale timer
+// later fires on a still-`Unknown` route nothing is delivered.
+#[test]
+fn timeout_cancelled_monitor_does_not_fire() {
+    let (mut ctx, mut rx) = test_ctx();
+    let root = actor(&mut ctx, "root");
+    let watcher = actor(&mut ctx, "watcher");
+    connect(&mut ctx, root, watcher, "inproc://can-watcher");
+    drain_commands(&mut ctx, &mut rx);
+
+    monitor_with_timeout(&mut ctx, watcher, 0, "target", "DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    ctx.run_command(Command::CancelMonitor {
+        actor: watcher,
+        id: 0,
+    });
+    drain_commands(&mut ctx, &mut rx);
+
+    // Force the route back to `Unknown` (cancel emptied its monitors) and drive the
+    // stale timer: the monitoring actor's local entry is gone, so no delivery.
+    check_monitor_timeout(&mut ctx, root, "watcher", "target");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(buffered_strings(&ctx, watcher), vec!["watcher", "root"]);
+}
+
 #[test]
 fn dead_route_is_carried_up_as_dead_when_gaining_a_parent() {
     let (mut ctx, mut rx) = test_ctx();
@@ -1492,11 +1725,33 @@ fn route_monitor_count(ctx: &Ctx, actor: Key, ident: &str) -> usize {
 }
 
 fn monitor(ctx: &mut Ctx, actor: Key, id: u64, to_monitor: &str, failure: &str) {
+    monitor_with_timeout(ctx, actor, id, to_monitor, failure, 0);
+}
+
+fn monitor_with_timeout(
+    ctx: &mut Ctx,
+    actor: Key,
+    id: u64,
+    to_monitor: &str,
+    failure: &str,
+    timeout_ms: u64,
+) {
     ctx.run_command(Command::Monitor {
         actor,
         id,
         to_monitor: MsgPart::from_bytes(to_monitor.as_bytes().to_vec()),
         failure_prefix: vec![MsgPart::from_bytes(failure.as_bytes().to_vec())],
+        timeout_ms,
+    });
+}
+
+/// Drive a non-existence timeout timer fire at common ancestor `at` (the
+/// in-process command a real timer would have sent on expiry).
+fn check_monitor_timeout(ctx: &mut Ctx, at: Key, dest: &str, to_monitor: &str) {
+    ctx.run_command(Command::CheckMonitorTimeout {
+        at,
+        dest: dest.as_bytes().to_vec(),
+        to_monitor: to_monitor.as_bytes().to_vec(),
     });
 }
 
@@ -1594,6 +1849,7 @@ fn runtime_monitor(ctx: &CtxHandle, actor: Key, id: u64, to_monitor: &str, failu
         id,
         to_monitor: MsgPart::from_bytes(to_monitor.as_bytes().to_vec()),
         failure_prefix: vec![MsgPart::from_bytes(failure.as_bytes().to_vec())],
+        timeout_ms: 0,
     })
     .expect("monitor should enqueue");
 }

--- a/monarch_mini/src/unix_framing.rs
+++ b/monarch_mini/src/unix_framing.rs
@@ -84,8 +84,13 @@ enum UnixFrame {
 /// target ident inline.
 #[derive(Serialize, Deserialize)]
 enum UnixPayload {
-    ActorMessage { parts: Vec<PartDesc> },
-    FireMonitor { to_monitor: Vec<u8> },
+    ActorMessage {
+        parts: Vec<PartDesc>,
+    },
+    FireMonitor {
+        to_monitor: Vec<u8>,
+        is_timeout: bool,
+    },
 }
 
 /// How one message part is represented on the wire. `Inline` parts have their
@@ -120,11 +125,18 @@ pub(crate) async fn write_command(
         } => write_actor_message(stream, destination_ident, parts, mapper, client).await,
         ConnectionCommand::SendMessage {
             destination_ident,
-            payload: SendPayload::FireMonitor(to_monitor),
+            payload:
+                SendPayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                },
         } => {
             let frame = UnixFrame::Message {
                 destination_ident,
-                payload: UnixPayload::FireMonitor { to_monitor },
+                payload: UnixPayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                },
             };
             write_header(stream, &frame).await
         }
@@ -323,7 +335,15 @@ async fn read_message_payload(
 ) -> std::io::Result<SendPayload> {
     let descs = match payload {
         UnixPayload::ActorMessage { parts } => parts,
-        UnixPayload::FireMonitor { to_monitor } => return Ok(SendPayload::FireMonitor(to_monitor)),
+        UnixPayload::FireMonitor {
+            to_monitor,
+            is_timeout,
+        } => {
+            return Ok(SendPayload::FireMonitor {
+                to_monitor,
+                is_timeout,
+            });
+        }
     };
 
     let n_fds = descs


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* __->__ #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add an optional non-existence timeout to the C, Python, and Rust monitor APIs, and propagate it with subscriptions as they move through the actor tree.
Fire a distinct `actor does not exist` reason only while the target route remains unknown, consume the monitor after firing, and cover disabled, cancellation, existence, migration, and late-death behavior.

Differential Revision: [D114750241](https://our.internmc.facebook.com/intern/diff/D114750241/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750241/)!