### PR TITLE
42/43 minimonarch: Stripe large messages across parallel data streams

### DIFF
--- a/monarch_mini/src/dataio.rs
+++ b/monarch_mini/src/dataio.rs
@@ -1,0 +1,810 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! Data-plane I/O for message parts, above the wire [`crate::framing`]: reading and
+//! writing each part in whichever form fits — a small part inline on the control stream,
+//! a large part read/written straight into a shared-memory slab (or a heap buffer with no
+//! slab), and a *large* part optionally **striped** across several parallel data streams
+//! of the connection to fill a fat cross-region pipe. [`crate::framing`] frames the
+//! header and drives these per part; the shared-memory and striping policy — *when* to
+//! stripe, opening the data streams, and holding a message back until its shards land —
+//! lives here, exposed as two objects framing/the transport drive directly:
+//!
+//! - [`PartWriter`] — [`write_message_parts`](PartWriter::write_message_parts) writes a
+//!   message's parts, each inline on the control stream or striped across the data streams.
+//! - [`PartReader`] — [`read_message_parts`](PartReader::read_message_parts) reads them
+//!   back, each part returned before its bytes land and its shards tracked for completion.
+//! - [`read_messages`] — the receive loop: reads frames, and delivers assembled messages
+//!   to the command loop **in order** (a straggling large message holds back only what
+//!   genuinely follows it) while reading ahead.
+//!
+//! A single stream is one throughput-bound flow (crypto core-bound, and cross-region
+//! cwnd/RTT-bound to one flow's share of the link), so striping a large message across
+//! several data streams gives the parallel flows that fill a fat pipe, while small
+//! messages stay inline on the control stream. See `PARALLEL_DATA_STREAMS_DESIGN.md`.
+//!
+//! ## Fixed stream indices (direction by parity)
+//!
+//! The control stream is index 0 and the heartbeat stream index 1 (see
+//! [`crate::net_transport`]). Data streams take higher indices, with **direction
+//! encoded by parity** so the two directions' index spaces never overlap regardless of
+//! how many streams each opens: `td` (toward-dialer) at even indices `2, 4, …` (the
+//! acceptor writes, the dialer reads) and `ta` (toward-acceptor) at odd indices
+//! `3, 5, …` (the dialer writes, the acceptor reads). Shard `k` of a direction is at
+//! `base + 2k`; both ends name the same fixed index, so their halves pair with no
+//! negotiation. Data streams carry **unframed** shard bytes — the control-stream
+//! descriptor ([`crate::framing::WirePart::Striped`]) fully determines the split.
+//!
+//! ## Streams and tasks
+//!
+//! Each object holds a clone of the (`Send`) connection handle and opens the data
+//! streams it needs itself, lazily on the first large message — blocking the control
+//! stream for that one setup is fine (unlike the heartbeat stream, the control stream
+//! has no deadline). Each open spawns one per-stream I/O task ([`shard_reader_task`] /
+//! [`shard_writer_task`]) via `tokio::spawn`; the halves are `Send`, so this composes
+//! with the data runtime the control coroutines may run on. There are no other tasks —
+//! no per-connection coordinator — and nothing exists until a connection carries a
+//! large message, and only for the direction(s) that do.
+//!
+//! ## The unsafe: shards write straight into the destination
+//!
+//! A striped part is read **zero-copy** into its final buffer: the reader allocates the
+//! destination once (a shared-memory slab block, or a plain heap `Vec` when there is no
+//! slab) and hands each per-stream reader a raw `*mut u8` into its shard's sub-range.
+//! This is a deliberately localized `unsafe` (we do not add a bespoke [`MsgPart`]
+//! constructor for it): the destination buffer is owned by the assembled [`MsgPart`],
+//! which [`read_messages`]'s buffer holds until *every* shard has landed, so the pointers
+//! stay valid for the whole of the (disjoint) writes.
+
+use std::collections::VecDeque;
+use std::future::Future;
+use std::io;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tokio::io::AsyncRead;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+
+use crate::framing::WirePart;
+use crate::msg::MsgPart;
+use crate::net::Net;
+use crate::net::NetConn;
+use crate::shm::MapperHandle;
+use crate::shm::SHM_THRESHOLD;
+use crate::shm::ShmClient;
+use crate::shm::ShmClientSlot;
+
+/// The send half of a connection's stream, for the protocol `N`.
+type ConnSend<N> = <<N as Net>::Conn as NetConn>::Send;
+/// The receive half of a connection's stream, for the protocol `N`.
+type ConnRecv<N> = <<N as Net>::Conn as NetConn>::Recv;
+
+/// Send priority of a data stream (quic; tcp ignores it): the same low priority as the
+/// control stream, below the heartbeat's, so a beat still packs ahead of bulk data.
+const PRIORITY_DATA: i32 = 0;
+
+/// Default size at/above which a message part is striped, when `MM_NET_LARGE_MSG_BYTES`
+/// is unset. 1 MiB — comfortably above the shared-memory inline threshold
+/// ([`crate::shm::SHM_THRESHOLD`]), so mid-size slab parts stay inline and only bulk
+/// payloads take the parallel path.
+const DEFAULT_LARGE_MSG_BYTES: u64 = 1 << 20;
+
+/// Number of data streams per striping direction (sender-side width). `0` (unset)
+/// disables striping entirely: every part stays inline and the transport behaves
+/// exactly as before. A *sender* knob — the receiver follows the wire descriptor — so
+/// the two ends need not agree.
+pub(crate) fn n_data_streams() -> usize {
+    std::env::var("MM_NET_N_DATA_STREAMS")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(0)
+}
+
+/// Size at/above which a message part is striped (see [`DEFAULT_LARGE_MSG_BYTES`]).
+fn large_msg_bytes() -> u64 {
+    std::env::var("MM_NET_LARGE_MSG_BYTES")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(DEFAULT_LARGE_MSG_BYTES)
+}
+
+/// The first data-stream index for a task that opened its connection by **dialing**
+/// (`dialed`) vs **accepting**, and in the given direction — `write` (toward the peer)
+/// or `read` (from the peer). Direction is encoded by parity: `ta` (odd) flows
+/// dialer→acceptor, `td` (even) acceptor→dialer, and shard `k` is at `base + 2k`, so the
+/// two ends of one stream name the same index. A one-directional gateway side channel
+/// (dialer writes, acceptor reads) needs no special case: both land on `ta` (base 3).
+fn stream_base(dialed: bool, write: bool) -> usize {
+    // toward-acceptor `ta` (odd, 3) when dialer-writing or acceptor-reading; else `td`.
+    if dialed == write { 3 } else { 2 }
+}
+
+/// Split `len` bytes evenly across `n` shards; the first `len % n` shards get one extra
+/// byte. For a striped part (`len >= large_msg_bytes`, `n` small) every shard is
+/// comfortably non-empty.
+fn even_split(len: u64, n: usize) -> Vec<u64> {
+    let n = n as u64;
+    let base = len / n;
+    let rem = len % n;
+    (0..n).map(|i| base + u64::from(i < rem)).collect()
+}
+
+/// A raw pointer to a shard's destination sub-range, made `Send` so it can ride to a
+/// per-stream reader task. Sound because the owning [`MsgPart`] keeps the buffer alive
+/// past every write and each pointer names a disjoint range (see the module docs).
+struct ShardDst(*mut u8);
+// SAFETY: see the module docs — the destination buffer outlives the writes and the
+// ranges are disjoint, so moving the raw pointer to the reader task is sound.
+unsafe impl Send for ShardDst {}
+
+/// One shard-read instruction to a per-stream reader: fill `[dst, dst+len)` from the
+/// stream, then acknowledge success or failure to the owning message's [`Batch`].
+struct ShardRead {
+    dst: ShardDst,
+    len: usize,
+    done: oneshot::Sender<io::Result<()>>,
+}
+
+/// A batch of in-flight shard reads and their completion acknowledgements. A
+/// [`PartReader`] accumulates a message's striped-part acknowledgements into the current
+/// batch; [`PartReader::sync`] then awaits all of them and rotates in a fresh batch.
+/// Waiting never stops at the first error because sibling readers may still be writing
+/// through raw pointers into the message's destination.
+struct Batch {
+    done: Vec<oneshot::Receiver<io::Result<()>>>,
+}
+
+impl Batch {
+    fn new() -> Self {
+        Self { done: Vec::new() }
+    }
+}
+
+/// Await every dispatched shard, retaining the first failure until all sibling reads
+/// have either completed or discarded their queued instruction.
+async fn wait_for_shards(done: Vec<oneshot::Receiver<io::Result<()>>>) -> io::Result<()> {
+    let mut first_error = None;
+    for completion in done {
+        let result = completion
+            .await
+            .unwrap_or_else(|_| Err(io::Error::other("data stream closed")));
+        match result {
+            Err(error) if first_error.is_none() => first_error = Some(error),
+            _ => {}
+        }
+    }
+    first_error.map_or(Ok(()), Err)
+}
+
+/// Keep a destination owner alive while already-dispatched shards finish after a
+/// higher-level operation has failed. The original operation's error takes precedence,
+/// so callers intentionally ignore the shard result after the lifetime barrier.
+async fn wait_for_shards_before_drop<T>(
+    keep_alive: T,
+    done: Vec<oneshot::Receiver<io::Result<()>>>,
+) -> io::Result<()> {
+    let result = wait_for_shards(done).await;
+    drop(keep_alive);
+    result
+}
+
+/// One shard-write job to a per-stream writer: write `part`'s `[offset, offset+len)`
+/// onto the stream. The whole part is shared (`Arc`) across the streams that carry its
+/// shards; no bytes are copied.
+struct ShardWrite {
+    part: Arc<MsgPart>,
+    offset: usize,
+    len: usize,
+}
+
+/// Read shards off one data stream in order, each straight into its instruction's
+/// destination sub-range, acknowledging success or failure as each finishes. A read
+/// error ends the task; dropping queued instructions closes their acknowledgement
+/// channels so their message waiters also observe failure.
+async fn shard_reader_task<N: Net>(
+    mut recv: ConnRecv<N>,
+    mut instrs: mpsc::UnboundedReceiver<ShardRead>,
+) {
+    while let Some(instr) = instrs.recv().await {
+        // SAFETY: `dst` points at `len` bytes of the destination buffer owned by the
+        // still-undelivered `MsgPart` (held in the delivery gate until every shard
+        // lands); this task is the sole writer of this disjoint sub-range. See the
+        // module docs on the localized unsafe.
+        let buf = unsafe { std::slice::from_raw_parts_mut(instr.dst.0, instr.len) };
+        let result = recv.read_exact(buf).await.map(|_| ());
+        let failed = result.is_err();
+        let _ = instr.done.send(result);
+        if failed {
+            return;
+        }
+    }
+}
+
+/// Write shards onto one data stream in the order the message writer enqueued them
+/// (per-stream FIFO by message). Ends when the striper drops its sender or a write
+/// fails (finishing the stream so the peer's reader sees EOF and severs).
+async fn shard_writer_task<N: Net>(
+    mut send: ConnSend<N>,
+    mut jobs: mpsc::UnboundedReceiver<ShardWrite>,
+) {
+    while let Some(job) = jobs.recv().await {
+        let bytes = &job.part.as_bytes()[job.offset..job.offset + job.len];
+        if send.write_all(bytes).await.is_err() || send.flush().await.is_err() {
+            return;
+        }
+    }
+    let _ = send.shutdown().await;
+}
+
+/// Writes a message's parts to the control stream (inline) or across the connection's
+/// data streams (striped), the send-side mirror of [`PartReader`]. It decides the split
+/// ([`Self::plan`], for the header framing writes) and writes each part
+/// ([`Self::write`]) — a small part inline, a large part striped across the data streams
+/// (opened lazily off the connection handle). When striping is disabled (`n == 0`)
+/// [`Self::plan`] marks every part inline and the wire is byte-for-byte the non-striped
+/// path. Striped writes are fire-and-forget (per-stream FIFO handles ordering), so —
+/// unlike [`PartReader`] — there is no completion to await.
+pub(crate) struct PartWriter<N: Net> {
+    conn: N::Conn,
+    base: usize,
+    n: usize,
+    threshold: u64,
+    writers: Vec<mpsc::UnboundedSender<ShardWrite>>,
+}
+
+impl<N: Net> PartWriter<N> {
+    /// A part writer over this side's outbound data streams. `dialed` (did we open this
+    /// connection by dialing?) picks the write direction's stream indices.
+    pub(crate) fn new(conn: N::Conn, dialed: bool) -> Self {
+        Self {
+            conn,
+            base: stream_base(dialed, true),
+            n: n_data_streams(),
+            threshold: large_msg_bytes(),
+            writers: Vec::new(),
+        }
+    }
+
+    /// Write a message's parts onto `control` after its routing header (written by
+    /// [`crate::framing`]): the per-part plan as a header, then each part — inline bytes
+    /// onto `control`, or striped across the data streams — and flush. The whole
+    /// message-part write path for both pathways (they differ only in the routing header
+    /// framing writes first). Striped shards are enqueued (they flow asynchronously)
+    /// before the flush; the peer reads the header, opens its data streams, and pairs
+    /// them, so nothing blocks here.
+    pub(crate) async fn write_message_parts<W: tokio::io::AsyncWrite + Unpin>(
+        &mut self,
+        control: &mut W,
+        parts: Vec<MsgPart>,
+    ) -> io::Result<()> {
+        let plan: Vec<WirePart> = parts
+            .iter()
+            .map(|part| self.plan(part.len() as u64))
+            .collect();
+        crate::framing::write_header(control, &plan).await?;
+        for (part, wire_part) in parts.into_iter().zip(&plan) {
+            self.write(control, part, wire_part).await?;
+        }
+        control.flush().await
+    }
+
+    /// The wire descriptor for a part of `len` bytes: inline, or striped with its
+    /// per-shard byte lengths. The plan goes in the header before any part bytes.
+    fn plan(&self, len: u64) -> WirePart {
+        if self.n > 0 && len >= self.threshold {
+            WirePart::Striped {
+                shard_lens: even_split(len, self.n),
+            }
+        } else {
+            WirePart::Inline { len }
+        }
+    }
+
+    /// Write one part per its `wire_part` descriptor: an inline part's bytes stream onto
+    /// `control`; a striped part's shards are handed to the data streams' per-stream
+    /// writers (opened lazily). Striped shards go out asynchronously, so this returns
+    /// once they are enqueued.
+    async fn write<W: tokio::io::AsyncWrite + Unpin>(
+        &mut self,
+        control: &mut W,
+        part: MsgPart,
+        wire_part: &WirePart,
+    ) -> io::Result<()> {
+        let WirePart::Striped { shard_lens } = wire_part else {
+            control.write_all(part.as_bytes()).await?;
+            return Ok(());
+        };
+        self.ensure(shard_lens.len()).await?;
+        let part = Arc::new(part);
+        let mut offset = 0usize;
+        for (i, &shard_len) in shard_lens.iter().enumerate() {
+            let len = shard_len as usize;
+            self.writers[i]
+                .send(ShardWrite {
+                    part: Arc::clone(&part),
+                    offset,
+                    len,
+                })
+                .map_err(|_| io::Error::other("data stream writer closed"))?;
+            offset += len;
+        }
+        Ok(())
+    }
+
+    /// Ensure `n` per-stream writers are open, opening stream `base + 2i` for each new
+    /// index and spawning its [`shard_writer_task`].
+    async fn ensure(&mut self, n: usize) -> io::Result<()> {
+        while self.writers.len() < n {
+            let index = self.base + 2 * self.writers.len();
+            let (send, _recv) = self.conn.stream(index, PRIORITY_DATA).await?;
+            let (tx, rx) = mpsc::unbounded_channel();
+            tokio::spawn(shard_writer_task::<N>(send, rx));
+            self.writers.push(tx);
+        }
+        Ok(())
+    }
+}
+
+/// Reads a message's parts off the control stream, returning each [`MsgPart`] before its
+/// bytes have landed. A small part is read inline (into the slab, or a heap buffer when
+/// there is no slab); a large part is striped across the connection's data streams
+/// (opened lazily off the handle), its shards read straight into the destination. It
+/// carries the shared-memory context and accumulates the in-flight shards into the
+/// current [`Batch`]; [`Self::sync`] hands back a future for that batch's completion and
+/// starts a fresh one, so the reader can deliver each message once its shards land.
+pub(crate) struct PartReader<N: Net> {
+    conn: N::Conn,
+    base: usize,
+    mapper: MapperHandle,
+    client: ShmClientSlot,
+    readers: Vec<mpsc::UnboundedSender<ShardRead>>,
+    batch: Batch,
+}
+
+impl<N: Net> PartReader<N> {
+    /// A part reader over this side's inbound data streams, landing striped parts in the
+    /// slab via `mapper`/`client`. `dialed` (did we open this connection by dialing?)
+    /// picks the read direction's stream indices.
+    pub(crate) fn new(
+        conn: N::Conn,
+        dialed: bool,
+        mapper: MapperHandle,
+        client: ShmClientSlot,
+    ) -> Self {
+        Self {
+            conn,
+            base: stream_base(dialed, false),
+            mapper,
+            client,
+            readers: Vec::new(),
+            batch: Batch::new(),
+        }
+    }
+
+    /// Read a message's parts off `control` after its routing header (read by
+    /// [`crate::framing`]): the per-part plan header, then each part — inline off
+    /// `control`, or striped from the data streams. The whole message-part read path for
+    /// both pathways. Striped parts come back before their bytes land, accumulated into
+    /// the current batch; the reader loop calls [`Self::sync`] afterward to gate delivery.
+    pub(crate) async fn read_message_parts<R: AsyncRead + Unpin>(
+        &mut self,
+        control: &mut R,
+    ) -> io::Result<Vec<MsgPart>> {
+        let plan: Vec<WirePart> = crate::framing::read_header(control).await?;
+        let mut out = Vec::with_capacity(plan.len());
+        for wire_part in plan {
+            match self.read(control, wire_part).await {
+                Ok(part) => out.push(part),
+                Err(error) => {
+                    let Batch { done } = std::mem::replace(&mut self.batch, Batch::new());
+                    let _ = wait_for_shards_before_drop(out, done).await;
+                    return Err(error);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    /// Read one part off `control`, per its wire descriptor. Returns before a striped
+    /// part's bytes land — they fill from the data streams into the returned part's
+    /// destination, tracked by the current batch (see [`Self::sync`]).
+    async fn read<R: AsyncRead + Unpin>(
+        &mut self,
+        control: &mut R,
+        part: WirePart,
+    ) -> io::Result<MsgPart> {
+        match part {
+            WirePart::Inline { len } => {
+                read_inline(control, len, self.mapper.clone(), self.client()).await
+            }
+            WirePart::Striped { shard_lens } => self.read_striped(&shard_lens).await,
+        }
+    }
+
+    /// A future that resolves once every shard read since the last `sync` has landed
+    /// (`Ok`) or a data stream died (`Err`), rotating in a fresh batch for the next
+    /// message's parts — or `None` for a message with no striped parts (the common case),
+    /// which is already complete and needs no waiting or allocation. Only a genuinely
+    /// striped message produces (and boxes) a future.
+    fn sync(&mut self) -> Option<Done> {
+        if self.batch.done.is_empty() {
+            return None;
+        }
+        let Batch { done } = std::mem::replace(&mut self.batch, Batch::new());
+        Some(Box::pin(wait_for_shards(done)))
+    }
+
+    /// Allocate the destination for a striped part and hand each shard's sub-range to its
+    /// per-stream reader, adding this part's shards to the current batch. Returns the
+    /// [`MsgPart`] (its bytes fill in as the shards land).
+    async fn read_striped(&mut self, shard_lens: &[u64]) -> io::Result<MsgPart> {
+        self.ensure(shard_lens.len()).await?;
+        let total: u64 = shard_lens.iter().sum();
+        let (part, base) = alloc_dst(self.mapper.clone(), self.client(), total).await?;
+
+        let mut done = Vec::with_capacity(shard_lens.len());
+        let mut offset = 0usize;
+        for (i, &shard_len) in shard_lens.iter().enumerate() {
+            let len = shard_len as usize;
+            // SAFETY: `base` is a `total`-byte destination and `offset + len <= total`,
+            // so `base + offset` starts a distinct in-bounds `len`-byte range.
+            let dst = ShardDst(unsafe { base.add(offset) });
+            let (done_tx, done_rx) = oneshot::channel();
+            if self.readers[i]
+                .send(ShardRead {
+                    dst,
+                    len,
+                    done: done_tx,
+                })
+                .is_err()
+            {
+                let error = io::Error::other("data stream reader closed");
+                let _ = wait_for_shards_before_drop(part, done).await;
+                return Err(error);
+            }
+            done.push(done_rx);
+            offset += len;
+        }
+        self.batch.done.extend(done);
+        Ok(part)
+    }
+
+    /// Snapshot the owning actor's gateway client (`None` until learned).
+    fn client(&self) -> Option<ShmClient> {
+        *self.client.lock().expect("shm client slot mutex poisoned")
+    }
+
+    /// Ensure `n` per-stream readers are open, opening stream `base + 2i` for each new
+    /// index and spawning its [`shard_reader_task`].
+    async fn ensure(&mut self, n: usize) -> io::Result<()> {
+        while self.readers.len() < n {
+            let index = self.base + 2 * self.readers.len();
+            let (_send, recv) = self.conn.stream(index, PRIORITY_DATA).await?;
+            let (tx, rx) = mpsc::unbounded_channel();
+            tokio::spawn(shard_reader_task::<N>(recv, rx));
+            self.readers.push(tx);
+        }
+        Ok(())
+    }
+}
+
+/// Why [`read_messages`] stopped.
+pub(crate) enum ReadStop {
+    /// The control stream ended or errored (the caller severs, folding in `io::Error`).
+    Ended(io::Error),
+    /// A data stream died mid-message, so a striped message can no longer complete and
+    /// order can't skip it (the caller severs).
+    DataStreamDied,
+    /// `on_message` returned `false` — its command sink is gone; stop quietly.
+    Delivered,
+}
+
+/// A striped message's shard-completion future ([`PartReader::sync`]), boxed so the
+/// buffer can hold it: `Ok` once every shard landed, `Err` if a data stream died. The
+/// buffer pairs each message with an `Option<Done>` — `None` for the common message with
+/// no striped parts (already complete), so only a striped one ever allocates a future.
+type Done = Pin<Box<dyn Future<Output = io::Result<()>> + Send>>;
+
+/// Reads and delivers a pathway's messages, driven by [`Self::read_messages`]. Each
+/// pathway (a join/serve connection, a gateway side channel) is one implementation,
+/// supplying how to decode a control frame ([`Self::read_frame`]) and where a ready
+/// message goes ([`Self::on_message`]); the loop and the striping/ordering are shared.
+///
+/// Making the pathway an implementation (rather than a generic closure) keeps
+/// [`Self::read_frame`]'s future *concrete per impl*, so its `Send`-ness — needed to run
+/// the loop on the data runtime — is checked structurally instead of as a higher-ranked
+/// bound the compiler can't yet discharge; that is why this is a trait and not two
+/// closures.
+pub(crate) trait MessageReader<N: Net>: Send {
+    /// The delivered message type (`ConnectionCommand` / `SideChannelMessage`).
+    type Item: Send;
+
+    /// Decode the next control frame off `control`, reading its parts through `parts`.
+    /// Not cancel-safe (a frame is several reads), so [`Self::read_messages`] drives one
+    /// to completion before starting the next.
+    fn read_frame(
+        control: &mut ConnRecv<N>,
+        parts: &mut PartReader<N>,
+    ) -> impl Future<Output = io::Result<Self::Item>> + Send;
+
+    /// Deliver one in-order message. Returns `false` if its sink is gone (stop the loop).
+    fn on_message(&mut self, item: Self::Item) -> bool;
+
+    /// The whole receive loop. Read a frame, then hand it to [`Self::on_message`] **in
+    /// order** — but read ahead while a large message's shards land, delivering a message
+    /// only once its batch ([`PartReader::sync`]) completes, so a straggler only delays
+    /// what genuinely follows it. A message with no striped parts completes at once, so
+    /// with nothing striped nothing is ever held.
+    fn read_messages(
+        &mut self,
+        mut control: ConnRecv<N>,
+        mut parts: PartReader<N>,
+    ) -> impl Future<Output = ReadStop> + Send {
+        async move {
+            // In-order, each with its shards' completion future — `None` when nothing was
+            // striped. Empty in the steady state; only a striped straggler and whatever
+            // arrives behind it ever land here.
+            let mut buffer: VecDeque<(Self::Item, Option<Done>)> = VecDeque::new();
+            loop {
+                // The latency path: nothing buffered ⇒ nothing to wait on, so just read
+                // the next frame directly — no completion race, no buffer round trip.
+                let frame = if buffer.is_empty() {
+                    Self::read_frame(&mut control, &mut parts).await
+                } else {
+                    // Something striped is still landing: read ahead while delivering any
+                    // already-complete leading messages. The read future is kept
+                    // un-cancelled (a frame is several reads) until it yields.
+                    let read = Self::read_frame(&mut control, &mut parts);
+                    tokio::pin!(read);
+                    loop {
+                        tokio::select! {
+                            frame = &mut read => break frame,
+                            done = await_front(&mut buffer) => match done {
+                                Err(_) => {
+                                    buffer.pop_front().expect("front just completed");
+                                    drain_buffer(&mut buffer).await;
+                                    return ReadStop::DataStreamDied;
+                                }
+                                Ok(()) => {
+                                    let (item, _) =
+                                        buffer.pop_front().expect("front just completed");
+                                    if !self.on_message(item) {
+                                        drain_buffer(&mut buffer).await;
+                                        return ReadStop::Delivered;
+                                    }
+                                }
+                            },
+                        }
+                    }
+                };
+                let item = match frame {
+                    Ok(item) => item,
+                    Err(err) => {
+                        drain_buffer(&mut buffer).await;
+                        return ReadStop::Ended(err);
+                    }
+                };
+                match parts.sync() {
+                    // The latency path continues: no shards to wait on and nothing ahead
+                    // of it — deliver straight through, never touching the buffer.
+                    None if buffer.is_empty() => {
+                        if !self.on_message(item) {
+                            return ReadStop::Delivered;
+                        }
+                    }
+                    // Striped (must wait), or something ahead of it is still landing
+                    // (deliver in order): buffer it behind the rest.
+                    done => buffer.push_back((item, done)),
+                }
+            }
+        }
+    }
+}
+
+/// Await the front buffered message's shard completion — pending forever when the buffer
+/// is empty, so the reader only reads. `Ok` ⇒ its shards all landed, or it had none
+/// (deliver it); `Err` ⇒ a data stream died.
+async fn await_front<Item>(buffer: &mut VecDeque<(Item, Option<Done>)>) -> io::Result<()> {
+    match buffer.front_mut() {
+        None => std::future::pending().await,
+        Some((_, None)) => Ok(()),
+        Some((_, Some(done))) => done.as_mut().await,
+    }
+}
+
+/// Wait out every buffered message's shard sync before dropping its destination parts.
+/// Errors are irrelevant once the reader has already decided to stop, but each `Done`
+/// must reach completion because its shard tasks may still hold raw destination pointers.
+async fn drain_buffer<Item>(buffer: &mut VecDeque<(Item, Option<Done>)>) {
+    while let Some((_, done)) = buffer.front_mut() {
+        if let Some(done) = done {
+            let _ = done.as_mut().await;
+        }
+        buffer.pop_front();
+    }
+}
+
+/// Read an inline part of `len` bytes off `control` into its destination. A part `>=
+/// SHM_THRESHOLD` whose actor has learned its gateway [`ShmClient`] lands straight in a
+/// freshly allocated slab block (the only copy is the unavoidable kernel-to-userspace
+/// one, and a later unix hop forwards the descriptor without recopying); everything else
+/// lands in an owned heap buffer. A free function (not a `&self` method) so the read
+/// future stays `Send` without requiring the connection handle to be `Sync`.
+async fn read_inline<R: AsyncRead + Unpin>(
+    control: &mut R,
+    len: u64,
+    mapper: MapperHandle,
+    client: Option<ShmClient>,
+) -> io::Result<MsgPart> {
+    // The slab only pays off for a large part, so filter the client out below the
+    // threshold; `alloc_dst` then gives a heap buffer for the small/no-slab case.
+    let (part, dst) = alloc_dst(mapper, client.filter(|_| len >= SHM_THRESHOLD), len).await?;
+    // SAFETY: `dst` is `len` writable bytes of the destination buffer owned by `part`
+    // (slab mapping or heap `Vec`), valid past this read; this is the sole writer.
+    let buf = unsafe { std::slice::from_raw_parts_mut(dst, len as usize) };
+    control.read_exact(buf).await?;
+    Ok(part)
+}
+
+/// Allocate a `total`-byte destination for a message part and return it plus a raw
+/// pointer to its start. With a gateway [`ShmClient`] it is a slab block (read
+/// zero-copy, ready to relay across a later unix hop by descriptor); without one it is
+/// a plain heap buffer. The pointer stays valid for the returned [`MsgPart`]'s lifetime
+/// (the slab mapping is context-lived; the heap `Vec`'s buffer never moves once boxed).
+async fn alloc_dst(
+    mapper: MapperHandle,
+    client: Option<ShmClient>,
+    total: u64,
+) -> io::Result<(MsgPart, *mut u8)> {
+    let Some(client) = client else {
+        // No slab: assemble into a plain heap buffer. Take the raw pointer from the
+        // freshly-allocated `Vec` before handing it to `MsgPart::from_bytes` — moving
+        // the `Vec` into the part does not move its heap allocation, so the pointer
+        // stays valid, and this side owns the part exclusively until delivery.
+        let mut buf: Vec<u8> = Vec::with_capacity(total as usize);
+        // SAFETY: the allocation above reserves capacity for `total` bytes, so growing
+        // the length to `total` names only those bytes. The buffer is exposed solely as
+        // a write destination (a raw `*mut u8`); every byte is filled by the
+        // `read_exact`/shard reads that follow before any is read, so its uninitialized
+        // contents are never observed. Skipping the zero-fill avoids wasted work.
+        // (`clippy::uninit_vec` flags this pattern generically; the read-before-use
+        // invariant above is exactly what makes it sound here.)
+        #[allow(clippy::uninit_vec)]
+        unsafe {
+            buf.set_len(total as usize)
+        };
+        let ptr = buf.as_mut_ptr();
+        return Ok((MsgPart::from_bytes(buf), ptr));
+    };
+    let (offset, token) = client.allocate(total).await?;
+    let ptr = {
+        let mut guard = mapper.lock().expect("shm mapper mutex poisoned");
+        // SAFETY: `offset` was just granted for `total` bytes against `client`'s slab,
+        // so the file covers it and the mapper can map the range.
+        unsafe { guard.map(client.slab_fd(), offset, total as usize)? }
+    };
+    Ok((
+        MsgPart::new_shm(mapper, client.slab_fd(), token, offset, total),
+        ptr,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn shard_failure_waits_for_sibling_completion() {
+        let (failed_tx, failed_rx) = oneshot::channel();
+        let (sibling_tx, sibling_rx) = oneshot::channel();
+        let waiter = tokio::spawn(wait_for_shards(vec![failed_rx, sibling_rx]));
+
+        failed_tx
+            .send(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "injected shard failure",
+            )))
+            .expect("failed shard should acknowledge");
+        tokio::task::yield_now().await;
+        assert!(
+            !waiter.is_finished(),
+            "the batch must wait for a sibling after the first failure"
+        );
+
+        sibling_tx
+            .send(Ok(()))
+            .expect("sibling shard should acknowledge");
+        let error = waiter
+            .await
+            .expect("batch waiter should finish")
+            .expect_err("the first shard failure should be returned");
+        assert_eq!(error.kind(), io::ErrorKind::UnexpectedEof);
+    }
+
+    struct DropNotice(Option<oneshot::Sender<()>>);
+
+    impl Drop for DropNotice {
+        fn drop(&mut self) {
+            if let Some(notice) = self.0.take() {
+                let _ = notice.send(());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_dispatch_keeps_destination_until_dispatched_shards_finish() {
+        let (shard_tx, shard_rx) = oneshot::channel();
+        let (drop_tx, mut drop_rx) = oneshot::channel();
+        let waiter = tokio::spawn(wait_for_shards_before_drop(
+            DropNotice(Some(drop_tx)),
+            vec![shard_rx],
+        ));
+
+        tokio::task::yield_now().await;
+        assert!(
+            matches!(drop_rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)),
+            "destination must remain alive while a shard is active"
+        );
+        shard_tx
+            .send(Ok(()))
+            .expect("dispatched shard should acknowledge");
+        waiter
+            .await
+            .expect("dispatch waiter should finish")
+            .expect("dispatched shard should finish successfully");
+        drop_rx
+            .await
+            .expect("destination should drop after the shard finishes");
+    }
+
+    #[tokio::test]
+    async fn buffered_drain_waits_for_syncs_after_front_failure() {
+        let (failed_tx, failed_rx) = oneshot::channel();
+        let (pending_tx, pending_rx) = oneshot::channel();
+        let (drop_tx, mut drop_rx) = oneshot::channel();
+        failed_tx
+            .send(Err(io::Error::other("injected front failure")))
+            .expect("front shard should acknowledge failure");
+
+        let mut buffer = VecDeque::new();
+        buffer.push_back((
+            DropNotice(None),
+            Some(Box::pin(wait_for_shards(vec![failed_rx])) as Done),
+        ));
+        buffer.push_back((
+            DropNotice(Some(drop_tx)),
+            Some(Box::pin(wait_for_shards(vec![pending_rx])) as Done),
+        ));
+        let waiter = tokio::spawn(async move {
+            drain_buffer(&mut buffer).await;
+            assert!(
+                buffer.is_empty(),
+                "drain should consume every buffered item"
+            );
+        });
+
+        tokio::task::yield_now().await;
+        assert!(
+            matches!(drop_rx.try_recv(), Err(oneshot::error::TryRecvError::Empty)),
+            "a later destination must remain alive after the front sync fails"
+        );
+        pending_tx
+            .send(Ok(()))
+            .expect("later shard should acknowledge");
+        waiter.await.expect("buffer drain should finish");
+        drop_rx
+            .await
+            .expect("later destination should drop after its shard finishes");
+    }
+}

--- a/monarch_mini/src/framing.rs
+++ b/monarch_mini/src/framing.rs
@@ -10,21 +10,17 @@
 //! its own framing (see [`crate::unix_framing`]) so machine-local shared-memory
 //! and fd-passing concerns never leak into the cross-machine wire format.
 //!
-//! Each frame is `[u64 header_len][header][raw part bytes...]`. The header is a
-//! bincode-encoded [`WireFrame`] holding only small metadata; for a message it
-//! carries the *lengths* of the parts, never their bytes. Message-part bytes are
-//! written straight from the owning `MsgPart`.
+//! A frame is a length-prefixed bincode header ([`WireFrame`]) holding only small
+//! routing/control metadata — never part bytes. An actor message's routing header is
+//! followed by a per-part plan ([`WirePart`], each part inline or striped) and then the
+//! inline parts' bytes: a small part streams inline right after the plan (from the owning
+//! `MsgPart`), a large part is **striped** across the connection's data streams and named
+//! only by its per-shard lengths (see [`crate::dataio`]).
 //!
-//! On the read side a small part is read into a freshly allocated owned buffer.
-//! A *large* part, when the receiving actor has learned its gateway's
-//! [`ShmClient`] (every actor on a quic link is a gateway, so it has one), is read
-//! **straight into a freshly allocated shared-memory slab block** instead: the
-//! reader allocates the block, maps it, and reads the stream bytes directly into
-//! the mapping, yielding a [`MsgPart::Shm`]. The payload then never touches an
-//! owned heap buffer — and if the message is later forwarded across a machine-local
-//! unix hop, that hop relays the slab descriptor by reference rather than copying
-//! the bytes into shared memory a second time. Either way the only copy is the
-//! unavoidable kernel-to-userspace one.
+//! This module owns the header/plan wire format and streams *inline* part bytes; the
+//! parts themselves go through the [`PartReader`]/[`PartWriter`] the read/write functions
+//! are handed (per part), so the shared-memory and striping concerns — a large part read
+//! straight into a slab block, or striped across data streams — never involve framing.
 //!
 //! The reader/writer are generic over tokio's [`AsyncRead`]/[`AsyncWrite`], so the
 //! same code drives a QUIC stream's `RecvStream`/`SendStream`. Liveness policy
@@ -46,19 +42,20 @@ use crate::connection::MonitorOp;
 use crate::connection::SendPayload;
 use crate::connection::SideChannelAction;
 use crate::connection::SideChannelMessage;
+use crate::dataio::PartReader;
+use crate::dataio::PartWriter;
 use crate::heartbeat::BeatKind;
 use crate::heartbeat::ConnectionId;
 use crate::heartbeat::Heartbeat;
-use crate::msg::MsgPart;
-use crate::shm::MapperHandle;
-use crate::shm::SHM_THRESHOLD;
-use crate::shm::ShmClient;
+use crate::net::Net;
 
-/// One frame on the data stream. There is a variant per [`ConnectionCommand`] that
-/// crosses the pipe (including `Establish`, which is how the two ends exchange
-/// identity). Message-part *bytes* are never carried here — only their lengths.
-/// Heartbeats are *not* here: they ride a dedicated stream and are serialized as a
-/// bare [`Heartbeat`] (see [`write_heartbeat`]/[`read_heartbeat`]).
+/// One frame header on the data stream. There is a variant per [`ConnectionCommand`]
+/// that crosses the pipe (including `Establish`, which is how the two ends exchange
+/// identity). A header is routing/control only — it carries no message-part bytes; an
+/// [`ActorMessage`](WireFrame::ActorMessage)'s parts follow it via
+/// [`PartWriter::write_message_parts`]/[`PartReader::read_message_parts`]. Heartbeats are *not* here: they ride
+/// a dedicated stream, serialized as a bare [`Heartbeat`] (see
+/// [`write_heartbeat`]/[`read_heartbeat`]).
 #[derive(Serialize, Deserialize)]
 enum WireFrame {
     Establish {
@@ -67,9 +64,17 @@ enum WireFrame {
         name_for_other: Option<Vec<u8>>,
         alive: bool,
     },
-    Message {
+    /// An actor message: this header carries only the destination; the parts follow.
+    ActorMessage {
         destination_ident: Vec<u8>,
-        payload: WirePayload,
+    },
+    /// A monitor fire — the only other [`SendMessage`](ConnectionCommand::SendMessage);
+    /// it has no parts, so it is a plain header (kept separate from `ActorMessage` so
+    /// only the message path deals with parts).
+    FireMonitorMessage {
+        destination_ident: Vec<u8>,
+        to_monitor: Vec<u8>,
+        is_timeout: bool,
     },
     PublishRoutes {
         live: Vec<Vec<u8>>,
@@ -91,31 +96,35 @@ enum WireFrame {
     },
 }
 
-/// Wire form of a [`SendMessage`](ConnectionCommand::SendMessage)'s payload. An
-/// actor message carries only its parts' *lengths* in the header (the bytes are
-/// streamed raw afterwards, zero-copy); a monitor fire carries the small dead
-/// target ident inline.
-#[derive(Serialize, Deserialize)]
-enum WirePayload {
-    ActorMessage {
-        part_lens: Vec<u64>,
-    },
-    FireMonitor {
-        to_monitor: Vec<u8>,
-        is_timeout: bool,
-    },
+/// How one message part is carried on the wire. A small part is streamed **inline**
+/// on the control stream right after the header (zero-copy, as always). A large part
+/// is **striped**: its bytes travel out-of-band on the connection's data streams (see
+/// [`crate::dataio`]), and the header carries only the per-shard byte lengths — one
+/// per data stream — which fully describe the split so the data streams themselves
+/// stay unframed. The sender alone decides inline-vs-striped (from its size heuristic
+/// and stream count), so the receiver never has to agree on a threshold: it just
+/// reads whichever form the descriptor names.
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) enum WirePart {
+    Inline { len: u64 },
+    Striped { shard_lens: Vec<u64> },
 }
 
-/// One frame on a gateway side-channel's *message* stream — the wire form of a
-/// [`SideChannelMessage`]. `Send` of an actor message reuses [`WirePayload`]'s
-/// zero-copy part-length header + streamed bytes (+ shm); every other case is
-/// header-only. Delegated heartbeats are not here — they ride the companion
-/// heartbeat stream as a bare [`SideChannelHeartbeat`].
+/// One frame header on a gateway side-channel's *message* stream — the wire form of a
+/// [`SideChannelMessage`], mirroring [`WireFrame`]. A `Send` of an actor message
+/// (`SendActorMessage`) is a routing-only header whose parts follow via
+/// [`PartWriter::write_message_parts`]/[`PartReader::read_message_parts`], exactly like a connection message;
+/// every other case is header-only. Delegated heartbeats are not here — they ride the
+/// companion heartbeat stream as a bare [`SideChannelHeartbeat`].
 #[derive(Serialize, Deserialize)]
 enum SideChannelFrame {
-    Send {
+    /// A `Send` of an actor message: this header carries only the gateway; parts follow.
+    SendActorMessage { gateway_for_actor: Vec<u8> },
+    /// A `Send` of a monitor fire — no parts, so a plain header.
+    SendFireMonitor {
         gateway_for_actor: Vec<u8>,
-        payload: WirePayload,
+        to_monitor: Vec<u8>,
+        is_timeout: bool,
     },
     UpdateRemoteMonitorState {
         gateway_for_actor: Vec<u8>,
@@ -133,12 +142,12 @@ fn bincode_config() -> bincode::config::Configuration {
 }
 
 /// Encode `value` as bincode and write it length-prefixed as `[u64 header_len]
-/// [header]`. This is the single place every framed write goes through for its
-/// header — callers layer their own concerns on top: trailing message-part bytes
-/// (see [`write_frame`]) and the flush (every caller decides when to flush, and
-/// this helper never does). The length prefix is little-endian, matching
-/// [`read_header`].
-async fn write_header<W: AsyncWrite + Unpin, T: Serialize>(
+/// [header]`. Every framed write goes through this for its header — the frame header,
+/// and (for a message) the per-part plan written by [`PartWriter::write_message_parts`]. Callers
+/// layer their own concerns on top: trailing inline part bytes and the flush (every
+/// caller decides when to flush; this helper never does). The length prefix is
+/// little-endian, matching [`read_header`].
+pub(crate) async fn write_header<W: AsyncWrite + Unpin, T: Serialize>(
     writer: &mut W,
     value: &T,
 ) -> std::io::Result<()> {
@@ -154,7 +163,7 @@ async fn write_header<W: AsyncWrite + Unpin, T: Serialize>(
 /// [`write_header`] and decode it as `T`. The single place every framed read goes
 /// through for its header; callers that carry trailing message-part bytes read them
 /// after this (see [`read_frame`]).
-async fn read_header<R: AsyncRead + Unpin, T: DeserializeOwned>(
+pub(crate) async fn read_header<R: AsyncRead + Unpin, T: DeserializeOwned>(
     reader: &mut R,
 ) -> std::io::Result<T> {
     let mut len_buf = [0u8; 8];
@@ -178,7 +187,7 @@ async fn read_header<R: AsyncRead + Unpin, T: DeserializeOwned>(
 /// - `Join` — an ordinary parent/child connection; the command loop takes over
 ///   (identity exchange, hello, routing) over the data stream.
 /// - `SideChannel` — a gateway-to-gateway channel: the accepting gateway reads
-///   [`WireFrame::Message`] frames and routes them locally. Never paired with a
+///   [`SideChannelFrame`] frames and routes them locally. Never paired with a
 ///   serve, never establishes a parent/child link.
 ///
 /// Only the joiner writes the preamble (one direction); the server never does, so
@@ -222,43 +231,40 @@ pub(crate) struct SideChannelHeartbeat {
     pub(crate) kind: BeatKind,
 }
 
-/// Serialize and write one command: a length-prefixed bincode header, then — for
-/// a message — each part's bytes streamed straight from its buffer. Flushes so the
-/// peer (and, for quic, its heartbeat deadline) sees it promptly.
-pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
+/// Serialize and write one command. An actor message writes a routing-only header then
+/// its parts via [`PartWriter::write_message_parts`] (planned and, if large, striped by
+/// `part_writer`); every other command is a header-only frame. Flushes so the peer (and,
+/// for quic, its heartbeat deadline) sees it promptly.
+pub(crate) async fn write_command<W, N>(
     writer: &mut W,
     command: ConnectionCommand,
-) -> std::io::Result<()> {
-    // A message additionally keeps a list of part bytes to stream raw after the
-    // header; every other command is header-only.
-    let mut parts: Vec<MsgPart> = Vec::new();
+    part_writer: &mut PartWriter<N>,
+) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    N: Net,
+{
     let frame = match command {
         ConnectionCommand::SendMessage {
             destination_ident,
-            payload,
+            payload: SendPayload::ActorMessage(parts),
         } => {
-            let payload = match payload {
-                SendPayload::ActorMessage(message_parts) => {
-                    let part_lens = message_parts
-                        .iter()
-                        .map(|part| part.as_bytes().len() as u64)
-                        .collect();
-                    parts = message_parts;
-                    WirePayload::ActorMessage { part_lens }
-                }
+            // Routing-only header, then the parts (plan + bytes) via the part writer.
+            write_header(writer, &WireFrame::ActorMessage { destination_ident }).await?;
+            return part_writer.write_message_parts(writer, parts).await;
+        }
+        ConnectionCommand::SendMessage {
+            destination_ident,
+            payload:
                 SendPayload::FireMonitor {
                     to_monitor,
                     is_timeout,
-                } => WirePayload::FireMonitor {
-                    to_monitor,
-                    is_timeout,
                 },
-            };
-            WireFrame::Message {
-                destination_ident,
-                payload,
-            }
-        }
+        } => WireFrame::FireMonitorMessage {
+            destination_ident,
+            to_monitor,
+            is_timeout,
+        },
         ConnectionCommand::Establish {
             role,
             ident,
@@ -289,7 +295,7 @@ pub(crate) async fn write_command<W: AsyncWrite + Unpin>(
         // forwarding it: skip without writing anything to the wire.
         ConnectionCommand::GatewayState { .. } => return Ok(()),
     };
-    write_frame(writer, &frame, &parts).await
+    write_frame(writer, &frame).await
 }
 
 /// Write a transport heartbeat probe carrying `heartbeat`. The dedicated heartbeat
@@ -299,7 +305,7 @@ pub(crate) async fn write_heartbeat<W: AsyncWrite + Unpin>(
     writer: &mut W,
     heartbeat: Heartbeat,
 ) -> std::io::Result<()> {
-    write_frame(writer, &heartbeat, &[]).await
+    write_frame(writer, &heartbeat).await
 }
 
 /// Read one heartbeat probe off a connection's dedicated heartbeat stream, written
@@ -311,59 +317,47 @@ pub(crate) async fn read_heartbeat<R: AsyncRead + Unpin>(
     read_header(reader).await
 }
 
+/// Write a header-only frame: the length-prefixed bincode header, then flush. An actor
+/// message instead writes its routing header and then its parts via
+/// [`PartWriter::write_message_parts`]; every command/action that reaches here is header-only.
 async fn write_frame<W: AsyncWrite + Unpin>(
     writer: &mut W,
     frame: &impl Serialize,
-    parts: &[MsgPart],
 ) -> std::io::Result<()> {
     write_header(writer, frame).await?;
-    // Write each part's bytes straight from its owning buffer — no copy.
-    for part in parts {
-        writer.write_all(part.as_bytes()).await?;
-    }
     writer.flush().await
 }
 
-/// Read one data-stream frame and map it back to its [`ConnectionCommand`]. For a
-/// message each part is read directly into its destination buffer — an owned heap
-/// buffer for a small part, or (when `client` is present and the part is large) a
-/// freshly allocated shared-memory slab block, so the only copy is the unavoidable
-/// kernel-to-userspace one. `mapper`/`client` are the receiving actor's
-/// shared-memory context (see [`read_part`]). Heartbeats never arrive here — they
-/// ride their own stream (see [`read_heartbeat`]).
-pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
+/// Read and decode one control-stream frame into its [`ConnectionCommand`]. An actor
+/// message's routing header comes back here; its parts are read through `part_reader`
+/// (which owns the shared memory and striping), so those concerns stay out of framing. A
+/// striped part's [`MsgPart`] is returned before its bytes have all landed; the caller
+/// gates delivery on the part reader's batch (see [`crate::dataio`]). Heartbeats never
+/// arrive here — they ride their own stream (see [`read_heartbeat`]).
+pub(crate) async fn read_frame<R, N>(
     reader: &mut R,
-    mapper: &MapperHandle,
-    client: Option<ShmClient>,
-) -> std::io::Result<ConnectionCommand> {
-    let frame = read_header::<_, WireFrame>(reader).await?;
-
-    Ok(match frame {
-        WireFrame::Message {
+    part_reader: &mut PartReader<N>,
+) -> std::io::Result<ConnectionCommand>
+where
+    R: AsyncRead + Unpin,
+    N: Net,
+{
+    Ok(match read_header::<_, WireFrame>(reader).await? {
+        WireFrame::ActorMessage { destination_ident } => ConnectionCommand::SendMessage {
             destination_ident,
-            payload,
-        } => {
-            let payload = match payload {
-                WirePayload::ActorMessage { part_lens } => {
-                    let mut parts = Vec::with_capacity(part_lens.len());
-                    for len in part_lens {
-                        parts.push(read_part(reader, len, mapper, client).await?);
-                    }
-                    SendPayload::ActorMessage(parts)
-                }
-                WirePayload::FireMonitor {
-                    to_monitor,
-                    is_timeout,
-                } => SendPayload::FireMonitor {
-                    to_monitor,
-                    is_timeout,
-                },
-            };
-            ConnectionCommand::SendMessage {
-                destination_ident,
-                payload,
-            }
-        }
+            payload: SendPayload::ActorMessage(part_reader.read_message_parts(reader).await?),
+        },
+        WireFrame::FireMonitorMessage {
+            destination_ident,
+            to_monitor,
+            is_timeout,
+        } => ConnectionCommand::SendMessage {
+            destination_ident,
+            payload: SendPayload::FireMonitor {
+                to_monitor,
+                is_timeout,
+            },
+        },
         WireFrame::Establish {
             role,
             ident,
@@ -393,43 +387,39 @@ pub(crate) async fn read_frame<R: AsyncRead + Unpin>(
     })
 }
 
-/// Serialize and write one [`SideChannelMessage`]: a length-prefixed bincode
-/// header, then — for a `Send` of an actor message — each part's bytes streamed
-/// raw after it (zero-copy, same scheme as [`write_command`]). Every other action
-/// is header-only.
-pub(crate) async fn write_side_channel<W: AsyncWrite + Unpin>(
+/// Serialize and write one [`SideChannelMessage`]. A `Send` of an actor message writes a
+/// routing-only header then its parts via [`PartWriter::write_message_parts`] (planned and, if
+/// large, striped by `part_writer`); every other action is a header-only frame.
+pub(crate) async fn write_side_channel<W, N>(
     writer: &mut W,
     message: SideChannelMessage,
-) -> std::io::Result<()> {
+    part_writer: &mut PartWriter<N>,
+) -> std::io::Result<()>
+where
+    W: AsyncWrite + Unpin,
+    N: Net,
+{
     let SideChannelMessage {
         gateway_for_actor,
         action,
     } = message;
-    let mut parts: Vec<MsgPart> = Vec::new();
     let frame = match action {
-        SideChannelAction::Send(payload) => {
-            let payload = match payload {
-                SendPayload::ActorMessage(message_parts) => {
-                    let part_lens = message_parts
-                        .iter()
-                        .map(|part| part.as_bytes().len() as u64)
-                        .collect();
-                    parts = message_parts;
-                    WirePayload::ActorMessage { part_lens }
-                }
-                SendPayload::FireMonitor {
-                    to_monitor,
-                    is_timeout,
-                } => WirePayload::FireMonitor {
-                    to_monitor,
-                    is_timeout,
-                },
-            };
-            SideChannelFrame::Send {
-                gateway_for_actor,
-                payload,
-            }
+        SideChannelAction::Send(SendPayload::ActorMessage(parts)) => {
+            write_header(
+                writer,
+                &SideChannelFrame::SendActorMessage { gateway_for_actor },
+            )
+            .await?;
+            return part_writer.write_message_parts(writer, parts).await;
         }
+        SideChannelAction::Send(SendPayload::FireMonitor {
+            to_monitor,
+            is_timeout,
+        }) => SideChannelFrame::SendFireMonitor {
+            gateway_for_actor,
+            to_monitor,
+            is_timeout,
+        },
         SideChannelAction::UpdateRemoteMonitorState { listener, op } => {
             SideChannelFrame::UpdateRemoteMonitorState {
                 gateway_for_actor,
@@ -442,7 +432,7 @@ pub(crate) async fn write_side_channel<W: AsyncWrite + Unpin>(
             monitoring,
         },
     };
-    write_frame(writer, &frame, &parts).await
+    write_frame(writer, &frame).await
 }
 
 /// Write a sibling side-channel heartbeat onto the heartbeat stream as a bare
@@ -461,47 +451,39 @@ pub(crate) async fn write_side_channel_heartbeat<W: AsyncWrite + Unpin>(
         conn_id,
         kind,
     };
-    write_frame(writer, &heartbeat, &[]).await
+    write_frame(writer, &heartbeat).await
 }
 
-/// Read one [`SideChannelMessage`] off a gateway side-channel's message stream. A
-/// `Send` of an actor message reads each part exactly like [`read_frame`] (small
-/// parts into owned buffers, large ones into the slab via `mapper`/`client`); other
-/// actions are header-only. Heartbeats travel on the companion heartbeat stream
-/// (see [`read_side_channel_heartbeat`]) and never appear here.
-pub(crate) async fn read_side_channel<R: AsyncRead + Unpin>(
+/// Read and decode one side-channel frame into its [`SideChannelMessage`]. A `Send` of an
+/// actor message reads its parts through `parts` (exactly like [`read_frame`]); every
+/// other action is header-only. Heartbeats travel on the companion heartbeat stream (see
+/// [`read_side_channel_heartbeat`]) and never appear here.
+pub(crate) async fn read_side_channel<R, N>(
     reader: &mut R,
-    mapper: &MapperHandle,
-    client: Option<ShmClient>,
-) -> std::io::Result<SideChannelMessage> {
-    let frame = read_header::<_, SideChannelFrame>(reader).await?;
-
-    let message = match frame {
-        SideChannelFrame::Send {
+    part_reader: &mut PartReader<N>,
+) -> std::io::Result<SideChannelMessage>
+where
+    R: AsyncRead + Unpin,
+    N: Net,
+{
+    Ok(match read_header::<_, SideChannelFrame>(reader).await? {
+        SideChannelFrame::SendActorMessage { gateway_for_actor } => SideChannelMessage {
             gateway_for_actor,
-            payload,
-        } => {
-            let payload = match payload {
-                WirePayload::ActorMessage { part_lens } => {
-                    let mut parts = Vec::with_capacity(part_lens.len());
-                    for len in part_lens {
-                        parts.push(read_part(reader, len, mapper, client).await?);
-                    }
-                    SendPayload::ActorMessage(parts)
-                }
-                WirePayload::FireMonitor {
-                    to_monitor,
-                    is_timeout,
-                } => SendPayload::FireMonitor {
-                    to_monitor,
-                    is_timeout,
-                },
-            };
-            SideChannelMessage {
-                gateway_for_actor,
-                action: SideChannelAction::Send(payload),
-            }
-        }
+            action: SideChannelAction::Send(SendPayload::ActorMessage(
+                part_reader.read_message_parts(reader).await?,
+            )),
+        },
+        SideChannelFrame::SendFireMonitor {
+            gateway_for_actor,
+            to_monitor,
+            is_timeout,
+        } => SideChannelMessage {
+            gateway_for_actor,
+            action: SideChannelAction::Send(SendPayload::FireMonitor {
+                to_monitor,
+                is_timeout,
+            }),
+        },
         SideChannelFrame::UpdateRemoteMonitorState {
             gateway_for_actor,
             listener,
@@ -517,8 +499,7 @@ pub(crate) async fn read_side_channel<R: AsyncRead + Unpin>(
             gateway_for_actor,
             action: SideChannelAction::AckRemoteMonitor { monitoring },
         },
-    };
-    Ok(message)
+    })
 }
 
 /// Read one delegated-heartbeat beat/ack/release off a gateway side-channel's
@@ -528,47 +509,4 @@ pub(crate) async fn read_side_channel_heartbeat<R: AsyncRead + Unpin>(
     reader: &mut R,
 ) -> std::io::Result<SideChannelHeartbeat> {
     read_header(reader).await
-}
-
-/// Read one message part of `len` bytes off the stream.
-///
-/// A part `>= SHM_THRESHOLD` on a connection whose actor has learned its gateway
-/// [`ShmClient`] is read straight into a freshly allocated slab block: allocate the
-/// block, map it through the context `mapper`, and read the stream bytes directly
-/// into the mapping — yielding a [`MsgPart::Shm`] that a later unix hop forwards by
-/// descriptor without copying into shared memory again. Everything else (no client,
-/// or a small part) is read into an owned heap buffer as before.
-async fn read_part<R: AsyncRead + Unpin>(
-    reader: &mut R,
-    len: u64,
-    mapper: &MapperHandle,
-    client: Option<ShmClient>,
-) -> std::io::Result<MsgPart> {
-    let Some(client) = client.filter(|_| len >= SHM_THRESHOLD) else {
-        let mut buf = vec![0u8; len as usize];
-        reader.read_exact(&mut buf).await?;
-        return Ok(MsgPart::from_bytes(buf));
-    };
-
-    let (offset, token) = client.allocate(len).await?;
-    let dst = {
-        let mut mapper = mapper.lock().expect("shm mapper mutex poisoned");
-        // SAFETY: `offset` was just granted for `len` bytes against `client`'s slab,
-        // so the file is grown to cover it and the mapper can map the range.
-        unsafe { mapper.map(client.slab_fd(), offset, len as usize)? }
-    };
-    // SAFETY: `dst` points at a writable mapping of exactly `len` bytes that stays
-    // valid for the mapper's (context's) lifetime — well past this read — so the
-    // slice is sound to fill across the await. The mapper lock was released above,
-    // so it is not held across IO. `len >= SHM_THRESHOLD > 0`, so this is non-empty.
-    let buf = unsafe { std::slice::from_raw_parts_mut(dst, len as usize) };
-    reader.read_exact(buf).await?;
-
-    Ok(MsgPart::new_shm(
-        mapper.clone(),
-        client.slab_fd(),
-        token,
-        offset,
-        len,
-    ))
 }

--- a/monarch_mini/src/lib.rs
+++ b/monarch_mini/src/lib.rs
@@ -9,6 +9,7 @@
 mod actor;
 mod connection;
 mod ctx;
+mod dataio;
 mod framing;
 mod heartbeat;
 mod inproc_transport;

--- a/monarch_mini/src/net.rs
+++ b/monarch_mini/src/net.rs
@@ -126,7 +126,18 @@ pub(crate) trait Net: Sized + 'static {
 /// preambles — it just hands out ordered streams, told per stream which side speaks
 /// first. `Debug` supplies the peer identity for diagnostics (quic: the remote
 /// address), used by the heartbeat send log.
-pub(crate) trait NetConn: Debug + 'static {
+///
+/// `Clone` is cheap and shares one underlying connection: the reader, the writer, and
+/// the heartbeat task each hold a clone and open the streams they own via
+/// [`Self::stream`] (for striping the reader and writer open their own data streams the
+/// same way), with no half handed between tasks. A quic dialer clones its `Connection`;
+/// the quic/tcp acceptors clone a request-sender to their demux; a tcp dialer clones
+/// its dial handle.
+///
+/// `Send` so a data coroutine holding the handle — the writer, the reader, and their
+/// striping objects that open their own data streams inline — can run on the data
+/// runtime.
+pub(crate) trait NetConn: Debug + Clone + Send + 'static {
     /// The send half of a stream; framing drives it via [`AsyncWrite`]. It keeps the
     /// underlying connection alive for its lifetime. `Send` so the data writer
     /// coroutine can run on a multi-threaded runtime (the connection handle and the
@@ -136,8 +147,10 @@ pub(crate) trait NetConn: Debug + 'static {
     /// the underlying connection alive for its lifetime. `Send` for the same reason as
     /// [`Self::Send`] — the data reader coroutine may run off the command-loop thread.
     type Recv: AsyncRead + Unpin + Send + 'static;
-    /// The awaitable that materializes one stream's halves on first poll.
-    type Stream: Future<Output = std::io::Result<(Self::Send, Self::Recv)>> + 'static;
+    /// The awaitable that materializes one stream's halves on first poll. `Send` so a
+    /// data coroutine on the data runtime can open a striping data stream inline (the
+    /// acceptor's variant just messages its demux; the dialer's opens/dials directly).
+    type Stream: Future<Output = std::io::Result<(Self::Send, Self::Recv)>> + Send + 'static;
 
     /// An awaitable for the stream addressed by `index`, paired with the peer's stream
     /// of the same index. On a *dialer* connection it opens the stream; on an *acceptor*

--- a/monarch_mini/src/net_transport.rs
+++ b/monarch_mini/src/net_transport.rs
@@ -57,6 +57,10 @@ use crate::connection::ConnectionTransport;
 use crate::connection::SideChannelMessage;
 use crate::connection::sever;
 use crate::ctx::Command;
+use crate::dataio::MessageReader;
+use crate::dataio::PartReader;
+use crate::dataio::PartWriter;
+use crate::dataio::ReadStop;
 use crate::framing;
 use crate::framing::Preamble;
 use crate::framing::SideChannelHeartbeat;
@@ -69,7 +73,6 @@ use crate::matcher::Matcher;
 use crate::net::Net;
 use crate::net::NetConn;
 use crate::shm::MapperHandle;
-use crate::shm::ShmClient;
 use crate::shm::ShmClientSlot;
 use crate::transport::Transport;
 
@@ -141,10 +144,14 @@ fn max_concurrent_connects<N: Net>() -> Option<usize> {
 
 /// Build the optional multi-threaded runtime that the per-connection data
 /// coroutines (the message writer/reader) run on, off the single-threaded command
-/// loop. `MM_NET_DATA_THREADS` selects it: unset or `0` keeps every coroutine on the
-/// command-loop thread (today's behaviour, no data parallelism); a positive `N`
-/// stands up an `N`-worker runtime so the data-stream framing/crypto/copy for many
-/// connections runs across cores while accounting stays serialized on one core.
+/// loop. `MM_NET_DATA_THREADS` selects it: unset defaults to the striping width
+/// ([`crate::dataio::n_data_streams`]), `0` explicitly keeps every coroutine on the
+/// command-loop thread (no data parallelism); otherwise an `N`-worker runtime runs the
+/// data-stream framing/crypto/copy for many connections across cores while accounting
+/// stays serialized on one core. The worker count is floored at the stream width —
+/// striping is inert without at least one core per parallel stream to spread the
+/// per-stream crypto/copy across, so a bare `MM_NET_N_DATA_STREAMS` gets a runtime wide
+/// enough to actually parallelize it.
 ///
 /// Only the two *data* coroutines move; the connection handle, heartbeat stream,
 /// side channels, and pairing all stay on the command-loop thread. The data stream
@@ -153,10 +160,15 @@ fn max_concurrent_connects<N: Net>() -> Option<usize> {
 /// in-task syscalls/copy), not the epoll wakeups. Fully decoupling the reactor would
 /// require materializing the streams on this runtime, a later step.
 fn data_runtime() -> Option<tokio::runtime::Runtime> {
-    let n = std::env::var("MM_NET_DATA_THREADS")
+    let requested = std::env::var("MM_NET_DATA_THREADS")
         .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .unwrap_or(0);
+        .and_then(|v| v.parse::<usize>().ok());
+    let streams = crate::dataio::n_data_streams();
+    let n = match requested {
+        None => streams,           // unset ⇒ default to the stream width
+        Some(0) => 0,              // explicit 0 ⇒ force single-threaded (off)
+        Some(r) => r.max(streams), // explicit ⇒ honor it, but never below the width
+    };
     if n == 0 {
         return None;
     }
@@ -201,10 +213,12 @@ struct ShmCtx {
 }
 
 impl ShmCtx {
-    /// Snapshot the owning actor's gateway client (`None` until it is learned; a
-    /// gateway seeds its own at creation, before any frame can arrive).
-    fn client(&self) -> Option<ShmClient> {
-        *self.client.lock().expect("shm client slot mutex poisoned")
+    /// The owning actor's gateway-client slot, shared with a striping reader/decoder so
+    /// it can snapshot the client (`None` until learned; a gateway seeds its own at
+    /// creation, before any frame can arrive) and land striped/inline parts in the slab
+    /// as soon as the gateway is known.
+    fn client_slot(&self) -> ShmClientSlot {
+        self.client.clone()
     }
 }
 
@@ -641,9 +655,11 @@ async fn listener_task<N: Net>(
                         // Messages and delegated beats arrive on separate streams, so
                         // read each in its own task. The message recv keeps the
                         // connection alive; the heartbeat reader materializes its own
-                        // stream, which may open late (on the first beat) or never.
+                        // stream, which may open late (on the first beat) or never. The
+                        // message reader gets a connection clone too, so it can open the
+                        // striped data streams a large message arrives on.
                         tokio::task::spawn_local(side_channel_reader_task::<N>(
-                            msg_recv, loop_tx.clone(), side_channel_shm.clone(),
+                            conn.clone(), msg_recv, loop_tx.clone(), side_channel_shm.clone(),
                         ));
                         tokio::task::spawn_local(side_channel_heartbeat_reader_task::<N>(
                             conn, heartbeat.clone(),
@@ -744,23 +760,50 @@ async fn acceptor_task<N: Net>(
 /// Read routable messages off a gateway side-channel's message stream and forward
 /// each to the command loop (which resolves the owning gateway). There is no
 /// establishment: an EOF or error just ends the reader (the sending gateway
-/// reconnects when it next has something to send). `recv` keeps the connection alive.
+/// reconnects when it next has something to send). `recv` keeps the connection alive;
+/// `conn` lets the striping reader open the data streams a large message arrives on.
 /// Delegated beats travel on the companion heartbeat stream (see
-/// [`side_channel_heartbeat_reader_task`]).
+/// [`side_channel_heartbeat_reader_task`]). Large messages are striped and assembled
+/// in `seq` order exactly like the connection reader ([`reader_task`]); a dead data
+/// stream just ends this reader (the sending gateway reconnects).
 async fn side_channel_reader_task<N: Net>(
-    mut recv: ConnRecv<N>,
+    conn: N::Conn,
+    recv: ConnRecv<N>,
     loop_tx: mpsc::UnboundedSender<Command>,
     shm: ShmCtx,
 ) {
-    loop {
-        match framing::read_side_channel(&mut recv, &shm.mapper, shm.client()).await {
-            Ok(message) => {
-                if loop_tx.send(Command::SideChannelDeliver(message)).is_err() {
-                    return;
-                }
-            }
-            Err(_) => return,
-        }
+    // The accepting end of a side channel — it never dialed, so `dialed = false`.
+    let part_reader = PartReader::<N>::new(conn, false, shm.mapper.clone(), shm.client_slot());
+
+    // A side channel has no establishment or failure signalling of its own: whatever
+    // ends the loop (control-stream EOF/error, a dead data stream, or a lost command
+    // loop) just ends the reader — the sending gateway reconnects when it next has
+    // something to send.
+    let _ = SideChannelReader { loop_tx }
+        .read_messages(recv, part_reader)
+        .await;
+}
+
+/// Delivers side-channel messages to the command loop — the [`MessageReader`] for the
+/// one-directional gateway side-channel pathway.
+struct SideChannelReader {
+    loop_tx: mpsc::UnboundedSender<Command>,
+}
+
+impl<N: Net> MessageReader<N> for SideChannelReader {
+    type Item = SideChannelMessage;
+
+    fn read_frame(
+        control: &mut ConnRecv<N>,
+        parts: &mut PartReader<N>,
+    ) -> impl std::future::Future<Output = std::io::Result<SideChannelMessage>> + Send {
+        framing::read_side_channel(control, parts)
+    }
+
+    fn on_message(&mut self, message: SideChannelMessage) -> bool {
+        self.loop_tx
+            .send(Command::SideChannelDeliver(message))
+            .is_ok()
     }
 }
 
@@ -898,6 +941,11 @@ async fn side_channel_writer_task<N: Net>(
     // heartbeat send stream once a beat has been sent. `None` means we must
     // (re)connect before the next write.
     let mut live: Option<LiveSideChannel<N>> = None;
+    // The part writer for the current connection's data streams, rebuilt on each
+    // (re)connect. A side channel is one-directional, so it only ever writes; large
+    // messages are striped, small ones stay inline (a disabled writer writes all parts
+    // inline).
+    let mut part_writer: Option<PartWriter<N>> = None;
     loop {
         let item = tokio::select! {
             item = rx.recv() => match item {
@@ -916,12 +964,17 @@ async fn side_channel_writer_task<N: Net>(
             else {
                 break; // shutting down before the gateway came up
             };
+            // The dialing end of a side channel — `dialed = true`.
+            part_writer = Some(PartWriter::<N>::new(conn.clone(), true));
             live = Some((conn, msg_send, None));
         }
         let (conn, msg_send, hb_send) = live.as_mut().expect("connected");
+        let active_writer = part_writer
+            .as_mut()
+            .expect("part writer set with live connection");
         let wrote = match item {
             SideChannelOut::Message(message) => {
-                framing::write_side_channel(msg_send, message).await
+                framing::write_side_channel(msg_send, message, active_writer).await
             }
             SideChannelOut::Heartbeat {
                 recipient,
@@ -947,6 +1000,7 @@ async fn side_channel_writer_task<N: Net>(
         };
         if wrote.is_err() {
             live = None; // dropped; reconnect on the next item
+            part_writer = None; // its data streams belong to the dropped connection
         }
     }
     if let Some((_conn, mut msg_send, hb_send)) = live {
@@ -1056,6 +1110,9 @@ fn spawn_connection<N: Net>(
     // command-loop thread — their captured state is `Send` (the `Send`-bounded stream
     // halves, channel handles, `Copy` connection ref, and `Arc`-backed shm); the
     // heartbeat/side-channel machinery below stays local.
+    // The writer and reader each own a part writer/reader over this side's data streams
+    // (outbound for the writer, inbound for the reader); `dialed` lets each pick its
+    // stream indices. Both hold a clone of the connection handle to open those streams.
     let writer = writer_task::<N>(
         data_send,
         writer_rx,
@@ -1063,15 +1120,19 @@ fn spawn_connection<N: Net>(
         alive,
         peer_responded_rx,
         hb_event_tx.clone(),
+        PartWriter::new(conn.clone(), dialed),
     );
     let reader = reader_task::<N>(
         data_recv,
         connection,
         loop_tx,
         peer_responded_tx,
-        shm,
         hb_event_tx.clone(),
+        PartReader::new(conn.clone(), dialed, shm.mapper.clone(), shm.client_slot()),
     );
+    // The data coroutines move to the data runtime for cross-connection parallelism; the
+    // per-stream shard tasks they spawn are `tokio::spawn`ed there too (the halves are
+    // `Send`), so striping composes with the data runtime.
     match &data_rt {
         Some(handle) => {
             handle.spawn(writer);
@@ -1149,6 +1210,9 @@ async fn writer_task<N: Net>(
     mut peer_responded: mpsc::UnboundedReceiver<()>,
     // To forward our own outgoing Establish's ident to the heartbeat task.
     hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
+    // Writes each command's parts inline or striped across this side's data streams
+    // (framing routes actor messages through it).
+    mut part_writer: PartWriter<N>,
 ) {
     let mut graceful = false;
     loop {
@@ -1165,7 +1229,7 @@ async fn writer_task<N: Net>(
                         local_ident: ident.clone(),
                     });
                 }
-                if framing::write_command(&mut send, command).await.is_err() {
+                if framing::write_command(&mut send, command, &mut part_writer).await.is_err() {
                     return;
                 }
             }
@@ -1175,7 +1239,7 @@ async fn writer_task<N: Net>(
                 // transport retransmits until delivered, so the peer learns of
                 // teardown directly rather than by inferring a dropped socket.
                 while let Ok(command) = rx.try_recv() {
-                    if framing::write_command(&mut send, command).await.is_err() {
+                    if framing::write_command(&mut send, command, &mut part_writer).await.is_err() {
                         return;
                     }
                 }
@@ -1184,6 +1248,7 @@ async fn writer_task<N: Net>(
                     ConnectionCommand::Severed {
                         reason: b"context shutdown".to_vec(),
                     },
+                    &mut part_writer,
                 )
                 .await;
                 graceful = true;
@@ -1284,95 +1349,113 @@ async fn heartbeat_reader_task<N: Net>(
 /// that detects an unclean peer loss even for a link whose beats are silent (a
 /// delegated child, or a live-but-idle connection).
 async fn reader_task<N: Net>(
-    mut recv: ConnRecv<N>,
+    recv: ConnRecv<N>,
     connection: ConnectionRef,
     loop_tx: mpsc::UnboundedSender<Command>,
     // Signals this connection's writer that the peer has responded to our shutdown
-    // (it sent its own Severed, or the connection ended) so the writer can close.
+    // (it sent its own Severed, or the connection ending) so the writer can close.
     peer_responded: mpsc::UnboundedSender<()>,
-    shm: ShmCtx,
     // Forwards inbound heartbeats and liveness/close signals to the heartbeat task.
     hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
+    // Reads/assembles each message's parts off this side's inbound data streams.
+    part_reader: PartReader<N>,
 ) {
     // Per-connection diagnostics, folded into the failure reason under MM_QUIC_DEBUG:
-    // did we ever read the peer's Establish? how many commands arrived, and how long
-    // since the last read? Tracked cheaply either way; only formatted when debug is on.
+    // did we ever read the peer's Establish, and how many commands arrived? The reader
+    // tracks them per delivered message; only formatted when debug is on.
     let debug = crate::ctx::connection_debug();
     let start = std::time::Instant::now();
-    let mut established = false;
-    let mut commands: u64 = 0;
-    let mut last_read: Option<std::time::Duration> = None;
-    let stats = |established: bool, commands, last_read: Option<_>| {
-        let last = match last_read {
-            Some(d) => format!(
-                "{:.1}s ago",
-                start.elapsed().saturating_sub(d).as_secs_f64()
-            ),
-            None => "never".to_owned(),
-        };
-        format!(
-            "established={established}, commands={commands}, age={:.1}s, last_read={last}",
-            start.elapsed().as_secs_f64(),
-        )
+
+    // Deliver each in-order message to the command loop (see [`ConnectionReader`]).
+    let mut reader = ConnectionReader {
+        connection,
+        loop_tx: loop_tx.clone(),
+        peer_responded: peer_responded.clone(),
+        hb_events: hb_events.clone(),
+        established: false,
+        commands: 0,
     };
-    loop {
-        // The owning actor's gateway client is snapshot per frame so a large part is
-        // read straight into the slab once the client is known (a gateway seeds its
-        // own at creation, before any frame arrives).
-        let read = framing::read_frame(&mut recv, &shm.mapper, shm.client());
-        match read.await {
-            Ok(action) => {
-                last_read = Some(start.elapsed());
-                commands += 1;
-                // The peer's Establish is how we learn its identity: reading it is the
-                // moment this side considers the connection established. Forward the
-                // peer ident to the heartbeat task (one-shot, at setup).
-                if let ConnectionCommand::Establish { ident, .. } = &action {
-                    established = true;
-                    if let Some(ident) = ident {
-                        let _ = hb_events.send(HeartbeatEvent::EstablishPeer {
-                            peer_ident: ident.clone(),
-                        });
-                    }
-                }
-                // A Severed from the peer is its response to our shutdown (or the peer
-                // initiating its own) — wake any writer waiting to close.
-                if matches!(action, ConnectionCommand::Severed { .. }) {
-                    let _ = peer_responded.send(());
-                }
-                if loop_tx
-                    .send(Command::ConnectionAction { connection, action })
-                    .is_err()
-                {
-                    return;
-                }
+    let stop = reader.read_messages(recv, part_reader).await;
+
+    // The reader is done: tell the writer (so a graceful-shutdown wait can end) and the
+    // heartbeat task (its backstop for an unclean loss), then sever with a reason —
+    // except when the command loop itself is already gone.
+    let _ = peer_responded.send(());
+    let _ = hb_events.send(HeartbeatEvent::ReaderClosed);
+    let reason = match stop {
+        ReadStop::Delivered => return, // command loop gone; nothing to sever to
+        ReadStop::DataStreamDied => b"quic data stream closed".to_vec(),
+        ReadStop::Ended(_) if !debug => b"quic connection closed".to_vec(),
+        ReadStop::Ended(err) => {
+            // Walk the io::Error source chain to recover the concrete underlying error —
+            // the top-level Display is often just a bare "connection lost", dropping the
+            // real cause ("timed out" vs "reset by peer" vs "closed by peer").
+            let mut detail = err.to_string();
+            let mut src = std::error::Error::source(&err);
+            while let Some(e) = src {
+                detail.push_str(": ");
+                detail.push_str(&e.to_string());
+                src = e.source();
             }
-            Err(err) => {
-                let _ = peer_responded.send(());
-                let _ = hb_events.send(HeartbeatEvent::ReaderClosed);
-                let reason = if debug {
-                    // Walk the io::Error source chain to recover the concrete
-                    // underlying error — the top-level Display is often just a bare
-                    // "connection lost", dropping the real cause ("timed out" vs
-                    // "reset by peer" vs "closed by peer").
-                    let mut detail = err.to_string();
-                    let mut src = std::error::Error::source(&err);
-                    while let Some(e) = src {
-                        detail.push_str(": ");
-                        detail.push_str(&e.to_string());
-                        src = e.source();
-                    }
-                    format!(
-                        "quic connection closed: {detail} ({})",
-                        stats(established, commands, last_read)
-                    )
-                    .into_bytes()
-                } else {
-                    b"quic connection closed".to_vec()
-                };
-                sever(&loop_tx, connection, reason);
-                return;
-            }
+            format!(
+                "quic connection closed: {detail} (established={}, commands={}, age={:.1}s)",
+                reader.established,
+                reader.commands,
+                start.elapsed().as_secs_f64(),
+            )
+            .into_bytes()
         }
+    };
+    sever(&loop_tx, connection, reason);
+}
+
+/// Delivers connection messages to the command loop — the [`MessageReader`] for the
+/// join/serve pathway. Snoops the peer's `Establish` (forwarding its ident to the
+/// heartbeat task) and `Severed` (waking the writer to close), and counts what it
+/// delivered for the failure diagnostics.
+struct ConnectionReader {
+    connection: ConnectionRef,
+    loop_tx: mpsc::UnboundedSender<Command>,
+    peer_responded: mpsc::UnboundedSender<()>,
+    hb_events: mpsc::UnboundedSender<HeartbeatEvent>,
+    established: bool,
+    commands: u64,
+}
+
+impl<N: Net> MessageReader<N> for ConnectionReader {
+    type Item = ConnectionCommand;
+
+    fn read_frame(
+        control: &mut ConnRecv<N>,
+        parts: &mut PartReader<N>,
+    ) -> impl std::future::Future<Output = std::io::Result<ConnectionCommand>> + Send {
+        framing::read_frame(control, parts)
+    }
+
+    fn on_message(&mut self, action: ConnectionCommand) -> bool {
+        self.commands += 1;
+        match &action {
+            // The peer's Establish is how we learn its identity — forward it to the
+            // heartbeat task (one-shot, at setup).
+            ConnectionCommand::Establish { ident, .. } => {
+                self.established = true;
+                if let Some(ident) = ident {
+                    let _ = self.hb_events.send(HeartbeatEvent::EstablishPeer {
+                        peer_ident: ident.clone(),
+                    });
+                }
+            }
+            // A Severed is the peer's response to our shutdown — wake the writer.
+            ConnectionCommand::Severed { .. } => {
+                let _ = self.peer_responded.send(());
+            }
+            _ => {}
+        }
+        self.loop_tx
+            .send(Command::ConnectionAction {
+                connection: self.connection,
+                action,
+            })
+            .is_ok()
     }
 }

--- a/monarch_mini/src/quic_net.rs
+++ b/monarch_mini/src/quic_net.rs
@@ -739,6 +739,11 @@ async fn quic_acceptor_demux(
 /// `accept_bi` work to a per-connection [`quic_acceptor_demux`] coroutine; its `stream`
 /// just sends a request down `requests` and awaits the paired stream. The demux holds the
 /// `Connection` alive; the acceptor keeps `remote` only for [`fmt::Debug`].
+///
+/// Cloneable so the reader, writer, heartbeat task, and striping coordinator can
+/// each hold a handle: a dialer clone shares the `Connection` (internally
+/// reference-counted); an acceptor clone shares the request-sender to the one demux.
+#[derive(Clone)]
 pub(crate) enum QuicConn {
     Dialer {
         conn: Connection,
@@ -787,7 +792,7 @@ fn quic_halves(conn: Connection, send: SendStream, recv: RecvStream) -> (QuicSen
 impl NetConn for QuicConn {
     type Send = QuicSend;
     type Recv = QuicRecv;
-    type Stream = Pin<Box<dyn Future<Output = io::Result<(QuicSend, QuicRecv)>>>>;
+    type Stream = Pin<Box<dyn Future<Output = io::Result<(QuicSend, QuicRecv)>> + Send>>;
 
     fn stream(&self, index: usize, priority: i32) -> Self::Stream {
         match self {

--- a/monarch_mini/src/tcp_net.rs
+++ b/monarch_mini/src/tcp_net.rs
@@ -801,7 +801,7 @@ impl fmt::Debug for TcpConn {
 impl NetConn for TcpConn {
     type Send = WriteHalf<TlsStream>;
     type Recv = ReadHalf<TlsStream>;
-    type Stream = Pin<Box<dyn Future<Output = io::Result<(Self::Send, Self::Recv)>>>>;
+    type Stream = Pin<Box<dyn Future<Output = io::Result<(Self::Send, Self::Recv)>> + Send>>;
 
     fn stream(&self, index: usize, _priority: i32) -> Self::Stream {
         match self {

--- a/monarch_mini/src/tests.rs
+++ b/monarch_mini/src/tests.rs
@@ -1818,6 +1818,190 @@ fn quic_gateway_reads_large_message_into_shared_memory() {
     shutdown(ctx);
 }
 
+/// Enable striping across `n` data streams per direction for the tests that exercise
+/// it. Global (like `set_quic_env`), but the default 1 MiB threshold means only the
+/// deliberately-large payloads below are striped; every other test's small messages
+/// stay inline regardless.
+fn set_striping_env(n: usize) {
+    std::env::set_var("MM_NET_N_DATA_STREAMS", n.to_string());
+}
+
+/// A large payload striped across quic data streams reassembles byte-for-byte at the
+/// gateway. Sized above the 1 MiB threshold, with a remainder past an even 4-way split
+/// (so the shards are unequal) and a companion small part (so one message mixes an
+/// inline part and a striped part). The striped part lands in the slab (`is_shm`).
+#[test]
+fn quic_stripes_large_message_across_data_streams() {
+    set_quic_env();
+    set_striping_env(4);
+    let ctx = CtxHandle::new().expect("context should start");
+    let gw = runtime_gateway_actor(&ctx, "q-stripe-gw");
+    let sender = runtime_actor(&ctx, "q-stripe-sender");
+    let (gw_poller, mut gw_rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, gw_poller, 0, gw);
+
+    let url = free_quic_url();
+    ctx.send_command(Command::Serve {
+        actor: gw,
+        url: url.clone(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: sender,
+        url,
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+    assert_eq!(
+        recv_strings(&mut gw_rx),
+        vec!["q-stripe-gw", "q-stripe-sender"]
+    );
+
+    let len = 3 * 1024 * 1024 + 777;
+    let payload: Vec<u8> = (0..len).map(|i| (i % 251) as u8).collect();
+    ctx.send_command(Command::Send {
+        sender,
+        destination_ident: MsgPart::from_bytes(b"q-stripe-gw".to_vec()),
+        parts: vec![
+            MsgPart::from_bytes(b"meta".to_vec()),
+            MsgPart::from_bytes(payload.clone()),
+        ],
+    })
+    .expect("send should enqueue");
+
+    let delivered = gw_rx.blocking_recv().expect("striped message delivered");
+    assert_eq!(delivered.msg.len(), 2, "both parts delivered");
+    assert_eq!(
+        delivered.msg[0].as_bytes(),
+        b"meta",
+        "the inline part is intact"
+    );
+    assert!(
+        delivered.msg[1].is_shm(),
+        "the large striped part lands in the slab"
+    );
+    assert_eq!(
+        delivered.msg[1].as_bytes(),
+        payload.as_slice(),
+        "the striped payload reassembles intact across the data streams"
+    );
+
+    shutdown(ctx);
+}
+
+/// The tcp analogue: a large payload striped across several tcp sockets (one per data
+/// stream) reassembles intact at the gateway.
+#[test]
+fn tcp_stripes_large_message_across_data_streams() {
+    set_quic_env(); // tcp reuses the same MM_QUIC_* cert material
+    set_striping_env(3);
+    let ctx = CtxHandle::new().expect("context should start");
+    let gw = runtime_gateway_actor(&ctx, "t-stripe-gw");
+    let sender = runtime_actor(&ctx, "t-stripe-sender");
+    let (gw_poller, mut gw_rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, gw_poller, 0, gw);
+
+    let url = free_tcp_url();
+    ctx.send_command(Command::Serve {
+        actor: gw,
+        url: url.clone(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: sender,
+        url,
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+    assert_eq!(
+        recv_strings(&mut gw_rx),
+        vec!["t-stripe-gw", "t-stripe-sender"]
+    );
+
+    let len = 2 * 1024 * 1024 + 5;
+    let payload: Vec<u8> = (0..len).map(|i| (i % 253) as u8).collect();
+    ctx.send_command(Command::Send {
+        sender,
+        destination_ident: MsgPart::from_bytes(b"t-stripe-gw".to_vec()),
+        parts: vec![MsgPart::from_bytes(payload.clone())],
+    })
+    .expect("send should enqueue");
+
+    let delivered = gw_rx.blocking_recv().expect("striped message delivered");
+    assert_eq!(delivered.msg.len(), 1, "one part delivered");
+    assert_eq!(
+        delivered.msg[0].as_bytes(),
+        payload.as_slice(),
+        "the striped payload reassembles intact across the tcp data sockets"
+    );
+
+    shutdown(ctx);
+}
+
+/// Delivery stays in `seq` order across striping: a small message sent right after a
+/// large striped one is held back until the large one is fully assembled, so the two
+/// arrive in send order even though the small one's bytes are trivially ready first.
+#[test]
+fn quic_striping_preserves_in_order_delivery() {
+    set_quic_env();
+    set_striping_env(4);
+    let ctx = CtxHandle::new().expect("context should start");
+    let gw = runtime_gateway_actor(&ctx, "q-order-gw");
+    let sender = runtime_actor(&ctx, "q-order-sender");
+    let (gw_poller, mut gw_rx) = runtime_poller(&ctx);
+    runtime_subscribe(&ctx, gw_poller, 0, gw);
+
+    let url = free_quic_url();
+    ctx.send_command(Command::Serve {
+        actor: gw,
+        url: url.clone(),
+        request: request(Role::Parent),
+    })
+    .expect("serve should enqueue");
+    ctx.send_command(Command::Join {
+        actor: sender,
+        url,
+        request: request(Role::Child),
+    })
+    .expect("join should enqueue");
+    assert_eq!(
+        recv_strings(&mut gw_rx),
+        vec!["q-order-gw", "q-order-sender"]
+    );
+
+    let len = 4 * 1024 * 1024 + 13;
+    let big: Vec<u8> = (0..len).map(|i| (i % 249) as u8).collect();
+    ctx.send_command(Command::Send {
+        sender,
+        destination_ident: MsgPart::from_bytes(b"q-order-gw".to_vec()),
+        parts: vec![MsgPart::from_bytes(big.clone())],
+    })
+    .expect("send big should enqueue");
+    ctx.send_command(Command::Send {
+        sender,
+        destination_ident: MsgPart::from_bytes(b"q-order-gw".to_vec()),
+        parts: vec![MsgPart::from_bytes(b"after".to_vec())],
+    })
+    .expect("send small should enqueue");
+
+    let first = gw_rx.blocking_recv().expect("first message");
+    assert_eq!(
+        first.msg[0].as_bytes(),
+        big.as_slice(),
+        "the large striped message is delivered first, in send order"
+    );
+    let second = gw_rx.blocking_recv().expect("second message");
+    assert_eq!(
+        second.msg[0].as_bytes(),
+        b"after",
+        "the following small message is delivered after the large one it followed"
+    );
+
+    shutdown(ctx);
+}
+
 #[test]
 fn quic_join_before_serve() {
     // The joiner's QUIC handshake fails until the server binds, so the connector


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* #4618
* __->__ #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Large message parts are striped over direction-specific QUIC or TCP data streams and assembled directly into shared-memory or heap destinations without zero-filling. Framing and receive delivery now coordinate shard completion while preserving message order, backed by QUIC and TCP reassembly tests and a QUIC ordering test.

Differential Revision: [D113115014](https://our.internmc.facebook.com/intern/diff/D113115014/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D113115014/)!