### PR TITLE
19/43 minimonarch: Declare and propagate dead gateways

### DIFF
--- a/monarch_mini/IMPLEMENTATION.md
+++ b/monarch_mini/IMPLEMENTATION.md
@@ -161,18 +161,55 @@ Key design points:
 
 - Gateway URLs include a pseudo-port in addition to the real port so that a
   recovered host reusing the same IP/port is distinguishable from the original
-  dead gateway.
-- When a parent gateway observes a child gateway failure, it announces the
-  failure up its ancestry so that all nodes eventually learn of it.
+  dead gateway. A tag once declared dead is therefore never reused, so a stale
+  live publication for a known-dead tag is simply dropped.
 - The total number of dead gateways is bounded by the number of machines
   (≤ ~1M), making full replication feasible. Only gateways need to track this
-  set; individual actors do not.
+  set (`dead_gateways`); individual actors do not.
 - Per-gateway OS-level monitoring runs on the gateway's own host; the
   assumption is that the gateway's death propagates reliably via this
   mechanism.
-- Nested gateway topologies are handled by having gateways include their
-  ancestry in join/serve announcements, so that observers can detect a nested
-  gateway failure even when an intermediate gateway does not announce it.
+
+### Gateway routes
+
+Every actor — gateway or not — keeps a `gateway_routes` table: per child
+connection, the set of gateway tags reachable through it. It is built by a
+`PublishGatewayRoutes` command that, unlike `PublishRoutes`, is **not bounded by
+gateway domains**: when a gateway gains a parent it publishes its own tag (plus
+any descendant gateway tags it already holds) up the new link, and every hop
+records the tags against the child connection they arrived on and forwards the
+newly-learned ones further up — all the way to the root. A non-gateway actor that
+sits between two gateways (a gateway nested under it) participates too, so the
+whole ancestry up to the root knows where every gateway lives.
+
+This table exists solely to publish gateway deaths, and it is what lets a nested
+gateway's death be announced even by a non-gateway parent: when a parent actor
+dies, its parent detects the severed connection and still holds the aggregated
+gateway routes for the entire lost subtree.
+
+### Declaring and propagating a death
+
+A gateway is declared dead in two cases:
+
+1. A connection carrying one or more gateways (its `gateway_routes` entry) fails.
+   The actor on the parent side detects this in `fail_connection` and declares
+   exactly the tags that connection carried.
+2. *(wired up with remote monitoring)* a monitor registration to a gateway is not
+   acknowledged within the monitor's timeout, so a non-owner declares it dead.
+
+Because deaths are rare, propagation is a simple up-to-root-then-down broadcast,
+carried by a single `GatewayDied` command whose direction is inferred from the
+connection it arrives on:
+
+- Arriving over a **child** connection it is still climbing: forget any routes to
+  the dead tags here and forward it up. At the root (no parent) it turns around.
+- Arriving over the **parent** connection it is fanning down: gateways record the
+  newly-dead tags (deduplicating against `dead_gateways` so repeated waves die
+  out; non-gateways merely relay), then forward it down every gateway-route child.
+
+Recording happens only on the way down, so the broadcast returning from the root
+still reaches the detector's other gateway children. A branch is dropped from the
+fan-out only once it carries no remaining live gateways.
 
 ---
 

