### PR TITLE
31/43 minimonarch: Separate heartbeat streams

### DIFF
--- a/monarch_mini/big_messages/bench.py
+++ b/monarch_mini/big_messages/bench.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Big-message vs. heartbeat stress: one role per process (root, a, b).
+
+Topology (see ``run.py`` for how the three processes are spawned):
+
+    root ── quic ──> child-a        (a is a direct heartbeat *keeper*)
+    root ── quic ──> child-b        (b is *delegated* to a: b heartbeats a over a
+                                      gateway side channel, a acks over another)
+    child-a ── side channel ──> child-b   (a routes messages to b gateway-to-gateway)
+
+With ``MM_QUIC_MAX_DIRECT_CHILDREN=1`` the root keeps exactly one child direct (a)
+and delegates the other (b) onto a, so b's liveness rides the a<->b side channels
+instead of its direct link to the root.
+
+The point: **hammer huge messages on every data path while the heartbeat timeout is
+shorter than a single message's transfer time**, and check that nothing severs.
+Heartbeats ride their own QUIC stream, so a multi-second message must not starve
+them:
+
+  * root<->a  — big messages on the connection's *data* stream vs. the direct
+    heartbeat on its *heartbeat* stream.
+  * a->b      — big messages on the a->b side channel's *message* stream vs. a's
+    delegate *acks* to b on that same channel's *heartbeat* stream.
+  * b->a      — big messages on the b->a side channel's *message* stream vs. b's
+    delegate *beats* to a on that channel's *heartbeat* stream.
+
+Every process bounces each big DATA message straight back to its sender, so a small
+pool of buffers ping-pongs forever with zero per-message allocation — keeping the
+streams continuously saturated for far longer than the heartbeat timeout. Any
+severed monitored link (delivered as an ``H_FAIL`` failure notice) fails the run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime
+import os
+import socket
+import sys
+import time
+
+import minimonarch
+from minimonarch import Actor
+
+ba = minimonarch.bytearray
+
+# part[0] headers (exact-match dispatch).
+H_FAIL = b"h:fail"  # [H_FAIL, dead_ident, reason]  a monitored link severed
+H_CFG = b"h:cfg"  # [H_CFG]                        root -> worker: start hammering
+H_DATA = b"h:data"  # [H_DATA, from_ident, payload] a big message; bounce to from
+H_STOP = b"h:stop"  # [H_STOP]                       root -> worker: wind down
+
+_HOST = socket.gethostname()
+
+
+def log(msg: str) -> None:
+    ts = datetime.datetime.now().strftime("%H:%M:%S.%f")[:-3]
+    print(f"{ts} {_HOST} {msg}", flush=True)
+
+
+def ident(name: str, addr: str) -> bytes:
+    """Ident for a worker: ``name@addr`` where ``addr`` (e.g. ``[::1]:26810``) is
+    the worker's own gateway ``@tag`` — the dialable address the root reaches it at
+    and a sibling opens a side channel to for delegated heartbeats."""
+    return f"{name}@{addr}".encode()
+
+
+def _require_certs() -> None:
+    if not all(
+        os.environ.get(v) for v in ("MM_QUIC_CERT", "MM_QUIC_KEY", "MM_QUIC_CA")
+    ):
+        raise SystemExit("MM_QUIC_CERT/MM_QUIC_KEY/MM_QUIC_CA must be set (see run.py)")
+
+
+async def run_worker(name: str, addr: str, peer_ident: bytes | None) -> int:
+    """Serve a quic listener as a child of the root, bounce every big DATA message
+    back to its sender, and — once the root says go (``H_CFG``) — seed the pool of
+    big buffers this worker originates (to the root, and to its peer if given).
+
+    Returns a process exit code: 0 on a clean wind-down, 1 if a monitored link
+    severed (a heartbeat failure under message load — the thing we are testing).
+    """
+    _require_certs()
+    me_ident = ident(name, addr)
+    tag = f"[{name}]"
+    me = Actor(me_ident)
+    me.serve(f"quic://{addr}", "child", failure=[ba(H_FAIL)])
+    log(f"{tag} serving quic://{addr} pid={os.getpid()}")
+
+    # Establishment hello: [self_ident, root_ident]. The root is a fixed name.
+    hello = await me.next()
+    root_ident = bytes(hello[1])
+    log(f"{tag} established with root {root_ident.decode(errors='replace')}")
+
+    msg_bytes = int(os.environ["BENCH_MSG_BYTES"])
+    pool = int(os.environ["BENCH_POOL"])
+    bounced = 0
+    rc = 0
+    start = time.monotonic()
+    while True:
+        msg = await me.next()
+        header = bytes(msg[0])
+        if header == H_DATA:
+            # Bounce the payload straight back to whoever sent it — reusing the
+            # received buffer (moved back out), so steady state never allocates.
+            sender = bytes(msg[1])
+            payload = msg[2]
+            bounced += len(payload)
+            me.send(sender, [ba(H_DATA), ba(me_ident), payload])
+        elif header == H_CFG:
+            # Go: originate this worker's own hammer. Seed `pool` big buffers to the
+            # root, and `pool` to the peer (a -> b) if we have one. Each seeded
+            # buffer then ping-pongs forever via the bounce above.
+            log(
+                f"{tag} go: seeding {pool} x {msg_bytes} B to root"
+                + (" and peer" if peer_ident else "")
+            )
+            for _ in range(pool):
+                me.send(root_ident, [ba(H_DATA), ba(me_ident), ba(msg_bytes)])
+                if peer_ident:
+                    me.send(peer_ident, [ba(H_DATA), ba(me_ident), ba(msg_bytes)])
+        elif header == H_STOP:
+            log(f"{tag} stop; bounced {bounced / 1e9:.2f} GB")
+            break
+        elif header == H_FAIL:
+            who = bytes(msg[1]).decode(errors="replace") if len(msg) > 1 else "?"
+            reason = bytes(msg[2]).decode(errors="replace") if len(msg) > 2 else "?"
+            # The root's shutdown notice severs our parent link cleanly at the end;
+            # that is expected. Any *other* sever (or a sever mid-run) is a failure.
+            log(f"{tag} FAIL link to {who} severed: {reason}")
+            if who != root_ident.decode(errors="replace"):
+                rc = 1
+            break
+        else:
+            log(f"{tag} unexpected header {header!r}; ignoring")
+
+    elapsed = max(time.monotonic() - start, 1e-9)
+    log(
+        f"{tag} done rc={rc}: {bounced / 1e9:.2f} GB over {elapsed:.1f}s "
+        f"= {bounced / elapsed / 1e9:.2f} GB/s"
+    )
+    minimonarch.close()
+    return rc
+
+
+async def run_root(a_addr: str, b_addr: str, duration: float) -> int:
+    """Join a and b, measure one big message's transfer time (to confirm it exceeds
+    the heartbeat timeout), then reflect big messages for `duration` seconds while
+    watching for any severed link. Returns 0 iff no link severed."""
+    _require_certs()
+    msg_bytes = int(os.environ["BENCH_MSG_BYTES"])
+    hb_timeout_s = int(os.environ["MM_QUIC_HEARTBEAT_TIMEOUT_MS"]) / 1000.0
+    a_ident = ident("child-a", a_addr)
+    b_ident = ident("child-b", b_addr)
+
+    root = Actor(b"root")
+    root.join(f"quic://{a_addr}", "parent", failure=[ba(H_FAIL)])
+    root.join(f"quic://{b_addr}", "parent", failure=[ba(H_FAIL)])
+
+    # Two establishment hellos ([b"root", worker_ident]), one per child.
+    established = set()
+    for _ in range(2):
+        hello = await root.next()
+        established.add(bytes(hello[1]))
+    log(
+        f"[root] both children established: "
+        f"{sorted(i.decode(errors='replace') for i in established)}"
+    )
+
+    # Probe: one big round-trip to a, timed, so we can report the single-message
+    # transfer time and confirm it is longer than the heartbeat timeout (the whole
+    # premise — a beat must survive a transfer it is shorter than).
+    t0 = time.perf_counter()
+    root.send(a_ident, [ba(H_DATA), ba(b"root"), ba(msg_bytes)])
+    probe = await root.next()
+    assert bytes(probe[0]) == H_DATA, f"probe returned {bytes(probe[0])!r}"
+    rt = time.perf_counter() - t0
+    one_way = rt / 2.0
+    log(
+        f"[root] single {msg_bytes / 1e6:.0f} MB message: round-trip {rt * 1e3:.0f} ms, "
+        f"one-way ~{one_way * 1e3:.0f} ms; heartbeat timeout {hb_timeout_s * 1e3:.0f} ms"
+    )
+    if one_way <= hb_timeout_s:
+        log(
+            f"[root] WARNING: one-way transfer ({one_way * 1e3:.0f} ms) <= heartbeat "
+            f"timeout ({hb_timeout_s * 1e3:.0f} ms); increase --msg-mb or lower "
+            f"--hb-timeout-ms so a single transfer outlasts a beat window"
+        )
+
+    # Go. a hammers root + b; b hammers root. Everyone (including us) bounces.
+    root.send(a_ident, [ba(H_CFG)])
+    root.send(b_ident, [ba(H_CFG)])
+    log(
+        f"[root] hammering for {duration:.0f}s "
+        f"(hb timeout {hb_timeout_s * 1e3:.0f} ms — links must survive on beats alone)"
+    )
+
+    deadline = time.monotonic() + duration
+    from_a = from_b = 0
+    failures: list[str] = []
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            msg = await asyncio.wait_for(root.next(), remaining)
+        except asyncio.TimeoutError:
+            break
+        header = bytes(msg[0])
+        if header == H_DATA:
+            sender = bytes(msg[1])
+            payload = msg[2]
+            if sender == a_ident:
+                from_a += len(payload)
+            elif sender == b_ident:
+                from_b += len(payload)
+            root.send(sender, [ba(H_DATA), ba(b"root"), payload])
+        elif header == H_FAIL:
+            who = bytes(msg[1]).decode(errors="replace") if len(msg) > 1 else "?"
+            reason = bytes(msg[2]).decode(errors="replace") if len(msg) > 2 else "?"
+            log(f"[root] FAILURE link to {who} severed under load: {reason}")
+            failures.append(f"{who}: {reason}")
+            break  # a sever is terminal — the thing we are guarding against
+        else:
+            log(f"[root] unexpected header {header!r}; ignoring")
+
+    ran = duration - max(deadline - time.monotonic(), 0.0)
+    ran = max(ran, 1e-9)
+    log(
+        f"[root] reflected: root<->a {from_a / 1e9:.2f} GB "
+        f"({from_a / ran / 1e9:.2f} GB/s), root<->b {from_b / 1e9:.2f} GB "
+        f"({from_b / ran / 1e9:.2f} GB/s) over {ran:.1f}s"
+    )
+
+    # Wind the workers down (best effort) before tearing our context down.
+    for wid in (a_ident, b_ident):
+        root.send(wid, [ba(H_STOP)])
+
+    if failures:
+        log(
+            f"[root] RESULT: FAIL — {len(failures)} link(s) severed under message "
+            f"load: {'; '.join(failures)}"
+        )
+        rc = 1
+    else:
+        log(
+            "[root] RESULT: PASS — no link severed; heartbeats survived continuous "
+            "big-message saturation on every data/side-channel stream"
+        )
+        rc = 0
+    minimonarch.close()
+    return rc
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--role", required=True, choices=["root", "a", "b"])
+    parser.add_argument("--port", type=int, help="worker (a/b) listen port")
+    parser.add_argument("--peer-port", type=int, help="a: child-b's port (a -> b)")
+    parser.add_argument("--a-addr", help="root: child-a address, e.g. [::1]:26810")
+    parser.add_argument("--b-addr", help="root: child-b address")
+    parser.add_argument("--duration", type=float, default=20.0, help="root: seconds")
+    parser.add_argument("--bind", default="::1", help="worker bind host")
+    args = parser.parse_args()
+
+    if args.role == "root":
+        sys.exit(asyncio.run(run_root(args.a_addr, args.b_addr, args.duration)))
+    else:
+        addr = f"[{args.bind}]:{args.port}"
+        peer = (
+            ident("child-b", f"[{args.bind}]:{args.peer_port}")
+            if args.peer_port
+            else None
+        )
+        name = "child-a" if args.role == "a" else "child-b"
+        sys.exit(asyncio.run(run_worker(name, addr, peer)))
+
+
+if __name__ == "__main__":
+    main()

