### PR TITLE
Add out-of-cluster mode to `SlurmJob` (#4653)

### DIFF
--- a/python/monarch/_src/job/slurm.py
+++ b/python/monarch/_src/job/slurm.py
@@ -20,6 +20,7 @@ from monarch._src.actor.bootstrap import attach_to_workers
 from monarch._src.job._batch_env import in_batch_job
 from monarch._src.job._slurm_batch import _WORKER_BOOTSTRAP
 from monarch._src.job.job import BatchJob, JobState, JobTrait
+from monarch.actor import attach
 
 
 logger: logging.Logger = logging.getLogger(__name__)
@@ -67,6 +68,8 @@ class SlurmJob(JobTrait):
         job_start_timeout: Optional[int] = None,
         account: Optional[str] = None,
         qos: Optional[str] = None,
+        out_of_cluster: bool = False,
+        attach_to: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -87,6 +90,12 @@ class SlurmJob(JobTrait):
                       This should account for potential queueing delays. If None (default), waits indefinitely.
             account: SLURM account to charge the job to (``#SBATCH --account``). If None, uses the cluster default.
             qos: SLURM quality-of-service to request (``#SBATCH --qos``). If None, uses the cluster default.
+            out_of_cluster: Whether the client runs outside the cluster network.
+                      The client attaches through the first allocated worker so
+                      workers can route messages back through that gateway.
+            attach_to: ZMQ-style address of the worker gateway for out-of-cluster
+                      access. When omitted in out-of-cluster mode, the first
+                      allocated worker's Monarch address is used.
         """
         configure(default_transport=ChannelTransport.TcpWithHostname)
         self._meshes = meshes
@@ -105,6 +114,9 @@ class SlurmJob(JobTrait):
         self._job_start_timeout = job_start_timeout
         self._account = account
         self._qos = qos
+        self._out_of_cluster = out_of_cluster
+        self._attach_to = attach_to
+        self._client_attached = False
         # Track the single SLURM job ID and all allocated hostnames
         self._slurm_job_id: Optional[str] = None
         self._all_hostnames: List[str] = []
@@ -117,6 +129,9 @@ class SlurmJob(JobTrait):
         # address remote workers can dial back, instead of an abstract unix
         # socket whose namespace is local to the original (head) node.
         self.__dict__.update(state)
+        # Attachment belongs to this process's global client context, not the
+        # serialized job state.
+        self._client_attached = False
         configure(default_transport=ChannelTransport.TcpWithHostname)
 
     def add_mesh(self, name: str, num_nodes: int) -> None:
@@ -352,6 +367,14 @@ class SlurmJob(JobTrait):
                 job_id, total_nodes, timeout=self._job_start_timeout
             )
 
+        attach_to = self._attach_to
+        if self._out_of_cluster and attach_to is None:
+            attach_to = f"tcp://{self._all_hostnames[0]}:{self._port}"
+        if attach_to is not None and not self._client_attached:
+            logger.info("Attaching client gateway via duplex address: %s", attach_to)
+            attach(attach_to)
+            self._client_attached = True
+
         # Distribute the allocated hostnames among meshes
         host_meshes = {}
         hostname_idx = 0
@@ -391,6 +414,8 @@ class SlurmJob(JobTrait):
             and spec._job_start_timeout == self._job_start_timeout
             and spec._account == self._account
             and spec._qos == self._qos
+            and spec._out_of_cluster == self._out_of_cluster
+            and spec._attach_to == self._attach_to
             and self._jobs_active()
         )
 

--- a/python/tests/_src/job/test_slurm.py
+++ b/python/tests/_src/job/test_slurm.py
@@ -6,6 +6,8 @@
 
 # pyre-unsafe
 
+import json
+import pickle
 import shlex
 import subprocess
 from unittest.mock import patch
@@ -20,6 +22,36 @@ def _fake_sbatch(*args, **kwargs):
     return subprocess.CompletedProcess(
         args=["sbatch"], returncode=0, stdout="Submitted batch job 12345\n", stderr=""
     )
+
+
+def _fake_running_slurm(*args, **kwargs):
+    command = args[0]
+    if command == ["sbatch"]:
+        return _fake_sbatch(*args, **kwargs)
+    if command[0] == "squeue":
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout=json.dumps(
+                {
+                    "jobs": [
+                        {
+                            "job_state": ["RUNNING"],
+                            "job_resources": {
+                                "nodes": {
+                                    "allocation": [
+                                        {"name": "trainer-host"},
+                                        {"name": "generator-host"},
+                                    ]
+                                }
+                            },
+                        }
+                    ]
+                }
+            ),
+            stderr="",
+        )
+    raise AssertionError(f"unexpected command: {command}")
 
 
 def _make_job(**overrides) -> SlurmJob:
@@ -94,6 +126,86 @@ def test_external_controller_mode_has_no_client(tmp_path, monkeypatch):
     assert "_slurm_batch" not in script
     assert "MONARCH_BATCH_JOB" not in script
     assert not (tmp_path / ".monarch" / "job_state.pkl").exists()
+
+
+def test_out_of_cluster_attaches_through_first_worker_before_meshes():
+    events = []
+
+    def _record_attach(address):
+        events.append(("attach", address))
+
+    def _record_mesh(*, name, **kwargs):
+        events.append(("mesh", name))
+        return object()
+
+    with (
+        patch(
+            "monarch._src.job.slurm.subprocess.run",
+            side_effect=_fake_running_slurm,
+        ),
+        patch("monarch._src.job.slurm.attach", side_effect=_record_attach),
+        patch("monarch._src.job.slurm.attach_to_workers", side_effect=_record_mesh),
+    ):
+        _make_job(out_of_cluster=True).state(cached_path=None)
+
+    assert events == [
+        ("attach", "tcp://trainer-host:22222"),
+        ("mesh", "trainer"),
+        ("mesh", "generator"),
+    ]
+
+
+def test_explicit_attach_to_overrides_automatic_worker_gateway():
+    with (
+        patch(
+            "monarch._src.job.slurm.subprocess.run",
+            side_effect=_fake_running_slurm,
+        ),
+        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
+    ):
+        _make_job(
+            out_of_cluster=True,
+            attach_to="tcp://127.0.0.1:45678",
+        ).state(cached_path=None)
+
+    attach.assert_called_once_with("tcp://127.0.0.1:45678")
+
+
+def test_out_of_cluster_attaches_once_per_loaded_job():
+    with (
+        patch(
+            "monarch._src.job.slurm.subprocess.run",
+            side_effect=_fake_running_slurm,
+        ),
+        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
+    ):
+        job = _make_job(out_of_cluster=True)
+        job.state(cached_path=None)
+        job.state(cached_path=None)
+
+        reloaded = pickle.loads(job.dumps())
+        reloaded.state(cached_path=None)
+
+    assert [entry.args[0] for entry in attach.call_args_list] == [
+        "tcp://trainer-host:22222",
+        "tcp://trainer-host:22222",
+    ]
+
+
+def test_in_cluster_state_does_not_attach_client_gateway():
+    with (
+        patch(
+            "monarch._src.job.slurm.subprocess.run",
+            side_effect=_fake_running_slurm,
+        ),
+        patch("monarch._src.job.slurm.attach") as attach,
+        patch("monarch._src.job.slurm.attach_to_workers", return_value=object()),
+    ):
+        _make_job().state(cached_path=None)
+
+    attach.assert_not_called()
 
 
 def test_submit_raises_when_job_id_unparseable(tmp_path, monkeypatch):


### PR DESCRIPTION
Summary:

Add `out_of_cluster` and `attach_to` configuration to `SlurmJob`. In
out-of-cluster mode, attach the client gateway through the first allocated
worker before materializing any host mesh. An explicit `attach_to` address can
override that worker address, including when a caller provides an SSH-forwarded
local endpoint.

Include both options in cached-job compatibility checks. Add regression tests
that exercise the public `state()` lifecycle and verify gateway selection,
attachment ordering, explicit overrides, and unchanged in-cluster behavior.

Differential Revision: D115629683


