### PR TITLE
Keep ActorMeshRef dense with owned monitoring (#4660)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3628,7 +3628,6 @@ dependencies = [
  "pin-project",
  "preempt_rwlock",
  "rand 0.10.2",
- "rankspace",
  "reqwest 0.13.4",
  "rustls-pemfile",
  "schemars 1.2.2",

--- a/hyperactor_mesh/Cargo.toml
+++ b/hyperactor_mesh/Cargo.toml
@@ -46,7 +46,6 @@ opentelemetry = "0.31"
 pin-project = "1.1.13"
 preempt_rwlock = { version = "0.0.0", path = "../preempt_rwlock" }
 rand = "0.10.2"
-rankspace = { version = "0.0.0", path = "../rankspace" }
 reqwest = { version = "0.13.2", features = ["blocking", "charset", "cookies", "gzip", "http2", "json", "multipart", "rustls", "socks", "stream", "system-proxy"], default-features = false }
 rustls-pemfile = "2.2.0"
 schemars = { version = "1.2.2", features = ["indexmap2"] }

--- a/hyperactor_mesh/src/actor_mesh.rs
+++ b/hyperactor_mesh/src/actor_mesh.rs
@@ -8,17 +8,17 @@
 
 //! ## Actor mesh invariants (AM-*)
 //!
-//! - **AM-1 (rank-space):** `ActorMeshRef` uses its `CastDomainRef` as
-//!   the source of truth for actor addresses. The cast domain stores
-//!   members in the same dense rank order as the mesh `Region`, so a
-//!   rank can be materialized by indexing the cast-domain member map
-//!   directly; the reference does not need to retain the `ProcMeshRef`
-//!   that created it.
+//! - **AM-1 (dense refs):** Every `ActorMeshRef` has exactly one actor ref per
+//!   rank in its `Region`. Managed refs materialize those refs from their cast
+//!   domain, while data refs store them in a `ValueMesh`.
 //! - **AM-2 (slice materialization):** `RankedSliceable::sliced` has no
 //!   caller context, so it carries only a raw cast-domain descriptor. The first
 //!   cast through that ref materializes the descriptor with the caller context
 //!   before sending the cast message, sequencing setup and delivery on the same
 //!   sender stream.
+//! - **AM-3 (explicit direct monitoring):** Each call to
+//!   `ActorMeshRef::monitor` creates an independent direct actor monitor. The
+//!   managed variant separately retains its legacy controller supervision.
 
 use std::collections::HashMap;
 use std::fmt;
@@ -52,12 +52,8 @@ use hyperactor_config::Flattrs;
 use hyperactor_config::attrs::declare_attrs;
 use ndslice::ViewExt as _;
 use ndslice::view;
+use ndslice::view::Ranked;
 use ndslice::view::Region;
-use ndslice::view::View;
-use rankspace::Rank;
-use rankspace::RankSpace;
-use rankspace::view::CompactView;
-use rankspace::view::View as _;
 use serde::Deserialize;
 use serde::Deserializer;
 use serde::Serialize;
@@ -133,21 +129,19 @@ enum ActorMeshLifecycle {
 /// The data-only variant of [`ActorMeshRef`]: a cheap, detached cast/address
 /// surface built directly from actor refs.
 ///
-/// Membership is a [`RankSpace`] paired with its visible actor refs. The rank
-/// space can be sparse, so a mesh can represent failed or absent ranks as
-/// occlusions. It carries no identity beyond its members (two data refs over the
-/// same rank space and refs are interchangeable) and no remote supervision
-/// stream; a caller monitors it on demand via [`Self::monitor`]. Casting iterates
-/// the members and posts to each directly — the simple, unoptimized data path.
+/// Membership is a [`Region`] paired with exactly one actor ref per rank. It
+/// carries no identity beyond its members (two data refs over the same region
+/// and refs are interchangeable) and no remote supervision stream; a caller
+/// monitors it on demand via [`ActorMeshRef::monitor`]. Casting iterates the
+/// members and posts to each directly — the simple, unoptimized data path.
 pub struct DataActorMesh<A: Referable> {
-    members: CompactView<Vec<ActorRef<A>>>,
+    members: ValueMesh<ActorRef<A>>,
 }
 
 impl<A: Referable> fmt::Debug for DataActorMesh<A> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DataActorMesh")
-            .field("space", self.members.space())
-            .field("members", self.members.data())
+            .field("members", &self.members)
             .finish_non_exhaustive()
     }
 }