--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -7,6 +7,7 @@
  */
 
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -40,11 +41,22 @@ pub(crate) struct ActorEntry {
     /// `Unsubscribe` is debounced via [`TargetMonitors::unsub_timer`], so rapid
     /// monitor/cancel churn on one target sends no per-cycle traffic.
     pub(crate) monitored: HashMap<Vec<u8>, TargetMonitors>,
-    /// Whether this actor is a gateway: the entry point for its process group,
-    /// with no parent or a network (quic/tcp) parent. Set once at creation and
-    /// never flipped — a gateway owns the shared-memory slab for the actors that
-    /// route through it. Joining a gateway to a non-network parent is rejected.
-    pub(crate) gateway: bool,
+    /// Whether this actor is a gateway, and if so the state only a gateway holds.
+    /// A gateway is the entry point for its process group, with no parent or a
+    /// network (quic/tcp) parent; it owns the shared-memory slab for the actors that
+    /// route through it. Set once at creation and never flipped, so gateway-only
+    /// state is unrepresentable on a non-gateway. Joining a gateway to a non-network
+    /// parent is rejected.
+    pub(crate) gateway: GatewayState,
+    /// Per child connection, the set of *gateway* tags reachable through it. Unlike
+    /// [`Self::routes`] (which stops at gateway boundaries), gateway routes are
+    /// carried all the way up to the root and exist solely to publish gateway
+    /// deaths: when a child connection fails, every gateway tag it carried is
+    /// implicitly dead, and a death broadcast fans back out down exactly these
+    /// connections. Held even at non-gateway actors, so a nested gateway under a
+    /// non-gateway parent is still announced when that parent (and thus the
+    /// connection to the gateway) dies.
+    pub(crate) gateway_routes: HashMap<ChildConnectionKey, HashSet<Vec<u8>>>,
     pub(crate) alive: bool,
     /// This actor's gateway shared-memory client, once it learns its gateway (the
     /// context's shared slab for a gateway, or a parent's slab received via
@@ -77,6 +89,20 @@ pub(crate) enum TargetMonitors {
     PendingUnsubscribe(tokio::task::AbortHandle),
 }
 
+/// Whether an actor is a gateway, carrying the gateway-only state inline in the
+/// `Gateway` variant so it cannot exist on a non-gateway. Set once at creation and
+/// never flipped; callers `match` on it directly to reach the fields.
+pub(crate) enum GatewayState {
+    NotAGateway,
+    Gateway {
+        /// Known-dead gateway tags. The set is replicated to every gateway as
+        /// deaths are broadcast, and a gateway consults it to deduplicate repeated
+        /// broadcasts (and, later, to fire monitors on actors that lived on a
+        /// now-dead gateway).
+        dead_gateways: HashSet<Vec<u8>>,
+    },
+}
+
 impl ActorEntry {
     pub(crate) fn new(ident: Option<Vec<u8>>, gateway: bool) -> Self {
         Self {
@@ -88,10 +114,22 @@ impl ActorEntry {
             children: SlotMap::with_key(),
             routes: HashMap::new(),
             monitored: HashMap::new(),
-            gateway,
+            gateway: if gateway {
+                GatewayState::Gateway {
+                    dead_gateways: HashSet::new(),
+                }
+            } else {
+                GatewayState::NotAGateway
+            },
+            gateway_routes: HashMap::new(),
             alive: true,
             shm_client: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Whether this actor is a gateway.
+    pub(crate) fn is_gateway(&self) -> bool {
+        matches!(self.gateway, GatewayState::Gateway { .. })
     }
 
     /// Record that `ident` is live through child connection `child`, so that if that

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -189,6 +189,24 @@ pub(crate) enum ConnectionCommand {
     GatewayState {
         client: ShmClient,
     },
+    /// Carry newly-reachable gateway tags up the ancestry. Each hop records them
+    /// against the child connection they arrived on (in
+    /// [`gateway_routes`](crate::actor::ActorEntry::gateway_routes)) and forwards
+    /// them up — *without* stopping at gateway boundaries, so the whole ancestry up
+    /// to the root learns where each gateway lives. This builds the tree a gateway
+    /// death is later broadcast over. Crosses every transport (gateway routing is
+    /// inherently cross-machine).
+    PublishGatewayRoutes {
+        live: Vec<Vec<u8>>,
+    },
+    /// Announce that one or more gateways have died. The direction is inferred from
+    /// the connection it arrives on: arriving from a child it travels *up* toward
+    /// the root; the root turns it around and it travels *down* every gateway-route
+    /// child connection, reaching every gateway so each records the death in its
+    /// [`dead_gateways`](crate::actor::ActorEntry::dead_gateways) set.
+    GatewayDied {
+        dead: Vec<Vec<u8>>,
+    },
 }
 
 impl Connection {

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -26,6 +26,7 @@ use crate::Role;
 use crate::actor::ActorEntry;
 use crate::actor::ActorName;
 use crate::actor::Delivery;
+use crate::actor::GatewayState;
 use crate::actor::MonitorSub;
 use crate::actor::Route;
 use crate::actor::TargetMonitors;
@@ -534,7 +535,7 @@ impl Ctx {
         // (no specifier) still climb the parent chain; destinations in our own
         // domain that we simply do not know yet are buffered locally — never sent
         // up, which would only bounce them back to us.
-        if self.actor(sender).gateway {
+        if self.actor(sender).is_gateway() {
             let own_tag = gateway_tag(self.actor(sender).name().unwrap_or_default()).to_vec();
             let dest_tag = gateway_tag(&destination_ident).to_vec();
             if !dest_tag.is_empty() && dest_tag != own_tag {
@@ -658,7 +659,7 @@ impl Ctx {
     /// (quic/tcp) parent; a unix/inproc parent would demote it. Only a `Child`
     /// role gains a parent, so a `Parent` role never trips this.
     fn gateway_parent_rejected(&self, actor: Key, role: Role, url: &str) -> bool {
-        role == Role::Child && self.actor(actor).gateway && !is_network_scheme(url)
+        role == Role::Child && self.actor(actor).is_gateway() && !is_network_scheme(url)
     }
 
     fn attach_connection(&mut self, actor: Key, request: ConnectRequest) -> Option<ConnectionRef> {
@@ -871,7 +872,7 @@ impl Ctx {
         // on one gateway out of another gateway's routing tables — cross-gateway
         // delivery uses direct side-channels (see route_message) instead. (Message
         // forwarding up the parent chain is unaffected; only route publication is.)
-        if self.actor(actor).gateway {
+        if self.actor(actor).is_gateway() {
             return;
         }
         let actor = self.actor_mut(actor);
@@ -936,6 +937,30 @@ impl Ctx {
                 }
                 self.actor_mut(ofactor).routes = kept;
                 self.publish_routes_to_parent(ofactor, live, dead);
+
+                // Gaining a parent is also where gateway routes climb the next hop.
+                // Re-publish every gateway tag reachable below us — and, if we are a
+                // gateway, our own tag — up the new link, so the ancestry up to the
+                // root can route a gateway-death broadcast back down to us. Unlike
+                // actor routes, this does not stop at gateway boundaries.
+                let mut tags: Vec<Vec<u8>> = self
+                    .actor(ofactor)
+                    .gateway_routes
+                    .values()
+                    .flatten()
+                    .cloned()
+                    .collect();
+                if self.actor(ofactor).is_gateway() {
+                    if let Some(own) = self
+                        .actor(ofactor)
+                        .name()
+                        .map(|name| gateway_tag(name).to_vec())
+                        .filter(|own| !own.is_empty())
+                    {
+                        tags.push(own);
+                    }
+                }
+                self.publish_gateway_routes_to_parent(ofactor, tags);
             }
         }
     }
@@ -989,6 +1014,53 @@ impl Ctx {
                 // on to our own machine-local children.
                 self.receive_gateway_state(connection.owning_actor(), client);
             }
+            ConnectionCommand::PublishGatewayRoutes { live } => {
+                // Gateway routes always arrive over a child connection (they climb
+                // toward the root). Record each against that child, then forward the
+                // ones we had not already recorded further up — never stopping at a
+                // gateway boundary, so they accumulate all the way to the root.
+                let ConnectionRef::ChildConnection { ofactor, slot } = connection else {
+                    panic!("published gateway routes should arrive on a child connection");
+                };
+                let entry = self.actor_mut(ofactor);
+                let mut forward = Vec::new();
+                for tag in live {
+                    // A gateway that died never returns under the same tag (a
+                    // recovered host reuses its address with a fresh pseudo-port), so
+                    // a tag already known dead is stale — drop it rather than
+                    // resurrect a route to it. (Only a gateway holds a dead-set; a
+                    // non-gateway relay never filters here.)
+                    let known_dead = match &entry.gateway {
+                        GatewayState::Gateway { dead_gateways } => dead_gateways.contains(&tag),
+                        GatewayState::NotAGateway => false,
+                    };
+                    if known_dead {
+                        continue;
+                    }
+                    if entry
+                        .gateway_routes
+                        .entry(slot)
+                        .or_default()
+                        .insert(tag.clone())
+                    {
+                        forward.push(tag);
+                    }
+                }
+                self.publish_gateway_routes_to_parent(ofactor, forward);
+            }
+            ConnectionCommand::GatewayDied { dead } => {
+                // The direction is the connection's role: a death arriving over a
+                // child connection is still climbing toward the root; one arriving
+                // over the parent connection is fanning back down.
+                match connection {
+                    ConnectionRef::ChildConnection { ofactor, .. } => {
+                        self.gateway_died(ofactor, dead, false)
+                    }
+                    ConnectionRef::ParentConnection { ofactor } => {
+                        self.gateway_died(ofactor, dead, true)
+                    }
+                }
+            }
         }
     }
 
@@ -1022,6 +1094,18 @@ impl Ctx {
                     unreachable!("a Role::Parent connection is a child connection");
                 };
                 self.populate_routes(actor, slot, Vec::new(), routed_idents.into_iter().collect());
+                // Any gateways reachable only through this now-failed connection are
+                // implicitly dead — including ones nested below us under a
+                // non-gateway child. Begin the gateway-death propagation for them
+                // (climbing toward the root, hence `only_downward: false`). A
+                // gateway-route entry is always non-empty, so there is nothing to
+                // guard against. (This also covers a parent actor's own death: its
+                // death severs its parent link, and *that* actor's parent detects the
+                // failure here, holding the aggregated gateway routes for the whole
+                // lost subtree.)
+                if let Some(tags) = self.actor_mut(actor).gateway_routes.remove(&slot) {
+                    self.gateway_died(actor, tags.into_iter().collect(), false);
+                }
             }
         }
     }
@@ -1177,6 +1261,74 @@ impl Ctx {
         if let Some(connection) = entry.parent.as_mut() {
             connection.send(ConnectionCommand::Severed { reason });
             *connection = Connection::Failed;
+        }
+    }
+
+    // -- Gateway death management -----------------------------------------------
+
+    /// Forward live gateway tags up to the parent. Unlike
+    /// [`publish_routes_to_parent`](Self::publish_routes_to_parent), this does *not*
+    /// stop at gateway boundaries: every gateway tag must reach the root so a death
+    /// broadcast can fan back down to every gateway. At the root (no parent) there
+    /// is nothing above to inform.
+    fn publish_gateway_routes_to_parent(&mut self, at: Key, live: Vec<Vec<u8>>) {
+        if live.is_empty() {
+            return;
+        }
+        if let Some(parent) = self.actor_mut(at).parent.as_mut() {
+            let _ = parent.send(ConnectionCommand::PublishGatewayRoutes { live });
+        }
+    }
+
+    /// Propagate a gateway death through `at`. First forget any routes to the dead
+    /// gateways here. Then, unless `only_downward`, forward the announcement up the
+    /// parent toward the root (which is what carries it there); `only_downward`
+    /// masks off that link, as does simply having no parent (the root). Once the
+    /// announcement is heading down — at the root turn-around, or because it arrived
+    /// from above — record the deaths (gateways only, deduplicating so repeated
+    /// waves die out; non-gateways merely relay) and fan it out down every
+    /// gateway-route child, so every gateway below is reached. Recording on the way
+    /// down (never up) is what lets the broadcast returning from the root still
+    /// reach the detector's other gateway children.
+    fn gateway_died(&mut self, at: Key, dead: Vec<Vec<u8>>, only_downward: bool) {
+        // Forget routes to the dead gateways: they no longer route anywhere, and a
+        // child entry left empty is dropped. Idempotent — an absent tag is a no-op.
+        let entry = self.actor_mut(at);
+        for tags in entry.gateway_routes.values_mut() {
+            for tag in &dead {
+                tags.remove(tag);
+            }
+        }
+        entry.gateway_routes.retain(|_, tags| !tags.is_empty());
+
+        // Still climbing toward the root: forward up and stop here.
+        if !only_downward {
+            if let Some(parent) = self.actor_mut(at).parent.as_mut() {
+                let _ = parent.send(ConnectionCommand::GatewayDied { dead });
+                return;
+            }
+        }
+
+        // Heading down: record the deaths, then fan out to every gateway-route child.
+        let newly: Vec<Vec<u8>> = match &mut self.actor_mut(at).gateway {
+            GatewayState::Gateway { dead_gateways } => dead
+                .into_iter()
+                .filter(|tag| dead_gateways.insert(tag.clone()))
+                .collect(),
+            GatewayState::NotAGateway => dead,
+        };
+        if newly.is_empty() {
+            return;
+        }
+        // (Remote-monitor firing on these deaths is wired up in the next change.)
+        let slots: Vec<ChildConnectionKey> =
+            self.actor(at).gateway_routes.keys().copied().collect();
+        for slot in slots {
+            if let Some(connection) = self.actor_mut(at).children.get_mut(slot) {
+                let _ = connection.send(ConnectionCommand::GatewayDied {
+                    dead: newly.clone(),
+                });
+            }
         }
     }
 

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -76,6 +76,12 @@ enum WireFrame {
     Severed {
         reason: Vec<u8>,
     },
+    PublishGatewayRoutes {
+        live: Vec<Vec<u8>>,
+    },
+    GatewayDied {
+        dead: Vec<Vec<u8>>,
+    },
     /// Transport-internal liveness probe; consumed by the reader to refresh its
     /// deadline and never surfaced as a [`ConnectionCommand`].
     Heartbeat,
@@ -213,6 +219,10 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
             payload,
         },
         ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
+        ConnectionCommand::PublishGatewayRoutes { live } => {
+            WireFrame::PublishGatewayRoutes { live }
+        }
+        ConnectionCommand::GatewayDied { dead } => WireFrame::GatewayDied { dead },
         // Shared memory is machine-local, so quic drops gateway state rather than
         // forwarding it: skip without writing anything to the wire.
         ConnectionCommand::GatewayState { .. } => return Ok(()),
@@ -313,6 +323,12 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
             payload,
         }),
         WireFrame::Severed { reason } => Incoming::Command(ConnectionCommand::Severed { reason }),
+        WireFrame::PublishGatewayRoutes { live } => {
+            Incoming::Command(ConnectionCommand::PublishGatewayRoutes { live })
+        }
+        WireFrame::GatewayDied { dead } => {
+            Incoming::Command(ConnectionCommand::GatewayDied { dead })
+        }
     })
 }
 

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -17,10 +17,14 @@ use crate::Role;
 use crate::actor::ActorEntry;
 use crate::actor::ActorName;
 use crate::actor::Delivery;
+use crate::actor::GatewayState;
 use crate::actor::Route;
 use crate::connection::ConnectRequest;
 use crate::connection::Connection;
+use crate::connection::ConnectionCommand;
+use crate::connection::ConnectionRef;
 use crate::connection::SendPayload;
+use crate::ctx::ChildConnectionKey;
 use crate::ctx::Command;
 use crate::ctx::Ctx;
 use crate::ctx::CtxHandle;
@@ -199,7 +203,7 @@ fn dead_pending_connect_fails_when_matched() {
         ctx.actors[joiner].parent,
         Some(Connection::Failed)
     ));
