### PR TITLE
37/43 minimonarch: Make MAST smoke benchmarks tolerate missing workers

### DIFF
--- a/monarch_mini/mast/build_mast.py
+++ b/monarch_mini/mast/build_mast.py
@@ -184,6 +184,8 @@ def make_jobspec(
     server_subtype: int | None = None,
     cluster: str = "MastGenAICluster",
     entitlement: str = "monarch_cicd",
+    opec_tag: int = 0,
+    graceful_preempt: bool = False,
 ) -> dict:
     """A CPU MAST job that runs the bootstrap on every task.
 
@@ -195,6 +197,13 @@ def make_jobspec(
     ``entitlement`` selects the MAST entitlement/tenant. Use ``monarch_training``
     for the classic-MAST clusters (CPUTrainingWorkloads / MastProdCluster), which
     ``monarch_cicd`` is not authorized on.
+
+    ``opec_tag`` is the `OpecTag` thrift enum (hpcscheduler_enums.thrift): 0 =
+    DEDICATED_ONLY (dedicated capacity only), 2 = OPEC_ONLY (elastic/borrowable
+    capacity only), 3 = OPEC_FLOATING (either). The monarch tenants hold NO
+    dedicated CPU quota (only GPU reservations), so a best-effort CPU job MUST use
+    OPEC_ONLY/OPEC_FLOATING to place on the shared elastic pool — a DEDICATED_ONLY
+    CPU job has zero eligible hosts and sits in AWAITING_RESOURCE forever.
     """
     tenant_path = _ENTITLEMENT_TENANT_PATHS.get(entitlement)
     if tenant_path is None:
@@ -258,7 +267,7 @@ def make_jobspec(
                         "failJobOnFinalFailure": True,
                     },
                     "ttlsConfig": {"enable": False},
-                    "opecTag": 0,
+                    "opecTag": opec_tag,
                 },
             }
         ],
@@ -270,7 +279,7 @@ def make_jobspec(
         },
         "identity": {"name": "hyper_monarch"},
         "owner": {"oncallShortname": "monarch", "unixname": os.environ["USER"]},
-        "enableGracefulPreemption": False,
+        "enableGracefulPreemption": graceful_preempt,
         "maxJobFailures": 0,
         "jobType": 0,
         "aiTrainingMetadata": {
@@ -422,12 +431,36 @@ def main() -> None:
         "clusters, else monarch_cicd)",
     )
     parser.add_argument(
+        "--opec-tag",
+        choices=["dedicated_only", "opec_only", "opec_floating"],
+        default="opec_only",
+        help="OpecTag scheduling class (default: opec_only). The monarch tenants "
+        "hold no dedicated CPU quota, so best-effort CPU jobs must run on the "
+        "shared elastic pool. 'opec_only' (elastic only) is what the CPU/Bergamo "
+        "elastic pool accepts; 'opec_floating' (dedicated or elastic) is REJECTED "
+        "by the CPU elastic target (ineligibilityReason=OPEC_FLOATING_JOB). "
+        "'dedicated_only' has zero eligible CPU hosts and sits in AWAITING_RESOURCE "
+        "forever — use it only if you have a reservation.",
+    )
+    parser.add_argument(
+        "--graceful-preempt",
+        action="store_true",
+        help="set enableGracefulPreemption: when running on preemptible (OPEC) "
+        "capacity, gives tasks a grace window (~30 min) after a preempt signal "
+        "before release, so an in-progress sweep can finish instead of the whole "
+        "job being reclaimed and re-queued mid-run.",
+    )
+    parser.add_argument(
         "--launch",
         action="store_true",
         help="submit the job now via thrift (thriftdbg -> the cluster's write "
         "tier) instead of only printing instructions",
     )
     args = parser.parse_args()
+
+    # OpecTag thrift enum (hpcscheduler_enums.thrift): note 1 (OPEC_ELIGIBLE) is
+    # deprecated/skipped, so the enum is non-contiguous.
+    opec_tag = {"dedicated_only": 0, "opec_only": 2, "opec_floating": 3}[args.opec_tag]
 
     extra_env: dict[str, str] = {}
     for item in args.env:
