### PR TITLE
Make a worker's advertised address and its peers' dial address the same string

### DIFF
--- a/python/monarch/_src/job/_slurm_batch.py
+++ b/python/monarch/_src/job/_slurm_batch.py
@@ -27,14 +27,33 @@ import sys
 from typing import List, Optional
 
 from monarch._src.job._batch_env import MONARCH_BATCH_JOB_ENV
+from monarch.tools.network import get_consistent_sockaddr
 
-# Bootstraps one monarch worker bound to this node's hostname. Passed as python
-# ``-c`` argv (no shell), so quoting inside is irrelevant.
+# Bootstraps one monarch worker on this node. Passed as python ``-c`` argv (no
+# shell), so quoting inside is irrelevant. The address comes from
+# ``worker_address``, which the controller also calls to build its dial address
+# (see ``SlurmJob._state``), so the two agree by construction.
 _WORKER_BOOTSTRAP: str = (
     "import socket; from monarch.actor import run_worker_loop_forever; "
-    'run_worker_loop_forever(address=f"tcp://{socket.gethostname()}:%d", '
+    "from monarch._src.job._slurm_batch import worker_address; "
+    "run_worker_loop_forever("
+    "address=worker_address(socket.gethostname(), %d), "
     'ca="trust_all_connections")'
 )
+
+
+def worker_address(hostname: str, port: int) -> str:
+    """The ``tcp://`` URL of the monarch worker serving on ``hostname``.
+
+    Called by both sides of the SLURM bootstrap -- the worker passes it to
+    ``run_worker_loop_forever``, the controller to ``attach_to_workers`` -- so
+    that the address the worker advertises and the one the controller dials come
+    from one expression rather than two files agreeing by convention. They must
+    be the *same string*, not merely mutually reachable: see
+    :func:`monarch.tools.network.get_consistent_sockaddr` for why, and for why
+    the hostname is resolved here instead of left in the URL.
+    """
+    return f"tcp://{get_consistent_sockaddr(hostname, port)}"
 
 
 def main(argv: Optional[List[str]] = None) -> None:

--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -18,7 +18,7 @@ from monarch._rust_bindings.monarch_hyperactor.channel import ChannelTransport
 from monarch._rust_bindings.monarch_hyperactor.config import configure
 from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job
-from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP
+from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP, worker_address
 from monarch._src.job.job import BatchJob, JobState, JobTrait
 
 
@@ -362,7 +362,11 @@ class SlurmJob(JobTrait):
             ]
             hostname_idx += num_nodes
 
