### PR TITLE
32/43 minimonarch: Add examples and per-actor Rust receive

### DIFF
--- a/monarch_mini/IMPLEMENTATION.md
+++ b/monarch_mini/IMPLEMENTATION.md
@@ -12,6 +12,89 @@ Philosophy:
 
 ---
 
+## A Complete Example
+
+The whole API fits in a short program. A root `parent` joins two children, `a`
+and `b`, that each *serve* a quic listener on loopback; the parent sends `a` a
+message, then `a` *monitors* its sibling `b` and observes its death.
+
+Two children are what makes `monitor` worth showing: a parent↔child link is
+already watched implicitly (a severed link is delivered via the `failure`
+prefix registered on `serve`/`join`), so an explicit `monitor` only matters
+*between actors with no direct link* — here `a` has no connection to `b`, so it
+must monitor `b` by name. When `b` dies, **both** notices fire: the parent's
+implicit link failure (`[failure_prefix, b, reason]`, carrying `b`'s own death
+reason) and `a`'s explicit monitor (`[failure_prefix, b, "actor died"]`, always
+that fixed reason). The monitor climbs to their common ancestor (the parent) and
+fires from there.
+
+quic reads its TLS material from `MM_QUIC_CERT` / `MM_QUIC_KEY` / `MM_QUIC_CA`
+(see `mast/smoke.py`); an actor that serves a quic listener carries that address
+as the `@endpoint` in its ident, while a root omits the `@` entirely.
+
+Both bindings read *per actor*: Python's `actor.next()` and Rust's
+`actor.recv()` each return that one actor's next message. (Rust also has an
+explicit [`Poller`] for fanning in over many actors at once; `recv` is the
+single-actor convenience that lazily makes a poller under the hood.)
+
+### Python
+
+```python
+import asyncio, minimonarch as mm
+ba = mm.bytearray
+
+async def main():
+    parent = mm.Actor(b"parent")                                    # root; ident omits the @endpoint
+    a, b = mm.Actor(b"a@[::1]:7001"), mm.Actor(b"b@[::1]:7002")
+    a.serve("quic://[::1]:7001", "child"); b.serve("quic://[::1]:7002", "child")
+    parent.join("quic://[::1]:7001", "parent", failure=[ba(b"LINKDOWN")])
+    parent.join("quic://[::1]:7002", "parent", failure=[ba(b"LINKDOWN")])
+    await a.next(); await b.next(); await parent.next(); await parent.next()   # 4 establishment hellos
+
+    parent.send(b"a@[::1]:7001", [ba(b"ping")])                     # route a message parent -> a
+    print(await a.next())                                           # [b"ping"]
+
+    a.monitor(b"b@[::1]:7002", failure=[ba(b"DOWN")])               # sibling monitor: a has no link to b
+    b.die(b"bye")
+    # b's death reaches both actors linked to it:
+    print(await parent.next())   # parent link failed: [b"LINKDOWN", b"b@[::1]:7002", b"bye"]
+    print(await a.next())        # a's monitor fired:   [b"DOWN", b"b@[::1]:7002", b"actor died"]
+
+asyncio.run(main())
+```
+
+### Rust
+
+```rust
+use monarch_mini_rs::{Context, Part, Role};
+
+#[tokio::main]
+async fn main() -> Result<(), monarch_mini_rs::Error> {
+    let ctx = Context::new()?;
+    let parent = ctx.actor(Some(b"parent"), true)?;                 // root; ident omits the @endpoint
+    let a = ctx.actor(Some(b"a@[::1]:7001"), true)?;
+    let b = ctx.actor(Some(b"b@[::1]:7002"), true)?;
+
+    a.serve("quic://[::1]:7001", Role::Child, None, &[], &[])?;
+    b.serve("quic://[::1]:7002", Role::Child, None, &[], &[])?;
+    parent.join("quic://[::1]:7001", Role::Parent, None, &[], &[b"LINKDOWN"])?;
+    parent.join("quic://[::1]:7002", Role::Parent, None, &[], &[b"LINKDOWN"])?;
+    a.recv().await?; b.recv().await?; parent.recv().await?; parent.recv().await?;  // 4 establishment hellos
+
+    parent.send(b"a@[::1]:7001", vec![Part::copy_from(b"ping")])?;  // route a message parent -> a
+    println!("{:?}", a.recv().await?);                              // [b"ping"]
+
+    a.monitor(b"b@[::1]:7002", &[b"DOWN"], 0)?;                      // sibling monitor: a has no link to b
+    b.die(b"bye");
+    // b's death reaches both actors linked to it:
+    println!("{:?}", parent.recv().await?);  // parent link failed: [b"LINKDOWN", b"b@[::1]:7002", b"bye"]
+    println!("{:?}", a.recv().await?);        // a's monitor fired:   [b"DOWN", b"b@[::1]:7002", b"actor died"]
+    Ok(())
+}
+```
+
+---
+
 ## Context
 
 The context is the single runtime state object for a process. It owns:

