### PR TITLE
24/43 minimonarch: Move the MAST smoke test into a dedicated example

### DIFF
--- a/monarch_mini/mast/MAST_USE.md
+++ b/monarch_mini/mast/MAST_USE.md
@@ -1,0 +1,163 @@
+# Running the minimonarch smoke test on MAST
+
+This describes how to launch the multi-host QUIC smoke test on MAST and how to
+query its logs. It is written from the debugging workflow used to scale the test
+to 64k–128k workers.
+
+## Topology recap
+
+- Every MAST task starts `SMOKE_WORKERS_PER_HOST` worker processes on sequential
+  ports (`SMOKE_PORT`, `SMOKE_PORT+1`, …). Each worker serves a `quic://` listener.
+- **Task 0 is the root** (pinned via `TW_TASK_ID == "0"` in `mast_bootstrap.py`).
+  It additionally dials every worker across the whole job, times connect +
+  round-trip, and prints a summary. Because the root is always task 0, its logs
+  are fetchable with a single-task query (see below) — critical at scale.
+
+## Launching
+
+`build_mast.py` builds the fbpkg, writes a job spec, and submits it via Thrift.
+
+Full build + launch:
+
+```bash
+python3 build_mast.py \
+  --hosts 4096 --workers-per-host 32 \
+  --cluster CPUTrainingWorkloads \
+  --env MM_QUIC_UDP_BUF_BYTES=134217728 \
+  --env MM_QUIC_MAX_CONCURRENT_CONNECTS=1024 \
+  --launch
+```
+
+On success it prints the **fbpkg id**, the **job name** (e.g.
+`minimonarch_smoke_zdevito_<epoch>`), and `scheduled OK`.
+
+Re-launch reusing an already-built package (skips the Rust/Python build — fast,
+and guarantees the identical binary):
+
+```bash
+python3 build_mast.py \
+  --hosts 4096 --workers-per-host 32 \
+  --cluster CPUTrainingWorkloads \
+  --skip-build --package monarch_additional_packages:<fbpkg-id> \
+  --env ... \
+  --launch
+```
+
+Total workers = `hosts * workers-per-host`. `4096 * 32 = 131072`.
+
+### Tuning env vars (pass each with its own `--env KEY=VALUE`)
+
+| Var | Meaning |
+|-----|---------|
+| `MM_QUIC_UDP_BUF_BYTES` | Total kernel UDP buffer budget across the client endpoint pool (bytes). |
+| `MM_QUIC_CLIENT_ENDPOINTS` | Number of client recv endpoints (UDP sockets). Unset ⇒ adaptive. More is **not** better — extra drivers compete on the single thread. |
+| `MM_QUIC_MAX_CONCURRENT_CONNECTS` | Cap on simultaneous connect *attempts*. Bounds the connect storm at high fan-out. Unset/`0` ⇒ unlimited. |
+| `MM_QUIC_HEARTBEAT_INTERVAL_MS` | Heartbeat send cadence (default 5000). Raise at very high fan-out to cut steady-state heartbeat load. |
+| `MM_QUIC_HEARTBEAT_TIMEOUT_MS` | Sever a connection after this long with no frame (default 20000). Keep ≈ 4× the interval. |
+| `SMOKE_WORKERS_PER_HOST` | Set automatically from `--workers-per-host`. |
+
+## Checking job status
+
+```bash
+# Top-level job state (RUNNING / COMPLETE / DEAD / SHUTTING_DOWN)
+mast get-status <job-name>
+
+# Per-task state counts (allocation progress, restarts, preemption)
+mast get-status <job-name> --output json | python3 -c "
+import sys, json, collections
+d = json.load(sys.stdin); c = collections.Counter()
+def walk(o):
+    if isinstance(o, dict):
+        if 'taskInstanceIdentifier' in o and 'state' in o: c[o['state']] += 1
+        for v in o.values(): walk(v)
+    elif isinstance(o, list):
+        [walk(x) for x in o]
+walk(d); print(dict(c))
+"
+```
+
+## Querying logs
+
+**Important:** this cluster ships task logs only to **Logarithm**, not Scribe, so
+`tw log` reports "Failed to find log files". Use `mast get-logs`.
+
+**Also important:** a bare `mast get-logs <job>` fans out **one query per task**
+across all tasks and instantly trips Logarithm's per-user rate limit
+(`API_THROTTLE 429`, ~150 queries/min). Always scope to specific tasks with
+`--twjob` (a regex on the task handle, which ends in `/<task-id>`).
+
+### The root (all `[root]` / summary / FAILURE lines) — single query
+
+The root is task 0, so `--twjob ".*/0$"` reads exactly one task:
+
+```bash
+# Summary and outcome (stdout = Python output)
+mast get-logs <job-name> --file-path stdout --twjob ".*/0$" \
+  --regex "joining|all .*connected|summary|failures:|connect:|round-trip|ERROR"
+
+# Every per-connection failure with its diagnostic fields
+mast get-logs <job-name> --file-path stdout --twjob ".*/0$" --regex "FAILURE"
+
+# Bucket failures by whether the connection had established
+mast get-logs <job-name> --file-path stdout --twjob ".*/0$" --regex "FAILURE" \
+  | grep -oE "established=(true|false)" | sort | uniq -c
+```
+
+Rust debug instrumentation goes to **stderr**:
+
+```bash
+# Command-loop throughput, mpsc backlog, scheduler lag
+mast get-logs <job-name> --file-path stderr --twjob ".*/0$" --regex "MM_CTX"
+
+# UDP ingress health: received datagrams + kernel drops (RcvbufErrors/InErrors)
+mast get-logs <job-name> --file-path stderr --twjob ".*/0$" --regex "MM_UDP"
+
+# Client endpoint pool size + connect-concurrency cap confirmation
+mast get-logs <job-name> --file-path stderr --twjob ".*/0$" \
+  --regex "client pool|connect concurrency"
+```
+
+### A specific worker host — map hostname → task id, then one query
+
+Failure lines name the peer as `worker-<hostname>-<port>`. To inspect that
+worker's send side (e.g. heartbeat sends `MM_HB`), find its task id from
+`get-status` and query just that task:
+
+```bash
+HOST=twshared46013.01.atn6
+TID=$(mast get-status <job-name> --output json 2>/dev/null | python3 -c "
+import sys, json, re
+d = json.load(sys.stdin); H = '$HOST'
+def walk(o):
+    if isinstance(o, dict):
+        if o.get('hostname') == H and 'taskInstanceIdentifier' in o:
+            m = re.search(r'/(\d+):\d+\$', o['taskInstanceIdentifier'])
+            if m: print(m.group(1))
+        for v in o.values(): walk(v)
+    elif isinstance(o, list):
+        [walk(x) for x in o]
+walk(d)")
+
+# Worker-side heartbeat sends (proves what the sender emitted, tagged by pid)
+mast get-logs <job-name> --file-path stderr --twjob ".*/$TID\$" --regex "MM_HB"
+```
+
+Workers log their `pid` at startup (`[worker :PORT] serving … pid=PID`), so
+`MM_HB pid=…` lines can be mapped back to a worker's port within a task's log.
+
+## Log line reference
+
+| Prefix | Stream | Meaning |
+|--------|--------|---------|
+| `[bootstrap]` | stdout | Task startup: host, rank0, task_id, host/worker counts. |
+| `[root]` | stdout | Root progress, `--- summary ---`, `FAILURE (connect/reply) <who>: <reason>`. |
+| `[worker :PORT]` | stdout | Worker serving/connected/`root gone`; includes `pid=`. |
+| `MM_CTX` | stderr | Per-second: `cmds/s`, mpsc `backlog`, `sched-lag(max)` (runtime scheduler lag). |
+| `MM_UDP` | stderr | Per-second UDP delta: `in +/s`, `in_err +`, `rcvbuf_err +` (kernel ingress drops). |
+| `MM_HB` | stderr | One line per heartbeat *sent* by a serving worker: `pid=`, `sent=`, peer addr. |
+| `MM_QUIC …` | stderr | Endpoint pool size, per-socket buffer grants, connect-concurrency cap. |
+
+A `FAILURE` reason carries per-reader diagnostics:
+`established=<bool>, heartbeats=<n>, commands=<n>, age=<s>, last_read=<s ago|never>`
+— i.e. whether the peer's identity handshake completed, how many heartbeats/frames
+this side received, connection lifetime, and how long since the last frame.

