### PR TITLE
39/43 minimonarch: Option for parallel TCP and QUIC transport

### DIFF
--- a/monarch_mini/python/net_parallel_bench.py
+++ b/monarch_mini/python/net_parallel_bench.py
@@ -1,0 +1,332 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""net_parallel_bench.py — does the net-data plane actually run crypto in parallel?
+
+Verifies the `MM_NET_DATA_THREADS` change: with it set, the per-connection message
+writer/reader coroutines run on a multi-threaded runtime, so the CPU work of
+processing many streams (framing + TLS crypto) should spread across cores instead of
+serializing on the single `monarch-mini` command-loop thread.
+
+How it measures (no guessing from wall-clock alone): each process reads its own
+per-thread CPU time from `/proc/self/task/<tid>/{comm,stat}` before and after a blast
+and attributes the delta by thread name. The tokio worker threads are named
+`mm-net-data`; the command loop (and, for quic, quinn's endpoint driver) run on
+`monarch-mini`. The telling number is **CPU-seconds on the data threads / wall-seconds**
+during the blast: > 1 means several data threads ran at once, i.e. genuine parallelism.
+
+Topology: two processes joined over `scheme://127.0.0.1:port`, one connection per
+port. The client (child) blasts `msgs` payloads of `size` bytes to the server (parent)
+on each of `conns` independent connections; the server decrypts them. Both processes
+report their own per-thread CPU, so we see sender (encrypt) and receiver (decrypt)
+parallelism separately.
+
+Run the default matrix (tcp/quic x 1/N threads) from this directory:
+
+    uv run python net_parallel_bench.py
+
+or one cell (it re-execs itself as the two subprocesses):
+
+    uv run python net_parallel_bench.py --scheme tcp --threads 8 --conns 8
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from collections import defaultdict
+
+import minimonarch
+from minimonarch import Actor
+
+ba = minimonarch.bytearray
+
+# Thread names (tokio sets these) whose CPU we attribute the networking work to.
+DATA_THREAD = "mm-net-data"  # multi-threaded data-plane workers (the parallel target)
+LOOP_THREAD = "monarch-mini"  # the single command loop + quic endpoint driver
+_CLK_TCK = os.sysconf("SC_CLK_TCK")
+_RESULT_MARKER = "BENCH_RESULT "
+
+
+def sample_thread_cpu() -> dict[str, float]:
+    """CPU seconds (utime+stime) consumed so far, summed by thread name.
+
+    Reads every thread of this process from `/proc/self/task`. A name may cover
+    several threads (the `mm-net-data` pool), so values are summed per name.
+    """
+    totals: dict[str, float] = defaultdict(float)
+    task_dir = "/proc/self/task"
+    for tid in os.listdir(task_dir):
+        try:
+            with open(f"{task_dir}/{tid}/comm") as f:
+                name = f.read().strip()
+            with open(f"{task_dir}/{tid}/stat") as f:
+                stat = f.read()
+        except FileNotFoundError:
+            continue  # thread exited between listdir and read
+        # comm can contain spaces/parens; fields after the ")" are space-separated,
+        # with utime/stime at positions 14/15 (1-indexed) of the whole line.
+        fields = stat[stat.rfind(")") + 2 :].split()
+        utime, stime = int(fields[11]), int(fields[12])
+        totals[name] += (utime + stime) / _CLK_TCK
+    return dict(totals)
+
+
+def cpu_delta(before: dict[str, float], after: dict[str, float]) -> dict[str, float]:
+    names = set(before) | set(after)
+    return {n: after.get(n, 0.0) - before.get(n, 0.0) for n in names}
+
+
+def url(scheme: str, port: int) -> str:
+    return f"{scheme}://127.0.0.1:{port}"
+
+
+def free_ports(n: int, scheme: str) -> list[int]:
+    """`n` distinct free ports for the scheme's socket type (UDP for quic, TCP else).
+
+    Bound all at once then released, so the returned ports are distinct; serve/join
+    retry, so the brief unbound gap before the transport rebinds is harmless.
+    """
+    kind = socket.SOCK_DGRAM if scheme == "quic" else socket.SOCK_STREAM
+    socks = [socket.socket(socket.AF_INET, kind) for _ in range(n)]
+    try:
+        for s in socks:
+            s.bind(("127.0.0.1", 0))
+        return [s.getsockname()[1] for s in socks]
+    finally:
+        for s in socks:
+            s.close()
+
+
+def _emit_result(payload: dict[str, object]) -> None:
+    # A single machine-readable line the driver greps out of stdout.
+    print(_RESULT_MARKER + json.dumps(payload), flush=True)
+
+
+async def _recv_windowed(actor: Actor, peer: bytes, msgs: int, window: int) -> int:
+    """Receive `msgs` payloads in `window`-sized rounds, acking each round.
+
+    The per-window ack lets the sender bound its outstanding (unsent) buffers, so a
+    large total volume never has to be resident at once.
+    """
+    total = 0
+    got = 0
+    while got < msgs:
+        n = min(window, msgs - got)
+        for _ in range(n):
+            parts = await actor.next()
+            total += sum(len(p) for p in parts)
+        got += n
+        actor.send(peer, [ba(b"ack")])
+    return total
+
+
+async def run_server(scheme: str, ports: list[int], msgs: int, window: int) -> None:
+    """Serve one parent per port, receive `msgs` blasts on each, ack, and report CPU."""
+    actors = [Actor(f"srv{i}".encode()) for i in range(len(ports))]
+    for actor, port in zip(actors, ports):
+        actor.serve(url(scheme, port), "parent")
+    peers = [bytes((await actor.next())[1]) for actor in actors]  # [self, peer]
+
+    base = sample_thread_cpu()
+    t0 = time.perf_counter()
+    received = await asyncio.gather(
+        *(_recv_windowed(a, p, msgs, window) for a, p in zip(actors, peers))
+    )
+    wall = time.perf_counter() - t0
+
+    _emit_result(
+        {
+            "who": "server",
+            "wall_s": wall,
+            "bytes": sum(received),
+            "cpu": cpu_delta(base, sample_thread_cpu()),
+        }
+    )
+    minimonarch.close()
+
+
+async def _blast_windowed(
+    actor: Actor, peer: bytes, msgs: int, size: int, window: int
+) -> None:
+    payload = bytes(size)  # contents are irrelevant to crypto/throughput cost
+    sent = 0
+    while sent < msgs:
+        n = min(window, msgs - sent)
+        for _ in range(n):
+            actor.send(peer, [ba(payload)])  # ba(bytes) copies; send moves it out
+        sent += n
+        await actor.next()  # the server's ack for this window (bounds our backlog)
+
+
+async def run_client(
+    scheme: str, ports: list[int], msgs: int, size: int, window: int
+) -> None:
+    """Join one child per port, blast `msgs` payloads on each, and report CPU."""
+    actors = [Actor(f"cli{i}".encode()) for i in range(len(ports))]
+    for actor, port in zip(actors, ports):
+        actor.join(url(scheme, port), "child")
+    peers = [bytes((await actor.next())[1]) for actor in actors]
+
+    base = sample_thread_cpu()
+    t0 = time.perf_counter()
+    await asyncio.gather(
+        *(_blast_windowed(a, p, msgs, size, window) for a, p in zip(actors, peers))
+    )
+    wall = time.perf_counter() - t0
+
+    _emit_result(
+        {
+            "who": "client",
+            "wall_s": wall,
+            "bytes": msgs * size * len(ports),
+            "cpu": cpu_delta(base, sample_thread_cpu()),
+        }
+    )
+    minimonarch.close()
+
+
+def _child_env(threads: int) -> dict[str, str]:
+    env = os.environ.copy()
+    env["MM_NET_DATA_THREADS"] = str(threads)
+    certs = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "test_certs"))
+    env["MM_QUIC_CERT"] = os.path.join(certs, "cert.pem")
+    env["MM_QUIC_KEY"] = os.path.join(certs, "key.pem")
+    env["MM_QUIC_CA"] = os.path.join(certs, "ca.pem")
+    return env
+
+
+def _spawn(role: str, scheme: str, ports: list[int], args: argparse.Namespace, env):
+    csv = ",".join(str(p) for p in ports)
+    cmd = [
+        sys.executable,
+        os.path.abspath(__file__),
+        "--role",
+        role,
+        "--scheme",
+        scheme,
+        "--ports",
+        csv,
+        "--msgs",
+        str(args.msgs),
+        "--size",
+        str(args.size),
+        "--window",
+        str(args.window),
+    ]
+    return subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, text=True)
+
+
+def _parse_result(output: str) -> dict[str, object]:
+    for line in output.splitlines():
+        if line.startswith(_RESULT_MARKER):
+            return json.loads(line[len(_RESULT_MARKER) :])
+    raise RuntimeError(f"no result line in subprocess output:\n{output}")
+
+
+def _run_cell(scheme: str, threads: int, args: argparse.Namespace) -> dict[str, object]:
+    """Run one (scheme, threads) cell across two subprocesses; return their reports."""
+    env = _child_env(threads)
+    ports = free_ports(args.conns, scheme)
+    server = _spawn("server", scheme, ports, args, env)
+    client = _spawn("client", scheme, ports, args, env)
+    try:
+        client_out, _ = client.communicate(timeout=args.timeout)
+        server_out, _ = server.communicate(timeout=args.timeout)
+    except subprocess.TimeoutExpired:
+        server.kill()
+        client.kill()
+        raise
+    if client.returncode != 0 or server.returncode != 0:
+        raise RuntimeError(
+            f"subprocess failed (server rc={server.returncode}, client rc={client.returncode})\n"
+            f"--- server ---\n{server_out}\n--- client ---\n{client_out}"
+        )
+    return {"server": _parse_result(server_out), "client": _parse_result(client_out)}
+
+
+def _summarize(who: dict[str, object], total_mb: float) -> dict[str, float]:
+    wall = float(who["wall_s"])
+    cpu = who["cpu"]
+    data = float(cpu.get(DATA_THREAD, 0.0))
+    loop = float(cpu.get(LOOP_THREAD, 0.0))
+    return {
+        "mb_per_s": total_mb / wall if wall else 0.0,
+        "data_cpu_s": data,
+        "loop_cpu_s": loop,
+        # Avg data-thread cores busy over the window: > 1 ⇒ genuine parallelism.
+        "data_parallelism": data / wall if wall else 0.0,
+    }
+
+
+def _print_report(args: argparse.Namespace, cells: dict) -> None:
+    total_mb = args.conns * args.msgs * args.size / 1e6
+    print(
+        f"\nnet_parallel_bench: conns={args.conns} msgs/conn={args.msgs} "
+        f"size={args.size}B total={total_mb:.0f}MB\n"
+        f"'data_par' = CPU-seconds on {DATA_THREAD} threads / wall-seconds "
+        f"(>1 means crypto ran on several cores at once)\n"
+    )
+    header = f"{'scheme':6} {'thr':>3} {'side':6} {'MB/s':>8} {'data_cpu_s':>11} {'loop_cpu_s':>11} {'data_par':>9}"
+    print(header)
+    print("-" * len(header))
+    for (scheme, threads), report in cells.items():
+        for side in ("server", "client"):
+            s = _summarize(report[side], total_mb)
+            print(
+                f"{scheme:6} {threads:>3} {side:6} {s['mb_per_s']:>8.1f} "
+                f"{s['data_cpu_s']:>11.2f} {s['loop_cpu_s']:>11.2f} {s['data_parallelism']:>9.2f}"
+            )
+    print()
+
+
+def _run_driver(args: argparse.Namespace) -> None:
+    schemes = args.scheme.split(",") if args.scheme else ["tcp", "quic"]
+    thread_counts = [int(t) for t in args.matrix_threads.split(",")]
+    cells: dict = {}
+    for scheme in schemes:
+        for threads in thread_counts:
+            print(f"running {scheme} threads={threads} ...", file=sys.stderr)
+            cells[(scheme, threads)] = _run_cell(scheme, threads, args)
+    _print_report(args, cells)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--role", choices=["server", "client"], default=None)
+    parser.add_argument("--scheme", default=None, help="csv of tcp,quic (driver)")
+    parser.add_argument("--ports", default=None, help="csv of ports (subprocess)")
+    parser.add_argument("--conns", type=int, default=8)
+    parser.add_argument("--msgs", type=int, default=256, help="messages per connection")
+    parser.add_argument("--size", type=int, default=256 * 1024, help="payload bytes")
+    parser.add_argument(
+        "--window", type=int, default=32, help="unacked messages in flight per conn"
+    )
+    parser.add_argument("--threads", type=int, default=8, help="single-cell threads")
+    parser.add_argument("--matrix-threads", default="1,8", help="driver thread sweep")
+    parser.add_argument("--timeout", type=float, default=120.0)
+    args = parser.parse_args()
+
+    if args.role is None:
+        # Driver mode. A single --scheme (no matrix override) still sweeps threads.
+        _run_driver(args)
+        return
+
+    ports = [int(p) for p in args.ports.split(",")]
+    if args.role == "server":
+        asyncio.run(run_server(args.scheme, ports, args.msgs, args.window))
+    else:
+        asyncio.run(run_client(args.scheme, ports, args.msgs, args.size, args.window))
+
+
+if __name__ == "__main__":
+    main()