--- a/monarch_mini/README.md
+++ b/monarch_mini/README.md
@@ -1,0 +1,123 @@
+# mimic
+
+*A miniature Monarch actor system in 16 C functions and 6 MB.*
+
+API inspired by zmq: what is the smallest set of functionality to get monitored actors?
+
+```c
+// ctx_t - context, owns the event loop, one per process
+err_t ctx_create(ctx_t* out);
+void ctx_destroy(ctx_t ctx);
+
+// actor_t - actor, actor tree also establishes message routing and acts as gateways.
+err_t actor_create(ctx_t ctx, msg_part_t* ident, bool gateway, actor_t* out);
+void actor_destroy(actor_t actor);
+
+err_t actor_send(actor_t actor, msg_part_t receiver_ident, const msg_t* msg);
+
+void actor_die(actor_t actor, msg_part_t reason);
+
+err_t actor_serve(actor_t actor, const char* url, const connect_args_t* args);
+err_t actor_join(actor_t actor, const char* url, const connect_args_t* args);
+
+err_t actor_monitor(actor_t actor, msg_part_t to_monitor_ident, const msg_t* failure_prefix, uint64_t timeout_for_nonexistence, monitor_handle_t* out);
+void monitor_handle_cancel(actor_t actor, monitor_handle_t handle);
+
+err_t poller_create(ctx_t ctx, int* fd_out, poller_t* out);
+void poller_destroy(poller_t poller);
+err_t poller_subscribe(poller_t poller, size_t index, actor_t actor);
+void poller_unsubscribe(poller_t poller, size_t index);
+
+err_t poller_next(poller_t poller, size_t* index_out, msg_part_t* parts, size_t parts_cap, size_t* n_parts_out);
+
+const char* last_error(void);
+```
+
+With Python bindings:
+
+```python
+import asyncio, minimonarch as mm
+ba = mm.bytearray
+
+async def main():
+    parent = mm.Actor(b"parent")
+    a, b = mm.Actor(b"a@[::1]:7001"), mm.Actor(b"b@[::1]:7002")
+    a.serve("quic://[::1]:7001", "child"); b.serve("quic://[::1]:7002", "child")
+    parent.join("quic://[::1]:7001", "parent", failure=[ba(b"LINKDOWN")])
+    parent.join("quic://[::1]:7002", "parent", failure=[ba(b"LINKDOWN")])
+    await a.next(); await b.next(); await parent.next(); await parent.next()   # 4 establishment hellos
+
+    parent.send(b"a@[::1]:7001", [ba(b"ping")])                     # route a message parent -> a
+    print(await a.next())                                           # [b"ping"]
+
+    a.monitor(b"b@[::1]:7002", failure=[ba(b"DOWN")])               # sibling monitor: a has no link to b
+    b.die(b"bye")
+    # b's death reaches both actors linked to it:
+    print(await parent.next())   # parent link failed: [b"LINKDOWN", b"b@[::1]:7002", b"bye"]
+    print(await a.next())        # a's monitor fired:   [b"DOWN", b"b@[::1]:7002", b"actor died"]
+
+asyncio.run(main())
+```
+
+Or Rust bindings:
+
+```rust
+use monarch_mini_rs::{Context, Part, Role};
+
+#[tokio::main]
+async fn main() -> Result<(), monarch_mini_rs::Error> {
+    let ctx = Context::new()?;
+    let parent = ctx.actor(Some(b"parent"), true)?;
+    let a = ctx.actor(Some(b"a@[::1]:7001"), true)?;
+    let b = ctx.actor(Some(b"b@[::1]:7002"), true)?;
+
+    a.serve("quic://[::1]:7001", Role::Child, None, &[], &[])?;
+    b.serve("quic://[::1]:7002", Role::Child, None, &[], &[])?;
+    parent.join("quic://[::1]:7001", Role::Parent, None, &[], &[b"LINKDOWN"])?;
+    parent.join("quic://[::1]:7002", Role::Parent, None, &[], &[b"LINKDOWN"])?;
+    a.recv().await?; b.recv().await?; parent.recv().await?; parent.recv().await?;  // 4 establishment hellos
+
+    parent.send(b"a@[::1]:7001", vec![Part::copy_from(b"ping")])?;  // route a message parent -> a
+    println!("{:?}", a.recv().await?);                              // [b"ping"]
+
+    a.monitor(b"b@[::1]:7002", &[b"DOWN"], 0)?;                      // sibling monitor: a has no link to b
+    b.die(b"bye");
+    // b's death reaches both actors linked to it:
+    println!("{:?}", parent.recv().await?);  // parent link failed: [b"LINKDOWN", b"b@[::1]:7002", b"bye"]
+    println!("{:?}", a.recv().await?);        // a's monitor fired:   [b"DOWN", b"b@[::1]:7002", b"actor died"]
+    Ok(())
+}
+```
+
+## Conceptual differences from Monarch
+
+- Serve/join links represent physical parent/child relationships; children do not outlast parents.
+- Despite manual parent/child links, any actor can message any other actor in the same tree.
+- The connection links are always represented by parent/child actor pairs.
+
+## Built on what we learned building Monarch
+
+- Careful separation of user and message-system event loops.
+- Immediate generation of actor ids.
+- Join/serve direction is independent of parent/child and of who names whom.
+- Gateways providing addressable entry points to a single machine.
+- Monitoring as a key primitive for building supervision relationships.
+- Offloading of heartbeating to enable scale-out of gateways.
+
+## New experiments to make things more minimal
+
+- No opinions about message serialization: messages are multi-part, with each part just being bytes.
+- No opinion about the consumer's event loop: we just provide messages received, and a file descriptor to wait on.
+- No ports: instead this is accomplished with headers.
+- No replies: accomplished with headers. Things that reply normally take a prefix — the set of headers to prepend before sending the response. For instance, when a monitor fires it prepends the message with a prefix the user provided when the monitor was created.
+- quic for scalable messaging: a root can have thousands of idle connections, and gateways can directly address for cheap routing.
+- The connection between parent and child is the way faults are detected. Heartbeats are just the way the quic transport type implements connections.
+- Scalable large fan-out implemented at the individual "sea-of-actors" layer. Tested up to 131k actors directly connected to root as a child.
+  - Lets actors fail individually without having to make sure they do not interrupt the liveness of other directly connected actors.
+  - Uses quic, and large fan-in actors delegate heartbeating to siblings at the connection transport level to implement it.
+- Passes large messages between processes using shared-memory allocations to avoid copies.
+- Monitors are implemented as subscriptions to the death of an actor, or the death of its gateway, so non-gateway actor deaths are reported immediately.
+
+## Performance
+
+Simple design means baseline linear performance is pretty good: with 131k direct quic connections to 4096 unique CPU machines, the root can send a message to everyone and get a response in 6 seconds from Python.

