### PR TITLE
23/43 minimonarch: QUIC connection debug logging behind `MM_QUIC_DEBUG`

### DIFF
--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -6,10 +6,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+use std::cell::Cell;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::os::fd::OwnedFd;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::thread;
@@ -53,6 +55,56 @@ use crate::shm::ShmMapper;
 use crate::shm::ShmServer;
 use crate::transport::Transport;
 use crate::unix_transport::UnixTransport;
+
+/// Whether verbose per-connection debug logging is enabled (`MM_QUIC_DEBUG` set).
+/// Gates the command-loop `MM_CTX`/`MM_UDP` lines and scheduler-lag probe here, and
+/// the per-connection reader diagnostics and heartbeat-send (`MM_HB`) logging in the
+/// quic transport — all off by default so they cost nothing in normal operation.
+pub(crate) fn connection_debug() -> bool {
+    std::env::var_os("MM_QUIC_DEBUG").is_some_and(|v| !v.is_empty())
+}
+
+/// Cumulative UDP-over-IPv6 datagram counters from `/proc/net/snmp6`, as
+/// `(InDatagrams, InErrors, RcvbufErrors)`. `RcvbufErrors` counts datagrams the
+/// kernel dropped because a receiving socket's buffer was full — the direct signal
+/// for root-side ingress overflow (packets arriving faster than the single-threaded
+/// driver can drain them). System-wide, but on the root host our traffic dominates.
+/// Reading this proc pseudo-file is an instant, non-blocking memory read, so
+/// `std::fs` is fine here (debug instrumentation on the once-per-second log path).
+fn read_udp6_stats() -> Option<(u64, u64, u64)> {
+    let text = std::fs::read_to_string("/proc/net/snmp6").ok()?;
+    let (mut indg, mut inerr, mut rcv) = (None, None, None);
+    for line in text.lines() {
+        let mut it = line.split_whitespace();
+        let (Some(name), Some(val)) = (it.next(), it.next()) else {
+            continue;
+        };
+        match name {
+            "Udp6InDatagrams" => indg = val.parse().ok(),
+            "Udp6InErrors" => inerr = val.parse().ok(),
+            "Udp6RcvbufErrors" => rcv = val.parse().ok(),
+            _ => {}
+        }
+    }
+    Some((indg?, inerr?, rcv?))
+}
+
+/// Current wall-clock time as `HH:MM:SS.mmm` (UTC), for debug log lines. Kept
+/// dependency-free (no chrono): derived straight from the UNIX epoch, so it lines
+/// up with the smoke test's Python `log()` timestamps when hosts run in UTC.
+pub(crate) fn wall_clock_hms() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = now.as_secs();
+    format!(
+        "{:02}:{:02}:{:02}.{:03}",
+        (secs / 3600) % 24,
+        (secs / 60) % 60,
+        secs % 60,
+        now.subsec_millis(),
+    )
+}
 
 /// Whether `url`'s scheme is one we have a transport for. Kept separate from
 /// [`Ctx::transport_for`] so the scheme can be validated — before the connection
