### PR TITLE
ActorMesh owns lifecycle (#4644)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3591,6 +3591,7 @@ dependencies = [
  "hyperactor_cast",
  "hyperactor_config",
  "hyperactor_mesh_macros",
+ "hyperactor_remote",
  "hyperactor_telemetry",
  "inventory",
  "jsonschema",

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -37,6 +37,7 @@ hyperactor = { version = "0.0.0", path = "../hyperactor" }
 hyperactor_cast = { version = "0.0.0", path = "../hyperactor_cast" }
 hyperactor_config = { version = "0.0.0", path = "../hyperactor_config" }
 hyperactor_mesh_macros = { version = "0.0.0", path = "../hyperactor_mesh_macros" }
+hyperactor_remote = { version = "0.0.0", path = "../hyperactor_remote" }
 hyperactor_telemetry = { version = "0.0.0", path = "../hyperactor_telemetry" }
 inventory = "0.3.24"
 libc = "0.2.186"

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -32,6 +32,7 @@ use std::time::Duration;
 use hyperactor::ActorAddr;
 use hyperactor::ActorLocal;
 use hyperactor::ActorRef;
+use hyperactor::AnyActorHandle;
 use hyperactor::Endpoint as _;
 use hyperactor::PortRef;
 use hyperactor::RemoteEndpoint as _;
@@ -56,6 +57,7 @@ use ndslice::view::View;
 use rankspace::Rank;
 use rankspace::RankSpace;
 use rankspace::view::CompactView;
+use rankspace::view::View as _;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -98,33 +100,45 @@ declare_attrs! {
     pub attr SUPERVISION_WATCHDOG_TIMEOUT: Duration = Duration::from_mins(2);
 }
 
-/// An ActorMesh is a collection of ranked A-typed actors.
+/// An ActorMesh is a collection of ranked A-typed actors: the lifecycle owner
+/// over an [`ActorMeshRef`], which is the cast/address surface.
 ///
-/// Bound note: `A: Referable` because the mesh stores/returns
-/// `ActorRef<A>`, which is only defined for `A: Referable`.
+/// The mesh may be *managed* — created via `ProcMesh` and backed by a controller
+/// — or *data-only* — spawned through an `ActorSpawner` and carrying each rank's
+/// local lifecycle handle. Both variants own their actors and can stop them.
+/// Monitoring works through the mesh's members in either case.
+///
+/// Bound note: `A: Referable` because the mesh stores/returns `ActorRef<A>`,
+/// which is only defined for `A: Referable`.
 #[derive(Debug)]
 pub struct ActorMesh<A: Referable> {
-    proc_mesh: ProcMeshRef,
-    id: ActorMeshId,
+    /// The cast/address surface, either controller-backed (`Managed`) or
+    /// detached (`Data`).
     current_ref: ActorMeshRef<A>,
-    /// If present, this is the controller for the mesh. The controller ensures
-    /// the mesh is stopped when the actor owning it is stopped, and can provide
-    /// supervision events via subscribing.
-    /// It may not be present for some types of actors, typically system actors
-    /// such as ProcAgent or CastActor.
-    controller: Option<ActorRef<ActorMeshController<A>>>,
+    lifecycle: ActorMeshLifecycle,
 }
 
-/// A data-only actor mesh.
+/// The local lifecycle handle for one spawner-backed rank.
+pub(crate) type ActorMeshStopHandle = AnyActorHandle;
+
+#[derive(Debug, Clone)]
+enum ActorMeshLifecycle {
+    Managed,
+    Data {
+        stop_handles: Vec<ActorMeshStopHandle>,
+        stop_requested: Arc<OnceCell<()>>,
+    },
+}
+
+/// The data-only variant of [`ActorMeshRef`]: a cheap, detached cast/address
+/// surface built directly from actor refs.
 ///
-/// This mesh is the data variant of [`ActorMeshRef`]: a [`RankSpace`] paired
-/// with its visible actor refs. The rank space can be sparse, so a mesh can
-/// represent failed or absent ranks as occlusions.
-///
-/// The mesh carries no identity beyond its members: two data meshes over the
-/// same rank space and refs are interchangeable. It holds no supervision state
-/// either; a caller monitors it on demand via [`Self::monitor`], which is the
-/// (one and only) supervision relationship, established by `hyperactor_remote`.
+/// Membership is a [`RankSpace`] paired with its visible actor refs. The rank
+/// space can be sparse, so a mesh can represent failed or absent ranks as
+/// occlusions. It carries no identity beyond its members (two data refs over the
+/// same rank space and refs are interchangeable) and no remote supervision
+/// stream; a caller monitors it on demand via [`Self::monitor`]. Casting iterates
+/// the members and posts to each directly — the simple, unoptimized data path.
 pub struct DataActorMesh<A: Referable> {
     members: CompactView<Vec<ActorRef<A>>>,
 }
@@ -146,47 +160,113 @@ impl<A: Referable> ActorMesh<A> {
         controller: Option<ActorRef<ActorMeshController<A>>>,
         members: Arc<ValueMesh<ActorAddr>>,
     ) -> Self {
+        let region = proc_mesh.region().clone();
         let current_ref = ActorMeshRef::new_managed(
             id.clone(),
             Some(proc_mesh.id().clone()),
-            proc_mesh.region().clone(),
+            region,
             controller.clone(),
             members,
         );
 
         Self {
-            proc_mesh,
-            id,
             current_ref,
-            controller,
+            lifecycle: ActorMeshLifecycle::Managed,
         }
     }
 
-    pub fn id(&self) -> &ActorMeshId {
-        &self.id
+    /// Create a data actor mesh from actor refs and their lifecycle handles.
+    pub(crate) fn try_new_data(
+        space: impl Into<RankSpace>,
+        members: Vec<ActorRef<A>>,
+        stop_handles: Vec<ActorMeshStopHandle>,
+    ) -> crate::Result<Self> {
+        assert!(!stop_handles.is_empty(), "data actor mesh must own actors");
+        assert_eq!(
+            stop_handles.len(),
+            members.len(),
+            "data actor mesh must own one lifecycle handle per member"
+        );
+        let current_ref = ActorMeshRef::try_new_data(space, members).inspect_err(|_| {
+            stop_handles.iter().for_each(|handle| {
+                let _ = handle.stop("data mesh construction failed");
+            });
+        })?;
+        Ok(Self {
+            current_ref,
+            lifecycle: ActorMeshLifecycle::Data {
+                stop_handles,
+                stop_requested: Arc::new(OnceCell::new()),
+            },
+        })
+    }
+
+    /// Return the mesh id, if any. Only managed meshes carry an id; data meshes
+    /// are nameless, identified by their members.
+    pub fn id(&self) -> Option<&ActorMeshId> {
+        self.current_ref.as_managed().map(|managed| managed.id())
     }
 
     pub(crate) fn set_controller(&mut self, controller: Option<ActorRef<ActorMeshController<A>>>) {
-        self.controller = controller.clone();
-        if let ActorMeshRef::Managed(current_ref) = &mut self.current_ref {
-            current_ref.set_controller(controller);
-        }
+        self.current_ref
+            .as_managed_mut()
+            .expect("data actor meshes do not use a controller")
+            .set_controller(controller);
+    }
+
+    /// Return a [`MeshMonitor`] over this mesh's members.
+    pub fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
+        self.current_ref.monitor(cx)
     }
 
     /// Stop actors on this mesh across all procs.
+    ///
+    /// A data mesh stops each rank's local supervisor proxy. The shared stop
+    /// fence makes this operation one-shot across owner clones.
     pub async fn stop(&mut self, cx: &impl context::Actor, reason: String) -> crate::Result<()> {
-        let ActorMeshRef::Managed(ref mut current_ref) = self.current_ref else {
-            return Err(Error::Other(anyhow::anyhow!(
-                "cannot stop an ActorMesh of DataActorMeshRef"
-            )));
-        };
-        let actor_mesh_name = self.id.to_string();
-        // Remove the controller as an optimization so all future meshes
+        if let ActorMeshLifecycle::Data {
+            stop_handles,
+            stop_requested,
+        } = &mut self.lifecycle
+        {
+            if stop_requested.set(()).is_err() {
+                return Ok(());
+            }
+            let stop_handles = std::mem::take(stop_handles);
+            assert!(
+                !stop_handles.is_empty(),
+                "live data actor mesh must own actors"
+            );
+            let mut stop_error = None;
+            for handle in &stop_handles {
+                if let Err(error) = handle.stop(&reason)
+                    && stop_error.is_none()
+                {
+                    stop_error = Some(error);
+                }
+            }
+            return match stop_error {
+                Some(error) => Err(Error::Other(anyhow::Error::new(error))),
+                None => Ok(()),
+            };
+        }
+        // Remove the controller so all future meshes
         // created from this one (such as slices) know they are already stopped.
         // Refs and slices on other machines will still be able to query the
         // controller and will be sent a notification about this stop by the controller
         // itself.
-        if let Some(controller) = self.controller.take() {
+        let (controller, id, num_ranks) = {
+            let managed = self
+                .current_ref
+                .as_managed_mut()
+                .expect("managed actor mesh has a managed ref");
+            (
+                managed.take_controller(),
+                managed.id().resource_id().clone(),
+                managed.region().num_ranks(),
+            )
+        };
+        if let Some(controller) = controller {
             // Run the Stop/GetState exchange. We wrap it so that, no matter
             // how it ends, we can record a single unhealthy event
             // afterwards. Taking the controller is one-way: once it is gone,
@@ -194,8 +274,6 @@ impl<A: Referable> ActorMesh<A> {
             // silently-still-healthy mesh with a vanished controller would
             // hide the fact that the stop never reached (or never confirmed)
             // the actors.
-            let id = self.id.resource_id().clone();
-            let num_ranks = current_ref.region().num_ranks();
             let result: crate::Result<()> = async {
                 controller.post(
                     cx,
@@ -257,31 +335,10 @@ impl<A: Referable> ActorMesh<A> {
                 Ok(()) => ActorStatus::Stopped("mesh stopped".to_string()),
                 Err(e) => ActorStatus::Stopped(format!("mesh stop failed: {e}")),
             };
-            let mut entry = current_ref.health_state.entry(cx).or_default();
-            let health_state = entry.get_mut();
-            health_state.unhealthy_event = Some(Unhealthy::StreamClosed(MeshFailure {
-                actor_mesh_name: Some(actor_mesh_name),
-                event: ActorSupervisionEvent::new(
-                    // Use an actor id from the mesh.
-                    ndslice::view::Ranked::get(current_ref.as_ref(), 0)
-                        .unwrap()
-                        .actor_addr()
-                        .clone(),
-                    None,
-                    status,
-                    None,
-                ),
-                crashed_ranks: vec![],
-                // MFCA-4: synthesized locally by the mesh handle, not a
-                // controller report.
-                reporting_controller: None,
-            }));
+            self.current_ref.record_stopped(cx, status);
 
             result?;
         }
-        // Also take the controller from the ref, since that is used for
-        // some operations.
-        current_ref.controller.take();
         Ok(())
     }
 }
@@ -305,21 +362,21 @@ impl<A: Referable> Deref for ActorMesh<A> {
 impl<A: Referable> Clone for ActorMesh<A> {
     fn clone(&self) -> Self {
         Self {
-            proc_mesh: self.proc_mesh.clone(),
-            id: self.id.clone(),
             current_ref: self.current_ref.clone(),
-            controller: self.controller.clone(),
+            lifecycle: self.lifecycle.clone(),
         }
     }
 }
 
 impl<A: Referable> Drop for ActorMesh<A> {
     fn drop(&mut self) {
-        tracing::info!(
-            name = "ActorMeshStatus",
-            actor_name = %self.id,
-            status = "Dropped",
-        );
+        if let Some(id) = self.id() {
+            tracing::info!(
+                name = "ActorMeshStatus",
+                actor_name = %id,
+                status = "Dropped",
+            );
+        }
     }
 }
 
@@ -378,7 +435,7 @@ impl<A: Referable> DataActorMesh<A> {
     ///
     /// The caller drives the returned monitor (await it, or run a future under
     /// [`MeshMonitor::guard`]) to observe rank failures, and drops it to stop
-    /// monitoring. The mesh holds no supervision state of its own.
+    /// monitoring.
     pub fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
         let actors = self.members.map(|actor| actor.actor_addr().clone());
         MeshMonitor::spawn(cx, actors)
@@ -386,6 +443,8 @@ impl<A: Referable> DataActorMesh<A> {
 
     /// Cast `message` to every member. The data path has no cast domain, so it
     /// iterates the members and posts to each directly: correct but unoptimized.
+    /// This initiates delivery without waiting for it; use [`Self::monitor`] to
+    /// observe actors that stop or fail.
     pub fn cast<M>(&self, cx: &impl context::Actor, message: M) -> crate::Result<()>
     where
         A: RemoteHandles<M>,
@@ -415,7 +474,9 @@ impl<A: Referable> DataActorMesh<A> {
 
 impl<A: Referable> Clone for DataActorMesh<A> {
     fn clone(&self) -> Self {
-        Self::new_unchecked(self.members.clone())
+        Self {
+            members: self.members.clone(),
+        }
     }
 }
 
@@ -497,7 +558,25 @@ impl<A: Referable> ActorMeshRef<A> {
         }
     }
 
+    /// Return a [`MeshMonitor`] over this mesh's members.
+    pub fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
+        match self {
+            Self::Managed(managed) => managed.monitor(cx),
+            Self::Data(data) => data.monitor(cx),
+        }
+    }
+
+    /// Return the legacy dense ref mutably when this is the managed variant.
+    pub fn as_managed_mut(&mut self) -> Option<&mut ManagedActorMeshRef<A>> {
+        match self {
+            Self::Managed(managed) => Some(managed),
+            Self::Data(_) => None,
+        }
+    }
     /// Cast a message to all the actors in this mesh.
+    ///
+    /// This initiates delivery without waiting for it; use [`Self::monitor`] to
+    /// observe actors that stop or fail.
     pub fn cast<M>(&self, cx: &impl context::Actor, message: M) -> crate::Result<()>
     where
         A: RemoteHandles<M>,
@@ -542,6 +621,12 @@ impl<A: Referable> ActorMeshRef<A> {
             Self::Managed(m) => Self::Managed(Box::new(m.clone_with_supervision_receiver())),
             Self::Data(d) => Self::Data(d.clone()),
         }
+    }
+
+    pub(crate) fn record_stopped(&self, cx: &impl context::Actor, status: ActorStatus) {
+        self.as_managed()
+            .expect("only managed actor meshes record local stopped state")
+            .record_stopped(cx, status);
     }
 }
 
@@ -1024,7 +1109,6 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         A: RemoteHandles<M>,
         M: RemoteMessage + Clone,
     {
-        self.check_cached_failure(cx)?;
         self.emit_sent_message_telemetry(cx, view::Ranked::region(self));
 
         let mut headers = caller_headers.clone();
@@ -1058,7 +1142,6 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         A: RemoteHandles<M>,
         M: RemoteMessage + Clone,
     {
-        self.check_cached_failure(cx)?;
         self.emit_sent_message_telemetry(
             cx,
             &Region::new(
@@ -1091,22 +1174,6 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         })?;
 
         self.post_cast_direct(cx, point, actor, message, caller_headers)
-    }
-
-    #[allow(clippy::result_large_err)]
-    fn check_cached_failure(&self, cx: &impl context::Actor) -> crate::Result<()> {
-        // First check if the mesh is already dead before sending out any messages
-        // to a possibly undeliverable actor.
-        if let Some(failure) = self.cached_failure(cx) {
-            tracing::debug!(
-                actor_mesh = %self.id,
-                crashed_ranks = ?failure.crashed_ranks,
-                "rejecting cast due to cached supervision failure"
-            );
-            return Err(crate::Error::Supervision(Box::new(failure)));
-        }
-
-        Ok(())
     }
 
     fn emit_sent_message_telemetry(&self, cx: &impl context::Actor, region: &Region) {
@@ -1221,6 +1288,10 @@ impl<A: Referable> ManagedActorMeshRef<A> {
 
     pub fn controller(&self) -> &Option<ActorRef<ActorMeshController<A>>> {
         &self.controller
+    }
+
+    fn take_controller(&mut self) -> Option<ActorRef<ActorMeshController<A>>> {
+        self.controller.take()
     }
 
     fn set_controller(&mut self, controller: Option<ActorRef<ActorMeshController<A>>>) {
@@ -1408,6 +1479,48 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         Ok(message)
     }
 
+    fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
+        let space = self.space();
+        let addrs = space
+            .iter_ranks()
+            .map(|rank| {
+                self.get_rank(rank)
+                    .expect("visible rank materializes an actor ref")
+                    .actor_addr()
+                    .clone()
+            })
+            .collect();
+        let actors = CompactView::new(space.clone(), addrs)
+            .expect("managed mesh members form a valid compact view");
+        MeshMonitor::spawn(cx, actors)
+    }
+
+    /// Record a synthetic "stopped" unhealthy event so future casts through this
+    /// ref (and its slices) observe the mesh as no longer live.
+    pub(crate) fn record_stopped(&self, cx: &impl context::Actor, status: ActorStatus) {
+        let mut entry = self.health_state.entry(cx).or_default();
+        let health_state = entry.get_mut();
+        health_state.unhealthy_event = Some(Unhealthy::StreamClosed(MeshFailure {
+            actor_mesh_name: Some(self.id().to_string()),
+            event: ActorSupervisionEvent::new(
+                // Use an actor id from the mesh.
+                self.space()
+                    .iter_ranks()
+                    .next()
+                    .and_then(|rank| self.get_rank(rank))
+                    .expect("mesh must have at least one rank")
+                    .actor_addr()
+                    .clone(),
+                None,
+                status,
+                None,
+            ),
+            crashed_ranks: vec![],
+            // MFCA-4: synthesized locally by the mesh handle, not a controller
+            // report.
+            reporting_controller: None,
+        }));
+    }
     /// Same as Clone, but includes a shared supervision receiver. This copy will
     /// share the same health state and get the same supervision events.
     /// Will have a separate cache.
@@ -1613,7 +1726,7 @@ mod tests {
     use ndslice::view::RankedSliceable;
     use rankspace::Rank;
     use rankspace::RankSpace;
-    use rankspace::view::View as _;
+    use rankspace::view::View;
     use timed_test::assert_no_process_leak;
     use timed_test::async_timed_test;
     use tokio::time::Duration;
@@ -1731,6 +1844,9 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(5), target)
             .await
             .expect("timed out waiting for target to stop");
+
+        mesh.cast(&client, ())
+            .expect("casting to a stopped actor should still initiate delivery");
     }
 
     #[tokio::test]
@@ -1755,7 +1871,7 @@ mod tests {
         };
         let amr: ActorMeshRef<testactor::TestActor> =
             ActorMeshRef::Managed(Box::new(super::ManagedActorMeshRef::with_page_size(
-                am.id().clone(),
+                am.id().expect("spawned actor mesh has an id").clone(),
                 managed.proc_mesh_id.clone(),
                 am.region().clone(),
                 page_size,
@@ -1764,6 +1880,7 @@ mod tests {
             )));
         assert_eq!(amr.extent(), extent!(hosts = 2, gpus = 2));
         assert_eq!(amr.region().num_ranks(), 4);
+        assert_eq!(amr.values().count(), 4);
 
         // 3) Within-rank pointer stability (OnceLock caches &ActorRef)
         let p0_a = amr.get(0).expect("rank 0 exists") as *const _;

--- a/hyperactor_mesh/src/lib.rs
+++ b/hyperactor_mesh/src/lib.rs
@@ -101,7 +101,6 @@ use crate::host_mesh::HostMeshRefParseError;
 use crate::host_mesh::host_agent::ProcState;
 use crate::resource::RankedValues;
 use crate::resource::Status;
-use crate::supervision::MeshFailure;
 
 /// A mesh of per-rank lifecycle statuses.
 ///
@@ -239,9 +238,6 @@ pub enum Error {
 
     #[error("proc {0} must be direct-addressable")]
     RankedProc(ProcAddr),
-
-    #[error("{0}")]
-    Supervision(Box<MeshFailure>),
 
     #[error("error: {0} does not exist")]
     NotExist(mesh_id::ResourceId),

--- a/hyperactor_mesh/src/proc_agent.rs
+++ b/hyperactor_mesh/src/proc_agent.rs
@@ -47,6 +47,8 @@ use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
+use hyperactor_remote::ActorSpawner;
+use hyperactor_remote::proc_spawner::actor_spawner_uid;
 use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
@@ -360,6 +362,12 @@ impl ProcAgent {
             hyperactor_cast::cast_actor::CastActor::default(),
         )?;
         cast_handle.bind::<hyperactor_cast::cast_actor::CastActor>();
+
+        // `spawn_data` discovers the per-proc ActorSpawner at its well-known UID,
+        // so legacy ProcAgent bootstrapping must install it. This compatibility
+        // step goes away when proc bootstrapping moves off ProcAgent entirely.
+        let actor_spawner_handle = proc.spawn_with_uid(actor_spawner_uid(), ActorSpawner)?;
+        let _well_known_actor = actor_spawner_handle.bind::<ActorSpawner>();
 
         let orphan_timeout = hyperactor_config::global::get(MESH_ORPHAN_TIMEOUT);
         let agent = ProcAgent {

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -22,6 +22,7 @@ use hyperactor::Handler;
 use hyperactor::ProcAddr;
 use hyperactor::RemoteMessage;
 use hyperactor::RemoteSpawn;
+use hyperactor::Uid;
 use hyperactor::accum::StreamingReducerOpts;
 use hyperactor::actor::ActorStatus;
 use hyperactor::actor::remote::Remote;
@@ -31,6 +32,10 @@ use hyperactor::supervision::ActorSupervisionEvent;
 use hyperactor_config::CONFIG;
 use hyperactor_config::ConfigAttr;
 use hyperactor_config::attrs::declare_attrs;
+use hyperactor_remote::ActorSpawner;
+use hyperactor_remote::ActorSpawnerEndpoint;
+use hyperactor_remote::KeepaliveLink;
+use hyperactor_remote::proc_spawner::actor_spawner_uid;
 use hyperactor_telemetry::hash_to_u64;
 use ndslice::Extent;
 use ndslice::ViewExt as _;
@@ -47,6 +52,7 @@ use crate::ActorMeshRef;
 use crate::Error;
 use crate::HostMeshRef;
 use crate::ValueMesh;
+use crate::actor_mesh::ActorMeshStopHandle;
 use crate::host_mesh::GET_PROC_STATE_MAX_IDLE;
 use crate::host_mesh::host_agent::GetHostProcStates;
 use crate::host_mesh::host_agent::ProcState;
@@ -113,6 +119,11 @@ impl ProcRef {
 
     pub(crate) fn actor_addr(&self, id: &ActorMeshId) -> ActorAddr {
         self.proc_id.actor_addr_uid(id.uid().clone())
+    }
+
+    /// Return the actor spawner hosted by this proc.
+    pub(crate) fn spawner(&self) -> ActorRef<ActorSpawner> {
+        ActorRef::attest(self.proc_id.actor_addr_uid(actor_spawner_uid()))
     }
 }
 
@@ -778,6 +789,63 @@ impl ProcMeshRef {
         result
     }
 
+    /// Spawn an actor on all procs in this mesh using the new data-only mesh API.
+    ///
+    /// This initiates an actor spawn on each proc and constructs a stoppable
+    /// data mesh from the actor refs and local supervisor handles without
+    /// waiting for the remote supervision sessions to link. If a later spawn
+    /// fails, all previously created local supervisors receive a best-effort
+    /// stop request.
+    ///
+    /// Bounds:
+    /// - `A: Actor` - the actor actually runs inside each proc.
+    /// - `A: Referable` - so we can return typed `ActorRef<A>`s inside the `ActorMesh`.
+    /// - `A::Params: RemoteMessage` - spawn parameters must be serializable and routable.
+    pub async fn spawn_data<A: RemoteSpawn, C: context::Actor>(
+        &self,
+        cx: &C,
+        params: &A::Params,
+    ) -> crate::Result<ActorMesh<A>>
+    where
+        A::Params: RemoteMessage + Clone,
+    {
+        // Data meshes are nameless: they are identified by their members, not an id.
+        let region = self.region().clone();
+        let actor_uid = Uid::anonymous();
+        let mut members = Vec::with_capacity(self.ranks.len());
+        let mut stop_handles = Vec::with_capacity(self.ranks.len());
+
+        let stop_spawned = |handles: &[ActorMeshStopHandle], reason: &str| {
+            for handle in handles {
+                let _ = handle.stop(reason);
+            }
+        };
+
+        // Serially spawn an actor on each proc using the proc's actor spawner endpoint.
+        // The actor spawner is a well-known singleton actor running on each proc with
+        // the name "spawner".
+        for proc_ref in self.ranks.iter() {
+            let actor_spawner = proc_ref.spawner();
+            let (actor_ref, stop_handle) = match actor_spawner.spawn_uid_with_link_and_ready(
+                cx,
+                actor_uid.clone(),
+                params.clone(),
+                KeepaliveLink::default(),
+                None,
+            ) {
+                Ok(spawned) => spawned,
+                Err(error) => {
+                    stop_spawned(&stop_handles, "data mesh spawn failed");
+                    return Err(Error::Other(error));
+                }
+            };
+            members.push(actor_ref);
+            stop_handles.push(stop_handle.into_any());
+        }
+
+        ActorMesh::try_new_data(region, members, stop_handles)
+    }
+
     /// Spawn an actor on all procs in this mesh under the given
     /// [`ActorMeshId`](crate::mesh_id::ActorMeshId), returning a new `ActorMesh`.
     ///
@@ -868,7 +936,7 @@ impl ProcMeshRef {
             let controller_name = format!(
                 "{}_{}",
                 crate::mesh_controller::ACTOR_MESH_CONTROLLER_NAME,
-                mesh.id()
+                mesh.id().expect("managed actor mesh should have an id")
             );
             let controller = cx.spawn_with_label(&controller_name, controller);
             // Controller and ActorMesh both depend on references from each other, break
@@ -1020,11 +1088,11 @@ impl ProcMeshRef {
         );
         // Notify telemetry that an actor mesh was created.
         {
-            let id_str = mesh.id().to_string();
+            let id_str = actor_mesh_id.to_string();
 
             // Hash the proc mesh id for parent_mesh_id.
             let parent_mesh_id_hash = hash_to_u64(self.id());
-            let mesh_id_hash = telemetry_actor_mesh_id(self.id(), mesh.id());
+            let mesh_id_hash = telemetry_actor_mesh_id(self.id(), &actor_mesh_id);
 
             hyperactor_telemetry::notify_mesh_created(hyperactor_telemetry::MeshEvent {
                 id: mesh_id_hash,
@@ -1033,8 +1101,7 @@ impl ProcMeshRef {
                     .as_deref()
                     .and_then(python_class_from_supervision_name)
                     .unwrap_or(actor_type),
-                given_name: mesh
-                    .id()
+                given_name: actor_mesh_id
                     .display_label()
                     .map(|l| l.as_str())
                     .unwrap_or("unnamed")
@@ -1319,6 +1386,44 @@ mod tests {
 
     #[async_timed_test(timeout_secs = 300)]
     #[cfg(fbcode_build)]
+    async fn spawn_data_uses_default_actor_spawner() {
+        let instance = testing::instance();
+        let mut hm = testing::host_mesh(1).await;
+        let proc_mesh = hm
+            .spawn(instance, "spawn_data", extent!(gpus = 2), None, None)
+            .await
+            .expect("spawn proc mesh");
+
+        let mut actor_mesh: ActorMesh<testactor::TestActor> = proc_mesh
+            .spawn_data(instance, &())
+            .await
+            .expect("spawn data actor mesh through default spawner");
+        assert_eq!(rankspace::view::View::space(&*actor_mesh).cardinality(), 2);
+        let actor_uids: HashSet<_> = rankspace::view::View::iter(&*actor_mesh)
+            .map(|(_, actor)| actor.actor_addr().id().uid().clone())
+            .collect();
+        assert_eq!(
+            actor_uids.len(),
+            1,
+            "all data mesh actors should share one uid"
+        );
+        let mut actor_mesh_clone = actor_mesh.clone();
+        actor_mesh
+            .stop(instance, "test complete".to_string())
+            .await
+            .expect("stop data actor mesh");
+        actor_mesh_clone
+            .stop(instance, "test complete".to_string())
+            .await
+            .expect("stopping a data actor mesh clone should be idempotent");
+
+        hm.shutdown(instance)
+            .await
+            .expect("host mesh shutdown should complete");
+    }
+
+    #[async_timed_test(timeout_secs = 300)]
+    #[cfg(fbcode_build)]
     async fn actor_environment_survives_two_remote_hops_and_excludes_cast_point() {
         const SENTINEL: u64 = 0xA0FE;
         let operation_timeout = Duration::from_secs(120);
@@ -1535,7 +1640,10 @@ mod tests {
             .await
             .unwrap();
         assert_shared(&w1, &s1);
-        let s1_states = slice.actor_states(instance, s1.id().clone()).await.unwrap();
+        let s1_states = slice
+            .actor_states(instance, s1.id().unwrap().clone())
+            .await
+            .unwrap();
         for rank in 0..slice.region().num_ranks() {
             assert_eq!(
                 s1_states
@@ -1557,7 +1665,10 @@ mod tests {
             .await
             .unwrap();
         assert_shared(&w2, &s2);
-        let w2_states = whole.actor_states(instance, w2.id().clone()).await.unwrap();
+        let w2_states = whole
+            .actor_states(instance, w2.id().unwrap().clone())
+            .await
+            .unwrap();
         for rank in 0..whole.region().num_ranks() {
             assert_eq!(
                 w2_states
@@ -1582,7 +1693,7 @@ mod tests {
             .spawn_service::<testactor::TestActor, _>(instance, "svc_wait", &())
             .await
             .unwrap();
-        let id = sw.id().resource_id().clone();
+        let id = sw.id().unwrap().resource_id().clone();
         let region = slice.region().clone();
         let num_ranks = region.num_ranks();
         let (port, rx) = instance.mailbox().open_accum_port_opts(

--- a/hyperactor_remote/src/actor_spawner.rs
+++ b/hyperactor_remote/src/actor_spawner.rs
@@ -112,6 +112,7 @@
 
 use async_trait::async_trait;
 use hyperactor::Actor;
+use hyperactor::ActorHandle;
 use hyperactor::ActorRef;
 use hyperactor::Context;
 use hyperactor::Endpoint;
@@ -169,6 +170,30 @@ pub trait ActorSpawnerEndpoint {
         self.spawn_uid::<A>(cx, Uid::anonymous(), params)
     }
 
+    /// Spawn a registered actor and return its local supervisor handle.
+    ///
+    /// The returned actor ref identifies the eventual remote actor. The handle
+    /// controls its local supervisor proxy and can be stopped immediately,
+    /// including before the remote supervision session links.
+    fn spawn_with_handle<A>(
+        &self,
+        cx: &impl context::Actor,
+        params: A::Params,
+    ) -> anyhow::Result<(ActorRef<A>, ActorHandle<Supervisor>)>
+    where
+        A: RemoteSpawn,
+        Self: Clone + Send + 'static,
+        for<'a> &'a Self: Endpoint<SpawnActorMessage>,
+    {
+        self.spawn_uid_with_link_and_ready::<A>(
+            cx,
+            Uid::anonymous(),
+            params,
+            KeepaliveLink::default(),
+            None,
+        )
+    }
+
     /// Spawn a registered actor with an explicit actor uid.
     fn spawn_uid<A>(
         &self,
@@ -211,6 +236,7 @@ pub trait ActorSpawnerEndpoint {
             KeepaliveLink::default(),
             Some(ready),
         )
+        .map(|(actor_ref, _supervisor)| actor_ref)
     }
 
     /// Spawn a registered actor with an explicit actor uid and liveness link.
@@ -227,6 +253,7 @@ pub trait ActorSpawnerEndpoint {
         for<'a> &'a Self: Endpoint<SpawnActorMessage>,
     {
         self.spawn_uid_with_link_and_ready::<A>(cx, uid, params, liveness, None)
+            .map(|(actor_ref, _supervisor)| actor_ref)
     }
 
     /// Spawn a registered actor with an explicit actor uid, liveness link, and
@@ -240,7 +267,7 @@ pub trait ActorSpawnerEndpoint {
         params: A::Params,
         liveness: KeepaliveLink,
         ready: Option<OncePortHandle<()>>,
-    ) -> anyhow::Result<ActorRef<A>>
+    ) -> anyhow::Result<(ActorRef<A>, ActorHandle<Supervisor>)>
     where
         A: RemoteSpawn,
         Self: Clone + Send + 'static,
@@ -261,7 +288,7 @@ pub trait ActorSpawnerEndpoint {
         );
         let actor_spawner = self.clone();
         let gspawn = Gspawn::for_actor_uid::<A>(cx, uid, params)?;
-        cx.instance().spawn(Supervisor::bootstrap_uid(
+        let supervisor = cx.instance().spawn(Supervisor::bootstrap_uid(
             liveness,
             SupervisionOptions::default(),
             Uid::anonymous(),
@@ -272,7 +299,7 @@ pub trait ActorSpawnerEndpoint {
                 Ok(())
             },
         ));
-        Ok(actor_ref)
+        Ok((actor_ref, supervisor))
     }
 }
 
@@ -293,6 +320,7 @@ mod tests {
     use hyperactor::Instance;
     use hyperactor::Label;
     use hyperactor::OncePortHandle;
+    use hyperactor::OncePortRef;
     use hyperactor::PortRef;
     use hyperactor::Proc;
     use hyperactor::RemoteSpawn;
@@ -472,6 +500,41 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Debug, Serialize, Deserialize, Named)]
+    struct Ping(OncePortRef<()>);
+    wirevalue::register_type!(Ping);
+
+    #[derive(Debug)]
+    #[hyperactor::export(Ping)]
+    struct StoppingSpawner {
+        actor_spawner: ActorHandle<ActorSpawner>,
+        stopped: Option<OncePortHandle<()>>,
+    }
+
+    #[async_trait]
+    impl Actor for StoppingSpawner {
+        async fn init(&mut self, this: &Instance<Self>) -> anyhow::Result<()> {
+            let (_child, supervisor) = self
+                .actor_spawner
+                .spawn_with_handle::<TestChild>(this, ())?;
+            supervisor.stop("test complete")?;
+            let _status = supervisor.await;
+            self.stopped
+                .take()
+                .expect("stopping spawner initialized once")
+                .post(this, ());
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl Handler<Ping> for StoppingSpawner {
+        async fn handle(&mut self, cx: &Context<Self>, message: Ping) -> anyhow::Result<()> {
+            message.0.post(cx, ());
+            Ok(())
+        }
+    }
+
     fn encoded_unit() -> Vec<u8> {
         bincode::serde::encode_to_vec((), bincode::config::legacy()).unwrap()
     }
@@ -572,6 +635,47 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(5), actor_spawner)
             .await
             .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_spawn_with_handle_stops_only_spawned_actor() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let actor_spawner = proc.spawn(ActorSpawner);
+        let (stopped, stopped_rx) = client.open_once_port::<()>();
+        let parent = proc.spawn(StoppingSpawner {
+            actor_spawner: actor_spawner.clone(),
+            stopped: Some(stopped),
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), stopped_rx.recv())
+            .await
+            .expect("spawned actor stop timed out")
+            .expect("spawned actor stop signal closed");
+        assert!(
+            !parent.status().borrow().is_terminal(),
+            "stopping the spawned actor should not stop its parent"
+        );
+        assert!(
+            !actor_spawner.status().borrow().is_terminal(),
+            "stopping the spawned actor should not stop the actor spawner"
+        );
+
+        let (pong, pong_rx) = client.open_once_port::<()>();
+        parent.post(&client, Ping(pong.bind()));
+        tokio::time::timeout(Duration::from_secs(5), pong_rx.recv())
+            .await
+            .expect("parent ping timed out")
+            .expect("parent ping port closed");
+
+        parent.stop("test complete").expect("stop parent");
+        tokio::time::timeout(Duration::from_secs(5), parent)
+            .await
+            .expect("parent stop timed out");
+        actor_spawner.stop("test").expect("stop actor spawner");
+        tokio::time::timeout(Duration::from_secs(5), actor_spawner)
+            .await
+            .expect("actor spawner stop timed out");
     }
 
     #[tokio::test]

--- a/hyperactor_remote/src/proc_spawner.rs
+++ b/hyperactor_remote/src/proc_spawner.rs
@@ -137,7 +137,7 @@ pub(crate) const ACTOR_SPAWNER_NAME: &str = "spawner";
 /// The singleton uid of a proc's actor-spawn endpoint. The spawner
 /// attests the endpoint ref at this uid, and the child proc spawns its
 /// `ActorSpawner` under it, so the two agree without a round trip.
-pub(crate) fn actor_spawner_uid() -> Uid {
+pub fn actor_spawner_uid() -> Uid {
     Uid::singleton(Label::strip(ACTOR_SPAWNER_NAME))
 }
 

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -144,12 +144,7 @@ pub struct Supervisor {
     liveness_handle: Option<ActorHandle<KeepaliveSupervisor>>,
     session: Option<SupervisorSession>,
     pending_stop: Option<PendingStop>,
-    /// If set, a bare readiness signal is posted here once the worker reports
-    /// [`SupervisorEvent::Linked`] — i.e., once the remote child has become
-    /// reachable. The child's address is returned synchronously by the spawn
-    /// call, so this carries no payload. Fires at most once, hence a
-    /// [`OncePortHandle`]; the supervisor and the caller that opened the port
-    /// are always on the same proc.
+    /// Optional one-shot notification posted after the worker links the child.
     ready: Option<OncePortHandle<()>>,
 }
 
@@ -193,10 +188,8 @@ impl Supervisor {
     /// supervisor has no worker control endpoint; stop requests are therefore
     /// held pending. `fallback_actor` is used only to synthesize a supervision
     /// event if liveness fails before the worker reports the supervised child.
-    /// When `ready` is set, a bare readiness signal is posted to it once the
-    /// worker reports `Linked` — the earliest point at which messages to the
-    /// child are guaranteed to route — so callers can wait for reachability
-    /// instead of guessing with a delay.
+    /// When `ready` is set, it is posted once the worker reports `Linked` — the
+    /// earliest point at which messages to the child are guaranteed to route.
     pub(crate) fn bootstrap_uid<F>(
         liveness: KeepaliveLink,
         options: SupervisionOptions,

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -568,10 +568,6 @@ pub(crate) struct PyActorMeshRef {
     name = "PythonActorMeshImpl",
     module = "monarch._rust_bindings.monarch_hyperactor.actor_mesh"
 )]
-#[expect(
-    clippy::large_enum_variant,
-    reason = "PyO3 #[pyclass] enum; Box wrapping interacts with PyO3 codegen and Python interop — separate diff"
-)]
 pub(crate) enum PythonActorMeshImpl {
     Owned(PyActorMesh),
     Ref(PyActorMeshRef),
@@ -683,14 +679,8 @@ impl SupervisableActorMesh for PythonActorMeshImpl {
     }
 }
 
-// Convert a hyperactor_mesh::Error to a Python exception. hyperactor_mesh::Error::Supervision becomes a SupervisionError,
-// all others become a RuntimeError.
 fn cast_error_to_py_error(err: hyperactor_mesh::Error) -> PyErr {
-    if let hyperactor_mesh::Error::Supervision(failure) = err {
-        SupervisionError::new_err_from(*failure)
-    } else {
-        PyRuntimeError::new_err(err.to_string())
-    }
+    PyRuntimeError::new_err(err.to_string())
 }
 
 impl ActorMeshProtocol for ActorMeshRef<PythonActor> {


### PR DESCRIPTION
Summary:

Part of: https://github.com/meta-pytorch/monarch/issues/4137

Make `ActorMesh` the lifecycle owner while `ActorMeshRef` remains the cast and address surface.

Managed meshes continue to stop through their controller. Data meshes constructed directly from actor refs remain unowned, while spawner-backed data meshes retain one caller-side `ActorHandle<Supervisor>` per rank. Stopping such a mesh signals the ordinary local proxy actors; the existing supervisor pending-stop path covers stops requested before the remote worker links. This removes `RemoteActorHandle` and all associated wire-protocol changes.

`ProcMesh::spawn_data` initiates every remote spawn and returns the data mesh without waiting for a `Ready` or `Linked` signal. It gathers the eventual actor refs and local proxy handles synchronously, and best-effort stops already-created proxies if a later spawn request cannot be initiated.

`ActorMesh` stores only its `ActorMeshRef`, common rank space, and data-mesh stop handles. Managed identity, proc-mesh identity, and controller state have a single source of truth in `ManagedActorMeshRef`; the redundant full `ProcMeshRef`, mesh id, and controller fields are removed from `ActorMesh`. Data refs cast directly to their members and can be monitored through `MeshMonitor`.

A data ref retains only a shared one-shot local stop-requested fence so clones and slices reject casts immediately after their owner consumes the stop handles. This fence is not an observed actor status and does not store or synthesize a `MeshFailure`; cast attempts return `Error::MeshStopped`. `MeshMonitor` remains the source of eventual per-actor stopped or failed observations.

Caveat: asynchronous remote spawn returns an attested `ActorRef` before the remote mailbox is necessarily bound. Hyperactor does not buffer messages for a not-yet-existing actor address, so messages sent before linking may be returned as `ActorNotExist`. Paths that promise an immediately usable mesh still wait for reachability; true local-like pre-link messaging requires a separate pending-route or proxy change.
Waiting on https://github.com/meta-pytorch/monarch/issues/4129 to fix that

Reviewed By: mariusae

Differential Revision: D114246217