--- a/monarch_mini/src/net.rs
+++ b/monarch_mini/src/net.rs
@@ -50,6 +50,7 @@ use std::net::SocketAddr;
 
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
+use tokio::runtime::Handle;
 
 /// The network-protocol-specific operations the generic transport is built on.
 pub(crate) trait Net: Sized + 'static {
@@ -64,7 +65,18 @@ pub(crate) trait Net: Sized + 'static {
 
     /// Build the shared per-context networking state, lazily, on the first serve or
     /// join (quic: install the crypto provider; TLS is loaded on first bind/dial).
-    fn create() -> anyhow::Result<Self>;
+    ///
+    /// `runtime`, when `Some`, is the multi-threaded runtime the caller wants this
+    /// protocol's network *work* to run on (so it spreads across cores rather than
+    /// serializing on the command-loop thread). A protocol whose work lives in a
+    /// background driver (quic: the per-endpoint driver quinn spawns at endpoint
+    /// construction) builds its endpoints/sockets with this runtime entered, placing
+    /// that driver — and thus its crypto — on the pool. A protocol whose work lives in
+    /// the foreground stream poll (tcp/kTLS: the read/write syscalls happen when the
+    /// stream is polled) cannot relocate its work from here — the generic transport
+    /// spawns its data coroutines on the same runtime instead — so it ignores this.
+    /// `None` ⇒ everything stays on the command-loop thread (single-core default).
+    fn create(runtime: Option<Handle>) -> anyhow::Result<Self>;
 
     /// Parse a transport url (e.g. `quic://[::1]:7001`, or a bare `@endpoint` tag)
     /// into a socket address.
