### PR TITLE
Resolve a local region's MemoryLocation once, at construction (#4642)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -482,7 +482,7 @@ impl Handler<InitializeBuffer> for CudaRdmaActor {
             let addr = self.cu_ptr;
             let size = self.cpu_buffer.len();
             // See the module-level note on `NoKeepalive`.
-            let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
+            let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive { addr, size }))?;
             let handle = self
                 .rdma_manager
                 .downcast_handle(cx)

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -209,7 +209,7 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
             let addr = self.weights_data.as_ptr() as usize;
             let size = self.weights_data.len();
             // See the module-level note on `NoKeepalive`.
-            let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
+            let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive { addr, size }))?;
             let handle = self
                 .owner_ref
                 .downcast_handle(cx)
@@ -229,7 +229,8 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
                 let addr = self.grad_buffer_data[rank].as_ptr() as usize;
                 let size = self.grad_buffer_data[rank].len();
                 // See the module-level note on `NoKeepalive`.
-                let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
+                let local_memory =
+                    KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive { addr, size }))?;
                 let handle = self
                     .owner_ref
                     .downcast_handle(cx)
@@ -400,10 +401,10 @@ impl Handler<WorkerStep> for WorkerActor {
             .as_ref()
             .expect("worker_actor should be initialized");
         // See the module-level note on `NoKeepalive`.
-        let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+        let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
             addr: self.local_gradients.as_ptr() as usize,
             size: self.local_gradients.len(),
-        }));
+        }))?;
 
         ps_grad_handle.write_from_local(cx, local_memory, 5).await?;
 
@@ -434,10 +435,10 @@ impl Handler<WorkerUpdate> for WorkerActor {
             .as_ref()
             .expect("worker_actor should be initialized");
         // See the module-level note on `NoKeepalive`.
-        let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+        let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
             addr: self.weights_data.as_ptr() as usize,
             size: self.weights_data.len(),
-        }));
+        }))?;
         ps_weights_handle
             .read_into_local(cx, local_memory, 5)
             .await?;

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -442,11 +442,12 @@ impl Keepalive for PyKeepalive {
 #[pymethods]
 impl PyLocalMemoryHandle {
     #[new]
-    fn new(obj: Py<PyAny>, addr: usize, size: usize) -> Self {
+    fn new(obj: Py<PyAny>, addr: usize, size: usize) -> PyResult<Self> {
         let keepalive: Arc<dyn Keepalive> = Arc::new(PyKeepalive { obj, addr, size });
-        Self {
-            inner: KeepaliveLocalMemory::new(keepalive),
-        }
+        Ok(Self {
+            inner: KeepaliveLocalMemory::try_new(keepalive)
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
+        })
     }
 
     #[getter]
@@ -563,7 +564,8 @@ fn _make_local_memory_handle_from_memoryview(
         size,
     });
     Ok(PyLocalMemoryHandle {
-        inner: KeepaliveLocalMemory::new(keepalive),
+        inner: KeepaliveLocalMemory::try_new(keepalive)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
     })
 }
 
@@ -592,7 +594,8 @@ fn _make_local_memory_handle_from_tensor(
         numel,
     });
     Ok(PyLocalMemoryHandle {
-        inner: KeepaliveLocalMemory::new(keepalive),
+        inner: KeepaliveLocalMemory::try_new(keepalive)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
     })
 }
 

