### PR TITLE
Make the multihost RDMA benchmark runnable on SLURM (#4641)

### DIFF
--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -19,6 +19,7 @@ pub mod device_selection;
 pub(crate) mod domain;
 pub mod efa_device;
 pub mod efa_domain;
+pub mod efa_queue_pair;
 pub mod manager_actor;
 pub mod memory_region;
 pub mod mlx_device;

--- a/monarch_rdma/src/backend/ibverbs/efa_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_domain.rs
@@ -8,12 +8,11 @@
 
 //! EFA domain strategy for [`IbvDomainImpl`].
 
-use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
+use super::efa_queue_pair::EfaQueuePair;
 use super::primitives::IbvConfig;
 use super::primitives::IbvContext;
 use super::primitives::IbvDeviceInfo;
-use super::queue_pair::legacy::IbvQueuePair;
 
 /// EFA [`IbvDomainImpl`]. Uses the default host/dmabuf MR registration;
 /// EFA has no device-specific memory-key binding to add.
@@ -21,7 +20,7 @@ use super::queue_pair::legacy::IbvQueuePair;
 pub struct EfaDomain;
 
 impl IbvDomainImpl for EfaDomain {
-    type QueuePair = IbvQueuePair;
+    type QueuePair = EfaQueuePair;
 
     unsafe fn new(
         _context: &IbvContext,
@@ -38,13 +37,35 @@ impl IbvDomainImpl for EfaDomain {
             | rdmaxcel_sys::ibv_access_flags::IBV_ACCESS_REMOTE_READ)
             .0 as i32
     }
+}
 
-    fn create_queue_pair(
-        domain: &IbvDomain<Self>,
-        config: &IbvConfig,
-    ) -> anyhow::Result<Self::QueuePair> {
-        // EFA builds the legacy single-type queue pair for now; it will
-        // become an EFA-specific queue pair.
-        IbvQueuePair::new(domain, config.clone())
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::backend::ibverbs::domain::IbvDomain;
+    use crate::backend::ibverbs::primitives::IbvPd;
+
+    // A domain with no protection domain cannot build a queue pair, and says so
+    // rather than reaching the driver with a null handle.
+    #[test]
+    fn create_queue_pair_rejects_null_pd() {
+        // SAFETY: `IbvPd::null()` holds a null PD (and, through it, a null
+        // context) whose `Drop`s are no-ops.
+        let domain = unsafe {
+            IbvDomain::for_test(
+                Arc::new(IbvPd::null()),
+                IbvDeviceInfo::for_test_named("efa0"),
+                EfaDomain,
+            )
+        };
+        let err = domain
+            .create_queue_pair(&IbvConfig::default())
+            .expect_err("a null protection domain cannot back a queue pair");
+        assert!(
+            err.to_string().contains("null protection domain"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/efa_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_queue_pair.rs
@@ -1,0 +1,774 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+//! EFA SRD queue pair built on the efadv and extended-verbs work-request
+//! builder.
+
+use std::io::Error;
+use std::result::Result;
+
+use super::IbvBuffer;
+use super::domain::IbvDomain;
+use super::domain::IbvDomainImpl;
+use super::primitives::Gid;
+use super::primitives::IbvAh;
+use super::primitives::IbvConfig;
+use super::primitives::IbvCq;
+use super::primitives::IbvQp;
+use super::primitives::IbvQpInfo;
+use super::primitives::IbvWc;
+use super::queue_pair::IbvQueuePair;
+use super::queue_pair::PollCompletionError;
+use super::queue_pair::PollTarget;
+use super::queue_pair::WorkRequestError;
+
+/// Queue key for EFA SRD traffic. Both peers must present the same value or the
+/// responder drops the traffic silently; [`IbvQpInfo`] carries no queue key, so
+/// this is a shared constant rather than something negotiated at connect time.
+const EFA_QKEY: u32 = 0x4242;
+
+/// The RDMA operations an EFA SRD queue pair posts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EfaOp {
+    Write,
+    Read,
+}
+
+/// One work request within a posting session: the byte offset into both the
+/// local and the remote buffer, the length, and the id its completion carries.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Chunk {
+    offset: usize,
+    len: usize,
+    wr_id: u64,
+}
+
+/// Splits a `total_size`-byte transfer into `chunk_max`-bound work requests,
+/// numbering them from `first_wr_id`. A zero-byte transfer still yields one
+/// work request, so every posted operation produces a completion.
+fn chunks(total_size: usize, chunk_max: usize, first_wr_id: u64) -> Vec<Chunk> {
+    assert!(chunk_max > 0, "chunk size must be positive");
+    let mut chunks = Vec::with_capacity(total_size.div_ceil(chunk_max).max(1));
+    let mut offset = 0;
+    let mut remaining = total_size;
+    loop {
+        let len = std::cmp::min(remaining, chunk_max);
+        let wr_id = first_wr_id + chunks.len() as u64;
+        chunks.push(Chunk { offset, len, wr_id });
+        offset += len;
+        remaining -= len;
+        if remaining == 0 {
+            break;
+        }
+    }
+    chunks
+}
+
+/// The address-handle attributes describing a peer reachable at `dgid`, sent
+/// from `port_num` using local GID-table entry `sgid_index`.
+///
+/// Only the destination GID reaches the EFA device: it resolves the handle from
+/// `grh.dgid` alone and returns an opaque routing token. The remaining GRH
+/// fields — `hop_limit`, `traffic_class`, `sl` — carry IP header values that
+/// matter on RoCE v2 and never reach the wire here, so they stay zero.
+/// `sgid_index` must still name a populated GID-table entry, because the kernel
+/// validates it whenever the handle is global.
+fn ah_attr(port_num: u8, dgid: Gid, sgid_index: u8) -> rdmaxcel_sys::ibv_ah_attr {
+    rdmaxcel_sys::ibv_ah_attr {
+        port_num,
+        is_global: 1,
+        grh: rdmaxcel_sys::ibv_global_route {
+            dgid: rdmaxcel_sys::ibv_gid::from(dgid),
+            sgid_index,
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// One RDMA work request to add to a [`WrSession`]. Addresses and lengths are
+/// resolved by the caller, so building it cannot fail.
+#[derive(Debug, Clone, Copy)]
+struct Wr {
+    op: EfaOp,
+    wr_id: u64,
+    laddr: u64,
+    lkey: u32,
+    raddr: u64,
+    rkey: u32,
+    len: u32,
+}
+
+/// An open work-request session on one queue pair's extended builder, borrowing
+/// both that queue pair and the peer it is routed to for as long as the session
+/// lives.
+///
+/// `ibv_wr_start` takes the send queue's lock, which only `ibv_wr_complete` or
+/// `ibv_wr_abort` releases. This guard makes that pairing unconditional: the
+/// session opens on construction and, if the guard is dropped without
+/// [`Self::post`] — an unwind out of the caller, say — `Drop` aborts it. Leaving
+/// it open would strand the lock and deadlock every later post on the queue
+/// pair, and `ibv_destroy_qp` would then destroy a held lock.
+struct WrSession<'a> {
+    qpex: *mut rdmaxcel_sys::ibv_qp_ex,
+    rdma_write: unsafe extern "C" fn(*mut rdmaxcel_sys::ibv_qp_ex, u32, u64),
+    rdma_read: unsafe extern "C" fn(*mut rdmaxcel_sys::ibv_qp_ex, u32, u64),
+    set_sge: unsafe extern "C" fn(*mut rdmaxcel_sys::ibv_qp_ex, u32, u64, u32),
+    set_ud_addr:
+        unsafe extern "C" fn(*mut rdmaxcel_sys::ibv_qp_ex, *mut rdmaxcel_sys::ibv_ah, u32, u32),
+    complete: unsafe extern "C" fn(*mut rdmaxcel_sys::ibv_qp_ex) -> std::os::raw::c_int,
+    abort: unsafe extern "C" fn(*mut rdmaxcel_sys::ibv_qp_ex),
+    /// The queue pair `qpex` points into. Never read: it is held so the borrow
+    /// checker keeps the queue pair alive for as long as the builder pointer
+    /// derived from it.
+    _qp: &'a IbvQp,
+    /// The destination every request in this session is routed to. Borrowed, so
+    /// the address handle cannot be destroyed while the session is open.
+    peer: &'a EfaPeer,
+    /// Set once `wr_complete` has run. It releases the lock even when it reports
+    /// failure, so past that point [`Drop`] must not abort.
+    completed: bool,
+}
+
+impl<'a> WrSession<'a> {
+    /// Resolves `qp`'s extended work-request builder and opens a session on it,
+    /// routed to `peer`.
+    ///
+    /// Every entry point is resolved before the session opens, so a queue pair
+    /// missing one fails here rather than partway through building requests.
+    ///
+    /// # Safety
+    ///
+    /// `qp` must hold a non-null, live `ibv_qp`, and `peer`'s address handle must
+    /// be a live handle created on the same protection domain as `qp`. Borrowing
+    /// `peer` keeps that handle from being destroyed for the life of the session,
+    /// but says nothing about which device or domain it addresses.
+    unsafe fn start(qp: &'a IbvQp, peer: &'a EfaPeer) -> Result<Self, anyhow::Error> {
+        // SAFETY: `qp` holds a live `ibv_qp` (caller contract).
+        // `ibv_qp_to_qp_ex` returns null unless the QP was created with
+        // `IBV_QP_INIT_ATTR_SEND_OPS_FLAGS`.
+        let qpex = unsafe { rdmaxcel_sys::ibv_qp_to_qp_ex(qp.as_ptr()) };
+        if qpex.is_null() {
+            anyhow::bail!(
+                "queue pair has no extended work-request builder; it was not created with IBV_QP_INIT_ATTR_SEND_OPS_FLAGS"
+            );
+        }
+
+        // SAFETY: `qpex` is non-null (checked above) and points into the live
+        // `qp`, so reading its function-pointer fields is sound.
+        let ops = unsafe { &*qpex };
+        let session = Self {
+            qpex,
+            rdma_write: ops.wr_rdma_write.ok_or_else(|| missing("wr_rdma_write"))?,
+            rdma_read: ops.wr_rdma_read.ok_or_else(|| missing("wr_rdma_read"))?,
+            set_sge: ops.wr_set_sge.ok_or_else(|| missing("wr_set_sge"))?,
+            set_ud_addr: ops
+                .wr_set_ud_addr
+                .ok_or_else(|| missing("wr_set_ud_addr"))?,
+            complete: ops.wr_complete.ok_or_else(|| missing("wr_complete"))?,
+            abort: ops.wr_abort.ok_or_else(|| missing("wr_abort"))?,
+            _qp: qp,
+            peer,
+            completed: false,
+        };
+        let start = ops.wr_start.ok_or_else(|| missing("wr_start"))?;
+        // SAFETY: `qpex` is the live builder resolved above. From here the
+        // send-queue lock is held, and `session`'s `Drop` releases it on any
+        // path that does not reach `post`.
+        unsafe { start(qpex) };
+        Ok(session)
+    }
+
+    /// Adds one signaled work request to the session.
+    fn add(&mut self, wr: Wr) {
+        // SAFETY: `self.qpex` is the live builder this open session was started
+        // on, and `self.peer`'s address handle is borrowed for the session, so it
+        // is still live. Each request is fully specified — `wr_id`/`wr_flags`,
+        // then the opcode builder, then the scatter/gather entry, then the
+        // destination — before the next one begins.
+        unsafe {
+            // The builder call below reads both of these, so they are set per
+            // request rather than once per session.
+            (*self.qpex).wr_id = wr.wr_id;
+            (*self.qpex).wr_flags = rdmaxcel_sys::ibv_send_flags::IBV_SEND_SIGNALED.0;
+            match wr.op {
+                EfaOp::Write => (self.rdma_write)(self.qpex, wr.rkey, wr.raddr),
+                EfaOp::Read => (self.rdma_read)(self.qpex, wr.rkey, wr.raddr),
+            }
+            // Order matters: `wr_set_sge` dispatches on the opcode the builder
+            // just wrote.
+            (self.set_sge)(self.qpex, wr.lkey, wr.laddr, wr.len);
+            (self.set_ud_addr)(
+                self.qpex,
+                self.peer.ah.as_ptr(),
+                self.peer.remote_qpn,
+                self.peer.qkey,
+            );
+        }
+    }
+
+    /// Closes the session, posting every request added to it.
+    ///
+    /// All-or-nothing: on failure the provider rolls the whole session back, so
+    /// no completion arrives for any of its requests.
+    fn post(mut self) -> Result<(), anyhow::Error> {
+        // SAFETY: `self.qpex` is the live builder this open session was started
+        // on.
+        let errno = unsafe { (self.complete)(self.qpex) };
+        // `wr_complete` releases the send-queue lock whether or not it
+        // succeeded, so the session is closed either way and `Drop` must not
+        // abort it. Nothing may be inserted above this line: `Drop` would then
+        // be reachable for a session that is already unlocked.
+        self.completed = true;
+        if errno != 0 {
+            return Err(anyhow::anyhow!(
+                "failed to post work-request session: {}",
+                Error::from_raw_os_error(errno)
+            ));
+        }
+        Ok(())
+    }
+}
+
+impl Drop for WrSession<'_> {
+    fn drop(&mut self) {
+        if self.completed {
+            return;
+        }
+        // Abandoned without posting — an unwind out of the caller, say. Roll the
+        // session back so the send-queue lock is released; leaving it held would
+        // deadlock every later post on this queue pair.
+        // SAFETY: the session is still open (`completed` is false) and
+        // `self.qpex` is the live builder it was started on.
+        unsafe { (self.abort)(self.qpex) };
+    }
+}
+
+fn missing(verb: &str) -> anyhow::Error {
+    anyhow::anyhow!("EFA queue pair is missing the {} extended verb", verb)
+}
+
+/// Transitions `qp` to the state in `attr`, reporting a failure using
+/// the string in `target`.
+///
+/// # Safety
+///
+/// `qp` must be a live `ibv_qp` (non-null).
+unsafe fn modify_qp(
+    qp: *mut rdmaxcel_sys::ibv_qp,
+    attr: &mut rdmaxcel_sys::ibv_qp_attr,
+    mask: rdmaxcel_sys::ibv_qp_attr_mask,
+    target: &str,
+) -> Result<(), anyhow::Error> {
+    // SAFETY: `qp` is a live `ibv_qp` (caller contract); `attr` is a valid
+    // `ibv_qp_attr` whose populated fields match `mask`. `ibv_modify_qp` returns
+    // the errno.
+    let errno = unsafe { rdmaxcel_sys::ibv_modify_qp(qp, attr, mask.0 as i32) };
+    if errno != 0 {
+        return Err(anyhow::anyhow!(
+            "failed to transition EFA queue pair to {}: {}",
+            target,
+            Error::from_raw_os_error(errno)
+        ));
+    }
+    Ok(())
+}
+
+/// Queries the EFA-specific attributes of the device behind `context`.
+///
+/// # Safety
+///
+/// `context` must be a live `ibv_context` belonging to an EFA device.
+unsafe fn query_device(
+    context: *mut rdmaxcel_sys::ibv_context,
+) -> Result<rdmaxcel_sys::efadv_device_attr, anyhow::Error> {
+    let mut attr = rdmaxcel_sys::efadv_device_attr::default();
+    // SAFETY: `context` is a live EFA device context (caller contract); the
+    // out-param is a writable, properly aligned `efadv_device_attr` whose size
+    // we pass as `inlen`. `efadv_query_device` returns the errno.
+    let errno = unsafe {
+        rdmaxcel_sys::efadv_query_device(
+            context,
+            &mut attr,
+            std::mem::size_of::<rdmaxcel_sys::efadv_device_attr>() as u32,
+        )
+    };
+    if errno != 0 {
+        return Err(anyhow::anyhow!(
+            "failed to query EFA device attributes: {}",
+            Error::from_raw_os_error(errno)
+        ));
+    }
+    Ok(attr)
+}
+
+/// The remote endpoint of a connected [`EfaQueuePair`].
+///
+/// EFA SRD is UD-addressed: the destination is not a queue-pair attribute, so
+/// every work request names it explicitly through an address handle, the peer's
+/// queue-pair number, and the queue key.
+#[derive(Debug)]
+struct EfaPeer {
+    ah: IbvAh,
+    remote_qpn: u32,
+    qkey: u32,
+}
+
+/// An EFA SRD queue pair, created through `efadv_create_qp_ex` and driven by the
+/// extended work-request builder reached via `ibv_qp_to_qp_ex`.
+///
+/// SRD is a driver queue-pair type that the device runs through the unreliable
+/// datagram state machine, so this shares almost nothing with the
+/// reliable-connected path: the connection handshake carries a queue key rather
+/// than access flags, and each work request supplies its own destination. Only
+/// endpoint discovery, state queries, and completion polling are common, and
+/// those delegate to the shared helpers in [`super::queue_pair`].
+///
+/// Single-owner: it owns the [`IbvQp`] — which in turn owns its two completion
+/// queues and the protection domain — and destroys them on drop, so the type is
+/// intentionally `!Clone`.
+#[derive(Debug)]
+pub struct EfaQueuePair {
+    qp: IbvQp,
+    /// Declared after `qp` so the queue pair is destroyed first. Every work
+    /// request embeds the address handle's device token, so the handle has to
+    /// outlive any request still referencing it.
+    peer: Option<EfaPeer>,
+    config: IbvConfig,
+    /// The source GID, always table entry 0: EFA is not RoCE, so its
+    /// `gid_attrs/types` never reports "RoCE v2" and its table holds one entry.
+    gid: Gid,
+    /// Largest transfer issued as a single work request, from the device's
+    /// reported `max_rdma_size`.
+    max_msg_size: usize,
+    /// Monotonic work-request id, handed out one per posted WR. The extended
+    /// verbs carry no internal counter, so the queue pair tracks its own.
+    next_wr_id: u64,
+}
+
+impl EfaQueuePair {
+    /// Posts `op` over `total_size` bytes from `laddr` to `raddr` as a single
+    /// work-request session, split into [`Self::max_msg_size`]-bound chunks, and
+    /// returns one work-request id per chunk.
+    ///
+    /// The session is all-or-nothing: on failure `ibv_wr_complete` rolls every
+    /// request in it back, so an `Err` means nothing was posted and no
+    /// completion will arrive for any of the ids.
+    fn post_chunked(
+        &mut self,
+        op: EfaOp,
+        laddr: usize,
+        lkey: u32,
+        raddr: usize,
+        rkey: u32,
+        total_size: usize,
+    ) -> Result<Vec<u64>, anyhow::Error> {
+        if self.peer.is_none() {
+            anyhow::bail!("cannot post on an EfaQueuePair that has not been connected");
+        }
+
+        // Resolve every request before opening the session, so the window where
+        // the send-queue lock is held does no arithmetic and no allocation.
+        // `WrSession` makes an unwind there recoverable.
+        let plan = chunks(total_size, self.max_msg_size, self.next_wr_id);
+        self.next_wr_id += plan.len() as u64;
+        let wrs: Vec<Wr> = plan
+            .iter()
+            .map(|chunk| Wr {
+                op,
+                wr_id: chunk.wr_id,
+                laddr: (laddr + chunk.offset) as u64,
+                lkey,
+                raddr: (raddr + chunk.offset) as u64,
+                rkey,
+                len: chunk.len as u32,
+            })
+            .collect();
+
+        let peer = self.peer.as_ref().expect("checked above");
+        // SAFETY: `self.qp` holds the live queue pair created in `new`, and
+        // `peer`'s address handle is owned by `self` and outlives the session.
+        let mut session = unsafe { WrSession::start(&self.qp, peer) }?;
+        for wr in wrs {
+            session.add(wr);
+        }
+        session.post().map_err(|e| {
+            anyhow::anyhow!("{:?} session of {} work request(s): {e}", op, plan.len())
+        })?;
+        Ok(plan.into_iter().map(|chunk| chunk.wr_id).collect())
+    }
+}
+
+impl IbvQueuePair for EfaQueuePair {
+    unsafe fn new<I: IbvDomainImpl<QueuePair = Self>>(
+        domain: &IbvDomain<I>,
+        config: IbvConfig,
+    ) -> Result<Self, anyhow::Error> {
+        tracing::debug!("creating an EfaQueuePair from config {}", config);
+        // `IbvDomain`'s `pd` accessor permits null (e.g. a test domain); a real
+        // queue pair needs one, so reject null up front. Everything below then
+        // has a live context too, since a PD is only ever allocated against one.
+        let pd = domain.as_ptr();
+        if pd.is_null() {
+            anyhow::bail!("cannot create an EfaQueuePair on a null protection domain");
+        }
+        let context = domain.context().as_ptr();
+
+        // Resolve the source GID up front (before allocating any FFI resources),
+        // so a port without a usable GID fails cleanly here.
+        let gid = domain.device_info().gid_at(config.port_num, 0)?;
+
+        // SAFETY: `context` is the live context the PD above was allocated
+        // against.
+        let device_attr = unsafe { query_device(context) }?;
+        let required = rdmaxcel_sys::EFADV_DEVICE_ATTR_CAPS_RDMA_READ
+            | rdmaxcel_sys::EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE;
+        anyhow::ensure!(
+            device_attr.device_caps & required == required,
+            "EFA device does not support both RDMA read and RDMA write (device_caps: {:#x})",
+            device_attr.device_caps
+        );
+        let max_msg_size = device_attr.max_rdma_size as usize;
+        anyhow::ensure!(
+            max_msg_size > 0,
+            "EFA device reports a maximum RDMA transfer size of 0"
+        );
+
+        // EFA accepts exactly one scatter/gather entry per RDMA work request.
+        // `EfaDevice::apply_config_defaults` already caps these, but the manager
+        // seeds those defaults only when it spawns without an explicit config,
+        // so enforce it here rather than trust the caller.
+        let mut config = config;
+        config.max_send_sge = 1;
+        config.max_recv_sge = 1;
+        // The queue depths must fit the device. Reject rather than clamp: the
+        // owning `QueuePairActor` budgets send-queue credits against the depth in
+        // its own config, so quietly granting fewer would let it over-commit.
+        anyhow::ensure!(
+            config.max_send_wr <= device_attr.max_sq_wr,
+            "configured max_send_wr ({}) exceeds the EFA device's limit ({})",
+            config.max_send_wr,
+            device_attr.max_sq_wr
+        );
+        anyhow::ensure!(
+            config.max_recv_wr <= device_attr.max_rq_wr,
+            "configured max_recv_wr ({}) exceeds the EFA device's limit ({})",
+            config.max_recv_wr,
+            device_attr.max_rq_wr
+        );
+
+        // Separate send/recv completion queues, each owning a clone of the
+        // device context. Each `IbvCq` destroys its queue on drop, so an early
+        // return below cleans them up.
+        // SAFETY: `context` is live (see above); `IbvCq::create` rejects a null
+        // context.
+        let send_cq = unsafe { IbvCq::create(domain.context().clone(), config.cq_entries) }?;
+        // SAFETY: as for `send_cq` above.
+        let recv_cq = unsafe { IbvCq::create(domain.context().clone(), config.cq_entries) }?;
+
+        // An SRD queue pair: a driver queue-pair type selected through
+        // `efadv_qp_init_attr`. The send-ops flags both request the RDMA
+        // builders and are what makes `ibv_qp_to_qp_ex` yield a builder at all.
+        let mut init_attr = rdmaxcel_sys::ibv_qp_init_attr_ex {
+            send_cq: send_cq.as_ptr(),
+            recv_cq: recv_cq.as_ptr(),
+            cap: rdmaxcel_sys::ibv_qp_cap {
+                max_send_wr: config.max_send_wr,
+                max_recv_wr: config.max_recv_wr,
+                max_send_sge: config.max_send_sge,
+                max_recv_sge: config.max_recv_sge,
+                max_inline_data: 0,
+            },
+            qp_type: rdmaxcel_sys::ibv_qp_type::IBV_QPT_DRIVER,
+            sq_sig_all: 0,
+            pd,
+            comp_mask: rdmaxcel_sys::IBV_QP_INIT_ATTR_PD
+                | rdmaxcel_sys::IBV_QP_INIT_ATTR_SEND_OPS_FLAGS,
+            send_ops_flags: (rdmaxcel_sys::IBV_QP_EX_WITH_RDMA_WRITE
+                | rdmaxcel_sys::IBV_QP_EX_WITH_RDMA_READ) as u64,
+            ..Default::default()
+        };
+        let mut efa_attr = rdmaxcel_sys::efadv_qp_init_attr {
+            driver_qp_type: rdmaxcel_sys::EFADV_QP_DRIVER_TYPE_SRD,
+            ..Default::default()
+        };
+        // `efadv_create_qp_ex` writes the granted queue depths back into
+        // `init_attr.cap`, hence the mutable borrow.
+        // SAFETY: `context` and `pd` are non-null (checked above) and live; both
+        // attr structs are fully initialized and outlive the call, and
+        // `init_attr`'s CQ pointers came from the freshly created
+        // `send_cq`/`recv_cq`. `efadv_create_qp_ex` returns null on failure.
+        let qp = unsafe {
+            rdmaxcel_sys::efadv_create_qp_ex(
+                context,
+                &mut init_attr,
+                &mut efa_attr,
+                std::mem::size_of::<rdmaxcel_sys::efadv_qp_init_attr>() as u32,
+            )
+        };
+        if qp.is_null() {
+            // `send_cq`/`recv_cq` drop here, destroying the CQs.
+            anyhow::bail!(
+                "failed to create EFA SRD queue pair (QP): {}",
+                Error::last_os_error()
+            );
+        }
+
+        // SAFETY: `qp` is a live SRD QP just created against `pd` with
+        // `send_cq`/`recv_cq`; `IbvQp` takes ownership of all of them plus the
+        // PD and destroys them in order on drop.
+        let qp = unsafe { IbvQp::from_raw(qp, send_cq, recv_cq, domain.pd().clone()) };
+
+        Ok(Self {
+            qp,
+            peer: None,
+            config,
+            gid,
+            max_msg_size,
+            next_wr_id: 0,
+        })
+    }
+
+    fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
+        let Some(dgid) = info.gid else {
+            anyhow::bail!(
+                "EFA addresses peers by GID, but the peer endpoint {:?} carries none",
+                info
+            );
+        };
+
+        // Build the address handle before the transitions. It is a
+        // protection-domain operation that does not depend on queue-pair state,
+        // so failing here leaves the queue pair in RESET rather than in RTS with
+        // no route — a state in which every post would fail.
+        let mut attr = ah_attr(self.config.port_num, dgid, self.gid.index());
+        // SAFETY: the queue pair was created against this PD, which it keeps
+        // alive; `attr` is fully initialized and outlives the call.
+        let ah = unsafe { IbvAh::create(self.qp.pd().clone(), &mut attr) }?;
+
+        // The device runs an SRD queue pair through the unreliable datagram
+        // state machine: INIT carries the queue key in place of access flags,
+        // RTR carries nothing but the state, and RTS only the send-queue packet
+        // sequence number. None of the reliable-connected path attributes apply,
+        // because the destination travels with each work request instead.
+        let qp = self.qp.as_ptr();
+        let mut attr = rdmaxcel_sys::ibv_qp_attr {
+            qp_state: rdmaxcel_sys::ibv_qp_state::IBV_QPS_INIT,
+            qkey: EFA_QKEY,
+            pkey_index: self.config.pkey_index,
+            port_num: self.config.port_num,
+            ..Default::default()
+        };
+        let mask = rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_STATE
+            | rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_PKEY_INDEX
+            | rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_PORT
+            | rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_QKEY;
+        // SAFETY: `qp` is the live queue pair, kept alive for `self`'s lifetime.
+        unsafe { modify_qp(qp, &mut attr, mask, "INIT") }?;
+
+        let mut attr = rdmaxcel_sys::ibv_qp_attr {
+            qp_state: rdmaxcel_sys::ibv_qp_state::IBV_QPS_RTR,
+            ..Default::default()
+        };
+        let mask = rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_STATE;
+        // SAFETY: as for the INIT transition above.
+        unsafe { modify_qp(qp, &mut attr, mask, "RTR") }?;
+
+        let mut attr = rdmaxcel_sys::ibv_qp_attr {
+            qp_state: rdmaxcel_sys::ibv_qp_state::IBV_QPS_RTS,
+            sq_psn: self.config.psn,
+            ..Default::default()
+        };
+        let mask = rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_STATE
+            | rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_SQ_PSN;
+        // SAFETY: as for the INIT transition above.
+        unsafe { modify_qp(qp, &mut attr, mask, "RTS") }?;
+
+        self.peer = Some(EfaPeer {
+            ah,
+            remote_qpn: info.qp_num,
+            qkey: EFA_QKEY,
+        });
+        tracing::debug!(
+            "EfaQueuePair reached RTS and is routed to {:?} (qp: {:?})",
+            info,
+            qp
+        );
+        Ok(())
+    }
+
+    fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
+        let context = self.qp.context().as_ptr();
+        // SAFETY: `self.qp` is the live queue pair and `context` its non-null
+        // device context (both validated in `new`), valid for `self`'s lifetime.
+        unsafe { super::queue_pair::get_qp_info(self.qp.as_ptr(), context, &self.config, self.gid) }
+    }
+
+    fn state(&mut self) -> Result<u32, anyhow::Error> {
+        // SAFETY: `self.qp` is the live queue pair, kept alive for `self`'s
+        // lifetime.
+        unsafe { super::queue_pair::state(self.qp.as_ptr()) }
+    }
+
+    fn max_msg_size(&self) -> usize {
+        self.max_msg_size
+    }
+
+    fn put(
+        &mut self,
+        remote_dst: IbvBuffer,
+        local_src: IbvBuffer,
+    ) -> Result<Vec<u64>, anyhow::Error> {
+        if remote_dst.size < local_src.size {
+            return Err(anyhow::anyhow!(
+                "remote buffer size ({}) is smaller than local buffer size ({})",
+                remote_dst.size,
+                local_src.size
+            ));
+        }
+        self.post_chunked(
+            EfaOp::Write,
+            local_src.addr,
+            local_src.lkey,
+            remote_dst.addr,
+            remote_dst.rkey,
+            local_src.size,
+        )
+    }
+
+    fn get(
+        &mut self,
+        local_dst: IbvBuffer,
+        remote_src: IbvBuffer,
+    ) -> Result<Vec<u64>, anyhow::Error> {
+        if local_dst.size < remote_src.size {
+            return Err(anyhow::anyhow!(
+                "local buffer size ({}) is smaller than remote buffer size ({})",
+                local_dst.size,
+                remote_src.size
+            ));
+        }
+        self.post_chunked(
+            EfaOp::Read,
+            local_dst.addr,
+            local_dst.lkey,
+            remote_src.addr,
+            remote_src.rkey,
+            remote_src.size,
+        )
+    }
+
+    fn poll_completion(
+        &mut self,
+        target: PollTarget,
+    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
+        // SAFETY: `self.qp` owns the live queue pair built in `new`, along with
+        // its completion queues and device context, all non-null and alive for
+        // `self`'s lifetime.
+        unsafe { super::queue_pair::poll_one(&self.qp, target) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv6Addr;
+
+    use super::*;
+
+    // A transfer that fits in one work request still gets exactly one, and it
+    // is numbered from the id handed in.
+    #[test]
+    fn chunks_fitting_transfer_yields_one_wr() {
+        assert_eq!(
+            chunks(1024, 4096, 7),
+            vec![Chunk {
+                offset: 0,
+                len: 1024,
+                wr_id: 7
+            }]
+        );
+    }
+
+    // A zero-byte transfer still yields one work request, so the caller always
+    // receives a completion to match against.
+    #[test]
+    fn chunks_zero_byte_transfer_yields_one_wr() {
+        assert_eq!(
+            chunks(0, 4096, 0),
+            vec![Chunk {
+                offset: 0,
+                len: 0,
+                wr_id: 0
+            }]
+        );
+    }
+
+    // An oversized transfer splits into consecutive, contiguous chunks with a
+    // short final one, each carrying the next id.
+    #[test]
+    fn chunks_oversized_transfer_splits_with_short_tail() {
+        let plan = chunks(2500, 1000, 100);
+        assert_eq!(
+            plan,
+            vec![
+                Chunk {
+                    offset: 0,
+                    len: 1000,
+                    wr_id: 100
+                },
+                Chunk {
+                    offset: 1000,
+                    len: 1000,
+                    wr_id: 101
+                },
+                Chunk {
+                    offset: 2000,
+                    len: 500,
+                    wr_id: 102
+                },
+            ]
+        );
+        let total: usize = plan.iter().map(|chunk| chunk.len).sum();
+        assert_eq!(total, 2500, "chunks must cover the transfer exactly");
+    }
+
+    // An exact multiple of the chunk size produces no trailing empty request.
+    #[test]
+    fn chunks_exact_multiple_has_no_empty_tail() {
+        let plan = chunks(2000, 1000, 0);
+        assert_eq!(plan.len(), 2, "2000 bytes at 1000 per WR is two requests");
+        assert!(plan.iter().all(|chunk| chunk.len == 1000));
+    }
+
+    // The address handle carries the peer's GID and the *local* source-GID
+    // index, and leaves the RoCE-only GRH fields zero.
+    #[test]
+    fn ah_attr_carries_peer_gid_and_local_sgid_index() {
+        let peer = Gid::for_test(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2), 3);
+        let attr = ah_attr(1, peer, 0);
+
+        assert_eq!(attr.port_num, 1);
+        assert_eq!(attr.is_global, 1, "EFA requires a global address handle");
+        // SAFETY: `raw` is one arm of the `ibv_gid` union and is always
+        // initialized; reading the 16 address bytes back is sound.
+        let dgid = unsafe { attr.grh.dgid.raw };
+        assert_eq!(
+            dgid,
+            Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2).octets(),
+            "the handle must address the peer's GID"
+        );
+        assert_eq!(
+            attr.grh.sgid_index, 0,
+            "sgid_index names the local GID table entry, not the peer's index 3"
+        );
+        assert_eq!(attr.grh.hop_limit, 0, "hop_limit is RoCE-only");
+        assert_eq!(attr.grh.traffic_class, 0, "traffic_class is RoCE-only");
+        assert_eq!(attr.sl, 0);
+        assert_eq!(attr.dlid, 0, "EFA has no LID");
+    }
+}

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -1297,6 +1297,13 @@ impl IbvQp {
         &self.recv_cq
     }
 
+    /// The protection domain this QP was created against, shareable as a
+    /// keepalive by resources built on the same PD.
+    #[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+    pub(super) fn pd(&self) -> &Arc<IbvPd> {
+        &self.pd
+    }
+
     /// The device context this QP was created on, sourced from its PD.
     pub(super) fn context(&self) -> &IbvContext {
         self.pd.context()
@@ -1532,6 +1539,80 @@ impl Drop for IbvMr {
         let ret = unsafe { rdmaxcel_sys::ibv_dereg_mr(self.mr) };
         if ret != 0 {
             tracing::error!("failed to deregister MR {:p}: error code {}", self.mr, ret);
+        }
+    }
+}
+
+/// Owns an `ibv_ah` together with the `Arc<IbvPd>` it was created against,
+/// destroying the address handle on drop before releasing the PD. Holding the PD
+/// keeps it (and, through it, the context) alive across `ibv_destroy_ah`.
+///
+/// Unlike the other handles here there is no null placeholder: [`Self::create`]
+/// is the only constructor and it rejects a null result, so the pointer is
+/// always live.
+#[derive(Debug)]
+#[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+pub(super) struct IbvAh {
+    ah: *mut rdmaxcel_sys::ibv_ah,
+    /// Keeps the PD open until after `ibv_destroy_ah`. Never read.
+    _pd: Arc<IbvPd>,
+}
+
+// SAFETY: the only raw member is the `ibv_ah` pointer. The ibverbs AH it names is
+// not thread-affine — it may be created on one thread and used or destroyed on
+// another (`Send`) — and `IbvAh` exposes no operation that mutates the AH through
+// a shared `&` (`as_ptr` only hands back the pointer value), so sharing an
+// `&IbvAh` cannot race (`Sync`).
+unsafe impl Send for IbvAh {}
+// SAFETY: as for `Send` above.
+unsafe impl Sync for IbvAh {}
+
+#[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
+impl IbvAh {
+    /// Creates an address handle on `pd` from `attr`.
+    ///
+    /// # Safety
+    ///
+    /// `pd` must hold a live protection domain; a null PD yields `Err`.
+    pub(super) unsafe fn create(
+        pd: Arc<IbvPd>,
+        attr: &mut rdmaxcel_sys::ibv_ah_attr,
+    ) -> Result<Self, anyhow::Error> {
+        if pd.as_ptr().is_null() {
+            anyhow::bail!("cannot create an address handle on a null protection domain");
+        }
+        // SAFETY: `pd.as_ptr()` is non-null (checked above) and, per this
+        // function's contract, a live protection domain; `attr` is a valid,
+        // fully initialized `ibv_ah_attr` that outlives the call.
+        // `ibv_create_ah` returns null on failure.
+        let ah = unsafe { rdmaxcel_sys::ibv_create_ah(pd.as_ptr(), attr) };
+        if ah.is_null() {
+            anyhow::bail!(
+                "failed to create address handle: {}",
+                Error::last_os_error()
+            );
+        }
+        Ok(Self { ah, _pd: pd })
+    }
+
+    /// The raw `ibv_ah`, always live.
+    pub(super) fn as_ptr(&self) -> *mut rdmaxcel_sys::ibv_ah {
+        self.ah
+    }
+}
+
+impl Drop for IbvAh {
+    fn drop(&mut self) {
+        // SAFETY: `self.ah` was returned non-null by `ibv_create_ah` and, since
+        // `IbvAh` is not `Clone`, is destroyed exactly once. `_pd` drops only
+        // after this returns, so the PD is still alive.
+        let ret = unsafe { rdmaxcel_sys::ibv_destroy_ah(self.ah) };
+        if ret != 0 {
+            tracing::error!(
+                "failed to destroy address handle {:p}: error code {}",
+                self.ah,
+                ret
+            );
         }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/primitives.rs
+++ b/monarch_rdma/src/backend/ibverbs/primitives.rs
@@ -85,6 +85,14 @@ impl Gid {
         self.index
     }
 
+    /// Builds a GID at table index `index` from `addr`, for tests that need a
+    /// concrete GID without a device. The RoCE type is left `Unknown`, matching
+    /// what a non-RoCE fabric reports.
+    #[cfg(test)]
+    pub(super) fn for_test(addr: Ipv6Addr, index: u8) -> Self {
+        Self::new(addr, GidType::Unknown, index)
+    }
+
     /// The GID's address scope.
     fn scope(&self) -> GidScope {
         self.scope
@@ -1299,7 +1307,6 @@ impl IbvQp {
 
     /// The protection domain this QP was created against, shareable as a
     /// keepalive by resources built on the same PD.
-    #[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
     pub(super) fn pd(&self) -> &Arc<IbvPd> {
         &self.pd
     }
@@ -1551,7 +1558,6 @@ impl Drop for IbvMr {
 /// is the only constructor and it rejects a null result, so the pointer is
 /// always live.
 #[derive(Debug)]
-#[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
 pub(super) struct IbvAh {
     ah: *mut rdmaxcel_sys::ibv_ah,
     /// Keeps the PD open until after `ibv_destroy_ah`. Never read.
@@ -1567,7 +1573,6 @@ unsafe impl Send for IbvAh {}
 // SAFETY: as for `Send` above.
 unsafe impl Sync for IbvAh {}
 
-#[expect(dead_code, reason = "used by EfaQueuePair in a follow-up commit")]
 impl IbvAh {
     /// Creates an address handle on `pd` from `attr`.
     ///

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -202,6 +202,15 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// Returns the current `ibv_qp_state` of the QP.
     fn state(&mut self) -> Result<u32, anyhow::Error>;
 
+    /// Largest transfer this QP issues as a single work request; [`Self::put`]
+    /// and [`Self::get`] split anything larger into that many WRs. The owning
+    /// [`QueuePairActor`] budgets send-queue credits against this value, so an
+    /// implementation that chunks more finely must report it here or it will
+    /// over-commit the send queue.
+    fn max_msg_size(&self) -> usize {
+        MAX_RDMA_MSG_SIZE
+    }
+
     /// Post an RDMA WRITE of `local_src` into `remote_dst`. The request may
     /// be chunked into multiple WRs. This method returns the list of WR ids
     /// that were posted.
@@ -326,7 +335,7 @@ pub(super) unsafe fn get_qp_info(
 /// # Safety
 ///
 /// `qp` must be a live `ibv_qp` (non-null).
-unsafe fn state(qp: *mut rdmaxcel_sys::ibv_qp) -> Result<u32, anyhow::Error> {
+pub(super) unsafe fn state(qp: *mut rdmaxcel_sys::ibv_qp) -> Result<u32, anyhow::Error> {
     let mut qp_attr = rdmaxcel_sys::ibv_qp_attr::default();
     let mut qp_init_attr = rdmaxcel_sys::ibv_qp_init_attr::default();
     let mask = rdmaxcel_sys::ibv_qp_attr_mask::IBV_QP_STATE;
@@ -448,6 +457,68 @@ pub(super) unsafe fn connect(
         ));
     }
     Ok(())
+}
+
+/// Polls `target`'s completion queue on `qp` for a single work completion,
+/// through the device context's `poll_cq` verb. Shared by every queue-pair
+/// implementation built on an [`IbvQp`]; see
+/// [`IbvQueuePair::poll_completion`] for the meaning of the return value.
+///
+/// # Safety
+///
+/// `qp` must hold a non-null, live `ibv_qp` whose send and receive completion
+/// queues and device context are likewise non-null and live: this invokes the
+/// `poll_cq` verb through them without re-checking. A placeholder [`IbvQp`]
+/// built from null handles does not qualify.
+pub(super) unsafe fn poll_one(
+    qp: &IbvQp,
+    target: PollTarget,
+) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
+    let (cq, cq_type) = match target {
+        PollTarget::Send => (qp.send_cq().as_ptr(), "send"),
+        PollTarget::Recv => (qp.recv_cq().as_ptr(), "recv"),
+    };
+    let context = qp.context().as_ptr();
+    // SAFETY: `context` is `qp`'s live device context (caller contract); we
+    // invoke its `poll_cq` verb through the ops table.
+    let poll_cq = unsafe {
+        (*context)
+            .ops
+            .poll_cq
+            .expect("poll_cq verb missing from ibv_context ops")
+    };
+    let mut wc = rdmaxcel_sys::ibv_wc::default();
+    // SAFETY: `cq` is a live `ibv_cq` belonging to `qp` (caller contract);
+    // `&mut wc` has room for the single entry requested, and `poll_cq`
+    // overwrites it whenever it returns a completion (`ret >= 1`).
+    let ret = unsafe { poll_cq(cq, 1, &mut wc) };
+
+    if ret < 0 {
+        return Err(PollCompletionError {
+            message: format!("{} CQ poll failed (ibv_poll_cq returned {})", cq_type, ret),
+        });
+    }
+    if ret == 0 {
+        return Ok(None);
+    }
+
+    // `ret >= 1`: a single entry was requested, so `wc` holds one completion.
+    // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
+    if let Some((status, vendor_err)) = wc.error() {
+        return Ok(Some(Err(WorkRequestError {
+            wr_id: wc.wr_id(),
+            status,
+            vendor_err,
+            message: format!(
+                "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
+                cq_type,
+                wc.wr_id(),
+                status,
+                vendor_err,
+            ),
+        })));
+    }
+    Ok(Some(Ok(IbvWc::from(wc))))
 }
 
 /// An RDMA reliable-connected (RC) queue pair built on plain ibverbs
@@ -722,51 +793,10 @@ impl IbvQueuePair for RCQueuePair {
         &mut self,
         target: PollTarget,
     ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        let (cq, cq_type) = match target {
-            PollTarget::Send => (self.qp.send_cq().as_ptr(), "send"),
-            PollTarget::Recv => (self.qp.recv_cq().as_ptr(), "recv"),
-        };
-        let context = self.qp.context().as_ptr();
-        // SAFETY: `context` is the QP's live device context (read from the live
-        // `qp`); we invoke its `poll_cq` verb through the ops table.
-        let poll_cq = unsafe {
-            (*context)
-                .ops
-                .poll_cq
-                .expect("poll_cq verb missing from ibv_context ops")
-        };
-        let mut wc = rdmaxcel_sys::ibv_wc::default();
-        // SAFETY: `cq` is a live `ibv_cq` belonging to this QP; `&mut wc` has
-        // room for the single entry requested, and `poll_cq` overwrites it
-        // whenever it returns a completion (`ret >= 1`).
-        let ret = unsafe { poll_cq(cq, 1, &mut wc) };
-
-        if ret < 0 {
-            return Err(PollCompletionError {
-                message: format!("{} CQ poll failed (ibv_poll_cq returned {})", cq_type, ret),
-            });
-        }
-        if ret == 0 {
-            return Ok(None);
-        }
-
-        // `ret >= 1`: a single entry was requested, so `wc` holds one completion.
-        // `error()` is `Some` exactly when the status is not `IBV_WC_SUCCESS`.
-        if let Some((status, vendor_err)) = wc.error() {
-            return Ok(Some(Err(WorkRequestError {
-                wr_id: wc.wr_id(),
-                status,
-                vendor_err,
-                message: format!(
-                    "{} completion failed for wr_id={}: status={:?}, vendor_err={}",
-                    cq_type,
-                    wc.wr_id(),
-                    status,
-                    vendor_err,
-                ),
-            })));
-        }
-        Ok(Some(Ok(IbvWc::from(wc))))
+        // SAFETY: `self.qp` wraps a live, fully non-null `ibv_qp` — everything
+        // reached through it included — per `from_qp`'s contract, and it stays
+        // alive for `self`'s lifetime.
+        unsafe { poll_one(&self.qp, target) }
     }
 }
 
@@ -1001,10 +1031,10 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 
     /// Number of WRs the QP will issue for an op that targets
     /// `local_size` bytes. The QP splits large transfers into
-    /// `MAX_RDMA_MSG_SIZE`-bound chunks; a zero-byte op still
+    /// [`IbvQueuePair::max_msg_size`]-bound chunks; a zero-byte op still
     /// consumes one WR.
-    fn wr_count(local_size: usize) -> u32 {
-        local_size.div_ceil(MAX_RDMA_MSG_SIZE).max(1) as u32
+    fn wr_count(&self, local_size: usize) -> u32 {
+        local_size.div_ceil(self.qp.max_msg_size()).max(1) as u32
     }
 
     /// Try to post the head of `queue`.
@@ -1309,7 +1339,7 @@ impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps<M>> for QueuePairActor<M, 
         msg: ProcessOps<M>,
     ) -> Result<(), anyhow::Error> {
         for (op_idx, op, mrv) in msg.items.into_iter() {
-            let wrs = Self::wr_count(op.local_memory.size());
+            let wrs = self.wr_count(op.local_memory.size());
             let is_read = matches!(op.op_type, RdmaOpType::ReadIntoLocal);
             self.queue.push_back(PendingOp {
                 op_idx,

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -245,50 +245,6 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
     ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError>;
 }
 
-impl IbvQueuePair for legacy::IbvQueuePair {
-    unsafe fn new<I: IbvDomainImpl<QueuePair = Self>>(
-        domain: &IbvDomain<I>,
-        config: IbvConfig,
-    ) -> Result<Self, anyhow::Error> {
-        legacy::IbvQueuePair::new(domain, config)
-    }
-
-    fn connect(&mut self, info: &IbvQpInfo) -> Result<(), anyhow::Error> {
-        legacy::IbvQueuePair::connect(self, info)
-    }
-
-    fn get_qp_info(&mut self) -> Result<IbvQpInfo, anyhow::Error> {
-        legacy::IbvQueuePair::get_qp_info(self)
-    }
-
-    fn state(&mut self) -> Result<u32, anyhow::Error> {
-        legacy::IbvQueuePair::state(self)
-    }
-
-    fn put(
-        &mut self,
-        remote_dst: IbvBuffer,
-        local_src: IbvBuffer,
-    ) -> Result<Vec<u64>, anyhow::Error> {
-        legacy::IbvQueuePair::put(self, local_src, remote_dst)
-    }
-
-    fn get(
-        &mut self,
-        local_dst: IbvBuffer,
-        remote_src: IbvBuffer,
-    ) -> Result<Vec<u64>, anyhow::Error> {
-        legacy::IbvQueuePair::get(self, local_dst, remote_src)
-    }
-
-    fn poll_completion(
-        &mut self,
-        target: PollTarget,
-    ) -> Result<Option<Result<IbvWc, WorkRequestError>>, PollCompletionError> {
-        legacy::IbvQueuePair::poll_completion(self, target)
-    }
-}
-
 /// Queries the local endpoint info for `qp`, whose device `context` and the QP
 /// `config` (port, PSN) describe the connection. `gid` is the port's source GID.
 ///

--- a/python/benches/multihost_rdma/benchmark_common.py
+++ b/python/benches/multihost_rdma/benchmark_common.py
@@ -1,0 +1,962 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+Multi-host RDMA Performance Benchmark, independent of any job scheduler.
+
+Measures RDMA transfer throughput and latency between actors on a
+configurable proc mesh, using either ibverbs or TCP transport.
+
+Each configuration is run twice: once driving RDMA READ (peer-as-initiator,
+pulling our local tensors) and once driving RDMA WRITE (us-as-initiator,
+pushing into the peer's RDMA buffers). Both directions move data in the
+same logical direction (A's tensors -> B's tensors); only the initiator
+of the ibverbs op changes.
+
+Each side's memory kind is set independently with ``--sender-device`` and
+``--receiver-device``; both default to the ``--gpu``/``--cpu`` setting.
+
+The host shape is selected with mutually-exclusive ``--cross-host`` (default)
+or ``--same-host`` flags.
+
+Wrappers expose two subcommands: ``run`` drives the benchmark from the calling
+process, and ``run-batch`` submits it to run inside its own allocation. Shared
+flags precede the subcommand; the flags that only mean something to a driving
+process belong to ``run``.
+
+This module knows nothing about how the hosts are provisioned. A wrapper
+supplies a fully-configured :py:class:`~monarch.job.JobTrait` through
+:py:func:`run`, which only ever calls ``state()``, ``spawn_procs``, ``kill()``,
+and — for ``run-batch`` — ``apply()`` on it. See ``slurm_benchmark.py`` for an
+open-source wrapper.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import shlex
+import statistics
+import sys
+import time
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TYPE_CHECKING
+
+import monarch
+import torch
+import xxhash
+from monarch.actor import Actor, current_rank, endpoint, ProcMesh, this_host
+from monarch.rdma import RDMAAction, RDMABuffer
+
+# Avoid importing `monarch.job` at module scope. Workers import this module
+# to unpickle `TestRDMA`, but the worker conda environments might not have
+# all of the necessary dependencies.
+if TYPE_CHECKING:
+    from monarch.job import JobTrait
+
+
+DIRECTIONS: tuple[str, ...] = ("read", "write")
+
+RUN_COMMAND: str = "run"
+BATCH_COMMAND: str = "run-batch"
+
+# When to kill the job once the benchmark is done.
+TEARDOWN_NEVER: str = "never"
+TEARDOWN_ON_FAILURE: str = "on_failure"
+TEARDOWN_ALWAYS: str = "always"
+TEARDOWN_POLICIES: tuple[str, ...] = (
+    TEARDOWN_NEVER,
+    TEARDOWN_ON_FAILURE,
+    TEARDOWN_ALWAYS,
+)
+
+
+class TestRDMA(Actor):
+    """RDMA test actor for benchmarking performance between hosts."""
+
+    def __init__(self) -> None:
+        self.tensors: list[torch.Tensor] = []
+        self.rdma_buffers: list[RDMABuffer] = []
+        self.receiving_actor: Any = None
+        self.gpu_id: int = current_rank()["gpus"]
+
+    @endpoint
+    async def receiving_actors(self, actors: Any) -> None:
+        self.receiving_actor = actors.slice(**current_rank())
+
+    @endpoint
+    async def alloc(
+        self, tensor_shape: tuple[int, ...], concurrent_ops: int, use_gpu: bool
+    ) -> None:
+        """Allocate this side's tensors and register them as RDMA buffers.
+
+        ``use_gpu`` selects this side's memory kind, so the sender and the
+        receiver can be allocated on different kinds.
+
+        Every tensor is allocated before any buffer is registered. Interleaving
+        the two makes each registration cover an allocator segment that the next
+        allocation then grows, so the registrations cover ever-larger segments.
+        """
+        for buf in self.rdma_buffers:
+            await buf.drop()
+        self.tensors = []
+        self.rdma_buffers = []
+        device = f"cuda:{self.gpu_id}" if use_gpu else "cpu"
+        for _ in range(concurrent_ops):
+            self.tensors.append(
+                torch.rand(tensor_shape, dtype=torch.float32, device=device)
+            )
+        for tensor in self.tensors:
+            self.rdma_buffers.append(
+                RDMABuffer(tensor.view(dtype=torch.uint8).flatten())
+            )
+
+    @endpoint
+    async def expose_buffers(self) -> list[RDMABuffer]:
+        return self.rdma_buffers
+
+    @endpoint
+    async def timed_read(self, remote_buffers: list[RDMABuffer]) -> float:
+        """Pull from ``remote_buffers`` into local tensors via a single
+        ``RDMAAction``. Returns the wall time of that batch.
+
+        This is the inner timed step of the READ benchmark: the *peer*
+        actor invokes this, so the peer is the initiator of the ibverbs
+        RDMA-READ ops."""
+        assert len(remote_buffers) == len(self.tensors), (
+            f"timed_read received {len(remote_buffers)} buffers but actor was "
+            f"allocated with {len(self.tensors)} tensors"
+        )
+        t = time.perf_counter()
+        action = RDMAAction()
+        for tensor, buffer in zip(self.tensors, remote_buffers):
+            action.read_remote(tensor.view(dtype=torch.uint8).flatten(), buffer)
+        await action.submit()
+        return time.perf_counter() - t
+
+    @endpoint
+    async def execute_round(self, sends_per_actor: int, direction: str) -> float:
+        """Drive ``sends_per_actor`` iterations of ``direction`` against
+        ``self.receiving_actor`` and return the cumulative ibverbs-op time.
+
+        ``direction`` is ``"read"`` or ``"write"``. Both directions move
+        data from our local tensors into the peer's buffers; the
+        difference is which side initiates the ibverbs op.
+
+        - ``read``: the peer (``self.receiving_actor``) runs ``timed_read``
+          and pulls our buffers (peer-initiated RDMA READ).
+        - ``write``: we fetch the peer's buffers via ``expose_buffers``
+          and push our local tensors with ``RDMAAction.write_remote``
+          (us-initiated RDMA WRITE).
+        """
+        total = 0.0
+        if direction == "read":
+            for _ in range(sends_per_actor):
+                total += await self.receiving_actor.timed_read.call_one(
+                    self.rdma_buffers
+                )
+        elif direction == "write":
+            peer_buffers = await self.receiving_actor.expose_buffers.call_one()
+            assert len(peer_buffers) == len(self.tensors), (
+                f"peer exposed {len(peer_buffers)} buffers but we have "
+                f"{len(self.tensors)} tensors"
+            )
+            for _ in range(sends_per_actor):
+                t = time.perf_counter()
+                action = RDMAAction()
+                for tensor, buffer in zip(self.tensors, peer_buffers):
+                    action.write_remote(
+                        buffer, tensor.view(dtype=torch.uint8).flatten()
+                    )
+                await action.submit()
+                total += time.perf_counter() - t
+        else:
+            raise ValueError(f"unknown direction: {direction!r}")
+        return total
+
+    @endpoint
+    async def reset(self) -> None:
+        for buf in self.rdma_buffers:
+            await buf.drop()
+        self.tensors = []
+        self.rdma_buffers = []
+
+    @endpoint
+    async def tensor_hashes(self) -> list[str]:
+        """Return the xxh64 hex digest of each tensor's raw bytes.
+
+        Used to verify data integrity after an RDMA round: after a
+        successful read or write, the receiver's tensors should hash
+        to the same values as the sender's.
+        """
+        out: list[str] = []
+        for t in self.tensors:
+            arr = (
+                t.detach().contiguous().view(dtype=torch.uint8).flatten().cpu().numpy()
+            )
+            out.append(xxhash.xxh64(arr.tobytes()).hexdigest())
+        return out
+
+
+@dataclass(frozen=True)
+class BenchConfig:
+    """Everything the benchmark needs that is not scheduler-specific."""
+
+    transport: str
+    payload_size_mb: float
+    runs_per_config: int
+    sends_per_actor: int
+    concurrent_ops: int
+    warmup: int
+    procs_per_host: int
+    sender_use_gpu: bool
+    receiver_use_gpu: bool
+    cross_host: bool
+    local_sender: bool
+    output_csv: str
+    command: str
+    cached_path: str | None
+    teardown_policy: str
+
+    @property
+    def num_hosts(self) -> int:
+        """Hosts taking part in the measurement."""
+        return 2 if self.cross_host else 1
+
+    @property
+    def job_hosts(self) -> int:
+        """Hosts the job must provision. Under ``--local-sender`` the client's
+        own host supplies one side, so the job provides one fewer — and for the
+        same-host shape it provides none, meaning no job at all."""
+        return self.num_hosts - 1 if self.local_sender else self.num_hosts
+
+    @property
+    def sender_label(self) -> str:
+        return "gpu" if self.sender_use_gpu else "cpu"
+
+    @property
+    def receiver_label(self) -> str:
+        return "gpu" if self.receiver_use_gpu else "cpu"
+
+    @property
+    def shape_label(self) -> str:
+        return "cross-host" if self.cross_host else "same-host"
+
+
+def configure_transport(transport: str) -> None:
+    """Configure RDMA transport backend."""
+    if transport == "ibverbs":
+        monarch.configure(rdma_allow_tcp_fallback=False)
+    else:
+        monarch.configure(rdma_disable_ibverbs=True, rdma_allow_tcp_fallback=True)
+
+
+def calculate_statistics(
+    values: list[float],
+) -> tuple[float, float, float, float]:
+    """Calculate median, mean, standard deviation, and p90."""
+    if not values:
+        return 0.0, 0.0, 0.0, 0.0
+
+    median = statistics.median(values)
+    mean = statistics.mean(values)
+    std_dev = statistics.stdev(values) if len(values) > 1 else 0.0
+    p90 = (
+        statistics.quantiles(values, n=10)[8]
+        if len(values) >= 10
+        else sorted(values)[int(len(values) * 0.9)]
+        if values
+        else 0.0
+    )
+
+    return median, mean, std_dev, p90
+
+
+async def setup_single_run(
+    sending_actors: Any,
+    receiving_actors: Any,
+    tensor_size_mb: float,
+    concurrent_ops: int,
+    sender_use_gpu: bool,
+    receiver_use_gpu: bool,
+) -> tuple[int, float]:
+    """Reset actors and allocate tensors. Returns (tensor_size, nbyte_gb)."""
+    await sending_actors.reset.call()
+    await receiving_actors.reset.call()
+
+    tensor_size = int(tensor_size_mb * 1024 * 1024 // 4)
+    nbyte_gb = tensor_size_mb / 1000
+
+    await sending_actors.receiving_actors.call(receiving_actors)
+    await sending_actors.alloc.call((tensor_size,), concurrent_ops, sender_use_gpu)
+    await receiving_actors.alloc.call((tensor_size,), concurrent_ops, receiver_use_gpu)
+
+    return tensor_size, nbyte_gb
+
+
+async def run_single_configuration(
+    sending_actors: Any,
+    receiving_actors: Any,
+    tensor_size_mb: float,
+    runs_per_config: int,
+    sends_per_actor: int,
+    concurrent_ops: int,
+    warmup: int,
+    direction: str,
+    sender_use_gpu: bool,
+    receiver_use_gpu: bool,
+) -> tuple[list[float], list[float], list[float], bool]:
+    """Run benchmark for a single (config, direction) pair.
+
+    ``sender_use_gpu`` and ``receiver_use_gpu`` select each side's memory
+    kind and are forwarded to :py:func:`setup_single_run`.
+
+    ``direction`` is ``"read"`` or ``"write"`` and is forwarded to
+    :py:meth:`TestRDMA.execute_round`. Each timed run is preceded by
+    ``warmup`` untimed iterations of the *same* direction so the
+    first-send costs (MR registration, lazy QP work,
+    page-faulting fresh allocations) are paid before measurement begins.
+
+    Returns ``(per_actor_throughputs, per_actor_latencies,
+    aggregate_throughputs, success)``. Aggregate throughput is the sum of
+    all per-actor throughputs within a single run, representing total
+    bandwidth across all initiator/peer pairs. Each "send" transfers
+    ``concurrent_ops`` tensors via a single ``RDMAAction``, so a run's
+    transferred bytes are scaled accordingly.
+    """
+    throughput_results: list[float] = []
+    latency_results: list[float] = []
+    aggregate_throughput_results: list[float] = []
+
+    print(
+        f"\nTesting {tensor_size_mb}MB payload, direction={direction!r}, "
+        f"{runs_per_config} timed runs, {sends_per_actor} sends per actor, "
+        f"{warmup} warmup sends per run, {concurrent_ops} concurrent ops..."
+    )
+
+    for run_idx in range(runs_per_config):
+        should_print = (run_idx + 1) % 10 == 0 or (run_idx + 1) == runs_per_config
+
+        try:
+            _tensor_size, nbyte_gb = await setup_single_run(
+                sending_actors,
+                receiving_actors,
+                tensor_size_mb,
+                concurrent_ops,
+                sender_use_gpu,
+                receiver_use_gpu,
+            )
+
+            if warmup > 0:
+                await sending_actors.execute_round.call(warmup, direction)
+
+            results_mesh = await sending_actors.execute_round.call(
+                sends_per_actor, direction
+            )
+
+            # Verify data integrity: after read or write, each
+            # receiver actor's tensors should be byte-identical to
+            # the paired sender actor's tensors. We use xxh64 of each
+            # tensor's raw bytes so we can compare per-tensor without
+            # round-tripping the data through Python. Pair sender and
+            # receiver actors by iteration order: both meshes have the
+            # same per-host shape (procs-per-host), so the i-th
+            # iteration entry on each side maps to the same logical
+            # rank.
+            sender_hashes_mesh = await sending_actors.tensor_hashes.call()
+            receiver_hashes_mesh = await receiving_actors.tensor_hashes.call()
+            sender_items = list(sender_hashes_mesh.items())
+            receiver_items = list(receiver_hashes_mesh.items())
+            if len(sender_items) != len(receiver_items):
+                raise RuntimeError(
+                    f"actor count mismatch: "
+                    f"sender={len(sender_items)}, "
+                    f"receiver={len(receiver_items)}"
+                )
+            for (sender_point, sender_hashes), (
+                receiver_point,
+                receiver_hashes,
+            ) in zip(sender_items, receiver_items):
+                rank = f"sender={sender_point} receiver={receiver_point}"
+                if len(sender_hashes) != len(receiver_hashes):
+                    raise RuntimeError(
+                        f"hash count mismatch on {rank}: "
+                        f"sender={len(sender_hashes)}, "
+                        f"receiver={len(receiver_hashes)}"
+                    )
+                mismatches: list[int] = [
+                    i
+                    for i, (s, r) in enumerate(zip(sender_hashes, receiver_hashes))
+                    if s != r
+                ]
+                if mismatches:
+                    preview = mismatches[:10]
+                    raise RuntimeError(
+                        f"DATA CORRUPTION on {rank}: "
+                        f"{len(mismatches)} of {len(sender_hashes)} "
+                        f"tensors differ after {direction} on run "
+                        f"{run_idx + 1}; first mismatched indices = "
+                        f"{preview}; e.g. tensor[{preview[0]}]: "
+                        f"sender={sender_hashes[preview[0]]}, "
+                        f"receiver={receiver_hashes[preview[0]]}"
+                    )
+
+            run_throughputs: list[float] = []
+            for _rank, receiver_time in results_mesh.items():
+                if receiver_time and receiver_time > 0:
+                    throughput_gbs = (
+                        nbyte_gb * sends_per_actor * concurrent_ops
+                    ) / receiver_time
+                    latency_ms = receiver_time * 1000
+                    throughput_results.append(throughput_gbs)
+                    latency_results.append(latency_ms)
+                    run_throughputs.append(throughput_gbs)
+
+            if run_throughputs:
+                aggregate_throughput_results.append(sum(run_throughputs))
+
+            if should_print and run_throughputs:
+                print(
+                    f"  Run {run_idx + 1}/{runs_per_config} ({direction}) - "
+                    f"Per-actor: {run_throughputs[-1]:.2f} GB/s, "
+                    f"Aggregate: {sum(run_throughputs):.2f} GB/s, "
+                    f"Latency: {latency_results[-1]:.2f} ms"
+                )
+
+        except Exception as e:
+            print(f"  Run {run_idx + 1} ({direction}) failed: {e}")
+            return (
+                throughput_results,
+                latency_results,
+                aggregate_throughput_results,
+                False,
+            )
+
+    return throughput_results, latency_results, aggregate_throughput_results, True
+
+
+def print_summary_table(cfg: BenchConfig, rows: list[dict[str, Any]]) -> None:
+    """Print a compact summary table of all configurations."""
+    if not rows:
+        return
+
+    shape_width = max(8, max(len(r["shape"]) for r in rows))
+    direction_width = max(9, max(len(r["direction"]) for r in rows))
+
+    print(f"\n{'=' * 70}")
+    print("SUMMARY")
+    print(f"  Memory: sender={cfg.sender_label}  |  receiver={cfg.receiver_label}")
+    print(
+        f"  Transport: {cfg.transport}  |  Payload: {cfg.payload_size_mb} MB  |  "
+        f"Sends/actor: {cfg.sends_per_actor}  |  Concurrent ops: {cfg.concurrent_ops}  |  "
+        f"Runs/config: {cfg.runs_per_config}"
+    )
+    print(f"{'=' * 70}")
+    header = (
+        f"{'Config':>{shape_width}}  {'Direction':>{direction_width}}  "
+        f"{'Per-actor (GB/s)':>16}  {'Aggregate (GB/s)':>17}  "
+        f"{'Latency med (ms)':>17}  {'Latency p90 (ms)':>17}"
+    )
+    print(header)
+    print("-" * len(header))
+    for r in rows:
+        print(
+            f"{r['shape']:>{shape_width}}  {r['direction']:>{direction_width}}  "
+            f"{r['tp_med']:>16.2f}  {r['agg_med']:>17.2f}  "
+            f"{r['lat_med']:>17.2f}  {r['lat_p90']:>17.2f}"
+        )
+    print()
+
+
+def add_benchmark_args(parser: argparse.ArgumentParser, *, batch: bool = True) -> None:
+    """Add the scheduler-independent flags, then the subcommands.
+
+    Wrappers add their own flags on top; because those land on the parent parser
+    they are given before the subcommand, as in
+    ``slurm_benchmark.py --partition x run --teardown-policy on_failure``.
+
+    Set ``batch=False`` for a backend that cannot run the benchmark inside its
+    own allocation, which drops the ``run-batch`` subcommand entirely rather
+    than accepting it and failing later.
+    """
+    parser.add_argument(
+        "--transport",
+        choices=["ibverbs", "tcp"],
+        default="ibverbs",
+        help="RDMA transport backend (default: ibverbs)",
+    )
+    parser.add_argument(
+        "--payload-size-mb",
+        type=float,
+        default=1024,
+        help="Payload size in MB (default: 1024)",
+    )
+    parser.add_argument(
+        "--runs-per-config",
+        type=int,
+        default=3,
+        help="Number of runs per configuration (default: 3)",
+    )
+    parser.add_argument(
+        "--warmup",
+        type=int,
+        default=3,
+        help=(
+            "Number of untimed warmup sends issued against the freshly-allocated "
+            "buffers before each timed run. Each timed run still does its own "
+            "setup; warmup sends sit between setup and the timed loop so "
+            "first-send costs like MR registration are amortized. "
+            "Applied separately per direction (read and write each get this "
+            "many warmup iterations) (default: 3)."
+        ),
+    )
+    parser.add_argument(
+        "--sends-per-actor",
+        type=int,
+        default=10,
+        help="Number of sends per actor per run (default: 10)",
+    )
+    parser.add_argument(
+        "--concurrent-ops",
+        type=int,
+        default=1,
+        help=(
+            "Number of concurrent RDMA ops per send. Each actor "
+            "allocates this many tensors and uses one ``RDMAAction`` "
+            "to transfer them in parallel (default: 1)."
+        ),
+    )
+    parser.add_argument(
+        "--procs-per-host",
+        type=int,
+        default=8,
+        help="GPU processes per host (default: 8)",
+    )
+    parser.add_argument(
+        "--output-csv",
+        default="/tmp/rdma_benchmark_results.csv",
+        help=(
+            "Destination CSV for per-direction results (default: "
+            "/tmp/rdma_benchmark_results.csv). Override per parallel run "
+            "so concurrent benchmarks don't clobber each other's results."
+        ),
+    )
+
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument("--gpu", action="store_true", default=False)
+    mode_group.add_argument("--cpu", action="store_true", default=False)
+
+    parser.add_argument(
+        "--sender-device",
+        choices=["cpu", "gpu"],
+        default=None,
+        help=(
+            "Memory kind for the sending actors' tensors. Defaults to the "
+            "--gpu/--cpu setting, which applies to both sides."
+        ),
+    )
+    parser.add_argument(
+        "--receiver-device",
+        choices=["cpu", "gpu"],
+        default=None,
+        help=(
+            "Memory kind for the receiving actors' tensors. Defaults to the "
+            "--gpu/--cpu setting, which applies to both sides."
+        ),
+    )
+
+    shape_group = parser.add_mutually_exclusive_group()
+    shape_group.add_argument(
+        "--cross-host",
+        action="store_true",
+        default=False,
+        help="Run only the cross-host configuration (default).",
+    )
+    shape_group.add_argument(
+        "--same-host",
+        action="store_true",
+        default=False,
+        help="Run only the same-host (loopback) configuration instead of cross-host.",
+    )
+
+    _add_subcommands(parser, batch=batch)
+
+
+def _add_subcommands(parser: argparse.ArgumentParser, *, batch: bool) -> None:
+    """Attach the ``run`` / ``run-batch`` subcommands.
+
+    Everything above is shared and so belongs before the subcommand on the
+    command line. The flags below apply only when this process drives the
+    benchmark, which is why none of them exist on ``run-batch``.
+    """
+    sub = parser.add_subparsers(dest="command", required=True, metavar="COMMAND")
+
+    run_parser = sub.add_parser(
+        RUN_COMMAND,
+        help="Drive the benchmark from this process, exiting non-zero if a direction fails.",
+    )
+    run_parser.add_argument(
+        "--local-sender",
+        action="store_true",
+        default=False,
+        help="Run sending actors on the client host via this_host(). "
+        "Without this flag, all actors run on the job's hosts.",
+    )
+    run_parser.add_argument(
+        "--teardown-policy",
+        choices=TEARDOWN_POLICIES,
+        default=TEARDOWN_ALWAYS,
+        help=(
+            f"When to kill the job (default: {TEARDOWN_ALWAYS}). "
+            f"'{TEARDOWN_ON_FAILURE}' leaves a fully successful run's job up so "
+            "the next run can reuse it via --cached-path, while still tearing "
+            f"down a failed or partial one. '{TEARDOWN_NEVER}' always leaves it "
+            f"up, and is what {BATCH_COMMAND} passes its in-allocation client, "
+            "whose runner owns the allocation."
+        ),
+    )
+    run_parser.add_argument(
+        "--cached-path",
+        default=None,
+        help=(
+            "Path to a pickle file used to cache + reconnect to the job state. "
+            "When unset (default), an explicit None is passed so no cache is "
+            "used and a fresh job is always created. Set this to a unique path "
+            "per parallel benchmark run so concurrent runs don't collide on the "
+            "same cache."
+        ),
+    )
+
+    if batch:
+        sub.add_parser(
+            BATCH_COMMAND,
+            help=(
+                "Submit the benchmark to run inside its own allocation and "
+                "return immediately. Exits 0 once submitted: the scheduler "
+                "exposes no completion status, so read the job's log or "
+                "--output-csv for the result. --output-csv is written by the "
+                "in-allocation client, so point it somewhere still visible "
+                "afterwards — the default lives in /tmp, which is node-local."
+            ),
+        )
+
+
+def config_from_args(args: argparse.Namespace) -> BenchConfig:
+    """Build a :py:class:`BenchConfig` from :py:func:`add_benchmark_args` flags."""
+    # --gpu/--cpu set both sides; --sender-device/--receiver-device override
+    # each side independently.
+    default_use_gpu: bool = not args.cpu
+    return BenchConfig(
+        transport=args.transport,
+        payload_size_mb=float(args.payload_size_mb),
+        runs_per_config=int(args.runs_per_config),
+        sends_per_actor=int(args.sends_per_actor),
+        concurrent_ops=int(args.concurrent_ops),
+        warmup=int(args.warmup),
+        procs_per_host=int(args.procs_per_host),
+        sender_use_gpu=(
+            args.sender_device == "gpu" if args.sender_device else default_use_gpu
+        ),
+        receiver_use_gpu=(
+            args.receiver_device == "gpu" if args.receiver_device else default_use_gpu
+        ),
+        cross_host=not args.same_host,
+        output_csv=args.output_csv,
+        command=args.command,
+        # These exist only on the `run` subparser.
+        local_sender=getattr(args, "local_sender", False),
+        cached_path=getattr(args, "cached_path", None),
+        teardown_policy=getattr(args, "teardown_policy", TEARDOWN_ALWAYS),
+    )
+
+
+def _spawn_job_mesh(job: JobTrait, mesh_name: str, cfg: BenchConfig) -> ProcMesh:
+    state = job.state(cached_path=cfg.cached_path)
+    return getattr(state, mesh_name).spawn_procs(per_host={"gpus": cfg.procs_per_host})
+
+
+async def _drive(
+    cfg: BenchConfig,
+    job: JobTrait | None,
+    mesh_name: str,
+    banner: Sequence[str],
+) -> tuple[int, int]:
+    """Run every direction and return ``(successful, total)``."""
+    configure_transport(cfg.transport)
+
+    print("=" * 70)
+    print("RDMA Benchmark")
+    print("=" * 70)
+    for line in banner:
+        print(line)
+    print(f"Transport: {cfg.transport}")
+    print(f"Payload: {cfg.payload_size_mb} MB")
+    print(f"Runs per config: {cfg.runs_per_config}")
+    print(f"Sends per actor: {cfg.sends_per_actor}")
+    print(f"Warmup: {cfg.warmup}")
+    print(f"Concurrent ops: {cfg.concurrent_ops}")
+    print(f"Procs per host: {cfg.procs_per_host}")
+    print(f"Memory: sender={cfg.sender_label}, receiver={cfg.receiver_label}")
+    print(f"Host shape: {cfg.shape_label}")
+    print(f"Directions: {', '.join(DIRECTIONS)}")
+    print(f"Output: {cfg.output_csv}")
+
+    with open(cfg.output_csv, "w") as f:
+        f.write(
+            "payload_size_mb,num_hosts,num_gpus_per_host,sends_per_actor,concurrent_ops,transport,"
+            "sender_device,receiver_device,direction,"
+            "per_actor_tp_median_gbs,per_actor_tp_avg_gbs,per_actor_tp_std_gbs,per_actor_tp_p90_gbs,"
+            "aggregate_tp_median_gbs,aggregate_tp_avg_gbs,aggregate_tp_std_gbs,aggregate_tp_p90_gbs,"
+            "latency_median_ms,latency_avg_ms,latency_std_ms,latency_p90_ms\n"
+        )
+
+    # Accumulate per-(shape, direction) results for the summary table.
+    summary_rows: list[dict[str, Any]] = []
+
+    successful = 0
+    proc_meshes: list[ProcMesh] = []
+    try:
+        sending_actors: Any
+        receiving_actors: Any
+
+        if cfg.local_sender:
+            local_proc_mesh = this_host().spawn_procs(
+                per_host={"gpus": cfg.procs_per_host}
+            )
+            proc_meshes.append(local_proc_mesh)
+
+            if cfg.cross_host:
+                assert job is not None, "cross-host --local-sender needs a job"
+                sending_actors = local_proc_mesh.spawn("local_actors", TestRDMA)
+                job_proc_mesh = _spawn_job_mesh(job, mesh_name, cfg)
+                proc_meshes.append(job_proc_mesh)
+                receiving_actors = job_proc_mesh.spawn("remote_receivers", TestRDMA)
+                print(
+                    f"Local: 1x{cfg.procs_per_host}, "
+                    f"remote: {cfg.job_hosts}x{cfg.procs_per_host} "
+                    f"(sender={cfg.sender_label}, receiver={cfg.receiver_label}); "
+                    f"shape={cfg.shape_label}"
+                )
+            else:
+                sending_actors = local_proc_mesh.spawn("local_senders", TestRDMA)
+                receiving_actors = local_proc_mesh.spawn("local_receivers", TestRDMA)
+                print(
+                    f"Local: 1x{cfg.procs_per_host} (sender={cfg.sender_label}, "
+                    f"receiver={cfg.receiver_label}); "
+                    f"shape={cfg.shape_label} (loopback)"
+                )
+        else:
+            assert job is not None, "a job is required unless running fully local"
+            job_proc_mesh = _spawn_job_mesh(job, mesh_name, cfg)
+            proc_meshes.append(job_proc_mesh)
+
+            print(
+                f"Job: {cfg.job_hosts}x{cfg.procs_per_host} "
+                f"(sender={cfg.sender_label}, receiver={cfg.receiver_label}); "
+                f"shape={cfg.shape_label}"
+            )
+
+            if cfg.cross_host:
+                actors = job_proc_mesh.spawn("rdma_test_actors", TestRDMA)
+                sending_actors = actors.slice(hosts=0)
+                receiving_actors = actors.slice(hosts=1)
+            else:
+                sending_actors = job_proc_mesh.spawn("rdma_senders", TestRDMA)
+                receiving_actors = job_proc_mesh.spawn("rdma_receivers", TestRDMA)
+
+        for direction in DIRECTIONS:
+            print(f"\n{'=' * 70}")
+            print(f"Configuration: {cfg.shape_label} / {direction}")
+            print("=" * 70)
+
+            try:
+                (
+                    throughputs,
+                    latencies,
+                    agg_throughputs,
+                    success,
+                ) = await run_single_configuration(
+                    sending_actors,
+                    receiving_actors,
+                    cfg.payload_size_mb,
+                    cfg.runs_per_config,
+                    cfg.sends_per_actor,
+                    cfg.concurrent_ops,
+                    cfg.warmup,
+                    direction,
+                    cfg.sender_use_gpu,
+                    cfg.receiver_use_gpu,
+                )
+
+                if not success or not throughputs:
+                    print(f"Configuration {cfg.shape_label}/{direction} failed")
+                    continue
+
+                tp_med, tp_avg, tp_std, tp_p90 = calculate_statistics(throughputs)
+                agg_med, agg_avg, agg_std, agg_p90 = calculate_statistics(
+                    agg_throughputs
+                )
+                lat_med, lat_avg, lat_std, lat_p90 = calculate_statistics(latencies)
+
+                with open(cfg.output_csv, "a") as f:
+                    f.write(
+                        f"{cfg.payload_size_mb},{cfg.num_hosts},{cfg.procs_per_host},"
+                        f"{cfg.sends_per_actor},{cfg.concurrent_ops},"
+                        f"{cfg.transport},{cfg.sender_label},{cfg.receiver_label},{direction},"
+                        f"{tp_med:.4f},{tp_avg:.4f},{tp_std:.4f},{tp_p90:.4f},"
+                        f"{agg_med:.4f},{agg_avg:.4f},{agg_std:.4f},{agg_p90:.4f},"
+                        f"{lat_med:.4f},{lat_avg:.4f},{lat_std:.4f},{lat_p90:.4f}\n"
+                    )
+
+                summary_rows.append(
+                    {
+                        "shape": cfg.shape_label,
+                        "direction": direction,
+                        "tp_med": tp_med,
+                        "agg_med": agg_med,
+                        "lat_med": lat_med,
+                        "lat_p90": lat_p90,
+                    }
+                )
+
+                print(f"\nResults for {cfg.shape_label} / {direction}:")
+                print(
+                    f"  Per-actor throughput  - Median: {tp_med:.2f} GB/s, "
+                    f"Avg: {tp_avg:.2f} GB/s, Std: {tp_std:.2f} GB/s, "
+                    f"P90: {tp_p90:.2f} GB/s"
+                )
+                print(
+                    f"  Aggregate throughput  - Median: {agg_med:.2f} GB/s, "
+                    f"Avg: {agg_avg:.2f} GB/s, Std: {agg_std:.2f} GB/s, "
+                    f"P90: {agg_p90:.2f} GB/s"
+                )
+                print(
+                    f"  Latency              - Median: {lat_med:.2f} ms, "
+                    f"Avg: {lat_avg:.2f} ms, Std: {lat_std:.2f} ms, "
+                    f"P90: {lat_p90:.2f} ms"
+                )
+
+                successful += 1
+                await asyncio.sleep(2)
+
+            except Exception as e:
+                print(f"Failed to run {cfg.shape_label}/{direction}: {e}")
+                continue
+
+        print(f"\n{'=' * 70}")
+        print(f"BENCHMARK COMPLETED: {successful}/{len(DIRECTIONS)} directions")
+        print(f"Results saved to: {cfg.output_csv}")
+        print("=" * 70)
+
+        print_summary_table(cfg, summary_rows)
+
+        return successful, len(DIRECTIONS)
+
+    except Exception as e:
+        print(f"BENCHMARK FAILED: {e}")
+        raise
+    finally:
+        # Stop the meshes before killing the job whose hosts they run on.
+        for mesh in proc_meshes:
+            try:
+                await mesh.stop()
+            except Exception as stop_e:
+                print(f"Warning: Failed to stop proc mesh: {stop_e}")
+        if job is not None:
+            failed = successful < len(DIRECTIONS)
+            teardown = cfg.teardown_policy == TEARDOWN_ALWAYS or (
+                cfg.teardown_policy == TEARDOWN_ON_FAILURE and failed
+            )
+            if teardown:
+                try:
+                    job.kill()
+                    print("Killed job")
+                except Exception as kill_e:
+                    print(f"Warning: Failed to kill job: {kill_e}")
+            else:
+                print(f"Leaving job running (--teardown-policy {cfg.teardown_policy})")
+
+
+def _batch_client_command() -> str:
+    """This same invocation, rewritten to be the in-allocation client.
+
+    ``run-batch`` becomes ``run``, and the two flags that make the client attach
+    to the surrounding allocation are appended: ``--cached-path`` so it reads the
+    ``BatchJob`` the scheduler dumped there instead of submitting a second
+    allocation from inside the first, and ``--teardown-policy never`` because the
+    runner — not the client — owns the allocation.
+    """
+    from monarch.job import DEFAULT_JOB_PATH
+
+    argv = sys.argv[1:]
+    # The subcommand is a bare word, so a flag *value* could also equal it (e.g.
+    # --output-csv run-batch). Rewriting the wrong one would silently submit a
+    # nested batch job, so require it to be unambiguous.
+    positions = [i for i, arg in enumerate(argv) if arg == BATCH_COMMAND]
+    if len(positions) != 1:
+        raise SystemExit(
+            f"cannot rebuild the client command: {BATCH_COMMAND!r} appears "
+            f"{len(positions)} times in the arguments; it must appear exactly "
+            "once, as the subcommand"
+        )
+    argv[positions[0]] = RUN_COMMAND
+
+    return shlex.join(
+        [
+            sys.executable,
+            str(Path(sys.argv[0]).resolve()),
+            *argv,
+            "--cached-path",
+            DEFAULT_JOB_PATH,
+            "--teardown-policy",
+            TEARDOWN_NEVER,
+        ]
+    )
+
+
+def run(
+    cfg: BenchConfig,
+    *,
+    make_job: Callable[[BenchConfig], JobTrait],
+    mesh_name: str,
+    banner: Sequence[str] = (),
+) -> int:
+    """Run or submit the benchmark against a job built by ``make_job``.
+
+    Returns a process exit code.
+
+    ``make_job`` is called only when hosts are actually needed, so the fully
+    local ``--same-host --local-sender`` shape never provisions anything. It is
+    called before any ``this_host()`` call, which matters because some job types
+    configure the channel transport as a side effect of construction.
+    """
+    job: JobTrait | None = None
+    if cfg.job_hosts > 0:
+        job = make_job(cfg)
+
+    if cfg.command == BATCH_COMMAND:
+        # job_hosts is only 0 under --local-sender, which run-batch does not offer.
+        assert job is not None
+        job.apply(client_script=_batch_client_command())
+        print(
+            f"Submitted batch run; results will be written to {cfg.output_csv}. "
+            "The scheduler reports no completion status, so check the job's log."
+        )
+        return 0
+
+    successful, total = asyncio.run(_drive(cfg, job, mesh_name, banner))
+    if successful < total:
+        print(
+            f"BENCHMARK FAILED: {successful}/{total} directions succeeded",
+            flush=True,
+        )
+        return 1
+    return 0

--- a/python/benches/multihost_rdma/slurm_benchmark.py
+++ b/python/benches/multihost_rdma/slurm_benchmark.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+"""
+SLURM wrapper around the multi-host RDMA benchmark.
+
+The benchmark itself lives in ``benchmark_common`` and knows nothing about
+SLURM. This file only builds the ``SlurmJob`` it runs on and adds the SLURM
+flags.
+
+Two subcommands:
+
+- ``run``: this process allocates the job and drives the actors, exiting
+  non-zero if a direction fails.
+- ``run-batch``: submit the benchmark to run inside its own allocation and
+  return immediately. Submit from a filesystem shared with the head node — the
+  job state is cached at the CWD-relative ``.monarch/job_state.pkl``, which the
+  in-allocation client reads back.
+
+Shared flags precede the subcommand:
+``slurm_benchmark.py --partition p --cross-host run --teardown-policy on_failure``.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from benchmark_common import add_benchmark_args, BenchConfig, config_from_args, run
+from monarch.job import SlurmJob
+
+
+MESH_NAME = "workers"
+
+
+def make_slurm_job(cfg: BenchConfig, args: argparse.Namespace) -> SlurmJob:
+    """Build the SLURM job the benchmark runs on."""
+    return SlurmJob(
+        meshes={MESH_NAME: cfg.job_hosts},
+        job_name="monarch_rdma_bench",
+        partition=args.partition,
+        gpus_per_node=args.gpus_per_node,
+        cpus_per_task=args.cpus_per_task,
+        mem=args.mem,
+        qos=args.qos,
+        exclusive=args.exclusive,
+        slurm_args=tuple(args.slurm_arg),
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Multi-host RDMA Performance Benchmark (SLURM)"
+    )
+    add_benchmark_args(parser)
+    parser.add_argument(
+        "--partition",
+        default=None,
+        help="SLURM partition to submit to (default: the cluster's default)",
+    )
+    parser.add_argument(
+        "--gpus-per-node",
+        type=int,
+        default=1,
+        help="GPUs to request per node (default: 1)",
+    )
+    parser.add_argument(
+        "--cpus-per-task",
+        type=int,
+        default=None,
+        help="CPUs per task (default: the cluster's default)",
+    )
+    parser.add_argument(
+        "--mem",
+        default=None,
+        help="Memory per node, e.g. '64G' (default: the cluster's default)",
+    )
+    parser.add_argument(
+        "--qos",
+        default=None,
+        help="SLURM quality-of-service to request (default: the cluster's default)",
+    )
+    parser.add_argument(
+        "--exclusive",
+        action="store_true",
+        default=False,
+        help=(
+            "Request exclusive node access. Off by default; note that sharing a "
+            "node while --partition and --gpus-per-node are set makes SlurmJob "
+            "call share_node(), which raises unless the clusterscope package is "
+            "installed."
+        ),
+    )
+    parser.add_argument(
+        "--slurm-arg",
+        action="append",
+        default=[],
+        metavar="ARG",
+        help=(
+            "Extra sbatch directive, repeatable, e.g. --slurm-arg=--time=01:00:00 "
+            "--slurm-arg=--account=my_account. Each value starting with '-' "
+            "becomes a raw #SBATCH line."
+        ),
+    )
+
+    args = parser.parse_args()
+    cfg = config_from_args(args)
+
+    banner = [
+        f"Mode: {'local sender -> SLURM receivers' if cfg.local_sender else 'all SLURM'}",
+        f"Partition: {args.partition or 'default'}",
+        f"GPUs per node: {args.gpus_per_node}",
+    ]
+
+    exit_code = run(
+        cfg,
+        make_job=lambda c: make_slurm_job(c, args),
+        mesh_name=MESH_NAME,
+        banner=banner,
+    )
+
+    if exit_code:
+        raise SystemExit(exit_code)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary:

Factor out the scheduler agnostic parts of the multihost RDMA benchmark, and provide a wrapper implementation that uses SLURM.

`benchmark_common.py` holds the `TestRDMA` actor, the read/write driver, stats,
and CSV, and takes the job it runs on from its caller using only `JobTrait` API. No benchmark logic changed, so numbers are comparable across the move.

Differential Revision: D115473374
