### PR TITLE
29/43 minimonarch: Use a heap rather than round robin

### DIFF
--- a/monarch_mini/mast/build_mast.py
+++ b/monarch_mini/mast/build_mast.py
@@ -486,7 +486,14 @@ def main() -> None:
 
     if args.launch:
         submit_via_thrift(spec)
+        # Execution-details page for rank 0 (the root task). The ':' in the run id
+        # (<job>:prod:0) is percent-encoded as %3A so the link pastes cleanly.
+        run_id = f"{job_name}%3Aprod%3A0"
+        details_url = (
+            f"https://msl-runs.internalmeta.com/mast/{run_id}/execution-details"
+        )
         print(f"\nmonitor with:  mast get-status {job_name}", flush=True)
+        print(f"details:       {details_url}", flush=True)
     else:
         print("\nTo launch (rerun with --launch, or submit directly):", flush=True)
         print(

--- a/monarch_mini/mast/local_smoke.py
+++ b/monarch_mini/mast/local_smoke.py
@@ -13,8 +13,7 @@ It is meant for exercising the *delegated* heartbeat path without a cluster:
 
   * ``--max-direct`` (``MM_QUIC_MAX_DIRECT_CHILDREN``) is set well below the worker
     count, so the root cannot heartbeat every worker directly and must delegate the
-    excess to sibling workers (cover hosts). ``--coverage`` caps how many one
-    sibling may cover.
+    excess onto that many sibling workers (cover hosts), balanced across them.
   * ``--hb-interval-ms`` / ``--hb-timeout-ms`` speed the heartbeat cadence and
     timeout way down (defaults 300 / 1200) so a run of a few seconds spans many
     heartbeat cycles.
@@ -44,7 +43,6 @@ def child_env(args: argparse.Namespace) -> dict[str, str]:
     """Environment for the worker/root children: heartbeat + delegation tunables."""
     env = dict(os.environ)
     env["MM_QUIC_MAX_DIRECT_CHILDREN"] = str(args.max_direct)
-    env["MM_QUIC_MAX_COVERAGE_PER_SIBLING"] = str(args.coverage)
     env["MM_QUIC_HEARTBEAT_INTERVAL_MS"] = str(args.hb_interval_ms)
     env["MM_QUIC_HEARTBEAT_TIMEOUT_MS"] = str(args.hb_timeout_ms)
     if args.debug:
@@ -64,15 +62,9 @@ def main() -> None:
         "--max-direct",
         type=int,
         default=2,
-        help="MM_QUIC_MAX_DIRECT_CHILDREN: children the root keeps direct before "
-        "delegating the rest (default: 2). Keep < --workers to force delegation.",
-    )
-    parser.add_argument(
-        "--coverage",
-        type=int,
-        default=4,
-        help="MM_QUIC_MAX_COVERAGE_PER_SIBLING: max children one cover host may take "
-        "(default: 4)",
+        help="MM_QUIC_MAX_DIRECT_CHILDREN: children the root keeps direct; the rest "
+        "are delegated onto them, balanced (default: 2). Keep < --workers to force "
+        "delegation.",
     )
     parser.add_argument("--hb-interval-ms", type=int, default=300)
     parser.add_argument("--hb-timeout-ms", type=int, default=1200)
@@ -87,6 +79,13 @@ def main() -> None:
         type=float,
         default=2.0,
         help="seconds between ping rounds (default: 2, > heartbeat timeout)",
