### PR TITLE
20/43 minimonarch: Remote monitoring support

### DIFF
--- a/monarch_mini/src/actor.rs
+++ b/monarch_mini/src/actor.rs
@@ -95,12 +95,39 @@ pub(crate) enum TargetMonitors {
 pub(crate) enum GatewayState {
     NotAGateway,
     Gateway {
-        /// Known-dead gateway tags. The set is replicated to every gateway as
-        /// deaths are broadcast, and a gateway consults it to deduplicate repeated
-        /// broadcasts (and, later, to fire monitors on actors that lived on a
-        /// now-dead gateway).
-        dead_gateways: HashSet<Vec<u8>>,
+        /// Per *owning* gateway tag, the cross-gateway monitor state this gateway
+        /// holds for it. A tag with no entry is assumed alive and carries no
+        /// monitors; a [`GatewayMonitors::Dead`] entry both records the death (so a
+        /// repeated death wave is deduplicated and a new subscribe fires at once)
+        /// and replaces the base's separate dead-gateway set. The map is consulted
+        /// when a death is broadcast (to fire the monitors held for the now-dead
+        /// gateway) and when filtering stale routes to a known-dead gateway.
+        gateway_state: HashMap<Vec<u8>, GatewayMonitors>,
     },
+}
+
+/// The cross-gateway monitor state a gateway holds for one *owning* gateway tag.
+pub(crate) enum GatewayMonitors {
+    /// The owning gateway is known dead. Encodes "already dead" directly: a new
+    /// subscribe to a target on it fires immediately, and a repeat death broadcast
+    /// for the tag is deduplicated.
+    Dead,
+    /// Live monitors this (subscribing) gateway holds on actors owned by the tag's
+    /// gateway. Each fires its `listener` when the owning gateway is known dead.
+    Subscribed(Vec<MonitorToFire>),
+}
+
+/// One cross-gateway monitor held at the *subscribing* gateway. Fires `listener`
+/// when `monitoring` (on the owning gateway) is known to have died.
+pub(crate) struct MonitorToFire {
+    /// Whether the owning gateway has acknowledged this registration. Until then
+    /// the "must exist" timer may declare the gateway dead (the gateway never
+    /// answered, so it is treated as unreachable).
+    pub(crate) acked: bool,
+    /// The actor to fire to (the monitoring actor, `== dest`).
+    pub(crate) listener: Vec<u8>,
+    /// The monitored target ident on the owning gateway.
+    pub(crate) monitoring: Vec<u8>,
 }
 
 impl ActorEntry {
@@ -116,7 +143,7 @@ impl ActorEntry {
             monitored: HashMap::new(),
             gateway: if gateway {
                 GatewayState::Gateway {
-                    dead_gateways: HashSet::new(),
+                    gateway_state: HashMap::new(),
                 }
             } else {
                 GatewayState::NotAGateway

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -129,19 +129,46 @@ pub(crate) enum SendPayload {
     },
 }
 
-/// What a [`ConnectionCommand::ToAncestor`] does once it reaches the common
-/// ancestor of `to_monitor` (the first actor up the tree that holds it in its
-/// routing table, or the root). Both variants route up that same path, differing
-/// only in the action at the ancestor; `dest` is the monitoring actor a fire
-/// returns to.
-#[derive(Serialize, Deserialize)]
-pub(crate) enum AncestorPayload {
-    /// Register the subscription on the target's route (firing at once if it is
-    /// already dead). `timeout_ms` (0 = none) arms a non-existence timer at the
-    /// ancestor that installs the subscription, and rides up with it on migration.
-    Subscribe { dest: Vec<u8>, timeout_ms: u64 },
-    /// Remove the matching subscription from the target's route.
-    Unsubscribe { dest: Vec<u8> },
+/// A monitor subscription change, carried both up the local hierarchy (in
+/// [`ConnectionCommand::UpdateMonitorSubscription`]) and across a gateway
+/// side-channel (in [`SideChannelAction::UpdateRemoteMonitorState`]). It crosses
+/// both wire formats, so it is `Serialize`/`Deserialize`.
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub(crate) enum MonitorOp {
+    /// Register a monitor. `timeout_ms` (0 = none) is the "must exist" timeout:
+    /// for a local target it arms a non-existence timer; for a remote one it also
+    /// bounds how long the owning gateway has to acknowledge the registration.
+    Subscribe { timeout_ms: u64 },
+    /// Cancel a previously registered monitor.
+    Unsubscribe,
+}
+
+/// A self-addressing message crossing a gateway-to-gateway side-channel.
+/// `gateway_for_actor` names the actor whose gateway should receive it, and the
+/// side-channel is dialed at `gateway_tag(gateway_for_actor)` — there is no
+/// separate destination tag. Routing never inspects the action; the receiving
+/// gateway resolves the gateway once and dispatches on [`SideChannelAction`].
+pub(crate) struct SideChannelMessage {
+    /// Ident of the actor whose gateway gets this message. For a `Send` it is also
+    /// the destination actor; for an ack it is the `listener`. The side-channel is
+    /// dialed at `gateway_tag(this)`.
+    pub(crate) gateway_for_actor: Vec<u8>,
+    pub(crate) action: SideChannelAction,
+}
+
+/// What a [`SideChannelMessage`] does at the owning gateway.
+pub(crate) enum SideChannelAction {
+    /// Deliver this payload to `gateway_for_actor` (an ordinary cross-gateway
+    /// message, or a `FireMonitor` headed back to a listener).
+    Send(SendPayload),
+    /// Register/cancel a monitor on `gateway_for_actor` (the target) firing to
+    /// `listener`. The owning gateway applies it and, for a subscribe, replies with
+    /// [`SideChannelAction::AckRemoteMonitor`].
+    UpdateRemoteMonitorState { listener: Vec<u8>, op: MonitorOp },
+    /// Confirm a registration. The carrying message's `gateway_for_actor` is the
+    /// `listener`; `monitoring` identifies the target (hence the owning gateway, by
+    /// its `@tag`).
+    AckRemoteMonitor { monitoring: Vec<u8> },
 }
 
 pub(crate) enum ConnectionCommand {
@@ -174,13 +201,17 @@ pub(crate) enum ConnectionCommand {
         live: Vec<Vec<u8>>,
         dead: Vec<Vec<u8>>,
     },
-    /// Route a monitor operation up toward the common ancestor that has
-    /// `to_monitor` in its routing table (or the root): one per monitoring actor
-    /// per target — no per-monitor id, since a fire is identified by the dead
-    /// ident. The [`AncestorPayload`] selects register vs. cancel.
-    ToAncestor {
-        to_monitor: Vec<u8>,
-        payload: AncestorPayload,
+    /// Climb a monitor subscription change up the *local* hierarchy toward the
+    /// actor that handles `target` (the common ancestor that routes it, or the
+    /// gateway at the top of the domain). One per monitoring actor per target — no
+    /// per-monitor id, since a fire is identified by the dead ident. The
+    /// [`MonitorOp`] selects register vs. cancel. Acks never travel this link —
+    /// they only ever cross side-channels as
+    /// [`SideChannelAction::AckRemoteMonitor`].
+    UpdateMonitorSubscription {
+        listener: Vec<u8>,
+        target: Vec<u8>,
+        op: MonitorOp,
     },
     /// The parent handing the child its gateway's [`ShmClient`] (the slab + dgram
     /// request socket fds), so the child can move large parts through the same
@@ -203,7 +234,7 @@ pub(crate) enum ConnectionCommand {
     /// the connection it arrives on: arriving from a child it travels *up* toward
     /// the root; the root turns it around and it travels *down* every gateway-route
     /// child connection, reaching every gateway so each records the death in its
-    /// [`dead_gateways`](crate::actor::ActorEntry::dead_gateways) set.
+    /// gateway state (firing any monitors it held for the now-dead gateway).
     GatewayDied {
         dead: Vec<Vec<u8>>,
     },

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -26,17 +26,21 @@ use crate::Role;
 use crate::actor::ActorEntry;
 use crate::actor::ActorName;
 use crate::actor::Delivery;
+use crate::actor::GatewayMonitors;
 use crate::actor::GatewayState;
 use crate::actor::MonitorSub;
+use crate::actor::MonitorToFire;
 use crate::actor::Route;
 use crate::actor::TargetMonitors;
-use crate::connection::AncestorPayload;
 use crate::connection::ConnectRequest;
 use crate::connection::Connection;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
+use crate::connection::MonitorOp;
 use crate::connection::SendPayload;
+use crate::connection::SideChannelAction;
+use crate::connection::SideChannelMessage;
 use crate::inproc_transport::InprocTransport;
 use crate::msg::MsgPart;
 use crate::poller::Delivered;
@@ -144,12 +148,10 @@ pub(crate) enum Command {
         action: ConnectionCommand,
     },
     // A message arrived over a gateway side-channel (a direct gateway-to-gateway
-    // QUIC connection, not a parent/child link). The receiving gateway is resolved
-    // from the destination, since several gateways may share one endpoint url.
-    SideChannelDeliver {
-        destination_ident: Vec<u8>,
-        payload: SendPayload,
-    },
+    // QUIC connection, not a parent/child link). The self-addressing message names
+    // the actor whose gateway should handle it; the receiving gateway is resolved
+    // from that (several gateways may share one endpoint url).
+    SideChannelDeliver(SideChannelMessage),
     // A transport's pipe is up; install it on the connection. Transport-agnostic:
     // both inproc and unix emit it, and the command loop drives establishment
     // from here (sends our Establish along the transport).
@@ -172,14 +174,15 @@ pub(crate) enum Command {
         actor: Key,
         id: u64,
     },
-    // Fired by a non-existence timeout timer armed at common ancestor `at`. A
-    // local check only: if `to_monitor`'s route at `at` is still `Unknown` the
-    // target never appeared, so fire the timeout; any other state (it exists, it
-    // died, or the subscription has migrated away leaving no route) is a no-op.
+    // Fired by a "must exist" timer armed at `at` by a local or remote subscribe.
+    // Remote (a `gateway_state` entry for `target`'s tag whose `MonitorToFire` is
+    // still unacked): the owning gateway never answered, so declare it dead. Local
+    // (a still-`Unknown` route to `target` at `at`): the target never appeared, so
+    // fire the non-existence timeout. Anything else is a no-op.
     CheckMonitorTimeout {
         at: Key,
-        dest: Vec<u8>,
-        to_monitor: Vec<u8>,
+        listener: Vec<u8>,
+        target: Vec<u8>,
     },
     // Fired by a debounce timer: if `to_monitor` is still `PendingUnsubscribe`
     // (i.e. it was not re-monitored in the grace window), send the upstream
@@ -222,12 +225,13 @@ struct Ctx {
     // the quic listener coroutines. Empty until the first gateway creates the
     // server. A clone of this slot lives in the quic transport.
     shm_client: ShmClientSlot,
-    // Side-channel messages whose destination no gateway in this context can route
-    // yet, keyed by destination ident. The destination's owning gateway is not
-    // known up front (several gateways may serve the same endpoint url), so these
-    // are held context-wide and flushed once a gateway learns a route to the
-    // destination — or the destination actor is created here.
-    pending_side_channel: HashMap<Vec<u8>, Vec<SendPayload>>,
+    // Side-channel messages whose `gateway_for_actor` no gateway in this context can
+    // resolve yet, keyed by that ident. The owning gateway is not known up front
+    // (several gateways may serve the same endpoint url, and the actor may not exist
+    // yet), so the *whole* self-addressing message is held context-wide — regardless
+    // of its action — and replayed through `deliver_side_channel` once a route to the
+    // ident is learned (see `populate_routes`).
+    pending_side_channel: HashMap<Vec<u8>, Vec<SideChannelMessage>>,
     // Every gateway actor ever created in this context, so resolving a side-channel
     // destination scans only gateways (a handful) rather than every actor. A
     // *dead* gateway is kept: its routing table still tells us whether a destination
@@ -389,11 +393,8 @@ impl Ctx {
             } => {
                 self.transport_connected(connection, transport);
             }
-            Command::SideChannelDeliver {
-                destination_ident,
-                payload,
-            } => {
-                self.deliver_side_channel(destination_ident, payload);
+            Command::SideChannelDeliver(message) => {
+                self.deliver_side_channel(message);
             }
             Command::Die { actor, reason } => {
                 let reason = reason.as_bytes().to_vec();
@@ -414,32 +415,10 @@ impl Ctx {
             }
             Command::CheckMonitorTimeout {
                 at,
-                dest,
-                to_monitor,
+                listener,
+                target,
             } => {
-                // A non-existence timer armed at `at` expired. Inspect the target's
-                // route *here* only: `Unknown` means the subscription is still held
-                // here and the target never appeared → fire the timeout.
-                // `Connection` (target exists), `Dead` (already fired on the death
-                // path), and absent/`None` (the subscription migrated up, leaving
-                // this ancestor's route gone) are all no-ops. No wire traffic and no
-                // ancestry walk.
-                let still_unknown = matches!(
-                    self.actors
-                        .get(at)
-                        .map(|actor| actor.routes.get(to_monitor.as_slice())),
-                    Some(Some(Route::Unknown { .. }))
-                );
-                if still_unknown {
-                    self.route_message(
-                        at,
-                        dest,
-                        SendPayload::FireMonitor {
-                            to_monitor,
-                            is_timeout: true,
-                        },
-                    );
-                }
+                self.check_monitor_timeout(at, listener, target);
             }
             Command::UnsubscribeMonitor { actor, to_monitor } => {
                 self.unsubscribe_monitor(actor, to_monitor);
@@ -539,17 +518,10 @@ impl Ctx {
             let own_tag = gateway_tag(self.actor(sender).name().unwrap_or_default()).to_vec();
             let dest_tag = gateway_tag(&destination_ident).to_vec();
             if !dest_tag.is_empty() && dest_tag != own_tag {
-                match std::str::from_utf8(&dest_tag) {
-                    Ok(tag) => {
-                        self.quic
-                            .send_to_gateway(tag.to_owned(), destination_ident, payload)
-                    }
-                    Err(_) => {
-                        tracing::warn!(
-                            "gateway destination has non-utf8 specifier; dropping message"
-                        )
-                    }
-                }
+                self.send_to_gateway(SideChannelMessage {
+                    gateway_for_actor: destination_ident,
+                    action: SideChannelAction::Send(payload),
+                });
                 return;
             }
             if !own_tag.is_empty() && dest_tag == own_tag {
@@ -794,18 +766,11 @@ impl Ctx {
             // route and flush its buffered messages. Monitors stay here: this actor is
             // the responsible ancestor for the destination (it is reachable below it).
             let previous = self.actor_mut(parent).routes.remove(ident.as_slice());
-            let (monitors, mut buffered) = match previous {
+            let (monitors, buffered) = match previous {
                 Some(Route::Unknown { messages, monitors }) => (monitors, messages),
                 Some(Route::Connection { monitors, .. }) => (monitors, Vec::new()),
                 _ => (Vec::new(), Vec::new()),
             };
-            // Side-channel messages held context-wide for this destination become
-            // routable at this same moment, so route them alongside the buffered
-            // ones — this is the one place a previously-unroutable side-channel
-            // destination gains a route.
-            if let Some(pending) = self.pending_side_channel.remove(ident.as_slice()) {
-                buffered.extend(pending);
-            }
             self.actor_mut(parent).routes.insert(
                 ident.clone(),
                 Route::Connection {
@@ -818,11 +783,18 @@ impl Ctx {
             self.actor_mut(parent)
                 .record_routed_via_child(child_connection, ident);
 
-            // Re-route every payload that was waiting on this route (buffered against
-            // the Unknown route, plus any pending side-channel messages); route_message
-            // sends them down the child connection we just recorded.
+            // Re-route every payload buffered against the now-resolved Unknown route;
+            // route_message sends them down the child connection we just recorded.
             for payload in buffered {
                 self.route_message(parent, ident.clone(), payload);
+            }
+            // Self-addressing side-channel messages held context-wide for this ident
+            // can now be resolved, so replay each through deliver_side_channel — the
+            // one place a previously-unresolvable side-channel ident gains a route.
+            if let Some(pending) = self.pending_side_channel.remove(ident.as_slice()) {
+                for message in pending {
+                    self.deliver_side_channel(message);
+                }
             }
         }
 
@@ -898,7 +870,7 @@ impl Ctx {
                 // must travel up *as dead*, else the parent treats a known-dead actor
                 // as alive), while buffered Unknown routes — which we could not place
                 // while parentless — are dropped and their held messages and monitor
-                // subscriptions re-routed up (route_message / route_ancestor now
+                // subscriptions re-routed up (route_message / route_monitor_change now
                 // forward, since there is a parent and no local route).
                 let mut live = vec![local_ident];
                 let mut dead = Vec::new();
@@ -923,11 +895,11 @@ impl Ctx {
                                 // timer where the subscription now lives. The old
                                 // ancestor's route for this target is now `None`,
                                 // so its still-pending timer no-ops when it fires.
-                                self.route_ancestor(
+                                self.route_monitor_change(
                                     ofactor,
+                                    sub.dest,
                                     ident.clone(),
-                                    AncestorPayload::Subscribe {
-                                        dest: sub.dest,
+                                    MonitorOp::Subscribe {
                                         timeout_ms: sub.timeout_ms,
                                     },
                                 );
@@ -1003,11 +975,12 @@ impl Ctx {
                 };
                 self.populate_routes(ofactor, slot, live, dead);
             }
-            ConnectionCommand::ToAncestor {
-                to_monitor,
-                payload,
+            ConnectionCommand::UpdateMonitorSubscription {
+                listener,
+                target,
+                op,
             } => {
-                self.route_ancestor(connection.owning_actor(), to_monitor, payload);
+                self.route_monitor_change(connection.owning_actor(), listener, target, op);
             }
             ConnectionCommand::GatewayState { client } => {
                 // Our parent handed us its gateway's client: adopt it and pass it
@@ -1031,7 +1004,9 @@ impl Ctx {
                     // resurrect a route to it. (Only a gateway holds a dead-set; a
                     // non-gateway relay never filters here.)
                     let known_dead = match &entry.gateway {
-                        GatewayState::Gateway { dead_gateways } => dead_gateways.contains(&tag),
+                        GatewayState::Gateway { gateway_state } => {
+                            matches!(gateway_state.get(&tag), Some(GatewayMonitors::Dead))
+                        }
                         GatewayState::NotAGateway => false,
                     };
                     if known_dead {
@@ -1310,17 +1285,42 @@ impl Ctx {
         }
 
         // Heading down: record the deaths, then fan out to every gateway-route child.
+        // A gateway records each death in its `gateway_state` (deduplicating against
+        // an already-`Dead` entry so repeated waves die out) and, at the moment of
+        // transition, fires every cross-gateway monitor it held for that gateway. A
+        // non-gateway holds no state and merely relays.
+        let mut to_fire: Vec<(Vec<u8>, Vec<u8>)> = Vec::new(); // (listener, monitoring)
         let newly: Vec<Vec<u8>> = match &mut self.actor_mut(at).gateway {
-            GatewayState::Gateway { dead_gateways } => dead
-                .into_iter()
-                .filter(|tag| dead_gateways.insert(tag.clone()))
-                .collect(),
+            GatewayState::Gateway { gateway_state } => {
+                let mut newly = Vec::new();
+                for tag in dead {
+                    if matches!(gateway_state.get(&tag), Some(GatewayMonitors::Dead)) {
+                        continue; // already dead; broadcast already fanned out
+                    }
+                    if let Some(GatewayMonitors::Subscribed(subs)) =
+                        gateway_state.insert(tag.clone(), GatewayMonitors::Dead)
+                    {
+                        to_fire.extend(subs.into_iter().map(|m| (m.listener, m.monitoring)));
+                    }
+                    newly.push(tag);
+                }
+                newly
+            }
             GatewayState::NotAGateway => dead,
         };
+        for (listener, monitoring) in to_fire {
+            self.route_message(
+                at,
+                listener,
+                SendPayload::FireMonitor {
+                    to_monitor: monitoring,
+                    is_timeout: false,
+                },
+            );
+        }
         if newly.is_empty() {
             return;
         }
-        // (Remote-monitor firing on these deaths is wired up in the next change.)
         let slots: Vec<ChildConnectionKey> =
             self.actor(at).gateway_routes.keys().copied().collect();
         for slot in slots {
@@ -1403,28 +1403,106 @@ impl Ctx {
 
     // -- Side-channel delivery --------------------------------------------------
 
-    /// Route a message that arrived over a gateway side-channel. Because several
-    /// gateways may serve the same endpoint url, the destination's owning gateway is
-    /// not known up front, so find the first gateway that has the destination in its
-    /// routing table (or *is* it) and hand off to `route_message`, which delivers a
-    /// live route, drops a dead one, drops anything via a dead gateway, and buffers
-    /// an `Unknown` entry. An `Unknown` entry counts: it means an actor under that
-    /// gateway already addressed the destination, so it is expected to appear there.
-    /// If no gateway knows the destination at all, hold the message in
-    /// `pending_side_channel` until a route is recorded (see `populate_routes`).
-    fn deliver_side_channel(&mut self, destination_ident: Vec<u8>, payload: SendPayload) {
-        let routable = self.gateways.iter().copied().find(|&key| {
-            let actor = &self.actors[key];
-            actor.name() == Some(destination_ident.as_slice())
-                || actor.routes.contains_key(&destination_ident)
-        });
-        match routable {
-            Some(key) => self.route_message(key, destination_ident, payload),
-            None => self
-                .pending_side_channel
-                .entry(destination_ident)
+    /// Handle a message that arrived over a gateway side-channel. The owning gateway
+    /// is resolved *once* from `gateway_for_actor` (see [`Self::gateway_for`]),
+    /// uniformly for every action. If it cannot be resolved yet, the whole
+    /// self-addressing message is held in `pending_side_channel` and replayed when a
+    /// route to `gateway_for_actor` is learned (see `populate_routes`) — there is no
+    /// per-action resolution or dropping. Once resolved, the action is dispatched:
+    ///
+    /// - `Send`: hand off to `route_message`, which delivers a live route, drops a
+    ///   dead one, and buffers an `Unknown` entry.
+    /// - `UpdateRemoteMonitorState`: register/cancel the monitor at the owning
+    ///   gateway via the *same* `route_monitor_change` (where the target is now
+    ///   same-domain, so it becomes an ordinary local `MonitorSub`); a subscribe is
+    ///   then confirmed back to the listener's gateway with `AckRemoteMonitor`.
+    /// - `AckRemoteMonitor`: mark the matching held `MonitorToFire` acked so its
+    ///   "must exist" timer stops being able to declare the gateway dead.
+    fn deliver_side_channel(&mut self, message: SideChannelMessage) {
+        let Some(gw) = self.gateway_for(&message.gateway_for_actor) else {
+            self.pending_side_channel
+                .entry(message.gateway_for_actor.clone())
                 .or_default()
-                .push(payload),
+                .push(message);
+            return;
+        };
+        let SideChannelMessage {
+            gateway_for_actor,
+            action,
+        } = message;
+        match action {
+            SideChannelAction::Send(payload) => self.route_message(gw, gateway_for_actor, payload),
+            SideChannelAction::UpdateRemoteMonitorState { listener, op } => {
+                let is_subscribe = matches!(op, MonitorOp::Subscribe { .. });
+                self.route_monitor_change(gw, listener.clone(), gateway_for_actor.clone(), op);
+                if is_subscribe {
+                    // Confirm the registration back to the listener's gateway.
+                    self.send_to_gateway(SideChannelMessage {
+                        gateway_for_actor: listener,
+                        action: SideChannelAction::AckRemoteMonitor {
+                            monitoring: gateway_for_actor,
+                        },
+                    });
+                }
+            }
+            SideChannelAction::AckRemoteMonitor { monitoring } => {
+                let tag = gateway_tag(&monitoring).to_vec();
+                if let GatewayState::Gateway { gateway_state } = &mut self.actor_mut(gw).gateway {
+                    if let Some(GatewayMonitors::Subscribed(subs)) = gateway_state.get_mut(&tag) {
+                        for m in subs.iter_mut() {
+                            if m.listener == gateway_for_actor && m.monitoring == monitoring {
+                                m.acked = true;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// The gateway in this context that owns `ident`: the first gateway that already
+    /// routes or names it, else (for a target not yet created) the gateway whose own
+    /// `@tag` serves `ident`'s `@tag`. An exact route/name match always wins over the
+    /// tag fallback. `None` if no gateway owns it yet (the caller holds or drops the
+    /// message accordingly).
+    fn gateway_for(&self, ident: &[u8]) -> Option<Key> {
+        if let Some(key) = self.gateways.iter().copied().find(|&key| {
+            let actor = &self.actors[key];
+            actor.name() == Some(ident) || actor.routes.contains_key(ident)
+        }) {
+            return Some(key);
+        }
+        let tag = gateway_tag(ident);
+        if tag.is_empty() {
+            return None;
+        }
+        self.gateways
+            .iter()
+            .copied()
+            .find(|&key| gateway_tag(self.actors[key].name().unwrap_or_default()) == tag)
+    }
+
+    /// Ship a self-addressing side-channel message to the gateway that owns
+    /// `msg.gateway_for_actor`, dialing the side-channel at that actor's `@tag`.
+    /// Without a tokio runtime (the sync unit-test harness) this is a no-op; those
+    /// tests drive the receive side (`deliver_side_channel`) directly.
+    fn send_to_gateway(&mut self, msg: SideChannelMessage) {
+        if tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let tag = gateway_tag(&msg.gateway_for_actor);
+        if tag.is_empty() {
+            tracing::warn!("side-channel message has no gateway specifier; dropping");
+            return;
+        }
+        match std::str::from_utf8(tag) {
+            Ok(tag) => {
+                let tag = tag.to_owned();
+                self.quic.send_to_gateway(tag, msg);
+            }
+            Err(_) => {
+                tracing::warn!("gateway destination has non-utf8 specifier; dropping message");
+            }
         }
     }
 
@@ -1454,13 +1532,11 @@ impl Ctx {
             })
             .collect();
         for (to_monitor, timeout_ms) in deferred {
-            self.route_ancestor(
+            self.route_monitor_change(
                 actor,
+                name.clone(),
                 to_monitor,
-                AncestorPayload::Subscribe {
-                    dest: name.clone(),
-                    timeout_ms,
-                },
+                MonitorOp::Subscribe { timeout_ms },
             );
         }
     }
@@ -1520,11 +1596,7 @@ impl Ctx {
             ActorName::Named(name) => name.clone(),
             ActorName::Unknown { .. } => return,
         };
-        self.route_ancestor(
-            actor,
-            to_monitor,
-            AncestorPayload::Subscribe { dest, timeout_ms },
-        );
+        self.route_monitor_change(actor, dest, to_monitor, MonitorOp::Subscribe { timeout_ms });
     }
 
     /// Remove local monitor `id` (found by scanning its target). Dropping the last
@@ -1612,103 +1684,268 @@ impl Ctx {
             ActorName::Named(name) => name.clone(),
             ActorName::Unknown { .. } => return,
         };
-        self.route_ancestor(actor, to_monitor, AncestorPayload::Unsubscribe { dest });
+        self.route_monitor_change(actor, dest, to_monitor, MonitorOp::Unsubscribe);
     }
 
-    /// Route a monitor operation up to the *common ancestor* of `to_monitor`: the
-    /// first actor from `at` upward that holds `to_monitor` in its routing table
-    /// (or the root). That ancestor is where a normal message to the target turns
-    /// downward, so it is where a subscription is held and where a fire originates.
-    /// Both subscribe and cancel travel this one path, differing only in the
-    /// [`AncestorPayload`] handler that runs once the ancestor is reached.
-    fn route_ancestor(&mut self, at: Key, to_monitor: Vec<u8>, payload: AncestorPayload) {
-        // Forward up while this actor is not yet the common ancestor (it has no
-        // route to the target) and a parent exists. Otherwise we are the ancestor —
-        // or the root, where the target may not exist yet and the subscription is
-        // held until it does — so the payload acts here.
-        if !self.actor(at).routes.contains_key(to_monitor.as_slice()) {
-            if let Some(parent) = self.actor_mut(at).parent.as_mut() {
-                let _ = parent.send(ConnectionCommand::ToAncestor {
-                    to_monitor,
-                    payload,
-                });
+    /// Apply a monitor subscribe/cancel, sending it to the actor responsible for
+    /// `target`. (Replaces the base's `route_ancestor`.) The responsible actor is
+    /// chosen by the target's domain, relative to ours:
+    ///
+    /// - **Root domain** (blank tag): the common ancestor that routes the target —
+    ///   climbing transparently *past* gateways, up to the root. Held locally there.
+    /// - **Our own domain**: the common ancestor, or — failing that — our gateway, the
+    ///   top of the domain, which holds it until the target appears. Held locally.
+    /// - **Another gateway's domain**: our gateway, which mirrors the monitor onto the
+    ///   gateway that owns the target over a side-channel.
+    ///
+    /// Until we reach that actor we forward the change one hop up (see
+    /// [`Self::forward_monitor_up`]).
+    fn route_monitor_change(&mut self, at: Key, listener: Vec<u8>, target: Vec<u8>, op: MonitorOp) {
+        let target_domain = gateway_tag(&target);
+        let my_domain = gateway_tag(self.actor(at).name().unwrap_or_default());
+        let routes_target = self.actor(at).routes.contains_key(target.as_slice());
+        let is_gateway = self.actor(at).is_gateway();
+
+        if target_domain.is_empty() {
+            // Root domain: only the common ancestor that routes the target handles it;
+            // gateways are transparent, so an unrouted target keeps climbing to the root.
+            if routes_target {
+                self.establish_local_monitor(at, listener, target, op);
+            } else {
+                self.forward_monitor_up(at, listener, target, op);
+            }
+        } else if target_domain == my_domain {
+            // Our own domain: the common ancestor, or our gateway (the top of the
+            // domain), holds it; anyone below them forwards up.
+            if routes_target || is_gateway {
+                self.establish_local_monitor(at, listener, target, op);
+            } else {
+                self.forward_monitor_up(at, listener, target, op);
+            }
+        } else {
+            // Another gateway's domain: our gateway mirrors it onto the owning gateway;
+            // anyone below the gateway forwards up to it.
+            if is_gateway {
+                self.mirror_monitor_to_gateway(at, listener, target, op);
+            } else {
+                self.forward_monitor_up(at, listener, target, op);
+            }
+        }
+    }
+
+    /// Forward a monitor change one hop up toward the actor responsible for `target`.
+    /// At the root (no parent) there is nowhere left to climb, so we are that actor:
+    /// hold the monitor locally until the target appears.
+    fn forward_monitor_up(&mut self, at: Key, listener: Vec<u8>, target: Vec<u8>, op: MonitorOp) {
+        if let Some(parent) = self.actor_mut(at).parent.as_mut() {
+            let _ = parent.send(ConnectionCommand::UpdateMonitorSubscription {
+                listener,
+                target,
+                op,
+            });
+        } else {
+            self.establish_local_monitor(at, listener, target, op);
+        }
+    }
+
+    /// Establish a *local* monitor on `target`'s route at the responsible actor `at`
+    /// (the target is in `at`'s own domain). A subscribe fires immediately if the
+    /// route is already `Dead`, else holds a `MonitorSub` (creating an `Unknown`
+    /// buffer if the target is not known here yet) and arms the non-existence timer
+    /// while the route is `Unknown` — on a `Connection` route the target exists, so a
+    /// non-existence timeout is meaningless. An unsubscribe drops the matching
+    /// `MonitorSub` (idempotent: a sub that already fired or was never registered
+    /// leaves nothing to remove).
+    fn establish_local_monitor(
+        &mut self,
+        at: Key,
+        listener: Vec<u8>,
+        target: Vec<u8>,
+        op: MonitorOp,
+    ) {
+        let timeout_ms = match op {
+            MonitorOp::Unsubscribe => {
+                if let Some(monitors) = self
+                    .actor_mut(at)
+                    .routes
+                    .get_mut(target.as_slice())
+                    .and_then(Route::monitors_mut)
+                {
+                    monitors.retain(|sub| sub.dest != listener);
+                }
                 return;
             }
-        }
-        match payload {
-            AncestorPayload::Subscribe { dest, timeout_ms } => {
-                self.subscribe(at, dest, to_monitor, timeout_ms)
-            }
-            AncestorPayload::Unsubscribe { dest } => self.unsubscribe(at, dest, to_monitor),
-        }
-    }
+            MonitorOp::Subscribe { timeout_ms } => timeout_ms,
+        };
 
-    /// Register a subscription at the common ancestor `at`: fire immediately if the
-    /// target is already known dead, otherwise hold the subscription on its route
-    /// (creating an `Unknown` buffer if the target is not yet known here). This is
-    /// the single place a non-existence timer is armed: if `timeout_ms != 0` and the
-    /// resulting route is `Unknown` (the target is not known here) a timer task is
-    /// spawned that, after the timeout, sends a [`Command::CheckMonitorTimeout`] to
-    /// recheck this same ancestor. The timer is never tracked or cancelled —
-    /// correctness comes from that fire-time route check, not from cancellation.
-    fn subscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>, timeout_ms: u64) {
         if matches!(
-            self.actor(at).routes.get(to_monitor.as_slice()),
+            self.actor(at).routes.get(target.as_slice()),
             Some(Route::Dead)
         ) {
             self.route_message(
                 at,
-                dest,
+                listener,
                 SendPayload::FireMonitor {
-                    to_monitor,
+                    to_monitor: target,
                     is_timeout: false,
                 },
             );
             return;
         }
         self.actor_mut(at).buffer_monitor(
-            to_monitor.clone(),
+            target.clone(),
             MonitorSub {
-                dest: dest.clone(),
+                dest: listener.clone(),
                 timeout_ms,
             },
         );
-        // Arm a non-existence timer only when requested and the target is not
-        // currently known here (route is `Unknown`). On a `Connection` route the
-        // target exists, so a non-existence timeout is meaningless. Without a tokio
-        // runtime (unit-test harness) we skip arming; tests drive
-        // `CheckMonitorTimeout` directly.
-        if timeout_ms != 0
-            && matches!(
-                self.actor(at).routes.get(to_monitor.as_slice()),
-                Some(Route::Unknown { .. })
-            )
-            && tokio::runtime::Handle::try_current().is_ok()
-        {
-            let loop_tx = self.loop_tx.clone();
-            let timeout = Duration::from_millis(timeout_ms);
-            tokio::task::spawn_local(async move {
-                tokio::time::sleep(timeout).await;
-                let _ = loop_tx.send(Command::CheckMonitorTimeout {
-                    at,
-                    dest,
-                    to_monitor,
-                });
-            });
+        if matches!(
+            self.actor(at).routes.get(target.as_slice()),
+            Some(Route::Unknown { .. })
+        ) {
+            self.arm_must_exist_timer(at, listener, target, timeout_ms);
         }
     }
 
-    /// Remove the matching subscription at the common ancestor `at`. Idempotent: a
-    /// sub that already fired (and was removed), targets a now-dead route, or was
-    /// never registered is a no-op.
-    fn unsubscribe(&mut self, at: Key, dest: Vec<u8>, to_monitor: Vec<u8>) {
-        if let Some(monitors) = self
-            .actor_mut(at)
-            .routes
-            .get_mut(to_monitor.as_slice())
-            .and_then(Route::monitors_mut)
-        {
-            monitors.retain(|sub| sub.dest != dest);
+    /// Mirror a cross-gateway monitor onto the gateway that owns `target`, from the
+    /// subscribing gateway `at`. A subscribe records an (unacked) `MonitorToFire`
+    /// against the owning gateway's tag — so a later death of that gateway fires the
+    /// listener — unless the gateway is already known dead, in which case it fires
+    /// straight back and holds nothing. A cancel drops the matching `MonitorToFire`,
+    /// removing the tag entry if it empties so a stale timer cannot later declare the
+    /// gateway dead. Either way the op is relayed to the owning gateway (which applies
+    /// it as an ordinary local monitor on `target`); a subscribe additionally arms the
+    /// "must exist" timer that declares the gateway dead if it never acknowledges.
+    fn mirror_monitor_to_gateway(
+        &mut self,
+        at: Key,
+        listener: Vec<u8>,
+        target: Vec<u8>,
+        op: MonitorOp,
+    ) {
+        let tag = gateway_tag(&target).to_vec();
+        match op {
+            MonitorOp::Subscribe { timeout_ms } => {
+                let already_dead = matches!(
+                    &self.actor(at).gateway,
+                    GatewayState::Gateway { gateway_state }
+                        if matches!(gateway_state.get(&tag), Some(GatewayMonitors::Dead))
+                );
+                if already_dead {
+                    self.route_message(
+                        at,
+                        listener,
+                        SendPayload::FireMonitor {
+                            to_monitor: target,
+                            is_timeout: false,
+                        },
+                    );
+                    return;
+                }
+                let GatewayState::Gateway { gateway_state } = &mut self.actor_mut(at).gateway
+                else {
+                    unreachable!("a cross-gateway target is handled only at a gateway");
+                };
+                let GatewayMonitors::Subscribed(subs) = gateway_state
+                    .entry(tag)
+                    .or_insert_with(|| GatewayMonitors::Subscribed(Vec::new()))
+                else {
+                    unreachable!("a known-dead gateway fired above and returned");
+                };
+                subs.push(MonitorToFire {
+                    acked: false,
+                    listener: listener.clone(),
+                    monitoring: target.clone(),
+                });
+                self.relay_to_owning_gateway(&listener, &target, op);
+                self.arm_must_exist_timer(at, listener, target, timeout_ms);
+            }
+            MonitorOp::Unsubscribe => {
+                if let GatewayState::Gateway { gateway_state } = &mut self.actor_mut(at).gateway {
+                    if let Some(GatewayMonitors::Subscribed(subs)) = gateway_state.get_mut(&tag) {
+                        subs.retain(|m| !(m.listener == listener && m.monitoring == target));
+                        if subs.is_empty() {
+                            gateway_state.remove(&tag);
+                        }
+                    }
+                }
+                self.relay_to_owning_gateway(&listener, &target, op);
+            }
+        }
+    }
+
+    /// Forward a monitor op to the gateway that owns `target` over a side-channel, so
+    /// it (un)registers an ordinary local monitor on `target` firing back to
+    /// `listener`.
+    fn relay_to_owning_gateway(&mut self, listener: &[u8], target: &[u8], op: MonitorOp) {
+        self.send_to_gateway(SideChannelMessage {
+            gateway_for_actor: target.to_vec(),
+            action: SideChannelAction::UpdateRemoteMonitorState {
+                listener: listener.to_vec(),
+                op,
+            },
+        });
+    }
+
+    /// The "must exist" timer, armed by both local and remote subscribes. After
+    /// `timeout_ms` it sends a [`Command::CheckMonitorTimeout`] back to `at`. Never
+    /// tracked or cancelled — correctness comes from the fire-time check, not from
+    /// cancellation. Without a tokio runtime (unit-test harness) it is a no-op;
+    /// those tests drive `CheckMonitorTimeout` directly.
+    fn arm_must_exist_timer(&self, at: Key, listener: Vec<u8>, target: Vec<u8>, timeout_ms: u64) {
+        if timeout_ms == 0 || tokio::runtime::Handle::try_current().is_err() {
+            return;
+        }
+        let loop_tx = self.loop_tx.clone();
+        let timeout = Duration::from_millis(timeout_ms);
+        tokio::task::spawn_local(async move {
+            tokio::time::sleep(timeout).await;
+            let _ = loop_tx.send(Command::CheckMonitorTimeout {
+                at,
+                listener,
+                target,
+            });
+        });
+    }
+
+    /// A "must exist" timer armed at `at` expired. Remote and local cases are
+    /// mutually exclusive (only a cross-gateway target has a `gateway_state` entry;
+    /// only a same-domain one has a local route):
+    /// - Remote, still unacknowledged: the owning gateway never answered the
+    ///   registration, so treat it as unreachable — declare it dead, which fires the
+    ///   monitor as the death propagates back (Trigger 2).
+    /// - Local, never appeared: the route is still `Unknown`, so the target never
+    ///   existed — fire the non-existence timeout. Any other route state (it exists,
+    ///   it died, or the subscription migrated up leaving no route) is a no-op.
+    fn check_monitor_timeout(&mut self, at: Key, listener: Vec<u8>, target: Vec<u8>) {
+        let tag = gateway_tag(&target).to_vec();
+        let unacked_remote = match self.actors.get(at).map(|actor| &actor.gateway) {
+            Some(GatewayState::Gateway { gateway_state }) => matches!(
+                gateway_state.get(&tag),
+                Some(GatewayMonitors::Subscribed(subs))
+                    if subs.iter().any(|m| m.listener == listener && m.monitoring == target && !m.acked)
+            ),
+            _ => false,
+        };
+        if unacked_remote {
+            self.gateway_died(at, vec![tag], false);
+            return;
+        }
+        let still_unknown = matches!(
+            self.actors
+                .get(at)
+                .map(|actor| actor.routes.get(target.as_slice())),
+            Some(Some(Route::Unknown { .. }))
+        );
+        if still_unknown {
+            self.route_message(
+                at,
+                listener,
+                SendPayload::FireMonitor {
+                    to_monitor: target,
+                    is_timeout: true,
+                },
+            );
         }
     }
 

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -41,9 +41,11 @@ use tokio::io::AsyncWrite;
 use tokio::io::AsyncWriteExt;
 
 use crate::Role;
-use crate::connection::AncestorPayload;
 use crate::connection::ConnectionCommand;
+use crate::connection::MonitorOp;
 use crate::connection::SendPayload;
+use crate::connection::SideChannelAction;
+use crate::connection::SideChannelMessage;
 use crate::msg::MsgPart;
 use crate::shm::MapperHandle;
 use crate::shm::SHM_THRESHOLD;
@@ -69,9 +71,10 @@ enum WireFrame {
         live: Vec<Vec<u8>>,
         dead: Vec<Vec<u8>>,
     },
-    ToAncestor {
-        to_monitor: Vec<u8>,
-        payload: AncestorPayload,
+    UpdateMonitorSubscription {
+        listener: Vec<u8>,
+        target: Vec<u8>,
+        op: MonitorOp,
     },
     Severed {
         reason: Vec<u8>,
@@ -99,6 +102,26 @@ enum WirePayload {
     FireMonitor {
         to_monitor: Vec<u8>,
         is_timeout: bool,
+    },
+}
+
+/// One frame on a gateway side-channel — the wire form of a [`SideChannelMessage`].
+/// `Send` of an actor message reuses [`WirePayload`]'s zero-copy part-length header
+/// + streamed bytes (+ shm); every other case is header-only.
+#[derive(Serialize, Deserialize)]
+enum SideChannelFrame {
+    Send {
+        gateway_for_actor: Vec<u8>,
+        payload: WirePayload,
+    },
+    UpdateRemoteMonitorState {
+        gateway_for_actor: Vec<u8>,
+        listener: Vec<u8>,
+        op: MonitorOp,
+    },
+    AckRemoteMonitor {
+        gateway_for_actor: Vec<u8>,
+        monitoring: Vec<u8>,
     },
 }
 
@@ -211,12 +234,14 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
             alive,
         },
         ConnectionCommand::PublishRoutes { live, dead } => WireFrame::PublishRoutes { live, dead },
-        ConnectionCommand::ToAncestor {
-            to_monitor,
-            payload,
-        } => WireFrame::ToAncestor {
-            to_monitor,
-            payload,
+        ConnectionCommand::UpdateMonitorSubscription {
+            listener,
+            target,
+            op,
+        } => WireFrame::UpdateMonitorSubscription {
+            listener,
+            target,
+            op,
         },
         ConnectionCommand::Severed { reason } => WireFrame::Severed { reason },
         ConnectionCommand::PublishGatewayRoutes { live } => {
@@ -237,7 +262,7 @@ pub(crate) async fn write_heartbeat<W: AsyncWrite + Unpin>(writer: &mut W) -> st
 
 async fn write_frame<W: AsyncWrite + Unpin>(
     writer: &mut W,
-    frame: &WireFrame,
+    frame: &impl Serialize,
     parts: &[MsgPart],
 ) -> std::io::Result<()> {
     let header = bincode::serde::encode_to_vec(frame, bincode_config())
@@ -315,12 +340,14 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
         WireFrame::PublishRoutes { live, dead } => {
             Incoming::Command(ConnectionCommand::PublishRoutes { live, dead })
         }
-        WireFrame::ToAncestor {
-            to_monitor,
-            payload,
-        } => Incoming::Command(ConnectionCommand::ToAncestor {
-            to_monitor,
-            payload,
+        WireFrame::UpdateMonitorSubscription {
+            listener,
+            target,
+            op,
+        } => Incoming::Command(ConnectionCommand::UpdateMonitorSubscription {
+            listener,
+            target,
+            op,
         }),
         WireFrame::Severed { reason } => Incoming::Command(ConnectionCommand::Severed { reason }),
         WireFrame::PublishGatewayRoutes { live } => {
@@ -329,6 +356,121 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
         WireFrame::GatewayDied { dead } => {
             Incoming::Command(ConnectionCommand::GatewayDied { dead })
         }
+    })
+}
+
+/// Serialize and write one [`SideChannelMessage`]: a length-prefixed bincode
+/// header, then — for a `Send` of an actor message — each part's bytes streamed
+/// raw after it (zero-copy, same scheme as [`write_command`]). Every other action
+/// is header-only.
+pub(crate) async fn write_side_channel<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    message: SideChannelMessage,
+) -> std::io::Result<()> {
+    let SideChannelMessage {
+        gateway_for_actor,
+        action,
+    } = message;
+    let mut parts: Vec<MsgPart> = Vec::new();
+    let frame = match action {
+        SideChannelAction::Send(payload) => {
+            let payload = match payload {
+                SendPayload::ActorMessage(message_parts) => {
+                    let part_lens = message_parts
+                        .iter()
+                        .map(|part| part.as_bytes().len() as u64)
+                        .collect();
+                    parts = message_parts;
+                    WirePayload::ActorMessage { part_lens }
+                }
+                SendPayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                } => WirePayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                },
+            };
+            SideChannelFrame::Send {
+                gateway_for_actor,
+                payload,
+            }
+        }
+        SideChannelAction::UpdateRemoteMonitorState { listener, op } => {
+            SideChannelFrame::UpdateRemoteMonitorState {
+                gateway_for_actor,
+                listener,
+                op,
+            }
+        }
+        SideChannelAction::AckRemoteMonitor { monitoring } => SideChannelFrame::AckRemoteMonitor {
+            gateway_for_actor,
+            monitoring,
+        },
+    };
+    write_frame(writer, &frame, &parts).await
+}
+
+/// Read one [`SideChannelMessage`] off a gateway side-channel. A `Send` of an
+/// actor message reads each part exactly like [`read_frame`] (small parts into
+/// owned buffers, large ones into the slab via `mapper`/`client`); other actions
+/// are header-only.
+pub(crate) async fn read_side_channel<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    mapper: &MapperHandle,
+    client: Option<ShmClient>,
+) -> std::io::Result<SideChannelMessage> {
+    let mut len_buf = [0u8; 8];
+    reader.read_exact(&mut len_buf).await?;
+    let header_len = u64::from_le_bytes(len_buf) as usize;
+
+    let mut header = vec![0u8; header_len];
+    reader.read_exact(&mut header).await?;
+    let (frame, _) =
+        bincode::serde::decode_from_slice::<SideChannelFrame, _>(&header, bincode_config())
+            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+
+    Ok(match frame {
+        SideChannelFrame::Send {
+            gateway_for_actor,
+            payload,
+        } => {
+            let payload = match payload {
+                WirePayload::ActorMessage { part_lens } => {
+                    let mut parts = Vec::with_capacity(part_lens.len());
+                    for len in part_lens {
+                        parts.push(read_part(reader, len, mapper, client).await?);
+                    }
+                    SendPayload::ActorMessage(parts)
+                }
+                WirePayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                } => SendPayload::FireMonitor {
+                    to_monitor,
+                    is_timeout,
+                },
+            };
+            SideChannelMessage {
+                gateway_for_actor,
+                action: SideChannelAction::Send(payload),
+            }
+        }
+        SideChannelFrame::UpdateRemoteMonitorState {
+            gateway_for_actor,
+            listener,
+            op,
+        } => SideChannelMessage {
+            gateway_for_actor,
+            action: SideChannelAction::UpdateRemoteMonitorState { listener, op },
+        },
+        SideChannelFrame::AckRemoteMonitor {
+            gateway_for_actor,
+            monitoring,
+        } => SideChannelMessage {
+            gateway_for_actor,
+            action: SideChannelAction::AckRemoteMonitor { monitoring },
+        },
     })
 }
 

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -56,7 +56,7 @@ use tokio::time::MissedTickBehavior;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
-use crate::connection::SendPayload;
+use crate::connection::SideChannelMessage;
 use crate::ctx::Command;
 use crate::framing;
 use crate::framing::Incoming;
@@ -178,7 +178,7 @@ pub(crate) struct QuicTransport {
     // `@specifier` tag). Each owns a task that lazily connects (retrying until the
     // gateway is live), streams message frames, and reconnects if the connection
     // drops. Never heartbeated; cached across messages.
-    side_channels: HashMap<String, mpsc::UnboundedSender<ConnectionCommand>>,
+    side_channels: HashMap<String, mpsc::UnboundedSender<SideChannelMessage>>,
     tls: Option<Arc<TlsConfig>>,
     // Liveness-token issuer: each connection's writer holds a clone for its
     // lifetime. Teardown drops this issuing copy and waits for `alive_rx` to close
@@ -235,17 +235,13 @@ impl QuicTransport {
         Ok(tls)
     }
 
-    /// Send a message to a remote gateway over a direct side-channel, opening (and
-    /// caching) the connection on first use. The caller (the command loop) has
-    /// already determined `tag` is a different gateway than the sender's own. The
-    /// side-channel is best-effort and not heartbeated; a message enqueued while
-    /// the remote gateway is not yet live waits for the connection to come up.
-    pub(crate) fn send_to_gateway(
-        &mut self,
-        tag: String,
-        destination_ident: Vec<u8>,
-        payload: SendPayload,
-    ) {
+    /// Send a self-addressing [`SideChannelMessage`] to a remote gateway over a
+    /// direct side-channel, opening (and caching) the connection on first use. The
+    /// caller (the command loop) has already derived `tag` from the message's
+    /// `gateway_for_actor`. The side-channel is best-effort and not heartbeated; a
+    /// message enqueued while the remote gateway is not yet live waits for the
+    /// connection to come up.
+    pub(crate) fn send_to_gateway(&mut self, tag: String, message: SideChannelMessage) {
         if !self.side_channels.contains_key(&tag) {
             let client = match self.tls() {
                 Ok(tls) => tls.client.clone(),
@@ -275,10 +271,7 @@ impl QuicTransport {
             .side_channels
             .get(&tag)
             .expect("side channel just inserted")
-            .send(ConnectionCommand::SendMessage {
-                destination_ident,
-                payload,
-            });
+            .send(message);
     }
 
     /// Signal every writer to flush and exit, then wait until they all have — the
@@ -505,23 +498,12 @@ async fn side_channel_reader_task(
     shm: ShmCtx,
 ) {
     loop {
-        match framing::read_frame(&mut recv, &shm.mapper, shm.client()).await {
-            Ok(Incoming::Command(ConnectionCommand::SendMessage {
-                destination_ident,
-                payload,
-            })) => {
-                if loop_tx
-                    .send(Command::SideChannelDeliver {
-                        destination_ident,
-                        payload,
-                    })
-                    .is_err()
-                {
+        match framing::read_side_channel(&mut recv, &shm.mapper, shm.client()).await {
+            Ok(message) => {
+                if loop_tx.send(Command::SideChannelDeliver(message)).is_err() {
                     return;
                 }
             }
-            // A side-channel carries only messages; ignore anything else.
-            Ok(_) => {}
             Err(_) => return,
         }
     }
@@ -614,7 +596,7 @@ async fn connector_task(
 async fn side_channel_writer_task(
     addr: SocketAddr,
     client_config: ClientConfig,
-    mut rx: mpsc::UnboundedReceiver<ConnectionCommand>,
+    mut rx: mpsc::UnboundedReceiver<SideChannelMessage>,
     mut shutdown: watch::Receiver<bool>,
     _alive: mpsc::UnboundedSender<()>,
 ) {
@@ -633,9 +615,9 @@ async fn side_channel_writer_task(
     // QUIC connection open. `None` means we must (re)connect before the next write.
     let mut stream: Option<(SendStream, KeepAlive)> = None;
     loop {
-        let command = tokio::select! {
-            command = rx.recv() => match command {
-                Some(command) => command,
+        let message = tokio::select! {
+            message = rx.recv() => match message {
+                Some(message) => message,
                 None => break, // sender dropped (gateway gone)
             },
             _ = shutdown.changed() => break,
@@ -656,7 +638,7 @@ async fn side_channel_writer_task(
             stream = Some((send, keep));
         }
         let (send, _keep) = stream.as_mut().expect("stream is connected");
-        if framing::write_command(send, command).await.is_err() {
+        if framing::write_side_channel(send, message).await.is_err() {
             stream = None; // dropped; reconnect on the next message
         }
     }

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -17,13 +17,17 @@ use crate::Role;
 use crate::actor::ActorEntry;
 use crate::actor::ActorName;
 use crate::actor::Delivery;
+use crate::actor::GatewayMonitors;
 use crate::actor::GatewayState;
 use crate::actor::Route;
 use crate::connection::ConnectRequest;
 use crate::connection::Connection;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
+use crate::connection::MonitorOp;
 use crate::connection::SendPayload;
+use crate::connection::SideChannelAction;
+use crate::connection::SideChannelMessage;
 use crate::ctx::ChildConnectionKey;
 use crate::ctx::Command;
 use crate::ctx::Ctx;
@@ -296,14 +300,8 @@ fn side_channel_routes_to_owning_gateway_among_several_on_one_endpoint() {
     connect(&mut ctx, gw2, c2, "inproc://gw2-c2");
     drain_commands(&mut ctx, &mut rx);
 
-    ctx.deliver_side_channel(
-        b"c2@X".to_vec(),
-        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"two".to_vec())]),
-    );
-    ctx.deliver_side_channel(
-        b"c1@X".to_vec(),
-        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"one".to_vec())]),
-    );
+    side_channel_send(&mut ctx, "c2@X", b"two");
+    side_channel_send(&mut ctx, "c1@X", b"one");
     drain_commands(&mut ctx, &mut rx);
 
     assert_eq!(buffered_strings(&ctx, c2), vec!["c2@X", "gw2@X", "two"]);
@@ -312,23 +310,21 @@ fn side_channel_routes_to_owning_gateway_among_several_on_one_endpoint() {
 
 #[test]
 fn side_channel_message_pends_until_a_gateway_route_is_known() {
-    // A side-channel message for a destination no gateway can route yet is held in
-    // the context-wide pending table, then flushed once a gateway learns the route.
+    // A side-channel message that arrives before any gateway for its destination's
+    // tag even exists cannot be resolved, so it is held in the context-wide pending
+    // table, then flushed once a gateway learns the route.
     let (mut ctx, mut rx) = test_ctx();
-    let gw = gateway_actor(&mut ctx, "gw@X");
-    let child = actor(&mut ctx, "c@X");
 
-    ctx.deliver_side_channel(
-        b"c@X".to_vec(),
-        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"held".to_vec())]),
-    );
+    side_channel_send(&mut ctx, "c@X", b"held");
     assert!(
         ctx.pending_side_channel.contains_key(b"c@X".as_slice()),
         "unroutable side-channel message should pend"
     );
 
-    // The destination joins the gateway; its route propagates up and the pending
-    // message flushes down to it.
+    // The gateway and destination appear; the destination's route propagates up and
+    // the pending message flushes down to it.
+    let gw = gateway_actor(&mut ctx, "gw@X");
+    let child = actor(&mut ctx, "c@X");
     connect(&mut ctx, gw, child, "inproc://gw-c");
     drain_commands(&mut ctx, &mut rx);
 
@@ -355,10 +351,7 @@ fn side_channel_message_dropped_when_owning_gateway_is_dead() {
         reason: MsgPart::from_bytes(b"gone".to_vec()),
     });
 
-    ctx.deliver_side_channel(
-        b"c@X".to_vec(),
-        SendPayload::ActorMessage(vec![MsgPart::from_bytes(b"x".to_vec())]),
-    );
+    side_channel_send(&mut ctx, "c@X", b"x");
     assert!(
         !ctx.pending_side_channel.contains_key(b"c@X".as_slice()),
         "a message for a dead gateway's subtree should be dropped, not pended"
@@ -395,10 +388,37 @@ fn has_gateway_route(ctx: &Ctx, actor: Key, tag: &str) -> bool {
         .any(|tags| tags.contains(tag.as_bytes()))
 }
 
-/// `actor`'s known-dead gateway set (panics if `actor` is not a gateway).
-fn dead_gateways(ctx: &Ctx, actor: Key) -> &std::collections::HashSet<Vec<u8>> {
+/// `actor`'s cross-gateway monitor map (panics if `actor` is not a gateway).
+fn gateway_state(ctx: &Ctx, actor: Key) -> &std::collections::HashMap<Vec<u8>, GatewayMonitors> {
     match &ctx.actors[actor].gateway {
-        GatewayState::Gateway { dead_gateways } => dead_gateways,
+        GatewayState::Gateway { gateway_state } => gateway_state,
+        GatewayState::NotAGateway => panic!("actor should be a gateway"),
+    }
+}
+
+/// Whether `actor` (a gateway) has recorded `tag` as dead.
+fn gateway_is_dead(ctx: &Ctx, actor: Key, tag: &str) -> bool {
+    matches!(
+        gateway_state(ctx, actor).get(tag.as_bytes()),
+        Some(GatewayMonitors::Dead)
+    )
+}
+
+/// How many gateway tags `actor` (a gateway) has recorded as dead.
+fn dead_gateway_count(ctx: &Ctx, actor: Key) -> usize {
+    gateway_state(ctx, actor)
+        .values()
+        .filter(|state| matches!(state, GatewayMonitors::Dead))
+        .count()
+}
+
+/// Mark `tag` dead in `actor`'s (a gateway's) gateway state, as a death broadcast
+/// would.
+fn mark_gateway_dead(ctx: &mut Ctx, actor: Key, tag: &str) {
+    match &mut ctx.actors[actor].gateway {
+        GatewayState::Gateway { gateway_state } => {
+            gateway_state.insert(tag.as_bytes().to_vec(), GatewayMonitors::Dead);
+        }
         GatewayState::NotAGateway => panic!("actor should be a gateway"),
     }
 }
@@ -439,10 +459,7 @@ fn populate_gateway_routes_ignores_already_dead_tags() {
     connect(&mut ctx, root, child, "inproc://dead-tag");
     drain_commands(&mut ctx, &mut rx);
 
-    match &mut ctx.actors[root].gateway {
-        GatewayState::Gateway { dead_gateways } => dead_gateways.insert(b"A".to_vec()),
-        GatewayState::NotAGateway => panic!("root is a gateway"),
-    };
+    mark_gateway_dead(&mut ctx, root, "A");
     let root_to_child = only_child_slot(&ctx, root);
     publish_gateway_routes(&mut ctx, root, root_to_child, vec![b"A".to_vec()]);
 
@@ -479,7 +496,7 @@ fn connection_failure_announces_nested_gateway_death_to_root() {
     drain_commands(&mut ctx, &mut rx);
 
     assert!(
-        dead_gateways(&ctx, root).contains(b"G".as_slice()),
+        gateway_is_dead(&ctx, root, "G"),
         "the root learns the gateway died"
     );
     assert!(
@@ -527,7 +544,7 @@ fn gateway_death_fans_down_through_nongateway_relays() {
     ctx.gateway_died(root, vec![b"D".to_vec()], true);
     drain_commands(&mut ctx, &mut rx);
 
-    assert!(dead_gateways(&ctx, root).contains(b"D".as_slice()));
+    assert!(gateway_is_dead(&ctx, root, "D"));
     assert!(
         has_gateway_route(&ctx, root, "S"),
         "the still-live sibling route is untouched"
@@ -549,9 +566,248 @@ fn gateway_death_is_recorded_once_at_a_gateway() {
     ctx.gateway_died(gw, vec![b"B".to_vec()], true);
 
     assert_eq!(
-        dead_gateways(&ctx, gw).len(),
+        dead_gateway_count(&ctx, gw),
         1,
         "a repeated death wave is absorbed without duplication"
+    );
+}
+
+// -- Cross-gateway (remote) monitors, driven synchronously -------------------
+
+/// Number of cross-gateway monitors `gw` holds against owning-gateway `tag` (0 if
+/// the tag has no `Subscribed` entry).
+fn remote_monitor_count(ctx: &Ctx, gw: Key, tag: &str) -> usize {
+    match gateway_state(ctx, gw).get(tag.as_bytes()) {
+        Some(GatewayMonitors::Subscribed(subs)) => subs.len(),
+        _ => 0,
+    }
+}
+
+/// Whether `gw` holds an *acked* cross-gateway monitor for (`listener`,
+/// `monitoring`).
+fn remote_monitor_acked(ctx: &Ctx, gw: Key, listener: &str, monitoring: &str) -> bool {
+    let tag = monitoring.rsplit('@').next().unwrap_or("");
+    matches!(
+        gateway_state(ctx, gw).get(tag.as_bytes()),
+        Some(GatewayMonitors::Subscribed(subs))
+            if subs.iter().any(|m| m.listener == listener.as_bytes()
+                && m.monitoring == monitoring.as_bytes()
+                && m.acked)
+    )
+}
+
+/// The parts of `actor`'s most recently buffered message (panics if none).
+fn last_message(ctx: &Ctx, actor: Key) -> Vec<String> {
+    let Delivery::NoPoller { buffered } = &ctx.actors[actor].delivery else {
+        panic!("actor should not be subscribed");
+    };
+    buffered
+        .back()
+        .expect("a message should have been buffered")
+        .iter()
+        .map(|part| String::from_utf8(part.as_bytes().to_vec()).unwrap())
+        .collect()
+}
+
+/// Deliver a side-channel `AckRemoteMonitor` confirming (`listener`, `monitoring`).
+fn deliver_ack(ctx: &mut Ctx, listener: &str, monitoring: &str) {
+    ctx.deliver_side_channel(SideChannelMessage {
+        gateway_for_actor: listener.as_bytes().to_vec(),
+        action: SideChannelAction::AckRemoteMonitor {
+            monitoring: monitoring.as_bytes().to_vec(),
+        },
+    });
+}
+
+/// Build a gateway `gwA@A` with a local listener child `L@A` joined over inproc,
+/// returning `(gateway, listener)` with establishment hellos drained.
+fn gateway_with_listener(ctx: &mut Ctx, rx: &mut mpsc::UnboundedReceiver<Command>) -> (Key, Key) {
+    let gw = gateway_actor(ctx, "gwA@A");
+    let listener = actor(ctx, "L@A");
+    connect(ctx, gw, listener, "inproc://rm-listener");
+    drain_commands(ctx, rx);
+    (gw, listener)
+}
+
+#[test]
+fn remote_monitor_fires_when_owning_gateway_dies() {
+    // L@A monitors T@B (a different gateway). The subscription climbs to gwA and is
+    // held there as a cross-gateway monitor against tag B. When B is announced dead,
+    // gwA fires the held monitor back to L and records B as dead.
+    let (mut ctx, mut rx) = test_ctx();
+    let (gw, listener) = gateway_with_listener(&mut ctx, &mut rx);
+
+    monitor(&mut ctx, listener, 1, "T@B", "T-DOWN");
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        remote_monitor_count(&ctx, gw, "B"),
+        1,
+        "the cross-gateway subscription is held at gwA"
+    );
+
+    ctx.gateway_died(gw, vec![b"B".to_vec()], true);
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(gateway_is_dead(&ctx, gw, "B"), "B is recorded dead");
+    assert_eq!(
+        last_message(&ctx, listener),
+        vec!["T-DOWN", "T@B", "actor died"],
+        "the listener's monitor fired"
+    );
+}
+
+#[test]
+fn unacked_remote_subscribe_timeout_declares_gateway_dead() {
+    // The owning gateway never acknowledges the registration (the sync harness sends
+    // nothing back), so the must-exist timer at gwA treats B as unreachable: it
+    // declares B dead, which fires the monitor.
+    let (mut ctx, mut rx) = test_ctx();
+    let (gw, listener) = gateway_with_listener(&mut ctx, &mut rx);
+
+    monitor_with_timeout(&mut ctx, listener, 1, "T@B", "T-DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(remote_monitor_count(&ctx, gw, "B"), 1);
+    assert!(
+        !remote_monitor_acked(&ctx, gw, "L@A", "T@B"),
+        "no ack arrived in the sync harness"
+    );
+
+    check_monitor_timeout(&mut ctx, gw, "L@A", "T@B");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(
+        gateway_is_dead(&ctx, gw, "B"),
+        "the unreachable gateway is dead"
+    );
+    assert_eq!(
+        last_message(&ctx, listener),
+        vec!["T-DOWN", "T@B", "actor died"]
+    );
+}
+
+#[test]
+fn acked_remote_subscribe_timeout_is_noop() {
+    // Once the owning gateway acknowledges, the must-exist timer no longer declares
+    // it dead: the registration is confirmed, so a timer fire is a no-op.
+    let (mut ctx, mut rx) = test_ctx();
+    let (gw, listener) = gateway_with_listener(&mut ctx, &mut rx);
+
+    monitor_with_timeout(&mut ctx, listener, 1, "T@B", "T-DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    deliver_ack(&mut ctx, "L@A", "T@B");
+    assert!(
+        remote_monitor_acked(&ctx, gw, "L@A", "T@B"),
+        "the registration is acked"
+    );
+
+    check_monitor_timeout(&mut ctx, gw, "L@A", "T@B");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(
+        !gateway_is_dead(&ctx, gw, "B"),
+        "an acked gateway is not declared dead"
+    );
+    assert_eq!(
+        remote_monitor_count(&ctx, gw, "B"),
+        1,
+        "the monitor is still held"
+    );
+    assert_eq!(
+        buffered_strings(&ctx, listener),
+        vec!["L@A", "gwA@A"],
+        "no monitor fired (only the establishment hellos)"
+    );
+}
+
+#[test]
+fn cancelled_remote_monitor_timeout_does_not_declare_dead() {
+    // Cancelling the monitor drops the held cross-gateway record and its now-empty
+    // tag entry, so a stale must-exist timer finds nothing and does not declare the
+    // gateway dead.
+    let (mut ctx, mut rx) = test_ctx();
+    let (gw, listener) = gateway_with_listener(&mut ctx, &mut rx);
+
+    monitor_with_timeout(&mut ctx, listener, 1, "T@B", "T-DOWN", 50);
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(remote_monitor_count(&ctx, gw, "B"), 1);
+
+    ctx.run_command(Command::CancelMonitor {
+        actor: listener,
+        id: 1,
+    });
+    drain_commands(&mut ctx, &mut rx);
+    assert_eq!(
+        remote_monitor_count(&ctx, gw, "B"),
+        0,
+        "cancellation drops the held monitor"
+    );
+
+    check_monitor_timeout(&mut ctx, gw, "L@A", "T@B");
+    drain_commands(&mut ctx, &mut rx);
+    assert!(
+        !gateway_is_dead(&ctx, gw, "B"),
+        "a stale timer must not declare the gateway dead after cancellation"
+    );
+}
+
+#[test]
+fn subscribe_on_already_dead_gateway_fires_immediately() {
+    // Subscribing to a target on a gateway already known dead fires the monitor at
+    // once and holds nothing.
+    let (mut ctx, mut rx) = test_ctx();
+    let (gw, listener) = gateway_with_listener(&mut ctx, &mut rx);
+    mark_gateway_dead(&mut ctx, gw, "B");
+
+    monitor(&mut ctx, listener, 1, "T@B", "T-DOWN");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert_eq!(
+        remote_monitor_count(&ctx, gw, "B"),
+        0,
+        "no monitor is held for an already-dead gateway"
+    );
+    assert_eq!(
+        last_message(&ctx, listener),
+        vec!["T-DOWN", "T@B", "actor died"],
+        "the monitor fired immediately"
+    );
+}
+
+#[test]
+fn pending_side_channel_holds_any_action_until_resolvable() {
+    // A non-`Send` side-channel action (a remote subscribe) that arrives before its
+    // owning gateway exists is held whole in pending_side_channel — not dropped —
+    // and replayed once the gateway and target route appear, registering an ordinary
+    // local monitor at the owning gateway.
+    let (mut ctx, mut rx) = test_ctx();
+
+    ctx.deliver_side_channel(SideChannelMessage {
+        gateway_for_actor: b"T@B".to_vec(),
+        action: SideChannelAction::UpdateRemoteMonitorState {
+            listener: b"L@A".to_vec(),
+            op: MonitorOp::Subscribe { timeout_ms: 0 },
+        },
+    });
+    assert!(
+        ctx.pending_side_channel.contains_key(b"T@B".as_slice()),
+        "an unresolvable remote subscribe should pend, not be dropped"
+    );
+
+    // gwB and its child T@B appear; the route propagates and the pended subscribe is
+    // replayed, becoming a local MonitorSub on gwB's route to T.
+    let gw_b = gateway_actor(&mut ctx, "gwB@B");
+    let target = actor(&mut ctx, "T@B");
+    connect(&mut ctx, gw_b, target, "inproc://pend-t");
+    drain_commands(&mut ctx, &mut rx);
+
+    assert!(
+        !ctx.pending_side_channel.contains_key(b"T@B".as_slice()),
+        "the pending message is released once T@B is resolvable"
+    );
+    assert_eq!(
+        route_monitor_count(&ctx, gw_b, "T@B"),
+        1,
+        "the replayed subscribe registered a local monitor at the owning gateway"
     );
 }
 
@@ -1768,6 +2024,195 @@ fn quic_gateway_reaches_root_actor_and_its_inproc_child() {
 }
 
 #[test]
+fn quic_monitor_on_root_domain_target_climbs_to_root() {
+    // A child of gateway A monitors a root-domain target (blank specifier). The
+    // subscription must climb gwA's parent link to the root — where the target
+    // actually lives — rather than being held at gwA (which would never see the
+    // target and would fire a false non-existence). Killing the root-domain target
+    // then fires the monitor back to the gateway child over a side-channel.
+    set_quic_env();
+    let root_ctx = CtxHandle::new().expect("root ctx");
+    let a_ctx = CtxHandle::new().expect("a ctx");
+
+    let root_url = free_quic_url();
+    let a_url = free_quic_url();
+    let a_tag = quic_authority(&a_url);
+
+    let root = runtime_gateway_actor(&root_ctx, "root");
+    let rootchild = runtime_actor(&root_ctx, "rootchild");
+    let gw_a = runtime_gateway_actor(&a_ctx, &format!("gwA@{a_tag}"));
+    let a1 = runtime_actor(&a_ctx, &format!("a1@{a_tag}"));
+
+    let (rc_poller, mut rc_rx) = runtime_poller(&root_ctx);
+    let (a1_poller, mut a1_rx) = runtime_poller(&a_ctx);
+    runtime_subscribe(&root_ctx, rc_poller, 0, rootchild);
+    runtime_subscribe(&a_ctx, a1_poller, 0, a1);
+
+    runtime_serve(&root_ctx, root, &root_url);
+    runtime_join(&a_ctx, gw_a, &root_url);
+    // gwA serves its own endpoint so root can side-channel the fire back to it.
+    runtime_serve(&a_ctx, gw_a, &a_url);
+    runtime_connect(&root_ctx, root, rootchild, "inproc://climb-rc");
+    runtime_connect(&a_ctx, gw_a, a1, "inproc://climb-a");
+
+    // Drain establishment hellos so rootchild is routable before a1 subscribes.
+    assert_eq!(recv_strings(&mut rc_rx), vec!["rootchild", "root"]);
+    assert_eq!(
+        recv_strings(&mut a1_rx),
+        vec![format!("a1@{a_tag}"), format!("gwA@{a_tag}")]
+    );
+
+    // a1@A monitors rootchild (root domain); the subscribe climbs gwA -> root.
+    runtime_monitor(&a_ctx, a1, 1, "rootchild", "RC-DOWN");
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    root_ctx
+        .send_command(Command::Die {
+            actor: rootchild,
+            reason: MsgPart::from_bytes(b"boom".to_vec()),
+        })
+        .expect("die should enqueue");
+
+    assert_eq!(
+        recv_strings(&mut a1_rx),
+        vec!["RC-DOWN", "rootchild", "actor died"],
+        "the root-domain target's death fired the gateway child's monitor"
+    );
+
+    shutdown(a_ctx);
+    shutdown(root_ctx);
+}
+
+/// Build a three-context cross-gateway topology (root + gwA + gwB) with a listener
+/// `L@A` under gwA and a target `T@B` under gwB, all establishment hellos drained.
+/// Returns the contexts, the gwB/target keys, the listener's delivery receiver, and
+/// the `b_tag`. Mirrors `quic_gateway_to_gateway_bypasses_root`'s wiring.
+fn quic_cross_gateway_monitor_setup() -> (
+    CtxHandle,
+    CtxHandle,
+    CtxHandle,
+    Key,
+    Key,
+    Key,
+    mpsc::UnboundedReceiver<Delivered>,
+    String,
+) {
+    set_quic_env();
+    let root_ctx = CtxHandle::new().expect("root ctx");
+    let a_ctx = CtxHandle::new().expect("a ctx");
+    let b_ctx = CtxHandle::new().expect("b ctx");
+
+    let root_url = free_quic_url();
+    let a_url = free_quic_url();
+    let b_url = free_quic_url();
+    let a_tag = quic_authority(&a_url);
+    let b_tag = quic_authority(&b_url);
+
+    let root = runtime_gateway_actor(&root_ctx, "root");
+    let gw_a = runtime_gateway_actor(&a_ctx, &format!("gwA@{a_tag}"));
+    let listener = runtime_actor(&a_ctx, &format!("L@{a_tag}"));
+    let gw_b = runtime_gateway_actor(&b_ctx, &format!("gwB@{b_tag}"));
+    let target = runtime_actor(&b_ctx, &format!("T@{b_tag}"));
+
+    let (l_poller, l_rx) = runtime_poller(&a_ctx);
+    let (t_poller, mut t_rx) = runtime_poller(&b_ctx);
+    runtime_subscribe(&a_ctx, l_poller, 0, listener);
+    runtime_subscribe(&b_ctx, t_poller, 0, target);
+
+    // root is the shared rendezvous (serves once per joining gateway).
+    runtime_serve(&root_ctx, root, &root_url);
+    runtime_serve(&root_ctx, root, &root_url);
+    runtime_join(&a_ctx, gw_a, &root_url);
+    runtime_join(&b_ctx, gw_b, &root_url);
+    // Each gateway serves its own endpoint so a sibling can side-channel to it.
+    runtime_serve(&a_ctx, gw_a, &a_url);
+    runtime_serve(&b_ctx, gw_b, &b_url);
+    runtime_connect(&a_ctx, gw_a, listener, "inproc://rm-listener");
+    runtime_connect(&b_ctx, gw_b, target, "inproc://rm-target");
+
+    let mut l_rx = l_rx;
+    // Drain the local-child hellos so T is routable before L subscribes.
+    assert_eq!(
+        recv_strings(&mut l_rx),
+        vec![format!("L@{a_tag}"), format!("gwA@{a_tag}")]
+    );
+    assert_eq!(
+        recv_strings(&mut t_rx),
+        vec![format!("T@{b_tag}"), format!("gwB@{b_tag}")]
+    );
+
+    (root_ctx, a_ctx, b_ctx, gw_b, target, listener, l_rx, b_tag)
+}
+
+#[test]
+fn quic_remote_monitor_fires_when_target_dies() {
+    // L@A monitors T@B across gateways. The subscription crosses to gwB over a
+    // side-channel and is held as a local monitor on gwB's route to T. When T dies,
+    // gwB fires it straight back to L over a side-channel.
+    let (root_ctx, a_ctx, b_ctx, _gw_b, target, listener, mut l_rx, b_tag) =
+        quic_cross_gateway_monitor_setup();
+
+    runtime_monitor(&a_ctx, listener, 1, &format!("T@{b_tag}"), "T-DOWN");
+    // Let the cross-gateway subscribe register at gwB before T dies.
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    b_ctx
+        .send_command(Command::Die {
+            actor: target,
+            reason: MsgPart::from_bytes(b"boom".to_vec()),
+        })
+        .expect("die should enqueue");
+
+    assert_eq!(
+        recv_strings(&mut l_rx),
+        vec![
+            "T-DOWN".to_string(),
+            format!("T@{b_tag}"),
+            "actor died".to_string()
+        ],
+        "the target's death fires L's monitor"
+    );
+
+    shutdown(a_ctx);
+    shutdown(b_ctx);
+    shutdown(root_ctx);
+}
+
+#[test]
+fn quic_remote_monitor_fires_when_owning_gateway_dies() {
+    // L@A monitors T@B. Killing all of gwB drops its link to root; root broadcasts
+    // the gateway death down to gwA, which fires the cross-gateway monitor it held
+    // for B directly — even though T itself never sent a death.
+    let (root_ctx, a_ctx, b_ctx, gw_b, _target, listener, mut l_rx, b_tag) =
+        quic_cross_gateway_monitor_setup();
+
+    runtime_monitor(&a_ctx, listener, 1, &format!("T@{b_tag}"), "GW-DOWN");
+    // The MonitorToFire is recorded at gwA as soon as the monitor is processed.
+    std::thread::sleep(std::time::Duration::from_millis(300));
+
+    b_ctx
+        .send_command(Command::Die {
+            actor: gw_b,
+            reason: MsgPart::from_bytes(b"gateway gone".to_vec()),
+        })
+        .expect("die should enqueue");
+
+    assert_eq!(
+        recv_strings(&mut l_rx),
+        vec![
+            "GW-DOWN".to_string(),
+            format!("T@{b_tag}"),
+            "actor died".to_string()
+        ],
+        "the owning gateway's death fires L's monitor"
+    );
+
+    shutdown(a_ctx);
+    shutdown(b_ctx);
+    shutdown(root_ctx);
+}
+
+#[test]
 fn quic_heartbeat_timeout_severs_connection() {
     // A peer that holds the QUIC connection open but never sends anything (no
     // Establish, no heartbeats) can't be detected by EOF — only the heartbeat
@@ -1939,13 +2384,23 @@ fn monitor_with_timeout(
     });
 }
 
-/// Drive a non-existence timeout timer fire at common ancestor `at` (the
-/// in-process command a real timer would have sent on expiry).
-fn check_monitor_timeout(ctx: &mut Ctx, at: Key, dest: &str, to_monitor: &str) {
+/// Drive a "must exist" timer fire at `at` (the in-process command a real timer
+/// would have sent on expiry).
+fn check_monitor_timeout(ctx: &mut Ctx, at: Key, listener: &str, target: &str) {
     ctx.run_command(Command::CheckMonitorTimeout {
         at,
-        dest: dest.as_bytes().to_vec(),
-        to_monitor: to_monitor.as_bytes().to_vec(),
+        listener: listener.as_bytes().to_vec(),
+        target: target.as_bytes().to_vec(),
+    });
+}
+
+/// Deliver a side-channel `Send` of a single-part actor message to `dest`.
+fn side_channel_send(ctx: &mut Ctx, dest: &str, body: &[u8]) {
+    ctx.deliver_side_channel(SideChannelMessage {
+        gateway_for_actor: dest.as_bytes().to_vec(),
+        action: SideChannelAction::Send(SendPayload::ActorMessage(vec![MsgPart::from_bytes(
+            body.to_vec(),
+        )])),
     });
 }
 

--- a/monarch_mini/src/unix_framing.rs
+++ b/monarch_mini/src/unix_framing.rs
@@ -38,8 +38,8 @@ use tokio::io::Interest;
 use tokio::net::UnixStream;
 
 use crate::Role;
-use crate::connection::AncestorPayload;
 use crate::connection::ConnectionCommand;
+use crate::connection::MonitorOp;
 use crate::connection::SendPayload;
 use crate::msg::MsgPart;
 use crate::shm::MapperHandle;
@@ -67,9 +67,10 @@ enum UnixFrame {
         live: Vec<Vec<u8>>,
         dead: Vec<Vec<u8>>,
     },
-    ToAncestor {
-        to_monitor: Vec<u8>,
-        payload: AncestorPayload,
+    UpdateMonitorSubscription {
+        listener: Vec<u8>,
+        target: Vec<u8>,
+        op: MonitorOp,
     },
     Severed {
         reason: Vec<u8>,
@@ -166,15 +167,17 @@ pub(crate) async fn write_command(
         ConnectionCommand::PublishRoutes { live, dead } => {
             write_header(stream, &UnixFrame::PublishRoutes { live, dead }).await
         }
-        ConnectionCommand::ToAncestor {
-            to_monitor,
-            payload,
+        ConnectionCommand::UpdateMonitorSubscription {
+            listener,
+            target,
+            op,
         } => {
             write_header(
                 stream,
-                &UnixFrame::ToAncestor {
-                    to_monitor,
-                    payload,
+                &UnixFrame::UpdateMonitorSubscription {
+                    listener,
+                    target,
+                    op,
                 },
             )
             .await
@@ -314,12 +317,14 @@ pub(crate) async fn read_command(
             alive,
         },
         UnixFrame::PublishRoutes { live, dead } => ConnectionCommand::PublishRoutes { live, dead },
-        UnixFrame::ToAncestor {
-            to_monitor,
-            payload,
-        } => ConnectionCommand::ToAncestor {
-            to_monitor,
-            payload,
+        UnixFrame::UpdateMonitorSubscription {
+            listener,
+            target,
+            op,
+        } => ConnectionCommand::UpdateMonitorSubscription {
+            listener,
+            target,
+            op,
         },
         UnixFrame::Severed { reason } => ConnectionCommand::Severed { reason },
         UnixFrame::PublishGatewayRoutes { live } => {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* __->__ #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Adds cross-gateway monitor subscriptions over QUIC side channels, including acknowledgements, cancellation, and must-exist timeout handling. Gateways now retain remote monitor state and fire listeners when the target or owning gateway dies, with synchronous and end-to-end coverage for routing, pending actions, and root-domain monitors.

Differential Revision: [D114750245](https://our.internmc.facebook.com/intern/diff/D114750245/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750245/)!