@@ -470,6 +503,8 @@ def main() -> None:
         else (10018 if args.bergamo else None),
         cluster=args.cluster,
         entitlement=entitlement,
+        opec_tag=opec_tag,
+        graceful_preempt=args.graceful_preempt,
     )
 
     spec_path = Path(tempfile.mkdtemp(prefix="mm_smoke_spec_")) / "jobspec.json"

--- a/monarch_mini/mast/mast_bootstrap.py
+++ b/monarch_mini/mast/mast_bootstrap.py
@@ -68,6 +68,20 @@ SMOKE_SETTLE_MS = float(os.environ.get("SMOKE_SETTLE_MS", "0"))
 # every job's hosts and injects them into the one root it picks. See smoke.py's
 # --wait-for-addresses / run_root_coordinated.
 SMOKE_COORD_PORT = int(os.environ.get("SMOKE_COORD_PORT", "0"))
+# Max sweep size (worker count actually exercised). 0 ⇒ sweep every launched worker.
+# Set this BELOW the launched worker count (hosts * WORKERS_PER_HOST) to over-provision:
+# the root builds the sweep from the first SMOKE_TARGET workers that connect and
+# backfills from the reserve when borrowed (preemptible) hosts drop. See smoke.py's
+# --target / run_root.
+SMOKE_TARGET = int(os.environ.get("SMOKE_TARGET", "0"))
+# Network transport for the worker serve / root join, passed to smoke.py's
+# --transport (default quic). The worker and root must agree, so it is read once
+# here and applied to both. Validated against smoke.py's choices.
+SMOKE_TRANSPORT = os.environ.get("SMOKE_TRANSPORT", "quic")
+if SMOKE_TRANSPORT not in ("quic", "tcp"):
+    raise SystemExit(
+        f"SMOKE_TRANSPORT must be 'quic' or 'tcp', got {SMOKE_TRANSPORT!r}"
+    )
 
 
 def task_hosts() -> list[str]:
@@ -124,7 +138,17 @@ def main() -> None:
     # Every task runs WORKERS_PER_HOST workers on sequential ports.
     workers = [
         subprocess.Popen(
-            [python, smoke, "--worker", "--port", str(PORT + i), "--bind", "::"],
+            [
+                python,
+                smoke,
+                "--worker",
+                "--port",
+                str(PORT + i),
+                "--bind",
+                "::",
+                "--transport",
+                SMOKE_TRANSPORT,
+            ],
             cwd=HERE,
             env=env,
         )
@@ -161,6 +185,9 @@ def main() -> None:
             str(SMOKE_CHAIN_LENGTH),
             "--settle-ms",
             str(SMOKE_SETTLE_MS),
+            "--transport",
+            SMOKE_TRANSPORT,
+            *(["--target", str(SMOKE_TARGET)] if SMOKE_TARGET > 0 else []),
         ]
         root_env = env
     else:
@@ -174,12 +201,15 @@ def main() -> None:
         # ~sqrt(N) children direct and delegates the rest, balanced, onto them, so
         # both the keeper count and each keeper's delegated load grow as sqrt(N).
         total_workers = len(hosts) * WORKERS_PER_HOST
-        max_direct = max(1, round(math.sqrt(total_workers)))
+        # The root heartbeats the *swept* (connected) set, which is SMOKE_TARGET when
+        # over-provisioning, else every launched worker. Size the keeper set off that.
+        swept = SMOKE_TARGET if SMOKE_TARGET > 0 else total_workers
+        max_direct = max(1, round(math.sqrt(swept)))
         root_env = dict(env)
         root_env["MM_QUIC_MAX_DIRECT_CHILDREN"] = str(max_direct)
         print(
             f"[bootstrap] root MM_QUIC_MAX_DIRECT_CHILDREN={max_direct} "
-            f"(sqrt of {total_workers} workers)",
+            f"(sqrt of {swept} swept workers; {total_workers} launched)",
             flush=True,
         )
         addrs = [
@@ -209,6 +239,9 @@ def main() -> None:
             str(SMOKE_CHAIN_LENGTH),
             "--settle-ms",
             str(SMOKE_SETTLE_MS),
+            "--transport",
+            SMOKE_TRANSPORT,
+            *(["--target", str(SMOKE_TARGET)] if SMOKE_TARGET > 0 else []),
         ]
 
     rc = subprocess.call(root_cmd, cwd=HERE, env=root_env)