@@ -2029,6 +2081,32 @@ impl CtxHandle {
                     let mut handled_at_last_log: u64 = 0;
                     let mut last_log = std::time::Instant::now();
                     let log_every = std::time::Duration::from_secs(1);
+                    // Verbose loop instrumentation is opt-in (MM_QUIC_DEBUG): when off
+                    // we skip the counters, the UDP-stat reads, and the scheduler-lag
+                    // probe entirely so normal runs pay nothing.
+                    let debug = connection_debug();
+                    let mut prev_udp = if debug { read_udp6_stats() } else { None };
+                    // Scheduler-lag probe: sleep a fixed interval and record how much
+                    // *longer* than that it took to be polled again — "how late an
+                    // arbitrary future gets polled", the same starvation a reader's
+                    // heartbeat timeout races against. Reported as the max per window.
+                    let sched_lag_us: Option<Rc<Cell<u64>>> = debug.then(|| {
+                        let cell = Rc::new(Cell::new(0u64));
+                        let probe = Rc::clone(&cell);
+                        tokio::task::spawn_local(async move {
+                            let interval = std::time::Duration::from_millis(100);
+                            loop {
+                                let before = std::time::Instant::now();
+                                tokio::time::sleep(interval).await;
+                                let overrun = before.elapsed().saturating_sub(interval);
+                                let us = overrun.as_micros() as u64;
+                                if us > probe.get() {
+                                    probe.set(us);
+                                }
+                            }
+                        });
+                        cell
+                    });
                     while let Some(command) = rx.recv().await {
                         if let Command::Shutdown { done } = command {
                             // Wait for the socket transports to flush every pending
@@ -2046,18 +2124,46 @@ impl CtxHandle {
                         ctx.run_command(command);
                         handled_total += 1;
 
-                        let elapsed = last_log.elapsed();
-                        if elapsed >= log_every {
-                            let handled = handled_total - handled_at_last_log;
-                            let backlog = rx.len();
-                            eprintln!(
-                                "MM_CTX loop: {:.0} cmds/s, backlog {}, total {}",
-                                handled as f64 / elapsed.as_secs_f64(),
-                                backlog,
-                                handled_total
-                            );
-                            handled_at_last_log = handled_total;
-                            last_log = std::time::Instant::now();
+                        if debug {
+                            let elapsed = last_log.elapsed();
+                            if elapsed >= log_every {
+                                let handled = handled_total - handled_at_last_log;
+                                let backlog = rx.len();
+                                let sched_lag_ms = sched_lag_us
+                                    .as_ref()
+                                    .map_or(0.0, |c| c.replace(0) as f64 / 1000.0);
+                                // One atomic write (timestamped, newline-terminated) so
+                                // the line isn't spliced with other interleaved output.
+                                eprint!(
+                                    "{} MM_CTX loop: {:.0} cmds/s, backlog {}, \
+                                     sched-lag(max) {:.0}ms, total {}\n",
+                                    wall_clock_hms(),
+                                    handled as f64 / elapsed.as_secs_f64(),
+                                    backlog,
+                                    sched_lag_ms,
+                                    handled_total,
+                                );
+                                // UDP ingress health: delta of received datagrams and
+                                // of drops (InErrors / RcvbufErrors) since the last log.
+                                let now_udp = read_udp6_stats();
+                                if let (Some((i0, e0, r0)), Some((i1, e1, r1))) =
+                                    (prev_udp, now_udp)
+                                {
+                                    eprintln!(
+                                        "{} MM_UDP in +{}/s, in_err +{}, rcvbuf_err +{} \
+                                         (cum in_err {}, rcvbuf_err {})",
+                                        wall_clock_hms(),
+                                        i1.saturating_sub(i0),
+                                        e1.saturating_sub(e0),
+                                        r1.saturating_sub(r0),
+                                        e1,
+                                        r1,
+                                    );
+                                }
+                                prev_udp = now_udp;
+                                handled_at_last_log = handled_total;
+                                last_log = std::time::Instant::now();
+                            }
                         }
                     }
                 });

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -707,6 +707,8 @@ async fn listener_task(
                         loop_tx.clone(), shutdown.clone(), alive.clone(),
                         conn,
                         shm,
+                        // Serving/acceptor side: log heartbeat sends (under MM_QUIC_DEBUG).
+                        true,
                     )
                 });
             }
@@ -720,6 +722,8 @@ async fn listener_task(
                                 loop_tx.clone(), shutdown.clone(), alive.clone(),
                                 conn,
                                 shm,
+                                // Serving/acceptor side: log heartbeat sends (under MM_QUIC_DEBUG).
+                                true,
                             )
                         });
                     }
@@ -844,7 +848,11 @@ async fn connector_task(
                     }
                     // Connection is up; free the attempt slot before handing off.
                     drop(permit);