+    )
+    parser.add_argument(
+        "--chain-length",
+        type=int,
+        default=0,
+        help="cap the ring into chains of at most this many workers (default: 0 = "
+        "one chain of all workers)",
     )
     parser.add_argument("--startup-grace", type=float, default=2.0)
     parser.add_argument(
@@ -112,7 +111,7 @@ def main() -> None:
 
     print(
         f"[local] {args.workers} workers on ::1 ports {ports[0]}..{ports[-1]}; "
-        f"max_direct={args.max_direct} coverage={args.coverage} "
+        f"max_direct={args.max_direct} "
         f"hb={args.hb_interval_ms}/{args.hb_timeout_ms}ms "
         f"duration={args.duration}s send_interval={args.send_interval}s",
         flush=True,
@@ -121,18 +120,15 @@ def main() -> None:
     worker_outs = [out_for(f"worker-{p}") for p in ports]
     workers = [
         subprocess.Popen(
-            # --advertise-host ::1 gives each worker a dialable @tag so the root can
-            # delegate its heartbeat to a sibling (siblings dial each other locally).
+            # Each worker binds all interfaces (default) and auto-advertises its own
+            # routable IPv6 as a dialable @tag, so the root can delegate its heartbeat
+            # to a sibling (siblings dial each other at that advertised address).
             [
                 sys.executable,
                 SMOKE,
                 "--worker",
                 "--port",
                 str(p),
-                "--bind",
-                "::1",
-                "--advertise-host",
-                "::1",
             ],
             env=env,
             stdout=out,
@@ -154,6 +150,8 @@ def main() -> None:
                 str(args.duration),
                 "--send-interval",
                 str(args.send_interval),
+                "--chain-length",
+                str(args.chain_length),
                 "--timeout",
                 "5",
                 "--connect-timeout",

--- a/monarch_mini/mast/mast_bootstrap.py
+++ b/monarch_mini/mast/mast_bootstrap.py
@@ -49,6 +49,12 @@ PORT = int(os.environ.get("SMOKE_PORT", "26600"))
 WORKERS_PER_HOST = int(os.environ.get("SMOKE_WORKERS_PER_HOST", "1"))
 # Seconds rank 0 waits before dialing, giving every worker time to bind.
 STARTUP_GRACE = float(os.environ.get("SMOKE_STARTUP_GRACE", "15"))
+# Heartbeat timeout in effect (env override, else minimonarch's 20s default). The
+# root's inter-round gap and end-of-run settle window are sized off this so that
+# between rounds no data flows and only heartbeats hold the links up.
+HB_TIMEOUT_MS = int(os.environ.get("MM_QUIC_HEARTBEAT_TIMEOUT_MS", "20000"))
+# Number of ping/ring rounds the root runs, each separated by a heartbeat-only gap.
+SMOKE_ROUNDS = int(os.environ.get("SMOKE_ROUNDS", "5"))
 
 
 def task_hosts() -> list[str]:
@@ -134,7 +140,37 @@ def main() -> None:
     addr_file = os.path.join(tempfile.gettempdir(), "mm_root_hosts.txt")
     with open(addr_file, "w") as f:
         f.write("\n".join(addrs))
-    rc = subprocess.call([python, smoke, "--root-file", addr_file], cwd=HERE, env=env)
+
+    # Run several rounds back-to-back (a short send-interval, well under the
+    # heartbeat timeout, so data keeps flowing between them), then idle for a single
+    # heartbeat-only gap before teardown: the end-sleep, sized above the heartbeat
+    # timeout, is the one window where links must survive on heartbeats alone.
+    hb_timeout_s = HB_TIMEOUT_MS / 1000.0
+    send_interval = float(os.environ.get("SMOKE_SEND_INTERVAL", "1"))
+    duration = send_interval * max(SMOKE_ROUNDS - 1, 0)
+    end_sleep = hb_timeout_s * 1.5
+    print(
+        f"[bootstrap] root: {SMOKE_ROUNDS} rounds, send-interval {send_interval:.1f}s, "
+        f"duration {duration:.1f}s, single heartbeat gap (end-sleep) {end_sleep:.1f}s "
+        f"(heartbeat timeout {hb_timeout_s:.1f}s)",
+        flush=True,
+    )
+    rc = subprocess.call(
+        [
+            python,
+            smoke,
+            "--root-file",
+            addr_file,
+            "--duration",
+            str(duration),
+            "--send-interval",
+            str(send_interval),
+            "--end-sleep",
+            str(end_sleep),
+        ],
+        cwd=HERE,
+        env=env,
+    )
     print(f"[bootstrap] root finished with code {rc}", flush=True)
 
     # The smoke test is done; tear down our local workers and exit with its status.

--- a/monarch_mini/mast/smoke.py
+++ b/monarch_mini/mast/smoke.py
@@ -9,8 +9,18 @@
 
 Topology: a single root node connects to N worker nodes. Each worker *serves*
 a quic:// listener; the root *joins* (connects out to) every worker. Once all
-workers are connected the root sends one message to each worker, and each
-worker replies with its own identity. Every phase is timed.
+workers are connected each timed round exercises two message patterns:
+
+  * *direct*: the root sends every worker a ping and each replies with its own
+    identity (a star of independent round-trips through the root).
+  * *ring*: the root wires each worker to its successor (the last worker back to
+    the root), then injects a token at the first worker carrying an integer count.
+    Each worker logs the count it saw and forwards count+1 to its next hop, so the
+    token threads the whole ring hop-by-hop and returns to the root as the worker
+    count. This exercises worker-to-worker routing, not just root round-trips.
+
+Every phase is timed. Every message carries its type as a header part (see the
+``H_*`` constants) so dispatch is an exact header match, never a payload sniff.
 
 Worker IPs are not known until runtime and we never use DNS: the root is given
 the worker addresses directly on the command line (or, on MAST, via an env var)
@@ -52,11 +62,17 @@ ba = minimonarch.bytearray
 # from Python, but not otherwise used by this script.
 SERVER_NAME = "monarch-mini"
 
-# Sentinel prefix a worker registers as its connection-failure message. When the
-# root tears down (clean exit or crash) the worker's parent link severs and
-# minimonarch delivers [_DOWN, root_ident, reason]; the worker uses the prefix to
-# tell that death notice apart from a normal ping and shut itself down.
-_DOWN = b"__worker_down__"
+# Message-type headers: part[0] of every application message. Dispatch is an exact
+# match on this header, so we never sniff a payload to learn a message's type.
+# H_FAIL is special: it is the failure *prefix* both the worker's serve and the
+# root's join register, so minimonarch delivers a severed link as
+# [H_FAIL, dead_ident, reason] — the same shape as our own messages.
+H_FAIL = b"h:fail"  # [H_FAIL, dead_ident, reason]   a connection severed
+H_PING = b"h:ping"  # [H_PING]                        root -> worker, direct round
+H_REPLY = b"h:reply"  # [H_REPLY, worker_ident]       worker -> root, direct reply
+H_NEXT = b"h:next"  # [H_NEXT, next_hop_ident]         root -> worker, ring wiring
+H_RING = b"h:ring"  # [H_RING, count]                 circulating ring token (count
+#                                                      is a decimal-ascii integer)
 
 # Short hostname, included in every log line so multi-host logs are easy to read.
 _HOST = socket.gethostname()
@@ -109,27 +125,46 @@ def ensure_quic_certs(certs_dir: str | None) -> None:
     )
 
 
-def worker_ident(port: int, advertise_host: str | None = None) -> bytes:
+def _advertised_host() -> str:
+    """This worker's own routable IPv6 address, for the dialable gateway ``@tag``.
+
+    Siblings need a concrete address to reach us for delegated heartbeats, and it
+    must be the *same* address the root reaches us at (the root dials each peer by
+    resolving its FQDN to IPv6 — see ``resolve_ipv6`` in ``mast_bootstrap.py``).
+    Resolving our own FQDN yields exactly that address, so a sibling's side channel
+    lands on the same listener the root uses.
+    """
+    host = socket.getfqdn()
+    # MAST peers need this task's concrete FQDN address; this is not service discovery.
+    # ast-grep-ignore: python/python-dns-deps
+    infos = socket.getaddrinfo(host, None, socket.AF_INET6, socket.SOCK_DGRAM)
+    if not infos:
+        raise RuntimeError(f"no IPv6 address for {host}")
+    return infos[0][4][0]
+
+
+def worker_ident(port: int) -> bytes:
     """A unique, human-readable identity for this worker process.
 
-    If ``advertise_host`` is given, the ident carries a dialable gateway ``@tag``
-    (``...@[<host>]:<port>``) so a *sibling* worker can open a side channel to us.
-    Without it a peer can only reach us over a connection it already holds — which
-    is why the root can delegate our heartbeat to a sibling only when we advertise.
+    The ident always carries a dialable gateway ``@tag`` (``...@[<host>]:<port>``)
+    built from this worker's own routable IPv6 (see ``_advertised_host``) so a
+    *sibling* worker can open a side channel to us — which is what lets the root
+    delegate our heartbeat to a sibling.
     """
-    base = f"worker-{socket.gethostname()}-{port}"
-    if advertise_host:
-        base = f"{base}@[{advertise_host}]:{port}"
-    return base.encode()
+    return (
+        f"worker-{socket.gethostname()}-{port}@[{_advertised_host()}]:{port}".encode()
+    )
 
 
 def _failure_notice(parts: list) -> tuple[str, str]:
-    """Decode a failure notice the root receives when a connection to a worker
-    severs. The root joined each worker with no failure prefix, so minimonarch
-    delivers ``[worker_ident, reason]`` (unlike the worker, which registered the
-    ``_DOWN`` prefix). Returns (worker, reason) as strings for logging."""
-    who = bytes(parts[0]).decode(errors="replace") if parts else "?"
-    reason = bytes(parts[1]).decode(errors="replace") if len(parts) > 1 else "?"
+    """Decode an ``[H_FAIL, dead_ident, reason]`` notice into (who, reason) strings.
+
+    Both the worker's serve and the root's join register ``H_FAIL`` as their failure
+    prefix, so a severed link arrives with the dead ident at ``parts[1]`` and the
+    reason at ``parts[2]`` — the header at ``parts[0]`` has already been matched by
+    the caller."""
+    who = bytes(parts[1]).decode(errors="replace") if len(parts) > 1 else "?"
+    reason = bytes(parts[2]).decode(errors="replace") if len(parts) > 2 else "?"
     return who, reason
 
 
@@ -145,7 +180,7 @@ def _report_progress(label: str, done: int, total: int, step: int) -> None:
         log(f"[root]   {label} {done}/{total} ({pct}%)")
 
 
-async def run_worker(port: int, bind: str, advertise_host: str | None = None) -> None:
+async def run_worker(port: int, bind: str) -> None:
     """Serve a quic listener, answer round-trips, and exit when the root dies.
 
     The worker is the *child* of the root: it serves (listens) and the root
@@ -153,17 +188,22 @@ async def run_worker(port: int, bind: str, advertise_host: str | None = None) ->
     from the establishment hello, then echoes back its own identity so the root
     can report exactly who replied.
 
-    The worker registers ``_DOWN`` as its failure prefix, so when the root sends
+    The worker registers ``H_FAIL`` as its failure prefix, so when the root sends
     its explicit "context shutdown" notice the severed parent link delivers
-    ``[_DOWN, root_ident, reason]``. The worker then calls ``minimonarch.close()``
+    ``[H_FAIL, root_ident, reason]``. The worker then calls ``minimonarch.close()``
     to tear its own context down gracefully — which sends its shutdown notice back
     to the root, the response the root waits for before it closes that connection.
+
+    Beyond the direct ping/reply, the worker participates in the ring: an ``H_NEXT``
+    message wires its successor, and each ``H_RING`` token is logged and forwarded
+    (count+1) to that successor. Ring routing is plain destination routing — a token
+    to a sibling or the root climbs to the common ancestor (the root) and back down.
     """
-    ident = worker_ident(port, advertise_host)
+    ident = worker_ident(port)
     tag = f"[worker :{port}]"
     url = f"quic://[{bind}]:{port}"
     me = Actor(ident)
-    me.serve(url, "child", failure=[ba(_DOWN)])
+    me.serve(url, "child", failure=[ba(H_FAIL)])
     # pid lets us map the Rust writer's MM_HB heartbeat-send lines (tagged by pid)
     # back to this worker's port when correlating send vs. receive at scale.
     log(f"{tag} serving {url} pid={os.getpid()}")
@@ -173,40 +213,89 @@ async def run_worker(port: int, bind: str, advertise_host: str | None = None) ->
     root_ident = bytes(hello[1])
     log(f"{tag} connected to root {root_ident.decode()}")
 
-    # Answer every message the root sends with our identity. A death notice for
-    # the root (the registered _DOWN failure) ends the process.
+    # Our successor in the ring, learned from the root's H_NEXT wiring. The root
+    # wires the whole ring before injecting any token, so this is set before the
+    # first H_RING arrives.
+    next_hop: bytes | None = None
+
+    # Dispatch on the message header. A death notice for the root (the registered
+    # H_FAIL failure) ends the process.
     while True:
         msg = await me.next()
-        if msg and bytes(msg[0]) == _DOWN:
+        header = bytes(msg[0])
+        if header == H_FAIL:
             reason = bytes(msg[2]).decode() if len(msg) > 2 else "unknown"
             log(f"{tag} root {root_ident.decode()} gone ({reason}); shutting down")
             # Graceful close: replies to the root's shutdown so it can close
             # promptly instead of waiting out its ack timeout.
             minimonarch.close()
             return
-        log(f"{tag} got message; replying")
-        me.send(root_ident, [ba(b"hello from " + ident)])
+        if header == H_PING:
+            log(f"{tag} ping; replying")
+            me.send(root_ident, [ba(H_REPLY), ba(ident)])
+        elif header == H_NEXT:
+            next_hop = bytes(msg[1])
+            log(f"{tag} ring wired: next hop = {next_hop.decode()}")
+        elif header == H_RING:
+            count = int(bytes(msg[1]))
+            log(f"{tag} ring: had count {count}")
+            assert next_hop is not None, "ring token arrived before H_NEXT wiring"
+            me.send(next_hop, [ba(H_RING), ba(str(count + 1).encode())])
+        else:
+            log(f"{tag} unexpected header {header!r}; ignoring")
 
 
-async def _ping_round(root: Actor, workers: list[bytes], timeout: float) -> int:
+async def _direct_round(root: Actor, workers: list[bytes], timeout: float) -> int:
     """Send one ping to every worker, await each reply, return the failure count.
 
     Each connected worker yields exactly one terminal message per round: a reply
-    (``[b"hello from ..."]``) or a failure notice (``[worker_ident, reason]``) if
-    its connection dropped (e.g. a heartbeat timeout severed it). Raises
-    ``asyncio.TimeoutError`` if a worker neither replies nor fails within
+    (``[H_REPLY, worker_ident]``) or a failure notice (``[H_FAIL, worker_ident,
+    reason]``) if its connection dropped (e.g. a heartbeat timeout severed it).
+    Raises ``asyncio.TimeoutError`` if a worker neither replies nor fails within
     ``timeout`` — the signal that a connection silently stalled.
     """
     for wid in workers:
-        root.send(wid, [ba(b"ping")])
+        root.send(wid, [ba(H_PING)])
     failures = 0
     for _ in range(len(workers)):
         msg = await asyncio.wait_for(root.next(), timeout)
-        if msg and bytes(msg[0]).startswith(b"hello from "):
+        if bytes(msg[0]) == H_REPLY:
             continue
         who, reason = _failure_notice(msg)
         failures += 1
         log(f"[root] FAILURE (reply) {who}: {reason}")
+    return failures
+
+
+async def _ring_round(
+    root: Actor, workers: list[bytes], timeout: float, heads: list[int]
+) -> int:
+    """Inject a token at each chain head and wait for every chain to return.
+
+    ``heads`` are the chain-start indices. Each token's count starts at 0; workers
+    log the count they saw and forward count+1 to their wired next hop, which the
+    root set to itself at each chain boundary. A chain of ``L`` workers therefore
+    returns ``[H_RING, L]`` to the root, so the counts across all chains sum to the
+    worker count. The root expects exactly ``len(heads)`` replies; a severed link
+    substitutes an ``[H_FAIL, ...]`` notice (or the await times out if a token
+    stalled). Returns the failure count.
+    """
+    for h in heads:
+        root.send(workers[h], [ba(H_RING), ba(b"0")])
+    total = 0
+    failures = 0
+    for _ in range(len(heads)):
+        msg = await asyncio.wait_for(root.next(), timeout)
+        if bytes(msg[0]) == H_RING:
+            total += int(bytes(msg[1]))
+            continue
+        who, reason = _failure_notice(msg)
+        log(f"[root] FAILURE (ring) {who}: {reason}")
+        failures += 1
+    # Every worker must have been visited exactly once across all chains.
+    if not failures and total != len(workers):
+        log(f"[root] ERROR: ring visited {total} workers, expected {len(workers)}")
+        return 1
     return failures
 
 
@@ -216,6 +305,8 @@ async def run_root(
     connect_timeout: float,
     duration: float = 0.0,
     send_interval: float = 1.0,
+    chain_length: int = 0,
+    end_sleep: float = 0.0,
 ) -> int:
     """Dial every worker, time connection + round-trip, and report.
 
@@ -228,6 +319,17 @@ async def run_root(
     data traffic, so the connections stay up only if heartbeats (direct and
     delegated) keep them alive — which is exactly what this exercises.
 
+    ``chain_length`` caps the ring into independent chains of at most that many
+    workers (``<= 0`` = a single chain of all workers). Each chain returns to the
+    root on its own, so at scale ring latency is bounded by the chain length rather
+    than the whole worker count, and one broken link fails only its own chain.
+
+    ``end_sleep`` > 0 adds a final heartbeat-only settling window after the last
+    round: the root stops sending data and simply watches for that long, so links
+    survive purely on heartbeats. Sizing it above the heartbeat timeout confirms
+    steady-state heartbeating holds and keeps a teardown-race severance from being
+    misread as a real failure. Any message arriving in the window is a failure.
+
     Returns a process exit code (0 on full success).
     """
     root = Actor(b"root")
@@ -238,7 +340,10 @@ async def run_root(
         log(f"[root] joining {total} worker(s)...")
         t_join = time.monotonic()
         for host in hosts:
-            root.join(f"quic://{host}", "parent")
+            # Register H_FAIL as the failure prefix so a severed worker link is
+            # delivered as [H_FAIL, worker_ident, reason] — a header we dispatch on
+            # instead of sniffing the payload.
+            root.join(f"quic://{host}", "parent", failure=[ba(H_FAIL)])
 
         # Every failure notice the root receives (a severed connection to a
         # worker) is printed as it arrives so we can see exactly which workers
@@ -247,8 +352,8 @@ async def run_root(
         failures = 0
         # Loop until every worker has connected. A message is either an
         # establishment hello ([b"root", worker_ident]) or a failure notice
-        # ([worker_ident, reason]); only hellos count toward `total`, failures
-        # are printed and tallied.
+        # ([H_FAIL, worker_ident, reason]); only hellos count toward `total`,
+        # failures are printed and tallied.
         while len(workers) < total:
             try:
                 msg = await asyncio.wait_for(root.next(), connect_timeout)
@@ -258,9 +363,10 @@ async def run_root(
                     f"connected within {connect_timeout:.0f}s ({failures} failures)"
                 )
                 return 1
-            if len(msg) >= 2 and bytes(msg[0]) == b"root":
-                # Establishment hello: record who connected. Progress is printed
-                # only at decile boundaries (bounded prints) so it stays cheap.
+            if bytes(msg[0]) == b"root":
+                # Establishment hello ([b"root", worker_ident]): record who
+                # connected. Progress is printed only at decile boundaries
+                # (bounded prints) so it stays cheap.
                 workers.append(bytes(msg[1]))
                 _report_progress("connected", len(workers), total, step)
             else:
@@ -270,17 +376,44 @@ async def run_root(
         connect_ms = (time.monotonic() - t_join) * 1e3
         log(f"[root] all {len(workers)} workers connected in {connect_ms:.1f} ms")
 
-        # --- Phase 2: ping/reply, once or repeatedly for `duration` seconds --
+        # Wire the ring once, capped into chains of at most `cap` workers: a
+        # worker's next hop is the root (not its normal successor) at each chain
+        # boundary and at the very end. `heads` are the chain-start indices where
+        # the root injects a token. Done before any token is injected so every
+        # worker knows its next hop before a token can reach it.
+        cap = chain_length if chain_length > 0 else len(workers)
+        heads = list(range(0, len(workers), cap))
+        for i, wid in enumerate(workers):
+            boundary = (i + 1) % cap == 0 or i + 1 == len(workers)
+            nxt = b"root" if boundary else workers[i + 1]
+            root.send(wid, [ba(H_NEXT), ba(nxt)])
+        log(
+            f"[root] wired {len(heads)} chain(s) of <= {cap} over {len(workers)} workers"
+        )
+
+        # --- Phase 2: each round runs a direct pass then a ring pass, once or
+        # repeatedly for `duration` seconds --
         t_send = time.monotonic()
         deadline = t_send + max(duration, 0.0)
         rounds = 0
         try:
             while True:
                 rounds += 1
-                failures += await _ping_round(root, workers, timeout)
+                t_direct = time.monotonic()
+                failures += await _direct_round(root, workers, timeout)
                 if failures:
                     break
-                log(f"[root]   round {rounds} ok ({len(workers)} replies)")
+                direct_ms = (time.monotonic() - t_direct) * 1e3
+                t_ring = time.monotonic()
+                failures += await _ring_round(root, workers, timeout, heads)
+                if failures:
+                    break
+                ring_ms = (time.monotonic() - t_ring) * 1e3
+                log(
+                    f"[root]   round {rounds} ok ({len(workers)} workers): "
+                    f"direct {direct_ms:.1f} ms, ring {ring_ms:.1f} ms "
+                    f"({len(heads)} chain(s))"
+                )
                 if time.monotonic() >= deadline:
                     break
                 # Idle gap: no data flows, so only heartbeats keep the links up.
@@ -292,6 +425,27 @@ async def run_root(
             )
             return 1
         roundtrip_ms = (time.monotonic() - t_send) * 1e3
+
+        # Final heartbeat-only settling window: with the root no longer sending
+        # data, links survive purely on heartbeats. Idling here (>= the heartbeat
+        # timeout) before teardown confirms steady-state heartbeating holds and
+        # avoids attributing a teardown-race severance to a real failure. Any
+        # message that arrives in this window is a failure notice.
+        if end_sleep > 0 and failures == 0:
+            log(f"[root] idle {end_sleep:.1f}s (heartbeat-only) before teardown...")
+            idle_deadline = time.monotonic() + end_sleep
+            while True:
+                remaining = idle_deadline - time.monotonic()
+                if remaining <= 0:
+                    break
+                try:
+                    msg = await asyncio.wait_for(root.next(), remaining)
+                except asyncio.TimeoutError:
+                    break
+                who, reason = _failure_notice(msg)
+                failures += 1
+                log(f"[root] FAILURE (idle) {who}: {reason}")
+            log(f"[root] idle window done ({failures} failures)")
 
         log("[root] --- summary ---")
         log(f"[root] connect:    {connect_ms:.1f} ms ({len(workers)} workers)")
@@ -336,12 +490,6 @@ def main() -> None:
         help="worker bind address (default: '::' = all IPv6 interfaces)",
     )
     parser.add_argument(
-        "--advertise-host",
-        default=None,
-        help="worker: IPv6 host siblings can dial us at; adds a gateway @tag to our "
-        "ident so the root can delegate our heartbeat to a sibling (e.g. '::1' locally)",
-    )
-    parser.add_argument(
         "--certs-dir", default=None, help="directory holding cert.pem/key.pem/ca.pem"
     )
     parser.add_argument(
@@ -373,12 +521,29 @@ def main() -> None:
         "Set larger than the heartbeat timeout so heartbeats, not data, hold the "
         "links open between rounds.",
     )
+    parser.add_argument(
+        "--chain-length",
+        type=int,
+        default=0,
+        help="root: cap the ring into independent chains of at most this many "
+        "workers, each returning to the root on its own (default: 0 = one chain of "
+        "all workers). Bounds ring latency and blast radius at large worker counts.",
+    )
+    parser.add_argument(
+        "--end-sleep",
+        type=float,
+        default=0.0,
+        help="root: after the last round, idle for this many seconds in a "
+        "heartbeat-only window before tearing down (default: 0 = none). Set above "
+        "the heartbeat timeout to confirm heartbeats hold with no data flowing and "
+        "avoid teardown-race false failures.",
+    )
     args = parser.parse_args()
 
     ensure_quic_certs(args.certs_dir)
 
     if args.worker:
-        asyncio.run(run_worker(args.port, args.bind, args.advertise_host))
+        asyncio.run(run_worker(args.port, args.bind))
     else:
         if args.root_file:
             with open(args.root_file) as f:
@@ -393,6 +558,8 @@ def main() -> None:
                     args.connect_timeout,
                     args.duration,
                     args.send_interval,
+                    args.chain_length,
+                    args.end_sleep,
                 )
             )
         )

--- a/monarch_mini/src/quic_heartbeat.rs
+++ b/monarch_mini/src/quic_heartbeat.rs
@@ -62,7 +62,6 @@ type Handle = mpsc::UnboundedSender<HeartbeatEvent>;
 // ---------------------------------------------------------------------------
 
 const DEFAULT_MAX_DIRECT_CHILDREN: usize = 256;
-const DEFAULT_MAX_COVERAGE_PER_SIBLING: usize = 32;
 
 /// How often each side emits a heartbeat, and how long a side waits for any beat
 /// before declaring the connection broken. The timeout is several intervals so a
@@ -100,18 +99,11 @@ pub(crate) fn heartbeat_timeout() -> Duration {
         .unwrap_or(DEFAULT_HEARTBEAT_TIMEOUT)
 }
 
-/// Threshold above which a parent's new children are delegated rather than
-/// monitored directly.
+/// The number of children a parent heartbeats directly. Any beyond this are
+/// delegated to (balanced across) the direct ones, so the parent's steady-state
+/// heartbeat load is bounded by this regardless of fan-out.
 fn max_direct_children() -> usize {
     env_usize("MM_QUIC_MAX_DIRECT_CHILDREN", DEFAULT_MAX_DIRECT_CHILDREN)
-}
-
-/// Cap on how many delegated connections one sibling may cover.
-fn max_coverage_per_sibling() -> usize {
-    env_usize(
-        "MM_QUIC_MAX_COVERAGE_PER_SIBLING",
-        DEFAULT_MAX_COVERAGE_PER_SIBLING,
-    )
 }
 
 /// The heartbeat tunables, resolved once and carried by [`Heartbeats`] into every
@@ -123,7 +115,6 @@ pub(crate) struct HeartbeatConfig {
     pub(crate) interval: Duration,
     pub(crate) timeout: Duration,
     pub(crate) max_direct_children: usize,
-    pub(crate) max_coverage_per_sibling: usize,
 }
 
 impl HeartbeatConfig {
@@ -133,7 +124,6 @@ impl HeartbeatConfig {
             interval: heartbeat_interval(),
             timeout: heartbeat_timeout(),
             max_direct_children: max_direct_children(),
-            max_coverage_per_sibling: max_coverage_per_sibling(),
         }
     }
 }
@@ -165,7 +155,7 @@ impl Heartbeats {
     pub(crate) fn with_config(config: HeartbeatConfig) -> Self {
         Self {
             shared: Rc::new(RefCell::new(HeartbeatShared::new(
-                config.max_coverage_per_sibling,
+                config.max_direct_children,
             ))),
             config,
         }
@@ -321,8 +311,8 @@ enum ChildStatus {
 }
 
 /// A parent's record of one child connection. Owned by [`ParentPool`], the single
-/// source of truth for it: the direct-heartbeat count and each sibling's coverage are
-/// *derived* from these fields as statuses transition, never poked by callers.
+/// source of truth for it: the keeper set and each target's coverage are *derived*
+/// from these fields as statuses transition, never poked by callers.
 struct SiblingInfo {
     /// The child's ident, once its `Establish` is snooped. `Some` implies the child
     /// has established; whether it is *addressable* (has a dialable gateway tag) is
@@ -332,109 +322,198 @@ struct SiblingInfo {
     /// serve as a delegate.
     dialed: bool,
     status: ChildStatus,
-    /// The sibling we delegated this child to; meaningful only while `Delegating` /
-    /// `Paused`.
-    sibling: Option<ConnectionId>,
-    /// How many other children we have *requested* this one cover for us (charged at
-    /// delegation-decision time, which may run ahead of the coverage the sibling has
-    /// actually reported); nonzero only while `Direct`.
-    requested_covers: usize,
+    /// The delegate (a sibling keeper) we offloaded this child to; meaningful only
+    /// while `Delegating` / `Paused`.
+    delegated_to: Option<ConnectionId>,
 }
 
 impl SiblingInfo {
-    /// Whether this child may be handed another child to cover right now: it must be a
-    /// direct child under its coverage cap, dialed by us, and addressable.
-    fn is_delegate_candidate(&self, cap: usize) -> bool {
+    /// Whether this child may be offloaded to a delegate right now: it must be a
+    /// live direct child, dialed by us, and addressable (a sibling needs a dialable
+    /// gateway tag to reach it). A child already chosen as a delegate target
+    /// (a keeper) is excluded by the caller, not here.
+    fn is_delegable(&self) -> bool {
         self.status == ChildStatus::Direct
-            && self.requested_covers < cap
             && self.dialed
             && self.ident.as_deref().is_some_and(is_addressable)
     }
 }
 
-/// The set of connections currently eligible to be handed a sibling to cover, kept in
-/// sync by [`ParentPool::set_status`]. A `Vec` gives the round-robin cursor something to
-/// index; the position map makes add/remove O(1) (remove is `swap_remove` + an index
-/// fixup for the element that moved into the hole).
+/// The parent's delegate targets: the (at most `max_direct`) children it keeps
+/// heartbeating directly, each labelled with how many delegated siblings it
+/// currently covers. Every new delegate is handed to the least-loaded target, so
+/// coverage stays balanced. Capping the target count at `max_direct` is what makes
+/// the parent's direct-heartbeat load respect `max_direct`: the targets are the
+/// only permanently-direct children, and everything else is delegated onto them.
+///
+/// Internally a binary min-heap keyed by cover count: `heap[0]` is always a
+/// least-loaded target. An index map (`pos`) locates any target in the array in O(1)
+/// so its count can be re-heaped in place. Add, remove, and re-charge are all
+/// O(log n); reading the least-loaded target is O(1). All the heap machinery is
+/// contained here; callers only add/remove targets, read the least-loaded one, and
+/// report a `+/-1` cover-count change.
 #[derive(Default)]
-struct CandidateRing {
-    ids: Vec<ConnectionId>,
+struct DelegateTargets {
+    /// Cap on the number of targets — i.e. on children heartbeated directly.
+    max_direct: usize,
+    /// Target ids in min-heap order by cover count; `heap[0]` is least loaded.
+    heap: Vec<ConnectionId>,
+    /// id -> its index in `heap`.
     pos: HashMap<ConnectionId, usize>,
+    /// id -> its current cover count (the heap key).
+    count: HashMap<ConnectionId, usize>,
 }
 
-impl CandidateRing {
-    fn insert(&mut self, id: ConnectionId) {
-        if self.pos.contains_key(&id) {
-            return;
+impl DelegateTargets {
+    fn new(max_direct: usize) -> Self {
+        Self {
+            max_direct,
+            ..Default::default()
         }
-        self.pos.insert(id, self.ids.len());
-        self.ids.push(id);
     }
 
+    fn len(&self) -> usize {
+        self.heap.len()
+    }
+
+    fn is_full(&self) -> bool {
+        self.heap.len() >= self.max_direct
+    }
+
+    fn contains(&self, id: ConnectionId) -> bool {
+        self.pos.contains_key(&id)
+    }
+
+    fn load_of(&self, id: ConnectionId) -> usize {
+        self.count.get(&id).copied().unwrap_or(0)
+    }
+
+    /// The least-loaded target, or `None` if there are none.
+    fn least_loaded(&self) -> Option<ConnectionId> {
+        self.heap.first().copied()
+    }
+
+    /// Add `id` as a target with zero cover count. Caller ensures `!is_full()` and
+    /// that `id` is not already present. Push at the end and sift up (zero is the
+    /// minimum key, so it bubbles to the root).
+    fn add(&mut self, id: ConnectionId) {
+        debug_assert!(!self.contains(id), "target added twice");
+        let i = self.heap.len();
+        self.heap.push(id);
+        self.pos.insert(id, i);
+        self.count.insert(id, 0);
+        self.heap_up(i);
+    }
+
+    /// Drop a target that is gone; the children it covered fall back on their own.
+    /// Move the last element into the hole and re-heap from there.
     fn remove(&mut self, id: ConnectionId) {
         let Some(i) = self.pos.remove(&id) else {
             return;
         };
-        let last = self.ids.len() - 1;
-        self.ids.swap(i, last);
-        self.ids.pop();
-        if i != last {
-            *self
-                .pos
-                .get_mut(&self.ids[i])
-                .expect("swapped id is tracked") = i;
+        self.count.remove(&id);
+        let last = self.heap.len() - 1;
+        self.heap.swap(i, last);
+        self.heap.pop();
+        if i < self.heap.len() {
+            self.pos.insert(self.heap[i], i);
+            self.reheap(i);
         }
     }
 
-    /// The next candidate other than `exclude` (the child being delegated is itself a
-    /// candidate), advancing the cursor. `None` if there is no other candidate.
-    fn next(&self, rr: &mut usize, exclude: ConnectionId) -> Option<ConnectionId> {
-        let n = self.ids.len();
-        for _ in 0..n {
-            let id = self.ids[*rr % n];
-            *rr = rr.wrapping_add(1);
-            if id != exclude {
-                return Some(id);
-            }
+    /// Report that `id`'s cover count changed by `delta` (+1 when it takes on a
+    /// delegate, -1 when one leaves) and restore the heap. A no-op if `id` is not a
+    /// current target: a keeper can die (its slot freed by [`Self::remove`]) while
+    /// children still point at it, and those children shed their coverage only
+    /// afterwards.
+    fn change_count_if_present(&mut self, id: ConnectionId, delta: i64) {
+        let Some(&i) = self.pos.get(&id) else {
+            return;
+        };
+        let new = (self.count[&id] as i64 + delta).max(0) as usize;
+        self.count.insert(id, new);
+        self.reheap(i);
+    }
+
+    // --- heap internals ---
+
+    /// Cover count of the target at heap index `i`.
+    fn count_at(&self, i: usize) -> usize {
+        self.count[&self.heap[i]]
+    }
+
+    /// Swap two heap slots and fix both index-map entries.
+    fn swap(&mut self, i: usize, j: usize) {
+        self.heap.swap(i, j);
+        self.pos.insert(self.heap[i], i);
+        self.pos.insert(self.heap[j], j);
+    }
+
+    /// Restore the heap property at `i`, which may need to move in either direction
+    /// (used after a removal drops an arbitrary element into the hole).
+    fn reheap(&mut self, i: usize) {
+        if i > 0 && self.count_at(i) < self.count_at((i - 1) / 2) {
+            self.heap_up(i);
+        } else {
+            self.heap_down(i);
         }
-        None
+    }
+
+    /// Sift the element at `i` toward the root while it is lighter than its parent.
+    fn heap_up(&mut self, mut i: usize) {
+        while i > 0 {
+            let parent = (i - 1) / 2;
+            if self.count_at(i) >= self.count_at(parent) {
+                break;
+            }
+            self.swap(i, parent);
+            i = parent;
+        }
+    }
+
+    /// Sift the element at `i` toward the leaves while a child is lighter than it.
+    fn heap_down(&mut self, mut i: usize) {
+        let n = self.heap.len();
+        loop {
+            let mut smallest = i;
+            for child in [2 * i + 1, 2 * i + 2] {
+                if child < n && self.count_at(child) < self.count_at(smallest) {
+                    smallest = child;
+                }
+            }
+            if smallest == i {
+                break;
+            }
+            self.swap(i, smallest);
+            i = smallest;
+        }
     }
 }
 
 /// A parent's pool of child connections and the delegation state derived from them.
 /// It owns the per-child [`SiblingInfo`] records and is the *only* place eligibility
-/// and the direct-heartbeat count are computed: callers narrate connection events
-/// (the lifecycle methods below) and never touch the derived state.
+/// and the keeper set are computed: callers narrate connection events (the lifecycle
+/// methods below) and never touch the derived state.
 struct ParentPool {
     siblings: HashMap<ConnectionId, SiblingInfo>,
-    /// Count of children currently heartbeated directly. Derived — maintained as
-    /// statuses transition — and drives the delegation budget.
-    active_direct: i64,
-    /// Round-robin cursor over `candidates`, so consecutive delegations spread across
-    /// siblings and a just-failed one is unlikely to be re-picked immediately.
-    rr: usize,
-    /// Connections eligible to cover a sibling right now, maintained incrementally by
-    /// `set_status` so `pick_delegate` is O(1).
-    candidates: CandidateRing,
-    /// Max children any one sibling may be asked to cover; feeds `is_delegate_candidate`.
-    cap: usize,
+    /// The children kept direct (the delegate targets), capped at `max_direct`, with
+    /// their cover counts. Every child beyond these is delegated onto the
+    /// least-loaded one of them. Its size *is* the direct-heartbeat budget.
+    delegate_targets: DelegateTargets,
 }
 
 impl ParentPool {
-    fn new(cap: usize) -> Self {
+    fn new(max_direct: usize) -> Self {
         Self {
             siblings: HashMap::new(),
-            active_direct: 0,
-            rr: 0,
-            candidates: CandidateRing::default(),
-            cap,
+            delegate_targets: DelegateTargets::new(max_direct),
         }
     }
 
     // --- connection lifecycle (the only way callers change pool state) ---
 
-    /// A child connection was added (not yet established). We beat it directly from now
-    /// on, so it immediately counts toward the budget.
+    /// A child connection was added (not yet established). We beat it directly until
+    /// it establishes and is possibly delegated.
     fn add_child(&mut self, conn_id: ConnectionId, dialed: bool) {
         self.siblings.insert(
             conn_id,
@@ -442,11 +521,9 @@ impl ParentPool {
                 ident: None,
                 dialed,
                 status: ChildStatus::NotEstablished,
-                sibling: None,
-                requested_covers: 0,
+                delegated_to: None,
             },
         );
-        self.active_direct += 1;
     }
 
     /// The child's `Establish` arrived: record its ident and treat it as a live
@@ -455,49 +532,63 @@ impl ParentPool {
         if let Some(info) = self.siblings.get_mut(&conn_id) {
             info.ident = Some(ident);
         }
-        self.set_status(conn_id, Some(ChildStatus::Direct));
+        self.restore_direct(conn_id);
     }
 
-    /// If we are over the direct-heartbeat budget and `conn_id` is a plain live direct
-    /// child, delegate it to an eligible sibling: record the delegation, charge that
-    /// sibling's coverage, and return the [`Delegate`] instruction to send. `None` if
-    /// not over budget, the child isn't delegable, or no sibling is free.
-    fn delegate(&mut self, conn_id: ConnectionId, config: HeartbeatConfig) -> Option<Delegate> {
-        let info = self.siblings.get(&conn_id)?;
-        // Only a plain, established, dialed direct child is delegated — never a cover
-        // host, an already-delegating/paused one, or one we can't dial or address.
-        if info.status != ChildStatus::Direct
-            || info.requested_covers != 0
-            || !info.dialed
-            || info.ident.is_none()
+    /// Decide what to do with `conn_id`, which just beat us:
+    ///
+    /// - If it is a keeper (delegate target), keep heartbeating it directly.
+    /// - Else if the keeper set has room, make it a keeper — so the first `max_direct`
+    ///   delegable children become the direct set.
+    /// - Once the keeper set is full, offload it: delegate it to the least-loaded
+    ///   keeper and return the [`Delegate`] instruction. `assign_delegate` charges
+    ///   that keeper's cover count, rebalancing the target order.
+    ///
+    /// The keeper cap *is* the budget: at most `max_direct` children are ever
+    /// heartbeated directly, and every other child is delegated and balanced across
+    /// them. (A non-keeper only reaches the offload path once the set is full, which
+    /// is exactly when there are more direct children than the cap.)
+    fn delegate(&mut self, conn_id: ConnectionId) -> Option<Delegate> {
+        // A keeper is heartbeated directly forever.
+        if self.delegate_targets.contains(conn_id) {
+            return None;
+        }
+        // Only a plain, established, dialed, addressable direct child is offloaded.
+        if !self
+            .siblings
+            .get(&conn_id)
+            .is_some_and(SiblingInfo::is_delegable)
         {
             return None;
         }
-        if !self.over_budget(config.max_direct_children) {
+        // Fill the keeper set first; only once it is full do we start offloading.
+        if !self.delegate_targets.is_full() {
+            self.delegate_targets.add(conn_id);
+            if crate::ctx::connection_debug() {
+                eprintln!(
+                    "MM_DELEG keeper conn_id={conn_id} keepers={}/{}",
+                    self.delegate_targets.len(),
+                    self.delegate_targets.max_direct,
+                );
+            }
             return None;
         }
+        let target = self.delegate_targets.least_loaded()?;
+        let sibling_ident = self.siblings.get(&target)?.ident.clone()?;
         if crate::ctx::connection_debug() {
             eprintln!(
-                "MM_DELEG over budget: active_direct={} max_direct={} candidates={}",
-                self.active_direct,
-                config.max_direct_children,
-                self.candidates.ids.len(),
+                "MM_DELEG pick child={conn_id} -> target={target} target_load={} keepers={}",
+                self.delegate_targets.load_of(target),
+                self.delegate_targets.len(),
             );
         }
-        let (sibling_conn, sibling_ident) = self.pick_delegate(conn_id)?;
-        // Point the child at its delegate, then transition: `set_status` charges
-        // `sibling_conn`'s coverage as the child enters `Delegating`.
-        self.siblings.get_mut(&conn_id)?.sibling = Some(sibling_conn);
-        self.set_status(conn_id, Some(ChildStatus::Delegating));
+        // Enter `Delegating`, pointing the child at its target and charging that
+        // target's cover count.
+        self.assign_delegate(conn_id, target);
         Some(Delegate {
             connection_id: conn_id,
             sibling_ident,
         })
-    }
-
-    /// Whether we are over the direct-heartbeat budget.
-    fn over_budget(&self, max_direct_children: usize) -> bool {
-        self.active_direct > max_direct_children as i64
     }
 
     /// This child's current status, if we still track it.
@@ -506,102 +597,64 @@ impl ParentPool {
     }
 
     // --- derived-state maintenance (internal) ---
+    //
+    // The only derived state is a target's cover count, and it moves solely when a
+    // child *crosses the delegation boundary*: entering the delegated set charges its
+    // target +1 (`assign_delegate`), leaving it charges its old target -1
+    // (`restore_direct`, `remove_child`). Staying on the same side of the boundary
+    // (`acknowledge_delegate`, the `Delegating` → `Paused` step) moves nothing. Every
+    // record is `add_child`ed before its parent task's loop runs and dropped only by
+    // the single teardown `remove_child`, so each call in between finds its record
+    // present.
 
-    /// Move a child to `status` (or, if `None`, remove it entirely — a connection is
-    /// gone). All accounting is done here by reversing what the child contributed before
-    /// the change, then applying what it contributes after; the candidate list follows
-    /// the child's own candidacy across the transition (the coverage change to any
-    /// *sibling* is reflected in `account`, where that sibling's count moves).
-    fn set_status(&mut self, conn_id: ConnectionId, status: Option<ChildStatus>) {
-        let was_candidate = self.is_candidate(conn_id);
-        self.account(conn_id, -1);
-        match status {
-            Some(status) => {
-                let Some(info) = self.siblings.get_mut(&conn_id) else {
-                    return;
-                };
-                info.status = status;
-                // Only a delegated child points at a sibling.
-                if !matches!(status, ChildStatus::Delegating | ChildStatus::Paused) {
-                    info.sibling = None;
-                }
-                self.account(conn_id, 1);
-            }
-            None => {
-                self.siblings.remove(&conn_id);
-            }
-        }
-        self.refresh_candidate(conn_id, was_candidate);
-    }
-
-    /// Apply (`sign` = 1) or reverse (`sign` = -1) the bookkeeping the child at `conn_id`
-    /// implies given its current status: whether we heartbeat it directly (the budget),
-    /// and the unit of coverage it consumes from the sibling it is delegated to.
-    fn account(&mut self, conn_id: ConnectionId, sign: i64) {
-        let Some(info) = self.siblings.get(&conn_id) else {
-            return;
-        };
-        let (status, sibling) = (info.status, info.sibling);
-        match status {
-            // We heartbeat it directly — it counts toward the budget.
-            ChildStatus::NotEstablished | ChildStatus::Direct => self.active_direct += sign,
-            // Delegated to a sibling: once we *request* delegation we treat it as
-            // offloaded (so we don't keep delegating others while the pause is in
-            // flight), and we charge the sibling one requested cover. `Delegating` still
-            // watches directly at the loop level, but for the budget it no longer counts;
-            // if the delegation falls back it reverts to `Direct` and counts again. The
-            // sibling may already be gone if it died before the child it was covering.
-            ChildStatus::Delegating | ChildStatus::Paused => {
-                let sibling = sibling.expect("a delegated child has a sibling");
-                let was_candidate = self.is_candidate(sibling);
-                if let Some(info) = self.siblings.get_mut(&sibling) {
-                    info.requested_covers =
-                        info.requested_covers.saturating_add_signed(sign as isize);
-                }
-                // Changing the sibling's `requested_covers` can move it across the cap.
-                self.refresh_candidate(sibling, was_candidate);
-            }
-        }
-    }
-
-    /// Whether `conn_id` is currently a delegate candidate.
-    fn is_candidate(&self, conn_id: ConnectionId) -> bool {
+    /// The record for `conn_id`, which every lifecycle call after `add_child` (and
+    /// before `remove_child`) is guaranteed to find (see the note above).
+    fn info_mut(&mut self, conn_id: ConnectionId) -> &mut SiblingInfo {
         self.siblings
-            .get(&conn_id)
-            .is_some_and(|i| i.is_delegate_candidate(self.cap))
+            .get_mut(&conn_id)
+            .expect("no record for connection (never add_child'd, or already removed)")
     }
 
-    /// Sync `conn_id`'s membership in the candidate ring after a change, given whether it
-    /// was a candidate beforehand.
-    fn refresh_candidate(&mut self, conn_id: ConnectionId, was_candidate: bool) {
-        match (was_candidate, self.is_candidate(conn_id)) {
-            (false, true) => self.candidates.insert(conn_id),
-            (true, false) => self.candidates.remove(conn_id),
-            _ => {}
+    /// Restore `conn_id` to a live direct child (it just established, beat us directly
+    /// after being delegated, or a sibling stopped covering it). If it had been
+    /// delegated, its old target sheds a unit of coverage.
+    fn restore_direct(&mut self, conn_id: ConnectionId) {
+        let info = self.info_mut(conn_id);
+        info.status = ChildStatus::Direct;
+        // Only a delegated child points at a target; clearing it uncharges that target.
+        if let Some(target) = info.delegated_to.take() {
+            self.delegate_targets.change_count_if_present(target, -1);
         }
     }
 
-    /// Round-robin pick of a delegate candidate other than `exclude`.
-    fn pick_delegate(&mut self, exclude: ConnectionId) -> Option<(ConnectionId, Vec<u8>)> {
-        let chosen = self.candidates.next(&mut self.rr, exclude)?;
-        let ident = self.siblings.get(&chosen)?.ident.clone()?;
-        Some((chosen, ident))
+    /// Offload `conn_id` to `target`: it enters `Delegating` and charges `target`'s
+    /// cover count +1. It is still watched directly at the loop level until its
+    /// delegate acks (see `acknowledge_delegate`).
+    fn assign_delegate(&mut self, conn_id: ConnectionId, target: ConnectionId) {
+        let info = self.info_mut(conn_id);
+        info.status = ChildStatus::Delegating;
+        info.delegated_to = Some(target);
+        self.delegate_targets.change_count_if_present(target, 1);
     }
 
-    /// Rebuild the candidate ring from scratch (tests that stuff `siblings` directly,
-    /// bypassing the incremental `set_status` maintenance).
-    #[cfg(test)]
-    fn rebuild_candidates(&mut self) {
-        self.candidates = CandidateRing::default();
-        let ids: Vec<ConnectionId> = self
+    /// Acknowledge that `conn_id`'s delegate now covers it: it goes silent to us
+    /// (`Delegating` → `Paused`). It keeps the same target, so no cover count moves.
+    fn acknowledge_delegate(&mut self, conn_id: ConnectionId) {
+        self.info_mut(conn_id).status = ChildStatus::Paused;
+    }
+
+    /// Drop `conn_id` entirely — its connection is gone. If it was delegated, its
+    /// target sheds a unit of coverage; if it was itself a keeper, its slot is freed
+    /// so its covered children fall back to direct.
+    fn remove_child(&mut self, conn_id: ConnectionId) {
+        let info = self
             .siblings
-            .iter()
-            .filter(|(_, i)| i.is_delegate_candidate(self.cap))
-            .map(|(&id, _)| id)
-            .collect();
-        for id in ids {
-            self.candidates.insert(id);
+            .remove(&conn_id)
+            .expect("remove_child on a connection that was never add_child'd");
+        if let Some(target) = info.delegated_to {
+            self.delegate_targets.change_count_if_present(target, -1);
         }
+        self.delegate_targets.remove(conn_id);
     }
 }
 
@@ -618,18 +671,19 @@ pub(crate) struct HeartbeatShared {
     parents_by_conn_id: HashMap<ConnectionId, Handle>,
     /// For each local actor that parents quic children, its delegate pool.
     parents: HashMap<Key, ParentPool>,
-    /// Max children any one sibling may cover; seeded into each [`ParentPool`].
-    max_coverage_per_sibling: usize,
+    /// Number of children each parent heartbeats directly; seeded into each
+    /// [`ParentPool`] as the keeper cap.
+    max_direct: usize,
 }
 
 impl HeartbeatShared {
-    pub(crate) fn new(max_coverage_per_sibling: usize) -> Self {
+    pub(crate) fn new(max_direct: usize) -> Self {
         Self {
             next_conn_id: 0,
             children_by_ident: HashMap::new(),
             parents_by_conn_id: HashMap::new(),
             parents: HashMap::new(),
-            max_coverage_per_sibling,
+            max_direct,
         }
     }
 
@@ -646,10 +700,10 @@ impl HeartbeatShared {
     }
 
     fn pool_mut(&mut self, key: Key) -> &mut ParentPool {
-        let cap = self.max_coverage_per_sibling;
+        let max_direct = self.max_direct;
         self.parents
             .entry(key)
-            .or_insert_with(|| ParentPool::new(cap))
+            .or_insert_with(|| ParentPool::new(max_direct))
     }
 
     /// Route a delegate host's coverage diff to the covered connections' Parent-side
@@ -831,7 +885,7 @@ async fn parent_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
     // deregister. (A delegate host's covered children are resumed by
     // `parent_cover_loop` itself as it exits.)
     let mut s = shared.borrow_mut();
-    s.pool_mut(key).set_status(conn_id, None);
+    s.pool_mut(key).remove_child(conn_id);
     s.parents_by_conn_id.remove(&conn_id);
 }
 
@@ -883,7 +937,7 @@ async fn parent_direct_loop(
                         shared
                             .borrow_mut()
                             .pool_mut(key)
-                            .set_status(conn_id, Some(ChildStatus::Direct));
+                            .restore_direct(conn_id);
 
                         if !cover_add.is_empty() {
                             // First coverage report: it is now a delegate host. Answer this
@@ -896,7 +950,7 @@ async fn parent_direct_loop(
                         // Answer the beat, carrying a delegate instruction if we are over
                         // budget. The child sends no further direct beat until it processes
                         // this answer, so a delegate here is its last one.
-                        let delegate = shared.borrow_mut().pool_mut(key).delegate(conn_id, config);
+                        let delegate = shared.borrow_mut().pool_mut(key).delegate(conn_id);
                         let _ = beats.send(Heartbeat::FromParent { delegate });
                     }
                     HeartbeatEvent::ReceivedHeartbeat(Heartbeat::TransportActivity) => {
@@ -921,7 +975,7 @@ async fn parent_direct_loop(
                             );
                         }
                         if pool.status(conn_id) == Some(ChildStatus::Delegating) {
-                            pool.set_status(conn_id, Some(ChildStatus::Paused));
+                            pool.acknowledge_delegate(conn_id);
                             deadline = None;
                         }
                     }
@@ -930,7 +984,7 @@ async fn parent_direct_loop(
                         shared
                             .borrow_mut()
                             .pool_mut(key)
-                            .set_status(conn_id, Some(ChildStatus::Direct));
+                            .restore_direct(conn_id);
                         deadline = Some(Instant::now() + config.timeout);
                     }
                     HeartbeatEvent::EstablishPeer { peer_ident } => {
@@ -1327,9 +1381,8 @@ mod tests {
             interval: Duration::from_millis(INTERVAL_MS),
             timeout: Duration::from_millis(TIMEOUT_MS),
             // A parent may keep one child direct; a second established child is over
-            // budget and gets delegated.
+            // budget and gets delegated onto the first.
             max_direct_children: 1,
-            max_coverage_per_sibling: 8,
         }
     }
 
@@ -1438,54 +1491,130 @@ mod tests {
             .unwrap()
     }
 
-    /// Delegate selection skips any sibling that is not a *live* candidate (status
-    /// isn't `Direct`, or it isn't dialed / addressable / under capacity) and
-    /// round-robins over the ones that are — so a dead-but-not-yet-reaped sibling is
-    /// never handed a child.
+    /// `DelegateTargets` hands each new delegate to the least-loaded target and keeps
+    /// coverage balanced as counts move by one, staying correctly sorted throughout.
     #[test]
-    fn pick_delegate_skips_non_candidates_and_round_robins() {
-        let cap = 8;
-        let mut pool = ParentPool::new(cap);
-        let sib = |ident: &[u8], dialed, status, requested_covers| SiblingInfo {
-            ident: Some(ident.to_vec()),
-            dialed,
-            status,
-            sibling: None,
-            requested_covers,
-        };
-        pool.siblings
-            .insert(1, sib(b"c1@x", true, ChildStatus::Direct, 0)); // candidate
-        pool.siblings
-            .insert(2, sib(b"c2@x", true, ChildStatus::Direct, 1)); // candidate (already covers one)
-        pool.siblings
-            .insert(3, sib(b"paused@x", true, ChildStatus::Paused, 0)); // delegated away
-        pool.siblings.insert(
-            4,
-            sib(b"unestablished@x", true, ChildStatus::NotEstablished, 0),
-        ); // not established
-        pool.siblings
-            .insert(5, sib(b"nodial@x", false, ChildStatus::Direct, 0)); // we didn't dial it
-        pool.siblings
-            .insert(6, sib(b"noaddr", true, ChildStatus::Direct, 0)); // no gateway tag
-        pool.siblings
-            .insert(7, sib(b"full@x", true, ChildStatus::Direct, cap)); // at capacity
-        pool.rebuild_candidates();
+    fn delegate_targets_balances_least_loaded() {
+        let mut t = DelegateTargets::new(3);
+        t.add(1);
+        t.add(2);
+        t.add(3); // three targets, all cover count 0
 
-        // The child being delegated (excluded) is conn 99.
-        let picks: Vec<ConnectionId> = (0..6)
-            .map(|_| {
-                pool.pick_delegate(99)
-                    .expect("an eligible sibling exists")
-                    .0
-            })
-            .collect();
-        assert!(
-            picks.iter().all(|&id| id == 1 || id == 2),
-            "only live, dialed, addressable, under-capacity candidates picked: {picks:?}",
+        // Assign six delegates, each to the least-loaded target (charge +1 after each
+        // pick, as the pool does when a child enters `Delegating`).
+        for _ in 0..6 {
+            let id = t.least_loaded().expect("a target exists");
+            t.change_count_if_present(id, 1);
+        }
+        // Balanced: 6 delegates across 3 targets => 2 each.
+        for id in [1, 2, 3] {
+            assert_eq!(t.load_of(id), 2, "target {id} balanced to 2");
+        }
+        assert!(t.is_full(), "three targets fills a cap of three");
+
+        // Discharging one makes it strictly least loaded, so it is picked next.
+        t.change_count_if_present(2, -1);
+        assert_eq!(t.load_of(2), 1, "target 2 now covers one");
+        assert_eq!(
+            t.least_loaded(),
+            Some(2),
+            "the discharged target is least loaded"
         );
-        assert!(
-            picks.contains(&1) && picks.contains(&2),
-            "round-robin uses both candidates: {picks:?}",
+
+        // Removing a target drops it entirely; order among the rest is preserved.
+        t.remove(1);
+        assert!(!t.contains(1), "removed target is gone");
+        assert_eq!(t.len(), 2);
+    }
+
+    /// Stress the min-heap internals: interleave add/remove/charge with a
+    /// deterministic pseudo-random schedule and check, after every mutation, that the
+    /// heap invariant holds, the index map is consistent, and `least_loaded` really is
+    /// a minimum-count target.
+    #[test]
+    fn delegate_targets_heap_invariant_under_churn() {
+        // Assert every structural invariant of `t`.
+        fn check(t: &DelegateTargets) {
+            assert_eq!(t.heap.len(), t.pos.len(), "pos covers exactly the heap");
+            assert_eq!(t.heap.len(), t.count.len(), "count covers exactly the heap");
+            for (i, &id) in t.heap.iter().enumerate() {
+                assert_eq!(t.pos[&id], i, "pos[{id}] tracks its heap slot");
+                if i > 0 {
+                    let parent = (i - 1) / 2;
+                    assert!(
+                        t.count_at(parent) <= t.count_at(i),
+                        "min-heap: parent at {parent} <= child at {i}"
+                    );
+                }
+            }
+            if let Some(top) = t.least_loaded() {
+                let min = t.heap.iter().map(|&id| t.load_of(id)).min().unwrap();
+                assert_eq!(t.load_of(top), min, "least_loaded is a true minimum");
+            }
+        }
+
+        // A tiny deterministic LCG so the test is reproducible without an rng dep.
+        let mut seed: u64 = 0x9e3779b97f4a7c15;
+        let mut rng = || {
+            seed = seed.wrapping_mul(6364136223846793005).wrapping_add(1);
+            (seed >> 33) as usize
+        };
+
+        // Big cap so `add` is never rejected; ids cycle through a small space so
+        // adds, removes, and re-adds all collide and exercise every path.
+        let mut t = DelegateTargets::new(1_000);
+        for _ in 0..5_000 {
+            let id = (rng() % 32) as ConnectionId;
+            match rng() % 3 {
+                0 if !t.contains(id) => t.add(id),
+                1 => t.remove(id), // no-op if absent
+                _ if t.contains(id) => {
+                    // Move the count by +/-1, as the pool does.
+                    let delta = if rng() % 2 == 0 { 1 } else { -1 };
+                    t.change_count_if_present(id, delta);
+                }
+                _ => {}
+            }
+            check(&t);
+        }
+    }
+
+    /// The pool keeps at most `max_direct` children direct (the keepers) and delegates
+    /// every other established child onto them, balanced — so the number of direct
+    /// children settles at exactly `max_direct`, never above it.
+    #[test]
+    fn delegate_respects_max_direct_and_balances() {
+        let mut pool = ParentPool::new(2); // keep at most two children direct
+        for id in 0..6 {
+            pool.add_child(id, true);
+            pool.established(id, format!("c{id}@x").into_bytes());
+        }
+
+        // Each child beats once: the first two become keepers, the rest are delegated
+        // onto them.
+        for id in 0..6 {
+            let _ = pool.delegate(id);
+        }
+
+        let direct = pool
+            .siblings
+            .values()
+            .filter(|s| s.status == ChildStatus::Direct)
+            .count();
+        assert_eq!(direct, 2, "exactly max_direct children remain direct");
+        assert_eq!(pool.delegate_targets.len(), 2, "the two keepers");
+        // The four delegated children are balanced two-per-keeper.
+        let mut loads: Vec<usize> = pool
+            .delegate_targets
+            .heap
+            .iter()
+            .map(|&k| pool.delegate_targets.load_of(k))
+            .collect();
+        loads.sort_unstable();
+        assert_eq!(
+            loads,
+            vec![2, 2],
+            "four delegates balanced across two keepers"
         );
     }
 
@@ -1671,9 +1800,20 @@ mod tests {
             let mut d = spawn_child(&hb, d);
             establish_child(&d, b"D@d", b"B@b");
             establish_parent(&bc, b"C@c");
-            establish_parent(&bd, b"D@d"); // active_direct = 2 > max_direct = 1
+            establish_parent(&bd, b"D@d"); // 2 direct children > max_direct = 1
             nap(INTERVAL_MS).await;
 
+            // One beat from C promotes it to the sole keeper (max_direct = 1); then it
+            // goes silent forever (we never pump `bc` again), so it is the doomed
+            // delegate. Beating B–D next delegates D onto C.
+            send(
+                &bc,
+                HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromChild {
+                    cover_add: vec![],
+                    cover_del: vec![],
+                }),
+            );
+            nap(INTERVAL_MS).await;
             // Trigger B–D to delegate D to the doomed C.
             send(
                 &bd,
@@ -1752,10 +1892,20 @@ mod tests {
             establish_child(&c, b"C@c", b"B@b");
             establish_child(&d, b"D@d", b"B@b");
             establish_parent(&bc, b"C@c");
-            establish_parent(&bd, b"D@d"); // now active_direct = 2 > max_direct = 1
+            establish_parent(&bd, b"D@d"); // now 2 direct children > max_direct = 1
             nap(INTERVAL_MS).await;
 
-            // Trigger B–D to delegate D to C (a FromChild beat while over budget).
+            // With max_direct = 1 the first over-budget beat promotes a keeper and the
+            // next delegates onto it. Beat B–C first so C becomes the sole keeper...
+            send(
+                &bc,
+                HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromChild {
+                    cover_add: vec![],
+                    cover_del: vec![],
+                }),
+            );
+            nap(INTERVAL_MS).await;
+            // ...then beat B–D so D is delegated to C.
             send(
                 &bd,
                 HeartbeatEvent::ReceivedHeartbeat(Heartbeat::FromChild {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* __->__ #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Replace round-robin, per-sibling-capped heartbeat delegation with a bounded min-heap of direct keeper children that assigns delegated siblings to the least-loaded keeper and maintains counts across lifecycle transitions. Expand the Python MAST smoke workflow with direct and ring message rounds, routable worker identities, chain controls, heartbeat-only gaps, and execution-details output.

Differential Revision: [D114750246](https://our.internmc.facebook.com/intern/diff/D114750246/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750246/)!