### PR TITLE
28/43 minimonarch: Add delegated heartbeat smoke coverage and telemetry

### DIFF
--- a/monarch_mini/mast/local_smoke.py
+++ b/monarch_mini/mast/local_smoke.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Run the minimonarch smoke test locally, on one host, with delegated heartbeats.
+
+This is the single-host analogue of ``mast_bootstrap.py``: it starts N worker
+processes on sequential localhost ports and one root process that dials them all.
+It is meant for exercising the *delegated* heartbeat path without a cluster:
+
+  * ``--max-direct`` (``MM_QUIC_MAX_DIRECT_CHILDREN``) is set well below the worker
+    count, so the root cannot heartbeat every worker directly and must delegate the
+    excess to sibling workers (cover hosts). ``--coverage`` caps how many one
+    sibling may cover.
+  * ``--hb-interval-ms`` / ``--hb-timeout-ms`` speed the heartbeat cadence and
+    timeout way down (defaults 300 / 1200) so a run of a few seconds spans many
+    heartbeat cycles.
+  * The root pings in a loop for ``--duration`` seconds with ``--send-interval``
+    (default 2s, > the timeout) between rounds, so between rounds *no data flows*
+    and the links survive only if heartbeats — direct and delegated — keep them
+    alive. A broken delegated heartbeat would sever a worker and fail the run.
+
+Usage (from the python/ dir so `minimonarch` is importable, e.g. via `uv run`):
+
+    uv run python ../mast/local_smoke.py --workers 8 --duration 12
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SMOKE = os.path.join(HERE, "smoke.py")
+
+
+def child_env(args: argparse.Namespace) -> dict[str, str]:
+    """Environment for the worker/root children: heartbeat + delegation tunables."""
+    env = dict(os.environ)
+    env["MM_QUIC_MAX_DIRECT_CHILDREN"] = str(args.max_direct)
+    env["MM_QUIC_MAX_COVERAGE_PER_SIBLING"] = str(args.coverage)
+    env["MM_QUIC_HEARTBEAT_INTERVAL_MS"] = str(args.hb_interval_ms)
+    env["MM_QUIC_HEARTBEAT_TIMEOUT_MS"] = str(args.hb_timeout_ms)
+    if args.debug:
+        env["MM_QUIC_DEBUG"] = "1"
+    return env
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--workers", type=int, default=8, help="worker count (default: 8)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=26700, help="base port (default: 26700)"
+    )
+    parser.add_argument(
+        "--max-direct",
+        type=int,
+        default=2,
+        help="MM_QUIC_MAX_DIRECT_CHILDREN: children the root keeps direct before "
+        "delegating the rest (default: 2). Keep < --workers to force delegation.",
+    )
+    parser.add_argument(
+        "--coverage",
+        type=int,
+        default=4,
+        help="MM_QUIC_MAX_COVERAGE_PER_SIBLING: max children one cover host may take "
+        "(default: 4)",
+    )
+    parser.add_argument("--hb-interval-ms", type=int, default=300)
+    parser.add_argument("--hb-timeout-ms", type=int, default=1200)
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=12.0,
+        help="root ping-loop seconds (default: 12)",
+    )
+    parser.add_argument(
+        "--send-interval",
+        type=float,
+        default=2.0,
+        help="seconds between ping rounds (default: 2, > heartbeat timeout)",
+    )
+    parser.add_argument("--startup-grace", type=float, default=2.0)
+    parser.add_argument(
+        "--debug", action="store_true", help="set MM_QUIC_DEBUG=1 (MM_HB logs)"
+    )
+    parser.add_argument(
+        "--logdir",
+        default=None,
+        help="if set, each worker/root writes its own stdout+stderr file here "
+        "(untangles the interleaved multi-process output)",
+    )
+    args = parser.parse_args()
+
+    env = child_env(args)
+    ports = [args.port + i for i in range(args.workers)]
+
+    def out_for(name: str):
+        """Per-process output file (or None → inherit our stdout/stderr)."""
+        if not args.logdir:
+            return None
+        os.makedirs(args.logdir, exist_ok=True)
+        return open(os.path.join(args.logdir, f"{name}.log"), "w")
+
+    print(
+        f"[local] {args.workers} workers on ::1 ports {ports[0]}..{ports[-1]}; "
+        f"max_direct={args.max_direct} coverage={args.coverage} "
+        f"hb={args.hb_interval_ms}/{args.hb_timeout_ms}ms "
+        f"duration={args.duration}s send_interval={args.send_interval}s",
+        flush=True,
+    )
+
+    worker_outs = [out_for(f"worker-{p}") for p in ports]
+    workers = [
+        subprocess.Popen(
+            # --advertise-host ::1 gives each worker a dialable @tag so the root can
+            # delegate its heartbeat to a sibling (siblings dial each other locally).
+            [
+                sys.executable,
+                SMOKE,
+                "--worker",
+                "--port",
+                str(p),
+                "--bind",
+                "::1",
+                "--advertise-host",
+                "::1",
+            ],
+            env=env,
+            stdout=out,
+            stderr=subprocess.STDOUT if out else None,
+        )
+        for p, out in zip(ports, worker_outs)
+    ]
+    try:
+        time.sleep(args.startup_grace)  # let every worker bind before dialing
+        addrs = [f"[::1]:{p}" for p in ports]
+        root_out = out_for("root")
+        rc = subprocess.call(
+            [
+                sys.executable,
+                SMOKE,
+                "--root",
+                *addrs,
+                "--duration",
+                str(args.duration),
+                "--send-interval",
+                str(args.send_interval),
+                "--timeout",
+                "5",
+                "--connect-timeout",
+                "30",
+            ],
+            env=env,
+            stdout=root_out,
+            stderr=subprocess.STDOUT if root_out else None,
+        )
+        print(f"[local] root finished with code {rc}", flush=True)
+        sys.exit(rc)
+    finally:
+        for w in workers:
+            w.terminate()
+        for w in workers:
+            try:
+                w.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                w.kill()
+
+
+if __name__ == "__main__":
+    main()