@@ -106,11 +118,14 @@ pub(crate) trait Net: Sized + 'static {
 /// address), used by the heartbeat send log.
 pub(crate) trait NetConn: Debug + 'static {
     /// The send half of a stream; framing drives it via [`AsyncWrite`]. It keeps the
-    /// underlying connection alive for its lifetime.
-    type Send: AsyncWrite + Unpin + 'static;
+    /// underlying connection alive for its lifetime. `Send` so the data writer
+    /// coroutine can run on a multi-threaded runtime (the connection handle and the
+    /// heartbeat stream stay single-threaded; only the two data halves cross threads).
+    type Send: AsyncWrite + Unpin + Send + 'static;
     /// The receive half of a stream; framing drives it via [`AsyncRead`]. It keeps
-    /// the underlying connection alive for its lifetime.
-    type Recv: AsyncRead + Unpin + 'static;
+    /// the underlying connection alive for its lifetime. `Send` for the same reason as
+    /// [`Self::Send`] — the data reader coroutine may run off the command-loop thread.
+    type Recv: AsyncRead + Unpin + Send + 'static;
     /// The awaitable that materializes one stream's halves on first poll.
     type Stream: Future<Output = std::io::Result<(Self::Send, Self::Recv)>> + 'static;
 

--- a/monarch_mini/src/net_transport.rs
+++ b/monarch_mini/src/net_transport.rs
@@ -44,6 +44,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 
 use tokio::io::AsyncWriteExt;
