### PR TITLE
30/43 minimonarch: Add scalable multi-region smoke performance sweeps

### DIFF
--- a/monarch_mini/mast/MAST_USE.md
+++ b/monarch_mini/mast/MAST_USE.md
@@ -56,6 +56,60 @@ Total workers = `hosts * workers-per-host`. `4096 * 32 = 131072`.
 | `MM_QUIC_HEARTBEAT_TIMEOUT_MS` | Sever a connection after this long with no frame (default 20000). Keep ≈ 4× the interval. |
 | `SMOKE_WORKERS_PER_HOST` | Set automatically from `--workers-per-host`. |
 
+## Running across multiple regions (`multi_region.py`)
+
+A single MAST job **cannot span regions** — MAST's allocators are per-region and all
+task groups of a job must land in one region (multi-region single-job is experimental,
+gated behind the `enable_multi_region_jobs` entitlement, which we don't have). So a run
+larger than one region's free capacity can't be placed as one job. On CPUTrainingWorkloads
+the T1 fleet lives in only 6 regions (pnb, atn, vll, ftw, nha, ncg); pnb/atn/vll each have
+the most headroom. Single-region tops out around ~2048 whole hosts for our best-effort
+tenant, so ~4096 hosts (131072 workers) will not schedule in one region.
+
+`multi_region.py` works around this by stitching several single-region jobs into one
+logical run, orchestrated from the devserver:
+
+1. It schedules N MAST jobs (one per region) in **coordinated mode** (`SMOKE_COORD_PORT`
+   set). Each job's rank-0 task serves a minimonarch *coordination* listener
+   (`smoke.py --wait-for-addresses PORT`) and waits — it does **not** read the worker
+   list from its own env. Every job serves such a root; all but one go unused.
+2. It polls `mast get-status` until every job is RUNNING with all task hostnames published.
+3. It gathers the union of every job's worker addresses.
+4. It locally joins the chosen job's coordination root over minimonarch and sends the full
+   address list (split into `<=4MB` pickled chunks). The root acks, spins up the real
+   `b"root"` actor, and runs the normal sweep against every worker across all jobs —
+   genuinely cross-region.
+5. On completion (the root reports back) it kills every job.
+
+Run it under the built minimonarch (it imports the extension); it shells out to `python3`
+for `build_mast.py` and to `mast` for status/kill. From the `python/` dir:
+
+```bash
+# Small validation run (2 jobs, auto-region):
+.venv/bin/python ../mast/multi_region.py --hosts-per-job 2 --workers-per-host 1 --jobs 2
+
+# Full cross-region run: 2 jobs x 2048 hosts x 32 workers = 131072 workers, pnb + atn:
+.venv/bin/python ../mast/multi_region.py \
+  --hosts-per-job 2048 --workers-per-host 32 --regions pnb,atn \
+  --cluster CPUTrainingWorkloads \
+  --env MM_QUIC_UDP_BUF_BYTES=134217728 \
+  --env MM_QUIC_MAX_CONCURRENT_CONNECTS=1024 \
+  --env MM_QUIC_MAX_DIRECT_CHILDREN=362
+```
+
+Key options: `--regions r1,r2,...` (one job per region; number of jobs = number of regions;
+omit for `--jobs N` auto-region), `--hosts-per-job`, `--workers-per-host`, `--coord-port`
+(default 26599, distinct from the worker ports), `--env KEY=VALUE` (forwarded to every job),
+`--keep-jobs` (skip cleanup for debugging). Because the run is long, launch it with `nohup
+... &` and tail its log; the per-size sweep numbers are in the **chosen root's** MAST logs
+(task 0 of the first job), fetchable exactly like any single-job run below.
+
+Notes:
+- `MM_QUIC_MAX_DIRECT_CHILDREN` can't be auto-sized per job (no job knows the cross-job
+  total), so pass it explicitly via `--env` (e.g. round(sqrt(total workers))).
+- Pick regions with capacity (see the capacity note above); a region without ~`hosts-per-job`
+  free whole hosts will sit PENDING or hard-reject at enqueue.
+
 ## Checking job status
 
 ```bash

--- a/monarch_mini/mast/local_smoke.py
+++ b/monarch_mini/mast/local_smoke.py
@@ -69,16 +69,10 @@ def main() -> None:
     parser.add_argument("--hb-interval-ms", type=int, default=300)
     parser.add_argument("--hb-timeout-ms", type=int, default=1200)
     parser.add_argument(
-        "--duration",
-        type=float,
-        default=12.0,
-        help="root ping-loop seconds (default: 12)",
-    )
-    parser.add_argument(
-        "--send-interval",
-        type=float,
-        default=2.0,
-        help="seconds between ping rounds (default: 2, > heartbeat timeout)",
+        "--rounds",
+        type=int,
+        default=5,
+        help="direct+ring rounds the root runs at each sweep size (default: 5)",
     )
     parser.add_argument(
         "--chain-length",
@@ -113,7 +107,7 @@ def main() -> None:
         f"[local] {args.workers} workers on ::1 ports {ports[0]}..{ports[-1]}; "
         f"max_direct={args.max_direct} "
         f"hb={args.hb_interval_ms}/{args.hb_timeout_ms}ms "
-        f"duration={args.duration}s send_interval={args.send_interval}s",
+        f"sweep rounds={args.rounds}",
         flush=True,
     )
 
@@ -146,10 +140,8 @@ def main() -> None:
                 SMOKE,
                 "--root",
                 *addrs,
-                "--duration",
-                str(args.duration),
-                "--send-interval",
-                str(args.send_interval),
+                "--min-rounds",
+                str(args.rounds),
                 "--chain-length",
                 str(args.chain_length),
                 "--timeout",

--- a/monarch_mini/mast/mast_bootstrap.py
+++ b/monarch_mini/mast/mast_bootstrap.py
@@ -35,6 +35,7 @@ automatically.
 
 from __future__ import annotations
 
+import math
 import os
 import socket
 import subprocess
@@ -49,12 +50,19 @@ PORT = int(os.environ.get("SMOKE_PORT", "26600"))
 WORKERS_PER_HOST = int(os.environ.get("SMOKE_WORKERS_PER_HOST", "1"))
 # Seconds rank 0 waits before dialing, giving every worker time to bind.
 STARTUP_GRACE = float(os.environ.get("SMOKE_STARTUP_GRACE", "15"))
-# Heartbeat timeout in effect (env override, else minimonarch's 20s default). The
-# root's inter-round gap and end-of-run settle window are sized off this so that
-# between rounds no data flows and only heartbeats hold the links up.
-HB_TIMEOUT_MS = int(os.environ.get("MM_QUIC_HEARTBEAT_TIMEOUT_MS", "20000"))
-# Number of ping/ring rounds the root runs, each separated by a heartbeat-only gap.
-SMOKE_ROUNDS = int(os.environ.get("SMOKE_ROUNDS", "5"))
+# Direct+ring rounds the root runs at each sweep size (passed as --min-rounds).
+SMOKE_ROUNDS = int(os.environ.get("SMOKE_ROUNDS", "10"))
+# Cap the ring into independent chains of at most this many workers, each returning
+# to the root on its own. Bounds ring latency and blast radius at scale (0 = one
+# chain of every worker).
+SMOKE_CHAIN_LENGTH = int(os.environ.get("SMOKE_CHAIN_LENGTH", "512"))
+# Coordination port (0 = disabled). When set, rank 0 does NOT read the worker list
+# from this job's env; instead it serves a coordination listener on this port and
+# waits for an external controller to send the worker addresses. This is how one
+# logical run spans multiple MAST jobs (e.g. across regions): the controller unions
+# every job's hosts and injects them into the one root it picks. See smoke.py's
+# --wait-for-addresses / run_root_coordinated.
+SMOKE_COORD_PORT = int(os.environ.get("SMOKE_COORD_PORT", "0"))
 
 
 def task_hosts() -> list[str]:
@@ -124,53 +132,77 @@ def main() -> None:
         codes = [w.wait() for w in workers]
         sys.exit(max(codes) if codes else 0)
 
-    # Rank 0 also runs the root. Give every worker a moment to bind first. The
-    # root dials every (host, port) pair across the whole job.
-    time.sleep(STARTUP_GRACE)
-    addrs = [
-        f"[{resolve_ipv6(h, PORT)}]:{PORT + i}"
-        for h in hosts
-        for i in range(WORKERS_PER_HOST)
-    ]
-    print(f"[bootstrap] root dialing {len(addrs)} workers", flush=True)
+    # Rank 0 also runs the root, in one of two modes.
+    if SMOKE_COORD_PORT:
+        # Coordinated multi-job mode: don't read this job's env host list at all.
+        # Serve a coordination listener and let an external controller supply the
+        # full (possibly multi-job / multi-region) worker list. MM_QUIC_MAX_DIRECT_
+        # CHILDREN, if it matters, is set globally by the controller via --env, since
+        # a single job cannot know the cross-job total.
+        print(
+            f"[bootstrap] root: coordinated mode, serving coord port "
+            f"{SMOKE_COORD_PORT}, {SMOKE_ROUNDS} rounds/size, "
+            f"chain-length {SMOKE_CHAIN_LENGTH}",
+            flush=True,
+        )
+        root_cmd = [
+            python,
+            smoke,
+            "--wait-for-addresses",
+            str(SMOKE_COORD_PORT),
+            "--min-rounds",
+            str(SMOKE_ROUNDS),
+            "--chain-length",
+            str(SMOKE_CHAIN_LENGTH),
+        ]
+        root_env = env
+    else:
+        # Env-based single-job mode. Give every worker a moment to bind, then sweep
+        # the addresses derived from this job's task-group hostnames.
+        time.sleep(STARTUP_GRACE)
 
-    # Pass addresses via a file, not argv: at tens of thousands of workers the
-    # combined command line exceeds the OS ARG_MAX limit (E2BIG). Write it to a
-    # writable temp dir — the fbpkg install dir (HERE) is a read-only mount.
-    addr_file = os.path.join(tempfile.gettempdir(), "mm_root_hosts.txt")
-    with open(addr_file, "w") as f:
-        f.write("\n".join(addrs))
-
-    # Run several rounds back-to-back (a short send-interval, well under the
-    # heartbeat timeout, so data keeps flowing between them), then idle for a single
-    # heartbeat-only gap before teardown: the end-sleep, sized above the heartbeat
-    # timeout, is the one window where links must survive on heartbeats alone.
-    hb_timeout_s = HB_TIMEOUT_MS / 1000.0
-    send_interval = float(os.environ.get("SMOKE_SEND_INTERVAL", "1"))
-    duration = send_interval * max(SMOKE_ROUNDS - 1, 0)
-    end_sleep = hb_timeout_s * 1.5
-    print(
-        f"[bootstrap] root: {SMOKE_ROUNDS} rounds, send-interval {send_interval:.1f}s, "
-        f"duration {duration:.1f}s, single heartbeat gap (end-sleep) {end_sleep:.1f}s "
-        f"(heartbeat timeout {hb_timeout_s:.1f}s)",
-        flush=True,
-    )
-    rc = subprocess.call(
-        [
+        # The root is the one actor that heartbeats the whole fleet, so it is the
+        # only place MM_QUIC_MAX_DIRECT_CHILDREN matters (leaf workers have no
+        # children). Size the keeper set to sqrt(total workers): the root keeps
+        # ~sqrt(N) children direct and delegates the rest, balanced, onto them, so
+        # both the keeper count and each keeper's delegated load grow as sqrt(N).
+        total_workers = len(hosts) * WORKERS_PER_HOST
+        max_direct = max(1, round(math.sqrt(total_workers)))
+        root_env = dict(env)
+        root_env["MM_QUIC_MAX_DIRECT_CHILDREN"] = str(max_direct)
+        print(
+            f"[bootstrap] root MM_QUIC_MAX_DIRECT_CHILDREN={max_direct} "
+            f"(sqrt of {total_workers} workers)",
+            flush=True,
+        )
+        addrs = [
+            f"[{resolve_ipv6(h, PORT)}]:{PORT + i}"
+            for h in hosts
+            for i in range(WORKERS_PER_HOST)
+        ]
+        # Pass addresses via a file, not argv: at tens of thousands of workers the
+        # combined command line exceeds the OS ARG_MAX limit (E2BIG). Write it to a
+        # writable temp dir — the fbpkg install dir (HERE) is a read-only mount.
+        addr_file = os.path.join(tempfile.gettempdir(), "mm_root_hosts.txt")
+        with open(addr_file, "w") as f:
+            f.write("\n".join(addrs))
+        print(
+            f"[bootstrap] root: perf sweep 2,4,8,..,{len(addrs)}, {SMOKE_ROUNDS} "
+            f"rounds/size, chain-length {SMOKE_CHAIN_LENGTH}",
+            flush=True,
+        )
+        root_cmd = [
             python,
             smoke,
             "--root-file",
             addr_file,
-            "--duration",
-            str(duration),
-            "--send-interval",
-            str(send_interval),
-            "--end-sleep",
-            str(end_sleep),
-        ],
-        cwd=HERE,
-        env=env,
-    )
+            "--min-rounds",
+            str(SMOKE_ROUNDS),
+            "--chain-length",
+            str(SMOKE_CHAIN_LENGTH),
+        ]
+
+    rc = subprocess.call(root_cmd, cwd=HERE, env=root_env)
     print(f"[bootstrap] root finished with code {rc}", flush=True)
 
     # The smoke test is done; tear down our local workers and exit with its status.

--- a/monarch_mini/mast/multi_region.py
+++ b/monarch_mini/mast/multi_region.py
@@ -1,0 +1,394 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Drive ONE logical minimonarch smoke run across MULTIPLE MAST jobs from a devserver.
+
+MAST cannot place a single job across regions (its allocators are regional), so a
+run bigger than one region's free capacity has to be split into several independent
+jobs. This orchestrator stitches them back into one run from *outside* MAST:
+
+  1. Schedule N MAST jobs (via ``build_mast.py``), each in coordinated mode
+     (``SMOKE_COORD_PORT`` set) and optionally pinned to its own region. Every job's
+     rank-0 task serves a minimonarch *coordination* listener and waits — it does NOT
+     read the worker list from its own env. (Every job serves such a root; all but
+     one go unused.)
+  2. Poll ``mast get-status`` until every job is RUNNING and has published all its
+     task hostnames.
+  3. Gather the union of every job's worker addresses (``[<ipv6>]:<port>`` for each
+     host x each worker port).
+  4. Locally (here, on the devserver) join the *chosen* job's coordination root over
+     minimonarch and send it that full address list. The root acks, spins up the
+     real ``b"root"`` actor, and runs the normal sweep against every worker across
+     all jobs — genuinely cross-job (and cross-region) connectivity.
+  5. Wait for the root to report completion, then kill every job.
+
+This is deliberately a hack: the "extra" roots are wasted, and control-plane traffic
+(the devserver <-> root channel) rides the same QUIC transport as the test.
+
+Run under the built minimonarch (e.g. ``.venv/bin/python``); it shells out to
+``python3`` for ``build_mast.py`` and to ``mast`` for status/kill.
+
+Usage (small test):
+
+    .venv/bin/python ../mast/multi_region.py --hosts-per-job 2 --workers-per-host 1
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import pickle
+import re
+import socket
+import subprocess
+import sys
+import time
+
+import minimonarch
+from minimonarch import Actor
+
+ba = minimonarch.bytearray
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD_MAST = os.path.join(HERE, "build_mast.py")
+TEST_CERTS = os.path.join(HERE, "..", "test_certs")
+
+# Must match smoke.py's coordination headers.
+H_FAIL = b"h:fail"
+H_ADDRS = b"h:addrs"
+H_ADDRS_END = b"h:addrs-end"
+H_ACK = b"h:ack"
+H_DONE = b"h:done"
+
+# Cap each address message at ~4MB so a huge fleet's list is split across chunks
+# rather than one oversized message.
+MAX_MSG_BYTES = 4 * 1024 * 1024
+
+
+def chunk_addrs(addrs: list[str]) -> list[list[str]]:
+    """Split addresses into sublists whose pickled size stays under MAX_MSG_BYTES.
+
+    Packs by a conservative per-address byte estimate (length + pickle overhead) so
+    a single pickled chunk never approaches the cap; no per-add re-pickling.
+    """
+    chunks: list[list[str]] = []
+    cur: list[str] = []
+    cur_bytes = 64  # pickle framing overhead
+    budget = MAX_MSG_BYTES - 4096  # margin for framing / header part
+    for a in addrs:
+        sz = len(a.encode()) + 16  # element bytes + generous pickle overhead
+        if cur and cur_bytes + sz > budget:
+            chunks.append(cur)
+            cur, cur_bytes = [], 64
+        cur.append(a)
+        cur_bytes += sz
+    if cur:
+        chunks.append(cur)
+    return chunks
+
+
+def log(msg: str) -> None:
+    ts = time.strftime("%H:%M:%S")
+    print(f"{ts} [multi-region] {msg}", flush=True)
+
+
+def ensure_certs() -> None:
+    """Point the local minimonarch transport at the shipped test certs if unset."""
+    if all(os.environ.get(v) for v in ("MM_QUIC_CERT", "MM_QUIC_KEY", "MM_QUIC_CA")):
+        return
+    for name, var in (
+        ("cert.pem", "MM_QUIC_CERT"),
+        ("key.pem", "MM_QUIC_KEY"),
+        ("ca.pem", "MM_QUIC_CA"),
+    ):
+        path = os.path.join(TEST_CERTS, name)
+        if not os.path.exists(path):
+            raise SystemExit(f"missing cert {path}; set MM_QUIC_* env vars instead")
+        os.environ[var] = path
+
+
+def resolve_ipv6(host: str, port: int) -> str:
+    """Resolve ``host`` to a single IPv6 address (we connect by IP, never DNS)."""
+    # MAST supplies task FQDNs to this OSS smoke test.
+    # ast-grep-ignore: python/python-dns-deps
+    infos = socket.getaddrinfo(host, port, socket.AF_INET6, socket.SOCK_DGRAM)
+    if not infos:
+        raise RuntimeError(f"no IPv6 address for {host}")
+    return infos[0][4][0]
+
+
+def schedule_job(
+    args: argparse.Namespace,
+    coord_port: int,
+    region: str | None,
+    package: str | None,
+) -> tuple[str, str]:
+    """Schedule one coordinated MAST job via build_mast.py.
+
+    Returns ``(job_name, fbpkg_id)``. If ``package`` is given the fbpkg build is
+    skipped and that package reused (so all jobs share one identical binary).
+    """
+    cmd = [
+        "python3",
+        BUILD_MAST,
+        "--hosts",
+        str(args.hosts_per_job),
+        "--workers-per-host",
+        str(args.workers_per_host),
+        "--port",
+        str(args.port),
+        "--cluster",
+        args.cluster,
+        "--env",
+        f"SMOKE_COORD_PORT={coord_port}",
+        "--env",
+        f"SMOKE_PORT={args.port}",
+        "--launch",
+    ]
+    for kv in args.env:
+        cmd += ["--env", kv]
+    if region:
+        cmd += ["--region", region]
+    if package:
+        cmd += ["--skip-build", "--package", package]
+    log(f"scheduling job (region={region or 'auto'}): {' '.join(cmd)}")
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    sys.stdout.write(out.stdout)
+    if out.returncode != 0:
+        sys.stderr.write(out.stderr)
+        raise SystemExit(f"build_mast.py failed (region={region})")
+    job_name = _parse_field(out.stdout, "job name:")
+    fbpkg = _parse_field(out.stdout, "fbpkg:")
+    if not job_name:
+        raise SystemExit(
+            f"could not parse job name from build_mast output:\n{out.stdout}"
+        )
+    return job_name, fbpkg
+
+
+def _parse_field(text: str, label: str) -> str:
+    for line in text.splitlines():
+        if line.strip().startswith(label):
+            return line.split(label, 1)[1].strip()
+    return ""
+
+
+def job_status(job: str) -> dict:
+    out = subprocess.check_output(
+        ["mast", "get-status", job, "--output", "json"],
+        stderr=subprocess.DEVNULL,
+    )
+    return json.loads(out)
+
+
+def job_state(status: dict) -> str:
+    """Top-level job state string (RUNNING / PENDING / DEAD / ...), best-effort."""
+    found = ["?"]
+
+    def walk(o: object) -> None:
+        if isinstance(o, dict):
+            if "state" in o and isinstance(o["state"], str) and found[0] == "?":
+                found[0] = o["state"]
+            for v in o.values():
+                walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+
+    walk(status)
+    return found[0]
+
+
+def task_hostnames(status: dict) -> dict[int, str]:
+    """Map task-id -> hostname for every task instance that has one, from status."""
+    out: dict[int, str] = {}
+
+    def walk(o: object) -> None:
+        if isinstance(o, dict):
+            tid = o.get("taskInstanceIdentifier")
+            host = o.get("hostname")
+            if isinstance(tid, str) and isinstance(host, str) and host:
+                m = re.search(r"/(\d+)(?::\d+)?$", tid)
+                if m:
+                    out[int(m.group(1))] = host
+            for v in o.values():
+                walk(v)
+        elif isinstance(o, list):
+            for v in o:
+                walk(v)
+
+    walk(status)
+    return out
+
+
+def wait_for_hosts(job: str, expected: int, timeout: float) -> dict[int, str]:
+    """Poll until ``job`` is RUNNING with ``expected`` task hostnames published."""
+    deadline = time.monotonic() + timeout
+    while True:
+        status = job_status(job)
+        state = job_state(status)
+        hosts = task_hostnames(status)
+        if state in ("DEAD", "FAILED", "SHUTTING_DOWN"):
+            raise SystemExit(f"job {job} entered {state} before running")
+        log(f"  {job}: state={state} hosts={len(hosts)}/{expected}")
+        if len(hosts) >= expected:
+            return hosts
+        if time.monotonic() > deadline:
+            raise SystemExit(f"timed out waiting for {job} ({len(hosts)}/{expected})")
+        time.sleep(10)
+
+
+def kill_job(job: str) -> None:
+    try:
+        subprocess.run(
+            ["mast", "kill", job, "--comment", "multi_region orchestrator cleanup"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        log(f"killed {job}")
+    except Exception as e:  # best-effort cleanup
+        log(f"failed to kill {job}: {e}")
+
+
+async def coordinate(root_ip: str, coord_port: int, addrs: list[str]) -> int:
+    """Join the chosen root, send it the full address list, await completion."""
+    ctrl = Actor(b"controller")
+    url = f"quic://[{root_ip}]:{coord_port}"
+    log(f"joining coordination root {url} ...")
+    ctrl.join(url, "parent", failure=[ba(H_FAIL)])
+
+    # Establishment hello: [self_ident, root_ident].
+    hello = await asyncio.wait_for(ctrl.next(), timeout=180)
+    root_ident = bytes(hello[1])
+    log(f"connected to root {root_ident.decode(errors='replace')}")
+
+    chunks = chunk_addrs(addrs)
+    log(f"sending {len(addrs)} worker addresses in {len(chunks)} chunk(s) (<=4MB each)")
+    for ch in chunks:
+        # This private MAST smoke channel exchanges only trusted controller data.
+        # @lint-ignore PYTHONPICKLEISBAD
+        ctrl.send(root_ident, [ba(H_ADDRS), ba(pickle.dumps(ch))])
+    ctrl.send(root_ident, [ba(H_ADDRS_END)])
+
+    # Ack, then the sweep runs (can be long), then completion.
+    msg = await asyncio.wait_for(ctrl.next(), timeout=120)
+    if bytes(msg[0]) != H_ACK:
+        log(f"unexpected reply (wanted ack): {bytes(msg[0])!r}")
+        return 1
+    log("root acked; running sweep (waiting for done)...")
+
+    while True:
+        msg = await ctrl.next()
+        header = bytes(msg[0])
+        if header == H_DONE:
+            rc = int(bytes(msg[1])) if len(msg) > 1 else 0
+            log(f"root reported done, rc={rc}")
+            return rc
+        if header == H_FAIL:
+            log("root connection failed before reporting done")
+            return 1
+        log(f"unexpected message {header!r}; ignoring")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--hosts-per-job", type=int, default=2, help="hosts per MAST job (default: 2)"
+    )
+    parser.add_argument(
+        "--workers-per-host", type=int, default=1, help="workers per host (default: 1)"
+    )
+    parser.add_argument("--port", type=int, default=26600, help="base worker port")
+    parser.add_argument(
+        "--coord-port", type=int, default=26599, help="root coordination port"
+    )
+    parser.add_argument(
+        "--cluster", default="CPUTrainingWorkloads", help="MAST cluster"
+    )
+    parser.add_argument(
+        "--regions",
+        default="",
+        help="comma-separated region per job (e.g. 'pnb,atn'); empty = auto for all. "
+        "The number of jobs is len(regions) if given, else --jobs.",
+    )
+    parser.add_argument(
+        "--jobs", type=int, default=2, help="number of jobs when --regions is empty"
+    )
+    parser.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="extra env var forwarded to every job (repeatable)",
+    )
+    parser.add_argument(
+        "--start-timeout",
+        type=float,
+        default=900.0,
+        help="seconds to wait for each job to reach RUNNING with hosts (default: 900)",
+    )
+    parser.add_argument(
+        "--keep-jobs",
+        action="store_true",
+        help="do not kill the jobs on exit (for debugging)",
+    )
+    args = parser.parse_args()
+
+    ensure_certs()
+
+    regions: list[str | None]
+    if args.regions.strip():
+        regions = [r.strip() for r in args.regions.split(",") if r.strip()]
+    else:
+        regions = [None] * args.jobs
+    if len(regions) < 1:
+        raise SystemExit("need at least one job")
+
+    jobs: list[str] = []
+    fbpkg: str | None = None
+    try:
+        # 1. Schedule every job (first one builds the fbpkg, the rest reuse it).
+        for region in regions:
+            job_name, built = schedule_job(args, args.coord_port, region, fbpkg)
+            jobs.append(job_name)
+            fbpkg = fbpkg or built
+        log(f"scheduled {len(jobs)} job(s): {jobs}")
+
+        # 2 + 3. Wait for every job's hosts, then union all worker addresses.
+        all_addrs: list[str] = []
+        root_ip: str | None = None
+        for i, job in enumerate(jobs):
+            hosts = wait_for_hosts(job, args.hosts_per_job, args.start_timeout)
+            if i == 0:
+                # The chosen root is job 0's task 0.
+                root_host = hosts[min(hosts)] if 0 not in hosts else hosts[0]
+                root_ip = resolve_ipv6(root_host, args.coord_port)
+                log(f"chosen root = {job} task0 host {root_host} -> [{root_ip}]")
+            for host in hosts.values():
+                ip = resolve_ipv6(host, args.port)
+                for w in range(args.workers_per_host):
+                    all_addrs.append(f"[{ip}]:{args.port + w}")
+        log(f"gathered {len(all_addrs)} worker addresses across {len(jobs)} job(s)")
+        assert root_ip is not None
+
+        # 4 + 5. Coordinate the run, then report.
+        rc = asyncio.run(coordinate(root_ip, args.coord_port, all_addrs))
+        log(f"=== run finished, rc={rc} ===")
+        sys.exit(rc)
+    finally:
+        minimonarch.close()
+        if not args.keep_jobs:
+            for job in jobs:
+                kill_job(job)
+
+
+if __name__ == "__main__":
+    main()

--- a/monarch_mini/mast/smoke.py
+++ b/monarch_mini/mast/smoke.py
@@ -48,6 +48,7 @@ import argparse
 import asyncio
 import datetime
 import os
+import pickle
 import socket
 import sys
 import time
@@ -73,6 +74,13 @@ H_REPLY = b"h:reply"  # [H_REPLY, worker_ident]       worker -> root, direct rep
 H_NEXT = b"h:next"  # [H_NEXT, next_hop_ident]         root -> worker, ring wiring
 H_RING = b"h:ring"  # [H_RING, count]                 circulating ring token (count
 #                                                      is a decimal-ascii integer)
+# Coordination headers (multi-job orchestration): an external controller joins the
+# root's coordination listener and hands it the worker list, so the root need not
+# read it from the environment. See ``run_root_coordinated``.
+H_ADDRS = b"h:addrs"  # controller -> root: [H_ADDRS, pickled list[str]] one chunk
+H_ADDRS_END = b"h:addrs-end"  # controller -> root: [H_ADDRS_END]  all chunks sent
+H_ACK = b"h:ack"  # root -> controller: [H_ACK]         addresses received
+H_DONE = b"h:done"  # root -> controller: [H_DONE, code]  sweep finished (ascii code)
 
 # Short hostname, included in every log line so multi-host logs are easy to read.
 _HOST = socket.gethostname()
@@ -303,162 +311,169 @@ async def run_root(
     hosts: list[str],
     timeout: float,
     connect_timeout: float,
-    duration: float = 0.0,
-    send_interval: float = 1.0,
+    min_rounds: int = 1,
     chain_length: int = 0,
-    end_sleep: float = 0.0,
+    close_ctx: bool = True,
 ) -> int:
-    """Dial every worker, time connection + round-trip, and report.
+    """Performance sweep: grow the connected set 2, 4, 8, ..., N and time each size.
 
-    ``connect_timeout`` bounds the connect phase (longer, since with hundreds of
-    hosts an occasional one is slow to boot); ``timeout`` bounds each reply.
+    Instead of one connect to every worker, the root connects in *doubling batches*:
+    it joins two workers, then two more, then four more, ... so the connected total
+    climbs 2, 4, 8, 16, ... up to the whole fleet. After each batch it re-wires the
+    ring over all currently-connected workers and runs ``min_rounds`` direct+ring
+    rounds back-to-back — with **no inter-round pause** and **no heartbeat-only
+    settle window** (every phase except the heartbeat pause) — reporting the connect
+    time for the batch and the direct/ring round-trip at that size.
 
-    If ``duration`` > 0 the ping/reply phase repeats for that many wall-clock
-    seconds, one round every ``send_interval`` seconds, instead of a single round.
-    A ``send_interval`` larger than the heartbeat timeout leaves gaps with *no*
-    data traffic, so the connections stay up only if heartbeats (direct and
-    delegated) keep them alive — which is exactly what this exercises.
-
-    ``chain_length`` caps the ring into independent chains of at most that many
-    workers (``<= 0`` = a single chain of all workers). Each chain returns to the
-    root on its own, so at scale ring latency is bounded by the chain length rather
-    than the whole worker count, and one broken link fails only its own chain.
-
-    ``end_sleep`` > 0 adds a final heartbeat-only settling window after the last
-    round: the root stops sending data and simply watches for that long, so links
-    survive purely on heartbeats. Sizing it above the heartbeat timeout confirms
-    steady-state heartbeating holds and keeps a teardown-race severance from being
-    misread as a real failure. Any message arriving in the window is a failure.
-
-    Returns a process exit code (0 on full success).
+    This measures small-scale message performance across a whole range of sizes from
+    within a single large job, so a scaling curve (2..N) comes out of one allocation
+    rather than one job per size. Returns a process exit code (0 on full success).
     """
     root = Actor(b"root")
+    rounds = max(min_rounds, 1)
     try:
-        # --- Phase 1: connect to all workers ---------------------------------
         total = len(hosts)
-        step = max(1, total // 10)
-        log(f"[root] joining {total} worker(s)...")
-        t_join = time.monotonic()
-        for host in hosts:
-            # Register H_FAIL as the failure prefix so a severed worker link is
-            # delivered as [H_FAIL, worker_ident, reason] — a header we dispatch on
-            # instead of sniffing the payload.
-            root.join(f"quic://{host}", "parent", failure=[ba(H_FAIL)])
+        # Doubling milestones 2, 4, 8, ... below the total, with the total itself as
+        # the final size (so the full fleet is always measured, power of two or not).
+        sizes: list[int] = []
+        n = 2
+        while n < total:
+            sizes.append(n)
+            n *= 2
+        if total >= 1 and (not sizes or sizes[-1] != total):
+            sizes.append(total)
+        log(f"[sweep] sizes {sizes} of {total} workers, {rounds} round(s) each")
 
-        # Every failure notice the root receives (a severed connection to a
-        # worker) is printed as it arrives so we can see exactly which workers
-        # dropped and why. `failures` keeps a running total across both phases.
         workers: list[bytes] = []
-        failures = 0
-        # Loop until every worker has connected. A message is either an
-        # establishment hello ([b"root", worker_ident]) or a failure notice
-        # ([H_FAIL, worker_ident, reason]); only hellos count toward `total`,
-        # failures are printed and tallied.
-        while len(workers) < total:
-            try:
-                msg = await asyncio.wait_for(root.next(), connect_timeout)
-            except asyncio.TimeoutError:
-                log(
-                    f"[root] ERROR: only {len(workers)}/{total} workers "
-                    f"connected within {connect_timeout:.0f}s ({failures} failures)"
-                )
-                return 1
-            if bytes(msg[0]) == b"root":
-                # Establishment hello ([b"root", worker_ident]): record who
-                # connected. Progress is printed only at decile boundaries
-                # (bounded prints) so it stays cheap.
-                workers.append(bytes(msg[1]))
-                _report_progress("connected", len(workers), total, step)
-            else:
-                who, reason = _failure_notice(msg)
-                failures += 1
-                log(f"[root] FAILURE (connect) {who}: {reason}")
-        connect_ms = (time.monotonic() - t_join) * 1e3
-        log(f"[root] all {len(workers)} workers connected in {connect_ms:.1f} ms")
-
-        # Wire the ring once, capped into chains of at most `cap` workers: a
-        # worker's next hop is the root (not its normal successor) at each chain
-        # boundary and at the very end. `heads` are the chain-start indices where
-        # the root injects a token. Done before any token is injected so every
-        # worker knows its next hop before a token can reach it.
-        cap = chain_length if chain_length > 0 else len(workers)
-        heads = list(range(0, len(workers), cap))
-        for i, wid in enumerate(workers):
-            boundary = (i + 1) % cap == 0 or i + 1 == len(workers)
-            nxt = b"root" if boundary else workers[i + 1]
-            root.send(wid, [ba(H_NEXT), ba(nxt)])
-        log(
-            f"[root] wired {len(heads)} chain(s) of <= {cap} over {len(workers)} workers"
-        )
-
-        # --- Phase 2: each round runs a direct pass then a ring pass, once or
-        # repeatedly for `duration` seconds --
-        t_send = time.monotonic()
-        deadline = t_send + max(duration, 0.0)
-        rounds = 0
-        try:
-            while True:
-                rounds += 1
-                t_direct = time.monotonic()
-                failures += await _direct_round(root, workers, timeout)
-                if failures:
-                    break
-                direct_ms = (time.monotonic() - t_direct) * 1e3
-                t_ring = time.monotonic()
-                failures += await _ring_round(root, workers, timeout, heads)
-                if failures:
-                    break
-                ring_ms = (time.monotonic() - t_ring) * 1e3
-                log(
-                    f"[root]   round {rounds} ok ({len(workers)} workers): "
-                    f"direct {direct_ms:.1f} ms, ring {ring_ms:.1f} ms "
-                    f"({len(heads)} chain(s))"
-                )
-                if time.monotonic() >= deadline:
-                    break
-                # Idle gap: no data flows, so only heartbeats keep the links up.
-                await asyncio.sleep(send_interval)
-        except asyncio.TimeoutError:
-            log(
-                f"[root] ERROR: a worker stalled (no reply within {timeout:.0f}s) "
-                f"in round {rounds} ({failures} failures so far)"
-            )
-            return 1
-        roundtrip_ms = (time.monotonic() - t_send) * 1e3
-
-        # Final heartbeat-only settling window: with the root no longer sending
-        # data, links survive purely on heartbeats. Idling here (>= the heartbeat
-        # timeout) before teardown confirms steady-state heartbeating holds and
-        # avoids attributing a teardown-race severance to a real failure. Any
-        # message that arrives in this window is a failure notice.
-        if end_sleep > 0 and failures == 0:
-            log(f"[root] idle {end_sleep:.1f}s (heartbeat-only) before teardown...")
-            idle_deadline = time.monotonic() + end_sleep
-            while True:
-                remaining = idle_deadline - time.monotonic()
-                if remaining <= 0:
-                    break
+        joined = 0
+        for size in sizes:
+            # Join only the next batch to grow the connected set to `size`.
+            batch = hosts[joined:size]
+            t_join = time.monotonic()
+            for host in batch:
+                root.join(f"quic://{host}", "parent", failure=[ba(H_FAIL)])
+            joined = size
+            while len(workers) < size:
                 try:
-                    msg = await asyncio.wait_for(root.next(), remaining)
+                    msg = await asyncio.wait_for(root.next(), connect_timeout)
                 except asyncio.TimeoutError:
-                    break
-                who, reason = _failure_notice(msg)
-                failures += 1
-                log(f"[root] FAILURE (idle) {who}: {reason}")
-            log(f"[root] idle window done ({failures} failures)")
+                    log(f"[sweep] ERROR: only {len(workers)}/{size} workers connected")
+                    return 1
+                if bytes(msg[0]) == b"root":
+                    workers.append(bytes(msg[1]))
+                else:
+                    who, reason = _failure_notice(msg)
+                    log(f"[sweep] FAILURE (connect) {who}: {reason}")
+                    return 1
+            connect_ms = (time.monotonic() - t_join) * 1e3
 
-        log("[root] --- summary ---")
-        log(f"[root] connect:    {connect_ms:.1f} ms ({len(workers)} workers)")
-        log(f"[root] round-trip: {roundtrip_ms:.1f} ms ({rounds} round(s))")
-        log(f"[root] failures:   {failures}")
-        # Success only if nothing severed across every round.
-        return 0 if failures == 0 else 1
+            # Re-wire the ring over the whole current set (new workers included), so
+            # every worker knows its next hop before a token can reach it.
+            cap = chain_length if chain_length > 0 else len(workers)
+            heads = list(range(0, len(workers), cap))
+            for i, wid in enumerate(workers):
+                boundary = (i + 1) % cap == 0 or i + 1 == len(workers)
+                nxt = b"root" if boundary else workers[i + 1]
+                root.send(wid, [ba(H_NEXT), ba(nxt)])
+
+            # Rounds back-to-back: no inter-round sleep, no end-sleep. Track the best
+            # (min) and mean of each phase across the rounds.
+            direct_best = ring_best = float("inf")
+            direct_sum = ring_sum = 0.0
+            try:
+                for _ in range(rounds):
+                    t_d = time.monotonic()
+                    if await _direct_round(root, workers, timeout):
+                        log(f"[sweep] FAILURE in direct at size {size}")
+                        return 1
+                    d = (time.monotonic() - t_d) * 1e3
+                    t_r = time.monotonic()
+                    if await _ring_round(root, workers, timeout, heads):
+                        log(f"[sweep] FAILURE in ring at size {size}")
+                        return 1
+                    r = (time.monotonic() - t_r) * 1e3
+                    direct_best, direct_sum = min(direct_best, d), direct_sum + d
+                    ring_best, ring_sum = min(ring_best, r), ring_sum + r
+            except asyncio.TimeoutError:
+                log(f"[sweep] ERROR: a worker stalled at size {size}")
+                return 1
+            log(
+                f"[sweep] size={size:>6}  connect(+{len(batch)})={connect_ms:9.1f} ms  "
+                f"direct min={direct_best:8.2f} avg={direct_sum / rounds:8.2f} ms  "
+                f"ring min={ring_best:8.2f} avg={ring_sum / rounds:8.2f} ms  "
+                f"({len(heads)} chain(s))"
+            )
+        log("[sweep] done (0 failures)")
+        return 0
     finally:
-        # Gracefully tear down the context *inside the event loop*: this flushes
-        # an "actor destroyed" death notice to every worker before the loop
-        # thread stops, so workers shut down promptly instead of waiting out the
-        # quic heartbeat timeout. Runs on success, timeout, and error paths.
-        minimonarch.close()
+        # In coordinated mode the caller keeps the context alive to report back to
+        # its controller, so it closes the context itself.
+        if close_ctx:
+            minimonarch.close()
+
+
+async def run_root_coordinated(
+    coord_port: int,
+    bind: str,
+    timeout: float,
+    connect_timeout: float,
+    min_rounds: int = 1,
+    chain_length: int = 0,
+) -> int:
+    """Root variant that waits for a controller to hand it the worker addresses.
+
+    Rather than reading the worker list from ``--root``/``--root-file`` (i.e. from
+    a single MAST job's task-group env), the root serves a coordination listener on
+    ``coord_port`` and waits for a controller to join and send an ``H_ADDRS`` message
+    carrying every worker address. This lets one logical run span *multiple* MAST
+    jobs that the scheduler cannot place as one job (e.g. across regions): an
+    external controller (a devserver running minimonarch) gathers the union of all
+    jobs' hosts and injects it here. The root acks, runs the normal sweep against
+    those addresses as a fresh ``b"root"`` actor, then reports the exit code back to
+    the controller before tearing the context down.
+    """
+    coord = Actor(b"coord")
+    coord.serve(f"quic://[{bind}]:{coord_port}", "child", failure=[ba(H_FAIL)])
+    log(f"[coord] serving quic://[{bind}]:{coord_port}; waiting for controller...")
+
+    # Establishment hello: [self_ident, controller_ident].
+    hello = await coord.next()
+    controller = bytes(hello[1])
+    log(f"[coord] controller joined: {controller.decode(errors='replace')}")
+
+    # Accumulate the address list, delivered as one or more pickled chunks (kept
+    # under a few MB each) terminated by H_ADDRS_END, or abort on controller failure.
+    hosts: list[str] = []
+    while True:
+        msg = await coord.next()
+        header = bytes(msg[0])
+        if header == H_ADDRS:
+            # This private MAST smoke channel exchanges only trusted controller data.
+            # @lint-ignore PYTHONPICKLEISBAD
+            hosts.extend(pickle.loads(bytes(msg[1])))
+            continue
+        if header == H_ADDRS_END:
+            break
+        if header == H_FAIL:
+            who, reason = _failure_notice(msg)
+            log(f"[coord] controller {who} gone before addresses ({reason}); aborting")
+            minimonarch.close()
+            return 1
+        log(f"[coord] unexpected header {header!r} before addresses; ignoring")
+    log(f"[coord] received {len(hosts)} worker addresses; acking")
+    coord.send(controller, [ba(H_ACK)])
+
+    # Run the normal sweep as a fresh root actor, but keep the context alive so we
+    # can report completion to the controller afterward.
+    rc = await run_root(
+        hosts, timeout, connect_timeout, min_rounds, chain_length, close_ctx=False
+    )
+
+    log(f"[coord] sweep finished rc={rc}; notifying controller and closing")
+    coord.send(controller, [ba(H_DONE), ba(str(rc).encode())])
+    # close() flushes already-posted messages (the H_DONE) before tearing down.
+    minimonarch.close()
+    return rc
 
 
 def main() -> None:
@@ -477,6 +492,16 @@ def main() -> None:
         help="run as the root, reading worker addresses (one per line) from PATH. "
         "Use this instead of --root at high host counts: tens of thousands of "
         "addresses on argv exceed the OS ARG_MAX limit.",
+    )
+    mode.add_argument(
+        "--wait-for-addresses",
+        type=int,
+        metavar="PORT",
+        help="run as the root but WAIT for an external controller to supply the "
+        "worker addresses over a coordination actor served on PORT, instead of "
+        "reading them from --root/--root-file (i.e. from a single job's env). Used "
+        "to span multiple MAST jobs: a controller gathers every job's hosts and "
+        "sends them here. See run_root_coordinated.",
     )
     mode.add_argument(
         "--worker", action="store_true", help="run as a worker (serve a listener)"
@@ -506,22 +531,6 @@ def main() -> None:
         "larger than --timeout because with many hosts one can be slow to boot",
     )
     parser.add_argument(
-        "--duration",
-        type=float,
-        default=0.0,
-        help="root: repeat the ping/reply phase for this many seconds (default: 0 "
-        "= a single round). Use a value well over the heartbeat timeout to keep the "
-        "run alive across many heartbeat cycles.",
-    )
-    parser.add_argument(
-        "--send-interval",
-        type=float,
-        default=1.0,
-        help="root: seconds between ping rounds when --duration > 0 (default: 1). "
-        "Set larger than the heartbeat timeout so heartbeats, not data, hold the "
-        "links open between rounds.",
-    )
-    parser.add_argument(
         "--chain-length",
         type=int,
         default=0,
@@ -530,13 +539,11 @@ def main() -> None:
         "all workers). Bounds ring latency and blast radius at large worker counts.",
     )
     parser.add_argument(
-        "--end-sleep",
-        type=float,
-        default=0.0,
-        help="root: after the last round, idle for this many seconds in a "
-        "heartbeat-only window before tearing down (default: 0 = none). Set above "
-        "the heartbeat timeout to confirm heartbeats hold with no data flowing and "
-        "avoid teardown-race false failures.",
+        "--min-rounds",
+        type=int,
+        default=1,
+        help="root: run this many direct+ring rounds at each sweep size "
+        "(default: 1). More rounds give a min/avg per size.",
     )
     args = parser.parse_args()
 
@@ -544,6 +551,19 @@ def main() -> None:
 
     if args.worker:
         asyncio.run(run_worker(args.port, args.bind))
+    elif args.wait_for_addresses is not None:
+        sys.exit(
+            asyncio.run(
+                run_root_coordinated(
+                    args.wait_for_addresses,
+                    args.bind,
+                    args.timeout,
+                    args.connect_timeout,
+                    args.min_rounds,
+                    args.chain_length,
+                )
+            )
+        )
     else:
         if args.root_file:
             with open(args.root_file) as f:
@@ -556,10 +576,8 @@ def main() -> None:
                     hosts,
                     args.timeout,
                     args.connect_timeout,
-                    args.duration,
-                    args.send_interval,
+                    args.min_rounds,
                     args.chain_length,
-                    args.end_sleep,
                 )
             )
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* __->__ #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

This replaces fixed-duration smoke runs with doubling worker-count sweeps that report connection and direct/ring latency while automatically sizing the root's direct-child cap.
It adds a coordinated multi-region MAST controller that sends chunked worker addresses to a selected root and cleans up all participating jobs after the sweep completes.

Differential Revision: [D114750232](https://our.internmc.facebook.com/intern/diff/D114750232/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750232/)!