### PR TITLE
Fix self-deadlock in the local-memory cache eviction path

### DIFF
--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -231,8 +231,23 @@ _local_memory_cache: "Dict[Tuple[int, int, int], _WeakLocalMemoryHandle]" = {}
 # cannot evict a fresh registration whose backing reused a freed id.
 _local_memory_cache_refs: "Dict[Tuple[int, int, int], weakref.ref]" = {}
 # Serializes the get/upgrade/insert and eviction sequences; the GIL
-# only makes the individual dict ops atomic.
-_local_memory_cache_lock = threading.Lock()
+# only makes the individual dict ops atomic. Reentrant by necessity.
+# In pyo3, when a rust-based python object (e.g., a Py<T>) is dropped
+# when the current thread doesn't hold the GIL, decrementing the refcount
+# is deferred until the next time the GIL is acquired. So the following
+# sequence is possible:
+#   1. Rust drops the strong handle backing a _WeakLocalMemoryHandle in
+#      the cache, but decref is deferred.
+#   2. Back in python, a different object backing a different _WeakLocalMemoryHandle
+#      drops, immediately triggering _evict_local_memory.
+#   3. _evict_local_memory acquires the cachelock and drops the _WeakLocalMemoryHandle
+#      from step (2). Because _WeakLocalMemoryHandle is a pyo3 object, it calls
+#      into rust to run the destructor and in doing so, pyo3 acquires the GIL.
+#   4. With the GIL, pyo3 executes the deferred decref from step (1), leading to
+#      another _evict_local_memory call. But the caller already holds the lock,
+#      so we get deadlock.
+# An identical sequence is possible with weak.upgrade() in _make_local_memory_handle.
+_local_memory_cache_lock = threading.RLock()
 
 
 def _evict_local_memory(key: Tuple[int, int, int], ref: "weakref.ref") -> None:

--- a/python/tests/test_rdma.py
+++ b/python/tests/test_rdma.py
@@ -140,6 +140,65 @@ def test_device_memory_handle_read_write():
         handle.write_at(4, bytes([1, 2, 3]))
 
 
+def test_local_memory_cache_reentrant_eviction():
+    """Evicting an entry whose release triggers a nested eviction must not
+    deadlock.
+
+    Releasing a cached handle runs native code that can collect an
+    unrelated backing, firing that backing's eviction callback on the same
+    thread while the first eviction is still in progress.
+    """
+    import threading
+    import weakref as weakref_mod
+
+    from monarch._src.rdma.rdma import (
+        _evict_local_memory,
+        _local_memory_cache,
+        _local_memory_cache_refs,
+    )
+
+    outer_key = (-1, -1, 1)
+    inner_key = (-2, -2, 2)
+
+    class Backing:
+        pass
+
+    inner_backing = Backing()
+    inner_ref = weakref_mod.ref(inner_backing)
+
+    class EvictsOnRelease:
+        """Stands in for a cached handle whose release collects `inner_key`."""
+
+        def __del__(self) -> None:
+            _evict_local_memory(inner_key, inner_ref)
+
+    outer_backing = Backing()
+    outer_ref = weakref_mod.ref(outer_backing)
+
+    _local_memory_cache[outer_key] = EvictsOnRelease()
+    _local_memory_cache_refs[outer_key] = outer_ref
+    _local_memory_cache[inner_key] = object()
+    _local_memory_cache_refs[inner_key] = inner_ref
+
+    finished = threading.Event()
+
+    def evict() -> None:
+        _evict_local_memory(outer_key, outer_ref)
+        finished.set()
+
+    try:
+        worker = threading.Thread(target=evict, daemon=True)
+        worker.start()
+        worker.join(timeout=60)
+        assert finished.is_set(), "nested eviction deadlocked"
+        assert outer_key not in _local_memory_cache
+        assert inner_key not in _local_memory_cache
+    finally:
+        for key in (outer_key, inner_key):
+            _local_memory_cache.pop(key, None)
+            _local_memory_cache_refs.pop(key, None)
+
+
 # ---------------------------------------------------------------------------
 # RDMA tests (require hardware)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
`_evict_local_memory` ran under `_local_memory_cache_lock`, a non-reentrant
`threading.Lock`. Popping the cache entry destroys a cached
`_WeakLocalMemoryHandle`, whose native destructor takes a GIL token and so
flushes `Py` decrefs queued by an earlier off-GIL release (pyo3's `py-clone`
deferral). That can collect an *unrelated* backing and fire its eviction
callback on the same thread, re-entering `_evict_local_memory` before the pop
returns -- where it blocked forever on the lock its own caller held.

The fix is to use a reentrant lock instead of a basic lock.

Differential Revision: D114910244