+use tokio::runtime::Handle;
 use tokio::sync::Semaphore;
 use tokio::sync::mpsc;
 use tokio::sync::watch;
@@ -134,6 +135,44 @@ fn max_concurrent_connects<N: Net>() -> Option<usize> {
     }
 }
 
+/// Build the optional multi-threaded runtime that the per-connection data
+/// coroutines (the message writer/reader) run on, off the single-threaded command
+/// loop. `MM_NET_DATA_THREADS` selects it: unset or `0` keeps every coroutine on the
+/// command-loop thread (today's behaviour, no data parallelism); a positive `N`
+/// stands up an `N`-worker runtime so the data-stream framing/crypto/copy for many
+/// connections runs across cores while accounting stays serialized on one core.
+///
+/// Only the two *data* coroutines move; the connection handle, heartbeat stream,
+/// side channels, and pairing all stay on the command-loop thread. The data stream
+/// halves were materialized on the command-loop runtime's I/O driver, so readiness is
+/// still driven there — this offloads the per-frame CPU work (notably kTLS-over-TCP's
+/// in-task syscalls/copy), not the epoll wakeups. Fully decoupling the reactor would
+/// require materializing the streams on this runtime, a later step.
+fn data_runtime() -> Option<tokio::runtime::Runtime> {
+    let n = std::env::var("MM_NET_DATA_THREADS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0);
+    if n == 0 {
+        return None;
+    }
+    match tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(n)
+        .thread_name("mm-net-data")
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => {
+            eprintln!("MM_NET_DATA_THREADS: net data coroutines on a {n}-worker runtime");
+            Some(rt)
+        }
+        Err(err) => {
+            tracing::warn!("MM_NET_DATA_THREADS set but runtime build failed: {err:#}");
+            None
+        }
+    }
+}
+
 /// The gateway dial tag of `ident` (the substring after the last `@`), as a
 /// `String`, or `None` if it has none or is non-utf8. This is the address a beat is
 /// dialed at — the recipient's own gateway.
@@ -198,6 +237,9 @@ struct SideChannels<N: Net> {
     /// for its lifetime. Teardown drops this issuing copy so `alive_rx` closes once
     /// every writer has flushed and exited.
     alive_tx: Option<mpsc::UnboundedSender<()>>,
+    /// The data runtime handle, handed to [`Net::create`] so a protocol whose work is
+    /// in a background driver (quic) builds its endpoints there. `None` ⇒ single core.
+    data_rt: Option<Handle>,
 }
 
 /// Owns all transport state and coroutines. The command loop holds one and forwards