--- a/monarch_mini/mast/smoke.py
+++ b/monarch_mini/mast/smoke.py
@@ -258,20 +258,21 @@ async def run_worker(port: int, bind: str, transport: str) -> None:
             log(f"{tag} unexpected header {header!r}; ignoring")
 
 
-async def _direct_round(root: Actor, workers: list[bytes], timeout: float) -> int:
+async def _direct_round(root: Actor, workers: list[bytes], timeout: float, recv) -> int:
     """Send one ping to every worker, await each reply, return the failure count.
 
     Each connected worker yields exactly one terminal message per round: a reply
     (``[H_REPLY, worker_ident]``) or a failure notice (``[H_FAIL, worker_ident,
     reason]``) if its connection dropped (e.g. a heartbeat timeout severed it).
-    Raises ``asyncio.TimeoutError`` if a worker neither replies nor fails within
-    ``timeout`` — the signal that a connection silently stalled.
+    Reads via ``recv`` so establishment hellos from still-connecting spare reserve
+    workers are parked, not counted. Raises ``asyncio.TimeoutError`` if a worker
+    neither replies nor fails within ``timeout`` — a connection silently stalled.
     """
     for wid in workers:
         root.send(wid, [ba(H_PING)])
     failures = 0
     for _ in range(len(workers)):
-        msg = await asyncio.wait_for(root.next(), timeout)
+        msg = await recv(timeout)
         if bytes(msg[0]) == H_REPLY:
             continue
         who, reason = _failure_notice(msg)
@@ -281,7 +282,7 @@ async def _direct_round(root: Actor, workers: list[bytes], timeout: float) -> in
 
 
 async def _ring_round(
-    root: Actor, workers: list[bytes], timeout: float, heads: list[int]
+    root: Actor, workers: list[bytes], timeout: float, heads: list[int], recv
 ) -> int:
     """Inject a token at each chain head and wait for every chain to return.
 
@@ -298,7 +299,7 @@ async def _ring_round(
     total = 0
     failures = 0
     for _ in range(len(heads)):
-        msg = await asyncio.wait_for(root.next(), timeout)
+        msg = await recv(timeout)
         if bytes(msg[0]) == H_RING:
             total += int(bytes(msg[1]))
             continue
@@ -321,6 +322,7 @@ async def run_root(
     close_ctx: bool = True,
     settle_ms: float = 0.0,
     transport: str = "quic",
+    target: int | None = None,
 ) -> int:
     """Performance sweep: grow the connected set 2, 4, 8, ..., N and time each size.
 
