### PR TITLE
ibverbs: add IbvAh, and share state/poll/chunk-size helpers (#4623)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1289,6 +1289,13 @@ impl IbvQp {
         &self.recv_cq
     }
 
+    /// The protection domain this QP was created against, shareable as a
+    /// keepalive by resources built on the same PD.
+    #[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+    pub(super) fn pd(&self) -> &Arc<IbvPd> {
+        &self.pd
+    }
+
     /// The device context this QP was created on, sourced from its PD.
     pub(super) fn context(&self) -> &IbvContext {
         self.pd.context()
@@ -1524,6 +1531,80 @@ impl Drop for IbvMr {
         let ret = unsafe { rdmaxcel_sys::ibv_dereg_mr(self.mr) };
         if ret != 0 {
             tracing::error!("failed to deregister MR {:p}: error code {}", self.mr, ret);
+        }
+    }
+}
+
+/// Owns an `ibv_ah` together with the `Arc<IbvPd>` it was created against,
+/// destroying the address handle on drop before releasing the PD. Holding the PD
+/// keeps it (and, through it, the context) alive across `ibv_destroy_ah`.
+///
+/// Unlike the other handles here there is no null placeholder: [`Self::create`]
+/// is the only constructor and it rejects a null result, so the pointer is
+/// always live.
+#[derive(Debug)]
+#[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+pub(super) struct IbvAh {
+    ah: *mut rdmaxcel_sys::ibv_ah,
+    /// Keeps the PD open until after `ibv_destroy_ah`. Never read.
+    _pd: Arc<IbvPd>,
+}
+
+// SAFETY: the only raw member is the `ibv_ah` pointer. The ibverbs AH it names is
+// not thread-affine — it may be created on one thread and used or destroyed on
+// another (`Send`) — and `IbvAh` exposes no operation that mutates the AH through
+// a shared `&` (`as_ptr` only hands back the pointer value), so sharing an
+// `&IbvAh` cannot race (`Sync`).
+unsafe impl Send for IbvAh {}
+// SAFETY: as for `Send` above.
+unsafe impl Sync for IbvAh {}
+
+#[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+impl IbvAh {
+    /// Creates an address handle on `pd` from `attr`.
+    ///
+    /// # Safety
+    ///
+    /// `pd` must hold a live protection domain; a null PD yields `Err`.
+    pub(super) unsafe fn create(
+        pd: Arc<IbvPd>,
+        attr: &mut rdmaxcel_sys::ibv_ah_attr,
+    ) -> Result<Self, anyhow::Error> {
+        if pd.as_ptr().is_null() {
+            anyhow::bail!("cannot create an address handle on a null protection domain");
+        }
+        // SAFETY: `pd.as_ptr()` is non-null (checked above) and, per this
+        // function's contract, a live protection domain; `attr` is a valid,
+        // fully initialized `ibv_ah_attr` that outlives the call.
+        // `ibv_create_ah` returns null on failure.
+        let ah = unsafe { rdmaxcel_sys::ibv_create_ah(pd.as_ptr(), attr) };
+        if ah.is_null() {
+            anyhow::bail!(
+                "failed to create address handle: {}",
+                Error::last_os_error()
+            );
+        }
+        Ok(Self { ah, _pd: pd })
+    }
+
+    /// The raw `ibv_ah`, always live.
+    pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_ah {
+        self.ah
+    }
+}
+
+impl Drop for IbvAh {
+    fn drop(&mut self) {
+        // SAFETY: `self.ah` was returned non-null by `ibv_create_ah` and, since
+        // `IbvAh` is not `Clone`, is destroyed exactly once. `_pd` drops only
+        // after this returns, so the PD is still alive.
+        let ret = unsafe { rdmaxcel_sys::ibv_destroy_ah(self.ah) };
+        if ret != 0 {
+            tracing::error!(
+                "failed to destroy address handle {:p}: error code {}",
+                self.ah,
+                ret
+            );
         }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1297,6 +1297,13 @@ impl IbvQp {
         &self.recv_cq
     }
 
+    /// The protection domain this QP was created against, shareable as a
+    /// keepalive by resources built on the same PD.
+    #[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+    pub(super) fn pd(&self) -> &Arc<IbvPd> {
+        &self.pd
+    }
+
     /// The device context this QP was created on, sourced from its PD.
     pub(super) fn context(&self) -> &IbvContext {
         self.pd.context()
@@ -1532,6 +1539,80 @@ impl Drop for IbvMr {
         let ret = unsafe { rdmaxcel_sys::ibv_dereg_mr(self.mr) };
         if ret != 0 {
             tracing::error!("failed to deregister MR {:p}: error code {}", self.mr, ret);
+        }
+    }
+}
+
+/// Owns an `ibv_ah` together with the `Arc<IbvPd>` it was created against,
+/// destroying the address handle on drop before releasing the PD. Holding the PD
+/// keeps it (and, through it, the context) alive across `ibv_destroy_ah`.
+///
+/// Unlike the other handles here there is no null placeholder: [`Self::create`]
+/// is the only constructor and it rejects a null result, so the pointer is
+/// always live.
+#[derive(Debug)]
+#[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+pub(super) struct IbvAh {
+    ah: *mut rdmaxcel_sys::ibv_ah,
+    /// Keeps the PD open until after `ibv_destroy_ah`. Never read.
+    _pd: Arc<IbvPd>,
+}
+
+// SAFETY: the only raw member is the `ibv_ah` pointer. The ibverbs AH it names is
+// not thread-affine — it may be created on one thread and used or destroyed on
+// another (`Send`) — and `IbvAh` exposes no operation that mutates the AH through
+// a shared `&` (`as_ptr` only hands back the pointer value), so sharing an
+// `&IbvAh` cannot race (`Sync`).
+unsafe impl Send for IbvAh {}
+// SAFETY: as for `Send` above.
+unsafe impl Sync for IbvAh {}
+
+#[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+impl IbvAh {
+    /// Creates an address handle on `pd` from `attr`.
+    ///
+    /// # Safety
+    ///
+    /// `pd` must hold a live protection domain; a null PD yields `Err`.
+    pub(super) unsafe fn create(
+        pd: Arc<IbvPd>,
+        attr: &mut rdmaxcel_sys::ibv_ah_attr,
+    ) -> Result<Self, anyhow::Error> {
+        if pd.as_ptr().is_null() {
+            anyhow::bail!("cannot create an address handle on a null protection domain");
+        }
+        // SAFETY: `pd.as_ptr()` is non-null (checked above) and, per this
+        // function's contract, a live protection domain; `attr` is a valid,
+        // fully initialized `ibv_ah_attr` that outlives the call.
+        // `ibv_create_ah` returns null on failure.
+        let ah = unsafe { rdmaxcel_sys::ibv_create_ah(pd.as_ptr(), attr) };
+        if ah.is_null() {
+            anyhow::bail!(
+                "failed to create address handle: {}",
+                Error::last_os_error()
+            );
+        }
+        Ok(Self { ah, _pd: pd })
+    }
+
+    /// The raw `ibv_ah`, always live.
+    pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_ah {
+        self.ah
+    }
+}
+
+impl Drop for IbvAh {
+    fn drop(&mut self) {
+        // SAFETY: `self.ah` was returned non-null by `ibv_create_ah` and, since
+        // `IbvAh` is not `Clone`, is destroyed exactly once. `_pd` drops only
+        // after this returns, so the PD is still alive.
+        let ret = unsafe { rdmaxcel_sys::ibv_destroy_ah(self.ah) };
+        if ret != 0 {
+            tracing::error!(
+                "failed to destroy address handle {:p}: error code {}",
+                self.ah,
+                ret
+            );
         }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -202,6 +202,15 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// Returns the current `ibv_qp_state` of the QP.
     fn state(&mut self) -> Result<u32, anyhow::Error>;
 
+    /// Largest transfer this QP issues as a single work request; [`Self::put`]
+    /// and [`Self::get`] split anything larger into that many WRs. The owning
+    /// [`QueuePairActor`] budgets send-queue credits against this value, so an
+    /// implementation that chunks more finely must report it here or it will
+    /// over-commit the send queue.
+    fn max_msg_size(&self) -> usize {
+        MAX_RDMA_MSG_SIZE
+    }
+
     /// Post an RDMA WRITE of `local_src` into `remote_dst`. The request may
     /// be chunked into multiple WRs. This method returns the list of WR ids
     /// that were posted.
@@ -326,7 +335,7 @@ pub(super) unsafe fn get_qp_info(
 /// # Safety
 ///
 /// `qp` must be a live `ibv_qp` (non-null).
-unsafe fn state(qp: *mut rdmaxcel_sys::ibv_qp) -> Result<u32, anyhow::Error> {
+pub(super) unsafe fn state(qp: *mut rdmaxcel_sys::ibv_qp) -> Result<u32, anyhow::Error> {
     let mut qp_attr = rdmaxcel_sys::ibv_qp_attr::default();
     let mut qp_init_attr = rdmaxcel_sys::ibv_qp_init_attr::default();
     let mask = rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_STATE;
@@ -448,6 +457,68 @@ pub(super) unsafe fn connect(
         ));
     }
     Ok(())
+}
+
+/// Polls `target`'s completion queue on `qp` for a single work completion,
+/// through the device context's `poll_cq` verb. Shared by every queue-pair
+/// implementation built on an [`IbvQp`]; see
+/// [`IbvQueuePair::poll_completion`] for the meaning of the return value.
+///
+/// # Safety
+///
+/// `qp` must hold a non-null, live `ibv_qp` whose send and receive completion
+/// queues and device context are likewise non-null and live: this invokes the
+/// `poll_cq` verb through them without re-checking. A placeholder [`IbvQp`]
+/// built from null handles does not qualify.
+pub(super) unsafe fn poll_one(
+    qp: &IbvQp,
+    target: PollTarget,
+) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
+    let (cq, cq_type) = match target {
+        PollTarget::Send => (qp.send_cq().as_ptr(), "send"),
+        PollTarget::Recv => (qp.recv_cq().as_ptr(), "recv"),
+    };
+    let context = qp.context().as_ptr();
+    // SAFETY: `context` is `qp`'s live device context (caller contract); we
+    // invoke its `poll_cq` verb through the ops table.
+    let poll_cq = unsafe {
+        (*context)
+            .ops
+            .poll_cq
+            .expect("poll_cq verb missing from ibv_context ops")
+    };
+    let mut wc = rdmaxcel_sys::ibv_wc::default();
+    // SAFETY: `cq` is a live `ibv_cq` belonging to `qp` (caller contract);
+    // `&mut wc` has room for the single entry requested, and `poll_cq`
+    // overwrites it whenever it returns a completion (`ret >= 1`).
+    let ret = unsafe { poll_cq(cq, 1, &mut wc) };
+
+    if ret < 0 {
+        return Err(PollCompletionError {
+            message: format!("{} CQ poll failed (ibv_poll_cq returned {})", cq_type, ret),
+        });
+    }
+    if ret == 0 {
+        return Ok(None);
+    }
+
+    // `ret >= 1`: a single entry was requested, so `wc` holds one completion.
+    // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
+    if let Some((status, vendor_err)) = wc.error() {
+        return Ok(Some(Err(WorkRequestError {
+            wr_id: wc.wr_id(),
+            status,
+            vendor_err,
+            message: format!(
+                "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
+                cq_type,
+                wc.wr_id(),
+                status,
+                vendor_err,
+            ),
+        })));
+    }
+    Ok(Some(Ok(IbvWc::from(wc))))
 }
 
 /// An RDMA reliable-connected (RC) queue pair built on plain ibverbs
@@ -722,51 +793,10 @@ impl IbvQueuePair for RCQueuePair {
         &mut self,
         target: PollTarget,
     ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        let (cq, cq_type) = match target {
-            PollTarget::Send => (self.qp.send_cq().as_ptr(), "send"),
-            PollTarget::Recv => (self.qp.recv_cq().as_ptr(), "recv"),
-        };
-        let context = self.qp.context().as_ptr();
-        // SAFETY: `context` is the QP's live device context (read from the live
-        // `qp`); we invoke its `poll_cq` verb through the ops table.
-        let poll_cq = unsafe {
-            (*context)
-                .ops
-                .poll_cq
-                .expect("poll_cq verb missing from ibv_context ops")
-        };
-        let mut wc = rdmaxcel_sys::ibv_wc::default();
-        // SAFETY: `cq` is a live `ibv_cq` belonging to this QP; `&mut wc` has
-        // room for the single entry requested, and `poll_cq` overwrites it
-        // whenever it returns a completion (`ret >= 1`).
-        let ret = unsafe { poll_cq(cq, 1, &mut wc) };
-
-        if ret < 0 {
-            return Err(PollCompletionError {
-                message: format!("{} CQ poll failed (ibv_poll_cq returned {})", cq_type, ret),
-            });
-        }
-        if ret == 0 {
-            return Ok(None);
-        }
-
-        // `ret >= 1`: a single entry was requested, so `wc` holds one completion.
-        // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
-        if let Some((status, vendor_err)) = wc.error() {
-            return Ok(Some(Err(WorkRequestError {
-                wr_id: wc.wr_id(),
-                status,
-                vendor_err,
-                message: format!(
-                    "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
-                    cq_type,
-                    wc.wr_id(),
-                    status,
-                    vendor_err,
-                ),
-            })));
-        }
-        Ok(Some(Ok(IbvWc::from(wc))))
+        // SAFETY: `self.qp` wraps a live, fully non-null `ibv_qp` — everything
+        // reached through it included — per `from_qp`'s contract, and it stays
+        // alive for `self`'s lifetime.
+        unsafe { poll_one(&self.qp, target) }
     }
 }
 