--- a/monarch_mini/big_messages/run.py
+++ b/monarch_mini/big_messages/run.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""Driver for the big-message vs. heartbeat stress (see bench.py).
+
+Spawns three *separate* processes — root, child-a, child-b — so their event loops
+run on independent interpreters and never contend on the GIL (the whole point is to
+actually saturate the QUIC links, which a single-process GIL-bound run could not).
+
+It forces delegation and a short heartbeat window via the environment:
+
+  * ``MM_QUIC_MAX_DIRECT_CHILDREN=1`` — the root keeps a direct, delegates b onto a,
+    so b's heartbeat rides the a<->b side channels.
+  * ``MM_QUIC_HEARTBEAT_TIMEOUT_MS`` — kept *below* a single big message's transfer
+    time (bench.py measures and reports the actual transfer time so you can confirm).
+
+Usage (from the python/ dir so the extension is importable, e.g. via uv):
+
+    uv run python ../big_messages/run.py --msg-mb 1024 --duration 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import time
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BENCH = os.path.join(HERE, "bench.py")
+TEST_CERTS = os.path.join(HERE, "..", "test_certs")
+
+
+def child_env(args: argparse.Namespace) -> dict[str, str]:
+    env = dict(os.environ)
+    env["MM_QUIC_MAX_DIRECT_CHILDREN"] = str(args.max_direct)
+    env["MM_QUIC_HEARTBEAT_INTERVAL_MS"] = str(args.hb_interval_ms)
+    env["MM_QUIC_HEARTBEAT_TIMEOUT_MS"] = str(args.hb_timeout_ms)
+    env["BENCH_MSG_BYTES"] = str(args.msg_mb * 1024 * 1024)
+    env["BENCH_POOL"] = str(args.pool)
+    # Certs: reuse the repo's fixture set unless already pointed elsewhere.
+    for var, pem in (
+        ("MM_QUIC_CERT", "cert.pem"),
+        ("MM_QUIC_KEY", "key.pem"),
+        ("MM_QUIC_CA", "ca.pem"),
+    ):
+        env.setdefault(var, os.path.join(TEST_CERTS, pem))
+    if args.debug:
+        env["MM_QUIC_DEBUG"] = "1"
+    return env
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--msg-mb", type=int, default=1024, help="message size (MiB)")
+    parser.add_argument(
+        "--pool",
+        type=int,
+        default=1,
+        help="big buffers each sender keeps in flight per destination (default 1); "
+        ">1 saturates the stream more but uses proportionally more memory",
+    )
+    parser.add_argument("--duration", type=float, default=20.0, help="hammer seconds")
+    parser.add_argument(
+        "--max-direct",
+        type=int,
+        default=1,
+        help="MM_QUIC_MAX_DIRECT_CHILDREN (default 1: b is delegated onto a)",
+    )
+    parser.add_argument("--hb-interval-ms", type=int, default=250)
+    parser.add_argument(
+        "--hb-timeout-ms",
+        type=int,
+        default=1000,
+        help="keep below a single message's transfer time (bench.py reports it)",
+    )
+    parser.add_argument("--port-a", type=int, default=26810)
+    parser.add_argument("--port-b", type=int, default=26811)
+    parser.add_argument("--startup-grace", type=float, default=2.0)
+    parser.add_argument("--debug", action="store_true", help="MM_QUIC_DEBUG=1")
+    parser.add_argument(
+        "--logdir", default=None, help="write each process's output to its own file"
+    )
+    args = parser.parse_args()
+
+    env = child_env(args)
+    a_addr = f"[::1]:{args.port_a}"
+    b_addr = f"[::1]:{args.port_b}"
+
+    def out_for(name: str):
+        if not args.logdir:
+            return None
+        os.makedirs(args.logdir, exist_ok=True)
+        return open(os.path.join(args.logdir, f"{name}.log"), "w")
+
+    print(
+        f"[bench] msg={args.msg_mb} MiB pool={args.pool} duration={args.duration}s "
+        f"max_direct={args.max_direct} hb={args.hb_interval_ms}/{args.hb_timeout_ms}ms "
+        f"a={a_addr} b={b_addr}",
+        flush=True,
+    )
+
+    def spawn(role_args: list[str], name: str) -> subprocess.Popen:
+        out = out_for(name)
+        return subprocess.Popen(
+            [sys.executable, BENCH, *role_args],
+            env=env,
+            stdout=out,
+            stderr=subprocess.STDOUT if out else None,
+        )
+
+    # Workers first (they serve); then the root (it dials).
+    a = spawn(
+        ["--role", "a", "--port", str(args.port_a), "--peer-port", str(args.port_b)],
+        "child-a",
+    )
+    b = spawn(["--role", "b", "--port", str(args.port_b)], "child-b")
+    try:
+        time.sleep(args.startup_grace)
+        root = spawn(
+            [
+                "--role",
+                "root",
+                "--a-addr",
+                a_addr,
+                "--b-addr",
+                b_addr,
+                "--duration",
+                str(args.duration),
+            ],
+            "root",
+        )
+        rc = root.wait()
+        print(f"[bench] root finished with code {rc}", flush=True)
+        sys.exit(rc)
+    finally:
+        for w in (a, b):
+            w.terminate()
+        for w in (a, b):
+            try:
+                w.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                w.kill()
+
+
+if __name__ == "__main__":
+    main()

--- a/monarch_mini/mast/local_smoke.py
+++ b/monarch_mini/mast/local_smoke.py
@@ -81,6 +81,14 @@ def main() -> None:
         help="cap the ring into chains of at most this many workers (default: 0 = "
         "one chain of all workers)",
     )
+    parser.add_argument(
+        "--settle-ms",
+        type=float,
+        default=0.0,
+        help="after each sweep size, idle the set with no data for this many ms "
+        "(exceed --hb-timeout-ms), then verify every link survived — isolates "
+        "heartbeat-only liveness (0 = disabled)",
+    )
     parser.add_argument("--startup-grace", type=float, default=2.0)
     parser.add_argument(
         "--debug", action="store_true", help="set MM_QUIC_DEBUG=1 (MM_HB logs)"
@@ -144,6 +152,8 @@ def main() -> None:
                 str(args.rounds),
                 "--chain-length",
                 str(args.chain_length),
+                "--settle-ms",
+                str(args.settle_ms),
                 "--timeout",
                 "5",
                 "--connect-timeout",

--- a/monarch_mini/mast/mast_bootstrap.py
+++ b/monarch_mini/mast/mast_bootstrap.py
@@ -56,6 +56,11 @@ SMOKE_ROUNDS = int(os.environ.get("SMOKE_ROUNDS", "10"))
 # to the root on its own. Bounds ring latency and blast radius at scale (0 = one
 # chain of every worker).
 SMOKE_CHAIN_LENGTH = int(os.environ.get("SMOKE_CHAIN_LENGTH", "512"))
+# After the final (largest) sweep size, idle the whole connected set with no data
+# for this many ms (should exceed the heartbeat timeout), then verify every link
+# survived — a heartbeat-only liveness check the back-to-back sweep never does.
+# 0 (default) disables it. Passed to smoke.py as --settle-ms.
+SMOKE_SETTLE_MS = float(os.environ.get("SMOKE_SETTLE_MS", "0"))
 # Coordination port (0 = disabled). When set, rank 0 does NOT read the worker list
 # from this job's env; instead it serves a coordination listener on this port and
 # waits for an external controller to send the worker addresses. This is how one
@@ -154,6 +159,8 @@ def main() -> None:
             str(SMOKE_ROUNDS),
             "--chain-length",
             str(SMOKE_CHAIN_LENGTH),
+            "--settle-ms",
+            str(SMOKE_SETTLE_MS),
         ]
         root_env = env
     else:
@@ -200,6 +207,8 @@ def main() -> None:
             str(SMOKE_ROUNDS),
             "--chain-length",
             str(SMOKE_CHAIN_LENGTH),
+            "--settle-ms",
+            str(SMOKE_SETTLE_MS),
         ]
 
     rc = subprocess.call(root_cmd, cwd=HERE, env=root_env)

--- a/monarch_mini/mast/smoke.py
+++ b/monarch_mini/mast/smoke.py
@@ -314,6 +314,7 @@ async def run_root(
     min_rounds: int = 1,
     chain_length: int = 0,
     close_ctx: bool = True,
+    settle_ms: float = 0.0,
 ) -> int:
     """Performance sweep: grow the connected set 2, 4, 8, ..., N and time each size.
 
@@ -397,6 +398,26 @@ async def run_root(
             except asyncio.TimeoutError:
                 log(f"[sweep] ERROR: a worker stalled at size {size}")
                 return 1
+            # Optional heartbeat-only settle: idle the whole connected set with *no
+            # data* for longer than the heartbeat timeout, so a link survives only if
+            # its heartbeats (direct or delegated) keep flowing. Then one direct+ring
+            # round confirms every link is still alive. This is what the back-to-back
+            # rounds above deliberately do not test. Run it only once, at the final
+            # (largest) size — it costs a full timeout window, so doing it per size
+            # would dominate the whole sweep's runtime.
+            if settle_ms > 0 and size == sizes[-1]:
+                await asyncio.sleep(settle_ms / 1000.0)
+                try:
+                    if await _direct_round(root, workers, timeout):
+                        log(f"[sweep] FAILURE after settle (direct) at size {size}")
+                        return 1
+                    if await _ring_round(root, workers, timeout, heads):
+                        log(f"[sweep] FAILURE after settle (ring) at size {size}")
+                        return 1
+                except asyncio.TimeoutError:
+                    log(f"[sweep] ERROR: a worker stalled after settle at size {size}")
+                    return 1
+                log(f"[sweep] size={size:>6}  settled {settle_ms:.0f}ms OK")
             log(
                 f"[sweep] size={size:>6}  connect(+{len(batch)})={connect_ms:9.1f} ms  "
                 f"direct min={direct_best:8.2f} avg={direct_sum / rounds:8.2f} ms  "
@@ -419,6 +440,7 @@ async def run_root_coordinated(
     connect_timeout: float,
     min_rounds: int = 1,
     chain_length: int = 0,
+    settle_ms: float = 0.0,
 ) -> int:
     """Root variant that waits for a controller to hand it the worker addresses.
 
