### PR TITLE
40/43 minimonarch: Allow Net connections to request indexed streams on demand

### DIFF
--- a/monarch_mini/src/net.rs
+++ b/monarch_mini/src/net.rs
@@ -16,33 +16,40 @@
 //! address, building the shared dialing state, binding a listener, dialing, and
 //! producing a [`NetConn`] that hands out ordered byte-stream pairs.
 //!
-//! ## Streams and "who speaks first"
+//! ## Streams, addressed by index
 //!
-//! Every connection carries a fixed number of independent, ordered stream pairs (the
-//! `STREAMS` count in [`crate::net_transport`], passed to [`Net::bind`]/
-//! [`Net::connect`] so a protocol that maps each stream onto its own OS connection
-//! (tcp) knows how many to pair; quic multiplexes them on one connection). Each call
-//! to [`NetConn::stream`] hands back the *next* stream in sequence — there is no
-//! index to get wrong, so the pairs cannot be requested out of order. The two peers
-//! request their streams in the same order, so stream *k* on one side pairs with
-//! stream *k* on the other; each successive stream carries a higher send priority, so
-//! the heartbeat stream (requested after the data stream) is packed ahead of a
-//! backlogged data stream.
+//! A connection hands out independent, ordered stream pairs on demand via
+//! [`NetConn::stream`], each addressed by an explicit `index`. The two peers name the
+//! same index for the two halves of one logical stream, so stream *k* on one side pairs
+//! with stream *k* on the other regardless of the order either side requests them — the
+//! index is carried on the wire (a small prefix), so the pairing can never drift.
+//! `priority` is the send priority (quic uses it to pack a higher-priority stream — the
+//! heartbeat stream — ahead of a backlogged data stream; tcp has no per-stream priority
+//! and ignores it).
 //!
-//! The connection abstraction knows nothing about heartbeats or parent/child roles.
-//! For each stream it is simply told, via [`NetConn::stream`]'s `first_messenger`
-//! flag, whether **this** side opens it and writes first or waits for the peer to
-//! open it — the two peers pass complementary values. The generic transport (which
-//! *does* know about heartbeats) computes those flags.
+//! **Direction is a property of the connection, not the call.** A [`Net::connect`]
+//! yields a *dialer* connection whose [`NetConn::stream`] **opens** each stream (quic:
+//! `open_bi`; tcp: dials a fresh socket); a [`Net::accept`] yields an *acceptor*
+//! connection whose [`NetConn::stream`] **awaits** the peer's matching stream (quic:
+//! `accept_bi`, demultiplexed by the index prefix; tcp: the socket the listener routed
+//! to this connection for that index). Both peers just call `stream(k, prio)` — the
+//! generic transport never has to reason about who speaks first. This is what lets a
+//! plain tcp socket work: only the dialer can open one, so only the dialer's `stream`
+//! opens; the acceptor's waits.
+//!
+//! The connection knows nothing about heartbeats or parent/child roles. The generic
+//! transport picks the indices: index 0 is the data/control stream, index 1 is the
+//! heartbeat stream (a higher `priority`), and it may later request further data-stream
+//! indices for striping large messages.
 //!
 //! ## Laziness
 //!
-//! [`NetConn::stream`] returns an awaitable that touches the wire only on its first
-//! poll (quic: `open_bi`/`accept_bi`). The generic transport awaits the data stream
-//! immediately but holds the heartbeat stream un-awaited until a beat actually needs
-//! to flow, so a message-only side channel never establishes a heartbeat stream. The
-//! data stream is always requested before the heartbeat stream, which is how the two
-//! peers keep their pairs aligned.
+//! [`NetConn::stream`] returns an awaitable that touches the wire only on its first poll
+//! (quic dialer: `open_bi`; quic acceptor: an `accept_bi` demux; tcp dialer: a socket
+//! dial). The generic transport awaits the data stream immediately but can hold a
+//! heartbeat or data stream un-awaited until it is actually needed, so a message-only
+//! side channel (whose dialer never opens index 1) never establishes a heartbeat
+//! stream.
 
 use std::fmt::Debug;
 use std::future::Future;
@@ -86,18 +93,21 @@ pub(crate) trait Net: Sized + 'static {
     /// pool.
     fn dialer(&mut self, addr: SocketAddr) -> anyhow::Result<Self::Dialer>;
 
-    /// Bind a server listener on `addr`. `streams` is how many parallel streams
-    /// every accepted connection will carry (a per-stream-per-socket protocol pairs
-    /// that many; quic ignores it).
-    fn bind(&mut self, addr: SocketAddr, streams: usize) -> anyhow::Result<Self::Listener>;
+    /// Bind a server listener on `addr`. Streams are opened lazily and addressed by
+    /// index (see [`NetConn::stream`]), so the listener needs no stream count up front.
+    fn bind(&mut self, addr: SocketAddr) -> anyhow::Result<Self::Listener>;
 
-    /// The next inbound connection, or `None` once `listener` is closed.
+    /// The next inbound connection, or `None` once `listener` is closed. The returned
+    /// connection is an *acceptor* connection: its [`NetConn::stream`] awaits the peer's
+    /// streams rather than opening them.
     async fn accept(listener: &Self::Listener) -> Option<Self::Conn>;
 
-    /// Dial `addr` once, or `None` on failure — the caller retries with backoff (a
-    /// join may precede its serve). `streams` is as in [`Net::bind`].
-    async fn connect(dialer: &Self::Dialer, addr: SocketAddr, streams: usize)
-    -> Option<Self::Conn>;
+    /// Dial `addr` once, or `None` on failure — the caller retries with backoff (a join
+    /// may precede its serve). The returned connection is a *dialer* connection: its
+    /// [`NetConn::stream`] opens streams. No stream is opened here (quic does complete
+    /// its handshake; tcp opens nothing until the first [`NetConn::stream`]), so a tcp
+    /// join's reachability is proven by the first `stream` call, not by `connect`.
+    async fn connect(dialer: &Self::Dialer, addr: SocketAddr) -> Option<Self::Conn>;
 
     /// The default cap on simultaneous client connect *attempts* when
     /// `MM_QUIC_MAX_CONCURRENT_CONNECTS` is unset (see [`crate::net_transport`]'s
@@ -129,12 +139,13 @@ pub(crate) trait NetConn: Debug + 'static {
     /// The awaitable that materializes one stream's halves on first poll.
     type Stream: Future<Output = std::io::Result<(Self::Send, Self::Recv)>> + 'static;
 
-    /// An awaitable for the **next** stream on this connection. Each call advances a
-    /// per-connection cursor, so streams cannot be requested out of order and the two
-    /// peers' *k*-th streams pair up. `first_messenger` selects whether **this** side
-    /// opens the stream and writes first, or waits for the peer to open it; the two
-    /// peers pass complementary values. Each successive stream is given a higher send
-    /// priority, so a later stream (the heartbeat stream) outranks an earlier one (the
-    /// data stream). Nothing touches the wire until the returned future is polled.
-    fn stream(&self, first_messenger: bool) -> Self::Stream;
+    /// An awaitable for the stream addressed by `index`, paired with the peer's stream
+    /// of the same index. On a *dialer* connection it opens the stream; on an *acceptor*
+    /// connection it awaits the peer's matching one (see the module docs). The index is
+    /// carried on the wire so the two peers' *k*-th streams pair up regardless of request
+    /// order. `priority` is the send priority (quic; tcp ignores it) — the transport
+    /// gives the heartbeat stream a higher priority than the data stream so a beat is
+    /// packed ahead of backlogged data. Nothing touches the wire until the returned
+    /// future is polled.
+    fn stream(&self, index: usize, priority: i32) -> Self::Stream;
 }

--- a/monarch_mini/src/net_transport.rs
+++ b/monarch_mini/src/net_transport.rs
@@ -17,12 +17,13 @@
 //!
 //! ## Two streams per connection
 //!
