### PR TITLE
35/43 minimonarch: Add TLS-over-TCP transport and smoke-test support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4742,6 +4742,7 @@ dependencies = [
  "slotmap",
  "socket2 0.6.5",
  "tokio",
+ "tokio-rustls",
  "tracing",
 ]
 

--- a/monarch_mini/mast/local_smoke.py
+++ b/monarch_mini/mast/local_smoke.py
@@ -94,6 +94,13 @@ def main() -> None:
         "--debug", action="store_true", help="set MM_QUIC_DEBUG=1 (MM_HB logs)"
     )
     parser.add_argument(
+        "--transport",
+        choices=["quic", "tcp"],
+        default="quic",
+        help="network transport for the worker serve / root join (default: quic). "
+        "tcp is the cross-region fallback; both sides use the same value.",
+    )
+    parser.add_argument(
         "--logdir",
         default=None,
         help="if set, each worker/root writes its own stdout+stderr file here "
@@ -131,6 +138,8 @@ def main() -> None:
                 "--worker",
                 "--port",
                 str(p),
+                "--transport",
+                args.transport,
             ],
             env=env,
             stdout=out,
@@ -158,6 +167,8 @@ def main() -> None:
                 "5",
                 "--connect-timeout",
                 "30",
+                "--transport",
+                args.transport,
             ],
             env=env,
             stdout=root_out,

--- a/monarch_mini/mast/smoke.py
+++ b/monarch_mini/mast/smoke.py
@@ -151,17 +151,22 @@ def _advertised_host() -> str:
     return infos[0][4][0]
 
 
-def worker_ident(port: int) -> bytes:
+def worker_ident(port: int, transport: str) -> bytes:
     """A unique, human-readable identity for this worker process.
 
-    The ident always carries a dialable gateway ``@tag`` (``...@[<host>]:<port>``)
-    built from this worker's own routable IPv6 (see ``_advertised_host``) so a
-    *sibling* worker can open a side channel to us — which is what lets the root
-    delegate our heartbeat to a sibling.
+    The ident always carries a dialable gateway ``@tag`` built from this worker's own
+    routable IPv6 (see ``_advertised_host``) so a *sibling* worker can open a side
+    channel to us — which is what lets the root delegate our heartbeat to a sibling.
+
+    The tag encodes the transport so ctx routes the side channel correctly: a bare
+    ``...@[<host>]:<port>`` is quic (the backward-compatible default), while tcp uses
+    an explicit ``...@tcp://[<host>]:<port>`` scheme.
     """