--- a/monarch_mini/mast/build_mast.py
+++ b/monarch_mini/mast/build_mast.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Package the minimonarch smoke test for MAST and emit a job spec.
+
+This does NOT need a venv or any extra Python packages: MAST machines already
+have a platform010 Python 3.12, and the only non-stdlib import is the compiled
+``minimonarch`` extension, which we ship as a single ``.so`` placed directly on
+the bootstrap's ``PYTHONPATH``.
+
+Steps:
+  1. Build the minimonarch extension via ``uv run`` (which rebuilds on any
+     Rust/C change) and copy the resulting cp312 ``.so``.
+  2. Stage ``smoke.py``, ``mast_bootstrap.py``, the ``.so`` and ``certs/``
+     (cert.pem/key.pem/ca.pem) into one directory.
+  3. Upload that directory as an ephemeral fbpkg.
+  4. Write a MAST job spec that runs ``mast_bootstrap.py`` on every task.
+
+By default it stops after writing the spec and prints the ``mast schedule``
+command for you to run. It never schedules a job itself.
+
+Usage:
+    python build_mast.py --hosts 4            # build pkg + write spec
+    python build_mast.py --hosts 4 --print-spec
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent  # monarch_mini/mast/
+_MONARCH_MINI_DIR = _HERE.parent  # monarch_mini/
+# The minimonarch extension's uv/pyproject project lives here; the .so is built by
+# running uv in this directory (its cache-keys pull in ../src for the Rust sources).
+_PYTHON_DIR = _MONARCH_MINI_DIR / "python"
+_TEST_CERTS = _MONARCH_MINI_DIR / "test_certs"
+# Interpreter used in the MAST job command; the cp312 extension we ship is
+# ABI-compatible with it.
+_MAST_PACKAGE_PYTHON = "/usr/local/fbcode/platform010/bin/python3"
+
+# Must be an already-registered fbpkg package name; we reuse the one the
+# monarch examples use rather than inventing a new (unregistered) name, which
+# fails with NO_SUCH_PACKAGE / METADATA_PACKAGE_NOT_FOUND_ERROR.
+_FBPKG_NAME = "monarch_additional_packages"
+_DEFAULT_PORT = 26600
+
+# SMC tier of the MAST ResourceLocatorService (maps a cluster -> its scheduler
+# frontend's write tier). Used to submit directly via thrift, since `mast schedule`
+# routes writes only to the GenAI/MSL frontend.
+_RESOURCE_LOCATOR_TIER = "mast.lookup.prod"
+
+# Known entitlement -> tenantPath. monarch_cicd is authorized only on
+# MastGenAICluster; monarch_training is also authorized on the classic-MAST
+# clusters (MastProdCluster / CPUTrainingWorkloads) with their large T1 pools.
+_ENTITLEMENT_TENANT_PATHS = {
+    "monarch_cicd": "root/gen_ai/msl/msl_infra/cicd/monarch_cicd",
+    "monarch_training": (
+        "root/cfp/ai_rnd/ai_systems_rnd/ai_infra_training_rnd_tc/monarch_training"
+    ),
+}
+
+# Clusters served by the classic-MAST frontend; their applicationMetadata backing
+# cluster is MastProdCluster (matching how real jobs on these clusters are shaped).
+_MAST_BACKED_CLUSTERS = {"MastProdCluster", "CPUTrainingWorkloads"}
+
+
+def run(cmd: list[str], **kwargs: object) -> None:
+    print(f"+ {' '.join(str(c) for c in cmd)}", flush=True)
+    subprocess.run(cmd, check=True, **kwargs)  # pyre-ignore[6]
+
+
+def build_so(out_dir: Path) -> Path:
+    """Build the minimonarch extension and copy the ``.so`` into ``out_dir``.
+
+    We build via ``uv run`` (which respects pyproject's ``cache-keys`` and so
+    rebuilds whenever the Rust sources or ``minimonarch.c`` change) and copy the
+    freshly built, imported ``.so``.
+
+    We deliberately do NOT use ``uv build``: its isolated build did not pick up
+    working-tree changes to the out-of-tree Rust sources (``../src``) and linked a
+    stale staticlib, producing a ``.so`` that did not match the source. The ``uv
+    run`` path builds in place against the real workspace ``target/`` and the
+    current sources. The resulting ``.so`` is a CPython 3.12 (cp312) extension,
+    ABI-compatible with the platform010 cp312 runtime on MAST.
+    """
+    # Build (cache-keys trigger a rebuild on any Rust/C change) and locate it.
+    # Run uv in the extension's project dir (python/), not this script's dir.
+    run(["uv", "run", "python", "-c", "import minimonarch"], cwd=str(_PYTHON_DIR))
+    so_path = Path(
+        subprocess.check_output(
+            [
+                "uv",
+                "run",
+                "python",
+                "-c",
+                "import minimonarch, sys; sys.stdout.write(minimonarch.__file__)",
+            ],
+            cwd=str(_PYTHON_DIR),
+        )
+        .decode()
+        .strip()
+    )
+    if not so_path.exists():
+        print(f"ERROR: built extension not found at {so_path}", file=sys.stderr)
+        sys.exit(1)
+    dest = out_dir / so_path.name
+    shutil.copy2(so_path, dest)
+    return dest
+
+
+def stage_package(staging: Path) -> None:
+    """Assemble everything the MAST tasks need into ``staging``."""
+    staging.mkdir(parents=True, exist_ok=True)
+
+    so = build_so(staging)
+    print(f"staged extension: {so.name}", flush=True)
+
+    for name in ("smoke.py", "mast_bootstrap.py"):
+        shutil.copy2(_HERE / name, staging / name)
+
+    certs_out = staging / "certs"
+    certs_out.mkdir(exist_ok=True)
+    for pem in ("cert.pem", "key.pem", "ca.pem"):
+        src = _TEST_CERTS / pem
+        if not src.exists():
+            print(f"ERROR: missing cert {src}", file=sys.stderr)
+            sys.exit(1)
+        shutil.copy2(src, certs_out / pem)
+    print(f"staged certs: {sorted(p.name for p in certs_out.iterdir())}", flush=True)
+
+
+def create_fbpkg(name: str, directory: Path, expire: str) -> str:
+    """Upload directory contents as an ephemeral fbpkg. Returns 'name:version'."""
+    config_dir = tempfile.mkdtemp()
+    materialized_dir = os.path.join(config_dir, "materialized_configs")
+    os.makedirs(materialized_dir)
+    json_path = os.path.join(materialized_dir, f"{name}.fbpkg.materialized_JSON")
+
+    package_json = {"paths": os.listdir(directory), "build_command": ""}
+    with open(json_path, "w") as f:
+        json.dump(package_json, f)
+
+    output = subprocess.check_output(
+        [
+            "fbpkg",
+            "build",
+            "--yes",
+            "--ephemeral",
+            "--configerator-path",
+            config_dir,
+            name,
+            "--expire",
+            expire,
+        ],
+        cwd=str(directory),
+    ).decode("utf-8")
+    print(output, flush=True)
+    lines = [line for line in output.splitlines() if line.strip()]
+    return lines[-1].strip()
+
+
+def make_jobspec(
+    *,
+    name: str,
+    package_name: str,
+    package_version: str,
+    hosts: int,
+    port: int,
+    workers_per_host: int,
+    extra_env: dict[str, str] | None = None,
+    region: str | None = None,
+    server_subtype: int | None = None,
+    cluster: str = "MastGenAICluster",
+    entitlement: str = "monarch_cicd",
+) -> dict:
+    """A CPU MAST job that runs the bootstrap on every task.
+
+    By default it constrains to serverType 100 (classic T1: Skylake/CooperLake/
+    Milan). Pass ``server_subtype`` (e.g. 10018 = T1_BGM Bergamo) to instead pin a
+    specific CPU sub-type — required to land on Bergamo, which the plain T1
+    serverType does not cover.
+
+    ``entitlement`` selects the MAST entitlement/tenant. Use ``monarch_training``
+    for the classic-MAST clusters (CPUTrainingWorkloads / MastProdCluster), which
+    ``monarch_cicd`` is not authorized on.
+    """
+    tenant_path = _ENTITLEMENT_TENANT_PATHS.get(entitlement)
+    if tenant_path is None:
+        raise ValueError(
+            f"unknown entitlement {entitlement!r}; known: "
+            f"{sorted(_ENTITLEMENT_TENANT_PATHS)}"
+        )
+    # applicationMetadata backing cluster: MastProdCluster for the classic-MAST
+    # clusters (matches how real jobs on those clusters are shaped), else itself.
+    app_cluster = "MastProdCluster" if cluster in _MAST_BACKED_CLUSTERS else cluster
+    command = f"{_MAST_PACKAGE_PYTHON} /packages/{package_name}/mast_bootstrap.py"
+    machine_constraints = (
+        {"types": {"serverSubTypes": [server_subtype]}}
+        if server_subtype is not None
+        else {"types": {"serverTypes": [100]}}
+    )
+    env = {
+        "SMOKE_PORT": str(port),
+        "SMOKE_WORKERS_PER_HOST": str(workers_per_host),
+    }
+    if extra_env:
+        env.update(extra_env)
+    spec = {
+        "name": name,
+        "hpcClusterUuid": cluster,
+        "hpcTaskGroups": [
+            {
+                "name": "workers",
+                "taskCount": hosts,
+                "taskCountPerHost": 1,
+                "hardwareSpecificTaskGroupOverride": {},
+                "spec": {
+                    "command": command,
+                    "arguments": [],
+                    "applicationPackages": [
+                        {
+                            "name": package_name,
+                            "version": {"ephemeralId": package_version},
+                            "fbpkgIdentifier": f"{package_name}:{package_version}",
+                        }
+                    ],
+                    "packages": [],
+                    "env": env,
+                    "resourceLimit": {
+                        "ramMB": 54272,
+                        "compute": {"cpu": 15, "gpu": 0},
+                        "enableSwapAndSenpai": False,
+                        "limitType": 0,
+                        "wholeHost": True,
+                    },
+                    "machineConstraints": machine_constraints,
+                    "networkAffinity": {"preferredScope": 2, "fallbackScope": 1},
+                    "oncallShortname": "monarch",
+                    "bindMounts": [],
+                    "runningTimeoutSec": 3600,
+                    "unixUser": "root",
+                    "restartPolicy": {
+                        "scope": 0,
+                        "maxTotalFailures": 0,
+                        "failoverOnHostFailures": False,
+                        "failJobOnFinalFailure": True,
+                    },
+                    "ttlsConfig": {"enable": False},
+                    "opecTag": 0,
+                },
+            }
+        ],
+        "networkAffinity": {"preferredScope": 2, "fallbackScope": 1},
+        "applicationMetadata": {
+            "model_type_name": "gen_ai_default",
+            "rm_attribution": entitlement,
+            "hpcClusterUuid": app_cluster,
+        },
+        "identity": {"name": "hyper_monarch"},
+        "owner": {"oncallShortname": "monarch", "unixname": os.environ["USER"]},
+        "enableGracefulPreemption": False,
+        "maxJobFailures": 0,
+        "jobType": 0,
+        "aiTrainingMetadata": {
+            "jobType": 0,
+            "modelTypeName": "gen_ai_default",
+            "entitlement": entitlement,
+            "tenantPath": tenant_path,
+            "productGroup": "gen_ai",
+            "mastJobID": name,
+            "model_lifecycle_status": {},
+        },
+    }
+    if region:
+        # Pin every task to a single region (locality=1 = region scope) so the
+        # whole fleet lands together where capacity is — required when one region
+        # must hold all the hosts.
+        spec["localityConstraints"] = {"locality": 1, "options": [region]}
+    return spec
+
+
+def locate_write_tier(cluster: str) -> str:
+    """Resolve a cluster's scheduler write tier via MAST's ResourceLocatorService.
+
+    `mast schedule` only ever hits the GenAI/MSL frontend, so it can't create jobs
+    on the classic-MAST clusters. We instead ask the locator which frontend serves
+    the cluster and submit straight to that write tier (see `submit_via_thrift`).
+    """
+    out = subprocess.check_output(
+        [
+            "thriftdbg",
+            "sendRequest",
+            "locateHpcCluster",
+            json.dumps({"request": {"hpcClusterUuid": cluster}}),
+            "--tier",
+            _RESOURCE_LOCATOR_TIER,
+        ],
+        text=True,
+    )
+    line = [ln for ln in out.strip().splitlines() if ln.strip()][-1]
+    return json.loads(line)["smcTiers"]["writeTier"]
+
+
+def submit_via_thrift(spec: dict) -> None:
+    """Submit the job by calling HpcSchedulerService.scheduleHpcJob directly.
+
+    Both `mast schedule` and torchx ultimately call this same RPC; we call it via
+    `thriftdbg` against the cluster's own write tier, which lets us reach the
+    classic-MAST clusters (CPUTrainingWorkloads / MastProdCluster) that the CLI's
+    fixed GenAI/MSL write endpoint rejects.
+    """
+    cluster = spec["hpcClusterUuid"]
+    tier = locate_write_tier(cluster)
+    print(f"=== submitting to write tier {tier} (cluster {cluster}) ===", flush=True)
+    request = {"request": {"hpcJob": spec}}
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".json", delete=False, prefix="mm_sched_req_"
+    ) as f:
+        json.dump(request, f)
+        req_path = f.name
+    proc = subprocess.run(
+        [
+            "thriftdbg",
+            "sendRequest",
+            "scheduleHpcJob",
+            "",
+            "--request_json",
+            req_path,
+            "--tier",
+            tier,
+            "--request_timeout_ms",
+            "90000",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        print(proc.stderr.strip() or proc.stdout.strip(), file=sys.stderr)
+        sys.exit("scheduleHpcJob failed (see error above)")
+    # A successful scheduleHpcJob returns an empty struct "{}".
+    print(f"scheduled OK: {proc.stdout.strip() or '{}'}", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--hosts", type=int, default=2, help="number of MAST tasks")
+    parser.add_argument(
+        "--workers-per-host",
+        type=int,
+        default=1,
+        help="worker processes per host on sequential ports (default: 1); lets "
+        "you scale worker count without more machines",
+    )
+    parser.add_argument(
+        "--port", type=int, default=_DEFAULT_PORT, help="base worker port"
+    )
+    parser.add_argument("--expire", default="1w", help="fbpkg expiry (default: 1w)")
+    parser.add_argument(
+        "--name", default=None, help="job name (default: minimonarch_smoke_<user>)"
+    )
+    parser.add_argument(
+        "--print-spec", action="store_true", help="print the job spec JSON"
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="reuse an existing fbpkg id from --package instead of rebuilding",
+    )
+    parser.add_argument(
+        "--package",
+        default=None,
+        help="existing 'name:version' to reuse with --skip-build",
+    )
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="extra environment variable for the job (repeatable), e.g. "
+        "--env MM_QUIC_CLIENT_ENDPOINTS=8",
+    )
+    parser.add_argument(
+        "--region",
+        default=None,
+        help="pin all tasks to a single region (e.g. vcn) so the whole fleet "
+        "lands where there is capacity",
+    )
+    parser.add_argument(
+        "--cluster",
+        default="MastGenAICluster",
+        help="MAST cluster (default: MastGenAICluster; CPUTrainingWorkloads has a "
+        "much larger best-effort T1 pool)",
+    )
+    parser.add_argument(
+        "--bergamo",
+        action="store_true",
+        help="target Bergamo CPU hosts (T1_BGM, serverSubType 10018; ~88 cores, "
+        "256 GB) instead of classic T1 — needed to use the large vcn pool",
+    )
+    parser.add_argument(
+        "--server-subtype",
+        type=int,
+        default=None,
+        help="explicit LogicalServerSubType to constrain to (overrides --bergamo)",
+    )
+    parser.add_argument(
+        "--entitlement",
+        default=None,
+        help="MAST entitlement (default: monarch_training for classic-MAST "
+        "clusters, else monarch_cicd)",
+    )
+    parser.add_argument(
+        "--launch",
+        action="store_true",
+        help="submit the job now via thrift (thriftdbg -> the cluster's write "
+        "tier) instead of only printing instructions",
+    )
+    args = parser.parse_args()
+
+    extra_env: dict[str, str] = {}
+    for item in args.env:
+        if "=" not in item:
+            parser.error(f"--env expects KEY=VALUE, got {item!r}")
+        key, value = item.split("=", 1)
+        extra_env[key] = value
+
+    if args.skip_build:
+        if not args.package:
+            parser.error("--skip-build requires --package name:version")
+        identifier = args.package
+    else:
+        staging = Path(tempfile.mkdtemp(prefix="mm_smoke_pkg_"))
+        print(f"=== staging package in {staging} ===", flush=True)
+        stage_package(staging)
+        print("=== uploading ephemeral fbpkg ===", flush=True)
+        identifier = create_fbpkg(_FBPKG_NAME, staging, args.expire)
+
+    package_name, package_version = identifier.split(":", 1)
+    entitlement = args.entitlement or (
+        "monarch_training" if args.cluster in _MAST_BACKED_CLUSTERS else "monarch_cicd"
+    )
+    # MAST rejects duplicate job names, so make each launch unique unless the
+    # caller pinned an exact --name.
+    base_name = args.name or f"minimonarch_smoke_{os.environ['USER']}"
+    job_name = base_name if args.name else f"{base_name}_{int(time.time())}"
+
+    spec = make_jobspec(
+        name=job_name,
+        package_name=package_name,
+        package_version=package_version,
+        hosts=args.hosts,
+        port=args.port,
+        workers_per_host=args.workers_per_host,
+        extra_env=extra_env,
+        region=args.region,
+        server_subtype=args.server_subtype
+        if args.server_subtype is not None
+        else (10018 if args.bergamo else None),
+        cluster=args.cluster,
+        entitlement=entitlement,
+    )
+
+    spec_path = Path(tempfile.mkdtemp(prefix="mm_smoke_spec_")) / "jobspec.json"
+    spec_path.write_text(json.dumps(spec, indent=2))
+
+    if args.print_spec:
+        print(json.dumps(spec, indent=2), flush=True)
+
+    print("\n=== ready ===", flush=True)
+    print(f"fbpkg:       {identifier}", flush=True)
+    print(f"job name:    {job_name}", flush=True)
+    print(f"cluster:     {args.cluster}  entitlement: {entitlement}", flush=True)
+    print(f"job spec:    {spec_path}", flush=True)
+
+    if args.launch:
+        submit_via_thrift(spec)
+        print(f"\nmonitor with:  mast get-status {job_name}", flush=True)
+    else:
+        print("\nTo launch (rerun with --launch, or submit directly):", flush=True)
+        print(
+            f"    thriftdbg sendRequest scheduleHpcJob '' --request_json "
+            f"<{{'request':{{'hpcJob': <spec>}}}}> --tier "
+            f"<writeTier for {args.cluster}>",
+            flush=True,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/monarch_mini/mast/mast_bootstrap.py
+++ b/monarch_mini/mast/mast_bootstrap.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""MAST entry point for the minimonarch smoke test.
+
+This runs once on *every* task of the MAST job. The behaviour is:
+
+  * Every task starts a worker (``smoke.py --worker``) that serves a quic
+    listener on all IPv6 interfaces.
+  * Rank 0 *additionally* starts the root (``smoke.py --root ...``), which dials
+    every host in the task group, times the connect + round-trip, and exits with
+    the smoke test's status.
+
+Host discovery uses the MAST-provided environment:
+
+  * ``MAST_HPC_TASK_GROUP_HOSTNAMES`` — comma-separated FQDNs of every task host
+    (includes this host).
+  * ``TW_TASK_ID`` / ``HOSTNAME`` — used to decide which task is rank 0. MAST may
+    order the host list differently from ``TW_TASK_ID``, so we identify rank 0 by
+    matching our own hostname against ``hostnames[0]`` and fall back to
+    ``TW_TASK_ID == "0"``.
+
+We never connect by DNS name: each peer FQDN is resolved to a concrete IPv6
+address with ``getaddrinfo`` and the root dials ``[<ipv6>]:<port>``.
+
+The package layout (see build_mast.py) places ``smoke.py``, the compiled
+``minimonarch*.so`` and a ``certs/`` directory all next to this file, so the
+worker/root subprocesses import the extension from here and pick up TLS material
+automatically.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PORT = int(os.environ.get("SMOKE_PORT", "26600"))
+# How many worker processes to run on each host, on sequential ports
+# PORT, PORT+1, ... This lets you scale the worker count without more machines.
+WORKERS_PER_HOST = int(os.environ.get("SMOKE_WORKERS_PER_HOST", "1"))
+# Seconds rank 0 waits before dialing, giving every worker time to bind.
+STARTUP_GRACE = float(os.environ.get("SMOKE_STARTUP_GRACE", "15"))
+
+
+def task_hosts() -> list[str]:
+    """Every host FQDN in this task group, in MAST's order (includes self)."""
+    raw = os.environ.get("MAST_HPC_TASK_GROUP_HOSTNAMES", "")
+    return [h for h in raw.split(",") if h]
+
+
+def is_rank0() -> bool:
+    """True on the one task that should also run the root.
+
+    Pinned to ``TW_TASK_ID == "0"`` so the root is *always* task 0 and its logs
+    can be fetched with a single-task query (``tw log <job>/0``) — critical at
+    scale, where a job-wide log fan-out across thousands of tasks trips
+    Logarithm's per-user query rate limit. The root dials the full host list from
+    ``MAST_HPC_TASK_GROUP_HOSTNAMES`` regardless of which task/host it runs on, so
+    nothing requires it to be ``hosts[0]``; any single task works.
+    """
+    return os.environ.get("TW_TASK_ID", "0") == "0"
+
+
+def resolve_ipv6(host: str, port: int) -> str:
+    """Resolve ``host`` to a single IPv6 address (we connect by IP, never DNS)."""
+    # MAST supplies task FQDNs to this OSS smoke test.
+    # ast-grep-ignore: python/python-dns-deps
+    infos = socket.getaddrinfo(host, port, socket.AF_INET6, socket.SOCK_DGRAM)
+    if not infos:
+        raise RuntimeError(f"no IPv6 address for {host}")
+    return infos[0][4][0]
+
+
+def _child_env() -> dict[str, str]:
+    # Make the bundled extension importable from the package directory.
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH", "")
+    env["PYTHONPATH"] = HERE + (os.pathsep + existing if existing else "")
+    return env
+
+
+def main() -> None:
+    python = sys.executable
+    smoke = os.path.join(HERE, "smoke.py")
+    env = _child_env()
+    hosts = task_hosts()
+    rank0 = is_rank0()
+
+    print(
+        f"[bootstrap] host={socket.getfqdn()} rank0={rank0} "
+        f"task_id={os.environ.get('TW_TASK_ID')} hosts={len(hosts)} "
+        f"port={PORT} workers_per_host={WORKERS_PER_HOST}",
+        flush=True,
+    )
+
+    # Every task runs WORKERS_PER_HOST workers on sequential ports.
+    workers = [
+        subprocess.Popen(
+            [python, smoke, "--worker", "--port", str(PORT + i), "--bind", "::"],
+            cwd=HERE,
+            env=env,
+        )
+        for i in range(WORKERS_PER_HOST)
+    ]
+
+    if not rank0:
+        # Plain worker task: serve until the workers shut down (on the root's
+        # death notice) or the job is torn down. Fail if any worker fails.
+        codes = [w.wait() for w in workers]
+        sys.exit(max(codes) if codes else 0)
+
+    # Rank 0 also runs the root. Give every worker a moment to bind first. The
+    # root dials every (host, port) pair across the whole job.
+    time.sleep(STARTUP_GRACE)
+    addrs = [
+        f"[{resolve_ipv6(h, PORT)}]:{PORT + i}"
+        for h in hosts
+        for i in range(WORKERS_PER_HOST)
+    ]
+    print(f"[bootstrap] root dialing {len(addrs)} workers", flush=True)
+
+    # Pass addresses via a file, not argv: at tens of thousands of workers the
+    # combined command line exceeds the OS ARG_MAX limit (E2BIG). Write it to a
+    # writable temp dir — the fbpkg install dir (HERE) is a read-only mount.
+    addr_file = os.path.join(tempfile.gettempdir(), "mm_root_hosts.txt")
+    with open(addr_file, "w") as f:
+        f.write("\n".join(addrs))
+    rc = subprocess.call([python, smoke, "--root-file", addr_file], cwd=HERE, env=env)
+    print(f"[bootstrap] root finished with code {rc}", flush=True)
+
+    # The smoke test is done; tear down our local workers and exit with its status.
+    for w in workers:
+        w.terminate()
+    for w in workers:
+        try:
+            w.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            w.kill()
+    sys.exit(rc)
+
+
+if __name__ == "__main__":
+    main()

--- a/monarch_mini/mast/smoke.py
+++ b/monarch_mini/mast/smoke.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Multi-machine smoke test for minimonarch over QUIC (TLS-encrypted).
+
+Topology: a single root node connects to N worker nodes. Each worker *serves*
+a quic:// listener; the root *joins* (connects out to) every worker. Once all
+workers are connected the root sends one message to each worker, and each
+worker replies with its own identity. Every phase is timed.
+
+Worker IPs are not known until runtime and we never use DNS: the root is given
+the worker addresses directly on the command line (or, on MAST, via an env var)
+and dials them by IPv6 address.
+
+Usage:
+
+    # On each worker machine (binds all interfaces on PORT):
+    python smoke.py --worker --port 26600
+
+    # On the root machine, given the worker addresses:
+    python smoke.py --root "[2401:db00::1]:26600" "[2401:db00::2]:26600"
+
+TLS: the quic transport reads its material from MM_QUIC_CERT / MM_QUIC_KEY /
+MM_QUIC_CA. The client verifies the server certificate against the CA for a
+*fixed* server name ("monarch-mini", baked into the transport), so a single
+shared cert/key/ca set works on every machine regardless of its IP -- no
+per-host certificate signing and no CA private key distribution is required.
+See ``ensure_quic_certs`` and the README section in this file's module docstring.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import os
+import socket
+import sys
+import time
+
+import minimonarch
+from minimonarch import Actor
+
+ba = minimonarch.bytearray
+
+# The fixed server name the transport's TLS client verifies against; the shipped
+# leaf cert carries it as a SAN. Documented here so the cert story is discoverable
+# from Python, but not otherwise used by this script.
+SERVER_NAME = "monarch-mini"
+
+# Sentinel prefix a worker registers as its connection-failure message. When the
+# root tears down (clean exit or crash) the worker's parent link severs and
+# minimonarch delivers [_DOWN, root_ident, reason]; the worker uses the prefix to
+# tell that death notice apart from a normal ping and shut itself down.
+_DOWN = b"__worker_down__"
+
+# Short hostname, included in every log line so multi-host logs are easy to read.
+_HOST = socket.gethostname()
+
+
+def log(msg: str) -> None:
+    """Print a flushed, wall-clock-timestamped, host-tagged log line.
+
+    The timestamp (with milliseconds) and host let us correlate events across
+    machines when debugging at scale; clocks are NTP-synced closely enough for
+    sub-second ordering within a short run.
+    """
+    ts = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+    print(f"{ts} {_HOST} {msg}", flush=True)
+
+
+def ensure_quic_certs(certs_dir: str | None) -> None:
+    """Point the quic transport at a cert/key/ca set via its env vars.
+
+    If MM_QUIC_CERT / MM_QUIC_KEY / MM_QUIC_CA are already set we leave them
+    alone. Otherwise we search ``certs_dir`` (if given), then a ``certs``
+    directory next to this script, then the repo's ``test_certs`` directory, and
+    use the first that holds all three PEM files.
+    """
+    needed = ("MM_QUIC_CERT", "MM_QUIC_KEY", "MM_QUIC_CA")
+    if all(os.environ.get(v) for v in needed):
+        return
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    candidates: list[str] = []
+    if certs_dir:
+        candidates.append(certs_dir)
+    candidates.append(os.path.join(here, "certs"))
+    candidates.append(os.path.join(here, "..", "test_certs"))
+
+    for d in candidates:
+        cert = os.path.join(d, "cert.pem")
+        key = os.path.join(d, "key.pem")
+        ca = os.path.join(d, "ca.pem")
+        if os.path.exists(cert) and os.path.exists(key) and os.path.exists(ca):
+            os.environ["MM_QUIC_CERT"] = cert
+            os.environ["MM_QUIC_KEY"] = key
+            os.environ["MM_QUIC_CA"] = ca
+            log(f"[certs] using TLS material from {os.path.abspath(d)}")
+            return
+
+    raise SystemExit(
+        "no quic certs found: set MM_QUIC_CERT/MM_QUIC_KEY/MM_QUIC_CA or pass "
+        f"--certs-dir (looked in: {', '.join(candidates)})"
+    )
+
+
+def worker_ident(port: int) -> bytes:
+    """A unique, human-readable identity for this worker process."""
+    return f"worker-{socket.gethostname()}-{port}".encode()
+
+
+def _failure_notice(parts: list) -> tuple[str, str]:
+    """Decode a failure notice the root receives when a connection to a worker
+    severs. The root joined each worker with no failure prefix, so minimonarch
+    delivers ``[worker_ident, reason]`` (unlike the worker, which registered the
+    ``_DOWN`` prefix). Returns (worker, reason) as strings for logging."""
+    who = bytes(parts[0]).decode(errors="replace") if parts else "?"
+    reason = bytes(parts[1]).decode(errors="replace") if len(parts) > 1 else "?"
+    return who, reason
+
+
+def _report_progress(label: str, done: int, total: int, step: int) -> None:
+    """Print a ``label`` progress line at most ~11 times for the whole loop.
+
+    Only prints on a decile boundary (every ``step``) or on the final item, so
+    the number of prints stays bounded as the host count ramps up and does not
+    skew the timed phase.
+    """
+    if done % step == 0 or done == total:
+        pct = 100 * done // total
+        log(f"[root]   {label} {done}/{total} ({pct}%)")
+
+
+async def run_worker(port: int, bind: str) -> None:
+    """Serve a quic listener, answer round-trips, and exit when the root dies.
+
+    The worker is the *child* of the root: it serves (listens) and the root
+    joins (dials). On each established link the worker learns the root's identity
+    from the establishment hello, then echoes back its own identity so the root
+    can report exactly who replied.
+
+    The worker registers ``_DOWN`` as its failure prefix, so when the root sends
+    its explicit "context shutdown" notice the severed parent link delivers
+    ``[_DOWN, root_ident, reason]``. The worker then calls ``minimonarch.close()``
+    to tear its own context down gracefully — which sends its shutdown notice back
+    to the root, the response the root waits for before it closes that connection.
+    """
+    ident = worker_ident(port)
+    tag = f"[worker :{port}]"
+    url = f"quic://[{bind}]:{port}"
+    me = Actor(ident)
+    me.serve(url, "child", failure=[ba(_DOWN)])
+    # pid lets us map the Rust writer's MM_HB heartbeat-send lines (tagged by pid)
+    # back to this worker's port when correlating send vs. receive at scale.
+    log(f"{tag} serving {url} pid={os.getpid()}")
+
+    # Establishment hello: [self_ident, root_ident].
+    hello = await me.next()
+    root_ident = bytes(hello[1])
+    log(f"{tag} connected to root {root_ident.decode()}")
+
+    # Answer every message the root sends with our identity. A death notice for
+    # the root (the registered _DOWN failure) ends the process.
+    while True:
+        msg = await me.next()
+        if msg and bytes(msg[0]) == _DOWN:
+            reason = bytes(msg[2]).decode() if len(msg) > 2 else "unknown"
+            log(f"{tag} root {root_ident.decode()} gone ({reason}); shutting down")
+            # Graceful close: replies to the root's shutdown so it can close
+            # promptly instead of waiting out its ack timeout.
+            minimonarch.close()
+            return
+        log(f"{tag} got message; replying")
+        me.send(root_ident, [ba(b"hello from " + ident)])
+
+
+async def run_root(hosts: list[str], timeout: float, connect_timeout: float) -> int:
+    """Dial every worker, time connection + round-trip, and report.
+
+    ``connect_timeout`` bounds the connect phase (longer, since with hundreds of
+    hosts an occasional one is slow to boot); ``timeout`` bounds each reply.
+    Returns a process exit code (0 on full success).
+    """
+    root = Actor(b"root")
+    try:
+        # --- Phase 1: connect to all workers ---------------------------------
+        total = len(hosts)
+        step = max(1, total // 10)
+        log(f"[root] joining {total} worker(s)...")
+        t_join = time.monotonic()
+        for host in hosts:
+            root.join(f"quic://{host}", "parent")
+
+        # Every failure notice the root receives (a severed connection to a
+        # worker) is printed as it arrives so we can see exactly which workers
+        # dropped and why. `failures` keeps a running total across both phases.
+        workers: list[bytes] = []
+        failures = 0
+        # Loop until every worker has connected. A message is either an
+        # establishment hello ([b"root", worker_ident]) or a failure notice
+        # ([worker_ident, reason]); only hellos count toward `total`, failures
+        # are printed and tallied.
+        while len(workers) < total:
+            try:
+                msg = await asyncio.wait_for(root.next(), connect_timeout)
+            except asyncio.TimeoutError:
+                log(
+                    f"[root] ERROR: only {len(workers)}/{total} workers "
+                    f"connected within {connect_timeout:.0f}s ({failures} failures)"
+                )
+                return 1
+            if len(msg) >= 2 and bytes(msg[0]) == b"root":
+                # Establishment hello: record who connected. Progress is printed
+                # only at decile boundaries (bounded prints) so it stays cheap.
+                workers.append(bytes(msg[1]))
+                _report_progress("connected", len(workers), total, step)
+            else:
+                who, reason = _failure_notice(msg)
+                failures += 1
+                log(f"[root] FAILURE (connect) {who}: {reason}")
+        connect_ms = (time.monotonic() - t_join) * 1e3
+        log(f"[root] all {len(workers)} workers connected in {connect_ms:.1f} ms")
+
+        # --- Phase 2: one message to each worker, await each reply -----------
+        t_send = time.monotonic()
+        for wid in workers:
+            root.send(wid, [ba(b"ping")])
+        log(f"[root] sent ping to {len(workers)} workers")
+
+        # Each connected worker yields exactly one terminal message: a reply
+        # ([b"hello from ..."]) or a failure notice ([worker_ident, reason]) if
+        # its connection dropped after connecting. Consume that many messages,
+        # counting replies (progress at decile boundaries) and printing every
+        # failure as it arrives.
+        replies = 0
+        reply_failures = 0
+        for _ in range(len(workers)):
+            try:
+                msg = await asyncio.wait_for(root.next(), timeout)
+            except asyncio.TimeoutError:
+                log(
+                    f"[root] ERROR: only {replies}/{len(workers)} replies within "
+                    f"{timeout:.0f}s ({failures + reply_failures} failures)"
+                )
+                return 1
+            if msg and bytes(msg[0]).startswith(b"hello from "):
+                replies += 1
+                _report_progress("replies", replies, len(workers), step)
+            else:
+                who, reason = _failure_notice(msg)
+                reply_failures += 1
+                log(f"[root] FAILURE (reply) {who}: {reason}")
+        failures += reply_failures
+        roundtrip_ms = (time.monotonic() - t_send) * 1e3
+
+        log("[root] --- summary ---")
+        log(f"[root] connect:    {connect_ms:.1f} ms ({len(workers)} workers)")
+        log(f"[root] round-trip: {roundtrip_ms:.1f} ms ({replies} replies)")
+        log(f"[root] failures:   {failures}")
+        # Success only if every worker replied and nothing severed along the way.
+        return 0 if replies == len(workers) and failures == 0 else 1
+    finally:
+        # Gracefully tear down the context *inside the event loop*: this flushes
+        # an "actor destroyed" death notice to every worker before the loop
+        # thread stops, so workers shut down promptly instead of waiting out the
+        # quic heartbeat timeout. Runs on success, timeout, and error paths.
+        minimonarch.close()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument(
+        "--root",
+        nargs="+",
+        metavar="HOST",
+        help="run as the root and connect to these worker addresses "
+        "(e.g. '[::1]:26600')",
+    )
+    mode.add_argument(
+        "--root-file",
+        metavar="PATH",
+        help="run as the root, reading worker addresses (one per line) from PATH. "
+        "Use this instead of --root at high host counts: tens of thousands of "
+        "addresses on argv exceed the OS ARG_MAX limit.",
+    )
+    mode.add_argument(
+        "--worker", action="store_true", help="run as a worker (serve a listener)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=26600, help="worker listen port (default: 26600)"
+    )
+    parser.add_argument(
+        "--bind",
+        default="::",
+        help="worker bind address (default: '::' = all IPv6 interfaces)",
+    )
+    parser.add_argument(
+        "--certs-dir", default=None, help="directory holding cert.pem/key.pem/ca.pem"
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=60.0,
+        help="root: seconds to wait for each reply (default: 60)",
+    )
+    parser.add_argument(
+        "--connect-timeout",
+        type=float,
+        default=180.0,
+        help="root: seconds to wait for all workers to connect (default: 180); "
+        "larger than --timeout because with many hosts one can be slow to boot",
+    )
+    args = parser.parse_args()
+
+    ensure_quic_certs(args.certs_dir)
+
+    if args.worker:
+        asyncio.run(run_worker(args.port, args.bind))
+    else:
+        if args.root_file:
+            with open(args.root_file) as f:
+                hosts = [line.strip() for line in f if line.strip()]
+        else:
+            hosts = args.root
+        sys.exit(asyncio.run(run_root(hosts, args.timeout, args.connect_timeout)))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* __->__ #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Move the multi-host QUIC smoke test, MAST bootstrap, and package launcher into `monarch_mini/mast`, with build paths adjusted for the new layout. Document large-scale launch and task-scoped log workflows while pinning the root to task 0 and reporting connection failures and worker PIDs more clearly.

Differential Revision: [D114750221](https://our.internmc.facebook.com/intern/diff/D114750221/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750221/)!