-//! Every connection carries [`STREAMS`] ordered stream pairs. A single reliable,
-//! in-order stream head-of-line-blocks everything queued behind a large message —
-//! including heartbeats, whose whole job is to keep flowing while data does. So we
-//! put heartbeats on their **own** stream, separate from the data/control stream;
-//! the heartbeat stream is requested second so it carries a higher send priority, and
-//! a beat is packed ahead of queued data even under a full congestion window.
+//! Every connection carries a data/control stream (index 0) and a heartbeat stream
+//! (index 1). A single reliable, in-order stream head-of-line-blocks everything queued
+//! behind a large message — including heartbeats, whose whole job is to keep flowing
+//! while data does. So we put heartbeats on their **own** stream, separate from the
+//! data/control stream; the heartbeat stream is given a higher send priority
+//! ([`PRIORITY_HEARTBEAT`]), so a beat is packed ahead of queued data even under a full
+//! congestion window.
 //!
 //! The heartbeat stream is materialized lazily (see [`crate::net`]): a message-only
 //! gateway side channel never opens it. A parent/child link always heartbeats, so it
@@ -50,7 +51,6 @@ use tokio::sync::mpsc;
 use tokio::sync::watch;
 use tokio::time::Duration;
 
-use crate::Role;
 use crate::connection::ConnectionCommand;
 use crate::connection::ConnectionRef;
 use crate::connection::ConnectionTransport;
@@ -83,12 +83,16 @@ type ConnRecv<N> = <<N as Net>::Conn as NetConn>::Recv;
 /// heartbeat send stream once a beat has been sent (`None` until then).
 type LiveSideChannel<N> = (<N as Net>::Conn, ConnSend<N>, Option<ConnSend<N>>);
 
-/// Streams every connection carries, passed to [`Net::bind`]/[`Net::connect`]. Each
-/// connection requests them in order via [`NetConn::stream`]: first the data/control
-/// stream (the preamble and every [`ConnectionCommand`] frame), then the heartbeat
-/// stream (bare heartbeat probes, materialized lazily and — being requested second —
-/// given a higher send priority than the data stream).
-const STREAMS: usize = 2;
+/// Stream index of the data/control stream: the preamble and every
+/// [`ConnectionCommand`] frame. Opened first, at establishment.
+const STREAM_DATA: usize = 0;
+/// Stream index of the heartbeat stream: bare heartbeat probes, materialized lazily.
+const STREAM_HEARTBEAT: usize = 1;
+/// Send priority of the data stream (quic; tcp ignores it). Lower than the heartbeat's.
+const PRIORITY_DATA: i32 = 0;
+/// Send priority of the heartbeat stream — higher than the data stream, so a beat is
+/// packed ahead of backlogged data under a full congestion window.
+const PRIORITY_HEARTBEAT: i32 = 1;
 
 /// Connect-retry backoff bounds. A join may precede its serve, and the handshake
 /// fails until the server is bound, so the connector polls — fast at first, backing
@@ -365,9 +369,11 @@ impl<N: Net> SideChannels<N> {
         self.net()?.dialer(addr)
     }
 
