### PR TITLE
Vendor mdns-sd 0.21.0 for LDCR mDNS discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,9 +4284,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"


### PR DESCRIPTION
Summary:
Bump `mdns-sd` 0.19.2 -> 0.21.0, the current latest stable, and re-vendor via
`fbcode/common/rust/tools/reindeer/vendor`. The previous version of this diff
vendored 0.19.2, which review flagged as three months stale. LDCR consumes the
crate in the child diff to advertise `_ldcr._tcp.local.`.

0.19.2 stays vendored because `adb_client` pins `mdns-sd ^0.19.2`, so the crate
now exposes both a `:0.19` and a `:0.21` target. Two subdependencies move with
the bump: `socket-pktinfo` 0.3.2 -> 0.4.1, required by mdns-sd 0.20+, and
transitively `libc` 0.2.186 -> 0.2.189, which `socket-pktinfo` 0.4.1 declares as
`^0.2.189`. That libc bump is why the seven `fbcode/**/Cargo.lock` files change:
`autocargo` regenerates those workspaces' lockfiles from Buck. Avoiding it would
mean deliberately pinning `socket-pktinfo` back to 0.4.0. `flume` moves
0.11.1 -> 0.12.0 on this chain; `mio`, `wasi`, `socket2` and `if-addrs` see no
version change.

`mdns-sd` is declared in the non-wasm `cfg` section of
`third-party/rust/Cargo.toml`, which keeps it out of the wasm32 universes:
`socket2` 0.6 `compile_error!`s on `wasm32-unknown-unknown`. Doing it at the
declaration rather than by editing generated files leaves `top/BUCK` untouched
and reduces `third-party/rust/BUCK` to a one-line alias change, and it survives
the next 3p-bot re-vendor.

Differential Revision: D115722045