--- a/monarch_mini/mast/smoke.py
+++ b/monarch_mini/mast/smoke.py
@@ -109,9 +109,18 @@ def ensure_quic_certs(certs_dir: str | None) -> None:
     )
 
 
-def worker_ident(port: int) -> bytes:
-    """A unique, human-readable identity for this worker process."""
-    return f"worker-{socket.gethostname()}-{port}".encode()
+def worker_ident(port: int, advertise_host: str | None = None) -> bytes:
+    """A unique, human-readable identity for this worker process.
+
+    If ``advertise_host`` is given, the ident carries a dialable gateway ``@tag``
+    (``...@[<host>]:<port>``) so a *sibling* worker can open a side channel to us.
+    Without it a peer can only reach us over a connection it already holds — which
+    is why the root can delegate our heartbeat to a sibling only when we advertise.
+    """
+    base = f"worker-{socket.gethostname()}-{port}"
+    if advertise_host:
+        base = f"{base}@[{advertise_host}]:{port}"
+    return base.encode()
 
 
 def _failure_notice(parts: list) -> tuple[str, str]:
@@ -136,7 +145,7 @@ def _report_progress(label: str, done: int, total: int, step: int) -> None:
         log(f"[root]   {label} {done}/{total} ({pct}%)")
 
 
-async def run_worker(port: int, bind: str) -> None:
+async def run_worker(port: int, bind: str, advertise_host: str | None = None) -> None:
     """Serve a quic listener, answer round-trips, and exit when the root dies.
 
     The worker is the *child* of the root: it serves (listens) and the root
@@ -150,7 +159,7 @@ async def run_worker(port: int, bind: str) -> None:
     to tear its own context down gracefully — which sends its shutdown notice back
     to the root, the response the root waits for before it closes that connection.
     """
