### PR TITLE
22/43 minimonarch: Bound QUIC connect concurrency and configure heartbeats for high fan-out

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4740,6 +4740,7 @@ dependencies = [
  "rustls-pki-types",
  "serde",
  "slotmap",
+ "socket2 0.6.5",
  "tokio",
  "tracing",
 ]

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -2020,6 +2020,15 @@ impl CtxHandle {
                 // before the runtime — and with it the writer tasks — is dropped.
                 local.block_on(&rt, async move {
                     let mut ctx = Ctx::new(runtime_tx);
+                    // DEBUG instrumentation: track command throughput and channel
+                    // backlog so we can tell whether the single-threaded event loop
+                    // is falling behind (incoming faster than handled). We log at
+                    // most once per second and only while commands are flowing; a
+                    // backlog that grows means the loop is saturated.
+                    let mut handled_total: u64 = 0;
+                    let mut handled_at_last_log: u64 = 0;
+                    let mut last_log = std::time::Instant::now();
+                    let log_every = std::time::Duration::from_secs(1);
                     while let Some(command) = rx.recv().await {
                         if let Command::Shutdown { done } = command {
                             // Wait for the socket transports to flush every pending
@@ -2035,6 +2044,21 @@ impl CtxHandle {
                             break;
                         }
                         ctx.run_command(command);
+                        handled_total += 1;
+
+                        let elapsed = last_log.elapsed();
+                        if elapsed >= log_every {
+                            let handled = handled_total - handled_at_last_log;
+                            let backlog = rx.len();
+                            eprintln!(
+                                "MM_CTX loop: {:.0} cmds/s, backlog {}, total {}",
+                                handled as f64 / elapsed.as_secs_f64(),
+                                backlog,
+                                handled_total
+                            );
+                            handled_at_last_log = handled_total;
+                            last_log = std::time::Instant::now();
+                        }
                     }
                 });
             })?;

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -48,6 +48,7 @@ use quinn::ServerConfig;
 use rustls::RootCertStore;
 use rustls_pki_types::CertificateDer;
 use rustls_pki_types::PrivateKeyDer;
+use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::Duration;
@@ -80,8 +81,48 @@ const CONNECT_RETRY_MAX: Duration = Duration::from_millis(1000);
 /// How often each side emits a heartbeat, and how long a side waits for any frame
 /// before declaring the connection broken. The timeout is several intervals so a
 /// stray scheduling delay doesn't trip it.