--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -195,18 +195,20 @@ impl CudaAllocation {
     /// `[ptr + offset, ptr + offset + size)` of this allocation. The handle
     /// keeps the whole allocation mapped for its lifetime.
     ///
-    /// Panics if the sub-range does not fit within the currently mapped extent.
+    /// Panics if the sub-range does not fit within the currently mapped extent,
+    /// or if the CUDA driver will not name the device that owns the allocation.
     pub fn keepalive_slice(&self, offset: usize, size: usize) -> KeepaliveLocalMemory {
         let mapped = self.size();
         assert!(
             offset.checked_add(size).is_some_and(|end| end <= mapped),
             "slice [0x{offset:x}, 0x{offset:x}+{size}) exceeds mapped allocation size {mapped}",
         );
-        KeepaliveLocalMemory::new(Arc::new(CudaAllocationSlice {
+        KeepaliveLocalMemory::try_new(Arc::new(CudaAllocationSlice {
             alloc: self.clone(),
             offset,
             size,
         }))
+        .expect("this allocation's own device should be resolvable")
     }
 
     /// Try to free the backing CUDA memory. Returns `true` if the
@@ -709,7 +711,7 @@ impl ReceiverMessageHandler for ReceiverActor {
         // unwritten destination is distinguishable from a successful
         // read.
         let buf: Box<[u8]> = vec![!expected_pattern; size].into_boxed_slice();
-        let local = KeepaliveLocalMemory::new(Arc::new(buf));
+        let local = KeepaliveLocalMemory::try_new(Arc::new(buf))?;
 
         let read_result = remote
             .read_into_local(cx, local.clone(), timeout_secs)
@@ -746,7 +748,7 @@ impl ReceiverMessageHandler for ReceiverActor {
         timeout_secs: u64,
     ) -> Result<Result<(), String>, anyhow::Error> {
         let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
-        let local = KeepaliveLocalMemory::new(Arc::new(buf));
+        let local = KeepaliveLocalMemory::try_new(Arc::new(buf))?;
 
         let result = remote
             .write_from_local(cx, local, timeout_secs)

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -29,8 +29,8 @@ use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMr;
 use super::primitives::IbvPd;
 use super::queue_pair::IbvQueuePair;
+use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
-use crate::local_memory::is_device_ptr;
 
 /// Manages RDMA resources including context and protection domain.
 ///
@@ -421,9 +421,10 @@ pub(super) unsafe fn register_dmabuf_mr(
     // so make the pointer's own device context current first. Without this, in a
     // multi-GPU process it fails with `CUDA_ERROR_NOT_FOUND` whenever the active
     // context belongs to a different device than `addr`.
-    // SAFETY: this path is only taken for device memory (`is_device_ptr(addr)`
-    // in `register_host_or_dmabuf_mr`), so `addr` is a valid CUDA device pointer
-    // as `set_ctx_for_ptr` requires. The guard restores the prior context on drop.
+    // SAFETY: this path is only taken for device memory (the
+    // `MemoryLocation::Gpu` arm in `register_host_or_dmabuf_mr`), so `addr` is a
+    // valid CUDA device pointer as `set_ctx_for_ptr` requires. The guard
+    // restores the prior context on drop.
     let _ctx_guard = unsafe { crate::local_memory::set_ctx_for_ptr(addr)? };
 
     let (base, base_size) = cuda_alloc_range(addr)?;
@@ -476,10 +477,9 @@ pub(super) unsafe fn register_host_or_dmabuf_mr<I: IbvDomainImpl>(
     // PD (the helpers error on null), and `[addr, addr + size)` stays valid for
     // the returned MR's lifetime.
     let (mr, mr_offset) = unsafe {
-        if is_device_ptr(addr) {
-            register_dmabuf_mr(domain.pd(), addr, size, access_flags)?
-        } else {
-            (register_host_mr(domain.pd(), addr, size, access_flags)?, 0)
+        match mem.location() {
+            MemoryLocation::Gpu(_) => register_dmabuf_mr(domain.pd(), addr, size, access_flags)?,
+            MemoryLocation::Cpu(_) => (register_host_mr(domain.pd(), addr, size, access_flags)?, 0),
         }
     };
 

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -237,10 +237,10 @@ impl Handler<CudaActorMessage> for CudaActor {
 
                 // Register via RdmaManagerActor request_buffer.
                 // See the module-level note on `NoKeepalive`.
-                let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+                let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                     addr: dptr,
                     size: padded_size,
-                }));
+                }))?;
                 let handle = rdma_actor
                     .downcast_handle(cx)
                     .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -635,10 +635,10 @@ impl DoorbellTestEnv {
                 len: buffer.len(),
                 cpu_ref: Some(buffer),
             });
-            local_memory_1 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            local_memory_1 = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                 addr: ptr as usize,
                 size: buffer_size,
-            }));
+            }))?;
             let handle_1 = actor_1
                 .downcast_handle(&instance_1)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -655,10 +655,10 @@ impl DoorbellTestEnv {
                 .await?;
             rdma_handle_1 = rdma_buf;
             device_ptr_1 = Some(dev_ptr);
-            local_memory_1 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            local_memory_1 = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                 addr: dev_ptr,
                 size: buffer_size,
-            }));
+            }))?;
 
             buf_vec.push(Buffer {
                 ptr: dev_ptr as u64,
@@ -676,10 +676,10 @@ impl DoorbellTestEnv {
                 len: buffer.len(),
                 cpu_ref: Some(buffer),
             });
-            local_memory_2 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            local_memory_2 = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                 addr: ptr as usize,
                 size: buffer_size,
-            }));
+            }))?;
             let handle_2 = actor_2
                 .downcast_handle(&instance_2)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -696,10 +696,10 @@ impl DoorbellTestEnv {
                 .await?;
             rdma_handle_2 = rdma_buf;
             device_ptr_2 = Some(dev_ptr);
-            local_memory_2 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            local_memory_2 = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                 addr: dev_ptr,
                 size: buffer_size,
-            }));
+            }))?;
 
             buf_vec.push(Buffer {
                 ptr: dev_ptr as u64,

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -70,7 +70,6 @@ use crate::backend::RdmaConfig;
 use crate::backend::ResolveRemoteBackendContext;
 use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
-use crate::local_memory::is_device_ptr;
 use crate::rdma_components::RdmaRemoteBuffer;
 use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::validate_execution_context;
@@ -324,10 +323,10 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
 
     /// Resolve `mem` to an [`IbvMemoryRegionView`] using the slot shared by
     /// every clone of `mem`. On a cold slot, picks the RDMA device (an explicit
-    /// `config.target` if set, else the CUDA-co-located NIC for device memory,
-    /// else a hash-assigned NIC for host memory) and registers the region
-    /// through that device's [`IbvDomainImpl`] strategy, installing the result;
-    /// on a warm slot, returns the cached view.
+    /// `config.target` if set, else one of the NICs with the best path to
+    /// `mem`'s [`MemoryLocation`]) and registers the region through that
+    /// device's [`IbvDomainImpl`] strategy, installing the result; on a warm
+    /// slot, returns the cached view.
     fn resolve_local_mr(
         &mut self,
         mem: &KeepaliveLocalMemory,
@@ -335,81 +334,20 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         if let Some(mrv) = mem.mr_slot().get() {
             return Ok(mrv.clone());
         }
-        let addr = mem.addr();
 
-        // Device selection, in priority order:
-        //   1. an explicit `config.target`, resolved to its NIC;
-        //   2. otherwise the CUDA-co-located NIC for device memory;
-        //   3. otherwise a host-memory NIC assigned by hashing (addr, size).
-        let device_name = if let Some(target) = &self.config.target {
-            resolve_target::<I>(target)?
+        // An explicit `config.target` wins; otherwise take the NICs tied for
+        // the best path to the memory and pick one of them.
+        let device_name = match &self.config.target {
+            Some(target) => resolve_target::<I>(target)?
                 .ok_or_else(|| anyhow::anyhow!("configured device target {:?} not found", target))?
                 .name()
-                .clone()
-        } else {
-            let cuda_nic = if is_device_ptr(addr) {
-                let mut device_ordinal: i32 = -1;
-                // SAFETY: `addr` is a CUDA device pointer (per `is_device_ptr`);
-                // the FFI call writes the owning device ordinal through the
-                // out-pointer.
-                let err = unsafe {
-                    rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
-                        &mut device_ordinal as *mut _ as *mut std::ffi::c_void,
-                        rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
-                        addr as rdmaxcel_sys::CUdeviceptr,
-                    )
-                };
-                let ordinal = (err == rdmaxcel_sys::CUDA_SUCCESS)
-                    .then_some(device_ordinal)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "could not get CUDA device ordinal for device memory at 0x{:x}: {}",
-                            addr,
-                            err
-                        )
-                    })?;
-                assert!(ordinal >= 0, "CUDA device ordinal must be non-negative");
-                Some(
-                    super::device_selection::get_cuda_device_to_ibv_devices::<I>()?
-                        .get(ordinal as usize)
-                        .and_then(|nics| nics.first())
-                        .cloned()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "no RDMA device found for CUDA device ordinal {}",
-                                ordinal
-                            )
-                        })?,
-                )
-            } else {
-                None
-            };
-            match cuda_nic {
-                Some(info) => info.name().clone(),
-                None => {
-                    // Host memory has no co-located GPU NIC. Rather than funnel
-                    // every host registration through a single device, spread them
-                    // across all NICs that tie for the best CPU path by hashing the
-                    // region's (addr, size); the NICs share the load for host
-                    // memory, increasing aggregate throughput.
-                    let devices = select_optimal_ibv_devices::<I>(MemoryLocation::Cpu(None))?;
-                    match devices.len() {
-                        0 => anyhow::bail!("no RDMA devices found"),
-                        n => {
-                            let mut hasher = DefaultHasher::new();
-                            (mem.addr(), mem.size()).hash(&mut hasher);
-                            devices[(hasher.finish() % n as u64) as usize]
-                                .name()
-                                .clone()
-                        }
-                    }
-                }
-            }
+                .clone(),
+            None => Self::pick_optimal_device(mem)?,
         };
         tracing::debug!(
             "Using RDMA device: {} for memory at 0x{:x}",
             device_name,
-            addr
+            mem.addr()
         );
 
         let domain = self.get_or_create_device_domain(&device_name)?;
