### PR TITLE
monarch python shell (#4656)

### DIFF
--- a/docs/source/api/monarch.job.rst
+++ b/docs/source/api/monarch.job.rst
@@ -44,6 +44,15 @@ Job State
    :show-inheritance:
 
 
+Interactive Shell
+=================
+
+Use a singleton slice of a job's host mesh to open an interactive terminal on
+that host.
+
+.. autofunction:: shell
+
+
 Job Base Class
 ==============
 

--- a/python/monarch/_src/actor/actor_mesh.py
+++ b/python/monarch/_src/actor/actor_mesh.py
@@ -1702,7 +1702,7 @@ class Actor(MeshTrait):
         ...
 
     @_doc_stub
-    def __cleanup__(self, exc: Exception | None) -> None:
+    def __cleanup__(self, exc: Exception | None) -> None | Awaitable[None]:
         """Called when the actor stops, normally (via ``ActorMesh.stop()``) or
         because of an error. The same ``__cleanup__`` runs in both cases;
         ``exc`` is ``None`` on a normal stop and carries the exception on an

--- a/python/monarch/_src/job/shell.py
+++ b/python/monarch/_src/job/shell.py
@@ -1,0 +1,493 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+# pyre-strict
+
+import asyncio
+import contextlib
+import errno
+import fcntl
+import os
+import signal
+import struct
+import sys
+import termios
+import tty
+from typing import AsyncIterator, Callable, Iterator, NamedTuple, TypeAlias
+
+from monarch.actor import (
+    Actor,
+    Channel,
+    context,
+    endpoint,
+    HostMesh,
+    Port,
+    PortReceiver,
+)
+
+
+class _ShellInputData(NamedTuple):
+    data: bytes
+
+
+class _ShellInputWindowSize(NamedTuple):
+    window_size: tuple[int, int]
+
+
+class _ShellInputClose(NamedTuple):
+    pass
+
+
+_ShellInput: TypeAlias = _ShellInputData | _ShellInputWindowSize | _ShellInputClose
+
+
+class _ShellOutputData(NamedTuple):
+    data: bytes
+
+
+class _ShellOutputReturncode(NamedTuple):
+    returncode: int
+
+
+class _ShellOutputError(NamedTuple):
+    error: str
+
+
+_ShellOutput: TypeAlias = _ShellOutputData | _ShellOutputReturncode | _ShellOutputError
+
+
+_CHUNK_SIZE = 16 * 1024
+_PROCESS_GRACE_SECONDS = 1
+
+
+def _set_window_size(fd: int, window_size: tuple[int, int]) -> None:
+    rows, columns = window_size
+    fcntl.ioctl(fd, termios.TIOCSWINSZ, struct.pack("HHHH", rows, columns, 0, 0))
+
+
+def _window_size(fd: int) -> tuple[int, int]:
+    try:
+        size = os.get_terminal_size(fd)
+    except OSError:
+        return 24, 80
+    return size.lines, size.columns
+
+
+def _rank_env() -> dict[str, str]:
+    rank = context().actor_instance.rank
+    return {
+        **{f"MONARCH_RANK_{key}": str(value) for key, value in dict(rank).items()},
+        **{
+            f"MONARCH_SIZE_{key}": str(value)
+            for key, value in zip(rank.extent.keys(), rank.extent.sizes)
+        },
+    }
+
+
+def _normalize_returncode(returncode: int) -> int:
+    return returncode if returncode >= 0 else min(128 - returncode, 255)
+
+
+def _process_groups(master_fd: int, process: asyncio.subprocess.Process) -> set[int]:
+    groups = {process.pid}
+    with contextlib.suppress(OSError):
+        groups.add(os.tcgetpgrp(master_fd))
+    groups.discard(os.getpgrp())
+    return {group for group in groups if group > 1}
+
+
+def _signal_process_groups(groups: set[int], sig: signal.Signals) -> None:
+    for group in groups:
+        with contextlib.suppress(ProcessLookupError):
+            os.killpg(group, sig)
+
+
+def _live_process_groups(groups: set[int]) -> set[int]:
+    live = set()
+    for group in groups:
+        try:
+            os.killpg(group, 0)
+        except ProcessLookupError:
+            continue
+        except PermissionError:
+            pass
+        live.add(group)
+    return live
+
+
+async def _stop_process(
+    master_fd: int,
+    process: asyncio.subprocess.Process,
+) -> None:
+    groups = _process_groups(master_fd, process)
+    _signal_process_groups(groups, signal.SIGHUP)
+    if process.returncode is None:
+        try:
+            await asyncio.wait_for(process.wait(), timeout=_PROCESS_GRACE_SECONDS)
+        except asyncio.TimeoutError:
+            pass
+
+    live = _live_process_groups(groups)
+    if live:
+        _signal_process_groups(live, signal.SIGTERM)
+        await asyncio.sleep(_PROCESS_GRACE_SECONDS)
+        _signal_process_groups(_live_process_groups(live), signal.SIGKILL)
+
+    if process.returncode is None:
+        with contextlib.suppress(ProcessLookupError):
+            process.kill()
+        await process.wait()
+
+
+class _ShellActor(Actor):
+    def __init__(self) -> None:
+        self._process: asyncio.subprocess.Process | None = None
+        self._master_fd: int | None = None
+        self._session_task: asyncio.Task[None] | None = None
+
+    async def _read_output(
+        self,
+        master_fd: int,
+        process: asyncio.subprocess.Process,
+        output: Port[_ShellOutput],
+    ) -> None:
+        async with _read_stream(master_fd) as reader:
+            while True:
+                try:
+                    data = await reader.read(_CHUNK_SIZE)
+                except OSError as error:
+                    if error.errno == errno.EIO:
+                        break
+                    raise
+                if not data:
+                    break
+                output.send(_ShellOutputData(data))
+        returncode = await process.wait()
+        output.send(_ShellOutputReturncode(_normalize_returncode(returncode)))
+
+    async def _write_input(
+        self,
+        receiver: PortReceiver[_ShellInput],
+        master_fd: int,
+        process: asyncio.subprocess.Process,
+    ) -> None:
+        async with _write_stream(master_fd) as writer:
+            while process.returncode is None:
+                message = await receiver.recv()
+                match message:
+                    case _ShellInputClose():
+                        await _stop_process(master_fd, process)
+                        return
+                    case _ShellInputWindowSize(window_size):
+                        _set_window_size(master_fd, window_size)
+                    case _ShellInputData(data):
+                        writer.write(data)
+                        await writer.drain()
+
+    async def _run_session(
+        self,
+        receiver: PortReceiver[_ShellInput],
+        master_fd: int,
+        process: asyncio.subprocess.Process,
+        output: Port[_ShellOutput],
+    ) -> None:
+        input_task = asyncio.create_task(
+            self._write_input(
+                receiver,
+                master_fd,
+                process,
+            ),
+            name="monarch-shell-input",
+        )
+        output_task = asyncio.create_task(
+            self._read_output(master_fd, process, output),
+            name="monarch-shell-output",
+        )
+        try:
+            done, _ = await asyncio.wait(
+                (input_task, output_task),
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if output_task in done:
+                await output_task
+                return
+            await input_task
+            await output_task
+        except Exception as error:
+            with contextlib.suppress(Exception):
+                output.send(_ShellOutputError(str(error)))
+            await _stop_process(master_fd, process)
+        finally:
+            input_task.cancel()
+            output_task.cancel()
+            await asyncio.gather(input_task, output_task, return_exceptions=True)
+
+    @endpoint
+    async def start(
+        self,
+        output: Port[_ShellOutput],
+        env: dict[str, str] | None,
+        workdir: str | None,
+        client_cwd: str,
+        terminal: str,
+        window_size: tuple[int, int],
+    ) -> Port[_ShellInput]:
+        if self._process is not None:
+            raise RuntimeError("shell is already running")
+
+        input_port, input_receiver = Channel[_ShellInput].open()
+        master_fd, slave_fd = os.openpty()
+        _set_window_size(master_fd, window_size)
+        child_env = {**os.environ, **_rank_env(), **(env or {}), "TERM": terminal}
+        effective_workdir = workdir or (
+            client_cwd if os.path.isdir(client_cwd) else None
+        )
+        shell_executable = child_env.get("SHELL", "/bin/bash")
+        try:
+            process = await asyncio.create_subprocess_exec(
+                "/usr/bin/setsid",
+                "--ctty",
+                shell_executable,
+                "-i",
+                stdin=slave_fd,
+                stdout=slave_fd,
+                stderr=slave_fd,
+                cwd=effective_workdir,
+                env=child_env,
+            )
+        except (OSError, ValueError):
+            os.close(master_fd)
+            raise
+        finally:
+            os.close(slave_fd)
+
+        self._process = process
+        self._master_fd = master_fd
+        self._session_task = asyncio.create_task(
+            self._run_session(input_receiver, master_fd, process, output),
+            name="monarch-shell-session",
+        )
+        return input_port
+
+    async def __cleanup__(self, exc: Exception | None) -> None:
+        process = self._process
+        if process is not None and process.returncode is None:
+            assert self._master_fd is not None
+            await _stop_process(self._master_fd, process)
+        if self._session_task is not None:
+            self._session_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._session_task
+            self._session_task = None
+        if self._master_fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(self._master_fd)
+            self._master_fd = None
+
+
+@contextlib.contextmanager
+def _raw_terminal(fd: int) -> Iterator[None]:
+    if not os.isatty(fd):
+        yield
+        return
+
+    attributes = termios.tcgetattr(fd)
+    tty.setraw(fd)
+    try:
+        yield
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, attributes)
+
+
+@contextlib.contextmanager
+def _nonblocking(fd: int) -> Iterator[None]:
+    blocking = os.get_blocking(fd)
+    os.set_blocking(fd, False)
+    try:
+        yield
+    finally:
+        os.set_blocking(fd, blocking)
+
+
+@contextlib.contextmanager
+def _resize_handler(notify: Callable[[], None]) -> Iterator[None]:
+    loop = asyncio.get_running_loop()
+    previous = signal.getsignal(signal.SIGWINCH)
+    try:
+        loop.add_signal_handler(signal.SIGWINCH, notify)
+    except (RuntimeError, ValueError):
+        yield
+        return
+    try:
+        yield
+    finally:
+        loop.remove_signal_handler(signal.SIGWINCH)
+        signal.signal(signal.SIGWINCH, previous)
+
+
+@contextlib.asynccontextmanager
+async def _read_stream(fd: int) -> AsyncIterator[asyncio.StreamReader]:
+    loop = asyncio.get_running_loop()
+    pipe = os.fdopen(os.dup(fd), "rb", buffering=0)
+    reader = asyncio.StreamReader()
+    protocol = asyncio.StreamReaderProtocol(reader)
+    try:
+        transport, _ = await loop.connect_read_pipe(lambda: protocol, pipe)
+    except BaseException:
+        pipe.close()
+        raise
+    try:
+        yield reader
+    finally:
+        transport.close()
+
+
+@contextlib.asynccontextmanager
+async def _write_stream(fd: int) -> AsyncIterator[asyncio.StreamWriter]:
+    loop = asyncio.get_running_loop()
+    pipe = os.fdopen(os.dup(fd), "wb", buffering=0)
+    protocol = asyncio.streams.FlowControlMixin(loop=loop)
+    try:
+        transport, _ = await loop.connect_write_pipe(lambda: protocol, pipe)
+    except BaseException:
+        pipe.close()
+        raise
+    writer = asyncio.StreamWriter(transport, protocol, None, loop)
+    try:
+        yield writer
+    finally:
+        writer.close()
+        with contextlib.suppress(
+            BrokenPipeError, ConnectionResetError, NotImplementedError
+        ):
+            await writer.wait_closed()
+
+
+async def _forward_terminal(
+    input_port: Port[_ShellInput],
+    output_receiver: PortReceiver[_ShellOutput],
+    stdin_fd: int,
+    stdout_fd: int,
+) -> int:
+    async def forward_input(reader: asyncio.StreamReader) -> None:
+        try:
+            while data := await reader.read(_CHUNK_SIZE):
+                input_port.send(_ShellInputData(data))
+        except BaseException:
+            with contextlib.suppress(Exception):
+                input_port.send(_ShellInputClose())
+            raise
+        else:
+            input_port.send(_ShellInputClose())
+
+    async def forward_output(writer: asyncio.StreamWriter) -> int:
+        writer.write(b"\r")
+        await writer.drain()
+        while True:
+            message = await output_receiver.recv()
+            match message:
+                case _ShellOutputError(error):
+                    raise RuntimeError(error)
+                case _ShellOutputData(data):
+                    writer.write(data)
+                    await writer.drain()
+                case _ShellOutputReturncode(returncode):
+                    return returncode
+
+    def resize() -> None:
+        input_port.send(_ShellInputWindowSize(_window_size(stdin_fd)))
+
+    with (
+        _raw_terminal(stdin_fd),
+        _nonblocking(stdin_fd),
+        _nonblocking(stdout_fd),
+        _resize_handler(resize),
+    ):
+        async with (
+            _read_stream(stdin_fd) as reader,
+            _write_stream(stdout_fd) as writer,
+        ):
+            input_task = asyncio.create_task(
+                forward_input(reader),
+                name="monarch-shell-client-input",
+            )
+            output_task = asyncio.create_task(
+                forward_output(writer),
+                name="monarch-shell-client-output",
+            )
+            try:
+                done, _ = await asyncio.wait(
+                    (input_task, output_task),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if input_task in done:
+                    await input_task
+                return await output_task
+            finally:
+                input_task.cancel()
+                output_task.cancel()
+                await asyncio.gather(
+                    input_task,
+                    output_task,
+                    return_exceptions=True,
+                )
+
+
+async def _shell(
+    host_mesh_singleton: HostMesh,
+    env: dict[str, str] | None,
+    workdir: str | None,
+) -> int:
+    stdin_fd = sys.stdin.fileno()
+    stdout_fd = sys.stdout.fileno()
+    output_port, output_receiver = Channel[_ShellOutput].open()
+    procs = host_mesh_singleton.spawn_procs()
+    try:
+        actor = procs.spawn("shell", _ShellActor)
+        input_port = await actor.start.call_one(
+            output_port,
+            env,
+            workdir,
+            os.getcwd(),
+            os.environ.get("TERM", "xterm-256color"),
+            _window_size(stdin_fd),
+        )
+        return await _forward_terminal(
+            input_port,
+            output_receiver,
+            stdin_fd,
+            stdout_fd,
+        )
+    finally:
+        await procs.stop()
+
+
+def shell(
+    host_mesh_singleton: HostMesh,
+    *,
+    env: dict[str, str] | None = None,
+    workdir: str | None = None,
+) -> int:
+    """Run an interactive shell on a singleton host mesh.
+
+    The Python actors establish two native Monarch channels, then terminal
+    input and output travel directly through their Rust ports.
+
+    Args:
+        host_mesh_singleton: A HostMesh containing exactly one host.
+        env: Extra environment variables for the remote shell.
+        workdir: Working directory on the remote host. If omitted, the
+            client's working directory is used when it exists remotely.
+
+    Returns:
+        The remote shell's exit status.
+    """
+    if host_mesh_singleton.size() != 1:
+        raise ValueError(
+            "shell requires a singleton HostMesh; slice the mesh to one host first"
+        )
+
+    return asyncio.run(_shell(host_mesh_singleton, env, workdir))

--- a/python/monarch/_src/tools/commands.py
+++ b/python/monarch/_src/tools/commands.py
@@ -714,3 +714,48 @@ def exec_on_job(
         shutdown_context().get()
 
     return max_rc
+
+
+def shell_on_job(
+    mesh_name: Optional[str] = None,
+    point_str: Optional[str] = None,
+    env: Optional[list[str]] = None,
+    workdir: Optional[str] = None,
+    kill: bool = False,
+) -> int:
+    """Load the current job and open a shell on one of its hosts."""
+    from monarch._src.job.shell import shell  # pyre-ignore[21]
+
+    job = load_current_job()
+    state = job.state()
+    if not state._hosts:
+        raise RuntimeError("Job has no host meshes")
+
+    if mesh_name is None:
+        mesh_name = next(iter(state._hosts))
+    elif mesh_name not in state._hosts:
+        raise ValueError(
+            f"Mesh {mesh_name!r} not found. Available: {list(state._hosts)}"
+        )
+
+    host_mesh = state._hosts[mesh_name]
+    if point_str is not None:
+        host_mesh = host_mesh.slice(**_parse_point(point_str))
+    else:
+        host_mesh = host_mesh.flatten("rank").slice(rank=0)
+
+    shell_env = _parse_env(env)
+    executable = job._components.mounts.python_executable_for_mesh(mesh_name)
+    if executable is not None:
+        bin_dir = os.path.dirname(executable)
+        existing_path = shell_env.get("PATH", os.environ.get("PATH", ""))
+        shell_env["PATH"] = f"{bin_dir}:{existing_path}"
+
+    returncode = shell(host_mesh, env=shell_env, workdir=workdir)
+    if kill:
+        from monarch.actor import shutdown_context  # pyre-ignore[21]
+
+        host_mesh.shutdown().get()
+        job.kill()
+        shutdown_context().get()
+    return returncode

--- a/python/monarch/job/__init__.py
+++ b/python/monarch/job/__init__.py
@@ -19,6 +19,7 @@ from monarch._src.job.job import (
 )
 from monarch._src.job.job_state import JobState
 from monarch._src.job.process import ProcessJob
+from monarch._src.job.shell import shell
 from monarch._src.job.slurm import SlurmJob
 
 # Define exports
@@ -34,6 +35,7 @@ __all__ = [
     "MeshAdminConfig",
     "ProcessJob",
     "set_current_job",
+    "shell",
     "SlurmJob",
     "TelemetryConfig",
 ]

--- a/python/monarch/tools/SKILL.md
+++ b/python/monarch/tools/SKILL.md
@@ -21,6 +21,9 @@ Quick start:
   # Run a bash script
   monarch exec --script run.sh
 
+  # Open an interactive shell on rank 0
+  monarch shell
+
   # Kill the job when done
   monarch kill
 
@@ -28,6 +31,7 @@ Commands:
 
   apply   Provision workers from a job config Python file
   exec    Run a command on workers
+  shell   Open an interactive shell on one worker
   kill    Kill the active job
   context Manage named job contexts
   debug   Connect to the debug server
@@ -54,3 +58,11 @@ exec options:
   --workdir DIR       Working directory on workers
   --script FILE       Read bash script from FILE (use '-' for stdin)
   --kill              Kill the job after the command finishes
+
+shell options:
+
+  --mesh NAME       Select a mesh (default: first mesh)
+  --point DIM=N,..  Select a host coordinate (default: flat rank 0)
+  -e KEY=VALUE      Extra environment variable (repeatable)
+  --workdir DIR     Working directory on the worker
+  --kill            Kill the job after the shell exits

--- a/python/monarch/tools/cli.py
+++ b/python/monarch/tools/cli.py
@@ -20,6 +20,7 @@ from monarch.tools.commands import (
     context_use,
     debug,
     exec_on_job,
+    shell_on_job,
 )
 from monarch.tools.debug_env import _get_debug_server_host, _get_debug_server_port
 
@@ -174,6 +175,54 @@ class ExecCmd:
             sys.exit(rc)
 
 
+class ShellCmd:
+    def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
+        subparser.add_argument(
+            "--mesh",
+            type=str,
+            default=None,
+            metavar="NAME",
+            help="Open the shell on the named mesh (default: first mesh)",
+        )
+        subparser.add_argument(
+            "--point",
+            type=str,
+            default=None,
+            metavar="DIM=N,DIM=N",
+            help="Open the shell at a coordinate (default: flat rank 0)",
+        )
+        subparser.add_argument(
+            "-e",
+            "--env",
+            action="append",
+            default=[],
+            help="Extra environment variables as KEY=VALUE (can be repeated)",
+        )
+        subparser.add_argument(
+            "--workdir",
+            type=str,
+            default=None,
+            help="Working directory on the worker",
+        )
+        subparser.add_argument(
+            "--kill",
+            action="store_true",
+            default=False,
+            help="Kill the job after the shell exits",
+        )
+
+    def run(self, args: argparse.Namespace) -> None:
+        rc = shell_on_job(
+            mesh_name=args.mesh,
+            point_str=args.point,
+            env=args.env or None,
+            workdir=args.workdir,
+            kill=args.kill,
+        )
+        if rc != 0:
+            sys.exit(rc)
+
+
 class ContextCmd:
     def add_arguments(self, subparser: argparse.ArgumentParser) -> None:
         sub = subparser.add_subparsers(title="CONTEXT COMMANDS", dest="context_cmd")
@@ -263,6 +312,7 @@ def get_parser() -> argparse.ArgumentParser:
             "Run a command on workers. Sets MONARCH_RANK_<DIM> and MONARCH_SIZE_<DIM> "
             "env vars for each rank dimension.",
         ),
+        ("shell", ShellCmd(), "Open an interactive shell on one worker"),
         ("kill", KillCmd(), "Kill the active job"),
         ("debug", DebugCmd(), "Connect to the debug server"),
     ]:

--- a/python/monarch/tools/commands.py
+++ b/python/monarch/tools/commands.py
@@ -21,6 +21,7 @@ from monarch._src.tools.commands import (
     load_current_job,
     MONARCH_DIR,
     server_ready,
+    shell_on_job,
     torchx_runner,
 )
 
@@ -41,5 +42,6 @@ __all__ = [
     "load_current_job",
     "MONARCH_DIR",
     "server_ready",
+    "shell_on_job",
     "torchx_runner",
 ]

--- a/python/tests/_src/tools/test_commands.py
+++ b/python/tests/_src/tools/test_commands.py
@@ -513,3 +513,27 @@ class TestExecOnJobSignature(unittest.TestCase):
         from monarch._src.job.job import BashActor
 
         self.assertTrue(hasattr(BashActor, "run_streaming"))
+
+
+class TestShellOnJob(unittest.TestCase):
+    @mock.patch("monarch._src.job.shell.shell", return_value=0)
+    @mock.patch("monarch._src.tools.commands.load_current_job")
+    def test_defaults_to_rank_zero_of_first_mesh(
+        self, load_current_job: MagicMock, open_shell: MagicMock
+    ) -> None:
+        host_mesh = MagicMock()
+        selected_host = host_mesh.flatten.return_value.slice.return_value
+        job = load_current_job.return_value
+        job.state.return_value._hosts = {"workers": host_mesh}
+        job._components.mounts.python_executable_for_mesh.return_value = None
+
+        returncode = commands.shell_on_job(env=["FOO=bar"], workdir="/tmp/work")
+
+        self.assertEqual(returncode, 0)
+        host_mesh.flatten.assert_called_once_with("rank")
+        host_mesh.flatten.return_value.slice.assert_called_once_with(rank=0)
+        open_shell.assert_called_once_with(
+            selected_host,
+            env={"FOO": "bar"},
+            workdir="/tmp/work",
+        )

--- a/python/tests/test_shell.py
+++ b/python/tests/test_shell.py
@@ -1,0 +1,119 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+# All rights reserved.
+#
+# This source code is licensed under the BSD-style license found in the
+# LICENSE file in the root directory of this source tree.
+
+import os
+import shlex
+import sys
+import tempfile
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+from isolate_in_subprocess import isolate_in_subprocess
+from monarch.actor import this_host
+from monarch.job import shell
+
+
+def test_shell_requires_singleton_host_mesh() -> None:
+    host_mesh = MagicMock()
+    host_mesh.size.return_value = 2
+
+    with pytest.raises(ValueError, match="singleton HostMesh"):
+        shell(host_mesh)
+
+    host_mesh.spawn_procs.assert_not_called()
+
+
+@pytest.mark.timeout(60)
+@isolate_in_subprocess
+def test_shell_transfers_terminal_data_and_returns_exit_status() -> None:
+    input_read, input_write = os.pipe()
+    output_read, output_write = os.pipe()
+    os.write(
+        input_write,
+        b'printf "shell:%s\\n" "$MONARCH_SHELL_TEST"; exit 7\n',
+    )
+
+    try:
+        with (
+            os.fdopen(input_read, "r") as stdin,
+            os.fdopen(output_write, "w") as stdout,
+            patch.object(sys, "stdin", stdin),
+            patch.object(sys, "stdout", stdout),
+        ):
+            returncode = shell(this_host(), env={"MONARCH_SHELL_TEST": "connected"})
+        output = os.read(output_read, 64 * 1024).decode(errors="replace")
+    finally:
+        os.close(input_write)
+        os.close(output_read)
+
+    assert returncode == 7
+    assert "shell:connected" in output
+
+
+@pytest.mark.timeout(20)
+@isolate_in_subprocess
+def test_shell_eof_stops_foreground_process() -> None:
+    input_read, input_write = os.pipe()
+    output_read, output_write = os.pipe()
+    input_writer = os.fdopen(input_write, "wb", buffering=0)
+    stop_closer = threading.Event()
+
+    with tempfile.TemporaryDirectory() as directory:
+        child_pid_path = os.path.join(directory, "child-pid")
+        child_command = f"echo $$ > {shlex.quote(child_pid_path)}; exec sleep 30"
+        input_writer.write(f"sh -c {shlex.quote(child_command)}\n".encode())
+
+        def close_input_when_command_starts() -> None:
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline and not os.path.exists(child_pid_path):
+                if stop_closer.wait(0.01):
+                    return
+            input_writer.close()
+
+        closer = threading.Thread(target=close_input_when_command_starts, daemon=True)
+        closer.start()
+        try:
+            with (
+                os.fdopen(input_read, "r") as stdin,
+                os.fdopen(output_write, "w") as stdout,
+                patch.object(sys, "stdin", stdin),
+                patch.object(sys, "stdout", stdout),
+            ):
+                started = time.monotonic()
+                returncode = shell(this_host(), env={"SHELL": "/bin/bash"})
+                elapsed = time.monotonic() - started
+            os.read(output_read, 64 * 1024)
+        finally:
+            stop_closer.set()
+            input_writer.close()
+            closer.join(timeout=1)
+            os.close(output_read)
+
+        assert os.path.exists(child_pid_path)
+        assert not closer.is_alive()
+        assert elapsed < 10
+        assert returncode != 0
+
+
+@pytest.mark.timeout(20)
+@isolate_in_subprocess
+def test_shell_propagates_terminal_copy_failure() -> None:
+    input_read, input_write = os.pipe()
+    output_read, output_write = os.pipe()
+    os.close(output_read)
+    os.write(input_write, b'printf "output that cannot be written\\n"; exit\n')
+    os.close(input_write)
+
+    with (
+        os.fdopen(input_read, "r") as stdin,
+        os.fdopen(output_write, "w") as stdout,
+        patch.object(sys, "stdin", stdin),
+        patch.object(sys, "stdout", stdout),
+        pytest.raises((BrokenPipeError, ConnectionResetError)),
+    ):
+        shell(this_host(), env={"SHELL": "/bin/bash"})

--- a/python/tests/tools/test_cli.py
+++ b/python/tests/tools/test_cli.py
@@ -7,6 +7,7 @@
 # pyre-strict
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 from monarch.tools.cli import get_parser, main
 
@@ -42,6 +43,33 @@ class TestCli(unittest.TestCase):
         parser = get_parser()
         with self.assertRaises(SystemExit):
             parser.parse_args(["exec", "--all", "--mesh", "workers", "echo"])
+
+    @patch("monarch.tools.cli.shell_on_job", return_value=0)
+    def test_shell_forwards_single_host_options(self, shell_on_job: MagicMock) -> None:
+        parser = get_parser()
+        args = parser.parse_args(
+            [
+                "shell",
+                "--mesh",
+                "workers",
+                "--point",
+                "host=2",
+                "-e",
+                "FOO=bar",
+                "--workdir",
+                "/tmp/work",
+            ]
+        )
+
+        args.func(args)
+
+        shell_on_job.assert_called_once_with(
+            mesh_name="workers",
+            point_str="host=2",
+            env=["FOO=bar"],
+            workdir="/tmp/work",
+            kill=False,
+        )
 
     def test_help_has_job_reuse(self) -> None:
         import importlib.resources


### PR DESCRIPTION
Summary:

Adds `monarch.job.shell(host_mesh_singleton)` and a `monarch shell` command for opening an interactive PTY-backed shell on one host in an existing Monarch job. Python actors establish native Monarch port channels, then asynchronous terminal tasks transfer input, output, resize events, errors, and exit status directly between the local terminal and remote PTY.

The API supports environment overrides and remote working-directory selection, while the CLI adds mesh and point selection plus optional job teardown. The implementation supervises both transfer directions, propagates failures, terminates the shell and PTY foreground process group on EOF, restores local terminal state, and documents and tests the new API and command.

Reviewed By: thedavekwon

Differential Revision: D115745710