-    return (
-        f"worker-{socket.gethostname()}-{port}@[{_advertised_host()}]:{port}".encode()
+    host = _advertised_host()
+    tag = (
+        f"[{host}]:{port}" if transport == "quic" else f"{transport}://[{host}]:{port}"
     )
+    return f"worker-{socket.gethostname()}-{port}@{tag}".encode()
 
 
 def _failure_notice(parts: list) -> tuple[str, str]:
@@ -188,8 +193,8 @@ def _report_progress(label: str, done: int, total: int, step: int) -> None:
         log(f"[root]   {label} {done}/{total} ({pct}%)")
 
 
-async def run_worker(port: int, bind: str) -> None:
-    """Serve a quic listener, answer round-trips, and exit when the root dies.
+async def run_worker(port: int, bind: str, transport: str) -> None:
+    """Serve a listener, answer round-trips, and exit when the root dies.
 
     The worker is the *child* of the root: it serves (listens) and the root
     joins (dials). On each established link the worker learns the root's identity
@@ -207,9 +212,9 @@ async def run_worker(port: int, bind: str) -> None:
     (count+1) to that successor. Ring routing is plain destination routing — a token
     to a sibling or the root climbs to the common ancestor (the root) and back down.
     """
-    ident = worker_ident(port)
+    ident = worker_ident(port, transport)
     tag = f"[worker :{port}]"
-    url = f"quic://[{bind}]:{port}"
+    url = f"{transport}://[{bind}]:{port}"
     me = Actor(ident)
     me.serve(url, "child", failure=[ba(H_FAIL)])
     # pid lets us map the Rust writer's MM_HB heartbeat-send lines (tagged by pid)
@@ -315,6 +320,7 @@ async def run_root(
     chain_length: int = 0,
     close_ctx: bool = True,
     settle_ms: float = 0.0,
+    transport: str = "quic",
 ) -> int:
     """Performance sweep: grow the connected set 2, 4, 8, ..., N and time each size.
 
@@ -352,7 +358,7 @@ async def run_root(
             batch = hosts[joined:size]
             t_join = time.monotonic()
             for host in batch:
-                root.join(f"quic://{host}", "parent", failure=[ba(H_FAIL)])
+                root.join(f"{transport}://{host}", "parent", failure=[ba(H_FAIL)])
             joined = size
             while len(workers) < size:
                 try:
@@ -441,6 +447,7 @@ async def run_root_coordinated(
     min_rounds: int = 1,
     chain_length: int = 0,
     settle_ms: float = 0.0,
+    transport: str = "quic",
 ) -> int:
     """Root variant that waits for a controller to hand it the worker addresses.
 
@@ -455,8 +462,9 @@ async def run_root_coordinated(
     the controller before tearing the context down.
     """
     coord = Actor(b"coord")
-    coord.serve(f"quic://[{bind}]:{coord_port}", "child", failure=[ba(H_FAIL)])
-    log(f"[coord] serving quic://[{bind}]:{coord_port}; waiting for controller...")
+    coord_url = f"{transport}://[{bind}]:{coord_port}"
+    coord.serve(coord_url, "child", failure=[ba(H_FAIL)])
+    log(f"[coord] serving {coord_url}; waiting for controller...")
 
     # Establishment hello: [self_ident, controller_ident].
     hello = await coord.next()
@@ -495,6 +503,7 @@ async def run_root_coordinated(
         chain_length,
         close_ctx=False,
         settle_ms=settle_ms,
+        transport=transport,
     )
 
     log(f"[coord] sweep finished rc={rc}; notifying controller and closing")
@@ -546,6 +555,14 @@ def main() -> None:
         "--certs-dir", default=None, help="directory holding cert.pem/key.pem/ca.pem"
     )
     parser.add_argument(
+        "--transport",
+        choices=["quic", "tcp"],
+        default="quic",
+        help="network transport for worker serve / root join (default: quic). "
+        "quic is UDP-based (same-region); tcp is the cross-region fallback. The "
+        "worker/root pair MUST agree on this.",
+    )
+    parser.add_argument(
         "--timeout",
         type=float,
         default=60.0,
@@ -586,7 +603,7 @@ def main() -> None:
     ensure_quic_certs(args.certs_dir)
 
     if args.worker:
-        asyncio.run(run_worker(args.port, args.bind))
+        asyncio.run(run_worker(args.port, args.bind, args.transport))
     elif args.wait_for_addresses is not None:
         sys.exit(
             asyncio.run(
@@ -598,6 +615,7 @@ def main() -> None:
                     args.min_rounds,
                     args.chain_length,
                     args.settle_ms,
+                    args.transport,
                 )
             )
         )
@@ -616,6 +634,7 @@ def main() -> None:
                     args.min_rounds,
                     args.chain_length,
                     settle_ms=args.settle_ms,
+                    transport=args.transport,
                 )
             )
         )

--- a/monarch_mini/src/ctx.rs
+++ b/monarch_mini/src/ctx.rs
@@ -54,13 +54,15 @@ use crate::shm::ShmClient;
 use crate::shm::ShmClientSlot;
 use crate::shm::ShmMapper;
 use crate::shm::ShmServer;
+use crate::tcp_net::Tcp;
 use crate::transport::Transport;
 use crate::unix_transport::UnixTransport;
 
-/// The command-loop-facing QUIC transport: the generic [`NetTransport`] pinned to the
-/// [`Quic`] protocol. All transport logic is protocol-independent; only the [`Quic`]
-/// `Net` impl is quic-specific.
+/// The command-loop-facing network transports: the generic [`NetTransport`] pinned to
+/// each protocol. All transport logic is protocol-independent; only the [`Quic`]/
+/// [`Tcp`] `Net` impls are protocol-specific.
 type QuicTransport = NetTransport<Quic>;
+type TcpTransport = NetTransport<Tcp>;
 
 /// Whether verbose per-connection debug logging is enabled (`MM_QUIC_DEBUG` set).
 /// Gates the command-loop `MM_CTX`/`MM_UDP` lines and scheduler-lag probe here, and
