### PR TITLE
make the RDMA runtime worker-thread count configurable, and bump default from 4 to 16 (#4657)

### DIFF
--- a/monarch_rdma/src/config.rs
+++ b/monarch_rdma/src/config.rs
@@ -90,4 +90,15 @@ declare_attrs! {
         Some("rdma_ibverbs_target".to_string()),
     ))
     pub attr RDMA_IBVERBS_TARGET: String = String::new();
+
+    /// Worker-thread count for the shared rdma data-plane runtime, which
+    /// every `QueuePairActor` poll loop runs on.
+    ///
+    /// The runtime is built once, lazily, so this value is latched at the
+    /// first RDMA use in a process and later changes have no effect.
+    @meta(CONFIG = ConfigAttr::new(
+        Some("MONARCH_RDMA_RUNTIME_WORKER_THREADS".to_string()),
+        Some("rdma_runtime_worker_threads".to_string()),
+    ))
+    pub attr RDMA_RUNTIME_WORKER_THREADS: usize = 16;
 }

--- a/monarch_rdma/src/rdma_runtime.rs
+++ b/monarch_rdma/src/rdma_runtime.rs
@@ -37,15 +37,16 @@ use std::sync::OnceLock;
 
 use hyperactor::runtime_identity::build_data_plane_runtime;
 
-/// Worker-thread count for the shared rdma runtime. >1 so concurrent
-/// `QueuePairActor` ticks make progress in parallel.
-const RDMA_RUNTIME_WORKER_THREADS: usize = 4;
+/// Worker-thread count for the shared rdma runtime.
+fn worker_threads() -> usize {
+    hyperactor_config::global::get(crate::config::RDMA_RUNTIME_WORKER_THREADS)
+}
 
 /// The process-wide rdma data-plane runtime, built on first use and tagged
 /// `DataPlane("rdma")`.
 fn rdma_runtime() -> &'static tokio::runtime::Handle {
     static RT: OnceLock<tokio::runtime::Handle> = OnceLock::new();
-    RT.get_or_init(|| build_data_plane_runtime("rdma", RDMA_RUNTIME_WORKER_THREADS))
+    RT.get_or_init(|| build_data_plane_runtime("rdma", worker_threads()))
 }
 
 /// Spawn an actor server loop onto the shared rdma runtime and return its
@@ -109,5 +110,14 @@ mod tests {
     async fn handle_awaitable_from_caller_runtime() {
         let out = spawn_on_rdma_runtime(async { 7 }).await.unwrap();
         assert_eq!(out, 7);
+    }
+
+    // The worker count comes from config.
+    #[test]
+    fn worker_threads_reads_config() {
+        let lock = hyperactor_config::global::lock();
+        assert_eq!(worker_threads(), 16, "the default is 16");
+        let _guard = lock.override_key(crate::config::RDMA_RUNTIME_WORKER_THREADS, 32);
+        assert_eq!(worker_threads(), 32);
     }
 }

--- a/python/monarch/config/__init__.py
+++ b/python/monarch/config/__init__.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
             rdma_disable_ibverbs: NotRequired[bool]
             rdma_max_chunk_size_mb: NotRequired[int]
             rdma_ibverbs_target: NotRequired[str]
+            rdma_runtime_worker_threads: NotRequired[int]
 
         # pyrefly: ignore [invalid-annotation]
         ConfigureKwargsType = Unpack[ConfigureArgs]
@@ -188,6 +189,10 @@ def configure(**kwargs: "ConfigureKwargsType") -> None:
                 ``"gpu:<ordinal>"``, or ``"nic:<name>"``. Empty preserves
                 automatic selection. Non-empty value syntax is validated when
                 the RDMA manager starts.
+            rdma_runtime_worker_threads: Worker threads for the shared RDMA
+                data-plane runtime, which every queue pair's poll loop runs on.
+                Latched at the first RDMA use in a process; setting it later
+                has no effect.
 
         **kwargs: Reserved for future configuration keys exposed by Rust bindings.
     """

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -110,6 +110,15 @@ def test_rdma_ibverbs_target_round_trip_and_propagation() -> None:
     assert get_global_config()["rdma_ibverbs_target"] == ""
 
 
+def test_rdma_runtime_worker_threads_round_trip() -> None:
+    assert get_global_config()["rdma_runtime_worker_threads"] == 16
+
+    with configured(rdma_runtime_worker_threads=32) as config:
+        assert config["rdma_runtime_worker_threads"] == 32
+
+    assert get_global_config()["rdma_runtime_worker_threads"] == 16
+
+
 @isolate_in_subprocess
 def test_codec_max_frame_length_exceeds_default() -> None:
     """Test that sending 4 chunks of 256KiB fails with a 1 MiB limit."""


### PR DESCRIPTION
Summary:

Every queue pair's poll loop runs on one process-wide RDMA data-plane
runtime whose worker count was hard-coded to 4. A proc driving many peers
at once — a fan-out root, or any participant in an all-to-all — with `N` NICs and `P` peers (each with `N` NICs) has `O(N^2 * P)` active `QueuePairActor`s. If they all need to share 4 threads, this could quickly become the bottleneck, rather than being limited by the fabric itself.

This commit adds the `rdma_runtime_worker_threads` config attr so that the number of runtime threads is configurable, and also bumps the default to 16. The runtime is built once, lazily, so the value is latched at a process's
first RDMA use.

Differential Revision: D115753478


