### PR TITLE
classify unknown NUMA affinity as Sys, not Dis (#4631)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,7 +3546,7 @@ name = "hyperactor_config_macros"
 version = "0.0.0"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3562,7 +3562,7 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.119",
+ "syn 3.0.3",
  "timed_test",
  "tokio",
  "tracing",
@@ -4865,7 +4865,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7396,7 +7396,7 @@ version = "0.0.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7776,7 +7776,7 @@ name = "timed_test"
 version = "0.0.0"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
  "tokio",
 ]
 
@@ -8259,7 +8259,7 @@ name = "typeuri_macros"
 version = "0.0.0"
 dependencies = [
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -147,8 +147,9 @@ impl PciPath {
 /// Walks each endpoint's sysfs ancestor chain toward the root complex,
 /// finds their lowest common ancestor, and takes the minimum link
 /// bandwidth along the way. When the endpoints share no PCIe ancestor the
-/// path runs through the CPU: same NUMA node → [`PathType::Phb`],
-/// different nodes → [`PathType::Sys`], unknown → [`PathType::Dis`].
+/// path runs through the CPU: [`PathType::Phb`] when both sit on the same
+/// NUMA node, [`PathType::Sys`] otherwise — including when either
+/// endpoint's affinity is unknown.
 pub fn pci_path(a: &PCIAddress, b: &PCIAddress) -> PciPath {
     classify(
         &ancestor_chain(a),
@@ -210,12 +211,13 @@ fn classify(a: &[PciHop], numa_a: Option<u32>, b: &[PciHop], numa_b: Option<u32>
             bottleneck_mbytes_per_sec,
         };
     }
-    // No shared PCIe ancestor: the path runs through the CPU.
+    // No shared PCIe ancestor: the path runs through the CPU. An unknown
+    // NUMA node cannot be proven same-node, so it takes the worst reachable
+    // class instead of being reported as unreachable.
     let bottleneck_mbytes_per_sec = min_link_mbytes_per_sec(a).min(min_link_mbytes_per_sec(b));
     let path_type = match (numa_a, numa_b) {
         (Some(x), Some(y)) if x == y => PathType::Phb,
-        (Some(_), Some(_)) => PathType::Sys,
-        _ => PathType::Dis,
+        _ => PathType::Sys,
     };
     PciPath {
         path_type,
@@ -469,7 +471,17 @@ mod tests {
         assert_eq!(phb.bottleneck_mbytes_per_sec, 4000);
         // Different NUMA nodes → SYS.
         assert_eq!(classify(&a, Some(0), &b, Some(1)).path_type, PathType::Sys);
-        // Unknown NUMA node → DIS.
-        assert_eq!(classify(&a, None, &b, Some(0)).path_type, PathType::Dis);
+    }
+
+    #[test]
+    fn test_classify_unknown_numa_is_reachable() {
+        // An unknown NUMA node can't be proven same-node, so the path is SYS
+        // (the worst reachable class) rather than DIS. Reporting DIS would
+        // drop the device from selection entirely.
+        let a = vec![hop("/d/a", 4000), hop("/d/root_a", 16000)];
+        let b = vec![hop("/d/b", 8000), hop("/d/root_b", 16000)];
+        assert_eq!(classify(&a, None, &b, Some(0)).path_type, PathType::Sys);
+        assert_eq!(classify(&a, Some(0), &b, None).path_type, PathType::Sys);
+        assert_eq!(classify(&a, None, &b, None).path_type, PathType::Sys);
     }
 }

--- a/python/monarch/_src/rdma/rdma.py
+++ b/python/monarch/_src/rdma/rdma.py
@@ -375,17 +375,15 @@ class RDMABuffer:
     ) -> None:
         """
         RDMABuffer supports 1d contiguous tensors (including tensor views/slices) or 1d c-contiguous memoryviews.
+        Both CPU and GPU memory are supported.
 
         Args:
             data: torch.Tensor or memoryview to create the buffer from. Must be 1d and contiguous.
                   If provided, addr and size must not be specified.
 
         Raises:
-            ValueError: If data is not 1d contiguous, if size is 0, or if data is a GPU tensor.
+            ValueError: If data is not 1d contiguous, or if its size is 0.
             RuntimeError: If no RDMA backend is available on this platform.
-
-        Note:
-            Currently only CPU tensors are supported. GPU tensor support will be added in the future.
 
         TODO: Create TensorBuffer, which will be main user API supporting non-contiguous tensors
         """


### PR DESCRIPTION
Summary:

When two PCI addresses do not share a common PCI ancestor and at least one of their numa nodes is unknown, classify the path between them as `Sys` rather than `Dis`.

Differential Revision: D115129408


