### PR TITLE
43/43 minimonarch: Document Monarch Mini

### DIFF
--- a/.github/workflows/test-cpu-rust-macos.yml
+++ b/.github/workflows/test-cpu-rust-macos.yml
@@ -57,6 +57,7 @@ jobs:
           RUSTFLAGS: --cfg tracing_unstable --cfg hyperactor_verify_auto_traits
         run: |
           set -eux
+          ./monarch_mini/test_certs/generate.sh
           cargo nextest run --locked --workspace --profile ci \
             -E "$(cat .config/nextest-filter.txt)" \
             --exclude monarch_messages \

--- a/.github/workflows/test-cpu-rust.yml
+++ b/.github/workflows/test-cpu-rust.yml
@@ -55,6 +55,7 @@ jobs:
         free -h || true
         echo "=== end runner spec ==="
         echo "Running CPU Rust tests..."
+        ./monarch_mini/test_certs/generate.sh
         # The CI profile is configured in .config/nextest.toml
         # It includes individual test timeouts and a timeout for the entire test run.
         # Capture the test exit code so stage_test_artifacts still runs on

--- a/.github/workflows/test-gpu-rust.yml
+++ b/.github/workflows/test-gpu-rust.yml
@@ -58,6 +58,7 @@ jobs:
 
         # Run GPU Rust tests
         echo "Running OSS Rust tests..."
+        ./monarch_mini/test_certs/generate.sh
         # Uses cargo nextest to run tests in separate processes, which better matches
         # internal buck test behavior.
         # The CI profile is configured in .config/nextest.toml

--- a/monarch_mini/Cargo.toml
+++ b/monarch_mini/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "monarch_mini"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+# staticlib: an opaque native archive exporting only the `mm_*` C ABI, with its
+# own std/tokio bundled and internalized — this is how consumers (Python, C, and
+# the Rust bindings) link it, so its runtime is fully isolated from the caller's
+# (no shared allocator, panic runtime, or thread-local state). rlib is kept for
+# any in-tree Rust consumer that wants the crate directly.
+crate-type = ["staticlib", "rlib"]
+
+[dependencies]
+anyhow = "1"
+bincode = { version = "2", features = ["serde"] }
+ktls = { version = "6", default-features = false, features = ["ring", "tls12"] }
+libc = "0.2"
+quinn = { version = "0.11", default-features = false, features = ["runtime-tokio", "rustls-ring", "log"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+rustls-pemfile = "2"
+rustls-pki-types = "1"
+serde = { version = "1.0.219", features = ["derive"] }
+socket2 = "0.6"
+slotmap = "1"
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "sync", "net", "io-util", "time", "fs", "macros"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "logging", "tls12"] }
+tracing = "0.1.41"

--- a/monarch_mini/README.md
+++ b/monarch_mini/README.md
@@ -1,15 +1,20 @@
-# mimic
+# Monarch Mini
 
-*A miniature Monarch actor system in 16 C functions and 6 MB.*
+*A miniature Monarch actor system in 16 C functions and 7.2 MB.*
 
-API inspired by zmq: what is the smallest set of functionality to get monitored actors?
+Monarch was designed for _easy_ use. What if we instead designed for simplicity?
+Monarch Mini is a prototype to answer this question. It lets us experiment with low-level
+design choices and optimizations without having to thread them through Monarch's layers.
+
+The API is inspired by ZeroMQ: define the smallest set of functionality needed for monitored actors.
+It is just these 16 C functions:
 
 ```c
 // ctx_t - context, owns the event loop, one per process
 err_t ctx_create(ctx_t* out);
 void ctx_destroy(ctx_t ctx);
 
-// actor_t - actor, actor tree also establishes message routing and acts as gateways.
+// actor_t - an actor. The actor tree establishes message routing and acts as gateways.
 err_t actor_create(ctx_t ctx, msg_part_t* ident, bool gateway, actor_t* out);
 void actor_destroy(actor_t actor);
 
@@ -33,7 +38,7 @@ err_t poller_next(poller_t poller, size_t* index_out, msg_part_t* parts, size_t 
 const char* last_error(void);
 ```
 
-With Python bindings:
+With simple Python bindings:
 
 ```python
 import asyncio, minimonarch as mm

--- a/monarch_mini/rust/Cargo.toml
+++ b/monarch_mini/rust/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "monarch_mini_rs"
+version = "0.1.0"
+edition = "2021"
+# Declares that this crate links the native `monarch_mini` library, so the link
+# directives emitted by build.rs propagate to downstream binaries.
+links = "monarch_mini"
+
+[lib]
+# Rust-native safe bindings over the minimonarch C ABI.
+
+[dependencies]
+thiserror = "2"
+# `Poller::recv` awaits the poller's wakeup fd via tokio's `AsyncFd`; `Actor`'s
+# lazily-created per-actor poller is guarded by a `tokio::sync::Mutex`. Only the
+# caller's own runtime is used; no multi-thread runtime is required.
+tokio = { version = "1", features = ["net", "rt", "sync"] }
+
+[build-dependencies]
+# minimonarch is linked as an opaque native library over its C ABI, NOT as a
+# Rust crate: `artifact = "staticlib"` builds its self-contained `.a` (own
+# std/tokio, internalized symbols) and `lib = false` keeps its rlib off our
+# dependency graph, so its runtime stays fully isolated from ours. Declared as a
+# build-dependency so build.rs receives the archive path and emits the link
+# directives; cargo builds and orders it. Requires `-Z bindeps` (enabled
+# workspace-wide in .cargo/config.toml).
+monarch_mini = { path = "..", artifact = "staticlib", lib = false }
+
+[dev-dependencies]
+# Compile-time assertions for the Send/Sync tagging (incl. the negative
+# `Poller: !Sync`, which a plain trait bound cannot express).
+static_assertions = "1"
+# Runtime + macros so tests/examples can `#[tokio::test]`/`#[tokio::main]`.
+tokio = { version = "1", features = ["rt", "macros", "net"] }


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack/tree/0.15.0) (oldest at bottom):
* __->__ #4618
* #4617
* #4616
* #4615
* #4614
* #4613
* #4612
* #4611
* #4610
* #4609
* #4608
* #4607
* #4606
* #4605
* #4604
* #4603
* #4602
* #4601
* #4600
* #4599
* #4598
* #4597
* #4596
* #4595
* #4594
* #4593
* #4592
* #4591
* #4590
* #4589
* #4588
* #4587
* #4586
* #4585
* #4584
* #4583
* #4582
* #4581
* #4580
* #4579
* #4578
* #4577
* #4576

Reframe Monarch Mini as a compact actor-system prototype for experimenting with low-level design choices outside Monarch's full stack. Update its reported footprint and clarify the 16-function C API and Python bindings.

Differential Revision: [D114750228](https://our.internmc.facebook.com/intern/diff/D114750228/)

**NOTE FOR REVIEWERS**: This PR has internal Meta-specific changes or comments, please review them on [Phabricator](https://our.internmc.facebook.com/intern/diff/D114750228/)!