### PR TITLE
Rename IbvBuffer -> IbvRemoteMemoryRegionView (#4651)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -482,7 +482,7 @@ impl Handler<InitializeBuffer> for CudaRdmaActor {
             let addr = self.cu_ptr;
             let size = self.cpu_buffer.len();
             // See the module-level note on `NoKeepalive`.
-            let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
+            let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive { addr, size }))?;
             let handle = self
                 .rdma_manager
                 .downcast_handle(cx)

--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -296,6 +296,9 @@ pub struct CudaRdmaActor {
     cu_ptr: usize,
     // RDMA buffer handle for the CUDA memory
     rdma_buffer_handle: Option<RdmaRemoteBuffer>,
+    // The registered CUDA memory. Held because the ping-pong addresses it
+    // through its local registration, which is the only place its `lkey` lives.
+    local_memory: Option<KeepaliveLocalMemory>,
     // Reference to the RDMA manager actor
     rdma_manager: ActorRef<RdmaManagerActor>,
     // Legacy queue pair for the GPU doorbell ping-pong, created via
@@ -417,6 +420,7 @@ impl RemoteSpawn for CudaRdmaActor {
                 cpu_buffer,
                 cu_ptr: dptr as usize,
                 rdma_buffer_handle: None,
+                local_memory: None,
                 rdma_manager,
                 raw_qp: None,
             })
@@ -487,8 +491,9 @@ impl Handler<InitializeBuffer> for CudaRdmaActor {
                 .rdma_manager
                 .downcast_handle(cx)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
-            let buffer_handle = handle.request_buffer(cx, local_memory).await?;
+            let buffer_handle = handle.request_buffer(cx, local_memory.clone()).await?;
             self.rdma_buffer_handle = Some(buffer_handle);
+            self.local_memory = Some(local_memory);
         }
 
         reply.post(cx, true);
@@ -614,10 +619,19 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
         }
 
         // Resolve the local/remote buffer transport details for the ping-pong.
-        let local_ibv = local_buffer
+        // The local side goes through the registration itself: the wire view a
+        // peer would get carries no `lkey`.
+        let local_device = local_buffer
             .resolve_mlx()
             .ok_or_else(|| anyhow::anyhow!("Mellanox backend not found for local buffer"))?
-            .buffer;
+            .buffer
+            .device_name;
+        let local_ibv = self
+            .local_memory
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Local buffer not registered"))?
+            .registered_mr(&local_device)?
+            .ok_or_else(|| anyhow::anyhow!("local buffer has no registration on {local_device}"))?;
         let remote_ibv = remote_buffer
             .resolve_mlx()
             .ok_or_else(|| anyhow::anyhow!("Mellanox backend not found for remote buffer"))?
@@ -640,7 +654,7 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
             let dv_recv_cq = qp.dv_recv_cq as *mut rdmaxcel_sys::mlx5dv_cq;
             let mut params = rdma_params_t {
                 cu_ptr: self.cu_ptr,
-                laddr: local_ibv.addr,
+                laddr: local_ibv.rdma_addr,
                 lsize: local_ibv.size,
                 lkey: local_ibv.lkey,
                 raddr: remote_ibv.addr,

--- a/monarch_rdma/examples/parameter_server/src/parameter_server.rs
+++ b/monarch_rdma/examples/parameter_server/src/parameter_server.rs
@@ -209,7 +209,7 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
             let addr = self.weights_data.as_ptr() as usize;
             let size = self.weights_data.len();
             // See the module-level note on `NoKeepalive`.
-            let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
+            let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive { addr, size }))?;
             let handle = self
                 .owner_ref
                 .downcast_handle(cx)
@@ -229,7 +229,8 @@ impl Handler<PsGetBuffers> for ParameterServerActor {
                 let addr = self.grad_buffer_data[rank].as_ptr() as usize;
                 let size = self.grad_buffer_data[rank].len();
                 // See the module-level note on `NoKeepalive`.
-                let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive { addr, size }));
+                let local_memory =
+                    KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive { addr, size }))?;
                 let handle = self
                     .owner_ref
                     .downcast_handle(cx)
@@ -400,10 +401,10 @@ impl Handler<WorkerStep> for WorkerActor {
             .as_ref()
             .expect("worker_actor should be initialized");
         // See the module-level note on `NoKeepalive`.
-        let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+        let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
             addr: self.local_gradients.as_ptr() as usize,
             size: self.local_gradients.len(),
-        }));
+        }))?;
 
         ps_grad_handle.write_from_local(cx, local_memory, 5).await?;
 
@@ -434,10 +435,10 @@ impl Handler<WorkerUpdate> for WorkerActor {
             .as_ref()
             .expect("worker_actor should be initialized");
         // See the module-level note on `NoKeepalive`.
-        let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+        let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
             addr: self.weights_data.as_ptr() as usize,
             size: self.weights_data.len(),
-        }));
+        }))?;
         ps_weights_handle
             .read_into_local(cx, local_memory, 5)
             .await?;

--- a/monarch_rdma/extension/lib.rs
+++ b/monarch_rdma/extension/lib.rs
@@ -442,11 +442,12 @@ impl Keepalive for PyKeepalive {
 #[pymethods]
 impl PyLocalMemoryHandle {
     #[new]
-    fn new(obj: Py<PyAny>, addr: usize, size: usize) -> Self {
+    fn new(obj: Py<PyAny>, addr: usize, size: usize) -> PyResult<Self> {
         let keepalive: Arc<dyn Keepalive> = Arc::new(PyKeepalive { obj, addr, size });
-        Self {
-            inner: KeepaliveLocalMemory::new(keepalive),
-        }
+        Ok(Self {
+            inner: KeepaliveLocalMemory::try_new(keepalive)
+                .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
+        })
     }
 
     #[getter]
@@ -563,7 +564,8 @@ fn _make_local_memory_handle_from_memoryview(
         size,
     });
     Ok(PyLocalMemoryHandle {
-        inner: KeepaliveLocalMemory::new(keepalive),
+        inner: KeepaliveLocalMemory::try_new(keepalive)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
     })
 }
 
@@ -592,7 +594,8 @@ fn _make_local_memory_handle_from_tensor(
         numel,
     });
     Ok(PyLocalMemoryHandle {
-        inner: KeepaliveLocalMemory::new(keepalive),
+        inner: KeepaliveLocalMemory::try_new(keepalive)
+            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?,
     })
 }
 