-    assert!(!ctx.actors[joiner].gateway);
+    assert!(!ctx.actors[joiner].is_gateway());
 }
 
 #[test]
@@ -358,6 +362,196 @@ fn side_channel_message_dropped_when_owning_gateway_is_dead() {
     assert!(
         !ctx.pending_side_channel.contains_key(b"c@X".as_slice()),
         "a message for a dead gateway's subtree should be dropped, not pended"
+    );
+}
+
+/// The single child connection key of `actor` (the harness only ever gives a test
+/// actor one child where these helpers are used).
+fn only_child_slot(ctx: &Ctx, actor: Key) -> ChildConnectionKey {
+    ctx.actors[actor]
+        .children
+        .keys()
+        .next()
+        .expect("actor should have a child connection")
+}
+
+/// Simulate a `PublishGatewayRoutes` arriving over `actor`'s established child
+/// connection `slot` — the same path the production handler runs.
+fn publish_gateway_routes(ctx: &mut Ctx, actor: Key, slot: ChildConnectionKey, live: Vec<Vec<u8>>) {
+    ctx.run_command(Command::ConnectionAction {
+        connection: ConnectionRef::ChildConnection {
+            ofactor: actor,
+            slot,
+        },
+        action: ConnectionCommand::PublishGatewayRoutes { live },
+    });
+}
+
+/// Whether `actor` holds a gateway route to `tag` on any child connection.
+fn has_gateway_route(ctx: &Ctx, actor: Key, tag: &str) -> bool {
+    ctx.actors[actor]
+        .gateway_routes
+        .values()
+        .any(|tags| tags.contains(tag.as_bytes()))
+}
+
+/// `actor`'s known-dead gateway set (panics if `actor` is not a gateway).
+fn dead_gateways(ctx: &Ctx, actor: Key) -> &std::collections::HashSet<Vec<u8>> {
+    match &ctx.actors[actor].gateway {
+        GatewayState::Gateway { dead_gateways } => dead_gateways,
+        GatewayState::NotAGateway => panic!("actor should be a gateway"),
+    }
+}
+
+#[test]
+fn gateway_routes_climb_to_root_through_a_nongateway() {
+    // Gateway routes, unlike actor routes, are not bounded by gateway domains: a
+    // gateway reachable below a non-gateway `mid` must be recorded at `mid` *and*
+    // carried up to the root, so the whole ancestry can route a death broadcast
+    // back down to it.
+    let (mut ctx, mut rx) = test_ctx();
+    let root = gateway_actor(&mut ctx, "root");
+    let mid = actor(&mut ctx, "mid");
+    let leaf = actor(&mut ctx, "leaf");
+    connect(&mut ctx, root, mid, "inproc://gr-root-mid");
+    connect(&mut ctx, mid, leaf, "inproc://gr-mid-leaf");
+    drain_commands(&mut ctx, &mut rx);
+
+    // A gateway with tag "A" becomes reachable through mid's connection to leaf.
+    let mid_to_leaf = only_child_slot(&ctx, mid);
+    publish_gateway_routes(&mut ctx, mid, mid_to_leaf, vec![b"A".to_vec()]);
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(has_gateway_route(&ctx, mid, "A"), "mid records the route");
+    assert!(
+        has_gateway_route(&ctx, root, "A"),
+        "the route climbs past the non-gateway mid up to the root"
+    );
+}
+
+#[test]
+fn populate_gateway_routes_ignores_already_dead_tags() {
+    // A gateway that died never returns under the same tag, so a stale live
+    // publication for a known-dead tag is dropped rather than resurrecting a route.
+    let (mut ctx, mut rx) = test_ctx();
+    let root = gateway_actor(&mut ctx, "root");
+    let child = actor(&mut ctx, "child");
+    connect(&mut ctx, root, child, "inproc://dead-tag");
+    drain_commands(&mut ctx, &mut rx);
+
+    match &mut ctx.actors[root].gateway {
+        GatewayState::Gateway { dead_gateways } => dead_gateways.insert(b"A".to_vec()),
+        GatewayState::NotAGateway => panic!("root is a gateway"),
+    };
+    let root_to_child = only_child_slot(&ctx, root);
+    publish_gateway_routes(&mut ctx, root, root_to_child, vec![b"A".to_vec()]);
+
+    assert!(
+        !has_gateway_route(&ctx, root, "A"),
+        "a route to a known-dead gateway is not recorded"
+    );
+}
+
+#[test]
+fn connection_failure_announces_nested_gateway_death_to_root() {
+    // When the connection carrying a (nested) gateway fails, its non-gateway parent
+    // begins the death propagation: it climbs to the root, which records the death
+    // in its dead-gateway set. This is the connection-loss trigger.
+    let (mut ctx, mut rx) = test_ctx();
+    let root = gateway_actor(&mut ctx, "root");
+    let mid = actor(&mut ctx, "mid");
+    let gwconn = actor(&mut ctx, "gwconn");
+    connect(&mut ctx, root, mid, "inproc://nd-root-mid");
+    connect(&mut ctx, mid, gwconn, "inproc://nd-mid-gw");
+    drain_commands(&mut ctx, &mut rx);
+
+    // Tag "G" is reachable through mid's connection to gwconn; it climbs to root.
+    let mid_to_gw = only_child_slot(&ctx, mid);
+    publish_gateway_routes(&mut ctx, mid, mid_to_gw, vec![b"G".to_vec()]);
+    drain_commands(&mut ctx, &mut rx);
+    assert!(has_gateway_route(&ctx, root, "G"));
+
+    // The gateway dies: its connection to mid drops. mid detects it and announces.
+    ctx.run_command(Command::Die {
+        actor: gwconn,
+        reason: MsgPart::from_bytes(b"gone".to_vec()),
+    });
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(
+        dead_gateways(&ctx, root).contains(b"G".as_slice()),
+        "the root learns the gateway died"
+    );
+    assert!(
+        !has_gateway_route(&ctx, mid, "G"),
+        "mid forgets the route to the dead gateway"
+    );
+    assert!(
+        !has_gateway_route(&ctx, root, "G"),
+        "the root forgets the route to the dead gateway"
+    );
+}
+
+#[test]
+fn gateway_death_fans_down_through_nongateway_relays() {
+    // The root turns an upward death around and fans it out down its gateway-route
+    // children, traversing non-gateway relays so a gateway nested below them is
+    // reached. (A real gateway cannot be an inproc child — it would be rejected — so
+    // the broadcast reaching `relay` is observed by `relay` forgetting the route to
+    // the now-dead gateway it carried.)
+    let (mut ctx, mut rx) = test_ctx();
+    let root = gateway_actor(&mut ctx, "root");
+    let relay = actor(&mut ctx, "relay");
+    let leaf = actor(&mut ctx, "leaf");
+    connect(&mut ctx, root, relay, "inproc://bc-relay");
+    connect(&mut ctx, relay, leaf, "inproc://bc-leaf");
+    drain_commands(&mut ctx, &mut rx);
+
+    // Root reaches a still-live gateway "S" through `relay` (keeping that branch
+    // alive so the broadcast is forwarded down it), while the doomed gateway "D" is
+    // reachable through `relay`'s connection to `leaf`.
+    let root_to_relay = only_child_slot(&ctx, root);
+    ctx.actors[root]
+        .gateway_routes
+        .entry(root_to_relay)
+        .or_default()
+        .insert(b"S".to_vec());
+    let relay_to_leaf = only_child_slot(&ctx, relay);
+    ctx.actors[relay]
+        .gateway_routes
+        .entry(relay_to_leaf)
+        .or_default()
+        .insert(b"D".to_vec());
+
+    // A death announcement for "D" reaches the root and fans back down.
+    ctx.gateway_died(root, vec![b"D".to_vec()], true);
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(dead_gateways(&ctx, root).contains(b"D".as_slice()));
+    assert!(
+        has_gateway_route(&ctx, root, "S"),
+        "the still-live sibling route is untouched"
+    );
+    assert!(
+        !has_gateway_route(&ctx, relay, "D"),
+        "the broadcast reached the non-gateway relay, which forgot the dead route"
+    );
+}
+
+#[test]
+fn gateway_death_is_recorded_once_at_a_gateway() {
+    // A gateway deduplicates repeated death waves against its dead-gateway set, so a
+    // second broadcast of the same tag changes nothing and does not re-fan-out.
+    let (mut ctx, _rx) = test_ctx();
+    let gw = gateway_actor(&mut ctx, "gw@A");
+
+    ctx.gateway_died(gw, vec![b"B".to_vec()], true);
+    ctx.gateway_died(gw, vec![b"B".to_vec()], true);
+
+    assert_eq!(
+        dead_gateways(&ctx, gw).len(),
+        1,
+        "a repeated death wave is absorbed without duplication"
     );
 }
 