@@ -225,6 +267,10 @@ pub(crate) struct NetTransport<N: Net> {
     // Client dialing + side-channel writers, shared with the heartbeat coroutines so
     // the transport drives every side-channel path without ctx involvement.
     side_channels: Rc<RefCell<SideChannels<N>>>,
+    // Optional multi-threaded runtime the per-connection data coroutines run on (see
+    // `data_runtime`). `None` ⇒ they run on the command-loop thread like everything
+    // else. Owned here for its lifetime; torn down (non-blocking) in `shutdown`.
+    data_rt: Option<tokio::runtime::Runtime>,
 }
 
 impl<N: Net> NetTransport<N> {
@@ -238,6 +284,11 @@ impl<N: Net> NetTransport<N> {
         if let Some(n) = max_concurrent_connects::<N>() {
             eprintln!("MM_QUIC connect concurrency capped at {n} simultaneous attempts");
         }
+        // The data runtime is owned here for its lifetime; its handle is shared with
+        // the side channels (→ `Net::create`, for quic's endpoint drivers) and with
+        // `spawn_connection` via `data_handle` (for the tcp data coroutines).
+        let data_rt = data_runtime();
+        let data_rt_handle = data_rt.as_ref().map(|rt| rt.handle().clone());
         Self {
             loop_tx,
             mapper,
@@ -251,8 +302,16 @@ impl<N: Net> NetTransport<N> {
                 net: None,
                 channels: HashMap::new(),
                 alive_tx: Some(alive_tx),
+                data_rt: data_rt_handle,
             })),
+            data_rt,
         }
+    }
+
+    /// A handle to the data-coroutine runtime, or `None` to run them on the
+    /// command-loop thread. Cloned per connection and passed to [`spawn_connection`].
+    fn data_handle(&self) -> Option<Handle> {
+        self.data_rt.as_ref().map(|rt| rt.handle().clone())
     }
 
     /// A connection's shared-memory context: the context mapper paired with the given
@@ -282,6 +341,13 @@ impl<N: Net> NetTransport<N> {
     pub(crate) async fn shutdown(&mut self) {
         self.side_channels.borrow_mut().begin_shutdown();
         let _ = self.alive_rx.recv().await;
+        // Tear the data runtime down without blocking: we are inside the command
+        // loop's async context, where dropping a `Runtime` (which blocks on its worker
+        // threads) would panic. The writers above have already flushed and the peers
+        // acknowledged, so its tasks have nothing left to do.
+        if let Some(rt) = self.data_rt.take() {
+            rt.shutdown_background();
+        }
     }
 }
 
@@ -289,7 +355,7 @@ impl<N: Net> SideChannels<N> {
     /// The shared networking state, built on first use.
     fn net(&mut self) -> anyhow::Result<&mut N> {
         if self.net.is_none() {
-            self.net = Some(N::create()?);
+            self.net = Some(N::create(self.data_rt.clone())?);
         }
         Ok(self.net.as_mut().expect("net just created"))
     }
@@ -405,6 +471,7 @@ impl<N: Net> Transport for NetTransport<N> {
             let context_shm = self.shm_ctx(self.context_shm.clone());
             let shutdown = self.side_channels.borrow().subscribe_shutdown();
             let alive = self.side_channels.borrow().alive_token();
+            let data_rt = self.data_handle();
             // Bind synchronously so a port-in-use failure is known now; a failed bind
             // spawns a task that severs every serve on this url until teardown rather
             // than respawn-retrying.
@@ -419,6 +486,7 @@ impl<N: Net> Transport for NetTransport<N> {
                         context_shm,
                         self.heartbeat.clone(),
                         self.side_channels.clone(),
+                        data_rt,
                     ));
                 }
                 Err(err) => {
@@ -462,6 +530,7 @@ impl<N: Net> Transport for NetTransport<N> {
         };
         let shutdown = self.side_channels.borrow().subscribe_shutdown();
         let alive = self.side_channels.borrow().alive_token();
+        let data_rt = self.data_handle();
         tokio::task::spawn_local(connector_task::<N>(
             dialer,
             addr,
@@ -473,6 +542,7 @@ impl<N: Net> Transport for NetTransport<N> {
             self.connect_sem.clone(),
             self.heartbeat.clone(),
             self.side_channels.clone(),
+            data_rt,
         ));
     }
 }
