### PR TITLE
Resolve CUDA ordinals from the CUDA driver (#4628)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4828,7 +4828,6 @@ dependencies = [
  "paste",
  "rand 0.10.2",
  "rdmaxcel-sys",
- "regex",
  "serde",
  "serde_multipart",
  "timed_test",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4823,7 +4823,6 @@ dependencies = [
  "paste",
  "rand 0.10.2",
  "rdmaxcel-sys",
- "regex",
  "serde",
  "serde_multipart",
  "timed_test",

--- a/monarch_rdma/Cargo.toml
+++ b/monarch_rdma/Cargo.toml
@@ -24,7 +24,6 @@ ndslice = { version = "0.0.0", path = "../ndslice" }
 paste = "1.0.14"
 rand = "0.10.2"
 rdmaxcel-sys = { path = "../rdmaxcel-sys" }
-regex = "1.13.1"
 serde = { version = "1.0.229", features = ["derive", "rc"] }
 serde_multipart = { version = "0.0.0", path = "../serde_multipart" }
 tokio = { version = "1.52.4", features = ["full", "test-util", "tracing"] }

--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -437,10 +437,11 @@ impl CudaAllocator {
 }
 
 /// Number of CUDA devices the driver can use, or 0 on failure. Initializes
-/// CUDA (loading the driver if needed) and queries the driver directly, so it
-/// honors `CUDA_VISIBLE_DEVICES` — unlike
-/// [`crate::backend::ibverbs::device_selection::cuda_device_count`], which
-/// counts the kernel-visible GPUs without initializing CUDA.
+/// CUDA, loading the driver if needed — unlike
+/// [`crate::device_selection::cuda_device_count`], which adopts an
+/// already-resident driver and errors when there is none. Tests that reach
+/// device selection call this first so that ranking against a CUDA ordinal has
+/// a driver to ask.
 #[cfg(test)]
 pub(crate) fn cuda_device_count() -> i32 {
     // SAFETY: FFI to the CUDA driver. rdmaxcel only adopts an already-loaded

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -24,7 +24,8 @@ use crate::device_selection::MemoryLocation;
 use crate::device_selection::PCIAddress;
 use crate::device_selection::PciPath;
 use crate::device_selection::cpu_path;
-use crate::device_selection::get_cuda_pci_address;
+use crate::device_selection::cuda_device_count;
+use crate::device_selection::cuda_pci_address;
 use crate::device_selection::pci_path;
 
 /// What an [`IbvConfig`](super::primitives::IbvConfig) targets: a memory
@@ -121,33 +122,60 @@ pub fn get_pci_address(device: &IbvDeviceInfo) -> Result<PCIAddress> {
 /// [`PciPath::is_better_than`] (most local, then highest port-capped
 /// bandwidth) and returning all that tie for best.
 ///
-/// NICs with no ACTIVE port are excluded, so this is empty on a host whose
-/// RDMA links are all down.
+/// A NIC that cannot be ranked -- no ACTIVE port, unresolvable PCI address -- is
+/// logged and skipped, so a host with no usable NIC yields an empty list rather
+/// than an error. Errors are reserved for a memory location that cannot be
+/// resolved at all, which no NIC could have compensated for.
 ///
-/// A NIC's path bandwidth is the lesser of its PCIe-chain bottleneck and
-/// its RDMA port speed. Results are cached per `(backend, location)` since
-/// the PCI/NUMA topology is fixed for the process lifetime.
+/// A NIC's path bandwidth is the lesser of its PCIe-chain bottleneck and its
+/// RDMA port speed. Results are cached per `(backend, location)`, empty ones
+/// included, since the PCI/NUMA topology is fixed for the process lifetime. A
+/// host whose links are all down at the first call therefore keeps an empty
+/// answer for the rest of the process.
 pub fn select_optimal_ibv_devices<I: IbvDeviceImpl>(
     location: MemoryLocation,
-) -> Vec<IbvDeviceInfo> {
+) -> Result<Vec<IbvDeviceInfo>> {
     static CACHE: LazyLock<DashMap<(&'static str, MemoryLocation), Vec<IbvDeviceInfo>>> =
         LazyLock::new(DashMap::new);
     let key = (I::typename(), location);
     if let Some(cached) = CACHE.get(&key) {
-        return cached.value().clone();
+        return Ok(cached.value().clone());
     }
-    let result = compute_optimal_ibv_devices::<I>(location);
+    let result = compute_optimal_ibv_devices::<I>(location)?;
     CACHE.insert(key, result.clone());
-    result
+    Ok(result)
 }
 
 /// Uncached core of [`select_optimal_ibv_devices`].
-fn compute_optimal_ibv_devices<I: IbvDeviceImpl>(location: MemoryLocation) -> Vec<IbvDeviceInfo> {
+fn compute_optimal_ibv_devices<I: IbvDeviceImpl>(
+    location: MemoryLocation,
+) -> Result<Vec<IbvDeviceInfo>> {
+    // Resolve the GPU side once, before ranking NICs. An unresolvable GPU
+    // location is a fact about the request, not a reason to skip each NIC in
+    // turn.
+    let gpus = match location {
+        MemoryLocation::Cpu(_) => Vec::new(),
+        MemoryLocation::Gpu(ordinal) => gpu_pci_addresses(ordinal).with_context(|| {
+            format!(
+                "cannot rank RDMA NICs for {location:?}; if the CUDA driver is not initialized \
+                 in this process, initialize it first -- allocate a tensor on the device, call \
+                 torch.cuda.init(), or use your method of choice."
+            )
+        })?,
+    };
+
     let mut best: Option<PciPath> = None;
     let mut devices: Vec<IbvDeviceInfo> = Vec::new();
     for nic in IbvDevice::<I>::list() {
-        let Some(path) = nic_path(&nic, location) else {
-            continue;
+        // A NIC that cannot be ranked is not a failure of the request; drop it
+        // and say why, rather than failing the whole ranking or skipping in
+        // silence.
+        let path = match nic_path(&nic, location, &gpus) {
+            Ok(path) => path,
+            Err(error) => {
+                tracing::warn!("excluding RDMA device {}: {error:#}", nic.name());
+                continue;
+            }
         };
         match best {
             Some(current) if current.is_better_than(&path) => continue,
@@ -157,35 +185,43 @@ fn compute_optimal_ibv_devices<I: IbvDeviceImpl>(location: MemoryLocation) -> Ve
         best = Some(path);
         devices.push(nic);
     }
-    devices
+    Ok(devices)
 }
 
-/// The best [`PciPath`] from `location` to `nic`, capped by the NIC's RDMA
-/// port speed. `None` when the NIC cannot carry traffic or the path can't be
-/// computed: the NIC has no ACTIVE port, or its PCI address or a required GPU
-/// address can't be resolved.
-fn nic_path(nic: &IbvDeviceInfo, location: MemoryLocation) -> Option<PciPath> {
+/// The PCI addresses a [`MemoryLocation::Gpu`] names: just the one for a specific
+/// ordinal, or every visible device in ordinal order when unspecified.
+fn gpu_pci_addresses(ordinal: Option<u32>) -> Result<Vec<PCIAddress>> {
+    match ordinal {
+        Some(ordinal) => Ok(vec![cuda_pci_address(ordinal)?]),
+        None => (0..cuda_device_count()? as u32)
+            .map(cuda_pci_address)
+            .collect(),
+    }
+}
+
+/// The best [`PciPath`] from `location` to `nic`, capped by the NIC's RDMA port
+/// speed. Errors when `nic` cannot be ranked, naming the reason so the caller
+/// can report which device it dropped and why.
+///
+/// `gpus` holds the already-resolved GPU addresses for a
+/// [`MemoryLocation::Gpu`] location, and is empty for a CPU location.
+fn nic_path(nic: &IbvDeviceInfo, location: MemoryLocation, gpus: &[PCIAddress]) -> Result<PciPath> {
     // A NIC with no ACTIVE port cannot carry traffic, so drop it from the
     // candidate set. Leaving it in with a zero bandwidth is not equivalent:
     // `is_better_than` compares `PathType` first, so a down NIC that happens to
     // be PCIe-closer would outrank a working but more distant one.
-    let port_speed_mbytes_per_sec = NonZeroU32::new(nic.port_speed_mbytes_per_sec())?;
-    let nic_addr = get_pci_address(nic).ok()?;
+    let port_speed_mbytes_per_sec =
+        NonZeroU32::new(nic.port_speed_mbytes_per_sec()).context("no ACTIVE port")?;
+    let nic_addr = get_pci_address(nic)?;
     let base = match location {
         MemoryLocation::Cpu(numa) => cpu_path(&nic_addr, numa),
-        MemoryLocation::Gpu(Some(ordinal)) => pci_path(&get_cuda_pci_address(ordinal)?, &nic_addr),
-        MemoryLocation::Gpu(None) => best_gpu_path(&nic_addr)?,
+        MemoryLocation::Gpu(_) => gpus
+            .iter()
+            .map(|gpu_addr| pci_path(gpu_addr, &nic_addr))
+            .reduce(|a, b| if b.is_better_than(&a) { b } else { a })
+            .context("no visible CUDA device to measure a path from")?,
     };
-    Some(cap_by_port_speed(base, port_speed_mbytes_per_sec))
-}
-
-/// The best path from any visible CUDA device to `nic_addr`, or `None` if
-/// no GPU's PCI address resolves.
-fn best_gpu_path(nic_addr: &PCIAddress) -> Option<PciPath> {
-    (0..cuda_device_count())
-        .filter_map(|ordinal| get_cuda_pci_address(ordinal as u32))
-        .map(|gpu_addr| pci_path(&gpu_addr, nic_addr))
-        .reduce(|a, b| if b.is_better_than(&a) { b } else { a })
+    Ok(cap_by_port_speed(base, port_speed_mbytes_per_sec))
 }
 
 /// Caps `path`'s bottleneck at the NIC's RDMA port speed, so a wide PCIe path
@@ -199,53 +235,37 @@ fn cap_by_port_speed(path: PciPath, port_speed_mbytes_per_sec: NonZeroU32) -> Pc
     }
 }
 
-/// Number of NVIDIA GPUs visible to the kernel driver, counted from the
-/// per-GPU directories under `/proc/driver/nvidia/gpus`. This reads kernel
-/// driver state, so unlike `cuDeviceGetCount` it needs no CUDA
-/// initialization; it returns 0 when the NVIDIA driver is absent (no GPU, or
-/// a non-NVIDIA platform).
-///
-/// TODO(slurye): Generalize this (and `get_cuda_pci_address`) to support AMD.
-pub(crate) fn cuda_device_count() -> i32 {
-    std::fs::read_dir("/proc/driver/nvidia/gpus")
-        .map(|entries| entries.flatten().count() as i32)
-        .unwrap_or(0)
-}
-
 /// Resolves an [`IbvDeviceTarget`] to a single NIC of backend `I`: the
 /// named device for [`IbvDeviceTarget::Nic`], or the best NIC for a memory
 /// location. Both arms are scoped to backend `I`, so a name belonging to a
-/// different backend resolves to `None`.
-pub fn resolve_target<I: IbvDeviceImpl>(target: &IbvDeviceTarget) -> Option<IbvDeviceInfo> {
+/// different backend resolves to `Ok(None)`.
+///
+/// `Ok(None)` means "no such device"; an error means the target could not be
+/// evaluated at all, which for a GPU location includes CUDA not being
+/// initialized in this process.
+pub fn resolve_target<I: IbvDeviceImpl>(target: &IbvDeviceTarget) -> Result<Option<IbvDeviceInfo>> {
     match target {
-        IbvDeviceTarget::Nic(name) => IbvDevice::<I>::list()
+        IbvDeviceTarget::Nic(name) => Ok(IbvDevice::<I>::list()
             .into_iter()
-            .find(|device| device.name() == name),
-        IbvDeviceTarget::MemoryLocation(location) => select_optimal_ibv_devices::<I>(*location)
-            .into_iter()
-            .next(),
+            .find(|device| device.name() == name)),
+        IbvDeviceTarget::MemoryLocation(location) => {
+            Ok(select_optimal_ibv_devices::<I>(*location)?
+                .into_iter()
+                .next())
+        }
     }
 }
 
-/// Process-wide CUDA ordinal → optimal NIC map, computed once per backend and
-/// cached. CPU-only workloads pay no initialization cost.
-pub fn get_cuda_device_to_ibv_device<I: IbvDeviceImpl>() -> &'static Vec<Option<IbvDeviceInfo>> {
-    // A function-local `static` in a generic fn is one cell shared across every
-    // `I`, so the cache must be keyed per backend; `I::typename()` selects it.
-    // Each backend's map is `Box::leak`ed once so the cache stores (and returns) a
-    // `&'static`.
-    static CACHE: LazyLock<DashMap<&'static str, &'static Vec<Option<IbvDeviceInfo>>>> =
-        LazyLock::new(DashMap::new);
-    *CACHE.entry(I::typename()).or_insert_with(|| {
-        let result: Vec<Option<IbvDeviceInfo>> = (0..cuda_device_count())
-            .map(|ordinal| {
-                select_optimal_ibv_devices::<I>(MemoryLocation::Gpu(Some(ordinal as u32)))
-                    .into_iter()
-                    .next()
-            })
-            .collect();
-        Box::leak(Box::new(result))
-    })
+/// The NICs of backend `I` for each CUDA runtime ordinal, indexed by ordinal.
+///
+/// Each entry holds every NIC tied for the best path to that ordinal, so it is
+/// empty when no NIC could be ranked against it. Errors only when the ordinals
+/// themselves cannot be enumerated, which in practice means the CUDA driver is
+/// not initialized in this process.
+pub fn get_cuda_device_to_ibv_devices<I: IbvDeviceImpl>() -> Result<Vec<Vec<IbvDeviceInfo>>> {
+    (0..cuda_device_count()?)
+        .map(|ordinal| select_optimal_ibv_devices::<I>(MemoryLocation::Gpu(Some(ordinal as u32))))
+        .collect()
 }
 
 #[cfg(test)]
@@ -322,9 +342,14 @@ mod tests {
             MemoryLocation::Gpu(None),
             MemoryLocation::Gpu(Some(0)),
         ] {
+            let error = format!(
+                "{:#}",
+                nic_path(&down, location, &[])
+                    .expect_err("a NIC with no ACTIVE port must not be a selection candidate")
+            );
             assert!(
-                nic_path(&down, location).is_none(),
-                "a NIC with no ACTIVE port must not be a selection candidate",
+                error.contains("no ACTIVE port"),
+                "the error should name the reason the NIC was excluded, got: {error}"
             );
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -9,6 +9,7 @@
 //! ibverbs-specific device selection: pairs a [`MemoryLocation`] with the
 //! RDMA NIC(s) that have the best PCIe path to it.
 
+use std::num::NonZeroU32;
 use std::str::FromStr;
 use std::sync::LazyLock;
 
@@ -120,6 +121,9 @@ pub fn get_pci_address(device: &IbvDeviceInfo) -> Result<PCIAddress> {
 /// [`PciPath::is_better_than`] (most local, then highest port-capped
 /// bandwidth) and returning all that tie for best.
 ///
+/// NICs with no ACTIVE port are excluded, so this is empty on a host whose
+/// RDMA links are all down.
+///
 /// A NIC's path bandwidth is the lesser of its PCIe-chain bottleneck and
 /// its RDMA port speed. Results are cached per `(backend, location)` since
 /// the PCI/NUMA topology is fixed for the process lifetime.
@@ -157,16 +161,22 @@ fn compute_optimal_ibv_devices<I: IbvDeviceImpl>(location: MemoryLocation) -> Ve
 }
 
 /// The best [`PciPath`] from `location` to `nic`, capped by the NIC's RDMA
-/// port speed. `None` when the path can't be computed — e.g. the NIC's PCI
-/// address or a required GPU address can't be resolved.
+/// port speed. `None` when the NIC cannot carry traffic or the path can't be
+/// computed: the NIC has no ACTIVE port, or its PCI address or a required GPU
+/// address can't be resolved.
 fn nic_path(nic: &IbvDeviceInfo, location: MemoryLocation) -> Option<PciPath> {
+    // A NIC with no ACTIVE port cannot carry traffic, so drop it from the
+    // candidate set. Leaving it in with a zero bandwidth is not equivalent:
+    // `is_better_than` compares `PathType` first, so a down NIC that happens to
+    // be PCIe-closer would outrank a working but more distant one.
+    let port_speed_mbytes_per_sec = NonZeroU32::new(nic.port_speed_mbytes_per_sec())?;
     let nic_addr = get_pci_address(nic).ok()?;
     let base = match location {
         MemoryLocation::Cpu(numa) => cpu_path(&nic_addr, numa),
         MemoryLocation::Gpu(Some(ordinal)) => pci_path(&get_cuda_pci_address(ordinal)?, &nic_addr),
         MemoryLocation::Gpu(None) => best_gpu_path(&nic_addr)?,
     };
-    Some(cap_by_port_speed(base, nic))
+    Some(cap_by_port_speed(base, port_speed_mbytes_per_sec))
 }
 
 /// The best path from any visible CUDA device to `nic_addr`, or `None` if
@@ -178,13 +188,13 @@ fn best_gpu_path(nic_addr: &PCIAddress) -> Option<PciPath> {
         .reduce(|a, b| if b.is_better_than(&a) { b } else { a })
 }
 
-/// Caps `path`'s bottleneck at the NIC's RDMA port speed. A NIC with no
-/// ACTIVE port reports a port speed of 0, dragging the path to the worst case.
-fn cap_by_port_speed(path: PciPath, nic: &IbvDeviceInfo) -> PciPath {
+/// Caps `path`'s bottleneck at the NIC's RDMA port speed, so a wide PCIe path
+/// to a slow NIC is not ranked as though the NIC could saturate it.
+fn cap_by_port_speed(path: PciPath, port_speed_mbytes_per_sec: NonZeroU32) -> PciPath {
     PciPath {
         bottleneck_mbytes_per_sec: path
             .bottleneck_mbytes_per_sec
-            .min(nic.port_speed_mbytes_per_sec()),
+            .min(port_speed_mbytes_per_sec.get()),
         ..path
     }
 }
@@ -296,6 +306,27 @@ mod tests {
             configured_ibverbs_target().expect("configured target should be valid"),
             Some(IbvDeviceTarget::nic("mlx5_1")),
         );
+    }
+
+    #[test]
+    fn nic_with_no_active_port_is_not_a_candidate() {
+        // `for_test_named` builds a device with no ports, so its port speed is 0.
+        // Such a NIC cannot carry traffic and must be rejected outright: capping
+        // it to zero bandwidth instead would leave it eligible, and
+        // `is_better_than` compares `PathType` before bandwidth.
+        let down = IbvDeviceInfo::for_test_named("mlx5_down");
+        assert_eq!(down.port_speed_mbytes_per_sec(), 0);
+        for location in [
+            MemoryLocation::Cpu(None),
+            MemoryLocation::Cpu(Some(0)),
+            MemoryLocation::Gpu(None),
+            MemoryLocation::Gpu(Some(0)),
+        ] {
+            assert!(
+                nic_path(&down, location).is_none(),
+                "a NIC with no ACTIVE port must not be a selection candidate",
+            );
+        }
     }
 
     #[test]

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -179,8 +179,7 @@ fn best_gpu_path(nic_addr: &PCIAddress) -> Option<PciPath> {
 }
 
 /// Caps `path`'s bottleneck at the NIC's RDMA port speed. A NIC with no
-/// ACTIVE port reports a port speed of 0 and is dragged to the worst
-/// case, like an unreadable PCIe link.
+/// ACTIVE port reports a port speed of 0, dragging the path to the worst case.
 fn cap_by_port_speed(path: PciPath, nic: &IbvDeviceInfo) -> PciPath {
     PciPath {
         bottleneck_mbytes_per_sec: path

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -512,9 +512,10 @@ pub(super) unsafe fn register_host_or_dmabuf_mr<I: IbvDomainImpl>(
 mod tests {
     use super::*;
     use crate::backend::cuda_test_utils::CudaAllocator;
+    use crate::backend::cuda_test_utils::cuda_device_count;
     use crate::backend::ibverbs::device::IbvDevice;
     use crate::backend::ibverbs::device::IbvDeviceImpl;
-    use crate::backend::ibverbs::device_selection::get_cuda_device_to_ibv_device;
+    use crate::backend::ibverbs::device_selection::get_cuda_device_to_ibv_devices;
     use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::mlx_domain::MlxDomain;
 
@@ -528,9 +529,20 @@ mod tests {
     /// open/creation failure panics. The returned domain owns its context, so it
     /// (and its PD) stays valid after the local [`IbvDevice`] drops.
     fn open_domain_for_cuda_device(device: i32) -> IbvDomain<MlxDomain> {
-        let nic = get_cuda_device_to_ibv_device::<MlxDevice>()
+        // Ranking NICs against a CUDA ordinal asks the driver for the GPU's PCI
+        // address, and `device_selection` deliberately never loads or initializes
+        // the driver itself. Do it here: nothing else in this module touches CUDA
+        // before this point, so the ranking below would otherwise fail with
+        // `CUDA_ERROR_NOT_INITIALIZED`.
+        assert!(
+            cuda_device_count() > device,
+            "CUDA device {device} is required by this test",
+        );
+        let ordinal_to_nics = get_cuda_device_to_ibv_devices::<MlxDevice>()
+            .expect("the CUDA driver is initialized above");
+        let nic = ordinal_to_nics
             .get(device as usize)
-            .and_then(|nic| nic.as_ref())
+            .and_then(|nics| nics.first())
             .expect("CUDA device should map to RDMA NIC")
             .name()
             .clone();

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -342,7 +342,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         //   2. otherwise the CUDA-co-located NIC for device memory;
         //   3. otherwise a host-memory NIC assigned by hashing (addr, size).
         let device_name = if let Some(target) = &self.config.target {
-            resolve_target::<I>(target)
+            resolve_target::<I>(target)?
                 .ok_or_else(|| anyhow::anyhow!("configured device target {:?} not found", target))?
                 .name()
                 .clone()
@@ -370,9 +370,10 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                     })?;
                 assert!(ordinal >= 0, "CUDA device ordinal must be non-negative");
                 Some(
-                    super::device_selection::get_cuda_device_to_ibv_device::<I>()
+                    super::device_selection::get_cuda_device_to_ibv_devices::<I>()?
                         .get(ordinal as usize)
-                        .and_then(|d| d.clone())
+                        .and_then(|nics| nics.first())
+                        .cloned()
                         .ok_or_else(|| {
                             anyhow::anyhow!(
                                 "no RDMA device found for CUDA device ordinal {}",
@@ -391,7 +392,7 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                     // across all NICs that tie for the best CPU path by hashing the
                     // region's (addr, size); the NICs share the load for host
                     // memory, increasing aggregate throughput.
-                    let devices = select_optimal_ibv_devices::<I>(MemoryLocation::Cpu(None));
+                    let devices = select_optimal_ibv_devices::<I>(MemoryLocation::Cpu(None))?;
                     match devices.len() {
                         0 => anyhow::bail!("no RDMA devices found"),
                         n => {

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -28,7 +28,7 @@ use std::sync::OnceLock;
 
 use anyhow::Context;
 
-use super::device_selection::get_cuda_device_to_ibv_device;
+use super::device_selection::get_cuda_device_to_ibv_devices;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::domain::register_dmabuf_range;
@@ -120,7 +120,7 @@ pub(super) trait MlxDomainOps: Send + Sync + 'static {
 
     /// CUDA ordinals whose optimal NIC is this domain's device; only segments
     /// on these ordinals are bound here.
-    fn assigned_cuda_devices(&self) -> Vec<i32>;
+    fn assigned_cuda_devices(&self) -> anyhow::Result<Vec<i32>>;
 
     /// Enumerate the currently-live CUDA segments.
     fn scan_segments(&self) -> Vec<ScannedSegment>;
@@ -212,16 +212,16 @@ impl MlxDomainOps for ProdMlxDomainOps {
         self.mlx5dv_enabled
     }
 
-    fn assigned_cuda_devices(&self) -> Vec<i32> {
-        get_cuda_device_to_ibv_device::<MlxDevice>()
-            .iter()
+    fn assigned_cuda_devices(&self) -> anyhow::Result<Vec<i32>> {
+        Ok(get_cuda_device_to_ibv_devices::<MlxDevice>()?
+            .into_iter()
             .enumerate()
-            .filter_map(|(ordinal, nic)| {
-                nic.as_ref()
-                    .filter(|n| n.name() == &self.device_name)
-                    .map(|_| ordinal as i32)
+            .filter_map(|(ordinal, nics)| {
+                nics.iter()
+                    .any(|nic| nic.name() == &self.device_name)
+                    .then_some(ordinal as i32)
             })
-            .collect()
+            .collect())
     }
 
     fn scan_segments(&self) -> Vec<ScannedSegment> {
@@ -648,9 +648,6 @@ pub struct MlxDomain {
     /// Config for the loopback binding QP.
     config: IbvConfig,
     mlx5dv_enabled: bool,
-    /// CUDA ordinals whose optimal NIC is this device. Only segments on
-    /// these ordinals are bound here.
-    cuda_ordinals: Vec<i32>,
     /// Caps the MRs bound to each segment's indirect key.
     mkey_max_entries: usize,
     /// Lazily-created loopback QP (an [`IbvQp`] owning its completion queues and
@@ -668,27 +665,23 @@ impl std::fmt::Debug for MlxDomain {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MlxDomain")
             .field("mlx5dv_enabled", &self.mlx5dv_enabled)
-            .field("cuda_ordinals", &self.cuda_ordinals)
             .finish_non_exhaustive()
     }
 }
 
 impl MlxDomain {
-    /// Build a domain over the given ops, deriving mlx5dv support and the
-    /// served CUDA ordinals from them. `mkey_max_entries` caps the MRs bound to
-    /// every segment's indirect key.
+    /// Build a domain over the given ops, deriving mlx5dv support from them.
+    /// `mkey_max_entries` caps the MRs bound to every segment's indirect key.
     fn new_with_ops(
         ops: Arc<dyn MlxDomainOps>,
         config: IbvConfig,
         mkey_max_entries: usize,
     ) -> Self {
         let mlx5dv_enabled = ops.mlx5dv_enabled();
-        let cuda_ordinals = ops.assigned_cuda_devices();
         Self {
             ops,
             config,
             mlx5dv_enabled,
-            cuda_ordinals,
             mkey_max_entries,
             loopback: OnceLock::new(),
             segments: Mutex::new(HashMap::new()),
@@ -738,12 +731,19 @@ impl MlxDomain {
             return Ok(RegisteredSegment::view(seg, addr, size));
         }
 
+        // Which ordinals this NIC serves, resolved now rather than at domain
+        // construction: the caller holds a CUDA address, so CUDA is initialized
+        // and the ordinal → NIC map is resolvable. If this were instead called
+        // only once at construction, if CUDA were not already initialized,
+        // this domain would permanently have an empty list of ordinals.
+        let cuda_ordinals = self.ops.assigned_cuda_devices()?;
+
         // Pull live segments and keep only the ones on ordinals we serve.
         let scanned: Vec<ScannedSegment> = self
             .ops
             .scan_segments()
             .into_iter()
-            .filter(|s| self.cuda_ordinals.contains(&s.cuda_ordinal))
+            .filter(|s| cuda_ordinals.contains(&s.cuda_ordinal))
             .collect();
 
         let qp = self.loopback_qp_ptr(domain)?;
@@ -789,7 +789,7 @@ impl MlxDomain {
                     "CUDA address 0x{:x} + size {} is not covered by any scanned segment on the CUDA ordinals {:?} mapped to this NIC",
                     addr,
                     size,
-                    self.cuda_ordinals,
+                    cuda_ordinals,
                 )
             })
     }
@@ -935,8 +935,8 @@ mod tests {
             self.lock().mlx5dv_enabled
         }
 
-        fn assigned_cuda_devices(&self) -> Vec<i32> {
-            self.lock().served_ordinals.clone()
+        fn assigned_cuda_devices(&self) -> anyhow::Result<Vec<i32>> {
+            Ok(self.lock().served_ordinals.clone())
         }
 
         fn scan_segments(&self) -> Vec<ScannedSegment> {
@@ -1344,11 +1344,35 @@ mod tests {
     // ----- MlxDomain integration tests -----
 
     #[test]
-    fn test_cuda_ordinals_and_mlx5dv_enabled_derived_from_ops() {
+    fn test_mlx5dv_enabled_derived_from_ops() {
         let mock = MockOps::new(SERVED_NIC, true, &[0, 2]);
         let domain = domain(mock);
-        assert_eq!(domain.domain_impl().cuda_ordinals, vec![0, 2]);
         assert!(domain.domain_impl().mlx5dv_enabled);
+    }
+
+    #[test]
+    fn test_served_ordinals_resolved_per_use_not_at_construction() {
+        // A domain is normally opened by a host registration, before CUDA is
+        // initialized and so before any ordinal resolves to a NIC. Capturing the
+        // served set at construction would exclude every CUDA segment for the
+        // domain's lifetime, so it must be re-read per registration.
+        let base = 0x10_0000_0000;
+        let mock = MockOps::new(SERVED_NIC, true, &[]);
+        let domain = domain(mock.clone());
+        mock.lock().scan = vec![seg(base, MIB2, 0)];
+
+        assert!(
+            register_cuda(&domain, base, 4096).is_err(),
+            "ordinal 0 is not served yet, so its segment must not bind"
+        );
+
+        // CUDA comes up; ordinal 0 now resolves to this NIC.
+        mock.lock().served_ordinals = vec![0];
+
+        let view = register_cuda(&domain, base, 4096)
+            .expect("the segment must bind once its ordinal becomes served");
+        assert_eq!(view.size, 4096);
+        assert_eq!(mock.lock().bind_calls.len(), 1, "one segment bound");
     }
 
     #[test]

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -513,8 +513,8 @@ impl IbvDeviceInfo {
     }
 
     /// Aggregate bandwidth (MB/s) of the device's fastest active port,
-    /// derived from its IB `active_speed` / `active_width`. 0 if no port
-    /// is active, which ranks the device at the worst case.
+    /// derived from its IB `active_speed` / `active_width`. 0 if no port is
+    /// active.
     pub fn port_speed_mbytes_per_sec(&self) -> u32 {
         self.ports
             .iter()

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -565,7 +565,15 @@ impl IbvDeviceInfo {
         reason = "generic over the backend impl, so it cannot be the parameterless Default::default"
     )]
     pub fn default<I: IbvDeviceImpl>() -> Self {
+        // A CPU location never consults the CUDA driver, so the error arm is
+        // unreachable here; it is surfaced rather than swallowed all the same.
         resolve_target::<I>(&IbvDeviceTarget::MemoryLocation(MemoryLocation::Cpu(None)))
+            .unwrap_or_else(|error| {
+                panic!(
+                    "resolving the default RDMA device for backend {}: {error:#}",
+                    I::backend_name()
+                )
+            })
             .unwrap_or_else(|| panic!("no RDMA device for backend {}", I::backend_name()))
     }
 

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1372,7 +1372,9 @@ mod tests {
             use_gpu_direct: false,
             ..Default::default()
         };
-        let device_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
+        let device_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0))
+            .expect("resolving cpu:0 should succeed")
+            .expect("cpu:0 should resolve to a NIC");
         let mut device = IbvDevice::<MlxDevice>::open(device_info.name(), config.clone())
             .expect("resolved device should open");
         let domain = device
@@ -1398,14 +1400,18 @@ mod tests {
             ..Default::default()
         };
 
-        let server_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
+        let server_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0))
+            .expect("resolving cpu:0 should succeed")
+            .expect("cpu:0 should resolve to a NIC");
         let mut server_device =
             IbvDevice::<MlxDevice>::open(server_info.name(), server_config.clone())
                 .expect("server device should open");
         let server_domain = server_device
             .get_or_create_domain("test")
             .expect("server domain creation should succeed");
-        let client_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
+        let client_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0))
+            .expect("resolving cpu:0 should succeed")
+            .expect("cpu:0 should resolve to a NIC");
         let mut client_device =
             IbvDevice::<MlxDevice>::open(client_info.name(), client_config.clone())
                 .expect("client device should open");

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -1363,7 +1363,9 @@ mod tests {
             use_gpu_direct: false,
             ..Default::default()
         };
-        let device_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
+        let device_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0))
+            .expect("resolving cpu:0 should succeed")
+            .expect("cpu:0 should resolve to a NIC");
         let mut device = IbvDevice::<MlxDevice>::open(device_info.name(), config.clone())
             .expect("resolved device should open");
         let domain = device
@@ -1389,14 +1391,18 @@ mod tests {
             ..Default::default()
         };
 
-        let server_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
+        let server_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0))
+            .expect("resolving cpu:0 should succeed")
+            .expect("cpu:0 should resolve to a NIC");
         let mut server_device =
             IbvDevice::<MlxDevice>::open(server_info.name(), server_config.clone())
                 .expect("server device should open");
         let server_domain = server_device
             .get_or_create_domain("test")
             .expect("server domain creation should succeed");
-        let client_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0)).unwrap();
+        let client_info = resolve_target::<MlxDevice>(&IbvDeviceTarget::cpu(0))
+            .expect("resolving cpu:0 should succeed")
+            .expect("cpu:0 should resolve to a NIC");
         let mut client_device =
             IbvDevice::<MlxDevice>::open(client_info.name(), client_config.clone())
                 .expect("client device should open");

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -19,36 +19,108 @@ use std::sync::LazyLock;
 use anyhow::Error;
 use anyhow::Result;
 use dashmap::DashSet;
-use regex::Regex;
+use rdmaxcel_sys::CUresult;
 
-/// PCI address of the CUDA device with ordinal `idx`, read from
-/// `/proc/driver/nvidia/gpus/*/information` (the NVIDIA driver keys each
-/// GPU's bus id there by its device minor, which equals the CUDA ordinal).
-pub fn get_cuda_pci_address(idx: u32) -> Option<PCIAddress> {
-    let gpu_proc_dir = "/proc/driver/nvidia/gpus";
-    if !Path::new(gpu_proc_dir).exists() {
-        return None;
+fn cuda_error_string(rc: CUresult) -> String {
+    // The lookup below goes through the same driver wrapper as every other call,
+    // so it cannot name the one code that means there is no driver to ask: it
+    // would fail the same way and leave `s` null.
+    if rc == rdmaxcel_sys::CUDA_ERROR_NOT_INITIALIZED {
+        return "CUDA_ERROR_NOT_INITIALIZED".to_owned();
     }
-
-    let minor_regex =
-        Regex::new(r"Device Minor:\s*(\d+)").expect("should compile: regex literal is valid");
-    for entry in fs::read_dir(gpu_proc_dir).ok()? {
-        let entry = entry.ok()?;
-        let info_file = entry.path().join("information");
-
-        if let Ok(content) = fs::read_to_string(&info_file)
-            && let Some(captures) = minor_regex.captures(&content)
-            && let Ok(device_minor) = captures
-                .get(1)
-                .expect("should be present: capture group 1 matched")
-                .as_str()
-                .parse::<u32>()
-            && device_minor == idx
-        {
-            return PCIAddress::parse(&entry.file_name().to_string_lossy().to_lowercase());
-        }
+    let mut s: *const std::os::raw::c_char = std::ptr::null();
+    // SAFETY: `&mut s` is a valid, properly aligned, writable pointer
+    // to a `const char*`, valid for the duration of the call.
+    unsafe { rdmaxcel_sys::rdmaxcel_cuGetErrorString(rc, &mut s) };
+    if s.is_null() {
+        format!("unknown error code ({rc})")
+    } else {
+        // SAFETY: `s` is non-null (checked above) and points to a
+        // null-terminated string with static lifetime, as guaranteed
+        // by `cuGetErrorString`.
+        unsafe { std::ffi::CStr::from_ptr(s) }
+            .to_string_lossy()
+            .into_owned()
     }
-    None
+}
+
+/// Number of CUDA devices visible to this process.
+///
+/// Never loads libcuda and never calls `cuInit`. The `rdmaxcel_cu*` wrappers
+/// adopt an already-resident driver via `dlopen(RTLD_NOLOAD)` and otherwise
+/// report `CUDA_ERROR_NOT_INITIALIZED`, so a process that has not touched CUDA
+/// pays only a failed symbol lookup and never gains a CUDA context -- and gets
+/// an error here.
+pub fn cuda_device_count() -> Result<i32> {
+    let mut count: i32 = 0;
+    // SAFETY: FFI writes one `i32` through the out-pointer and has no other
+    // effect; on a non-success status `count` is left unread.
+    let rc = unsafe { rdmaxcel_sys::rdmaxcel_cuDeviceGetCount(&mut count) };
+    anyhow::ensure!(
+        rc == rdmaxcel_sys::CUDA_SUCCESS,
+        "cuDeviceGetCount failed: {}",
+        cuda_error_string(rc),
+    );
+    Ok(count)
+}
+
+/// One `cuDeviceGetAttribute` query on `device`.
+fn cuda_device_attribute(attr: rdmaxcel_sys::CUdevice_attribute, device: i32) -> Result<i32> {
+    let mut value: i32 = 0;
+    // SAFETY: FFI writes one `i32` through the out-pointer and has no other effect.
+    let rc = unsafe { rdmaxcel_sys::rdmaxcel_cuDeviceGetAttribute(&mut value, attr, device) };
+    anyhow::ensure!(
+        rc == rdmaxcel_sys::CUDA_SUCCESS,
+        "cuDeviceGetAttribute({attr}) failed on CUDA device {device}: {}",
+        cuda_error_string(rc),
+    );
+    Ok(value)
+}
+
+/// PCI address of the CUDA device with runtime ordinal `ordinal`, from the CUDA
+/// driver.
+///
+/// `ordinal` is a *runtime* ordinal: the numbering CUDA exposes after applying
+/// `CUDA_VISIBLE_DEVICES`, as reported by `CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL`
+/// or `torch.cuda.current_device()`. Asking the driver rather than
+/// reconstructing that numbering from `/proc/driver/nvidia` keeps it correct for
+/// every `CUDA_VISIBLE_DEVICES` form (indices, `GPU-<uuid>`, `MIG-<uuid>`), for
+/// any `CUDA_DEVICE_ORDER`, and inside a container exposing a GPU subset.
+///
+/// Errors when the CUDA driver is not initialized in this process, or when
+/// `ordinal` is not visible.
+///
+/// Backend-agnostic: under ROCm rdmaxcel's wrappers resolve to `hipDeviceGet` /
+/// `hipGetDeviceCount` / `hipDeviceGetAttribute`, and `rocm_compat` aliases the
+/// `CU_DEVICE_ATTRIBUTE_PCI_*` constants to their HIP equivalents.
+/// TODO(slurye): validate that this actually works on ROCm.
+pub fn cuda_pci_address(ordinal: u32) -> Result<PCIAddress> {
+    let count = cuda_device_count()?;
+    anyhow::ensure!(
+        i64::from(ordinal) < i64::from(count),
+        "CUDA device {ordinal} is not visible to this process ({count} visible)"
+    );
+
+    let mut device: rdmaxcel_sys::CUdevice = 0;
+    // SAFETY: FFI writes one `CUdevice` through the out-pointer; `ordinal` is in
+    // range per the check above.
+    let rc = unsafe { rdmaxcel_sys::rdmaxcel_cuDeviceGet(&mut device, ordinal as i32) };
+    anyhow::ensure!(
+        rc == rdmaxcel_sys::CUDA_SUCCESS,
+        "cuDeviceGet failed for CUDA device {ordinal}: {}",
+        cuda_error_string(rc),
+    );
+
+    let domain = cuda_device_attribute(rdmaxcel_sys::CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID, device)?;
+    let bus = cuda_device_attribute(rdmaxcel_sys::CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, device)?;
+    let slot = cuda_device_attribute(rdmaxcel_sys::CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, device)?;
+    Ok(PCIAddress {
+        domain: u16::try_from(domain)?,
+        bus: u8::try_from(bus)?,
+        device: u8::try_from(slot)?,
+        // Assume GPUs are always PCI function 0
+        function: 0,
+    })
 }
 
 /// A PCI address, e.g. `0000:07:00.0`, as found under
@@ -415,6 +487,22 @@ mod tests {
         );
         assert_eq!(PCIAddress::parse("not-an-address"), None);
         assert_eq!(PCIAddress::parse("0000:07:00"), None);
+    }
+
+    #[test]
+    fn test_cuda_pci_address_rejects_an_absent_ordinal() {
+        // Deterministic whether or not another test in this binary has already
+        // initialized CUDA: ordinal 4096 is never visible, so this errors either
+        // way. What matters is that the message names the cause — an
+        // uninitialized driver is the one a caller can act on.
+        let error = format!(
+            "{:#}",
+            cuda_pci_address(4096).expect_err("ordinal 4096 must not resolve")
+        );
+        assert!(
+            error.contains("CUDA_ERROR_NOT_INITIALIZED") || error.contains("not visible"),
+            "the error should name its cause, got: {error}"
+        );
     }
 
     #[test]

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -19,36 +19,108 @@ use std::sync::LazyLock;
 use anyhow::Error;
 use anyhow::Result;
 use dashmap::DashSet;
-use regex::Regex;
+use rdmaxcel_sys::CUresult;
 
-/// PCI address of the CUDA device with ordinal `idx`, read from
-/// `/proc/driver/nvidia/gpus/*/information` (the NVIDIA driver keys each
-/// GPU's bus id there by its device minor, which equals the CUDA ordinal).
-pub fn get_cuda_pci_address(idx: u32) -> Option<PCIAddress> {
-    let gpu_proc_dir = "/proc/driver/nvidia/gpus";
-    if !Path::new(gpu_proc_dir).exists() {
-        return None;
+fn cuda_error_string(rc: CUresult) -> String {
+    // The lookup below goes through the same driver wrapper as every other call,
+    // so it cannot name the one code that means there is no driver to ask: it
+    // would fail the same way and leave `s` null.
+    if rc == rdmaxcel_sys::CUDA_ERROR_NOT_INITIALIZED {
+        return "CUDA_ERROR_NOT_INITIALIZED".to_owned();
     }
-
-    let minor_regex =
-        Regex::new(r"Device Minor:\s*(\d+)").expect("should compile: regex literal is valid");
-    for entry in fs::read_dir(gpu_proc_dir).ok()? {
-        let entry = entry.ok()?;
-        let info_file = entry.path().join("information");
-
-        if let Ok(content) = fs::read_to_string(&info_file)
-            && let Some(captures) = minor_regex.captures(&content)
-            && let Ok(device_minor) = captures
-                .get(1)
-                .expect("should be present: capture group 1 matched")
-                .as_str()
-                .parse::<u32>()
-            && device_minor == idx
-        {
-            return PCIAddress::parse(&entry.file_name().to_string_lossy().to_lowercase());
-        }
+    let mut s: *const std::os::raw::c_char = std::ptr::null();
+    // SAFETY: `&mut s` is a valid, properly aligned, writable pointer
+    // to a `const char*`, valid for the duration of the call.
+    unsafe { rdmaxcel_sys::rdmaxcel_cuGetErrorString(rc, &mut s) };
+    if s.is_null() {
+        format!("unknown error code ({rc})")
+    } else {
+        // SAFETY: `s` is non-null (checked above) and points to a
+        // null-terminated string with static lifetime, as guaranteed
+        // by `cuGetErrorString`.
+        unsafe { std::ffi::CStr::from_ptr(s) }
+            .to_string_lossy()
+            .into_owned()
     }
-    None
+}
+
+/// Number of CUDA devices visible to this process.
+///
+/// Never loads libcuda and never calls `cuInit`. The `rdmaxcel_cu*` wrappers
+/// adopt an already-resident driver via `dlopen(RTLD_NOLOAD)` and otherwise
+/// report `CUDA_ERROR_NOT_INITIALIZED`, so a process that has not touched CUDA
+/// pays only a failed symbol lookup and never gains a CUDA context -- and gets
+/// an error here.
+pub fn cuda_device_count() -> Result<i32> {
+    let mut count: i32 = 0;
+    // SAFETY: FFI writes one `i32` through the out-pointer and has no other
+    // effect; on a non-success status `count` is left unread.
+    let rc = unsafe { rdmaxcel_sys::rdmaxcel_cuDeviceGetCount(&mut count) };
+    anyhow::ensure!(
+        rc == rdmaxcel_sys::CUDA_SUCCESS,
+        "cuDeviceGetCount failed: {}",
+        cuda_error_string(rc),
+    );
+    Ok(count)
+}
+
+/// One `cuDeviceGetAttribute` query on `device`.
+fn cuda_device_attribute(attr: rdmaxcel_sys::CUdevice_attribute, device: i32) -> Result<i32> {
+    let mut value: i32 = 0;
+    // SAFETY: FFI writes one `i32` through the out-pointer and has no other effect.
+    let rc = unsafe { rdmaxcel_sys::rdmaxcel_cuDeviceGetAttribute(&mut value, attr, device) };
+    anyhow::ensure!(
+        rc == rdmaxcel_sys::CUDA_SUCCESS,
+        "cuDeviceGetAttribute({attr}) failed on CUDA device {device}: {}",
+        cuda_error_string(rc),
+    );
+    Ok(value)
+}
+
+/// PCI address of the CUDA device with runtime ordinal `ordinal`, from the CUDA
+/// driver.
+///
+/// `ordinal` is a *runtime* ordinal: the numbering CUDA exposes after applying
+/// `CUDA_VISIBLE_DEVICES`, as reported by `CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL`
+/// or `torch.cuda.current_device()`. Asking the driver rather than
+/// reconstructing that numbering from `/proc/driver/nvidia` keeps it correct for
+/// every `CUDA_VISIBLE_DEVICES` form (indices, `GPU-<uuid>`, `MIG-<uuid>`), for
+/// any `CUDA_DEVICE_ORDER`, and inside a container exposing a GPU subset.
+///
+/// Errors when the CUDA driver is not initialized in this process, or when
+/// `ordinal` is not visible.
+///
+/// Backend-agnostic: under ROCm rdmaxcel's wrappers resolve to `hipDeviceGet` /
+/// `hipGetDeviceCount` / `hipDeviceGetAttribute`, and `rocm_compat` aliases the
+/// `CU_DEVICE_ATTRIBUTE_PCI_*` constants to their HIP equivalents.
+/// TODO(slurye): validate that this actually works on ROCm.
+pub fn cuda_pci_address(ordinal: u32) -> Result<PCIAddress> {
+    let count = cuda_device_count()?;
+    anyhow::ensure!(
+        i64::from(ordinal) < i64::from(count),
+        "CUDA device {ordinal} is not visible to this process ({count} visible)"
+    );
+
+    let mut device: rdmaxcel_sys::CUdevice = 0;
+    // SAFETY: FFI writes one `CUdevice` through the out-pointer; `ordinal` is in
+    // range per the check above.
+    let rc = unsafe { rdmaxcel_sys::rdmaxcel_cuDeviceGet(&mut device, ordinal as i32) };
+    anyhow::ensure!(
+        rc == rdmaxcel_sys::CUDA_SUCCESS,
+        "cuDeviceGet failed for CUDA device {ordinal}: {}",
+        cuda_error_string(rc),
+    );
+
+    let domain = cuda_device_attribute(rdmaxcel_sys::CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID, device)?;
+    let bus = cuda_device_attribute(rdmaxcel_sys::CU_DEVICE_ATTRIBUTE_PCI_BUS_ID, device)?;
+    let slot = cuda_device_attribute(rdmaxcel_sys::CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID, device)?;
+    Ok(PCIAddress {
+        domain: u16::try_from(domain)?,
+        bus: u8::try_from(bus)?,
+        device: u8::try_from(slot)?,
+        // Assume GPUs are always PCI function 0
+        function: 0,
+    })
 }
 
 /// A PCI address, e.g. `0000:07:00.0`, as found under
@@ -420,6 +492,22 @@ mod tests {
         );
         assert_eq!(PCIAddress::parse("not-an-address"), None);
         assert_eq!(PCIAddress::parse("0000:07:00"), None);
+    }
+
+    #[test]
+    fn test_cuda_pci_address_rejects_an_absent_ordinal() {
+        // Deterministic whether or not another test in this binary has already
+        // initialized CUDA: ordinal 4096 is never visible, so this errors either
+        // way. What matters is that the message names the cause — an
+        // uninitialized driver is the one a caller can act on.
+        let error = format!(
+            "{:#}",
+            cuda_pci_address(4096).expect_err("ordinal 4096 must not resolve")
+        );
+        assert!(
+            error.contains("CUDA_ERROR_NOT_INITIALIZED") || error.contains("not visible"),
+            "the error should name its cause, got: {error}"
+        );
     }
 
     #[test]

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -14,7 +14,11 @@ use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
+use anyhow::Error;
+use anyhow::Result;
+use dashmap::DashSet;
 use regex::Regex;
 
 /// PCI address of the CUDA device with ordinal `idx`, read from
@@ -235,10 +239,10 @@ fn common_ancestor(a: &[PciHop], b: &[PciHop]) -> Option<(usize, usize)> {
     })
 }
 
-/// Minimum upstream link bandwidth (MB/s) across `hops`. A hop whose
-/// bandwidth couldn't be read is 0 and drags the whole range to 0, so a
-/// path with an unmeasurable link is treated as the worst case. 0 when
-/// `hops` is empty.
+/// Minimum upstream link bandwidth (MB/s) across `hops`. Per-hop bandwidths
+/// are never 0 — unreadable link attributes fall back to a default — so this
+/// is 0 only for an empty `hops`, meaning a device whose sysfs ancestor chain
+/// could not be resolved at all.
 fn min_link_mbytes_per_sec(hops: &[PciHop]) -> u32 {
     hops.iter()
         .map(|h| h.link_mbytes_per_sec)
@@ -286,9 +290,22 @@ fn numa_node(addr: &PCIAddress) -> Option<u32> {
     u32::try_from(raw.trim().parse::<i32>().ok()?).ok()
 }
 
+/// Per-lane PCIe rate (Mbit/s) assumed when `max_link_speed` is missing or
+/// unrecognized: Gen3, mirroring NCCL's `kvDictPciGen` fallback
+/// (graph/topo.cc).
+const DEFAULT_SPEED_MBITS_PER_LANE: u32 = 6000;
+
+/// Lane count assumed when `max_link_width` is missing or unparseable,
+/// mirroring NCCL's `if (width == 0) width = 16` (graph/topo.cc).
+const DEFAULT_LINK_WIDTH: u32 = 16;
+
 /// Bandwidth (MB/s) of the PCIe link immediately upstream of the device at
-/// `sysfs`, from its own `max_link_speed` / `max_link_width`. An unreadable
-/// value is 0, so the link is treated as the worst case.
+/// `sysfs`, from its own `max_link_speed` / `max_link_width`.
+///
+/// Missing or unparseable attributes fall back to Gen3 x16 rather than to 0.
+/// Link bandwidths are combined with `min` along a path, so a 0 here would
+/// erase every real measurement on that path and collapse unrelated
+/// candidates into a spurious tie.
 fn link_bandwidth_mbytes_per_sec(sysfs: &Path) -> u32 {
     let speed = read_speed_mbits_per_lane(sysfs);
     let width = read_link_width(sysfs);
@@ -298,37 +315,79 @@ fn link_bandwidth_mbytes_per_sec(sysfs: &Path) -> u32 {
     speed.saturating_mul(width) / 8
 }
 
-/// PCIe lane count from `<dir>/max_link_width`, or 0 if unreadable.
-fn read_link_width(dir: &Path) -> u32 {
-    fs::read_to_string(dir.join("max_link_width"))
-        .ok()
-        .and_then(|s| s.trim().parse().ok())
-        .unwrap_or(0)
+/// Report, at most once per `(attr, dir)`, that a PCIe link attribute could not
+/// be used, and why. Selection still works — the bandwidth falls back to Gen3
+/// x16 — but every ranking that traverses this link then rests on an assumed
+/// value, and nothing else makes that visible.
+fn warn_unusable_link_attr(attr: &str, dir: &Path, error: &str) {
+    static WARNED: LazyLock<DashSet<(String, String)>> = LazyLock::new(DashSet::new);
+    // `insert` is true only for the first caller to claim this key, and it takes
+    // the shard lock, so exactly one of them warns.
+    if WARNED.insert((attr.to_string(), dir.to_string_lossy().into_owned())) {
+        tracing::warn!(
+            "unusable PCIe {attr} at {}: {error}; assuming Gen3 x16, so RDMA device selection may rank NICs on an assumed bandwidth",
+            dir.display()
+        );
+    }
 }
 
-/// Per-lane PCIe rate (Mbit/s) from `<dir>/max_link_speed`, or 0 if unreadable.
+/// PCIe lane count from `<dir>/max_link_width`, or [`DEFAULT_LINK_WIDTH`] if
+/// the attribute is missing or does not parse as an integer.
+fn read_link_width(dir: &Path) -> u32 {
+    let parsed = fs::read_to_string(dir.join("max_link_width"))
+        .map_err(Error::from)
+        .and_then(|raw| raw.trim().parse::<u32>().map_err(Error::from));
+    match parsed {
+        Ok(width) => {
+            if width == 0 {
+                DEFAULT_LINK_WIDTH
+            } else {
+                width
+            }
+        }
+        Err(error) => {
+            warn_unusable_link_attr("max_link_width", dir, &format!("{error:#}"));
+            DEFAULT_LINK_WIDTH
+        }
+    }
+}
+
+/// Per-lane PCIe rate (Mbit/s) from `<dir>/max_link_speed`, or
+/// [`DEFAULT_SPEED_MBITS_PER_LANE`] if the attribute is missing or names no
+/// generation this knows.
 fn read_speed_mbits_per_lane(dir: &Path) -> u32 {
-    fs::read_to_string(dir.join("max_link_speed"))
-        .ok()
-        .map(|s| pcie_speed_mbits_per_lane(&s))
-        .unwrap_or(0)
+    let parsed = fs::read_to_string(dir.join("max_link_speed"))
+        .map_err(Error::from)
+        .and_then(|raw| pcie_speed_mbits_per_lane(&raw));
+    match parsed {
+        Ok(speed) => speed,
+        Err(error) => {
+            warn_unusable_link_attr("max_link_speed", dir, &format!("{error:#}"));
+            DEFAULT_SPEED_MBITS_PER_LANE
+        }
+    }
 }
 
 /// Per-lane PCIe bandwidth (Mbit/s) for a `max_link_speed` string such as
 /// `"16 GT/s PCIe"`, with line-encoding overhead folded in. `rate * lanes
-/// / 8` gives the link's MB/s. The values and the Gen3 fallback mirror
-/// NCCL's `kvDictPciGen` (graph/topo.cc).
-fn pcie_speed_mbits_per_lane(speed: &str) -> u32 {
+/// / 8` gives the link's MB/s. The values mirror NCCL's `kvDictPciGen`
+/// (graph/topo.cc).
+///
+/// Errors when the rate names no generation in the table, which is what a
+/// generation newer than this list looks like. The caller substitutes a default
+/// and warns; returning one from here would make that silent.
+fn pcie_speed_mbits_per_lane(speed: &str) -> Result<u32> {
     // Match the leading "<rate> GT/s" token; the kernel may append a
     // trailing "PCIe" and prints either "8" or "8.0" style rates.
-    match speed.split_whitespace().next().unwrap_or("") {
-        "2.5" => 1500,          // Gen1
-        "5" | "5.0" => 3000,    // Gen2
-        "8" | "8.0" => 6000,    // Gen3
-        "16" | "16.0" => 12000, // Gen4
-        "32" | "32.0" => 24000, // Gen5
-        "64" | "64.0" => 48000, // Gen6
-        _ => 6000,
+    let rate = speed.split_whitespace().next().unwrap_or("");
+    match rate {
+        "2.5" => Ok(1500),          // Gen1
+        "5" | "5.0" => Ok(3000),    // Gen2
+        "8" | "8.0" => Ok(6000),    // Gen3
+        "16" | "16.0" => Ok(12000), // Gen4
+        "32" | "32.0" => Ok(24000), // Gen5
+        "64" | "64.0" => Ok(48000), // Gen6
+        other => anyhow::bail!("unrecognized PCIe rate {other:?}"),
     }
 }
 
@@ -392,15 +451,40 @@ mod tests {
 
     #[test]
     fn test_pcie_speed_mbits_per_lane() {
-        assert_eq!(pcie_speed_mbits_per_lane("2.5 GT/s PCIe"), 1500);
-        assert_eq!(pcie_speed_mbits_per_lane("5 GT/s"), 3000);
-        assert_eq!(pcie_speed_mbits_per_lane("8.0 GT/s"), 6000);
-        assert_eq!(pcie_speed_mbits_per_lane("16 GT/s PCIe"), 12000);
-        assert_eq!(pcie_speed_mbits_per_lane("32 GT/s"), 24000);
-        assert_eq!(pcie_speed_mbits_per_lane("64 GT/s"), 48000);
-        // Unrecognized / empty defaults to Gen3.
-        assert_eq!(pcie_speed_mbits_per_lane("garbage"), 6000);
-        assert_eq!(pcie_speed_mbits_per_lane(""), 6000);
+        let rate = |s: &str| pcie_speed_mbits_per_lane(s).expect("known generation");
+        assert_eq!(rate("2.5 GT/s PCIe"), 1500);
+        assert_eq!(rate("5 GT/s"), 3000);
+        assert_eq!(rate("8.0 GT/s"), 6000);
+        assert_eq!(rate("16 GT/s PCIe"), 12000);
+        assert_eq!(rate("32 GT/s"), 24000);
+        assert_eq!(rate("64 GT/s"), 48000);
+        // An unrecognized rate errors so the caller warns, rather than
+        // substituting a default here where nothing would report it. "128 GT/s"
+        // stands in for a generation newer than the table.
+        for unknown in ["garbage", "", "128 GT/s"] {
+            assert!(
+                pcie_speed_mbits_per_lane(unknown).is_err(),
+                "{unknown:?} names no known PCIe generation"
+            );
+        }
+    }
+
+    #[test]
+    fn test_missing_link_attrs_fall_back_to_gen3_x16() {
+        // A path with no max_link_speed / max_link_width must not report a
+        // zero-bandwidth link: link bandwidths are combined with `min`, so a 0
+        // would erase every real measurement on the path.
+        let missing = Path::new("/nonexistent/pci/device");
+        assert_eq!(read_link_width(missing), DEFAULT_LINK_WIDTH);
+        assert_eq!(
+            read_speed_mbits_per_lane(missing),
+            DEFAULT_SPEED_MBITS_PER_LANE
+        );
+        assert_eq!(
+            link_bandwidth_mbytes_per_sec(missing),
+            12000,
+            "Gen3 (6000 Mbit/s per lane) x16 is 12000 MB/s"
+        );
     }
 
     fn hop(sysfs: &str, link_mbytes_per_sec: u32) -> PciHop {

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -14,7 +14,11 @@ use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::LazyLock;
 
+use anyhow::Error;
+use anyhow::Result;
+use dashmap::DashSet;
 use regex::Regex;
 
 /// PCI address of the CUDA device with ordinal `idx`, read from
@@ -235,10 +239,10 @@ fn common_ancestor(a: &[PciHop], b: &[PciHop]) -> Option<(usize, usize)> {
     })
 }
 
-/// Minimum upstream link bandwidth (MB/s) across `hops`. A hop whose
-/// bandwidth couldn't be read is 0 and drags the whole range to 0, so a
-/// path with an unmeasurable link is treated as the worst case. 0 when
-/// `hops` is empty.
+/// Minimum upstream link bandwidth (MB/s) across `hops`. Per-hop bandwidths
+/// are never 0 — unreadable link attributes fall back to a default — so this
+/// is 0 only for an empty `hops`, meaning a device whose sysfs ancestor chain
+/// could not be resolved at all.
 fn min_link_mbytes_per_sec(hops: &[PciHop]) -> u32 {
     hops.iter()
         .map(|h| h.link_mbytes_per_sec)
@@ -286,9 +290,22 @@ fn numa_node(addr: &PCIAddress) -> Option<u32> {
     u32::try_from(raw.trim().parse::<i32>().ok()?).ok()
 }
 
+/// Per-lane PCIe rate (Mbit/s) assumed when `max_link_speed` is missing or
+/// unrecognized: Gen3, mirroring NCCL's `kvDictPciGen` fallback
+/// (graph/topo.cc).
+const DEFAULT_SPEED_MBITS_PER_LANE: u32 = 6000;
+
+/// Lane count assumed when `max_link_width` is missing or unparseable,
+/// mirroring NCCL's `if (width == 0) width = 16` (graph/topo.cc).
+const DEFAULT_LINK_WIDTH: u32 = 16;
+
 /// Bandwidth (MB/s) of the PCIe link immediately upstream of the device at
-/// `sysfs`, from its own `max_link_speed` / `max_link_width`. An unreadable
-/// value is 0, so the link is treated as the worst case.
+/// `sysfs`, from its own `max_link_speed` / `max_link_width`.
+///
+/// Missing or unparseable attributes fall back to Gen3 x16 rather than to 0.
+/// Link bandwidths are combined with `min` along a path, so a 0 here would
+/// erase every real measurement on that path and collapse unrelated
+/// candidates into a spurious tie.
 fn link_bandwidth_mbytes_per_sec(sysfs: &Path) -> u32 {
     let speed = read_speed_mbits_per_lane(sysfs);
     let width = read_link_width(sysfs);
@@ -298,37 +315,84 @@ fn link_bandwidth_mbytes_per_sec(sysfs: &Path) -> u32 {
     speed.saturating_mul(width) / 8
 }
 
-/// PCIe lane count from `<dir>/max_link_width`, or 0 if unreadable.
-fn read_link_width(dir: &Path) -> u32 {
-    fs::read_to_string(dir.join("max_link_width"))
-        .ok()
-        .and_then(|s| s.trim().parse().ok())
-        .unwrap_or(0)
+/// Report, at most once per `(attr, dir)`, that a PCIe link attribute could not
+/// be used, and why. Selection still works — the bandwidth falls back to Gen3
+/// x16 — but every ranking that traverses this link then rests on an assumed
+/// value, and nothing else makes that visible.
+fn warn_unusable_link_attr(attr: &str, dir: &Path, error: &str) {
+    static WARNED: LazyLock<DashSet<(String, String)>> = LazyLock::new(DashSet::new);
+    // `insert` is true only for the first caller to claim this key, and it takes
+    // the shard lock, so exactly one of them warns.
+    if WARNED.insert((attr.to_string(), dir.to_string_lossy().into_owned())) {
+        tracing::warn!(
+            "unusable PCIe {attr} at {}: {error}; assuming Gen3 x16, so RDMA device selection may rank NICs on an assumed bandwidth",
+            dir.display()
+        );
+    }
 }
 
-/// Per-lane PCIe rate (Mbit/s) from `<dir>/max_link_speed`, or 0 if unreadable.
+/// PCIe lane count from `<dir>/max_link_width`, or [`DEFAULT_LINK_WIDTH`] if
+/// the attribute is missing or does not parse as an integer.
+fn read_link_width(dir: &Path) -> u32 {
+    let parsed = fs::read_to_string(dir.join("max_link_width"))
+        .map_err(Error::from)
+        .and_then(|raw| {
+            raw.trim()
+                .parse::<u32>()
+                .map_err(Error::from)
+                .and_then(|w| {
+                    if w == 0 {
+                        Err(anyhow::anyhow!("max_link_width must be > 0"))
+                    } else {
+                        Ok(w)
+                    }
+                })
+        });
+    match parsed {
+        Ok(width) => width,
+        Err(error) => {
+            warn_unusable_link_attr("max_link_width", dir, &format!("{error:#}"));
+            DEFAULT_LINK_WIDTH
+        }
+    }
+}
+
+/// Per-lane PCIe rate (Mbit/s) from `<dir>/max_link_speed`, or
+/// [`DEFAULT_SPEED_MBITS_PER_LANE`] if the attribute is missing or names no
+/// generation this knows.
 fn read_speed_mbits_per_lane(dir: &Path) -> u32 {
-    fs::read_to_string(dir.join("max_link_speed"))
-        .ok()
-        .map(|s| pcie_speed_mbits_per_lane(&s))
-        .unwrap_or(0)
+    let parsed = fs::read_to_string(dir.join("max_link_speed"))
+        .map_err(Error::from)
+        .and_then(|raw| pcie_speed_mbits_per_lane(&raw));
+    match parsed {
+        Ok(speed) => speed,
+        Err(error) => {
+            warn_unusable_link_attr("max_link_speed", dir, &format!("{error:#}"));
+            DEFAULT_SPEED_MBITS_PER_LANE
+        }
+    }
 }
 
 /// Per-lane PCIe bandwidth (Mbit/s) for a `max_link_speed` string such as
 /// `"16 GT/s PCIe"`, with line-encoding overhead folded in. `rate * lanes
-/// / 8` gives the link's MB/s. The values and the Gen3 fallback mirror
-/// NCCL's `kvDictPciGen` (graph/topo.cc).
-fn pcie_speed_mbits_per_lane(speed: &str) -> u32 {
+/// / 8` gives the link's MB/s. The values mirror NCCL's `kvDictPciGen`
+/// (graph/topo.cc).
+///
+/// Errors when the rate names no generation in the table, which is what a
+/// generation newer than this list looks like. The caller substitutes a default
+/// and warns; returning one from here would make that silent.
+fn pcie_speed_mbits_per_lane(speed: &str) -> Result<u32> {
     // Match the leading "<rate> GT/s" token; the kernel may append a
     // trailing "PCIe" and prints either "8" or "8.0" style rates.
-    match speed.split_whitespace().next().unwrap_or("") {
-        "2.5" => 1500,          // Gen1
-        "5" | "5.0" => 3000,    // Gen2
-        "8" | "8.0" => 6000,    // Gen3
-        "16" | "16.0" => 12000, // Gen4
-        "32" | "32.0" => 24000, // Gen5
-        "64" | "64.0" => 48000, // Gen6
-        _ => 6000,
+    let rate = speed.split_whitespace().next().unwrap_or("");
+    match rate {
+        "2.5" => Ok(1500),          // Gen1
+        "5" | "5.0" => Ok(3000),    // Gen2
+        "8" | "8.0" => Ok(6000),    // Gen3
+        "16" | "16.0" => Ok(12000), // Gen4
+        "32" | "32.0" => Ok(24000), // Gen5
+        "64" | "64.0" => Ok(48000), // Gen6
+        other => anyhow::bail!("unrecognized PCIe rate {other:?}"),
     }
 }
 
@@ -392,15 +456,40 @@ mod tests {
 
     #[test]
     fn test_pcie_speed_mbits_per_lane() {
-        assert_eq!(pcie_speed_mbits_per_lane("2.5 GT/s PCIe"), 1500);
-        assert_eq!(pcie_speed_mbits_per_lane("5 GT/s"), 3000);
-        assert_eq!(pcie_speed_mbits_per_lane("8.0 GT/s"), 6000);
-        assert_eq!(pcie_speed_mbits_per_lane("16 GT/s PCIe"), 12000);
-        assert_eq!(pcie_speed_mbits_per_lane("32 GT/s"), 24000);
-        assert_eq!(pcie_speed_mbits_per_lane("64 GT/s"), 48000);
-        // Unrecognized / empty defaults to Gen3.
-        assert_eq!(pcie_speed_mbits_per_lane("garbage"), 6000);
-        assert_eq!(pcie_speed_mbits_per_lane(""), 6000);
+        let rate = |s: &str| pcie_speed_mbits_per_lane(s).expect("known generation");
+        assert_eq!(rate("2.5 GT/s PCIe"), 1500);
+        assert_eq!(rate("5 GT/s"), 3000);
+        assert_eq!(rate("8.0 GT/s"), 6000);
+        assert_eq!(rate("16 GT/s PCIe"), 12000);
+        assert_eq!(rate("32 GT/s"), 24000);
+        assert_eq!(rate("64 GT/s"), 48000);
+        // An unrecognized rate errors so the caller warns, rather than
+        // substituting a default here where nothing would report it. "128 GT/s"
+        // stands in for a generation newer than the table.
+        for unknown in ["garbage", "", "128 GT/s"] {
+            assert!(
+                pcie_speed_mbits_per_lane(unknown).is_err(),
+                "{unknown:?} names no known PCIe generation"
+            );
+        }
+    }
+
+    #[test]
+    fn test_missing_link_attrs_fall_back_to_gen3_x16() {
+        // A path with no max_link_speed / max_link_width must not report a
+        // zero-bandwidth link: link bandwidths are combined with `min`, so a 0
+        // would erase every real measurement on the path.
+        let missing = Path::new("/nonexistent/pci/device");
+        assert_eq!(read_link_width(missing), DEFAULT_LINK_WIDTH);
+        assert_eq!(
+            read_speed_mbits_per_lane(missing),
+            DEFAULT_SPEED_MBITS_PER_LANE
+        );
+        assert_eq!(
+            link_bandwidth_mbytes_per_sec(missing),
+            12000,
+            "Gen3 (6000 Mbit/s per lane) x16 is 12000 MB/s"
+        );
     }
 
     fn hop(sysfs: &str, link_mbytes_per_sec: u32) -> PciHop {

--- a/monarch_rdma/tests/multi_pd_test.rs
+++ b/monarch_rdma/tests/multi_pd_test.rs
@@ -20,17 +20,18 @@ use monarch_rdma::backend::cuda_test_utils::ReceiverMessageClient;
 use monarch_rdma::backend::cuda_test_utils::SenderActor;
 use monarch_rdma::backend::cuda_test_utils::SenderMessageClient;
 use monarch_rdma::backend::ibverbs::device_selection::IbvDeviceTarget;
-use monarch_rdma::backend::ibverbs::device_selection::get_cuda_device_to_ibv_device;
+use monarch_rdma::backend::ibverbs::device_selection::get_cuda_device_to_ibv_devices;
 use monarch_rdma::backend::ibverbs::mlx_device::MlxDevice;
 use ndslice::ViewExt;
 
 /// Finds two CUDA devices that map to different RDMA NICs via PCI topology.
 /// Returns `Some((device_a, device_b))` or `None` if all devices share one NIC.
 fn find_devices_on_different_nics() -> Option<(i32, i32)> {
-    let gpu_to_nic: Vec<(i32, String)> = get_cuda_device_to_ibv_device::<MlxDevice>()
-        .iter()
+    let gpu_to_nic: Vec<(i32, String)> = get_cuda_device_to_ibv_devices::<MlxDevice>()
+        .expect("ranking NICs against the CUDA devices")
+        .into_iter()
         .enumerate()
-        .filter_map(|(idx, nic)| nic.as_ref().map(|d| (idx as i32, d.name().to_string())))
+        .filter_map(|(idx, nics)| nics.first().map(|d| (idx as i32, d.name().to_string())))
         .collect();
 
     for i in 0..gpu_to_nic.len() {

--- a/rdmaxcel-sys/src/lib.rs
+++ b/rdmaxcel-sys/src/lib.rs
@@ -47,7 +47,9 @@ mod inner {
         pub type CUmemAccessDesc = hipMemAccessDesc;
 
         // Error codes
+        pub type CUresult = hipError_t;
         pub const CUDA_SUCCESS: hipError_t = hipSuccess;
+        pub const CUDA_ERROR_NOT_INITIALIZED: hipError_t = hipErrorNotInitialized;
 
         // Pointer attributes
         pub const CU_POINTER_ATTRIBUTE_MEMORY_TYPE: hipPointer_attribute =
@@ -56,6 +58,14 @@ mod inner {
             HIP_POINTER_ATTRIBUTE_DEVICE_ORDINAL;
         pub const CU_POINTER_ATTRIBUTE_CONTEXT: hipPointer_attribute =
             HIP_POINTER_ATTRIBUTE_CONTEXT;
+
+        // Device attributes
+        pub type CUdevice_attribute = hipDeviceAttribute_t;
+        pub const CU_DEVICE_ATTRIBUTE_PCI_BUS_ID: hipDeviceAttribute_t = hipDeviceAttributePciBusId;
+        pub const CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID: hipDeviceAttribute_t =
+            hipDeviceAttributePciDeviceId;
+        pub const CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID: hipDeviceAttribute_t =
+            hipDeviceAttributePciDomainId;
 
         // Memory types
         pub const CU_MEMORYTYPE_DEVICE: u32 = 2; // hipMemoryTypeDevice = 2


### PR DESCRIPTION
Summary:

`get_cuda_pci_address(idx)` found the GPU whose
`/proc/driver/nvidia/gpus/*/information` reports `Device Minor: <idx>`, and its
doc asserted that the device minor "equals the CUDA ordinal". That does not hold
when `CUDA_VISIBLE_DEVICES` is set, which both selects and reorders devices.

The failure is silent and the common case is bad. A host running one process per
GPU with `CUDA_VISIBLE_DEVICES=<rank>` gives every process a single visible GPU
at ordinal 0, so every process resolved ordinal 0 to the GPU at minor 0 and all
but one picked a NIC chosen for the wrong GPU. `cuda_device_count` had the
matching problem: it counted every directory under `/proc/driver/nvidia/gpus`, so
a process restricted to one GPU still reported eight, and
`get_cuda_device_to_ibv_device` built a table whose later entries described GPUs
the process cannot address.

Ask the CUDA driver instead: `cuDeviceGet(ordinal)` then `cuDeviceGetAttribute`
for `PCI_DOMAIN_ID` / `PCI_BUS_ID` / `PCI_DEVICE_ID`. That is correct by
construction for every `CUDA_VISIBLE_DEVICES` form (indices, `GPU-<uuid>`,
`MIG-<uuid>`), for any `CUDA_DEVICE_ORDER`, and inside a container exposing only
a subset of GPUs. Reconstructing the mapping from `/proc` instead would have to
assume device-minor order matches CUDA's enumeration order, which is an invalid assumption.

It never calls `cuInit`, so a process that has not touched
CUDA pays only a failed symbol lookup and never gains a CUDA context.

"CUDA is not initialized yet" is now a state worth handling, so selection
separates a request it cannot resolve (fatal) from a NIC it cannot rank (logged
and skipped, where it used to be a silent `continue`). Two places also stopped
freezing an early answer for the whole process: the ordinal-to-NIC map lost its
own cache, and `MlxDomain` no longer captures its served ordinals when the domain
opens -- usually a host registration, which says nothing about CUDA being up.

One deliberate tradeoff: empty results are cached like any other, so a host whose
links are all down at the first call keeps an empty answer for the process.

Drops `regex`, used only to parse `Device Minor:`. The `rocm_compat` aliases this
needs are added but unexercised -- nothing that builds from a CUDA host compiles
them.

Reviewed By: zdevito

Differential Revision: D115129407