@@ -117,15 +119,18 @@ pub(crate) fn wall_clock_hms() -> String {
 /// is attached, while the request can still report failure — without a `&mut self`
 /// borrow.
 fn valid_scheme(url: &str) -> bool {
-    url.starts_with("inproc://") || url.starts_with("unix://") || url.starts_with("quic://")
+    url.starts_with("inproc://")
+        || url.starts_with("unix://")
+        || url.starts_with("quic://")
+        || url.starts_with("tcp://")
 }
 
 /// Whether `url`'s scheme connects across machines (a network transport). A
 /// gateway may only gain a parent over such a link — a gateway joined to a
 /// unix/inproc parent is rejected, since it would no longer be the entry point
-/// for its process group. (Today only quic; tcp joins this set later.)
+/// for its process group.
 fn is_network_scheme(url: &str) -> bool {
-    url.starts_with("quic://")
+    url.starts_with("quic://") || url.starts_with("tcp://")
 }
 
 /// The gateway specifier (the `@endpoint` suffix) of an ident, or an empty slice
@@ -288,6 +293,11 @@ struct Ctx {
     inproc: InprocTransport,
     unix: UnixTransport,
     quic: QuicTransport,
+    // TCP is the cross-region fallback (quic's UDP is packet-filtered across
+    // regions). An actor is reached over tcp iff its `@endpoint` tag carries the
+    // `tcp://` scheme; a bare or `quic://` tag routes over quic (see
+    // `send_to_gateway` and `valid_scheme`).
+    tcp: TcpTransport,
     // The context-global shared-memory address-space manager. Always present
     // (idle if shm is unused); handed to the unix and quic transports, and unmaps
     // everything when the context — and thus this last reference — is dropped.
@@ -336,6 +346,7 @@ impl Ctx {
             inproc: InprocTransport::new(tx.clone()),
             unix: UnixTransport::new(tx.clone(), mapper.clone()),
             quic: QuicTransport::new(tx.clone(), mapper.clone(), shm_client.clone()),
+            tcp: TcpTransport::new(tx.clone(), mapper.clone(), shm_client.clone()),
             mapper,
             shm_server: None,
             shm_client,
@@ -663,6 +674,8 @@ impl Ctx {
             &mut self.unix
         } else if url.starts_with("quic://") {
             &mut self.quic
+        } else if url.starts_with("tcp://") {
+            &mut self.tcp
         } else {
             unreachable!("scheme already validated by valid_scheme");
         }
@@ -1712,7 +1725,16 @@ impl Ctx {
         match std::str::from_utf8(tag) {
             Ok(tag) => {
                 let tag = tag.to_owned();
-                self.quic.send_to_gateway(tag, msg);
+                // Pick the transport from the tag's scheme: a `tcp://` gateway is
+                // reached over tcp, everything else (a bare `@addr`, for backward
+                // compat, or an explicit `quic://`) over quic. The tag is passed
+                // through verbatim; each transport's `parse_addr` strips its own
+                // scheme prefix.
+                if tag.starts_with("tcp://") {
+                    self.tcp.send_to_gateway(tag, msg);
+                } else {
+                    self.quic.send_to_gateway(tag, msg);
+                }
             }
             Err(_) => {
                 tracing::warn!("gateway destination has non-utf8 specifier; dropping message");
@@ -2276,6 +2298,7 @@ impl CtxHandle {
                             // the coroutines) is torn down.
                             ctx.unix.shutdown().await;
                             ctx.quic.shutdown().await;
+                            ctx.tcp.shutdown().await;
                             let thread = ctx
                                 .thread
                                 .take()

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -19,6 +19,7 @@ mod net_transport;
 mod poller;
 mod quic_net;
 mod shm;
+mod tcp_net;
 mod transport;
 mod unix_framing;
 mod unix_transport;

--- a/monarch_mini/src/tcp_net.rs
+++ b/monarch_mini/src/tcp_net.rs
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! TCP implementation of the [`Net`] transport seam — the cross-region fallback.
+//!
+//! QUIC runs over UDP, which is silently packet-filter-dropped across regions, so a
+//! devserver can only reach same-region QUIC workers. A TLS-over-TCP flow is what the
+//! cross-region enforcer clears, so `tcp://` reaches workers in any region. It reuses
+//! the same TLS material as quic (`MM_QUIC_CERT`/`MM_QUIC_KEY`/`MM_QUIC_CA`), verified
+//! against the CA for the fixed server name [`SERVER_NAME`].
+//!
+//! Everything protocol-independent — establishment, heartbeats (on their own stream),
+//! matching serves to joins, side channels, retry/backoff, shutdown — lives in
+//! [`crate::net_transport`], generic over [`Net`]. This module supplies only the raw
+//! networking. The command loop drives tcp as `NetTransport<Tcp>` (aliased
+//! `TcpTransport` in [`crate::ctx`]).
+//!
+//! ## Streams: one socket each, paired by a prefix
+//!
+//! A QUIC connection multiplexes its two streams (data + heartbeat) on one transport
+//! connection; TCP has no multiplexing, so each stream is its own TLS-over-TCP socket.
+//! Unlike quic — where a stream is materialized lazily and the "first messenger" side
+//! opens it — TCP must open **both** sockets up front on connect: the generic layer
+//! may make either side the first messenger of a given stream, and a plain socket has
+//! no way to be opened "from the accepting side". So the dialer opens all `streams`
+//! sockets eagerly, each prefixed with `(connection_id, stream_index)`; the listener
+//! reads that prefix and groups sockets with the same id into one logical connection,
+//! ordered by index. [`NetConn::stream`] then just hands back the pre-opened sockets
+//! in order (`first_messenger` is irrelevant — a socket is full-duplex). This is
+//! cruder than the quic path (two sockets even for a message-only side channel, and a
+//! slow TLS handshake head-of-line-blocks accept), but tcp is the fallback, so simple
+//! and correct beats optimal.
+//!
+//! ## No transport keepalive
+//!
+//! A root opens a huge number of connections, so — exactly like the quic side, which
+//! disables quinn's PING keep-alive and idle timeout — these sockets must carry **zero**
+//! periodic per-connection traffic of their own. We never enable TCP keepalive
+//! (`SO_KEEPALIVE`, off by default and left off), and TCP has no idle timeout, so an
+//! idle connection stays open sending nothing. Liveness is entirely the heartbeat
+//! subsystem's job (its own stream, and delegated so the root's steady-state cost is
+//! bounded); a link with no heartbeat obligation — e.g. a delegated one — is genuinely
+//! silent, which is what lets the connection count scale.
+
+use std::cell::Cell;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fmt;
+use std::future::Ready;
+use std::hash::BuildHasher;
+use std::io;
+use std::net::SocketAddr;
+use std::pin::Pin;
+use std::rc::Rc;
+use std::rc::Weak;
+use std::sync::Arc;
+use std::task::Context;
+use std::task::Poll;
+use std::time::Duration;
+
+use rustls::RootCertStore;
+use rustls_pki_types::CertificateDer;
+use rustls_pki_types::PrivateKeyDer;
+use rustls_pki_types::ServerName;
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWrite;
+use tokio::io::AsyncWriteExt;
+use tokio::io::ReadBuf;
+use tokio::io::ReadHalf;
+use tokio::io::WriteHalf;
+use tokio::net::TcpListener;
+use tokio::net::TcpStream;
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::TlsConnector;
+use tokio_rustls::client::TlsStream as ClientTlsStream;
+use tokio_rustls::server::TlsStream as ServerTlsStream;
+
+use crate::net::Net;
+use crate::net::NetConn;
+
+/// Server name the client uses to verify the server's certificate (the cert's SAN
+/// must cover it). Shared with the quic transport, which uses the same cert set.
+const SERVER_NAME: &str = "monarch-mini";
+
+/// How long a connection may stay half-paired — some of its sockets arrived, but not
+/// all — before the listener reaps it, dropping the sockets that did arrive and freeing
+/// their fds.
+///
+/// Deliberately **longer than the heartbeat timeout**: a connection whose sockets pair
+/// (even slowly) finishes setup and starts heartbeating well within this window, so we
+/// never reap a valid pairing; and once set up, an inactive link is severed by the
+/// heartbeat subsystem, not by us. That makes a reap indistinguishable from "the
+/// connection set up, then was severed for inactivity" — a path the peer already
+/// handles — rather than a special failure. A truly abandoned pairing (a client that
+/// could not open every socket, so its `connect` failed and the generic connector is
+/// already retrying with a fresh id) is all that is left for us to clean up.
+fn pending_reap_timeout() -> Duration {
+    crate::heartbeat::heartbeat_timeout() * 2
+}
+
+/// The ring crypto provider, passed explicitly to every rustls config builder so this
+/// transport does not depend on a process-global default being installed.
+fn provider() -> Arc<rustls::crypto::CryptoProvider> {
+    Arc::new(rustls::crypto::ring::default_provider())
+}
+
+/// Server + client TLS configs, built once from the environment and shared by all tcp
+/// serves/joins in this context.
+struct TlsConfig {
+    server: Arc<rustls::ServerConfig>,
+    client: Arc<rustls::ClientConfig>,
+}
+
+fn load_certs(path: &str) -> anyhow::Result<Vec<CertificateDer<'static>>> {
+    let data = std::fs::read(path).map_err(|err| anyhow::anyhow!("reading {path}: {err}"))?;
+    let certs = rustls_pemfile::certs(&mut &data[..]).collect::<Result<Vec<_>, _>>()?;
+    anyhow::ensure!(!certs.is_empty(), "no certificates in {path}");
+    Ok(certs)
+}
+
+fn load_key(path: &str) -> anyhow::Result<PrivateKeyDer<'static>> {
+    let data = std::fs::read(path).map_err(|err| anyhow::anyhow!("reading {path}: {err}"))?;
+    rustls_pemfile::private_key(&mut &data[..])?
+        .ok_or_else(|| anyhow::anyhow!("no private key in {path}"))
+}
+
+fn load_tls() -> anyhow::Result<TlsConfig> {
+    let cert_path =
+        std::env::var("MM_QUIC_CERT").map_err(|_| anyhow::anyhow!("MM_QUIC_CERT not set"))?;
+    let key_path =
+        std::env::var("MM_QUIC_KEY").map_err(|_| anyhow::anyhow!("MM_QUIC_KEY not set"))?;
+    let ca_path = std::env::var("MM_QUIC_CA").map_err(|_| anyhow::anyhow!("MM_QUIC_CA not set"))?;
+
+    let server = rustls::ServerConfig::builder_with_provider(provider())
+        .with_safe_default_protocol_versions()
+        .map_err(|err| anyhow::anyhow!("tls server versions: {err}"))?
+        .with_no_client_auth()
+        .with_single_cert(load_certs(&cert_path)?, load_key(&key_path)?)?;
+
+    let mut roots = RootCertStore::empty();
+    for ca in load_certs(&ca_path)? {
+        roots.add(ca)?;
+    }
+    let client = rustls::ClientConfig::builder_with_provider(provider())
+        .with_safe_default_protocol_versions()
+        .map_err(|err| anyhow::anyhow!("tls client versions: {err}"))?
+        .with_root_certificates(roots)
+        .with_no_client_auth();
+
+    Ok(TlsConfig {
+        server: Arc::new(server),
+        client: Arc::new(client),
+    })
+}
+
+/// Parse a `tcp://host:port` (or bare `host:port`) url into a socket address.
+fn parse_addr(url: &str) -> anyhow::Result<SocketAddr> {
+    let authority = url.strip_prefix("tcp://").unwrap_or(url);
+    authority
+        .parse::<SocketAddr>()
+        .map_err(|err| anyhow::anyhow!("invalid tcp address {authority:?}: {err}"))
+}
+
+/// A fresh, effectively-unique connection id used to pair the sockets of one logical
+/// connection at the listener. 128 random bits (two independently-seeded `RandomState`
+/// hashes) — a collision would require two live connections to a single server to draw
+/// the same 128-bit id, which is negligible.
+fn new_connection_id() -> u128 {
+    let hi = std::collections::hash_map::RandomState::new().hash_one(0xA5u8) as u128;
+    let lo = std::collections::hash_map::RandomState::new().hash_one(0x5Au8) as u128;
+    (hi << 64) | lo
+}
+
+/// Write the socket-pairing prefix (`connection_id` then `stream_index`) that lets the
+/// listener group the sockets of one logical connection. Precedes every generic frame.
+async fn write_pairing_prefix<W: AsyncWrite + Unpin>(
+    writer: &mut W,
+    connection_id: u128,
+    stream_index: usize,
+) -> io::Result<()> {
+    writer.write_all(&connection_id.to_le_bytes()).await?;
+    writer.write_all(&[stream_index as u8]).await?;
+    writer.flush().await
+}
+
+/// Read the socket-pairing prefix written by [`write_pairing_prefix`]. `None` on EOF
+/// or a short read (a peer that spoke a bad dialect — the socket is dropped).
+async fn read_pairing_prefix<R: AsyncRead + Unpin>(reader: &mut R) -> Option<(u128, usize)> {
+    let mut id = [0u8; 16];
+    reader.read_exact(&mut id).await.ok()?;
+    let mut index = [0u8; 1];
+    reader.read_exact(&mut index).await.ok()?;
+    Some((u128::from_le_bytes(id), index[0] as usize))
+}
+
+/// A TLS-over-TCP stream, server- or client-side. Both appear as one `Net::Conn`
+/// stream type, so they are unified in an enum that delegates the async IO traits.
+pub(crate) enum TlsStream {
+    Server(ServerTlsStream<TcpStream>),
+    Client(ClientTlsStream<TcpStream>),
+}
+
+impl AsyncRead for TlsStream {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Server(s) => Pin::new(s).poll_read(cx, buf),
+            TlsStream::Client(s) => Pin::new(s).poll_read(cx, buf),
+        }
+    }
+}
+
+impl AsyncWrite for TlsStream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            TlsStream::Server(s) => Pin::new(s).poll_write(cx, buf),
+            TlsStream::Client(s) => Pin::new(s).poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Server(s) => Pin::new(s).poll_flush(cx),
+            TlsStream::Client(s) => Pin::new(s).poll_flush(cx),
+        }
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Server(s) => Pin::new(s).poll_shutdown(cx),
+            TlsStream::Client(s) => Pin::new(s).poll_shutdown(cx),
+        }
+    }
+}
+
+/// The shared per-context TCP state: TLS configs, loaded lazily on first use.
+pub(crate) struct Tcp {
+    tls: Option<Arc<TlsConfig>>,
+}
+
+impl Tcp {
+    fn tls(&mut self) -> anyhow::Result<Arc<TlsConfig>> {
+        if let Some(tls) = &self.tls {
+            return Ok(tls.clone());
+        }
+        let tls = Arc::new(load_tls()?);
+        self.tls = Some(tls.clone());
+        Ok(tls)
+    }
+}
+
+/// A cheap, cloneable dialing handle: the TLS connector plus the fixed server name.
+#[derive(Clone)]
+pub(crate) struct TcpDialer {
+    connector: TlsConnector,
+    server_name: ServerName<'static>,
+}
+
+/// Connection ids mid-pairing, each mapped to its per-index sockets so far. A
+/// completed connection is removed from the map (and handed up); an abandoned one is
+/// removed by its [`reap_unpaired`] timeout coroutine.
+type PendingMap = HashMap<u128, Vec<Option<TlsStream>>>;
+
+/// A bound TCP server plus the pairing state accept needs. `accept` runs the TLS
+/// handshake, reads each socket's pairing prefix, and groups sockets by connection id
+/// until a logical connection has all its streams. `pending` is interior-mutable
+/// because [`Net::accept`] takes `&self` (single-threaded, so the `RefCell` is never
+/// contended and no borrow is held across an await); it is shared with the per-
+/// connection [`reap_unpaired`] timeout coroutines via a `Weak`, so it drops (with any
+/// half-paired sockets) as soon as the listener does.
+pub(crate) struct TcpListenerHandle {
+    listener: TcpListener,
+    acceptor: TlsAcceptor,
+    streams: usize,
+    pending: Rc<RefCell<PendingMap>>,
+}
+
+/// Reap `connection_id` if it never finishes pairing. Spawned when its first socket
+/// arrives: after [`pending_reap_timeout`], if the id is still in the map it never
+/// completed (its client abandoned the connect after opening only some sockets), so
+/// drop it, freeing the orphaned sockets' fds. If the id is already gone, it completed
+/// and there is nothing to do.
+async fn reap_unpaired(pending: Weak<RefCell<PendingMap>>, connection_id: u128) {
+    tokio::time::sleep(pending_reap_timeout()).await;
+    if let Some(pending) = pending.upgrade() {
+        pending.borrow_mut().remove(&connection_id);
+    }
+}
+
+impl Net for Tcp {
+    type Dialer = TcpDialer;
+    type Listener = TcpListenerHandle;
+    type Conn = TcpConn;
+
+    fn create() -> anyhow::Result<Self> {
+        Ok(Self { tls: None })
+    }
+
+    fn parse_addr(url: &str) -> anyhow::Result<SocketAddr> {
+        parse_addr(url)
+    }
+
+    fn dialer(&mut self, _addr: SocketAddr) -> anyhow::Result<TcpDialer> {
+        let connector = TlsConnector::from(self.tls()?.client.clone());
+        let server_name = ServerName::try_from(SERVER_NAME)
+            .map_err(|err| anyhow::anyhow!("tcp server name: {err}"))?
+            .to_owned();
+        Ok(TcpDialer {
+            connector,
+            server_name,
+        })
+    }
+
+    fn bind(&mut self, addr: SocketAddr, streams: usize) -> anyhow::Result<TcpListenerHandle> {
+        let acceptor = TlsAcceptor::from(self.tls()?.server.clone());
+        // `bind` is synchronous (the command loop can't await); build the listener via
+        // std and adopt it into tokio without an await.
+        let std_listener = std::net::TcpListener::bind(addr)?;
+        std_listener.set_nonblocking(true)?;
+        let listener = TcpListener::from_std(std_listener)?;
+        let pending: Rc<RefCell<PendingMap>> = Rc::new(RefCell::new(HashMap::new()));
+        Ok(TcpListenerHandle {
+            listener,
+            acceptor,
+            streams,
+            pending,
+        })
+    }
+
+    async fn accept(listener: &TcpListenerHandle) -> Option<TcpConn> {
+        loop {
+            let Ok((tcp, peer)) = listener.listener.accept().await else {
+                continue; // transient accept error; the listener stays open
+            };
+            let Ok(mut stream) = listener.acceptor.accept(tcp).await.map(TlsStream::Server) else {
+                continue; // TLS handshake failed
+            };
+            let Some((connection_id, index)) = read_pairing_prefix(&mut stream).await else {
+                continue; // bad/short prefix
+            };
+            if index >= listener.streams {
+                continue; // out-of-range index; drop this socket
+            }
+            // Group by connection id. No await is held across this borrow.
+            let mut pending = listener.pending.borrow_mut();
+            let is_new = !pending.contains_key(&connection_id);
+            let slots = pending
+                .entry(connection_id)
+                .or_insert_with(|| (0..listener.streams).map(|_| None).collect());
+            slots[index] = Some(stream);
+            if slots.iter().all(Option::is_some) {
+                // Complete: remove it (so its reaper sees it gone and knows it
+                // completed) and hand it up.
+                let slots = pending.remove(&connection_id).expect("just inserted");
+                let streams = slots
+                    .into_iter()
+                    .map(|s| s.expect("all slots filled"))
+                    .collect();
+                return Some(TcpConn::new(peer, streams));
+            }
+            if is_new {
+                // First socket for this id: bound how long it may stay half-paired.
+                tokio::task::spawn_local(reap_unpaired(
+                    Rc::downgrade(&listener.pending),
+                    connection_id,
+                ));
+            }
+        }
+    }
+
+    async fn connect(dialer: &TcpDialer, addr: SocketAddr, streams: usize) -> Option<TcpConn> {
+        // Open every stream up front (see the module docs): the accepting side may be
+        // the first messenger of a stream, and a plain socket can't be opened from the
+        // accepting side. Each socket is prefixed so the listener can pair them.
+        let connection_id = new_connection_id();
+        let mut opened = Vec::with_capacity(streams);
+        for index in 0..streams {
+            let tcp = TcpStream::connect(addr).await.ok()?;
+            let tls = dialer
+                .connector
+                .connect(dialer.server_name.clone(), tcp)
+                .await
+                .ok()?;
+            let mut stream = TlsStream::Client(tls);
+            write_pairing_prefix(&mut stream, connection_id, index)
+                .await
+                .ok()?;
+            opened.push(stream);
+        }
+        Some(TcpConn::new(addr, opened))
+    }
+}
+
+/// One logical TCP connection: the `streams` pre-opened, pairing-ordered sockets.
+/// [`NetConn::stream`] hands them out in index order (`first_messenger` is irrelevant
+/// — each socket is full-duplex, and both ends already hold their matching socket).
+pub(crate) struct TcpConn {
+    remote: SocketAddr,
+    streams: RefCell<Vec<Option<TlsStream>>>,
+    cursor: Cell<usize>,
+}
+
+impl TcpConn {
+    fn new(remote: SocketAddr, streams: Vec<TlsStream>) -> Self {
+        Self {
+            remote,
+            streams: RefCell::new(streams.into_iter().map(Some).collect()),
+            cursor: Cell::new(0),
+        }
+    }
+}
+
+impl fmt::Debug for TcpConn {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("TcpConn").field(&self.remote).finish()
+    }
+}
+
+impl NetConn for TcpConn {
+    type Send = WriteHalf<TlsStream>;
+    type Recv = ReadHalf<TlsStream>;
+    // The sockets are already open, so producing a stream is synchronous — a ready
+    // future, never touching the wire (the generic layer just awaits it like quic's).
+    type Stream = Ready<io::Result<(Self::Send, Self::Recv)>>;
+
+    fn stream(&self, _first_messenger: bool) -> Self::Stream {
+        let index = self.cursor.get();
+        self.cursor.set(index + 1);
+        let taken = self
+            .streams
+            .borrow_mut()
+            .get_mut(index)
+            .and_then(Option::take);
+        match taken {
+            Some(stream) => {
+                let (recv, send) = tokio::io::split(stream);
+                std::future::ready(Ok((send, recv)))
+            }
+            None => std::future::ready(Err(io::Error::other("tcp stream index exhausted"))),
+        }
+    }
+}

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -1956,6 +1956,153 @@ fn quic_gateway_to_gateway_bypasses_root() {
 }
 
 #[test]