-    ident = worker_ident(port)
+    ident = worker_ident(port, advertise_host)
     tag = f"[worker :{port}]"
     url = f"quic://[{bind}]:{port}"
     me = Actor(ident)
@@ -179,11 +188,46 @@ async def run_worker(port: int, bind: str) -> None:
         me.send(root_ident, [ba(b"hello from " + ident)])
 
 
-async def run_root(hosts: list[str], timeout: float, connect_timeout: float) -> int:
+async def _ping_round(root: Actor, workers: list[bytes], timeout: float) -> int:
+    """Send one ping to every worker, await each reply, return the failure count.
+
+    Each connected worker yields exactly one terminal message per round: a reply
+    (``[b"hello from ..."]``) or a failure notice (``[worker_ident, reason]``) if
+    its connection dropped (e.g. a heartbeat timeout severed it). Raises
+    ``asyncio.TimeoutError`` if a worker neither replies nor fails within
+    ``timeout`` — the signal that a connection silently stalled.
+    """
+    for wid in workers:
+        root.send(wid, [ba(b"ping")])
+    failures = 0
+    for _ in range(len(workers)):
+        msg = await asyncio.wait_for(root.next(), timeout)
+        if msg and bytes(msg[0]).startswith(b"hello from "):
+            continue
+        who, reason = _failure_notice(msg)
+        failures += 1
+        log(f"[root] FAILURE (reply) {who}: {reason}")
+    return failures
+
+
+async def run_root(
+    hosts: list[str],
+    timeout: float,
+    connect_timeout: float,
+    duration: float = 0.0,
+    send_interval: float = 1.0,
+) -> int:
     """Dial every worker, time connection + round-trip, and report.
 
     ``connect_timeout`` bounds the connect phase (longer, since with hundreds of
     hosts an occasional one is slow to boot); ``timeout`` bounds each reply.
+
+    If ``duration`` > 0 the ping/reply phase repeats for that many wall-clock
+    seconds, one round every ``send_interval`` seconds, instead of a single round.
+    A ``send_interval`` larger than the heartbeat timeout leaves gaps with *no*
+    data traffic, so the connections stay up only if heartbeats (direct and
+    delegated) keep them alive — which is exactly what this exercises.
+
     Returns a process exit code (0 on full success).
     """
     root = Actor(b"root")
@@ -226,44 +270,35 @@ async def run_root(hosts: list[str], timeout: float, connect_timeout: float) -> 
         connect_ms = (time.monotonic() - t_join) * 1e3
         log(f"[root] all {len(workers)} workers connected in {connect_ms:.1f} ms")
 
-        # --- Phase 2: one message to each worker, await each reply -----------
+        # --- Phase 2: ping/reply, once or repeatedly for `duration` seconds --
         t_send = time.monotonic()
-        for wid in workers:
-            root.send(wid, [ba(b"ping")])
-        log(f"[root] sent ping to {len(workers)} workers")
-
-        # Each connected worker yields exactly one terminal message: a reply
-        # ([b"hello from ..."]) or a failure notice ([worker_ident, reason]) if
-        # its connection dropped after connecting. Consume that many messages,
-        # counting replies (progress at decile boundaries) and printing every
-        # failure as it arrives.
-        replies = 0
-        reply_failures = 0
-        for _ in range(len(workers)):
-            try:
-                msg = await asyncio.wait_for(root.next(), timeout)
-            except asyncio.TimeoutError:
-                log(
-                    f"[root] ERROR: only {replies}/{len(workers)} replies within "
-                    f"{timeout:.0f}s ({failures + reply_failures} failures)"
-                )
-                return 1
-            if msg and bytes(msg[0]).startswith(b"hello from "):
-                replies += 1
-                _report_progress("replies", replies, len(workers), step)
-            else:
-                who, reason = _failure_notice(msg)
-                reply_failures += 1
-                log(f"[root] FAILURE (reply) {who}: {reason}")
-        failures += reply_failures
+        deadline = t_send + max(duration, 0.0)
+        rounds = 0
+        try:
+            while True:
+                rounds += 1
+                failures += await _ping_round(root, workers, timeout)
+                if failures:
+                    break
+                log(f"[root]   round {rounds} ok ({len(workers)} replies)")
+                if time.monotonic() >= deadline:
+                    break
+                # Idle gap: no data flows, so only heartbeats keep the links up.
+                await asyncio.sleep(send_interval)
+        except asyncio.TimeoutError:
+            log(
+                f"[root] ERROR: a worker stalled (no reply within {timeout:.0f}s) "
+                f"in round {rounds} ({failures} failures so far)"
+            )
+            return 1
         roundtrip_ms = (time.monotonic() - t_send) * 1e3
 
         log("[root] --- summary ---")
         log(f"[root] connect:    {connect_ms:.1f} ms ({len(workers)} workers)")
