### PR TITLE
25/43 minimonarch: Add safe Rust bindings for the Minimonarch C ABI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -57,3 +57,9 @@ rustflags = [
     "-Aunused_braces",
     "-Astable_features"
 ]
+
+# Enables artifact dependencies (`artifact = "staticlib"`), used by
+# monarch_mini/rust to link minimonarch as an opaque native library over its C
+# ABI while cargo builds and orders the staticlib for us.
+[unstable]
+bindeps = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4746,6 +4746,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "monarch_mini_rs"
+version = "0.1.0"
+dependencies = [
+ "monarch_mini",
+ "static_assertions",
+ "thiserror 2.0.19",
+ "tokio",
+]
+
+[[package]]
 name = "monarch_monarch_bench"
 version = "0.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "3"
 members = [
     "algebra",
     "monarch_mini",
+    "monarch_mini/rust",
     "build_utils",
     "erased_lifetime",
     "hyper",
@@ -49,6 +50,7 @@ members = [
 default-members = [
     "algebra",
     "monarch_mini",
+    "monarch_mini/rust",
     "build_utils",
     "erased_lifetime",
     "hyper",

--- a/monarch_mini/minimonarch.h
+++ b/monarch_mini/minimonarch.h
@@ -54,7 +54,7 @@ typedef struct mm_msg {
 /* Opaque handle types. */
 typedef struct mm_ctx* mm_ctx_t;
 typedef struct mm_actor* mm_actor_t;
-typedef struct mm_monitor_handle* mm_monitor_handle_t;
+typedef uint64_t mm_monitor_handle_t;
 typedef struct mm_poller* mm_poller_t;
 
 typedef enum mm_role {
@@ -107,7 +107,7 @@ mm_err_t mm_actor_monitor(
     const mm_msg_t* failure_prefix,
     uint64_t timeout_for_nonexistence,
     mm_monitor_handle_t* out);
-void mm_monitor_handle_cancel(mm_monitor_handle_t handle);
+void mm_monitor_handle_cancel(mm_actor_t actor, mm_monitor_handle_t handle);
 mm_err_t mm_poller_create(mm_ctx_t ctx, int* fd_out, mm_poller_t* out);
 void mm_poller_destroy(mm_poller_t poller);
 mm_err_t
@@ -286,7 +286,9 @@ void mm_actor_die(mm_actor_t actor, mm_msg_part_t reason);
  * reason]
  * where reason is "actor died".
  *
- * On success, writes the new handle to `*out`.
+ * On success, writes the monitor handle (an id scoped to `actor`) to `*out`.
+ * Pass it back to mm_monitor_handle_cancel(actor, handle) to cancel; there is
+ * nothing to free.
  *
  * Non-existence timeout
  * ---------------------
@@ -323,13 +325,17 @@ mm_err_t mm_actor_monitor(
  */
 
 /*
- * Cancel the monitor.
+ * Cancel the monitor identified by `handle` on `actor` (the actor that created
+ * it via mm_actor_monitor).
  *
  * The failure message will no longer be delivered after this call. If there
  * is one still undelivered in the internal queue it will be dropped before
  * delivery on mm_poller_next().
+ *
+ * The handle owns nothing, so cancelling is optional: discarding a handle
+ * simply leaves the monitor active.
  */
-void mm_monitor_handle_cancel(mm_monitor_handle_t handle);
+void mm_monitor_handle_cancel(mm_actor_t actor, mm_monitor_handle_t handle);
 
 /* ---------------------------------------------------------------------------
  * Poller

--- a/monarch_mini/python/minimonarch.c
+++ b/monarch_mini/python/minimonarch.c
@@ -108,7 +108,8 @@ typedef struct {
 } Actor;
 
 typedef struct {
-  PyObject_HEAD mm_monitor_handle_t handle;
+  PyObject_HEAD PyObject* actor; // creating Actor (strong ref; owns mm_actor_t)
+  mm_monitor_handle_t handle; // monitor id (owns nothing)
 } MonitorHandle;
 
 // ---------------------------------------------------------------------------
@@ -1132,7 +1133,7 @@ static PyObject* Actor_monitor(Actor* self, PyObject* args, PyObject* kwds) {
     failure_ptr = &failure_msg;
   }
 
-  mm_monitor_handle_t handle = NULL;
+  mm_monitor_handle_t handle = 0;
   mm_err_t err = mm_actor_monitor(
       self->actor,
       to_monitor,
@@ -1148,6 +1149,8 @@ static PyObject* Actor_monitor(Actor* self, PyObject* args, PyObject* kwds) {
   if (!mh) {
     return NULL;
   }
+  Py_INCREF(self);
+  mh->actor = (PyObject*)self;
   mh->handle = handle;
   return (PyObject*)mh;
 }
@@ -1197,14 +1200,18 @@ static PyTypeObject ActorType = {
 static PyObject* MonitorHandle_cancel(
     MonitorHandle* self,
     PyObject* Py_UNUSED(ignored)) {
-  if (self->handle) {
-    mm_monitor_handle_cancel(self->handle);
-    self->handle = NULL;
+  if (self->actor) {
+    mm_monitor_handle_cancel(((Actor*)self->actor)->actor, self->handle);
+    // Release the actor and mark cancelled so repeat calls are no-ops.
+    Py_CLEAR(self->actor);
   }
   Py_RETURN_NONE;
 }
 
+// Dropping the handle does NOT cancel the monitor (it stays active); we only
+// release our reference to the actor.
 static void MonitorHandle_dealloc(MonitorHandle* self) {
+  Py_XDECREF(self->actor);
   Py_TYPE(self)->tp_free((PyObject*)self);
 }
 

--- a/monarch_mini/rust/build.rs
+++ b/monarch_mini/rust/build.rs
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Links minimonarch as an opaque native library over its C ABI.
+//!
+//! minimonarch is declared as a `staticlib` artifact dependency (see
+//! Cargo.toml), so cargo builds its self-contained `libmonarch_mini-*.a` — whose
+//! only exported symbols are the `mm_*` C ABI, with its std and tokio bundled
+//! and internalized — and hands us its path via an env var. We link that archive
+//! directly. The outer program cannot tell minimonarch is implemented in Rust
+//! and shares no runtime state with it (own allocator, panic runtime, and
+//! thread-locals). This is the same archive the Python and C consumers link.
+
+use std::path::PathBuf;
+
+fn main() {
+    // cargo (with -Z bindeps) sets this to the built `.a` for the staticlib
+    // artifact dependency `monarch_mini`.
+    let archive = PathBuf::from(
+        std::env::var("CARGO_STATICLIB_FILE_MONARCH_MINI_monarch_mini")
+            .or_else(|_| std::env::var("CARGO_STATICLIB_FILE_MONARCH_MINI"))
+            .expect("cargo should provide the monarch_mini staticlib artifact path"),
+    );
+    let dir = archive
+        .parent()
+        .expect("artifact path should have a parent directory");
+    // The artifact is named `libmonarch_mini-<hash>.a`, so link it by its exact
+    // file name via the `verbatim` modifier rather than the `-lmonarch_mini`
+    // naming convention.
+    let file_name = archive
+        .file_name()
+        .expect("artifact path should have a file name")
+        .to_str()
+        .expect("artifact file name should be valid UTF-8");
+
+    println!("cargo:rustc-link-search=native={}", dir.display());
+    println!("cargo:rustc-link-lib=static:+verbatim={file_name}");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/monarch_mini/rust/examples/hello.rs
+++ b/monarch_mini/rust/examples/hello.rs
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! minimonarch hello world in Rust, mirroring `examples/hello.c`.
+//!
+//! Creates a parent and child actor over an `inproc://` connection and passes a
+//! message each way. Run with `cargo run -p monarch_mini_rs --example hello`.
+
+use monarch_mini_rs::Context;
+use monarch_mini_rs::Part;
+use monarch_mini_rs::Role;
+
+// A single-threaded runtime suffices — minimonarch runs its own runtime inside
+// its native library, so nothing here requires a multi-threaded executor.
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> monarch_mini_rs::Result<()> {
+    let ctx = Context::new()?;
+
+    let parent = ctx.actor(Some(b"hello-actor"), /*gateway=*/ true)?;
+    let child = ctx.actor(Some(b"child-actor"), /*gateway=*/ false)?;
+
+    let mut parent_poller = ctx.poller()?;
+    parent_poller.subscribe(0, &parent)?;
+    let mut child_poller = ctx.poller()?;
+    child_poller.subscribe(0, &child)?;
+
+    // Send a message to self before anyone is listening; the actor buffers it.
+    parent.send(b"hello-actor", vec![Part::copy_from(b"hello, self")])?;
+    let (_, parts) = parent_poller.recv().await?;
+    println!("received: {}", String::from_utf8_lossy(parts[0].as_bytes()));
+
+    // Establish the parent/child link over inproc.
+    let url = "inproc://hello-child";
+    parent.serve(url, Role::Parent, None, &[], &[])?;
+    child.join(url, Role::Child, None, &[], &[])?;
+
+    let (_, parts) = parent_poller.recv().await?;
+    println!(
+        "parent joined: {} -> {}",
+        String::from_utf8_lossy(parts[0].as_bytes()),
+        String::from_utf8_lossy(parts[1].as_bytes()),
+    );
+    let (_, parts) = child_poller.recv().await?;
+    println!(
+        "child joined: {} -> {}",
+        String::from_utf8_lossy(parts[0].as_bytes()),
+        String::from_utf8_lossy(parts[1].as_bytes()),
+    );
+
+    // Parent -> child, then child -> parent.
+    parent.send(b"child-actor", vec![Part::copy_from(b"hello, child")])?;
+    let (_, parts) = child_poller.recv().await?;
+    println!(
+        "child received: {}",
+        String::from_utf8_lossy(parts[0].as_bytes())
+    );
+
+    child.send(b"hello-actor", vec![Part::copy_from(b"hello, parent")])?;
+    let (_, parts) = parent_poller.recv().await?;
+    println!(
+        "parent received: {}",
+        String::from_utf8_lossy(parts[0].as_bytes())
+    );
+
+    Ok(())
+}

--- a/monarch_mini/rust/src/ffi.rs
+++ b/monarch_mini/rust/src/ffi.rs
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Raw, `unsafe` FFI declarations for the minimonarch C ABI.
+//!
+//! These mirror `monarch_mini/minimonarch.h` verbatim: same layout, same
+//! function signatures, same error codes. This is the *only* place that talks
+//! to the C symbols; the safe wrappers in [`crate`] are built exclusively on
+//! top of these declarations so the bindings go through the stable C ABI rather
+//! than the internal Rust implementation.
+//!
+//! Nothing here is safe to call directly — the layout contracts (valid
+//! pointers, ownership transfer of `mm_msg_part_t`, single-threaded poller use)
+//! are documented on the safe wrappers.
+
+#![expect(non_camel_case_types, reason = "mirror the C ABI type names exactly")]
+
+use std::ffi::c_char;
+use std::ffi::c_int;
+use std::ffi::c_void;
+
+/// A single part of a multipart message (mirrors `mm_msg_part_t`).
+///
+/// Ownership of the buffer is transferred *by value* into the runtime on
+/// `mm_actor_send`/`mm_actor_serve`/etc.: after the call the runtime invokes
+/// `deleter(deleter_ctx)` exactly once when the bytes are no longer needed.
+#[repr(C)]
+pub struct mm_msg_part_t {
+    pub data: *const c_void,
+    pub len: usize,
+    /// Called with `deleter_ctx` when this part's memory may be freed. May be
+    /// `None` (NULL in C) for borrowed data with no owned storage.
+    pub deleter: Option<unsafe extern "C" fn(ctx: *mut c_void)>,
+    pub deleter_ctx: *mut c_void,
+}
+
+/// A complete multipart message: an array of `n_parts` parts (mirrors `mm_msg_t`).
+#[repr(C)]
+pub struct mm_msg_t {
+    pub parts: *mut mm_msg_part_t,
+    pub n_parts: usize,
+}
+
+// Opaque handle types. The C header exposes these only as pointers.
+pub enum mm_ctx {}
+pub enum mm_actor {}
+pub enum mm_poller {}
+
+/// A monitor handle is just an opaque integer id, scoped to its actor (mirrors
+/// `mm_monitor_handle_t`). It owns nothing.
+pub type mm_monitor_handle_t = u64;
+
+/// This actor's role in a serve/join pair (mirrors `mm_role_t`).
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum mm_role_t {
+    Child = 0,
+    Parent = 1,
+}
+
+/// Arguments shared by `mm_actor_serve` and `mm_actor_join` (mirrors
+/// `mm_connect_args_t`).
+#[repr(C)]
+pub struct mm_connect_args_t {
+    pub role: mm_role_t,
+    /// Optional: assign a name to the remote actor (NULL to skip). Transferred
+    /// by value like any other part.
+    pub name_for_other: *mut mm_msg_part_t,
+    /// Prefix for the connection-established message (NULL for none).
+    pub hello_prefix: *const mm_msg_t,
+    /// Prefix for connection-failure messages (NULL for none).
+    pub failure_prefix: *const mm_msg_t,
+}
+
+/// Result code returned by the fallible `mm_*` functions (mirrors `mm_err_t`).
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[expect(
+    dead_code,
+    reason = "variants are produced by the C ABI across the FFI boundary and matched on, not constructed in Rust"
+)]
+pub enum mm_err_t {
+    /// Success.
+    Ok = 0,
+    /// No message available (`mm_poller_next`).
+    NoMsg = 1,
+    /// Parts buffer too small; `n_parts_out` holds the required size.
+    BufSz = -1,
+    /// Internal error; see `mm_last_error`.
+    Internal = -2,
+}
+
+unsafe extern "C" {
+    pub fn mm_last_error() -> *const c_char;
+
+    pub fn mm_ctx_create(out: *mut *mut mm_ctx) -> mm_err_t;
+    pub fn mm_ctx_destroy(ctx: *mut mm_ctx);
+
+    pub fn mm_actor_create(
+        ctx: *mut mm_ctx,
+        ident: *mut mm_msg_part_t,
+        gateway: bool,
+        out: *mut *mut mm_actor,
+    ) -> mm_err_t;
+    pub fn mm_actor_destroy(actor: *mut mm_actor);
+    pub fn mm_actor_send(
+        actor: *mut mm_actor,
+        receiver_ident: mm_msg_part_t,
+        msg: *const mm_msg_t,
+    ) -> mm_err_t;
+    pub fn mm_actor_serve(
+        actor: *mut mm_actor,
+        url: *const c_char,
+        args: *const mm_connect_args_t,
+    ) -> mm_err_t;
+    pub fn mm_actor_join(
+        actor: *mut mm_actor,
+        url: *const c_char,
+        args: *const mm_connect_args_t,
+    ) -> mm_err_t;
+    pub fn mm_actor_die(actor: *mut mm_actor, reason: mm_msg_part_t);
+    pub fn mm_actor_monitor(
+        actor: *mut mm_actor,
+        to_monitor_ident: mm_msg_part_t,
+        failure_prefix: *const mm_msg_t,
+        timeout_for_nonexistence: u64,
+        out: *mut mm_monitor_handle_t,
+    ) -> mm_err_t;
+
+    pub fn mm_monitor_handle_cancel(actor: *mut mm_actor, handle: mm_monitor_handle_t);
+
+    pub fn mm_poller_create(
+        ctx: *mut mm_ctx,
+        fd_out: *mut c_int,
+        out: *mut *mut mm_poller,
+    ) -> mm_err_t;
+    pub fn mm_poller_destroy(poller: *mut mm_poller);
+    pub fn mm_poller_subscribe(
+        poller: *mut mm_poller,
+        index: usize,
+        actor: *mut mm_actor,
+    ) -> mm_err_t;
+    pub fn mm_poller_unsubscribe(poller: *mut mm_poller, index: usize);
+    pub fn mm_poller_next(
+        poller: *mut mm_poller,
+        index_out: *mut usize,
+        parts: *mut mm_msg_part_t,
+        parts_cap: usize,
+        n_parts_out: *mut usize,
+    ) -> mm_err_t;
+}

--- a/monarch_mini/rust/src/lib.rs
+++ b/monarch_mini/rust/src/lib.rs
@@ -1,0 +1,763 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Safe Rust bindings for the minimonarch C ABI.
+//!
+//! This crate is the Rust analogue of the Python bindings (`minimonarch.pyi`):
+//! a thin, idiomatic wrapper over the stable C ABI declared in
+//! [`minimonarch.h`]. Every call goes through the C ABI (see [`ffi`]) — the
+//! bindings never reach into the internal Rust implementation — so the ABI
+//! contract, and long-term compatibility, is the same one C and Python callers
+//! depend on.
+//!
+//! # Shape
+//!
+//! Unlike Python, Rust has no ambient event loop, so the context and poller the
+//! Python API hides are explicit here:
+//!
+//! - [`Context`] owns the runtime (one background event loop). Handles are
+//!   plain owned values with no borrows tying them to it; dropping the context
+//!   tears the runtime down, and any later use of an [`Actor`] simply returns
+//!   an error rather than misbehaving.
+//! - [`Actor`] is an addressable endpoint: [`send`](Actor::send),
+//!   [`serve`](Actor::serve), [`join`](Actor::join), [`die`](Actor::die),
+//!   [`monitor`](Actor::monitor).
+//! - [`Poller`] drives message delivery. Subscribe actors to it, then drain
+//!   with [`try_recv`](Poller::try_recv) (non-blocking) or [`recv`](Poller::recv)
+//!   (blocks on the wakeup fd), integrating with any fd-based event loop via
+//!   [`fd`](Poller::fd).
+//! - [`Part`] is a multipart-message segment. It owns its bytes (like
+//!   `minimonarch.bytearray`) and can be *moved* into a message zero-copy —
+//!   including forwarding a received part without copying.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use monarch_mini_rs::Context;
+//! use monarch_mini_rs::Part;
+//! use monarch_mini_rs::Role;
+//!
+//! # async fn example() -> Result<(), monarch_mini_rs::Error> {
+//! let ctx = Context::new()?;
+//! let actor = ctx.actor(Some(b"hello-actor"), /*gateway=*/ true)?;
+//!
+//! let mut poller = ctx.poller()?;
+//! poller.subscribe(0, &actor)?;
+//!
+//! actor.send(b"hello-actor", vec![Part::copy_from(b"hello, self")])?;
+//! let (index, parts) = poller.recv().await?;
+//! assert_eq!(index, 0);
+//! assert_eq!(parts[0].as_bytes(), b"hello, self");
+//! # Ok(())
+//! # }
+//! ```
+
+mod ffi;
+
+// The `mm_*` C ABI symbols are resolved by statically linking minimonarch's
+// self-contained native archive (`libmonarch_mini-*.a`); see build.rs. It is an
+// opaque native library — its std and tokio are bundled and internalized, so
+// from this crate's point of view it is indistinguishable from a C library, and
+// its runtime is fully isolated from ours (no shared allocator, panic runtime,
+// or thread-local state).
+
+use std::ffi::CString;
+use std::ffi::c_void;
+use std::os::fd::AsRawFd;
+use std::os::fd::RawFd;
+
+use ffi::mm_msg_part_t;
+use ffi::mm_msg_t;
+use tokio::io::unix::AsyncFd;
+
+/// An error from the minimonarch runtime, carrying the C ABI's last-error
+/// string for the failing call.
+#[derive(Debug, thiserror::Error)]
+#[error("minimonarch: {0}")]
+pub struct Error(String);
+
+/// Result alias for the fallible bindings API.
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+    /// Capture the current thread's last-error string from the C ABI.
+    fn last() -> Self {
+        // SAFETY: `mm_last_error` returns a valid NUL-terminated pointer owned
+        // by the runtime, valid until the next `mm_*` call on this thread; we
+        // copy it out immediately.
+        let ptr = unsafe { ffi::mm_last_error() };
+        let msg = if ptr.is_null() {
+            String::new()
+        } else {
+            // SAFETY: `ptr` is a valid C string per the ABI contract above.
+            unsafe { std::ffi::CStr::from_ptr(ptr) }
+                .to_string_lossy()
+                .into_owned()
+        };
+        Error(msg)
+    }
+}
+
+/// Translate a `mm_err_t` from a fallible non-poller call into a `Result`.
+fn check(err: ffi::mm_err_t) -> Result<()> {
+    match err {
+        ffi::mm_err_t::Ok => Ok(()),
+        _ => Err(Error::last()),
+    }
+}
+
+// A few C calls (`mm_ctx_destroy`, `mm_actor_create`, `mm_poller_create`,
+// `mm_poller_subscribe`) block briefly for a round-trip to minimonarch's own
+// runtime thread. minimonarch is linked as an opaque native library (a static
+// archive with its own std/tokio; see build.rs), so that wait is invisible to
+// the caller's async runtime — there is no shared thread-local runtime context to
+// trip over. These calls therefore just block the calling thread, exactly like
+// any synchronous C function, on any runtime flavor and with no special
+// handling. (The same round-trip is what the Python bindings block the asyncio
+// loop thread for.)
+
+/// This actor's role in a serve/join pair. Exactly one side of a connection
+/// must be [`Role::Parent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// This actor becomes the parent of the remote actor.
+    Parent,
+    /// This actor becomes the child of the remote actor.
+    Child,
+}
+
+impl From<Role> for ffi::mm_role_t {
+    fn from(role: Role) -> Self {
+        match role {
+            Role::Parent => ffi::mm_role_t::Parent,
+            Role::Child => ffi::mm_role_t::Child,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Part
+// ---------------------------------------------------------------------------
+
+/// A single part of a multipart message: an owned byte buffer.
+///
+/// A `Part` owns its storage through a C-style deleter, mirroring
+/// `minimonarch.bytearray`. It is either bytes allocated on the Rust side or a
+/// buffer adopted from a received message (possibly backed by a shared-memory
+/// slab). Either way, sending a `Part` *moves* it into the message zero-copy —
+/// so a received part can be forwarded onward without copying its bytes.
+///
+/// `Part` is intentionally neither `Send` nor `Sync`: parts are built and
+/// consumed inline with a [`send`](Actor::send) or drained from a [`Poller`],
+/// so they never need to cross a thread boundary on their own.
+pub struct Part {
+    data: *const c_void,
+    len: usize,
+    deleter: Option<unsafe extern "C" fn(*mut c_void)>,
+    deleter_ctx: *mut c_void,
+}
+
+/// Deleter for a `Part` backed by a Rust `Box<Vec<u8>>`.
+unsafe extern "C" fn drop_boxed_vec(ctx: *mut c_void) {
+    // SAFETY: `ctx` was produced by `Part::from_vec` via
+    // `Box::into_raw(Box<Vec<u8>>)`, installed as the sole deleter, so it runs
+    // exactly once here.
+    unsafe {
+        drop(Box::from_raw(ctx.cast::<Vec<u8>>()));
+    }
+}
+
+impl Part {
+    /// An empty part.
+    pub fn empty() -> Self {
+        Part {
+            data: std::ptr::null(),
+            len: 0,
+            deleter: None,
+            deleter_ctx: std::ptr::null_mut(),
+        }
+    }
+
+    /// Take ownership of `bytes`, moving it into a part with no copy of the
+    /// underlying buffer.
+    pub fn from_vec(bytes: Vec<u8>) -> Self {
+        if bytes.is_empty() {
+            return Part::empty();
+        }
+        let boxed = Box::new(bytes);
+        let data = boxed.as_ptr().cast();
+        let len = boxed.len();
+        Part {
+            data,
+            len,
+            deleter: Some(drop_boxed_vec),
+            deleter_ctx: Box::into_raw(boxed).cast(),
+        }
+    }
+
+    /// Copy `bytes` into a new owned part.
+    pub fn copy_from(bytes: &[u8]) -> Self {
+        Part::from_vec(bytes.to_vec())
+    }
+
+    /// The part's bytes.
+    pub fn as_bytes(&self) -> &[u8] {
+        if self.data.is_null() || self.len == 0 {
+            return &[];
+        }
+        // SAFETY: `data`/`len` describe a buffer this part owns for its whole
+        // lifetime (Rust-allocated or adopted from a received part); we only
+        // read it immutably.
+        unsafe { std::slice::from_raw_parts(self.data.cast::<u8>(), self.len) }
+    }
+
+    /// The part's length in bytes.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Whether the part is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Copy the part's bytes into an owned `Vec`.
+    pub fn to_vec(&self) -> Vec<u8> {
+        self.as_bytes().to_vec()
+    }
+
+    /// Adopt a raw part handed back from the C ABI (a received message part),
+    /// taking over its buffer and deleter.
+    ///
+    /// # Safety
+    /// `raw` must be a part just produced by the runtime (e.g. via
+    /// `mm_poller_next`) whose ownership is being transferred exactly once.
+    unsafe fn from_raw(raw: mm_msg_part_t) -> Self {
+        Part {
+            data: raw.data,
+            len: raw.len,
+            deleter: raw.deleter,
+            deleter_ctx: raw.deleter_ctx,
+        }
+    }
+
+    /// Transfer ownership of the buffer to the C ABI, suppressing this part's
+    /// drop so the deleter runs once, on the runtime side.
+    fn into_raw(self) -> mm_msg_part_t {
+        let me = std::mem::ManuallyDrop::new(self);
+        mm_msg_part_t {
+            data: me.data,
+            len: me.len,
+            deleter: me.deleter,
+            deleter_ctx: me.deleter_ctx,
+        }
+    }
+}
+
+impl Drop for Part {
+    fn drop(&mut self) {
+        if let Some(deleter) = self.deleter {
+            // SAFETY: `deleter_ctx` was paired with `deleter` at construction
+            // and this is the sole owner, so the deleter runs exactly once.
+            unsafe { deleter(self.deleter_ctx) };
+        }
+    }
+}
+
+impl From<Vec<u8>> for Part {
+    fn from(bytes: Vec<u8>) -> Self {
+        Part::from_vec(bytes)
+    }
+}
+
+impl From<&[u8]> for Part {
+    fn from(bytes: &[u8]) -> Self {
+        Part::copy_from(bytes)
+    }
+}
+
+/// A borrowed multipart message: a temporary `Vec<mm_msg_part_t>` that keeps
+/// the parts' ownership until the C call consumes them. Dropping it *without*
+/// leaking runs every remaining part's deleter, so it is always leaked
+/// (`ManuallyDrop`) once handed to a C call that takes ownership.
+struct RawParts {
+    parts: Vec<mm_msg_part_t>,
+}
+
+impl RawParts {
+    /// Move `parts` into their raw C representation.
+    fn new(parts: Vec<Part>) -> Self {
+        RawParts {
+            parts: parts.into_iter().map(Part::into_raw).collect(),
+        }
+    }
+
+    /// Build owned copies of a slice of byte-slice prefixes.
+    fn copied(prefix: &[&[u8]]) -> Self {
+        RawParts::new(prefix.iter().map(|b| Part::copy_from(b)).collect())
+    }
+
+    fn as_msg(&mut self) -> mm_msg_t {
+        mm_msg_t {
+            parts: self.parts.as_mut_ptr(),
+            n_parts: self.parts.len(),
+        }
+    }
+}
+
+impl Drop for RawParts {
+    fn drop(&mut self) {
+        // Run each not-yet-consumed part's deleter by rehydrating it as a
+        // `Part`. Only reached if a C call was *not* made (e.g. an error before
+        // the send); a successful call transfers ownership and this drains an
+        // already-empty vec.
+        for raw in self.parts.drain(..) {
+            // SAFETY: each `raw` came from `Part::into_raw`, so reconstructing
+            // the owning `Part` restores the single-owner invariant.
+            drop(unsafe { Part::from_raw(raw) });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+/// The minimonarch runtime for a process: a single background event loop plus
+/// the actors and pollers created from it.
+///
+/// A `Context` is a handle to that event loop; every operation is dispatched to
+/// it over an internal channel, so the handle is safe to move and share across
+/// threads.
+pub struct Context {
+    ptr: *mut ffi::mm_ctx,
+}
+
+// SAFETY: a `Context` handle only ever forwards commands to the runtime over an
+// internal `Send + Sync` channel and blocks on a reply; it holds no
+// thread-affine state, so it is safe to move between threads (`Send`) and to
+// share (`Sync`) — concurrent creates each use their own reply channel.
+unsafe impl Send for Context {}
+unsafe impl Sync for Context {}
+
+impl Context {
+    /// Create a new context and its background event loop.
+    pub fn new() -> Result<Self> {
+        let mut ptr: *mut ffi::mm_ctx = std::ptr::null_mut();
+        // SAFETY: `out` points to a valid slot we own; on `Ok` it is populated
+        // with a context pointer we take ownership of.
+        check(unsafe { ffi::mm_ctx_create(&mut ptr) })?;
+        Ok(Context { ptr })
+    }
+
+    /// Create an actor bound to this context.
+    ///
+    /// `ident` must be unique across the whole run; if `None`, a name must be
+    /// assigned by the peer in a later `serve`/`join`. `gateway` declares the
+    /// actor as the entry point for its process group (no parent or a network
+    /// parent); it is fixed at creation.
+    pub fn actor(&self, ident: Option<&[u8]>, gateway: bool) -> Result<Actor> {
+        // Keep the ident part alive across the call; the runtime takes ownership
+        // of it (like every other part) when a name is supplied.
+        let mut ident_raw = ident.map(|b| Part::copy_from(b).into_raw());
+        let ident_ptr = ident_raw
+            .as_mut()
+            .map_or(std::ptr::null_mut(), |p| p as *mut mm_msg_part_t);
+
+        let mut ptr: *mut ffi::mm_actor = std::ptr::null_mut();
+        // SAFETY: `self.ptr` is a live context; `ident_ptr` is either null or a
+        // valid part whose ownership transfers to the runtime; `out` is ours.
+        let err = unsafe { ffi::mm_actor_create(self.ptr, ident_ptr, gateway, &mut ptr) };
+        check(err)?;
+        Ok(Actor { ptr })
+    }
+
+    /// Create a [`Poller`] bound to this context.
+    pub fn poller(&self) -> Result<Poller> {
+        let mut ptr: *mut ffi::mm_poller = std::ptr::null_mut();
+        let mut fd: RawFd = -1;
+        // SAFETY: `self.ptr` is a live context; `fd_out` and `out` point to slots
+        // we own and are populated on success.
+        let err = unsafe { ffi::mm_poller_create(self.ptr, &mut fd, &mut ptr) };
+        check(err)?;
+        Ok(Poller {
+            ptr,
+            fd,
+            async_fd: None,
+        })
+    }
+}
+
+impl Drop for Context {
+    fn drop(&mut self) {
+        // SAFETY: `self.ptr` is a live context we own; this consumes it,
+        // flushing pending messages and joining minimonarch's runtime thread.
+        // Actors/pollers are self-contained C handles that stay safe to drop
+        // afterwards (they each hold their own runtime sender), so no
+        // drop-ordering relationship with them is required.
+        unsafe { ffi::mm_ctx_destroy(self.ptr) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Actor
+// ---------------------------------------------------------------------------
+
+/// An addressable messaging endpoint, created from a [`Context`].
+///
+/// An `Actor` is a plain owned handle: it may outlive its [`Context`], and any
+/// method called after the context is dropped returns an error rather than
+/// misbehaving.
+pub struct Actor {
+    ptr: *mut ffi::mm_actor,
+}
+
+// SAFETY: every `Actor` method takes `&self` and only forwards a command to the
+// runtime over its internal `Send + Sync` channel (monitor-id allocation uses an
+// atomic), so an `Actor` is safe to move between threads (`Send`) and to call
+// concurrently from several threads (`Sync`) — the classic "send from many
+// threads" pattern.
+unsafe impl Send for Actor {}
+unsafe impl Sync for Actor {}
+
+impl Actor {
+    /// Send a multipart message to `receiver`. Each [`Part`] is moved into the
+    /// message; `receiver` is copied.
+    pub fn send(&self, receiver: &[u8], parts: Vec<Part>) -> Result<()> {
+        let mut raw = RawParts::new(parts);
+        let msg = raw.as_msg();
+        let receiver_raw = Part::copy_from(receiver).into_raw();
+        // SAFETY: `self.ptr` is a live actor. `receiver_raw` and every part in
+        // `msg` are valid owned parts whose ownership transfers to the runtime
+        // (which always consumes them, even on error), so we leak `raw` to
+        // avoid double-freeing.
+        let err = unsafe { ffi::mm_actor_send(self.ptr, receiver_raw, &msg) };
+        std::mem::forget(raw);
+        check(err)
+    }
+
+    /// Serve (listen) on `url`, taking `role` in the resulting pair.
+    ///
+    /// On success this actor is later delivered `[hello..., self, other]`; on
+    /// failure `[failure..., other, reason]`. `name` optionally assigns a name
+    /// to the peer. See [`Actor::join`] for the joining side.
+    pub fn serve(
+        &self,
+        url: &str,
+        role: Role,
+        name: Option<&[u8]>,
+        hello: &[&[u8]],
+        failure: &[&[u8]],
+    ) -> Result<()> {
+        self.connect(url, role, name, hello, failure, ffi::mm_actor_serve)
+    }
+
+    /// Join (connect to) `url`, taking `role` in the resulting pair. See
+    /// [`Actor::serve`] for the semantics of the arguments.
+    pub fn join(
+        &self,
+        url: &str,
+        role: Role,
+        name: Option<&[u8]>,
+        hello: &[&[u8]],
+        failure: &[&[u8]],
+    ) -> Result<()> {
+        self.connect(url, role, name, hello, failure, ffi::mm_actor_join)
+    }
+
+    /// Shared implementation of `serve`/`join`, which take identical arguments.
+    fn connect(
+        &self,
+        url: &str,
+        role: Role,
+        name: Option<&[u8]>,
+        hello: &[&[u8]],
+        failure: &[&[u8]],
+        // `serve` and `join` have the same signature; pick one.
+        call: unsafe extern "C" fn(
+            *mut ffi::mm_actor,
+            *const std::ffi::c_char,
+            *const ffi::mm_connect_args_t,
+        ) -> ffi::mm_err_t,
+    ) -> Result<()> {
+        let curl = CString::new(url).map_err(|e| Error(e.to_string()))?;
+
+        let mut name_raw = name.map(|b| Part::copy_from(b).into_raw());
+        let name_ptr = name_raw
+            .as_mut()
+            .map_or(std::ptr::null_mut(), |p| p as *mut mm_msg_part_t);
+
+        let mut hello_raw = RawParts::copied(hello);
+        let mut failure_raw = RawParts::copied(failure);
+        let hello_msg = hello_raw.as_msg();
+        let failure_msg = failure_raw.as_msg();
+
+        let args = ffi::mm_connect_args_t {
+            role: role.into(),
+            name_for_other: name_ptr,
+            hello_prefix: &hello_msg,
+            failure_prefix: &failure_msg,
+        };
+        // SAFETY: `self.ptr` is a live actor; `curl` is a valid NUL-terminated
+        // string; `args` and the parts it references are valid for the call,
+        // and the runtime takes ownership of the (owned) parts.
+        let err = unsafe { call(self.ptr, curl.as_ptr(), &args) };
+        std::mem::forget(hello_raw);
+        std::mem::forget(failure_raw);
+        check(err)
+    }
+
+    /// Signal that this actor is dead to its parent, children, and monitors.
+    /// `reason` is a UTF-8 string explaining why.
+    pub fn die(&self, reason: &[u8]) {
+        let reason_raw = Part::copy_from(reason).into_raw();
+        // SAFETY: `self.ptr` is a live actor; `reason_raw` is a valid owned part
+        // whose ownership transfers to the runtime.
+        unsafe { ffi::mm_actor_die(self.ptr, reason_raw) };
+    }
+
+    /// Monitor `ident`. If it dies (or is already dead), this actor is sent
+    /// `[failure..., ident, b"actor died"]`.
+    ///
+    /// If `timeout_for_nonexistence` is non-zero and `ident` is still not known
+    /// anywhere after that many milliseconds, the monitor fires once with
+    /// reason `b"actor does not exist"` and is consumed. `0` disables the
+    /// timeout. Only the first monitor on a given target arms a timeout.
+    pub fn monitor(
+        &self,
+        ident: &[u8],
+        failure: &[&[u8]],
+        timeout_for_nonexistence: u64,
+    ) -> Result<MonitorHandle> {
+        let ident_raw = Part::copy_from(ident).into_raw();
+        let mut failure_raw = RawParts::copied(failure);
+        let failure_msg = failure_raw.as_msg();
+
+        let mut handle: ffi::mm_monitor_handle_t = 0;
+        // SAFETY: `self.ptr` is a live actor; `ident_raw` and the failure parts
+        // are valid owned parts transferred to the runtime; `out` is ours.
+        let err = unsafe {
+            ffi::mm_actor_monitor(
+                self.ptr,
+                ident_raw,
+                &failure_msg,
+                timeout_for_nonexistence,
+                &mut handle,
+            )
+        };
+        std::mem::forget(failure_raw);
+        check(err)?;
+        Ok(MonitorHandle { handle })
+    }
+
+    /// Cancel `monitor`, which must have been created by this actor. Its failure
+    /// message will no longer be delivered, and any already-queued failure is dropped
+    /// before delivery. Consumes the handle; dropping it instead leaves the monitor
+    /// active.
+    pub fn cancel_monitor(&self, monitor: MonitorHandle) {
+        // SAFETY: `self.ptr` is a live actor, and `monitor.handle` is an opaque monitor
+        // id consumed by this call. The cancel is addressed by (actor, id) and frees
+        // nothing.
+        unsafe { ffi::mm_monitor_handle_cancel(self.ptr, monitor.handle) };
+    }
+
+    /// The raw actor pointer, for [`Poller::subscribe`].
+    fn as_ptr(&self) -> *mut ffi::mm_actor {
+        self.ptr
+    }
+}
+
+impl Drop for Actor {
+    fn drop(&mut self) {
+        // SAFETY: `self.ptr` is a live actor we own; this consumes it.
+        unsafe { ffi::mm_actor_destroy(self.ptr) };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// MonitorHandle
+// ---------------------------------------------------------------------------
+
+/// Handle to a registered monitor, analogous to a [`tokio::task::JoinHandle`]:
+/// **dropping it does not cancel the monitor** — it detaches, and the monitor
+/// keeps running (it will still fire on the target's death/absence). Keep the
+/// handle only if you may want to pass it to [`Actor::cancel_monitor`] later.
+///
+/// (Consistent with the Python bindings, whose handle also does not cancel on
+/// GC.) The handle owns nothing — it is just the monitor's id — so dropping it
+/// is free and leaks nothing.
+pub struct MonitorHandle {
+    handle: ffi::mm_monitor_handle_t,
+}
+
+// No `Drop` impl: dropping a `MonitorHandle` detaches (JoinHandle semantics) and
+// must not cancel the monitor.
+
+// ---------------------------------------------------------------------------
+// Poller
+// ---------------------------------------------------------------------------
+
+/// Drives message delivery for a set of subscribed actors, integrating with a
+/// Tokio runtime.
+///
+/// [`recv`](Poller::recv) is `async`: it awaits the poller's wakeup fd on the
+/// caller's Tokio reactor (via [`AsyncFd`]), draining delivered messages — the
+/// same fd-reader model the Python bindings install on the asyncio loop.
+///
+/// Unlike [`Context`] and [`Actor`], a `Poller` is `Send` but **not** `Sync`:
+/// the C ABI requires that calls on a single poller be externally serialized.
+/// It can be owned by, or moved to, one task/thread that drives it, but it
+/// cannot be shared for concurrent use. `!Sync` (from the raw pointer) enforces
+/// this; draining still goes through `&mut self`.
+pub struct Poller {
+    ptr: *mut ffi::mm_poller,
+    fd: RawFd,
+    // The wakeup fd registered with the Tokio reactor, created lazily on the
+    // first `recv` (registration must happen inside a runtime).
+    async_fd: Option<AsyncFd<WakeupFd>>,
+}
+
+// SAFETY: a `Poller` owns only a runtime handle, a `Send` receiver, and a
+// non-thread-affine wakeup fd, so it is sound to move to another thread
+// (`Send`). It is deliberately left `!Sync` (the `*mut` field withholds the
+// auto-impl): the C ABI requires calls on one poller to be externally
+// serialized, so it must not be shared for concurrent access.
+unsafe impl Send for Poller {}
+
+/// Borrows the poller's wakeup fd for Tokio registration *without owning it* —
+/// the fd belongs to the poller (the C ABI says not to close it), and dropping
+/// a `RawFd` does nothing, so the `AsyncFd` only registers/deregisters it.
+struct WakeupFd(RawFd);
+
+impl AsRawFd for WakeupFd {
+    fn as_raw_fd(&self) -> RawFd {
+        self.0
+    }
+}
+
+impl Poller {
+    /// The wakeup file descriptor. It becomes readable when more delivered
+    /// messages may exist; suitable for `select`/`poll`/`epoll`. Owned by the
+    /// poller — do not close it.
+    pub fn fd(&self) -> RawFd {
+        self.fd
+    }
+
+    /// Watch `actor` for incoming messages, associating it with `index`. An
+    /// actor may be subscribed to at most one poller at a time.
+    pub fn subscribe(&self, index: usize, actor: &Actor) -> Result<()> {
+        // SAFETY: `self.ptr` and `actor` are live handles into the same runtime.
+        check(unsafe { ffi::mm_poller_subscribe(self.ptr, index, actor.as_ptr()) })
+    }
+
+    /// Stop watching the actor previously assigned `index`.
+    pub fn unsubscribe(&self, index: usize) {
+        // SAFETY: `self.ptr` is a live poller we own.
+        unsafe { ffi::mm_poller_unsubscribe(self.ptr, index) };
+    }
+
+    /// Read the next delivered message without blocking, returning
+    /// `Ok(Some((index, parts)))` for a message, or `Ok(None)` if none is
+    /// available. Arms the wakeup [`fd`](Poller::fd) when it returns `None`.
+    pub fn try_recv(&mut self) -> Result<Option<(usize, Vec<Part>)>> {
+        // Grow the parts buffer on demand: `mm_poller_next` reports the required
+        // size via `n_parts_out` on `BufSz` without consuming the message.
+        let mut cap = 8usize;
+        loop {
+            let mut index_out: usize = 0;
+            let mut n_parts_out: usize = 0;
+            let mut buf: Vec<mm_msg_part_t> = Vec::with_capacity(cap);
+            // SAFETY: `self.ptr` is a live poller; `buf` has `cap` writable
+            // slots; the out-params point to locals we own. On `Ok` the runtime
+            // writes `n_parts_out` parts whose ownership transfers to us.
+            let err = unsafe {
+                ffi::mm_poller_next(
+                    self.ptr,
+                    &mut index_out,
+                    buf.as_mut_ptr(),
+                    cap,
+                    &mut n_parts_out,
+                )
+            };
+            match err {
+                ffi::mm_err_t::Ok => {
+                    // SAFETY: the runtime initialized `n_parts_out` parts.
+                    unsafe { buf.set_len(n_parts_out) };
+                    let parts = buf
+                        .into_iter()
+                        // SAFETY: each part was just produced by the runtime and
+                        // its ownership transferred to us exactly once.
+                        .map(|raw| unsafe { Part::from_raw(raw) })
+                        .collect();
+                    return Ok(Some((index_out, parts)));
+                }
+                ffi::mm_err_t::NoMsg => return Ok(None),
+                ffi::mm_err_t::BufSz => {
+                    // Nothing was written or consumed; retry with a big-enough
+                    // buffer.
+                    cap = n_parts_out;
+                    continue;
+                }
+                ffi::mm_err_t::Internal => return Err(Error::last()),
+            }
+        }
+    }
+
+    /// Await the next delivered message — the Rust analogue of the Python API's
+    /// awaitable `next()`.
+    ///
+    /// Drains [`try_recv`](Poller::try_recv); when empty, awaits the poller's
+    /// wakeup fd on the current Tokio reactor and retries. Must be called from
+    /// within a Tokio runtime (the fd is registered lazily on first use).
+    pub async fn recv(&mut self) -> Result<(usize, Vec<Part>)> {
+        loop {
+            if let Some(message) = self.try_recv()? {
+                return Ok(message);
+            }
+            // `try_recv` drained the wakeup fd and armed the poller; await the
+            // runtime signalling it (an enqueued message writes the eventfd).
+            let async_fd = self.ensure_async_fd()?;
+            let mut guard = async_fd
+                .readable()
+                .await
+                .map_err(|e| Error(format!("await poller wakeup fd: {e}")))?;
+            // Readiness may be stale — `try_recv` drains the fd itself, behind
+            // the reactor's back — so clear it and re-check the channel; a real
+            // message always re-signals via a fresh edge.
+            guard.clear_ready();
+        }
+    }
+
+    /// Register the wakeup fd with the current Tokio reactor on first use.
+    fn ensure_async_fd(&mut self) -> Result<&AsyncFd<WakeupFd>> {
+        match self.async_fd {
+            Some(ref async_fd) => Ok(async_fd),
+            None => {
+                let async_fd = AsyncFd::new(WakeupFd(self.fd))
+                    .map_err(|e| Error(format!("register poller wakeup fd with tokio: {e}")))?;
+                Ok(self.async_fd.insert(async_fd))
+            }
+        }
+    }
+}
+
+impl Drop for Poller {
+    fn drop(&mut self) {
+        // Deregister the wakeup fd from the Tokio reactor *before* the C side
+        // closes it (mm_poller_destroy drops the poller's owned fd). Dropping
+        // the `AsyncFd` only removes it from the reactor; it does not close the
+        // borrowed fd.
+        self.async_fd = None;
+        // SAFETY: `self.ptr` is a live poller we own; this consumes it. The fd
+        // is owned by the poller, so we do not close it.
+        unsafe { ffi::mm_poller_destroy(self.ptr) };
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/monarch_mini/rust/src/tests.rs
+++ b/monarch_mini/rust/src/tests.rs
@@ -1,0 +1,372 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+use static_assertions::assert_impl_all;
+use static_assertions::assert_not_impl_any;
+
+use crate::Actor;
+use crate::Context;
+use crate::MonitorHandle;
+use crate::Part;
+use crate::Poller;
+use crate::Role;
+
+// The thread-safety tagging is part of the API contract, asserted at compile
+// time. `Context`, `Actor`, and `MonitorHandle` dispatch every operation to the
+// runtime over an internal channel, so they are `Send + Sync` (send from many
+// threads). A `Poller` may be moved to the thread that drives it (`Send`) but
+// the C ABI requires its calls to be externally serialized, so it must not be
+// shared concurrently (`!Sync`).
+assert_impl_all!(Context: Send, Sync);
+assert_impl_all!(Actor: Send, Sync);
+assert_impl_all!(MonitorHandle: Send, Sync);
+assert_impl_all!(Poller: Send);
+assert_not_impl_any!(Poller: Sync);
+
+/// A part built from a `Vec` exposes exactly those bytes and copies out cleanly.
+#[test]
+fn part_roundtrips_bytes() {
+    let part = Part::from_vec(b"payload".to_vec());
+    assert_eq!(part.as_bytes(), b"payload");
+    assert_eq!(part.len(), 7);
+    assert!(!part.is_empty());
+    assert_eq!(part.to_vec(), b"payload".to_vec());
+
+    let empty = Part::empty();
+    assert!(empty.is_empty());
+    assert_eq!(empty.as_bytes(), b"");
+}
+
+/// An actor can send a message to itself and receive it back through a poller.
+/// Runs on a single-threaded runtime — the blocking setup calls (actor/poller
+/// creation, subscribe) work with no special handling because minimonarch's
+/// runtime is isolated in its own native library.
+#[tokio::test(flavor = "current_thread")]
+async fn send_to_self() {
+    let ctx = Context::new().expect("context should be creatable");
+    let actor = ctx
+        .actor(Some(b"self-actor"), /*gateway=*/ true)
+        .expect("actor should be creatable");
+    let mut poller = ctx.poller().expect("poller should be creatable");
+    poller
+        .subscribe(0, &actor)
+        .expect("subscribe should succeed");
+
+    actor
+        .send(b"self-actor", vec![Part::copy_from(b"ping")])
+        .expect("send should succeed");
+
+    let (index, parts) = poller.recv().await.expect("a message should arrive");
+    assert_eq!(index, 0, "message should come from the subscribed index");
+    assert_eq!(parts.len(), 1);
+    assert_eq!(parts[0].as_bytes(), b"ping");
+}
+
+/// A parent/child pair over inproc exchanges hello messages and payloads both
+/// directions, on a single-threaded runtime.
+#[tokio::test(flavor = "current_thread")]
+async fn parent_child_inproc() {
+    let ctx = Context::new().expect("context should be creatable");
+    let parent = ctx
+        .actor(Some(b"p-actor"), true)
+        .expect("parent should be creatable");
+    let child = ctx
+        .actor(Some(b"c-actor"), false)
+        .expect("child should be creatable");
+
+    let mut p_poll = ctx.poller().expect("poller");
+    p_poll.subscribe(0, &parent).expect("subscribe");
+    let mut c_poll = ctx.poller().expect("poller");
+    c_poll.subscribe(0, &child).expect("subscribe");
+
+    let url = "inproc://rs-test-parent-child";
+    parent
+        .serve(url, Role::Parent, None, &[], &[])
+        .expect("serve should succeed");
+    child
+        .join(url, Role::Child, None, &[], &[])
+        .expect("join should succeed");
+
+    // Both sides get a hello: [self, other].
+    let (_, hello) = p_poll.recv().await.expect("parent hello");
+    assert_eq!(hello[0].as_bytes(), b"p-actor");
+    assert_eq!(hello[1].as_bytes(), b"c-actor");
+    let (_, hello) = c_poll.recv().await.expect("child hello");
+    assert_eq!(hello[0].as_bytes(), b"c-actor");
+    assert_eq!(hello[1].as_bytes(), b"p-actor");
+
+    // Parent -> child.
+    parent
+        .send(b"c-actor", vec![Part::copy_from(b"down")])
+        .expect("send down");
+    let (_, msg) = c_poll.recv().await.expect("child receives");
+    assert_eq!(msg[0].as_bytes(), b"down");
+
+    // Child -> parent.
+    child
+        .send(b"p-actor", vec![Part::copy_from(b"up")])
+        .expect("send up");
+    let (_, msg) = p_poll.recv().await.expect("parent receives");
+    assert_eq!(msg[0].as_bytes(), b"up");
+}
+
+/// A hello prefix is prepended to the delivered connection-established message.
+#[tokio::test(flavor = "current_thread")]
+async fn hello_prefix_is_delivered() {
+    let ctx = Context::new().expect("context");
+    let parent = ctx.actor(Some(b"pp"), true).expect("parent");
+    let child = ctx.actor(Some(b"cc"), false).expect("child");
+
+    let mut p_poll = ctx.poller().expect("poller");
+    p_poll.subscribe(0, &parent).expect("subscribe");
+
+    let url = "inproc://rs-test-hello-prefix";
+    parent
+        .serve(url, Role::Parent, None, &[b"CONNECTED"], &[])
+        .expect("serve");
+    child.join(url, Role::Child, None, &[], &[]).expect("join");
+
+    // Delivered shape is [hello..., self, other].
+    let (_, msg) = p_poll.recv().await.expect("parent hello");
+    assert_eq!(msg[0].as_bytes(), b"CONNECTED");
+    assert_eq!(msg[1].as_bytes(), b"pp");
+    assert_eq!(msg[2].as_bytes(), b"cc");
+}
+
+/// An actor may outlive its context; using it afterwards returns an error
+/// rather than misbehaving, and dropping it stays safe.
+#[test]
+fn actor_use_after_context_drop_errors() {
+    let ctx = Context::new().expect("context");
+    let actor = ctx.actor(Some(b"orphan"), true).expect("actor");
+
+    drop(ctx);
+
+    let err = actor
+        .send(b"orphan", vec![Part::copy_from(b"lost")])
+        .expect_err("send after context drop should error");
+    assert!(
+        err.to_string().contains("context"),
+        "error should mention the stopped context, got: {err}"
+    );
+    // Dropping `actor` here (after the context is gone) must not misbehave.
+}
+
+/// Sending a large multipart message drives the `mm_poller_next` buffer-growth
+/// path (initial capacity is 8 parts).
+#[tokio::test(flavor = "current_thread")]
+async fn large_multipart_grows_buffer() {
+    let ctx = Context::new().expect("context");
+    let actor = ctx.actor(Some(b"multi"), true).expect("actor");
+    let mut poller = ctx.poller().expect("poller");
+    poller.subscribe(0, &actor).expect("subscribe");
+
+    let parts: Vec<Part> = (0..20)
+        .map(|i| Part::from_vec(format!("part-{i}").into_bytes()))
+        .collect();
+    actor.send(b"multi", parts).expect("send");
+
+    let (_, received) = poller.recv().await.expect("message");
+    assert_eq!(received.len(), 20, "all 20 parts should be delivered");
+    assert_eq!(received[0].as_bytes(), b"part-0");
+    assert_eq!(received[19].as_bytes(), b"part-19");
+}
+
+/// Establish a parent/child inproc link under `root` and drain both hello
+/// messages, so the topology (and its routing) is in place before the test acts.
+async fn connect(
+    root: &Actor,
+    root_poll: &mut Poller,
+    url: &str,
+    child: &Actor,
+    child_poll: &mut Poller,
+) {
+    root.serve(url, Role::Parent, None, &[], &[])
+        .expect("serve");
+    child.join(url, Role::Child, None, &[], &[]).expect("join");
+    root_poll.recv().await.expect("root hello");
+    child_poll.recv().await.expect("child hello");
+}
+
+/// A monitor fires when its target dies: the failure climbs to the common
+/// ancestor (root) and returns to the watcher as [failure.., target, reason].
+#[tokio::test(flavor = "current_thread")]
+async fn monitor_fires_when_target_dies() {
+    let ctx = Context::new().expect("context");
+    let root = ctx.actor(Some(b"root"), false).expect("root");
+    let watcher = ctx.actor(Some(b"watcher"), false).expect("watcher");
+    let target = ctx.actor(Some(b"target"), false).expect("target");
+
+    let mut root_poll = ctx.poller().expect("poller");
+    root_poll.subscribe(0, &root).expect("subscribe");
+    let mut watcher_poll = ctx.poller().expect("poller");
+    watcher_poll.subscribe(0, &watcher).expect("subscribe");
+    let mut target_poll = ctx.poller().expect("poller");
+    target_poll.subscribe(0, &target).expect("subscribe");
+
+    connect(
+        &root,
+        &mut root_poll,
+        "inproc://rs-mon-w",
+        &watcher,
+        &mut watcher_poll,
+    )
+    .await;
+    connect(
+        &root,
+        &mut root_poll,
+        "inproc://rs-mon-t",
+        &target,
+        &mut target_poll,
+    )
+    .await;
+
+    let handle = watcher.monitor(b"target", &[b"DOWN"], 0).expect("monitor");
+    // Dropping the handle detaches (JoinHandle semantics); the monitor stays
+    // active and must still fire.
+    drop(handle);
+
+    target.die(b"boom");
+
+    let (index, msg) = watcher_poll
+        .recv()
+        .await
+        .expect("monitor should fire even after its handle is dropped");
+    assert_eq!(index, 0);
+    assert_eq!(msg.len(), 3, "shape is [failure.., target, reason]");
+    assert_eq!(msg[0].as_bytes(), b"DOWN");
+    assert_eq!(msg[1].as_bytes(), b"target");
+    assert_eq!(msg[2].as_bytes(), b"actor died");
+}
+
+/// A cancelled monitor must not deliver, even after the target dies. Proven with
+/// a sentinel: it must be the first (and only) message the watcher receives.
+#[tokio::test(flavor = "current_thread")]
+async fn cancelled_monitor_does_not_fire() {
+    let ctx = Context::new().expect("context");
+    let root = ctx.actor(Some(b"root"), false).expect("root");
+    let watcher = ctx.actor(Some(b"watcher"), false).expect("watcher");
+    let target = ctx.actor(Some(b"target"), false).expect("target");
+
+    let mut root_poll = ctx.poller().expect("poller");
+    root_poll.subscribe(0, &root).expect("subscribe");
+    let mut watcher_poll = ctx.poller().expect("poller");
+    watcher_poll.subscribe(0, &watcher).expect("subscribe");
+    let mut target_poll = ctx.poller().expect("poller");
+    target_poll.subscribe(0, &target).expect("subscribe");
+
+    connect(
+        &root,
+        &mut root_poll,
+        "inproc://rs-monc-w",
+        &watcher,
+        &mut watcher_poll,
+    )
+    .await;
+    connect(
+        &root,
+        &mut root_poll,
+        "inproc://rs-monc-t",
+        &target,
+        &mut target_poll,
+    )
+    .await;
+
+    let handle = watcher.monitor(b"target", &[b"DOWN"], 0).expect("monitor");
+    watcher.cancel_monitor(handle);
+    target.die(b"boom");
+
+    watcher
+        .send(b"watcher", vec![Part::copy_from(b"sentinel")])
+        .expect("send sentinel");
+    let (_, msg) = watcher_poll.recv().await.expect("sentinel");
+    assert_eq!(
+        msg[0].as_bytes(),
+        b"sentinel",
+        "cancelled monitor must not have delivered ahead of the sentinel"
+    );
+}
+
+/// With a non-existence timeout, monitoring a target that never appears fires
+/// once with reason "actor does not exist" after the timeout elapses.
+#[tokio::test(flavor = "current_thread")]
+async fn monitor_timeout_fires_when_target_never_exists() {
+    let ctx = Context::new().expect("context");
+    let root = ctx.actor(Some(b"root"), false).expect("root");
+    let watcher = ctx.actor(Some(b"watcher"), false).expect("watcher");
+
+    let mut root_poll = ctx.poller().expect("poller");
+    root_poll.subscribe(0, &root).expect("subscribe");
+    let mut watcher_poll = ctx.poller().expect("poller");
+    watcher_poll.subscribe(0, &watcher).expect("subscribe");
+
+    connect(
+        &root,
+        &mut root_poll,
+        "inproc://rs-mont-w",
+        &watcher,
+        &mut watcher_poll,
+    )
+    .await;
+
+    // 30ms non-existence timeout; "target" never appears.
+    let _handle = watcher.monitor(b"target", &[b"DOWN"], 30).expect("monitor");
+
+    let (_, msg) = watcher_poll.recv().await.expect("timeout should fire");
+    assert_eq!(msg[0].as_bytes(), b"DOWN");
+    assert_eq!(msg[1].as_bytes(), b"target");
+    assert_eq!(msg[2].as_bytes(), b"actor does not exist");
+}
+
+/// Monitoring an actor already known dead fires immediately rather than waiting.
+#[tokio::test(flavor = "current_thread")]
+async fn monitor_on_already_dead_actor_fires_immediately() {
+    let ctx = Context::new().expect("context");
+    let root = ctx.actor(Some(b"root"), false).expect("root");
+    let watcher = ctx.actor(Some(b"watcher"), false).expect("watcher");
+    let target = ctx.actor(Some(b"target"), false).expect("target");
+
+    let mut root_poll = ctx.poller().expect("poller");
+    root_poll.subscribe(0, &root).expect("subscribe");
+    let mut watcher_poll = ctx.poller().expect("poller");
+    watcher_poll.subscribe(0, &watcher).expect("subscribe");
+    let mut target_poll = ctx.poller().expect("poller");
+    target_poll.subscribe(0, &target).expect("subscribe");
+
+    connect(
+        &root,
+        &mut root_poll,
+        "inproc://rs-mond-w",
+        &watcher,
+        &mut watcher_poll,
+    )
+    .await;
+    connect(
+        &root,
+        &mut root_poll,
+        "inproc://rs-mond-t",
+        &target,
+        &mut target_poll,
+    )
+    .await;
+
+    target.die(b"boom");
+    // root is target's parent, so it gets the connection-failure notification;
+    // draining it confirms root recorded target as dead before we subscribe.
+    let (_, down) = root_poll.recv().await.expect("root sees target death");
+    assert_eq!(down[0].as_bytes(), b"target");
+
+    let _handle = watcher.monitor(b"target", &[b"DOWN"], 0).expect("monitor");
+    let (_, msg) = watcher_poll
+        .recv()
+        .await
+        .expect("monitor fires immediately");
+    assert_eq!(msg[0].as_bytes(), b"DOWN");
+    assert_eq!(msg[1].as_bytes(), b"target");
+    assert_eq!(msg[2].as_bytes(), b"actor died");
+}

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -84,12 +84,6 @@ pub struct CPoller {
     armed_at: Option<u64>,
 }
 
-pub struct CMonitorHandle {
-    ctx: CtxHandle,
-    actor: Key,
-    id: u64,
-}
-
 // ---------------------------------------------------------------------------
 // C-compatible enums and structs (mirror minimonarch.h)
 // ---------------------------------------------------------------------------
@@ -390,11 +384,12 @@ pub unsafe extern "C" fn mm_actor_monitor(
     to_monitor_ident: CMsgPart,
     failure_prefix: *const CMsg,
     timeout_for_nonexistence: u64,
-    out: *mut *mut CMonitorHandle,
+    out: *mut u64,
 ) -> Error {
     let a = &*actor;
     // Allocate the id locally and fire the command without waiting: this runs in
-    // messaging loops and must never block on the event loop thread.
+    // messaging loops and must never block on the event loop thread. The handle
+    // is simply that id — no allocation, so nothing to free.
     let id = a.next_monitor_id.fetch_add(1, Ordering::Relaxed);
     match a.ctx.send_command(Command::Monitor {
         actor: a.key,
@@ -404,11 +399,7 @@ pub unsafe extern "C" fn mm_actor_monitor(
         timeout_ms: timeout_for_nonexistence,
     }) {
         Ok(()) => {
-            *out = Box::into_raw(Box::new(CMonitorHandle {
-                ctx: a.ctx.clone(),
-                actor: a.key,
-                id,
-            }));
+            *out = id;
             Error::Ok
         }
         Err(e) => e.into(),
@@ -420,11 +411,11 @@ pub unsafe extern "C" fn mm_actor_monitor(
 // ---------------------------------------------------------------------------
 
 #[no_mangle]
-pub unsafe extern "C" fn mm_monitor_handle_cancel(handle: *mut CMonitorHandle) {
-    let handle = Box::from_raw(handle);
-    let _ = handle.ctx.send_command(Command::CancelMonitor {
-        actor: handle.actor,
-        id: handle.id,
+pub unsafe extern "C" fn mm_monitor_handle_cancel(actor: *mut CActor, handle: u64) {
+    let a = &*actor;
+    let _ = a.ctx.send_command(Command::CancelMonitor {
+        actor: a.key,
+        id: handle,
     });
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* __->__ #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add an idiomatic Rust crate that wraps the stable Minimonarch C ABI with owned message parts, actors, pollers, connection management, monitoring, and asynchronous receive support. Link the core runtime as an isolated static-library artifact, align monitor handles across the C and Python bindings, and test message delivery, ownership, lifecycle, routing, and monitor behavior.

Differential Revision: [D114750222](https://our.internmc.facebook.com/intern/diff/D114750222/)