+fn tcp_serve_join_establishes_and_routes() {
+    // The tcp analogue of `quic_serve_join_establishes_and_routes`: connect opens the
+    // data + heartbeat sockets up front (paired by prefix), establishment runs over
+    // the data socket, and messages route both directions. Exercises the whole tcp
+    // Net impl and the generic transport driving it.
+    set_quic_env(); // tcp reuses the same MM_QUIC_* cert material
+    let ctx = CtxHandle::new().expect("context should start");
+    let parent = runtime_actor(&ctx, "t-parent");
+    let child = runtime_actor(&ctx, "t-child");
+    let (parent_poller, mut parent_rx) = runtime_poller(&ctx);
+    let (child_poller, mut child_rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, parent_poller, 0, parent);
+    runtime_subscribe(&ctx, child_poller, 0, child);
+
+    let url = free_tcp_url();
+    ctx.send_command(Command::Serve {
+        actor: parent,
+        url: url.clone(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: child,
+        url,
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+
+    // The TLS handshake completes on both sockets and both sides get their hello.
+    assert_eq!(recv_strings(&mut parent_rx), vec!["t-parent", "t-child"]);
+    assert_eq!(recv_strings(&mut child_rx), vec!["t-child", "t-parent"]);
+
+    // A message both directions is framed over the data socket and delivered intact.
+    ctx.send_command(Command::Send {
+        sender: parent,
+        destination_ident: MsgPart::from_bytes(b"t-child".to_vec()),
+        parts: vec![
+            MsgPart::from_bytes(b"down".to_vec()),
+            MsgPart::from_bytes(b"socket".to_vec()),
+        ],
+    })
+    .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut child_rx), vec!["down", "socket"]);
+
+    ctx.send_command(Command::Send {
+        sender: child,
+        destination_ident: MsgPart::from_bytes(b"t-parent".to_vec()),
+        parts: vec![MsgPart::from_bytes(b"up".to_vec())],
+    })
+    .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut parent_rx), vec!["up"]);
+
+    shutdown(ctx);
+}
+
+#[test]
+fn tcp_gateway_to_gateway_bypasses_root() {
+    // The tcp analogue of `quic_gateway_to_gateway_bypasses_root`. The gateway tags
+    // carry the `tcp://` scheme, so ctx's `send_to_gateway` routes the direct
+    // gateway-to-gateway side-channels over tcp (not quic). Exercises the eager
+    // two-socket side-channel open and the scheme-aware routing.
+    set_quic_env();
+    let root_ctx = CtxHandle::new().expect("root ctx");
+    let a_ctx = CtxHandle::new().expect("a ctx");
+    let b_ctx = CtxHandle::new().expect("b ctx");
+
+    let root_url = free_tcp_url();
+    let a_url = free_tcp_url();
+    let b_url = free_tcp_url();
+    // The gateway tag *is* the full `tcp://addr` url, so the ident carries the scheme
+    // and cross-gateway routing picks the tcp transport.
+    let a_tag = a_url.clone();
+    let b_tag = b_url.clone();
+
+    let root = runtime_gateway_actor(&root_ctx, "root");
+    let gw_a = runtime_gateway_actor(&a_ctx, &format!("gwA@{a_tag}"));
+    let a1 = runtime_actor(&a_ctx, &format!("a1@{a_tag}"));
+    let gw_b = runtime_gateway_actor(&b_ctx, &format!("gwB@{b_tag}"));
+    let b1 = runtime_actor(&b_ctx, &format!("b1@{b_tag}"));
+
+    let (root_poller, mut root_rx) = runtime_poller(&root_ctx);
+    let (a1_poller, mut a1_rx) = runtime_poller(&a_ctx);
+    let (b1_poller, mut b1_rx) = runtime_poller(&b_ctx);
+    runtime_subscribe(&root_ctx, root_poller, 0, root);
+    runtime_subscribe(&a_ctx, a1_poller, 0, a1);
+    runtime_subscribe(&b_ctx, b1_poller, 0, b1);
+
+    runtime_serve(&root_ctx, root, &root_url);
+    runtime_serve(&root_ctx, root, &root_url);
+    runtime_join(&a_ctx, gw_a, &root_url);
+    runtime_join(&b_ctx, gw_b, &root_url);
+
+    runtime_serve(&a_ctx, gw_a, &a_url);
+    runtime_serve(&b_ctx, gw_b, &b_url);
+    runtime_connect(&a_ctx, gw_a, a1, "inproc://bypass-tcp-a");
+    runtime_connect(&b_ctx, gw_b, b1, "inproc://bypass-tcp-b");
+
+    assert_eq!(
+        recv_strings(&mut a1_rx),
+        vec![format!("a1@{a_tag}"), format!("gwA@{a_tag}")]
+    );
+    assert_eq!(
+        recv_strings(&mut b1_rx),
+        vec![format!("b1@{b_tag}"), format!("gwB@{b_tag}")]
+    );
+
+    let mut peers: Vec<String> = (0..2)
+        .map(|_| {
+            let hello = recv_strings(&mut root_rx);
+            assert_eq!(hello[0], "root");
+            hello[1].clone()
+        })
+        .collect();
+    peers.sort();
+    assert_eq!(peers, vec![format!("gwA@{a_tag}"), format!("gwB@{b_tag}")]);
+
+    // a1@A -> b1@B: gwA opens a direct tcp side-channel to gwB, bypassing root.
+    a_ctx
+        .send_command(Command::Send {
+            sender: a1,
+            destination_ident: MsgPart::from_bytes(format!("b1@{b_tag}").into_bytes()),
+            parts: vec![MsgPart::from_bytes(b"cross-gateway".to_vec())],
+        })
+        .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut b1_rx), vec!["cross-gateway"]);
+
+    b_ctx
+        .send_command(Command::Send {
+            sender: b1,
+            destination_ident: MsgPart::from_bytes(format!("a1@{a_tag}").into_bytes()),
+            parts: vec![MsgPart::from_bytes(b"reply".to_vec())],
+        })
+        .expect("send should enqueue");
+    assert_eq!(recv_strings(&mut a1_rx), vec!["reply"]);
+
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    assert!(
+        root_rx.try_recv().is_err(),
+        "root must not receive cross-gateway traffic"
+    );
+
+    shutdown(a_ctx);
+    shutdown(b_ctx);
+    shutdown(root_ctx);
+}
+
+#[test]
 fn quic_gateway_reaches_root_actor_and_its_inproc_child() {
     // From a child of gateway A, a message to the root domain (an empty specifier)
     // climbs A's parent link to root rather than side-channelling: it reaches both
@@ -2312,6 +2459,13 @@ fn free_quic_url() -> String {
     let port = socket.local_addr().expect("local addr").port();
     drop(socket);
     format!("quic://127.0.0.1:{port}")
+}
+
+fn free_tcp_url() -> String {
+    let socket = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral tcp");
+    let port = socket.local_addr().expect("local addr").port();
+    drop(socket);
+    format!("tcp://127.0.0.1:{port}")
 }
 
 fn unix_test_url(name: &str) -> String {


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* __->__ #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add a TLS-over-TCP backend that reuses the generic network transport, routes scheme-qualified gateways correctly, and pairs data and heartbeat sockets into logical connections. Extend the smoke runner with a transport selector and add end-to-end tests for TCP routing and direct gateway side channels.

Differential Revision: [D114750247](https://our.internmc.facebook.com/intern/diff/D114750247/)