-                    spawn_connection(send, recv, connection, loop_tx, shutdown, alive, conn, shm);
+                    // Joiner side (the root has tens of thousands of writers): do not
+                    // log heartbeat sends here even under debug — it would flood.
+                    spawn_connection(
+                        send, recv, connection, loop_tx, shutdown, alive, conn, shm, false,
+                    );
                     return;
                 }
                 Err(_) => {
@@ -963,6 +971,9 @@ fn spawn_connection(
     alive: mpsc::UnboundedSender<()>,
     conn: Connection,
     shm: ShmCtx,
+    // Forwarded to the writer: log heartbeat sends (gated to the serve/acceptor side
+    // by the call sites, and further gated by MM_QUIC_DEBUG in the writer).
+    log_heartbeats: bool,
 ) {
     let (writer_tx, writer_rx) = mpsc::unbounded_channel();
     // Reader → writer signal: the peer responded to our shutdown, so the writer
@@ -980,6 +991,7 @@ fn spawn_connection(
         alive,
         peer_responded_rx,
         conn,
+        log_heartbeats,
     ));
     tokio::task::spawn_local(reader_task(
         recv,
@@ -1018,9 +1030,15 @@ async fn writer_task(
     // Held only to keep the QUIC connection alive for the writer's lifetime;
     // dropping it closes the connection, which the peer's reader observes.
     _conn: Connection,
+    // When set (acceptor/serve side only, so the joiner root's tens of thousands of
+    // writers don't flood), and MM_QUIC_DEBUG is on, log each heartbeat sent — so a
+    // connection the peer later reaps can be proven to have kept sending.
+    log_heartbeats: bool,
 ) {
     let mut heartbeat = tokio::time::interval(heartbeat_interval());
     heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let log_heartbeats = log_heartbeats && crate::ctx::connection_debug();
+    let mut heartbeats_sent: u64 = 0;
     let mut graceful = false;
     loop {
         tokio::select! {
@@ -1035,6 +1053,18 @@ async fn writer_task(
             _ = heartbeat.tick() => {
                 if framing::write_heartbeat(&mut send).await.is_err() {
                     return;
+                }
+                // Flushed to the QUIC stream; log it from the *sender* so loss vs. a
+                // stalled sender can be told apart at the far (receiving) end.
+                if log_heartbeats {
+                    heartbeats_sent += 1;
+                    eprintln!(
+                        "{} MM_HB pid={} sent={} on {:?}",
+                        crate::ctx::wall_clock_hms(),
+                        std::process::id(),
+                        heartbeats_sent,
+                        _conn.remote_address(),
+                    );
                 }
             }
             _ = shutdown.changed() => {
@@ -1085,6 +1115,31 @@ async fn reader_task(
     shm: ShmCtx,
 ) {
     let hb_timeout = heartbeat_timeout();
+    // Per-connection diagnostics, folded into the failure reason under MM_QUIC_DEBUG:
+    // did we ever read the peer's Establish (identity exchange)? how many heartbeats
+    // and other frames arrived, and how long since the last read? This pinpoints
+    // exactly how far a reaped connection got. Tracked cheaply either way; only
+    // formatted into the reason when debug is on.
+    let debug = crate::ctx::connection_debug();
+    let start = std::time::Instant::now();
+    let mut established = false;
+    let mut heartbeats: u64 = 0;
+    let mut commands: u64 = 0;
+    let mut last_read: Option<std::time::Duration> = None;
+    let stats = |established: bool, heartbeats, commands, last_read: Option<_>| {
+        let last = match last_read {
+            Some(d) => format!(
+                "{:.1}s ago",
+                start.elapsed().saturating_sub(d).as_secs_f64()
+            ),
+            None => "never".to_owned(),
+        };
+        format!(
+            "established={established}, heartbeats={heartbeats}, commands={commands}, \
+             age={:.1}s, last_read={last}",
+            start.elapsed().as_secs_f64(),
+        )
+    };
     loop {
         // The owning actor's gateway client is snapshot per frame so a large part
         // is read straight into the slab once the client is known (a gateway seeds
@@ -1093,10 +1148,26 @@ async fn reader_task(
         match tokio::time::timeout(hb_timeout, read).await {
             Err(_elapsed) => {
                 let _ = peer_responded.send(());
-                sever(&loop_tx, connection, b"quic heartbeat timeout".to_vec());
+                let reason = if debug {
+                    format!(
+                        "quic heartbeat timeout ({})",
+                        stats(established, heartbeats, commands, last_read)
+                    )
+                    .into_bytes()
+                } else {
+                    b"quic heartbeat timeout".to_vec()
+                };
+                sever(&loop_tx, connection, reason);
                 return;
             }
             Ok(Ok(Incoming::Command(action))) => {
+                last_read = Some(start.elapsed());
+                commands += 1;
+                // The peer's Establish is how we learn its identity: reading it is
+                // the moment this side considers the connection established.
+                if matches!(action, ConnectionCommand::Establish { .. }) {
+                    established = true;
+                }
                 // A Severed from the peer is its response to our shutdown (or the
                 // peer initiating its own) — wake any writer waiting to close.
                 if matches!(action, ConnectionCommand::Severed { .. }) {
@@ -1109,10 +1180,34 @@ async fn reader_task(
                     return;
                 }
             }
-            Ok(Ok(Incoming::Heartbeat)) => continue,
-            Ok(Err(_)) => {
+            Ok(Ok(Incoming::Heartbeat)) => {
+                last_read = Some(start.elapsed());
+                heartbeats += 1;
+                continue;
+            }
+            Ok(Err(err)) => {
                 let _ = peer_responded.send(());
-                sever(&loop_tx, connection, b"quic connection closed".to_vec());
+                let reason = if debug {
+                    // Walk the io::Error source chain to recover the concrete quinn
+                    // ConnectionError — ReadError::ConnectionLost's own Display is just
+                    // the bare "connection lost", dropping the real cause ("timed out"
+                    // vs "reset by peer" vs "closed by peer").
+                    let mut detail = err.to_string();
+                    let mut src = std::error::Error::source(&err);
+                    while let Some(e) = src {
+                        detail.push_str(": ");
+                        detail.push_str(&e.to_string());
+                        src = e.source();
+                    }
+                    format!(
+                        "quic connection closed: {detail} ({})",
+                        stats(established, heartbeats, commands, last_read)
+                    )
+                    .into_bytes()
+                } else {
+                    b"quic connection closed".to_vec()
+                };
+                sever(&loop_tx, connection, reason);
                 return;
             }
         }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* __->__ #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Gate command-loop throughput, scheduler-lag, and UDP ingress diagnostics behind the `MM_QUIC_DEBUG` environment variable so normal operation incurs no instrumentation work. Add opt-in per-connection heartbeat, lifecycle, and error-chain details that distinguish sender stalls, reader starvation, socket-buffer overflow, and concrete QUIC failures.

Differential Revision: [D114750238](https://our.internmc.facebook.com/intern/diff/D114750238/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750238/)!