### PR TITLE
Carry a list of registrations per remote buffer (#4652)

### DIFF
--- a/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
+++ b/monarch_rdma/examples/cuda_ping_pong/src/cuda_ping_pong.rs
@@ -86,6 +86,7 @@ use monarch_rdma::RdmaManagerMessageClient;
 use monarch_rdma::RdmaRemoteBuffer;
 use monarch_rdma::backend::ibverbs::device_selection::IbvDeviceTarget;
 use monarch_rdma::backend::ibverbs::manager_actor::RawQueuePair;
+use monarch_rdma::backend::ibverbs::memory_region::IbvRemoteMemoryRegionView;
 use monarch_rdma::backend::ibverbs::primitives::IbvQpInfo;
 use monarch_rdma::backend::ibverbs::queue_pair::legacy::IbvQueuePair;
 use monarch_rdma::cu_check;
@@ -145,6 +146,17 @@ pub fn ping_pong(
     let result = unsafe { launchPingPong(params, iterations, initial_length, device_id) };
 
     if result == 0 { Ok(()) } else { Err(result) }
+}
+
+/// The NIC serving a buffer's first registration. A buffer may be registered on
+/// several; this example drives a single queue pair, and taking the first entry
+/// is a stable choice because the registrations come back in device-name order.
+fn first_device(buffers: &[IbvRemoteMemoryRegionView]) -> Result<String, anyhow::Error> {
+    Ok(buffers
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("buffer carries no ibverbs registration"))?
+        .device_name
+        .clone())
 }
 
 // HACK — `NoKeepalive` keeps nothing alive. The CUDA allocation
