### PR TITLE
Let `Kill` preempt actor cleanup (#4648)

### DIFF
--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -128,7 +128,9 @@ pub trait Actor: Sized + Send + 'static {
     /// as an ActorError.
     /// This function is not called if there is a panic in the actor, as the
     /// actor may be in an indeterminate state. It is also not called if the
-    /// process is killed, there is no atexit handler or signal handler.
+    /// actor is stopped with [`Instance::kill`] or if the process is killed. If
+    /// [`Instance::kill`] is called while cleanup is running, the cleanup future
+    /// is cancelled.
     async fn cleanup(
         &mut self,
         _this: &Instance<Self>,

--- a/hyperactor/src/actor.rs
+++ b/hyperactor/src/actor.rs
@@ -730,9 +730,6 @@ pub enum Signal {
     /// Exit the actor loop with the provided stop reason.
     ExitRequested(String),
 
-    /// The direct child with the given uid was stopped.
-    ChildStopped(crate::id::Uid),
-
     /// Kill the actor. This will exit the actor loop with an error,
     /// causing a supervision event to propagate up the supervision
     /// hierarchy.
@@ -745,7 +742,6 @@ impl fmt::Display for Signal {
             Signal::DrainAndStop(reason) => write!(f, "DrainAndStop({})", reason),
             Signal::Stop(reason) => write!(f, "Stop({})", reason),
             Signal::ExitRequested(reason) => write!(f, "ExitRequested({})", reason),
-            Signal::ChildStopped(uid) => write!(f, "ChildStopped({})", uid),
             Signal::Kill(reason) => write!(f, "Kill({})", reason),
         }
     }

--- a/hyperactor/src/introspect.rs
+++ b/hyperactor/src/introspect.rs
@@ -109,15 +109,15 @@
 //!   is derived from root-cause actor identity; a parent that failed
 //!   due to a child's event must report `failure_is_propagated ==
 //!   true`.
-//! - **FI-9 (stored-terminal vs delivered-zombie):** For an actor
+//! - **FI-9 (detached-zombie completion suppression):** For an actor
 //!   marked `Zombie` during teardown that then reaches a terminal
 //!   status, `InstanceCell::supervision_event` records the true
-//!   terminal event (`Stopped`/`Failed`, for introspection) while
-//!   the supervision event delivered to the parent/proc remains the
-//!   non-error `Zombie` verdict (for supervision policy). The two
-//!   intentionally diverge; enforced in `proc.rs` `serve()`, where
-//!   the stored `event` and the delivered `event_to_deliver` are
-//!   computed separately.
+//!   terminal event (`Stopped`/`Failed`, for introspection), and the
+//!   terminal status replaces `Zombie`. Because detachment already
+//!   removed the actor from its parent's completion barrier and
+//!   transferred it to proc ownership, the terminal event does not
+//!   re-enter supervision. `try_handle_completion_event` makes this decision
+//!   while holding the supervision ownership lock.
 //!
 //! ## Attrs view invariants (AV-*)
 //!

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3263,30 +3263,68 @@ impl<A: Actor> Instance<A> {
                 }
             }
         }
+        let was_killed = result
+            .as_ref()
+            .is_err_and(|err| matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)));
         // Run the actor cleanup function before the actor stops to delete
         // resources. If it times out, continue with stopping the actor.
         // Don't call it if there was a panic, because the actor may
         // be in an invalid state and unable to access anything, for example
         // the GIL.