@@ -536,6 +606,7 @@ async fn listener_task<N: Net>(
     side_channel_shm: ShmCtx,
     heartbeat: Heartbeats,
     side_channels: Rc<RefCell<SideChannels<N>>>,
+    data_rt: Option<Handle>,
 ) {
     // Accepting a connection, its data stream, and its preamble is a multi-step
     // handshake; run it off the pairing loop so a slow handshake doesn't stall
@@ -549,7 +620,7 @@ async fn listener_task<N: Net>(
             serve = serves.recv() => {
                 let Some((connection, shm)) = serve else { return; };
                 if let Some((left, right)) = matcher.push_left((connection, shm), |l, r| (l, r)) {
-                    spawn_join(left, right, &loop_tx, &shutdown, &alive, &heartbeat, &side_channels);
+                    spawn_join(left, right, &loop_tx, &shutdown, &alive, &heartbeat, &side_channels, &data_rt);
                 }
             }
             accepted = accepted_rx.recv() => {
@@ -557,7 +628,7 @@ async fn listener_task<N: Net>(
                     None => return,
                     Some(Accepted::Join(streams)) => {
                         if let Some((left, right)) = matcher.push_right(streams, |l, r| (l, r)) {
-                            spawn_join(left, right, &loop_tx, &shutdown, &alive, &heartbeat, &side_channels);
+                            spawn_join(left, right, &loop_tx, &shutdown, &alive, &heartbeat, &side_channels, &data_rt);
                         }
                     }
                     Some(Accepted::SideChannel { conn, msg_recv }) => {
@@ -585,6 +656,10 @@ async fn listener_task<N: Net>(
 /// true` and `dialed = false` (the peer dialed us). The data-stream halves were
 /// already split (with `first_messenger = false`) and the preamble read by the
 /// acceptor.
+#[expect(
+    clippy::too_many_arguments,
+    reason = "each argument is a distinct piece of per-connection state forwarded to spawn_connection; bundling adds indirection without clarifying anything"
+)]
 fn spawn_join<N: Net>(
     serve: (ConnectionRef, ShmCtx),
     streams: JoinStreams<N>,
@@ -593,6 +668,7 @@ fn spawn_join<N: Net>(
     alive: &mpsc::UnboundedSender<()>,
     heartbeat: &Heartbeats,
     side_channels: &Rc<RefCell<SideChannels<N>>>,
+    data_rt: &Option<Handle>,
 ) {
     let (connection, shm) = serve;
     let JoinStreams {
@@ -613,6 +689,7 @@ fn spawn_join<N: Net>(
         false,
         heartbeat.clone(),
         side_channels.clone(),
+        data_rt.clone(),
     );
 }
 
@@ -732,6 +809,7 @@ async fn connector_task<N: Net>(
     connect_sem: Option<Arc<Semaphore>>,
     heartbeat: Heartbeats,
     side_channels: Rc<RefCell<SideChannels<N>>>,
+    data_rt: Option<Handle>,
 ) {
     let mut retry = CONNECT_RETRY_MIN;
     loop {
@@ -780,6 +858,7 @@ async fn connector_task<N: Net>(
                         true,
                         heartbeat,
                         side_channels,
+                        data_rt,
                     );
                     return;
                 }
@@ -937,6 +1016,10 @@ fn spawn_connection<N: Net>(
     dialed: bool,
     heartbeat: Heartbeats,
     side_channels: Rc<RefCell<SideChannels<N>>>,
+    // When `Some`, the data writer/reader run on this multi-threaded runtime instead
+    // of the command-loop thread (see `data_runtime`). The heartbeat stream, side
+    // channels, and pairing always stay on the command-loop thread.
+    data_rt: Option<Handle>,
 ) {
     let (writer_tx, writer_rx) = mpsc::unbounded_channel();
     // Reader → writer signal: the peer responded to our shutdown, so the writer may
@@ -962,23 +1045,38 @@ fn spawn_connection<N: Net>(
     // Spawn the coroutine; the returned sender is how the readers/writer feed it
     // inbound beats, Establish snoops, and reader-closed.
     let hb_event_tx = heartbeat.spawn(connection, dialed, beats_tx, send_beat, loop_tx.clone());
-    // Data stream: command writer and frame reader.
-    tokio::task::spawn_local(writer_task::<N>(
+    // Data stream: command writer and frame reader. Built here (moving in their state)
+    // then spawned either on the data runtime (parallel across connections) or, by
+    // default, on the command-loop thread. Only these two coroutines may move off the
+    // command-loop thread — their captured state is `Send` (the `Send`-bounded stream
+    // halves, channel handles, `Copy` connection ref, and `Arc`-backed shm); the
+    // heartbeat/side-channel machinery below stays local.
+    let writer = writer_task::<N>(
         data_send,
         writer_rx,
         shutdown.clone(),
         alive,
         peer_responded_rx,
         hb_event_tx.clone(),
-    ));
-    tokio::task::spawn_local(reader_task::<N>(
+    );
+    let reader = reader_task::<N>(
         data_recv,
         connection,
         loop_tx,
         peer_responded_tx,
         shm,
         hb_event_tx.clone(),
-    ));
+    );
+    match &data_rt {
+        Some(handle) => {
+            handle.spawn(writer);
+            handle.spawn(reader);
+        }
+        None => {
+            tokio::task::spawn_local(writer);
+            tokio::task::spawn_local(reader);
+        }
+    }
     // Heartbeat stream: materialized off the establishment path, then a beat writer
     // and reader run on it. `first_messenger` is whether this side is the heartbeat
     // **Child** — which always beats first — so the Child opens the stream and the

--- a/monarch_mini/src/quic_net.rs
+++ b/monarch_mini/src/quic_net.rs
@@ -65,6 +65,7 @@ use rustls_pki_types::PrivateKeyDer;
 use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
 use tokio::io::ReadBuf;
+use tokio::runtime::Handle;
 
 use crate::net::Net;
 use crate::net::NetConn;
@@ -103,8 +104,28 @@ fn stream_recv_window_bytes() -> u64 {
 fn ensure_crypto_provider() {
     static INSTALLED: OnceLock<()> = OnceLock::new();
     INSTALLED.get_or_init(|| {
-        let _ = rustls::crypto::ring::default_provider().install_default();
+        let _ = selected_provider().install_default();
     });
+}
+
+/// The ring crypto provider, optionally restricted to a single TLS 1.3 AEAD by
+/// `MM_QUIC_CIPHER` (`aes128` | `aes256` | `chacha20`) so quic's encryption cost can
+/// be A/B'd. Unset ⇒ ring's default suite set and preference order (AES-256-GCM
+/// first on x86). Affects quic only; the tcp/kTLS transport builds its own provider.
+fn selected_provider() -> rustls::crypto::CryptoProvider {
+    use rustls::crypto::ring::cipher_suite;
+    let base = rustls::crypto::ring::default_provider();
+    let suite = match std::env::var("MM_QUIC_CIPHER").ok().as_deref() {
+        Some("aes128") => cipher_suite::TLS13_AES_128_GCM_SHA256,
+        Some("aes256") => cipher_suite::TLS13_AES_256_GCM_SHA384,
+        Some("chacha20") => cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+        _ => return base,
+    };
+    eprintln!("MM_QUIC_CIPHER: restricting quic to a single cipher suite");
+    rustls::crypto::CryptoProvider {
+        cipher_suites: vec![suite],
+        ..base
+    }
 }
 
 /// Server + client TLS configs, built once from the environment and shared by all
@@ -442,6 +463,10 @@ pub(crate) struct Quic {
     client_endpoints_v6: Vec<Endpoint>,
     // Round-robin cursor for assigning connections to pool endpoints.
     client_rr: usize,
+    // When set, the multi-threaded runtime to build endpoints under, so quinn spawns
+    // each endpoint's driver (which runs the packet crypto) on the pool rather than on
+    // the command-loop thread. Entered around `Endpoint::new` in `bind`/`dialer`.
+    rt: Option<Handle>,
 }
 
 impl Quic {
@@ -526,22 +551,40 @@ impl Quic {
     }
 }
 
+/// A dialing handle: a pooled client endpoint plus the data runtime to enter when
+/// dialing, so quinn spawns the resulting connection's driver (which runs its packet
+/// crypto) on that runtime rather than on whatever thread calls [`Net::connect`] (the
+/// command loop). `None` ⇒ the connection driver follows the caller (single core).
+#[derive(Clone)]
+pub(crate) struct QuicDialer {
+    endpoint: Endpoint,
+    rt: Option<Handle>,
+}
+
+/// A bound server endpoint plus the data runtime to enter when accepting, for the same
+/// reason as [`QuicDialer`]: the accepted connection's driver spawns on that runtime.
+pub(crate) struct QuicListener {
+    endpoint: Endpoint,
+    rt: Option<Handle>,
+}
+
 impl Net for Quic {
-    // A client endpoint clone (cheap; internally reference-counted). Dialing through it
-    // repeatedly is what a connector/side-channel task does.
-    type Dialer = Endpoint;
-    // A server endpoint. quic multiplexes all streams on one connection, so it ignores
-    // the stream count passed to `bind`.
-    type Listener = Endpoint;
+    // A pooled client endpoint (cheap clone; internally reference-counted) plus the
+    // runtime to place dialed connections' drivers on.
+    type Dialer = QuicDialer;
+    // A server endpoint plus that runtime. quic multiplexes all streams on one
+    // connection, so it ignores the stream count passed to `bind`.
+    type Listener = QuicListener;
     type Conn = QuicConn;
 
-    fn create() -> anyhow::Result<Self> {
+    fn create(runtime: Option<Handle>) -> anyhow::Result<Self> {
         ensure_crypto_provider();
         Ok(Self {
             tls: None,
             client_endpoints_v4: Vec::new(),
             client_endpoints_v6: Vec::new(),
             client_rr: 0,
+            rt: runtime,
         })
     }
 
@@ -549,26 +592,53 @@ impl Net for Quic {
         parse_addr(url)
     }
 
-    fn dialer(&mut self, addr: SocketAddr) -> anyhow::Result<Endpoint> {
-        self.client_endpoint(&addr)
+    fn dialer(&mut self, addr: SocketAddr) -> anyhow::Result<QuicDialer> {
+        // Enter the data runtime (if any) so quinn spawns the pool endpoints' *endpoint*
+        // drivers there. Clone the handle first: the guard borrows the clone, leaving
+        // `self` free for the `&mut self` pool build below. The handle also rides along
+        // on the QuicDialer so `connect` can place each connection's driver there too.
+        let rt = self.rt.clone();
+        let endpoint = {
+            let _guard = rt.as_ref().map(Handle::enter);
+            self.client_endpoint(&addr)?
+        };
+        Ok(QuicDialer { endpoint, rt })
     }
 
-    fn bind(&mut self, addr: SocketAddr, _streams: usize) -> anyhow::Result<Endpoint> {
+    fn bind(&mut self, addr: SocketAddr, _streams: usize) -> anyhow::Result<QuicListener> {
         let server = self.tls()?.server.clone();
-        make_server_endpoint(addr, server)
+        // Enter the data runtime (if any) so quinn spawns this server endpoint's driver
+        // there; the handle also rides on the QuicListener for `accept` to use.
+        let rt = self.rt.clone();
+        let endpoint = {
+            let _guard = rt.as_ref().map(Handle::enter);
+            make_server_endpoint(addr, server)?
+        };
+        Ok(QuicListener { endpoint, rt })
     }
 
-    async fn accept(listener: &Endpoint) -> Option<QuicConn> {
-        let incoming = listener.accept().await?;
-        let connecting = incoming.accept().ok()?;
+    async fn accept(listener: &QuicListener) -> Option<QuicConn> {
+        let incoming = listener.endpoint.accept().await?;
+        // `incoming.accept()` synchronously creates the Connecting and spawns its
+        // connection driver (via ambient `tokio::spawn`), so enter the data runtime
+        // around exactly that call to place the driver — and its crypto — on the pool.
+        let connecting = {
+            let _guard = listener.rt.as_ref().map(Handle::enter);
+            incoming.accept().ok()?
+        };
         let conn = connecting.await.ok()?;
         Some(QuicConn::new(conn))
     }
 
-    async fn connect(dialer: &Endpoint, addr: SocketAddr, _streams: usize) -> Option<QuicConn> {
+    async fn connect(dialer: &QuicDialer, addr: SocketAddr, _streams: usize) -> Option<QuicConn> {
         // connect() fails synchronously on a bad config; the handshake (.await) fails
-        // until the server is up. Both surface as `None` and the caller retries.
-        let connecting = dialer.connect(addr, SERVER_NAME).ok()?;
+        // until the server is up. Both surface as `None` and the caller retries. Enter
+        // the data runtime around the synchronous connect() — which spawns the
+        // connection driver — so that driver's crypto runs on the pool, not the caller.
+        let connecting = {
+            let _guard = dialer.rt.as_ref().map(Handle::enter);
+            dialer.endpoint.connect(addr, SERVER_NAME).ok()?
+        };
         let conn = connecting.await.ok()?;
         Some(QuicConn::new(conn))
     }

--- a/monarch_mini/src/tcp_net.rs
+++ b/monarch_mini/src/tcp_net.rs
@@ -139,6 +139,7 @@ use tokio::io::WriteHalf;
 use tokio::net::TcpListener;
 use tokio::net::TcpSocket;
 use tokio::net::TcpStream;
+use tokio::runtime::Handle;
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls::TlsConnector;
 use tokio_rustls::client::TlsStream as ClientTlsStream;
@@ -613,7 +614,10 @@ impl Net for Tcp {
     type Listener = TcpListenerHandle;
     type Conn = TcpConn;
 
-    fn create() -> anyhow::Result<Self> {
+    fn create(_runtime: Option<Handle>) -> anyhow::Result<Self> {
+        // Ignored: kTLS/rustls crypto runs in the stream poll (the read/write syscall),
+        // not a background driver, so it follows whichever task polls the stream. The
+        // generic transport places those data coroutines on the runtime instead.
         Ok(Self { tls: None })
     }
 


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* #4615
* __->__ #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Add an opt-in multi-threaded Tokio runtime that moves per-connection TCP data tasks and QUIC endpoint drivers off the single-threaded command loop, allowing framing and cryptographic work to run across cores. Preserve the existing single-threaded default while adding QUIC cipher selection and a Python benchmark that reports sender and receiver data-thread CPU parallelism.

Differential Revision: [D112587131](https://our.internmc.facebook.com/intern/diff/D112587131/)