--- a/monarch_mini/rust/src/lib.rs
+++ b/monarch_mini/rust/src/lib.rs
@@ -26,11 +26,14 @@
 //!   an error rather than misbehaving.
 //! - [`Actor`] is an addressable endpoint: [`send`](Actor::send),
 //!   [`serve`](Actor::serve), [`join`](Actor::join), [`die`](Actor::die),
-//!   [`monitor`](Actor::monitor).
-//! - [`Poller`] drives message delivery. Subscribe actors to it, then drain
-//!   with [`try_recv`](Poller::try_recv) (non-blocking) or [`recv`](Poller::recv)
-//!   (blocks on the wakeup fd), integrating with any fd-based event loop via
-//!   [`fd`](Poller::fd).
+//!   [`monitor`](Actor::monitor), and [`recv`](Actor::recv) to await this
+//!   actor's own next message (the analogue of Python's `actor.next()`).
+//! - [`Poller`] drives message delivery for *several* actors at once. Subscribe
+//!   actors to it, then drain with [`try_recv`](Poller::try_recv) (non-blocking)
+//!   or [`recv`](Poller::recv) (blocks on the wakeup fd), integrating with any
+//!   fd-based event loop via [`fd`](Poller::fd). [`Actor::recv`] is the
+//!   single-actor convenience built on top: it lazily creates and stores a
+//!   private poller the first time it is called.
 //! - [`Part`] is a multipart-message segment. It owns its bytes (like
 //!   `minimonarch.bytearray`) and can be *moved* into a message zero-copy —
 //!   including forwarding a received part without copying.