-    /// Bind a server listener on `addr` carrying `STREAMS` streams.
+    /// Bind a server listener on `addr`. The stream count is not passed here: tcp learns
+    /// it from each connecting side's pairing prefix, and quic multiplexes on one
+    /// connection (see [`Net::bind`]).
     fn bind(&mut self, addr: SocketAddr) -> anyhow::Result<N::Listener> {
-        self.net()?.bind(addr, STREAMS)
+        self.net()?.bind(addr)
     }
 
     fn alive_token(&self) -> mpsc::UnboundedSender<()> {
@@ -653,9 +659,8 @@ async fn listener_task<N: Net>(
 /// Pair a queued serve with an accepted join and wire up the connection. Both the
 /// serve-first (`push_left`) and accept-first (`push_right`) paths land here, so a
 /// pairing spawns identically: this is the serve/acceptor side, so `log_heartbeats =
-/// true` and `dialed = false` (the peer dialed us). The data-stream halves were
-/// already split (with `first_messenger = false`) and the preamble read by the
-/// acceptor.
+/// true` and `dialed = false` (the peer dialed us). The data-stream halves were already
+/// accepted (`conn.stream(STREAM_DATA, …)`) and the preamble read by the acceptor.
 #[expect(
     clippy::too_many_arguments,
     reason = "each argument is a distinct piece of per-connection state forwarded to spawn_connection; bundling adds indirection without clarifying anything"
@@ -693,10 +698,9 @@ fn spawn_join<N: Net>(
     );
 }
 
-/// Accept connections on `listener`, split each one's data stream (this side is the
-/// responder, so `first_messenger = false`), read its preamble, and forward the
-/// classified result. Each handshake runs in its own task so one slow peer doesn't
-/// block others.
+/// Accept connections on `listener`, accept each one's data stream (index 0), read its
+/// preamble, and forward the classified result. Each handshake runs in its own task so
+/// one slow peer doesn't block others.
 async fn acceptor_task<N: Net>(
     listener: N::Listener,
     accepted_tx: mpsc::UnboundedSender<Accepted<N>>,
@@ -713,7 +717,7 @@ async fn acceptor_task<N: Net>(
                     // (by the heartbeat task, or the side-channel heartbeat reader),
                     // so establishment/pairing never waits on the first beat.
                     let Ok((data_send, mut data_recv)) =
-                        conn.stream(false).await else { return; };
+                        conn.stream(STREAM_DATA, PRIORITY_DATA).await else { return; };
                     let accepted = match framing::read_preamble(&mut data_recv).await {
                         Ok(Preamble::Join) => Accepted::Join(JoinStreams {
                             conn,
@@ -763,12 +767,12 @@ async fn side_channel_reader_task<N: Net>(
 /// Read delegated-heartbeat beats/acks/releases off a gateway side-channel's
 /// heartbeat stream and route them *directly* into the heartbeat subsystem — they
 /// never reach ctx. Kept on its own stream so a large routed message can never delay
-/// a beat. The heartbeat stream is materialized here (this side is the responder,
-/// `first_messenger = false`): it may open late (on the peer's first beat) or never
-/// (a channel that only carries messages), and awaiting it here never blocks the
+/// a beat. This side is the acceptor, so awaiting the heartbeat stream (index 1) never
+/// opens it: it materializes only if the dialing peer opens it (on its first beat), and
+/// never for a channel that only carries messages, so this await never blocks the
 /// message reader.
 async fn side_channel_heartbeat_reader_task<N: Net>(conn: N::Conn, heartbeat: Heartbeats) {
-    let Ok((_send, mut recv)) = conn.stream(false).await else {
+    let Ok((_send, mut recv)) = conn.stream(STREAM_HEARTBEAT, PRIORITY_HEARTBEAT).await else {
         return; // connection closed before any heartbeat stream opened
     };
     loop {
@@ -786,10 +790,10 @@ async fn side_channel_heartbeat_reader_task<N: Net>(conn: N::Conn, heartbeat: He
     }
 }
 
-/// Connect to `addr`, retrying until the server binds and the handshake succeeds (so
-/// a join may precede its serve), then split the data stream, announce ourselves as
-/// the joiner via the preamble, and wire it up. This side is the *first messenger* on
-/// the data stream (`first_messenger = true`).
+/// Connect to `addr`, retrying until the server binds and the data stream (index 0)
+/// opens (so a join may precede its serve), then announce ourselves as the joiner via
+/// the preamble and wire it up. This is the dialer side, so `conn.stream` opens each
+/// stream.
 #[expect(
     clippy::too_many_arguments,
     reason = "each argument is a distinct piece of connector state; bundling adds indirection without clarifying anything"
@@ -812,12 +816,17 @@ async fn connector_task<N: Net>(
     data_rt: Option<Handle>,
 ) {
     let mut retry = CONNECT_RETRY_MIN;
-    loop {
+    // Retry until both the connect and the *first* stream open succeed. For quic the
+    // handshake is in `connect`; for tcp `connect` is cheap and the data stream (index
+    // 0) is where the socket is actually dialed — so either failing means the server is
+    // not up yet (a join may precede its serve), and we back off and retry.
+    let (mut data_send, data_recv, conn) = loop {
         if *shutdown.borrow() {
             return;
         }
         // Take a connect-attempt permit before doing any handshake work, so a root
-        // joining tens of thousands of peers drives at most N handshakes at once.
+        // joining tens of thousands of peers drives at most N handshakes at once. Held
+        // across the data-stream dial (the throttled work) and released before backoff.
         let permit = match &connect_sem {
             Some(sem) => Some(
                 Arc::clone(sem)
@@ -827,45 +836,10 @@ async fn connector_task<N: Net>(
             ),
             None => None,
         };
-        if let Some(conn) = N::connect(&dialer, addr, STREAMS).await {
-            match conn.stream(true).await {
-                Ok((mut data_send, data_recv)) => {
-                    // Tell the acceptor this is an ordinary join (not a side-channel)
-                    // before the command loop drives establishment over the stream.
-                    if framing::write_preamble(&mut data_send, Preamble::Join)
-                        .await
-                        .is_err()
-                    {
-                        sever(&loop_tx, connection, b"quic open stream failed".to_vec());
-                        return;
-                    }
-                    // Connection is up; free the attempt slot before handing off.
-                    drop(permit);
-                    // Joiner side (the root has tens of thousands of writers): do not
-                    // log heartbeat sends here even under debug — it would flood.
-                    // `dialed = true`: this is one half of the delegation guard (only
-                    // a link the parent dialed may be delegated).
-                    spawn_connection::<N>(
-                        data_send,
-                        data_recv,
-                        connection,
-                        loop_tx,
-                        shutdown,
-                        alive,
-                        conn,
-                        shm,
-                        false,
-                        true,
-                        heartbeat,
-                        side_channels,
-                        data_rt,
-                    );
-                    return;
-                }
-                Err(_) => {
-                    sever(&loop_tx, connection, b"quic open stream failed".to_vec());
-                    return;
-                }
+        if let Some(conn) = N::connect(&dialer, addr).await {
+            if let Ok((data_send, data_recv)) = conn.stream(STREAM_DATA, PRIORITY_DATA).await {
+                drop(permit); // connection is up; free the attempt slot before handing off
+                break (data_send, data_recv, conn);
             }
         }
         // Attempt failed; release the slot so another task can try while we back off.
@@ -875,7 +849,34 @@ async fn connector_task<N: Net>(
             _ = shutdown.changed() => return,
         }
         retry = (retry * 2).min(CONNECT_RETRY_MAX);
+    };
+    // Tell the acceptor this is an ordinary join (not a side-channel) before the command
+    // loop drives establishment over the stream.
+    if framing::write_preamble(&mut data_send, Preamble::Join)
+        .await
+        .is_err()
+    {
+        sever(&loop_tx, connection, b"quic open stream failed".to_vec());
+        return;
     }
+    // Joiner side (the root has tens of thousands of writers): do not log heartbeat sends
+    // here even under debug — it would flood. `dialed = true`: this is one half of the
+    // delegation guard (only a link the parent dialed may be delegated).
+    spawn_connection::<N>(
+        data_send,
+        data_recv,
+        connection,
+        loop_tx,
+        shutdown,
+        alive,
+        conn,
+        shm,
+        false,
+        true,
+        heartbeat,
+        side_channels,
+        data_rt,
+    );
 }
 
 /// Drive a gateway side-channel writer: drain queued outbound items — routable
@@ -906,21 +907,15 @@ async fn side_channel_writer_task<N: Net>(
             _ = shutdown.changed() => break,
         };
         if live.is_none() {
-            let Some(conn) = connect_side_channel::<N>(&dialer, addr, &mut shutdown).await else {
+            // `connect_side_channel` opens the message stream (index 0) and writes the
+            // preamble as part of its retry, so it returns a ready-to-write send half.
+            // The heartbeat stream (index 1) is opened lazily below, so a message-only
+            // channel never opens it.
+            let Some((conn, msg_send)) =
+                connect_side_channel::<N>(&dialer, addr, &mut shutdown).await
+            else {
                 break; // shutting down before the gateway came up
             };
-            // The message stream (index 0) carries the preamble (which also opens it
-            // on the wire). The heartbeat stream (index 1) carries no preamble and is
-            // opened lazily below, so a message-only channel never opens it.
-            let Ok((mut msg_send, _msg_recv)) = conn.stream(true).await else {
-                continue; // reconnect on the next item
-            };
-            if framing::write_preamble(&mut msg_send, Preamble::SideChannel)
-                .await
-                .is_err()
-            {
-                continue; // reconnect on the next item (this one is dropped)
-            }
             live = Some((conn, msg_send, None));
         }
         let (conn, msg_send, hb_send) = live.as_mut().expect("connected");
@@ -938,7 +933,7 @@ async fn side_channel_writer_task<N: Net>(
                 // higher-priority stream (index > the message stream), so a beat jumps
                 // ahead of queued message bytes under a full congestion window.
                 if hb_send.is_none() {
-                    match conn.stream(true).await {
+                    match conn.stream(STREAM_HEARTBEAT, PRIORITY_HEARTBEAT).await {
                         Ok((send, _recv)) => *hb_send = Some(send),
                         Err(_) => {
                             live = None; // reconnect on the next item
@@ -962,22 +957,32 @@ async fn side_channel_writer_task<N: Net>(
     }
 }
 
-/// Connect a side-channel to `addr`, retrying with backoff until the gateway binds
-/// and the handshake succeeds, or until teardown (then `None`). Streams are opened
-/// lazily by the caller. Mirrors the join connector's retry so a side-channel may be
-/// opened before its target gateway is live.
+/// Connect a side-channel to `addr` and open its message stream, retrying with backoff
+/// until the gateway binds and the handshake succeeds, or until teardown (then `None`).
+/// Returns the connection and the message send half, with the `SideChannel` preamble
+/// already written. Folding the first stream open into the retry gives tcp — whose
+/// `connect` is cheap and whose reachability is proven only when the socket is dialed —
+/// proper backoff. Mirrors the join connector so a side-channel may be opened before its
+/// target gateway is live.
 async fn connect_side_channel<N: Net>(
     dialer: &N::Dialer,
     addr: SocketAddr,
     shutdown: &mut watch::Receiver<bool>,
-) -> Option<N::Conn> {
+) -> Option<(N::Conn, ConnSend<N>)> {
     let mut retry = CONNECT_RETRY_MIN;
     loop {
         if *shutdown.borrow() {
             return None;
         }
-        if let Some(conn) = N::connect(dialer, addr, STREAMS).await {
-            return Some(conn);
+        if let Some(conn) = N::connect(dialer, addr).await {
+            if let Ok((mut msg_send, _msg_recv)) = conn.stream(STREAM_DATA, PRIORITY_DATA).await {
+                if framing::write_preamble(&mut msg_send, Preamble::SideChannel)
+                    .await
+                    .is_ok()
+                {
+                    return Some((conn, msg_send));
+                }
+            }
         }
         tokio::select! {
             _ = tokio::time::sleep(retry) => {}
@@ -1077,16 +1082,14 @@ fn spawn_connection<N: Net>(
             tokio::task::spawn_local(reader);
         }
     }
-    // Heartbeat stream: materialized off the establishment path, then a beat writer
-    // and reader run on it. `first_messenger` is whether this side is the heartbeat
-    // **Child** — which always beats first — so the Child opens the stream and the
-    // Parent accepts it. This (not `dialed`) is what avoids a deadlock: the Child
-    // writes its first beat as soon as it opens the stream, so the Parent's accept
-    // resolves.
-    let hb_first = connection.role() == Role::Child;
+    // Heartbeat stream (index 1): materialized off the establishment path, then a beat
+    // writer and reader run on it. Direction is a property of the connection now — the
+    // dialer opens it, the acceptor awaits it (see [`crate::net`]) — so no per-call flag.
+    // The dialer opens it proactively here (a parent/child link always heartbeats), and
+    // its index-prefix write is what resolves the acceptor's await; whoever is the
+    // heartbeat **Child** then beats first over the established stream.
     tokio::task::spawn_local(heartbeat_stream_task::<N>(
         conn,
-        hb_first,
         beats_rx,
         hb_event_tx,
         shutdown,
@@ -1094,21 +1097,19 @@ fn spawn_connection<N: Net>(
     ));
 }
 
-/// Materialize the connection's heartbeat stream and run the beat writer + reader on
-/// it. `first_messenger` follows the heartbeat *role*, not who dialed the connection:
-/// the **Child** (which always beats first) opens the stream, and the **Parent**
-/// (which only ever answers) accepts it. Materialization happens here, in a task
-/// spawned *after* the connection is established and paired, so the first beat never
-/// delays either. If the connection dies before the stream comes up, this just ends.
+/// Materialize the connection's heartbeat stream (index 1) and run the beat writer +
+/// reader on it. Materialization happens here, in a task spawned *after* the connection
+/// is established, so the first beat never delays establishment; the dialer opens the
+/// stream and the acceptor awaits it. If the connection dies before the stream comes up,
+/// this just ends.
 async fn heartbeat_stream_task<N: Net>(
     conn: N::Conn,
-    first_messenger: bool,
     beats_rx: mpsc::UnboundedReceiver<Heartbeat>,
     hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
     shutdown: watch::Receiver<bool>,
     log_heartbeats: bool,
 ) {
-    let Ok((hb_send, hb_recv)) = conn.stream(first_messenger).await else {
+    let Ok((hb_send, hb_recv)) = conn.stream(STREAM_HEARTBEAT, PRIORITY_HEARTBEAT).await else {
         return; // connection died before the heartbeat stream came up
     };
     // Reader in its own task; writer runs inline (it owns `conn` to keep it alive and

--- a/monarch_mini/src/quic_net.rs
+++ b/monarch_mini/src/quic_net.rs
@@ -41,7 +41,7 @@
 //! `MM_QUIC_CA` (the authority a joiner trusts). The server presents its cert; the
 //! client verifies it against the CA for the fixed server name [`SERVER_NAME`].
 
-use std::cell::Cell;
+use std::collections::HashMap;
 use std::fmt;
 use std::future::Future;
 use std::io;
@@ -66,7 +66,10 @@ use tokio::io::AsyncRead;
 use tokio::io::AsyncWrite;
 use tokio::io::ReadBuf;
 use tokio::runtime::Handle;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 
+use crate::matcher::Matcher;
 use crate::net::Net;
 use crate::net::NetConn;
 
@@ -573,7 +576,7 @@ impl Net for Quic {
     // runtime to place dialed connections' drivers on.
     type Dialer = QuicDialer;
     // A server endpoint plus that runtime. quic multiplexes all streams on one
-    // connection, so it ignores the stream count passed to `bind`.
+    // connection; each stream is opened/accepted on demand, addressed by index.
     type Listener = QuicListener;
     type Conn = QuicConn;
 
@@ -605,7 +608,7 @@ impl Net for Quic {
         Ok(QuicDialer { endpoint, rt })
     }
 
-    fn bind(&mut self, addr: SocketAddr, _streams: usize) -> anyhow::Result<QuicListener> {
+    fn bind(&mut self, addr: SocketAddr) -> anyhow::Result<QuicListener> {
         let server = self.tls()?.server.clone();
         // Enter the data runtime (if any) so quinn spawns this server endpoint's driver
         // there; the handle also rides on the QuicListener for `accept` to use.
@@ -627,10 +630,10 @@ impl Net for Quic {
             incoming.accept().ok()?
         };
         let conn = connecting.await.ok()?;
-        Some(QuicConn::new(conn))
+        Some(QuicConn::new_acceptor(conn))
     }
 
-    async fn connect(dialer: &QuicDialer, addr: SocketAddr, _streams: usize) -> Option<QuicConn> {
+    async fn connect(dialer: &QuicDialer, addr: SocketAddr) -> Option<QuicConn> {
         // connect() fails synchronously on a bad config; the handshake (.await) fails
         // until the server is up. Both surface as `None` and the caller retries. Enter
         // the data runtime around the synchronous connect() — which spawns the
@@ -640,7 +643,7 @@ impl Net for Quic {
             dialer.endpoint.connect(addr, SERVER_NAME).ok()?
         };
         let conn = connecting.await.ok()?;
-        Some(QuicConn::new(conn))
+        Some(QuicConn::new_dialer(conn))
     }
 
     /// quic multiplexes all streams on one endpoint-paced connection, so a large number
@@ -651,36 +654,134 @@ impl Net for Quic {
     }
 }
 
-/// One QUIC connection. Each [`NetConn::stream`] call hands out the *next*
-/// bidirectional stream — `open_bi` when this side is the first messenger, `accept_bi`
-/// otherwise. quinn pairs streams in open/accept order, and the two peers call
-/// `stream` in the same order, so the pairs line up without any explicit index.
-///
-/// `next_priority` is the send priority handed to the next stream, bumped each call,
-/// so a later stream (the heartbeat stream) outranks an earlier one (the data
-/// stream). Not `Clone`: the cursor is per-connection state, and each connection is
-/// created once and moved between its tasks (single-threaded runtime, so the `Cell`
-/// is never contended).
-pub(crate) struct QuicConn {
+/// The two-byte little-endian index prefix the dialer writes at the head of every
+/// bidirectional stream it opens, so the acceptor can pair it with the peer's stream of
+/// the same index (a bare quic connection is already private to the two peers, so unlike
+/// tcp no connection id is needed — only the stream index). `open_bi`/`accept_bi` pair
+/// in open order per initiator, but only the dialer opens, and it opens streams in
+/// whatever order the transport requests them; the explicit index removes any dependence
+/// on that order and lets the acceptor demultiplex.
+async fn write_index_prefix(send: &mut SendStream, index: usize) -> io::Result<()> {
+    // quinn's inherent `write_all` returns its own `WriteError`; map it to io::Error.
+    send.write_all(&(index as u16).to_le_bytes())
+        .await
+        .map_err(io::Error::other)
+}
+
+async fn read_index_prefix(recv: &mut RecvStream) -> io::Result<usize> {
+    let mut buf = [0u8; 2];
+    // quinn's inherent `read_exact` returns its own `ReadExactError`; map it to io::Error.
+    recv.read_exact(&mut buf).await.map_err(io::Error::other)?;
+    Ok(u16::from_le_bytes(buf) as usize)
+}
+
+/// A [`NetConn::stream`] request handed to an acceptor connection's demux: the wanted
+/// index, its send priority, and the one-shot the demux fulfils with the paired stream.
+pub(crate) struct QuicStreamRequest {
+    index: usize,
+    priority: i32,
+    reply: oneshot::Sender<io::Result<(QuicSend, QuicRecv)>>,
+}
+
+/// Fulfil a request with its paired stream: set the send priority and send the halves
+/// back through the one-shot.
+fn fulfill_quic(conn: &Connection, req: QuicStreamRequest, stream: (SendStream, RecvStream)) {
+    let (send, recv) = stream;
+    let _ = send.set_priority(req.priority);
+    let _ = req.reply.send(Ok(quic_halves(conn.clone(), send, recv)));
+}
+
+/// The acceptor-side demux for one connection: the single owner of `accept_bi`. It reads
+/// each accepted stream's index prefix and pairs it with the matching [`QuicStreamRequest`]
+/// using a per-index [`Matcher`] (each index sees at most one stream and one request,
+/// whichever arrives first parks for the other). Being the only accept-driver means
+/// `stream` never touches `accept_bi` directly — it just sends a request and awaits the
+/// one-shot — so there is no mutex held across an await. Ends when the connection drops
+/// (its senders close) or `accept_bi` errors; dropping the parked requests then fails
+/// their awaiting `stream` calls.
+async fn quic_acceptor_demux(
     conn: Connection,
-    next_priority: Cell<i32>,
+    mut requests: mpsc::UnboundedReceiver<QuicStreamRequest>,
+) {
+    let mut matchers: HashMap<usize, Matcher<QuicStreamRequest, (SendStream, RecvStream)>> =
+        HashMap::new();
+    loop {
+        tokio::select! {
+            req = requests.recv() => {
+                let Some(req) = req else {
+                    return; // every `stream` handle dropped: the connection is going away
+                };
+                matchers
+                    .entry(req.index)
+                    .or_insert_with(Matcher::new)
+                    .push_left(req, |req, stream| fulfill_quic(&conn, req, stream));
+            }
+            // `accept_bi` is cancel-safe, so racing it in `select!` never drops a stream.
+            accepted = conn.accept_bi() => {
+                let Ok((send, mut recv)) = accepted else {
+                    return; // connection lost: dropping the matchers fails parked requests
+                };
+                let Ok(index) = read_index_prefix(&mut recv).await else {
+                    continue; // peer opened a stream with a bad prefix — drop it
+                };
+                matchers
+                    .entry(index)
+                    .or_insert_with(Matcher::new)
+                    .push_right((send, recv), |req, stream| fulfill_quic(&conn, req, stream));
+            }
+        }
+    }
+}
+
+/// One QUIC connection, in one of two roles set at construction. A **dialer** connection
+/// (from [`Net::connect`]) opens each requested stream with `open_bi` and writes the
+/// index prefix. An **acceptor** connection (from [`Net::accept`]) delegates all
+/// `accept_bi` work to a per-connection [`quic_acceptor_demux`] coroutine; its `stream`
+/// just sends a request down `requests` and awaits the paired stream. The demux holds the
+/// `Connection` alive; the acceptor keeps `remote` only for [`fmt::Debug`].
+pub(crate) enum QuicConn {
+    Dialer {
+        conn: Connection,
+    },
+    Acceptor {
+        remote: SocketAddr,
+        requests: mpsc::UnboundedSender<QuicStreamRequest>,
+    },
 }
 
 impl QuicConn {
-    fn new(conn: Connection) -> Self {
-        Self {
-            conn,
-            next_priority: Cell::new(0),
-        }
+    fn new_dialer(conn: Connection) -> Self {
+        Self::Dialer { conn }
+    }
+
+    fn new_acceptor(conn: Connection) -> Self {
+        let remote = conn.remote_address();
+        let (requests, rx) = mpsc::unbounded_channel();
+        // Spawn on the command-loop LocalSet (`accept` runs there); the demux owns the
+        // connection and lives until every `stream` handle is dropped or it errors.
+        tokio::task::spawn_local(quic_acceptor_demux(conn, rx));
+        Self::Acceptor { remote, requests }
     }
 }
 
 impl fmt::Debug for QuicConn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("QuicConn")
-            .field(&self.conn.remote_address())
-            .finish()
+        let remote = match self {
+            QuicConn::Dialer { conn } => conn.remote_address(),
+            QuicConn::Acceptor { remote, .. } => *remote,
+        };
+        f.debug_tuple("QuicConn").field(&remote).finish()
     }
+}
+
+fn quic_halves(conn: Connection, send: SendStream, recv: RecvStream) -> (QuicSend, QuicRecv) {
+    (
+        QuicSend {
+            send,
+            _conn: conn.clone(),
+        },
+        QuicRecv { recv, _conn: conn },
+    )
 }
 
 impl NetConn for QuicConn {
@@ -688,30 +789,33 @@ impl NetConn for QuicConn {
     type Recv = QuicRecv;
     type Stream = Pin<Box<dyn Future<Output = io::Result<(QuicSend, QuicRecv)>>>>;
 
-    fn stream(&self, first_messenger: bool) -> Self::Stream {
-        // Claim this stream's send priority now (at call order), not at poll time.
-        let priority = self.next_priority.get();
-        self.next_priority.set(priority + 1);
-        let conn = self.conn.clone();
-        Box::pin(async move {
-            let (send, recv) = if first_messenger {
-                conn.open_bi().await
-            } else {
-                conn.accept_bi().await
+    fn stream(&self, index: usize, priority: i32) -> Self::Stream {
+        match self {
+            QuicConn::Dialer { conn } => {
+                let conn = conn.clone();
+                Box::pin(async move {
+                    let (mut send, recv) = conn.open_bi().await.map_err(io::Error::other)?;
+                    write_index_prefix(&mut send, index).await?;
+                    let _ = send.set_priority(priority);
+                    Ok(quic_halves(conn, send, recv))
+                })
             }
-            .map_err(io::Error::other)?;
-            // A later stream ⇒ higher send priority, so a beat (the heartbeat stream,
-            // opened after the data stream) is packed ahead of queued data under a full
-            // congestion window.
-            let _ = send.set_priority(priority);
-            Ok((
-                QuicSend {
-                    send,
-                    _conn: conn.clone(),
-                },
-                QuicRecv { recv, _conn: conn },
-            ))
-        })
+            QuicConn::Acceptor { requests, .. } => {
+                let requests = requests.clone();
+                Box::pin(async move {
+                    let (reply, rx) = oneshot::channel();
+                    requests
+                        .send(QuicStreamRequest {
+                            index,
+                            priority,
+                            reply,
+                        })
+                        .map_err(|_| io::Error::other("quic connection closed"))?;
+                    rx.await
+                        .map_err(|_| io::Error::other("quic connection closed"))?
+                })
+            }
+        }
     }
 }
 

--- a/monarch_mini/src/tcp_net.rs
+++ b/monarch_mini/src/tcp_net.rs
@@ -43,21 +43,24 @@
 //! networking. The command loop drives tcp as `NetTransport<Tcp>` (aliased
 //! `TcpTransport` in [`crate::ctx`]).
 //!
-//! ## Streams: one socket each, paired by a prefix
+//! ## Streams: one socket each, opened on demand and paired by index
 //!
-//! A QUIC connection multiplexes its two streams (data + heartbeat) on one transport
+//! A QUIC connection multiplexes its streams (data + heartbeat) on one transport
 //! connection; TCP has no multiplexing, so each stream is its own TLS-over-TCP socket.
-//! Unlike quic — where a stream is materialized lazily and the "first messenger" side
-//! opens it — TCP must open **both** sockets up front on connect: the generic layer
-//! may make either side the first messenger of a given stream, and a plain socket has
-//! no way to be opened "from the accepting side". So the dialer opens all `streams`
-//! sockets eagerly, each prefixed with `(connection_id, stream_index)`; the listener
-//! reads that prefix and groups sockets with the same id into one logical connection,
-//! ordered by index. [`NetConn::stream`] then just hands back the pre-opened sockets
-//! in order (`first_messenger` is irrelevant — a socket is full-duplex). This is
-//! cruder than the quic path (two sockets even for a message-only side channel, and a
-//! slow TLS handshake head-of-line-blocks accept), but tcp is the fallback, so simple
-//! and correct beats optimal.
+//! A plain socket can only be opened from the dialing side, so a tcp connection is
+//! *directional*: the dialer's [`NetConn::stream`] dials a fresh socket, the acceptor's
+//! awaits one. Each socket the dialer opens carries a `(connection_id, stream_index)`
+//! prefix. Many logical connections share one listening socket, so a single listener
+//! demux pairs each accepted socket with the acceptor-side `stream` request naming the
+//! same `(connection_id, index)` — a matcher per pair, dropped as soon as the two halves
+//! meet. A socket for stream index 0 (the connection's first stream) surfaces the
+//! connection out of [`Net::accept`]; later sockets (the heartbeat stream, or data
+//! streams for striping) just pair against their requests.
+//!
+//! Streams are opened lazily and per index — nothing is pre-opened at connect time — so
+//! a message-only side channel opens exactly one socket, and the transport can request a
+//! heartbeat or additional data stream whenever it needs one. `priority` is ignored:
+//! tcp has no per-stream send priority.
 //!
 //! ## No transport keepalive
 //!
@@ -102,26 +105,21 @@
 //!   `CAP_NET_ADMIN`, e.g. as root on MAST) with a fall back to the ordinary setters
 //!   otherwise.
 
-use std::cell::Cell;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use std::fmt;
-use std::future::Ready;
+use std::future::Future;
 use std::hash::BuildHasher;
 use std::io;
 use std::net::SocketAddr;
 use std::os::fd::AsRawFd;
 use std::os::fd::RawFd;
 use std::pin::Pin;
-use std::rc::Rc;
-use std::rc::Weak;
 use std::sync::Arc;
 use std::sync::OnceLock;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::task::Context;
 use std::task::Poll;
-use std::time::Duration;
 
 use ktls::CorkStream;
 use ktls::KtlsStream;
@@ -140,11 +138,15 @@ use tokio::net::TcpListener;
 use tokio::net::TcpSocket;
 use tokio::net::TcpStream;
 use tokio::runtime::Handle;
+use tokio::sync::Mutex;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls::TlsConnector;
 use tokio_rustls::client::TlsStream as ClientTlsStream;
 use tokio_rustls::server::TlsStream as ServerTlsStream;
 
+use crate::matcher::Matcher;
 use crate::net::Net;
 use crate::net::NetConn;
 
@@ -267,22 +269,6 @@ fn set_congestion(fd: RawFd) {
     }
 }
 
-/// How long a connection may stay half-paired — some of its sockets arrived, but not
-/// all — before the listener reaps it, dropping the sockets that did arrive and freeing
-/// their fds.
-///
-/// Deliberately **longer than the heartbeat timeout**: a connection whose sockets pair
-/// (even slowly) finishes setup and starts heartbeating well within this window, so we
-/// never reap a valid pairing; and once set up, an inactive link is severed by the
-/// heartbeat subsystem, not by us. That makes a reap indistinguishable from "the
-/// connection set up, then was severed for inactivity" — a path the peer already
-/// handles — rather than a special failure. A truly abandoned pairing (a client that
-/// could not open every socket, so its `connect` failed and the generic connector is
-/// already retrying with a fresh id) is all that is left for us to clean up.
-fn pending_reap_timeout() -> Duration {
-    crate::heartbeat::heartbeat_timeout() * 2
-}
-
 /// The ring crypto provider, passed explicitly to every rustls config builder so this
 /// transport does not depend on a process-global default being installed.
 fn provider() -> Arc<rustls::crypto::CryptoProvider> {
@@ -361,25 +347,29 @@ fn new_connection_id() -> u128 {
 }
 
 /// Write the socket-pairing prefix (`connection_id` then `stream_index`) that lets the
-/// listener group the sockets of one logical connection. Precedes every generic frame.
+/// listener demux group the sockets of one logical connection and route each to its
+/// stream-index request. Precedes every generic frame on a dialed socket.
 async fn write_pairing_prefix<W: AsyncWrite + Unpin>(
     writer: &mut W,
     connection_id: u128,
     stream_index: usize,
 ) -> io::Result<()> {
     writer.write_all(&connection_id.to_le_bytes()).await?;
-    writer.write_all(&[stream_index as u8]).await?;
+    writer
+        .write_all(&(stream_index as u16).to_le_bytes())
+        .await?;
     writer.flush().await
 }
 
-/// Read the socket-pairing prefix written by [`write_pairing_prefix`]. `None` on EOF
-/// or a short read (a peer that spoke a bad dialect — the socket is dropped).
+/// Read the socket-pairing prefix written by [`write_pairing_prefix`], as
+/// `(connection_id, stream_index)`. `None` on EOF or a short read (a peer that spoke a
+/// bad dialect — the socket is dropped).
 async fn read_pairing_prefix<R: AsyncRead + Unpin>(reader: &mut R) -> Option<(u128, usize)> {
     let mut id = [0u8; 16];
     reader.read_exact(&mut id).await.ok()?;
-    let mut index = [0u8; 1];
+    let mut index = [0u8; 2];
     reader.read_exact(&mut index).await.ok()?;
-    Some((u128::from_le_bytes(id), index[0] as usize))
+    Some((u128::from_le_bytes(id), u16::from_le_bytes(index) as usize))
 }
 
 /// A TLS-over-TCP stream in one of three flavors, unified so framing (and the pairing
@@ -562,48 +552,97 @@ pub(crate) struct TcpDialer {
     server_name: ServerName<'static>,
 }
 
-/// Connection ids mid-pairing, each mapped to its per-index sockets so far. A
-/// completed connection is removed from the map (and handed up); an abandoned one is
-/// removed by its [`reap_unpaired`] timeout coroutine.
-type PendingMap = HashMap<u128, Vec<Option<TlsStream>>>;
-
-/// A bound TCP server plus the pairing state accept needs. `accept` runs the TLS
-/// handshake, reads each socket's pairing prefix, and groups sockets by connection id
-/// until a logical connection has all its streams. `pending` is interior-mutable
-/// because [`Net::accept`] takes `&self` (single-threaded, so the `RefCell` is never
-/// contended and no borrow is held across an await); it is shared with the per-
-/// connection [`reap_unpaired`] timeout coroutines via a `Weak`, so it drops (with any
-/// half-paired sockets) as soon as the listener does.
+/// A bound TCP server. All accept/pairing work runs in the [`listener_demux`] coroutine
+/// spawned by [`Net::bind`]; the handle keeps only the receiving end of the
+/// newly-surfaced-connection channel. [`Net::accept`] pulls the next new connection from
+/// it. `Mutex` (tokio) because `accept` takes `&self` and holds the receiver across the
+/// await — uncontended, since a single task accepts.
 pub(crate) struct TcpListenerHandle {
-    listener: TcpListener,
-    acceptor: TlsAcceptor,
-    streams: usize,
-    pending: Rc<RefCell<PendingMap>>,
+    new_conns: Mutex<mpsc::UnboundedReceiver<TcpConn>>,
 }
 
-/// Reap `connection_id` if it never finishes pairing. Spawned when its first socket
-/// arrives: after [`pending_reap_timeout`], if the id is still in the map it never
-/// completed (its client abandoned the connect after opening only some sockets), so
-/// drop it, freeing the orphaned sockets' fds. If the id is already gone, it completed
-/// and there is nothing to do.
-async fn reap_unpaired(pending: Weak<RefCell<PendingMap>>, connection_id: u128) {
-    tokio::time::sleep(pending_reap_timeout()).await;
-    if let Some(pending) = pending.upgrade() {
-        // If the id is still present it never finished pairing: the peer opened some
-        // but not all of its sockets (or they arrived too far apart). Log which stream
-        // indices did arrive (under `MM_QUIC_DEBUG`) so a server-side half-open — the
-        // other way a rank goes missing at high fan-out — is visible, not silent.
-        if let Some(slots) = pending.borrow_mut().remove(&connection_id) {
-            if crate::ctx::connection_debug() {
-                let arrived: Vec<usize> = slots
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, s)| s.as_ref().map(|_| i))
-                    .collect();
-                eprintln!(
-                    "MM_TCP reaped half-paired connection {connection_id:#x}: only stream indices {arrived:?} of {} arrived",
-                    slots.len()
-                );
+/// The single demux for a bound tcp server. Many logical connections share one listening
+/// socket, so it pairs each accepted socket with the [`TcpStreamRequest`] naming the same
+/// `(connection_id, index)` — one [`Matcher`] per pair, removed the moment its two halves
+/// meet, so a healthy connection leaves nothing behind (no per-connection coroutine, no
+/// live map). A socket for stream index 0 is a connection's first stream (it carries the
+/// preamble and arrives once), so it surfaces a fresh [`TcpConn`] out of [`Net::accept`].
+///
+/// Each socket's TLS handshake + prefix read runs in its own task — so a slow handshake
+/// doesn't head-of-line-block accept — then lands on `sockets`. Requests from every
+/// acceptor connection's `stream` calls share `requests`. The loop holds no lock and
+/// never awaits while touching the matchers, so sockets and requests never block each
+/// other.
+async fn listener_demux(
+    listener: TcpListener,
+    acceptor: TlsAcceptor,
+    new_conns: mpsc::UnboundedSender<TcpConn>,
+) {
+    // Requests from every acceptor connection's `stream` calls. The sender is cloned into
+    // each surfaced connection; the loop keeps `requests_tx` too, so `requests.recv()`
+    // never closes on its own.
+    let (requests_tx, mut requests) = mpsc::unbounded_channel::<TcpStreamRequest>();
+    // Handshaked sockets from the per-socket handshake tasks.
+    let (sock_tx, mut sockets) = mpsc::unbounded_channel::<(SocketAddr, u128, usize, TlsStream)>();
+    // For each (connection_id, index): the socket or the request that arrived first,
+    // parked until its partner shows up. An entry lives only while a half is waiting.
+    let mut matchers: HashMap<(u128, usize), Matcher<TcpStreamRequest, TlsStream>> = HashMap::new();
+    loop {
+        tokio::select! {
+            accepted = listener.accept() => {
+                let Ok((tcp, peer)) = accepted else {
+                    continue; // transient accept error; the listener stays open
+                };
+                // The connection is up (accept returned), so pin nodelay/congestion now;
+                // the buffer window scale was inherited from the listening socket.
+                tune_established(&tcp);
+                let acceptor = acceptor.clone();
+                let sock_tx = sock_tx.clone();
+                tokio::task::spawn_local(async move {
+                    let Ok(mut stream) = server_tls(&acceptor, tcp).await else {
+                        return; // TLS/kTLS handshake failed
+                    };
+                    let Some((cid, index)) = read_pairing_prefix(&mut stream).await else {
+                        return; // bad/short prefix
+                    };
+                    let _ = sock_tx.send((peer, cid, index, stream));
+                });
+            }
+            sock = sockets.recv() => {
+                let Some((peer, cid, index, stream)) = sock else { continue; };
+                let key = (cid, index);
+                if matchers
+                    .entry(key)
+                    .or_insert_with(Matcher::new)
+                    .push_right(stream, fulfill_tcp)
+                    .is_some()
+                {
+                    matchers.remove(&key);
+                }
+                // Index 0 is the connection's first stream; surface it once, here.
+                if index == 0 {
+                    let conn = TcpConn::Acceptor {
+                        remote: peer,
+                        connection_id: cid,
+                        requests: requests_tx.clone(),
+                    };
+                    if new_conns.send(conn).is_err() {
+                        return; // transport gone
+                    }
+                }
+            }
+            req = requests.recv() => {
+                // We hold `requests_tx`, so recv never returns None; guard anyway.
+                let Some(req) = req else { return; };
+                let key = (req.connection_id, req.index);
+                if matchers
+                    .entry(key)
+                    .or_insert_with(Matcher::new)
+                    .push_left(req, fulfill_tcp)
+                    .is_some()
+                {
+                    matchers.remove(&key);
+                }
             }
         }
     }
@@ -636,13 +675,12 @@ impl Net for Tcp {
         })
     }
 
-    fn bind(&mut self, addr: SocketAddr, streams: usize) -> anyhow::Result<TcpListenerHandle> {
+    fn bind(&mut self, addr: SocketAddr) -> anyhow::Result<TcpListenerHandle> {
         log_tuning_once();
         let acceptor = TlsAcceptor::from(self.tls()?.server.clone());
-        // `bind` is synchronous (the command loop can't await); build the listener
-        // socket directly so the kernel buffers can be enlarged *before* bind (so the
-        // window scale accepted sockets inherit reflects the enlarged window), then
-        // bind and listen — none of which awaits.
+        // Build the listener socket directly so the kernel buffers can be enlarged
+        // *before* bind (so the window scale accepted sockets inherit reflects the
+        // enlarged window), then bind and listen — none of which awaits.
         let socket = if addr.is_ipv6() {
             TcpSocket::new_v6()?
         } else {
@@ -652,185 +690,159 @@ impl Net for Tcp {
         socket.set_reuseaddr(true)?;
         socket.bind(addr)?;
         let listener = socket.listen(LISTEN_BACKLOG)?;
-        let pending: Rc<RefCell<PendingMap>> = Rc::new(RefCell::new(HashMap::new()));
+        // Spawn the demux on the command-loop LocalSet (bind is called from it). It owns
+        // the listener and pairs accepted sockets to stream requests, surfacing new
+        // connections on `new_tx`.
+        let (new_tx, new_rx) = mpsc::unbounded_channel();
+        tokio::task::spawn_local(listener_demux(listener, acceptor, new_tx));
         Ok(TcpListenerHandle {
-            listener,
-            acceptor,
-            streams,
-            pending,
+            new_conns: Mutex::new(new_rx),
         })
     }
 
     async fn accept(listener: &TcpListenerHandle) -> Option<TcpConn> {
-        loop {
-            let Ok((tcp, peer)) = listener.listener.accept().await else {
-                continue; // transient accept error; the listener stays open
-            };
-            // The connection is up (accept returned), so pin nodelay/congestion now;
-            // the buffer window scale was inherited from the listening socket.
-            tune_established(&tcp);
-            let Ok(mut stream) = server_tls(&listener.acceptor, tcp).await else {
-                continue; // TLS/kTLS handshake failed
-            };
-            let Some((connection_id, index)) = read_pairing_prefix(&mut stream).await else {
-                continue; // bad/short prefix
-            };
-            if index >= listener.streams {
-                continue; // out-of-range index; drop this socket
-            }
-            // Group by connection id. No await is held across this borrow.
-            let mut pending = listener.pending.borrow_mut();
-            let is_new = !pending.contains_key(&connection_id);
-            let slots = pending
-                .entry(connection_id)
-                .or_insert_with(|| (0..listener.streams).map(|_| None).collect());
-            slots[index] = Some(stream);
-            if slots.iter().all(Option::is_some) {
-                // Complete: remove it (so its reaper sees it gone and knows it
-                // completed) and hand it up.
-                let slots = pending.remove(&connection_id).expect("just inserted");
-                let streams = slots
-                    .into_iter()
-                    .map(|s| s.expect("all slots filled"))
-                    .collect();
-                return Some(TcpConn::new(peer, streams));
-            }
-            if is_new {
-                // First socket for this id: bound how long it may stay half-paired.
-                tokio::task::spawn_local(reap_unpaired(
-                    Rc::downgrade(&listener.pending),
-                    connection_id,
-                ));
-            }
-        }
+        listener.new_conns.lock().await.recv().await
     }
 
-    async fn connect(dialer: &TcpDialer, addr: SocketAddr, streams: usize) -> Option<TcpConn> {
-        // Open every stream up front (see the module docs): the accepting side may be
-        // the first messenger of a stream, and a plain socket can't be opened from the
-        // accepting side. Each socket is prefixed so the listener can pair them.
-        log_tuning_once();
-        // Each failure path below logs (under `MM_QUIC_DEBUG`) the exact peer address,
-        // stream index, and stage that failed, so a connect that never completes at high
-        // fan-out can be traced to the specific rank (the root dials in rank order).
-        let debug = crate::ctx::connection_debug();
-        let connection_id = new_connection_id();
-        let mut opened = Vec::with_capacity(streams);
-        for index in 0..streams {
-            // Build the socket directly so the kernel buffers can be enlarged *before*
-            // connect (so window scaling is negotiated for the enlarged window), then
-            // pin nodelay/congestion once the connection is up.
-            let socket = match if addr.is_ipv6() {
-                TcpSocket::new_v6()
-            } else {
-                TcpSocket::new_v4()
-            } {
-                Ok(s) => s,
-                Err(e) => {
-                    if debug {
-                        eprintln!(
-                            "MM_TCP connect {addr} stream {index}/{streams}: socket() failed: {e}"
-                        );
-                    }
-                    return None;
-                }
-            };
-            set_buffers(socket.as_raw_fd());
-            let tcp = match socket.connect(addr).await {
-                Ok(t) => t,
-                Err(e) => {
-                    if debug {
-                        eprintln!(
-                            "MM_TCP connect {addr} stream {index}/{streams}: connect() failed: {e}"
-                        );
-                    }
-                    return None;
-                }
-            };
-            tune_established(&tcp);
-            let mut stream = match client_tls(&dialer.connector, dialer.server_name.clone(), tcp)
-                .await
-            {
-                Ok(s) => s,
-                Err(e) => {
-                    if debug {
-                        eprintln!(
-                            "MM_TCP connect {addr} stream {index}/{streams}: TLS/kTLS handshake failed: {e:#}"
-                        );
-                    }
-                    return None;
-                }
-            };
-            if let Err(e) = write_pairing_prefix(&mut stream, connection_id, index).await {
-                if debug {
-                    eprintln!(
-                        "MM_TCP connect {addr} stream {index}/{streams}: pairing-prefix write failed: {e}"
-                    );
-                }
-                return None;
-            }
-            opened.push(stream);
-        }
-        Some(TcpConn::new(addr, opened))
+    async fn connect(dialer: &TcpDialer, addr: SocketAddr) -> Option<TcpConn> {
+        // Lazy: no socket is opened here. Each stream dials its own socket on demand (see
+        // `TcpConn::stream`), so a tcp join's reachability is proven by the first stream
+        // call, not here. Just mint the id that groups this connection's sockets.
+        Some(TcpConn::Dialer {
+            dialer: dialer.clone(),
+            addr,
+            connection_id: new_connection_id(),
+        })
     }
 
-    /// tcp opens `STREAMS` OS sockets plus a TLS handshake per connection and pairs
-    /// them on the acceptor, so it needs a much smaller default than quic: an
-    /// unthrottled connect storm at high fan-out leaves stragglers whose sockets never
-    /// finish pairing (seen as the root's `only N-1/N workers connected` aborts). 128
-    /// has proven safe through a full 65k-worker sweep; raise with
-    /// `MM_QUIC_MAX_CONCURRENT_CONNECTS` if a run needs faster connect ramp.
+    /// tcp opens an OS socket plus a TLS handshake per stream, so it needs a much smaller
+    /// default than quic: an unthrottled connect storm at high fan-out leaves stragglers
+    /// whose first socket never finishes handshaking (seen as the root's `only N-1/N
+    /// workers connected` aborts). 128 has proven safe through a full 65k-worker sweep;
+    /// raise with `MM_QUIC_MAX_CONCURRENT_CONNECTS` if a run needs faster connect ramp.
+    /// (The throttle covers the first stream's dial; the heartbeat and any data streams
+    /// open later, naturally staggered.)
     fn default_connect_concurrency() -> Option<usize> {
         Some(128)
     }
 }
 
-/// One logical TCP connection: the `streams` pre-opened, pairing-ordered sockets.
-/// [`NetConn::stream`] hands them out in index order (`first_messenger` is irrelevant
-/// — each socket is full-duplex, and both ends already hold their matching socket).
-pub(crate) struct TcpConn {
-    remote: SocketAddr,
-    streams: RefCell<Vec<Option<TlsStream>>>,
-    cursor: Cell<usize>,
+/// The send/recv halves of one paired tcp stream.
+type TcpHalves = (WriteHalf<TlsStream>, ReadHalf<TlsStream>);
+
+/// A [`NetConn::stream`] request from an acceptor connection to the listener demux: which
+/// `(connection_id, index)` socket it wants, and the one-shot the demux fulfils with the
+/// paired socket's halves. (tcp has no per-stream priority, so none is carried.)
+pub(crate) struct TcpStreamRequest {
+    connection_id: u128,
+    index: usize,
+    reply: oneshot::Sender<io::Result<TcpHalves>>,
 }
 
-impl TcpConn {
-    fn new(remote: SocketAddr, streams: Vec<TlsStream>) -> Self {
-        Self {
-            remote,
-            streams: RefCell::new(streams.into_iter().map(Some).collect()),
-            cursor: Cell::new(0),
-        }
-    }
+/// Fulfil a request with the socket the demux paired to its `(connection_id, index)`:
+/// split the socket and send the halves back through the one-shot.
+fn fulfill_tcp(req: TcpStreamRequest, stream: TlsStream) {
+    let (recv, send) = tokio::io::split(stream);
+    let _ = req.reply.send(Ok((send, recv)));
+}
+
+/// Dial one TLS-over-TCP socket to `addr` (see the module tuning docs for the socket
+/// options). The caller ([`NetConn::stream`]) writes the pairing prefix afterwards.
+async fn dial_one(dialer: &TcpDialer, addr: SocketAddr) -> io::Result<TlsStream> {
+    log_tuning_once();
+    // Build the socket directly so the kernel buffers can be enlarged *before* connect
+    // (so window scaling is negotiated for the enlarged window), then pin
+    // nodelay/congestion once the connection is up.
+    let socket = if addr.is_ipv6() {
+        TcpSocket::new_v6()?
+    } else {
+        TcpSocket::new_v4()?
+    };
+    set_buffers(socket.as_raw_fd());
+    let tcp = socket.connect(addr).await?;
+    tune_established(&tcp);
+    client_tls(&dialer.connector, dialer.server_name.clone(), tcp)
+        .await
+        .map_err(|e| io::Error::other(format!("tcp/tls dial {addr}: {e:#}")))
+}
+
+/// One logical TCP connection, in one of two roles set at construction, and cloneable so
+/// several tasks (data reader/writer, heartbeat) can each open the streams they own. A
+/// **dialer** connection (from [`Net::connect`]) opens each requested stream by dialing a
+/// fresh socket and writing its `(connection_id, index)` prefix. An **acceptor**
+/// connection (from [`Net::accept`]) sends each request — tagged with its `connection_id`
+/// and index — to the shared [`listener_demux`], which pairs it with the matching socket.
+/// The demux keeps no per-connection state past a pending pair, so cloning the handle is
+/// free of lifecycle concerns.
+#[derive(Clone)]
+pub(crate) enum TcpConn {
+    Dialer {
+        dialer: TcpDialer,
+        addr: SocketAddr,
+        connection_id: u128,
+    },
+    Acceptor {
+        remote: SocketAddr,
+        connection_id: u128,
+        requests: mpsc::UnboundedSender<TcpStreamRequest>,
+    },
 }
 
 impl fmt::Debug for TcpConn {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("TcpConn").field(&self.remote).finish()
+        let remote = match self {
+            TcpConn::Dialer { addr, .. } => addr,
+            TcpConn::Acceptor { remote, .. } => remote,
+        };
+        f.debug_tuple("TcpConn").field(remote).finish()
     }
 }
 
 impl NetConn for TcpConn {
     type Send = WriteHalf<TlsStream>;
     type Recv = ReadHalf<TlsStream>;
-    // The sockets are already open, so producing a stream is synchronous — a ready
-    // future, never touching the wire (the generic layer just awaits it like quic's).
-    type Stream = Ready<io::Result<(Self::Send, Self::Recv)>>;
+    type Stream = Pin<Box<dyn Future<Output = io::Result<(Self::Send, Self::Recv)>>>>;
 
-    fn stream(&self, _first_messenger: bool) -> Self::Stream {
-        let index = self.cursor.get();
-        self.cursor.set(index + 1);
-        let taken = self
-            .streams
-            .borrow_mut()
-            .get_mut(index)
-            .and_then(Option::take);
-        match taken {
-            Some(stream) => {
-                let (recv, send) = tokio::io::split(stream);
-                std::future::ready(Ok((send, recv)))
+    fn stream(&self, index: usize, _priority: i32) -> Self::Stream {
+        match self {
+            // Dialer: open a fresh socket for this index and tag it with the prefix.
+            TcpConn::Dialer {
+                dialer,
+                addr,
+                connection_id,
+            } => {
+                let dialer = dialer.clone();
+                let addr = *addr;
+                let connection_id = *connection_id;
+                Box::pin(async move {
+                    let mut stream = dial_one(&dialer, addr).await?;
+                    write_pairing_prefix(&mut stream, connection_id, index).await?;
+                    let (recv, send) = tokio::io::split(stream);
+                    Ok((send, recv))
+                })
             }
-            None => std::future::ready(Err(io::Error::other("tcp stream index exhausted"))),
+            // Acceptor: ask the demux for this (connection, index) socket and await the
+            // paired halves.
+            TcpConn::Acceptor {
+                connection_id,
+                requests,
+                ..
+            } => {
+                let connection_id = *connection_id;
+                let requests = requests.clone();
+                Box::pin(async move {
+                    let (reply, rx) = oneshot::channel();
+                    requests
+                        .send(TcpStreamRequest {
+                            connection_id,
+                            index,
+                            reply,
+                        })
+                        .map_err(|_| io::Error::other("tcp connection closed"))?;
+                    rx.await
+                        .map_err(|_| io::Error::other("tcp connection closed"))?
+                })
+            }
         }
     }
 }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* #4617
* #4616
* __->__ #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Replace the fixed stream count and call-order pairing with explicit stream indices and caller-supplied priorities. Add lazy QUIC and TCP acceptor demultiplexers so dialers can open data, heartbeat, and future streams independently while preserving retry and pairing behavior.

Differential Revision: [D114750244](https://our.internmc.facebook.com/intern/diff/D114750244/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750244/)!