-        log(f"[root] round-trip: {roundtrip_ms:.1f} ms ({replies} replies)")
+        log(f"[root] round-trip: {roundtrip_ms:.1f} ms ({rounds} round(s))")
         log(f"[root] failures:   {failures}")
-        # Success only if every worker replied and nothing severed along the way.
-        return 0 if replies == len(workers) and failures == 0 else 1
+        # Success only if nothing severed across every round.
+        return 0 if failures == 0 else 1
     finally:
         # Gracefully tear down the context *inside the event loop*: this flushes
         # an "actor destroyed" death notice to every worker before the loop
@@ -301,6 +336,12 @@ def main() -> None:
         help="worker bind address (default: '::' = all IPv6 interfaces)",
     )
     parser.add_argument(
+        "--advertise-host",
+        default=None,
+        help="worker: IPv6 host siblings can dial us at; adds a gateway @tag to our "
+        "ident so the root can delegate our heartbeat to a sibling (e.g. '::1' locally)",
+    )
+    parser.add_argument(
         "--certs-dir", default=None, help="directory holding cert.pem/key.pem/ca.pem"
     )
     parser.add_argument(
@@ -316,19 +357,45 @@ def main() -> None:
         help="root: seconds to wait for all workers to connect (default: 180); "
         "larger than --timeout because with many hosts one can be slow to boot",
     )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        default=0.0,
+        help="root: repeat the ping/reply phase for this many seconds (default: 0 "
+        "= a single round). Use a value well over the heartbeat timeout to keep the "
+        "run alive across many heartbeat cycles.",
+    )
+    parser.add_argument(
+        "--send-interval",
+        type=float,
+        default=1.0,
+        help="root: seconds between ping rounds when --duration > 0 (default: 1). "
+        "Set larger than the heartbeat timeout so heartbeats, not data, hold the "
+        "links open between rounds.",
+    )
     args = parser.parse_args()
 
     ensure_quic_certs(args.certs_dir)
 
     if args.worker:
-        asyncio.run(run_worker(args.port, args.bind))
+        asyncio.run(run_worker(args.port, args.bind, args.advertise_host))
     else:
         if args.root_file:
             with open(args.root_file) as f:
                 hosts = [line.strip() for line in f if line.strip()]
         else:
             hosts = args.root