-const HEARTBEAT_INTERVAL: Duration = Duration::from_millis(250);
-const HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(2);
+// Heartbeat every 5s; sever after 20s (4 missed beats) of no frame. This is the
+// realistic steady-state liveness setting — heartbeats are active and a lapse
+// actually severs the connection (see reader_task). Both are tunable via
+// `MM_QUIC_HEARTBEAT_INTERVAL_MS` / `MM_QUIC_HEARTBEAT_TIMEOUT_MS`: at very high
+// fan-out the single-threaded root cannot write+service tens of thousands of
+// heartbeats on a 5s cadence, so a longer interval (with a proportionally longer
+// timeout) cuts the steady-state heartbeat load without weakening liveness.
+const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+const DEFAULT_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(20);
+
+fn heartbeat_interval() -> Duration {
+    std::env::var("MM_QUIC_HEARTBEAT_INTERVAL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_HEARTBEAT_INTERVAL)
+}
+
+fn heartbeat_timeout() -> Duration {
+    std::env::var("MM_QUIC_HEARTBEAT_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_HEARTBEAT_TIMEOUT)
+}
+
+/// On graceful shutdown each writer sends an explicit `Severed{"context shutdown"}`
+/// frame (reliable stream data — retransmitted by QUIC, unlike `CONNECTION_CLOSE`),
+/// then keeps the connection open until the peer *responds* (its own `Severed`/EOF,
+/// observed by our reader) before closing — so we close as soon as we know the peer
+/// got it, rather than after a fixed delay. This is the upper bound on that wait,
+/// for a peer that never responds (e.g. already dead). Tunable via
+/// `MM_QUIC_SHUTDOWN_ACK_TIMEOUT_MS`.
+const DEFAULT_SHUTDOWN_ACK_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn shutdown_ack_timeout() -> Duration {
+    std::env::var("MM_QUIC_SHUTDOWN_ACK_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_SHUTDOWN_ACK_TIMEOUT)
+}
 
 /// What a connection's reader needs for shared memory: the context-global mapper
 /// and the owning actor's gateway-client slot. Mirrors the unix transport's
@@ -173,6 +214,128 @@ fn client_bind_addr(target: &SocketAddr) -> SocketAddr {
     }
 }
 
+/// Default *total* kernel UDP buffer budget across the whole client endpoint pool
+/// (64 MiB). It is divided evenly among the pool's sockets (see
+/// [`client_udp_buf_per_socket`]), so adding endpoints shrinks each socket's share
+/// while keeping the aggregate fixed. This matters for non-root deployments: a
+/// per-socket request is clamped to `net.core.rmem_max`, so to reach a large total
+/// without `CAP_NET_ADMIN` you spread it over more sockets. Override the total with
+/// `MM_QUIC_UDP_BUF_BYTES`.
+const DEFAULT_UDP_BUF_TOTAL_BYTES: usize = 64 * 1024 * 1024;
+
+fn client_udp_buf_total_bytes() -> usize {
+    std::env::var("MM_QUIC_UDP_BUF_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_UDP_BUF_TOTAL_BYTES)
+}
+
+/// Optional explicit override for the number of client endpoints. When unset, the
+/// pool size is chosen adaptively (see [`QuicTransport::build_client_pool`]): one
+/// socket if it can hold the whole buffer budget, otherwise enough sockets to reach
+/// it. When set, exactly that many sockets are used, each requesting an even split
+/// of the budget.
+fn explicit_client_endpoints() -> Option<usize> {
+    std::env::var("MM_QUIC_CLIENT_ENDPOINTS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+}
+
+/// Optional cap on how many client connect *attempts* may be in flight at once
+/// across the whole context. A root that joins tens of thousands of peers spawns
+/// that many connector tasks, each driving a QUIC handshake; run all at once on the
+/// single-threaded runtime they compete for CPU and reorder connection setup
+/// badly. `MM_QUIC_MAX_CONCURRENT_CONNECTS` bounds the simultaneous attempts (each
+/// connector still retries independently, and the permit is released while it backs
+/// off). Unset or `0` ⇒ unlimited (the original behaviour).
+fn max_concurrent_connects() -> Option<usize> {
+    std::env::var("MM_QUIC_MAX_CONCURRENT_CONNECTS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+}
+
+/// When `MM_QUIC_UDP_BUF_NO_FORCE` is set, skip the privileged `SO_*BUFFORCE`
+/// options so the buffer is exactly what an unprivileged process would get
+/// (clamped to `net.core.rmem_max`). Used to validate a non-root-deployable
+/// config even while the job happens to run as root.
+fn udp_buf_force_disabled() -> bool {
+    std::env::var("MM_QUIC_UDP_BUF_NO_FORCE").is_ok_and(|v| v != "0" && !v.is_empty())
+}
+
+/// Enlarge a UDP socket's kernel send/recv buffers, best-effort. Tries the
+/// privileged `SO_*BUFFORCE` options first — these bypass the
+/// `net.core.{r,w}mem_max` ceiling and work when the process has `CAP_NET_ADMIN`
+/// (e.g. running as root on MAST) — and falls back to the ordinary setters (which
+/// the kernel clamps to that ceiling) when not permitted.
+fn set_udp_buffers(socket: &socket2::Socket, bytes: usize) {
+    use std::os::fd::AsRawFd;
+
+    if udp_buf_force_disabled() {
+        // Non-root path only: the kernel clamps these to net.core.{r,w}mem_max.
+        let _ = socket.set_recv_buffer_size(bytes);
+        let _ = socket.set_send_buffer_size(bytes);
+        return;
+    }
+
+    let fd = socket.as_raw_fd();
+    let size = bytes.min(i32::MAX as usize) as libc::c_int;
+    let len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    // SAFETY: `fd` is a valid UDP socket for the call's duration; the option value
+    // is an `int` of length `len`, as required by SO_RCVBUFFORCE/SO_SNDBUFFORCE.
+    let (forced_recv, forced_send) = unsafe {
+        let value = std::ptr::from_ref(&size).cast::<libc::c_void>();
+        (
+            libc::setsockopt(fd, libc::SOL_SOCKET, libc::SO_RCVBUFFORCE, value, len),
+            libc::setsockopt(fd, libc::SOL_SOCKET, libc::SO_SNDBUFFORCE, value, len),
+        )
+    };
+    if forced_recv != 0 {
+        let _ = socket.set_recv_buffer_size(bytes);
+    }
+    if forced_send != 0 {
+        let _ = socket.set_send_buffer_size(bytes);
+    }
+}
+
+/// Build a client [`Endpoint`] on a UDP socket whose kernel buffers we request at
+/// `requested` bytes (see [`set_udp_buffers`]), bound to `bind`, with
+/// `client_config` as its default. Returns the endpoint and the *usable* recv
+/// buffer the kernel actually granted (it reports ~2× the usable size for
+/// bookkeeping, so we halve it), which the caller uses to decide whether one
+/// socket reached the target or a pool is needed.
+fn make_client_endpoint(
+    bind: SocketAddr,
+    client_config: ClientConfig,
+    requested: usize,
+) -> anyhow::Result<(Endpoint, usize)> {
+    let domain = if bind.is_ipv6() {
+        socket2::Domain::IPV6
+    } else {
+        socket2::Domain::IPV4
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
+    set_udp_buffers(&socket, requested);
+    let granted = socket.recv_buffer_size().unwrap_or(0);
+    let usable = granted / 2;
+    eprintln!(
+        "MM_QUIC client endpoint: recv buf requested {} B, granted {} B (~{} B usable, force={})",
+        requested,
+        granted,
+        usable,
+        !udp_buf_force_disabled()
+    );
+    socket.bind(&bind.into())?;
+    let std_socket: std::net::UdpSocket = socket.into();
+    let runtime =
+        quinn::default_runtime().ok_or_else(|| anyhow::anyhow!("no quic async runtime"))?;
+    let mut endpoint = Endpoint::new(quinn::EndpointConfig::default(), None, std_socket, runtime)?;
+    endpoint.set_default_client_config(client_config);
+    Ok((endpoint, usable))
+}
+
 /// Owns all QUIC transport state and coroutines. Mirrors `UnixTransport`: the
 /// command loop holds one and forwards serves/joins to it; it never sees streams
 /// or pairing state. TLS configs are built lazily on first use and cached.
@@ -196,6 +359,24 @@ pub(crate) struct QuicTransport {
     // drops. Never heartbeated; cached across messages.
     side_channels: HashMap<String, mpsc::UnboundedSender<SideChannelMessage>>,
     tls: Option<Arc<TlsConfig>>,
+    // A *pool* of client endpoints (one UDP socket + driver each) per address
+    // family, created lazily and assigned round-robin to joins/side-channels.
+    //
+    // One endpoint per connection (the original behaviour) exhausted sockets and
+    // the event loop at high fan-out. Collapsing to a single shared endpoint fixed
+    // that but made the one UDP socket a throughput bottleneck: a burst of tens of
+    // thousands of sends/receives overflows its buffers, dropping packets and
+    // forcing multi-second QUIC retransmit timeouts. A small pool is the middle
+    // ground — connections (and their burst load) are spread across `K` sockets.
+    // `K` is `MM_QUIC_CLIENT_ENDPOINTS` (default below).
+    client_endpoints_v4: Vec<Endpoint>,
+    client_endpoints_v6: Vec<Endpoint>,
+    // Round-robin cursor for assigning connections to pool endpoints.
+    client_rr: usize,
+    // Bounds simultaneous client connect attempts (see `max_concurrent_connects`).
+    // Shared by every connector task; `None` ⇒ unlimited. Created once so all joins
+    // in this context contend for the same pool of attempt slots.
+    connect_sem: Option<Arc<Semaphore>>,
     // Liveness-token issuer: each connection's writer holds a clone for its
     // lifetime. Teardown drops this issuing copy and waits for `alive_rx` to close
     // — i.e. for every writer to have flushed and exited.
@@ -211,6 +392,9 @@ impl QuicTransport {
     ) -> Self {
         let (shutdown_tx, _) = watch::channel(false);
         let (alive_tx, alive_rx) = mpsc::unbounded_channel();
+        if let Some(n) = max_concurrent_connects() {
+            eprintln!("MM_QUIC connect concurrency capped at {n} simultaneous attempts");
+        }
         Self {
             loop_tx,
             shutdown_tx,
@@ -219,6 +403,10 @@ impl QuicTransport {
             listeners: HashMap::new(),
             side_channels: HashMap::new(),
             tls: None,
+            client_endpoints_v4: Vec::new(),
+            client_endpoints_v6: Vec::new(),
+            client_rr: 0,
+            connect_sem: max_concurrent_connects().map(|n| Arc::new(Semaphore::new(n))),
             alive_tx: Some(alive_tx),
             alive_rx,
         }
@@ -251,6 +439,77 @@ impl QuicTransport {
         Ok(tls)
     }
 
+    /// A client [`Endpoint`] for `target`'s address family, assigned round-robin
+    /// from a lazily-created pool of [`Self::client_pool_size`] endpoints. Returns
+    /// a cheap clone (the endpoint is internally reference-counted). Spreading
+    /// connections across several UDP sockets keeps any one socket's send/receive
+    /// buffers from overflowing under a fan-out burst, which otherwise causes
+    /// packet loss and multi-second QUIC retransmit stalls.
+    fn client_endpoint(&mut self, target: &SocketAddr) -> anyhow::Result<Endpoint> {
+        let is_v6 = target.is_ipv6();
+        let empty = if is_v6 {
+            self.client_endpoints_v6.is_empty()
+        } else {
+            self.client_endpoints_v4.is_empty()
+        };
+        if empty {
+            let pool = self.build_client_pool(client_bind_addr(target))?;
+            if is_v6 {
+                self.client_endpoints_v6 = pool;
+            } else {
+                self.client_endpoints_v4 = pool;
+            }
+        }
+        let pool = if is_v6 {
+            &self.client_endpoints_v6
+        } else {
+            &self.client_endpoints_v4
+        };
+        let endpoint = pool[self.client_rr % pool.len()].clone();
+        self.client_rr = self.client_rr.wrapping_add(1);
+        Ok(endpoint)
+    }
+
+    /// Build the client endpoint pool for one address family. Aim for
+    /// [`client_udp_buf_total_bytes`] of total UDP buffer. First try to get it all
+    /// on a single socket; if the kernel caps a single socket below the target
+    /// (e.g. unprivileged, clamped to `net.core.rmem_max`), fall back to enough
+    /// sockets — each requesting the measured per-socket max — to reach the total.
+    /// `MM_QUIC_CLIENT_ENDPOINTS` overrides this with a fixed pool size.
+    fn build_client_pool(&mut self, bind: SocketAddr) -> anyhow::Result<Vec<Endpoint>> {
+        let total = client_udp_buf_total_bytes();
+        let client_config = self.tls()?.client.clone();
+
+        if let Some(n) = explicit_client_endpoints() {
+            let per = (total / n).max(1);
+            let mut pool = Vec::with_capacity(n);
+            for _ in 0..n {
+                pool.push(make_client_endpoint(bind, client_config.clone(), per)?.0);
+            }
+            eprintln!("MM_QUIC client pool: {n} endpoints (explicit), {per} B requested each");
+            return Ok(pool);
+        }
+
+        // Adaptive: try to put the whole budget on one socket.
+        let (first, usable) = make_client_endpoint(bind, client_config.clone(), total)?;
+        if usable >= total {
+            eprintln!("MM_QUIC client pool: 1 endpoint holds the full {total} B budget");
+            return Ok(vec![first]);
+        }
+
+        // Capped below target — spread across enough sockets of `usable` each.
+        let n = total.div_ceil(usable.max(1));
+        eprintln!(
+            "MM_QUIC client pool: single socket capped at {usable} B usable; using {n} endpoints to reach {total} B total"
+        );
+        let mut pool = Vec::with_capacity(n);
+        pool.push(first);
+        for _ in 1..n {
+            pool.push(make_client_endpoint(bind, client_config.clone(), usable)?.0);
+        }
+        Ok(pool)
+    }
+
     /// Send a self-addressing [`SideChannelMessage`] to a remote gateway over a
     /// direct side-channel, opening (and caching) the connection on first use. The
     /// caller (the command loop) has already derived `tag` from the message's
@@ -259,13 +518,6 @@ impl QuicTransport {
     /// connection to come up.
     pub(crate) fn send_to_gateway(&mut self, tag: String, message: SideChannelMessage) {
         if !self.side_channels.contains_key(&tag) {
-            let client = match self.tls() {
-                Ok(tls) => tls.client.clone(),
-                Err(err) => {
-                    tracing::warn!("side channel tls: {err:#}");
-                    return;
-                }
-            };
             let addr = match parse_addr(&tag) {
                 Ok(addr) => addr,
                 Err(err) => {
@@ -273,10 +525,17 @@ impl QuicTransport {
                     return;
                 }
             };
+            let endpoint = match self.client_endpoint(&addr) {
+                Ok(endpoint) => endpoint,
+                Err(err) => {
+                    tracing::warn!("side channel endpoint: {err:#}");
+                    return;
+                }
+            };
             let (tx, rx) = mpsc::unbounded_channel();
             tokio::task::spawn_local(side_channel_writer_task(
                 addr,
-                client,
+                endpoint,
                 rx,
                 self.shutdown_tx.subscribe(),
                 self.alive_token(),
@@ -290,8 +549,14 @@ impl QuicTransport {
             .send(message);
     }
 
-    /// Signal every writer to flush and exit, then wait until they all have — the
-    /// same teardown contract as the UNIX transport.
+    /// Signal every writer to flush and exit, then wait until they all have.
+    ///
+    /// Each writer, on this signal, sends an explicit `Severed{"context shutdown"}`
+    /// frame and then holds its connection open for [`shutdown_grace`] so QUIC can
+    /// reliably deliver that frame (retransmitting if the first packet is lost)
+    /// before the connection is dropped. So by the time every writer has exited
+    /// (`alive_rx` closed) the peers have been told — we do not rely on the lossy
+    /// `CONNECTION_CLOSE`/socket-drop being noticed.
     pub(crate) async fn shutdown(&mut self) {
         let _ = self.shutdown_tx.send(true);
         self.alive_tx = None;
@@ -346,17 +611,6 @@ impl Transport for QuicTransport {
     }
 
     fn join(&mut self, url: String, connection: ConnectionRef, shm_client: ShmClientSlot) {
-        let tls = match self.tls() {
-            Ok(tls) => tls,
-            Err(err) => {
-                sever(
-                    &self.loop_tx,
-                    connection,
-                    format!("quic tls: {err:#}").into_bytes(),
-                );
-                return;
-            }
-        };
         let addr = match parse_addr(&url) {
             Ok(addr) => addr,
             Err(err) => {
@@ -364,14 +618,26 @@ impl Transport for QuicTransport {
                 return;
             }
         };
+        let endpoint = match self.client_endpoint(&addr) {
+            Ok(endpoint) => endpoint,
+            Err(err) => {
+                sever(
+                    &self.loop_tx,
+                    connection,
+                    format!("quic client endpoint: {err:#}").into_bytes(),
+                );
+                return;
+            }
+        };
         tokio::task::spawn_local(connector_task(
             addr,
-            tls.client.clone(),
+            endpoint,
             connection,
             self.loop_tx.clone(),
             self.shutdown_tx.subscribe(),
             self.alive_token(),
             self.shm_ctx(shm_client),
+            self.connect_sem.clone(),
         ));
     }
 }
@@ -439,7 +705,7 @@ async fn listener_task(
                     spawn_connection(
                         send, recv, connection,
                         loop_tx.clone(), shutdown.clone(), alive.clone(),
-                        KeepAlive { _endpoint: None, _connection: conn },
+                        conn,
                         shm,
                     )
                 });
@@ -452,7 +718,7 @@ async fn listener_task(
                             spawn_connection(
                                 send, recv, connection,
                                 loop_tx.clone(), shutdown.clone(), alive.clone(),
-                                KeepAlive { _endpoint: None, _connection: conn },
+                                conn,
                                 shm,
                             )
                         });
@@ -529,33 +795,35 @@ async fn side_channel_reader_task(
 /// (so a join may precede its serve), then open one bi-stream and wire it up.
 async fn connector_task(
     addr: SocketAddr,
-    client_config: ClientConfig,
+    endpoint: Endpoint,
     connection: ConnectionRef,
     loop_tx: mpsc::UnboundedSender<Command>,
     mut shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
     shm: ShmCtx,
+    // Bounds how many connect attempts run at once across the context (see
+    // `max_concurrent_connects`). `None` ⇒ unlimited. A permit is held only for the
+    // duration of one attempt (connect + handshake + open_bi) and released before
+    // backing off, so a waiting task can attempt while this one sleeps.
+    connect_sem: Option<Arc<Semaphore>>,
 ) {
-    let endpoint = match Endpoint::client(client_bind_addr(&addr)) {
-        Ok(mut endpoint) => {
-            endpoint.set_default_client_config(client_config);
-            endpoint
-        }
-        Err(err) => {
-            sever(
-                &loop_tx,
-                connection,
-                format!("quic client bind failed: {err}").into_bytes(),
-            );
-            return;
-        }
-    };
-
     let mut retry = CONNECT_RETRY_MIN;
     loop {
         if *shutdown.borrow() {
             return;
         }
+        // Take a connect-attempt permit before doing any handshake work, so a root
+        // joining tens of thousands of peers drives at most N handshakes at once
+        // instead of spawning them all to fight over the single-threaded runtime.
+        let permit = match &connect_sem {
+            Some(sem) => Some(
+                Arc::clone(sem)
+                    .acquire_owned()
+                    .await
+                    .expect("connect semaphore never closed"),
+            ),
+            None => None,
+        };
         // connect() fails synchronously on a bad config; the handshake (.await)
         // fails until the server is up. Both just back off and retry.
         let connected = match endpoint.connect(addr, SERVER_NAME) {
@@ -574,19 +842,9 @@ async fn connector_task(
                         sever(&loop_tx, connection, b"quic open stream failed".to_vec());
                         return;
                     }
-                    spawn_connection(
-                        send,
-                        recv,
-                        connection,
-                        loop_tx,
-                        shutdown,
-                        alive,
-                        KeepAlive {
-                            _endpoint: Some(endpoint),
-                            _connection: conn,
-                        },
-                        shm,
-                    );
+                    // Connection is up; free the attempt slot before handing off.
+                    drop(permit);
+                    spawn_connection(send, recv, connection, loop_tx, shutdown, alive, conn, shm);
                     return;
                 }
                 Err(_) => {
@@ -595,6 +853,8 @@ async fn connector_task(
                 }
             }
         }
+        // Attempt failed; release the slot so another task can try while we back off.
+        drop(permit);
         tokio::select! {
             _ = tokio::time::sleep(retry) => {}
             _ = shutdown.changed() => return,
@@ -611,25 +871,14 @@ async fn connector_task(
 /// is best-effort by design (any gateway may drop a side-channel to reclaim state).
 async fn side_channel_writer_task(
     addr: SocketAddr,
-    client_config: ClientConfig,
+    endpoint: Endpoint,
     mut rx: mpsc::UnboundedReceiver<SideChannelMessage>,
     mut shutdown: watch::Receiver<bool>,
     _alive: mpsc::UnboundedSender<()>,
 ) {
-    let endpoint = match Endpoint::client(client_bind_addr(&addr)) {
-        Ok(mut endpoint) => {
-            endpoint.set_default_client_config(client_config);
-            endpoint
-        }
-        Err(err) => {
-            tracing::warn!("side channel client bind failed: {err}");
-            return;
-        }
-    };
-
-    // The current connection, if up: its send stream plus a keep-alive holding the
-    // QUIC connection open. `None` means we must (re)connect before the next write.
-    let mut stream: Option<(SendStream, KeepAlive)> = None;
+    // The current connection, if up: its send stream plus the QUIC connection,
+    // held to keep it open. `None` means we must (re)connect before the next write.
+    let mut stream: Option<(SendStream, Connection)> = None;
     loop {
         let message = tokio::select! {
             message = rx.recv() => match message {
@@ -639,7 +888,7 @@ async fn side_channel_writer_task(
             _ = shutdown.changed() => break,
         };
         if stream.is_none() {
-            let Some((mut send, keep)) = connect_side_channel(&endpoint, addr, &mut shutdown).await
+            let Some((mut send, conn)) = connect_side_channel(&endpoint, addr, &mut shutdown).await
             else {
                 break; // shutting down before the gateway came up
             };
@@ -651,14 +900,14 @@ async fn side_channel_writer_task(
             {
                 continue; // reconnect on the next message (this one is dropped)
             }
-            stream = Some((send, keep));
+            stream = Some((send, conn));
         }
-        let (send, _keep) = stream.as_mut().expect("stream is connected");
+        let (send, _conn) = stream.as_mut().expect("stream is connected");
         if framing::write_side_channel(send, message).await.is_err() {
             stream = None; // dropped; reconnect on the next message
         }
     }
-    if let Some((mut send, _keep)) = stream {
+    if let Some((mut send, _conn)) = stream {
         let _ = send.finish();
     }
 }
@@ -671,7 +920,7 @@ async fn connect_side_channel(
     endpoint: &Endpoint,
     addr: SocketAddr,
     shutdown: &mut watch::Receiver<bool>,
-) -> Option<(SendStream, KeepAlive)> {
+) -> Option<(SendStream, Connection)> {
     let mut retry = CONNECT_RETRY_MIN;
     loop {
         if *shutdown.borrow() {
@@ -683,13 +932,7 @@ async fn connect_side_channel(
         };
         if let Some(conn) = connected {
             if let Ok((send, _recv)) = conn.open_bi().await {
-                return Some((
-                    send,
-                    KeepAlive {
-                        _endpoint: None,
-                        _connection: conn,
-                    },
-                ));
+                return Some((send, conn));
             }
         }
         tokio::select! {
@@ -703,8 +946,10 @@ async fn connect_side_channel(
 /// Wire up an established bi-stream: build its [`QuicConnectionTransport`], announce
 /// it to the command loop, and spawn the writer (drains commands → frames, plus a
 /// heartbeat tick) and reader (frames → `ConnectionAction`, with a heartbeat
-/// timeout). `keep` holds the QUIC connection (and, for a joiner, the client
-/// endpoint) alive for the duration of the writer.
+/// timeout). `conn` (the QUIC connection) is moved into the writer to keep it
+/// alive for the writer's duration; dropping it closes the connection, which the
+/// peer observes. The client endpoint is not held per-connection — it is owned
+/// (shared) by the [`QuicTransport`] for the whole context lifetime.
 #[expect(
     clippy::too_many_arguments,
     reason = "each argument is a distinct piece of per-connection state handed off to the writer or reader; bundling them adds indirection without clarifying anything"
@@ -716,24 +961,33 @@ fn spawn_connection(
     loop_tx: mpsc::UnboundedSender<Command>,
     shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
-    keep: KeepAlive,
+    conn: Connection,
     shm: ShmCtx,
 ) {
     let (writer_tx, writer_rx) = mpsc::unbounded_channel();
+    // Reader → writer signal: the peer responded to our shutdown, so the writer
+    // may close. Unbounded but only ever carries a single `()`.
+    let (peer_responded_tx, peer_responded_rx) = mpsc::unbounded_channel();
     let transport = Box::new(QuicConnectionTransport { tx: writer_tx });
     let _ = loop_tx.send(Command::TransportConnected {
         connection,
         transport,
     });
-    tokio::task::spawn_local(writer_task(send, writer_rx, shutdown, alive, keep));
-    tokio::task::spawn_local(reader_task(recv, connection, loop_tx, shm));
-}
-
-/// Keeps the QUIC connection (and a joiner's client endpoint) alive for as long as
-/// the writer runs; dropping it closes them, which the peer observes.
-struct KeepAlive {
-    _endpoint: Option<Endpoint>,
-    _connection: Connection,
+    tokio::task::spawn_local(writer_task(
+        send,
+        writer_rx,
+        shutdown,
+        alive,
+        peer_responded_rx,
+        conn,
+    ));
+    tokio::task::spawn_local(reader_task(
+        recv,
+        connection,
+        loop_tx,
+        peer_responded_tx,
+        shm,
+    ));
 }
 
 /// Transport for one end of a QUIC stream: `send` hands a command to the writer
@@ -757,10 +1011,17 @@ async fn writer_task(
     mut rx: mpsc::UnboundedReceiver<ConnectionCommand>,
     mut shutdown: watch::Receiver<bool>,
     _alive: mpsc::UnboundedSender<()>,
-    _keep: KeepAlive,
+    // Signalled by this connection's reader once the peer responds to our shutdown
+    // (its own Severed frame, or the connection ending) — our cue that the peer
+    // received the shutdown notice and we can close.
+    mut peer_responded: mpsc::UnboundedReceiver<()>,
+    // Held only to keep the QUIC connection alive for the writer's lifetime;
+    // dropping it closes the connection, which the peer's reader observes.
+    _conn: Connection,
 ) {
-    let mut heartbeat = tokio::time::interval(HEARTBEAT_INTERVAL);
+    let mut heartbeat = tokio::time::interval(heartbeat_interval());
     heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut graceful = false;
     loop {
         tokio::select! {
             command = rx.recv() => {
@@ -777,20 +1038,38 @@ async fn writer_task(
                 }
             }
             _ = shutdown.changed() => {
-                // Teardown: no further commands will be enqueued. Flush whatever is
-                // already queued, then stop.
+                // Graceful teardown. Flush whatever is already queued, then send an
+                // explicit shutdown notice. A Severed frame is stream data, which
+                // QUIC retransmits until delivered (unlike CONNECTION_CLOSE), so the
+                // peer learns of teardown directly rather than by inferring a dropped
+                // socket.
                 while let Ok(command) = rx.try_recv() {
                     if framing::write_command(&mut send, command).await.is_err() {
                         return;
                     }
                 }
+                let _ = framing::write_command(
+                    &mut send,
+                    ConnectionCommand::Severed {
+                        reason: b"context shutdown".to_vec(),
+                    },
+                )
+                .await;
+                graceful = true;
                 break;
             }
         }
     }
-    // Finish the stream so the peer's reader sees EOF promptly (the fast path); the
-    // heartbeat timeout is the backstop when a peer dies without finishing.
+    // Finish the stream so the peer's reader sees EOF promptly (the fast path).
     let _ = send.finish();
+    // On graceful shutdown, hold the connection (`_conn`) open until the peer
+    // responds to our shutdown notice — keeping it open lets QUIC retransmit the
+    // notice if the first packet was lost, and we close as soon as the peer's reply
+    // arrives rather than after a fixed delay. Bounded so a peer that never replies
+    // (e.g. already dead) can't hang teardown.
+    if graceful {
+        let _ = tokio::time::timeout(shutdown_ack_timeout(), peer_responded.recv()).await;
+    }
 }
 
 /// Decode each frame off the stream and forward it to the command loop. A read
@@ -800,19 +1079,29 @@ async fn reader_task(
     mut recv: RecvStream,
     connection: ConnectionRef,
     loop_tx: mpsc::UnboundedSender<Command>,
+    // Signals this connection's writer that the peer has responded to our shutdown
+    // (it sent its own Severed, or the connection ended) so the writer can close.
+    peer_responded: mpsc::UnboundedSender<()>,
     shm: ShmCtx,
 ) {
+    let hb_timeout = heartbeat_timeout();
     loop {
         // The owning actor's gateway client is snapshot per frame so a large part
         // is read straight into the slab once the client is known (a gateway seeds
         // its own at creation, before any frame arrives).
         let read = framing::read_frame(&mut recv, &shm.mapper, shm.client());
-        match tokio::time::timeout(HEARTBEAT_TIMEOUT, read).await {
+        match tokio::time::timeout(hb_timeout, read).await {
             Err(_elapsed) => {
+                let _ = peer_responded.send(());
                 sever(&loop_tx, connection, b"quic heartbeat timeout".to_vec());
                 return;
             }
             Ok(Ok(Incoming::Command(action))) => {
+                // A Severed from the peer is its response to our shutdown (or the
+                // peer initiating its own) — wake any writer waiting to close.
+                if matches!(action, ConnectionCommand::Severed { .. }) {
+                    let _ = peer_responded.send(());
+                }
                 if loop_tx
                     .send(Command::ConnectionAction { connection, action })
                     .is_err()
@@ -822,6 +1111,7 @@ async fn reader_task(
             }
             Ok(Ok(Incoming::Heartbeat)) => continue,
             Ok(Err(_)) => {
+                let _ = peer_responded.send(());
                 sever(&loop_tx, connection, b"quic connection closed".to_vec());
                 return;
             }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* __->__ #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Share QUIC client connections across an adaptive, round-robin UDP endpoint pool with configurable buffer budgets, and cap concurrent handshake attempts to prevent packet loss and event-loop starvation at high fan-out. Make heartbeat and shutdown acknowledgement timeouts configurable, deliver explicit sever frames during graceful teardown, and emit command-loop throughput diagnostics.

Differential Revision: [D114750242](https://our.internmc.facebook.com/intern/diff/D114750242/)