@@ -46,12 +49,8 @@
 //! let ctx = Context::new()?;
 //! let actor = ctx.actor(Some(b"hello-actor"), /*gateway=*/ true)?;
 //!
-//! let mut poller = ctx.poller()?;
-//! poller.subscribe(0, &actor)?;
-//!
 //! actor.send(b"hello-actor", vec![Part::copy_from(b"hello, self")])?;
-//! let (index, parts) = poller.recv().await?;
-//! assert_eq!(index, 0);
+//! let parts = actor.recv().await?; // lazily creates this actor's own poller
 //! assert_eq!(parts[0].as_bytes(), b"hello, self");
 //! # Ok(())
 //! # }
@@ -374,7 +373,11 @@ impl Context {
         // valid part whose ownership transfers to the runtime; `out` is ours.
         let err = unsafe { ffi::mm_actor_create(self.ptr, ident_ptr, gateway, &mut ptr) };
         check(err)?;
-        Ok(Actor { ptr })
+        Ok(Actor {
+            ptr,
+            ctx: self.ptr,
+            poller: tokio::sync::Mutex::new(None),
+        })
     }
 
     /// Create a [`Poller`] bound to this context.
@@ -415,13 +418,26 @@ impl Drop for Context {
 /// misbehaving.
 pub struct Actor {
     ptr: *mut ffi::mm_actor,
+    // The context this actor was created from, kept so [`Actor::recv`] can lazily
+    // build its own [`Poller`]. A raw pointer (not a `Context` handle) so an
+    // actor never keeps the runtime alive; if the context is gone, poller
+    // creation simply errors.
+    ctx: *mut ffi::mm_ctx,
+    // A per-actor poller, created on the first call to [`Actor::recv`] and reused
+    // thereafter, so `actor.recv().await` works without the caller ever managing
+    // a [`Poller`] — the Rust analogue of the Python bindings' `actor.next()`.
+    // Behind a `tokio::sync::Mutex` (whose guard is held across the `await`) so
+    // the actor stays `Send + Sync` even though a `Poller` is `!Sync`.
+    poller: tokio::sync::Mutex<Option<Poller>>,
 }
 
-// SAFETY: every `Actor` method takes `&self` and only forwards a command to the
-// runtime over its internal `Send + Sync` channel (monitor-id allocation uses an
-// atomic), so an `Actor` is safe to move between threads (`Send`) and to call
-// concurrently from several threads (`Sync`) — the classic "send from many
-// threads" pattern.
+// SAFETY: every `Actor` method forwards a command to the runtime over its
+// internal `Send + Sync` channel (monitor-id allocation uses an atomic), so an
+// `Actor` is safe to move between threads (`Send`) and to call concurrently from
+// several threads (`Sync`) — the classic "send from many threads" pattern. The
+// raw pointers are just runtime handles; the lazily-created per-actor poller is
+// guarded by a `tokio::sync::Mutex` (itself `Send + Sync` since `Poller: Send`),
+// which serializes the otherwise-`!Sync` poller's use.
 unsafe impl Send for Actor {}
 unsafe impl Sync for Actor {}
 
@@ -566,6 +582,48 @@ impl Actor {
         unsafe { ffi::mm_monitor_handle_cancel(self.ptr, monitor.handle) };
     }
 
+    /// Await this actor's next delivered message — the Rust analogue of the
+    /// Python bindings' awaitable `actor.next()`.
+    ///
+    /// On the first call, the actor lazily creates a private [`Poller`],
+    /// subscribes itself to it, and stores it on the handle; subsequent calls
+    /// reuse it. This is the convenience path for the common "just read this
+    /// actor's messages" case, so the caller never has to manage a [`Poller`]
+    /// or actor indices. Must be called from within a Tokio runtime.
+    ///
+    /// Do not also subscribe this actor to a separate [`Poller`]: the C ABI
+    /// allows an actor on at most one poller at a time, so mixing the two paths
+    /// makes this call (or the manual `subscribe`) fail. For fan-in over many
+    /// actors, use an explicit [`Poller`] instead of per-actor `recv`.
+    pub async fn recv(&self) -> Result<Vec<Part>> {
+        let mut guard = self.poller.lock().await;
+        if guard.is_none() {
+            *guard = Some(self.make_poller()?);
+        }
+        // The guard is held across the await so the `!Sync` poller is used by
+        // one task at a time; concurrent `recv`s on the same actor serialize.
+        let poller = guard.as_mut().expect("poller just created");
+        let (_index, parts) = poller.recv().await?;
+        Ok(parts)
+    }
+
+    /// Build the actor's private poller and subscribe itself at index 0.
+    fn make_poller(&self) -> Result<Poller> {
+        let mut ptr: *mut ffi::mm_poller = std::ptr::null_mut();
+        let mut fd: RawFd = -1;
+        // SAFETY: `self.ctx` is the context this actor was created from; `fd_out`
+        // and `out` point to slots we own and are populated on success. (If the
+        // context has been dropped, this returns an error instead.)
+        check(unsafe { ffi::mm_poller_create(self.ctx, &mut fd, &mut ptr) })?;
+        let poller = Poller {
+            ptr,
+            fd,
+            async_fd: None,
+        };
+        poller.subscribe(0, self)?;
+        Ok(poller)
+    }
+
     /// The raw actor pointer, for [`Poller::subscribe`].
     fn as_ptr(&self) -> *mut ffi::mm_actor {
         self.ptr
@@ -574,6 +632,10 @@ impl Actor {
 
 impl Drop for Actor {
     fn drop(&mut self) {
+        // Drop the lazily-created per-actor poller (if any) first: it holds this
+        // actor subscribed and owns a wakeup fd, so it must be torn down before
+        // the actor. `get_mut` needs no lock — we have exclusive access here.
+        self.poller.get_mut().take();
         // SAFETY: `self.ptr` is a live actor we own; this consumes it.
         unsafe { ffi::mm_actor_destroy(self.ptr) };
     }

--- a/monarch_mini/src/quic_transport.rs
+++ b/monarch_mini/src/quic_transport.rs
@@ -135,9 +135,9 @@ fn shutdown_ack_timeout() -> Duration {
 /// very many connections all mid-large-transfer — so it is env-tunable
 /// (`MM_QUIC_STREAM_RECV_WINDOW_BYTES`). Only the data stream ever fills it; the
 /// companion heartbeat stream carries tiny frames. The connection-level
-/// `receive_window` is left at quinn's default (`VarInt::MAX`); with just two
-/// streams per connection the per-stream window already bounds what one connection
-/// can buffer.
+/// `receive_window` is raised in lockstep (to `window * 8`, matching the send
+/// window) in [`load_tls`] so the connection does not re-throttle its streams below
+/// this per-stream window.
 const DEFAULT_STREAM_RECV_WINDOW_BYTES: u64 = 16 * 1024 * 1024;
 
 fn stream_recv_window_bytes() -> u64 {
@@ -219,6 +219,19 @@ fn load_tls() -> anyhow::Result<TlsConfig> {
     let window = stream_recv_window_bytes();
     transport.stream_receive_window(VarInt::from_u64(window).unwrap_or(VarInt::MAX));
     transport.send_window(window.saturating_mul(8));
+    // Raise the connection-level receive window in lockstep with the send window so
+    // the aggregate of a connection's streams can fill the bandwidth-delay product
+    // on a high-RTT cross-region path, rather than being re-throttled below the
+    // per-stream window. Sized to match `send_window` (window * 8).
+    let conn_window = window.saturating_mul(8);
+    transport.receive_window(VarInt::from_u64(conn_window).unwrap_or(VarInt::MAX));
+    // Congestion control: quinn defaults to CUBIC, which on a high-RTT cross-region
+    // path with sporadic loss ramps slowly and backs off hard (quinn#2262: CUBIC
+    // stalls at ~1 MiB cwnd where iperf/BBR reach the BDP). Pin BBR unconditionally
+    // — it is delay-model-based and holds a higher steady rate across light loss,
+    // and on loopback / the lossless intra-cluster fabric it is ~neutral. quinn
+    // re-exports BbrConfig at quinn::congestion.
+    transport.congestion_controller_factory(Arc::new(quinn::congestion::BbrConfig::default()));
     let transport = Arc::new(transport);
 
     let mut server = ServerConfig::with_single_cert(load_certs(&cert_path)?, load_key(&key_path)?)?;


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* __->__ #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add a concise README and end-to-end Python and Rust examples that demonstrate joining, messaging, sibling monitoring, and failure delivery. Add `Actor::recv` backed by a lazily created per-actor poller, and tune QUIC receive flow control plus BBR for high-RTT transfers.

Differential Revision: [D111470664](https://our.internmc.facebook.com/intern/diff/D111470664/)