-            workers = [f"tcp://{hostname}:{self._port}" for hostname in mesh_hostnames]
+            # Same helper the workers serve on (_slurm_batch._WORKER_BOOTSTRAP),
+            # so the dialed address is byte-for-byte the advertised one.
+            workers = [
+                worker_address(hostname, self._port) for hostname in mesh_hostnames
+            ]
             host_mesh = attach_to_workers(
                 name=mesh_name,
                 ca="trust_all_connections",

--- a/python/monarch/_src/spmd/host_mesh.py
+++ b/python/monarch/_src/spmd/host_mesh.py
@@ -47,6 +47,7 @@ from typing import Final, Protocol
 
 from monarch._src.actor.host_mesh import HostMesh
 from monarch.actor import attach_to_workers, enable_transport
+from monarch.tools.network import get_consistent_sockaddr
 
 logger: logging.Logger = logging.getLogger(__name__)
 
@@ -76,7 +77,7 @@ def _worker_address(
     name: str,
     ipc_dir: str | None,
 ) -> str:
-    """Build a ZMQ-style listen address for ``run_worker_loop_forever``.
+    """Build a ZMQ-style listen address for this host's ``run_worker_loop_forever``.
 
     ``monarch_port == 0`` is rejected for TCP and metatls transports: the
     kernel would assign a free port at bind time, but the caller can't
@@ -84,6 +85,12 @@ def _worker_address(
     the port pre-spawn via a short-lived socket races against other
     listeners on the host. Forcing an explicit port keeps the parent's
     pre-computed address honest.
+
+    The TCP address is *resolved* here rather than published as a hostname: a
+    name in the store is resolved once by the worker that binds it and again by
+    the rank 0 that dials it, and a node can resolve its own name differently
+    from how its peers do. See
+    :func:`monarch.tools.network.get_consistent_sockaddr`.
     """
     if transport == "ipc":
         assert ipc_dir is not None
@@ -95,7 +102,14 @@ def _worker_address(
                 f"transport {transport!r}"
             )
         if transport == "tcp":
-            return f"tcp://{socket.getfqdn()}:{monarch_port}"
+            # gethostname() rather than getfqdn(): the name is now only resolver
+            # input, and it is what hyperactor's own ChannelAddr::any starts
+            # from for TcpMode::Hostname.
+            return (
+                f"tcp://{get_consistent_sockaddr(socket.gethostname(), monarch_port)}"
+            )
+        # TLS keeps the hostname: ChannelAddr::MetaTls stores it and resolves per
+        # dial, so the advertised name is the cert-validated name.
         return f"metatls://{socket.getfqdn()}:{monarch_port}"
     raise ValueError(
         f"unsupported transport {transport!r}; expected one of "

--- a/python/monarch/tools/network.py
+++ b/python/monarch/tools/network.py
@@ -54,6 +54,75 @@ def get_sockaddr(hostname: str, port: int) -> str:
     )
 
 
+def get_consistent_sockaddr(hostname: str, port: int) -> str:
+    """Returns the socket address of `hostname:port` that *every* host resolves alike.
+
+    Same return shape as `get_sockaddr`: `{ipv4}:{port}` or `[{ipv6}]:{port}`.
+
+    Use this rather than `get_sockaddr` when the address is a shared *identity*:
+    one host advertises where it can be reached and another dials it, and the
+    two strings must be equal, not merely both reachable. `ChannelAddr::Tcp`
+    holds a resolved socket address and a worker's host identity is derived from
+    the address it advertises, so a peer that resolves the same name differently
+    connects and then fails delivery with "ttl expired".
+
+    Resolvers do differ: a node's own name goes through its `/etc/hosts`, which
+    can publish families that DNS does not -- on CoreWeave GB300 each node's
+    `/etc/hosts` adds an IPv6 GUA for its own name while cluster DNS serves only
+    an A record. So drop loopback and link-local (the routability rule
+    `ChannelAddr::any` uses), prefer IPv4, and break ties by address. IPv4-first
+    is what makes the side that sees the extra IPv6 agree with the side that
+    does not; `AddrType.Default` is IPv6-first and would not, and pinning
+    `AddrType.IPv4` would agree but break IPv6-only clusters.
+
+    Raises a `RuntimeError` if `hostname` resolves to no routable address.
+    """
+    candidates: list[tuple[int, ipaddress.IPv4Address | ipaddress.IPv6Address]] = []
+    # patternlint-disable-next-line python-dns-deps (only used for oss)
+    for family, _, _, _, sockaddr in socket.getaddrinfo(
+        hostname, port, type=socket.SOCK_STREAM
+    ):
+        # Strip any scope id ("fe80::1%eth0"), which ip_address rejects.
+        addr = str(sockaddr[0]).partition("%")[0]
+        ipaddr = ipaddress.ip_address(addr)
+        # Loopback is dropped as well as link-local (unlike `_resolve_ipaddr`):
+        # every host resolves it alike, but no peer can reach it.
+        if ipaddr.is_loopback or ipaddr.is_link_local:
+            logger.info(
+                "skipping unroutable address `%s` for `%s:%d`"
+                " (loopback and link-local addresses cannot be dialed by a peer)",
+                addr,
+                hostname,
+                port,
+            )
+            continue
+        candidates.append((family, ipaddr))
+
+    if not candidates:
+        raise RuntimeError(
+            f"Unable to resolve `{hostname}` to a routable (non-loopback,"
+            " non-link-local) address that can bind TCP socket."
+            " Check the network configuration on the host."
+        )
+
+    # Least address within the preferred family, not the first one the resolver
+    # happened to list: that ordering is host-specific (RFC 6724, gai.conf) and
+    # a name with several A records would otherwise resolve differently per host.
+    family, ipaddr = min(
+        candidates, key=lambda c: (c[0] != socket.AF_INET, c[1].packed)
+    )
+    socket_address = (
+        f"[{ipaddr}]:{port}" if family == socket.AF_INET6 else f"{ipaddr}:{port}"
+    )
+    logger.info(
+        "resolved consistent address `%s` for `%s:%d`",
+        socket_address,
+        hostname,
+        port,
+    )
+    return socket_address
+
+
 class AddrType(Enum):
     # Default to IPv6, and fallback to IPv4 if IPv6 is not available on the host.
     Default = auto()

--- a/python/tests/_src/job/test_slurm.py
+++ b/python/tests/_src/job/test_slurm.py
@@ -7,6 +7,7 @@
 # pyre-unsafe
 
 import shlex
+import socket
 import subprocess
 from unittest.mock import patch
 
@@ -91,7 +92,9 @@ def test_external_controller_mode_has_no_client(tmp_path, monkeypatch):
     script = _submitted_script(mock)
     assert "srun" in script
     assert "run_worker_loop_forever" in script
-    assert "_slurm_batch" not in script
+    # No in-allocation runner. Matches the invocation, not the bare module name:
+    # the worker bootstrap legitimately imports worker_address from _slurm_batch.
+    assert "-m monarch._src.job._slurm_batch" not in script
     assert "MONARCH_BATCH_JOB" not in script
     assert not (tmp_path / ".monarch" / "job_state.pkl").exists()
 
@@ -270,3 +273,26 @@ def test_runner_kills_workers_if_terminate_times_out(monkeypatch):
     _run_runner(monkeypatch, workers)
     assert workers.terminated is True
     assert workers.killed is True  # falls back to SIGKILL when terminate hangs
+
+
+def test_worker_address_is_the_shared_rule_with_a_tcp_prefix():
+    """``worker_address`` must stay a thin wrapper -- the resolution rule and its
+    own tests live in ``monarch.tools.network``."""
+    with patch(
+        "socket.getaddrinfo",
+        return_value=[
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::2", 22222, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 22222)),
+        ],
+    ):
+        assert _slurm_batch.worker_address("node-0", 22222) == "tcp://10.0.0.1:22222"
+
+
+def test_worker_bootstrap_derives_its_address_from_worker_address():
+    """The worker's served address and the controller's dial address must come
+    from the same helper; if the bootstrap ever computes its own, they can drift
+    apart again."""
+    bootstrap = _slurm_batch._WORKER_BOOTSTRAP % 22222
+    assert "worker_address(socket.gethostname(), 22222)" in bootstrap
+    assert "'" not in bootstrap  # embedded in a single-quoted srun argument
+    compile(bootstrap, "<bootstrap>", "exec")

--- a/python/tests/test_spmd_host_mesh.py
+++ b/python/tests/test_spmd_host_mesh.py
@@ -9,16 +9,19 @@
 import os
 import shutil
 import signal
+import socket
 import subprocess
 import sys
 import time
 from typing import Callable
+from unittest.mock import patch
 
 import pytest
 from monarch._src.spmd.host_mesh import (
     _IN_PAR,
     _spawn_worker_process,
     _worker_addr_key,
+    _worker_address,
     host_mesh_from_store,
 )
 
@@ -89,6 +92,32 @@ def test_net_transports_require_explicit_port() -> None:
     for transport in ("tcp", "metatls", "metatls-hostname"):
         with pytest.raises(ValueError, match="monarch_port must be an explicit"):
             _spawn_worker_process(transport=transport, monarch_port=0)
+
+
+def test_worker_address_tcp_publishes_a_resolved_address() -> None:
+    """The tcp address goes into a store for another rank to dial back, so it
+    must be resolved here rather than left as a name: the node's own resolver
+    can answer with a family its peers cannot see (here the IPv6 GUA)."""
+    with patch(
+        "socket.getaddrinfo",
+        return_value=[
+            (socket.AF_INET6, socket.SOCK_STREAM, 6, "", ("::2", 22222, 0, 0)),
+            (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.1", 22222)),
+        ],
+    ):
+        addr = _worker_address("tcp", monarch_port=22222, name="w", ipc_dir=None)
+    assert addr == "tcp://10.0.0.1:22222"
+
+
+def test_worker_address_metatls_keeps_the_hostname() -> None:
+    """TLS deliberately stays on the hostname: ChannelAddr::MetaTls stores it and
+    resolves per dial, so the advertised name is the cert-validated name."""
+    with patch("socket.getfqdn", return_value="node-0.example.com"):
+        for transport in ("metatls", "metatls-hostname"):
+            addr = _worker_address(
+                transport, monarch_port=22222, name="w", ipc_dir=None
+            )
+            assert addr == "metatls://node-0.example.com:22222"
 
 
 @pytest.mark.parametrize(

--- a/python/tests/tools/test_network.py
+++ b/python/tests/tools/test_network.py
@@ -182,3 +182,75 @@ class TestNetwork(unittest.TestCase):
         # since we patched `socket.getaddrinfo` above
         # don't patch and just make sure things don't error out
         self.assertIsNotNone(network.get_sockaddr(socket.getfqdn(), 8080))
+
+
+def _addrinfo(*addrs: tuple[int, str], port: int = 8080) -> List[Any]:
+    """A `socket.getaddrinfo` result for the given `(family, ip)` pairs."""
+    entries: List[Any] = []
+    for family, ip in addrs:
+        sockaddr = (ip, port) if family == socket.AF_INET else (ip, port, 0, 0)
+        entries.append((family, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", sockaddr))
+    return entries
+
+
+class TestConsistentSockaddr(unittest.TestCase):
+    """`get_consistent_sockaddr` promises one thing: any two hosts resolving the
+    same name produce the same string. Each test pins part of that promise."""
+
+    IPV6: tuple[int, str] = (socket.AF_INET6, "2a03:83e4:4027:846b::cba7")
+    IPV4: tuple[int, str] = (socket.AF_INET, "10.130.53.206")
+
+    def _resolve(self, *addrs: tuple[int, str]) -> str:
+        with mock.patch("socket.getaddrinfo", return_value=_addrinfo(*addrs)):
+            return network.get_consistent_sockaddr("node-0", 8080)
+
+    def test_agrees_when_only_one_side_sees_an_extra_ipv6(self) -> None:
+        """The bug: a node's own `/etc/hosts` adds an IPv6 GUA that the A record
+        its peers get from DNS does not have. Both sides must still pick the
+        same address."""
+        advertised = self._resolve(self.IPV6, self.IPV4)  # the node's own view
+        dialed = self._resolve(self.IPV4)  # what DNS gives its peers
+        self.assertEqual(advertised, dialed)
+        self.assertEqual("10.130.53.206:8080", advertised)
+
+    def test_choice_is_independent_of_resolver_order(self) -> None:
+        """getaddrinfo ordering is host-configurable (RFC 6724, gai.conf), so it
+        must not decide the answer -- across families or within one."""
+        other_ipv4 = (socket.AF_INET, "10.130.53.7")
+        for view in ((self.IPV6, self.IPV4), (self.IPV4, self.IPV6)):
+            self.assertEqual("10.130.53.206:8080", self._resolve(*view))
+        for view in ((self.IPV4, other_ipv4), (other_ipv4, self.IPV4)):
+            self.assertEqual("10.130.53.7:8080", self._resolve(*view))
+
+    def test_ipv6_only_host_gets_a_bracketed_ipv6(self) -> None:
+        """No family is hardcoded: unlike `AddrType.IPv4`, an IPv6-only cluster
+        still resolves rather than failing."""
+        self.assertEqual("[2a03:83e4:4027:846b::cba7]:8080", self._resolve(self.IPV6))
+
+    def test_unroutable_addresses_dropped(self) -> None:
+        """Loopback is dropped as well as link-local: both sides would agree on
+        it, but no peer can reach it."""
+        for unroutable in [
+            (socket.AF_INET, "127.0.1.1"),
+            (socket.AF_INET6, "::1"),
+            (socket.AF_INET6, "fe80::222:48ff:fe49:ba90"),
+            (socket.AF_INET, "169.254.1.1"),
+            # a scope id ("fe80::1%eth0") must be stripped before the routability
+            # check, not crash `ipaddress.ip_address` on the way to dropping it
+            (socket.AF_INET6, "fe80::222:48ff:fe49:ba90%eth0"),
+        ]:
+            with self.subTest(unroutable=unroutable[1]):
+                self.assertEqual(
+                    "10.130.53.206:8080", self._resolve(unroutable, self.IPV4)
+                )
+
+    def test_raises_when_nothing_routable_resolves(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "routable"):
+            self._resolve((socket.AF_INET, "127.0.0.1"))
+
+    def test_real_hostname_resolves(self) -> None:
+        # unpatched, like `TestNetwork.test_network`: just make sure the rule
+        # runs against a real resolver on this host.
+        self.assertIsNotNone(
+            network.get_consistent_sockaddr(socket.gethostname(), 8080)
+        )


### PR DESCRIPTION
## Problem

On CoreWeave GB300 each node's `/etc/hosts` adds an IPv6 GUA for its own name while cluster DNS publishes only an A record, so a worker serves on `tcp://[GUA]:PORT` while the controller dials `tcp://IPv4:PORT`. As a result, multi-node attach times out with `MESH_ATTACH_CONFIG_TIMEOUT` on clusters where a node's own name resolves differently on the node than it does from its peers. Single node works by accident: the controller resolves that node through the same `/etc/hosts` the worker did.

The two addresses must agree **byte for byte**, not merely be mutually reachable. A worker's host identity is the `service` proc derived from the address it *advertises*, and `Proc::is_local_delivery_target_at` compares the terminal channel address for that proc — so a mismatch fails delivery with `ttl expired` after the TCP connection has already succeeded. That rules out the fix this looks like it wants: widening the bind (the `advertise@bind` alias form with a wildcard bind, as `KubernetesJob` uses) fixes reachability, which was never the problem.

## Fix 
Both sides now apply one deterministic rule to whatever their resolver returned — drop loopback and link-local, prefer IPv4, break ties by address — landing in `monarch/tools/network.py` as `get_consistent_sockaddr`. Full rationale, including why this is a new function rather than an `AddrType` variant and why the metatls branches keep `getfqdn()`, is in the commit message.

## Call sites

- `_src/job/_slurm_batch.py` + `_src/job/slurm.py` — `_WORKER_BOOTSTRAP` and `SlurmJob._state` derived the address independently and hoped they matched; they now share `worker_address`, so they agree by construction rather than by convention across two files.
- `_src/spmd/host_mesh.py` — `_worker_address` published `tcp://{getfqdn()}:{port}` into the store. Publishing a hostname doesn't help, because `ChannelAddr::Tcp` holds a *resolved* `SocketAddr`; publishing a literal does, because it resolves to itself.

## Verification

Resolving one node name from both sides on the CoreWeave GB300 cluster (fair-cw-use2-3):

```
node itself   raw: AF_INET6 2a03:83e4:4027:8adc::be0d, AF_INET 10.133.110.19
login side    raw: AF_INET 10.133.110.19

get_consistent_sockaddr   both sides -> 10.133.110.19:22222        (agree)
get_sockaddr (IPv6-first) node       -> [2a03:...::be0d]:22222
                          login      -> 10.133.110.19:22222        (disagree)
```

End to end — two-node `SlurmJob` in batch mode, same client and allocation shape, swapping only the monarch Python:

| | result |
|---|---|
| before | **FAIL** — `config push failed during attach on 1 host(s): tcp:10.133.173.11:22222 reply timed out after MESH_ATTACH_CONFIG_TIMEOUT` |
| after | **PASS** — actors ran on both `g3-154-001` and `g3-154-005` |

One of two hosts failing is the signature this predicts: the head node resolves its own name the same way its worker did, so that half agrees by accident, while the remote node's name comes from DNS as IPv4 and its worker had bound the GUA.

Caveat on scope: the end-to-end runs overlaid this branch's Python onto a prebuilt `_rust_bindings` (2026-07-29) rather than a from-source build of current `main`. All four changed files are pure Python, so this exercises the actual changed code, but not a full rebuild.

## Notes for reviewers

- **Tie-break by address, not resolver order.** `getaddrinfo` ordering is host-configurable (RFC 6724, `gai.conf`), so a name with several A records would otherwise still resolve differently per host — the exact failure this exists to prevent. No-op on this cluster (one A + one AAAA per node).
- **The rule absorbs one asymmetry, not every one.** An extra IPv6 visible only to the node can't change the choice; an extra IPv4 would. That's the case in the field, and the docstring says so rather than overclaiming.
- **`test_external_controller_mode_has_no_client`** now matches `-m monarch._src.job._slurm_batch` instead of the bare module name, because the worker bootstrap legitimately imports `worker_address` from it.

## Out of scope

The worker could publish the address it actually bound and the controller consume it through the `Future[str]` support `attach_to_workers` already documents, removing independent resolution entirely rather than making two resolutions agree. The SLURM worker could also name itself with `$SLURMD_NODENAME`, which matches squeue's node name by definition even when a site sets `NodeName != NodeHostname`. Separately, the `tcp://*` guard in `run_worker_loop_forever` is a substring test over the whole address, so it also rejects a wildcard in the `bind_to` half of an alias, where one is legitimate.