--- a/monarch_rdma/src/backend/cuda_test_utils.rs
+++ b/monarch_rdma/src/backend/cuda_test_utils.rs
@@ -195,18 +195,20 @@ impl CudaAllocation {
     /// `[ptr + offset, ptr + offset + size)` of this allocation. The handle
     /// keeps the whole allocation mapped for its lifetime.
     ///
-    /// Panics if the sub-range does not fit within the currently mapped extent.
+    /// Panics if the sub-range does not fit within the currently mapped extent,
+    /// or if the CUDA driver will not name the device that owns the allocation.
     pub fn keepalive_slice(&self, offset: usize, size: usize) -> KeepaliveLocalMemory {
         let mapped = self.size();
         assert!(
             offset.checked_add(size).is_some_and(|end| end <= mapped),
             "slice [0x{offset:x}, 0x{offset:x}+{size}) exceeds mapped allocation size {mapped}",
         );
-        KeepaliveLocalMemory::new(Arc::new(CudaAllocationSlice {
+        KeepaliveLocalMemory::try_new(Arc::new(CudaAllocationSlice {
             alloc: self.clone(),
             offset,
             size,
         }))
+        .expect("this allocation's own device should be resolvable")
     }
 
     /// Try to free the backing CUDA memory. Returns `true` if the
@@ -709,7 +711,7 @@ impl ReceiverMessageHandler for ReceiverActor {
         // unwritten destination is distinguishable from a successful
         // read.
         let buf: Box<[u8]> = vec![!expected_pattern; size].into_boxed_slice();
-        let local = KeepaliveLocalMemory::new(Arc::new(buf));
+        let local = KeepaliveLocalMemory::try_new(Arc::new(buf))?;
 
         let read_result = remote
             .read_into_local(cx, local.clone(), timeout_secs)
@@ -746,7 +748,7 @@ impl ReceiverMessageHandler for ReceiverActor {
         timeout_secs: u64,
     ) -> Result<Result<(), String>, anyhow::Error> {
         let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
-        let local = KeepaliveLocalMemory::new(Arc::new(buf));
+        let local = KeepaliveLocalMemory::try_new(Arc::new(buf))?;
 
         let result = remote
             .write_from_local(cx, local, timeout_secs)

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -10,8 +10,6 @@
 
 use hyperactor::ActorRef;
 use hyperactor::actor::Referable;
-use serde::Deserialize;
-use serde::Serialize;
 use typeuri::Named;
 
 pub mod device;
@@ -29,6 +27,7 @@ pub mod primitives;
 pub mod queue_pair;
 
 use manager_actor::IbvManagerActor;
+use memory_region::IbvRemoteMemoryRegionView;
 use mlx_device::MlxDevice;
 pub use queue_pair::IbvQueuePair;
 pub use queue_pair::PollTarget;
@@ -43,34 +42,6 @@ mod mlx5dv_tests;
 use crate::RdmaOpType;
 use crate::local_memory::KeepaliveLocalMemory;
 
-/// Lazily-initialized ibverbs transport details for a registered memory
-/// region. Retrieved on demand from the [`IbvManagerActor`] via
-/// [`IbvManagerMessage::RequestBuffer`].
-#[derive(Debug, Clone, Serialize, Deserialize, Named)]
-pub struct IbvBuffer {
-    pub lkey: u32,
-    pub rkey: u32,
-    /// RDMA address (may differ from virtual address for CUDA memory).
-    pub addr: usize,
-    pub size: usize,
-    /// Name of the RDMA device this buffer is associated with (e.g., "mlx5_0").
-    pub device_name: String,
-}
-
-impl From<&memory_region::IbvMemoryRegionView> for IbvBuffer {
-    /// The wire transport details are fully derived from the registered MR
-    /// view: the keys, the RDMA address, the size, and the device name.
-    fn from(view: &memory_region::IbvMemoryRegionView) -> Self {
-        Self {
-            lkey: view.lkey,
-            rkey: view.rkey,
-            addr: view.rdma_addr,
-            size: view.size,
-            device_name: view.device_name.clone(),
-        }
-    }
-}
-
 /// A single RDMA op for the [`IbvBackend`](manager_actor::IbvBackend).
 ///
 /// Generic over the manager actor type so unit tests can swap in a
@@ -79,7 +50,7 @@ impl From<&memory_region::IbvMemoryRegionView> for IbvBuffer {
 pub struct IbvOp<M: Referable = IbvManagerActor<MlxDevice>> {
     pub op_type: RdmaOpType,
     pub local_memory: KeepaliveLocalMemory,
-    pub remote_buffer: IbvBuffer,
+    pub remote_buffer: IbvRemoteMemoryRegionView,
     pub remote_manager: ActorRef<M>,
 }
 

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -29,8 +29,8 @@ use super::primitives::IbvDeviceInfo;
 use super::primitives::IbvMr;
 use super::primitives::IbvPd;
 use super::queue_pair::IbvQueuePair;
+use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
-use crate::local_memory::is_device_ptr;
 
 /// Manages RDMA resources including context and protection domain.
 ///
@@ -421,9 +421,10 @@ pub(super) unsafe fn register_dmabuf_mr(
     // so make the pointer's own device context current first. Without this, in a
     // multi-GPU process it fails with `CUDA_ERROR_NOT_FOUND` whenever the active
     // context belongs to a different device than `addr`.
-    // SAFETY: this path is only taken for device memory (`is_device_ptr(addr)`
-    // in `register_host_or_dmabuf_mr`), so `addr` is a valid CUDA device pointer
-    // as `set_ctx_for_ptr` requires. The guard restores the prior context on drop.
+    // SAFETY: this path is only taken for device memory (the
+    // `MemoryLocation::Gpu` arm in `register_host_or_dmabuf_mr`), so `addr` is a
+    // valid CUDA device pointer as `set_ctx_for_ptr` requires. The guard
+    // restores the prior context on drop.
     let _ctx_guard = unsafe { crate::local_memory::set_ctx_for_ptr(addr)? };
 
     let (base, base_size) = cuda_alloc_range(addr)?;
@@ -476,10 +477,9 @@ pub(super) unsafe fn register_host_or_dmabuf_mr<I: IbvDomainImpl>(
     // PD (the helpers error on null), and `[addr, addr + size)` stays valid for
     // the returned MR's lifetime.
     let (mr, mr_offset) = unsafe {
-        if is_device_ptr(addr) {
-            register_dmabuf_mr(domain.pd(), addr, size, access_flags)?
-        } else {
-            (register_host_mr(domain.pd(), addr, size, access_flags)?, 0)
+        match mem.location() {
+            MemoryLocation::Gpu(_) => register_dmabuf_mr(domain.pd(), addr, size, access_flags)?,
+            MemoryLocation::Cpu(_) => (register_host_mr(domain.pd(), addr, size, access_flags)?, 0),
         }
     };
 

--- a/monarch_rdma/src/backend/ibverbs/domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/domain.rs
@@ -747,9 +747,8 @@ mod tests {
         let view = unsafe { register_host_or_dmabuf_mr(&domain, &mem) }.unwrap();
         // Tie the view's lifetime to the allocation's lifetime so that the safety contract
         // above holds.
-        mem.mr_slot()
-            .set(view.clone())
-            .expect("mr_slot not already set");
+        mem.install_mr(view.clone())
+            .expect("the region has no registration on this device yet");
         assert_eq!(view.virtual_addr, alloc.ptr());
         assert_eq!(view.size, alloc.size());
         assert_eq!(view.rdma_addr, 0, "whole allocation starts at MR offset 0");
@@ -775,9 +774,8 @@ mod tests {
         let view = unsafe { register_host_or_dmabuf_mr(&domain, &mem) }.unwrap();
         // Tie the view's lifetime to the allocation's lifetime so that the safety contract
         // above holds.
-        mem.mr_slot()
-            .set(view.clone())
-            .expect("mr_slot not already set");
+        mem.install_mr(view.clone())
+            .expect("the region has no registration on this device yet");
         assert_eq!(view.virtual_addr, alloc.ptr() + offset);
         assert_eq!(view.size, size);
         assert_eq!(view.rdma_addr, offset, "rdma_addr is the sub-range offset");
@@ -799,9 +797,8 @@ mod tests {
         let view = unsafe { register_host_or_dmabuf_mr(&domain, &mem) }.unwrap();
         // Tie the view's lifetime to the allocation's lifetime so that the safety contract
         // above holds.
-        mem.mr_slot()
-            .set(view.clone())
-            .expect("mr_slot not already set");
+        mem.install_mr(view.clone())
+            .expect("the region has no registration on this device yet");
         assert_eq!(view.virtual_addr, alloc.ptr() + offset);
         assert_eq!(view.size, size);
         assert_eq!(view.rdma_addr, offset);
@@ -820,9 +817,8 @@ mod tests {
         let view = unsafe { register_host_or_dmabuf_mr(&domain, &mem) }.unwrap();
         // Tie the view's lifetime to the allocation's lifetime so that the safety contract
         // above holds.
-        mem.mr_slot()
-            .set(view.clone())
-            .expect("mr_slot not already set");
+        mem.install_mr(view.clone())
+            .expect("the region has no registration on this device yet");
         assert_eq!(view.virtual_addr, alloc.ptr());
         assert_eq!(view.size, size);
         assert_eq!(view.rdma_addr, 0);

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -28,10 +28,11 @@ use hyperactor::Uid;
 use hyperactor::channel::ChannelAddr;
 use hyperactor_config::Flattrs;
 
-use super::IbvBuffer;
 use super::device_selection::IbvDeviceTarget;
 use super::manager_actor::IbvManagerActor;
 use super::manager_actor::IbvManagerMessageClient;
+use super::memory_region::IbvMemoryRegionView;
+use super::memory_region::IbvRemoteMemoryRegionView;
 use super::mlx_device::MlxDevice;
 use super::queue_pair::PollTarget;
 use super::queue_pair::legacy::IbvQueuePair;
@@ -351,8 +352,8 @@ pub async fn wait_for_completion(
 /// Posts a work request to the send queue of the given RDMA queue pair.
 pub async fn send_wqe_gpu(
     qp: &mut IbvQueuePair,
-    lhandle: &IbvBuffer,
-    rhandle: &IbvBuffer,
+    lhandle: &IbvMemoryRegionView,
+    rhandle: &IbvRemoteMemoryRegionView,
     op_type: u32,
 ) -> Result<(), anyhow::Error> {
     // SAFETY: `qp` is borrowed for the duration of this call; the
@@ -363,7 +364,7 @@ pub async fn send_wqe_gpu(
         let dv_qp = qp.dv_qp as *mut rdmaxcel_sys::mlx5dv_qp;
         let send_wqe_idx = rdmaxcel_sys::rdmaxcel_qp_load_send_wqe_idx(ibv_qp);
         let params = rdmaxcel_sys::wqe_params_t {
-            laddr: lhandle.addr,
+            laddr: lhandle.rdma_addr,
             length: lhandle.size,
             lkey: lhandle.lkey,
             wr_id: send_wqe_idx,
@@ -386,8 +387,8 @@ pub async fn send_wqe_gpu(
 /// Posts a work request to the receive queue of the given RDMA queue pair.
 pub async fn recv_wqe_gpu(
     qp: &mut IbvQueuePair,
-    lhandle: &IbvBuffer,
-    _rhandle: &IbvBuffer,
+    lhandle: &IbvMemoryRegionView,
+    _rhandle: &IbvRemoteMemoryRegionView,
     op_type: u32,
 ) -> Result<(), anyhow::Error> {
     // SAFETY: `qp` is borrowed for the duration of this call; the
@@ -398,7 +399,7 @@ pub async fn recv_wqe_gpu(
         let dv_qp = qp.dv_qp as *mut rdmaxcel_sys::mlx5dv_qp;
         let recv_wqe_idx = rdmaxcel_sys::rdmaxcel_qp_load_recv_wqe_idx(rdmaxcel_qp);
         let params = rdmaxcel_sys::wqe_params_t {
-            laddr: lhandle.addr,
+            laddr: lhandle.rdma_addr,
             length: lhandle.size,
             lkey: lhandle.lkey,
             wr_id: recv_wqe_idx,
@@ -521,8 +522,14 @@ pub struct DoorbellTestEnv {
     pub rdma_handle_2: RdmaRemoteBuffer,
     pub local_memory_1: KeepaliveLocalMemory,
     pub local_memory_2: KeepaliveLocalMemory,
-    pub ibv_buffer_1: IbvBuffer,
-    pub ibv_buffer_2: IbvBuffer,
+    /// Each side's own registration, which is what it addresses its memory
+    /// through when it is the initiator.
+    pub local_mrv_1: IbvMemoryRegionView,
+    pub local_mrv_2: IbvMemoryRegionView,
+    /// The same regions as the other side sees them: the target of a WR posted
+    /// from the peer.
+    pub remote_mrv_1: IbvRemoteMemoryRegionView,
+    pub remote_mrv_2: IbvRemoteMemoryRegionView,
     cuda_actor_1: Option<ActorRef<CudaActor>>,
     cuda_actor_2: Option<ActorRef<CudaActor>>,
     device_ptr_1: Option<usize>,
@@ -546,6 +553,27 @@ fn accel_target(accel: &str) -> IbvDeviceTarget {
         "nic" => IbvDeviceTarget::nic(idx),
         _ => IbvDeviceTarget::cpu(idx.parse().unwrap()),
     }
+}
+
+/// The local view of `mem`'s registration on `rdma`'s proc: what that side
+/// addresses its own memory through when it posts a work request.
+async fn local_view(
+    rdma: &ActorRef<RdmaManagerActor>,
+    client: &hyperactor::Client,
+    mem: &KeepaliveLocalMemory,
+) -> Result<IbvMemoryRegionView, anyhow::Error> {
+    let handle = rdma
+        .downcast_handle(client)
+        .ok_or_else(|| anyhow::anyhow!("RdmaManagerActor is not in this process"))?;
+    let device = handle
+        .request_buffer(client, mem.clone())
+        .await?
+        .resolve_mlx()
+        .ok_or_else(|| anyhow::anyhow!("local buffer has no Mellanox backend"))?
+        .buffer
+        .device_name;
+    mem.registered_mr(&device)?
+        .ok_or_else(|| anyhow::anyhow!("request_buffer should have registered on {device}"))
 }
 
 /// Helper function to parse accelerator strings
@@ -710,9 +738,11 @@ impl DoorbellTestEnv {
         }
 
         let ctx_1 = rdma_handle_1.resolve_mlx().expect("buffer 1 is Mellanox");
-        let (ibv_actor_1, ibv_buffer_1) = (ctx_1.manager, ctx_1.buffer);
+        let (ibv_actor_1, remote_mrv_1) = (ctx_1.manager, ctx_1.buffer);
         let ctx_2 = rdma_handle_2.resolve_mlx().expect("buffer 2 is Mellanox");
-        let (ibv_actor_2, ibv_buffer_2) = (ctx_2.manager, ctx_2.buffer);
+        let (ibv_actor_2, remote_mrv_2) = (ctx_2.manager, ctx_2.buffer);
+        let local_mrv_1 = local_view(&actor_1, &instance_1, &local_memory_1).await?;
+        let local_mrv_2 = local_view(&actor_2, &instance_2, &local_memory_2).await?;
         let ibv_handle_1: ActorHandle<IbvManagerActor<MlxDevice>> = ibv_actor_1
             .downcast_handle(&instance_1)
             .ok_or_else(|| anyhow::anyhow!("ibv_actor_1 is not in proc_1"))?;
@@ -754,8 +784,10 @@ impl DoorbellTestEnv {
             rdma_handle_2,
             local_memory_1,
             local_memory_2,
-            ibv_buffer_1,
-            ibv_buffer_2,
+            local_mrv_1,
+            local_mrv_2,
+            remote_mrv_1,
+            remote_mrv_2,
             cuda_actor_1,
             cuda_actor_2,
             device_ptr_1,

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -237,10 +237,10 @@ impl Handler<CudaActorMessage> for CudaActor {
 
                 // Register via RdmaManagerActor request_buffer.
                 // See the module-level note on `NoKeepalive`.
-                let local_memory = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+                let local_memory = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                     addr: dptr,
                     size: padded_size,
-                }));
+                }))?;
                 let handle = rdma_actor
                     .downcast_handle(cx)
                     .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -635,10 +635,10 @@ impl DoorbellTestEnv {
                 len: buffer.len(),
                 cpu_ref: Some(buffer),
             });
-            local_memory_1 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            local_memory_1 = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                 addr: ptr as usize,
                 size: buffer_size,
-            }));
+            }))?;
             let handle_1 = actor_1
                 .downcast_handle(&instance_1)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -655,10 +655,10 @@ impl DoorbellTestEnv {
                 .await?;
             rdma_handle_1 = rdma_buf;
             device_ptr_1 = Some(dev_ptr);
-            local_memory_1 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            local_memory_1 = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                 addr: dev_ptr,
                 size: buffer_size,
-            }));
+            }))?;
 
             buf_vec.push(Buffer {
                 ptr: dev_ptr as u64,
@@ -676,10 +676,10 @@ impl DoorbellTestEnv {
                 len: buffer.len(),
                 cpu_ref: Some(buffer),
             });
-            local_memory_2 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            local_memory_2 = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                 addr: ptr as usize,
                 size: buffer_size,
-            }));
+            }))?;
             let handle_2 = actor_2
                 .downcast_handle(&instance_2)
                 .ok_or_else(|| anyhow::anyhow!("failed to get handle"))?;
@@ -696,10 +696,10 @@ impl DoorbellTestEnv {
                 .await?;
             rdma_handle_2 = rdma_buf;
             device_ptr_2 = Some(dev_ptr);
-            local_memory_2 = KeepaliveLocalMemory::new(Arc::new(NoKeepalive {
+            local_memory_2 = KeepaliveLocalMemory::try_new(Arc::new(NoKeepalive {
                 addr: dev_ptr,
                 size: buffer_size,
-            }));
+            }))?;
 
             buf_vec.push(Buffer {
                 ptr: dev_ptr as u64,

--- a/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
@@ -52,22 +52,22 @@ mod tests {
         Ok(())
     }
 
-    /// Brings up a connected legacy QP pair: `qp_1` on `ibv_buffer_1`'s device
-    /// (via `ibv_handle_1`), `qp_2` on `ibv_buffer_2`'s device.
+    /// Brings up a connected legacy QP pair: `qp_1` on side 1's registration
+    /// device (via `ibv_handle_1`), `qp_2` on side 2's.
     async fn connected_pair(
         env: &DoorbellTestEnv,
     ) -> Result<(IbvQueuePair, IbvQueuePair), anyhow::Error> {
         let mut qp_1 = request_queue_pair(
             &env.ibv_handle_1,
             &env.client_1,
-            env.ibv_buffer_1.device_name.clone(),
+            env.local_mrv_1.device_name.clone(),
         )
         .await?
         .map_err(|e| anyhow::anyhow!(e))?;
         let mut qp_2 = request_queue_pair(
             &env.ibv_handle_2,
             &env.client_2,
-            env.ibv_buffer_2.device_name.clone(),
+            env.local_mrv_2.device_name.clone(),
         )
         .await?
         .map_err(|e| anyhow::anyhow!(e))?;
@@ -98,7 +98,7 @@ mod tests {
         }
         let env = DoorbellTestEnv::setup(BSIZE, "cpu:0", "cpu:0").await?;
         let (mut qp_1, _qp_2) = connected_pair(&env).await?;
-        let wr_id = qp_1.enqueue_put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
+        let wr_id = qp_1.enqueue_put(env.local_mrv_1.clone(), env.remote_mrv_2.clone())?;
         qp_1.ring_doorbell()?;
         wait_for_completion(&mut qp_1, PollTarget::Send, &wr_id, 5).await?;
 
@@ -122,7 +122,7 @@ mod tests {
         }
         let env = DoorbellTestEnv::setup(BSIZE, "cpu:0", "cpu:1").await?;
         let (_qp_1, mut qp_2) = connected_pair(&env).await?;
-        let wr_id = qp_2.enqueue_get(env.ibv_buffer_2.clone(), env.ibv_buffer_1.clone())?;
+        let wr_id = qp_2.enqueue_get(env.local_mrv_2.clone(), env.remote_mrv_1.clone())?;
         qp_2.ring_doorbell()?;
         wait_for_completion(&mut qp_2, PollTarget::Send, &wr_id, 5).await?;
 
@@ -151,7 +151,7 @@ mod tests {
         }
         let env = DoorbellTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
         let (mut qp_1, _qp_2) = connected_pair(&env).await?;
-        qp_1.enqueue_put(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
+        qp_1.enqueue_put(env.local_mrv_1.clone(), env.remote_mrv_2.clone())?;
         ring_db_gpu(&qp_1).await?;
         wait_for_completion_gpu(&mut qp_1, PollTarget::Send, 5).await?;
 
@@ -183,7 +183,7 @@ mod tests {
         }
         let env = DoorbellTestEnv::setup(BSIZE, "cuda:0", "cuda:1").await?;
         let (mut qp_1, _qp_2) = connected_pair(&env).await?;
-        qp_1.enqueue_get(env.ibv_buffer_1.clone(), env.ibv_buffer_2.clone())?;
+        qp_1.enqueue_get(env.local_mrv_1.clone(), env.remote_mrv_2.clone())?;
         ring_db_gpu(&qp_1).await?;
         wait_for_completion_gpu(&mut qp_1, PollTarget::Send, 5).await?;
 
@@ -217,15 +217,15 @@ mod tests {
         let (mut qp_1, mut qp_2) = connected_pair(&env).await?;
         recv_wqe_gpu(
             &mut qp_1,
-            &env.ibv_buffer_1,
-            &env.ibv_buffer_2,
+            &env.local_mrv_1,
+            &env.remote_mrv_2,
             rdmaxcel_sys::ibv_wc_opcode::IBV_WC_RECV,
         )
         .await?;
         send_wqe_gpu(
             &mut qp_2,
-            &env.ibv_buffer_2,
-            &env.ibv_buffer_1,
+            &env.local_mrv_2,
+            &env.remote_mrv_1,
             rdmaxcel_sys::MLX5_OPCODE_RDMA_WRITE_IMM,
         )
         .await?;

--- a/monarch_rdma/src/backend/ibverbs/efa_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/efa_queue_pair.rs
@@ -12,9 +12,10 @@
 use std::io::Error;
 use std::result::Result;
 
-use super::IbvBuffer;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
+use super::memory_region::IbvMemoryRegionView;
+use super::memory_region::IbvRemoteMemoryRegionView;
 use super::primitives::Gid;
 use super::primitives::IbvAh;
 use super::primitives::IbvConfig;
@@ -621,8 +622,8 @@ impl IbvQueuePair for EfaQueuePair {
 
     fn put(
         &mut self,
-        remote_dst: IbvBuffer,
-        local_src: IbvBuffer,
+        remote_dst: IbvRemoteMemoryRegionView,
+        local_src: IbvMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         if remote_dst.size < local_src.size {
             return Err(anyhow::anyhow!(
@@ -633,7 +634,7 @@ impl IbvQueuePair for EfaQueuePair {
         }
         self.post_chunked(
             EfaOp::Write,
-            local_src.addr,
+            local_src.rdma_addr,
             local_src.lkey,
             remote_dst.addr,
             remote_dst.rkey,
@@ -643,8 +644,8 @@ impl IbvQueuePair for EfaQueuePair {
 
     fn get(
         &mut self,
-        local_dst: IbvBuffer,
-        remote_src: IbvBuffer,
+        local_dst: IbvMemoryRegionView,
+        remote_src: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         if local_dst.size < remote_src.size {
             return Err(anyhow::anyhow!(
@@ -655,7 +656,7 @@ impl IbvQueuePair for EfaQueuePair {
         }
         self.post_chunked(
             EfaOp::Read,
-            local_dst.addr,
+            local_dst.rdma_addr,
             local_dst.lkey,
             remote_src.addr,
             remote_src.rkey,

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -321,22 +321,13 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             .get_or_create_domain(DEFAULT_DOMAIN)
     }
 
-    /// Resolve `mem` to an [`IbvMemoryRegionView`] using the slot shared by
-    /// every clone of `mem`. On a cold slot, picks the RDMA device (an explicit
-    /// `config.target` if set, else one of the NICs with the best path to
-    /// `mem`'s [`MemoryLocation`]) and registers the region through that
-    /// device's [`IbvDomainImpl`] strategy, installing the result; on a warm
-    /// slot, returns the cached view.
+    /// Resolve `mem` to an [`IbvMemoryRegionView`] on the device this manager
+    /// would choose for it: an explicit `config.target` if set, else one of
+    /// the NICs with the best path to `mem`'s [`MemoryLocation`].
     fn resolve_local_mr(
         &mut self,
         mem: &KeepaliveLocalMemory,
     ) -> Result<IbvMemoryRegionView, anyhow::Error> {
-        if let Some(mrv) = mem.mr_slot().get() {
-            return Ok(mrv.clone());
-        }
-
-        // An explicit `config.target` wins; otherwise take the NICs tied for
-        // the best path to the memory and pick one of them.
         let device_name = match &self.config.target {
             Some(target) => resolve_target::<I>(target)?
                 .ok_or_else(|| anyhow::anyhow!("configured device target {:?} not found", target))?
@@ -344,17 +335,44 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
                 .clone(),
             None => Self::pick_optimal_device(mem)?,
         };
+        self.resolve_local_mr_on(mem, &device_name)
+    }
+
+    /// Resolve `mem` to its [`IbvMemoryRegionView`] on `device_name`,
+    /// registering the region there on first use.
+    ///
+    /// The registration lives on `mem` itself, shared by every clone of that
+    /// handle, so one handle registers a given device at most once. Nothing
+    /// deduplicates separate handles over the same region, though: each
+    /// carries its own registrations, so a region covered by two handles is
+    /// registered once per handle. A failure is recorded on `mem` too and
+    /// returned to later callers rather than retried.
+    fn resolve_local_mr_on(
+        &mut self,
+        mem: &KeepaliveLocalMemory,
+        device_name: &str,
+    ) -> Result<IbvMemoryRegionView, anyhow::Error> {
+        if let Some(mrv) = mem.registered_mr(device_name)? {
+            return Ok(mrv);
+        }
         tracing::debug!(
             "Using RDMA device: {} for memory at 0x{:x}",
             device_name,
             mem.addr()
         );
 
-        let domain = self.get_or_create_device_domain(&device_name)?;
         // The backend strategy handles host vs. device memory (standard MR,
         // dmabuf MR, or a device-specific segment binding).
-        let mrv = domain.register_mr(mem)?;
-        Ok(mem.mr_slot().get_or_init(|| mrv).clone())
+        let registered = self
+            .get_or_create_device_domain(device_name)
+            .and_then(|domain| domain.register_mr(mem));
+        match registered {
+            Ok(mrv) => mem.install_mr(mrv),
+            Err(error) => {
+                mem.record_mr_failure(device_name, &error);
+                Err(error)
+            }
+        }
     }
 
     /// One of the NICs of backend `I` tied for the best path to `mem`.
@@ -868,6 +886,8 @@ mod tests {
     use crate::backend::cuda_test_utils::CudaAllocator;
     use crate::backend::ibverbs::device::list_all_devices;
     use crate::backend::ibverbs::device_selection::IbvDeviceTarget;
+    use crate::backend::ibverbs::device_selection::resolve_target;
+    use crate::backend::ibverbs::mlx_device::MlxDevice;
     use crate::backend::ibverbs::primitives::IbvQpType;
     use crate::local_memory::KeepaliveLocalMemory;
 
@@ -1353,26 +1373,31 @@ mod tests {
     // Tests
     // ====================================================================
 
-    /// `register_remote_buffer` must populate the MR slot shared by
-    /// every clone of the `KeepaliveLocalMemory` it is handed, so that
-    /// later `resolve_local_mr` calls reuse the registered MR instead
-    /// of registering the same region again.
+    /// `register_remote_buffer` must record its registration on the
+    /// `KeepaliveLocalMemory` it is handed — under the name of the device it
+    /// registered on — so that later `resolve_local_mr` calls for that device
+    /// reuse it instead of registering the same region again.
     #[timed_test::async_timed_test(timeout_secs = 60)]
-    async fn test_register_remote_buffer_fills_mr_slot() -> Result<(), anyhow::Error> {
+    async fn test_register_remote_buffer_records_its_registration() -> Result<(), anyhow::Error> {
         require_rdma();
-        let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
+        let target = IbvDeviceTarget::cpu(0);
+        let device = resolve_target::<MlxDevice>(&target)?
+            .expect("cpu:0 should resolve to a NIC")
+            .name()
+            .clone();
+        let env = TestEnv::same_config(IbvConfig::targeting(target)).await?;
         let buf: Box<[u8]> = vec![0u8; 1024].into_boxed_slice();
         let local = KeepaliveLocalMemory::try_new(Arc::new(buf))?;
         assert!(
-            local.mr_slot().get().is_none(),
-            "MR slot should be empty before registration",
+            local.registered_mr(&device)?.is_none(),
+            "the region should have no registration before it is registered",
         );
         RdmaManagerActor::local_handle(&env.client)
             .request_buffer(&env.client, local.clone())
             .await?;
         assert!(
-            local.mr_slot().get().is_some(),
-            "registration should populate the MR slot",
+            local.registered_mr(&device)?.is_some(),
+            "registration should be recorded under the pinned device {device}",
         );
         env.shutdown().await
     }

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -43,7 +43,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-use super::IbvBuffer;
 use super::IbvOp;
 use super::device::IbvDevice;
 use super::device::IbvDeviceImpl;
@@ -53,6 +52,7 @@ use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::efa_device::EfaDevice;
 use super::memory_region::IbvMemoryRegionView;
+use super::memory_region::IbvRemoteMemoryRegionView;
 use super::mlx_device::MlxDevice;
 use super::primitives::IbvConfig;
 use super::primitives::IbvQpInfo;
@@ -136,7 +136,7 @@ wirevalue::register_type!(IbvManagerMessage);
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
     /// Register a remote-facing buffer's MR and return its
-    /// [`IbvBuffer`]. Called by
+    /// [`IbvRemoteMemoryRegionView`]. Called by
     /// [`crate::rdma_manager_actor::RdmaManagerActor::request_buffer`]
     /// at buffer-creation time.
     ///
@@ -146,7 +146,7 @@ pub enum IbvManagerLocalMessage {
         remote_buf_id: usize,
         local: KeepaliveLocalMemory,
         #[reply]
-        reply: OncePortHandle<Result<IbvBuffer, String>>,
+        reply: OncePortHandle<Result<IbvRemoteMemoryRegionView, String>>,
     },
 }
 
@@ -198,8 +198,8 @@ pub struct IbvManagerActor<I: IbvDeviceImpl> {
     /// Map from buffer_id to the registered MR view. The view keeps the MR (and
     /// its PD) alive for the lifetime of the registration; `ReleaseBuffer` drops
     /// the entry, and the FFI resources are released by the `Arc`s' `Drop`s once
-    /// no other holder of the view remains. The wire-facing [`IbvBuffer`] is
-    /// derived from the view on demand.
+    /// no other holder of the view remains. The wire-facing
+    /// [`IbvRemoteMemoryRegionView`] is derived from the view on demand.
     buffer_registrations: HashMap<usize, IbvMemoryRegionView>,
 }
 
@@ -599,9 +599,9 @@ impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
         _cx: &Context<Self>,
         remote_buf_id: usize,
         local: KeepaliveLocalMemory,
-    ) -> Result<Result<IbvBuffer, String>, anyhow::Error> {
+    ) -> Result<Result<IbvRemoteMemoryRegionView, String>, anyhow::Error> {
         if let Some(mrv) = self.buffer_registrations.get(&remote_buf_id) {
-            return Ok(Ok(IbvBuffer::from(mrv)));
+            return Ok(Ok(IbvRemoteMemoryRegionView::from(mrv)));
         }
         // `resolve_local_mr` installs the view in `local`'s shared MR
         // slot, so every clone of this handle — including the one the
@@ -611,7 +611,7 @@ impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
             Ok(v) => v,
             Err(e) => return Ok(Err(e.to_string())),
         };
-        let buf = IbvBuffer::from(&mrv);
+        let buf = IbvRemoteMemoryRegionView::from(&mrv);
         self.buffer_registrations.insert(remote_buf_id, mrv);
         Ok(Ok(buf))
     }
@@ -656,7 +656,7 @@ impl<I: IbvDeviceImpl> std::ops::Deref for IbvBackend<I> {
 #[serde(bound = "")]
 pub struct IbvRemoteBackendContext<I: IbvDeviceImpl> {
     pub manager: ActorRef<IbvManagerActor<I>>,
-    pub buffer: IbvBuffer,
+    pub buffer: IbvRemoteMemoryRegionView,
 }
 
 // `Clone` and `Debug` are hand-rolled to avoid the spurious `I: Clone`

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -70,7 +70,6 @@ use crate::backend::RdmaConfig;
 use crate::backend::ResolveRemoteBackendContext;
 use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
-use crate::local_memory::is_device_ptr;
 use crate::rdma_components::RdmaRemoteBuffer;
 use crate::rdma_manager_actor::RdmaManagerActor;
 use crate::validate_execution_context;
@@ -324,10 +323,10 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
 
     /// Resolve `mem` to an [`IbvMemoryRegionView`] using the slot shared by
     /// every clone of `mem`. On a cold slot, picks the RDMA device (an explicit
-    /// `config.target` if set, else the CUDA-co-located NIC for device memory,
-    /// else a hash-assigned NIC for host memory) and registers the region
-    /// through that device's [`IbvDomainImpl`] strategy, installing the result;
-    /// on a warm slot, returns the cached view.
+    /// `config.target` if set, else one of the NICs with the best path to
+    /// `mem`'s [`MemoryLocation`]) and registers the region through that
+    /// device's [`IbvDomainImpl`] strategy, installing the result; on a warm
+    /// slot, returns the cached view.
     fn resolve_local_mr(
         &mut self,
         mem: &KeepaliveLocalMemory,
@@ -335,81 +334,20 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         if let Some(mrv) = mem.mr_slot().get() {
             return Ok(mrv.clone());
         }
-        let addr = mem.addr();
 
-        // Device selection, in priority order:
-        //   1. an explicit `config.target`, resolved to its NIC;
-        //   2. otherwise the CUDA-co-located NIC for device memory;
-        //   3. otherwise a host-memory NIC assigned by hashing (addr, size).
-        let device_name = if let Some(target) = &self.config.target {
-            resolve_target::<I>(target)?
+        // An explicit `config.target` wins; otherwise take the NICs tied for
+        // the best path to the memory and pick one of them.
+        let device_name = match &self.config.target {
+            Some(target) => resolve_target::<I>(target)?
                 .ok_or_else(|| anyhow::anyhow!("configured device target {:?} not found", target))?
                 .name()
-                .clone()
-        } else {
-            let cuda_nic = if is_device_ptr(addr) {
-                let mut device_ordinal: i32 = -1;
-                // SAFETY: `addr` is a CUDA device pointer (per `is_device_ptr`);
-                // the FFI call writes the owning device ordinal through the
-                // out-pointer.
-                let err = unsafe {
-                    rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
-                        &mut device_ordinal as *mut _ as *mut std::ffi::c_void,
-                        rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
-                        addr as rdmaxcel_sys::CUdeviceptr,
-                    )
-                };
-                let ordinal = (err == rdmaxcel_sys::CUDA_SUCCESS)
-                    .then_some(device_ordinal)
-                    .ok_or_else(|| {
-                        anyhow::anyhow!(
-                            "could not get CUDA device ordinal for device memory at 0x{:x}: {}",
-                            addr,
-                            err
-                        )
-                    })?;
-                assert!(ordinal >= 0, "CUDA device ordinal must be non-negative");
-                Some(
-                    super::device_selection::get_cuda_device_to_ibv_devices::<I>()?
-                        .get(ordinal as usize)
-                        .and_then(|nics| nics.first())
-                        .cloned()
-                        .ok_or_else(|| {
-                            anyhow::anyhow!(
-                                "no RDMA device found for CUDA device ordinal {}",
-                                ordinal
-                            )
-                        })?,
-                )
-            } else {
-                None
-            };
-            match cuda_nic {
-                Some(info) => info.name().clone(),
-                None => {
-                    // Host memory has no co-located GPU NIC. Rather than funnel
-                    // every host registration through a single device, spread them
-                    // across all NICs that tie for the best CPU path by hashing the
-                    // region's (addr, size); the NICs share the load for host
-                    // memory, increasing aggregate throughput.
-                    let devices = select_optimal_ibv_devices::<I>(MemoryLocation::Cpu(None))?;
-                    match devices.len() {
-                        0 => anyhow::bail!("no RDMA devices found"),
-                        n => {
-                            let mut hasher = DefaultHasher::new();
-                            (mem.addr(), mem.size()).hash(&mut hasher);
-                            devices[(hasher.finish() % n as u64) as usize]
-                                .name()
-                                .clone()
-                        }
-                    }
-                }
-            }
+                .clone(),
+            None => Self::pick_optimal_device(mem)?,
         };
         tracing::debug!(
             "Using RDMA device: {} for memory at 0x{:x}",
             device_name,
-            addr
+            mem.addr()
         );
 
         let domain = self.get_or_create_device_domain(&device_name)?;
@@ -417,6 +355,30 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
         // dmabuf MR, or a device-specific segment binding).
         let mrv = domain.register_mr(mem)?;
         Ok(mem.mr_slot().get_or_init(|| mrv).clone())
+    }
+
+    /// One of the NICs of backend `I` tied for the best path to `mem`.
+    ///
+    /// Host memory picks by hashing the region's `(addr, size)` instead of
+    /// funneling every host registration through a single device. GPU memory
+    /// just takes the first, for now.
+    fn pick_optimal_device(mem: &KeepaliveLocalMemory) -> Result<String, anyhow::Error> {
+        let location = mem.location();
+        let devices = select_optimal_ibv_devices::<I>(location)?;
+        anyhow::ensure!(
+            !devices.is_empty(),
+            "no {} RDMA device has a path to {location:?}",
+            I::backend_name(),
+        );
+        let index = match location {
+            MemoryLocation::Cpu(_) => {
+                let mut hasher = DefaultHasher::new();
+                (mem.addr(), mem.size()).hash(&mut hasher);
+                (hasher.finish() % devices.len() as u64) as usize
+            }
+            MemoryLocation::Gpu(_) => 0,
+        };
+        Ok(devices[index].name().clone())
     }
 
     /// Build a passive-side mirror QP for `qp_key`, connect it to
@@ -1019,11 +981,11 @@ mod tests {
             let local = match device {
                 BufferDevice::Cpu => {
                     let buf: Box<[u8]> = vec![pattern; size].into_boxed_slice();
-                    KeepaliveLocalMemory::new(Arc::new(buf))
+                    KeepaliveLocalMemory::try_new(Arc::new(buf))?
                 }
                 BufferDevice::Cuda(device_id) => {
                     let alloc = CudaAllocator::get().allocate(device_id, size, size);
-                    let local = KeepaliveLocalMemory::new(Arc::new(alloc.clone()));
+                    let local = KeepaliveLocalMemory::try_new(Arc::new(alloc.clone()))?;
                     self.cuda_allocs.push(alloc);
                     let fill = vec![pattern; size];
                     // SAFETY: `local` is freshly constructed; no other
@@ -1400,7 +1362,7 @@ mod tests {
         require_rdma();
         let env = TestEnv::same_config(IbvConfig::targeting(IbvDeviceTarget::cpu(0))).await?;
         let buf: Box<[u8]> = vec![0u8; 1024].into_boxed_slice();
-        let local = KeepaliveLocalMemory::new(Arc::new(buf));
+        let local = KeepaliveLocalMemory::try_new(Arc::new(buf))?;
         assert!(
             local.mr_slot().get().is_none(),
             "MR slot should be empty before registration",

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -8,14 +8,22 @@
 
 //! Registered memory regions returned by [`IbvDomainImpl::register_mr`].
 //!
-//! [`IbvMemoryRegionView`] is the cheap, cloneable handle peers use: the keys
-//! and addresses for a slice of registered memory, plus an `Arc<dyn IbvMemoryRegionKeepalive>`
-//! that keeps the backing registration's resources alive until the last clone
-//! of the view drops.
+//! [`IbvMemoryRegionView`] is the cheap, cloneable handle this process addresses
+//! its own registered memory through: the keys and addresses for a slice of
+//! registered memory, plus an `Arc<dyn IbvMemoryRegionKeepalive>` that keeps the
+//! backing registration's resources alive until the last clone of the view
+//! drops.
+//!
+//! [`IbvRemoteMemoryRegionView`] is what a peer gets instead: the same region
+//! reduced to what the wire can carry and the far side can use.
 //!
 //! [`IbvDomainImpl::register_mr`]: super::domain::IbvDomainImpl::register_mr
 
 use std::sync::Arc;
+
+use serde::Deserialize;
+use serde::Serialize;
+use typeuri::Named;
 
 use super::primitives::IbvMr;
 
@@ -87,5 +95,36 @@ impl IbvMemoryRegionView {
             device_name.to_string(),
             Arc::new(IbvMr::null()),
         )
+    }
+}
+
+/// What a peer needs in order to address one of our registered memory regions
+/// over RDMA: the region's `rkey`, its RDMA address, its size, and the device
+/// serving it.
+///
+/// This is the wire form of an [`IbvMemoryRegionView`]. It carries no `lkey` and
+/// no keepalive: an `lkey` only means anything to the protection domain that
+/// issued it, and the registration is kept alive by the views the owning side
+/// holds.
+#[derive(Debug, Clone, Serialize, Deserialize, Named)]
+pub struct IbvRemoteMemoryRegionView {
+    pub rkey: u32,
+    /// RDMA address (may differ from virtual address).
+    pub addr: usize,
+    pub size: usize,
+    /// Name of the RDMA device this region is registered on (e.g., "mlx5_0").
+    pub device_name: String,
+}
+
+impl From<&IbvMemoryRegionView> for IbvRemoteMemoryRegionView {
+    /// The wire transport details are fully derived from the registered MR
+    /// view: the remote key, the RDMA address, the size, and the device name.
+    fn from(view: &IbvMemoryRegionView) -> Self {
+        Self {
+            rkey: view.rkey,
+            addr: view.rdma_addr,
+            size: view.size,
+            device_name: view.device_name.clone(),
+        }
     }
 }

--- a/monarch_rdma/src/backend/ibverbs/memory_region.rs
+++ b/monarch_rdma/src/backend/ibverbs/memory_region.rs
@@ -71,4 +71,21 @@ impl IbvMemoryRegionView {
             _guard: guard,
         }
     }
+
+    /// Fabricate a zero-sized view naming `device_name` and carrying `key` as
+    /// both its `lkey` and its `rkey`, over a null MR keepalive whose `Drop`
+    /// is a no-op. For tests that care only about which device a registration
+    /// belongs to, and which of several registrations they are holding.
+    #[cfg(test)]
+    pub(crate) fn for_test(device_name: &str, key: u32) -> Self {
+        Self::new(
+            0,
+            0,
+            0,
+            key,
+            key,
+            device_name.to_string(),
+            Arc::new(IbvMr::null()),
+        )
+    }
 }

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -127,10 +127,10 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
     Ok(())
 }
 
-/// Extract the ibverbs `(lkey, rkey)` from a remote buffer.
-fn ibv_keys_of(remote: &crate::RdmaRemoteBuffer) -> Result<(u32, u32), anyhow::Error> {
+/// Extract the ibverbs `rkey` from a remote buffer.
+fn ibv_rkey_of(remote: &crate::RdmaRemoteBuffer) -> Result<u32, anyhow::Error> {
     let ctx = remote.resolve_mlx().expect("remote buffer is Mellanox");
-    Ok((ctx.buffer.lkey, ctx.buffer.rkey))
+    Ok(ctx.buffer.rkey)
 }
 
 /// Integration test for the indirect-mkey segment-growth path.
@@ -223,12 +223,11 @@ async fn test_indirect_mkey_rebind_grows_existing_segment() -> Result<(), anyhow
         .next()
         .expect("buf B");
 
-    let (lkey_a, rkey_a) = ibv_keys_of(&buf_a)?;
-    let (lkey_b, rkey_b) = ibv_keys_of(&buf_b)?;
+    let rkey_a = ibv_rkey_of(&buf_a)?;
+    let rkey_b = ibv_rkey_of(&buf_b)?;
     assert_ne!(
-        (lkey_a, rkey_a),
-        (lkey_b, rkey_b),
-        "buffers in distinct segments must have distinct (lkey, rkey)",
+        rkey_a, rkey_b,
+        "buffers in distinct segments must have distinct rkeys",
     );
 
     // Expand S1 in place; the next miss triggers a register_segments
@@ -241,20 +240,18 @@ async fn test_indirect_mkey_rebind_grows_existing_segment() -> Result<(), anyhow
         .next()
         .expect("buf C");
 
-    let (lkey_c, rkey_c) = ibv_keys_of(&buf_c)?;
+    let rkey_c = ibv_rkey_of(&buf_c)?;
     // Growth rotates the segment onto a fresh indirect mkey (parking the prior
     // one), so buf C — carved after the grow — carries a new key, distinct from
     // buf A's pre-grow key; the round-trips below confirm A's parked key stays
     // valid. It is also distinct from buf B's separate segment.
     assert_ne!(
-        (lkey_c, rkey_c),
-        (lkey_a, rkey_a),
-        "growth rotates the expandable segment onto a new (lkey, rkey)",
+        rkey_c, rkey_a,
+        "growth rotates the expandable segment onto a new rkey",
     );
     assert_ne!(
-        (lkey_c, rkey_c),
-        (lkey_b, rkey_b),
-        "buffers in distinct segments must have distinct (lkey, rkey)",
+        rkey_c, rkey_b,
+        "buffers in distinct segments must have distinct rkeys",
     );
 
     // Each buffer was filled with its own pattern at registration;
@@ -417,29 +414,29 @@ async fn test_indirect_mkey_rebind_falls_back_to_dmabuf_at_max_sge() -> Result<(
         .expect("buf C");
 
     // Buf B took the dmabuf path (the override forced
-    // register_segments to fail), so its lkey differs from buf A's
+    // register_segments to fail), so its key differs from buf A's
     // indirect mkey — sanity check that the override took effect.
     // Buf C lands at an address inside the [mr_size, phys_size) gap;
-    // it must also fall through to dmabuf and get a distinct lkey.
-    let (lkey_a, _) = ibv_keys_of(&buf_a)?;
-    let (lkey_b, _) = ibv_keys_of(&buf_b)?;
-    let (lkey_c, _) = ibv_keys_of(&buf_c)?;
+    // it must also fall through to dmabuf and get a distinct key.
+    let rkey_a = ibv_rkey_of(&buf_a)?;
+    let rkey_b = ibv_rkey_of(&buf_b)?;
+    let rkey_c = ibv_rkey_of(&buf_c)?;
     assert_ne!(
-        lkey_a, lkey_b,
+        rkey_a, rkey_b,
         "buf B should be registered via the dmabuf fallback after \
          register_segments hit the max_sge override and therefore have \
-         a different lkey from buf A's indirect mkey"
+         a different rkey from buf A's indirect mkey"
     );
     assert_ne!(
-        lkey_a, lkey_c,
+        rkey_a, rkey_c,
         "buf C lands in the [mr_size, phys_size) gap and must fall \
          through to dmabuf; reusing buf A's indirect mkey here would \
-         hand the NIC a stale (lkey, offset) past the bound"
+         hand the NIC a bad (key, offset) past the bound"
     );
 
     // Round-trip every buffer: read the registration pattern, write
-    // a fresh one, read it back. Even if the lkey check above
-    // somehow passed, a stale (lkey, offset) on buf C would fail at
+    // a fresh one, read it back. Even if the rkey check above
+    // somehow passed, a bad (key, offset) on buf C would fail at
     // the NIC with LOC_PROT_ERR.
     for (label, buf, pattern) in [
         ("A", &buf_a, PATTERN_A),

--- a/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_domain.rs
@@ -47,8 +47,8 @@ use super::primitives::IbvQp;
 use super::queue_pair::connect;
 use super::queue_pair::get_qp_info;
 use crate::backend::ibverbs::mlx_device::MlxDevice;
+use crate::device_selection::MemoryLocation;
 use crate::local_memory::KeepaliveLocalMemory;
-use crate::local_memory::is_device_ptr;
 
 /// A single MR must be 2 MiB aligned and covers at most 4 GiB (one page
 /// under). Larger segments are split across multiple MRs bound to one key.
@@ -820,7 +820,7 @@ impl IbvDomainImpl for MlxDomain {
         mem: &KeepaliveLocalMemory,
     ) -> anyhow::Result<IbvMemoryRegionView> {
         let this = domain.domain_impl();
-        if this.mlx5dv_enabled && is_device_ptr(mem.addr()) {
+        if this.mlx5dv_enabled && matches!(mem.location(), MemoryLocation::Gpu(_)) {
             // SAFETY: `domain.as_ptr()` is null or a live PD, per this method's
             // contract.
             match unsafe { this.register_cuda_mlx5dv_mr(domain, mem.addr(), mem.size()) } {

--- a/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx_queue_pair.rs
@@ -11,9 +11,10 @@
 use std::io::Error;
 use std::result::Result;
 
-use super::IbvBuffer;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
+use super::memory_region::IbvMemoryRegionView;
+use super::memory_region::IbvRemoteMemoryRegionView;
 use super::primitives::GidScope;
 use super::primitives::GidType;
 use super::primitives::IbvConfig;
@@ -151,16 +152,16 @@ impl IbvQueuePair for MlxQueuePair {
 
     fn put(
         &mut self,
-        remote_dst: IbvBuffer,
-        local_src: IbvBuffer,
+        remote_dst: IbvRemoteMemoryRegionView,
+        local_src: IbvMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         self.0.put(remote_dst, local_src)
     }
 
     fn get(
         &mut self,
-        local_dst: IbvBuffer,
-        remote_src: IbvBuffer,
+        local_dst: IbvMemoryRegionView,
+        remote_src: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         self.0.get(local_dst, remote_src)
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -43,12 +43,12 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-use super::IbvBuffer;
 use super::IbvOp;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::manager_actor::CreatePeerQueuePair;
 use super::memory_region::IbvMemoryRegionView;
+use super::memory_region::IbvRemoteMemoryRegionView;
 use super::primitives::Gid;
 use super::primitives::GidScope;
 use super::primitives::GidType;
@@ -216,8 +216,8 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// that were posted.
     fn put(
         &mut self,
-        remote_dst: IbvBuffer,
-        local_src: IbvBuffer,
+        remote_dst: IbvRemoteMemoryRegionView,
+        local_src: IbvMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error>;
 
     /// Post an RDMA READ of `remote_src` into `local_dst`. The request may
@@ -225,8 +225,8 @@ pub trait IbvQueuePair: std::fmt::Debug + Send + Sync + 'static + Sized {
     /// that were posted.
     fn get(
         &mut self,
-        local_dst: IbvBuffer,
-        remote_src: IbvBuffer,
+        local_dst: IbvMemoryRegionView,
+        remote_src: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error>;
 
     /// Poll `target`'s completion queue for a single work completion.
@@ -703,8 +703,8 @@ impl IbvQueuePair for RCQueuePair {
 
     fn put(
         &mut self,
-        remote_dst: IbvBuffer,
-        local_src: IbvBuffer,
+        remote_dst: IbvRemoteMemoryRegionView,
+        local_src: IbvMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         if remote_dst.size < local_src.size {
             return Err(anyhow::anyhow!(
@@ -715,7 +715,7 @@ impl IbvQueuePair for RCQueuePair {
         }
         self.post_chunked(
             IbvOperation::Write,
-            local_src.addr,
+            local_src.rdma_addr,
             local_src.lkey,
             remote_dst.addr,
             remote_dst.rkey,
@@ -725,8 +725,8 @@ impl IbvQueuePair for RCQueuePair {
 
     fn get(
         &mut self,
-        local_dst: IbvBuffer,
-        remote_src: IbvBuffer,
+        local_dst: IbvMemoryRegionView,
+        remote_src: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         if local_dst.size < remote_src.size {
             return Err(anyhow::anyhow!(
@@ -737,7 +737,7 @@ impl IbvQueuePair for RCQueuePair {
         }
         self.post_chunked(
             IbvOperation::Read,
-            local_dst.addr,
+            local_dst.rdma_addr,
             local_dst.lkey,
             remote_src.addr,
             remote_src.rkey,
@@ -1015,19 +1015,11 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
             is_read,
         } = pending;
 
-        let local_buf = IbvBuffer {
-            lkey: mrv.lkey,
-            rkey: mrv.rkey,
-            addr: mrv.rdma_addr,
-            size: mrv.size,
-            device_name: mrv.device_name.clone(),
-        };
-
         // 1. Per-op fatal: op alone exceeds the QP's capacity.
         if wrs > self.max_send_wr {
             let err = format!(
                 "op too large for this QP [op_idx={}, qp_key={:?}, op_type={:?}, wrs={}, max_send_wr={}, local: {:?}, remote: {:?}]",
-                op_idx, self.qp_key, op.op_type, wrs, self.max_send_wr, local_buf, op.remote_buffer,
+                op_idx, self.qp_key, op.op_type, wrs, self.max_send_wr, mrv, op.remote_buffer,
             );
             reply.try_post(
                 cx,
@@ -1041,7 +1033,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         if is_read && wrs > self.max_rd_atomic {
             let err = format!(
                 "read op too large for this QP [op_idx={}, qp_key={:?}, wrs={}, max_rd_atomic={}, local: {:?}, remote: {:?}]",
-                op_idx, self.qp_key, wrs, self.max_rd_atomic, local_buf, op.remote_buffer,
+                op_idx, self.qp_key, wrs, self.max_rd_atomic, mrv, op.remote_buffer,
             );
             reply.try_post(
                 cx,
@@ -1073,8 +1065,8 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
 
         // 3. Post.
         let post_result = match op.op_type {
-            RdmaOpType::WriteFromLocal => self.qp.put(op.remote_buffer.clone(), local_buf.clone()),
-            RdmaOpType::ReadIntoLocal => self.qp.get(local_buf.clone(), op.remote_buffer.clone()),
+            RdmaOpType::WriteFromLocal => self.qp.put(op.remote_buffer.clone(), mrv.clone()),
+            RdmaOpType::ReadIntoLocal => self.qp.get(mrv.clone(), op.remote_buffer.clone()),
         };
         let wr_ids = post_result.map_err(|e| {
             anyhow::anyhow!(
@@ -1082,7 +1074,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 if is_read { "get" } else { "put" },
                 op_idx,
                 self.qp_key,
-                local_buf,
+                mrv,
                 op.remote_buffer,
             )
         })?;
@@ -1536,13 +1528,13 @@ mod tests {
     #[derive(Debug)]
     enum PostedOp {
         Put {
-            remote_dst: IbvBuffer,
-            local_src: IbvBuffer,
+            remote_dst: IbvRemoteMemoryRegionView,
+            local_src: IbvMemoryRegionView,
             wr_ids: Vec<u64>,
         },
         Get {
-            local_dst: IbvBuffer,
-            remote_src: IbvBuffer,
+            local_dst: IbvMemoryRegionView,
+            remote_src: IbvRemoteMemoryRegionView,
             wr_ids: Vec<u64>,
         },
     }
@@ -1658,7 +1650,11 @@ mod tests {
             Ok(rdmaxcel_sys::ibv_qp_state::IBV_QPS_RTS)
         }
 
-        fn put(&mut self, remote_dst: IbvBuffer, local_src: IbvBuffer) -> Result<Vec<u64>> {
+        fn put(
+            &mut self,
+            remote_dst: IbvRemoteMemoryRegionView,
+            local_src: IbvMemoryRegionView,
+        ) -> Result<Vec<u64>> {
             let mut inner = self.inner.lock().unwrap();
             if let Some(msg) = inner.post_error.take() {
                 return Err(anyhow::anyhow!(msg));
@@ -1677,7 +1673,11 @@ mod tests {
             Ok(wr_ids)
         }
 
-        fn get(&mut self, local_dst: IbvBuffer, remote_src: IbvBuffer) -> Result<Vec<u64>> {
+        fn get(
+            &mut self,
+            local_dst: IbvMemoryRegionView,
+            remote_src: IbvRemoteMemoryRegionView,
+        ) -> Result<Vec<u64>> {
             let mut inner = self.inner.lock().unwrap();
             if let Some(msg) = inner.post_error.take() {
                 return Err(anyhow::anyhow!(msg));
@@ -2066,8 +2066,7 @@ mod tests {
         IbvOp {
             op_type,
             local_memory: fake_local_memory(addr, size),
-            remote_buffer: IbvBuffer {
-                lkey: 0,
+            remote_buffer: IbvRemoteMemoryRegionView {
                 rkey: 0,
                 addr: 0x4000_0000,
                 size,
@@ -2166,7 +2165,7 @@ mod tests {
         }
     }
 
-    fn expect_put(p: PostedOp) -> (IbvBuffer, IbvBuffer, Vec<u64>) {
+    fn expect_put(p: PostedOp) -> (IbvMemoryRegionView, IbvRemoteMemoryRegionView, Vec<u64>) {
         match p {
             PostedOp::Put {
                 remote_dst,
@@ -2177,7 +2176,7 @@ mod tests {
         }
     }
 
-    fn expect_get(p: PostedOp) -> (IbvBuffer, IbvBuffer, Vec<u64>) {
+    fn expect_get(p: PostedOp) -> (IbvMemoryRegionView, IbvRemoteMemoryRegionView, Vec<u64>) {
         match p {
             PostedOp::Get {
                 local_dst,
@@ -2246,7 +2245,7 @@ mod tests {
         // wr_ids start at 0 (fresh MockQp), so the single WR is wr 0.
         let (lhandle, rhandle, wr_ids) = expect_put(recv_posted(&mut posted_rx).await);
         assert_eq!(wr_ids, vec![0]);
-        assert_eq!(lhandle.addr, 0x1000);
+        assert_eq!(lhandle.rdma_addr, 0x1000);
         assert_eq!(lhandle.size, 4096);
         assert_eq!(lhandle.lkey, 0x1234);
         assert_eq!(lhandle.rkey, 0x5678);

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -2010,7 +2010,8 @@ mod tests {
     }
 
     fn fake_local_memory(addr: usize, size: usize) -> KeepaliveLocalMemory {
-        KeepaliveLocalMemory::new(Arc::new(FakeKeepalive { addr, size }))
+        KeepaliveLocalMemory::try_new(Arc::new(FakeKeepalive { addr, size }))
+            .expect("a fake host address has a location")
     }
 
     /// [`Keepalive`] that sets `dropped` when it goes away, so a test can
@@ -2084,11 +2085,12 @@ mod tests {
         dropped: Arc<AtomicBool>,
     ) -> IbvOp<QpaMockManager> {
         IbvOp {
-            local_memory: KeepaliveLocalMemory::new(Arc::new(DropFlagKeepalive {
+            local_memory: KeepaliveLocalMemory::try_new(Arc::new(DropFlagKeepalive {
                 addr,
                 size,
                 dropped,
-            })),
+            }))
+            .expect("a fake host address has a location"),
             ..make_op(op_type, addr, size)
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair/legacy.rs
@@ -325,7 +325,11 @@ impl IbvQueuePair {
         Ok(())
     }
 
-    pub fn recv(&mut self, lhandle: IbvBuffer, rhandle: IbvBuffer) -> Result<u64, anyhow::Error> {
+    pub fn recv(
+        &mut self,
+        lhandle: IbvMemoryRegionView,
+        rhandle: IbvRemoteMemoryRegionView,
+    ) -> Result<u64, anyhow::Error> {
         unsafe {
             let qp = self.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
             let idx = rdmaxcel_sys::rdmaxcel_qp_fetch_add_recv_wqe_idx(qp);
@@ -347,14 +351,14 @@ impl IbvQueuePair {
 
     pub fn put_with_recv(
         &mut self,
-        lhandle: IbvBuffer,
-        rhandle: IbvBuffer,
+        lhandle: IbvMemoryRegionView,
+        rhandle: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         unsafe {
             let qp = self.qp as *mut rdmaxcel_sys::rdmaxcel_qp;
             let idx = rdmaxcel_sys::rdmaxcel_qp_fetch_add_send_wqe_idx(qp);
             self.post_op(
-                lhandle.addr,
+                lhandle.rdma_addr,
                 lhandle.lkey,
                 lhandle.size,
                 idx,
@@ -371,8 +375,8 @@ impl IbvQueuePair {
 
     pub fn put(
         &mut self,
-        lhandle: IbvBuffer,
-        rhandle: IbvBuffer,
+        lhandle: IbvMemoryRegionView,
+        rhandle: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         let total_size = lhandle.size;
         if rhandle.size < total_size {
@@ -395,7 +399,7 @@ impl IbvQueuePair {
             };
             wr_ids.push(idx);
             self.post_op(
-                lhandle.addr + offset,
+                lhandle.rdma_addr + offset,
                 lhandle.lkey,
                 chunk_size,
                 idx,
@@ -450,8 +454,8 @@ impl IbvQueuePair {
     /// Enqueues a put operation without ringing the doorbell.
     pub fn enqueue_put(
         &mut self,
-        lhandle: IbvBuffer,
-        rhandle: IbvBuffer,
+        lhandle: IbvMemoryRegionView,
+        rhandle: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         let idx = unsafe {
             rdmaxcel_sys::rdmaxcel_qp_fetch_add_send_wqe_idx(
@@ -460,7 +464,7 @@ impl IbvQueuePair {
         };
 
         self.send_wqe(
-            lhandle.addr,
+            lhandle.rdma_addr,
             lhandle.lkey,
             lhandle.size,
             idx,
@@ -475,8 +479,8 @@ impl IbvQueuePair {
     /// Enqueues a put-with-receive operation without ringing the doorbell.
     pub fn enqueue_put_with_recv(
         &mut self,
-        lhandle: IbvBuffer,
-        rhandle: IbvBuffer,
+        lhandle: IbvMemoryRegionView,
+        rhandle: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         let idx = unsafe {
             rdmaxcel_sys::rdmaxcel_qp_fetch_add_send_wqe_idx(
@@ -485,7 +489,7 @@ impl IbvQueuePair {
         };
 
         self.send_wqe(
-            lhandle.addr,
+            lhandle.rdma_addr,
             lhandle.lkey,
             lhandle.size,
             idx,
@@ -500,8 +504,8 @@ impl IbvQueuePair {
     /// Enqueues a get operation without ringing the doorbell.
     pub fn enqueue_get(
         &mut self,
-        lhandle: IbvBuffer,
-        rhandle: IbvBuffer,
+        lhandle: IbvMemoryRegionView,
+        rhandle: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         let idx = unsafe {
             rdmaxcel_sys::rdmaxcel_qp_fetch_add_send_wqe_idx(
@@ -510,7 +514,7 @@ impl IbvQueuePair {
         };
 
         self.send_wqe(
-            lhandle.addr,
+            lhandle.rdma_addr,
             lhandle.lkey,
             lhandle.size,
             idx,
@@ -524,8 +528,8 @@ impl IbvQueuePair {
 
     pub fn get(
         &mut self,
-        lhandle: IbvBuffer,
-        rhandle: IbvBuffer,
+        lhandle: IbvMemoryRegionView,
+        rhandle: IbvRemoteMemoryRegionView,
     ) -> Result<Vec<u64>, anyhow::Error> {
         let total_size = rhandle.size;
         if rhandle.size > lhandle.size {
@@ -550,7 +554,7 @@ impl IbvQueuePair {
             wr_ids.push(idx);
 
             self.post_op(
-                lhandle.addr + offset,
+                lhandle.rdma_addr + offset,
                 lhandle.lkey,
                 chunk_size,
                 idx,

--- a/monarch_rdma/src/backend/tcp/manager_actor.rs
+++ b/monarch_rdma/src/backend/tcp/manager_actor.rs
@@ -1120,7 +1120,7 @@ mod tests {
             buffer_size: usize,
         ) -> anyhow::Result<(KeepaliveLocalMemory, crate::RdmaRemoteBuffer)> {
             let cpu_buf = vec![0u8; buffer_size].into_boxed_slice();
-            let local_memory = KeepaliveLocalMemory::new(Arc::new(cpu_buf));
+            let local_memory = KeepaliveLocalMemory::try_new(Arc::new(cpu_buf))?;
             let rdma_remote_buf = rdma_handle
                 .request_buffer(instance, local_memory.clone())
                 .await?;
@@ -1649,7 +1649,7 @@ mod tests {
             );
 
             let alloc = CudaAllocator::get().allocate(device, buffer_size, buffer_size);
-            let local_memory = KeepaliveLocalMemory::new(Arc::new(alloc));
+            let local_memory = KeepaliveLocalMemory::try_new(Arc::new(alloc))?;
             let rdma_remote_buf = rdma_handle
                 .request_buffer(&instance, local_memory.clone())
                 .await?;

--- a/monarch_rdma/src/device_selection.rs
+++ b/monarch_rdma/src/device_selection.rs
@@ -21,6 +21,8 @@ use anyhow::Result;
 use dashmap::DashSet;
 use rdmaxcel_sys::CUresult;
 
+use crate::local_memory::is_device_ptr;
+
 fn cuda_error_string(rc: CUresult) -> String {
     // The lookup below goes through the same driver wrapper as every other call,
     // so it cannot name the one code that means there is no driver to ask: it
@@ -181,6 +183,40 @@ pub enum MemoryLocation {
     Cpu(Option<u32>),
     /// GPU memory on the given CUDA device ordinal, or any GPU if `None`.
     Gpu(Option<u32>),
+}
+
+impl MemoryLocation {
+    /// Where the memory at `addr` lives.
+    ///
+    /// A device pointer resolves to the CUDA ordinal that owns it. Host memory
+    /// is [`Self::Cpu(None)`]: the NUMA node backing the allocation is not
+    /// resolved.
+    ///
+    /// Errors when `addr` is device memory whose owning ordinal cannot be
+    /// queried.
+    pub fn from_addr(addr: usize) -> Result<Self> {
+        if !is_device_ptr(addr) {
+            return Ok(Self::Cpu(None));
+        }
+        let mut ordinal: i32 = -1;
+        // SAFETY: FFI writes one `i32` through the out-pointer; `addr` is passed
+        // by value as an opaque device address and never dereferenced.
+        let rc = unsafe {
+            rdmaxcel_sys::rdmaxcel_cuPointerGetAttribute(
+                &mut ordinal as *mut _ as *mut std::ffi::c_void,
+                rdmaxcel_sys::CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                addr as rdmaxcel_sys::CUdeviceptr,
+            )
+        };
+        anyhow::ensure!(
+            rc == rdmaxcel_sys::CUDA_SUCCESS,
+            "cuPointerGetAttribute(DEVICE_ORDINAL) failed for device memory at {addr:#x}: {}",
+            cuda_error_string(rc),
+        );
+        Ok(Self::Gpu(Some(
+            u32::try_from(ordinal).expect("CUDA device ordinal should be non-negative"),
+        )))
+    }
 }
 
 /// Locality of a path between two PCI endpoints, ordered best to worst.

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -18,6 +18,7 @@ use std::sync::Mutex;
 use std::sync::OnceLock;
 
 use crate::backend::ibverbs::memory_region::IbvMemoryRegionView;
+use crate::device_selection::MemoryLocation;
 
 /// Returns `true` when `addr` is a CUDA device pointer.
 ///
@@ -386,6 +387,8 @@ impl Keepalive for Box<[u8]> {
 pub(crate) struct LocalMemoryInner {
     addr: usize,
     size: usize,
+    /// Where the region lives, resolved once at construction.
+    location: MemoryLocation,
     /// Bandwidth (bytes/s) for direct host-thread pointer access, or `None`
     /// if the memory is not host-accessible.
     direct_access_host_bandwidth: Option<u64>,
@@ -402,21 +405,22 @@ pub(crate) struct LocalMemoryInner {
 }
 
 impl LocalMemoryInner {
-    fn new(addr: usize, size: usize) -> Self {
+    fn try_new(addr: usize, size: usize) -> Result<Self, anyhow::Error> {
+        let location = MemoryLocation::from_addr(addr)?;
         // TODO(slurye): Using placeholder values for now. Fill in with real values.
-        let (host_bw, device_bw) = if is_device_ptr(addr) {
-            (None, Some(1))
-        } else {
-            (Some(1), None)
+        let (host_bw, device_bw) = match location {
+            MemoryLocation::Cpu(_) => (Some(1), None),
+            MemoryLocation::Gpu(_) => (None, Some(1)),
         };
-        Self {
+        Ok(Self {
             addr,
             size,
+            location,
             direct_access_host_bandwidth: host_bw,
             direct_access_device_bandwidth: device_bw,
             mr_slot: Arc::new(OnceLock::new()),
             access: Arc::new(AccessLock::new()),
-        }
+        })
     }
 }
 
@@ -450,6 +454,7 @@ impl Debug for KeepaliveLocalMemory {
         f.debug_struct("KeepaliveLocalMemory")
             .field("addr", &self.inner.addr)
             .field("size", &self.inner.size)
+            .field("location", &self.inner.location)
             .field(
                 "direct_access_host_bandwidth",
                 &self.inner.direct_access_host_bandwidth,
@@ -463,18 +468,19 @@ impl Debug for KeepaliveLocalMemory {
 }
 
 impl KeepaliveLocalMemory {
-    /// Create a new handle. Derives `addr` and `size` from the
-    /// `keepalive` via [`Keepalive::addr`] /
-    /// [`Keepalive::size`], then probes the CUDA driver to
-    /// determine whether the address is a device pointer and sets the
-    /// bandwidth fields accordingly.
-    pub fn new(keepalive: Arc<dyn Keepalive>) -> Self {
+    /// Try to create a new handle. Derives `addr` and `size` from the
+    /// `keepalive` via [`Keepalive::addr`] / [`Keepalive::size`], then
+    /// resolves the region's [`MemoryLocation`] and sets the bandwidth fields
+    /// accordingly.
+    ///
+    /// Errors when the location cannot be resolved.
+    pub fn try_new(keepalive: Arc<dyn Keepalive>) -> Result<Self, anyhow::Error> {
         let addr = keepalive.addr();
         let size = keepalive.size();
-        Self {
-            inner: LocalMemoryInner::new(addr, size),
+        Ok(Self {
+            inner: LocalMemoryInner::try_new(addr, size)?,
             _keepalive: keepalive,
-        }
+        })
     }
 
     /// Starting virtual address of the memory region.
@@ -485,6 +491,11 @@ impl KeepaliveLocalMemory {
     /// Size of the memory region in bytes.
     pub fn size(&self) -> usize {
         self.inner.size
+    }
+
+    /// Where this region lives.
+    pub fn location(&self) -> MemoryLocation {
+        self.inner.location
     }
 
     /// Shared slot for the [`IbvMemoryRegionView`] registered against
@@ -663,11 +674,30 @@ impl WeakLocalMemory {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::backend::cuda_test_utils::CudaAllocator;
 
     // -- KeepaliveLocalMemory (host) --
 
     fn host_keepalive_mem(data: Box<[u8]>) -> KeepaliveLocalMemory {
-        KeepaliveLocalMemory::new(Arc::new(data))
+        KeepaliveLocalMemory::try_new(Arc::new(data)).expect("host memory has a location")
+    }
+
+    #[test]
+    fn keepalive_host_location() {
+        let mem = host_keepalive_mem(Box::from([1, 2, 3]));
+        // No NUMA node is resolved.
+        assert_eq!(mem.location(), MemoryLocation::Cpu(None));
+    }
+
+    #[test]
+    fn keepalive_device_location_names_its_cuda_ordinal() {
+        let alloc = CudaAllocator::get().allocate(0, 4096, 4096);
+        assert_eq!(
+            alloc.keepalive_slice(0, 4096).location(),
+            MemoryLocation::Gpu(Some(0)),
+            "a device pointer should resolve to the ordinal that owns it",
+        );
+        alloc.try_free();
     }
 
     #[test]

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -15,7 +15,9 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use std::sync::Condvar;
 use std::sync::Mutex;
-use std::sync::OnceLock;
+
+use dashmap::DashMap;
+use dashmap::mapref::entry::Entry;
 
 use crate::backend::ibverbs::memory_region::IbvMemoryRegionView;
 use crate::device_selection::MemoryLocation;
@@ -375,11 +377,11 @@ impl Keepalive for Box<[u8]> {
 /// Backing state of a [`KeepaliveLocalMemory`].
 ///
 /// Holds the addressing/bandwidth metadata, the access-coordination
-/// lock, and a single-slot home for an [`IbvMemoryRegionView`]
-/// registered against this region. Cloning shares the slot and the
-/// access lock by `Arc`, so every handle derived from the same
-/// allocation observes the same registered MR and the same
-/// reader/writer coordination.
+/// lock, and the per-device [`IbvMemoryRegionView`]s this handle has
+/// registered against the region. Cloning shares the registrations and
+/// the access lock by `Arc`, so every clone observes the same registered
+/// MRs and the same reader/writer coordination. Two of these built
+/// separately over the same allocation share nothing.
 ///
 /// All access goes through methods on [`KeepaliveLocalMemory`];
 /// nothing outside the module pokes at these fields directly.
@@ -395,13 +397,27 @@ pub(crate) struct LocalMemoryInner {
     /// Bandwidth (bytes/s) for direct device-thread pointer access, or
     /// `None` if the memory is not device-accessible.
     direct_access_device_bandwidth: Option<u64>,
-    /// Per-allocation slot for the [`IbvMemoryRegionView`] registered
-    /// against this region. Populated lazily by
-    /// `IbvManagerActor::resolve_local_mr` on first use.
-    mr_slot: Arc<OnceLock<IbvMemoryRegionView>>,
+    /// The registrations this handle has made, keyed by RDMA device name.
+    /// Populated lazily by `IbvManagerActor::resolve_local_mr` as devices are
+    /// needed. Keying by device is what makes the entries substitutable for
+    /// one another: an `lkey`/`rkey` pair is only meaningful to the device
+    /// whose protection domain issued it.
+    mrs: Arc<DashMap<String, MrEntry>>,
     /// Coordinates concurrent reads, exclusive writes, and parallel
     /// disjoint writes against this region.
     access: Arc<AccessLock>,
+}
+
+/// The outcome of registering a region on one device.
+///
+/// Failures are recorded, not just dropped, so a device that cannot
+/// register this region is not retried on every subsequent transfer.
+/// Registration is not cheap, and a device that fails once for a
+/// given region fails for a reason that will not have changed.
+#[derive(Debug, Clone)]
+enum MrEntry {
+    Registered(IbvMemoryRegionView),
+    Failed(String),
 }
 
 impl LocalMemoryInner {
@@ -418,7 +434,7 @@ impl LocalMemoryInner {
             location,
             direct_access_host_bandwidth: host_bw,
             direct_access_device_bandwidth: device_bw,
-            mr_slot: Arc::new(OnceLock::new()),
+            mrs: Arc::new(DashMap::new()),
             access: Arc::new(AccessLock::new()),
         })
     }
@@ -498,13 +514,73 @@ impl KeepaliveLocalMemory {
         self.inner.location
     }
 
-    /// Shared slot for the [`IbvMemoryRegionView`] registered against
-    /// this region. Populated lazily by
-    /// [`IbvManagerActor::resolve_local_mr`] on first use; the slot
-    /// is cloned `Arc` so every handle derived from the same
-    /// allocation sees the same registered MR.
-    pub fn mr_slot(&self) -> &Arc<OnceLock<IbvMemoryRegionView>> {
-        &self.inner.mr_slot
+    /// This handle's registration of the region on `device`, if it has one.
+    ///
+    /// `Err` means a previous attempt to register on `device` failed and
+    /// carries that error; the caller should not retry. `Ok(None)` means this
+    /// handle has never registered there.
+    ///
+    /// The registrations are shared by `Arc` across clones of this handle, and
+    /// with any [`WeakLocalMemory`] downgraded from it, so one clone's
+    /// registration is visible to all of them. Handles built separately over
+    /// the same region share nothing.
+    pub fn registered_mr(
+        &self,
+        device: &str,
+    ) -> Result<Option<IbvMemoryRegionView>, anyhow::Error> {
+        match self.inner.mrs.get(device).as_deref() {
+            Some(MrEntry::Registered(view)) => Ok(Some(view.clone())),
+            Some(MrEntry::Failed(error)) => anyhow::bail!(
+                "registering [{:#x}, {:#x}) on {device} failed earlier: {error}",
+                self.inner.addr,
+                self.inner.addr + self.inner.size,
+            ),
+            None => Ok(None),
+        }
+    }
+
+    /// Record `view` as this handle's registration on `view.device_name` and
+    /// return the registration now in force there.
+    ///
+    /// Idempotent: a registration already present wins, and `view` is dropped
+    /// (deregistering it, since nothing else holds it).
+    ///
+    /// Errors when the device already carries a recorded failure, which two
+    /// callers registering the same region on the same device at once can
+    /// reach: one fails and records it, the other succeeds and arrives here.
+    /// The recorded failure stands and `view` is dropped, so the region keeps
+    /// answering with the failure rather than flip-flopping on who got there
+    /// last.
+    pub fn install_mr(
+        &self,
+        view: IbvMemoryRegionView,
+    ) -> Result<IbvMemoryRegionView, anyhow::Error> {
+        match self.inner.mrs.entry(view.device_name.clone()) {
+            Entry::Vacant(vacant) => {
+                vacant.insert(MrEntry::Registered(view.clone()));
+                Ok(view)
+            }
+            Entry::Occupied(occupied) => match occupied.get() {
+                MrEntry::Registered(installed) => Ok(installed.clone()),
+                MrEntry::Failed(error) => anyhow::bail!(
+                    "cannot install a registration of [{:#x}, {:#x}) on {}: an earlier attempt there failed: {error}",
+                    self.inner.addr,
+                    self.inner.addr + self.inner.size,
+                    view.device_name,
+                ),
+            },
+        }
+    }
+
+    /// Record that registering this region on `device` failed, so later
+    /// transfers see the failure instead of retrying it. A registration
+    /// already in force on `device` wins: one caller's failure does not
+    /// invalidate another's working keys.
+    pub fn record_mr_failure(&self, device: &str, error: &anyhow::Error) {
+        self.inner
+            .mrs
+            .entry(device.to_string())
+            .or_insert_with(|| MrEntry::Failed(format!("{error:#}")));
     }
 
     /// Copy `dst.len()` bytes from this memory region starting at `offset`
@@ -608,7 +684,7 @@ impl KeepaliveLocalMemory {
     }
 
     /// Pair off a [`WeakLocalMemory`] that shares this handle's
-    /// [`LocalMemoryInner`] (and therefore the same MR slot and
+    /// [`LocalMemoryInner`] (and therefore the same registrations and
     /// access lock). Returns `None` when the underlying [`Keepalive`]
     /// does not provide a weak form.
     pub fn downgrade(&self) -> Option<WeakLocalMemory> {
@@ -623,7 +699,7 @@ impl KeepaliveLocalMemory {
 /// Non-pinning counterpart of [`KeepaliveLocalMemory`].
 ///
 /// Holds the shared [`LocalMemoryInner`] (so a re-promoted strong
-/// handle sees the same MR slot and access lock) plus a
+/// handle sees the same registrations and access lock) plus a
 /// [`WeakKeepalive`] that can be upgraded to a fresh
 /// [`Arc<dyn Keepalive>`] as long as the referent is still alive.
 #[derive(Clone)]
@@ -698,6 +774,87 @@ mod tests {
             "a device pointer should resolve to the ordinal that owns it",
         );
         alloc.try_free();
+    }
+
+    // -- per-device registrations --
+
+    #[test]
+    fn registrations_are_independent_per_device() {
+        let mem = host_keepalive_mem(vec![0; 8].into_boxed_slice());
+        let first = mem
+            .install_mr(IbvMemoryRegionView::for_test("mlx5_0", 10))
+            .unwrap();
+        assert_eq!(first.device_name, "mlx5_0");
+        mem.install_mr(IbvMemoryRegionView::for_test("mlx5_1", 20))
+            .unwrap();
+
+        // Each device answers with its own registration; keys issued by one
+        // device's protection domain mean nothing to another.
+        for (device, key) in [("mlx5_0", 10), ("mlx5_1", 20)] {
+            let view = mem.registered_mr(device).unwrap().unwrap();
+            assert_eq!(view.device_name, device);
+            assert_eq!(
+                view.lkey, key,
+                "{device} answered with another device's key"
+            );
+        }
+        assert!(mem.registered_mr("mlx5_2").unwrap().is_none());
+    }
+
+    #[test]
+    fn install_mr_keeps_the_registration_already_in_force() {
+        let mem = host_keepalive_mem(vec![0; 8].into_boxed_slice());
+        mem.install_mr(IbvMemoryRegionView::for_test("mlx5_0", 10))
+            .unwrap();
+        // A second registration of the same region on the same device loses:
+        // holders of the first view keep addressing through it.
+        let second = mem
+            .install_mr(IbvMemoryRegionView::for_test("mlx5_0", 20))
+            .unwrap();
+        assert_eq!(second.lkey, 10, "the loser's key must not be handed back");
+        assert_eq!(
+            mem.registered_mr("mlx5_0").unwrap().unwrap().lkey,
+            10,
+            "nor recorded for later resolutions",
+        );
+    }
+
+    #[test]
+    fn install_mr_leaves_a_recorded_failure_standing() {
+        let mem = host_keepalive_mem(vec![0; 8].into_boxed_slice());
+        mem.record_mr_failure("mlx5_0", &anyhow::anyhow!("out of memory keys"));
+        // Reached when two callers register the same region on the same device
+        // at once and only one of them fails.
+        let error = format!(
+            "{:#}",
+            mem.install_mr(IbvMemoryRegionView::for_test("mlx5_0", 10))
+                .expect_err("installing over a recorded failure should fail")
+        );
+        assert!(
+            error.contains("out of memory keys"),
+            "the error should carry the recorded failure: {error}",
+        );
+        assert!(
+            mem.registered_mr("mlx5_0").is_err(),
+            "the recorded failure should still be what the device answers with",
+        );
+    }
+
+    #[test]
+    fn a_recorded_failure_is_reported_rather_than_retried() {
+        let mem = host_keepalive_mem(vec![0; 8].into_boxed_slice());
+        mem.record_mr_failure("mlx5_0", &anyhow::anyhow!("out of memory keys"));
+        let error = format!(
+            "{:#}",
+            mem.registered_mr("mlx5_0")
+                .expect_err("a recorded failure should surface")
+        );
+        assert!(
+            error.contains("out of memory keys"),
+            "the error should carry the original failure: {error}",
+        );
+        // Other devices are unaffected by one device's failure.
+        assert!(mem.registered_mr("mlx5_1").unwrap().is_none());
     }
 
     #[test]


### PR DESCRIPTION
Summary:

Change the name of `IbvBuffer` to `IbvRemoteMemoryRegionView` to more accurately reflect what it is, and remove extraneous information from it. Signatures that used to take instances of `IbvBuffer` to represent both local and remote memory now take `IbvMemoryRegionView` and `IbvRemoteMemoryRegionView`, respectively.

Differential Revision: D115616080


