### PR TITLE
26/43 minimonarch: Delegated heartbeat

### DIFF
--- a/monarch_mini/HEARTBEAT_DELEGATION_DESIGN.md
+++ b/monarch_mini/HEARTBEAT_DELEGATION_DESIGN.md
@@ -1,0 +1,475 @@
+# Delegated Heartbeating (QUIC scale-out)
+
+Design proposal for offloading heartbeat cost from a high-fan-out parent to its
+children, keeping the whole mechanism inside the QUIC subsystem. This is the
+`IMPLEMENTATION.md` "TCP Scale-out" idea, adapted to QUIC.
+
+> Status: design for review. Pseudocode is illustrative, not final. The goal is a
+> normalized set of data structures so the eventual edit touches few places.
+
+---
+
+## 1. Goals & invariants
+
+- **Ctx/Actors are unchanged in what they observe.** From the command loop's point
+  of view an actor still has N child connections and still receives the same
+  `Establish` / `PublishRoutes` / `Severed` notices. Only *how liveness is proven*
+  changes. All new state and coroutines live in the QUIC transport.
+- **Steady-state heartbeat cost is bounded per node.** A parent `B` actively
+  heartbeats at most `MM_QUIC_MAX_DIRECT_CHILDREN` children; the rest are
+  *delegated* to sibling children, who prove liveness on `B`'s behalf and report a
+  running `+/-` diff of the connections they cover.
+- **A delegated connection is quiet on the physical link.** No app heartbeat, and
+  QUIC keep-alive / idle-timeout disabled (§9), so a delegated connection generates
+  no periodic traffic. Liveness rides side channels between siblings instead.
+- **Delegation is best-effort and self-healing.** If a delegate dies, or a child
+  loses its delegate, the child falls straight back to heartbeating `B` directly,
+  which re-runs the delegation decision.
+
+---
+
+## 2. Terminology & topology
+
+Consider base actor `B` with children `C` (established) and `D` (new).
+
+```
+        B                     B  = parent, dialed both children (quic connect)
+       / \                    C  = existing child, addressable (quic serve)
+      C   D                   D  = new child, addressable (quic serve)
+```
+
+For one physical QUIC connection there are two heartbeat *roles*, chosen by
+`ConnectionRef`:
+
+| Role         | ConnectionRef       | Responsibility                                    |
+|--------------|---------------------|---------------------------------------------------|
+| **Parent**   | `ChildConnection`   | Detect the peer child's death; may *delegate* it. |
+| **Child**    | `ParentConnection`  | Prove liveness to the parent; may *cover* siblings.|
+
+(These match `ConnectionRef::role()` — a `ChildConnection` has `Role::Parent`.)
+So on the `B–D` link, `B` runs a Parent coroutine and `D` a Child coroutine. The
+delegate `C` is a Child toward `B` **and** additionally hosts *coverage watches*
+for the siblings it has taken on.
+
+**Guard (both must hold to delegate a link):** the parent *dialed* the connection
+(`join`, "quic connect") and the child *served* it ("quic serve", so it has a
+dial-able gateway tag). See §8.
+
+---
+
+## 3. Two identifiers: connection id vs. actor ident
+
+The protocol uses each for what it is good at:
+
+- **`ConnectionId` (`u64`)** — the identity of a parent→child connection, assigned
+  ctx-globally by the **Parent side** at `spawn_connection` (a counter in the shared
+  state). It names *which delegated link* a message concerns, independent of whether
+  actor names are known yet. It appears in the delegation instruction (`B` tells `D`
+  "you are connection X") and in coverage diffs (`C` reports "I cover X"). `B`
+  correlates a coverage report to its child connection via a `ConnectionId → Parent
+  task` index.
+- **Actor ident** — the *addressing* key for side-channel beats/acks. A beat is sent
+  to `gateway_tag(recipient_ident)` and delivered to the connection where that actor
+  is the child (unique — an actor has one parent). See §6.2.
+
+**Establish snooping** fills in the idents on both ends: the heartbeat coroutine
+snoops the `Establish` frames that already flow through the writer (outgoing → local
+ident) and reader (incoming → peer ident) — no new threading into ctx. From `ident =
+name@tag`, `gateway_tag()` (suffix after the last `@`) is the dial address. Both the
+child `D` and the delegate `C` must be named before delegation begins (the guard,
+§8).
+
+---
+
+## 4. Coroutine topology (per connection)
+
+Today `spawn_connection` starts a **writer** and a **reader**. Add a third: the
+**heartbeat coroutine** (`heartbeat_task`). The reader/writer become dumb plumbing; the
+heartbeat_task owns all liveness policy (interval + timeout + delegation).
+
+```
+        ┌────────────┐  WriterCtrl (SendBeat{payload})   ┌──────────┐
+        │  heartbeat_task   │ ────────────────────────────────► │  writer  │──► stream
+        │            │ ◄──── HeartbeatEvent::EstablishOut ────── │          │
+        │  (Parent   │                                    └──────────┘
+        │     or     │  HeartbeatEvent::{Beat, EstablishIn,      ┌──────────┐
+        │   Child)   │ ◄─── ReaderClosed} ─────────────── │  reader  │◄── stream
+        │            │                                    └──────────┘
+        │            │ ──► loop_tx: Severed (on timeout)
+        │            │ ◄──► Rc<RefCell<HeartbeatShared>>  (siblings, coverage indices)
+        │            │ ──► loop_tx: SendSideChannel(msg)  (beats reuse the gateway
+        │            │                                     side channel, §6.2)
+        └────────────┘
+```
+
+Reader/writer changes:
+- **writer**: delete the self-driven `heartbeat.tick()` arm. Instead select on a
+  new `WriterCtrl` channel from heartbeat_task; on `SendBeat(payload)` write
+  `WireFrame::Heartbeat(payload)`. On seeing an outgoing `Establish` command,
+  forward `HeartbeatEvent::EstablishOut{local_ident}` to heartbeat_task. (Shutdown behavior
+  unchanged.)
+- **reader**: remove the heartbeat-timeout wrapper around the read — the *timeout
+  moves to heartbeat_task*. Forwarding rules, designed so a message flood does **not**
+  flood the heartbeat_task:
+  - **Heartbeat frames** always forward as `HeartbeatEvent::FromChild` /
+    `FromParent` (per the `Heartbeat` variant) — they are rare (one per interval)
+    and carry the coverage diff / delegate instruction the heartbeat_task must
+    process anyway.
+  - **`Establish`** forwards to the loop as today and also sends
+    `HeartbeatEvent::EstablishIn{peer_ident}` (one-shot, at setup).
+  - **Ordinary message/route frames** forward to the loop as today, but notify the
+    heartbeat_task only as a *throttled backstop*: the reader keeps a local
+    `last_notify: Instant` (bumped by any event it sends, including real beats) and
+    sends an *empty* beat — `FromChild{}` or `FromParent{None}` per the reader's own
+    role — only when `now - last_notify >= 2 × HEARTBEAT_INTERVAL`. So while real
+    heartbeats arrive on cadence, data frames cost nothing; if the peer stops
+    heartbeating but traffic still flows, the pipe is still proven live at ≤ one
+    event per two intervals.
+  - **error/EOF** still emits `Severed` to the loop (hard close is transport-level,
+    not heartbeat policy) and sends `HeartbeatEvent::ReaderClosed`.
+
+  There is no separate liveness event: a backstop is just an empty beat, which
+  refreshes the `Direct` deadline and is a no-op for coverage/delegation.
+
+The heartbeat_task may **park** (no active timer, no beats) when a Child is fully
+delegated or a Parent is fully covered; it is woken by `HeartbeatEvent`s and by shared
+state notifications.
+
+---
+
+## 5. `quic_heartbeat.rs` data structures
+
+```rust
+type ConnectionId = u64;
+type Handle = mpsc::UnboundedSender<HeartbeatEvent>;   // control channel to one heartbeat_task
+
+/// One per QuicTransport (per context). Single-threaded → Rc<RefCell<>>.
+pub(crate) struct HeartbeatShared {
+    /// The next unused ConnectionId; bumped once per connection at spawn.
+    next_conn_id: ConnectionId,
+
+    /// For each local actor, the control handle of the heartbeat_task on that
+    /// actor's parent connection (the Child-side task). Keyed by the actor's own
+    /// ident. At most one entry per actor (an actor has one parent).
+    children_by_ident: HashMap<Vec<u8>, Handle>,
+
+    /// For each local parent→child connection, the control handle of its Parent-side
+    /// heartbeat_task. Keyed by that connection's ConnectionId.
+    parents_by_conn_id: HashMap<ConnectionId, Handle>,
+
+    /// For each local actor that parents quic children, its delegate pool.
+    parents: HashMap<Key, ParentPool>,
+}
+
+struct ParentPool {
+    /// The ConnectionIds of this parent's children that are currently usable as a
+    /// delegate (established + addressable + dialed + under coverage capacity).
+    eligible: VecDeque<ConnectionId>,
+    /// How many of this parent's children are monitored directly (not delegated).
+    active_direct: usize,
+}
+```
+
+Per-connection state each loop actually holds. There is **no stored `mode` object** —
+a loop's "mode" is just which timeout it is currently awaiting (see the execution
+model below), so only genuinely-persistent data lives here:
+
+```rust
+/// Held by the Parent-side loop (B, watching child D).
+struct ParentLink {
+    conn_id: ConnectionId,               // this connection's id (assigned at spawn)
+    peer_ident: Option<Vec<u8>>,         // the child's ident, once snooped
+    dialed: bool,                        // whether we dialed the child (join); see §8
+    /// If this child is itself a delegate, the ConnectionIds it currently covers
+    /// (from its cover_add/del diffs). On this link's failure, each is released via
+    /// `Uncovered` to its own Parent loop.
+    covers: HashSet<ConnectionId>,
+}
+
+/// Held by the Child-side loop (D, proving liveness to parent B). The same task
+/// also owns this actor's coverage loops (its delegate-host duty as C).
+struct ChildLink {
+    own_ident: Option<Vec<u8>>,          // this actor's own ident, once snooped
+    parent_ident: Option<Vec<u8>>,       // the parent's ident, once snooped
+    /// Coverage changes not yet reported to the parent, produced by the coverage
+    /// loops and drained onto the next FromChild beat.
+    cover_add: Vec<ConnectionId>,
+    cover_del: Vec<ConnectionId>,
+}
+```
+
+**Execution model — one timeout per loop.** Every heartbeat loop owns exactly one
+timeout ("did the thing I watch arrive in time?") and fires exactly one failure
+event on lapse. Delegation moves *which loop owns the timeout* for a connection; it
+is not a state machine.
+
+- **Parent loop (B ⇢ D).** Directly watching: `select!` D's physical `FromChild`
+  beats (reset the deadline) against the deadline (⇒ `sever`). On deciding to
+  delegate, it emits the `Delegate` instruction and stops timing out — it now awaits
+  a `Covered`/`Uncovered` event on its channel (a grace timeout guards the gap until
+  the first `Covered`). `Covered` ⇒ parked (no timeout; the delegate owns it);
+  `Uncovered` ⇒ re-arm the direct timeout (D will reconnect and beat directly).
+- **Child loop (D ⇢ B).** Directly: beat B on the interval and time out on B's
+  physical `FromParent` beats. On `Delegate{connection_id, sibling}`: beat the
+  sibling `C` over the side channel and let the single timeout watch C's *acks*
+  instead. Ack lapse ⇒ revert to beating B directly (B re-decides).
+- **Coverage loop (C ⇢ X), one per covered connection.** Spawned by C's Child task
+  when it first sees a side-channel beat for connection `X`; owns a single timeout
+  on `X`'s beats. Each beat resets it and is acked; the first enqueues `cover_add(X)`
+  and a lapse enqueues `cover_del(X)` and ends the loop. C's Child loop drains those
+  onto its next `FromChild` beat to B — which is exactly what fires B's `Uncovered`
+  for `X`.
+
+Events into an heartbeat_task (a task is either a Parent or a Child, so it only ever
+sees the events for its role):
+
+```rust
+enum HeartbeatEvent {
+    // From the reader: an inbound physical heartbeat, split by direction. A task
+    // receives whichever direction its peer sends (a Parent gets FromChild, a Child
+    // gets FromParent). An empty one is the reader's liveness backstop.
+    FromChild  { cover_add: Vec<ConnectionId>, cover_del: Vec<ConnectionId> },
+    FromParent { delegate: Option<Delegate> },
+    EstablishLocal { local_ident: Vec<u8> },   // our outgoing Establish (from the writer)
+    EstablishPeer  { peer_ident: Vec<u8> },    // the peer's Establish (from the reader)
+    ReaderClosed,                            // reader hit error/EOF
+
+    // To a Parent-side task, when a sibling's coverage diff names this connection:
+    Covered   { by: Vec<u8> },               // now covered by sibling `by` (its ident)
+    Uncovered,                               // no longer covered
+
+    // To a Child-side task, from an inbound side-channel beat/ack (§6.2):
+    SideBeat  { from: Vec<u8>, conn_id: ConnectionId },  // a delegated child beating us
+    SideAck   { from: Vec<u8>, conn_id: ConnectionId },  // our delegate acking our beat
+}
+```
+
+---
+
+## 6. Wire protocol changes
+
+### 6.1 Physical heartbeat gains a directional body (`framing.rs`)
+
+`WireFrame::Heartbeat` becomes non-unit, carrying a `Heartbeat` that is
+discriminated by direction — a Child sends `FromChild`, a Parent sends `FromParent`:
+
+```rust
+WireFrame::Heartbeat(Heartbeat)
+
+#[derive(Serialize, Deserialize)]
+enum Heartbeat {
+    // Child → parent: the running diff of connections this child covers for the
+    // parent. Empty in both lists = a plain liveness beat (also the backstop).
+    FromChild { cover_add: Vec<ConnectionId>, cover_del: Vec<ConnectionId> },
+    // Parent → child: a delegation instruction, or None for a plain liveness beat.
+    // None never revokes — a child reverts on its own (ack-timeout), a parent on
+    // `Uncovered` — so the empty backstop beat is safe.
+    FromParent { delegate: Option<Delegate> },
+}
+
+#[derive(Serialize, Deserialize)]
+struct Delegate {
+    connection_id: ConnectionId,   // "you are connection X" (what the child presents to C)
+    sibling_ident: Vec<u8>,        // C — the child beats gateway_tag(C)
+}
+```
+
+`read_frame`/`write_command` are updated so `Incoming::Heartbeat` carries the
+`Heartbeat` (reader forwards it as `HeartbeatEvent::FromChild` / `FromParent` per
+its variant). Heartbeats are still consumed by the transport and never surface to
+ctx as a `ConnectionCommand`.
+
+### 6.2 Side-channel beats **reuse the existing gateway side channel**
+
+There is **no new stream, preamble, or dialer.** A beat/ack is just another
+`SideChannelMessage` on the path that already exists (`send_to_gateway` →
+`Preamble::SideChannel` writer → `Command::SideChannelDeliver` →
+`deliver_side_channel`). Add one action variant (`connection.rs`) and the matching
+`framing.rs` `SideChannelFrame`:
+
+```rust
+enum SideChannelAction {
+    Send(SendPayload),
+    UpdateRemoteMonitorState { .. },
+    AckRemoteMonitor { .. },
+    // + new: from = sender ident; conn_id = the delegated connection's id;
+    //        ack = false beat / true ack
+    Heartbeat { from: Vec<u8>, conn_id: ConnectionId, ack: bool },
+}
+```
+
+- **Beat** `D→C`: `SideChannelMessage { gateway_for_actor: C_ident, Heartbeat { from: D_ident, conn_id: X, ack: false } }`.
+- **Ack** `C→D`: `SideChannelMessage { gateway_for_actor: D_ident, Heartbeat { from: C_ident, conn_id: X, ack: true } }`.
+
+`gateway_for_actor` is the recipient's ident, so the message dials
+`gateway_tag(recipient)` and is delivered exactly like any cross-gateway message
+(including the free `pending_side_channel` parking/replay if the recipient's route
+isn't resolvable yet). At the recipient, `deliver_side_channel` routes the
+`Heartbeat` action into the heartbeat subsystem instead of to an actor:
+`self.quic.deliver_heartbeat(gateway_for_actor, from, conn_id, ack)`, which looks up
+`children_by_ident[gateway_for_actor]` and sends `SideBeat{from, conn_id}` /
+`SideAck{from, conn_id}` to that Child-side heartbeat_task — the one connection where
+the addressed actor is the child. If it isn't registered yet, drop it; the next beat
+retries.
+
+---
+
+## 7. Algorithms
+
+### 7.1 Parent side (B, the `B–D` link)
+
+One loop, one timeout. At spawn: `conn_id = shared.next_conn_id++`; register
+`parents_by_conn_id[conn_id] -> self`. `EstablishIn{peer_ident}` records the child
+ident and `active_direct += 1`.
+
+```
+# directly-watching D (owns D's liveness timeout):
+loop select:
+    FromChild{..}   -> deadline = now + TIMEOUT
+                       if should_delegate() and dialed and peer_ident known:
+                           C = pick_eligible_sibling()          # ident from ParentPool.eligible
+                           if C:
+                               next FromParent beat carries
+                                   Delegate{ connection_id: conn_id, sibling_ident: C }
+                               active_direct -= 1;  goto awaiting-coverage
+    deadline        -> sever("quic heartbeat timeout"); done    # the single timeout fires
+    ReaderClosed    -> sever; deregister; done
+
+# awaiting-coverage (stopped timing out D; a grace timer guards the gap):
+loop select:
+    Covered{by}     -> goto delegated                           # a delegate owns D now
+    FromChild{..}   -> active_direct += 1; goto directly-watching   # D fell back to us
+    grace           -> active_direct += 1; goto directly-watching   # nobody took it; reclaim
+    ReaderClosed    -> sever; done
+
+# delegated (no timeout here — the delegate's coverage loop owns it):
+loop select:
+    Uncovered       -> active_direct += 1; deadline = now + TIMEOUT; goto directly-watching
+    FromChild{..}   -> active_direct += 1; goto directly-watching   # D fell back to us
+    ReaderClosed    -> sever; done
+```
+
+`should_delegate(P)` = `parents[P].active_direct > MAX_DIRECT_CHILDREN`.
+
+`Covered`/`Uncovered` arrive from a *different* link: when `B`'s `B–C` Parent loop
+parses `C`'s `cover_add:[X]` / `cover_del:[X]`, it looks up `parents_by_conn_id[X]`
+and sends that loop `Covered{by=C_ident}` / `Uncovered`, and adds/removes `X` in
+`B–C`'s `covers` set — so if `B–C` fails, every `X` it covered is released via
+`Uncovered`.
+
+### 7.2 Child side (D, the `B–D` link)
+
+`beat(to_ident, conn_id, ack)` below = `loop_tx.send(SendSideChannel(
+SideChannelMessage{ gateway_for_actor: to_ident, action: Heartbeat{ from: own_ident,
+conn_id, ack } }))` — the existing gateway side channel (§6.2). `own_ident` is
+learned from `EstablishOut` (then register `children_by_ident[own_ident] -> self`).
+
+```
+# direct — prove liveness to B (single timeout watches B's beats):
+beat_timer = interval(INTERVAL); deadline = now + TIMEOUT
+loop select:
+    beat_timer               -> SendBeat(FromChild{ cover_add: drain, cover_del: drain })
+    FromParent{delegate}     -> deadline = now + TIMEOUT
+                                if Some(Delegate{connection_id, sibling_ident=C})
+                                   and own_ident is addressable:
+                                    goto delegated(connection_id, C)
+                                # None = plain liveness beat, no-op
+    deadline                 -> sever("parent heartbeat timeout"); done
+    SideBeat{from,conn_id}   -> feed coverage loop (§7.3)       # delegate-host duty
+    ReaderClosed             -> sever; done
+
+# delegated(X, C) — prove liveness via the side channel to C (timeout watches C's acks):
+beat_timer = interval(INTERVAL); ack_deadline = now + TIMEOUT
+loop select:
+    beat_timer               -> beat(C, X, ack=false)
+    SideAck{conn_id=X}       -> ack_deadline = now + TIMEOUT
+    ack_deadline             -> goto direct    # lost C; beat B directly, B re-decides (7.1)
+    SideBeat{from,conn_id}   -> feed coverage loop (§7.3)       # still a delegate host
+    ReaderClosed             -> sever; done
+```
+
+### 7.3 Coverage loop (C covering connection X on B's behalf)
+
+C's Child task spawns one coverage loop per delegated connection it hosts, on the
+first `SideBeat` for that `X`. Each owns a single timeout on `X`'s side-channel
+beats; its `cover_add`/`cover_del` feed C's Child link (§7.2), which drains them onto
+its next `FromChild` beat to B — that report is what fires B's `Covered`/`Uncovered`.
+
+```
+coverage_loop(X, from=D):
+    cover_add.push(X)                        # first sight of X -> B learns C covers X
+    deadline = now + TIMEOUT
+    loop select:
+        SideBeat{from=D, conn_id=X} -> deadline = now + TIMEOUT; beat(D, X, ack=true)
+        deadline                    -> cover_del.push(X); done   # X lapsed -> fires B's Uncovered(X)
+```
+
+If `C`'s `C–B` link fails outright, ctx severs it as usual; the coverage loops die
+with the process, and `B` releases everything `C` covered via the `covers`-set path
+in §7.1 (no per-loop cleanup needed).
+
+---
+
+## 8. Guards
+
+Delegation of link `B–D` is attempted only when **all** hold, else the link stays
+`Direct` (today's behavior):
+
+1. The Parent is the joiner of both the Child and the Delegate,
+   which are both spawner. Ensuring the children are side-channel addressable.
+   Remember it is possible for the relationship to be reversed (Child as joiner),
+   we will not delegate here.
+2. `B` knows `D`'s ident and the chosen sibling `C`'s ident (snooped Establish). This will
+    progress to be true over time so eventually heartbeats will transition as more info is known.
+
+`inproc`/`unix` links never enter this path (they have no quic heartbeat_task at all).
+
+---
+
+## 9. QUIC config & sending beats
+
+- **Disable periodic QUIC traffic** so a delegated link is truly silent. In
+  `load_tls` build a `quinn::TransportConfig` and apply to both `ServerConfig` and
+  `ClientConfig`: `keep_alive_interval = None` (no PING keep-alives) and
+  `max_idle_timeout = None` (QUIC must not reap an idle delegated connection —
+  liveness is now our responsibility, not the transport's). Message-carrying links
+  are unaffected; delegated links rely on the sibling fabric.
+- **Sending beats reuses the gateway side channel (§6.2).** A heartbeat_task, on its
+  timer, enqueues `Command::SendSideChannel(SideChannelMessage)` on `loop_tx`; the
+  loop hands it to the existing `Ctx::send_to_gateway`, which reuses the cached
+  per-gateway `Preamble::SideChannel` writer and the shared endpoint pool — no new
+  connection, preamble, or dialer. This is a small, deliberate ctx seam (one
+  `Command` arm + one `SideChannelAction::Heartbeat` dispatch arm, §10); the
+  heartbeat *policy* still lives entirely in `quic_heartbeat.rs`, ctx only ferries
+  the opaque side-channel message it already knows how to route.
+
+---
+
+## 10. Files & structures touched
+
+| File                | Change                                                                       |
+|---------------------|------------------------------------------------------------------------------|
+| `quic_heartbeat.rs` | **new** — `HeartbeatShared`, `ParentPool`, `ParentLink`, `ChildLink`, `HeartbeatEvent`, the `heartbeat_task` loops (Parent / Child / coverage), `QuicTransport::deliver_heartbeat`, delegation policy. |
+| `quic_transport.rs` | `QuicTransport` holds `Rc<RefCell<HeartbeatShared>>`; `spawn_connection` starts `heartbeat_task` + passes a `dialed` literal (true from `connector_task`, false from the serve-side `listener_task` arms) + shared handle; writer drops self-tick, gains `WriterCtrl`; reader drops timeout, forwards `HeartbeatEvent`s; `deliver_heartbeat` routes side-channel beats via `children_by_ident`; TLS `TransportConfig` (§9). *No new preamble/stream/dialer.* |
+| `framing.rs`        | `WireFrame::Heartbeat(Heartbeat)` (was unit) with the `FromChild`/`FromParent` enum + `Delegate`; `SideChannelFrame::Heartbeat`; read/write updates. |
+| `connection.rs`     | `SideChannelAction::Heartbeat { from, ack }` (new variant); no per-`Connection` state. |
+| `ctx.rs`            | **minimal, deliberate:** `Command::SendSideChannel(msg)` → `send_to_gateway`; `deliver_side_channel` gains a `Heartbeat` arm → `quic.deliver_heartbeat(..)`. Routing/monitor/gateway logic unchanged. |
+
+## 11. Tunables (env)
+
+- `MM_QUIC_MAX_DIRECT_CHILDREN` — threshold above which new children are delegated.
+- `MM_QUIC_MAX_COVERAGE_PER_SIBLING` — cap on how many coverage loops one sibling
+  hosts (feeds `ParentPool.eligible`).
+- `MM_QUIC_DELEGATE_GRACE_MS` — `AwaitingCoverage` grace before reverting.
+- Existing `MM_QUIC_HEARTBEAT_INTERVAL_MS` / `_TIMEOUT_MS` reused for both physical
+  and side-channel beats.
+
+---
+
+## 12. Open questions for review
+
+2. **Multi-level delegation:** Not needed, we'd need to get up to 2**28 directly connected actors
+    before heartbeating would need 3 levels.
+4. **Ident ambiguity:** Actor idents are not reused. Actors have at most one parent.
+    If we observe B -> C, then a new connection B -> ?, we know this new connection's actor
+    will be a sibling of C even though we do not yet know its ident.

--- a/monarch_mini/src/connection.rs
+++ b/monarch_mini/src/connection.rs
@@ -11,12 +11,28 @@ use std::collections::VecDeque;
 
 use serde::Deserialize;
 use serde::Serialize;
+use tokio::sync::mpsc;
 
 use crate::Role;
 use crate::ctx::ChildConnectionKey;
+use crate::ctx::Command;
 use crate::ctx::Key;
 use crate::msg::MsgPart;
 use crate::shm::ShmClient;
+
+/// Tear `connection` down by emitting a `Severed` to the command loop. Shared by
+/// every transport (the QUIC reader, its heartbeat coroutines, …) so the
+/// connection-failure signal is constructed in exactly one place.
+pub(crate) fn sever(
+    loop_tx: &mpsc::UnboundedSender<Command>,
+    connection: ConnectionRef,
+    reason: Vec<u8>,
+) {
+    let _ = loop_tx.send(Command::ConnectionAction {
+        connection,
+        action: ConnectionCommand::Severed { reason },
+    });
+}
 
 pub(crate) struct ConnectRequest {
     pub(crate) role: Role,

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -47,6 +47,9 @@ use crate::connection::SendPayload;
 use crate::connection::SideChannelAction;
 use crate::connection::SideChannelMessage;
 use crate::msg::MsgPart;
+use crate::quic_heartbeat::BeatKind;
+use crate::quic_heartbeat::ConnectionId;
+use crate::quic_heartbeat::Heartbeat;
 use crate::shm::MapperHandle;
 use crate::shm::SHM_THRESHOLD;
 use crate::shm::ShmClient;
@@ -85,9 +88,10 @@ enum WireFrame {
     GatewayDied {
         dead: Vec<Vec<u8>>,
     },
-    /// Transport-internal liveness probe; consumed by the reader to refresh its
-    /// deadline and never surfaced as a [`ConnectionCommand`].
-    Heartbeat,
+    /// Transport-internal liveness probe carrying a directional [`Heartbeat`] body
+    /// (a Child sends `FromChild`, a Parent sends `FromParent`). Consumed by the
+    /// reader/heartbeat coroutine and never surfaced as a [`ConnectionCommand`].
+    Heartbeat(Heartbeat),
 }
 
 /// Wire form of a [`SendMessage`](ConnectionCommand::SendMessage)'s payload. An
@@ -122,6 +126,16 @@ enum SideChannelFrame {
     AckRemoteMonitor {
         gateway_for_actor: Vec<u8>,
         monitoring: Vec<u8>,
+    },
+    /// A sibling side-channel heartbeat message (see [`crate::quic_heartbeat`]).
+    /// `gateway_for_actor` is the recipient (whose gateway tag the message is dialed
+    /// at); `from` is the sender's ident; `conn_id` is the delegated connection's id;
+    /// `kind` is the [`BeatKind`] (beat / ack / release).
+    Heartbeat {
+        gateway_for_actor: Vec<u8>,
+        from: Vec<u8>,
+        conn_id: ConnectionId,
+        kind: BeatKind,
     },
 }
 
@@ -182,7 +196,24 @@ pub(crate) async fn read_preamble<R: AsyncRead + Unpin>(
 /// heartbeat (consumed internally to refresh the liveness deadline).
 pub(crate) enum Incoming {
     Command(ConnectionCommand),
-    Heartbeat,
+    Heartbeat(Heartbeat),
+}
+
+/// A frame decoded off a gateway side-channel: either a routable
+/// [`SideChannelMessage`] for the command loop, or a transport-internal
+/// delegated-heartbeat beat/ack. The heartbeat variant is *never* surfaced to ctx
+/// — the receiving quic reader hands it straight to the heartbeat subsystem — so it
+/// stays out of ctx's [`SideChannelMessage`]/`SideChannelAction` routing types.
+pub(crate) enum SideChannelIncoming {
+    Message(SideChannelMessage),
+    Heartbeat {
+        /// The actor whose gateway received the beat — i.e. the one the addressed
+        /// heartbeat coroutine belongs to as a child.
+        recipient: Vec<u8>,
+        from: Vec<u8>,
+        conn_id: ConnectionId,
+        kind: BeatKind,
+    },
 }
 
 /// Serialize and write one command: a length-prefixed bincode header, then — for
@@ -255,9 +286,12 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
     write_frame(writer, &frame, &parts).await
 }
 
-/// Write a transport heartbeat probe.
-pub(crate) async fn write_heartbeat<W: AsyncWrite + Unpin>(writer: &mut W) -> std::io::Result<()> {
-    write_frame(writer, &WireFrame::Heartbeat, &[]).await
+/// Write a transport heartbeat probe carrying `heartbeat`.
+pub(crate) async fn write_heartbeat<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    heartbeat: Heartbeat,
+) -> std::io::Result<()> {
+    write_frame(writer, &WireFrame::Heartbeat(heartbeat), &[]).await
 }
 
 async fn write_frame<W: AsyncWrite + Unpin>(
@@ -300,7 +334,7 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
         .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
 
     Ok(match frame {
-        WireFrame::Heartbeat => Incoming::Heartbeat,
+        WireFrame::Heartbeat(heartbeat) => Incoming::Heartbeat(heartbeat),
         WireFrame::Message {
             destination_ident,
             payload,
@@ -411,6 +445,25 @@ pub(crate) async fn write_side_channel<W: AsyncWrite + Unpin>(
     write_frame(writer, &frame, &parts).await
 }
 
+/// Write a sibling side-channel heartbeat message as a frame. Header-only; the
+/// transport builds the wire frame directly, so heartbeats never pass through
+/// ctx's [`SideChannelMessage`] routing types.
+pub(crate) async fn write_side_channel_heartbeat<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    recipient: Vec<u8>,
+    from: Vec<u8>,
+    conn_id: ConnectionId,
+    kind: BeatKind,
+) -> std::io::Result<()> {
+    let frame = SideChannelFrame::Heartbeat {
+        gateway_for_actor: recipient,
+        from,
+        conn_id,
+        kind,
+    };
+    write_frame(writer, &frame, &[]).await
+}
+
 /// Read one [`SideChannelMessage`] off a gateway side-channel. A `Send` of an
 /// actor message reads each part exactly like [`read_frame`] (small parts into
 /// owned buffers, large ones into the slab via `mapper`/`client`); other actions
@@ -419,7 +472,7 @@ pub(crate) async fn read_side_channel<R: AsyncRead + Unpin>(
     reader: &mut R,
     mapper: &MapperHandle,
     client: Option<ShmClient>,
-) -> std::io::Result<SideChannelMessage> {
+) -> std::io::Result<SideChannelIncoming> {
     let mut len_buf = [0u8; 8];
     reader.read_exact(&mut len_buf).await?;
     let header_len = u64::from_le_bytes(len_buf) as usize;
@@ -430,7 +483,25 @@ pub(crate) async fn read_side_channel<R: AsyncRead + Unpin>(
         bincode::serde::decode_from_slice::<SideChannelFrame, _>(&header, bincode_config())
             .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
 
-    Ok(match frame {
+    // A heartbeat is transport-internal: return it as its own variant so the reader
+    // routes it into the heartbeat subsystem without ever building a ctx-level
+    // SideChannelMessage.
+    if let SideChannelFrame::Heartbeat {
+        gateway_for_actor,
+        from,
+        conn_id,
+        kind,
+    } = frame
+    {
+        return Ok(SideChannelIncoming::Heartbeat {
+            recipient: gateway_for_actor,
+            from,
+            conn_id,
+            kind,
+        });
+    }
+
+    let message = match frame {
         SideChannelFrame::Send {
             gateway_for_actor,
             payload,
@@ -471,7 +542,9 @@ pub(crate) async fn read_side_channel<R: AsyncRead + Unpin>(
             gateway_for_actor,
             action: SideChannelAction::AckRemoteMonitor { monitoring },
         },
-    })
+        SideChannelFrame::Heartbeat { .. } => unreachable!("heartbeat handled above"),
+    };
+    Ok(SideChannelIncoming::Message(message))
 }
 
 /// Read one message part of `len` bytes off the stream.

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -14,6 +14,7 @@ mod inproc_transport;
 mod matcher;
 mod msg;
 mod poller;
+mod quic_heartbeat;
 mod quic_transport;
 mod shm;
 mod transport;

--- a/monarch_mini/src/quic_heartbeat.rs
+++ b/monarch_mini/src/quic_heartbeat.rs
@@ -1,0 +1,1759 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Delegated heartbeating for the QUIC transport.
+//!
+//! At high fan-out a parent `B` cannot afford to actively heartbeat tens of
+//! thousands of children. This module offloads that cost: `B` heartbeats at most
+//! [`max_direct_children`] children directly; the rest are *delegated* to sibling
+//! children, who prove the delegated child's liveness on `B`'s behalf and report a
+//! running `+/-` diff of the connections they cover. A delegated link is silent on
+//! the physical QUIC connection (no app heartbeat, QUIC keep-alive / idle-timeout
+//! disabled) — liveness rides the sibling side channel instead.
+//!
+//! All of this lives in the transport. From the command loop's point of view an
+//! actor still has N child connections and still receives the same `Establish` /
+//! `PublishRoutes` / `Severed` notices; only *how liveness is proven* changes.
+//!
+//! ## Coroutine roles
+//!
+//! Every QUIC connection runs one `heartbeat_task`, whose role is fixed by the
+//! [`ConnectionRef`]: a [`ConnectionRef::ChildConnection`] (role
+//! [`Role::Parent`]) runs the [`parent_task`] (detect the peer child's death; may
+//! delegate it); a [`ConnectionRef::ParentConnection`] (role [`Role::Child`]) runs
+//! the [`child_task`] (prove liveness to the parent; may host coverage for
+//! siblings). Each owns exactly one primary timeout — "did the thing I watch arrive
+//! in time?" — and delegation just moves *which* task owns the timeout for a link.
+//!
+//! See `HEARTBEAT_DELEGATION_DESIGN.md` for the full model.
+
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::rc::Rc;
+
+use serde::Deserialize;
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tokio::time::Duration;
+use tokio::time::Instant;
+use tokio::time::MissedTickBehavior;
+
+use crate::Role;
+use crate::connection::ConnectionRef;
+use crate::connection::sever;
+use crate::ctx::Command;
+use crate::ctx::Key;
+
+/// The identity of one parent→child connection, assigned ctx-globally by the
+/// Parent side at spawn. Names *which delegated link* a message concerns,
+/// independent of whether actor names are known yet.
+pub(crate) type ConnectionId = u64;
+
+/// Control channel to one `heartbeat_task`.
+type Handle = mpsc::UnboundedSender<HeartbeatEvent>;
+
+// ---------------------------------------------------------------------------
+// Tunables (env). See `HEARTBEAT_DELEGATION_DESIGN.md` §11.
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MAX_DIRECT_CHILDREN: usize = 256;
+const DEFAULT_MAX_COVERAGE_PER_SIBLING: usize = 32;
+
+/// How often each side emits a heartbeat, and how long a side waits for any beat
+/// before declaring the connection broken. The timeout is several intervals so a
+/// stray scheduling delay doesn't trip it. Both are reused for physical and
+/// side-channel beats, and tunable via `MM_QUIC_HEARTBEAT_INTERVAL_MS` /
+/// `MM_QUIC_HEARTBEAT_TIMEOUT_MS`: at very high fan-out the single-threaded root
+/// cannot service tens of thousands of beats on a 5s cadence, so a longer interval
+/// (with a proportionally longer timeout) cuts steady-state load without weakening
+/// liveness. (Delegation exists to reduce that load further.)
+const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+const DEFAULT_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(20);
+
+fn env_usize(var: &str, default: usize) -> usize {
+    std::env::var(var)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+/// How often each side emits a heartbeat beat.
+pub(crate) fn heartbeat_interval() -> Duration {
+    std::env::var("MM_QUIC_HEARTBEAT_INTERVAL_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_HEARTBEAT_INTERVAL)
+}
+
+/// How long a side waits for any beat before declaring the connection broken.
+pub(crate) fn heartbeat_timeout() -> Duration {
+    std::env::var("MM_QUIC_HEARTBEAT_TIMEOUT_MS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .map(Duration::from_millis)
+        .unwrap_or(DEFAULT_HEARTBEAT_TIMEOUT)
+}
+
+/// Threshold above which a parent's new children are delegated rather than
+/// monitored directly.
+fn max_direct_children() -> usize {
+    env_usize("MM_QUIC_MAX_DIRECT_CHILDREN", DEFAULT_MAX_DIRECT_CHILDREN)
+}
+
+/// Cap on how many delegated connections one sibling may cover.
+fn max_coverage_per_sibling() -> usize {
+    env_usize(
+        "MM_QUIC_MAX_COVERAGE_PER_SIBLING",
+        DEFAULT_MAX_COVERAGE_PER_SIBLING,
+    )
+}
+
+/// The heartbeat tunables, resolved once and carried by [`Heartbeats`] into every
+/// coroutine it spawns. Injecting them (rather than reading env per call) keeps the
+/// policy in one place and lets tests drive the *real* coroutines with short
+/// intervals / a low delegation threshold without touching process-global env.
+#[derive(Clone, Copy)]
+pub(crate) struct HeartbeatConfig {
+    pub(crate) interval: Duration,
+    pub(crate) timeout: Duration,
+    pub(crate) max_direct_children: usize,
+    pub(crate) max_coverage_per_sibling: usize,
+}
+
+impl HeartbeatConfig {
+    /// Resolve from the environment (the production path).
+    fn from_env() -> Self {
+        Self {
+            interval: heartbeat_interval(),
+            timeout: heartbeat_timeout(),
+            max_direct_children: max_direct_children(),
+            max_coverage_per_sibling: max_coverage_per_sibling(),
+        }
+    }
+}
+
+/// Whether `ident` is side-channel addressable — i.e. it carries a non-empty
+/// gateway `@tag` a sibling can dial. A served (`quic serve`) child has one; a
+/// specifier-less root ident does not.
+fn is_addressable(ident: &[u8]) -> bool {
+    matches!(ident.iter().rposition(|&b| b == b'@'), Some(pos) if pos + 1 < ident.len())
+}
+
+/// A cheap, cloneable handle to the per-context delegated-heartbeat state. Owns the
+/// shared table behind an `Rc<RefCell<>>` (single-threaded — LocalSet). The quic
+/// transport holds one and hands clones to the heartbeat coroutines; it is also the
+/// entry point for routing an inbound side-channel beat/ack (see [`Self::deliver`]).
+#[derive(Clone)]
+pub(crate) struct Heartbeats {
+    shared: Rc<RefCell<HeartbeatShared>>,
+    config: HeartbeatConfig,
+}
+
+impl Heartbeats {
+    pub(crate) fn new() -> Self {
+        Self::with_config(HeartbeatConfig::from_env())
+    }
+
+    /// Construct with explicit tunables (used by tests to drive the real coroutines
+    /// with short intervals / a low delegation threshold).
+    pub(crate) fn with_config(config: HeartbeatConfig) -> Self {
+        Self {
+            shared: Rc::new(RefCell::new(HeartbeatShared::new(
+                config.max_coverage_per_sibling,
+            ))),
+            config,
+        }
+    }
+
+    /// Spawn the heartbeat coroutine for one freshly-established connection, and
+    /// return the event sender its reader and writer feed (inbound beats, `Establish`
+    /// snoops, reader-closed). `beats` is where the coroutine's own outbound beats go
+    /// (to the writer); `send_beat` sends side-channel beats to siblings; `loop_tx`
+    /// is used only to emit `Severed` on a hard failure.
+    pub(crate) fn spawn<S: SendBeat>(
+        &self,
+        connection: ConnectionRef,
+        dialed: bool,
+        beats: mpsc::UnboundedSender<Heartbeat>,
+        send_beat: S,
+        loop_tx: mpsc::UnboundedSender<Command>,
+    ) -> mpsc::UnboundedSender<HeartbeatEvent> {
+        let (events_tx, events_rx) = mpsc::unbounded_channel();
+        tokio::task::spawn_local(heartbeat_task(HeartbeatCtx {
+            connection,
+            dialed,
+            beats,
+            events: events_rx,
+            handle: events_tx.clone(),
+            shared: self.shared.clone(),
+            config: self.config,
+            send_beat,
+            loop_tx,
+        }));
+        events_tx
+    }
+
+    /// Deliver an inbound sibling side-channel message to the Child-side coroutine of
+    /// the connection where `recipient` is the child. Called directly by the quic
+    /// side-channel reader — heartbeats never pass through ctx. Dropped if no such
+    /// connection is registered yet (the next beat retries).
+    pub(crate) fn deliver(
+        &self,
+        recipient: &[u8],
+        from: Vec<u8>,
+        conn_id: ConnectionId,
+        kind: BeatKind,
+    ) {
+        let shared = self.shared.borrow();
+        if let Some(handle) = shared.child_handle(recipient) {
+            let _ = handle.send(HeartbeatEvent::Side(from, conn_id, kind));
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Wire types (serialized by `framing.rs`)
+// ---------------------------------------------------------------------------
+
+/// The body of a [`WireFrame::Heartbeat`](crate::framing) probe, discriminated by
+/// direction: a Child sends [`Heartbeat::FromChild`], a Parent sends
+/// [`Heartbeat::FromParent`]. An empty one (both cover lists empty, or `delegate:
+/// None`) is a plain liveness beat, also used as the reader's backstop.
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) enum Heartbeat {
+    /// Child → parent: the running diff of connections this child covers for the
+    /// parent.
+    FromChild {
+        cover_add: Vec<ConnectionId>,
+        cover_del: Vec<ConnectionId>,
+    },
+    /// Parent → child: a delegation instruction, or `None` for a plain beat.
+    /// `None` never revokes — a child reverts on its own ack-timeout, a parent on
+    /// `ResumeHeartbeat` — so the empty backstop beat is safe.
+    FromParent { delegate: Option<Delegate> },
+}
+
+impl Heartbeat {
+    /// The empty beat for a peer of `role` (what that peer's reader synthesizes as
+    /// a liveness backstop). A [`Role::Parent`] peer sends [`Heartbeat::FromChild`]
+    /// (it is the child), a [`Role::Child`] peer sends [`Heartbeat::FromParent`].
+    pub(crate) fn empty_for_peer(role: Role) -> Self {
+        match role {
+            Role::Parent => Heartbeat::FromChild {
+                cover_add: Vec::new(),
+                cover_del: Vec::new(),
+            },
+            Role::Child => Heartbeat::FromParent { delegate: None },
+        }
+    }
+}
+
+/// A delegation instruction carried on a `FromParent` beat: "you are connection
+/// `connection_id`; beat `gateway_tag(sibling_ident)` to prove your liveness."
+#[derive(Serialize, Deserialize, Clone)]
+pub(crate) struct Delegate {
+    pub(crate) connection_id: ConnectionId,
+    pub(crate) sibling_ident: Vec<u8>,
+}
+
+/// What a sibling side-channel heartbeat message is.
+#[derive(Serialize, Deserialize, Clone, Copy)]
+pub(crate) enum BeatKind {
+    /// Delegated child → delegate: prove liveness.
+    Beat,
+    /// Delegate → delegated child: acknowledge a beat.
+    Ack,
+    /// Delegate → delegated child: I am tearing down — stop delegating to me and
+    /// heartbeat your parent directly again.
+    Release,
+}
+
+// ---------------------------------------------------------------------------
+// Control channels
+// ---------------------------------------------------------------------------
+
+/// Events into a `heartbeat_task`. A task is either a Parent or a Child, so it only
+/// ever sees the events for its role.
+pub(crate) enum HeartbeatEvent {
+    /// An inbound physical heartbeat from the peer (a Parent-side task receives the
+    /// [`Heartbeat::FromChild`] variant, a Child-side task the
+    /// [`Heartbeat::FromParent`] variant; each ignores the other).
+    ReceivedHeartbeat(Heartbeat),
+    /// Our outgoing `Establish` (from the writer): our own ident.
+    EstablishLocal { local_ident: Vec<u8> },
+    /// The peer's `Establish` (from the reader): the peer's ident.
+    EstablishPeer { peer_ident: Vec<u8> },
+    /// The reader hit error/EOF (hard transport close).
+    ReaderClosed,
+
+    /// To a Parent-side task: a sibling now covers this connection, so pause
+    /// watching it directly (its delegate proves it live).
+    PauseHeartbeat,
+    /// To a Parent-side task: no sibling covers this connection any more, so resume
+    /// watching it directly.
+    ResumeHeartbeat,
+
+    /// To a Child-side task: an inbound sibling side-channel message `(from, conn_id,
+    /// kind)`. [`BeatKind::Beat`] is a delegated child beating us (we host its
+    /// coverage); [`BeatKind::Ack`] is our delegate acking our beat;
+    /// [`BeatKind::Release`] is our delegate tearing down (revert to direct).
+    Side(Vec<u8>, ConnectionId, BeatKind),
+}
+
+// ---------------------------------------------------------------------------
+// Shared state (one per QuicTransport / context)
+// ---------------------------------------------------------------------------
+
+/// Where one child connection sits in the delegation lifecycle, from the parent's
+/// point of view. [`ParentPool`] derives its accounting from this (whether we beat the
+/// child directly, and the coverage it consumes from a sibling), so no caller pokes
+/// that accounting directly.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ChildStatus {
+    /// Attached; its `Establish` (ident) has not arrived yet.
+    NotEstablished,
+    /// Established and beating us directly. Watched directly, and a valid delegate for
+    /// its siblings (it may itself cover some — see `SiblingInfo::requested_covers`).
+    Direct,
+    /// We asked it to delegate its liveness to its `sibling`; still watched directly at
+    /// the loop level (it is about to go silent), but already treated as offloaded for
+    /// the budget, and not itself offered as a delegate.
+    Delegating,
+    /// Its `sibling` now covers it; it is silent to us (paused).
+    Paused,
+}
+
+/// A parent's record of one child connection. Owned by [`ParentPool`], the single
+/// source of truth for it: the direct-heartbeat count and each sibling's coverage are
+/// *derived* from these fields as statuses transition, never poked by callers.
+struct SiblingInfo {
+    /// The child's ident, once its `Establish` is snooped. `Some` implies the child
+    /// has established; whether it is *addressable* (has a dialable gateway tag) is
+    /// derived from it.
+    ident: Option<Vec<u8>>,
+    /// Whether the parent dialed this child (join); only a dialed+served link may
+    /// serve as a delegate.
+    dialed: bool,
+    status: ChildStatus,
+    /// The sibling we delegated this child to; meaningful only while `Delegating` /
+    /// `Paused`.
+    sibling: Option<ConnectionId>,
+    /// How many other children we have *requested* this one cover for us (charged at
+    /// delegation-decision time, which may run ahead of the coverage the sibling has
+    /// actually reported); nonzero only while `Direct`.
+    requested_covers: usize,
+}
+
+impl SiblingInfo {
+    /// Whether this child may be handed another child to cover right now: it must be a
+    /// direct child under its coverage cap, dialed by us, and addressable.
+    fn is_delegate_candidate(&self, cap: usize) -> bool {
+        self.status == ChildStatus::Direct
+            && self.requested_covers < cap
+            && self.dialed
+            && self.ident.as_deref().is_some_and(is_addressable)
+    }
+}
+
+/// The set of connections currently eligible to be handed a sibling to cover, kept in
+/// sync by [`ParentPool::set_status`]. A `Vec` gives the round-robin cursor something to
+/// index; the position map makes add/remove O(1) (remove is `swap_remove` + an index
+/// fixup for the element that moved into the hole).
+#[derive(Default)]
+struct CandidateRing {
+    ids: Vec<ConnectionId>,
+    pos: HashMap<ConnectionId, usize>,
+}
+
+impl CandidateRing {
+    fn insert(&mut self, id: ConnectionId) {
+        if self.pos.contains_key(&id) {
+            return;
+        }
+        self.pos.insert(id, self.ids.len());
+        self.ids.push(id);
+    }
+
+    fn remove(&mut self, id: ConnectionId) {
+        let Some(i) = self.pos.remove(&id) else {
+            return;
+        };
+        let last = self.ids.len() - 1;
+        self.ids.swap(i, last);
+        self.ids.pop();
+        if i != last {
+            *self
+                .pos
+                .get_mut(&self.ids[i])
+                .expect("swapped id is tracked") = i;
+        }
+    }
+
+    /// The next candidate other than `exclude` (the child being delegated is itself a
+    /// candidate), advancing the cursor. `None` if there is no other candidate.
+    fn next(&self, rr: &mut usize, exclude: ConnectionId) -> Option<ConnectionId> {
+        let n = self.ids.len();
+        for _ in 0..n {
+            let id = self.ids[*rr % n];
+            *rr = rr.wrapping_add(1);
+            if id != exclude {
+                return Some(id);
+            }
+        }
+        None
+    }
+}
+
+/// A parent's pool of child connections and the delegation state derived from them.
+/// It owns the per-child [`SiblingInfo`] records and is the *only* place eligibility
+/// and the direct-heartbeat count are computed: callers narrate connection events
+/// (the lifecycle methods below) and never touch the derived state.
+struct ParentPool {
+    siblings: HashMap<ConnectionId, SiblingInfo>,
+    /// Count of children currently heartbeated directly. Derived — maintained as
+    /// statuses transition — and drives the delegation budget.
+    active_direct: i64,
+    /// Round-robin cursor over `candidates`, so consecutive delegations spread across
+    /// siblings and a just-failed one is unlikely to be re-picked immediately.
+    rr: usize,
+    /// Connections eligible to cover a sibling right now, maintained incrementally by
+    /// `set_status` so `pick_delegate` is O(1).
+    candidates: CandidateRing,
+    /// Max children any one sibling may be asked to cover; feeds `is_delegate_candidate`.
+    cap: usize,
+}
+
+impl ParentPool {
+    fn new(cap: usize) -> Self {
+        Self {
+            siblings: HashMap::new(),
+            active_direct: 0,
+            rr: 0,
+            candidates: CandidateRing::default(),
+            cap,
+        }
+    }
+
+    // --- connection lifecycle (the only way callers change pool state) ---
+
+    /// A child connection was added (not yet established). We beat it directly from now
+    /// on, so it immediately counts toward the budget.
+    fn add_child(&mut self, conn_id: ConnectionId, dialed: bool) {
+        self.siblings.insert(
+            conn_id,
+            SiblingInfo {
+                ident: None,
+                dialed,
+                status: ChildStatus::NotEstablished,
+                sibling: None,
+                requested_covers: 0,
+            },
+        );
+        self.active_direct += 1;
+    }
+
+    /// The child's `Establish` arrived: record its ident and treat it as a live
+    /// direct child.
+    fn established(&mut self, conn_id: ConnectionId, ident: Vec<u8>) {
+        if let Some(info) = self.siblings.get_mut(&conn_id) {
+            info.ident = Some(ident);
+        }
+        self.set_status(conn_id, Some(ChildStatus::Direct));
+    }
+
+    /// If we are over the direct-heartbeat budget and `conn_id` is a plain live direct
+    /// child, delegate it to an eligible sibling: record the delegation, charge that
+    /// sibling's coverage, and return the [`Delegate`] instruction to send. `None` if
+    /// not over budget, the child isn't delegable, or no sibling is free.
+    fn delegate(&mut self, conn_id: ConnectionId, config: HeartbeatConfig) -> Option<Delegate> {
+        let info = self.siblings.get(&conn_id)?;
+        // Only a plain, established, dialed direct child is delegated — never a cover
+        // host, an already-delegating/paused one, or one we can't dial or address.
+        if info.status != ChildStatus::Direct
+            || info.requested_covers != 0
+            || !info.dialed
+            || info.ident.is_none()
+        {
+            return None;
+        }
+        if !self.over_budget(config.max_direct_children) {
+            return None;
+        }
+        let (sibling_conn, sibling_ident) = self.pick_delegate(conn_id)?;
+        // Point the child at its delegate, then transition: `set_status` charges
+        // `sibling_conn`'s coverage as the child enters `Delegating`.
+        self.siblings.get_mut(&conn_id)?.sibling = Some(sibling_conn);
+        self.set_status(conn_id, Some(ChildStatus::Delegating));
+        Some(Delegate {
+            connection_id: conn_id,
+            sibling_ident,
+        })
+    }
+
+    /// Whether we are over the direct-heartbeat budget.
+    fn over_budget(&self, max_direct_children: usize) -> bool {
+        self.active_direct > max_direct_children as i64
+    }
+
+    /// This child's current status, if we still track it.
+    fn status(&self, conn_id: ConnectionId) -> Option<ChildStatus> {
+        self.siblings.get(&conn_id).map(|i| i.status)
+    }
+
+    // --- derived-state maintenance (internal) ---
+
+    /// Move a child to `status` (or, if `None`, remove it entirely — a connection is
+    /// gone). All accounting is done here by reversing what the child contributed before
+    /// the change, then applying what it contributes after; the candidate list follows
+    /// the child's own candidacy across the transition (the coverage change to any
+    /// *sibling* is reflected in `account`, where that sibling's count moves).
+    fn set_status(&mut self, conn_id: ConnectionId, status: Option<ChildStatus>) {
+        let was_candidate = self.is_candidate(conn_id);
+        self.account(conn_id, -1);
+        match status {
+            Some(status) => {
+                let Some(info) = self.siblings.get_mut(&conn_id) else {
+                    return;
+                };
+                info.status = status;
+                // Only a delegated child points at a sibling.
+                if !matches!(status, ChildStatus::Delegating | ChildStatus::Paused) {
+                    info.sibling = None;
+                }
+                self.account(conn_id, 1);
+            }
+            None => {
+                self.siblings.remove(&conn_id);
+            }
+        }
+        self.refresh_candidate(conn_id, was_candidate);
+    }
+
+    /// Apply (`sign` = 1) or reverse (`sign` = -1) the bookkeeping the child at `conn_id`
+    /// implies given its current status: whether we heartbeat it directly (the budget),
+    /// and the unit of coverage it consumes from the sibling it is delegated to.
+    fn account(&mut self, conn_id: ConnectionId, sign: i64) {
+        let Some(info) = self.siblings.get(&conn_id) else {
+            return;
+        };
+        let (status, sibling) = (info.status, info.sibling);
+        match status {
+            // We heartbeat it directly — it counts toward the budget.
+            ChildStatus::NotEstablished | ChildStatus::Direct => self.active_direct += sign,
+            // Delegated to a sibling: once we *request* delegation we treat it as
+            // offloaded (so we don't keep delegating others while the pause is in
+            // flight), and we charge the sibling one requested cover. `Delegating` still
+            // watches directly at the loop level, but for the budget it no longer counts;
+            // if the delegation falls back it reverts to `Direct` and counts again. The
+            // sibling may already be gone if it died before the child it was covering.
+            ChildStatus::Delegating | ChildStatus::Paused => {
+                let sibling = sibling.expect("a delegated child has a sibling");
+                let was_candidate = self.is_candidate(sibling);
+                if let Some(info) = self.siblings.get_mut(&sibling) {
+                    info.requested_covers =
+                        info.requested_covers.saturating_add_signed(sign as isize);
+                }
+                // Changing the sibling's `requested_covers` can move it across the cap.
+                self.refresh_candidate(sibling, was_candidate);
+            }
+        }
+    }
+
+    /// Whether `conn_id` is currently a delegate candidate.
+    fn is_candidate(&self, conn_id: ConnectionId) -> bool {
+        self.siblings
+            .get(&conn_id)
+            .is_some_and(|i| i.is_delegate_candidate(self.cap))
+    }
+
+    /// Sync `conn_id`'s membership in the candidate ring after a change, given whether it
+    /// was a candidate beforehand.
+    fn refresh_candidate(&mut self, conn_id: ConnectionId, was_candidate: bool) {
+        match (was_candidate, self.is_candidate(conn_id)) {
+            (false, true) => self.candidates.insert(conn_id),
+            (true, false) => self.candidates.remove(conn_id),
+            _ => {}
+        }
+    }
+
+    /// Round-robin pick of a delegate candidate other than `exclude`.
+    fn pick_delegate(&mut self, exclude: ConnectionId) -> Option<(ConnectionId, Vec<u8>)> {
+        let chosen = self.candidates.next(&mut self.rr, exclude)?;
+        let ident = self.siblings.get(&chosen)?.ident.clone()?;
+        Some((chosen, ident))
+    }
+
+    /// Rebuild the candidate ring from scratch (tests that stuff `siblings` directly,
+    /// bypassing the incremental `set_status` maintenance).
+    #[cfg(test)]
+    fn rebuild_candidates(&mut self) {
+        self.candidates = CandidateRing::default();
+        let ids: Vec<ConnectionId> = self
+            .siblings
+            .iter()
+            .filter(|(_, i)| i.is_delegate_candidate(self.cap))
+            .map(|(&id, _)| id)
+            .collect();
+        for id in ids {
+            self.candidates.insert(id);
+        }
+    }
+}
+
+/// One per [`QuicTransport`](crate::quic_transport::QuicTransport) (per context).
+/// Single-threaded → held behind `Rc<RefCell<>>`.
+pub(crate) struct HeartbeatShared {
+    next_conn_id: ConnectionId,
+    /// For each local actor, the control handle of the Child-side task on that
+    /// actor's parent connection. Keyed by the actor's own ident (an actor has one
+    /// parent, so at most one entry).
+    children_by_ident: HashMap<Vec<u8>, Handle>,
+    /// For each local parent→child connection, the control handle of its
+    /// Parent-side task. Keyed by that connection's [`ConnectionId`].
+    parents_by_conn_id: HashMap<ConnectionId, Handle>,
+    /// For each local actor that parents quic children, its delegate pool.
+    parents: HashMap<Key, ParentPool>,
+    /// Max children any one sibling may cover; seeded into each [`ParentPool`].
+    max_coverage_per_sibling: usize,
+}
+
+impl HeartbeatShared {
+    pub(crate) fn new(max_coverage_per_sibling: usize) -> Self {
+        Self {
+            next_conn_id: 0,
+            children_by_ident: HashMap::new(),
+            parents_by_conn_id: HashMap::new(),
+            parents: HashMap::new(),
+            max_coverage_per_sibling,
+        }
+    }
+
+    /// The Child-side task handle for the connection where `ident` is the child, if
+    /// registered. Used to deliver inbound side-channel beats/acks.
+    pub(crate) fn child_handle(&self, ident: &[u8]) -> Option<&Handle> {
+        self.children_by_ident.get(ident)
+    }
+
+    fn alloc_conn_id(&mut self) -> ConnectionId {
+        let id = self.next_conn_id;
+        self.next_conn_id += 1;
+        id
+    }
+
+    fn pool_mut(&mut self, key: Key) -> &mut ParentPool {
+        let cap = self.max_coverage_per_sibling;
+        self.parents
+            .entry(key)
+            .or_insert_with(|| ParentPool::new(cap))
+    }
+
+    /// Route a delegate host's coverage diff to the covered connections' Parent-side
+    /// loops: a first `cover_add(X)` pauses `X`'s loop, a `cover_del(X)` resumes it.
+    /// `covered` tracks this host's contributions so its teardown can resume them.
+    fn signal_coverage(
+        &self,
+        covered: &mut HashSet<ConnectionId>,
+        cover_add: Vec<ConnectionId>,
+        cover_del: Vec<ConnectionId>,
+    ) {
+        for x in cover_add {
+            if covered.insert(x) {
+                if let Some(h) = self.parents_by_conn_id.get(&x) {
+                    let _ = h.send(HeartbeatEvent::PauseHeartbeat);
+                }
+            }
+        }
+        for x in cover_del {
+            if covered.remove(&x) {
+                if let Some(h) = self.parents_by_conn_id.get(&x) {
+                    let _ = h.send(HeartbeatEvent::ResumeHeartbeat);
+                }
+            }
+        }
+    }
+
+    /// Resume every connection a delegate host was covering (called as the host tears
+    /// down, so its covered children reclaim themselves as direct).
+    fn resume_covered(&self, covered: &HashSet<ConnectionId>) {
+        for x in covered {
+            if let Some(h) = self.parents_by_conn_id.get(x) {
+                let _ = h.send(HeartbeatEvent::ResumeHeartbeat);
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Task entry point
+// ---------------------------------------------------------------------------
+
+/// Sends one sibling side-channel message out: `(recipient, from, conn_id, kind)`.
+/// The caller supplies this so the heartbeat module needs no knowledge of *how*
+/// beats travel — the quic transport wires in a closure over its gateway side
+/// channels, and tests can substitute their own.
+pub(crate) trait SendBeat: Fn(Vec<u8>, Vec<u8>, ConnectionId, BeatKind) + 'static {}
+impl<F: Fn(Vec<u8>, Vec<u8>, ConnectionId, BeatKind) + 'static> SendBeat for F {}
+
+/// Everything a `heartbeat_task` needs, bundled to keep the spawn site readable.
+/// Private — a task is only ever created through [`Heartbeats::spawn`].
+struct HeartbeatCtx<S: SendBeat> {
+    connection: ConnectionRef,
+    dialed: bool,
+    /// Physical heartbeat frames this task wants its connection's writer to send.
+    beats: mpsc::UnboundedSender<Heartbeat>,
+    events: mpsc::UnboundedReceiver<HeartbeatEvent>,
+    /// This task's own control handle, for registration in [`HeartbeatShared`].
+    handle: Handle,
+    shared: Rc<RefCell<HeartbeatShared>>,
+    config: HeartbeatConfig,
+    /// Sends a Child-side beat/ack out over a side channel (see [`SendBeat`]). The
+    /// module stays ignorant of the transport that carries it.
+    send_beat: S,
+    /// Only used to emit `Severed` on a hard failure — the same connection-failure
+    /// signal the reader uses, not a heartbeat routing path.
+    loop_tx: mpsc::UnboundedSender<Command>,
+}
+
+/// Run the heartbeat coroutine for one connection, dispatching on its role.
+async fn heartbeat_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
+    match ctx.connection.role() {
+        Role::Parent => parent_task(ctx).await,
+        Role::Child => child_task(ctx).await,
+    }
+}
+
+/// Await `deadline` if set, else never resolve (a parked timeout).
+async fn deadline_or_park(deadline: Option<Instant>) {
+    match deadline {
+        Some(d) => tokio::time::sleep_until(d).await,
+        None => std::future::pending::<()>().await,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Parent side (B watching child D)
+// ---------------------------------------------------------------------------
+
+/// How the direct (normal-connection) loop ended.
+enum DirectExit {
+    /// The connection closed / severed; the task is done.
+    Closed,
+    /// The child reported covering a sibling, so it is now a delegate host: hand off
+    /// to the cover loop (which always heartbeats and is never itself delegated),
+    /// carrying that first coverage diff.
+    BecameCover {
+        cover_add: Vec<ConnectionId>,
+        cover_del: Vec<ConnectionId>,
+    },
+}
+
+/// A Parent-side connection is one of two kinds, and the switch between them is
+/// one-way:
+///
+/// - **normal** — watched directly, and possibly *delegated to* a sibling
+///   (`PauseHeartbeat` parks us, `ResumeHeartbeat` un-parks us); we may also ask the
+///   child to delegate. This is [`parent_direct_loop`].
+/// - **delegate host** — once the child reports covering a sibling it is load-bearing
+///   for that sibling's liveness, so we commit to heartbeating it directly forever
+///   and never delegate it (no Pause/Resume). This is [`parent_cover_loop`].
+async fn parent_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
+    let HeartbeatCtx {
+        connection,
+        dialed,
+        beats,
+        mut events,
+        handle,
+        shared,
+        config,
+        // A Parent-side task never originates side-channel beats (it delegates over
+        // its own writer and watches physical beats), so it does not use this.
+        send_beat: _,
+        loop_tx,
+    } = ctx;
+    let key = connection.owning_actor();
+
+    // Assign this connection's id and register it so sibling loops can send
+    // `PauseHeartbeat`/`ResumeHeartbeat` here, and seed our record in the pool.
+    let conn_id = {
+        let mut s = shared.borrow_mut();
+        let conn_id = s.alloc_conn_id();
+        s.parents_by_conn_id.insert(conn_id, handle.clone());
+        s.pool_mut(key).add_child(conn_id, dialed);
+        conn_id
+    };
+
+    // Start as a normal connection; the first coverage report switches us — for good
+    // — to being a delegate host.
+    if let DirectExit::BecameCover {
+        cover_add,
+        cover_del,
+    } = parent_direct_loop(
+        connection,
+        conn_id,
+        key,
+        config,
+        &beats,
+        &mut events,
+        &shared,
+        &loop_tx,
+    )
+    .await
+    {
+        parent_cover_loop(
+            connection,
+            config,
+            cover_add,
+            cover_del,
+            &beats,
+            &mut events,
+            &shared,
+            &loop_tx,
+        )
+        .await;
+    }
+
+    // Teardown: drop our record (undoing our budget/coverage contributions) and
+    // deregister. (A delegate host's covered children are resumed by
+    // `parent_cover_loop` itself as it exits.)
+    let mut s = shared.borrow_mut();
+    s.pool_mut(key).set_status(conn_id, None);
+    s.parents_by_conn_id.remove(&conn_id);
+}
+
+/// The **normal-connection** loop: heartbeat the child and watch its beats. The
+/// connection may be delegated to a sibling — `PauseHeartbeat` parks it (we stop
+/// watching, the sibling proves it live), `ResumeHeartbeat` un-parks it — and we may
+/// ask the child to delegate (which does not change our state; a later
+/// `PauseHeartbeat` confirms a sibling took it). Returns when the connection closes,
+/// or [`DirectExit::BecameCover`] the first time the child reports covering a sibling.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each is a distinct per-connection channel/handle; bundling adds indirection"
+)]
+async fn parent_direct_loop(
+    connection: ConnectionRef,
+    conn_id: ConnectionId,
+    key: Key,
+    config: HeartbeatConfig,
+    beats: &mpsc::UnboundedSender<Heartbeat>,
+    events: &mut mpsc::UnboundedReceiver<HeartbeatEvent>,
+    shared: &Rc<RefCell<HeartbeatShared>>,
+    loop_tx: &mpsc::UnboundedSender<Command>,
+) -> DirectExit {
+    let mut beat_timer = tokio::time::interval(config.interval);
+    beat_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    // `Some` while watching directly (a lapse severs); `None` while paused (a sibling
+    // is proving the child live).
+    let mut deadline = Some(Instant::now() + config.timeout);
+
+    loop {
+        tokio::select! {
+            _ = beat_timer.tick() => {
+                // Silent while paused (the delegated child ignores us).
+                if deadline.is_some() {
+                    let _ = beats.send(Heartbeat::FromParent { delegate: None });
+                }
+            }
+            _ = deadline_or_park(deadline) => {
+                // The child has gone silent. Even if we had asked it to delegate, a
+                // live child reverts and beats us again within its (half-timeout)
+                // settle window — well before this full timeout — so reaching here
+                // means it is genuinely gone. Sever. (While paused the deadline is
+                // `None`, so this never fires for a covered child.)
+                sever(loop_tx, connection, b"quic heartbeat timeout".to_vec());
+                return DirectExit::Closed;
+            }
+            ev = events.recv() => {
+                let Some(ev) = ev else { return DirectExit::Closed };
+                match ev {
+                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromChild { cover_add, cover_del }) => {
+                        // The child is beating us directly (if it had been delegated it
+                        // has fallen back): refresh the deadline and reset it to direct.
+                        deadline = Some(Instant::now() + config.timeout);
+                        shared
+                            .borrow_mut()
+                            .pool_mut(key)
+                            .set_status(conn_id, Some(ChildStatus::Direct));
+
+                        if !cover_add.is_empty() {
+                            // First coverage report: it is now a delegate host (its
+                            // `requested_covers` was already bumped at delegation-decision
+                            // time, so no status change is needed). Hand off to the cover
+                            // loop, never to return here.
+                            return DirectExit::BecameCover { cover_add, cover_del };
+                        }
+
+                        // Otherwise, if we are over budget, ask it to delegate.
+                        if let Some(delegate) =
+                            shared.borrow_mut().pool_mut(key).delegate(conn_id, config)
+                        {
+                            let _ = beats.send(Heartbeat::FromParent { delegate: Some(delegate) });
+                        }
+                    }
+                    HeartbeatEvent::PauseHeartbeat => {
+                        // A sibling now covers this child: stop watching it directly — but
+                        // only while we are still delegating it. If it already fell back to
+                        // direct (its last direct beat raced this pause), keep watching.
+                        let mut s = shared.borrow_mut();
+                        let pool = s.pool_mut(key);
+                        if pool.status(conn_id) == Some(ChildStatus::Delegating) {
+                            pool.set_status(conn_id, Some(ChildStatus::Paused));
+                            deadline = None;
+                        }
+                    }
+                    HeartbeatEvent::ResumeHeartbeat => {
+                        // No sibling covers it any more: watch it directly again.
+                        shared
+                            .borrow_mut()
+                            .pool_mut(key)
+                            .set_status(conn_id, Some(ChildStatus::Direct));
+                        deadline = Some(Instant::now() + config.timeout);
+                    }
+                    HeartbeatEvent::EstablishPeer { peer_ident } => {
+                        shared
+                            .borrow_mut()
+                            .pool_mut(key)
+                            .established(conn_id, peer_ident);
+                    }
+                    HeartbeatEvent::EstablishLocal { .. } => {}
+                    HeartbeatEvent::ReaderClosed => return DirectExit::Closed,
+                    // These cannot reach a Parent-side loop: our child peer only ever
+                    // sends `FromChild`, and `Side` messages route via
+                    // `children_by_ident` to Child-side loops only.
+                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromParent { .. }) => {
+                        unreachable!("Parent-side loop received a FromParent beat")
+                    }
+                    HeartbeatEvent::Side(..) => {
+                        unreachable!("Parent-side loop received a side-channel message")
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// The **delegate-host** loop: this child covers one or more siblings, so we
+/// heartbeat it directly for good and never delegate it (no Pause/Resume). Its
+/// `FromChild` beats carry coverage diffs, which we forward as `PauseHeartbeat` /
+/// `ResumeHeartbeat` to the covered siblings' loops. On exit every covered sibling
+/// is resumed.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each is a distinct per-connection channel/handle; bundling adds indirection"
+)]
+async fn parent_cover_loop(
+    connection: ConnectionRef,
+    config: HeartbeatConfig,
+    cover_add: Vec<ConnectionId>,
+    cover_del: Vec<ConnectionId>,
+    beats: &mpsc::UnboundedSender<Heartbeat>,
+    events: &mut mpsc::UnboundedReceiver<HeartbeatEvent>,
+    shared: &Rc<RefCell<HeartbeatShared>>,
+    loop_tx: &mpsc::UnboundedSender<Command>,
+) {
+    let mut beat_timer = tokio::time::interval(config.interval);
+    beat_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let mut deadline = Instant::now() + config.timeout;
+    // The connections we cover; resumed if this link fails.
+    let mut covered: HashSet<ConnectionId> = HashSet::new();
+    shared
+        .borrow()
+        .signal_coverage(&mut covered, cover_add, cover_del);
+
+    loop {
+        tokio::select! {
+            _ = beat_timer.tick() => {
+                // A delegate host always heartbeats.
+                let _ = beats.send(Heartbeat::FromParent { delegate: None });
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                sever(loop_tx, connection, b"quic heartbeat timeout".to_vec());
+                break;
+            }
+            ev = events.recv() => {
+                let Some(ev) = ev else { break };
+                match ev {
+                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromChild { cover_add, cover_del }) => {
+                        deadline = Instant::now() + config.timeout;
+                        shared.borrow().signal_coverage(&mut covered, cover_add, cover_del);
+                    }
+                    // Establishment is a one-shot exchange that completed back in the
+                    // direct loop; a stray duplicate here is harmless.
+                    HeartbeatEvent::EstablishPeer { .. } | HeartbeatEvent::EstablishLocal { .. } => {}
+                    HeartbeatEvent::ReaderClosed => break,
+                    // A delegate host is never itself delegated, so no sibling ever
+                    // covers it → no Pause/Resume. Our child peer only sends
+                    // `FromChild`. `Side` routes to Child-side loops only. None reach.
+                    HeartbeatEvent::PauseHeartbeat | HeartbeatEvent::ResumeHeartbeat => {
+                        unreachable!("delegate host received Pause/Resume (it is never delegated)")
+                    }
+                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromParent { .. }) => {
+                        unreachable!("Parent-side loop received a FromParent beat")
+                    }
+                    HeartbeatEvent::Side(..) => {
+                        unreachable!("Parent-side loop received a side-channel message")
+                    }
+                }
+            }
+        }
+    }
+
+    // Stop covering everyone: each covered child's loop reclaims itself as direct.
+    shared.borrow().resume_covered(&covered);
+}
+
+// ---------------------------------------------------------------------------
+// Child side (D proving liveness to parent B; also hosts coverage as delegate C)
+// ---------------------------------------------------------------------------
+
+enum ChildState {
+    /// Prove liveness to B directly; time out on B's physical `FromParent` beats.
+    Direct,
+    /// Prove liveness via the side channel to sibling `c`; time out on its acks.
+    Delegated { x: ConnectionId, c: Vec<u8> },
+}
+
+async fn child_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
+    let HeartbeatCtx {
+        connection,
+        dialed: _,
+        beats,
+        mut events,
+        handle,
+        shared,
+        config,
+        send_beat,
+        loop_tx,
+    } = ctx;
+    let interval = config.interval;
+    let timeout = config.timeout;
+    // How long to wait for the *first* ack from a fresh delegate before giving up on
+    // it. Half a normal timeout, so that if the delegate never answers we fall back
+    // to beating our parent directly with time to spare — before the parent's own
+    // (full) timeout would declare us dead. Steady-state acks use the full timeout.
+    let settle = timeout / 2;
+
+    let mut own_ident: Option<Vec<u8>> = None;
+    let mut state = ChildState::Direct;
+    // Coverage-diff report to the parent, drained onto the next `FromChild` beat.
+    let mut cover_add: Vec<ConnectionId> = Vec::new();
+    let mut cover_del: Vec<ConnectionId> = Vec::new();
+    // Connections this child hosts coverage for (delegate-host duty): conn_id →
+    // (beating child's ident, deadline).
+    let mut coverage: HashMap<ConnectionId, (Vec<u8>, Instant)> = HashMap::new();
+
+    let mut beat_timer = tokio::time::interval(interval);
+    beat_timer.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    // The single primary timeout: B's beats (Direct) or C's acks (Delegated).
+    let mut primary = Instant::now() + timeout;
+
+    loop {
+        let cov_deadline = coverage.values().map(|(_, d)| *d).min();
+        tokio::select! {
+            _ = beat_timer.tick() => {
+                match &state {
+                    ChildState::Direct => {
+                        let _ = beats.send(Heartbeat::FromChild {
+                            cover_add: std::mem::take(&mut cover_add),
+                            cover_del: std::mem::take(&mut cover_del),
+                        });
+                    }
+                    ChildState::Delegated { x, c } => {
+                        if let Some(own) = &own_ident {
+                            // Beat our delegate C over the side channel.
+                            send_beat(c.clone(), own.clone(), *x, BeatKind::Beat);
+                        }
+                    }
+                }
+            }
+            _ = tokio::time::sleep_until(primary) => {
+                match &state {
+                    ChildState::Direct => {
+                        sever(&loop_tx, connection, b"quic heartbeat timeout".to_vec());
+                        break;
+                    }
+                    ChildState::Delegated { .. } => {
+                        // Lost our delegate; beat B directly again (B re-decides).
+                        state = ChildState::Direct;
+                        primary = Instant::now() + timeout;
+                    }
+                }
+            }
+            _ = deadline_or_park(cov_deadline), if cov_deadline.is_some() => {
+                let now = Instant::now();
+                let expired: Vec<ConnectionId> = coverage
+                    .iter()
+                    .filter(|(_, (_, d))| *d <= now)
+                    .map(|(&x, _)| x)
+                    .collect();
+                for x in expired {
+                    coverage.remove(&x);
+                    cover_del.push(x);
+                }
+            }
+            ev = events.recv() => {
+                let Some(ev) = ev else { break };
+                match ev {
+                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromParent { delegate }) => {
+                        // Any physical beat from B refreshes the direct deadline.
+                        if matches!(state, ChildState::Direct) {
+                            primary = Instant::now() + timeout;
+                        }
+                        if let Some(Delegate { connection_id, sibling_ident }) = delegate {
+                            let addressable = own_ident.as_deref().is_some_and(is_addressable);
+                            if addressable && matches!(state, ChildState::Direct) {
+                                state = ChildState::Delegated {
+                                    x: connection_id,
+                                    c: sibling_ident,
+                                };
+                                // Give the fresh delegate only the shorter settle
+                                // window to answer; a full ack later extends it.
+                                primary = Instant::now() + settle;
+                            }
+                        }
+                    }
+                    HeartbeatEvent::Side(from, conn_id, BeatKind::Beat) => {
+                        // Delegate-host duty: (re)arm coverage for `conn_id` and ack.
+                        let is_new = !coverage.contains_key(&conn_id);
+                        coverage.insert(conn_id, (from.clone(), Instant::now() + timeout));
+                        if is_new {
+                            cover_add.push(conn_id);
+                        }
+                        if let Some(own) = &own_ident {
+                            // Ack the delegated child that beat us.
+                            send_beat(from, own.clone(), conn_id, BeatKind::Ack);
+                        }
+                    }
+                    HeartbeatEvent::Side(_, conn_id, BeatKind::Ack) => {
+                        if let ChildState::Delegated { x, .. } = &state {
+                            if *x == conn_id {
+                                primary = Instant::now() + timeout;
+                            }
+                        }
+                    }
+                    HeartbeatEvent::Side(_, conn_id, BeatKind::Release) => {
+                        // Our delegate is tearing down: revert to beating our parent
+                        // directly again (no need to wait for the ack to lapse).
+                        if let ChildState::Delegated { x, .. } = &state {
+                            if *x == conn_id {
+                                state = ChildState::Direct;
+                                primary = Instant::now() + timeout;
+                            }
+                        }
+                    }
+                    HeartbeatEvent::EstablishLocal { local_ident } => {
+                        own_ident = Some(local_ident.clone());
+                        shared
+                            .borrow_mut()
+                            .children_by_ident
+                            .insert(local_ident, handle.clone());
+                    }
+                    HeartbeatEvent::EstablishPeer { .. } => {}
+                    HeartbeatEvent::ReaderClosed => {
+                        // The reader already severed with the detailed close reason;
+                        // this just stops the coroutine (its own `handle` clones keep
+                        // the event channel open, so it can't rely on that closing) so
+                        // the teardown below runs. Do *not* sever again here.
+                        break;
+                    }
+                    // These cannot reach a Child-side loop: our parent peer only ever
+                    // sends `FromParent`, and Pause/Resume route via
+                    // `parents_by_conn_id` to Parent-side loops only.
+                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromChild { .. }) => {
+                        unreachable!("Child-side loop received a FromChild beat")
+                    }
+                    HeartbeatEvent::PauseHeartbeat | HeartbeatEvent::ResumeHeartbeat => {
+                        unreachable!("Child-side loop received Pause/Resume")
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(own) = &own_ident {
+        // We are tearing down: tell every delegated child we were covering to stop
+        // delegating to us and heartbeat its parent directly again, so it re-homes
+        // immediately rather than waiting for our acks to lapse.
+        for (&conn_id, (child_ident, _)) in &coverage {
+            send_beat(child_ident.clone(), own.clone(), conn_id, BeatKind::Release);
+        }
+        shared.borrow_mut().children_by_ident.remove(own);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+//
+// These drive the *real* heartbeat coroutines ([`Heartbeats::spawn`]) but replace
+// the QUIC transport with a manual pump, so the order of messages into the
+// `Heartbeats` object is fully controlled:
+//
+//   * A connection's outgoing physical beats land in its `beats` receiver; a test
+//     forwards a peer's beats into this connection's `events` as `ReceivedHeartbeat`
+//     (this is what the reader would do). Withholding that forward simulates a
+//     silent / dead peer.
+//   * Sibling side-channel beats/acks/releases go through the real
+//     [`Heartbeats::deliver`] (the same call the side-channel reader makes), routed
+//     by `children_by_ident` — so one shared `Heartbeats` models the B/C/D fabric.
+//   * A `Severed` shows up on the connection's `loop_tx` receiver.
+//
+// Time is real but short (see [`test_config`]) so the tests run in well under a
+// second while exercising the genuine timers.
+#[cfg(test)]
+mod tests {
+    use slotmap::SlotMap;
+    use tokio::sync::mpsc;
+
+    use super::*;
+    use crate::connection::ConnectionCommand;
+    use crate::ctx::ChildConnectionKey;
+
+    const INTERVAL_MS: u64 = 20;
+    const TIMEOUT_MS: u64 = 200;
+
+    fn test_config() -> HeartbeatConfig {
+        HeartbeatConfig {
+            interval: Duration::from_millis(INTERVAL_MS),
+            timeout: Duration::from_millis(TIMEOUT_MS),
+            // A parent may keep one child direct; a second established child is over
+            // budget and gets delegated.
+            max_direct_children: 1,
+            max_coverage_per_sibling: 8,
+        }
+    }
+
+    /// One spawned coroutine's test-side handles.
+    struct Conn {
+        events: mpsc::UnboundedSender<HeartbeatEvent>,
+        beats: mpsc::UnboundedReceiver<Heartbeat>,
+        severs: mpsc::UnboundedReceiver<Command>,
+    }
+
+    /// Spawn a Parent-side coroutine (watches a child `slot` of actor `parent`).
+    /// `dialed` = we dialed the child (required for delegation).
+    fn spawn_parent(hb: &Heartbeats, parent: Key, slot: ChildConnectionKey, dialed: bool) -> Conn {
+        let (beats_tx, beats) = mpsc::unbounded_channel();
+        let (sever_tx, severs) = mpsc::unbounded_channel();
+        let connection = ConnectionRef::ChildConnection {
+            ofactor: parent,
+            slot,
+        };
+        // A parent never originates side-channel beats.
+        let events = hb.spawn(connection, dialed, beats_tx, |_, _, _, _| {}, sever_tx);
+        Conn {
+            events,
+            beats,
+            severs,
+        }
+    }
+
+    /// Spawn a Child-side coroutine for actor `actor`. Its side-channel beats/acks
+    /// are delivered through the same `Heartbeats` (the shared fabric).
+    fn spawn_child(hb: &Heartbeats, actor: Key) -> Conn {
+        let (beats_tx, beats) = mpsc::unbounded_channel();
+        let (sever_tx, severs) = mpsc::unbounded_channel();
+        let connection = ConnectionRef::ParentConnection { ofactor: actor };
+        let fabric = hb.clone();
+        let send_beat = move |recipient: Vec<u8>, from: Vec<u8>, conn_id: ConnectionId, kind| {
+            fabric.deliver(&recipient, from, conn_id, kind);
+        };
+        // `dialed` is irrelevant on the child side.
+        let events = hb.spawn(connection, false, beats_tx, send_beat, sever_tx);
+        Conn {
+            events,
+            beats,
+            severs,
+        }
+    }
+
+    fn send(c: &Conn, ev: HeartbeatEvent) {
+        let _ = c.events.send(ev);
+    }
+
+    fn establish_child(c: &Conn, own: &[u8], parent: &[u8]) {
+        send(
+            c,
+            HeartbeatEvent::EstablishLocal {
+                local_ident: own.to_vec(),
+            },
+        );
+        send(
+            c,
+            HeartbeatEvent::EstablishPeer {
+                peer_ident: parent.to_vec(),
+            },
+        );
+    }
+
+    fn establish_parent(c: &Conn, peer: &[u8]) {
+        send(
+            c,
+            HeartbeatEvent::EstablishPeer {
+                peer_ident: peer.to_vec(),
+            },
+        );
+    }
+
+    /// Forward every physical beat `from` has emitted into `to` (what a live reader
+    /// would do). Withholding this is how a test simulates a silent peer.
+    fn pump(from: &mut Conn, to: &Conn) {
+        while let Ok(hb) = from.beats.try_recv() {
+            let _ = to.events.send(HeartbeatEvent::ReceivedHeartbeat(hb));
+        }
+    }
+
+    /// Forward only a *coverage-bearing* `FromChild` beat (non-empty `cover_add`),
+    /// dropping plain ones — so a delegate host's parent loop sees its first beat as
+    /// `BecameCover` and never mistakenly delegates the host itself. Returns whether
+    /// one was forwarded.
+    fn pump_cover_beat(from: &mut Conn, to: &Conn) -> bool {
+        let mut forwarded = false;
+        while let Ok(hb) = from.beats.try_recv() {
+            if matches!(&hb, Heartbeat::FromChild { cover_add, .. } if !cover_add.is_empty()) {
+                let _ = to.events.send(HeartbeatEvent::ReceivedHeartbeat(hb));
+                forwarded = true;
+            }
+        }
+        forwarded
+    }
+
+    fn drain_beats(c: &mut Conn) {
+        while c.beats.try_recv().is_ok() {}
+    }
+
+    fn sever_reason(c: &mut Conn) -> Option<Vec<u8>> {
+        match c.severs.try_recv() {
+            Ok(Command::ConnectionAction {
+                action: ConnectionCommand::Severed { reason },
+                ..
+            }) => Some(reason),
+            _ => None,
+        }
+    }
+
+    async fn nap(ms: u64) {
+        tokio::time::sleep(Duration::from_millis(ms)).await;
+    }
+
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .unwrap()
+    }
+
+    /// Delegate selection skips any sibling that is not a *live* candidate (status
+    /// isn't `Direct`, or it isn't dialed / addressable / under capacity) and
+    /// round-robins over the ones that are — so a dead-but-not-yet-reaped sibling is
+    /// never handed a child.
+    #[test]
+    fn pick_delegate_skips_non_candidates_and_round_robins() {
+        let cap = 8;
+        let mut pool = ParentPool::new(cap);
+        let sib = |ident: &[u8], dialed, status, requested_covers| SiblingInfo {
+            ident: Some(ident.to_vec()),
+            dialed,
+            status,
+            sibling: None,
+            requested_covers,
+        };
+        pool.siblings
+            .insert(1, sib(b"c1@x", true, ChildStatus::Direct, 0)); // candidate
+        pool.siblings
+            .insert(2, sib(b"c2@x", true, ChildStatus::Direct, 1)); // candidate (already covers one)
+        pool.siblings
+            .insert(3, sib(b"paused@x", true, ChildStatus::Paused, 0)); // delegated away
+        pool.siblings.insert(
+            4,
+            sib(b"unestablished@x", true, ChildStatus::NotEstablished, 0),
+        ); // not established
+        pool.siblings
+            .insert(5, sib(b"nodial@x", false, ChildStatus::Direct, 0)); // we didn't dial it
+        pool.siblings
+            .insert(6, sib(b"noaddr", true, ChildStatus::Direct, 0)); // no gateway tag
+        pool.siblings
+            .insert(7, sib(b"full@x", true, ChildStatus::Direct, cap)); // at capacity
+        pool.rebuild_candidates();
+
+        // The child being delegated (excluded) is conn 99.
+        let picks: Vec<ConnectionId> = (0..6)
+            .map(|_| {
+                pool.pick_delegate(99)
+                    .expect("an eligible sibling exists")
+                    .0
+            })
+            .collect();
+        assert!(
+            picks.iter().all(|&id| id == 1 || id == 2),
+            "only live, dialed, addressable, under-capacity candidates picked: {picks:?}",
+        );
+        assert!(
+            picks.contains(&1) && picks.contains(&2),
+            "round-robin uses both candidates: {picks:?}",
+        );
+    }
+
+    /// B watching D directly: stable while both are pumped; B severs once D goes
+    /// silent.
+    #[test]
+    fn direct_liveness_and_parent_timeout() {
+        let rt = runtime();
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async {
+            let hb = Heartbeats::with_config(test_config());
+            let mut keys: SlotMap<Key, ()> = SlotMap::with_key();
+            let mut slots: SlotMap<ChildConnectionKey, ()> = SlotMap::with_key();
+            let b = keys.insert(());
+            let d = keys.insert(());
+            let d_slot = slots.insert(());
+
+            let mut bd = spawn_parent(&hb, b, d_slot, true);
+            let mut d = spawn_child(&hb, d);
+            establish_parent(&bd, b"D@d");
+            establish_child(&d, b"D@d", b"B@b");
+
+            // Steady state: both beat each other for several intervals — no sever.
+            for _ in 0..8 {
+                nap(INTERVAL_MS).await;
+                pump(&mut bd, &d);
+                pump(&mut d, &bd);
+            }
+            assert!(
+                sever_reason(&mut bd).is_none(),
+                "B should not sever while D beats"
+            );
+            assert!(
+                sever_reason(&mut d).is_none(),
+                "D should not sever while B beats"
+            );
+
+            // D goes silent (we stop forwarding its beats to B); keep B beating D so
+            // only B's watch of D lapses.
+            let mut reason = None;
+            for _ in 0..((TIMEOUT_MS / INTERVAL_MS) + 4) {
+                nap(INTERVAL_MS).await;
+                pump(&mut bd, &d);
+                drain_beats(&mut d);
+                if let Some(r) = sever_reason(&mut bd) {
+                    reason = Some(r);
+                    break;
+                }
+            }
+            assert_eq!(
+                reason.as_deref(),
+                Some(b"quic heartbeat timeout".as_slice()),
+                "B severs D once D stops beating"
+            );
+            assert!(
+                sever_reason(&mut d).is_none(),
+                "D itself did not sever (B kept beating it)"
+            );
+        });
+    }
+
+    /// A child severs when its parent goes silent.
+    #[test]
+    fn child_times_out_when_parent_silent() {
+        let rt = runtime();
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async {
+            let hb = Heartbeats::with_config(test_config());
+            let mut keys: SlotMap<Key, ()> = SlotMap::with_key();
+            let mut slots: SlotMap<ChildConnectionKey, ()> = SlotMap::with_key();
+            let b = keys.insert(());
+            let d = keys.insert(());
+            let d_slot = slots.insert(());
+
+            let mut bd = spawn_parent(&hb, b, d_slot, true);
+            let mut d = spawn_child(&hb, d);
+            establish_parent(&bd, b"D@d");
+            establish_child(&d, b"D@d", b"B@b");
+
+            for _ in 0..6 {
+                nap(INTERVAL_MS).await;
+                pump(&mut bd, &d);
+                pump(&mut d, &bd);
+            }
+            assert!(sever_reason(&mut d).is_none());
+
+            // B goes silent; keep forwarding D's beats to B so only D's watch lapses.
+            let mut reason = None;
+            for _ in 0..((TIMEOUT_MS / INTERVAL_MS) + 4) {
+                nap(INTERVAL_MS).await;
+                pump(&mut d, &bd);
+                drain_beats(&mut bd);
+                if let Some(r) = sever_reason(&mut d) {
+                    reason = Some(r);
+                    break;
+                }
+            }
+            assert_eq!(
+                reason.as_deref(),
+                Some(b"quic heartbeat timeout".as_slice()),
+                "D severs once its parent stops beating"
+            );
+        });
+    }
+
+    /// A delegated child whose delegate never acks reverts to beating its parent
+    /// directly (ack-timeout fallback), rather than severing.
+    #[test]
+    fn delegated_child_reverts_when_delegate_never_acks() {
+        let rt = runtime();
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async {
+            let hb = Heartbeats::with_config(test_config());
+            let mut keys: SlotMap<Key, ()> = SlotMap::with_key();
+            let d = keys.insert(());
+            let mut d = spawn_child(&hb, d);
+            establish_child(&d, b"D@d", b"B@b");
+            nap(INTERVAL_MS).await;
+
+            // Pretend B delegated us to sibling C@c (which does not exist here, so no
+            // acks ever come back).
+            send(
+                &d,
+                HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromParent {
+                    delegate: Some(Delegate {
+                        connection_id: 777,
+                        sibling_ident: b"C@c".to_vec(),
+                    }),
+                }),
+            );
+
+            // While delegated it beats the (absent) delegate over the side channel,
+            // not its parent — so no FromChild beats come out for a bit.
+            nap(INTERVAL_MS).await;
+            drain_beats(&mut d);
+
+            // After the ack timeout it must revert to Direct and beat its parent again
+            // (a FromChild beat), and must NOT sever.
+            let mut saw_from_child = false;
+            for _ in 0..((TIMEOUT_MS / INTERVAL_MS) + 6) {
+                nap(INTERVAL_MS).await;
+                while let Ok(hb) = d.beats.try_recv() {
+                    if matches!(hb, Heartbeat::FromChild { .. }) {
+                        saw_from_child = true;
+                    }
+                }
+                if saw_from_child {
+                    break;
+                }
+            }
+            assert!(
+                saw_from_child,
+                "delegated child reverts to beating its parent"
+            );
+            assert!(
+                sever_reason(&mut d).is_none(),
+                "reverting child does not sever"
+            );
+        });
+    }
+
+    /// B delegates D to a sibling C that is *about to* die: C is still eligible (has
+    /// not yet failed its own heartbeat with B) but never acks D. D must revert
+    /// within the settle window — before B's full timeout — so D is never severed
+    /// during that gap. Then C fails its timeout with B: B severs it and drops it
+    /// from the pool, so it is no longer an eligible delegate and D settles as a
+    /// direct child. (A dead C never recovers — idents are not reused.)
+    #[test]
+    fn delegate_to_dying_c_never_severs_d() {
+        let rt = runtime();
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async {
+            let hb = Heartbeats::with_config(test_config());
+            let mut keys: SlotMap<Key, ()> = SlotMap::with_key();
+            let mut slots: SlotMap<ChildConnectionKey, ()> = SlotMap::with_key();
+            let b = keys.insert(());
+            let d = keys.insert(());
+            let c_slot = slots.insert(());
+            let d_slot = slots.insert(());
+
+            // B's watch of C exists so C is an eligible delegate, but there is no live
+            // C coroutine: it never acks D's side-channel beats, and (since we never
+            // forward beats to `bc`) it will fail its own heartbeat with B.
+            let mut bc = spawn_parent(&hb, b, c_slot, true);
+            let mut bd = spawn_parent(&hb, b, d_slot, true);
+            let mut d = spawn_child(&hb, d);
+            establish_child(&d, b"D@d", b"B@b");
+            establish_parent(&bc, b"C@c");
+            establish_parent(&bd, b"D@d"); // active_direct = 2 > max_direct = 1
+            nap(INTERVAL_MS).await;
+
+            // Trigger B–D to delegate D to the doomed C.
+            send(
+                &bd,
+                HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromChild {
+                    cover_add: vec![],
+                    cover_del: vec![],
+                }),
+            );
+
+            // Until C is reaped, B may (re-)hand D to it; D reverts within the settle
+            // window each time and beats B — so B never severs D. Once C fails its own
+            // timeout, B severs it and it leaves the eligible pool.
+            let mut d_severed = false;
+            let mut bd_severed = false;
+            let mut c_severed = false;
+            for _ in 0..(TIMEOUT_MS * 4 / INTERVAL_MS) {
+                nap(INTERVAL_MS).await;
+                drain_beats(&mut bc); // C never hears B and never answers
+                pump(&mut bd, &d); // carries B's Delegate instructions and beats
+                pump(&mut d, &bd); // D's direct beats after each revert
+                if sever_reason(&mut d).is_some() {
+                    d_severed = true;
+                }
+                if sever_reason(&mut bd).is_some() {
+                    bd_severed = true;
+                }
+                if sever_reason(&mut bc).is_some() {
+                    c_severed = true;
+                }
+            }
+            assert!(!d_severed, "D is never severed while its delegate is dying");
+            assert!(!bd_severed, "B never severs D");
+            assert!(
+                c_severed,
+                "B severs the dead delegate C (it failed its timeout)"
+            );
+
+            // C is gone from the pool, so B can no longer delegate D to it; D is a
+            // plain direct child now — B keeps beating it and it survives.
+            drain_beats(&mut bd);
+            for _ in 0..8 {
+                nap(INTERVAL_MS).await;
+                pump(&mut bd, &d);
+                pump(&mut d, &bd);
+            }
+            assert!(
+                sever_reason(&mut d).is_none(),
+                "D remains a live direct child of B"
+            );
+            assert!(sever_reason(&mut bd).is_none());
+        });
+    }
+
+    /// Full B/C/D: D is delegated to sibling C, C covers D (so B pauses its watch of
+    /// D), then C tears down — D must survive by re-homing to B.
+    #[test]
+    fn delegation_then_c_dies_d_survives() {
+        let rt = runtime();
+        let local = tokio::task::LocalSet::new();
+        local.block_on(&rt, async {
+            let hb = Heartbeats::with_config(test_config());
+            let mut keys: SlotMap<Key, ()> = SlotMap::with_key();
+            let mut slots: SlotMap<ChildConnectionKey, ()> = SlotMap::with_key();
+            let b = keys.insert(());
+            let c = keys.insert(());
+            let d = keys.insert(());
+            let c_slot = slots.insert(());
+            let d_slot = slots.insert(());
+
+            // B's two parent loops, and C's and D's child loops.
+            let mut bc = spawn_parent(&hb, b, c_slot, true);
+            let mut bd = spawn_parent(&hb, b, d_slot, true);
+            let mut c = spawn_child(&hb, c);
+            let mut d = spawn_child(&hb, d);
+
+            establish_child(&c, b"C@c", b"B@b");
+            establish_child(&d, b"D@d", b"B@b");
+            establish_parent(&bc, b"C@c");
+            establish_parent(&bd, b"D@d"); // now active_direct = 2 > max_direct = 1
+            nap(INTERVAL_MS).await;
+
+            // Trigger B–D to delegate D to C (a FromChild beat while over budget).
+            send(
+                &bd,
+                HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromChild {
+                    cover_add: vec![],
+                    cover_del: vec![],
+                }),
+            );
+            nap(INTERVAL_MS).await;
+            // Deliver B–D's Delegate instruction to D (and any prior liveness beats).
+            pump(&mut bd, &d);
+            drain_beats(&mut bc); // do not feed B–C plain beats (would delegate C)
+
+            // D now beats C over the side channel; C acks and queues coverage. Let it
+            // run, then forward C's first *coverage-bearing* beat to B–C so B–C flips
+            // to being a delegate host and pauses B–D.
+            let mut b_c_became_cover = false;
+            for _ in 0..8 {
+                nap(INTERVAL_MS).await;
+                drain_beats(&mut d); // D's side-channel beats go via deliver, not here
+                if pump_cover_beat(&mut c, &bc) {
+                    b_c_became_cover = true;
+                    break;
+                }
+            }
+            assert!(b_c_became_cover, "C reported covering D to B");
+
+            // B–D should now be paused: it stops emitting FromParent beats.
+            nap(INTERVAL_MS).await;
+            drain_beats(&mut bd);
+            nap(INTERVAL_MS * 3).await;
+            let mut bd_beats = 0;
+            while bd.beats.try_recv().is_ok() {
+                bd_beats += 1;
+            }
+            assert_eq!(
+                bd_beats, 0,
+                "B pauses its direct heartbeat of the delegated D"
+            );
+            assert!(sever_reason(&mut bd).is_none(), "delegated D not severed");
+            assert!(
+                sever_reason(&mut d).is_none(),
+                "D not severed while delegated"
+            );
+
+            // --- C dies ---
+            // First, B's watch of C sees the transport close: B–C's cover loop tears
+            // down, resuming its coverage of D (so B reclaims D) and dropping C from
+            // the eligible-delegate set — before D re-homes, so D is never
+            // re-delegated to the dying C.
+            send(&bc, HeartbeatEvent::ReaderClosed);
+            nap(INTERVAL_MS).await;
+            // Then C's own coroutine tears down, releasing D over the side channel so
+            // it reverts to beating its parent directly.
+            send(&c, HeartbeatEvent::ReaderClosed);
+            nap(INTERVAL_MS).await;
+
+            // C is gone: side-channel beats addressed to it are now dropped.
+            assert!(
+                hb.shared.borrow().child_handle(b"C@c").is_none(),
+                "C is deregistered once it tears down"
+            );
+
+            // D re-homed to B; keep the B–D link pumped and confirm both survive and
+            // B is once again directly heartbeating D (un-paused).
+            for _ in 0..8 {
+                nap(INTERVAL_MS).await;
+                pump(&mut bd, &d);
+                pump(&mut d, &bd);
+            }
+            assert!(
+                sever_reason(&mut d).is_none(),
+                "D survives C's death by re-homing to B"
+            );
+            assert!(
+                sever_reason(&mut bd).is_none(),
+                "B keeps D alive after reclaiming it"
+            );
+            drain_beats(&mut bd);
+            nap(INTERVAL_MS * 3).await;
+            assert!(
+                bd.beats.try_recv().is_ok(),
+                "B resumes directly heartbeating D after reclaiming it"
+            );
+        });
+    }
+}

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -34,8 +34,10 @@
 //! `MM_QUIC_CA` (the authority a joiner trusts). The server presents its cert; the
 //! client verifies it against the CA for the fixed server name [`SERVER_NAME`].
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::net::SocketAddr;
+use std::rc::Rc;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
@@ -52,17 +54,23 @@ use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::Duration;
-use tokio::time::MissedTickBehavior;
 
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
 use crate::connection::SideChannelMessage;
+use crate::connection::sever;
 use crate::ctx::Command;
 use crate::framing;
 use crate::framing::Incoming;
 use crate::framing::Preamble;
+use crate::framing::SideChannelIncoming;
 use crate::matcher::Matcher;
+use crate::quic_heartbeat::BeatKind;
+use crate::quic_heartbeat::ConnectionId;
+use crate::quic_heartbeat::Heartbeat;
+use crate::quic_heartbeat::HeartbeatEvent;
+use crate::quic_heartbeat::Heartbeats;
 use crate::shm::MapperHandle;
 use crate::shm::ShmClient;
 use crate::shm::ShmClientSlot;
@@ -77,35 +85,6 @@ const SERVER_NAME: &str = "monarch-mini";
 /// first, backing off to a steady poll.
 const CONNECT_RETRY_MIN: Duration = Duration::from_millis(5);
 const CONNECT_RETRY_MAX: Duration = Duration::from_millis(1000);
-
-/// How often each side emits a heartbeat, and how long a side waits for any frame
-/// before declaring the connection broken. The timeout is several intervals so a
-/// stray scheduling delay doesn't trip it.
-// Heartbeat every 5s; sever after 20s (4 missed beats) of no frame. This is the
-// realistic steady-state liveness setting — heartbeats are active and a lapse
-// actually severs the connection (see reader_task). Both are tunable via
-// `MM_QUIC_HEARTBEAT_INTERVAL_MS` / `MM_QUIC_HEARTBEAT_TIMEOUT_MS`: at very high
-// fan-out the single-threaded root cannot write+service tens of thousands of
-// heartbeats on a 5s cadence, so a longer interval (with a proportionally longer
-// timeout) cuts the steady-state heartbeat load without weakening liveness.
-const DEFAULT_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
-const DEFAULT_HEARTBEAT_TIMEOUT: Duration = Duration::from_secs(20);
-
-fn heartbeat_interval() -> Duration {
-    std::env::var("MM_QUIC_HEARTBEAT_INTERVAL_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(DEFAULT_HEARTBEAT_INTERVAL)
-}
-
-fn heartbeat_timeout() -> Duration {
-    std::env::var("MM_QUIC_HEARTBEAT_TIMEOUT_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .map(Duration::from_millis)
-        .unwrap_or(DEFAULT_HEARTBEAT_TIMEOUT)
-}
 
 /// On graceful shutdown each writer sends an explicit `Severed{"context shutdown"}`
 /// frame (reliable stream data — retransmitted by QUIC, unlike `CONNECTION_CLOSE`),
@@ -180,15 +159,40 @@ fn load_tls() -> anyhow::Result<TlsConfig> {
         std::env::var("MM_QUIC_KEY").map_err(|_| anyhow::anyhow!("MM_QUIC_KEY not set"))?;
     let ca_path = std::env::var("MM_QUIC_CA").map_err(|_| anyhow::anyhow!("MM_QUIC_CA not set"))?;
 
-    let server = ServerConfig::with_single_cert(load_certs(&cert_path)?, load_key(&key_path)?)?;
+    // Disable all periodic QUIC traffic so a delegated link is truly silent:
+    // `keep_alive_interval = None` (no PING keep-alives) and `max_idle_timeout =
+    // None` (QUIC must not reap an idle delegated connection — liveness is now the
+    // heartbeat subsystem's responsibility, not the transport's). Applied to both
+    // roles. Message-carrying links are unaffected; delegated links rely on the
+    // sibling fabric. See `HEARTBEAT_DELEGATION_DESIGN.md` §9.
+    let mut transport = quinn::TransportConfig::default();
+    transport.keep_alive_interval(None);
+    transport.max_idle_timeout(None);
+    let transport = Arc::new(transport);
+
+    let mut server = ServerConfig::with_single_cert(load_certs(&cert_path)?, load_key(&key_path)?)?;
+    server.transport_config(transport.clone());
 
     let mut roots = RootCertStore::empty();
     for ca in load_certs(&ca_path)? {
         roots.add(ca)?;
     }
-    let client = ClientConfig::with_root_certificates(Arc::new(roots))?;
+    let mut client = ClientConfig::with_root_certificates(Arc::new(roots))?;
+    client.transport_config(transport);
 
     Ok(TlsConfig { server, client })
+}
+
+/// The gateway dial tag of `ident` (the substring after the last `@`), as a
+/// `String`, or `None` if it has none or is non-utf8. This is the address a beat is
+/// dialed at — the recipient's own gateway.
+fn gateway_tag_str(ident: &[u8]) -> Option<String> {
+    let pos = ident.iter().rposition(|&b| b == b'@')?;
+    let tag = &ident[pos + 1..];
+    if tag.is_empty() {
+        return None;
+    }
+    std::str::from_utf8(tag).ok().map(str::to_owned)
 }
 
 fn parse_addr(url: &str) -> anyhow::Result<SocketAddr> {
@@ -336,28 +340,28 @@ fn make_client_endpoint(
     Ok((endpoint, usable))
 }
 
-/// Owns all QUIC transport state and coroutines. Mirrors `UnixTransport`: the
-/// command loop holds one and forwards serves/joins to it; it never sees streams
-/// or pairing state. TLS configs are built lazily on first use and cached.
-pub(crate) struct QuicTransport {
-    loop_tx: mpsc::UnboundedSender<Command>,
+/// What a gateway side-channel writer carries: either a routable
+/// [`SideChannelMessage`] (from ctx) or a transport-internal delegated-heartbeat
+/// beat/ack (from the heartbeat coroutines). Both ride the same per-gateway writer,
+/// so a beat reuses the exact connection an ordinary message would.
+pub(crate) enum SideChannelOut {
+    Message(SideChannelMessage),
+    Heartbeat {
+        recipient: Vec<u8>,
+        from: Vec<u8>,
+        conn_id: ConnectionId,
+        kind: BeatKind,
+    },
+}
+
+/// The client-side dialing + gateway side-channel state, shared (`Rc<RefCell>`)
+/// between the command-loop-facing [`QuicTransport`] and the heartbeat coroutines.
+/// QUIC owns every side-channel path end to end — opening, reusing, and writing it
+/// — so a delegated-heartbeat beat is sent by the heartbeat coroutine directly
+/// through here, never routed through ctx. Single-threaded (LocalSet), hence
+/// `Rc<RefCell>`. TLS is built lazily on first use and cached.
+pub(crate) struct SideChannels {
     shutdown_tx: watch::Sender<bool>,
-    // The context-global address-space mapper, captured once at construction and
-    // handed to every connection's reader so a large incoming part can be read
-    // straight into a slab block.
-    mapper: MapperHandle,
-    // The context's single shm client slot, used *only* by side-channel readers,
-    // which are not tied to any actor. A join/serve connection reads into its
-    // owning actor's own slot instead (passed through serve/join).
-    context_shm: ShmClientSlot,
-    // One listener coroutine per url; serve connections are forwarded to it and it
-    // owns the serve/accept pairing.
-    listeners: HashMap<String, mpsc::UnboundedSender<(ConnectionRef, ShmCtx)>>,
-    // One side-channel writer per remote gateway, keyed by its dial address (the
-    // `@specifier` tag). Each owns a task that lazily connects (retrying until the
-    // gateway is live), streams message frames, and reconnects if the connection
-    // drops. Never heartbeated; cached across messages.
-    side_channels: HashMap<String, mpsc::UnboundedSender<SideChannelMessage>>,
     tls: Option<Arc<TlsConfig>>,
     // A *pool* of client endpoints (one UDP socket + driver each) per address
     // family, created lazily and assigned round-robin to joins/side-channels.
@@ -373,15 +377,46 @@ pub(crate) struct QuicTransport {
     client_endpoints_v6: Vec<Endpoint>,
     // Round-robin cursor for assigning connections to pool endpoints.
     client_rr: usize,
+    // One side-channel writer per remote gateway, keyed by its dial address (the
+    // `@specifier` tag). Each owns a task that lazily connects (retrying until the
+    // gateway is live), streams frames, and reconnects if the connection drops.
+    // Cached across messages/beats and shared by ordinary messages and heartbeats.
+    channels: HashMap<String, mpsc::UnboundedSender<SideChannelOut>>,
+    // Liveness-token issuer: each connection's/side-channel's writer holds a clone
+    // for its lifetime. Teardown drops this issuing copy so `alive_rx` closes once
+    // every writer has flushed and exited.
+    alive_tx: Option<mpsc::UnboundedSender<()>>,
+}
+
+/// Owns all QUIC transport state and coroutines. Mirrors `UnixTransport`: the
+/// command loop holds one and forwards serves/joins to it; it never sees streams
+/// or pairing state.
+pub(crate) struct QuicTransport {
+    loop_tx: mpsc::UnboundedSender<Command>,
+    // The context-global address-space mapper, captured once at construction and
+    // handed to every connection's reader so a large incoming part can be read
+    // straight into a slab block.
+    mapper: MapperHandle,
+    // The context's single shm client slot, used *only* by side-channel readers,
+    // which are not tied to any actor. A join/serve connection reads into its
+    // owning actor's own slot instead (passed through serve/join).
+    context_shm: ShmClientSlot,
+    // One listener coroutine per url; serve connections are forwarded to it and it
+    // owns the serve/accept pairing.
+    listeners: HashMap<String, mpsc::UnboundedSender<(ConnectionRef, ShmCtx)>>,
     // Bounds simultaneous client connect attempts (see `max_concurrent_connects`).
     // Shared by every connector task; `None` ⇒ unlimited. Created once so all joins
     // in this context contend for the same pool of attempt slots.
     connect_sem: Option<Arc<Semaphore>>,
-    // Liveness-token issuer: each connection's writer holds a clone for its
-    // lifetime. Teardown drops this issuing copy and waits for `alive_rx` to close
-    // — i.e. for every writer to have flushed and exited.
-    alive_tx: Option<mpsc::UnboundedSender<()>>,
+    // Closed once every writer has exited (see `SideChannels::alive_tx`).
     alive_rx: mpsc::UnboundedReceiver<()>,
+    // Delegated-heartbeat state, shared by every connection's heartbeat coroutine.
+    // Spawns the per-connection coroutines and routes inbound side-channel beats.
+    // See [`crate::quic_heartbeat`].
+    heartbeat: Heartbeats,
+    // Client dialing + side-channel writers, shared with the heartbeat coroutines
+    // so QUIC drives every side-channel path without ctx involvement.
+    side_channels: Rc<RefCell<SideChannels>>,
 }
 
 impl QuicTransport {
@@ -397,18 +432,21 @@ impl QuicTransport {
         }
         Self {
             loop_tx,
-            shutdown_tx,
             mapper,
             context_shm,
             listeners: HashMap::new(),
-            side_channels: HashMap::new(),
-            tls: None,
-            client_endpoints_v4: Vec::new(),
-            client_endpoints_v6: Vec::new(),
-            client_rr: 0,
             connect_sem: max_concurrent_connects().map(|n| Arc::new(Semaphore::new(n))),
-            alive_tx: Some(alive_tx),
             alive_rx,
+            heartbeat: Heartbeats::new(),
+            side_channels: Rc::new(RefCell::new(SideChannels {
+                shutdown_tx,
+                tls: None,
+                client_endpoints_v4: Vec::new(),
+                client_endpoints_v6: Vec::new(),
+                client_rr: 0,
+                channels: HashMap::new(),
+                alive_tx: Some(alive_tx),
+            })),
         }
     }
 
@@ -421,12 +459,18 @@ impl QuicTransport {
             client,
         }
     }
+}
 
+impl SideChannels {
     fn alive_token(&self) -> mpsc::UnboundedSender<()> {
         self.alive_tx
             .as_ref()
             .expect("alive-token issuer present before shutdown")
             .clone()
+    }
+
+    fn subscribe_shutdown(&self) -> watch::Receiver<bool> {
+        self.shutdown_tx.subscribe()
     }
 
     /// Build (or return the cached) TLS configs from the environment.
@@ -440,11 +484,11 @@ impl QuicTransport {
     }
 
     /// A client [`Endpoint`] for `target`'s address family, assigned round-robin
-    /// from a lazily-created pool of [`Self::client_pool_size`] endpoints. Returns
-    /// a cheap clone (the endpoint is internally reference-counted). Spreading
-    /// connections across several UDP sockets keeps any one socket's send/receive
-    /// buffers from overflowing under a fan-out burst, which otherwise causes
-    /// packet loss and multi-second QUIC retransmit stalls.
+    /// from a lazily-created pool of endpoints. Returns a cheap clone (the endpoint
+    /// is internally reference-counted). Spreading connections across several UDP
+    /// sockets keeps any one socket's send/receive buffers from overflowing under a
+    /// fan-out burst, which otherwise causes packet loss and multi-second QUIC
+    /// retransmit stalls.
     fn client_endpoint(&mut self, target: &SocketAddr) -> anyhow::Result<Endpoint> {
         let is_v6 = target.is_ipv6();
         let empty = if is_v6 {
@@ -510,26 +554,22 @@ impl QuicTransport {
         Ok(pool)
     }
 
-    /// Send a self-addressing [`SideChannelMessage`] to a remote gateway over a
-    /// direct side-channel, opening (and caching) the connection on first use. The
-    /// caller (the command loop) has already derived `tag` from the message's
-    /// `gateway_for_actor`. The side-channel is best-effort and not heartbeated; a
-    /// message enqueued while the remote gateway is not yet live waits for the
-    /// connection to come up.
-    pub(crate) fn send_to_gateway(&mut self, tag: String, message: SideChannelMessage) {
-        if !self.side_channels.contains_key(&tag) {
+    /// The writer for the gateway at `tag`, opening (and caching) it on first use.
+    /// `None` if the tag is unparseable or an endpoint can't be built.
+    fn writer_for(&mut self, tag: String) -> Option<&mpsc::UnboundedSender<SideChannelOut>> {
+        if !self.channels.contains_key(&tag) {
             let addr = match parse_addr(&tag) {
                 Ok(addr) => addr,
                 Err(err) => {
                     tracing::warn!("side channel address: {err:#}");
-                    return;
+                    return None;
                 }
             };
             let endpoint = match self.client_endpoint(&addr) {
                 Ok(endpoint) => endpoint,
                 Err(err) => {
                     tracing::warn!("side channel endpoint: {err:#}");
-                    return;
+                    return None;
                 }
             };
             let (tx, rx) = mpsc::unbounded_channel();
@@ -540,13 +580,59 @@ impl QuicTransport {
                 self.shutdown_tx.subscribe(),
                 self.alive_token(),
             ));
-            self.side_channels.insert(tag.clone(), tx);
+            self.channels.insert(tag.clone(), tx);
         }
-        let _ = self
-            .side_channels
-            .get(&tag)
-            .expect("side channel just inserted")
-            .send(message);
+        self.channels.get(&tag)
+    }
+
+    /// Send a self-addressing [`SideChannelMessage`] to the gateway at `tag`,
+    /// opening (and caching) the connection on first use. Best-effort and not
+    /// heartbeated; a message enqueued while the remote gateway is not yet live
+    /// waits for the connection to come up.
+    fn send_message(&mut self, tag: String, message: SideChannelMessage) {
+        if let Some(tx) = self.writer_for(tag) {
+            let _ = tx.send(SideChannelOut::Message(message));
+        }
+    }
+
+    /// Send a delegated-heartbeat beat/ack to `recipient`, dialing the side channel
+    /// at `recipient`'s own gateway `@tag` and reusing the same per-gateway side
+    /// channel an ordinary message would (design §6.2). Dropped if `recipient` has
+    /// no gateway tag to dial. Called by the heartbeat coroutines directly — never
+    /// via ctx.
+    pub(crate) fn send_heartbeat(
+        &mut self,
+        recipient: Vec<u8>,
+        from: Vec<u8>,
+        conn_id: ConnectionId,
+        kind: BeatKind,
+    ) {
+        let Some(tag) = gateway_tag_str(&recipient) else {
+            return;
+        };
+        if let Some(tx) = self.writer_for(tag) {
+            let _ = tx.send(SideChannelOut::Heartbeat {
+                recipient,
+                from,
+                conn_id,
+                kind,
+            });
+        }
+    }
+
+    /// Signal every writer to flush and exit, and drop the issuing alive token.
+    fn begin_shutdown(&mut self) {
+        let _ = self.shutdown_tx.send(true);
+        self.alive_tx = None;
+    }
+}
+
+impl QuicTransport {
+    /// Send a self-addressing [`SideChannelMessage`] to a remote gateway over a
+    /// direct side-channel. The caller (the command loop) has already derived `tag`
+    /// from the message's `gateway_for_actor`.
+    pub(crate) fn send_to_gateway(&mut self, tag: String, message: SideChannelMessage) {
+        self.side_channels.borrow_mut().send_message(tag, message);
     }
 
     /// Signal every writer to flush and exit, then wait until they all have.
@@ -558,15 +644,14 @@ impl QuicTransport {
     /// (`alive_rx` closed) the peers have been told — we do not rely on the lossy
     /// `CONNECTION_CLOSE`/socket-drop being noticed.
     pub(crate) async fn shutdown(&mut self) {
-        let _ = self.shutdown_tx.send(true);
-        self.alive_tx = None;
+        self.side_channels.borrow_mut().begin_shutdown();
         let _ = self.alive_rx.recv().await;
     }
 }
 
 impl Transport for QuicTransport {
     fn serve(&mut self, url: String, connection: ConnectionRef, shm_client: ShmClientSlot) {
-        let tls = match self.tls() {
+        let tls = match self.side_channels.borrow_mut().tls() {
             Ok(tls) => tls,
             Err(err) => {
                 sever(
@@ -591,14 +676,18 @@ impl Transport for QuicTransport {
             };
             let (tx, rx) = mpsc::unbounded_channel();
             let context_shm = self.shm_ctx(self.context_shm.clone());
+            let shutdown = self.side_channels.borrow().subscribe_shutdown();
+            let alive = self.side_channels.borrow().alive_token();
             tokio::task::spawn_local(listener_task(
                 addr,
                 tls.server.clone(),
                 rx,
                 self.loop_tx.clone(),
-                self.shutdown_tx.subscribe(),
-                self.alive_token(),
+                shutdown,
+                alive,
                 context_shm,
+                self.heartbeat.clone(),
+                self.side_channels.clone(),
             ));
             self.listeners.insert(url.clone(), tx);
         }
@@ -618,7 +707,7 @@ impl Transport for QuicTransport {
                 return;
             }
         };
-        let endpoint = match self.client_endpoint(&addr) {
+        let endpoint = match self.side_channels.borrow_mut().client_endpoint(&addr) {
             Ok(endpoint) => endpoint,
             Err(err) => {
                 sever(
@@ -629,15 +718,19 @@ impl Transport for QuicTransport {
                 return;
             }
         };
+        let shutdown = self.side_channels.borrow().subscribe_shutdown();
+        let alive = self.side_channels.borrow().alive_token();
         tokio::task::spawn_local(connector_task(
             addr,
             endpoint,
             connection,
             self.loop_tx.clone(),
-            self.shutdown_tx.subscribe(),
-            self.alive_token(),
+            shutdown,
+            alive,
             self.shm_ctx(shm_client),
             self.connect_sem.clone(),
+            self.heartbeat.clone(),
+            self.side_channels.clone(),
         ));
     }
 }
@@ -658,6 +751,10 @@ enum Accepted {
 /// command loop drops the serve sender. `side_channel_shm` is the *context* shm
 /// context, used only for side-channel readers (which have no owning actor); each
 /// Join connection instead uses the per-serve shm forwarded with it.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each argument is a distinct piece of listener state; bundling adds indirection without clarifying anything"
+)]
 async fn listener_task(
     addr: SocketAddr,
     server_config: ServerConfig,
@@ -666,6 +763,8 @@ async fn listener_task(
     mut shutdown: watch::Receiver<bool>,
     alive: mpsc::UnboundedSender<()>,
     side_channel_shm: ShmCtx,
+    heartbeat: Heartbeats,
+    side_channels: Rc<RefCell<SideChannels>>,
 ) {
     let endpoint = match Endpoint::server(server_config, addr) {
         Ok(endpoint) => endpoint,
@@ -697,39 +796,54 @@ async fn listener_task(
 
     let mut matcher: Matcher<(ConnectionRef, ShmCtx), (Connection, SendStream, RecvStream)> =
         Matcher::new();
+    // One spawn callback for both Matcher arms: the Matcher hands back
+    // `(serve_side, accepted_side)` either way, so a serve-first (`push_left`) and
+    // an accept-first (`push_right`) pairing spawn identically — serve/acceptor
+    // side, so `log_heartbeats = true` and `dialed = false` (the peer dialed us).
+    // Owns a `shutdown` clone (the select below needs `&mut shutdown` for
+    // `changed()`); the rest are cloned per spawn.
+    let spawn_shutdown = shutdown.clone();
+    let spawn = |(connection, shm): (ConnectionRef, ShmCtx),
+                 (conn, send, recv): (Connection, SendStream, RecvStream)| {
+        spawn_connection(
+            send,
+            recv,
+            connection,
+            loop_tx.clone(),
+            spawn_shutdown.clone(),
+            alive.clone(),
+            conn,
+            shm,
+            true,
+            false,
+            heartbeat.clone(),
+            side_channels.clone(),
+        );
+    };
+    // The Matcher just pairs the two sides; `spawn` (reused across iterations) does
+    // the work, so the pairing callback is a trivial identity.
     loop {
         tokio::select! {
             serve = serves.recv() => {
                 let Some((connection, shm)) = serve else { return; };
-                let _ = matcher.push_left((connection, shm), |(connection, shm), (conn, send, recv)| {
-                    spawn_connection(
-                        send, recv, connection,
-                        loop_tx.clone(), shutdown.clone(), alive.clone(),
-                        conn,
-                        shm,
-                        // Serving/acceptor side: log heartbeat sends (under MM_QUIC_DEBUG).
-                        true,
-                    )
-                });
+                if let Some((left, right)) = matcher.push_left((connection, shm), |l, r| (l, r)) {
+                    spawn(left, right);
+                }
             }
             accepted = accepted_rx.recv() => {
                 match accepted {
                     None => return,
                     Some(Accepted::Join(conn, send, recv)) => {
-                        let _ = matcher.push_right((conn, send, recv), |(connection, shm), (conn, send, recv)| {
-                            spawn_connection(
-                                send, recv, connection,
-                                loop_tx.clone(), shutdown.clone(), alive.clone(),
-                                conn,
-                                shm,
-                                // Serving/acceptor side: log heartbeat sends (under MM_QUIC_DEBUG).
-                                true,
-                            )
-                        });
+                        if let Some((left, right)) =
+                            matcher.push_right((conn, send, recv), |l, r| (l, r))
+                        {
+                            spawn(left, right);
+                        }
                     }
                     Some(Accepted::SideChannel(conn, recv)) => {
                         tokio::task::spawn_local(side_channel_reader_task(
                             conn, recv, loop_tx.clone(), side_channel_shm.clone(),
+                            heartbeat.clone(),
                         ));
                     }
                 }
@@ -772,23 +886,33 @@ async fn acceptor_task(
     }
 }
 
-/// Read message frames off a gateway side-channel and forward each to the command
-/// loop, which resolves the owning gateway from the destination. There is no
-/// heartbeat and no establishment: an EOF or error just ends the reader (the
-/// sending gateway reconnects when it next has something to send). `_conn` is held
-/// only to keep the QUIC connection (and thus `recv`) alive.
+/// Read frames off a gateway side-channel. A routable [`SideChannelMessage`] is
+/// forwarded to the command loop (which resolves the owning gateway); a
+/// delegated-heartbeat beat/ack is routed *directly* into the heartbeat subsystem
+/// here — it never reaches ctx. There is no establishment: an EOF or error just
+/// ends the reader (the sending gateway reconnects when it next has something to
+/// send). `_conn` is held only to keep the QUIC connection (and thus `recv`) alive.
 async fn side_channel_reader_task(
     _conn: Connection,
     mut recv: RecvStream,
     loop_tx: mpsc::UnboundedSender<Command>,
     shm: ShmCtx,
+    heartbeat: Heartbeats,
 ) {
     loop {
         match framing::read_side_channel(&mut recv, &shm.mapper, shm.client()).await {
-            Ok(message) => {
+            Ok(SideChannelIncoming::Message(message)) => {
                 if loop_tx.send(Command::SideChannelDeliver(message)).is_err() {
                     return;
                 }
+            }
+            Ok(SideChannelIncoming::Heartbeat {
+                recipient,
+                from,
+                conn_id,
+                kind,
+            }) => {
+                heartbeat.deliver(&recipient, from, conn_id, kind);
             }
             Err(_) => return,
         }
@@ -797,6 +921,10 @@ async fn side_channel_reader_task(
 
 /// Connect to `addr`, retrying until the server binds and the handshake succeeds
 /// (so a join may precede its serve), then open one bi-stream and wire it up.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each argument is a distinct piece of connector state; bundling adds indirection without clarifying anything"
+)]
 async fn connector_task(
     addr: SocketAddr,
     endpoint: Endpoint,
@@ -810,6 +938,8 @@ async fn connector_task(
     // duration of one attempt (connect + handshake + open_bi) and released before
     // backing off, so a waiting task can attempt while this one sleeps.
     connect_sem: Option<Arc<Semaphore>>,
+    heartbeat: Heartbeats,
+    side_channels: Rc<RefCell<SideChannels>>,
 ) {
     let mut retry = CONNECT_RETRY_MIN;
     loop {
@@ -851,7 +981,20 @@ async fn connector_task(
                     // Joiner side (the root has tens of thousands of writers): do not
                     // log heartbeat sends here even under debug — it would flood.
                     spawn_connection(
-                        send, recv, connection, loop_tx, shutdown, alive, conn, shm, false,
+                        send,
+                        recv,
+                        connection,
+                        loop_tx,
+                        shutdown,
+                        alive,
+                        conn,
+                        shm,
+                        false,
+                        // We dialed this connection (join): the delegation guard's
+                        // "parent is the joiner" precondition holds on this side.
+                        true,
+                        heartbeat,
+                        side_channels,
                     );
                     return;
                 }
@@ -871,16 +1014,16 @@ async fn connector_task(
     }
 }
 
-/// Drive a gateway side-channel writer: drain queued message commands, writing
-/// each as a frame to the remote gateway. The connection is established lazily on
-/// the first message (retrying until the gateway is live) and reconnected if it
-/// drops — there is no heartbeat, so a dropped connection is noticed on the next
-/// write. A message in flight when the connection drops may be lost; the channel
+/// Drive a gateway side-channel writer: drain queued outbound items — routable
+/// [`SideChannelMessage`]s and transport-internal heartbeat beats/acks alike —
+/// writing each as a frame to the remote gateway. The connection is established
+/// lazily on the first item (retrying until the gateway is live) and reconnected if
+/// it drops. An item in flight when the connection drops may be lost; the channel
 /// is best-effort by design (any gateway may drop a side-channel to reclaim state).
 async fn side_channel_writer_task(
     addr: SocketAddr,
     endpoint: Endpoint,
-    mut rx: mpsc::UnboundedReceiver<SideChannelMessage>,
+    mut rx: mpsc::UnboundedReceiver<SideChannelOut>,
     mut shutdown: watch::Receiver<bool>,
     _alive: mpsc::UnboundedSender<()>,
 ) {
@@ -888,9 +1031,9 @@ async fn side_channel_writer_task(
     // held to keep it open. `None` means we must (re)connect before the next write.
     let mut stream: Option<(SendStream, Connection)> = None;
     loop {
-        let message = tokio::select! {
-            message = rx.recv() => match message {
-                Some(message) => message,
+        let item = tokio::select! {
+            item = rx.recv() => match item {
+                Some(item) => item,
                 None => break, // sender dropped (gateway gone)
             },
             _ = shutdown.changed() => break,
@@ -906,13 +1049,22 @@ async fn side_channel_writer_task(
                 .await
                 .is_err()
             {
-                continue; // reconnect on the next message (this one is dropped)
+                continue; // reconnect on the next item (this one is dropped)
             }
             stream = Some((send, conn));
         }
         let (send, _conn) = stream.as_mut().expect("stream is connected");
-        if framing::write_side_channel(send, message).await.is_err() {
-            stream = None; // dropped; reconnect on the next message
+        let wrote = match item {
+            SideChannelOut::Message(message) => framing::write_side_channel(send, message).await,
+            SideChannelOut::Heartbeat {
+                recipient,
+                from,
+                conn_id,
+                kind,
+            } => framing::write_side_channel_heartbeat(send, recipient, from, conn_id, kind).await,
+        };
+        if wrote.is_err() {
+            stream = None; // dropped; reconnect on the next item
         }
     }
     if let Some((mut send, _conn)) = stream {
@@ -974,16 +1126,36 @@ fn spawn_connection(
     // Forwarded to the writer: log heartbeat sends (gated to the serve/acceptor side
     // by the call sites, and further gated by MM_QUIC_DEBUG in the writer).
     log_heartbeats: bool,
+    // Whether *we* dialed this connection (join / "quic connect"). One half of the
+    // delegation guard (§8): only a link the parent dialed may be delegated.
+    dialed: bool,
+    heartbeat: Heartbeats,
+    side_channels: Rc<RefCell<SideChannels>>,
 ) {
     let (writer_tx, writer_rx) = mpsc::unbounded_channel();
     // Reader → writer signal: the peer responded to our shutdown, so the writer
     // may close. Unbounded but only ever carries a single `()`.
     let (peer_responded_tx, peer_responded_rx) = mpsc::unbounded_channel();
+    // heartbeat coroutine → writer: beats to write out.
+    let (beats_tx, beats_rx) = mpsc::unbounded_channel();
     let transport = Box::new(QuicConnectionTransport { tx: writer_tx });
     let _ = loop_tx.send(Command::TransportConnected {
         connection,
         transport,
     });
+    // The heartbeat coroutine sends its side-channel beats through this closure — it
+    // never sees the transport's side-channel types, keeping `quic_heartbeat`
+    // decoupled from the transport. The closure reuses the existing gateway side
+    // channels.
+    let send_beat =
+        move |recipient: Vec<u8>, from: Vec<u8>, conn_id: ConnectionId, kind: BeatKind| {
+            side_channels
+                .borrow_mut()
+                .send_heartbeat(recipient, from, conn_id, kind);
+        };
+    // Spawn the coroutine; the returned sender is how the reader/writer feed it
+    // inbound beats, Establish snoops, and reader-closed.
+    let hb_event_tx = heartbeat.spawn(connection, dialed, beats_tx, send_beat, loop_tx.clone());
     tokio::task::spawn_local(writer_task(
         send,
         writer_rx,
@@ -992,6 +1164,8 @@ fn spawn_connection(
         peer_responded_rx,
         conn,
         log_heartbeats,
+        beats_rx,
+        hb_event_tx.clone(),
     ));
     tokio::task::spawn_local(reader_task(
         recv,
@@ -999,6 +1173,7 @@ fn spawn_connection(
         loop_tx,
         peer_responded_tx,
         shm,
+        hb_event_tx,
     ));
 }
 
@@ -1015,9 +1190,15 @@ impl ConnectionTransport for QuicConnectionTransport {
     }
 }
 
-/// Write each queued command as a frame, and a heartbeat every
-/// [`HEARTBEAT_INTERVAL`] so the peer's reader keeps seeing traffic. On teardown,
+/// Write each queued command as a frame, plus the heartbeat beats the connection's
+/// `heartbeat_task` sends over `beats` (the writer no longer drives its own tick —
+/// liveness policy lives in the heartbeat_task). Also snoops its own outgoing
+/// `Establish` and forwards the local ident to the heartbeat_task. On teardown,
 /// drains queued frames first, then finishes the stream.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each argument is a distinct per-connection channel/handle; bundling adds indirection without clarifying anything"
+)]
 async fn writer_task(
     mut send: SendStream,
     mut rx: mpsc::UnboundedReceiver<ConnectionCommand>,
@@ -1034,9 +1215,11 @@ async fn writer_task(
     // writers don't flood), and MM_QUIC_DEBUG is on, log each heartbeat sent — so a
     // connection the peer later reaps can be proven to have kept sending.
     log_heartbeats: bool,
+    // Beats this connection's heartbeat_task wants sent.
+    mut beats: mpsc::UnboundedReceiver<Heartbeat>,
+    // To forward our own outgoing Establish's ident to the heartbeat_task.
+    hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
 ) {
-    let mut heartbeat = tokio::time::interval(heartbeat_interval());
-    heartbeat.set_missed_tick_behavior(MissedTickBehavior::Delay);
     let log_heartbeats = log_heartbeats && crate::ctx::connection_debug();
     let mut heartbeats_sent: u64 = 0;
     let mut graceful = false;
@@ -1046,12 +1229,23 @@ async fn writer_task(
                 let Some(command) = command else {
                     break; // transport dropped
                 };
+                // Snoop our own Establish so the heartbeat_task learns our ident (its
+                // side-channel address / delegate-eligibility key) without any new
+                // threading through ctx.
+                if let ConnectionCommand::Establish { ident: Some(ident), .. } = &command {
+                    let _ = hb_events.send(HeartbeatEvent::EstablishLocal {
+                        local_ident: ident.clone(),
+                    });
+                }
                 if framing::write_command(&mut send, command).await.is_err() {
                     return;
                 }
             }
-            _ = heartbeat.tick() => {
-                if framing::write_heartbeat(&mut send).await.is_err() {
+            beat = beats.recv() => {
+                let Some(heartbeat) = beat else {
+                    break; // heartbeat_task gone
+                };
+                if framing::write_heartbeat(&mut send, heartbeat).await.is_err() {
                     return;
                 }
                 // Flushed to the QUIC stream; log it from the *sender* so loss vs. a
@@ -1102,9 +1296,18 @@ async fn writer_task(
     }
 }
 
-/// Decode each frame off the stream and forward it to the command loop. A read
-/// that does not complete within [`HEARTBEAT_TIMEOUT`] — or an error/EOF — emits
-/// `Severed`. Heartbeat frames refresh the deadline and are not forwarded.
+/// Decode each frame off the stream and forward it to the command loop. The
+/// heartbeat *timeout* has moved to this connection's `heartbeat_task`; the reader
+/// is dumb plumbing now. Heartbeat frames are forwarded to the heartbeat_task as
+/// [`HeartbeatEvent`]s (never to ctx). An error/EOF is a hard transport close: it
+/// emits `Severed` to the loop and `ReaderClosed` to the heartbeat_task.
+///
+/// A message flood must not flood the heartbeat_task, so ordinary data frames
+/// notify it only as a *throttled backstop*: the reader tracks `last_notify` and
+/// sends an empty beat (matching the peer's direction) only when a full
+/// `2 × HEARTBEAT_INTERVAL` has passed with no real beat — so real beats cost one
+/// event each while data frames cost nothing, yet a peer that stops beating but
+/// keeps sending data still proves the pipe live at ≤ one event per two intervals.
 async fn reader_task(
     mut recv: RecvStream,
     connection: ConnectionRef,
@@ -1113,8 +1316,13 @@ async fn reader_task(
     // (it sent its own Severed, or the connection ended) so the writer can close.
     peer_responded: mpsc::UnboundedSender<()>,
     shm: ShmCtx,
+    // Forwards inbound heartbeats and liveness/close signals to the heartbeat_task.
+    hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
 ) {
-    let hb_timeout = heartbeat_timeout();
+    // The peer's heartbeat direction: the peer of a Parent-side connection is a
+    // Child (sends FromChild) and vice versa. Used for the empty backstop beat.
+    let peer_role = connection.role();
+    let backstop_gap = crate::quic_heartbeat::heartbeat_interval() * 2;
     // Per-connection diagnostics, folded into the failure reason under MM_QUIC_DEBUG:
     // did we ever read the peer's Establish (identity exchange)? how many heartbeats
     // and other frames arrived, and how long since the last read? This pinpoints
@@ -1126,6 +1334,10 @@ async fn reader_task(
     let mut heartbeats: u64 = 0;
     let mut commands: u64 = 0;
     let mut last_read: Option<std::time::Duration> = None;
+    // When the heartbeat_task was last notified (by a real beat or a backstop),
+    // throttling the data-frame backstop. Seeded to now so a fresh pipe waits a
+    // full gap before its first backstop.
+    let mut last_notify = std::time::Instant::now();
     let stats = |established: bool, heartbeats, commands, last_read: Option<_>| {
         let last = match last_read {
             Some(d) => format!(
@@ -1145,33 +1357,34 @@ async fn reader_task(
         // is read straight into the slab once the client is known (a gateway seeds
         // its own at creation, before any frame arrives).
         let read = framing::read_frame(&mut recv, &shm.mapper, shm.client());
-        match tokio::time::timeout(hb_timeout, read).await {
-            Err(_elapsed) => {
-                let _ = peer_responded.send(());
-                let reason = if debug {
-                    format!(
-                        "quic heartbeat timeout ({})",
-                        stats(established, heartbeats, commands, last_read)
-                    )
-                    .into_bytes()
-                } else {
-                    b"quic heartbeat timeout".to_vec()
-                };
-                sever(&loop_tx, connection, reason);
-                return;
-            }
-            Ok(Ok(Incoming::Command(action))) => {
+        match read.await {
+            Ok(Incoming::Command(action)) => {
                 last_read = Some(start.elapsed());
                 commands += 1;
                 // The peer's Establish is how we learn its identity: reading it is
-                // the moment this side considers the connection established.
-                if matches!(action, ConnectionCommand::Establish { .. }) {
+                // the moment this side considers the connection established. Forward
+                // the peer ident to the heartbeat_task (one-shot, at setup).
+                if let ConnectionCommand::Establish { ident, .. } = &action {
                     established = true;
+                    if let Some(ident) = ident {
+                        let _ = hb_events.send(HeartbeatEvent::EstablishPeer {
+                            peer_ident: ident.clone(),
+                        });
+                    }
                 }
                 // A Severed from the peer is its response to our shutdown (or the
                 // peer initiating its own) — wake any writer waiting to close.
                 if matches!(action, ConnectionCommand::Severed { .. }) {
                     let _ = peer_responded.send(());
+                }
+                // Throttled liveness backstop: an ordinary frame proves the pipe is
+                // live even if the peer's beats stopped. An empty beat refreshes the
+                // heartbeat_task's Direct deadline and is a no-op for delegation.
+                if last_notify.elapsed() >= backstop_gap {
+                    last_notify = std::time::Instant::now();
+                    let _ = hb_events.send(HeartbeatEvent::ReceivedHeartbeat(
+                        Heartbeat::empty_for_peer(peer_role),
+                    ));
                 }
                 if loop_tx
                     .send(Command::ConnectionAction { connection, action })
@@ -1180,13 +1393,17 @@ async fn reader_task(
                     return;
                 }
             }
-            Ok(Ok(Incoming::Heartbeat)) => {
+            Ok(Incoming::Heartbeat(heartbeat)) => {
                 last_read = Some(start.elapsed());
                 heartbeats += 1;
-                continue;
+                // A real beat: forward it (with its coverage diff / delegate
+                // instruction) and count it as a notification for the backstop.
+                last_notify = std::time::Instant::now();
+                let _ = hb_events.send(HeartbeatEvent::ReceivedHeartbeat(heartbeat));
             }
-            Ok(Err(err)) => {
+            Err(err) => {
                 let _ = peer_responded.send(());
+                let _ = hb_events.send(HeartbeatEvent::ReaderClosed);
                 let reason = if debug {
                     // Walk the io::Error source chain to recover the concrete quinn
                     // ConnectionError — ReadError::ConnectionLost's own Display is just
@@ -1212,11 +1429,4 @@ async fn reader_task(
             }
         }
     }
-}
-
-fn sever(loop_tx: &mpsc::UnboundedSender<Command>, connection: ConnectionRef, reason: Vec<u8>) {
-    let _ = loop_tx.send(Command::ConnectionAction {
-        connection,
-        action: ConnectionCommand::Severed { reason },
-    });
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* __->__ #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add a dedicated QUIC heartbeat subsystem that caps direct parent-child monitoring, delegates excess liveness checks to eligible siblings over existing side channels, and falls back to direct heartbeats when coverage fails. Extend framing and transport plumbing for directional physical beats, delegation metadata, coverage updates, and side-channel beats and acknowledgments, with coroutine tests covering direct liveness, timeout behavior, candidate selection, and delegate failure recovery.

Differential Revision: [D114750233](https://our.internmc.facebook.com/intern/diff/D114750233/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750233/)!