@@ -466,7 +488,13 @@ async def run_root_coordinated(
     # Run the normal sweep as a fresh root actor, but keep the context alive so we
     # can report completion to the controller afterward.
     rc = await run_root(
-        hosts, timeout, connect_timeout, min_rounds, chain_length, close_ctx=False
+        hosts,
+        timeout,
+        connect_timeout,
+        min_rounds,
+        chain_length,
+        close_ctx=False,
+        settle_ms=settle_ms,
     )
 
     log(f"[coord] sweep finished rc={rc}; notifying controller and closing")
@@ -545,6 +573,14 @@ def main() -> None:
         help="root: run this many direct+ring rounds at each sweep size "
         "(default: 1). More rounds give a min/avg per size.",
     )
+    parser.add_argument(
+        "--settle-ms",
+        type=float,
+        default=0.0,
+        help="root: after each sweep size, idle the connected set with no data for "
+        "this many ms (should exceed the heartbeat timeout), then verify every link "
+        "survived. 0 (default) disables. Isolates heartbeat-only liveness failures.",
+    )
     args = parser.parse_args()
 
     ensure_quic_certs(args.certs_dir)
@@ -561,6 +597,7 @@ def main() -> None:
                     args.connect_timeout,
                     args.min_rounds,
                     args.chain_length,
+                    args.settle_ms,
                 )
             )
         )
@@ -578,6 +615,7 @@ def main() -> None:
                     args.connect_timeout,
                     args.min_rounds,
                     args.chain_length,
+                    settle_ms=args.settle_ms,
                 )
             )
         )

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -28,13 +28,13 @@
 //!
 //! The reader/writer are generic over tokio's [`AsyncRead`]/[`AsyncWrite`], so the
 //! same code drives a QUIC stream's `RecvStream`/`SendStream`. Liveness policy
-//! (heartbeats, timeouts, EOF) lives in each
-//! transport; this module only serializes frames — with the one exception of the
-//! [`WireFrame::Heartbeat`] probe, which a transport may emit/consume but which is
-//! never a [`ConnectionCommand`].
+//! (heartbeats, timeouts, EOF) lives in each transport; this module only serializes
+//! frames — data-stream [`WireFrame`]s, and the bare [`Heartbeat`] probe that rides
+//! its own stream (see [`write_heartbeat`]), which is never a [`ConnectionCommand`].
 
 use serde::Deserialize;
 use serde::Serialize;
+use serde::de::DeserializeOwned;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWrite;
@@ -54,10 +54,11 @@ use crate::shm::MapperHandle;
 use crate::shm::SHM_THRESHOLD;
 use crate::shm::ShmClient;
 
-/// One frame on the wire. There is a variant per [`ConnectionCommand`] that
+/// One frame on the data stream. There is a variant per [`ConnectionCommand`] that
 /// crosses the pipe (including `Establish`, which is how the two ends exchange