@@ -1001,10 +1031,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 
     /// Number of WRs the QP will issue for an op that targets
     /// `local_size` bytes. The QP splits large transfers into
-    /// `MAX_RDMA_MSG_SIZE`-bound chunks; a zero-byte op still
+    /// [`IbvQueuePair::max_msg_size`]-bound chunks; a zero-byte op still
     /// consumes one WR.
-    fn wr_count(local_size: usize) -> u32 {
-        local_size.div_ceil(MAX_RDMA_MSG_SIZE).max(1) as u32
+    fn wr_count(&self, local_size: usize) -> u32 {
+        local_size.div_ceil(self.qp.max_msg_size()).max(1) as u32
     }
 
     /// Try to post the head of `queue`.
@@ -1309,7 +1339,7 @@ impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps<M>> for QueuePairActor<M, 
         msg: ProcessOps<M>,
     ) -> Result<(), anyhow::Error> {
         for (op_idx, op, mrv) in msg.items.into_iter() {
-            let wrs = Self::wr_count(op.local_memory.size());
+            let wrs = self.wr_count(op.local_memory.size());
             let is_read = matches!(op.op_type, RdmaOpType::ReadIntoLocal);
             self.queue.push_back(PendingOp {
                 op_idx,

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -201,6 +201,15 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// Returns the current `ibv_qp_state` of the QP.
     fn state(&mut self) -> Result<u32, anyhow::Error>;
 
+    /// Largest transfer this QP issues as a single work request; [`Self::put`]
+    /// and [`Self::get`] split anything larger into that many WRs. The owning
+    /// [`QueuePairActor`] budgets send-queue credits against this value, so an
+    /// implementation that chunks more finely must report it here or it will
+    /// over-commit the send queue.
+    fn max_msg_size(&self) -> usize {
+        MAX_RDMA_MSG_SIZE
+    }
+
     /// Post an RDMA WRITE of `local_src` into `remote_dst`. The request may
     /// be chunked into multiple WRs. This method returns the list of WR ids
     /// that were posted.
@@ -325,7 +334,7 @@ pub(super) unsafe fn get_qp_info(
 /// # Safety
 ///
 /// `qp` must be a live `ibv_qp` (non-null).
-unsafe fn state(qp: *mut rdmaxcel_sys::ibv_qp) -> Result<u32, anyhow::Error> {
+pub(super) unsafe fn state(qp: *mut rdmaxcel_sys::ibv_qp) -> Result<u32, anyhow::Error> {
     let mut qp_attr = rdmaxcel_sys::ibv_qp_attr::default();
     let mut qp_init_attr = rdmaxcel_sys::ibv_qp_init_attr::default();
     let mask = rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_STATE;
@@ -447,6 +456,68 @@ pub(super) unsafe fn connect(
         ));
     }
     Ok(())
+}
+
+/// Polls `target`'s completion queue on `qp` for a single work completion,
+/// through the device context's `poll_cq` verb. Shared by every queue-pair
+/// implementation built on an [`IbvQp`]; see
+/// [`IbvQueuePair::poll_completion`] for the meaning of the return value.
+///
+/// # Safety
+///
+/// `qp` must hold a non-null, live `ibv_qp` whose send and receive completion
+/// queues and device context are likewise non-null and live: this invokes the
+/// `poll_cq` verb through them without re-checking. A placeholder [`IbvQp`]
+/// built from null handles does not qualify.
+pub(super) unsafe fn poll_one(
+    qp: &IbvQp,
+    target: PollTarget,
+) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
+    let (cq, cq_type) = match target {
+        PollTarget::Send => (qp.send_cq().as_ptr(), "send"),
+        PollTarget::Recv => (qp.recv_cq().as_ptr(), "recv"),
+    };
+    let context = qp.context().as_ptr();
+    // SAFETY: `context` is `qp`'s live device context (caller contract); we
+    // invoke its `poll_cq` verb through the ops table.
+    let poll_cq = unsafe {
+        (*context)
+            .ops
+            .poll_cq
+            .expect("poll_cq verb missing from ibv_context ops")
+    };
+    let mut wc = rdmaxcel_sys::ibv_wc::default();
+    // SAFETY: `cq` is a live `ibv_cq` belonging to `qp` (caller contract);
+    // `&mut wc` has room for the single entry requested, and `poll_cq`
+    // overwrites it whenever it returns a completion (`ret >= 1`).
+    let ret = unsafe { poll_cq(cq, 1, &mut wc) };
+
+    if ret < 0 {
+        return Err(PollCompletionError {
+            message: format!("{} CQ poll failed (ibv_poll_cq returned {})", cq_type, ret),
+        });
+    }
+    if ret == 0 {
+        return Ok(None);
+    }
+
+    // `ret >= 1`: a single entry was requested, so `wc` holds one completion.
+    // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
+    if let Some((status, vendor_err)) = wc.error() {
+        return Ok(Some(Err(WorkRequestError {
+            wr_id: wc.wr_id(),
+            status,
+            vendor_err,
+            message: format!(
+                "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
+                cq_type,
+                wc.wr_id(),
+                status,
+                vendor_err,
+            ),
+        })));
+    }
+    Ok(Some(Ok(IbvWc::from(wc))))
 }
 
 /// An RDMA reliable-connected (RC) queue pair built on plain ibverbs
@@ -721,51 +792,10 @@ impl IbvQueuePair for RCQueuePair {
         &mut self,
         target: PollTarget,
     ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        let (cq, cq_type) = match target {
-            PollTarget::Send => (self.qp.send_cq().as_ptr(), "send"),
-            PollTarget::Recv => (self.qp.recv_cq().as_ptr(), "recv"),
-        };
-        let context = self.qp.context().as_ptr();
-        // SAFETY: `context` is the QP's live device context (read from the live
-        // `qp`); we invoke its `poll_cq` verb through the ops table.
-        let poll_cq = unsafe {
-            (*context)
-                .ops
-                .poll_cq
-                .expect("poll_cq verb missing from ibv_context ops")
-        };
-        let mut wc = rdmaxcel_sys::ibv_wc::default();
-        // SAFETY: `cq` is a live `ibv_cq` belonging to this QP; `&mut wc` has
-        // room for the single entry requested, and `poll_cq` overwrites it
-        // whenever it returns a completion (`ret >= 1`).
-        let ret = unsafe { poll_cq(cq, 1, &mut wc) };
-
-        if ret < 0 {
-            return Err(PollCompletionError {
-                message: format!("{} CQ poll failed (ibv_poll_cq returned {})", cq_type, ret),
-            });
-        }
-        if ret == 0 {
-            return Ok(None);
-        }
-
-        // `ret >= 1`: a single entry was requested, so `wc` holds one completion.
-        // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
-        if let Some((status, vendor_err)) = wc.error() {
-            return Ok(Some(Err(WorkRequestError {
-                wr_id: wc.wr_id(),
-                status,
-                vendor_err,
-                message: format!(
-                    "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
-                    cq_type,
-                    wc.wr_id(),
-                    status,
-                    vendor_err,
-                ),
-            })));
-        }
-        Ok(Some(Ok(IbvWc::from(wc))))
+        // SAFETY: `self.qp` wraps a live, fully non-null `ibv_qp` — everything
+        // reached through it included — per `from_qp`'s contract, and it stays
+        // alive for `self`'s lifetime.
+        unsafe { poll_one(&self.qp, target) }
     }
 }
 
@@ -995,10 +1025,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 
     /// Number of WRs the QP will issue for an op that targets
     /// `local_size` bytes. The QP splits large transfers into
-    /// `MAX_RDMA_MSG_SIZE`-bound chunks; a zero-byte op still
+    /// [`IbvQueuePair::max_msg_size`]-bound chunks; a zero-byte op still
     /// consumes one WR.
-    fn wr_count(local_size: usize) -> u32 {
-        local_size.div_ceil(MAX_RDMA_MSG_SIZE).max(1) as u32
+    fn wr_count(&self, local_size: usize) -> u32 {
+        local_size.div_ceil(self.qp.max_msg_size()).max(1) as u32
     }
 
     /// Try to post the head of `queue`.
@@ -1302,7 +1332,7 @@ impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps<M>> for QueuePairActor<M, 
         msg: ProcessOps<M>,
     ) -> Result<(), anyhow::Error> {
         for (op_idx, op, mrv) in msg.items.into_iter() {
-            let wrs = Self::wr_count(op.local_memory.size());
+            let wrs = self.wr_count(op.local_memory.size());
             let is_read = matches!(op.op_type, RdmaOpType::ReadIntoLocal);
             self.queue.push_back(PendingOp {
                 op_idx,


### PR DESCRIPTION
Summary:

Groundwork for the EFA queue pair — what it needs from shared code but cannot
currently reach. Pure refactor.

Adds `IbvAh`, an RAII address-handle wrapper modeled on `IbvMr`, plus
`IbvQp::pd()`. Widens `state` to `pub(super)` and lifts
`RCQueuePair::poll_completion`'s body into a free `poll_one`; both are identical
for any queue pair built on an `IbvQp`.

Also adds `IbvQueuePair::max_msg_size()`, defaulted to `MAX_RDMA_MSG_SIZE`, and
routes `QueuePairActor::wr_count` through it. This closes a latent gap rather than
just enabling the next commit: credit gating predicted work-request counts from a
module constant regardless of what the queue pair actually chunks at, so an
implementation chunking more finely would over-commit the send queue and fail as
supervision teardown rather than backpressure. The default leaves every existing
implementation unchanged.

Differential Revision: D114949353


