### PR TITLE
36/43 minimonarch: Tune TCP and QUIC for higher bandwidth

### DIFF
--- a/monarch_mini/src/net.rs
+++ b/monarch_mini/src/net.rs
@@ -86,6 +86,18 @@ pub(crate) trait Net: Sized + 'static {
     /// join may precede its serve). `streams` is as in [`Net::bind`].
     async fn connect(dialer: &Self::Dialer, addr: SocketAddr, streams: usize)
     -> Option<Self::Conn>;
+
+    /// The default cap on simultaneous client connect *attempts* when
+    /// `MM_QUIC_MAX_CONCURRENT_CONNECTS` is unset (see [`crate::net_transport`]'s
+    /// connect throttle). `None` ⇒ unlimited; each protocol overrides with a concrete
+    /// bound. tcp needs a much smaller cap than quic: it opens `streams` OS sockets
+    /// *and* a TLS handshake per connection and pairs them on the acceptor, so a large
+    /// concurrent connect storm on the single-threaded runtime starves stragglers
+    /// (connections that never finish pairing), whereas quic multiplexes its streams on
+    /// one endpoint-paced connection.
+    fn default_connect_concurrency() -> Option<usize> {
+        None
+    }
 }
 
 /// An established connection. It knows nothing about heartbeats, roles, or