-        let cleanup_result = if !did_panic {
+        let cleanup_result = if !did_panic && !was_killed {
             let cleanup_timeout = hyperactor_config::global::get(config::CLEANUP_TIMEOUT);
-            match tokio::time::timeout(
+            let cleanup = tokio::time::timeout(
                 cleanup_timeout,
                 self.inner
                     .proc
                     .with_current(actor.cleanup(self, result.as_ref().err())),
-            )
-            .await
-            {
-                Ok(Ok(x)) => Ok(x),
-                Ok(Err(e)) => Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::cleanup(e),
-                )),
-                Err(e) => Err(ActorError::new(
-                    self.self_addr(),
-                    ActorErrorKind::cleanup(e.into()),
-                )),
+            );
+            tokio::pin!(cleanup);
+            let signal_receiver = &mut actor_loop_receivers.0;
+            let mut receive_signals = true;
+            loop {
+                tokio::select! {
+                    biased;
+                    signal = signal_receiver.recv(), if receive_signals => {
+                        match signal {
+                            Some(Signal::Kill(reason)) => {
+                                // Aborting discards `result`, so carry an
+                                // already-failed exit into the reason. It is
+                                // the root cause, and nothing downstream sees
+                                // `result` once we return.
+                                let reason = match result.as_ref() {
+                                    Err(err) => {
+                                        format!("{reason} (killed during cleanup after: {err})")
+                                    }
+                                    Ok(_) => reason,
+                                };
+                                return Err(ActorError::new(
+                                    self.self_addr(),
+                                    ActorErrorKind::Aborted(reason),
+                                ));
+                            }
+                            Some(
+                                Signal::Stop(_)
+                                | Signal::DrainAndStop(_)
+                                | Signal::ExitRequested(_),
+                            ) => {}
+                            None => receive_signals = false,
+                        }
+                    }
+                    cleanup_result = &mut cleanup => {
+                        break match cleanup_result {
+                            Ok(Ok(result)) => Ok(result),
+                            Ok(Err(err)) => Err(ActorError::new(
+                                self.self_addr(),
+                                ActorErrorKind::cleanup(err),
+                            )),
+                            Err(err) => Err(ActorError::new(
+                                self.self_addr(),
+                                ActorErrorKind::cleanup(err.into()),
+                            )),
+                        };
+                    }
+                }
             }
         } else {
             Ok(())
@@ -7093,6 +7131,154 @@ mod tests {
         parent.drain_and_stop("test").unwrap();
         assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
         assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[derive(Debug)]
+    struct CleanupReportingActor {
+        cleaned: Option<oneshot::Sender<()>>,
+    }
+
+    struct CleanupDropGuard(Option<oneshot::Sender<()>>);
+
+    impl Drop for CleanupDropGuard {
+        fn drop(&mut self) {
+            if let Some(dropped) = self.0.take() {
+                let _ = dropped.send(());
+            }
+        }
+    }
+
+    #[derive(Debug)]
+    struct BlockingCleanupActor {
+        cleanup_started: Option<oneshot::Sender<()>>,
+        cleanup_dropped: Option<oneshot::Sender<()>>,
+    }
+
+    #[async_trait]
+    impl Actor for BlockingCleanupActor {
+        async fn cleanup(
+            &mut self,
+            _this: &Instance<Self>,
+            _err: Option<&ActorError>,
+        ) -> Result<(), anyhow::Error> {
+            let _drop_guard = CleanupDropGuard(self.cleanup_dropped.take());
+            self.cleanup_started.take().unwrap().send(()).unwrap();
+            std::future::pending().await
+        }
+    }
+
+    #[async_trait]
+    impl Actor for CleanupReportingActor {
+        async fn cleanup(
+            &mut self,
+            _this: &Instance<Self>,
+            _err: Option<&ActorError>,
+        ) -> Result<(), anyhow::Error> {
+            self.cleaned.take().unwrap().send(()).unwrap();
+            Ok(())
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_skips_actor_cleanup() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let (cleaned_tx, cleaned_rx) = oneshot::channel();
+        let actor = proc.spawn(CleanupReportingActor {
+            cleaned: Some(cleaned_tx),
+        });
+        actor
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_idle)
+            .await
+            .unwrap();
+
+        actor.kill("kill").unwrap();
+
+        assert_matches!(
+            actor.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+        assert!(cleaned_rx.await.is_err(), "cleanup ran after kill");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_interrupts_actor_cleanup() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let (cleanup_started_tx, cleanup_started_rx) = oneshot::channel();
+        let (cleanup_dropped_tx, cleanup_dropped_rx) = oneshot::channel();
+        let actor = proc.spawn(BlockingCleanupActor {
+            cleanup_started: Some(cleanup_started_tx),
+            cleanup_dropped: Some(cleanup_dropped_tx),
+        });
+
+        actor.stop("stop").unwrap();
+        cleanup_started_rx.await.unwrap();
+        actor.kill("kill").unwrap();
+
+        assert_matches!(
+            tokio::time::timeout(Duration::from_secs(1), actor)
+                .await
+                .expect("kill should interrupt cleanup"),
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+        cleanup_dropped_rx
+            .await
+            .expect("cleanup future should be cancelled");
+    }
+
+    #[derive(Debug)]
+    struct FailingBlockingCleanupActor {
+        cleanup_started: Option<oneshot::Sender<()>>,
+    }
+
+    #[async_trait]
+    impl Actor for FailingBlockingCleanupActor {
+        async fn handle_stop(
+            &mut self,
+            _this: &Instance<Self>,
+            _mode: StopMode,
+            _reason: &str,
+        ) -> Result<(), anyhow::Error> {
+            Err(anyhow::anyhow!("original failure"))
+        }
+
+        async fn cleanup(
+            &mut self,
+            _this: &Instance<Self>,
+            _err: Option<&ActorError>,
+        ) -> Result<(), anyhow::Error> {
+            self.cleanup_started.take().unwrap().send(()).unwrap();
+            std::future::pending().await
+        }
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_during_cleanup_preserves_failure_cause() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let (cleanup_started_tx, cleanup_started_rx) = oneshot::channel();
+        let actor = proc.spawn(FailingBlockingCleanupActor {
+            cleanup_started: Some(cleanup_started_tx),
+        });
+
+        // The actor has already failed by the time cleanup starts, so the kill
+        // that interrupts cleanup must not erase why it failed.
+        actor.stop("stop").unwrap();
+        cleanup_started_rx.await.unwrap();
+        actor.kill("kill").unwrap();
+
+        assert_matches!(
+            tokio::time::timeout(Duration::from_secs(1), actor)
+                .await
+                .expect("kill should interrupt cleanup"),
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("kill") && reason.contains("original failure")
+        );
     }
 
     #[derive(Debug)]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -466,9 +466,6 @@ struct ProcState {
     /// All actor instances in this proc.
     instances: DashMap<ActorId, WeakInstanceCell>,
 
-    /// Root actor ids in this proc, tracked independently from uid shape.
-    root_actors: DashSet<ActorId>,
-
     /// Proc-level queue-pressure accounting (PD-6 through PD-9).
     /// Runtime-driven — updated from `account_enqueue` /
     /// `account_dequeue`, not from publish-time sampling.
@@ -813,7 +810,6 @@ impl Proc {
                 reserved_roots: DashSet::new(),
                 reserved_child_uids: DashSet::new(),
                 instances: DashMap::new(),
-                root_actors: DashSet::new(),
                 queue_stats: Arc::new(ProcQueueStats::new()),
                 terminated_snapshots: DashMap::new(),
                 actor_tombstones: DashMap::new(),
@@ -1308,15 +1304,14 @@ impl Proc {
         })
     }
 
-    /// Traverse all actor trees in this proc, starting from root actors.
+    /// Traverse all actor trees in this proc, starting from each
+    /// proc-supervised actor.
     pub fn traverse<F>(&self, f: &mut F)
     where
         F: FnMut(&InstanceCell, usize),
     {
-        for entry in self.state().root_actors.iter() {
-            if let Some(cell) = self.get_instance_by_id(entry.key()) {
-                cell.traverse(f);
-            }
+        for cell in self.proc_supervised_instances() {
+            cell.traverse(f);
         }
     }
 
@@ -1348,15 +1343,29 @@ impl Proc {
             .and_then(|cell| cell.upgrade())
     }
 
-    /// Returns the ActorAddrs of all root actors in this proc.
-    pub fn root_actor_ids(&self) -> Vec<ActorAddr> {
-        self.state()
-            .root_actors
+    /// Live instances supervised directly by this proc.
+    ///
+    /// Upgrades are collected before filtering: dropping a rejected cell inside
+    /// the iterator can run `InstanceCellState::drop`, which removes from
+    /// `instances` under the iteration guard.
+    fn proc_supervised_instances(&self) -> Vec<InstanceCell> {
+        let live: Vec<InstanceCell> = self
+            .state()
+            .instances
             .iter()
-            .filter_map(|entry| {
-                self.get_instance_by_id(entry.key())
-                    .map(|cell| cell.actor_addr().clone())
-            })
+            .filter_map(|entry| entry.value().upgrade())
+            .collect();
+        live.into_iter()
+            .filter(InstanceCell::is_proc_supervised)
+            .collect()
+    }
+
+    /// Returns the ActorAddrs of all actors supervised directly by this proc.
+    /// An actor whose parent link has expired is not a root.
+    pub fn root_actor_ids(&self) -> Vec<ActorAddr> {
+        self.proc_supervised_instances()
+            .into_iter()
+            .map(|cell| cell.actor_addr().clone())
             .collect()
     }
 
@@ -1567,10 +1576,8 @@ impl Proc {
         // (which must stay alive to receive stop events from the others).
         let mut statuses = HashMap::new();
         for actor_id in self
-            .state()
-            .root_actors
-            .iter()
-            .filter_map(|entry| self.get_instance_by_id(entry.key()))
+            .proc_supervised_instances()
+            .into_iter()
             .filter(|cell| !matches!(*cell.status().borrow(), ActorStatus::Client))
             .map(|cell| cell.actor_addr().clone())
             .collect::<Vec<_>>()
@@ -3770,7 +3777,7 @@ impl<A: Actor> Instance<A> {
 
     /// Return a handle to this instance's parent actor, if it has one.
     pub fn parent_handle<P: Actor>(&self) -> Option<ActorHandle<P>> {
-        let parent_cell = self.inner.cell.inner.parent.upgrade()?;
+        let parent_cell = self.inner.cell.parent()?;
         let ports = if let Ok(ports) = parent_cell.inner.ports.clone().downcast() {
             ports
         } else {
@@ -3988,8 +3995,8 @@ struct InstanceCellState {
     /// An observer that stores the current status of the actor.
     status: watch::Receiver<ActorStatus>,
 
-    /// A weak reference to this instance's parent.
-    parent: WeakInstanceCell,
+    /// The actor or proc that currently supervises this instance.
+    supervision_link: SupervisionLink,
 
     /// This instance's children by their uids.
     children: DashMap<crate::id::Uid, InstanceCell>,
@@ -4094,12 +4101,34 @@ struct InstanceCellState {
     actor_attrs_snapshot: RwLock<Option<Box<dyn Fn() -> hyperactor_config::Attrs + Send + Sync>>>,
 }
 
+/// Logical supervision ownership, independent of weak-reference liveness.
+///
+/// An expired `Actor` link is a broken topology edge, not proc supervision.
+#[derive(Debug)]
+enum SupervisionLink {
+    /// Supervised directly by the proc: a root.
+    Proc,
+    /// Supervised by an actor. The reference may expire; an expired link is a
+    /// broken edge, not proc ownership.
+    Actor(WeakInstanceCell),
+}
+
+impl SupervisionLink {
+    /// The supervising actor, if this link names one that is still live.
+    fn parent(&self) -> Option<InstanceCell> {
+        match self {
+            SupervisionLink::Actor(parent) => parent.upgrade(),
+            SupervisionLink::Proc => None,
+        }
+    }
+}
+
 impl InstanceCellState {
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.parent
-            .upgrade()
+        self.supervision_link
+            .parent()
             .filter(|parent| parent.inner.unlink(self))
     }
 
@@ -4207,7 +4236,6 @@ impl InstanceCell {
             Box<dyn Fn() -> crate::ordering::OrderingSnapshot + Send + Sync>,
         >,
     ) -> Self {
-        let is_root = parent.is_none();
         let _ais = actor_id.to_string();
         let cell = Self {
             inner: Arc::new(InstanceCellState {
@@ -4220,7 +4248,9 @@ impl InstanceCell {
                 actor_loop,
                 status_tx,
                 status,
-                parent: parent.map_or_else(WeakInstanceCell::new, |cell| cell.downgrade()),
+                supervision_link: parent.as_ref().map_or(SupervisionLink::Proc, |cell| {
+                    SupervisionLink::Actor(cell.downgrade())
+                }),
                 children: DashMap::new(),
                 actor_task_handle: OnceLock::new(),
                 exported_named_ports: DashMap::new(),
@@ -4245,9 +4275,6 @@ impl InstanceCell {
         proc.inner
             .instances
             .insert(actor_id.id().clone(), cell.downgrade());
-        if is_root {
-            proc.inner.root_actors.insert(actor_id.id().clone());
-        }
         cell
     }
 
@@ -4523,7 +4550,7 @@ impl InstanceCell {
 
     /// Link this instance to its parent, if it has one.
     fn maybe_link_parent(&self) {
-        if let Some(parent) = self.inner.parent.upgrade() {
+        if let Some(parent) = self.inner.supervision_link.parent() {
             parent.link(self.clone());
         }
     }
@@ -4662,7 +4689,13 @@ impl InstanceCell {
 
     /// Get parent instance cell, if it exists.
     pub fn parent(&self) -> Option<InstanceCell> {
-        self.inner.parent.upgrade()
+        self.inner.supervision_link.parent()
+    }
+
+    /// Whether the proc supervises this instance directly. Distinct from
+    /// `parent().is_none()`, which is also true of an expired actor link.
+    fn is_proc_supervised(&self) -> bool {
+        matches!(&self.inner.supervision_link, SupervisionLink::Proc)
     }
 
     /// The actor's type name.
@@ -4841,7 +4874,6 @@ impl Drop for InstanceCellState {
         {
             tracing::error!("instance {} was dropped but not in proc", self.actor_id);
         }
-        self.proc.inner.root_actors.remove(self.actor_id.id());
     }
 }
 
@@ -4852,18 +4884,7 @@ pub struct WeakInstanceCell {
     inner: Weak<InstanceCellState>,
 }
 
-impl Default for WeakInstanceCell {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl WeakInstanceCell {
-    /// Create a new weak instance cell that is never upgradeable.
-    pub fn new() -> Self {
-        Self { inner: Weak::new() }
-    }
-
     /// Upgrade this weak instance cell to a strong reference, if possible.
     pub fn upgrade(&self) -> Option<InstanceCell> {
         self.inner.upgrade().map(InstanceCell::wrap)
@@ -6420,10 +6441,7 @@ mod tests {
             child.actor_addr().proc_addr(),
             parent.actor_addr().proc_addr()
         );
-        assert_eq!(
-            child.inner.parent.upgrade().unwrap().actor_addr(),
-            parent.actor_addr()
-        );
+        assert_eq!(child.parent().unwrap().actor_addr(), parent.actor_addr());
         assert_matches!(
             parent.inner.children.get(child.uid()),
             Some(node) if node.actor_addr() == child.actor_addr()
@@ -6481,7 +6499,7 @@ mod tests {
         // Supervision tree is constructed correctly.
         validate_link(third.cell(), second.cell());
         validate_link(second.cell(), first.cell());
-        assert!(first.cell().inner.parent.upgrade().is_none());
+        assert!(first.cell().parent().is_none());
 
         // Supervision tree is torn down correctly.
         // Once each actor is stopped, it should have no linked children.
@@ -6489,6 +6507,11 @@ mod tests {
         third.drain_and_stop("test").unwrap();
         third.await;
         assert!(third_cell.inner.children.is_empty());
+        assert_eq!(
+            third_cell.parent().unwrap().actor_addr(),
+            second.actor_addr()
+        );
+        assert!(second.cell().get_child(third_cell.uid()).is_none());
         drop(third_cell);
         validate_link(second.cell(), first.cell());
 
@@ -6502,6 +6525,44 @@ mod tests {
         first.drain_and_stop("test").unwrap();
         first.await;
         assert!(first_cell.inner.children.is_empty());
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn expired_parent_link_is_not_a_root() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+
+        let parent = proc.spawn_with_label::<TestActor>("parent", TestActor);
+        let child = TestActor::spawn_child(&client, &parent).await;
+        let child_cell = child.cell().clone();
+        let child_addr = child_cell.actor_addr().clone();
+
+        assert!(parent.cell().is_proc_supervised());
+        assert!(!child_cell.is_proc_supervised());
+
+        parent.drain_and_stop("test").unwrap();
+        parent.await;
+        drop(child);
+
+        for i in 0..1000 {
+            if child_cell.parent().is_none() {
+                break;
+            }
+            if i < 50 {
+                tokio::task::yield_now().await;
+            } else {
+                tokio::time::sleep(Duration::from_millis(50)).await;
+            }
+        }
+        assert!(
+            child_cell.parent().is_none(),
+            "parent cell should be released once the parent stops"
+        );
+
+        // The link stays `Actor`, so an expired parent never promotes the
+        // child to a proc root.
+        assert!(!child_cell.is_proc_supervised());
+        assert!(!proc.root_actor_ids().contains(&child_addr));
     }
 
     #[async_timed_test(timeout_secs = 30)]

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -3150,33 +3150,14 @@ impl<A: Actor> Instance<A> {
         // Deliver the supervision event to the parent/proc BEFORE
         // change_status so that any observer waiting for this actor's
         // terminal state can only see it once the event has been
-        // enqueued at its destination.
-        if let Some(parent) = self.inner.cell.maybe_unlink_parent() {
-            if let Some(event) = event_to_deliver {
-                // Parent exists, failure should be propagated to the parent.
-                parent.send_supervision_event_or_crash(event);
-            }
-            // TODO: we should get rid of this signal, and use *only* supervision events for
-            // the purpose of conveying lifecycle changes
-            if let Err(err) = parent.signal(Signal::ChildStopped(self.inner.cell.uid().clone())) {
-                tracing::error!(
-                    "{}: failed to send stop message to parent uid {}: {:?}",
-                    self.self_addr(),
-                    parent.uid(),
-                    err
-                );
-            }
-        } else {
-            // Failure happened to the root actor or orphaned child actors.
-            // In either case, the failure should be propagated to proc.
-            //
-            // Note that orphaned actor is unexpected and would only happen if
-            // there is a bug.
-            if let Some(event) = event_to_deliver {
-                self.inner
-                    .proc
-                    .handle_unhandled_supervision_event(&self, event);
-            }
+        // enqueued at its destination. A returned event had no owning parent
+        // — the root actor, or an orphaned child, which would be a bug.
+        if let Some(event) = event_to_deliver
+            && let Some(event) = self.inner.cell.try_handle_completion_event(event)
+        {
+            self.inner
+                .proc
+                .handle_unhandled_supervision_event(&self, event);
         }
 
         self.stop_introspect(terminal_status.clone()).await;
@@ -3255,18 +3236,18 @@ impl<A: Actor> Instance<A> {
             self.inner.cell.unlink(&child);
         }
 
-        let (mut signal_receiver, _) = actor_loop_receivers;
+        let (_, mut supervision_event_receiver) = actor_loop_receivers;
         while self.inner.cell.child_count() > 0 {
-            match tokio::time::timeout(Duration::from_millis(500), signal_receiver.recv()).await {
-                Ok(Some(Signal::ChildStopped(uid))) => {
-                    assert!(self.inner.cell.get_child(&uid).is_none());
-                }
-                // Drain only tracks child termination; other signals are
-                // intentionally swallowed here.
+            match tokio::time::timeout(
+                Duration::from_millis(500),
+                supervision_event_receiver.recv(),
+            )
+            .await
+            {
                 Ok(Some(_)) => {}
                 Ok(None) => {
-                    // Signal channel closed: no further ChildStopped will
-                    // arrive, so we can no longer track child termination.
+                    // The supervision channel closed, so no further child
+                    // completion events can arrive.
                     // Drop remaining links and exit the drain loop, mirroring
                     // the timeout branch below.
                     self.inner.cell.unlink_all();
@@ -3274,7 +3255,7 @@ impl<A: Actor> Instance<A> {
                 }
                 Err(_) => {
                     tracing::warn!(
-                        "timeout waiting for ChildStopped signal from child on actor: {}, ignoring",
+                        "timeout waiting for child supervision event on actor: {}, ignoring",
                         self.self_addr()
                     );
                     // No more waiting to receive messages. Unlink all remaining
@@ -3381,9 +3362,6 @@ impl<A: Actor> Instance<A> {
                                 .with_current(actor.handle_stop(self, StopMode::DrainAndStop, &reason))
                                 .await
                                 .map_err(|err| ActorError::new(self.self_addr(), ActorErrorKind::processing(err)))?;
-                        },
-                        Signal::ChildStopped(uid) => {
-                            assert!(self.inner.cell.get_child(&uid).is_none());
                         },
                         Signal::ExitRequested(reason) => {
                             break 'messages reason;
@@ -4124,6 +4102,28 @@ impl SupervisionLink {
 }
 
 impl InstanceCellState {
+    /// Deliver this instance's terminal event to its supervising actor, then
+    /// unlink. Returns the event if there is no owning parent to take it.
+    ///
+    /// The parent's completion barrier is `child_count()`, so unlinking first
+    /// would let the parent finish before the event is enqueued.
+    fn try_handle_completion_event(
+        &self,
+        event: ActorSupervisionEvent,
+    ) -> Option<ActorSupervisionEvent> {
+        let Some(parent) = self.supervision_link.parent() else {
+            return Some(event);
+        };
+        let Some(child_entry) = parent.inner.children.get(self.actor_id.uid()) else {
+            return Some(event);
+        };
+
+        parent.send_supervision_event_or_crash(event);
+        drop(child_entry);
+        parent.inner.unlink(self);
+        None
+    }
+
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
@@ -4555,10 +4555,11 @@ impl InstanceCell {
         }
     }
 
-    /// Unlink this instance from its parent, if it has one. If it was unlinked,
-    /// the parent is returned.
-    fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.inner.maybe_unlink_parent()
+    fn try_handle_completion_event(
+        &self,
+        event: ActorSupervisionEvent,
+    ) -> Option<ActorSupervisionEvent> {
+        self.inner.try_handle_completion_event(event)
     }
 
     /// Return an iterator over this instance's children. This may deadlock if the
@@ -4581,7 +4582,7 @@ impl InstanceCell {
             .collect()
     }
 
-    /// Get a child by its uid.
+    #[cfg(test)]
     fn get_child(&self, uid: &crate::id::Uid) -> Option<InstanceCell> {
         self.inner.children.get(uid).map(|child| child.clone())
     }

--- a/hyperactor/src/proc.rs
+++ b/hyperactor/src/proc.rs
@@ -2088,26 +2088,10 @@ struct ActorStopped {
     stop_mode: StopMode,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-enum ChildTeardown {
-    Cooperative(StopMode),
-    Kill,
-}
-
-impl ChildTeardown {
-    fn from_run_result(result: &Result<ActorStopped, ActorError>) -> Self {
-        match result {
-            Ok(stopped) => Self::Cooperative(stopped.stop_mode),
-            Err(err) if matches!(err.kind.as_ref(), ActorErrorKind::Aborted(_)) => Self::Kill,
-            Err(_) => Self::Cooperative(StopMode::Stop),
-        }
-    }
-
-    fn cooperative_signal(mode: StopMode) -> Signal {
-        match mode {
-            StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
-            StopMode::Stop => Signal::Stop("parent stopping".to_string()),
-        }
+fn cooperative_child_signal(mode: StopMode) -> Signal {
+    match mode {
+        StopMode::DrainAndStop => Signal::DrainAndStop("parent draining".to_string()),
+        StopMode::Stop => Signal::Stop("parent stopping".to_string()),
     }
 }
 
@@ -3127,32 +3111,17 @@ impl<A: Actor> Instance<A> {
             },
         };
 
-        let current_status = self.inner.cell.status().borrow().clone();
-        // FI-9: supervisors observe the zombie lifecycle verdict, while the event
-        // stored below must describe the terminal status for introspection.
-        let event_to_deliver = if current_status.is_zombie() {
-            Some(ActorSupervisionEvent::new(
-                self.inner.cell.actor_addr().clone(),
-                actor.display_name(),
-                current_status,
-                None,
-            ))
-        } else {
-            event.clone()
-        };
-
         self.mailbox().close(terminal_status.clone());
         // FI-1: store supervision_event BEFORE change_status.
         if let Some(event) = &event {
             *self.inner.cell.inner.supervision_event.lock().unwrap() = Some(event.clone());
         }
 
-        // Deliver the supervision event to the parent/proc BEFORE
-        // change_status so that any observer waiting for this actor's
-        // terminal state can only see it once the event has been
-        // enqueued at its destination. A returned event had no owning parent
-        // — the root actor, or an orphaned child, which would be a bug.
-        if let Some(event) = event_to_deliver
+        // Resolve completion routing BEFORE change_status so that any observer
+        // waiting for this actor's terminal state cannot race the supervision
+        // decision. A returned event had no owning parent and must follow the
+        // proc's unhandled-supervision path.
+        if let Some(event) = event
             && let Some(event) = self.inner.cell.try_handle_completion_event(event)
         {
             self.inner
@@ -3164,9 +3133,40 @@ impl<A: Actor> Instance<A> {
         self.change_status(terminal_status);
     }
 
-    /// Runs the actor, and manages its supervision tree. When the function returns,
-    /// the whole tree rooted at this actor has stopped. On success, returns the reason
-    /// why the actor stopped. On failure, returns the error that caused the failure.
+    fn kill_residual_children(&self, reason: &str) {
+        // Detach the whole subtree, not just direct children: a child that
+        // never processes `Kill` would otherwise strand its own descendants
+        // under a zombie, where neither this parent nor the proc reaches them.
+        //
+        // Collecting first also keeps no child-map guard held while taking a
+        // child's supervision lock. Completion routing takes the supervision
+        // lock first.
+        let mut children = Vec::new();
+        self.inner.cell.traverse(&mut |cell: &InstanceCell, depth| {
+            if depth > 0 {
+                children.push(cell.clone());
+            }
+        });
+        for child in children {
+            if !child.detach_to_proc_as_zombie(format!(
+                "detached during forced parent teardown: {reason}"
+            )) {
+                continue;
+            }
+            if let Err(err) = child.signal(Signal::Kill(reason.to_string())) {
+                tracing::debug!(
+                    actor_id = %self.self_addr(),
+                    child_id = %child.actor_addr(),
+                    "detached child already stopped during forced teardown: {}",
+                    err,
+                );
+            }
+        }
+    }
+
+    /// Runs the actor and initiates teardown of its supervision tree. On success,
+    /// returns the reason why the actor stopped. On failure, returns the error that
+    /// caused the failure after transferring residual children to the proc.
     async fn run_actor_tree(
         &mut self,
         actor: &mut A,
@@ -3209,59 +3209,57 @@ impl<A: Actor> Instance<A> {
             tracing::error!("{}: actor failure: {}", self.self_addr(), err);
         }
 
-        // After this point, we know we won't spawn any more children,
-        // so we can safely read the current child keys.
-        let mut to_unlink = Vec::new();
-        let child_signal = match ChildTeardown::from_run_result(&result) {
-            ChildTeardown::Cooperative(mode) => ChildTeardown::cooperative_signal(mode),
-            ChildTeardown::Kill => {
-                // TODO: fan out kill once child teardown can detach
-                // unresponsive children without blocking this parent.
-                ChildTeardown::cooperative_signal(StopMode::Stop)
-            }
-        };
-        for child in self.inner.cell.child_iter() {
-            if let Err(err) = child.value().signal(child_signal.clone()) {
-                tracing::error!(
-                    "{}: failed to send stop signal to child pid {}: {:?}",
-                    self.self_addr(),
-                    child.key(),
-                    err
-                );
-                to_unlink.push(child.value().clone());
-            }
-        }
-        // Manually unlink children that have already been stopped.
-        for child in to_unlink {
-            self.inner.cell.unlink(&child);
-        }
-
-        let (_, mut supervision_event_receiver) = actor_loop_receivers;
-        while self.inner.cell.child_count() > 0 {
-            match tokio::time::timeout(
-                Duration::from_millis(500),
-                supervision_event_receiver.recv(),
-            )
-            .await
-            {
-                Ok(Some(_)) => {}
-                Ok(None) => {
-                    // The supervision channel closed, so no further child
-                    // completion events can arrive.
-                    // Drop remaining links and exit the drain loop, mirroring
-                    // the timeout branch below.
-                    self.inner.cell.unlink_all();
-                    break;
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        "timeout waiting for child supervision event on actor: {}, ignoring",
-                        self.self_addr()
+        if let Err(err) = &result {
+            let teardown_reason = format!("parent failed: {err}");
+            self.kill_residual_children(&teardown_reason);
+        } else if let Ok(stopped) = &result {
+            // After this point, we know we won't spawn any more children,
+            // so we can safely read the current child keys.
+            let mut to_unlink = Vec::new();
+            let child_signal = cooperative_child_signal(stopped.stop_mode);
+            for child in self.inner.cell.child_iter() {
+                if let Err(err) = child.value().signal(child_signal.clone()) {
+                    tracing::error!(
+                        "{}: failed to send stop signal to child pid {}: {:?}",
+                        self.self_addr(),
+                        child.key(),
+                        err
                     );
-                    // No more waiting to receive messages. Unlink all remaining
-                    // children.
-                    self.inner.cell.unlink_all();
-                    break;
+                    to_unlink.push(child.value().clone());
+                }
+            }
+            // Manually unlink children that have already been stopped.
+            for child in to_unlink {
+                self.inner.cell.unlink(&child);
+            }
+
+            let (_, mut supervision_event_receiver) = actor_loop_receivers;
+            while self.inner.cell.child_count() > 0 {
+                match tokio::time::timeout(
+                    Duration::from_millis(500),
+                    supervision_event_receiver.recv(),
+                )
+                .await
+                {
+                    Ok(Some(_)) => {}
+                    Ok(None) => {
+                        // The supervision channel closed, so no further child
+                        // completion events can arrive.
+                        // Drop remaining links and exit the drain loop, mirroring
+                        // the timeout branch below.
+                        self.inner.cell.unlink_all();
+                        break;
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "timeout waiting for child supervision event on actor: {}, ignoring",
+                            self.self_addr()
+                        );
+                        // No more waiting to receive messages. Unlink all remaining
+                        // children.
+                        self.inner.cell.unlink_all();
+                        break;
+                    }
                 }
             }
         }
@@ -3974,7 +3972,7 @@ struct InstanceCellState {
     status: watch::Receiver<ActorStatus>,
 
     /// The actor or proc that currently supervises this instance.
-    supervision_link: SupervisionLink,
+    supervision_link: Mutex<SupervisionLink>,
 
     /// This instance's children by their uids.
     children: DashMap<crate::id::Uid, InstanceCell>,
@@ -4102,22 +4100,41 @@ impl SupervisionLink {
 }
 
 impl InstanceCellState {
-    /// Deliver this instance's terminal event to its supervising actor, then
-    /// unlink. Returns the event if there is no owning parent to take it.
-    ///
-    /// The parent's completion barrier is `child_count()`, so unlinking first
-    /// would let the parent finish before the event is enqueued.
+    /// Tries to consume a terminal event while holding supervision ownership
+    /// against forced detachment. It delivers the event to an owning parent or
+    /// suppresses it after zombie detachment, returning it only when proc
+    /// supervision must handle it.
     fn try_handle_completion_event(
         &self,
         event: ActorSupervisionEvent,
     ) -> Option<ActorSupervisionEvent> {
-        let Some(parent) = self.supervision_link.parent() else {
+        let link = self.supervision_link.lock().unwrap();
+        // FI-9: detachment already removed a zombie from its parent's completion
+        // barrier. Preserve its terminal event for introspection without
+        // re-entering supervision.
+        if self.status.borrow().is_zombie() {
+            assert!(
+                matches!(&*link, SupervisionLink::Proc),
+                "zombie actor {} is not proc-supervised",
+                self.actor_id
+            );
+            return None;
+        }
+
+        let SupervisionLink::Actor(parent) = &*link else {
+            return Some(event);
+        };
+        let Some(parent) = parent.upgrade() else {
             return Some(event);
         };
         let Some(child_entry) = parent.inner.children.get(self.actor_id.uid()) else {
             return Some(event);
         };
 
+        // Keep completion delivery and parent-map removal in one ownership
+        // critical section so forced teardown cannot retarget between them.
+        // Delivery precedes the unlink because the parent's completion barrier
+        // is `child_count()`.
         parent.send_supervision_event_or_crash(event);
         drop(child_entry);
         parent.inner.unlink(self);
@@ -4127,9 +4144,9 @@ impl InstanceCellState {
     /// Unlink this instance from its parent, if it has one. If it was unlinked,
     /// the parent is returned.
     fn maybe_unlink_parent(&self) -> Option<InstanceCell> {
-        self.supervision_link
-            .parent()
-            .filter(|parent| parent.inner.unlink(self))
+        // Release the link before calling into the parent.
+        let parent = self.supervision_link.lock().unwrap().parent();
+        parent.filter(|parent| parent.inner.unlink(self))
     }
 
     /// Unlink this instance from a child.
@@ -4248,9 +4265,11 @@ impl InstanceCell {
                 actor_loop,
                 status_tx,
                 status,
-                supervision_link: parent.as_ref().map_or(SupervisionLink::Proc, |cell| {
-                    SupervisionLink::Actor(cell.downgrade())
-                }),
+                supervision_link: Mutex::new(
+                    parent.as_ref().map_or(SupervisionLink::Proc, |cell| {
+                        SupervisionLink::Actor(cell.downgrade())
+                    }),
+                ),
                 children: DashMap::new(),
                 actor_task_handle: OnceLock::new(),
                 exported_named_ports: DashMap::new(),
@@ -4317,13 +4336,26 @@ impl InstanceCell {
     /// the last status was active for.
     #[track_caller]
     fn change_status(&self, new: ActorStatus) {
+        let actor_linked = new.is_zombie()
+            && matches!(
+                &*self.inner.supervision_link.lock().unwrap(),
+                SupervisionLink::Actor(_)
+            );
+        self.change_status_inner(new, actor_linked);
+    }
+
+    /// `change_status`, with the supervision link already classified by the
+    /// caller. `supervision_link` is not reentrant, so a caller that holds it
+    /// must pass `actor_linked` instead of letting `change_status` re-lock.
+    #[track_caller]
+    fn change_status_inner(&self, new: ActorStatus, actor_linked: bool) {
         let mut old_status = None;
         let mut illegal_status = None;
         let actor_id = self.actor_addr().id().clone();
         let changed = self.inner.status_tx.send_if_modified(|status| {
             let old = status.clone();
             let mut status_change = classify_status_change(&old, &new);
-            if status_change == StatusChange::Apply && new.is_zombie() && self.parent().is_some() {
+            if status_change == StatusChange::Apply && new.is_zombie() && actor_linked {
                 status_change = StatusChange::Illegal(IllegalStatusChange::LinkedZombie);
             }
 
@@ -4538,9 +4570,8 @@ impl InstanceCell {
     }
 
     /// Unlink this instance from a child.
-    fn unlink(&self, child: &InstanceCell) {
-        assert_eq!(self.actor_addr().proc_id(), child.actor_addr().proc_id());
-        self.inner.children.remove(child.uid());
+    fn unlink(&self, child: &InstanceCell) -> bool {
+        self.inner.unlink(child.inner.as_ref())
     }
 
     /// Unlink this instance from all children.
@@ -4550,7 +4581,9 @@ impl InstanceCell {
 
     /// Link this instance to its parent, if it has one.
     fn maybe_link_parent(&self) {
-        if let Some(parent) = self.inner.supervision_link.parent() {
+        // Release the link before calling into the parent.
+        let parent = self.inner.supervision_link.lock().unwrap().parent();
+        if let Some(parent) = parent {
             parent.link(self.clone());
         }
     }
@@ -4560,6 +4593,30 @@ impl InstanceCell {
         event: ActorSupervisionEvent,
     ) -> Option<ActorSupervisionEvent> {
         self.inner.try_handle_completion_event(event)
+    }
+
+    /// Transfers a non-terminal child to proc supervision and publishes its
+    /// zombie status while holding the completion-routing lock.
+    ///
+    /// If detachment wins a completion race, the later terminal event remains
+    /// available to introspection but does not re-enter supervision.
+    fn detach_to_proc_as_zombie(&self, reason: String) -> bool {
+        let mut link = self.inner.supervision_link.lock().unwrap();
+        let SupervisionLink::Actor(parent) = &*link else {
+            return false;
+        };
+        if self.status().borrow().is_terminal() {
+            return false;
+        }
+        let parent = parent.clone();
+        if let Some(parent) = parent.upgrade()
+            && !parent.unlink(self)
+        {
+            return false;
+        }
+        *link = SupervisionLink::Proc;
+        self.change_status_inner(ActorStatus::zombie(reason), false);
+        true
     }
 
     /// Return an iterator over this instance's children. This may deadlock if the
@@ -4690,13 +4747,16 @@ impl InstanceCell {
 
     /// Get parent instance cell, if it exists.
     pub fn parent(&self) -> Option<InstanceCell> {
-        self.inner.supervision_link.parent()
+        self.inner.supervision_link.lock().unwrap().parent()
     }
 
     /// Whether the proc supervises this instance directly. Distinct from
     /// `parent().is_none()`, which is also true of an expired actor link.
     fn is_proc_supervised(&self) -> bool {
-        matches!(&self.inner.supervision_link, SupervisionLink::Proc)
+        matches!(
+            &*self.inner.supervision_link.lock().unwrap(),
+            SupervisionLink::Proc
+        )
     }
 
     /// The actor's type name.
@@ -6653,12 +6713,12 @@ mod tests {
         assert_matches!(handle.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
-    // FI-9: stored-terminal and delivered-zombie intentionally diverge.
+    // FI-9: a detached zombie stores its terminal event without propagating it.
     #[async_timed_test(timeout_secs = 60)]
-    async fn zombie_task_failure_stores_terminal_event_and_reports_zombie() {
+    async fn zombie_task_failure_stores_terminal_event_without_propagation() {
         let proc = Proc::isolated();
         let client = proc.client("client");
-        let (mut reported_event, _coordinator) =
+        let (mut reported_event, coordinator) =
             ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let handle = proc.spawn_with_label::<TestActor>("alive", TestActor);
         let actor_id = handle.actor_addr().clone();
@@ -6692,17 +6752,16 @@ mod tests {
         );
         assert_eq!(event.actor_status, terminal_status);
 
-        let propagated = tokio::time::timeout(Duration::from_secs(1), reported_event.recv())
-            .await
-            .expect("zombie supervision event should arrive");
-        assert!(
-            propagated.actor_status.is_zombie(),
-            "zombie task failure should report its zombie lifecycle verdict"
+        // The marker is posted after the zombie reaches terminal status. Receiving
+        // it first proves that the earlier zombie completion was not propagated.
+        let marker = ActorSupervisionEvent::new(
+            coordinator.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("completion barrier".to_string()),
+            None,
         );
-        assert!(
-            !propagated.is_error(),
-            "zombie supervision event should remain non-error"
-        );
+        coordinator.post(&client, marker.clone());
+        assert_eq!(reported_event.recv().await, marker);
 
         let view = wait_for_terminated_actor_view(&proc, &actor_id).await;
         assert_eq!(
@@ -6881,7 +6940,7 @@ mod tests {
     }
 
     #[async_timed_test(timeout_secs = 30)]
-    async fn failed_drain_stop_stops_children_immediately() {
+    async fn failed_stop_hard_kills_children() {
         let proc = Proc::isolated();
         let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
         let parent = proc.spawn(StopFailingActor);
@@ -6889,11 +6948,151 @@ mod tests {
 
         parent.drain_and_stop("test").unwrap();
 
-        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "parent stopping");
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
         assert_matches!(
             parent.await,
             ActorStatus::Failed(err) if err.to_string().contains("stop failed")
         );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_detaches_blocked_child() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let child_cell = child.cell().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.kill("kill").unwrap();
+
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+        child_cell
+            .status()
+            .clone()
+            .wait_for(ActorStatus::is_zombie)
+            .await
+            .unwrap();
+        assert!(child_cell.parent().is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(proc.root_actor_ids().contains(child_cell.actor_addr()));
+
+        release.send(()).unwrap();
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn kill_detaches_subtree_under_blocked_child() {
+        let proc = Proc::isolated();
+        let (_reported, _coordinator) = ProcSupervisionCoordinator::set(&proc).await.unwrap();
+        let client = proc.client("client");
+        let parent = proc.spawn(TestActor);
+        let child = proc.spawn_child(
+            parent.cell().clone(),
+            DrainCountingActor {
+                handled: Arc::new(AtomicUsize::new(0)),
+            },
+        );
+        let child_cell = child.cell().clone();
+        let grandchild = proc.spawn_child(child_cell.clone(), TestActor);
+        let grandchild_cell = grandchild.cell().clone();
+        let release = block_and_queue_counts(&client, &child, 0).await;
+
+        parent.kill("kill").unwrap();
+
+        assert_matches!(
+            parent.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason == "actor explicitly aborted due to: kill"
+        );
+
+        // The blocked child cannot process `Kill`, so it never tears down its
+        // own subtree. The grandchild must still reach the proc.
+        assert_eq!(child_cell.child_count(), 0);
+        assert!(grandchild_cell.parent().is_none());
+        assert!(proc.root_actor_ids().contains(grandchild_cell.actor_addr()));
+        assert_matches!(
+            grandchild.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+
+        release.send(()).unwrap();
+        assert_matches!(
+            child.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn completion_delivery_prevents_late_detach() {
+        let proc = Proc::isolated();
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(parent_cell.clone(), TestActor);
+        let child_cell = child.cell().clone();
+        let event = ActorSupervisionEvent::new(
+            child_cell.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("test completion".to_string()),
+            None,
+        );
+
+        assert!(child_cell.try_handle_completion_event(event).is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(!child_cell.detach_to_proc_as_zombie("forced teardown".to_string()));
+
+        child.drain_and_stop("test").unwrap();
+        parent.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
+    }
+
+    #[async_timed_test(timeout_secs = 30)]
+    async fn detach_suppresses_racing_completion() {
+        let proc = Proc::isolated();
+        let parent = proc.spawn(TestActor);
+        let parent_cell = parent.cell().clone();
+        let child = proc.spawn_child(parent_cell.clone(), TestActor);
+        let child_cell = child.cell().clone();
+
+        // Model completion creating its terminal event before forced teardown
+        // wins the ownership race.
+        let event = ActorSupervisionEvent::new(
+            child_cell.actor_addr().clone(),
+            None,
+            ActorStatus::Stopped("test completion".to_string()),
+            None,
+        );
+        assert!(child_cell.detach_to_proc_as_zombie("forced teardown".to_string()));
+        assert!(child_cell.try_handle_completion_event(event).is_none());
+        assert_eq!(parent_cell.child_count(), 0);
+        assert!(child_cell.parent().is_none());
+
+        child.drain_and_stop("test").unwrap();
+        parent.drain_and_stop("test").unwrap();
+        assert_matches!(child.await, ActorStatus::Stopped(reason) if reason == "test");
+        assert_matches!(parent.await, ActorStatus::Stopped(reason) if reason == "test");
     }
 
     #[derive(Debug)]
@@ -6998,15 +7197,20 @@ mod tests {
             ActorStatus::Failed(err) if err.to_string() == "some random failure"
         );
 
-        // TODO: should we provide finer-grained stop reasons, e.g., to indicate it was
-        // stopped by a parent failure?
-        // Currently the parent fails with an error related to the child's failure.
         assert_matches!(
             root.await,
             ActorStatus::Failed(err) if err.to_string().contains("some random failure")
         );
-        assert_matches!(root_2_1.await, ActorStatus::Stopped(_));
-        assert_matches!(root_1.await, ActorStatus::Stopped(_));
+        assert_matches!(
+            root_2_1.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
+        assert_matches!(
+            root_1.await,
+            ActorStatus::Failed(ActorErrorKind::Generic(reason))
+                if reason.contains("parent failed")
+        );
     }
 
     #[async_timed_test(timeout_secs = 30)]
@@ -8522,35 +8726,6 @@ mod tests {
         // would panic in debug builds if running_total had wrapped to u64::MAX.
         account_enqueue(&depth, &stats, "a");
         assert_eq!(stats.running_total(), 1);
-    }
-
-    #[test]
-    fn child_teardown_distinguishes_kill_from_failure() {
-        let actor_addr = test_actor_id("proc", "actor");
-
-        let stopped = Ok(ActorStopped {
-            reason: "test".to_string(),
-            stop_mode: StopMode::DrainAndStop,
-        });
-        assert_eq!(
-            ChildTeardown::from_run_result(&stopped),
-            ChildTeardown::Cooperative(StopMode::DrainAndStop)
-        );
-
-        let killed = Err(ActorError::new(
-            &actor_addr,
-            ActorErrorKind::Aborted("test kill".to_string()),
-        ));
-        assert_eq!(ChildTeardown::from_run_result(&killed), ChildTeardown::Kill);
-
-        let failed = Err(ActorError::new(
-            &actor_addr,
-            ActorErrorKind::Generic("test failure".to_string()),
-        ));
-        assert_eq!(
-            ChildTeardown::from_run_result(&failed),
-            ChildTeardown::Cooperative(StopMode::Stop)
-        );
     }
 
     hyperactor_config::attrs::declare_attrs! {

--- a/hyperactor_remote/src/supervision.rs
+++ b/hyperactor_remote/src/supervision.rs
@@ -1245,10 +1245,10 @@ mod tests {
     //         └── supervisor: Supervisor
     //             └── supervisor-side liveness actor: KeepaliveSupervisor
     //
-    // Killing Parent still tears down its local supervision subtree. Grandparent
+    // Killing Parent hard-kills its local supervision subtree. Grandparent
     // handles the parent failure so the test process does not treat it as an
-    // unhandled root failure. Parent stops Supervisor, Supervisor forwards the
-    // stop to Worker, and Worker stops TestChild.
+    // unhandled root failure. Since Supervisor does not run its graceful stop
+    // handler, Worker stops TestChild through the liveness orphan policy.
     #[tokio::test]
     async fn test_parent_kill_stops_remote_child() {
         let proc = Proc::isolated();
@@ -1282,7 +1282,7 @@ mod tests {
             .await
             .unwrap()
             .unwrap();
-        assert_eq!(reason, "parent stopping");
+        assert_eq!(reason, "supervision liveness failed");
 
         let event = tokio::time::timeout(Duration::from_secs(5), event_rx.recv())
             .await

--- a/hyperactor_remote/src/token_supervision_tests.rs
+++ b/hyperactor_remote/src/token_supervision_tests.rs
@@ -419,9 +419,9 @@ async fn test_token_join_parent_exit_drain_and_stops_child_first() -> anyhow::Re
 
 // Same topology as `test_token_join_parent_exit_stops_child_first`.
 //
-// Killing the parent actor is the in-process hard-stop path. The parent still
-// owns a local supervision tree, so the runtime stops Supervisor while cleaning
-// up that tree, and Supervisor forwards the stop to Worker.
+// Killing the parent actor is the in-process hard-stop path. The runtime kills
+// the local Supervisor instead of running its graceful stop handler, so the
+// worker-side orphan policy stops the child when the liveness link fails.
 #[tokio::test]
 async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
     let mut harness = Harness::new().await?;
@@ -431,7 +431,7 @@ async fn test_token_join_parent_kill_stops_child() -> anyhow::Result<()> {
         .post(&harness.observer, ParentControl::Kill);
 
     let reason = recv(&mut harness.child_stopped_rx).await?;
-    assert_eq!(reason, "parent stopping");
+    assert_eq!(reason, "supervision liveness failed");
     harness.stop().await?;
     Ok(())
 }

--- a/monarch_hyperactor/src/actor.rs
+++ b/monarch_hyperactor/src/actor.rs
@@ -1306,7 +1306,6 @@ impl PythonActor {
                                 break None;
                             },
                             Some(Signal::ExitRequested(_)) => break None,
-                            Some(Signal::ChildStopped(_)) => {},
                             Some(Signal::Kill(reason)) => {
                                 break Some(ActorError { actor_id: Box::new(instance.self_addr().clone()), kind: Box::new(ActorErrorKind::Aborted(reason)) })
                             },

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -288,10 +288,10 @@ class Instance(abc.ABC):
         lifecycle pattern (map-reduce shards, batch processing,
         worker pools, etc.; see ``sleep_actors.py`` for an example).
 
-        This is observable in the mesh: on exit the actor emits
-        ``Signal::ChildStopped`` to its parent (always), so
-        ProcAgent *does* see the stop, and terminated snapshots
-        preserve post‑mortem state for introspection.
+        This is observable in the mesh: on exit the runtime emits an
+        ``ActorSupervisionEvent`` to the actor's supervisor, so ProcAgent
+        *does* see the stop, and terminated snapshots preserve post‑mortem
+        state for introspection.
 
         Use ``ActorMesh.stop()`` when you need coordinated, mesh-wide
         shutdown.


### PR DESCRIPTION
Summary:

Keep forced escalation responsive during actor cleanup.

- Before: `Kill` ended the actor loop but still ran cleanup, and a later `Kill` could not interrupt cleanup already in progress.
- After: `Kill` skips or cancels cleanup; ordinary failures still clean up, and escalation retains the prior failure in the abort reason.

This is required since escalation is meaningless if an actor is hang on clean up forever.  We can consider simplifying this by not retaining prior failure reason.

Differential Revision: D115544227