--- a/monarch_mini/src/unix_framing.rs
+++ b/monarch_mini/src/unix_framing.rs
@@ -74,6 +74,12 @@ enum UnixFrame {
     Severed {
         reason: Vec<u8>,
     },
+    PublishGatewayRoutes {
+        live: Vec<Vec<u8>>,
+    },
+    GatewayDied {
+        dead: Vec<Vec<u8>>,
+    },
     /// Gateway-state handoff: the header carries nothing; two fds (the slab object
     /// then the dgram request socket) ride the fd-exchange step.
     GatewayState,
@@ -175,6 +181,12 @@ pub(crate) async fn write_command(
         }
         ConnectionCommand::Severed { reason } => {
             write_header(stream, &UnixFrame::Severed { reason }).await
+        }
+        ConnectionCommand::PublishGatewayRoutes { live } => {
+            write_header(stream, &UnixFrame::PublishGatewayRoutes { live }).await
+        }
+        ConnectionCommand::GatewayDied { dead } => {
+            write_header(stream, &UnixFrame::GatewayDied { dead }).await
         }
         ConnectionCommand::GatewayState { client } => {
             write_header(stream, &UnixFrame::GatewayState).await?;
@@ -310,6 +322,10 @@ pub(crate) async fn read_command(
             payload,
         },
         UnixFrame::Severed { reason } => ConnectionCommand::Severed { reason },
+        UnixFrame::PublishGatewayRoutes { live } => {
+            ConnectionCommand::PublishGatewayRoutes { live }
+        }
+        UnixFrame::GatewayDied { dead } => ConnectionCommand::GatewayDied { dead },
         UnixFrame::GatewayState => {
             // Two fds in the order they were sent: slab object, then dgram socket.
             // They must stay open for the process lifetime, so leak the received


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* __->__ #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Track gateway routes through the full actor ancestry and announce the gateway tags carried by a connection when that connection fails. Propagate each death through the root to every gateway, deduplicate recorded deaths, discard stale routes, and serialize the new commands across network and Unix transports.

Differential Revision: [D114750215](https://our.internmc.facebook.com/intern/diff/D114750215/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750215/)!