### PR TITLE
Keep telemetry retention off query paths (#4634)

### DIFF
--- a/docs/source/distributed-telemetry.md
+++ b/docs/source/distributed-telemetry.md
@@ -159,9 +159,9 @@ trace rows. A recent trace row is not displayed by span-joined views if its span
 has already expired. The default is 3600 seconds. Set it to `0` to disable
 automatic retention. Periodic maintenance runs approximately once per tenth of
 the retention window, bounded between 30 seconds and 5 minutes and never longer
-than the retention window. Query operations can run retention between periodic
-sweeps. Expired rows can remain visible until the next sweep. Other core tables
-have no automatic retention window.
+than the retention window. Queries do not run retention, so expired rows can
+remain visible until the next periodic sweep. Other core tables have no
+automatic retention window.
 
 `TelemetryConfig.snapshot_interval_secs` controls periodic Mesh Admin topology
 snapshots. The default is 30 seconds; set it to `0` to disable them. Snapshots

--- a/docs/source/distributed-telemetry.md
+++ b/docs/source/distributed-telemetry.md
@@ -157,9 +157,11 @@ continue operating.
 filtered independently by row timestamp, with spans filtered before dependent
 trace rows. A recent trace row is not displayed by span-joined views if its span
 has already expired. The default is 3600 seconds. Set it to `0` to disable
-automatic retention. Retention runs every 30 seconds, so expired rows can remain
-visible until the next sweep. Other core tables have no automatic retention
-window.
+automatic retention. Periodic maintenance runs approximately once per tenth of
+the retention window, bounded between 30 seconds and 5 minutes and never longer
+than the retention window. Query operations can run retention between periodic
+sweeps. Expired rows can remain visible until the next sweep. Other core tables
+have no automatic retention window.
 
 `TelemetryConfig.snapshot_interval_secs` controls periodic Mesh Admin topology
 snapshots. The default is 30 seconds; set it to `0` to disable them. Snapshots

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -570,7 +570,6 @@ impl DatabaseScanner {
 
     /// Get list of table names.
     fn table_names(&self) -> PyResult<Vec<String>> {
-        self.apply_retention_policies()?;
         let guard = self
             .table_data
             .lock()
@@ -580,7 +579,6 @@ impl DatabaseScanner {
 
     /// Get schema for a table in Arrow IPC format.
     fn schema_for<'py>(&self, py: Python<'py>, table: &str) -> PyResult<Bound<'py, PyBytes>> {
-        self.apply_retention_policies()?;
         let guard = self
             .table_data
             .lock()
@@ -636,8 +634,6 @@ impl DatabaseScanner {
         limit: Option<usize>,
         filter_expr: Option<String>,
     ) -> PyResult<usize> {
-        self.apply_retention_policies()?;
-
         // Get actor instance from context and extract the Rust Instance once
         let actor_module = py.import("monarch.actor")?;
         let ctx = actor_module.call_method0("context")?;
@@ -1005,34 +1001,6 @@ impl DatabaseScanner {
             local_buf.drain_to_record_batch()?,
         )?;
         Ok(())
-    }
-
-    /// Apply retention policies for all configured tables.
-    /// Skipped when retention_us is 0 (unlimited).
-    fn apply_retention_policies(&self) -> PyResult<()> {
-        if self.retention_us == 0 {
-            return Ok(());
-        }
-
-        let now_us = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .expect("system clock before unix epoch")
-            .as_micros() as i64;
-        let where_clause = Self::retention_where_clause(self.retention_us, now_us);
-        let result = if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            tokio::task::block_in_place(|| {
-                handle.block_on(Self::apply_retention_policies_to_tables(
-                    &self.table_data,
-                    &where_clause,
-                ))
-            })
-        } else {
-            get_tokio_runtime().block_on(Self::apply_retention_policies_to_tables(
-                &self.table_data,
-                &where_clause,
-            ))
-        };
-        result.map_err(|e| PyException::new_err(e.to_string()))
     }
 
     /// Return an opaque [`TableStore`] handle for external callers.

--- a/monarch_distributed_telemetry/src/database_scanner.rs
+++ b/monarch_distributed_telemetry/src/database_scanner.rs
@@ -341,8 +341,17 @@ const RETENTION_TABLES: &[&str] = &[
     METRIC_HISTOGRAMS,
 ];
 
-/// Interval between routine retention sweeps.
-const RETENTION_INTERVAL: Duration = Duration::from_secs(30);
+/// Bounds for routine retention sweeps.
+const MIN_RETENTION_INTERVAL: Duration = Duration::from_secs(30);
+const MAX_RETENTION_INTERVAL: Duration = Duration::from_secs(5 * 60);
+const RETENTION_INTERVAL_DIVISOR: i64 = 10;
+
+fn retention_interval_us(retention_us: i64) -> i64 {
+    let min_interval_us = MIN_RETENTION_INTERVAL.as_micros() as i64;
+    let max_interval_us = MAX_RETENTION_INTERVAL.as_micros() as i64;
+    let proportional_interval_us = retention_us / RETENTION_INTERVAL_DIVISOR;
+    retention_us.min(proportional_interval_us.clamp(min_interval_us, max_interval_us))
+}
 
 /// Target rows per batch streamed back to the query root.
 ///
@@ -725,9 +734,10 @@ impl DatabaseScanner {
         table_data: Arc<StdMutex<HashMap<String, Arc<LiveTableData>>>>,
         retention_us: i64,
     ) -> AbortHandle {
+        let interval = Duration::from_micros(retention_interval_us(retention_us) as u64);
         let handle = get_tokio_runtime().spawn(async move {
             loop {
-                tokio::time::sleep(RETENTION_INTERVAL).await;
+                tokio::time::sleep(interval).await;
                 let now_us = SystemTime::now()
                     .duration_since(UNIX_EPOCH)
                     .expect("system clock before unix epoch")
@@ -1798,6 +1808,15 @@ mod tests {
             &[SPANS, SPAN_EVENTS, EVENTS],
             "span definitions must be filtered before dependent trace rows"
         );
+    }
+
+    #[test]
+    fn test_retention_interval_scales_with_window() {
+        assert_eq!(retention_interval_us(0), 0);
+        assert_eq!(retention_interval_us(10_000_000), 10_000_000);
+        assert_eq!(retention_interval_us(5 * 60_000_000), 30_000_000);
+        assert_eq!(retention_interval_us(10 * 60_000_000), 60_000_000);
+        assert_eq!(retention_interval_us(60 * 60_000_000), 300_000_000);
     }
 
     #[test]


### PR DESCRIPTION
Summary:

- Rely on the collector-owned periodic task not on query time
- Remove automatic retention from `scan()`, `table_names()`, and `schema_for()` so queries never synchronously rewrite retained tables.
- Keep the explicit per-table `apply_retention()` API for caller-directed maintenance.

Benchmark results from three optimized self-message runs:

| Metric | Baseline | Periodic-only | Change |
| --- | ---: | ---: | ---: |
| Median query completion | 1,032.754 ms | 47.724 ms | -95.4% |
| Median throughput | 30,070.846 msg/s | 30,059.643 msg/s | -0.04% |
| Rows after catch-up | 164,000 | 164,000 | No loss |

Reviewed By: johnwhumphreys

Differential Revision: D115136433