@@ -339,40 +341,95 @@ async def run_root(
     root = Actor(b"root")
     rounds = max(min_rounds, 1)
     try:
-        total = len(hosts)
-        # Doubling milestones 2, 4, 8, ... below the total, with the total itself as
-        # the final size (so the full fleet is always measured, power of two or not).
+        reserve = len(hosts)
+        # `target` is the max sweep size. We deliberately launch a *reserve* larger
+        # than `target` so the sweep is built from the FIRST workers that connect and
+        # keeps going when some of the borrowed (preemptible) hosts fail to connect or
+        # drop mid-connect — we just backfill from the reserve. Sizes are milestones of
+        # `target`, not of the reserve.
+        target = min(target or reserve, reserve)
         sizes: list[int] = []
         n = 2
-        while n < total:
+        while n < target:
             sizes.append(n)
             n *= 2
-        if total >= 1 and (not sizes or sizes[-1] != total):
-            sizes.append(total)
-        log(f"[sweep] sizes {sizes} of {total} workers, {rounds} round(s) each")
+        if target >= 1 and (not sizes or sizes[-1] != target):
+            sizes.append(target)
+        log(
+            f"[sweep] target {target} workers (reserve {reserve}, "
+            f"+{reserve - target} spare); sizes {sizes}, {rounds} round(s) each"
+        )
 
-        workers: list[bytes] = []
-        joined = 0
-        for size in sizes:
-            # Join only the next batch to grow the connected set to `size`.
-            batch = hosts[joined:size]
-            t_join = time.monotonic()
-            for host in batch:
-                root.join(f"{transport}://{host}", "parent", failure=[ba(H_FAIL)])
-            joined = size
-            while len(workers) < size:
+        # Connected worker idents in connect order; `next_host` is the reserve cursor,
+        # `inflight` counts joins issued but not yet resolved.
+        # Each worker that connects announces itself with a [b"root", ident] hello.
+        # `pool` collects them in connect order; the sweep exercises `pool[:size]`. We
+        # dial the reserve INCREMENTALLY as the sweep grows — never all up front — so
+        # each step's connects are their own bounded batch and the per-size connect
+        # timing stays meaningful. At each step we keep the dial cursor `DIAL_AHEAD`
+        # ahead of the current need: a dead/preempted host never resolves (the transport
+        # retries the connect forever, signalling failure only on a severed *established*
+        # link), so dialing a little ahead lets the first `need` live hosts connect
+        # without a dead one stalling us; if the lead is entirely dead we widen it.
+        pool: list[bytes] = []
+        next_host = 0
+        DIAL_AHEAD = 128  # spare joins kept dialed beyond the immediate need
+
+        async def recv_round(timeout: float):
+            """Next round/failure message, parking establishment hellos from spare
+            dialed-ahead workers into `pool` (available for a later size) so they're
+            never misread as a round reply."""
+            while True:
+                msg = await asyncio.wait_for(root.next(), timeout)
+                if bytes(msg[0]) == b"root":
+                    pool.append(bytes(msg[1]))
+                    continue
+                return msg
+
+        def dial_through(end: int) -> None:
+            nonlocal next_host
+            end = min(end, reserve)
+            while next_host < end:
+                root.join(
+                    f"{transport}://{hosts[next_host]}", "parent", failure=[ba(H_FAIL)]
+                )
+                next_host += 1
+
+        async def grow_to(need: int) -> bool:
+            """Grow `pool` to `need`, dialing the reserve incrementally (kept
+            `DIAL_AHEAD` ahead of `need`, widened on a stall so dead hosts don't block).
+            False if the reserve is exhausted before `need` workers connect."""
+            dial_through(need + DIAL_AHEAD)
+            while len(pool) < need:
                 try:
                     msg = await asyncio.wait_for(root.next(), connect_timeout)
                 except asyncio.TimeoutError:
-                    log(f"[sweep] ERROR: only {len(workers)}/{size} workers connected")
-                    return 1
+                    if next_host >= reserve:
+                        return False  # whole reserve dialed, still short
+                    dial_through(
+                        next_host + DIAL_AHEAD
+                    )  # dead hosts ate the lead; widen
+                    continue
                 if bytes(msg[0]) == b"root":
-                    workers.append(bytes(msg[1]))
+                    pool.append(bytes(msg[1]))
                 else:
                     who, reason = _failure_notice(msg)
-                    log(f"[sweep] FAILURE (connect) {who}: {reason}")
-                    return 1
+                    log(f"[sweep] connect dropped {who}: {reason}")
+            return True
+
+        prev = 0
+        for size in sizes:
+            t_join = time.monotonic()
+            if not await grow_to(size):
+                log(
+                    f"[sweep] ERROR: only {len(pool)}/{size} workers connected "
+                    f"(reserve of {reserve} exhausted)"
+                )
+                return 1
+            workers = pool[:size]
             connect_ms = (time.monotonic() - t_join) * 1e3
+            grew = size - prev
+            prev = size
 
             # Re-wire the ring over the whole current set (new workers included), so
             # every worker knows its next hop before a token can reach it.
@@ -390,12 +447,12 @@ async def run_root(
             try:
                 for _ in range(rounds):
                     t_d = time.monotonic()
-                    if await _direct_round(root, workers, timeout):
+                    if await _direct_round(root, workers, timeout, recv_round):
                         log(f"[sweep] FAILURE in direct at size {size}")
                         return 1
                     d = (time.monotonic() - t_d) * 1e3
                     t_r = time.monotonic()
-                    if await _ring_round(root, workers, timeout, heads):
+                    if await _ring_round(root, workers, timeout, heads, recv_round):
                         log(f"[sweep] FAILURE in ring at size {size}")
                         return 1
                     r = (time.monotonic() - t_r) * 1e3
@@ -414,10 +471,10 @@ async def run_root(
             if settle_ms > 0 and size == sizes[-1]:
                 await asyncio.sleep(settle_ms / 1000.0)
                 try:
-                    if await _direct_round(root, workers, timeout):
+                    if await _direct_round(root, workers, timeout, recv_round):
                         log(f"[sweep] FAILURE after settle (direct) at size {size}")
                         return 1
-                    if await _ring_round(root, workers, timeout, heads):
+                    if await _ring_round(root, workers, timeout, heads, recv_round):
                         log(f"[sweep] FAILURE after settle (ring) at size {size}")
                         return 1
                 except asyncio.TimeoutError:
@@ -425,7 +482,7 @@ async def run_root(
                     return 1
                 log(f"[sweep] size={size:>6}  settled {settle_ms:.0f}ms OK")
             log(
-                f"[sweep] size={size:>6}  connect(+{len(batch)})={connect_ms:9.1f} ms  "
+                f"[sweep] size={size:>6}  connect(+{grew})={connect_ms:9.1f} ms  "
                 f"direct min={direct_best:8.2f} avg={direct_sum / rounds:8.2f} ms  "
                 f"ring min={ring_best:8.2f} avg={ring_sum / rounds:8.2f} ms  "
                 f"({len(heads)} chain(s))"
@@ -448,6 +505,7 @@ async def run_root_coordinated(
     chain_length: int = 0,
     settle_ms: float = 0.0,
     transport: str = "quic",
+    target: int | None = None,
 ) -> int:
     """Root variant that waits for a controller to hand it the worker addresses.
 
@@ -504,6 +562,7 @@ async def run_root_coordinated(
         close_ctx=False,
         settle_ms=settle_ms,
         transport=transport,
+        target=target,
     )
 
     log(f"[coord] sweep finished rc={rc}; notifying controller and closing")
@@ -591,6 +650,15 @@ def main() -> None:
         "(default: 1). More rounds give a min/avg per size.",
     )
     parser.add_argument(
+        "--target",
+        type=int,
+        default=None,
+        help="root: max sweep size (number of workers to actually exercise). Launch "
+        "MORE hosts than this (the reserve); the sweep is built from the first "
+        "--target workers that connect and backfills from the reserve when borrowed "
+        "hosts fail. Default: sweep every host given (no reserve).",
+    )
+    parser.add_argument(
         "--settle-ms",
         type=float,
         default=0.0,
@@ -616,6 +684,7 @@ def main() -> None:
                     args.chain_length,
                     args.settle_ms,
                     args.transport,
+                    args.target,
                 )
             )
         )
@@ -635,6 +704,7 @@ def main() -> None:
                     args.chain_length,
                     settle_ms=args.settle_ms,
                     transport=args.transport,
+                    target=args.target,
                 )
             )
         )


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* __->__ #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Adds OPEC scheduling and graceful-preemption controls to MAST job specs, and propagates the selected transport and sweep target through the bootstrap. Builds each benchmark size from the first available workers while dialing ahead into an over-provisioned reserve, so failed or preempted hosts do not stall the sweep.

Differential Revision: [D112145342](https://our.internmc.facebook.com/intern/diff/D112145342/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D112145342/)!