@@ -417,6 +355,30 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         // dmabuf MR, or a device-specific segment binding).
         let mrv = domain.register_mr(mem)?;
         Ok(mem.mr_slot().get_or_init(|| mrv).clone())
+    }
+
+    /// One of the NICs of backend `I` tied for the best path to `mem`.
+    ///
+    /// Host memory picks by hashing the region's `(addr, size)` instead of
+    /// funneling every host registration through a single device. GPU memory
+    /// just takes the first, for now.
+    fn pick_optimal_device(mem: &KeepaliveLocalMemory) -> Result<String, anyhow::Error> {
+        let location = mem.location();
+        let devices = select_optimal_ibv_devices::<I>(location)?;
+        anyhow::ensure!(
+            !devices.is_empty(),
+            "no {} RDMA device has a path to {location:?}",
+            I::backend_name(),
+        );
+        let index = match location {
+            MemoryLocation::Cpu(_) => {
+                let mut hasher = DefaultHasher::new();
+                (mem.addr(), mem.size()).hash(&mut hasher);
+                (hasher.finish() % devices.len() as u64) as usize
+            }
+            MemoryLocation::Gpu(_) => 0,
+        };
+        Ok(devices[index].name().clone())
     }
 
     /// Build a passive-side mirror QP for `qp_key`, connect it to