@@ -558,7 +570,7 @@ impl Handler<CreateRawQp> for CudaRdmaActor {
         manager_handle.try_post(
             cx,
             RawQueuePair {
-                self_device: local_ctx.buffer.device_name.clone(),
+                self_device: first_device(&local_ctx.buffers)?,
                 reply: reply_handle,
             },
         )?;
@@ -621,11 +633,12 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
         // Resolve the local/remote buffer transport details for the ping-pong.
         // The local side goes through the registration itself: the wire view a
         // peer would get carries no `lkey`.
-        let local_device = local_buffer
-            .resolve_mlx()
-            .ok_or_else(|| anyhow::anyhow!("Mellanox backend not found for local buffer"))?
-            .buffer
-            .device_name;
+        let local_device = first_device(
+            &local_buffer
+                .resolve_mlx()
+                .ok_or_else(|| anyhow::anyhow!("Mellanox backend not found for local buffer"))?
+                .buffers,
+        )?;
         let local_ibv = self
             .local_memory
             .as_ref()
@@ -635,7 +648,10 @@ impl Handler<PerformPingPong> for CudaRdmaActor {
         let remote_ibv = remote_buffer
             .resolve_mlx()
             .ok_or_else(|| anyhow::anyhow!("Mellanox backend not found for remote buffer"))?
-            .buffer;
+            .buffers
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("remote buffer carries no registration"))?;
 
         // The queue pair was created by `CreateRawQp` and connected by
         // `ConnectRawQp` before this message; drive the doorbell on it.

--- a/monarch_rdma/src/backend/ibverbs.rs
+++ b/monarch_rdma/src/backend/ibverbs.rs
@@ -50,7 +50,9 @@ use crate::local_memory::KeepaliveLocalMemory;
 pub struct IbvOp<M: Referable = IbvManagerActor<MlxDevice>> {
     pub op_type: RdmaOpType,
     pub local_memory: KeepaliveLocalMemory,
-    pub remote_buffer: IbvRemoteMemoryRegionView,
+    /// One memory registration for each NIC that the target memory
+    /// on the remote can be reached through.
+    pub remote_buffers: Vec<IbvRemoteMemoryRegionView>,
     pub remote_manager: ActorRef<M>,
 }
 
@@ -61,7 +63,7 @@ impl<M: Referable> Clone for IbvOp<M> {
         Self {
             op_type: self.op_type,
             local_memory: self.local_memory.clone(),
-            remote_buffer: self.remote_buffer.clone(),
+            remote_buffers: self.remote_buffers.clone(),
             remote_manager: self.remote_manager.clone(),
         }
     }

--- a/monarch_rdma/src/backend/ibverbs/device_selection.rs
+++ b/monarch_rdma/src/backend/ibverbs/device_selection.rs
@@ -132,6 +132,11 @@ pub fn get_pci_address(device: &IbvDeviceInfo) -> Result<PCIAddress> {
 /// included, since the PCI/NUMA topology is fixed for the process lifetime. A
 /// host whose links are all down at the first call therefore keeps an empty
 /// answer for the rest of the process.
+///
+/// The NICs come back in lexicographic order by name, per
+/// [`compute_optimal_ibv_devices`]; the cache hands back the same order.
+/// Callers rely on it to agree with their peers on which of several tied NICs to
+/// use without exchanging anything.
 pub fn select_optimal_ibv_devices<I: IbvDeviceImpl>(
     location: MemoryLocation,
 ) -> Result<Vec<IbvDeviceInfo>> {
@@ -146,7 +151,13 @@ pub fn select_optimal_ibv_devices<I: IbvDeviceImpl>(
     Ok(result)
 }
 
-/// Uncached core of [`select_optimal_ibv_devices`].
+/// Uncached core of [`select_optimal_ibv_devices`], returning the tied-best NICs
+/// in lexicographic order by device name.
+///
+/// That order is part of the contract rather than an artifact of how the devices
+/// were enumerated: two processes ranking the same [`MemoryLocation`] over the
+/// same NICs produce the same sequence, so each can pick the same element — the
+/// first, say — and know the other picked its counterpart.
 fn compute_optimal_ibv_devices<I: IbvDeviceImpl>(
     location: MemoryLocation,
 ) -> Result<Vec<IbvDeviceInfo>> {
@@ -185,6 +196,7 @@ fn compute_optimal_ibv_devices<I: IbvDeviceImpl>(
         best = Some(path);
         devices.push(nic);
     }
+    devices.sort_by(|a, b| a.name().cmp(b.name()));
     Ok(devices)
 }
 
@@ -240,6 +252,11 @@ fn cap_by_port_speed(path: PciPath, port_speed_mbytes_per_sec: NonZeroU32) -> Pc
 /// location. Both arms are scoped to backend `I`, so a name belonging to a
 /// different backend resolves to `Ok(None)`.
 ///
+/// Where several NICs tie for a memory location, this takes the first, which by
+/// [`select_optimal_ibv_devices`]'s ordering is the lexicographically smallest
+/// name. Two processes pinning the same location over the same NICs therefore
+/// resolve to the same device.
+///
 /// `Ok(None)` means "no such device"; an error means the target could not be
 /// evaluated at all, which for a GPU location includes CUDA not being
 /// initialized in this process.
@@ -258,10 +275,11 @@ pub fn resolve_target<I: IbvDeviceImpl>(target: &IbvDeviceTarget) -> Result<Opti
 
 /// The NICs of backend `I` for each CUDA runtime ordinal, indexed by ordinal.
 ///
-/// Each entry holds every NIC tied for the best path to that ordinal, so it is
-/// empty when no NIC could be ranked against it. Errors only when the ordinals
-/// themselves cannot be enumerated, which in practice means the CUDA driver is
-/// not initialized in this process.
+/// Each entry holds every NIC tied for the best path to that ordinal, in
+/// lexicographic order by name per [`select_optimal_ibv_devices`], so an entry
+/// is empty when no NIC could be ranked against its ordinal. Errors only when
+/// the ordinals themselves cannot be enumerated, which in practice means the
+/// CUDA driver is not initialized in this process.
 pub fn get_cuda_device_to_ibv_devices<I: IbvDeviceImpl>() -> Result<Vec<Vec<IbvDeviceInfo>>> {
     (0..cuda_device_count()?)
         .map(|ordinal| select_optimal_ibv_devices::<I>(MemoryLocation::Gpu(Some(ordinal as u32))))
@@ -270,6 +288,7 @@ pub fn get_cuda_device_to_ibv_devices<I: IbvDeviceImpl>() -> Result<Vec<Vec<IbvD
 
 #[cfg(test)]
 mod tests {
+    use super::super::mlx_device::MlxDevice;
     use super::*;
 
     #[test]
@@ -326,6 +345,25 @@ mod tests {
             configured_ibverbs_target().expect("configured target should be valid"),
             Some(IbvDeviceTarget::nic("mlx5_1")),
         );
+    }
+
+    #[test]
+    fn optimal_devices_come_back_in_name_order() {
+        // Peers pair their NICs by position in this list, so the order is part of
+        // the contract rather than a detail of how devices were enumerated. A
+        // host with no NIC trivially satisfies it, which is why this is not
+        // gated on hardware.
+        for location in [MemoryLocation::Cpu(None), MemoryLocation::Cpu(Some(0))] {
+            let names: Vec<String> = select_optimal_ibv_devices::<MlxDevice>(location)
+                .expect("ranking CPU memory needs no CUDA")
+                .iter()
+                .map(|nic| nic.name().clone())
+                .collect();
+            assert!(
+                names.is_sorted(),
+                "{location:?} ranked NICs out of order: {names:?}",
+            );
+        }
     }
 
     #[test]

--- a/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_test_utils.rs
@@ -30,7 +30,6 @@ use hyperactor_config::Flattrs;
 
 use super::device_selection::IbvDeviceTarget;
 use super::manager_actor::IbvManagerActor;
-use super::manager_actor::IbvManagerMessageClient;
 use super::memory_region::IbvMemoryRegionView;
 use super::memory_region::IbvRemoteMemoryRegionView;
 use super::mlx_device::MlxDevice;
@@ -39,6 +38,7 @@ use super::queue_pair::legacy::IbvQueuePair;
 use crate::IbvConfig;
 use crate::RdmaManagerMessageClient;
 use crate::RdmaRemoteBuffer;
+use crate::ReleaseBufferClient;
 use crate::local_memory::Keepalive;
 use crate::local_memory::KeepaliveLocalMemory;
 use crate::rdma_manager_actor::RdmaManagerActor;
@@ -570,7 +570,10 @@ async fn local_view(
         .await?
         .resolve_mlx()
         .ok_or_else(|| anyhow::anyhow!("local buffer has no Mellanox backend"))?
-        .buffer
+        .buffers
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("local buffer carries no registration"))?
         .device_name;
     mem.registered_mr(&device)?
         .ok_or_else(|| anyhow::anyhow!("request_buffer should have registered on {device}"))
@@ -737,10 +740,25 @@ impl DoorbellTestEnv {
             cuda_actor_2 = Some(cuda_actor_ref_2);
         }
 
+        // Both sides pin a NIC, so each buffer carries exactly one registration.
         let ctx_1 = rdma_handle_1.resolve_mlx().expect("buffer 1 is Mellanox");
-        let (ibv_actor_1, remote_mrv_1) = (ctx_1.manager, ctx_1.buffer);
+        let (ibv_actor_1, remote_mrv_1) = (
+            ctx_1.manager,
+            ctx_1
+                .buffers
+                .into_iter()
+                .next()
+                .expect("buffer 1 is registered"),
+        );
         let ctx_2 = rdma_handle_2.resolve_mlx().expect("buffer 2 is Mellanox");
-        let (ibv_actor_2, remote_mrv_2) = (ctx_2.manager, ctx_2.buffer);
+        let (ibv_actor_2, remote_mrv_2) = (
+            ctx_2.manager,
+            ctx_2
+                .buffers
+                .into_iter()
+                .next()
+                .expect("buffer 2 is registered"),
+        );
         let local_mrv_1 = local_view(&actor_1, &instance_1, &local_memory_1).await?;
         let local_mrv_2 = local_view(&actor_2, &instance_2, &local_memory_2).await?;
         let ibv_handle_1: ActorHandle<IbvManagerActor<MlxDevice>> = ibv_actor_1
@@ -796,11 +814,13 @@ impl DoorbellTestEnv {
     }
 
     pub async fn cleanup(self) -> Result<(), anyhow::Error> {
-        self.ibv_actor_1
+        // Release through the owning manager, which is what holds the memory
+        // handles the registrations hang off.
+        self.actor_1
             .release_buffer(&self.client_1, self.rdma_handle_1.id)
             .await?;
 
-        self.ibv_actor_2
+        self.actor_2
             .release_buffer(&self.client_2, self.rdma_handle_2.id)
             .await?;
         Ok(())

--- a/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/doorbell_tests.rs
@@ -133,6 +133,9 @@ mod tests {
 
     #[timed_test::async_timed_test(timeout_secs = 60)]
     async fn test_rdma_write_separate_devices_db_device_trigger() -> Result<(), anyhow::Error> {
+        if std::env::var("MONARCH_RDMA_RUN_ISOLATED").is_err() {
+            return Ok(());
+        }
         if is_cpu_only_mode() {
             println!("Skipping CUDA test in CPU-only mode");
             return Ok(());

--- a/monarch_rdma/src/backend/ibverbs/manager_actor.rs
+++ b/monarch_rdma/src/backend/ibverbs/manager_actor.rs
@@ -37,7 +37,6 @@ use hyperactor::Instance;
 use hyperactor::OncePortHandle;
 use hyperactor::OncePortRef;
 use hyperactor::PortHandle;
-use hyperactor::RefClient;
 use hyperactor::actor::Referable;
 use serde::Deserialize;
 use serde::Serialize;
@@ -62,6 +61,7 @@ use super::queue_pair::OpResult;
 use super::queue_pair::ProcessOps;
 use super::queue_pair::QpKey;
 use super::queue_pair::QueuePairActor;
+use super::queue_pair::QueuePairOp;
 use super::queue_pair::legacy;
 use crate::RdmaOp;
 use crate::RdmaTransportLevel;
@@ -123,30 +123,20 @@ pub struct RawQueuePair {
     pub reply: OncePortHandle<Result<legacy::IbvQueuePair, String>>,
 }
 
-/// Cross-proc messages handled by [`IbvManagerActor`].
-#[derive(Handler, HandleClient, RefClient, Debug, Serialize, Deserialize, Named)]
-pub enum IbvManagerMessage {
-    /// Release a buffer registration by `remote_buf_id`. Fire-and-forget
-    /// (no reply port) to avoid blocking the caller during teardown.
-    ReleaseBuffer { remote_buf_id: usize },
-}
-wirevalue::register_type!(IbvManagerMessage);
-
 /// Local-only messages for [`IbvManagerActor`].
 #[derive(Handler, HandleClient, Debug)]
 pub enum IbvManagerLocalMessage {
-    /// Register a remote-facing buffer's MR and return its
-    /// [`IbvRemoteMemoryRegionView`]. Called by
+    /// Register `local`'s MRs and reply with one
+    /// [`IbvRemoteMemoryRegionView`] per registration. Called by
     /// [`crate::rdma_manager_actor::RdmaManagerActor::request_buffer`]
     /// at buffer-creation time.
     ///
-    /// The MR lives in [`IbvManagerActor::buffer_registrations`] and
-    /// is deregistered on [`IbvManagerMessage::ReleaseBuffer`].
+    /// The registrations live on `local` itself, so they stay in force for as
+    /// long as any holder of that handle does.
     RegisterRemoteBuffer {
-        remote_buf_id: usize,
         local: KeepaliveLocalMemory,
         #[reply]
-        reply: OncePortHandle<Result<IbvRemoteMemoryRegionView, String>>,
+        reply: OncePortHandle<Result<Vec<IbvRemoteMemoryRegionView>, String>>,
     },
 }
 
@@ -165,7 +155,6 @@ const DEFAULT_DOMAIN: &str = "default";
 #[derive(Debug)]
 #[hyperactor::export(
     handlers = [
-        IbvManagerMessage,
         CreatePeerQueuePair<IbvManagerActor<I>>,
     ],
 )]
@@ -194,13 +183,6 @@ pub struct IbvManagerActor<I: IbvDeviceImpl> {
     devices: HashMap<String, IbvDevice<I>>,
 
     config: IbvConfig,
-
-    /// Map from buffer_id to the registered MR view. The view keeps the MR (and
-    /// its PD) alive for the lifetime of the registration; `ReleaseBuffer` drops
-    /// the entry, and the FFI resources are released by the `Arc`s' `Drop`s once
-    /// no other holder of the view remains. The wire-facing
-    /// [`IbvRemoteMemoryRegionView`] is derived from the view on demand.
-    buffer_registrations: HashMap<usize, IbvMemoryRegionView>,
 }
 
 #[async_trait]
@@ -239,9 +221,8 @@ impl<I: IbvDeviceImpl> Drop for IbvManagerActor<I> {
             let _ = handle.drain_and_stop("IbvManagerActor dropped");
         }
 
-        // The remaining fields (`peer_created_qps`,
-        // `buffer_registrations`, `devices`) free their FFI resources
-        // through their elements' `Drop`s when this struct is dropped.
+        // The remaining fields (`peer_created_qps`, `devices`) free their FFI
+        // resources through their elements' `Drop`s when this struct is dropped.
     }
 }
 
@@ -294,7 +275,6 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
             peer_created_qps: HashMap::new(),
             devices: HashMap::new(),
             config,
-            buffer_registrations: HashMap::new(),
         };
 
         Ok(actor)
@@ -467,35 +447,6 @@ impl<I: IbvDeviceImpl> IbvManagerActor<I> {
 }
 
 #[async_trait]
-impl<I: IbvDeviceImpl> IbvManagerMessageHandler for IbvManagerActor<I> {
-    async fn release_buffer(
-        &mut self,
-        _cx: &Context<Self>,
-        remote_buf_id: usize,
-    ) -> Result<(), anyhow::Error> {
-        // Dropping the entry releases the manager's `Arc` clones on
-        // the view's MR and PD; FFI cleanup happens via their `Drop`s
-        // once the last referencing view is gone.
-        self.buffer_registrations.remove(&remote_buf_id);
-        Ok(())
-    }
-}
-
-// `#[hyperactor::handle(IbvManagerMessage)]` would generate a
-// non-generic `impl Handler<...> for IbvManagerActor<I>` that
-// can't see `I`; we write the generic delegation by hand.
-#[async_trait]
-impl<I: IbvDeviceImpl> Handler<IbvManagerMessage> for IbvManagerActor<I> {
-    async fn handle(
-        &mut self,
-        cx: &Context<Self>,
-        message: IbvManagerMessage,
-    ) -> Result<(), anyhow::Error> {
-        <Self as IbvManagerMessageHandler>::handle(self, cx, message).await
-    }
-}
-
-#[async_trait]
 impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
     async fn handle(&mut self, cx: &Context<Self>, msg: SubmitOps<I>) -> Result<(), anyhow::Error> {
         let SubmitOps { ops, reply } = msg;
@@ -505,8 +456,20 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
         // one-item `ProcessOps` to that QP. The QP can then post and
         // poll op `i` while we run `resolve_local_mr` for op `i+1`.
         for (i, op) in ops.into_iter().enumerate() {
-            let mrv = match self.resolve_local_mr(&op.local_memory) {
-                Ok(mrv) => mrv,
+            // One pair per op for now: the peer's first registration against
+            // whichever NIC this side resolves the local MR on.
+            let Some(remote) = op.remote_buffers.first().cloned() else {
+                reply.try_post(
+                    cx,
+                    OpResult {
+                        op_idx: i,
+                        result: Err("the remote buffer carries no ibverbs registration".to_owned()),
+                    },
+                )?;
+                continue;
+            };
+            let self_device = match self.resolve_local_mr(&op.local_memory) {
+                Ok(mrv) => mrv.device_name.clone(),
                 Err(e) => {
                     reply.try_post(
                         cx,
@@ -519,12 +482,11 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
                 }
             };
             let qp_key = QpKey {
-                self_device: mrv.device_name.clone(),
+                self_device,
                 other_id: op.remote_manager.actor_addr().id().clone(),
-                other_device: op.remote_buffer.device_name.clone(),
+                other_device: remote.device_name.clone(),
             };
-            let peer_manager = op.remote_manager.clone();
-            let handle = match self.ensure_qp_actor(cx, &qp_key, peer_manager) {
+            let handle = match self.ensure_qp_actor(cx, &qp_key, op.remote_manager) {
                 Ok(h) => h,
                 Err(e) => {
                     reply.try_post(
@@ -540,7 +502,12 @@ impl<I: IbvDeviceImpl> Handler<SubmitOps<I>> for IbvManagerActor<I> {
             handle.try_post(
                 cx,
                 ProcessOps {
-                    items: vec![(i, op, mrv)],
+                    items: vec![QueuePairOp {
+                        op_idx: i,
+                        op_type: op.op_type,
+                        local_memory: op.local_memory,
+                        remote,
+                    }],
                     reply: reply.clone(),
                 },
             )?;
@@ -597,28 +564,21 @@ impl<I: IbvDeviceImpl> IbvManagerLocalMessageHandler for IbvManagerActor<I> {
     async fn register_remote_buffer(
         &mut self,
         _cx: &Context<Self>,
-        remote_buf_id: usize,
         local: KeepaliveLocalMemory,
-    ) -> Result<Result<IbvRemoteMemoryRegionView, String>, anyhow::Error> {
-        if let Some(mrv) = self.buffer_registrations.get(&remote_buf_id) {
-            return Ok(Ok(IbvRemoteMemoryRegionView::from(mrv)));
-        }
-        // `resolve_local_mr` installs the view in `local`'s shared MR
-        // slot, so every clone of this handle — including the one the
-        // caller holds — reuses this registration instead of registering
-        // the same region again.
-        let mrv = match self.resolve_local_mr(&local) {
-            Ok(v) => v,
-            Err(e) => return Ok(Err(e.to_string())),
-        };
-        let buf = IbvRemoteMemoryRegionView::from(&mrv);
-        self.buffer_registrations.insert(remote_buf_id, mrv);
-        Ok(Ok(buf))
+    ) -> Result<Result<Vec<IbvRemoteMemoryRegionView>, String>, anyhow::Error> {
+        // The registration is installed on `local`'s shared map, so every clone
+        // of this handle — including the one the caller holds — reuses it rather
+        // than registering the same region on that device again.
+        Ok(self
+            .resolve_local_mr(&local)
+            .map(|mrv| vec![IbvRemoteMemoryRegionView::from(&mrv)])
+            .map_err(|error| format!("{error:#}")))
     }
 }
 
-// `#[hyperactor::handle(IbvManagerLocalMessage)]` analogue, written
-// generically; see the `IbvManagerMessage` block above.
+// `#[hyperactor::handle(IbvManagerLocalMessage)]` would generate a non-generic
+// `impl Handler<...> for IbvManagerActor<I>` that can't see `I`; we write the
+// generic delegation by hand.
 #[async_trait]
 impl<I: IbvDeviceImpl> Handler<IbvManagerLocalMessage> for IbvManagerActor<I> {
     async fn handle(
@@ -650,13 +610,17 @@ impl<I: IbvDeviceImpl> std::ops::Deref for IbvBackend<I> {
     }
 }
 
-/// Serializable per-buffer context for an ibverbs backend: the manager
-/// to route ops through and the wire description of the registered MR.
+/// Serializable per-buffer context for an ibverbs backend: the manager to route
+/// ops through and the wire description of every MR the buffer is registered
+/// under, one per NIC serving it.
+///
+/// The order is [`select_optimal_ibv_devices`]'s, so an initiator that takes,
+/// say, the first entry picks the same NIC the owner would have named first.
 #[derive(Serialize, Deserialize, Named)]
 #[serde(bound = "")]
 pub struct IbvRemoteBackendContext<I: IbvDeviceImpl> {
     pub manager: ActorRef<IbvManagerActor<I>>,
-    pub buffer: IbvRemoteMemoryRegionView,
+    pub buffers: Vec<IbvRemoteMemoryRegionView>,
 }
 
 // `Clone` and `Debug` are hand-rolled to avoid the spurious `I: Clone`
@@ -666,7 +630,7 @@ impl<I: IbvDeviceImpl> Clone for IbvRemoteBackendContext<I> {
     fn clone(&self) -> Self {
         Self {
             manager: self.manager.clone(),
-            buffer: self.buffer.clone(),
+            buffers: self.buffers.clone(),
         }
     }
 }
@@ -675,7 +639,7 @@ impl<I: IbvDeviceImpl> std::fmt::Debug for IbvRemoteBackendContext<I> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IbvRemoteBackendContext")
             .field("manager", &self.manager)
-            .field("buffer", &self.buffer)
+            .field("buffers", &self.buffers)
             .finish()
     }
 }
@@ -721,26 +685,29 @@ where
     async fn register_remote_buffer(
         &self,
         cx: &(impl hyperactor::context::Actor + Send + Sync),
-        remote_buf_id: usize,
+        _remote_buf_id: usize,
         local: KeepaliveLocalMemory,
     ) -> Result<IbvRemoteBackendContext<I>> {
-        let buffer = self
+        let buffers = self
             .0
-            .register_remote_buffer(cx, remote_buf_id, local)
+            .register_remote_buffer(cx, local)
             .await?
             .map_err(|e| anyhow::anyhow!(e))?;
         Ok(IbvRemoteBackendContext {
             manager: self.0.bind(),
-            buffer,
+            buffers,
         })
     }
 
+    /// No-op: this backend holds no per-buffer state. A region's registrations
+    /// live on the [`KeepaliveLocalMemory`] they were made for, so a buffer is
+    /// released by its owner dropping that handle.
     async fn release_buffer(
         &self,
-        cx: &(impl hyperactor::context::Actor + Send + Sync),
-        remote_buf_id: usize,
+        _cx: &(impl hyperactor::context::Actor + Send + Sync),
+        _remote_buf_id: usize,
     ) -> Result<()> {
-        self.0.release_buffer(cx, remote_buf_id).await
+        Ok(())
     }
 
     /// Submit a batch of RDMA operations.
@@ -770,7 +737,7 @@ where
             ibv_ops.push(IbvOp {
                 op_type: op.op_type,
                 local_memory: op.local.clone(),
-                remote_buffer: ctx.buffer,
+                remote_buffers: ctx.buffers,
                 remote_manager: ctx.manager,
             });
         }
@@ -1891,14 +1858,14 @@ mod tests {
                 .backends
                 .mlx
                 .as_mut()
-                .map(|ctx| &mut ctx.buffer),
+                .map(|ctx| &mut ctx.buffers),
             bogus_remote
                 .backends
                 .efa
                 .as_mut()
-                .map(|ctx| &mut ctx.buffer),
+                .map(|ctx| &mut ctx.buffers),
         ];
-        for buf in bufs.into_iter().flatten() {
+        for buf in bufs.into_iter().flatten().flatten() {
             buf.rkey = 0xdead_beef;
             buf.addr = 0xdead_0000;
         }

--- a/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
+++ b/monarch_rdma/src/backend/ibverbs/mlx5dv_tests.rs
@@ -127,10 +127,17 @@ async fn test_indirect_mkey_read_at_large_offset() -> Result<(), anyhow::Error> 
     Ok(())
 }
 
-/// Extract the ibverbs `rkey` from a remote buffer.
+/// Extract the ibverbs `rkey` from a remote buffer. These tests pin one NIC,
+/// so the buffer carries exactly one registration.
 fn ibv_rkey_of(remote: &crate::RdmaRemoteBuffer) -> Result<u32, anyhow::Error> {
     let ctx = remote.resolve_mlx().expect("remote buffer is Mellanox");
-    Ok(ctx.buffer.rkey)
+    let [view] = ctx.buffers.as_slice() else {
+        anyhow::bail!(
+            "expected one registration on the pinned NIC, got {:?}",
+            ctx.buffers,
+        );
+    };
+    Ok(view.rkey)
 }
 
 /// Integration test for the indirect-mkey segment-growth path.

--- a/monarch_rdma/src/backend/ibverbs/queue_pair.rs
+++ b/monarch_rdma/src/backend/ibverbs/queue_pair.rs
@@ -43,7 +43,6 @@ use serde::Deserialize;
 use serde::Serialize;
 use typeuri::Named;
 
-use super::IbvOp;
 use super::domain::IbvDomain;
 use super::domain::IbvDomainImpl;
 use super::manager_actor::CreatePeerQueuePair;
@@ -840,18 +839,26 @@ pub(super) struct OpResult {
     pub(super) result: Result<(), String>,
 }
 
-/// Local-only message: enqueue a batch of ops on this QP. As each
-/// op resolves the actor sends one `(op_idx, result)` tuple on
-/// `reply` — `op_idx` is the original index of the op in the
-/// user-facing `IbvManagerActor::submit_ops` request, so the receiver
-/// can correlate replies across batches that were sliced per-QP. The
-/// inner `Result` is `Ok(())` if every WR for the op completed
-/// successfully, otherwise `Err` carrying the first per-WR error
-/// observed (held back until the op's other WRs also report, so the
-/// MR registration outlives the data path).
+/// One op the manager has assigned to a queue pair.
 #[derive(Debug)]
-pub(super) struct ProcessOps<M: Referable> {
-    pub(super) items: Vec<(usize, IbvOp<M>, IbvMemoryRegionView)>,
+pub(super) struct QueuePairOp {
+    /// Index of the op in the caller's `submit` batch, echoed back in the
+    /// [`OpResult`] so the manager can correlate replies across the batches it
+    /// sliced per QP.
+    pub(super) op_idx: usize,
+    pub(super) op_type: RdmaOpType,
+    pub(super) local_memory: KeepaliveLocalMemory,
+    pub(super) remote: IbvRemoteMemoryRegionView,
+}
+
+/// Local-only message: enqueue a batch of ops on this QP. As each op resolves
+/// the actor sends one [`OpResult`] on `reply`. Its inner `Result` is `Ok(())`
+/// if every WR for the op completed successfully, otherwise `Err` carrying the
+/// first per-WR error observed (held back until the op's other WRs also report,
+/// so the memory handle and MR registration outlive the data path).
+#[derive(Debug)]
+pub(super) struct ProcessOps {
+    pub(super) items: Vec<QueuePairOp>,
     pub(super) reply: PortHandle<OpResult>,
 }
 
@@ -861,10 +868,8 @@ struct Tick;
 
 /// An op accepted by the actor but not yet posted to the QP.
 #[derive(Debug)]
-struct PendingOp<M: Referable> {
-    op_idx: usize,
-    op: IbvOp<M>,
-    mrv: IbvMemoryRegionView,
+struct PendingOp {
+    op: QueuePairOp,
     reply: PortHandle<OpResult>,
     /// WR count this op will issue when posted, computed once at
     /// construction so retries from a credit head-block don't redo
@@ -879,18 +884,13 @@ struct PostedOpEntry {
     op_idx: usize,
     pending_wrs: HashSet<u64>,
     is_read: bool,
-    /// Kept alive so the MR registration outlives every in-flight
-    /// WR touching it. Field is intentionally unread.
-    _mrv: IbvMemoryRegionView,
-    /// Kept alive so the *memory* outlives every in-flight WR touching
-    /// it: `_mrv` above holds the registration open, but an `ibv_mr`
-    /// does not keep its backing pages mapped. Field is intentionally
-    /// unread.
+    /// Kept alive so both the memory and its registration outlive every
+    /// in-flight WR touching it.
     _local_memory: KeepaliveLocalMemory,
     reply: PortHandle<OpResult>,
     /// First per-WR error observed for this op. The op's final reply is
-    /// held back until `pending_wrs.is_empty()`, so `_mrv` and
-    /// `_local_memory` outlive every WR still in flight.
+    /// held back until `pending_wrs.is_empty()`, so `_local_memory` outlives
+    /// every WR still in flight.
     first_error: Option<String>,
 }
 
@@ -928,7 +928,7 @@ pub(super) struct QueuePairActor<M: Manager, Qp: IbvQueuePair> {
     /// head op bumps against either credit cap, ops queued behind
     /// it stall — a write stuck behind a credit-blocked read is the
     /// known consequence; smarter interleaving is future work.
-    queue: VecDeque<PendingOp<M>>,
+    queue: VecDeque<PendingOp>,
     /// op-id → entry, for tracking WR completion. op-ids are local
     /// to this actor (monotonic counter); they exist so we can
     /// route per-WR completions to the right `PostedOpEntry`
@@ -1007,19 +1007,18 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
     fn try_post_head(&mut self, cx: &Instance<Self>) -> Result<bool, anyhow::Error> {
         let pending = self.queue.pop_front().expect("non-empty queue");
         let PendingOp {
-            op_idx,
             op,
-            mrv,
             reply,
             wrs,
             is_read,
         } = pending;
+        let op_idx = op.op_idx;
 
         // 1. Per-op fatal: op alone exceeds the QP's capacity.
         if wrs > self.max_send_wr {
             let err = format!(
                 "op too large for this QP [op_idx={}, qp_key={:?}, op_type={:?}, wrs={}, max_send_wr={}, local: {:?}, remote: {:?}]",
-                op_idx, self.qp_key, op.op_type, wrs, self.max_send_wr, mrv, op.remote_buffer,
+                op_idx, self.qp_key, op.op_type, wrs, self.max_send_wr, op.local_memory, op.remote,
             );
             reply.try_post(
                 cx,
@@ -1033,7 +1032,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
         if is_read && wrs > self.max_rd_atomic {
             let err = format!(
                 "read op too large for this QP [op_idx={}, qp_key={:?}, wrs={}, max_rd_atomic={}, local: {:?}, remote: {:?}]",
-                op_idx, self.qp_key, wrs, self.max_rd_atomic, mrv, op.remote_buffer,
+                op_idx, self.qp_key, wrs, self.max_rd_atomic, op.local_memory, op.remote,
             );
             reply.try_post(
                 cx,
@@ -1053,9 +1052,7 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
             || (is_read && self.in_flight_reads + wrs > self.max_rd_atomic)
         {
             self.queue.push_front(PendingOp {
-                op_idx,
                 op,
-                mrv,
                 reply,
                 wrs,
                 is_read,
@@ -1063,10 +1060,39 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
             return Ok(false);
         }
 
-        // 3. Post.
+        // 3. Resolve the local side. A QP is bound to one device on each side,
+        //    so the only registration it can address is the one on
+        //    `self_device`: an `lkey` from any other protection domain means
+        //    nothing here.
+        let local = match op.local_memory.registered_mr(&self.qp_key.self_device) {
+            Ok(Some(view)) => view,
+            other => {
+                let err = match other {
+                    Ok(None) => format!(
+                        "local memory is not registered on this QP's device [op_idx={}, qp_key={:?}, local: {:?}]",
+                        op_idx, self.qp_key, op.local_memory,
+                    ),
+                    Err(error) => format!(
+                        "local memory cannot be registered on this QP's device [op_idx={}, qp_key={:?}]: {error:#}",
+                        op_idx, self.qp_key,
+                    ),
+                    Ok(Some(_)) => unreachable!("matched by the arm above"),
+                };
+                reply.try_post(
+                    cx,
+                    OpResult {
+                        op_idx,
+                        result: Err(err),
+                    },
+                )?;
+                return Ok(true);
+            }
+        };
+
+        // 4. Post.
         let post_result = match op.op_type {
-            RdmaOpType::WriteFromLocal => self.qp.put(op.remote_buffer.clone(), mrv.clone()),
-            RdmaOpType::ReadIntoLocal => self.qp.get(mrv.clone(), op.remote_buffer.clone()),
+            RdmaOpType::WriteFromLocal => self.qp.put(op.remote.clone(), local.clone()),
+            RdmaOpType::ReadIntoLocal => self.qp.get(local.clone(), op.remote.clone()),
         };
         let wr_ids = post_result.map_err(|e| {
             anyhow::anyhow!(
@@ -1074,12 +1100,12 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 if is_read { "get" } else { "put" },
                 op_idx,
                 self.qp_key,
-                mrv,
-                op.remote_buffer,
+                local,
+                op.remote,
             )
         })?;
 
-        // 4. Track in-flight state.
+        // 5. Track in-flight state.
         let op_id = self.next_op_id;
         self.next_op_id += 1;
         let mut pending_wrs = HashSet::with_capacity(wr_ids.len());
@@ -1098,7 +1124,6 @@ impl<M: Manager, Qp: IbvQueuePair> QueuePairActor<M, Qp> {
                 op_idx,
                 pending_wrs,
                 is_read,
-                _mrv: mrv,
                 _local_memory: op.local_memory,
                 reply,
                 first_error: None,
@@ -1280,19 +1305,13 @@ impl<M: Manager, Qp: IbvQueuePair> Actor for QueuePairActor<M, Qp> {
 }
 
 #[async_trait]
-impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps<M>> for QueuePairActor<M, Qp> {
-    async fn handle(
-        &mut self,
-        cx: &Context<Self>,
-        msg: ProcessOps<M>,
-    ) -> Result<(), anyhow::Error> {
-        for (op_idx, op, mrv) in msg.items.into_iter() {
+impl<M: Manager, Qp: IbvQueuePair> Handler<ProcessOps> for QueuePairActor<M, Qp> {
+    async fn handle(&mut self, cx: &Context<Self>, msg: ProcessOps) -> Result<(), anyhow::Error> {
+        for op in msg.items.into_iter() {
             let wrs = self.wr_count(op.local_memory.size());
             let is_read = matches!(op.op_type, RdmaOpType::ReadIntoLocal);
             self.queue.push_back(PendingOp {
-                op_idx,
                 op,
-                mrv,
                 reply: msg.reply.clone(),
                 wrs,
                 is_read,
@@ -2009,9 +2028,20 @@ mod tests {
         }
     }
 
+    /// Local memory already registered on [`SELF_DEVICE`], which is what the QP
+    /// resolves to post an op.
     fn fake_local_memory(addr: usize, size: usize) -> KeepaliveLocalMemory {
-        KeepaliveLocalMemory::try_new(Arc::new(FakeKeepalive { addr, size }))
-            .expect("a fake host address has a location")
+        registered(
+            KeepaliveLocalMemory::try_new(Arc::new(FakeKeepalive { addr, size }))
+                .expect("a fake host address has a location"),
+        )
+    }
+
+    /// Install a [`SELF_DEVICE`] registration over the whole of `mem`.
+    fn registered(mem: KeepaliveLocalMemory) -> KeepaliveLocalMemory {
+        mem.install_mr(fake_mrv(mem.addr(), mem.size()))
+            .expect("a fresh handle carries no registration");
+        mem
     }
 
     /// [`Keepalive`] that sets `dropped` when it goes away, so a test can
@@ -2042,55 +2072,49 @@ mod tests {
             size,
             0x1234,
             0x5678,
-            "dev0".to_string(),
+            SELF_DEVICE.to_string(),
             // A null MR keepalive: its `Drop` is a no-op.
             Arc::new(IbvMr::null()),
         )
     }
 
-    /// Build a `QpaMockManager` ref attested to an unrelated proc;
-    /// only used to populate `IbvOp::remote_manager` (the actor
-    /// never sends to it during op processing — it just reads
-    /// `op.remote_buffer`).
-    fn fake_remote_ref() -> ActorRef<QpaMockManager> {
-        let proc_id = hyperactor::id::ProcId::new(
-            hyperactor::id::Uid::Instance(0xc0ffee, None),
-            Some(hyperactor::id::Label::new("remote").unwrap()),
-        );
-        let proc_addr =
-            hyperactor::ProcAddr::new(proc_id, hyperactor::channel::ChannelAddr::Local(1).into());
-        ActorRef::attest(proc_addr.actor_addr("remote-mgr"))
-    }
+    /// Devices of the QP `spawn_ready_actor` builds. The local memory of an op
+    /// must be registered on `SELF_DEVICE` for the QP to post it.
+    const SELF_DEVICE: &str = "mlx5_0";
+    const PEER_DEVICE: &str = "mlx5_0";
 
-    fn make_op(op_type: RdmaOpType, addr: usize, size: usize) -> IbvOp<QpaMockManager> {
-        IbvOp {
+    fn make_op(op_idx: usize, op_type: RdmaOpType, addr: usize, size: usize) -> QueuePairOp {
+        QueuePairOp {
+            op_idx,
             op_type,
             local_memory: fake_local_memory(addr, size),
-            remote_buffer: IbvRemoteMemoryRegionView {
+            remote: IbvRemoteMemoryRegionView {
                 rkey: 0,
                 addr: 0x4000_0000,
                 size,
-                device_name: "remote_dev".to_string(),
+                device_name: PEER_DEVICE.to_string(),
             },
-            remote_manager: fake_remote_ref(),
         }
     }
 
     /// Like [`make_op`], but the local memory reports when it drops.
     fn make_op_watching_drop(
+        op_idx: usize,
         op_type: RdmaOpType,
         addr: usize,
         size: usize,
         dropped: Arc<AtomicBool>,
-    ) -> IbvOp<QpaMockManager> {
-        IbvOp {
-            local_memory: KeepaliveLocalMemory::try_new(Arc::new(DropFlagKeepalive {
-                addr,
-                size,
-                dropped,
-            }))
-            .expect("a fake host address has a location"),
-            ..make_op(op_type, addr, size)
+    ) -> QueuePairOp {
+        QueuePairOp {
+            local_memory: registered(
+                KeepaliveLocalMemory::try_new(Arc::new(DropFlagKeepalive {
+                    addr,
+                    size,
+                    dropped,
+                }))
+                .expect("a fake host address has a location"),
+            ),
+            ..make_op(op_idx, op_type, addr, size)
         }
     }
 
@@ -2124,9 +2148,9 @@ mod tests {
         )> {
             let (qp, posted_rx) = MockQp::new(0x1, 0x2);
             let qp_key = QpKey {
-                self_device: "mlx5_0".into(),
+                self_device: SELF_DEVICE.into(),
                 other_id: self.parent_id(),
-                other_device: "mlx5_0".into(),
+                other_device: PEER_DEVICE.into(),
             };
             let handle = self
                 .spawn_actor_with_caps(
@@ -2192,7 +2216,7 @@ mod tests {
     fn submit_ops(
         harness: &QpaHarness,
         actor: &ActorHandle<QueuePairActor<QpaMockManager, MockQp>>,
-        items: Vec<(usize, IbvOp<QpaMockManager>, IbvMemoryRegionView)>,
+        items: Vec<QueuePairOp>,
     ) -> Result<hyperactor::mailbox::PortReceiver<OpResult>> {
         let (reply, rx) = harness.client.mailbox().open_port::<OpResult>();
         actor.try_post(&harness.client, ProcessOps { items, reply })?;
@@ -2235,11 +2259,7 @@ mod tests {
         let harness = QpaHarness::build()?;
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
-        let items = vec![(
-            7usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(0x1000, 4096),
-        )];
+        let items = vec![make_op(7, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
         // wr_ids start at 0 (fresh MockQp), so the single WR is wr 0.
@@ -2249,14 +2269,49 @@ mod tests {
         assert_eq!(lhandle.size, 4096);
         assert_eq!(lhandle.lkey, 0x1234);
         assert_eq!(lhandle.rkey, 0x5678);
-        assert_eq!(lhandle.device_name, "dev0");
+        assert_eq!(lhandle.device_name, SELF_DEVICE);
         assert_eq!(rhandle.addr, 0x4000_0000);
         assert_eq!(rhandle.size, 4096);
-        assert_eq!(rhandle.device_name, "remote_dev");
+        assert_eq!(rhandle.device_name, PEER_DEVICE);
 
         qp.queue_completion(0);
         let replies = collect_replies(&mut rx, 1).await;
         assert_eq!(replies, vec![(7, Ok(()))]);
+        harness.teardown().await;
+        Ok(())
+    }
+
+    /// The QP addresses local memory through its registration on `self_device`,
+    /// which the manager makes before dispatching. An op whose memory carries no
+    /// such registration fails on its own, and nothing is posted.
+    #[timed_test::async_timed_test(timeout_secs = 60)]
+    async fn qpa_rejects_op_not_registered_on_its_device() -> Result<()> {
+        let harness = QpaHarness::build()?;
+        let (actor, _qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
+
+        let items = vec![QueuePairOp {
+            local_memory: KeepaliveLocalMemory::try_new(Arc::new(FakeKeepalive {
+                addr: 0x1000,
+                size: 4096,
+            }))
+            .expect("a fake host address has a location"),
+            ..make_op(3, RdmaOpType::WriteFromLocal, 0x1000, 4096)
+        }];
+        let mut rx = submit_ops(&harness, &actor, items)?;
+
+        let replies = collect_replies(&mut rx, 1).await;
+        let [(op_idx, result)] = replies.as_slice() else {
+            panic!("expected exactly one reply, got {replies:?}");
+        };
+        assert_eq!(*op_idx, 3);
+        let error = result
+            .as_ref()
+            .expect_err("unregistered local memory cannot be posted");
+        assert!(
+            error.contains("not registered on this QP's device"),
+            "the error should name the missing registration: {error}",
+        );
+        assert_no_post(&mut posted_rx, Duration::from_millis(200)).await;
         harness.teardown().await;
         Ok(())
     }
@@ -2267,26 +2322,19 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
         // Two ops: the second exists only to prove the first has left
-        // `try_post_head`, which is where the `IbvOp` — the batch's own
+        // `try_post_head`, which is where the `QueuePairOp` — the batch's own
         // hold on the allocation — drops. Until then the assertion below
         // would pass whether or not the posted entry pins anything.
         let dropped = Arc::new(AtomicBool::new(false));
         let items = vec![
-            (
-                0usize,
-                make_op_watching_drop(
-                    RdmaOpType::WriteFromLocal,
-                    0x1000,
-                    4096,
-                    Arc::clone(&dropped),
-                ),
-                fake_mrv(0x1000, 4096),
+            make_op_watching_drop(
+                0,
+                RdmaOpType::WriteFromLocal,
+                0x1000,
+                4096,
+                Arc::clone(&dropped),
             ),
-            (
-                1usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
+            make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2321,10 +2369,11 @@ mod tests {
 
         // A 3-chunk write (3 * MAX_RDMA_MSG_SIZE) splits into 3 WRs;
         // the op's reply must be held back until all 3 complete.
-        let items = vec![(
-            11usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-            fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
+        let items = vec![make_op(
+            11,
+            RdmaOpType::WriteFromLocal,
+            0x1000,
+            3 * MAX_RDMA_MSG_SIZE,
         )];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2357,10 +2406,11 @@ mod tests {
         // 3-WR write: simulate the second WR failing first; the op's
         // Err must not fire until the other 2 WRs have also reported
         // so the MR registration and local memory outlive every in-flight WR.
-        let items = vec![(
-            42usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-            fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
+        let items = vec![make_op(
+            42,
+            RdmaOpType::WriteFromLocal,
+            0x1000,
+            3 * MAX_RDMA_MSG_SIZE,
         )];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2405,16 +2455,8 @@ mod tests {
         // op_idx 1 is single-WR. One of op_idx 0's WRs fails;
         // op_idx 1's WR succeeds independently.
         let items = vec![
-            (
-                0usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(0x1000, 3 * MAX_RDMA_MSG_SIZE),
-            ),
-            (
-                1usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
+            make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 3 * MAX_RDMA_MSG_SIZE),
+            make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2454,13 +2496,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(8, 2).await?;
 
         let items = (0..3usize)
-            .map(|i| {
-                (
-                    i,
-                    make_op(RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096),
-                    fake_mrv(0x1000 + i * 0x1000, 4096),
-                )
-            })
+            .map(|i| make_op(i, RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096))
             .collect();
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2493,13 +2529,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(2, 0).await?;
 
         let items = (0..3usize)
-            .map(|i| {
-                (
-                    i,
-                    make_op(RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096),
-                    fake_mrv(0x1000 + i * 0x1000, 4096),
-                )
-            })
+            .map(|i| make_op(i, RdmaOpType::ReadIntoLocal, 0x1000 + i * 0x1000, 4096))
             .collect();
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2531,13 +2561,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(2, 8).await?;
 
         let items = (0..4usize)
-            .map(|i| {
-                (
-                    i,
-                    make_op(RdmaOpType::WriteFromLocal, 0x1000 + i * 0x1000, 4096),
-                    fake_mrv(0x1000 + i * 0x1000, 4096),
-                )
-            })
+            .map(|i| make_op(i, RdmaOpType::WriteFromLocal, 0x1000 + i * 0x1000, 4096))
             .collect();
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2579,31 +2603,11 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
         let items = vec![
-            (
-                0usize,
-                make_op(RdmaOpType::ReadIntoLocal, 0x1000, 4096),
-                fake_mrv(0x1000, 4096),
-            ),
-            (
-                1usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
-            (
-                2usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x3000, 4096),
-                fake_mrv(0x3000, 4096),
-            ),
-            (
-                3usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x4000, 4096),
-                fake_mrv(0x4000, 4096),
-            ),
-            (
-                4usize,
-                make_op(RdmaOpType::ReadIntoLocal, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(0x5000, 2 * MAX_RDMA_MSG_SIZE),
-            ),
+            make_op(0, RdmaOpType::ReadIntoLocal, 0x1000, 4096),
+            make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
+            make_op(2, RdmaOpType::WriteFromLocal, 0x3000, 4096),
+            make_op(3, RdmaOpType::WriteFromLocal, 0x4000, 4096),
+            make_op(4, RdmaOpType::ReadIntoLocal, 0x5000, 2 * MAX_RDMA_MSG_SIZE),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2652,32 +2656,16 @@ mod tests {
 
         // Batch A: 2 writes with op_idx 10, 11.
         let batch_a = vec![
-            (
-                10usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-                fake_mrv(0x1000, 4096),
-            ),
-            (
-                11usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
+            make_op(10, RdmaOpType::WriteFromLocal, 0x1000, 4096),
+            make_op(11, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
         let mut rx_a = submit_ops(&harness, &actor, batch_a)?;
 
         // Batch B: 2 writes with op_idx 20, 21. Shares the QP with
         // Batch A — together they sit at 4/4 max_send_wr.
         let batch_b = vec![
-            (
-                20usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x3000, 4096),
-                fake_mrv(0x3000, 4096),
-            ),
-            (
-                21usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x4000, 4096),
-                fake_mrv(0x4000, 4096),
-            ),
+            make_op(20, RdmaOpType::WriteFromLocal, 0x3000, 4096),
+            make_op(21, RdmaOpType::WriteFromLocal, 0x4000, 4096),
         ];
         let mut rx_b = submit_ops(&harness, &actor, batch_b)?;
 
@@ -2706,16 +2694,8 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(1, 1).await?;
 
         let items = vec![
-            (
-                0usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
-                fake_mrv(0x1000, 2 * MAX_RDMA_MSG_SIZE),
-            ),
-            (
-                1usize,
-                make_op(RdmaOpType::WriteFromLocal, 0x2000, 4096),
-                fake_mrv(0x2000, 4096),
-            ),
+            make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 2 * MAX_RDMA_MSG_SIZE),
+            make_op(1, RdmaOpType::WriteFromLocal, 0x2000, 4096),
         ];
         let mut rx = submit_ops(&harness, &actor, items)?;
 
@@ -2744,11 +2724,7 @@ mod tests {
         let (actor, qp, mut posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
         // Post one op so the next poll has something to look at.
-        let items = vec![(
-            0usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(0x1000, 4096),
-        )];
+        let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let _rx = submit_ops(&harness, &actor, items)?;
         let _ = recv_posted(&mut posted_rx).await;
         qp.queue_poll_error(PollCompletionError::for_test("simulated CQ poison"));
@@ -2774,11 +2750,7 @@ mod tests {
         let (actor, qp, _posted_rx) = harness.spawn_ready_actor(4, 2).await?;
 
         qp.queue_post_error("simulated post failure");
-        let items = vec![(
-            0usize,
-            make_op(RdmaOpType::WriteFromLocal, 0x1000, 4096),
-            fake_mrv(0x1000, 4096),
-        )];
+        let items = vec![make_op(0, RdmaOpType::WriteFromLocal, 0x1000, 4096)];
         let _rx = submit_ops(&harness, &actor, items)?;
 
         let event = harness.next_supervision_failure().await;

--- a/monarch_rdma/src/local_memory.rs
+++ b/monarch_rdma/src/local_memory.rs
@@ -461,6 +461,11 @@ impl LocalMemoryInner {
 /// memory is not directly accessible from that context.
 #[derive(Clone)]
 pub struct KeepaliveLocalMemory {
+    // Field order carries the drop order, and it matters: `inner` holds this
+    // handle's MR registrations, and they must go before `_keepalive` releases
+    // the memory. An `ibv_mr` does not keep its pages mapped, so a registration
+    // outliving the allocation is a window in which a peer's in-flight DMA
+    // lands in memory that has been freed and possibly handed out again.
     inner: LocalMemoryInner,
     _keepalive: Arc<dyn Keepalive>,
 }


### PR DESCRIPTION
Summary:

A remote buffer will need to advertise one memory registration per NIC that can
reach it, so that a transfer can be spread over several NIC pairs. This puts that
shape in place without yet registering more than one NIC:
`IbvRemoteBackendContext::buffer` becomes `buffers` and `IbvOp::remote_buffer`
becomes `remote_buffers`, each a `Vec`.

The manager narrows an op to a single pair of registrations before dispatching
it. A new `QueuePairOp` carries the one peer registration the queue pair will
address, and the QP resolves the local side on the memory handle itself, under
the device it is bound to. `compute_optimal_ibv_devices` gains lexicographic
device order as part of its contract, so that two sides picking out of such a
list agree on which entry they mean.

`IbvManagerActor::buffer_registrations` is gone, along with the `ReleaseBuffer`
message that existed to drop from it: a region's registrations live on the
`KeepaliveLocalMemory` they were made for, so a buffer is released by its owner
dropping that handle.

Differential Revision: D115630502