-/// identity), plus a transport-internal `Heartbeat`. Message-part *bytes* are
-/// never carried here — only their lengths.
+/// identity). Message-part *bytes* are never carried here — only their lengths.
+/// Heartbeats are *not* here: they ride a dedicated stream and are serialized as a
+/// bare [`Heartbeat`] (see [`write_heartbeat`]/[`read_heartbeat`]).
 #[derive(Serialize, Deserialize)]
 enum WireFrame {
     Establish {
@@ -88,10 +89,6 @@ enum WireFrame {
     GatewayDied {
         dead: Vec<Vec<u8>>,
     },
-    /// Transport-internal liveness probe carrying a directional [`Heartbeat`] body
-    /// (a Child sends `FromChild`, a Parent sends `FromParent`). Consumed by the
-    /// reader/heartbeat coroutine and never surfaced as a [`ConnectionCommand`].
-    Heartbeat(Heartbeat),
 }
 
 /// Wire form of a [`SendMessage`](ConnectionCommand::SendMessage)'s payload. An
@@ -109,9 +106,11 @@ enum WirePayload {
     },
 }
 
-/// One frame on a gateway side-channel — the wire form of a [`SideChannelMessage`].
-/// `Send` of an actor message reuses [`WirePayload`]'s zero-copy part-length header
-/// + streamed bytes (+ shm); every other case is header-only.
+/// One frame on a gateway side-channel's *message* stream — the wire form of a
+/// [`SideChannelMessage`]. `Send` of an actor message reuses [`WirePayload`]'s
+/// zero-copy part-length header + streamed bytes (+ shm); every other case is
+/// header-only. Delegated heartbeats are not here — they ride the companion
+/// heartbeat stream as a bare [`SideChannelHeartbeat`].
 #[derive(Serialize, Deserialize)]
 enum SideChannelFrame {
     Send {
@@ -127,35 +126,63 @@ enum SideChannelFrame {
         gateway_for_actor: Vec<u8>,
         monitoring: Vec<u8>,
     },
-    /// A sibling side-channel heartbeat message (see [`crate::quic_heartbeat`]).
-    /// `gateway_for_actor` is the recipient (whose gateway tag the message is dialed
-    /// at); `from` is the sender's ident; `conn_id` is the delegated connection's id;
-    /// `kind` is the [`BeatKind`] (beat / ack / release).
-    Heartbeat {
-        gateway_for_actor: Vec<u8>,
-        from: Vec<u8>,
-        conn_id: ConnectionId,
-        kind: BeatKind,
-    },
 }
 
 fn bincode_config() -> bincode::config::Configuration {
     bincode::config::standard()
 }
 
-/// The first frame a QUIC *joiner* (the connecting side) writes, declaring what
-/// the freshly opened bi-stream is for. The accepting side reads exactly one of
-/// these before deciding how to drive the stream:
+/// Encode `value` as bincode and write it length-prefixed as `[u64 header_len]
+/// [header]`. This is the single place every framed write goes through for its
+/// header — callers layer their own concerns on top: trailing message-part bytes
+/// (see [`write_frame`]) and the flush (every caller decides when to flush, and
+/// this helper never does). The length prefix is little-endian, matching
+/// [`read_header`].
+async fn write_header<W: AsyncWrite + Unpin, T: Serialize>(
+    writer: &mut W,
+    value: &T,
+) -> std::io::Result<()> {
+    let header = bincode::serde::encode_to_vec(value, bincode_config())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    writer
+        .write_all(&(header.len() as u64).to_le_bytes())
+        .await?;
+    writer.write_all(&header).await
+}
+
+/// Read a `[u64 header_len][header]`-framed bincode value written by
+/// [`write_header`] and decode it as `T`. The single place every framed read goes
+/// through for its header; callers that carry trailing message-part bytes read them
+/// after this (see [`read_frame`]).
+async fn read_header<R: AsyncRead + Unpin, T: DeserializeOwned>(
+    reader: &mut R,
+) -> std::io::Result<T> {
+    let mut len_buf = [0u8; 8];
+    reader.read_exact(&mut len_buf).await?;
+    let header_len = u64::from_le_bytes(len_buf) as usize;
+    let mut header = vec![0u8; header_len];
+    reader.read_exact(&mut header).await?;
+    let (value, _) = bincode::serde::decode_from_slice::<T, _>(&header, bincode_config())
+        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+    Ok(value)
+}
+
+/// The first frame a QUIC *joiner* (the connecting side) writes on the **first**
+/// bi-stream it opens, declaring what kind of connection this is. Every connection
+/// carries two bi-streams — a data/message stream and a companion heartbeat stream
+/// — so heartbeats never queue behind a large data transfer on a single ordered
+/// stream. Only the first stream carries a preamble: the second is *always* the
+/// heartbeat stream (opened right after the first), so the acceptor classifies it
+/// by order and reads no preamble on it.
 ///
 /// - `Join` — an ordinary parent/child connection; the command loop takes over
-///   (identity exchange, hello, heartbeated liveness) exactly as before.
-/// - `SideChannel` — a gateway-to-gateway message channel: the accepting gateway
-///   just reads [`WireFrame::Message`] frames and routes them locally. It is
-///   never paired with a serve, never establishes a parent/child link, and is
-///   never heartbeated.
+///   (identity exchange, hello, routing) over the data stream.
+/// - `SideChannel` — a gateway-to-gateway channel: the accepting gateway reads
+///   [`WireFrame::Message`] frames and routes them locally. Never paired with a
+///   serve, never establishes a parent/child link.
 ///
-/// Only the joiner writes a preamble (one direction); the server never does, so
-/// the joiner's own reader keeps reading [`WireFrame`]s as before.
+/// Only the joiner writes the preamble (one direction); the server never does, so
+/// the joiner's own readers keep reading frames as before.
 #[derive(Serialize, Deserialize)]
 pub(crate) enum Preamble {
     Join,
@@ -169,12 +196,7 @@ pub(crate) async fn write_preamble<W: AsyncWrite + Unpin>(
     writer: &mut W,
     preamble: Preamble,
 ) -> std::io::Result<()> {
-    let header = bincode::serde::encode_to_vec(&preamble, bincode_config())
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    writer
-        .write_all(&(header.len() as u64).to_le_bytes())
-        .await?;
-    writer.write_all(&header).await?;
+    write_header(writer, &preamble).await?;
     writer.flush().await
 }
 
@@ -182,38 +204,22 @@ pub(crate) async fn write_preamble<W: AsyncWrite + Unpin>(
 pub(crate) async fn read_preamble<R: AsyncRead + Unpin>(
     reader: &mut R,
 ) -> std::io::Result<Preamble> {
-    let mut len_buf = [0u8; 8];
-    reader.read_exact(&mut len_buf).await?;
-    let header_len = u64::from_le_bytes(len_buf) as usize;
-    let mut header = vec![0u8; header_len];
-    reader.read_exact(&mut header).await?;
-    let (preamble, _) = bincode::serde::decode_from_slice::<Preamble, _>(&header, bincode_config())
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    Ok(preamble)
+    read_header(reader).await
 }
 
-/// A frame decoded off the wire: either a command for the loop, or a transport
-/// heartbeat (consumed internally to refresh the liveness deadline).
-pub(crate) enum Incoming {
-    Command(ConnectionCommand),
-    Heartbeat(Heartbeat),
-}
-
-/// A frame decoded off a gateway side-channel: either a routable
-/// [`SideChannelMessage`] for the command loop, or a transport-internal
-/// delegated-heartbeat beat/ack. The heartbeat variant is *never* surfaced to ctx
-/// — the receiving quic reader hands it straight to the heartbeat subsystem — so it
-/// stays out of ctx's [`SideChannelMessage`]/`SideChannelAction` routing types.
-pub(crate) enum SideChannelIncoming {
-    Message(SideChannelMessage),
-    Heartbeat {
-        /// The actor whose gateway received the beat — i.e. the one the addressed
-        /// heartbeat coroutine belongs to as a child.
-        recipient: Vec<u8>,
-        from: Vec<u8>,
-        conn_id: ConnectionId,
-        kind: BeatKind,
-    },
+/// A delegated-heartbeat beat/ack/release carried on a gateway side-channel's
+/// dedicated heartbeat stream. It is the bare wire form on that stream (which
+/// carries only these), and is *never* surfaced to ctx — the receiving quic reader
+/// hands it straight to the heartbeat subsystem — so it stays out of ctx's
+/// [`SideChannelMessage`]/`SideChannelAction` routing types.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct SideChannelHeartbeat {
+    /// The actor whose gateway received the beat — i.e. the one the addressed
+    /// heartbeat coroutine belongs to as a child.
+    pub(crate) recipient: Vec<u8>,
+    pub(crate) from: Vec<u8>,
+    pub(crate) conn_id: ConnectionId,
+    pub(crate) kind: BeatKind,
 }
 
 /// Serialize and write one command: a length-prefixed bincode header, then — for
@@ -286,12 +292,23 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
     write_frame(writer, &frame, &parts).await
 }
 
-/// Write a transport heartbeat probe carrying `heartbeat`.
+/// Write a transport heartbeat probe carrying `heartbeat`. The dedicated heartbeat
+/// stream carries only these, so it is serialized as a bare [`Heartbeat`] (no
+/// enclosing frame variant) and has no message parts.
 pub(crate) async fn write_heartbeat<W: AsyncWrite + Unpin>(
     writer: &mut W,
     heartbeat: Heartbeat,
 ) -> std::io::Result<()> {
-    write_frame(writer, &WireFrame::Heartbeat(heartbeat), &[]).await
+    write_frame(writer, &heartbeat, &[]).await
+}
+
+/// Read one heartbeat probe off a connection's dedicated heartbeat stream, written
+/// by [`write_heartbeat`] as a bare [`Heartbeat`] (no message parts, so no
+/// shared-memory context is needed).
+pub(crate) async fn read_heartbeat<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<Heartbeat> {
+    read_header(reader).await
 }
 
 async fn write_frame<W: AsyncWrite + Unpin>(
@@ -299,12 +316,7 @@ async fn write_frame<W: AsyncWrite + Unpin>(
     frame: &impl Serialize,
     parts: &[MsgPart],
 ) -> std::io::Result<()> {
-    let header = bincode::serde::encode_to_vec(frame, bincode_config())
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-    writer
-        .write_all(&(header.len() as u64).to_le_bytes())
-        .await?;
-    writer.write_all(&header).await?;
+    write_header(writer, frame).await?;
     // Write each part's bytes straight from its owning buffer — no copy.
     for part in parts {
         writer.write_all(part.as_bytes()).await?;
@@ -312,29 +324,21 @@ async fn write_frame<W: AsyncWrite + Unpin>(
     writer.flush().await
 }
 
-/// Read one frame. For a message each part is read directly into its destination
-/// buffer — an owned heap buffer for a small part, or (when `client` is present
-/// and the part is large) a freshly allocated shared-memory slab block, so the
-/// only copy is the unavoidable kernel-to-userspace one. `mapper`/`client` are the
-/// receiving actor's shared-memory context (see [`read_part`]). A `Heartbeat`
-/// frame returns [`Incoming::Heartbeat`]; everything else maps straight back to a
-/// [`ConnectionCommand`].
+/// Read one data-stream frame and map it back to its [`ConnectionCommand`]. For a
+/// message each part is read directly into its destination buffer — an owned heap
+/// buffer for a small part, or (when `client` is present and the part is large) a
+/// freshly allocated shared-memory slab block, so the only copy is the unavoidable
+/// kernel-to-userspace one. `mapper`/`client` are the receiving actor's
+/// shared-memory context (see [`read_part`]). Heartbeats never arrive here — they
+/// ride their own stream (see [`read_heartbeat`]).
 pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
     reader: &mut R,
     mapper: &MapperHandle,
     client: Option<ShmClient>,
-) -> std::io::Result<Incoming> {
-    let mut len_buf = [0u8; 8];
-    reader.read_exact(&mut len_buf).await?;
-    let header_len = u64::from_le_bytes(len_buf) as usize;
-
-    let mut header = vec![0u8; header_len];
-    reader.read_exact(&mut header).await?;
-    let (frame, _) = bincode::serde::decode_from_slice::<WireFrame, _>(&header, bincode_config())
-        .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
+) -> std::io::Result<ConnectionCommand> {
+    let frame = read_header::<_, WireFrame>(reader).await?;
 
     Ok(match frame {
-        WireFrame::Heartbeat(heartbeat) => Incoming::Heartbeat(heartbeat),
         WireFrame::Message {
             destination_ident,
             payload,
@@ -355,41 +359,37 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
                     is_timeout,
                 },
             };
-            Incoming::Command(ConnectionCommand::SendMessage {
+            ConnectionCommand::SendMessage {
                 destination_ident,
                 payload,
-            })
+            }
         }
         WireFrame::Establish {
             role,
             ident,
             name_for_other,
             alive,
-        } => Incoming::Command(ConnectionCommand::Establish {
+        } => ConnectionCommand::Establish {
             role,
             ident,
             name_for_other,
             alive,
-        }),
-        WireFrame::PublishRoutes { live, dead } => {
-            Incoming::Command(ConnectionCommand::PublishRoutes { live, dead })
-        }
+        },
+        WireFrame::PublishRoutes { live, dead } => ConnectionCommand::PublishRoutes { live, dead },
         WireFrame::UpdateMonitorSubscription {
             listener,
             target,
             op,
-        } => Incoming::Command(ConnectionCommand::UpdateMonitorSubscription {
+        } => ConnectionCommand::UpdateMonitorSubscription {
             listener,
             target,
             op,
-        }),
-        WireFrame::Severed { reason } => Incoming::Command(ConnectionCommand::Severed { reason }),
+        },
+        WireFrame::Severed { reason } => ConnectionCommand::Severed { reason },
         WireFrame::PublishGatewayRoutes { live } => {
-            Incoming::Command(ConnectionCommand::PublishGatewayRoutes { live })
+            ConnectionCommand::PublishGatewayRoutes { live }
         }
-        WireFrame::GatewayDied { dead } => {
-            Incoming::Command(ConnectionCommand::GatewayDied { dead })
-        }
+        WireFrame::GatewayDied { dead } => ConnectionCommand::GatewayDied { dead },
     })
 }
 
@@ -445,9 +445,9 @@ pub(crate) async fn write_side_channel<W: AsyncWrite + Unpin>(
     write_frame(writer, &frame, &parts).await
 }
 
-/// Write a sibling side-channel heartbeat message as a frame. Header-only; the
-/// transport builds the wire frame directly, so heartbeats never pass through
-/// ctx's [`SideChannelMessage`] routing types.
+/// Write a sibling side-channel heartbeat onto the heartbeat stream as a bare
+/// [`SideChannelHeartbeat`] (no message parts). The transport builds it directly, so
+/// heartbeats never pass through ctx's [`SideChannelMessage`] routing types.
 pub(crate) async fn write_side_channel_heartbeat<W: AsyncWrite + Unpin>(
     writer: &mut W,
     recipient: Vec<u8>,
@@ -455,51 +455,26 @@ pub(crate) async fn write_side_channel_heartbeat<W: AsyncWrite + Unpin>(
     conn_id: ConnectionId,
     kind: BeatKind,
 ) -> std::io::Result<()> {
-    let frame = SideChannelFrame::Heartbeat {
-        gateway_for_actor: recipient,
+    let heartbeat = SideChannelHeartbeat {
+        recipient,
         from,
         conn_id,
         kind,
     };
-    write_frame(writer, &frame, &[]).await
+    write_frame(writer, &heartbeat, &[]).await
 }
 
-/// Read one [`SideChannelMessage`] off a gateway side-channel. A `Send` of an
-/// actor message reads each part exactly like [`read_frame`] (small parts into
-/// owned buffers, large ones into the slab via `mapper`/`client`); other actions
-/// are header-only.
+/// Read one [`SideChannelMessage`] off a gateway side-channel's message stream. A
+/// `Send` of an actor message reads each part exactly like [`read_frame`] (small
+/// parts into owned buffers, large ones into the slab via `mapper`/`client`); other
+/// actions are header-only. Heartbeats travel on the companion heartbeat stream
+/// (see [`read_side_channel_heartbeat`]) and never appear here.
 pub(crate) async fn read_side_channel<R: AsyncRead + Unpin>(
     reader: &mut R,
     mapper: &MapperHandle,
     client: Option<ShmClient>,
-) -> std::io::Result<SideChannelIncoming> {
-    let mut len_buf = [0u8; 8];
-    reader.read_exact(&mut len_buf).await?;
-    let header_len = u64::from_le_bytes(len_buf) as usize;
-
-    let mut header = vec![0u8; header_len];
-    reader.read_exact(&mut header).await?;
-    let (frame, _) =
-        bincode::serde::decode_from_slice::<SideChannelFrame, _>(&header, bincode_config())
-            .map_err(|err| std::io::Error::new(std::io::ErrorKind::InvalidData, err))?;
-
-    // A heartbeat is transport-internal: return it as its own variant so the reader
-    // routes it into the heartbeat subsystem without ever building a ctx-level
-    // SideChannelMessage.
-    if let SideChannelFrame::Heartbeat {
-        gateway_for_actor,
-        from,
-        conn_id,
-        kind,
-    } = frame
-    {
-        return Ok(SideChannelIncoming::Heartbeat {
-            recipient: gateway_for_actor,
-            from,
-            conn_id,
-            kind,
-        });
-    }
+) -> std::io::Result<SideChannelMessage> {
+    let frame = read_header::<_, SideChannelFrame>(reader).await?;
 
     let message = match frame {
         SideChannelFrame::Send {
@@ -542,9 +517,17 @@ pub(crate) async fn read_side_channel<R: AsyncRead + Unpin>(
             gateway_for_actor,
             action: SideChannelAction::AckRemoteMonitor { monitoring },
         },
-        SideChannelFrame::Heartbeat { .. } => unreachable!("heartbeat handled above"),
     };
-    Ok(SideChannelIncoming::Message(message))
+    Ok(message)
+}
+
+/// Read one delegated-heartbeat beat/ack/release off a gateway side-channel's
+/// dedicated heartbeat stream, written by [`write_side_channel_heartbeat`] as a bare
+/// [`SideChannelHeartbeat`] (no message parts).
+pub(crate) async fn read_side_channel_heartbeat<R: AsyncRead + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<SideChannelHeartbeat> {
+    read_header(reader).await
 }
 
 /// Read one message part of `len` bytes off the stream.

--- a/monarch_mini/src/quic_heartbeat.rs
+++ b/monarch_mini/src/quic_heartbeat.rs
@@ -211,13 +211,12 @@ impl Heartbeats {
 // Wire types (serialized by `framing.rs`)
 // ---------------------------------------------------------------------------
 
-/// The body of a [`WireFrame::Heartbeat`](crate::framing) probe. `FromChild` /
-/// `FromParent` are the *real*, request/response liveness beats — a Child sends
+/// The wire body of a heartbeat probe, serialized bare onto a connection's
+/// dedicated heartbeat stream (see [`crate::framing::write_heartbeat`]). `FromChild`
+/// / `FromParent` are the *real*, request/response liveness beats — a Child sends
 /// `FromChild`, its Parent answers with `FromParent` — and they drive delegation.
-/// `TransportActivity` is what a reader synthesizes when ordinary data flows over the
-/// link: it proves the pipe is alive without being a beat, so it refreshes the
-/// liveness deadline on whichever side reads it but is *not* a request/response — it
-/// never advances delegation state or the echo pacing.
+/// Riding their own stream, a beat is never delayed by a large data transfer and no
+/// synthesized "still here" backstop is needed.
 #[derive(Serialize, Deserialize, Clone)]
 pub(crate) enum Heartbeat {
     /// Child → parent: the running diff of connections this child covers for the
@@ -230,9 +229,6 @@ pub(crate) enum Heartbeat {
     /// `None` never revokes — a child reverts on its own ack-timeout, a parent on
     /// `ResumeHeartbeat`.
     FromParent { delegate: Option<Delegate> },
-    /// Reader → its own heartbeat_task: ordinary data arrived on the link, so it is
-    /// alive. "I am still here" — refresh the deadline, nothing more.
-    TransportActivity,
 }
 
 /// A delegation instruction carried on a `FromParent` beat: "you are connection
@@ -953,15 +949,6 @@ async fn parent_direct_loop(
                         let delegate = shared.borrow_mut().pool_mut(key).delegate(conn_id);
                         let _ = beats.send(Heartbeat::FromParent { delegate });
                     }
-                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::TransportActivity) => {
-                        // Data flowed over the link: it is alive. Refresh our watch, but
-                        // only while watching directly — a paused (delegated) connection
-                        // stays paused (its sibling proves it live). Not a real beat, so
-                        // no answer, no delegation, no un-pause.
-                        if deadline.is_some() {
-                            deadline = Some(Instant::now() + config.timeout);
-                        }
-                    }
                     HeartbeatEvent::PauseHeartbeat => {
                         // A sibling now covers this child: stop watching it directly — but
                         // only while we are still delegating it. If it already fell back to
@@ -1053,11 +1040,6 @@ async fn parent_cover_loop(
                         shared.borrow().signal_coverage(&mut covered, cover_add, cover_del);
                         // Answer so the delegate host paces its next beat.
                         let _ = beats.send(Heartbeat::FromParent { delegate: None });
-                    }
-                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::TransportActivity) => {
-                        // Data over the cover host's link proves it alive; refresh, but
-                        // do not answer (not a real beat).
-                        deadline = Instant::now() + config.timeout;
                     }
                     // Establishment is a one-shot exchange that completed back in the
                     // direct loop; a stray duplicate here is harmless.
@@ -1245,16 +1227,6 @@ async fn child_task<S: SendBeat>(ctx: HeartbeatCtx<S>) {
                                 next_beat = Some(Instant::now() + interval);
                             }
                             _ => {}
-                        }
-                    }
-                    HeartbeatEvent::ReceivedHeartbeat(Heartbeat::TransportActivity) => {
-                        // Data from the parent proves the pipe alive; refresh our direct
-                        // deadline. It is not an answer, so it does not pace the next beat.
-                        // Ignored while delegated — our liveness clock then tracks our
-                        // delegate's acks, not the parent, and the parent's death would
-                        // arrive as a reader close instead.
-                        if matches!(state, ChildState::Direct) {
-                            primary = Instant::now() + timeout;
                         }
                     }
                     HeartbeatEvent::Side(from, conn_id, BeatKind::Beat) => {

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -9,23 +9,35 @@
 //! QUIC transport for connecting actors across machines (or local processes).
 //!
 //! Structurally a sibling of the UNIX transport: a connection's coroutines bring
-//! up one bidirectional QUIC stream, produce a [`ConnectionTransport`] for it, and
-//! hand it to the command loop via `Command::TransportConnected`; the reader
+//! up **two** bidirectional QUIC streams — a data/control stream and a dedicated
+//! heartbeat stream — produce a [`ConnectionTransport`] for the data stream, and
+//! hand it to the command loop via `Command::TransportConnected`; the data reader
 //! forwards every decoded frame back as a `ConnectionAction`. Establishment policy
 //! (identity exchange, hello, liveness reporting) lives in the command loop and is
 //! identical across transports. Wire framing is shared (see [`crate::framing`]).
+//!
+//! ## Two streams per connection
+//!
+//! A single QUIC stream is a reliable, in-order byte stream, so a large message
+//! head-of-line-blocks everything queued behind it — including heartbeats, whose
+//! whole job is to keep flowing while data does. QUIC's streams are independently
+//! ordered and flow-controlled and interleave at the packet level, so we put
+//! heartbeats on their **own** stream: a multi-megabyte message on the data stream
+//! can no longer delay a beat. The heartbeat stream is given a higher send priority
+//! so beats are packed into packets ahead of data even under a full congestion
+//! window. (Flow-control *windows* are left at their defaults: they are credit
+//! ceilings, not pre-allocated buffers, and beats are tiny.)
 //!
 //! ## Why QUIC differs from UNIX
 //!
 //! QUIC runs over UDP in userspace, so there is no file-descriptor close to signal
 //! a lost peer: a crashed, frozen, or partitioned peer simply stops sending. So
 //! instead of relying on EOF we run an application-level **bidirectional
-//! heartbeat**: each side's writer emits a [`framing::write_heartbeat`] every
-//! [`HEARTBEAT_INTERVAL`], and each side's reader wraps every frame read in a
-//! [`HEARTBEAT_TIMEOUT`]; any frame (data or heartbeat) refreshes the deadline, and
-//! a timeout emits `Severed`. A clean drop still finishes the stream, so the peer
-//! also observes immediate EOF — the heartbeat is the backstop for the unclean
-//! cases.
+//! heartbeat** on the heartbeat stream: each side emits a [`framing::write_heartbeat`]
+//! every [`HEARTBEAT_INTERVAL`] and times out on the peer's beats after
+//! [`HEARTBEAT_TIMEOUT`], emitting `Severed` on a lapse. A clean drop still finishes
+//! both streams, so the peer also observes immediate EOF — the heartbeat is the
+//! backstop for the unclean cases.
 //!
 //! ## Security
 //!
@@ -47,6 +59,7 @@ use quinn::Endpoint;
 use quinn::RecvStream;
 use quinn::SendStream;
 use quinn::ServerConfig;
+use quinn::VarInt;
 use rustls::RootCertStore;
 use rustls_pki_types::CertificateDer;
 use rustls_pki_types::PrivateKeyDer;
@@ -55,6 +68,7 @@ use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::Duration;
 
+use crate::Role;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
@@ -62,9 +76,8 @@ use crate::connection::SideChannelMessage;
 use crate::connection::sever;
 use crate::ctx::Command;
 use crate::framing;
-use crate::framing::Incoming;
 use crate::framing::Preamble;
-use crate::framing::SideChannelIncoming;
+use crate::framing::SideChannelHeartbeat;
 use crate::matcher::Matcher;
 use crate::quic_heartbeat::BeatKind;
 use crate::quic_heartbeat::ConnectionId;
@@ -86,6 +99,13 @@ const SERVER_NAME: &str = "monarch-mini";
 const CONNECT_RETRY_MIN: Duration = Duration::from_millis(5);
 const CONNECT_RETRY_MAX: Duration = Duration::from_millis(1000);
 
+/// Send priority of a connection's heartbeat stream, above the data stream's
+/// default of `0`. quinn schedules higher-priority stream frames into packets
+/// first, so a beat is packed ahead of queued data-stream bytes even when a large
+/// message has the congestion window full — the heartbeat stream removes in-order
+/// head-of-line blocking, and this removes the congestion-window one.
+const HEARTBEAT_STREAM_PRIORITY: i32 = 1;
+
 /// On graceful shutdown each writer sends an explicit `Severed{"context shutdown"}`
 /// frame (reliable stream data — retransmitted by QUIC, unlike `CONNECTION_CLOSE`),
 /// then keeps the connection open until the peer *responds* (its own `Severed`/EOF,
@@ -101,6 +121,31 @@ fn shutdown_ack_timeout() -> Duration {
         .and_then(|v| v.parse::<u64>().ok())
         .map(Duration::from_millis)
         .unwrap_or(DEFAULT_SHUTDOWN_ACK_TIMEOUT)
+}
+
+/// Per-stream flow-control receive window (`MAX_STREAM_DATA`): how many bytes a peer
+/// may have in flight on one stream before it must wait for the receiver to extend
+/// the window. quinn's default is ~1.25 MB (sized for a 100 ms RTT), which caps a
+/// large message's throughput at window/RTT — a severe throttle on a fast, low-RTT
+/// link. We raise it so a big message can keep the pipe full.
+///
+/// This is a *ceiling* the receiver may buffer up to on a stream actively receiving
+/// unread data, not a preallocation: idle connections cost nothing. It does raise
+/// the worst-case memory a busy connection can hold, which matters for a root with
+/// very many connections all mid-large-transfer — so it is env-tunable
+/// (`MM_QUIC_STREAM_RECV_WINDOW_BYTES`). Only the data stream ever fills it; the
+/// companion heartbeat stream carries tiny frames. The connection-level
+/// `receive_window` is left at quinn's default (`VarInt::MAX`); with just two
+/// streams per connection the per-stream window already bounds what one connection
+/// can buffer.
+const DEFAULT_STREAM_RECV_WINDOW_BYTES: u64 = 16 * 1024 * 1024;
+
+fn stream_recv_window_bytes() -> u64 {
+    std::env::var("MM_QUIC_STREAM_RECV_WINDOW_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_STREAM_RECV_WINDOW_BYTES)
 }
 
 /// What a connection's reader needs for shared memory: the context-global mapper
@@ -168,6 +213,12 @@ fn load_tls() -> anyhow::Result<TlsConfig> {
     let mut transport = quinn::TransportConfig::default();
     transport.keep_alive_interval(None);
     transport.max_idle_timeout(None);
+    // Raise the per-stream flow-control window (and the send window with it, keeping
+    // quinn's 8x send:stream ratio) so a large message is not throttled to
+    // window/RTT. See `stream_recv_window_bytes`.
+    let window = stream_recv_window_bytes();
+    transport.stream_receive_window(VarInt::from_u64(window).unwrap_or(VarInt::MAX));
+    transport.send_window(window.saturating_mul(8));
     let transport = Arc::new(transport);
 
     let mut server = ServerConfig::with_single_cert(load_certs(&cert_path)?, load_key(&key_path)?)?;
@@ -735,13 +786,28 @@ impl Transport for QuicTransport {
     }
 }
 
-/// A connection accepted by the listener, classified by the joiner's preamble.
-/// A `Join` is paired with a serve and driven by the command loop as before; a
-/// `SideChannel` is a gateway-to-gateway message stream read directly into the
-/// home gateway's routing.
+/// A connection accepted by the listener, classified by the joiner's first-stream
+/// preamble. Every connection carries two bi-streams: a data/message stream and a
+/// companion heartbeat stream. Only the data/message stream is carried here — its
+/// acceptance is what establishes/pairs the connection, and it must not wait on the
+/// heartbeat stream (whose first bytes only arrive with the peer's first beat). The
+/// heartbeat stream is obtained lazily by the heartbeat management task instead
+/// (dialer opens it, acceptor accepts it). A `Join` is paired with a serve and
+/// driven by the command loop as before; a `SideChannel` is a gateway-to-gateway
+/// link read directly into the home gateway's routing (the joiner only sends, so we
+/// keep just the message recv).
 enum Accepted {
-    Join(Connection, SendStream, RecvStream),
+    Join(JoinStreams),
     SideChannel(Connection, RecvStream),
+}
+
+/// The QUIC connection plus the data-stream halves of a join link, as paired by the
+/// listener's [`Matcher`] and handed to [`spawn_connection`]. The
+/// heartbeat stream is not here — it is acquired later off the establishment path.
+struct JoinStreams {
+    conn: Connection,
+    data_send: SendStream,
+    data_recv: RecvStream,
 }
 
 /// Bind a QUIC server endpoint on `addr` and dispatch each accepted connection by
@@ -794,8 +860,7 @@ async fn listener_task(
         shutdown.clone(),
     ));
 
-    let mut matcher: Matcher<(ConnectionRef, ShmCtx), (Connection, SendStream, RecvStream)> =
-        Matcher::new();
+    let mut matcher: Matcher<(ConnectionRef, ShmCtx), JoinStreams> = Matcher::new();
     // One spawn callback for both Matcher arms: the Matcher hands back
     // `(serve_side, accepted_side)` either way, so a serve-first (`push_left`) and
     // an accept-first (`push_right`) pairing spawn identically — serve/acceptor
@@ -803,11 +868,15 @@ async fn listener_task(
     // Owns a `shutdown` clone (the select below needs `&mut shutdown` for
     // `changed()`); the rest are cloned per spawn.
     let spawn_shutdown = shutdown.clone();
-    let spawn = |(connection, shm): (ConnectionRef, ShmCtx),
-                 (conn, send, recv): (Connection, SendStream, RecvStream)| {
+    let spawn = |(connection, shm): (ConnectionRef, ShmCtx), streams: JoinStreams| {
+        let JoinStreams {
+            conn,
+            data_send,
+            data_recv,
+        } = streams;
         spawn_connection(
-            send,
-            recv,
+            data_send,
+            data_recv,
             connection,
             loop_tx.clone(),
             spawn_shutdown.clone(),
@@ -833,17 +902,21 @@ async fn listener_task(
             accepted = accepted_rx.recv() => {
                 match accepted {
                     None => return,
-                    Some(Accepted::Join(conn, send, recv)) => {
-                        if let Some((left, right)) =
-                            matcher.push_right((conn, send, recv), |l, r| (l, r))
-                        {
+                    Some(Accepted::Join(streams)) => {
+                        if let Some((left, right)) = matcher.push_right(streams, |l, r| (l, r)) {
                             spawn(left, right);
                         }
                     }
-                    Some(Accepted::SideChannel(conn, recv)) => {
+                    Some(Accepted::SideChannel(conn, msg_recv)) => {
+                        // Messages and delegated beats arrive on separate streams, so
+                        // read each in its own task. Both hold the connection to keep
+                        // it alive; the heartbeat reader accepts its (second) stream
+                        // itself, since it may open late or never.
                         tokio::task::spawn_local(side_channel_reader_task(
-                            conn, recv, loop_tx.clone(), side_channel_shm.clone(),
-                            heartbeat.clone(),
+                            conn.clone(), msg_recv, loop_tx.clone(), side_channel_shm.clone(),
+                        ));
+                        tokio::task::spawn_local(side_channel_heartbeat_reader_task(
+                            conn, heartbeat.clone(),
                         ));
                     }
                 }
@@ -871,11 +944,25 @@ async fn acceptor_task(
                 tokio::task::spawn_local(async move {
                     let Ok(connecting) = incoming.accept() else { return; };
                     let Ok(connection) = connecting.await else { return; };
+                    // Every connection opens two bi-streams: the data/message stream
+                    // (first, carrying the preamble) and its companion heartbeat
+                    // stream (second, no preamble — the first preamble already tells
+                    // us it follows). We accept and classify only the first stream
+                    // here: that is what establishes/pairs the connection, and it must
+                    // not wait on the heartbeat stream, whose first bytes only arrive
+                    // with the peer's first beat. The heartbeat stream is accepted by
+                    // the heartbeat management task (`accept` hands out streams in the
+                    // order the peer opened them, so it always gets the second one).
                     let Ok((send, mut recv)) = connection.accept_bi().await else { return; };
-                    // The joiner's first frame says what this stream is for.
                     let accepted = match framing::read_preamble(&mut recv).await {
-                        Ok(Preamble::Join) => Accepted::Join(connection, send, recv),
+                        Ok(Preamble::Join) => Accepted::Join(JoinStreams {
+                            conn: connection,
+                            data_send: send,
+                            data_recv: recv,
+                        }),
+                        // A side-channel is unidirectional (the joiner only sends).
                         Ok(Preamble::SideChannel) => Accepted::SideChannel(connection, recv),
+                        // A decode error: the peer spoke a bad dialect — drop it.
                         Err(_) => return,
                     };
                     let _ = accepted_tx.send(accepted);
@@ -886,27 +973,45 @@ async fn acceptor_task(
     }
 }
 
-/// Read frames off a gateway side-channel. A routable [`SideChannelMessage`] is
-/// forwarded to the command loop (which resolves the owning gateway); a
-/// delegated-heartbeat beat/ack is routed *directly* into the heartbeat subsystem
-/// here — it never reaches ctx. There is no establishment: an EOF or error just
-/// ends the reader (the sending gateway reconnects when it next has something to
-/// send). `_conn` is held only to keep the QUIC connection (and thus `recv`) alive.
+/// Read routable messages off a gateway side-channel's message stream and forward
+/// each to the command loop (which resolves the owning gateway). There is no
+/// establishment: an EOF or error just ends the reader (the sending gateway
+/// reconnects when it next has something to send). `_conn` is held only to keep the
+/// QUIC connection (and thus `recv`) alive. Delegated beats travel on the companion
+/// heartbeat stream (see [`side_channel_heartbeat_reader_task`]).
 async fn side_channel_reader_task(
     _conn: Connection,
     mut recv: RecvStream,
     loop_tx: mpsc::UnboundedSender<Command>,
     shm: ShmCtx,
-    heartbeat: Heartbeats,
 ) {
     loop {
         match framing::read_side_channel(&mut recv, &shm.mapper, shm.client()).await {
-            Ok(SideChannelIncoming::Message(message)) => {
+            Ok(message) => {
                 if loop_tx.send(Command::SideChannelDeliver(message)).is_err() {
                     return;
                 }
             }
-            Ok(SideChannelIncoming::Heartbeat {
+            Err(_) => return,
+        }
+    }
+}
+
+/// Read delegated-heartbeat beats/acks/releases off a gateway side-channel's
+/// heartbeat stream and route them *directly* into the heartbeat subsystem — they
+/// never reach ctx. Kept on its own stream so a large routed message on the message
+/// stream can never delay a beat. The heartbeat stream is the connection's *second*
+/// bi-stream (the message stream, already accepted, is the first), so this task
+/// accepts it itself: it may open late (on the first beat) or never (a channel that
+/// only carries messages), and awaiting it here never blocks the message reader.
+/// `conn` keeps the QUIC connection alive; an EOF or error just ends the reader.
+async fn side_channel_heartbeat_reader_task(conn: Connection, heartbeat: Heartbeats) {
+    let Ok((_send, mut recv)) = conn.accept_bi().await else {
+        return; // connection closed before any heartbeat stream opened
+    };
+    loop {
+        match framing::read_side_channel_heartbeat(&mut recv).await {
+            Ok(SideChannelHeartbeat {
                 recipient,
                 from,
                 conn_id,
@@ -976,7 +1081,10 @@ async fn connector_task(
                         sever(&loop_tx, connection, b"quic open stream failed".to_vec());
                         return;
                     }
-                    // Connection is up; free the attempt slot before handing off.
+                    // Connection is up; free the attempt slot before handing off. The
+                    // companion heartbeat stream is opened by the heartbeat management
+                    // task (its second `open_bi`, after this data stream), off the
+                    // establishment path — see `spawn_connection`.
                     drop(permit);
                     // Joiner side (the root has tens of thousands of writers): do not
                     // log heartbeat sends here even under debug — it would flood.
@@ -991,7 +1099,8 @@ async fn connector_task(
                         shm,
                         false,
                         // We dialed this connection (join): the delegation guard's
-                        // "parent is the joiner" precondition holds on this side.
+                        // "parent is the joiner" precondition holds on this side, and
+                        // the heartbeat task opens (not accepts) the heartbeat stream.
                         true,
                         heartbeat,
                         side_channels,
@@ -1027,9 +1136,12 @@ async fn side_channel_writer_task(
     mut shutdown: watch::Receiver<bool>,
     _alive: mpsc::UnboundedSender<()>,
 ) {
-    // The current connection, if up: its send stream plus the QUIC connection,
-    // held to keep it open. `None` means we must (re)connect before the next write.
-    let mut stream: Option<(SendStream, Connection)> = None;
+    // The current connection, if up: the message send stream, the heartbeat send
+    // stream, and the QUIC connection held to keep them open. `None` means we must
+    // (re)connect before the next write. Routed messages go on the message stream
+    // and delegated beats on the heartbeat stream, so a large message can never
+    // delay a beat.
+    let mut stream: Option<(SendStream, SendStream, Connection)> = None;
     loop {
         let item = tokio::select! {
             item = rx.recv() => match item {
@@ -1039,48 +1151,60 @@ async fn side_channel_writer_task(
             _ = shutdown.changed() => break,
         };
         if stream.is_none() {
-            let Some((mut send, conn)) = connect_side_channel(&endpoint, addr, &mut shutdown).await
+            let Some((mut msg_send, hb_send, conn)) =
+                connect_side_channel(&endpoint, addr, &mut shutdown).await
             else {
                 break; // shutting down before the gateway came up
             };
-            // Announce the stream as a side-channel so the peer reads messages
-            // rather than driving a join handshake.
-            if framing::write_preamble(&mut send, Preamble::SideChannel)
+            // Announce the connection kind on the message stream (which also opens it
+            // on the wire). The heartbeat stream carries no preamble — the peer knows
+            // from this one that a second (heartbeat) stream follows — and opens
+            // lazily on the first beat, so a message-only channel never opens it.
+            if framing::write_preamble(&mut msg_send, Preamble::SideChannel)
                 .await
                 .is_err()
             {
                 continue; // reconnect on the next item (this one is dropped)
             }
-            stream = Some((send, conn));
+            // Beats jump ahead of queued message bytes under a full congestion window.
+            let _ = hb_send.set_priority(HEARTBEAT_STREAM_PRIORITY);
+            stream = Some((msg_send, hb_send, conn));
         }
-        let (send, _conn) = stream.as_mut().expect("stream is connected");
+        let (msg_send, hb_send, _conn) = stream.as_mut().expect("stream is connected");
         let wrote = match item {
-            SideChannelOut::Message(message) => framing::write_side_channel(send, message).await,
+            SideChannelOut::Message(message) => {
+                framing::write_side_channel(msg_send, message).await
+            }
             SideChannelOut::Heartbeat {
                 recipient,
                 from,
                 conn_id,
                 kind,
-            } => framing::write_side_channel_heartbeat(send, recipient, from, conn_id, kind).await,
+            } => {
+                framing::write_side_channel_heartbeat(hb_send, recipient, from, conn_id, kind).await
+            }
         };
         if wrote.is_err() {
             stream = None; // dropped; reconnect on the next item
         }
     }
-    if let Some((mut send, _conn)) = stream {
-        let _ = send.finish();
+    if let Some((mut msg_send, mut hb_send, _conn)) = stream {
+        let _ = msg_send.finish();
+        let _ = hb_send.finish();
     }
 }
 
 /// Connect a side-channel to `addr`, retrying with backoff until the gateway binds
-/// and a bi-stream opens, or until teardown (then `None`). Mirrors the join
-/// connector's retry so a side-channel may be opened before its target gateway is
-/// live.
+/// and both bi-streams open, or until teardown (then `None`). Opens the message
+/// stream first and the heartbeat stream second (so the peer accepts them in that
+/// order) and returns `(message_send, heartbeat_send, connection)`. Mirrors the
+/// join connector's retry so a side-channel may be opened before its target gateway
+/// is live.
 async fn connect_side_channel(
     endpoint: &Endpoint,
     addr: SocketAddr,
     shutdown: &mut watch::Receiver<bool>,
-) -> Option<(SendStream, Connection)> {
+) -> Option<(SendStream, SendStream, Connection)> {
     let mut retry = CONNECT_RETRY_MIN;
     loop {
         if *shutdown.borrow() {
@@ -1091,8 +1215,10 @@ async fn connect_side_channel(
             Err(_) => None,
         };
         if let Some(conn) = connected {
-            if let Ok((send, _recv)) = conn.open_bi().await {
-                return Some((send, conn));
+            if let Ok((msg_send, _msg_recv)) = conn.open_bi().await {
+                if let Ok((hb_send, _hb_recv)) = conn.open_bi().await {
+                    return Some((msg_send, hb_send, conn));
+                }
             }
         }
         tokio::select! {
@@ -1103,13 +1229,20 @@ async fn connect_side_channel(
     }
 }
 
-/// Wire up an established bi-stream: build its [`QuicConnectionTransport`], announce
-/// it to the command loop, and spawn the writer (drains commands → frames, plus a
-/// heartbeat tick) and reader (frames → `ConnectionAction`, with a heartbeat
-/// timeout). `conn` (the QUIC connection) is moved into the writer to keep it
-/// alive for the writer's duration; dropping it closes the connection, which the
-/// peer observes. The client endpoint is not held per-connection — it is owned
-/// (shared) by the [`QuicTransport`] for the whole context lifetime.
+/// Wire up an established connection's two bi-streams: build its
+/// [`QuicConnectionTransport`] over the data stream, announce it to the command
+/// loop, and spawn three tasks — a data writer (commands → frames) and data reader
+/// (frames → `ConnectionAction`) on the data stream, plus a heartbeat management
+/// task that acquires the heartbeat stream and runs a beat writer + reader on it.
+/// Splitting the streams keeps a large message on the data stream from delaying a
+/// beat. Crucially, only the two data-stream halves are passed in: the heartbeat
+/// stream is acquired *inside* the management task (the dialer opens it, the
+/// acceptor accepts it), so neither establishment nor serve-pairing ever waits on
+/// the first heartbeat getting through. `conn` (the QUIC connection) is moved into
+/// the writer tasks to keep it alive for their duration; when they drop, the
+/// connection closes and the peer observes it. The client endpoint is not held
+/// per-connection — it is owned (shared) by the [`QuicTransport`] for the whole
+/// context lifetime.
 #[expect(
     clippy::too_many_arguments,
     reason = "each argument is a distinct piece of per-connection state handed off to the writer or reader; bundling them adds indirection without clarifying anything"
@@ -1123,11 +1256,13 @@ fn spawn_connection(
     alive: mpsc::UnboundedSender<()>,
     conn: Connection,
     shm: ShmCtx,
-    // Forwarded to the writer: log heartbeat sends (gated to the serve/acceptor side
-    // by the call sites, and further gated by MM_QUIC_DEBUG in the writer).
+    // Forwarded to the heartbeat writer: log heartbeat sends (gated to the
+    // serve/acceptor side by the call sites, and further gated by MM_QUIC_DEBUG).
     log_heartbeats: bool,
-    // Whether *we* dialed this connection (join / "quic connect"). One half of the
-    // delegation guard (§8): only a link the parent dialed may be delegated.
+    // Whether *we* dialed this connection (join / "quic connect"). Two roles: one
+    // half of the delegation guard (§8, only a link the parent dialed may be
+    // delegated), and it decides whether the heartbeat management task *opens* the
+    // heartbeat stream (dialer) or *accepts* it (the peer opened it).
     dialed: bool,
     heartbeat: Heartbeats,
     side_channels: Rc<RefCell<SideChannels>>,
@@ -1136,7 +1271,7 @@ fn spawn_connection(
     // Reader → writer signal: the peer responded to our shutdown, so the writer
     // may close. Unbounded but only ever carries a single `()`.
     let (peer_responded_tx, peer_responded_rx) = mpsc::unbounded_channel();
-    // heartbeat coroutine → writer: beats to write out.
+    // heartbeat coroutine → heartbeat writer: beats to write out.
     let (beats_tx, beats_rx) = mpsc::unbounded_channel();
     let transport = Box::new(QuicConnectionTransport { tx: writer_tx });
     let _ = loop_tx.send(Command::TransportConnected {
@@ -1153,18 +1288,17 @@ fn spawn_connection(
                 .borrow_mut()
                 .send_heartbeat(recipient, from, conn_id, kind);
         };
-    // Spawn the coroutine; the returned sender is how the reader/writer feed it
+    // Spawn the coroutine; the returned sender is how the readers/writer feed it
     // inbound beats, Establish snoops, and reader-closed.
     let hb_event_tx = heartbeat.spawn(connection, dialed, beats_tx, send_beat, loop_tx.clone());
+    // Data stream: command writer and frame reader.
     tokio::task::spawn_local(writer_task(
         send,
         writer_rx,
-        shutdown,
+        shutdown.clone(),
         alive,
         peer_responded_rx,
-        conn,
-        log_heartbeats,
-        beats_rx,
+        conn.clone(),
         hb_event_tx.clone(),
     ));
     tokio::task::spawn_local(reader_task(
@@ -1173,8 +1307,51 @@ fn spawn_connection(
         loop_tx,
         peer_responded_tx,
         shm,
-        hb_event_tx,
+        hb_event_tx.clone(),
     ));
+    // Heartbeat stream: acquired off the establishment path, then a beat writer and
+    // reader run on it. Open-vs-accept follows the heartbeat role (the Child opens
+    // and beats first, the Parent accepts) — not `dialed` — to avoid a deadlock when
+    // the beat-initiating child is the side that accepted the connection.
+    tokio::task::spawn_local(heartbeat_stream_task(
+        conn,
+        connection.role(),
+        beats_rx,
+        hb_event_tx,
+        shutdown,
+        log_heartbeats,
+    ));
+}
+
+/// Acquire the connection's heartbeat stream and run the beat writer + reader on
+/// it. Open-vs-accept is tied to the heartbeat *role*, not to who dialed the
+/// connection: the **Child** (which always beats first — [`child_task`] sends a
+/// `FromChild` immediately) *opens* the stream, and the **Parent** (which only ever
+/// *answers*) *accepts* it. This is what avoids a deadlock — if the acceptor were to
+/// wait on `accept_bi` for a stream the parent-dialer opened but, being the parent,
+/// never wrote to, neither side would ever beat. Because the child writes its first
+/// beat as soon as it opens the stream, the stream reaches the wire and the parent's
+/// `accept_bi` resolves. Acquisition happens here, in a task spawned *after* the
+/// connection is established and paired, so the first beat never delays either. If
+/// the connection dies before the stream is acquired, this just ends.
+async fn heartbeat_stream_task(
+    conn: Connection,
+    role: Role,
+    beats_rx: mpsc::UnboundedReceiver<Heartbeat>,
+    hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
+    shutdown: watch::Receiver<bool>,
+    log_heartbeats: bool,
+) {
+    let streams = match role {
+        Role::Child => conn.open_bi().await,
+        Role::Parent => conn.accept_bi().await,
+    };
+    let Ok((hb_send, hb_recv)) = streams else {
+        return; // connection died before the heartbeat stream came up
+    };
+    // Reader in its own task; writer runs inline (it owns `conn` to keep it alive).
+    tokio::task::spawn_local(heartbeat_reader_task(hb_recv, hb_events));
+    heartbeat_writer_task(hb_send, beats_rx, shutdown, conn, log_heartbeats).await;
 }
 
 /// Transport for one end of a QUIC stream: `send` hands a command to the writer
@@ -1190,15 +1367,11 @@ impl ConnectionTransport for QuicConnectionTransport {
     }
 }
 
-/// Write each queued command as a frame, plus the heartbeat beats the connection's
-/// `heartbeat_task` sends over `beats` (the writer no longer drives its own tick —
-/// liveness policy lives in the heartbeat_task). Also snoops its own outgoing
-/// `Establish` and forwards the local ident to the heartbeat_task. On teardown,
-/// drains queued frames first, then finishes the stream.
-#[expect(
-    clippy::too_many_arguments,
-    reason = "each argument is a distinct per-connection channel/handle; bundling adds indirection without clarifying anything"
-)]
+/// Write each queued command as a frame onto the data stream. Beats now travel on
+/// the separate heartbeat stream (see [`heartbeat_writer_task`]), so this task only
+/// handles data/control frames. Snoops its own outgoing `Establish` and forwards
+/// the local ident to the heartbeat_task. On teardown, drains queued frames first,
+/// then finishes the stream.
 async fn writer_task(
     mut send: SendStream,
     mut rx: mpsc::UnboundedReceiver<ConnectionCommand>,
@@ -1209,19 +1382,12 @@ async fn writer_task(
     // received the shutdown notice and we can close.
     mut peer_responded: mpsc::UnboundedReceiver<()>,
     // Held only to keep the QUIC connection alive for the writer's lifetime;
-    // dropping it closes the connection, which the peer's reader observes.
+    // dropping it (together with the heartbeat writer's clone) closes the
+    // connection, which the peer's reader observes.
     _conn: Connection,
-    // When set (acceptor/serve side only, so the joiner root's tens of thousands of
-    // writers don't flood), and MM_QUIC_DEBUG is on, log each heartbeat sent — so a
-    // connection the peer later reaps can be proven to have kept sending.
-    log_heartbeats: bool,
-    // Beats this connection's heartbeat_task wants sent.
-    mut beats: mpsc::UnboundedReceiver<Heartbeat>,
     // To forward our own outgoing Establish's ident to the heartbeat_task.
     hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
 ) {
-    let log_heartbeats = log_heartbeats && crate::ctx::connection_debug();
-    let mut heartbeats_sent: u64 = 0;
     let mut graceful = false;
     loop {
         tokio::select! {
@@ -1239,26 +1405,6 @@ async fn writer_task(
                 }
                 if framing::write_command(&mut send, command).await.is_err() {
                     return;
-                }
-            }
-            beat = beats.recv() => {
-                let Some(heartbeat) = beat else {
-                    break; // heartbeat_task gone
-                };
-                if framing::write_heartbeat(&mut send, heartbeat).await.is_err() {
-                    return;
-                }
-                // Flushed to the QUIC stream; log it from the *sender* so loss vs. a
-                // stalled sender can be told apart at the far (receiving) end.
-                if log_heartbeats {
-                    heartbeats_sent += 1;
-                    eprintln!(
-                        "{} MM_HB pid={} sent={} on {:?}",
-                        crate::ctx::wall_clock_hms(),
-                        std::process::id(),
-                        heartbeats_sent,
-                        _conn.remote_address(),
-                    );
                 }
             }
             _ = shutdown.changed() => {
@@ -1296,20 +1442,86 @@ async fn writer_task(
     }
 }
 
-/// Decode each frame off the stream and forward it to the command loop. The
-/// heartbeat *timeout* has moved to this connection's `heartbeat_task`; the reader
-/// is dumb plumbing now. Heartbeat frames are forwarded to the heartbeat_task as
-/// [`HeartbeatEvent`]s (never to ctx). An error/EOF is a hard transport close: it
-/// emits `Severed` to the loop and `ReaderClosed` to the heartbeat_task.
-///
-/// A message flood must not flood the heartbeat_task, so ordinary data frames notify
-/// it only as a *throttled backstop*: the reader tracks `last_notify` and sends a
-/// [`Heartbeat::TransportActivity`] ("still here") only when a full
-/// `2 × HEARTBEAT_INTERVAL` has passed with no real beat — so real beats cost one
-/// event each while data frames cost nothing, yet a peer that stops beating but keeps
-/// sending data still proves the pipe live at ≤ one event per two intervals. The
-/// activity beat only refreshes the reader's heartbeat deadline; it is not a real
-/// beat, so it never participates in the delegation request/response.
+/// Write each beat this connection's `heartbeat_task` produces onto the dedicated
+/// heartbeat stream, at a raised priority so beats are packed ahead of queued
+/// data-stream bytes under a full congestion window. Holds a clone of the QUIC
+/// connection so it stays alive while beats flow, and finishes the stream on
+/// shutdown. A write error just ends the task — the data reader is the one that
+/// severs on connection loss.
+async fn heartbeat_writer_task(
+    mut send: SendStream,
+    mut beats: mpsc::UnboundedReceiver<Heartbeat>,
+    mut shutdown: watch::Receiver<bool>,
+    // Held only to keep the QUIC connection alive while beats flow.
+    _conn: Connection,
+    // When set (acceptor/serve side only, so the joiner root's tens of thousands of
+    // connections don't flood), and MM_QUIC_DEBUG is on, log each heartbeat sent —
+    // so a connection the peer later reaps can be proven to have kept sending.
+    log_heartbeats: bool,
+) {
+    // Beats jump ahead of queued data-stream bytes under a full congestion window.
+    let _ = send.set_priority(HEARTBEAT_STREAM_PRIORITY);
+    let log_heartbeats = log_heartbeats && crate::ctx::connection_debug();
+    let mut heartbeats_sent: u64 = 0;
+    loop {
+        tokio::select! {
+            beat = beats.recv() => {
+                let Some(heartbeat) = beat else {
+                    break; // heartbeat_task gone
+                };
+                if framing::write_heartbeat(&mut send, heartbeat).await.is_err() {
+                    return;
+                }
+                // Flushed to the QUIC stream; log it from the *sender* so loss vs. a
+                // stalled sender can be told apart at the far (receiving) end.
+                if log_heartbeats {
+                    heartbeats_sent += 1;
+                    eprintln!(
+                        "{} MM_HB pid={} sent={} on {:?}",
+                        crate::ctx::wall_clock_hms(),
+                        std::process::id(),
+                        heartbeats_sent,
+                        _conn.remote_address(),
+                    );
+                }
+            }
+            _ = shutdown.changed() => break,
+        }
+    }
+    let _ = send.finish();
+}
+
+/// Read the peer's beats off the dedicated heartbeat stream and forward each to
+/// this connection's `heartbeat_task`. On EOF/error it ends quietly: liveness loss
+/// is caught either by the heartbeat_task's own beat timeout or by the data
+/// reader's `Severed` on connection close.
+async fn heartbeat_reader_task(
+    mut recv: RecvStream,
+    hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
+) {
+    loop {
+        match framing::read_heartbeat(&mut recv).await {
+            Ok(heartbeat) => {
+                if hb_events
+                    .send(HeartbeatEvent::ReceivedHeartbeat(heartbeat))
+                    .is_err()
+                {
+                    return;
+                }
+            }
+            Err(_) => return,
+        }
+    }
+}
+
+/// Decode each frame off the data stream and forward it to the command loop. Beats
+/// arrive on the separate heartbeat stream now (see [`heartbeat_reader_task`]), so
+/// this reader is pure data plumbing. An error/EOF is a hard transport close: it
+/// emits `Severed` to the loop and `ReaderClosed` to the heartbeat_task — this is
+/// the path that detects an unclean peer loss even for a link whose beats are
+/// silent (a delegated child, or a live-but-idle connection). (A stray heartbeat
+/// frame here would be a protocol error; it is defensively forwarded rather than
+/// trusted.)
 async fn reader_task(
     mut recv: RecvStream,
     connection: ConnectionRef,
@@ -1321,23 +1533,18 @@ async fn reader_task(
     // Forwards inbound heartbeats and liveness/close signals to the heartbeat_task.
     hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
 ) {
-    let backstop_gap = crate::quic_heartbeat::heartbeat_interval() * 2;
     // Per-connection diagnostics, folded into the failure reason under MM_QUIC_DEBUG:
-    // did we ever read the peer's Establish (identity exchange)? how many heartbeats
-    // and other frames arrived, and how long since the last read? This pinpoints
-    // exactly how far a reaped connection got. Tracked cheaply either way; only
-    // formatted into the reason when debug is on.
+    // did we ever read the peer's Establish (identity exchange)? how many commands
+    // arrived, and how long since the last read? This pinpoints exactly how far a
+    // reaped connection got. Tracked cheaply either way; only formatted into the
+    // reason when debug is on. (Heartbeats ride their own stream now, so they never
+    // pass through here.)
     let debug = crate::ctx::connection_debug();
     let start = std::time::Instant::now();
     let mut established = false;
-    let mut heartbeats: u64 = 0;
     let mut commands: u64 = 0;
     let mut last_read: Option<std::time::Duration> = None;
-    // When the heartbeat_task was last notified (by a real beat or a backstop),
-    // throttling the data-frame backstop. Seeded to now so a fresh pipe waits a
-    // full gap before its first backstop.
-    let mut last_notify = std::time::Instant::now();
-    let stats = |established: bool, heartbeats, commands, last_read: Option<_>| {
+    let stats = |established: bool, commands, last_read: Option<_>| {
         let last = match last_read {
             Some(d) => format!(
                 "{:.1}s ago",
@@ -1346,8 +1553,7 @@ async fn reader_task(
             None => "never".to_owned(),
         };
         format!(
-            "established={established}, heartbeats={heartbeats}, commands={commands}, \
-             age={:.1}s, last_read={last}",
+            "established={established}, commands={commands}, age={:.1}s, last_read={last}",
             start.elapsed().as_secs_f64(),
         )
     };
@@ -1357,7 +1563,7 @@ async fn reader_task(
         // its own at creation, before any frame arrives).
         let read = framing::read_frame(&mut recv, &shm.mapper, shm.client());
         match read.await {
-            Ok(Incoming::Command(action)) => {
+            Ok(action) => {
                 last_read = Some(start.elapsed());
                 commands += 1;
                 // The peer's Establish is how we learn its identity: reading it is
@@ -1376,29 +1582,12 @@ async fn reader_task(
                 if matches!(action, ConnectionCommand::Severed { .. }) {
                     let _ = peer_responded.send(());
                 }
-                // Throttled liveness backstop: an ordinary frame proves the pipe is
-                // live even if the peer's beats stopped. `TransportActivity` refreshes
-                // the heartbeat_task's deadline and is a no-op for delegation.
-                if last_notify.elapsed() >= backstop_gap {
-                    last_notify = std::time::Instant::now();
-                    let _ = hb_events.send(HeartbeatEvent::ReceivedHeartbeat(
-                        Heartbeat::TransportActivity,
-                    ));
-                }
                 if loop_tx
                     .send(Command::ConnectionAction { connection, action })
                     .is_err()
                 {
                     return;
                 }
-            }
-            Ok(Incoming::Heartbeat(heartbeat)) => {
-                last_read = Some(start.elapsed());
-                heartbeats += 1;
-                // A real beat: forward it (with its coverage diff / delegate
-                // instruction) and count it as a notification for the backstop.
-                last_notify = std::time::Instant::now();
-                let _ = hb_events.send(HeartbeatEvent::ReceivedHeartbeat(heartbeat));
             }
             Err(err) => {
                 let _ = peer_responded.send(());
@@ -1417,7 +1606,7 @@ async fn reader_task(
                     }
                     format!(
                         "quic connection closed: {detail} ({})",
-                        stats(established, heartbeats, commands, last_read)
+                        stats(established, commands, last_read)
                     )
                     .into_bytes()
                 } else {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* __->__ #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Move direct and delegated QUIC heartbeats onto dedicated high-priority bidirectional streams so large data and side-channel messages cannot head-of-line block liveness traffic. Raise the configurable stream receive window and add Python stress and smoke coverage for heartbeat survival during sustained large transfers and idle settle periods.

Differential Revision: [D111134463](https://our.internmc.facebook.com/intern/diff/D111134463/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D111134463/)!