@@ -1019,11 +981,11 @@ mod tests {
             let local = match device {
                 BufferDevice::Cpu => {
                     let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
-                    KeepaliveLocalMemory::new(Arc::new(buf))
+                    KeepaliveLocalMemory::try_new(Arc::new(buf))?
                 }
                 BufferDevice::Cuda(device_id) => {
                     let alloc = CudaAllocator::get().allocate(device_id, size, size);
-                    let local = KeepaliveLocalMemory::new(Arc::new(alloc.clone()));
+                    let local = KeepaliveLocalMemory::try_new(Arc::new(alloc.clone()))?;
                     self.cuda_allocs.push(alloc);
                     let fill = vec![pattern; size];
                     // SAFETY: `local` is freshly constructed; no other
@@ -1400,7 +1362,7 @@ mod tests {
         require_rdma();
         let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         let buf: Box<[u8]> = vec![0u8; 1024].into_boxed_slice();
-        let local = KeepaliveLocalMemory::new(Arc::new(buf));
+        let local = KeepaliveLocalMemory::try_new(Arc::new(buf))?;
         assert!(
             local.mr_slot().get().is_none(),
             "MR slot should be empty before registration",

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -47,8 +47,8 @@ use super::primitives::IbvQp;
 use super::queue_pair::connect;
 use super::queue_pair::get_qp_info;
 use crate::backend::ibverbs::mlx_device::MlxDevice;
+use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
-use crate::local_memory::is_device_ptr;
 
 /// A single MR must be 2 MiB aligned and covers at most 4 GiB (one page
 /// under). Larger segments are split across multiple MRs bound to one key.
@@ -820,7 +820,7 @@ impl IbvDomainImpl for MlxDomain {
         mem: &KeepaliveLocalMemory,
     ) -> anyhow::Result<IbvMemoryRegionView> {
         let this = domain.domain_impl();
-        if this.mlx5dv_enabled && is_device_ptr(mem.addr()) {
+        if this.mlx5dv_enabled && matches!(mem.location(), MemoryLocation::Gpu(_)) {
             // SAFETY: `domain.as_ptr()` is null or a live PD, per this method's
             // contract.
             match unsafe { this.register_cuda_mlx5dv_mr(domain, mem.addr(), mem.size()) } {

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -2010,7 +2010,8 @@ mod tests {
     }
 
     fn fake_local_memory(addr: usize, size: usize) -> KeepaliveLocalMemory {
-        KeepaliveLocalMemory::new(Arc::new(FakeKeepalive { addr, size }))
+        KeepaliveLocalMemory::try_new(Arc::new(FakeKeepalive { addr, size }))
+            .expect("a fake host address has a location")
     }
 
     /// [`Keepalive`] that sets `dropped` when it goes away, so a test can
@@ -2084,11 +2085,12 @@ mod tests {
         dropped: Arc<AtomicBool>,
     ) -> IbvOp<QpaMockManager> {
         IbvOp {
-            local_memory: KeepaliveLocalMemory::new(Arc::new(DropFlagKeepalive {
+            local_memory: KeepaliveLocalMemory::try_new(Arc::new(DropFlagKeepalive {
                 addr,
                 size,
                 dropped,
-            })),
+            }))
+            .expect("a fake host address has a location"),
             ..make_op(op_type, addr, size)
         }
     }

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -1120,7 +1120,7 @@ mod tests {
             buffer_size: usize,
         ) -> anyhow::Result<(KeepaliveLocalMemory, crate::RdmaRemoteBuffer)> {
             let cpu_buf = vec![0u8; buffer_size].into_boxed_slice();
-            let local_memory = KeepaliveLocalMemory::new(Arc::new(cpu_buf));
+            let local_memory = KeepaliveLocalMemory::try_new(Arc::new(cpu_buf))?;
             let rdma_remote_buf = rdma_handle
                 .request_buffer(instance, local_memory.clone())
                 .await?;
@@ -1649,7 +1649,7 @@ mod tests {
             );
 
             let alloc = CudaAllocator::get().allocate(device, buffer_size, buffer_size);
-            let local_memory = KeepaliveLocalMemory::new(Arc::new(alloc));
+            let local_memory = KeepaliveLocalMemory::try_new(Arc::new(alloc))?;
             let rdma_remote_buf = rdma_handle
                 .request_buffer(&instance, local_memory.clone())
                 .await?;

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -21,6 +21,8 @@ use anyhow::Result;
 use dashmap::DashSet;
 use rdmaxcel_sys::CUresult;
 
+use crate::local_memory::is_device_ptr;
+
 fn cuda_error_string(rc: CUresult) -> String {
     // The lookup below goes through the same driver wrapper as every other call,
     // so it cannot name the one code that means there is no driver to ask: it
@@ -181,6 +183,40 @@ pub enum MemoryLocation {
     Cpu(Option<u32>),
     /// GPU memory on the given CUDA device ordinal, or any GPU if `None`.
     Gpu(Option<u32>),
+}
+
+impl MemoryLocation {
+    /// Where the memory at `addr` lives.
+    ///
+    /// A device pointer resolves to the CUDA ordinal that owns it. Host memory
+    /// is [`Self::Cpu(None)`]: the NUMA node backing the allocation is not
+    /// resolved.
+    ///
+    /// Errors when `addr` is device memory whose owning ordinal cannot be
+    /// queried.
+    pub fn from_addr(addr: usize) -> Result<Self> {
+        if !is_device_ptr(addr) {
+            return Ok(Self::Cpu(None));
+        }
+        let mut ordinal: i32 = -1;
+        // SAFETY: FFI writes one `i32` through the out-pointer; `addr` is passed
+        // by value as an opaque device address and never dereferenced.
+        let rc = unsafe {
+            rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
+                &mut ordinal as *mut _ as *mut std::ffi::c_void,
+                rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                addr as rdmaxcel_sys::CUdeviceptr,
+            )
+        };
+        anyhow::ensure!(
+            rc == rdmaxcel_sys::CUDA_SUCCESS,
+            "cuPointerGetAttribute(DEVICE_ORDINAL) failed for device memory at {addr:#x}: {}",
+            cuda_error_string(rc),
+        );
+        Ok(Self::Gpu(Some(
+            u32::try_from(ordinal).expect("CUDA device ordinal should be non-negative"),
+        )))
+    }
 }
 
 /// Locality of a path between two PCI endpoints, ordered best to worst.

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -18,6 +18,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 use crate::backend::ibverbs::memory_region::IbvMemoryRegionView;
+use crate::device_selection::MemoryLocation;
 
 /// Returns `true` when `addr` is a CUDA device pointer.
 ///
@@ -386,6 +387,8 @@ impl Keepalive for Box<[u8]> {
 pub(crate) struct LocalMemoryInner {
     addr: usize,
     size: usize,
+    /// Where the region lives, resolved once at construction.
+    location: MemoryLocation,
     /// Bandwidth (bytes/s) for direct host-thread pointer access, or `None`
     /// if the memory is not host-accessible.
     direct_access_host_bandwidth: Option<u64>,
@@ -402,21 +405,22 @@ pub(crate) struct LocalMemoryInner {
 }
 
 impl LocalMemoryInner {
-    fn new(addr: usize, size: usize) -> Self {
+    fn try_new(addr: usize, size: usize) -> Result<Self, anyhow::Error> {
+        let location = MemoryLocation::from_addr(addr)?;
         // TODO(slurye): Using placeholder values for now. Fill in with real values.
-        let (host_bw, device_bw) = if is_device_ptr(addr) {
-            (None, Some(1))
-        } else {
-            (Some(1), None)
+        let (host_bw, device_bw) = match location {
+            MemoryLocation::Cpu(_) => (Some(1), None),
+            MemoryLocation::Gpu(_) => (None, Some(1)),
         };
-        Self {
+        Ok(Self {
             addr,
             size,
+            location,
             direct_access_host_bandwidth: host_bw,
             direct_access_device_bandwidth: device_bw,
             mr_slot: Arc::new(OnceLock::new()),
             access: Arc::new(AccessLock::new()),
-        }
+        })
     }
 }
 
@@ -450,6 +454,7 @@ impl Debug for KeepaliveLocalMemory {
         f.debug_struct("KeepaliveLocalMemory")
             .field("addr", &self.inner.addr)
             .field("size", &self.inner.size)
+            .field("location", &self.inner.location)
             .field(
                 "direct_access_host_bandwidth",
                 &self.inner.direct_access_host_bandwidth,
@@ -463,18 +468,19 @@ impl Debug for KeepaliveLocalMemory {
 }
 
 impl KeepaliveLocalMemory {
-    /// Create a new handle. Derives `addr` and `size` from the
-    /// `keepalive` via [`Keepalive::addr`] /
-    /// [`Keepalive::size`], then probes the CUDA driver to
-    /// determine whether the address is a device pointer and sets the
-    /// bandwidth fields accordingly.
-    pub fn new(keepalive: Arc<dyn Keepalive>) -> Self {
+    /// Try to create a new handle. Derives `addr` and `size` from the
+    /// `keepalive` via [`Keepalive::addr`] / [`Keepalive::size`], then
+    /// resolves the region's [`MemoryLocation`] and sets the bandwidth fields
+    /// accordingly.
+    ///
+    /// Errors when the location cannot be resolved.
+    pub fn try_new(keepalive: Arc<dyn Keepalive>) -> Result<Self, anyhow::Error> {
         let addr = keepalive.addr();
         let size = keepalive.size();
-        Self {
-            inner: LocalMemoryInner::new(addr, size),
+        Ok(Self {
+            inner: LocalMemoryInner::try_new(addr, size)?,
             _keepalive: keepalive,
-        }
+        })
     }
 
     /// Starting virtual address of the memory region.
@@ -485,6 +491,11 @@ impl KeepaliveLocalMemory {
     /// Size of the memory region in bytes.
     pub fn size(&self) -> usize {
         self.inner.size
+    }
+
+    /// Where this region lives.
+    pub fn location(&self) -> MemoryLocation {
+        self.inner.location
     }
 
     /// Shared slot for the [`IbvMemoryRegionView`] registered against
@@ -663,11 +674,30 @@ impl WeakLocalMemory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::cuda_test_utils::CudaAllocator;
 
     // -- KeepaliveLocalMemory (host) --
 
     fn host_keepalive_mem(data: Box<[u8]>) -> KeepaliveLocalMemory {
-        KeepaliveLocalMemory::new(Arc::new(data))
+        KeepaliveLocalMemory::try_new(Arc::new(data)).expect("host memory has a location")
+    }
+
+    #[test]
+    fn keepalive_host_location() {
+        let mem = host_keepalive_mem(Box::from([1, 2, 3]));
+        // No NUMA node is resolved.
+        assert_eq!(mem.location(), MemoryLocation::Cpu(None));
+    }
+
+    #[test]
+    fn keepalive_device_location_names_its_cuda_ordinal() {
+        let alloc = CudaAllocator::get().allocate(0, 4096, 4096);
+        assert_eq!(
+            alloc.keepalive_slice(0, 4096).location(),
+            MemoryLocation::Gpu(Some(0)),
+            "a device pointer should resolve to the ordinal that owns it",
+        );
+        alloc.try_free();
     }
 
     #[test]


### PR DESCRIPTION
Summary:

`MemoryLocation::from_addr` now answers "where does this memory live?" once,
and `LocalMemoryInner` resolves it at construction.

Which NIC a region lands on is unchanged. Groundwork for registering a
region on several NICs, which needs a region to know its whole optimal set.

Differential Revision: D115506016