-        sys.exit(asyncio.run(run_root(hosts, args.timeout, args.connect_timeout)))
+        sys.exit(
+            asyncio.run(
+                run_root(
+                    hosts,
+                    args.timeout,
+                    args.connect_timeout,
+                    args.duration,
+                    args.send_interval,
+                )
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/monarch_mini/src/quic_heartbeat.rs
+++ b/monarch_mini/src/quic_heartbeat.rs
@@ -305,7 +305,7 @@ pub(crate) enum HeartbeatEvent {
 /// point of view. [`ParentPool`] derives its accounting from this (whether we beat the
 /// child directly, and the coverage it consumes from a sibling), so no caller pokes
 /// that accounting directly.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum ChildStatus {
     /// Attached; its `Establish` (ident) has not arrived yet.
     NotEstablished,
@@ -475,6 +475,14 @@ impl ParentPool {
         }
         if !self.over_budget(config.max_direct_children) {
             return None;
+        }
+        if crate::ctx::connection_debug() {
+            eprintln!(
+                "MM_DELEG over budget: active_direct={} max_direct={} candidates={}",
+                self.active_direct,
+                config.max_direct_children,
+                self.candidates.ids.len(),
+            );
         }
         let (sibling_conn, sibling_ident) = self.pick_delegate(conn_id)?;
         // Point the child at its delegate, then transition: `set_status` charges
@@ -655,6 +663,10 @@ impl HeartbeatShared {
     ) {
         for x in cover_add {
             if covered.insert(x) {
+                let found = self.parents_by_conn_id.contains_key(&x);
+                if crate::ctx::connection_debug() {
+                    eprintln!("MM_COVER root pause conn_id={x} found_parent_loop={found}");
+                }
                 if let Some(h) = self.parents_by_conn_id.get(&x) {
                     let _ = h.send(HeartbeatEvent::PauseHeartbeat);
                 }
@@ -662,6 +674,9 @@ impl HeartbeatShared {
         }
         for x in cover_del {
             if covered.remove(&x) {
+                if crate::ctx::connection_debug() {
+                    eprintln!("MM_COVER root RESUME conn_id={x} (coverage dropped)");
+                }
                 if let Some(h) = self.parents_by_conn_id.get(&x) {
                     let _ = h.send(HeartbeatEvent::ResumeHeartbeat);
                 }
@@ -673,6 +688,9 @@ impl HeartbeatShared {
     /// down, so its covered children reclaim themselves as direct).
     fn resume_covered(&self, covered: &HashSet<ConnectionId>) {
         for x in covered {
+            if crate::ctx::connection_debug() {
+                eprintln!("MM_COVER root RESUME(host teardown) conn_id={x}");
+            }
             if let Some(h) = self.parents_by_conn_id.get(x) {
                 let _ = h.send(HeartbeatEvent::ResumeHeartbeat);
             }
@@ -849,6 +867,9 @@ async fn parent_direct_loop(
             _ = deadline_or_park(deadline) => {
                 // The child has gone silent (no beat within the timeout). While paused
                 // the deadline is `None`, so this never fires for a covered child.
+                if crate::ctx::connection_debug() {
+                    eprintln!("MM_SEVER direct-loop conn_id={conn_id}");
+                }
                 sever(loop_tx, connection, b"quic heartbeat timeout".to_vec());
                 return DirectExit::Closed;
             }
@@ -893,6 +914,12 @@ async fn parent_direct_loop(
                         // direct (a genuine fallback beat beat us to it), keep watching.
                         let mut s = shared.borrow_mut();
                         let pool = s.pool_mut(key);
+                        if crate::ctx::connection_debug() {
+                            eprintln!(
+                                "MM_PAUSE recv conn_id={conn_id} status={:?}",
+                                pool.status(conn_id)
+                            );
+                        }
                         if pool.status(conn_id) == Some(ChildStatus::Delegating) {
                             pool.set_status(conn_id, Some(ChildStatus::Paused));
                             deadline = None;
@@ -958,6 +985,9 @@ async fn parent_cover_loop(
     loop {
         tokio::select! {
             _ = tokio::time::sleep_until(deadline) => {
+                if crate::ctx::connection_debug() {
+                    eprintln!("MM_SEVER cover-loop (a cover host itself timed out)");
+                }
                 sever(loop_tx, connection, b"quic heartbeat timeout".to_vec());
                 break;
             }
@@ -1056,6 +1086,13 @@ async fn child_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
             _ = deadline_or_park(next_beat) => {
                 match &state {
                     ChildState::Direct => {
+                        if crate::ctx::connection_debug() && !cover_add.is_empty() {
+                            eprintln!(
+                                "MM_COVER pid={} report cover_add={:?}",
+                                std::process::id(),
+                                cover_add
+                            );
+                        }
                         let _ = beats.send(Heartbeat::FromChild {
                             cover_add: std::mem::take(&mut cover_add),
                             cover_del: std::mem::take(&mut cover_del),
@@ -1066,7 +1103,17 @@ async fn child_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
                     ChildState::Delegated { x, c } => {
                         if let Some(own) = &own_ident {
                             // Beat our delegate C over the side channel.
+                            if crate::ctx::connection_debug() {
+                                eprintln!(
+                                    "MM_CHILD pid={} beat delegate x={} c={}",
+                                    std::process::id(),
+                                    x,
+                                    String::from_utf8_lossy(c)
+                                );
+                            }
                             send_beat(c.clone(), own.clone(), *x, BeatKind::Beat);
+                        } else if crate::ctx::connection_debug() {
+                            eprintln!("MM_CHILD pid={} delegated but own_ident=None", std::process::id());
                         }
                         // Await C's ack; `primary` was armed on entry / last ack.
                     }
@@ -1097,6 +1144,13 @@ async fn child_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
                 for x in expired {
                     coverage.remove(&x);
                     cover_del.push(x);
+                    if crate::ctx::connection_debug() {
+                        eprintln!(
+                            "MM_COVER pid={} EXPIRE conn_id={} (no beat within timeout)",
+                            std::process::id(),
+                            x
+                        );
+                    }
                 }
             }
             ev = events.recv() => {
@@ -1104,6 +1158,18 @@ async fn child_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
                 match ev {
                     HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromParent { delegate }) => {
                         // Our parent's answer to our last direct beat.
+                        if crate::ctx::connection_debug() {
+                            if let Some(Delegate { connection_id, sibling_ident }) = &delegate {
+                                eprintln!(
+                                    "MM_CHILD pid={} got delegate x={} c={} own_addressable={} direct={}",
+                                    std::process::id(),
+                                    connection_id,
+                                    String::from_utf8_lossy(sibling_ident),
+                                    own_ident.as_deref().is_some_and(is_addressable),
+                                    matches!(state, ChildState::Direct),
+                                );
+                            }
+                        }
                         match delegate {
                             Some(Delegate { connection_id, sibling_ident })
                                 if own_ident.as_deref().is_some_and(is_addressable)
@@ -1139,10 +1205,26 @@ async fn child_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
                     }
                     HeartbeatEvent::Side(from, conn_id, BeatKind::Beat) => {
                         // Delegate-host duty: (re)arm coverage for `conn_id` and ack.
+                        if crate::ctx::connection_debug() {
+                            eprintln!(
+                                "MM_COVER pid={} beat-in conn_id={} from={}",
+                                std::process::id(),
+                                conn_id,
+                                String::from_utf8_lossy(&from)
+                            );
+                        }
                         let is_new = !coverage.contains_key(&conn_id);
                         coverage.insert(conn_id, (from.clone(), Instant::now() + timeout));
                         if is_new {
                             cover_add.push(conn_id);
+                            if crate::ctx::connection_debug() {
+                                eprintln!(
+                                    "MM_COVER pid={} add conn_id={} from={}",
+                                    std::process::id(),
+                                    conn_id,
+                                    String::from_utf8_lossy(&from)
+                                );
+                            }
                         }
                         if let Some(own) = &own_ident {
                             // Ack the delegated child that beat us.


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* __->__ #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add a single-host Python smoke harness that forces delegated QUIC heartbeats and repeatedly pings idle worker links across multiple timeout windows. Extend the smoke runner with dialable worker identities and repeated rounds, and add debug telemetry for delegation, coverage, pauses, resumes, and heartbeat timeouts.

Differential Revision: [D114750237](https://our.internmc.facebook.com/intern/diff/D114750237/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750237/)!