@@ -177,7 +171,7 @@ impl<A: Referable> ActorMesh<A> {
 
     /// Create a data actor mesh from actor refs and their lifecycle handles.
     pub(crate) fn try_new_data(
-        space: impl Into<RankSpace>,
+        region: Region,
         members: Vec<ActorRef<A>>,
         stop_handles: Vec<ActorMeshStopHandle>,
     ) -> crate::Result<Self> {
@@ -187,7 +181,7 @@ impl<A: Referable> ActorMesh<A> {
             members.len(),
             "data actor mesh must own one lifecycle handle per member"
         );
-        let current_ref = ActorMeshRef::try_new_data(space, members).inspect_err(|_| {
+        let current_ref = ActorMeshRef::try_new_data(region, members).inspect_err(|_| {
             stop_handles.iter().for_each(|handle| {
                 let _ = handle.stop("data mesh construction failed");
             });
@@ -212,11 +206,6 @@ impl<A: Referable> ActorMesh<A> {
             .as_managed_mut()
             .expect("data actor meshes do not use a controller")
             .set_controller(controller);
-    }
-
-    /// Return a [`MeshMonitor`] over this mesh's members.
-    pub fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
-        self.current_ref.monitor(cx)
     }
 
     /// Stop actors on this mesh across all procs.
@@ -381,64 +370,21 @@ impl<A: Referable> Drop for ActorMesh<A> {
 }
 
 impl<A: Referable> DataActorMesh<A> {
-    fn new_unchecked(members: CompactView<Vec<ActorRef<A>>>) -> Self {
+    fn new_unchecked(members: ValueMesh<ActorRef<A>>) -> Self {
         Self { members }
     }
 
-    /// Create a data-only actor mesh from a rank space and its actor refs.
+    /// Create a data-only actor mesh from a region and its actor refs.
     ///
-    /// `members` must hold one ref per visible rank, in rank order. The mesh
-    /// does not own, stop, or supervise the actors; it is a plain view over the
-    /// refs. Use [`Self::monitor`] to observe rank failures.
-    pub fn try_new(space: impl Into<RankSpace>, members: Vec<ActorRef<A>>) -> crate::Result<Self> {
-        let space = space.into();
-        let members = CompactView::new(space, members).map_err(|e| match &e {
-            rankspace::view::ViewError::InvalidCardinality { expected, actual } => {
-                Error::InvalidRankCardinality {
-                    expected: *expected,
-                    actual: *actual,
-                }
-            }
-            rankspace::view::ViewError::RankOutOfBounds { .. } => {
-                Error::Other(anyhow::anyhow!("{e}"))
-            }
-        })?;
-        Ok(Self::new_unchecked(members))
+    /// `members` must hold one ref per rank, in region order. The mesh does not
+    /// own, stop, or supervise the actors; it is a plain view over the refs.
+    pub fn try_new(region: Region, members: Vec<ActorRef<A>>) -> crate::Result<Self> {
+        Ok(Self::new_unchecked(ValueMesh::new(region, members)?))
     }
 
-    /// Return the mesh rank space.
-    pub fn space(&self) -> &RankSpace {
-        self.members.space()
-    }
-
-    /// Return the actor refs in visible rank order.
-    pub fn members(&self) -> &[ActorRef<A>] {
-        self.members.data().as_slice()
-    }
-
-    /// Return a sub-mesh over `space`, which must be a subspace of this mesh's
-    /// rank space. Each visible rank of `space` keeps the actor ref it holds in
-    /// this mesh.
-    ///
-    /// Returns [`Error::InvalidRankCardinality`] when `space` contains ranks
-    /// that are not visible in this mesh.
-    pub fn sliced(&self, space: impl Into<RankSpace>) -> crate::Result<Self> {
-        let space = space.into();
-        let members: Vec<ActorRef<A>> = space
-            .iter_ranks()
-            .filter_map(|rank| self.members.get_rank(rank).cloned())
-            .collect();
-        Self::try_new(space, members)
-    }
-
-    /// Return a [`MeshMonitor`] over this mesh's members, one monitor per rank.
-    ///
-    /// The caller drives the returned monitor (await it, or run a future under
-    /// [`MeshMonitor::guard`]) to observe rank failures, and drops it to stop
-    /// monitoring.
-    pub fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
-        let actors = self.members.map(|actor| actor.actor_addr().clone());
-        MeshMonitor::spawn(cx, actors)
+    /// Return the dense actor-ref mesh.
+    pub fn members(&self) -> &ValueMesh<ActorRef<A>> {
+        &self.members
     }
 
     /// Cast `message` to every member. The data path has no cast domain, so it
@@ -465,7 +411,7 @@ impl<A: Referable> DataActorMesh<A> {
         A: RemoteHandles<M>,
         M: RemoteMessage + Clone,
     {
-        for actor in self.members.data() {
+        for actor in self.members.values() {
             actor.post_with_headers(cx, caller_headers.clone(), message.clone());
         }
         Ok(())
@@ -480,24 +426,30 @@ impl<A: Referable> Clone for DataActorMesh<A> {
     }
 }
 
-impl<A: Referable> rankspace::view::View<ActorRef<A>> for DataActorMesh<A> {
-    fn space(&self) -> &RankSpace {
-        self.members.space()
+impl<A: Referable> view::Ranked for DataActorMesh<A> {
+    type Item = ActorRef<A>;
+
+    fn region(&self) -> &Region {
+        self.members.region()
     }
 
-    fn get_rank(&self, rank: Rank) -> Option<&ActorRef<A>> {
-        self.members.get_rank(rank)
+    fn get(&self, rank: usize) -> Option<&Self::Item> {
+        self.members.get(rank)
+    }
+}
+
+impl<A: Referable> view::RankedSliceable for DataActorMesh<A> {
+    fn sliced(&self, region: Region) -> Self {
+        Self::new_unchecked(self.members.sliced(region))
     }
 }
 
 /// A reference to a stable snapshot of an [`ActorMesh`]: the cast and address
 /// surface, cheap to clone and to serialize.
 ///
-/// `Managed` is the legacy controller-backed ref over a dense `ndslice` region;
-/// `Data` is the detached, rankspace-based data ref. Casting and rankspace
-/// addressing work on both. The legacy dense
-/// [`view::Ranked`]/[`view::RankedSliceable`] surface is meaningful only for
-/// `Managed`; use [`Self::as_managed`] to discriminate without panicking.
+/// `Managed` is the controller-backed ref with cast-tree delivery, and `Data`
+/// is the detached ref that casts directly. Both variants are dense and expose
+/// the same [`view::Ranked`] and [`view::RankedSliceable`] surface.
 #[derive(typeuri::Named)]
 pub enum ActorMeshRef<A: Referable> {
     // Boxed so the cheap `Data` variant does not pay the (much larger) `Managed`
@@ -522,7 +474,7 @@ enum ActorMeshRefRepr<A: Referable> {
             ActorMeshCastDomain,
         )>,
     ),
-    Data(CompactView<Vec<ActorRef<A>>>),
+    Data(ValueMesh<ActorRef<A>>),
 }
 
 impl<A: Referable> ActorMeshRef<A> {
@@ -542,12 +494,9 @@ impl<A: Referable> ActorMeshRef<A> {
         )))
     }
 
-    /// Create a data-only ref from a rank space and its actor refs.
-    pub fn try_new_data(
-        space: impl Into<RankSpace>,
-        members: Vec<ActorRef<A>>,
-    ) -> crate::Result<Self> {
-        Ok(Self::Data(DataActorMesh::try_new(space, members)?))
+    /// Create a data-only ref from a region and its actor refs.
+    pub fn try_new_data(region: Region, members: Vec<ActorRef<A>>) -> crate::Result<Self> {
+        Ok(Self::Data(DataActorMesh::try_new(region, members)?))
     }
 
     /// Return the legacy dense ref when this is the managed variant.
@@ -555,14 +504,6 @@ impl<A: Referable> ActorMeshRef<A> {
         match self {
             Self::Managed(managed) => Some(managed),
             Self::Data(_) => None,
-        }
-    }
-
-    /// Return a [`MeshMonitor`] over this mesh's members.
-    pub fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
-        match self {
-            Self::Managed(managed) => managed.monitor(cx),
-            Self::Data(data) => data.monitor(cx),
         }
     }
 
@@ -611,7 +552,7 @@ impl<A: Referable> ActorMeshRef<A> {
     ) -> Result<MeshFailure, anyhow::Error> {
         match self {
             Self::Managed(managed) => managed.next_supervision_event(cx).await,
-            Self::Data(data) => Ok((&data.monitor(cx)).await),
+            Self::Data(_) => Ok((&self.monitor(cx)).await),
         }
     }
 
@@ -627,6 +568,18 @@ impl<A: Referable> ActorMeshRef<A> {
         self.as_managed()
             .expect("only managed actor meshes record local stopped state")
             .record_stopped(cx, status);
+    }
+
+    /// Create a new, independent monitor over every rank.
+    pub fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
+        let region = self.region().clone();
+        let actors = self
+            .values()
+            .map(|actor| actor.actor_addr().clone())
+            .collect();
+        let actors = ValueMesh::new(region, actors)
+            .expect("actor addresses collected from a dense mesh preserve cardinality");
+        MeshMonitor::spawn(cx, actors)
     }
 }
 
@@ -726,43 +679,25 @@ impl<A: Referable> view::Ranked for ActorMeshRef<A> {
     type Item = ActorRef<A>;
 
     fn region(&self) -> &Region {
-        view::Ranked::region(
-            self.as_managed()
-                .expect("Data ActorMeshRef is sparse; use its rankspace View"),
-        )
+        match self {
+            Self::Managed(managed) => managed.as_ref().region(),
+            Self::Data(data) => data.region(),
+        }
     }
 
     fn get(&self, rank: usize) -> Option<&Self::Item> {
-        view::Ranked::get(
-            self.as_managed()
-                .expect("Data ActorMeshRef is sparse; use its rankspace View"),
-            rank,
-        )
+        match self {
+            Self::Managed(managed) => managed.as_ref().get(rank),
+            Self::Data(data) => data.get(rank),
+        }
     }
 }
 
 impl<A: Referable> view::RankedSliceable for ActorMeshRef<A> {
     fn sliced(&self, region: Region) -> Self {
-        Self::Managed(Box::new(view::RankedSliceable::sliced(
-            self.as_managed()
-                .expect("Data ActorMeshRef slices via rankspace, not a dense region"),
-            region,
-        )))
-    }
-}
-
-impl<A: Referable> rankspace::view::View<ActorRef<A>> for ActorMeshRef<A> {
-    fn space(&self) -> &RankSpace {
         match self {
-            Self::Managed(managed) => managed.space(),
-            Self::Data(data) => data.space(),
-        }
-    }
-
-    fn get_rank(&self, rank: Rank) -> Option<&ActorRef<A>> {
-        match self {
-            Self::Managed(managed) => managed.get_rank(rank),
-            Self::Data(data) => data.get_rank(rank),
+            Self::Managed(managed) => Self::Managed(Box::new(managed.as_ref().sliced(region))),
+            Self::Data(data) => Self::Data(data.sliced(region)),
         }
     }
 }
@@ -1059,7 +994,6 @@ pub struct ManagedActorMeshRef<A: Referable> {
             )>,
         >,
     >,
-    space: RankSpace,
     /// Lazily allocated collection of pages:
     /// - The outer `OnceCell` defers creating the vector until first
     ///   use.
@@ -1077,9 +1011,7 @@ pub struct ManagedActorMeshRef<A: Referable> {
 impl<A: Referable> ManagedActorMeshRef<A> {
     fn cached_failure(&self, cx: &impl context::Actor) -> Option<MeshFailure> {
         let health_state = self.health_state.entry(cx).or_default();
-        health_state
-            .get()
-            .failure_for_region(ndslice::view::Ranked::region(self))
+        health_state.get().failure_for_region(self.region())
     }
 
     /// Cast a message to all the actors in this mesh
@@ -1109,7 +1041,7 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         A: RemoteHandles<M>,
         M: RemoteMessage + Clone,
     {
-        self.emit_sent_message_telemetry(cx, view::Ranked::region(self));
+        self.emit_sent_message_telemetry(cx, self.region());
 
         let mut headers = caller_headers.clone();
         headers.set(
@@ -1267,7 +1199,6 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         cast_domain: ActorMeshCastDomain,
         page_size: usize,
     ) -> Self {
-        let space = cast_domain.region().clone().into();
         Self {
             id,
             proc_mesh_id,
@@ -1275,7 +1206,6 @@ impl<A: Referable> ManagedActorMeshRef<A> {
             cast_domain,
             health_state: ActorLocal::new(),
             receiver: ActorLocal::new(),
-            space,
             pages: OnceCell::new(),
             page_size: page_size.max(1),
         }
@@ -1328,7 +1258,9 @@ impl<A: Referable> ManagedActorMeshRef<A> {
             // same dense local-rank order as this mesh ref's region.
             debug_assert!(rank < self.len(), "rank must be within [0, len)");
             ActorRef::attest(
-                view::Ranked::get(cast_domain.members(), rank)
+                cast_domain
+                    .members()
+                    .get(rank)
                     .expect("rank must be present in cast-domain member map")
                     .clone(),
             )
@@ -1394,7 +1326,7 @@ impl<A: Referable> ManagedActorMeshRef<A> {
                     // whole mesh.
                     if let MessageOrFailure::Message(message) = message {
                         if let Some(message) = &message {
-                            let region = ndslice::view::Ranked::region(self).slice();
+                            let region = self.region().slice();
                             if message.crashed_ranks.is_empty() {
                                 // Whole-mesh event (e.g. mesh stop).
                                 true
@@ -1479,22 +1411,6 @@ impl<A: Referable> ManagedActorMeshRef<A> {
         Ok(message)
     }
 
-    fn monitor(&self, cx: &impl context::Actor) -> MeshMonitor {
-        let space = self.space();
-        let addrs = space
-            .iter_ranks()
-            .map(|rank| {
-                self.get_rank(rank)
-                    .expect("visible rank materializes an actor ref")
-                    .actor_addr()
-                    .clone()
-            })
-            .collect();
-        let actors = CompactView::new(space.clone(), addrs)
-            .expect("managed mesh members form a valid compact view");
-        MeshMonitor::spawn(cx, actors)
-    }
-
     /// Record a synthetic "stopped" unhealthy event so future casts through this
     /// ref (and its slices) observe the mesh as no longer live.
     pub(crate) fn record_stopped(&self, cx: &impl context::Actor, status: ActorStatus) {
@@ -1504,10 +1420,7 @@ impl<A: Referable> ManagedActorMeshRef<A> {
             actor_mesh_name: Some(self.id().to_string()),
             event: ActorSupervisionEvent::new(
                 // Use an actor id from the mesh.
-                self.space()
-                    .iter_ranks()
-                    .next()
-                    .and_then(|rank| self.get_rank(rank))
+                self.get(0)
                     .expect("mesh must have at least one rank")
                     .actor_addr()
                     .clone(),
@@ -1521,6 +1434,7 @@ impl<A: Referable> ManagedActorMeshRef<A> {
             reporting_controller: None,
         }));
     }
+
     /// Same as Clone, but includes a shared supervision receiver. This copy will
     /// share the same health state and get the same supervision events.
     /// Will have a separate cache.
@@ -1532,7 +1446,6 @@ impl<A: Referable> ManagedActorMeshRef<A> {
             cast_domain: self.cast_domain.clone(),
             health_state: self.health_state.clone(),
             receiver: self.receiver.clone(),
-            space: self.space.clone(),
             // Cache does not support Clone at this time.
             pages: OnceCell::new(),
             page_size: self.page_size,
@@ -1551,7 +1464,6 @@ impl<A: Referable> Clone for ManagedActorMeshRef<A> {
             // it should make a new subscriber.
             health_state: ActorLocal::new(),
             receiver: ActorLocal::new(),
-            space: self.space.clone(),
             pages: OnceCell::new(), // No clone cache.
             page_size: self.page_size,
         }
@@ -1666,7 +1578,7 @@ impl<A: Referable> view::RankedSliceable for ManagedActorMeshRef<A> {
         // mesh ref so new sub-slices do not race the controller replay path.
         // The supervision receiver stays independent because each slice applies
         // its own region filter to future updates.
-        debug_assert!(region.is_subset(view::Ranked::region(self)));
+        debug_assert!(region.is_subset(self.region()));
         Self {
             id: self.id.clone(),
             proc_mesh_id: self.proc_mesh_id.clone(),
@@ -1677,23 +1589,9 @@ impl<A: Referable> view::RankedSliceable for ManagedActorMeshRef<A> {
             ),
             health_state: self.health_state.clone(),
             receiver: ActorLocal::new(),
-            space: region.into(),
             pages: OnceCell::new(),
             page_size: self.page_size,
         }
-    }
-}
-
-impl<A: Referable> rankspace::view::View<ActorRef<A>> for ManagedActorMeshRef<A> {
-    fn space(&self) -> &RankSpace {
-        &self.space
-    }
-
-    fn get_rank(&self, rank: Rank) -> Option<&ActorRef<A>> {
-        // `Managed` is dense, so a base rank maps to an ordinal via its
-        // rank space, which then indexes the lazily-materialized ref.
-        let ordinal = self.space.local_index_of(rank)?;
-        view::Ranked::get(self, ordinal)
     }
 }
 
@@ -1702,7 +1600,6 @@ mod tests {
 
     use std::collections::HashMap;
     use std::collections::HashSet;
-    use std::future::IntoFuture;
     use std::ops::Deref;
     use std::sync::Arc;
 
@@ -1724,15 +1621,11 @@ mod tests {
     use ndslice::extent;
     use ndslice::view::Ranked;
     use ndslice::view::RankedSliceable;
-    use rankspace::Rank;
-    use rankspace::RankSpace;
-    use rankspace::view::View;
     use timed_test::assert_no_process_leak;
     use timed_test::async_timed_test;
     use tokio::time::Duration;
 
     use super::ActorMesh;
-    use super::DataActorMesh;
     use crate::ActorMeshRef;
     use crate::ProcMesh;
     use crate::host_mesh::GET_PROC_STATE_MAX_IDLE;
@@ -1759,7 +1652,6 @@ mod tests {
     #[test]
     fn test_actor_mesh_ref_data_variant_is_detached_data_structure() {
         let region: Region = extent!(replicas = 2).into();
-        let space = RankSpace::from(region);
         let members = vec![
             ActorRef::<testactor::TestActor>::attest(
                 ProcAddr::instance(ChannelAddr::Local(9000), "data").actor_addr("rank0"),
@@ -1770,40 +1662,42 @@ mod tests {
         ];
 
         let mesh: ActorMeshRef<testactor::TestActor> =
-            ActorMeshRef::try_new_data(space.clone(), members.clone()).unwrap();
+            ActorMeshRef::try_new_data(region.clone(), members.clone()).unwrap();
 
-        assert_eq!(mesh.space(), &space);
+        assert_eq!(mesh.region(), &region);
+        assert_eq!(mesh.get(1).unwrap().actor_addr(), members[1].actor_addr());
         assert_eq!(
-            mesh.get_rank(Rank(1)).unwrap().actor_addr(),
-            members[1].actor_addr()
+            mesh.values()
+                .map(|actor_ref| actor_ref.actor_addr().clone())
+                .collect::<Vec<_>>(),
+            members
+                .iter()
+                .map(|actor_ref| actor_ref.actor_addr().clone())
+                .collect::<Vec<_>>()
         );
         let ActorMeshRef::Data(data) = &mesh else {
             panic!("data constructor returned a managed ref");
         };
-        assert_eq!(data.members().len(), 2);
+        assert_eq!(data.members().values().count(), 2);
 
-        // Slice to the second replica; the rank space keeps base rank 1, so the
-        // sliced mesh addresses its single member by base rank rather than a
-        // renumbered ordinal.
-        let slice = data
-            .sliced(
-                mesh.space()
-                    .select("replicas", 1..2)
-                    .expect("rank 1 slice should exist"),
-            )
-            .expect("selected space should be a valid subspace");
-        assert_eq!(slice.members().len(), 1);
-        assert_eq!(
-            slice.get_rank(Rank(1)).unwrap().actor_addr(),
-            members[1].actor_addr()
-        );
+        let slice_region = region
+            .range("replicas", 1..2)
+            .expect("rank 1 slice should exist");
+        let slice = mesh.sliced(slice_region.clone());
+        assert!(matches!(&slice, ActorMeshRef::Data(_)));
+        assert_eq!(slice.region(), &slice_region);
+        assert_eq!(slice.values().count(), 1);
+        assert_eq!(slice.get(0).unwrap().actor_addr(), members[1].actor_addr());
 
-        let invalid_region = Region::new(
-            vec!["replicas".to_string()],
-            Slice::new(1, vec![2], vec![1]).expect("test region should be valid"),
-        );
+        let encoded = serde_json::to_vec(&mesh).expect("data ref should serialize");
+        let decoded: ActorMeshRef<testactor::TestActor> =
+            serde_json::from_slice(&encoded).expect("data ref should deserialize");
+        assert_eq!(decoded, mesh);
+        assert_eq!(decoded.region(), &region);
+        assert_eq!(decoded.values().count(), 2);
+
         assert!(matches!(
-            data.sliced(invalid_region),
+            ActorMeshRef::try_new_data(region, vec![members[0].clone()]),
             Err(crate::Error::InvalidRankCardinality {
                 expected: 2,
                 actual: 1,
@@ -1812,34 +1706,59 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_data_actor_mesh_monitors_rank_stop() {
+    async fn test_actor_mesh_ref_monitor_owns_status_and_guards_operations() {
         let proc = Proc::isolated();
         let client = proc.client("client");
         let target = client.spawn_with_label("rank0", testactor::TestActor);
         let region: Region = extent!(replicas = 1).into();
-        let mesh: DataActorMesh<testactor::TestActor> =
-            DataActorMesh::try_new(region, vec![target.bind()]).unwrap();
-
+        let actor_ref: ActorRef<testactor::TestActor> = target.bind();
+        let mesh = ActorMeshRef::try_new_data(region, vec![actor_ref.clone()])
+            .expect("data ref should be valid");
         let monitor = mesh.monitor(&client);
-        let mut wait = (&monitor).into_future();
-        tokio::select! {
-            biased;
-            failure = &mut wait => panic!("unexpected failure before stop: {failure:?}"),
-            _ = tokio::task::yield_now() => {}
-        }
+        let independent_monitor = mesh.monitor(&client);
 
-        target
-            .drain_and_stop("rank complete")
-            .expect("target should accept stop");
+        assert_eq!(monitor.status(0), Some(ActorStatus::Unknown));
+        assert_eq!(independent_monitor.status(0), Some(ActorStatus::Unknown));
+        assert_eq!(mesh.get(0).expect("rank 0 should exist"), &actor_ref);
 
-        let observed = tokio::time::timeout(Duration::from_secs(10), wait)
-            .await
-            .expect("timed out waiting for mesh monitor stop");
+        let observed = {
+            let mut wait = std::pin::pin!(monitor.guard(std::future::pending::<()>()));
+            tokio::select! {
+                biased;
+                failure = &mut wait => panic!("unexpected failure before stop: {failure:?}"),
+                _ = tokio::task::yield_now() => {}
+            }
+
+            target
+                .drain_and_stop("rank complete")
+                .expect("target should accept stop");
+
+            tokio::time::timeout(Duration::from_secs(10), wait)
+                .await
+                .expect("timed out waiting for monitored guard failure")
+                .expect_err("pending operation should lose to rank failure")
+        };
+        let independently_observed = tokio::time::timeout(
+            Duration::from_secs(10),
+            independent_monitor.guard(std::future::pending::<()>()),
+        )
+        .await
+        .expect("timed out waiting for independent monitor failure")
+        .expect_err("pending operation should lose to rank failure");
         assert_eq!(observed.crashed_ranks, vec![0]);
+        assert_eq!(independently_observed.crashed_ranks, vec![0]);
         assert!(matches!(
             observed.event.actor_status,
             ActorStatus::Stopped(ref reason) if reason == "rank complete"
         ));
+        assert!(matches!(
+            monitor.status(0).expect("rank 0 should remain monitored"),
+            ActorStatus::Stopped(ref reason) if reason == "rank complete"
+        ));
+
+        let (port, _rx) = mailbox::open_port(&client);
+        mesh.cast(&client, testactor::GetActorId(port.bind()))
+            .expect("casting does not implicitly check monitor status");
 
         tokio::time::timeout(Duration::from_secs(5), target)
             .await
@@ -1881,6 +1800,14 @@ mod tests {
         assert_eq!(amr.extent(), extent!(hosts = 2, gpus = 2));
         assert_eq!(amr.region().num_ranks(), 4);
         assert_eq!(amr.values().count(), 4);
+
+        let encoded = serde_json::to_vec(&amr).expect("managed ref should serialize");
+        let decoded: ActorMeshRef<testactor::TestActor> =
+            serde_json::from_slice(&encoded).expect("managed ref should deserialize");
+        assert!(matches!(&decoded, ActorMeshRef::Managed(_)));
+        assert_eq!(decoded, amr);
+        assert_eq!(decoded.region(), amr.region());
+        assert_eq!(decoded.get(3), amr.get(3));
 
         // 3) Within-rank pointer stability (OnceLock caches &ActorRef)
         let p0_a = amr.get(0).expect("rank 0 exists") as *const _;
@@ -2565,7 +2492,7 @@ mod tests {
             proc_mesh.spawn(instance, "test", &()).await.unwrap();
 
         // Cast through a sliced mesh — `cast` still means all, but all is
-        // scoped to the immutable sliced rank space.
+        // scoped to the immutable sliced region.
         let actor_mesh = root_actor_mesh.sliced(Region::new(
             vec!["rank".to_string()],
             Slice::new(0, vec![1], vec![1]).unwrap(),

--- a/hyperactor_mesh/src/monitor.rs
+++ b/hyperactor_mesh/src/monitor.rs
@@ -21,35 +21,68 @@ use std::pin::Pin;
 use futures::future::select_all;
 use hyperactor::ActorAddr;
 use hyperactor::ActorMonitor;
+use hyperactor::RemoteHandles;
+use hyperactor::RemoteMessage;
 use hyperactor::actor::ActorStatus;
+use hyperactor::actor::Referable;
 use hyperactor::context;
+use hyperactor::mailbox::Message;
+use hyperactor::mailbox::PortReceiver;
 use hyperactor::monitor::MonitorFailure;
+use hyperactor::monitor::MonitorStatus;
 use hyperactor::supervision::ActorSupervisionEvent;
-use rankspace::view::CompactView;
+use ndslice::ViewExt as _;
+use ndslice::view::Ranked as _;
+use ndslice::view::Region;
 
+use crate::ActorMeshRef;
+use crate::ValueMesh;
 use crate::supervision::MeshFailure;
 
 /// A liveness monitor over a set of ranked actors.
 ///
-/// A `MeshMonitor` owns one [`ActorMonitor`] per rank, keyed by the same
-/// [`RankSpace`](rankspace::RankSpace) as the mesh it observes. The monitors run
-/// until the `MeshMonitor` is dropped. Awaiting a `&MeshMonitor` resolves with the
-/// first rank failure, reported as a [`MeshFailure`] that names the rank; use
-/// [`MeshMonitor::guard`] to run a future until it completes or a rank fails.
+/// A `MeshMonitor` logically monitors one actor per rank in a region. Monitoring
+/// runs until the `MeshMonitor` is dropped. Awaiting a `&MeshMonitor` resolves
+/// with the first rank failure, reported as a [`MeshFailure`] that names the
+/// rank; use [`MeshMonitor::guard`] to run a future until it completes or a rank
+/// fails.
 pub struct MeshMonitor {
-    /// One monitor per visible rank, keyed by the mesh's rank space.
-    monitors: CompactView<Vec<ActorMonitor>>,
+    /// One monitor per rank, keyed by the mesh's region.
+    monitors: ValueMesh<ActorMonitor>,
 }
 
 impl MeshMonitor {
-    /// Spawn one [`ActorMonitor`] per visible rank as a child of `cx`.
+    /// Spawn one [`ActorMonitor`] per rank as a child of `cx`.
     ///
-    /// `actors` holds the actor addresses in the mesh's rank space, so the
-    /// resulting monitors share that space: each rank reports failures under the
-    /// same rank it holds in the mesh.
-    pub fn spawn(cx: &impl context::Actor, actors: CompactView<Vec<ActorAddr>>) -> Self {
-        let monitors = actors.map(|actor| ActorMonitor::spawn(cx, actor.clone()));
-        Self { monitors }
+    /// `actors` holds the actor addresses in the mesh's region, so the resulting
+    /// monitors share that region: each rank reports failures under the same rank
+    /// it holds in the mesh.
+    pub fn spawn(cx: &impl context::Actor, actors: ValueMesh<ActorAddr>) -> Self {
+        let region = actors.region().clone();
+        let monitors = actors
+            .values()
+            .map(|actor| ActorMonitor::spawn(cx, actor.clone()))
+            .collect();
+        Self {
+            monitors: ValueMesh::new(region, monitors)
+                .expect("actor monitors preserve actor mesh cardinality"),
+        }
+    }
+
+    /// Return the monitored region.
+    pub fn region(&self) -> &Region {
+        self.monitors.region()
+    }
+
+    /// Return the latest observed status for `rank`.
+    pub fn status(&self, rank: usize) -> Option<ActorStatus> {
+        self.monitors
+            .get(rank)
+            .map(|monitor| match monitor.status() {
+                MonitorStatus::Checking => ActorStatus::Unknown,
+                MonitorStatus::Alive(status) => status,
+                MonitorStatus::Failed(failure) => monitor_failure_to_actor_status(&failure),
+            })
     }
 
     /// Wait for the first monitored rank to fail, reported as a [`MeshFailure`].
@@ -58,10 +91,14 @@ impl MeshMonitor {
     /// [`Self::guard`], the public ways to observe failures. An empty monitor set
     /// never resolves: a mesh with no ranks has no rank that can fail.
     async fn wait_for_failure(&self) -> MeshFailure {
-        if self.monitors.data().is_empty() {
+        if self.region().num_ranks() == 0 {
             return std::future::pending().await;
         }
-        let waits = self.monitors.iter().map(|(rank, monitor)| {
+        let waits = (0..self.region().num_ranks()).map(|rank| {
+            let monitor = self
+                .monitors
+                .get(rank)
+                .expect("dense actor monitor mesh has one value per rank");
             Box::pin(async move {
                 // Guarding a never-completing future resolves only when the
                 // monitor reports a failure.
@@ -73,7 +110,7 @@ impl MeshMonitor {
             })
         });
         let ((rank, failure), _index, _rest) = select_all(waits).await;
-        monitor_failure_to_mesh_failure(rank.get(), failure)
+        monitor_failure_to_mesh_failure(rank, &failure)
     }
 
     /// Run `fut` until it completes or any monitored rank fails.
@@ -85,6 +122,42 @@ impl MeshMonitor {
         tokio::select! {
             result = fut => Ok(result),
             failure = self.wait_for_failure() => Err(failure),
+        }
+    }
+
+    /// Cast `message` and collect one response per rank unless a rank fails.
+    ///
+    /// `receiver` must receive exactly one response from each actor in
+    /// `actor_mesh`. Responses are returned in arrival order. The outer result
+    /// reports cast or mailbox errors; the inner result distinguishes all-rank
+    /// completion from a monitored rank failure. This monitor must have been
+    /// created from `actor_mesh`.
+    pub async fn cast_and_collect<A, M, R>(
+        &self,
+        actor_mesh: &ActorMeshRef<A>,
+        cx: &impl context::Actor,
+        message: M,
+        receiver: &mut PortReceiver<R>,
+    ) -> crate::Result<Result<Vec<R>, MeshFailure>>
+    where
+        A: Referable + RemoteHandles<M>,
+        M: RemoteMessage + Clone,
+        R: Message,
+    {
+        actor_mesh.cast(cx, message)?;
+        let num_ranks = actor_mesh.region().num_ranks();
+        let replies = async {
+            let mut replies = Vec::with_capacity(num_ranks);
+            for _ in 0..num_ranks {
+                replies.push(receiver.recv().await?);
+            }
+            Ok::<_, hyperactor::mailbox::MailboxError>(replies)
+        };
+
+        match self.guard(replies).await {
+            Ok(Ok(replies)) => Ok(Ok(replies)),
+            Ok(Err(error)) => Err(Box::new(error).into()),
+            Err(failure) => Ok(Err(failure)),
         }
     }
 }
@@ -100,15 +173,11 @@ impl<'a> IntoFuture for &'a MeshMonitor {
     }
 }
 
-fn monitor_failure_to_mesh_failure(rank: usize, failure: MonitorFailure) -> MeshFailure {
+fn monitor_failure_to_mesh_failure(rank: usize, failure: &MonitorFailure) -> MeshFailure {
     let actor_id = failure.actor_id().clone();
-    let actor_status = match failure {
-        MonitorFailure::ActorStopped { status, .. } => status,
-        MonitorFailure::ActorFailed { status, .. } if status.is_failed() => status,
-        failure => ActorStatus::generic_failure(failure.to_string()),
-    };
+    let actor_status = monitor_failure_to_actor_status(failure);
     // The failed actor is identified by `event.actor_id` and the rank; the mesh
-    // itself has no name to carry (data meshes are identified by their members).
+    // itself has no name to carry.
     MeshFailure {
         actor_mesh_name: None,
         event: ActorSupervisionEvent::new(actor_id, None, actor_status, None),
@@ -119,12 +188,22 @@ fn monitor_failure_to_mesh_failure(rank: usize, failure: MonitorFailure) -> Mesh
     }
 }
 
+fn monitor_failure_to_actor_status(failure: &MonitorFailure) -> ActorStatus {
+    match failure {
+        MonitorFailure::ActorStopped { status, .. } => status.clone(),
+        MonitorFailure::ActorFailed { status, .. } if status.is_failed() => status.clone(),
+        failure => ActorStatus::generic_failure(failure.to_string()),
+    }
+}
+
 #[cfg(all(test, fbcode_build))]
 mod tests {
+    use std::collections::HashSet;
+
+    use hyperactor::ActorRef;
     use hyperactor::Proc;
     use ndslice::Region;
     use ndslice::extent;
-    use rankspace::RankSpace;
     use tokio::time::Duration;
 
     use super::*;
@@ -136,9 +215,9 @@ mod tests {
         let client = proc.client("client");
         let target = client.spawn_with_label("rank0", testactor::TestActor);
         let region: Region = extent!(replicas = 1).into();
-        let space = RankSpace::from(region);
-        let actors = CompactView::new(space, vec![target.actor_addr().clone()]).unwrap();
+        let actors = ValueMesh::new(region, vec![target.actor_addr().clone()]).unwrap();
         let monitor = MeshMonitor::spawn(&client, actors);
+        assert_eq!(monitor.status(0), Some(ActorStatus::Unknown));
 
         // No failure should be observed while the actor is alive.
         let mut wait = (&monitor).into_future();
@@ -160,9 +239,82 @@ mod tests {
             failure.event.actor_status,
             ActorStatus::Stopped(ref reason) if reason == "rank complete"
         ));
+        assert!(matches!(
+            monitor.status(0).expect("rank 0 should remain monitored"),
+            ActorStatus::Stopped(ref reason) if reason == "rank complete"
+        ));
 
         tokio::time::timeout(Duration::from_secs(5), target)
             .await
             .expect("timed out waiting for target to stop");
+    }
+
+    #[tokio::test]
+    async fn test_cast_and_collect_returns_all_replies_or_rank_failure() {
+        let proc = Proc::isolated();
+        let client = proc.client("client");
+        let rank0 = client.spawn_with_label("rank0", testactor::TestActor);
+        let rank1 = client.spawn_with_label("rank1", testactor::TestActor);
+        let actor_refs: Vec<ActorRef<testactor::TestActor>> = vec![rank0.bind(), rank1.bind()];
+        let expected_actor_addrs: HashSet<_> = actor_refs
+            .iter()
+            .map(|actor_ref| actor_ref.actor_addr().clone())
+            .collect();
+        let region: Region = extent!(replicas = 2).into();
+        let actor_mesh = ActorMeshRef::try_new_data(region, actor_refs)
+            .expect("data actor mesh should be valid");
+        let monitor = actor_mesh.monitor(&client);
+
+        let (port, mut receiver) = client.open_port();
+        let replies = tokio::time::timeout(
+            Duration::from_secs(10),
+            monitor.cast_and_collect(
+                &actor_mesh,
+                &client,
+                testactor::GetActorId(port.bind()),
+                &mut receiver,
+            ),
+        )
+        .await
+        .expect("timed out waiting for all rank replies")
+        .expect("cast and receive should succeed")
+        .expect("all ranks should remain alive");
+        let actor_addrs: HashSet<_> = replies
+            .into_iter()
+            .map(|(actor_addr, _seq_info)| actor_addr)
+            .collect();
+        assert_eq!(actor_addrs, expected_actor_addrs);
+
+        let (_port, mut receiver): (_, PortReceiver<()>) = client.open_port();
+        let mut pending =
+            std::pin::pin!(monitor.cast_and_collect(&actor_mesh, &client, (), &mut receiver,));
+        tokio::select! {
+            biased;
+            result = &mut pending => panic!("cast unexpectedly completed: {result:?}"),
+            _ = tokio::task::yield_now() => {}
+        }
+        rank1
+            .drain_and_stop("rank complete")
+            .expect("rank 1 should accept stop");
+        let failure = tokio::time::timeout(Duration::from_secs(10), pending)
+            .await
+            .expect("timed out waiting for a rank failure")
+            .expect("cast should initiate")
+            .expect_err("rank failure should win before all replies arrive");
+        assert_eq!(failure.crashed_ranks, vec![1]);
+        assert!(matches!(
+            failure.event.actor_status,
+            ActorStatus::Stopped(ref reason) if reason == "rank complete"
+        ));
+
+        rank0
+            .drain_and_stop("test complete")
+            .expect("rank 0 should accept stop");
+        tokio::time::timeout(Duration::from_secs(5), rank0)
+            .await
+            .expect("timed out waiting for rank 0 to stop");
+        tokio::time::timeout(Duration::from_secs(5), rank1)
+            .await
+            .expect("timed out waiting for rank 1 to stop");
     }
 }

--- a/hyperactor_mesh/src/proc_mesh.rs
+++ b/hyperactor_mesh/src/proc_mesh.rs
@@ -1398,9 +1398,10 @@ mod tests {
             .spawn_data(instance, &())
             .await
             .expect("spawn data actor mesh through default spawner");
-        assert_eq!(rankspace::view::View::space(&*actor_mesh).cardinality(), 2);
-        let actor_uids: HashSet<_> = rankspace::view::View::iter(&*actor_mesh)
-            .map(|(_, actor)| actor.actor_addr().id().uid().clone())
+        assert_eq!(actor_mesh.region().num_ranks(), 2);
+        let actor_uids: HashSet<_> = actor_mesh
+            .values()
+            .map(|actor| actor.actor_addr().id().uid().clone())
             .collect();
         assert_eq!(
             actor_uids.len(),

--- a/monarch_hyperactor/src/actor_mesh.rs
+++ b/monarch_hyperactor/src/actor_mesh.rs
@@ -719,9 +719,11 @@ impl ActorMeshProtocol for ActorMeshRef<PythonActor> {
                     .cast_choose_with_headers(instance, &caller_headers, message)
                     .map_err(cast_error_to_py_error),
                 ActorMeshRef::Data(mesh) => {
-                    let members = mesh.members();
-                    if !members.is_empty() {
-                        let actor = &members[rand::rng().random_range(0..members.len())];
+                    let num_ranks = mesh.region().num_ranks();
+                    if num_ranks > 0 {
+                        let actor = mesh
+                            .get(rand::rng().random_range(0..num_ranks))
+                            .expect("selected rank should exist in dense data mesh");
                         actor.post_with_headers(instance, caller_headers, message);
                     }
                     Ok(())


### PR DESCRIPTION
Summary:

Keep `ActorMeshRef` as a dense, serializable descriptor over `Region` and `ValueMesh`, and keep live status in an explicit, non-serializable `MeshMonitor`. `ActorMeshRef::monitor` always creates a fresh monitor; no other `ActorMeshRef` API creates or consults one, so callers choose its lifecycle and how to compose it with mesh data.

This is in opposition to having a sparse, `RankSpace`-based `ActorMeshRef`. It also brings `DataActorMeshRef` in line with the old `ManagedActorMeshRef`: both are dense and implement `view::Ranked`.

Added `MeshMonitor::cast_and_collect` which showcases how it can combine normal ActorMeshRef::cast with monitoring for failures in the same way that `next_supervision_event` did.

A one-shot `ActorStatus` query can report healthy immediately before failure, so it cannot provide a meaningful ordering guarantee and is inherently stale. Monitoring instead tracks the monotonic live-to-dead transition; its cached state is a useful lower bound (`dead` stays dead, while `live` may later become dead), and callers can distinguish `unknown` from declared dead before using it. Keeping the monitor explicit preserves lifecycle control without turning monitoring into an implicit implementation detail of status.

Reviewed By: mariusae

Differential Revision: D115267478