--- a/monarch_mini/src/net_transport.rs
+++ b/monarch_mini/src/net_transport.rs
@@ -116,14 +116,22 @@ fn shutdown_ack_timeout() -> Duration {
 /// across the whole context. A root that joins tens of thousands of peers spawns
 /// that many connector tasks, each driving a handshake; run all at once on the
 /// single-threaded runtime they compete for CPU and reorder connection setup badly.
-/// `MM_QUIC_MAX_CONCURRENT_CONNECTS` bounds the simultaneous attempts (each connector
-/// still retries independently, and the permit is released while it backs off).
-/// Unset or `0` ⇒ unlimited.
-fn max_concurrent_connects() -> Option<usize> {
-    std::env::var("MM_QUIC_MAX_CONCURRENT_CONNECTS")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .filter(|&n| n > 0)
+/// Bounds the simultaneous attempts (each connector still retries independently, and
+/// the permit is released while it backs off).
+///
+/// `MM_QUIC_MAX_CONCURRENT_CONNECTS` overrides it: a positive value caps to that;
+/// `0` means unlimited. When the env var is unset (or unparseable) the protocol's
+/// [`Net::default_connect_concurrency`] applies — 1024 for quic, a much smaller cap for
+/// tcp, which otherwise starves stragglers under a large connect storm.
+fn max_concurrent_connects<N: Net>() -> Option<usize> {
+    match std::env::var("MM_QUIC_MAX_CONCURRENT_CONNECTS") {
+        Ok(v) => match v.parse::<usize>() {
+            Ok(0) => None,                              // explicit opt-out ⇒ unlimited
+            Ok(n) => Some(n),                           // explicit cap
+            Err(_) => N::default_connect_concurrency(), // unparseable ⇒ protocol default
+        },
+        Err(_) => N::default_connect_concurrency(), // unset ⇒ protocol default
+    }
 }
 
 /// The gateway dial tag of `ident` (the substring after the last `@`), as a
@@ -227,7 +235,7 @@ impl<N: Net> NetTransport<N> {
     ) -> Self {
         let (shutdown_tx, _) = watch::channel(false);
         let (alive_tx, alive_rx) = mpsc::unbounded_channel();
-        if let Some(n) = max_concurrent_connects() {
+        if let Some(n) = max_concurrent_connects::<N>() {
             eprintln!("MM_QUIC connect concurrency capped at {n} simultaneous attempts");
         }
         Self {
@@ -235,7 +243,7 @@ impl<N: Net> NetTransport<N> {
             mapper,
             context_shm,
             listeners: HashMap::new(),
-            connect_sem: max_concurrent_connects().map(|n| Arc::new(Semaphore::new(n))),
+            connect_sem: max_concurrent_connects::<N>().map(|n| Arc::new(Semaphore::new(n))),
             alive_rx,
             heartbeat: Heartbeats::new(),
             side_channels: Rc::new(RefCell::new(SideChannels {

--- a/monarch_mini/src/quic_net.rs
+++ b/monarch_mini/src/quic_net.rs
@@ -163,6 +163,22 @@ fn load_tls() -> anyhow::Result<TlsConfig> {
     // loopback / the lossless intra-cluster fabric it is ~neutral. quinn re-exports
     // BbrConfig at quinn::congestion.
     transport.congestion_controller_factory(Arc::new(quinn::congestion::BbrConfig::default()));
+    // Raise the MTU-discovery ceiling so QUIC can use the jumbo headroom of the
+    // intra-cluster fabric. On GPU hosts the frontend `eth0` carries a deliberate
+    // jumbo MTU of 5000 (chef sets `JUMBO_MTU=5000` for GPU_TC hosts), but quinn's
+    // default MTU discovery caps the UDP payload at 1452, so it never uses that
+    // headroom — leaving ~3x more datagrams and their per-packet kernel cost
+    // (`sendmsg` on TX, skb alloc/free on RX) on the table at the single-host receive
+    // ceiling. We only raise the *ceiling* (from `mtu_search_upper_bound`) and let
+    // quinn's DPLPMTUD *discover* the real path MTU — we never pin `initial_mtu` or
+    // disable discovery — so an over-large ceiling on a smaller path simply settles
+    // lower (a lost probe leaves the MTU where it was, it never stalls data or
+    // black-holes the handshake). The companion `endpoint_config()` advertises the
+    // same `max_udp_payload_size` on both roles; without that the peer would clamp our
+    // probes back to its 1472 default (quinn-proto `mtud`: `current_mtu.min(peer_max)`).
+    let mut mtud = quinn::MtuDiscoveryConfig::default();
+    mtud.upper_bound(mtu_search_upper_bound());
+    transport.mtu_discovery_config(Some(mtud));
     let transport = Arc::new(transport);
 
     let mut server = ServerConfig::with_single_cert(load_certs(&cert_path)?, load_key(&key_path)?)?;
@@ -176,6 +192,64 @@ fn load_tls() -> anyhow::Result<TlsConfig> {
     client.transport_config(transport);
 
     Ok(TlsConfig { server, client })
+}
+
+/// IP + UDP header overhead subtracted from a link MTU to get the largest QUIC UDP
+/// payload that fits. Cross-machine QUIC is IPv6 (40 B header) + UDP (8 B) = 48 B;
+/// using the IPv6 figure is the conservative choice (IPv4's 28 B is smaller, so this
+/// never over-estimates the payload).
+const IP_UDP_OVERHEAD: u16 = 48;
+
+/// Fallback UDP-payload discovery ceiling when the local link MTU can't be read (see
+/// [`eth0_udp_payload`]). Larger than quinn's 1452 default so discovery can still
+/// climb on a jumbo fabric; because it is only a *ceiling* for DPLPMTUD probing (never
+/// pinned), an over-large value on a smaller path just settles lower.
+const DEFAULT_MTU_SEARCH_UPPER_BOUND: u16 = 4800;
+
+/// The largest QUIC UDP payload that fits `eth0`'s link MTU (`mtu − IP_UDP_OVERHEAD`),
+/// or `None` if the sysfs file is absent/unparseable. `eth0` is the frontend fabric
+/// that on GPU hosts carries a jumbo MTU (chef sets `JUMBO_MTU=5000` for GPU_TC
+/// hosts). Deliberately reads only this one file — no interface scanning and no active
+/// probing.
+fn eth0_udp_payload() -> Option<u16> {
+    let mtu: u16 = std::fs::read_to_string("/sys/class/net/eth0/mtu")
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    mtu.checked_sub(IP_UDP_OVERHEAD).filter(|&p| p >= 1200)
+}
+
+/// The UDP-payload ceiling for QUIC MTU discovery, read in one place so the
+/// [`quinn::TransportConfig`] (the DPLPMTUD `upper_bound`) and the
+/// [`quinn::EndpointConfig`] (the advertised `max_udp_payload_size`, which caps what
+/// the peer probes toward us) stay consistent. It is `MM_QUIC_MTU` if set (≥1200; an
+/// operator override, e.g. to reduce the ceiling), else `eth0`'s link MTU (see
+/// [`eth0_udp_payload`]), else [`DEFAULT_MTU_SEARCH_UPPER_BOUND`]. This is only a
+/// ceiling — quinn always *discovers* the real path MTU up to it (see [`load_tls`]),
+/// so a too-large value never breaks a smaller path.
+fn mtu_search_upper_bound() -> u16 {
+    std::env::var("MM_QUIC_MTU")
+        .ok()
+        .and_then(|m| m.parse::<u16>().ok())
+        .filter(|&m| m >= 1200)
+        .or_else(eth0_udp_payload)
+        .unwrap_or(DEFAULT_MTU_SEARCH_UPPER_BOUND)
+}
+
+/// The [`quinn::EndpointConfig`] for every client/server socket in this context.
+/// quinn's default advertises `max_udp_payload_size = 1472` as this endpoint's receive
+/// limit, and QUIC clamps the *peer's* probed MTU down to it (quinn-proto
+/// `mtud::on_peer_max_udp_payload_size_received`: `current_mtu.min(peer_max)`), so
+/// raising the discovery ceiling on the sender alone is a no-op — the receiver must
+/// advertise the larger size too. We set it to [`mtu_search_upper_bound`] on both
+/// roles; this value also sizes quinn's GRO recv buffer (`max_udp_payload_size ·
+/// gro_segments · BATCH_SIZE`).
+fn endpoint_config() -> quinn::EndpointConfig {
+    let mut cfg = quinn::EndpointConfig::default();
+    // Only errors if the value is < 1200, already excluded by `mtu_search_upper_bound`.
+    let _ = cfg.max_udp_payload_size(mtu_search_upper_bound());
+    cfg
 }
 
 /// Parse a `quic://host:port` (or bare `host:port`) url into a socket address.
@@ -304,9 +378,51 @@ fn make_client_endpoint(
     let std_socket: std::net::UdpSocket = socket.into();
     let runtime =
         quinn::default_runtime().ok_or_else(|| anyhow::anyhow!("no quic async runtime"))?;
-    let mut endpoint = Endpoint::new(quinn::EndpointConfig::default(), None, std_socket, runtime)?;
+    let mut endpoint = Endpoint::new(endpoint_config(), None, std_socket, runtime)?;
     endpoint.set_default_client_config(client_config);
     Ok((endpoint, usable))
+}
+
+/// Default kernel recv-buffer size for the *server* UDP socket (64 MiB). quinn never
+/// raises `SO_RCVBUF` itself, so a high-rate receiver drops datagrams whenever the
+/// socket backlog spikes (→ QUIC RTO stalls, seen as throughput variance at the
+/// single-host ceiling). We force it up by default — matching the total budget the
+/// client pool targets ([`DEFAULT_UDP_BUF_TOTAL_BYTES`]) and the value validated in
+/// the throughput sweep. Override (typically to *reduce* it on a small host) with
+/// `MM_QUIC_SERVER_UDP_BUF_BYTES`.
+const DEFAULT_SERVER_UDP_BUF_BYTES: usize = 64 * 1024 * 1024;
+
+fn server_udp_buf_bytes() -> usize {
+    std::env::var("MM_QUIC_SERVER_UDP_BUF_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_SERVER_UDP_BUF_BYTES)
+}
+
+/// Build a server [`Endpoint`] bound to `addr`. Like [`Endpoint::server`] but (a) it
+/// uses [`endpoint_config`] so the advertised `max_udp_payload_size` matches our MTU
+/// discovery ceiling (a plain `Endpoint::server` hardcodes quinn's 1472 default, which
+/// would clamp the peer's probed MTU back down), and (b) it enlarges the receive
+/// buffer to [`server_udp_buf_bytes`] (best-effort; see [`set_udp_buffers`]).
+fn make_server_endpoint(addr: SocketAddr, server_config: ServerConfig) -> anyhow::Result<Endpoint> {
+    let domain = if addr.is_ipv6() {
+        socket2::Domain::IPV6
+    } else {
+        socket2::Domain::IPV4
+    };
+    let socket = socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
+    set_udp_buffers(&socket, server_udp_buf_bytes());
+    socket.bind(&addr.into())?;
+    let std_socket: std::net::UdpSocket = socket.into();
+    let runtime =
+        quinn::default_runtime().ok_or_else(|| anyhow::anyhow!("no quic async runtime"))?;
+    Ok(Endpoint::new(
+        endpoint_config(),
+        Some(server_config),
+        std_socket,
+        runtime,
+    )?)
 }
 
 /// The shared per-context QUIC state: TLS configs (loaded lazily on first use) and a
@@ -439,7 +555,7 @@ impl Net for Quic {
 
     fn bind(&mut self, addr: SocketAddr, _streams: usize) -> anyhow::Result<Endpoint> {
         let server = self.tls()?.server.clone();
-        Ok(Endpoint::server(server, addr)?)
+        make_server_endpoint(addr, server)
     }
 
     async fn accept(listener: &Endpoint) -> Option<QuicConn> {
@@ -455,6 +571,13 @@ impl Net for Quic {
         let connecting = dialer.connect(addr, SERVER_NAME).ok()?;
         let conn = connecting.await.ok()?;
         Some(QuicConn::new(conn))
+    }
+
+    /// quic multiplexes all streams on one endpoint-paced connection, so a large number
+    /// of simultaneous handshakes is cheap; 1024 has proven safe at 64k+ fan-out.
+    /// Overridable via `MM_QUIC_MAX_CONCURRENT_CONNECTS`.
+    fn default_connect_concurrency() -> Option<usize> {
+        Some(1024)
     }
 }
 

--- a/monarch_mini/src/tcp_net.rs
+++ b/monarch_mini/src/tcp_net.rs
@@ -46,6 +46,38 @@
 //! subsystem's job (its own stream, and delegated so the root's steady-state cost is
 //! bounded); a link with no heartbeat obligation — e.g. a delegated one — is genuinely
 //! silent, which is what lets the connection count scale.
+//!
+//! ## Throughput tuning
+//!
+//! The fast settings that are *safe* to enable everywhere are on by default; the ones
+//! whose cost or policy impact scales with the connection count are left opt-in.
+//!
+//! On by default (safe regardless of scale):
+//!
+//! - `TCP_NODELAY` — always on: framing flushes per frame, so Nagle would only add
+//!   latency.
+//! - Congestion control defaults to **BBR**, pinned with `TCP_CONGESTION` *after* the
+//!   connection is up — matching the quic transport, which pins BBR unconditionally.
+//!   The post-connect timing is deliberate: cross-region flows at Meta have a NetEdit
+//!   cgroup eBPF `sockops` force their own CUBIC variant at connect time, overriding
+//!   any pre-connect `setsockopt`; a post-connect set sticks. The set is best-effort,
+//!   so a host without the `tcp_bbr` module simply keeps the kernel default. Override
+//!   with `MM_TCP_CONGESTION` (e.g. `cubic`, or empty to pin nothing).
+//! - Listen backlog and `SO_REUSEADDR` on the listener — robustness with negligible
+//!   cost.
+//!
+//! Opt-in (unset ⇒ OS default), because a fixed kernel socket-buffer size both
+//! *disables* Linux's per-socket buffer autotuning and — since tcp uses one socket per
+//! stream per connection, and a root holds a huge number of connections — multiplies
+//! that fixed cost across every socket. Autotuning is the better default at scale;
+//! these are for reproducing the cross-region bandwidth ceilings in a bench:
+//!
+//! - `MM_TCP_SNDBUF_BYTES` / `MM_TCP_RCVBUF_BYTES` — kernel socket-buffer sizes,
+//!   set *before* connect/bind so TCP window scaling is negotiated for the enlarged
+//!   window (accepted sockets inherit the listener's scale). Requested with the
+//!   privileged `SO_*BUFFORCE` options (which bypass `net.core.{r,w}mem_max` under
+//!   `CAP_NET_ADMIN`, e.g. as root on MAST) with a fall back to the ordinary setters
+//!   otherwise.
 
 use std::cell::Cell;
 use std::cell::RefCell;
@@ -55,10 +87,13 @@ use std::future::Ready;
 use std::hash::BuildHasher;
 use std::io;
 use std::net::SocketAddr;
+use std::os::fd::AsRawFd;
+use std::os::fd::RawFd;
 use std::pin::Pin;
 use std::rc::Rc;
 use std::rc::Weak;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use std::task::Context;
 use std::task::Poll;
 use std::time::Duration;
@@ -75,6 +110,7 @@ use tokio::io::ReadBuf;
 use tokio::io::ReadHalf;
 use tokio::io::WriteHalf;
 use tokio::net::TcpListener;
+use tokio::net::TcpSocket;
 use tokio::net::TcpStream;
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls::TlsConnector;
@@ -87,6 +123,121 @@ use crate::net::NetConn;
 /// Server name the client uses to verify the server's certificate (the cert's SAN
 /// must cover it). Shared with the quic transport, which uses the same cert set.
 const SERVER_NAME: &str = "monarch-mini";
+
+/// Listen backlog. Generous so a burst of joiners (e.g. a many-connection bench
+/// against one server) is not refused before the accept loop drains them.
+const LISTEN_BACKLOG: u32 = 1024;
+
+/// Optional kernel send/recv buffer request, in bytes. Unset ⇒ OS default.
+fn sndbuf_bytes() -> Option<usize> {
+    env_usize("MM_TCP_SNDBUF_BYTES")
+}
+
+fn rcvbuf_bytes() -> Option<usize> {
+    env_usize("MM_TCP_RCVBUF_BYTES")
+}
+
+fn env_usize(name: &str) -> Option<usize> {
+    std::env::var(name)
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+}
+
+/// The congestion-control algorithm to pin after connect. Defaults to BBR — matching
+/// the quic transport, which pins BBR unconditionally: it holds a higher steady rate
+/// than CUBIC across the light loss of a high-RTT cross-region path (quinn#2262: CUBIC
+/// stalls at ~1 MiB cwnd where BBR reaches the BDP) and is ~neutral on the lossless
+/// intra-cluster fabric. Best-effort — if the `tcp_bbr` module is not loaded the set
+/// fails and the kernel default stays (see [`set_congestion`]). Override the algorithm
+/// with `MM_TCP_CONGESTION` (e.g. `cubic` to pin the classic default); an empty
+/// `MM_TCP_CONGESTION=` pins nothing at all, leaving whatever the kernel/NetEdit picks.
+fn congestion() -> Option<String> {
+    match std::env::var("MM_TCP_CONGESTION") {
+        Ok(name) if name.is_empty() => None, // explicit opt-out: pin nothing
+        Ok(name) => Some(name),
+        Err(_) => Some("bbr".to_owned()), // default
+    }
+}
+
+/// Log the active tuning knobs once per process, so a bench run records which
+/// levers were set without spamming a line per connection.
+fn log_tuning_once() {
+    static LOGGED: OnceLock<()> = OnceLock::new();
+    LOGGED.get_or_init(|| {
+        if sndbuf_bytes().is_some() || rcvbuf_bytes().is_some() || congestion().is_some() {
+            eprintln!(
+                "MM_TCP tuning: sndbuf={:?} rcvbuf={:?} congestion={:?}",
+                sndbuf_bytes(),
+                rcvbuf_bytes(),
+                congestion(),
+            );
+        }
+    });
+}
+
+/// Enlarge a socket's kernel send/recv buffers, best-effort, *before* connect/bind
+/// so TCP window scaling is negotiated for the enlarged window. Tries the privileged
+/// `SO_*BUFFORCE` options first — these bypass the `net.core.{r,w}mem_max` ceiling
+/// under `CAP_NET_ADMIN` (e.g. running as root on MAST) — and falls back to the
+/// ordinary setters (which the kernel clamps to that ceiling) when not permitted. A
+/// no-op for a buffer whose env knob is unset.
+fn set_buffers(fd: RawFd) {
+    if let Some(bytes) = sndbuf_bytes() {
+        set_buffer(fd, libc::SO_SNDBUFFORCE, libc::SO_SNDBUF, bytes);
+    }
+    if let Some(bytes) = rcvbuf_bytes() {
+        set_buffer(fd, libc::SO_RCVBUFFORCE, libc::SO_RCVBUF, bytes);
+    }
+}
+
+fn set_buffer(fd: RawFd, force_opt: libc::c_int, opt: libc::c_int, bytes: usize) {
+    let size = bytes.min(i32::MAX as usize) as libc::c_int;
+    let len = std::mem::size_of::<libc::c_int>() as libc::socklen_t;
+    // SAFETY: `fd` is a valid socket for the call's duration; the option value is an
+    // `int` of length `len`, as required by SO_*BUF{,FORCE}.
+    let forced = unsafe {
+        let value = std::ptr::from_ref(&size).cast::<libc::c_void>();
+        libc::setsockopt(fd, libc::SOL_SOCKET, force_opt, value, len)
+    };
+    if forced != 0 {
+        // SAFETY: as above; the ordinary setter is clamped by the kernel.
+        unsafe {
+            let value = std::ptr::from_ref(&size).cast::<libc::c_void>();
+            libc::setsockopt(fd, libc::SOL_SOCKET, opt, value, len);
+        }
+    }
+}
+
+/// Apply the post-connect socket tuning to an established socket: `TCP_NODELAY` (always
+/// on — framing flushes per frame, so Nagle would only add latency) and the pinned
+/// congestion-control algorithm (BBR by default; see [`congestion`]). Both are
+/// best-effort. The congestion set must run *after* connect — see the module docs on
+/// the NetEdit connect-time override.
+fn tune_established(stream: &TcpStream) {
+    let _ = stream.set_nodelay(true);
+    set_congestion(stream.as_raw_fd());
+}
+
+/// Pin the congestion-control algorithm on an established connection, if
+/// `MM_TCP_CONGESTION` / `MM_TCP_BBR` requested one. Best-effort: a failure (e.g. the
+/// `tcp_bbr` module is not loaded) leaves the kernel default in place.
+fn set_congestion(fd: RawFd) {
+    let Some(name) = congestion() else {
+        return;
+    };
+    // SAFETY: `fd` is a valid connected TCP socket; `name` bytes are a valid buffer
+    // of `name.len()`, the form TCP_CONGESTION expects (a non-terminated string).
+    unsafe {
+        libc::setsockopt(
+            fd,
+            libc::IPPROTO_TCP,
+            libc::TCP_CONGESTION,
+            name.as_ptr().cast::<libc::c_void>(),
+            name.len() as libc::socklen_t,
+        );
+    }
+}
 
 /// How long a connection may stay half-paired — some of its sockets arrived, but not
 /// all — before the listener reaps it, dropping the sockets that did arrive and freeing
@@ -296,7 +447,23 @@ pub(crate) struct TcpListenerHandle {
 async fn reap_unpaired(pending: Weak<RefCell<PendingMap>>, connection_id: u128) {
     tokio::time::sleep(pending_reap_timeout()).await;
     if let Some(pending) = pending.upgrade() {
-        pending.borrow_mut().remove(&connection_id);
+        // If the id is still present it never finished pairing: the peer opened some
+        // but not all of its sockets (or they arrived too far apart). Log which stream
+        // indices did arrive (under `MM_QUIC_DEBUG`) so a server-side half-open — the
+        // other way a rank goes missing at high fan-out — is visible, not silent.
+        if let Some(slots) = pending.borrow_mut().remove(&connection_id) {
+            if crate::ctx::connection_debug() {
+                let arrived: Vec<usize> = slots
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(i, s)| s.as_ref().map(|_| i))
+                    .collect();
+                eprintln!(
+                    "MM_TCP reaped half-paired connection {connection_id:#x}: only stream indices {arrived:?} of {} arrived",
+                    slots.len()
+                );
+            }
+        }
     }
 }
 
@@ -325,12 +492,21 @@ impl Net for Tcp {
     }
 
     fn bind(&mut self, addr: SocketAddr, streams: usize) -> anyhow::Result<TcpListenerHandle> {
+        log_tuning_once();
         let acceptor = TlsAcceptor::from(self.tls()?.server.clone());
-        // `bind` is synchronous (the command loop can't await); build the listener via
-        // std and adopt it into tokio without an await.
-        let std_listener = std::net::TcpListener::bind(addr)?;
-        std_listener.set_nonblocking(true)?;
-        let listener = TcpListener::from_std(std_listener)?;
+        // `bind` is synchronous (the command loop can't await); build the listener
+        // socket directly so the kernel buffers can be enlarged *before* bind (so the
+        // window scale accepted sockets inherit reflects the enlarged window), then
+        // bind and listen — none of which awaits.
+        let socket = if addr.is_ipv6() {
+            TcpSocket::new_v6()?
+        } else {
+            TcpSocket::new_v4()?
+        };
+        set_buffers(socket.as_raw_fd());
+        socket.set_reuseaddr(true)?;
+        socket.bind(addr)?;
+        let listener = socket.listen(LISTEN_BACKLOG)?;
         let pending: Rc<RefCell<PendingMap>> = Rc::new(RefCell::new(HashMap::new()));
         Ok(TcpListenerHandle {
             listener,
@@ -345,6 +521,9 @@ impl Net for Tcp {
             let Ok((tcp, peer)) = listener.listener.accept().await else {
                 continue; // transient accept error; the listener stays open
             };
+            // The connection is up (accept returned), so pin nodelay/congestion now;
+            // the buffer window scale was inherited from the listening socket.
+            tune_established(&tcp);
             let Ok(mut stream) = listener.acceptor.accept(tcp).await.map(TlsStream::Server) else {
                 continue; // TLS handshake failed
             };
@@ -385,22 +564,82 @@ impl Net for Tcp {
         // Open every stream up front (see the module docs): the accepting side may be
         // the first messenger of a stream, and a plain socket can't be opened from the
         // accepting side. Each socket is prefixed so the listener can pair them.
+        log_tuning_once();
+        // Each failure path below logs (under `MM_QUIC_DEBUG`) the exact peer address,
+        // stream index, and stage that failed, so a connect that never completes at high
+        // fan-out can be traced to the specific rank (the root dials in rank order).
+        let debug = crate::ctx::connection_debug();
         let connection_id = new_connection_id();
         let mut opened = Vec::with_capacity(streams);
         for index in 0..streams {
-            let tcp = TcpStream::connect(addr).await.ok()?;
-            let tls = dialer
+            // Build the socket directly so the kernel buffers can be enlarged *before*
+            // connect (so window scaling is negotiated for the enlarged window), then
+            // pin nodelay/congestion once the connection is up.
+            let socket = match if addr.is_ipv6() {
+                TcpSocket::new_v6()
+            } else {
+                TcpSocket::new_v4()
+            } {
+                Ok(s) => s,
+                Err(e) => {
+                    if debug {
+                        eprintln!(
+                            "MM_TCP connect {addr} stream {index}/{streams}: socket() failed: {e}"
+                        );
+                    }
+                    return None;
+                }
+            };
+            set_buffers(socket.as_raw_fd());
+            let tcp = match socket.connect(addr).await {
+                Ok(t) => t,
+                Err(e) => {
+                    if debug {
+                        eprintln!(
+                            "MM_TCP connect {addr} stream {index}/{streams}: connect() failed: {e}"
+                        );
+                    }
+                    return None;
+                }
+            };
+            tune_established(&tcp);
+            let tls = match dialer
                 .connector
                 .connect(dialer.server_name.clone(), tcp)
                 .await
-                .ok()?;
-            let mut stream = TlsStream::Client(tls);
-            write_pairing_prefix(&mut stream, connection_id, index)
-                .await
-                .ok()?;
+            {
+                Ok(t) => TlsStream::Client(t),
+                Err(e) => {
+                    if debug {
+                        eprintln!(
+                            "MM_TCP connect {addr} stream {index}/{streams}: TLS handshake failed: {e}"
+                        );
+                    }
+                    return None;
+                }
+            };
+            let mut stream = tls;
+            if let Err(e) = write_pairing_prefix(&mut stream, connection_id, index).await {
+                if debug {
+                    eprintln!(
+                        "MM_TCP connect {addr} stream {index}/{streams}: pairing-prefix write failed: {e}"
+                    );
+                }
+                return None;
+            }
             opened.push(stream);
         }
         Some(TcpConn::new(addr, opened))
+    }
+
+    /// tcp opens `STREAMS` OS sockets plus a TLS handshake per connection and pairs
+    /// them on the acceptor, so it needs a much smaller default than quic: an
+    /// unthrottled connect storm at high fan-out leaves stragglers whose sockets never
+    /// finish pairing (seen as the root's `only N-1/N workers connected` aborts). 128
+    /// has proven safe through a full 65k-worker sweep; raise with
+    /// `MM_QUIC_MAX_CONCURRENT_CONNECTS` if a run needs faster connect ramp.
+    fn default_connect_concurrency() -> Option<usize> {
+        Some(128)
     }
 }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* __->__ #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Adds protocol-specific connect concurrency defaults and detailed TCP failure diagnostics to keep large fan-out joins from starving or leaving half-paired sockets.
Tunes TCP congestion control, socket buffers, backlog, and QUIC MTU discovery and UDP receive buffering to improve high-rate transfers across cluster and cross-region networks.

Differential Revision: [D114750230](https://our.internmc.facebook.com/intern/diff/D114750230/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750230/)!